### PR TITLE
feat: Auto-assign subscription to new agents (round-robin) (#74)

### DIFF
--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,6 +1,6 @@
 ### 2026-03-25
 
-**feat: Auto-assign subscription to new agents via round-robin (#74)**
+✨ **Auto-assign subscription to new agents via round-robin (#74)**
 
 When creating a new agent, Trinity now automatically assigns a subscription using round-robin distribution (fewest agents first, alphabetical tie-break). Removes the manual step of assigning subscriptions after agent creation. Falls back to platform API key if no subscriptions exist or token decryption fails. System agents are unaffected (separate creation path).
 

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,16 @@
+### 2026-03-25
+
+**feat: Auto-assign subscription to new agents via round-robin (#74)**
+
+When creating a new agent, Trinity now automatically assigns a subscription using round-robin distribution (fewest agents first, alphabetical tie-break). Removes the manual step of assigning subscriptions after agent creation. Falls back to platform API key if no subscriptions exist or token decryption fails. System agents are unaffected (separate creation path).
+
+- `src/backend/db/subscriptions.py` — Added `get_least_used_subscription()` method (SQL: COUNT + ORDER BY agent_count ASC, name ASC)
+- `src/backend/database.py` — Added delegation method
+- `src/backend/services/agent_service/crud.py` — Auto-assign logic in `create_agent_internal()`: lookup before container creation, DB persist after `register_agent_owner()`
+- `tests/test_subscriptions.py` — Added `TestSubscriptionAutoAssign` class (4 tests: no-subs fallback, auto-assign, round-robin, alphabetical tie-break)
+
+---
+
 ### 2026-03-23
 
 **feat: Voice Chat — real-time voice conversations with agents via Gemini Live API (VOICE-001)**

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-03-25 | #74 | Auto-assign subscription to new agents (round-robin, rate-limit aware) | [subscription-management.md](feature-flows/subscription-management.md) |
 | 2026-03-23 | VOICE-001 | Voice Chat — real-time voice conversations with agents via Gemini Live API | [voice-chat.md](feature-flows/voice-chat.md) |
 | 2026-03-21 | SUB-003 | Auto-switch subscriptions on repeated rate-limit errors — setting, tracking, orchestration | [subscription-auto-switch.md](feature-flows/subscription-auto-switch.md) |
 | 2026-03-19 | CHAT-AC | Playbook autocomplete in chat input — slash-command dropdown, ghost text, arg hints | [playbook-autocomplete.md](feature-flows/playbook-autocomplete.md) |

--- a/docs/memory/feature-flows/subscription-management.md
+++ b/docs/memory/feature-flows/subscription-management.md
@@ -70,6 +70,34 @@ Admin's Machine                  Trinity Backend                    Agent Contai
 +----------------+              +-------------------+               +------------------+
 ```
 
+### Auto-Assign on Agent Creation (#74)
+
+New agents are automatically assigned the subscription with fewest agents (round-robin). Rate-limited subscriptions are skipped. Falls back to platform API key if no viable subscription exists.
+
+```
+create_agent_internal()
+  ├── db.get_least_used_subscription()       ← SQL: COUNT + ORDER BY agent_count ASC, name ASC
+  │     └── skip rate-limited (is_subscription_rate_limited)
+  ├── db.get_subscription_token(id)          ← AES-256 decrypt
+  ├── env_vars['CLAUDE_CODE_OAUTH_TOKEN'] = token
+  ├── env_vars.pop('ANTHROPIC_API_KEY')
+  ├── ... container creation ...
+  ├── db.register_agent_owner()
+  └── db.assign_subscription_to_agent()      ← persist assignment
+```
+
+**Files:**
+- `src/backend/db/subscriptions.py:540` — `get_least_used_subscription()` (iterates candidates, skips rate-limited)
+- `src/backend/services/agent_service/crud.py:294` — lookup + env var injection before container creation
+- `src/backend/services/agent_service/crud.py:500` — DB persist after `register_agent_owner()`
+
+**Edge cases:**
+- No subscriptions → skip, use `ANTHROPIC_API_KEY`
+- Token decrypt fails → warn, keep `ANTHROPIC_API_KEY`
+- Exception → warn, keep `ANTHROPIC_API_KEY`
+- System agents → separate `_create_system_agent()` path, unaffected
+- Equal agent count → alphabetical tie-break (`s.name ASC`)
+
 ---
 
 ## Entry Points

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -944,6 +944,17 @@ The Process Engine supports six step types:
   - `src/backend/services/subscription_service.py` - Auth mode detection
   - `src/mcp-server/src/tools/subscriptions.ts` - MCP tools
 
+### 20.3a Subscription Auto-Assign on Agent Creation (#74)
+- **Status**: ✅ Implemented (2026-03-25)
+- **GitHub Issue**: #74
+- **Extends**: SUB-002
+- **Description**: When a new agent is created, automatically assign the subscription with fewest assigned agents (round-robin). Tie-break: alphabetical by name. Falls back to platform API key if no subscriptions exist or token decryption fails. System agents (`trinity-system`) are unaffected (separate creation path).
+- **Key Features**:
+  - `get_least_used_subscription()` DB method (SQL: COUNT + ORDER BY)
+  - Auto-assign logic in `create_agent_internal()` — token injected before container creation, DB assignment after `register_agent_owner()`
+  - Graceful fallback: no subs → API key, decrypt fail → API key, exception → API key
+- **Files**: `db/subscriptions.py`, `database.py`, `services/agent_service/crud.py`
+
 ### 20.4 Subscription Auto-Switch on Rate Limit (SUB-003)
 - **Status**: ✅ Implemented (2026-03-21)
 - **Requirement ID**: SUB-003

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1069,6 +1069,9 @@ class DatabaseManager:
     def get_agent_subscription_id(self, agent_name: str):
         return self._subscription_ops.get_agent_subscription_id(agent_name)
 
+    def get_least_used_subscription(self):
+        return self._subscription_ops.get_least_used_subscription()
+
     # --- SUB-003: Rate-Limit Tracking ---
 
     def record_rate_limit_event(self, agent_name: str, subscription_id: str, error_message: str = ""):

--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -537,6 +537,29 @@ class SubscriptionOperations:
             conn.commit()
             return count
 
+    def get_least_used_subscription(self) -> Optional[SubscriptionCredential]:
+        """
+        Get subscription with fewest assigned agents (round-robin).
+
+        Tie-break: alphabetical by name.
+        Used for auto-assignment on agent creation (#74).
+
+        Returns:
+            SubscriptionCredential with fewest agents, or None if no subscriptions exist
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT s.*, u.email as owner_email,
+                    (SELECT COUNT(*) FROM agent_ownership WHERE subscription_id = s.id) as agent_count
+                FROM subscription_credentials s
+                JOIN users u ON s.owner_id = u.id
+                ORDER BY agent_count ASC, s.name ASC
+                LIMIT 1
+            """)
+            row = cursor.fetchone()
+            return self._row_to_subscription(row) if row else None
+
     def select_best_alternative_subscription(
         self,
         current_subscription_id: str

--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -542,10 +542,11 @@ class SubscriptionOperations:
         Get subscription with fewest assigned agents (round-robin).
 
         Tie-break: alphabetical by name.
+        Skips subscriptions that are currently rate-limited.
         Used for auto-assignment on agent creation (#74).
 
         Returns:
-            SubscriptionCredential with fewest agents, or None if no subscriptions exist
+            SubscriptionCredential with fewest agents, or None if no viable subscription
         """
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -555,10 +556,12 @@ class SubscriptionOperations:
                 FROM subscription_credentials s
                 JOIN users u ON s.owner_id = u.id
                 ORDER BY agent_count ASC, s.name ASC
-                LIMIT 1
             """)
-            row = cursor.fetchone()
-            return self._row_to_subscription(row) if row else None
+            for row in cursor.fetchall():
+                sub = self._row_to_subscription(row)
+                if not self.is_subscription_rate_limited(sub.id):
+                    return sub
+            return None
 
     def select_best_alternative_subscription(
         self,

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -291,6 +291,22 @@ async def create_agent_internal(
         'AGENT_RUNTIME_MODEL': config.runtime_model or ''
     }
 
+    # Auto-assign subscription (round-robin) — #74
+    auto_assigned_subscription_id = None
+    try:
+        least_used = db.get_least_used_subscription()
+        if least_used:
+            token = db.get_subscription_token(least_used.id)
+            if token:
+                env_vars['CLAUDE_CODE_OAUTH_TOKEN'] = token
+                env_vars.pop('ANTHROPIC_API_KEY', None)
+                auto_assigned_subscription_id = least_used.id
+                logger.info(f"Auto-assigned subscription '{least_used.name}' to agent {config.name}")
+            else:
+                logger.warning(f"Failed to decrypt subscription '{least_used.name}' token, using platform API key")
+    except Exception as e:
+        logger.warning(f"Subscription auto-assign failed for {config.name}: {e}")
+
     # Add Google API key if using Gemini runtime
     # Gemini CLI expects GEMINI_API_KEY environment variable
     if config.runtime == 'gemini-cli' or config.runtime == 'gemini':
@@ -480,6 +496,13 @@ async def create_agent_internal(
                 }))
 
             db.register_agent_owner(config.name, current_user.username)
+
+            # Persist auto-assigned subscription (#74)
+            if auto_assigned_subscription_id:
+                try:
+                    db.assign_subscription_to_agent(config.name, auto_assigned_subscription_id)
+                except Exception as e:
+                    logger.warning(f"Failed to persist subscription assignment for {config.name}: {e}")
 
             # AVATAR-003: Seed avatar prompt from template
             _avatar_prompt = template_data.get("avatar_prompt") if template_data else None

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -476,3 +476,123 @@ class TestSubscriptionCascade:
         )
         data = response.json()
         assert data["auth_mode"] != "subscription" or data["subscription_id"] is None
+
+
+# =============================================================================
+# Auto-Assign on Agent Creation Tests (#74)
+# =============================================================================
+
+class TestSubscriptionAutoAssign:
+    """#74: Auto-assign subscription to new agents via round-robin."""
+
+    def _create_subscription(self, api_client, name, token=VALID_TOKEN):
+        """Helper to create a subscription and return its id."""
+        response = api_client.post(
+            "/api/subscriptions",
+            json={"name": name, "token": token, "subscription_type": "max"}
+        )
+        assert_status(response, 200)
+        return response.json()["id"]
+
+    def _create_agent(self, api_client, name):
+        """Helper to create an agent and return its name."""
+        response = api_client.post(
+            "/api/agents",
+            json={"name": name, "template": "local:default"}
+        )
+        assert_status(response, 200)
+        return response.json()["name"]
+
+    def _get_auth(self, api_client, agent_name):
+        """Helper to get agent auth status."""
+        response = api_client.get(
+            f"/api/subscriptions/agents/{agent_name}/auth"
+        )
+        assert_status(response, 200)
+        return response.json()
+
+    def _cleanup_agent(self, api_client, agent_name):
+        """Helper to delete an agent."""
+        api_client.delete(f"/api/agents/{agent_name}")
+
+    def _cleanup_subscription(self, api_client, sub_id):
+        """Helper to delete a subscription."""
+        api_client.delete(f"/api/subscriptions/{sub_id}")
+
+    def test_create_agent_no_subscriptions(self, api_client: TrinityApiClient):
+        """Agent created with no subscriptions uses platform API key."""
+        agent_name = f"test-noauto-{uuid.uuid4().hex[:8]}"
+        try:
+            self._create_agent(api_client, agent_name)
+            auth = self._get_auth(api_client, agent_name)
+            assert auth["auth_mode"] in ["api_key", "not_configured"]
+        finally:
+            self._cleanup_agent(api_client, agent_name)
+
+    def test_create_agent_with_subscription(self, api_client: TrinityApiClient):
+        """Agent created with subscription registered is auto-assigned."""
+        sub_name = f"test-auto-sub-{uuid.uuid4().hex[:8]}"
+        agent_name = f"test-auto-{uuid.uuid4().hex[:8]}"
+        sub_id = self._create_subscription(api_client, sub_name)
+        try:
+            self._create_agent(api_client, agent_name)
+            auth = self._get_auth(api_client, agent_name)
+            assert auth["auth_mode"] == "subscription"
+            assert auth["subscription_name"] == sub_name
+        finally:
+            self._cleanup_agent(api_client, agent_name)
+            self._cleanup_subscription(api_client, sub_id)
+
+    def test_round_robin_distribution(self, api_client: TrinityApiClient):
+        """Two subscriptions distribute agents evenly via round-robin."""
+        sub_a_name = f"test-rr-a-{uuid.uuid4().hex[:8]}"
+        sub_b_name = f"test-rr-b-{uuid.uuid4().hex[:8]}"
+        sub_a_id = self._create_subscription(api_client, sub_a_name)
+        sub_b_id = self._create_subscription(api_client, sub_b_name)
+
+        agents = []
+        try:
+            # Create 3 agents — should distribute 2+1 across 2 subscriptions
+            for i in range(3):
+                name = f"test-rr-agent-{i}-{uuid.uuid4().hex[:6]}"
+                self._create_agent(api_client, name)
+                agents.append(name)
+
+            # Check distribution
+            assigned_subs = []
+            for name in agents:
+                auth = self._get_auth(api_client, name)
+                assert auth["auth_mode"] == "subscription"
+                assigned_subs.append(auth["subscription_id"])
+
+            # Both subscriptions should have at least 1 agent
+            assert sub_a_id in assigned_subs or sub_b_id in assigned_subs
+            # No subscription should have all 3
+            from collections import Counter
+            counts = Counter(assigned_subs)
+            assert max(counts.values()) <= 2, f"Uneven distribution: {counts}"
+        finally:
+            for name in agents:
+                self._cleanup_agent(api_client, name)
+            self._cleanup_subscription(api_client, sub_a_id)
+            self._cleanup_subscription(api_client, sub_b_id)
+
+    def test_alphabetical_tiebreak(self, api_client: TrinityApiClient):
+        """Equal agent counts resolve by alphabetical subscription name."""
+        # Create in reverse alphabetical order to verify sorting
+        sub_beta = f"beta-tie-{uuid.uuid4().hex[:6]}"
+        sub_alpha = f"alpha-tie-{uuid.uuid4().hex[:6]}"
+        beta_id = self._create_subscription(api_client, sub_beta)
+        alpha_id = self._create_subscription(api_client, sub_alpha)
+
+        agent_name = f"test-tie-{uuid.uuid4().hex[:8]}"
+        try:
+            self._create_agent(api_client, agent_name)
+            auth = self._get_auth(api_client, agent_name)
+            assert auth["auth_mode"] == "subscription"
+            # Should pick alphabetically first
+            assert auth["subscription_name"] == sub_alpha
+        finally:
+            self._cleanup_agent(api_client, agent_name)
+            self._cleanup_subscription(api_client, alpha_id)
+            self._cleanup_subscription(api_client, beta_id)


### PR DESCRIPTION
## Summary
- New agents are automatically assigned to the subscription with fewest agents (round-robin, alphabetical tie-break)
- Rate-limited subscriptions are skipped during auto-assignment
- Falls back to platform API key if no subscriptions exist or token decryption fails
- System agents (`trinity-system`) unaffected — separate creation path

## Changes
- `src/backend/db/subscriptions.py` — Added `get_least_used_subscription()` method
- `src/backend/database.py` — Added delegation method
- `src/backend/services/agent_service/crud.py` — Auto-assign in `create_agent_internal()`: lookup before container creation, DB persist after `register_agent_owner()`
- `tests/test_subscriptions.py` — 4 new tests (no-subs fallback, auto-assign, round-robin distribution, alphabetical tie-break)
- `docs/memory/changelog.md` — Changelog entry
- `docs/memory/requirements.md` — New requirement §20.3a
- `docs/memory/feature-flows/subscription-management.md` — Auto-Assign section with data flow diagram

## Test Plan
- [ ] New tests pass: `pytest tests/test_subscriptions.py::TestSubscriptionAutoAssign -v`
- [ ] Existing tests unaffected: `pytest tests/test_subscriptions.py -v`
- [ ] Manual: Create agent with 0 subscriptions → uses API key
- [ ] Manual: Register subscription → create agent → auth shows "subscription"
- [ ] Manual: 2 subs + 3 agents → round-robin distribution

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)