### PR TITLE
fix: Add ARM64 Alpine compatibility for frontend Docker build

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -5,8 +5,12 @@ WORKDIR /app
 # Copy package files
 COPY package.json package-lock.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies - use npm install instead of npm ci to handle optional deps better
+# and explicitly install rollup ARM64 Alpine binary if needed
+RUN npm install && \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        npm install --no-save @rollup/rollup-linux-arm64-musl || true; \
+    fi
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
## Summary
- Replace `npm ci` with `npm install` for better handling of optional dependencies
- Add conditional installation of `@rollup/rollup-linux-arm64-musl` for ARM64 Alpine Linux
- Fixes frontend build failures on Apple Silicon Macs and ARM-based servers

## Test plan
- [ ] Build frontend Docker image on ARM64 machine (Apple Silicon)
- [ ] Build frontend Docker image on x86_64 machine (should work unchanged)
- [ ] Verify Vite dev server starts correctly in container

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only change to the frontend Docker image; risk is limited to potential dependency drift from using `npm install` instead of `npm ci`.
> 
> **Overview**
> Updates the frontend `docker/frontend/Dockerfile` to use `npm install` (instead of `npm ci`) to better tolerate optional dependencies during container builds.
> 
> Adds an ARM64 Alpine workaround by conditionally installing `@rollup/rollup-linux-arm64-musl` when the image is built on `aarch64`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 719643214dc8b0e00a1f3156c92f4c9a1a13aabf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->