### PR TITLE
fix: Startup recovery for regular task executions (#128)

### DIFF
--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,15 @@
+### 2026-03-25
+
+**fix: Startup recovery for regular task executions (#128)**
+
+On backend restart, `schedule_executions` stuck in `running` status are now checked against agent containers and process registries. Orphaned executions (container down or not found in agent's process registry) are immediately marked `failed` with capacity slots released — instead of waiting 2 hours for the cleanup service timeout.
+
+- `src/backend/db/schedules.py` — Added `get_running_executions()` query
+- `src/backend/database.py` — Exposed `get_running_executions()` on `DatabaseManager`
+- `src/backend/services/cleanup_service.py` — Added `recover_orphaned_executions()` with container + HTTP registry checks
+- `src/backend/main.py` — Call recovery in lifespan handler after cleanup service start
+- `tests/unit/test_orphaned_execution_recovery.py` — 6 unit tests covering all recovery scenarios
+
 ### 2026-03-23
 
 **feat: Voice Chat — real-time voice conversations with agents via Gemini Live API (VOICE-001)**

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,6 +1,6 @@
-### 2026-03-25
+### 2026-03-25 02:00:55
 
-**fix: Startup recovery for regular task executions (#128)**
+🔧 **fix: Startup recovery for regular task executions (#128)**
 
 On backend restart, `schedule_executions` stuck in `running` status are now checked against agent containers and process registries. Orphaned executions (container down or not found in agent's process registry) are immediately marked `failed` with capacity slots released — instead of waiting 2 hours for the cleanup service timeout.
 

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -690,6 +690,10 @@ class DatabaseManager:
     # Cleanup Operations (for CleanupService)
     # =========================================================================
 
+    def get_running_executions(self):
+        """Get all schedule executions currently in 'running' status."""
+        return self._schedule_ops.get_running_executions()
+
     def mark_stale_executions_failed(self, timeout_minutes: int = 30):
         """Mark executions stuck in 'running' past threshold as failed."""
         return self._schedule_ops.mark_stale_executions_failed(timeout_minutes)

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -989,6 +989,23 @@ class ScheduleOperations:
             conn.commit()
             return cursor.rowcount > 0
 
+    def get_running_executions(self) -> list:
+        """Get all schedule executions currently in 'running' status.
+
+        Used by startup recovery to detect orphaned executions after a crash.
+
+        Returns:
+            List of dicts with id, agent_name, started_at, schedule_id.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT id, agent_name, started_at, schedule_id
+                FROM schedule_executions
+                WHERE status = ?
+            """, (TaskExecutionStatus.RUNNING,))
+            return [dict(row) for row in cursor.fetchall()]
+
     def mark_stale_executions_failed(self, timeout_minutes: int = 30) -> int:
         """Mark running executions older than timeout as failed.
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -276,6 +276,22 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         print(f"Error starting cleanup service: {e}")
 
+    # Recover orphaned regular task executions (Issue #128)
+    try:
+        from services.cleanup_service import recover_orphaned_executions
+        task_recovery = await recover_orphaned_executions()
+        if task_recovery["recovered"] > 0:
+            print(
+                f"Task execution recovery: "
+                f"recovered={task_recovery['recovered']}, "
+                f"still_running={task_recovery['still_running']}"
+            )
+        else:
+            print("Task execution recovery: no orphaned executions found")
+    except Exception as e:
+        print(f"Error recovering task executions: {e}")
+        # Don't fail startup - recovery is important but not critical
+
     # Run process execution recovery (IT5 P0 reliability feature)
     try:
         recovery_report = await run_execution_recovery()

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict
 
 from database import db
+from models import TaskExecutionStatus
 from services.slot_service import get_slot_service
 
 logger = logging.getLogger(__name__)
@@ -163,3 +164,93 @@ class CleanupService:
 
 # Global service instance
 cleanup_service = CleanupService()
+
+
+async def recover_orphaned_executions() -> Dict:
+    """Recover orphaned task executions on backend startup.
+
+    Checks each 'running' schedule execution against the agent's container
+    and process registry. Executions not found on the agent are marked failed
+    and their capacity slots released.
+
+    Returns:
+        Dict with recovered, still_running, and errors counts.
+    """
+    from collections import defaultdict
+
+    import httpx
+
+    from services.docker_service import get_agent_container
+
+    running = db.get_running_executions()
+    if not running:
+        return {"recovered": 0, "still_running": 0, "errors": 0}
+
+    slot_service = get_slot_service()
+
+    # Group by agent to minimize container/HTTP checks
+    by_agent: Dict[str, list] = defaultdict(list)
+    for execution in running:
+        by_agent[execution["agent_name"]].append(execution)
+
+    recovered = 0
+    still_running = 0
+    errors = 0
+
+    for agent_name, executions in by_agent.items():
+        # Check if container is running
+        container = get_agent_container(agent_name)
+        if not container or container.status != "running":
+            # Container down — all executions for this agent are orphaned
+            for execution in executions:
+                try:
+                    _mark_execution_orphaned(execution)
+                    await slot_service.release_slot(agent_name, execution["id"])
+                    recovered += 1
+                except Exception as e:
+                    logger.error(f"[Recovery] Error recovering execution {execution['id']}: {e}")
+                    errors += 1
+            continue
+
+        # Container is up — check agent's process registry
+        registry_ids: set = set()
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(
+                    f"http://agent-{agent_name}:8000/api/executions/running"
+                )
+                if resp.status_code == 200:
+                    registry_ids = {
+                        e["execution_id"] for e in resp.json().get("executions", [])
+                    }
+                # Non-200 means registry unreachable — treat all as orphaned
+        except Exception:
+            # Timeout or connection error — treat all as orphaned
+            pass
+
+        for execution in executions:
+            if execution["id"] in registry_ids:
+                still_running += 1
+            else:
+                try:
+                    _mark_execution_orphaned(execution)
+                    await slot_service.release_slot(agent_name, execution["id"])
+                    recovered += 1
+                except Exception as e:
+                    logger.error(f"[Recovery] Error recovering execution {execution['id']}: {e}")
+                    errors += 1
+
+    logger.info(
+        f"[Recovery] Task execution recovery complete: "
+        f"recovered={recovered}, still_running={still_running}, errors={errors}"
+    )
+    return {"recovered": recovered, "still_running": still_running, "errors": errors}
+
+
+def _mark_execution_orphaned(execution: Dict) -> None:
+    """Mark a single execution as failed due to orphan recovery."""
+    db.update_execution_status(
+        execution_id=execution["id"],
+        status=TaskExecutionStatus.FAILED,
+        error="Execution orphaned — recovered on backend restart",
+    )

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -176,10 +176,7 @@ async def recover_orphaned_executions() -> Dict:
     Returns:
         Dict with recovered, still_running, and errors counts.
     """
-    from collections import defaultdict
-
-    import httpx
-
+    from services.agent_client import AgentClientError, get_agent_client
     from services.docker_service import get_agent_container
 
     running = db.get_running_executions()
@@ -189,9 +186,9 @@ async def recover_orphaned_executions() -> Dict:
     slot_service = get_slot_service()
 
     # Group by agent to minimize container/HTTP checks
-    by_agent: Dict[str, list] = defaultdict(list)
+    by_agent: Dict[str, list] = {}
     for execution in running:
-        by_agent[execution["agent_name"]].append(execution)
+        by_agent.setdefault(execution["agent_name"], []).append(execution)
 
     recovered = 0
     still_running = 0
@@ -203,41 +200,31 @@ async def recover_orphaned_executions() -> Dict:
         if not container or container.status != "running":
             # Container down — all executions for this agent are orphaned
             for execution in executions:
-                try:
-                    _mark_execution_orphaned(execution)
-                    await slot_service.release_slot(agent_name, execution["id"])
+                if await _recover_execution(execution, agent_name, slot_service):
                     recovered += 1
-                except Exception as e:
-                    logger.error(f"[Recovery] Error recovering execution {execution['id']}: {e}")
+                else:
                     errors += 1
             continue
 
         # Container is up — check agent's process registry
-        registry_ids: set = set()
+        registry_ids: set[str] = set()
         try:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                resp = await client.get(
-                    f"http://agent-{agent_name}:8000/api/executions/running"
-                )
-                if resp.status_code == 200:
-                    registry_ids = {
-                        e["execution_id"] for e in resp.json().get("executions", [])
-                    }
-                # Non-200 means registry unreachable — treat all as orphaned
-        except Exception:
-            # Timeout or connection error — treat all as orphaned
-            pass
+            client = get_agent_client(agent_name)
+            resp = await client.get("/api/executions/running", timeout=5.0)
+            if resp.status_code == 200:
+                registry_ids = {
+                    e["execution_id"] for e in resp.json().get("executions", [])
+                }
+        except AgentClientError as e:
+            logger.warning(f"[Recovery] Could not reach agent {agent_name} registry: {e}")
 
         for execution in executions:
             if execution["id"] in registry_ids:
                 still_running += 1
             else:
-                try:
-                    _mark_execution_orphaned(execution)
-                    await slot_service.release_slot(agent_name, execution["id"])
+                if await _recover_execution(execution, agent_name, slot_service):
                     recovered += 1
-                except Exception as e:
-                    logger.error(f"[Recovery] Error recovering execution {execution['id']}: {e}")
+                else:
                     errors += 1
 
     logger.info(
@@ -247,10 +234,16 @@ async def recover_orphaned_executions() -> Dict:
     return {"recovered": recovered, "still_running": still_running, "errors": errors}
 
 
-def _mark_execution_orphaned(execution: Dict) -> None:
-    """Mark a single execution as failed due to orphan recovery."""
-    db.update_execution_status(
-        execution_id=execution["id"],
-        status=TaskExecutionStatus.FAILED,
-        error="Execution orphaned — recovered on backend restart",
-    )
+async def _recover_execution(execution: Dict, agent_name: str, slot_service) -> bool:
+    """Mark a single execution as orphaned and release its slot. Returns True on success."""
+    try:
+        db.update_execution_status(
+            execution_id=execution["id"],
+            status=TaskExecutionStatus.FAILED,
+            error="Execution orphaned — recovered on backend restart",
+        )
+        await slot_service.release_slot(agent_name, execution["id"])
+        return True
+    except Exception as e:
+        logger.error(f"[Recovery] Error recovering execution {execution['id']}: {e}")
+        return False

--- a/tests/unit/test_orphaned_execution_recovery.py
+++ b/tests/unit/test_orphaned_execution_recovery.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for orphaned task execution recovery on backend startup.
+
+Tests the recover_orphaned_executions() function which checks running
+schedule executions against agent containers and process registries,
+marking orphaned ones as failed.
+
+Issue: https://github.com/abilityai/trinity/issues/128
+Module: src/backend/services/cleanup_service.py
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# Backend source path
+_BACKEND = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'src', 'backend'
+))
+
+# ── Shared mocks ──────────────────────────────────────────────────────────
+_mock_db = MagicMock()
+_mock_slot_service = AsyncMock()
+_mock_docker_svc = MagicMock()
+
+_SYS_MOCKS = {
+    'database': Mock(db=_mock_db),
+    'models': Mock(TaskExecutionStatus=Mock(RUNNING='running', FAILED='failed')),
+    'services.slot_service': Mock(get_slot_service=Mock(return_value=_mock_slot_service)),
+    'services.docker_service': _mock_docker_svc,
+    'utils.helpers': Mock(utc_now_iso=Mock(return_value="2026-03-25T12:00:00Z")),
+    'db_models': Mock(),
+    'docker': Mock(),
+}
+
+# ── Load the module under test via importlib ──────────────────────────────
+with patch.dict('sys.modules', _SYS_MOCKS):
+    _spec = importlib.util.spec_from_file_location(
+        "cleanup_service_under_test",
+        os.path.join(_BACKEND, "services", "cleanup_service.py"),
+    )
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    _recover_fn = _mod.recover_orphaned_executions
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+def _make_execution(exec_id: str, agent_name: str) -> dict:
+    return {
+        "id": exec_id,
+        "agent_name": agent_name,
+        "started_at": "2026-03-25T10:00:00Z",
+        "schedule_id": f"sched-{exec_id}",
+    }
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _mock_httpx_client(response=None, side_effect=None):
+    """Create a mock httpx.AsyncClient context manager."""
+    client = AsyncMock()
+    if side_effect:
+        client.get.side_effect = side_effect
+    else:
+        client.get.return_value = response
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    _mock_db.reset_mock()
+    _mock_slot_service.reset_mock()
+    _mock_docker_svc.reset_mock()
+
+
+class TestRecoverOrphanedExecutions:
+    pytestmark = pytest.mark.unit
+
+    def test_no_running_executions(self):
+        _mock_db.get_running_executions.return_value = []
+
+        with patch.dict('sys.modules', _SYS_MOCKS):
+            result = _run(_recover_fn())
+
+        assert result == {"recovered": 0, "still_running": 0, "errors": 0}
+
+    def test_container_down_marks_orphaned(self):
+        _mock_db.get_running_executions.return_value = [
+            _make_execution("exec-1", "agent-alpha")
+        ]
+        _mock_docker_svc.get_agent_container.return_value = None
+
+        with patch.dict('sys.modules', _SYS_MOCKS):
+            result = _run(_recover_fn())
+
+        assert result["recovered"] == 1
+        assert result["still_running"] == 0
+        kw = _mock_db.update_execution_status.call_args[1]
+        assert kw["execution_id"] == "exec-1"
+        assert kw["status"] == "failed"
+        assert "orphaned" in kw["error"]
+        _mock_slot_service.release_slot.assert_awaited_once_with("agent-alpha", "exec-1")
+
+    def test_not_in_registry_marks_orphaned(self):
+        _mock_db.get_running_executions.return_value = [
+            _make_execution("exec-2", "agent-beta")
+        ]
+        _mock_docker_svc.get_agent_container.return_value = Mock(status="running")
+
+        resp = Mock(status_code=200)
+        resp.json.return_value = {"executions": []}
+
+        with patch.dict('sys.modules', _SYS_MOCKS), \
+             patch('httpx.AsyncClient', return_value=_mock_httpx_client(response=resp)):
+            result = _run(_recover_fn())
+
+        assert result["recovered"] == 1
+        _mock_slot_service.release_slot.assert_awaited_once_with("agent-beta", "exec-2")
+
+    def test_in_registry_left_alone(self):
+        _mock_db.get_running_executions.return_value = [
+            _make_execution("exec-3", "agent-gamma")
+        ]
+        _mock_docker_svc.get_agent_container.return_value = Mock(status="running")
+
+        resp = Mock(status_code=200)
+        resp.json.return_value = {
+            "executions": [{"execution_id": "exec-3"}]
+        }
+
+        with patch.dict('sys.modules', _SYS_MOCKS), \
+             patch('httpx.AsyncClient', return_value=_mock_httpx_client(response=resp)):
+            result = _run(_recover_fn())
+
+        assert result["recovered"] == 0
+        assert result["still_running"] == 1
+        _mock_db.update_execution_status.assert_not_called()
+
+    def test_multiple_agents_mixed(self):
+        _mock_db.get_running_executions.return_value = [
+            _make_execution("exec-a", "agent-up"),
+            _make_execution("exec-b", "agent-up"),
+            _make_execution("exec-c", "agent-down"),
+        ]
+        _mock_docker_svc.get_agent_container.side_effect = (
+            lambda n: Mock(status="running") if n == "agent-up" else None
+        )
+
+        resp = Mock(status_code=200)
+        resp.json.return_value = {
+            "executions": [{"execution_id": "exec-a"}]
+        }
+
+        with patch.dict('sys.modules', _SYS_MOCKS), \
+             patch('httpx.AsyncClient', return_value=_mock_httpx_client(response=resp)):
+            result = _run(_recover_fn())
+
+        # exec-b not in registry + exec-c container down = 2 recovered
+        assert result["recovered"] == 2
+        assert result["still_running"] == 1
+        assert _mock_db.update_execution_status.call_count == 2
+
+    def test_http_timeout_treats_as_orphaned(self):
+        _mock_db.get_running_executions.return_value = [
+            _make_execution("exec-t", "agent-slow")
+        ]
+        _mock_docker_svc.get_agent_container.return_value = Mock(status="running")
+
+        with patch.dict('sys.modules', _SYS_MOCKS), \
+             patch('httpx.AsyncClient', return_value=_mock_httpx_client(
+                 side_effect=Exception("timeout")
+             )):
+            result = _run(_recover_fn())
+
+        assert result["recovered"] == 1
+        assert result["still_running"] == 0

--- a/tests/unit/test_orphaned_execution_recovery.py
+++ b/tests/unit/test_orphaned_execution_recovery.py
@@ -26,12 +26,18 @@ _BACKEND = os.path.abspath(os.path.join(
 _mock_db = MagicMock()
 _mock_slot_service = AsyncMock()
 _mock_docker_svc = MagicMock()
+_mock_agent_client = AsyncMock()
+_AgentClientError = type('AgentClientError', (Exception,), {})
 
 _SYS_MOCKS = {
     'database': Mock(db=_mock_db),
     'models': Mock(TaskExecutionStatus=Mock(RUNNING='running', FAILED='failed')),
     'services.slot_service': Mock(get_slot_service=Mock(return_value=_mock_slot_service)),
     'services.docker_service': _mock_docker_svc,
+    'services.agent_client': Mock(
+        get_agent_client=Mock(return_value=_mock_agent_client),
+        AgentClientError=_AgentClientError,
+    ),
     'utils.helpers': Mock(utc_now_iso=Mock(return_value="2026-03-25T12:00:00Z")),
     'db_models': Mock(),
     'docker': Mock(),
@@ -66,16 +72,13 @@ def _run(coro):
         loop.close()
 
 
-def _mock_httpx_client(response=None, side_effect=None):
-    """Create a mock httpx.AsyncClient context manager."""
-    client = AsyncMock()
-    if side_effect:
-        client.get.side_effect = side_effect
-    else:
-        client.get.return_value = response
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=False)
-    return client
+def _set_agent_registry(execution_ids: list[str]):
+    """Configure mock agent client to return given execution IDs."""
+    resp = Mock(status_code=200)
+    resp.json.return_value = {
+        "executions": [{"execution_id": eid} for eid in execution_ids]
+    }
+    _mock_agent_client.get.return_value = resp
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────
@@ -84,6 +87,7 @@ def _reset_mocks():
     _mock_db.reset_mock()
     _mock_slot_service.reset_mock()
     _mock_docker_svc.reset_mock()
+    _mock_agent_client.reset_mock()
 
 
 class TestRecoverOrphanedExecutions:
@@ -119,12 +123,9 @@ class TestRecoverOrphanedExecutions:
             _make_execution("exec-2", "agent-beta")
         ]
         _mock_docker_svc.get_agent_container.return_value = Mock(status="running")
+        _set_agent_registry([])  # Empty registry
 
-        resp = Mock(status_code=200)
-        resp.json.return_value = {"executions": []}
-
-        with patch.dict('sys.modules', _SYS_MOCKS), \
-             patch('httpx.AsyncClient', return_value=_mock_httpx_client(response=resp)):
+        with patch.dict('sys.modules', _SYS_MOCKS):
             result = _run(_recover_fn())
 
         assert result["recovered"] == 1
@@ -135,14 +136,9 @@ class TestRecoverOrphanedExecutions:
             _make_execution("exec-3", "agent-gamma")
         ]
         _mock_docker_svc.get_agent_container.return_value = Mock(status="running")
+        _set_agent_registry(["exec-3"])
 
-        resp = Mock(status_code=200)
-        resp.json.return_value = {
-            "executions": [{"execution_id": "exec-3"}]
-        }
-
-        with patch.dict('sys.modules', _SYS_MOCKS), \
-             patch('httpx.AsyncClient', return_value=_mock_httpx_client(response=resp)):
+        with patch.dict('sys.modules', _SYS_MOCKS):
             result = _run(_recover_fn())
 
         assert result["recovered"] == 0
@@ -158,14 +154,9 @@ class TestRecoverOrphanedExecutions:
         _mock_docker_svc.get_agent_container.side_effect = (
             lambda n: Mock(status="running") if n == "agent-up" else None
         )
+        _set_agent_registry(["exec-a"])  # Only exec-a still running
 
-        resp = Mock(status_code=200)
-        resp.json.return_value = {
-            "executions": [{"execution_id": "exec-a"}]
-        }
-
-        with patch.dict('sys.modules', _SYS_MOCKS), \
-             patch('httpx.AsyncClient', return_value=_mock_httpx_client(response=resp)):
+        with patch.dict('sys.modules', _SYS_MOCKS):
             result = _run(_recover_fn())
 
         # exec-b not in registry + exec-c container down = 2 recovered
@@ -173,16 +164,14 @@ class TestRecoverOrphanedExecutions:
         assert result["still_running"] == 1
         assert _mock_db.update_execution_status.call_count == 2
 
-    def test_http_timeout_treats_as_orphaned(self):
+    def test_agent_unreachable_treats_as_orphaned(self):
         _mock_db.get_running_executions.return_value = [
             _make_execution("exec-t", "agent-slow")
         ]
         _mock_docker_svc.get_agent_container.return_value = Mock(status="running")
+        _mock_agent_client.get.side_effect = _AgentClientError("Connection timeout")
 
-        with patch.dict('sys.modules', _SYS_MOCKS), \
-             patch('httpx.AsyncClient', return_value=_mock_httpx_client(
-                 side_effect=Exception("timeout")
-             )):
+        with patch.dict('sys.modules', _SYS_MOCKS):
             result = _run(_recover_fn())
 
         assert result["recovered"] == 1


### PR DESCRIPTION
## Summary
- On backend restart, `schedule_executions` stuck in `running` are checked against agent containers and process registries
- Orphaned executions (container down or not in agent's process registry) are immediately marked `failed` with capacity slots released
- Reduces recovery time from **2 hours** (cleanup service timeout) to **seconds** (startup check)

## Changes
- `src/backend/db/schedules.py` — Added `get_running_executions()` query
- `src/backend/database.py` — Exposed new method on `DatabaseManager`
- `src/backend/services/cleanup_service.py` — Added `recover_orphaned_executions()` using existing `AgentClient` for HTTP checks
- `src/backend/main.py` — Call recovery in lifespan handler after cleanup service start
- `tests/unit/test_orphaned_execution_recovery.py` — 6 unit tests covering all scenarios
- `docs/memory/changelog.md` — Updated

## Test Plan
- [x] New unit tests pass: `pytest tests/unit/test_orphaned_execution_recovery.py -v` (6/6)
- [ ] Existing tests unaffected
- [ ] Manual verification: restart backend with running executions, verify they get recovered in logs

Closes #128

Generated with [Claude Code](https://claude.com/claude-code)