### PR TITLE
docs: Update stale feature flow docs for execution layer (#100)

### DIFF
--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,15 @@
+### 2026-03-25
+
+**docs: Update stale feature flow documentation for execution layer (#100)**
+
+Fixed contradictions between feature flow documents and actual code after the 2026-03-09 EXEC-024 consolidation:
+
+- **scheduling.md**: Fixed execution flow diagram — scheduler dispatches to `POST /api/internal/execute-task` (not direct agent calls). Updated architecture diagram and file references.
+- **execution-queue.md**: Added prominent status enum disambiguation table clarifying `QueueItemStatus` (Redis) vs `TaskExecutionStatus` (DB) vs `ExecutionStatus` (process engine).
+- **parallel-headless-execution.md**: Clarified that async mode on `/api/task` uses inline code, while async mode on `/api/internal/execute-task` (scheduler) uses `TaskExecutionService`.
+- **task-execution-service.md**: Replaced "all paths" claim with execution path coverage matrix showing which callers use the service and which bypass it (notably `/api/chat` and async `/api/task`).
+- **scheduler-service.md**: Fixed architecture diagram to show scheduler → backend → agent flow (not scheduler → agent directly).
+
 ### 2026-03-23
 
 **feat: Voice Chat — real-time voice conversations with agents via Gemini Live API (VOICE-001)**

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,6 +1,6 @@
 ### 2026-03-25
 
-**docs: Update stale feature flow documentation for execution layer (#100)**
+📝 **docs: Update stale feature flow documentation for execution layer (#100)**
 
 Fixed contradictions between feature flow documents and actual code after the 2026-03-09 EXEC-024 consolidation:
 

--- a/docs/memory/feature-flows/execution-queue.md
+++ b/docs/memory/feature-flows/execution-queue.md
@@ -128,7 +128,15 @@ class QueueItemStatus(str, Enum):
     TIMEOUT = "timeout"
 ```
 
-> **Note**: Renamed from `ExecutionStatus` to `QueueItemStatus` (#92) to avoid confusion with `TaskExecutionStatus` (DB-persisted execution status: `running/success/failed/cancelled/skipped`) and the process engine's own `ExecutionStatus`.
+> **⚠️ Status Enum Disambiguation**: There are three separate status systems in Trinity:
+>
+> | Enum | Scope | Values | Storage |
+> |------|-------|--------|---------|
+> | `QueueItemStatus` | Execution queue (this feature) | `queued`, `running`, `completed`, `failed`, `timeout` | Redis/in-memory |
+> | `TaskExecutionStatus` | Task/schedule executions | `running`, `success`, `failed`, `cancelled`, `skipped` | SQLite (`schedule_executions`, `task_executions`) |
+> | `ExecutionStatus` (process engine) | Process step executions | `pending`, `running`, `completed`, `failed`, `cancelled` | SQLite (`process_executions`) |
+>
+> Note: `QueueItemStatus.COMPLETED` ≠ `TaskExecutionStatus` — the queue uses `completed` while the DB uses `success`. Renamed from `ExecutionStatus` to `QueueItemStatus` (#92) to reduce confusion.
 
 ### Execution (Model)
 ```python

--- a/docs/memory/feature-flows/parallel-headless-execution.md
+++ b/docs/memory/feature-flows/parallel-headless-execution.md
@@ -501,7 +501,7 @@ When `async_mode=true` is specified:
 8. **Completes activities** asynchronously
 9. **Releases slot** in `finally` block
 
-Note: Async mode does **not** use `TaskExecutionService`. It uses the inline `_execute_task_background()` function because it needs to manage its own activity IDs, collaboration tracking, and slot release timing.
+Note: Async mode on the `/api/agents/{name}/task` endpoint does **not** use `TaskExecutionService`. It uses the inline `_execute_task_background()` function because it needs to manage its own activity IDs, collaboration tracking, and slot release timing. However, async mode on `/api/internal/execute-task` (used by the scheduler) **does** use `TaskExecutionService` inside its background coroutine — see [scheduler-service.md](scheduler-service.md).
 
 ### Architecture Diagram
 

--- a/docs/memory/feature-flows/scheduler-service.md
+++ b/docs/memory/feature-flows/scheduler-service.md
@@ -35,19 +35,19 @@ As a **platform administrator**, I want **scheduled tasks to execute exactly onc
 |                                                                    |
 |  +------------------+    +------------------+    +--------------+  |
 |  |     Backend      |    |    Scheduler     |    |    Agent     |  |
-|  |   (API only)     |    |   (singleton)    |    |  Containers  |  |
-|  |   N workers      |    |   1 replica      |    |              |  |
+|  |  (API + Task     |    |   (singleton)    |    |  Containers  |  |
+|  |   Execution)     |    |   1 replica      |    |              |  |
 |  +--------+---------+    +--------+---------+    +------+-------+  |
 |           |                       |                     ^          |
-|           |   CRUD operations     |                     |          |
+|           |   CRUD operations     | POST /api/internal/ |          |
+|           |                       | execute-task        |          |
 |           v                       v                     |          |
 |  +------------------+    +------------------+           |          |
-|  |     SQLite       |    |      Redis       |           |          |
-|  |  - Schedules     |<---|  - Locks         |           |          |
-|  |  - Executions    |    |  - Events        |           |          |
-|  +------------------+    |  - Heartbeats    |-----------+          |
-|                          +------------------+    HTTP POST         |
-|                                                  /api/task         |
+|  |     SQLite       |    |      Redis       |    Backend calls     |
+|  |  - Schedules     |<---|  - Locks         |    agent /api/task   |
+|  |  - Executions    |    |  - Events        |    via TaskExec-     |
+|  +------------------+    |  - Heartbeats    |    utionService      |
+|                          +------------------+                      |
 +------------------------------------------------------------------+
 ```
 

--- a/docs/memory/feature-flows/scheduling.md
+++ b/docs/memory/feature-flows/scheduling.md
@@ -78,18 +78,22 @@ The Agent Scheduling feature enables users to automate agent tasks by configurin
 │  │  src/scheduler/service.py (APScheduler)                          │    │
 │  │  ├── Load schedules from database on startup                     │    │
 │  │  ├── Sync schedules from database every 60 seconds               │    │
-│  │  ├── Execute: Send message to agent via HTTP                     │    │
-│  │  ├── Track activity via internal API                             │    │
+│  │  ├── Execute: POST /api/internal/execute-task (backend)           │    │
+│  │  ├── Backend handles: slot, activity, agent call, sanitize       │    │
 │  │  └── Broadcast: WebSocket events for execution status            │    │
 │  └─────────────────────────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
-                                    ▼ HTTP POST /api/task
+                                    ▼ HTTP POST /api/internal/execute-task
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                          Agent Container                                 │
+│                    Backend (TaskExecutionService)                         │
 │  ┌─────────────────────────────────────────────────────────────────┐    │
-│  │  agent-server.py                                                 │    │
-│  │  └── Receives scheduled message, processes with Claude           │    │
+│  │  routers/internal.py → services/task_execution_service.py        │    │
+│  │  ├── Acquire capacity slot                                       │    │
+│  │  ├── Track activity (CHAT_START)                                 │    │
+│  │  ├── POST to agent /api/task with retry                          │    │
+│  │  ├── Sanitize credentials from response                          │    │
+│  │  └── Release slot, complete activity                             │    │
 │  └─────────────────────────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
@@ -176,8 +180,8 @@ emit('create-schedule', msg)     - Switch to 'schedules' tab       - Pre-fill fo
 > **Note (2026-02-11)**: Execution now handled entirely by the dedicated scheduler service (`src/scheduler/`), not the backend. Activity tracking is done via internal API endpoints.
 
 ```
-Dedicated Scheduler               Backend Internal API              Agent
--------------------               --------------------              -----
+Dedicated Scheduler               Backend                              Agent
+-------------------               -------                              -----
 APScheduler fires
 service.py:_execute_schedule()
   |
@@ -191,32 +195,31 @@ db.create_execution(
   model_used=schedule.model)
   |
   v
-Track activity start ----------> POST /api/internal/activities/track
-                                  activity_service.track_activity()
-  |                               broadcast(started)
-  v
-Get agent client
-client.task(message,
-  model=schedule.model) ----------------------------------------> POST /api/task
-  |                                                               {model: "opus"}
-  |                                                               Claude Code exec
-  v
-Parse response
-task_response.metrics
+POST /api/internal/execute-task -> routers/internal.py
+  {async_mode: true,               |
+   execution_id: "...",             v
+   timeout_seconds: ...}          Spawn background task
+  |                               (asyncio.create_task)
+  v                                |
+Receive {"status": "accepted"}     v
+  |                               TaskExecutionService.execute_task()
+  v                                 ├── Acquire capacity slot
+Poll DB every 10s                   ├── Track activity (CHAT_START)
+(SCHED-ASYNC-001)                   ├── POST to agent /api/task -------> POST /api/task
+  |                                 │                                    {model: "opus"}
+  v                                 │                                    Claude Code exec
+Status != "running"?                ├── Sanitize response
+  |                                 ├── Update execution record
+  v                                 ├── Complete activity
+Update scheduler's                  └── Release slot (finally)
+  execution record
   |
   v
-Update execution status
-db.update_execution_status()
-  |
-  v
-Track activity complete -------> POST /api/internal/activities/{id}/complete
-                                  activity_service.complete_activity()
-  |                               broadcast(completed)
-  v
+Publish WebSocket event
 Release lock
 ```
 
-**Note**: Changed from `client.chat()` to `client.task()` on 2025-01-02. The `/api/task` endpoint returns raw Claude Code `stream-json` format which is required for the [Execution Log Viewer](execution-log-viewer.md) to properly render execution transcripts.
+> **Architecture change (2026-03-09, EXEC-024)**: Scheduler no longer calls agent containers directly or tracks activities via separate internal API endpoints. Instead, it dispatches to `POST /api/internal/execute-task` with `async_mode=True`. The backend's `TaskExecutionService` handles the full lifecycle (slot management, activity tracking, agent HTTP call with retry, credential sanitization). The scheduler polls the DB for completion.
 
 **Authentication** (Updated 2026-02-15):
 Claude Code uses whatever authentication is available in the agent container:
@@ -225,17 +228,17 @@ Claude Code uses whatever authentication is available in the agent container:
 
 This enables scheduled tasks to use Claude Max subscription billing instead of API billing. The mandatory `ANTHROPIC_API_KEY` check was removed from `execute_headless_task()` in `docker/base-image/agent_server/services/claude_code.py` to support this flow.
 
-**Queue Full Handling**: If the agent's queue is full (3 pending requests), the scheduled execution fails with error "Agent queue full (N waiting), skipping scheduled execution".
+**Capacity Handling**: If the agent's slots are full (`max_parallel_tasks` reached), `TaskExecutionService` returns a failed result and the scheduler records the execution as failed.
 
 **Files:**
 - `src/scheduler/service.py:237-345` - _execute_schedule_with_lock() execution logic
-- `src/scheduler/agent_client.py:44-100` - AgentClient.task() in dedicated scheduler
+- `src/scheduler/service.py:760+` - _call_backend_execute_task() dispatches to backend
 - `src/scheduler/database.py:167-250` - create_execution(), update_execution_status()
-- `src/backend/routers/internal.py` - Internal API for activity tracking
-- `src/backend/services/activity_service.py` - Activity service
+- `src/backend/routers/internal.py:186-270` - POST /api/internal/execute-task endpoint
+- `src/backend/services/task_execution_service.py` - TaskExecutionService (slot, activity, agent call, sanitization)
 
-**Key Implementation Detail (2026-02-11):**
-The dedicated scheduler tracks activities via internal API endpoints (`POST /api/internal/activities/track` and `POST /api/internal/activities/{id}/complete`). This ensures cron-triggered executions appear on the Timeline dashboard alongside manually-triggered ones.
+**Key Implementation Detail (SCHED-ASYNC-001):**
+The scheduler uses async fire-and-forget dispatch: the HTTP call to the backend returns immediately with `{"status": "accepted"}`, and the scheduler polls the SQLite DB every `POLL_INTERVAL` seconds (default 10s) until the execution status changes from `"running"` to `"success"` or `"failed"`. This prevents TCP connection drops on long-running tasks.
 
 ### 3. Manual Trigger Flow
 

--- a/docs/memory/feature-flows/task-execution-service.md
+++ b/docs/memory/feature-flows/task-execution-service.md
@@ -1,10 +1,23 @@
 # Feature: Task Execution Service (EXEC-024)
 
 ## Overview
-Unified service that encapsulates the full task-execution lifecycle (execution record, slot management, activity tracking, agent HTTP call with retry, credential sanitization, response persistence) so all callers share one code path.
+Service that encapsulates the task-execution lifecycle (execution record, slot management, activity tracking, agent HTTP call with retry, credential sanitization, response persistence). Used by most — but not all — execution paths.
 
 ## User Story
-As the platform, I want all task execution paths (authenticated tasks, public link chat, scheduled executions) to use a single orchestration service so that every execution gets consistent tracking, slot enforcement, credential sanitization, and dashboard visibility.
+As the platform, I want task execution paths (authenticated sync tasks, public link chat, scheduled executions) to use a shared orchestration service so that these executions get consistent tracking, slot enforcement, credential sanitization, and dashboard visibility.
+
+## Coverage
+
+> **Important**: Not all execution paths use TaskExecutionService. The table below shows which do and which don't.
+
+| Path | Entry Point | Uses TaskExecutionService? | Notes |
+|------|------------|---------------------------|-------|
+| Sync parallel task | `POST /api/agents/{name}/task` (sync) | **Yes** | EXEC-024 delegation |
+| Async parallel task | `POST /api/agents/{name}/task` (async) | **No** | Inline `_execute_task_background()` in `chat.py` |
+| Public link chat | `POST /api/public/chat/{token}` | **Yes** | Full lifecycle |
+| Scheduled execution | `POST /api/internal/execute-task` | **Yes** | Background coroutine wraps service call |
+| Interactive chat | `POST /api/agents/{name}/chat` | **No** | Direct agent HTTP call with inline retry in `chat.py` |
+| Process engine | Internal | **No** | Separate `ExecutionEngine` with own status enum |
 
 ## Entry Points
 


### PR DESCRIPTION
## Summary
- Fixed contradictions between 5 feature flow documents and actual code after the 2026-03-09 EXEC-024 consolidation
- **scheduling.md**: Updated execution flow — scheduler dispatches to `POST /api/internal/execute-task`, not direct agent calls
- **execution-queue.md**: Added prominent status enum disambiguation table (QueueItemStatus vs TaskExecutionStatus vs ExecutionStatus)
- **parallel-headless-execution.md**: Clarified async mode/TaskExecutionService relationship across different endpoints
- **task-execution-service.md**: Replaced "all paths use service" claim with accurate coverage matrix
- **scheduler-service.md**: Fixed architecture diagram to show scheduler → backend → agent flow

## Changes
- `docs/memory/feature-flows/scheduling.md` — Rewrote execution flow diagram, fixed architecture diagram
- `docs/memory/feature-flows/execution-queue.md` — Added status enum disambiguation table
- `docs/memory/feature-flows/parallel-headless-execution.md` — Clarified async note
- `docs/memory/feature-flows/task-execution-service.md` — Added coverage matrix, fixed overview
- `docs/memory/feature-flows/scheduler-service.md` — Fixed architecture diagram
- `docs/memory/changelog.md` — Added entry

## Test Plan
- [ ] Documentation-only changes — no code affected
- [ ] Verified all stale claims removed via grep
- [ ] Cross-referenced status values, timeouts, and execution paths across all 5 docs

Closes #100

Generated with [Claude Code](https://claude.com/claude-code)