### PR TITLE
fix: Add process documentation volume mounts for production

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,7 +51,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/agent-templates:/agent-configs/templates:ro
+      - ./config/process-templates:/agent-configs/process-templates:ro
       - ./config/trinity-meta-prompt:/trinity-meta-prompt:ro
+      - ./config/process-docs:/app/config/process-docs:ro
       - agent-configs:/agent-configs
       - ${TRINITY_DATA_PATH:-./trinity-data}:/data
     depends_on:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -40,6 +40,10 @@ COPY ../../src/backend/services /app/services/
 COPY ../../src/backend/utils /app/utils/
 COPY ../../src/backend/db /app/db/
 
+# Copy configuration files (documentation, templates)
+COPY ../../config/process-docs /app/config/process-docs/
+COPY ../../config/process-templates /app/config/process-templates/
+
 # Ensure all files are readable
 RUN chmod -R 644 /app/*.py && \
     chmod -R 755 /app/routers /app/services /app/utils /app/db && \


### PR DESCRIPTION
## Production Documentation Fix
- Add missing volume mounts for process-docs and process-templates in docker-compose.prod.yml
- Copy documentation files into backend Docker image during build
- Fixes 404 errors when loading documentation in production deployment

The backend now serves documentation through both:
1. Volume mounts (flexible, can update without rebuild)
2. Baked-in files (portable, works without mounts)

Changes:
- docker-compose.prod.yml: Add process-docs and process-templates volume mounts
- docker/backend/Dockerfile: Copy config files during image build

Fixes: Documentation not loading in production (404 errors on /api/docs/*)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures process documentation and templates are served in production, preventing 404s and allowing both baked-in and live-updatable sources.
> 
> - In `docker-compose.prod.yml`, add volume mounts for `./config/process-docs` -> `/app/config/process-docs:ro` and `./config/process-templates` -> `/agent-configs/process-templates:ro`
> - In `docker/backend/Dockerfile`, copy `../../config/process-docs` and `../../config/process-templates` into `/app/config/` during build
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d84160516a8b25a33f33f3650d16a18738e1a1f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->