### PR TITLE
fix: add missing logging_config.py to backend Dockerfile

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -32,6 +32,7 @@ COPY ../../src/backend/db_models.py /app/
 COPY ../../src/backend/dependencies.py /app/
 COPY ../../src/backend/credentials.py /app/
 COPY ../../src/backend/database.py /app/
+COPY ../../src/backend/logging_config.py /app/
 
 # Copy module directories
 COPY ../../src/backend/routers /app/routers/


### PR DESCRIPTION
The backend Dockerfile was missing COPY instruction for logging_config.py, causing ModuleNotFoundError when running in production mode (docker-compose.prod.yml).

Development mode works because it uses volume mounts that include all files, but production builds only the explicitly copied files.