### PR TITLE
fix: Guard stream-json parser against non-dict JSON lines (#151)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -148,6 +148,10 @@ def parse_stream_json_output(output: str) -> tuple[str, List[ExecutionLogEntry],
             logger.warning(f"Failed to parse line as JSON: {line[:100]}")
             continue
 
+        if not isinstance(msg, dict):
+            # stream-json can emit string literals; skip them
+            continue
+
         msg_type = msg.get("type")
 
         if msg_type == "init":
@@ -277,6 +281,10 @@ def process_stream_line(line: str, execution_log: List[ExecutionLogEntry], metad
         msg = json.loads(line)
     except json.JSONDecodeError:
         logger.warning(f"Failed to parse line as JSON: {line[:100]}")
+        return
+
+    if not isinstance(msg, dict):
+        # stream-json can emit string literals; skip them
         return
 
     msg_type = msg.get("type")
@@ -539,6 +547,9 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
                     # Capture raw JSON for full execution log (same as execute_headless_task)
                     try:
                         raw_msg = json.loads(line.strip())
+                        if not isinstance(raw_msg, dict):
+                            # stream-json can emit string literals; skip them
+                            continue
                         # SECURITY: Sanitize credentials from output before storing
                         raw_msg = sanitize_dict(raw_msg)
                         raw_messages.append(raw_msg)
@@ -871,6 +882,9 @@ async def execute_headless_task(
                     # Capture raw JSON for full execution log
                     try:
                         raw_msg = json.loads(line.strip())
+                        if not isinstance(raw_msg, dict):
+                            # stream-json can emit string literals; skip them
+                            continue
                         # SECURITY: Sanitize credentials from output before storing
                         raw_msg = sanitize_dict(raw_msg)
                         raw_messages.append(raw_msg)

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,5 +1,15 @@
 ### 2026-03-21
 
+**fix: Agent server stream-json parser crashes on non-dict JSON lines (#151)**
+
+Added `isinstance(raw_msg, dict)` guards in all four stream-json parsing locations in `claude_code.py`. Previously, `json.loads()` could return a string literal (valid JSON), and calling `.get()` on it raised `AttributeError`, killing the stdout loop and discarding all execution results.
+
+- `parse_stream_json_output()` (line ~148) — skip non-dict after json.loads
+- `process_stream_line()` (line ~283) — skip non-dict after json.loads
+- `_run_headless_with_streaming()` (line ~547, ~882) — skip non-dict before sanitize_dict
+
+---
+
 **feat: Add chart widget type to agent dashboards**
 
 Agents can now display charts (line, bar, area, pie, donut) in their dashboard via a new `type: chart` widget. Uses Chart.js/vue-chartjs (already in deps). Fully additive — no breaking changes to existing dashboards.


### PR DESCRIPTION
## Summary
- Added `isinstance(raw_msg, dict)` guards in all 4 stream-json parsing locations in `claude_code.py`
- Prevents `AttributeError: 'str' object has no attribute 'get'` when Claude Code emits JSON string literals
- Previously this crashed the stdout loop, discarding all execution results (cost, session_id, response)

## Changes
- `docker/base-image/agent_server/services/claude_code.py` — 4 guard clauses (lines ~148, ~283, ~547, ~882)
- `docs/memory/changelog.md` — New entry

## Test Plan
- [ ] Deploy agent with updated base image
- [ ] Run a scheduled task that uses `context: fork` with a subagent
- [ ] Verify execution completes successfully (no "Task returned empty response")
- [ ] Verify non-dict JSON lines are silently skipped in logs

Fixes #151

Generated with [Claude Code](https://claude.com/claude-code)