### PR TITLE
fix: Default Chat tab model to sonnet for subscription compatibility (#138)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -455,6 +455,15 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
         # 2. ANTHROPIC_API_KEY environment variable (API billing)
         # We don't require ANTHROPIC_API_KEY since users may be logged in with their subscription.
 
+        # Issue #138: Default to "sonnet" when no model is specified and none is set on state.
+        # Same fix as Issue #81 for execute_headless_task() — without --model, Claude Code
+        # uses the agent's ~/.claude/settings.json model, which may be incompatible with
+        # the assigned subscription (e.g., haiku on Claude Max), causing misleading
+        # "token expired" errors.
+        if not model and not agent_state.current_model:
+            model = "sonnet"
+            logger.debug("[Chat] No model specified, defaulting to 'sonnet' for subscription compatibility")
+
         # Update model if specified (persists for session)
         if model:
             agent_state.current_model = model

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,13 @@
+### 2026-03-16
+
+**fix: Chat tab model default for subscription compatibility (#138)**
+
+The Chat tab's `execute_claude_code()` did not default to a model when neither the request nor `agent_state.current_model` specified one. Claude Code fell back to the agent's `~/.claude/settings.json`, which could contain a model incompatible with the assigned subscription (e.g., `claude-3-5-haiku-latest` on Claude Max), producing a misleading "Subscription token may be expired" error. Applied the same `model="sonnet"` default that Issue #81 added to `execute_headless_task()` (Tasks tab).
+
+- `docker/base-image/agent_server/services/claude_code.py` — Default to `"sonnet"` in `execute_claude_code()` when no model specified
+
+---
+
 ### 2026-03-15
 
 **feat: Unified chat execution tracking (#96)**

--- a/docs/memory/feature-flows/parallel-headless-execution.md
+++ b/docs/memory/feature-flows/parallel-headless-execution.md
@@ -986,14 +986,22 @@ When using Claude Max/Pro subscriptions, headless task execution could fail with
 
 ### Solution
 
-`execute_headless_task()` now defaults to `model="sonnet"` when no model is specified:
+Both `execute_headless_task()` and `execute_claude_code()` now default to `model="sonnet"` when no model is specified:
 
-**File**: `docker/base-image/agent_server/services/claude_code.py:732-735`
+**Headless tasks** (Issue #81) — `docker/base-image/agent_server/services/claude_code.py:746-748`:
 ```python
 # Issue #81: Default to "sonnet" when model is not specified.
 if model is None:
     model = "sonnet"
     logger.debug("[Headless Task] No model specified, defaulting to 'sonnet' for subscription compatibility")
+```
+
+**Chat sessions** (Issue #138) — `docker/base-image/agent_server/services/claude_code.py:463-465`:
+```python
+# Issue #138: Default to "sonnet" when no model is specified and none is set on state.
+if not model and not agent_state.current_model:
+    model = "sonnet"
+    logger.debug("[Chat] No model specified, defaulting to 'sonnet' for subscription compatibility")
 ```
 
 ### Error Detection


### PR DESCRIPTION
## Summary
- Chat tab's `execute_claude_code()` lacked the `model="sonnet"` default that Issue #81 added to `execute_headless_task()` (Tasks tab)
- When no model was specified and `agent_state.current_model` was empty, Claude Code fell back to the agent's `settings.json` model — which could be incompatible with the subscription, producing a misleading "token expired" error
- Applied the same defensive default: if neither the request nor agent state has a model, default to `"sonnet"`

## Changes
- `docker/base-image/agent_server/services/claude_code.py` — Add model defaulting in `execute_claude_code()`
- `docs/memory/changelog.md` — Add changelog entry
- `docs/memory/feature-flows/parallel-headless-execution.md` — Document both code paths now having the fix

## Test Plan
- [ ] Existing tests unaffected (fix is inside agent container, not covered by API test suite)
- [ ] Manual verification: Create agent with Claude Max subscription, leave no model set, send message via Chat tab — should work instead of failing with "token expired"
- [ ] Verify Tasks tab still works (unchanged code path)
- [ ] After merge: rebuild base image (`./scripts/deploy/build-base-image.sh`) and restart agents

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)