### PR TITLE
Fix: Add missing Docker labels to system agent container

### DIFF
--- a/src/backend/services/system_agent_service.py
+++ b/src/backend/services/system_agent_service.py
@@ -225,9 +225,12 @@ class SystemAgentService:
             'trinity.platform': 'agent',
             'trinity.agent-name': SYSTEM_AGENT_NAME,
             'trinity.agent-type': agent_type,
+            'trinity.ssh-port': str(ssh_port),  # Required for port tracking
+            'trinity.cpu': str(resources.get('cpu', '4')),
+            'trinity.memory': resources.get('memory', '8g'),
+            'trinity.created': datetime.utcnow().isoformat(),
             'trinity.template': SYSTEM_AGENT_TEMPLATE,
             'trinity.is-system': 'true',  # Mark as system agent
-            'trinity.created-at': datetime.utcnow().isoformat()
         }
 
         # Create the container


### PR DESCRIPTION
The system agent was missing required Docker labels (trinity.ssh-port, trinity.cpu, trinity.memory, trinity.created), causing port allocation conflicts when creating new agents.

Without trinity.ssh-port label:
- get_agent_status_from_container() returns port=0
- get_next_available_port() filters out port 0
- System agent's port (2290) appears available
- New agents fail with 'port already allocated' error

This fix adds all required labels to match the standard agent creation pattern in routers/agents.py, ensuring proper port tracking and conflict prevention.