### PR TITLE
feat: Configurable MCP Server URL in Admin Settings (#76)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -610,6 +610,14 @@ Services that run continuously in the backend process:
 | GET | `/api/nevermined/settlement-failures` | Admin | Failed settlements |
 | POST | `/api/nevermined/retry-settlement/{log_id}` | Admin | Retry settlement |
 
+### Platform Settings (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/settings/mcp-url` | Get configured MCP server URL (any auth user) |
+| PUT | `/api/settings/mcp-url` | Set MCP server URL (admin-only) |
+| DELETE | `/api/settings/mcp-url` | Reset to auto-detect (admin-only) |
+
 ---
 
 ## Architectural Invariants

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -44,6 +44,7 @@
 | 2026-03-26 | EVT-001 | Agent Event Subscriptions — lightweight pub/sub for inter-agent pipelines | [agent-event-subscriptions.md](feature-flows/agent-event-subscriptions.md) |
 | 2026-03-25 | #129 | Active watchdog — reconcile DB state against agent process registries, recover orphans, auto-terminate timeouts | [cleanup-service.md](feature-flows/cleanup-service.md) |
 | 2026-03-25 | #148 | Fix silent subscription registration failure — encryption key auto-generation, status endpoint, frontend warning | [subscription-management.md](feature-flows/subscription-management.md) |
+| 2026-03-25 | #76 | Configurable MCP Server URL in Admin Settings | [platform-settings.md](feature-flows/platform-settings.md), [api-keys-page.md](feature-flows/api-keys-page.md) |
 | 2026-03-25 | #74 | Auto-assign subscription to new agents (round-robin, rate-limit aware) | [subscription-management.md](feature-flows/subscription-management.md) |
 | 2026-03-23 | VOICE-001 | Voice Chat — real-time voice conversations with agents via Gemini Live API | [voice-chat.md](feature-flows/voice-chat.md) |
 | 2026-03-23 | SLACK-002 | Channel adapter abstraction + multi-agent Slack routing | [slack-channel-routing.md](feature-flows/slack-channel-routing.md) |

--- a/docs/memory/feature-flows/api-keys-page.md
+++ b/docs/memory/feature-flows/api-keys-page.md
@@ -47,13 +47,14 @@ As a Trinity user, I want to manage my MCP API keys from a dedicated page so tha
 
 ### Lifecycle (onMounted)
 ```javascript
-// ApiKeys.vue:553-558
+// ApiKeys.vue
 onMounted(async () => {
-  await fetchUserRole()     // Check if user is admin
-  await fetchApiKeys()      // Load existing keys
+  await Promise.all([fetchMcpUrl(), fetchUserRole(), fetchApiKeys()])
   await ensureDefaultKey()  // Auto-create default key for first-time users
 })
 ```
+
+**MCP URL**: `fetchMcpUrl()` calls `GET /api/settings/mcp-url` to get the admin-configured URL. If set, `mcpServerUrl` computed uses it; otherwise falls back to auto-detect from `window.location.hostname`. (#76)
 
 ### Step 1: Fetch User Role
 ```javascript

--- a/docs/memory/feature-flows/platform-settings.md
+++ b/docs/memory/feature-flows/platform-settings.md
@@ -51,7 +51,7 @@ Admin-only page for managing system-wide configuration including API keys (Anthr
 | Trinity Prompt | 224-289 | Textarea for custom agent instructions |
 | Email Whitelist | 291-390 | Table of whitelisted emails with add/remove |
 | SSH Access Toggle | 392-430 | Toggle switch for enabling SSH access |
-| MCP Server URL | 827-889 | Configure external MCP URL with custom/auto-detect badge (#76) |
+| MCP Server URL | 1089-1149 | Configure external MCP URL with custom/auto-detect badge (#76) |
 | Default Avatars | 1054-1092 | Generate AI avatars for agents without custom ones (AVATAR-003) |
 
 **Key Reactive State**

--- a/docs/memory/feature-flows/platform-settings.md
+++ b/docs/memory/feature-flows/platform-settings.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Admin-only page for managing system-wide configuration including API keys (Anthropic, GitHub), Trinity Prompt, email whitelist, SSH access toggle, ops configuration settings, GitHub template configuration (TMPL-001), and default avatar generation (AVATAR-003).
+Admin-only page for managing system-wide configuration including API keys (Anthropic, GitHub), Trinity Prompt, email whitelist, SSH access toggle, ops configuration settings, GitHub template configuration (TMPL-001), MCP Server URL (#76), and default avatar generation (AVATAR-003).
 
 ## User Stories
 
@@ -14,6 +14,7 @@ Admin-only page for managing system-wide configuration including API keys (Anthr
 | SET-011 | As an admin, I want to update ops settings so that I can tune context warnings, cost limits, and other thresholds | Implemented |
 | SET-012 | As an admin, I want to reset ops settings to defaults so that I can restore standard configuration | Implemented |
 | AVATAR-003 | As an admin, I want to generate default avatars for all agents so that agents without custom avatars get AI-generated ones | Implemented |
+| MCP-URL-001 | As an admin, I want to configure the external MCP server URL so that API Keys page shows the correct URL for production deployments | Implemented |
 
 ## Entry Points
 
@@ -30,6 +31,9 @@ Admin-only page for managing system-wide configuration including API keys (Anthr
   - `GET /api/settings/github-templates` - Get GitHub templates config (TMPL-001)
   - `PUT /api/settings/github-templates` - Set GitHub templates (TMPL-001)
   - `DELETE /api/settings/github-templates` - Reset templates to defaults (TMPL-001)
+  - `GET /api/settings/mcp-url` - Get MCP URL config (any auth user) (#76)
+  - `PUT /api/settings/mcp-url` - Set custom MCP URL (admin-only) (#76)
+  - `DELETE /api/settings/mcp-url` - Reset MCP URL to auto-detect (admin-only) (#76)
   - `POST /api/agents/avatars/generate-defaults` - Generate avatars for agents without one (AVATAR-003, see [agent-avatars.md](agent-avatars.md))
 
 ---
@@ -47,6 +51,7 @@ Admin-only page for managing system-wide configuration including API keys (Anthr
 | Trinity Prompt | 224-289 | Textarea for custom agent instructions |
 | Email Whitelist | 291-390 | Table of whitelisted emails with add/remove |
 | SSH Access Toggle | 392-430 | Toggle switch for enabling SSH access |
+| MCP Server URL | 827-889 | Configure external MCP URL with custom/auto-detect badge (#76) |
 | Default Avatars | 1054-1092 | Generate AI avatars for agents without custom ones (AVATAR-003) |
 
 **Key Reactive State**

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -233,6 +233,14 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
 - **Key Features**: `list_recent_executions`, `get_execution_result`, `get_agent_activity_summary`; enables async polling pattern for agent-to-agent collaboration beyond 60s MCP timeout
 - **Spec**: `docs/requirements/MCP_EXECUTION_QUERY_TOOLS.md`
 
+### 7.4 Configurable MCP Server URL (MCP-URL-001)
+- **Status**: ✅ Implemented (2026-03-25)
+- **Requirement ID**: MCP-URL-001
+- **GitHub Issue**: #76
+- **Description**: Admin-configurable MCP server URL displayed on the API Keys page connection snippets. Replaces hardcoded `http://{hostname}:8080/mcp` which is wrong for production deployments where MCP is proxied through nginx.
+- **Key Features**: `GET/PUT/DELETE /api/settings/mcp-url` endpoints, URL validation (requires `http(s)://` and `/mcp` suffix), Settings UI section with save/reset, auto-detect fallback when not configured
+- **Flow**: `docs/memory/feature-flows/platform-settings.md`
+
 ---
 
 ## 8. Infrastructure

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -9,6 +9,7 @@ import os
 import re
 import httpx
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
@@ -991,8 +992,6 @@ def _get_default_mcp_url(request: Request) -> str:
 
 def _validate_mcp_url(url: str) -> str:
     """Validate and normalize MCP URL. Returns normalized URL or raises HTTPException."""
-    from urllib.parse import urlparse
-
     url = url.strip().rstrip("/")
 
     parsed = urlparse(url)

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -969,6 +969,116 @@ async def delete_github_templates(
 
 
 # ============================================================================
+# MCP Server URL Configuration (#76)
+# ============================================================================
+
+MCP_URL_SETTING_KEY = "mcp_external_url"
+
+
+class McpUrlUpdate(BaseModel):
+    """Request body for updating the MCP server URL."""
+    url: str
+
+
+def _get_default_mcp_url(request: Request) -> str:
+    """Compute the auto-detected MCP URL from the request hostname."""
+    host = request.headers.get("host", "localhost:8080")
+    hostname = host.split(":")[0]
+    if hostname in ("localhost", "127.0.0.1"):
+        return "http://localhost:8080/mcp"
+    return f"http://{hostname}:8080/mcp"
+
+
+def _validate_mcp_url(url: str) -> str:
+    """Validate and normalize MCP URL. Returns normalized URL or raises HTTPException."""
+    from urllib.parse import urlparse
+
+    url = url.strip().rstrip("/")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(
+            status_code=422,
+            detail="URL must start with http:// or https://"
+        )
+    if not parsed.netloc:
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid URL format"
+        )
+    if not parsed.path.endswith("/mcp"):
+        raise HTTPException(
+            status_code=422,
+            detail="URL must end with /mcp"
+        )
+
+    return url
+
+
+@router.get("/mcp-url")
+async def get_mcp_url(
+    request: Request,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Get the configured MCP server URL.
+
+    Any authenticated user can read this (used by API Keys page).
+    Returns both the stored custom URL (if any) and the auto-detected default.
+    """
+    stored_url = db.get_setting_value(MCP_URL_SETTING_KEY)
+    default_url = _get_default_mcp_url(request)
+
+    return {
+        "url": stored_url,
+        "default_url": default_url
+    }
+
+
+@router.put("/mcp-url")
+async def update_mcp_url(
+    body: McpUrlUpdate,
+    request: Request,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Set a custom MCP server URL.
+
+    Admin-only. Validates URL format (must be http/https, must end with /mcp).
+    """
+    require_admin(current_user)
+
+    validated_url = _validate_mcp_url(body.url)
+    db.set_setting(MCP_URL_SETTING_KEY, validated_url)
+
+    return {
+        "success": True,
+        "url": validated_url
+    }
+
+
+@router.delete("/mcp-url")
+async def delete_mcp_url(
+    request: Request,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Reset MCP server URL to auto-detect.
+
+    Admin-only. Removes the custom URL, reverting to hostname-based auto-detection.
+    """
+    require_admin(current_user)
+
+    deleted = db.delete_setting(MCP_URL_SETTING_KEY)
+
+    return {
+        "success": True,
+        "deleted": deleted,
+        "message": "MCP server URL reset to auto-detect"
+    }
+
+
+# ============================================================================
 # Generic Settings CRUD - /{key} catch-all routes
 # NOTE: These must come AFTER specific routes like /api-keys
 # ============================================================================

--- a/src/frontend/src/views/ApiKeys.vue
+++ b/src/frontend/src/views/ApiKeys.vue
@@ -309,6 +309,7 @@
 
 <script setup>
 import { ref, reactive, onMounted, computed } from 'vue'
+import axios from 'axios'
 import NavBar from '../components/NavBar.vue'
 import ConfirmDialog from '../components/ConfirmDialog.vue'
 import { useAuthStore } from '../stores/auth'
@@ -357,15 +358,8 @@ const mcpServerUrl = computed(() => {
 
 const fetchMcpUrl = async () => {
   try {
-    const response = await fetch('/api/settings/mcp-url', {
-      headers: {
-        'Authorization': `Bearer ${authStore.token}`
-      }
-    })
-    if (response.ok) {
-      const data = await response.json()
-      configuredMcpUrl.value = data.url || null
-    }
+    const response = await axios.get('/api/settings/mcp-url')
+    configuredMcpUrl.value = response.data.url || null
   } catch (error) {
     console.error('Failed to fetch MCP URL setting:', error)
   }
@@ -572,9 +566,7 @@ const formatDate = (dateString) => {
 }
 
 onMounted(async () => {
-  await fetchMcpUrl()
-  await fetchUserRole()
-  await fetchApiKeys()
+  await Promise.all([fetchMcpUrl(), fetchUserRole(), fetchApiKeys()])
   // After loading keys, ensure user has a default key (for first-time users)
   await ensureDefaultKey()
 })

--- a/src/frontend/src/views/ApiKeys.vue
+++ b/src/frontend/src/views/ApiKeys.vue
@@ -341,14 +341,35 @@ const confirmDialog = reactive({
   onConfirm: () => {}
 })
 
+// MCP server URL: use admin-configured URL if set, otherwise auto-detect from hostname
+const configuredMcpUrl = ref(null)
+
 const mcpServerUrl = computed(() => {
+  if (configuredMcpUrl.value) {
+    return configuredMcpUrl.value
+  }
   const host = window.location.hostname
   if (host === 'localhost' || host === '127.0.0.1') {
     return 'http://localhost:8080/mcp'
   }
-  // Production: MCP server runs on port 8080 (not proxied through nginx)
   return `http://${host}:8080/mcp`
 })
+
+const fetchMcpUrl = async () => {
+  try {
+    const response = await fetch('/api/settings/mcp-url', {
+      headers: {
+        'Authorization': `Bearer ${authStore.token}`
+      }
+    })
+    if (response.ok) {
+      const data = await response.json()
+      configuredMcpUrl.value = data.url || null
+    }
+  } catch (error) {
+    console.error('Failed to fetch MCP URL setting:', error)
+  }
+}
 
 // Filter out agent-scoped keys for non-admin users
 const displayedKeys = computed(() => {
@@ -551,6 +572,7 @@ const formatDate = (dateString) => {
 }
 
 onMounted(async () => {
+  await fetchMcpUrl()
   await fetchUserRole()
   await fetchApiKeys()
   // After loading keys, ensure user has a default key (for first-time users)

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -1110,6 +1110,67 @@ Example:
             </div>
           </div>
 
+          <!-- MCP Server URL Section (#76) -->
+          <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg">
+            <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+              <h2 class="text-lg font-medium text-gray-900 dark:text-white">MCP Server URL</h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Configure the external MCP server URL shown on the API Keys page. Leave empty to auto-detect from hostname.
+              </p>
+            </div>
+            <div class="px-6 py-4">
+              <div class="flex items-center gap-2 mb-4">
+                <span
+                  :class="[
+                    'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium',
+                    mcpUrlConfig.url
+                      ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300'
+                      : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
+                  ]"
+                >
+                  {{ mcpUrlConfig.url ? 'Custom' : 'Auto-detect' }}
+                </span>
+                <span v-if="mcpUrlConfig.url" class="text-sm text-gray-500 dark:text-gray-400 truncate">
+                  {{ mcpUrlConfig.url }}
+                </span>
+                <span v-else class="text-sm text-gray-500 dark:text-gray-400 truncate">
+                  {{ mcpUrlConfig.default_url || 'Loading...' }}
+                </span>
+              </div>
+
+              <div class="flex gap-3">
+                <input
+                  v-model="mcpUrlInput"
+                  type="url"
+                  :placeholder="mcpUrlConfig.default_url || 'https://your-domain.com/mcp'"
+                  class="flex-1 block rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                />
+                <button
+                  @click="saveMcpUrl"
+                  :disabled="!mcpUrlInput || savingMcpUrl"
+                  class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {{ savingMcpUrl ? 'Saving...' : 'Save' }}
+                </button>
+                <button
+                  v-if="mcpUrlConfig.url"
+                  @click="resetMcpUrl"
+                  :disabled="savingMcpUrl"
+                  class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50"
+                >
+                  Reset to Default
+                </button>
+              </div>
+
+              <p v-if="mcpUrlError" class="mt-2 text-sm text-red-600 dark:text-red-400">
+                {{ mcpUrlError }}
+              </p>
+              <p v-if="mcpUrlSuccess" class="mt-2 text-sm text-green-600 dark:text-green-400">
+                MCP server URL updated successfully.
+              </p>
+            </div>
+          </div>
+
           <!-- GitHub Templates Section (TMPL-001) -->
           <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg">
             <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
@@ -1589,6 +1650,13 @@ const currentUsername = computed(() => {
   return u?.email || null
 })
 
+// MCP Server URL state (#76)
+const mcpUrlConfig = ref({ url: null, default_url: '' })
+const mcpUrlInput = ref('')
+const savingMcpUrl = ref(false)
+const mcpUrlError = ref(null)
+const mcpUrlSuccess = ref(false)
+
 // GitHub Templates state (TMPL-001)
 const githubTemplates = ref([])
 const githubTemplatesOriginal = ref([])
@@ -1755,6 +1823,9 @@ async function loadSettings() {
 
     // Load Slack transport status (SLACK-002)
     await loadSlackTransportStatus()
+
+    // Load MCP URL config (#76)
+    await loadMcpUrl()
   } catch (e) {
     if (e.response?.status === 403) {
       error.value = 'Access denied. Admin privileges required.'
@@ -2162,6 +2233,54 @@ async function updateUserRole(username, role) {
   } catch (e) {
     alert(e.response?.data?.detail || 'Failed to update role')
     await loadUsers() // refresh to reset select
+  }
+}
+
+// MCP Server URL methods (#76)
+async function loadMcpUrl() {
+  try {
+    const response = await axios.get('/api/settings/mcp-url')
+    mcpUrlConfig.value = response.data
+  } catch (e) {
+    console.error('Failed to load MCP URL:', e)
+  }
+}
+
+async function saveMcpUrl() {
+  if (!mcpUrlInput.value) return
+
+  savingMcpUrl.value = true
+  mcpUrlError.value = null
+  mcpUrlSuccess.value = false
+
+  try {
+    await axios.put('/api/settings/mcp-url', { url: mcpUrlInput.value })
+    await loadMcpUrl()
+    mcpUrlInput.value = ''
+    mcpUrlSuccess.value = true
+    setTimeout(() => { mcpUrlSuccess.value = false }, 3000)
+  } catch (e) {
+    mcpUrlError.value = e.response?.data?.detail || 'Failed to save MCP URL'
+  } finally {
+    savingMcpUrl.value = false
+  }
+}
+
+async function resetMcpUrl() {
+  savingMcpUrl.value = true
+  mcpUrlError.value = null
+  mcpUrlSuccess.value = false
+
+  try {
+    await axios.delete('/api/settings/mcp-url')
+    await loadMcpUrl()
+    mcpUrlInput.value = ''
+    mcpUrlSuccess.value = true
+    setTimeout(() => { mcpUrlSuccess.value = false }, 3000)
+  } catch (e) {
+    mcpUrlError.value = e.response?.data?.detail || 'Failed to reset MCP URL'
+  } finally {
+    savingMcpUrl.value = false
   }
 }
 

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -1166,7 +1166,7 @@ Example:
                 {{ mcpUrlError }}
               </p>
               <p v-if="mcpUrlSuccess" class="mt-2 text-sm text-green-600 dark:text-green-400">
-                MCP server URL updated successfully.
+                {{ mcpUrlSuccess }}
               </p>
             </div>
           </div>
@@ -1655,7 +1655,7 @@ const mcpUrlConfig = ref({ url: null, default_url: '' })
 const mcpUrlInput = ref('')
 const savingMcpUrl = ref(false)
 const mcpUrlError = ref(null)
-const mcpUrlSuccess = ref(false)
+const mcpUrlSuccess = ref('')
 
 // GitHub Templates state (TMPL-001)
 const githubTemplates = ref([])
@@ -1812,20 +1812,14 @@ async function loadSettings() {
     trinityPrompt.value = settingsStore.trinityPrompt || ''
     originalPrompt.value = trinityPrompt.value
 
-    // Load public URL
-    await loadPublicUrl()
-
-    // Load API keys status
-    await loadApiKeyStatus()
-
-    // Load Slack settings (SLACK-001)
-    await loadSlackSettings()
-
-    // Load Slack transport status (SLACK-002)
-    await loadSlackTransportStatus()
-
-    // Load MCP URL config (#76)
-    await loadMcpUrl()
+    // Load independent settings in parallel
+    await Promise.all([
+      loadPublicUrl(),
+      loadApiKeyStatus(),
+      loadSlackSettings(),
+      loadSlackTransportStatus(),
+      loadMcpUrl(),
+    ])
   } catch (e) {
     if (e.response?.status === 403) {
       error.value = 'Access denied. Admin privileges required.'
@@ -2246,42 +2240,37 @@ async function loadMcpUrl() {
   }
 }
 
-async function saveMcpUrl() {
-  if (!mcpUrlInput.value) return
-
+async function _submitMcpUrl(action, successMsg) {
   savingMcpUrl.value = true
   mcpUrlError.value = null
-  mcpUrlSuccess.value = false
+  mcpUrlSuccess.value = ''
 
   try {
-    await axios.put('/api/settings/mcp-url', { url: mcpUrlInput.value })
+    await action()
     await loadMcpUrl()
     mcpUrlInput.value = ''
-    mcpUrlSuccess.value = true
-    setTimeout(() => { mcpUrlSuccess.value = false }, 3000)
+    mcpUrlSuccess.value = successMsg
+    setTimeout(() => { mcpUrlSuccess.value = '' }, 3000)
   } catch (e) {
-    mcpUrlError.value = e.response?.data?.detail || 'Failed to save MCP URL'
+    mcpUrlError.value = e.response?.data?.detail || 'Failed to update MCP URL'
   } finally {
     savingMcpUrl.value = false
   }
 }
 
-async function resetMcpUrl() {
-  savingMcpUrl.value = true
-  mcpUrlError.value = null
-  mcpUrlSuccess.value = false
+async function saveMcpUrl() {
+  if (!mcpUrlInput.value) return
+  await _submitMcpUrl(
+    () => axios.put('/api/settings/mcp-url', { url: mcpUrlInput.value }),
+    'MCP server URL updated successfully.'
+  )
+}
 
-  try {
-    await axios.delete('/api/settings/mcp-url')
-    await loadMcpUrl()
-    mcpUrlInput.value = ''
-    mcpUrlSuccess.value = true
-    setTimeout(() => { mcpUrlSuccess.value = false }, 3000)
-  } catch (e) {
-    mcpUrlError.value = e.response?.data?.detail || 'Failed to reset MCP URL'
-  } finally {
-    savingMcpUrl.value = false
-  }
+async function resetMcpUrl() {
+  await _submitMcpUrl(
+    () => axios.delete('/api/settings/mcp-url'),
+    'MCP server URL reset to auto-detect.'
+  )
 }
 
 // GitHub Templates methods (TMPL-001)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1029,3 +1029,114 @@ class TestOpsSettingsReset:
             if isinstance(setting, dict) and "is_default" in setting:
                 assert setting["is_default"] is True, \
                     f"Setting {key} should be at default after reset"
+
+
+class TestMcpUrlSettings:
+    """Tests for MCP Server URL configuration endpoints (#76)."""
+
+    pytestmark = pytest.mark.smoke
+
+    MCP_URL_ENDPOINT = "/api/settings/mcp-url"
+
+    def test_get_mcp_url_no_custom_setting(self, api_client: TrinityApiClient):
+        """GET /api/settings/mcp-url returns null url when no custom URL is set."""
+        # Ensure clean state
+        api_client.delete(self.MCP_URL_ENDPOINT)
+
+        response = api_client.get(self.MCP_URL_ENDPOINT)
+        assert_status(response, 200)
+        data = assert_json_response(response)
+        assert data["url"] is None
+        assert "default_url" in data
+        assert data["default_url"].endswith("/mcp")
+
+    def test_put_valid_https_url(self, api_client: TrinityApiClient):
+        """PUT /api/settings/mcp-url with valid HTTPS URL succeeds."""
+        try:
+            response = api_client.put(
+                self.MCP_URL_ENDPOINT,
+                json={"url": "https://example.com/mcp"}
+            )
+            assert_status(response, 200)
+            data = assert_json_response(response)
+            assert data["success"] is True
+            assert data["url"] == "https://example.com/mcp"
+
+            # Verify it's stored
+            get_response = api_client.get(self.MCP_URL_ENDPOINT)
+            assert get_response.json()["url"] == "https://example.com/mcp"
+        finally:
+            api_client.delete(self.MCP_URL_ENDPOINT)
+
+    def test_put_valid_http_url(self, api_client: TrinityApiClient):
+        """PUT /api/settings/mcp-url with valid HTTP URL succeeds."""
+        try:
+            response = api_client.put(
+                self.MCP_URL_ENDPOINT,
+                json={"url": "http://192.168.1.100:8080/mcp"}
+            )
+            assert_status(response, 200)
+            data = assert_json_response(response)
+            assert data["url"] == "http://192.168.1.100:8080/mcp"
+        finally:
+            api_client.delete(self.MCP_URL_ENDPOINT)
+
+    def test_put_invalid_url_no_protocol(self, api_client: TrinityApiClient):
+        """PUT /api/settings/mcp-url rejects URL without http/https."""
+        response = api_client.put(
+            self.MCP_URL_ENDPOINT,
+            json={"url": "example.com/mcp"}
+        )
+        assert_status(response, 422)
+
+    def test_put_invalid_url_not_ending_mcp(self, api_client: TrinityApiClient):
+        """PUT /api/settings/mcp-url rejects URL not ending in /mcp."""
+        response = api_client.put(
+            self.MCP_URL_ENDPOINT,
+            json={"url": "https://example.com/api"}
+        )
+        assert_status(response, 422)
+
+    def test_delete_resets_to_null(self, api_client: TrinityApiClient):
+        """DELETE /api/settings/mcp-url resets URL to auto-detect."""
+        # Set a custom URL first
+        api_client.put(
+            self.MCP_URL_ENDPOINT,
+            json={"url": "https://example.com/mcp"}
+        )
+
+        # Delete it
+        response = api_client.delete(self.MCP_URL_ENDPOINT)
+        assert_status(response, 200)
+
+        # Verify it's gone
+        get_response = api_client.get(self.MCP_URL_ENDPOINT)
+        assert get_response.json()["url"] is None
+
+    def test_unauthenticated_get_returns_401(self, unauthenticated_client: TrinityApiClient):
+        """GET /api/settings/mcp-url requires authentication."""
+        response = unauthenticated_client.get(self.MCP_URL_ENDPOINT, auth=False)
+        assert_status(response, 401)
+
+    def test_unauthenticated_put_returns_401(self, unauthenticated_client: TrinityApiClient):
+        """PUT /api/settings/mcp-url requires authentication."""
+        response = unauthenticated_client.put(
+            self.MCP_URL_ENDPOINT,
+            json={"url": "https://example.com/mcp"},
+            auth=False
+        )
+        assert_status(response, 401)
+
+    def test_put_strips_trailing_slash(self, api_client: TrinityApiClient):
+        """PUT /api/settings/mcp-url normalizes trailing slash before /mcp check."""
+        try:
+            response = api_client.put(
+                self.MCP_URL_ENDPOINT,
+                json={"url": "https://example.com/mcp/"}
+            )
+            # After stripping trailing slash, URL ends with /mcp — should succeed
+            assert_status(response, 200)
+            data = assert_json_response(response)
+            assert data["url"] == "https://example.com/mcp"
+        finally:
+            api_client.delete(self.MCP_URL_ENDPOINT)


### PR DESCRIPTION
## Summary
- Admin can now configure the MCP server URL in Settings (for production deployments proxied through nginx)
- API Keys page shows the configured URL in connection snippets (or auto-detects from hostname)
- Single endpoint with split auth: GET for any user, PUT/DELETE admin-only
- URL validation: must be http/https and end with `/mcp`

## Changes
- `src/backend/routers/settings.py` — GET/PUT/DELETE `/api/settings/mcp-url` endpoints
- `src/frontend/src/views/Settings.vue` — MCP URL config section with badge, save/reset
- `src/frontend/src/views/ApiKeys.vue` — Fetch configured URL on mount
- `tests/test_settings.py` — 9 new tests (`TestMcpUrlSettings`)
- `docs/memory/changelog.md` — Change entry
- `docs/memory/feature-flows/` — Updated platform-settings.md and api-keys-page.md

## Test Plan
- [ ] New tests pass: `pytest tests/test_settings.py::TestMcpUrlSettings -v`
- [ ] Existing tests unaffected: `pytest tests/test_settings.py -v`
- [ ] Manual: Settings → enter custom URL → Save → API Keys shows it
- [ ] Manual: Settings → Reset → API Keys reverts to auto-detect
- [ ] Validation: invalid URLs rejected with clear error

Closes #76

Generated with [Claude Code](https://claude.com/claude-code)