### PR TITLE
feat: MCP Execution Query Tools — async result polling (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ project_trinity/
 ├── src/
 │   ├── backend/          # FastAPI backend (main.py, database.py)
 │   ├── frontend/         # Vue.js 3 + Tailwind CSS
-│   └── mcp-server/       # Trinity MCP server (59 tools)
+│   └── mcp-server/       # Trinity MCP server (62 tools)
 ├── docker/
 │   ├── base-image/       # Universal agent base (agent-server.py)
 │   ├── backend/          # Backend Dockerfile

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Trinity implements four foundational capabilities that transform simple AI assis
 - **Shared Folders** — File-based state sharing between agents via Docker volumes
 - **System Manifest Deployment** — Deploy multi-agent systems from a single YAML configuration
 - **Scheduling** — Cron-based automation with dedicated scheduler service and Redis distributed locks
-- **MCP Integration** — 59 tools for external agent orchestration via Model Context Protocol
+- **MCP Integration** — 62 tools for external agent orchestration via Model Context Protocol
 - **Trinity Connect** — WebSocket event streaming for local Claude Code integration
 
 ### Operations
@@ -298,7 +298,7 @@ trinity/
 ├── src/
 │   ├── backend/          # FastAPI backend API
 │   ├── frontend/         # Vue.js 3 + Tailwind CSS web UI
-│   ├── mcp-server/       # Trinity MCP server (59 tools)
+│   ├── mcp-server/       # Trinity MCP server (62 tools)
 │   └── scheduler/        # Dedicated scheduler service (Redis locks)
 ├── docker/
 │   ├── base-image/       # Universal agent base image

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -79,7 +79,14 @@ Claude Code has a hardcoded 60-second timeout for all MCP HTTP tool calls. This 
        async=true
    )
    # Returns: { "execution_id": "abc123" }
-   # Poll for results later via API or shared folders
+
+   # Poll for results using get_execution_result (MCP-007)
+   result = mcp__trinity__get_execution_result(
+       agent_name="worker",
+       execution_id="abc123"
+   )
+   # Returns: { "status": "running" | "success" | "failed", "response": "...", ... }
+   # If still running, sleep 30s and poll again
    ```
 3. **Use shared folders** — Write results to `/home/developer/shared-out/` instead of returning them synchronously
 4. **Hybrid pattern** — Use async MCP to trigger work, shared folders for results

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -276,13 +276,14 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 - Tools access auth context via `context.session` parameter
 - Agent-to-agent collaboration uses agent-scoped keys for access control
 
-**59 Tools** across 12 tool modules (`src/tools/`):
+**62 Tools** across 13 tool modules (`src/tools/`):
 
 | Module | Tools | Description |
 |--------|-------|-------------|
 | `agents.ts` (17) | `list_agents`, `get_agent`, `get_agent_info`, `create_agent`, `rename_agent`, `delete_agent`, `start_agent`, `stop_agent`, `list_templates`, `get_credential_status`, `inject_credentials`, `export_credentials`, `import_credentials`, `get_credential_encryption_key`, `get_agent_ssh_access`, `deploy_local_agent`, `initialize_github_sync` | Agent lifecycle, credentials, SSH, local deploy, GitHub sync |
 | `chat.ts` (3) | `chat_with_agent`, `get_chat_history`, `get_agent_logs` | Chat (enforces sharing rules), history, logs |
 | `schedules.ts` (8) | `list_agent_schedules`, `create_agent_schedule`, `get_agent_schedule`, `update_agent_schedule`, `delete_agent_schedule`, `toggle_agent_schedule`, `trigger_agent_schedule`, `get_schedule_executions` | Schedule CRUD and execution history |
+| `executions.ts` (3) | `list_recent_executions`, `get_execution_result`, `get_agent_activity_summary` | Execution queries, async result polling, activity monitoring (MCP-007) |
 | `skills.ts` (7) | `list_skills`, `get_skill`, `get_skills_library_status`, `assign_skill_to_agent`, `set_agent_skills`, `sync_agent_skills`, `get_agent_skills` | Skill management and assignment |
 | `tags.ts` (5) | `list_tags`, `get_agent_tags`, `tag_agent`, `untag_agent`, `set_agent_tags` | Agent tagging |
 | `systems.ts` (4) | `deploy_system`, `list_systems`, `restart_system`, `get_system_manifest` | System manifest deployment |

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,24 @@
+### 2026-03-25
+
+**feat: MCP Execution Query Tools — agents can poll for async results (MCP-007) (#19)**
+
+Three new MCP tools enabling agents to query execution history and poll for async task results. This closes the async agent-to-agent collaboration loop: `chat_with_agent(async=true)` returns an `execution_id`, then `get_execution_result(id)` polls until complete.
+
+- `list_recent_executions` — List recent executions for an agent across all trigger types (schedule, manual, MCP, chat) with optional status filter
+- `get_execution_result` — Get full execution details including response text, cost, and optionally the full transcript/log
+- `get_agent_activity_summary` — High-level activity summary over a time window with counts by type and state
+
+**MCP Server:**
+- `src/mcp-server/src/tools/executions.ts` — NEW: 3 execution query tools with agent-scoped access control
+- `src/mcp-server/src/tools/index.ts` — Export new tools
+- `src/mcp-server/src/server.ts` — Register 3 new tools (total: 62 tools)
+- `src/mcp-server/src/client.ts` — Added `getExecution()`, `getExecutionLog()`, `getActivityTimeline()` client methods
+- `src/mcp-server/src/types.ts` — Added `ActivityTimelineResponse`, `ActivityEntry` types; extended `ScheduleExecution` with `model_used`, `claude_session_id`, etc.
+
+**No backend changes** — all tools wrap existing REST endpoints (`GET /api/agents/{name}/executions`, `GET /api/agents/{name}/executions/{id}`, `GET /api/activities/timeline`).
+
+---
+
 ### 2026-03-23
 
 **feat: Voice Chat — real-time voice conversations with agents via Gemini Live API (VOICE-001)**

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -172,7 +172,7 @@
 
 | Flow | Document | Description |
 |------|----------|-------------|
-| MCP Orchestration | [mcp-orchestration.md](feature-flows/mcp-orchestration.md) | 45+ MCP tools for agent orchestration |
+| MCP Orchestration | [mcp-orchestration.md](feature-flows/mcp-orchestration.md) | 62 MCP tools for agent orchestration |
 | Trinity Connect | [trinity-connect.md](feature-flows/trinity-connect.md) | Local-remote agent sync via WebSocket |
 
 ### GitHub Integration

--- a/docs/memory/feature-flows/mcp-orchestration.md
+++ b/docs/memory/feature-flows/mcp-orchestration.md
@@ -495,17 +495,27 @@ chat_with_agent({
 - Background jobs: trigger maintenance/analysis tasks that run independently
 - Load distribution: batch processing across multiple agents
 
-**Polling for results**:
+**Polling for results via MCP (MCP-007)**:
+```typescript
+// Poll using get_execution_result MCP tool
+get_execution_result({
+  agent_name: "worker-1",
+  execution_id: "abc123xyz"
+})
+// Returns: { "status": "running", ... }  -- keep polling
+// Returns: { "status": "success", "response": "...", "cost": 0.05, ... }  -- done
+
+// Also available: list_recent_executions to find execution IDs
+list_recent_executions({ agent_name: "worker-1", limit: 5 })
+
+// And: get_agent_activity_summary for monitoring
+get_agent_activity_summary({ agent_name: "worker-1", hours: 24 })
+```
+
+**Polling for results via REST API**:
 ```bash
-# Check execution status
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:8000/api/agents/worker-1/executions/abc123xyz
-
-# Response when running:
-# { "status": "running", "agent_name": "worker-1", ... }
-
-# Response when complete:
-# { "status": "success", "response": "...", "cost": 0.05, ... }
 ```
 
 See [Parallel Headless Execution](parallel-headless-execution.md) for implementation details.

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -202,12 +202,20 @@ Trinity implements infrastructure for "System 2" AI — Deep Agents that plan, r
 ### 7.1 Trinity MCP Server
 - **Status**: ✅ Implemented
 - **Description**: Agent orchestration via Model Context Protocol
-- **Key Features**: FastMCP with Streamable HTTP, 55 tools, API key authentication
+- **Key Features**: FastMCP with Streamable HTTP, 62 tools, API key authentication
 - **Flow**: `docs/memory/feature-flows/mcp-orchestration.md`
 
 ### 7.2 Per-User API Keys
 - **Status**: ✅ Implemented
 - **Description**: Generate, revoke, and track usage per key
+
+### 7.3 MCP Execution Query Tools (MCP-007)
+- **Status**: ✅ Implemented (2026-03-25)
+- **Requirement ID**: MCP-007
+- **GitHub Issue**: #19
+- **Description**: MCP tools for querying execution history, polling async results, and monitoring agent activity
+- **Key Features**: `list_recent_executions`, `get_execution_result`, `get_agent_activity_summary`; enables async polling pattern for agent-to-agent collaboration beyond 60s MCP timeout
+- **Spec**: `docs/requirements/MCP_EXECUTION_QUERY_TOOLS.md`
 
 ---
 

--- a/docs/requirements/MCP_EXECUTION_QUERY_TOOLS.md
+++ b/docs/requirements/MCP_EXECUTION_QUERY_TOOLS.md
@@ -2,7 +2,7 @@
 
 > **Requirement ID**: MCP-007
 > **Priority**: HIGH
-> **Status**: ⏳ Not Started
+> **Status**: ✅ Implemented (2026-03-25)
 > **Created**: 2026-02-05
 > **Source**: `docs/planning/WORKFLOW_PRIORITIES_2026-02.md`
 

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -20,6 +20,7 @@ import type {
   ScheduleExecution,
   ScheduleToggleResult,
   ScheduleTriggerResult,
+  ActivityTimelineResponse,
 } from "./types.js";
 
 /**
@@ -737,6 +738,53 @@ export class TrinityClient {
     return this.request<ScheduleExecution[]>(
       "GET",
       `/api/agents/${encodeURIComponent(agentName)}/executions?limit=${limit}`
+    );
+  }
+
+  /**
+   * Get a specific execution by ID (MCP-007)
+   */
+  async getExecution(
+    agentName: string,
+    executionId: string
+  ): Promise<ScheduleExecution> {
+    return this.request<ScheduleExecution>(
+      "GET",
+      `/api/agents/${encodeURIComponent(agentName)}/executions/${encodeURIComponent(executionId)}`
+    );
+  }
+
+  /**
+   * Get the full execution log/transcript for an execution (MCP-007)
+   */
+  async getExecutionLog(
+    agentName: string,
+    executionId: string
+  ): Promise<{ execution_id: string; agent_name: string; log: unknown }> {
+    return this.request(
+      "GET",
+      `/api/agents/${encodeURIComponent(agentName)}/executions/${encodeURIComponent(executionId)}/log`
+    );
+  }
+
+  /**
+   * Get cross-agent activity timeline (MCP-007)
+   */
+  async getActivityTimeline(params: {
+    start_time?: string;
+    end_time?: string;
+    activity_types?: string;
+    limit?: number;
+  } = {}): Promise<ActivityTimelineResponse> {
+    const searchParams = new URLSearchParams();
+    if (params.start_time) searchParams.set("start_time", params.start_time);
+    if (params.end_time) searchParams.set("end_time", params.end_time);
+    if (params.activity_types) searchParams.set("activity_types", params.activity_types);
+    if (params.limit) searchParams.set("limit", String(params.limit));
+    const qs = searchParams.toString();
+    return this.request<ActivityTimelineResponse>(
+      "GET",
+      `/api/activities/timeline${qs ? `?${qs}` : ""}`
     );
   }
 

--- a/src/mcp-server/src/server.ts
+++ b/src/mcp-server/src/server.ts
@@ -18,6 +18,7 @@ import { createNotificationTools } from "./tools/notifications.js";
 import { createSubscriptionTools } from "./tools/subscriptions.js";
 import { createMonitoringTools } from "./tools/monitoring.js";
 import { createNeverminedTools } from "./tools/nevermined.js";
+import { createExecutionTools } from "./tools/executions.js";
 import type { McpAuthContext } from "./types.js";
 
 export interface ServerConfig {
@@ -256,8 +257,14 @@ export async function createServer(config: ServerConfig = {}) {
   server.addTool(neverminedTools.toggleNevermined);
   server.addTool(neverminedTools.getNeverminedPayments);
 
-  const totalTools = Object.keys(agentTools).length + Object.keys(chatTools).length + Object.keys(systemTools).length + Object.keys(docsTools).length + Object.keys(skillsTools).length + Object.keys(scheduleTools).length + Object.keys(tagTools).length + Object.keys(notificationTools).length + Object.keys(subscriptionTools).length + Object.keys(monitoringTools).length + Object.keys(neverminedTools).length;
-  console.log(`Registered ${totalTools} tools (${Object.keys(agentTools).length} agent, ${Object.keys(chatTools).length} chat, ${Object.keys(systemTools).length} system, ${Object.keys(docsTools).length} docs, ${Object.keys(skillsTools).length} skills, ${Object.keys(scheduleTools).length} schedule, ${Object.keys(tagTools).length} tags, ${Object.keys(notificationTools).length} notifications, ${Object.keys(subscriptionTools).length} subscriptions, ${Object.keys(monitoringTools).length} monitoring, ${Object.keys(neverminedTools).length} nevermined)`);
+  // Register execution query tools (3 tools) - MCP-007
+  const executionTools = createExecutionTools(client, requireApiKey);
+  server.addTool(executionTools.listRecentExecutions);
+  server.addTool(executionTools.getExecutionResult);
+  server.addTool(executionTools.getAgentActivitySummary);
+
+  const totalTools = Object.keys(agentTools).length + Object.keys(chatTools).length + Object.keys(systemTools).length + Object.keys(docsTools).length + Object.keys(skillsTools).length + Object.keys(scheduleTools).length + Object.keys(tagTools).length + Object.keys(notificationTools).length + Object.keys(subscriptionTools).length + Object.keys(monitoringTools).length + Object.keys(neverminedTools).length + Object.keys(executionTools).length;
+  console.log(`Registered ${totalTools} tools (${Object.keys(agentTools).length} agent, ${Object.keys(chatTools).length} chat, ${Object.keys(systemTools).length} system, ${Object.keys(docsTools).length} docs, ${Object.keys(skillsTools).length} skills, ${Object.keys(scheduleTools).length} schedule, ${Object.keys(tagTools).length} tags, ${Object.keys(notificationTools).length} notifications, ${Object.keys(subscriptionTools).length} subscriptions, ${Object.keys(monitoringTools).length} monitoring, ${Object.keys(neverminedTools).length} nevermined, ${Object.keys(executionTools).length} executions)`);
 
   return { server, port, client, requireApiKey };
 }

--- a/src/mcp-server/src/tools/executions.ts
+++ b/src/mcp-server/src/tools/executions.ts
@@ -1,0 +1,276 @@
+/**
+ * Execution Query Tools (MCP-007)
+ *
+ * MCP tools for querying execution history, results, and agent activity.
+ * Enables async polling pattern: chat_with_agent(async=true) -> get_execution_result(id)
+ */
+
+import { z } from "zod";
+import { TrinityClient } from "../client.js";
+import type { McpAuthContext } from "../types.js";
+
+/**
+ * Create execution query tools with the given client
+ * @param client - Base Trinity client (provides base URL, no auth when requireApiKey=true)
+ * @param requireApiKey - Whether API key authentication is enabled
+ */
+export function createExecutionTools(
+  client: TrinityClient,
+  requireApiKey: boolean
+) {
+  /**
+   * Get Trinity client with appropriate authentication
+   */
+  const getClient = (authContext?: McpAuthContext): TrinityClient => {
+    if (requireApiKey) {
+      if (!authContext?.mcpApiKey) {
+        throw new Error("MCP API key authentication required but no API key found in request context");
+      }
+      const userClient = new TrinityClient(client.getBaseUrl());
+      userClient.setToken(authContext.mcpApiKey);
+      return userClient;
+    }
+    return client;
+  };
+
+  /**
+   * Check if agent-scoped key can access target agent for read operations.
+   * Execution queries are always read-only.
+   */
+  const checkAgentAccess = async (
+    apiClient: TrinityClient,
+    authContext: McpAuthContext | undefined,
+    targetAgent: string
+  ): Promise<{ allowed: boolean; reason?: string }> => {
+    if (authContext?.scope === "system") {
+      return { allowed: true };
+    }
+
+    if (authContext?.scope !== "agent" || !authContext?.agentName) {
+      return { allowed: true };
+    }
+
+    const callerAgentName = authContext.agentName;
+
+    if (targetAgent === callerAgentName) {
+      return { allowed: true };
+    }
+
+    const permittedAgents = await apiClient.getPermittedAgents(callerAgentName);
+    if (!permittedAgents.includes(targetAgent)) {
+      return {
+        allowed: false,
+        reason: `Agent '${callerAgentName}' does not have permission to access '${targetAgent}'`,
+      };
+    }
+
+    return { allowed: true };
+  };
+
+  return {
+    // ========================================================================
+    // list_recent_executions - List recent executions for an agent
+    // ========================================================================
+    listRecentExecutions: {
+      name: "list_recent_executions",
+      description:
+        "List recent executions for an agent across all trigger types (schedule, manual, MCP, chat). " +
+        "Returns execution summaries with status, timing, cost, and context usage. " +
+        "Use this to check what tasks ran recently or to find an execution_id for get_execution_result. " +
+        "Access control: agents can only list executions on self or permitted agents.",
+      parameters: z.object({
+        agent_name: z.string().describe("Name of the agent to list executions for"),
+        limit: z
+          .number()
+          .optional()
+          .default(20)
+          .describe("Maximum number of executions to return (default: 20, max: 100)"),
+        status: z
+          .string()
+          .optional()
+          .describe("Filter by status: pending, running, success, failed, cancelled"),
+      }),
+      execute: async (
+        { agent_name, limit = 20, status }: { agent_name: string; limit?: number; status?: string },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const authContext = context?.session;
+        const apiClient = getClient(authContext);
+
+        const accessCheck = await checkAgentAccess(apiClient, authContext, agent_name);
+        if (!accessCheck.allowed) {
+          console.log(`[list_recent_executions] Access denied: ${accessCheck.reason}`);
+          return JSON.stringify({
+            error: "Access denied",
+            reason: accessCheck.reason,
+          }, null, 2);
+        }
+
+        const effectiveLimit = Math.min(Math.max(1, limit), 100);
+        const executions = await apiClient.getAgentExecutions(agent_name, effectiveLimit);
+
+        // Client-side status filter (backend doesn't support it on this endpoint)
+        const filtered = status
+          ? executions.filter(e => e.status === status)
+          : executions;
+
+        console.log(`[list_recent_executions] Retrieved ${filtered.length} executions for agent '${agent_name}'${status ? ` (status=${status})` : ""}`);
+
+        return JSON.stringify({
+          agent_name,
+          execution_count: filtered.length,
+          executions: filtered,
+        }, null, 2);
+      },
+    },
+
+    // ========================================================================
+    // get_execution_result - Get details and result of a specific execution
+    // ========================================================================
+    getExecutionResult: {
+      name: "get_execution_result",
+      description:
+        "Get the full result of a specific execution including response text, cost, and status. " +
+        "Use this to poll for results after chat_with_agent(async=true, parallel=true) returns an execution_id. " +
+        "Optionally include the full execution transcript (tool calls, thinking, responses). " +
+        "Access control: agents can only view executions on self or permitted agents.",
+      parameters: z.object({
+        agent_name: z.string().describe("Name of the agent that ran the execution"),
+        execution_id: z.string().describe("Execution ID to retrieve (returned by async chat_with_agent or list_recent_executions)"),
+        include_log: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Include full execution transcript/log (can be large). Default: false"),
+      }),
+      execute: async (
+        { agent_name, execution_id, include_log = false }: { agent_name: string; execution_id: string; include_log?: boolean },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const authContext = context?.session;
+        const apiClient = getClient(authContext);
+
+        const accessCheck = await checkAgentAccess(apiClient, authContext, agent_name);
+        if (!accessCheck.allowed) {
+          console.log(`[get_execution_result] Access denied: ${accessCheck.reason}`);
+          return JSON.stringify({
+            error: "Access denied",
+            reason: accessCheck.reason,
+          }, null, 2);
+        }
+
+        const execution = await apiClient.getExecution(agent_name, execution_id);
+
+        console.log(`[get_execution_result] Retrieved execution ${execution_id} for agent '${agent_name}' (status=${execution.status})`);
+
+        const result: Record<string, unknown> = {
+          execution_id: execution.id,
+          agent_name: execution.agent_name,
+          status: execution.status,
+          message: execution.message,
+          response: execution.response || null,
+          error: execution.error || null,
+          started_at: execution.started_at,
+          completed_at: execution.completed_at || null,
+          duration_ms: execution.duration_ms || null,
+          triggered_by: execution.triggered_by,
+          cost: execution.cost || null,
+          context_used: execution.context_used || null,
+          context_max: execution.context_max || null,
+          model_used: execution.model_used || null,
+        };
+
+        if (include_log) {
+          try {
+            const logData = await apiClient.getExecutionLog(agent_name, execution_id);
+            result.execution_log = logData.log;
+          } catch (e) {
+            result.execution_log = null;
+            result.log_error = `Failed to retrieve log: ${e instanceof Error ? e.message : String(e)}`;
+          }
+        }
+
+        return JSON.stringify(result, null, 2);
+      },
+    },
+
+    // ========================================================================
+    // get_agent_activity_summary - High-level activity summary for monitoring
+    // ========================================================================
+    getAgentActivitySummary: {
+      name: "get_agent_activity_summary",
+      description:
+        "Get a high-level activity summary for an agent over a time window. " +
+        "Returns counts of activities by type and state (e.g., 5 chat_start completed, 2 schedule_start failed). " +
+        "Useful for monitoring agents, checking if scheduled tasks ran, and building dashboards. " +
+        "Access control: agents can only view activity for self or permitted agents.",
+      parameters: z.object({
+        agent_name: z
+          .string()
+          .optional()
+          .describe("Agent name to summarize. If omitted, returns activity across all accessible agents."),
+        hours: z
+          .number()
+          .optional()
+          .default(24)
+          .describe("Number of hours to look back (default: 24, max: 168 = 7 days)"),
+      }),
+      execute: async (
+        { agent_name, hours = 24 }: { agent_name?: string; hours?: number },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const authContext = context?.session;
+        const apiClient = getClient(authContext);
+
+        // If agent_name is specified, check access
+        if (agent_name) {
+          const accessCheck = await checkAgentAccess(apiClient, authContext, agent_name);
+          if (!accessCheck.allowed) {
+            console.log(`[get_agent_activity_summary] Access denied: ${accessCheck.reason}`);
+            return JSON.stringify({
+              error: "Access denied",
+              reason: accessCheck.reason,
+            }, null, 2);
+          }
+        }
+
+        const effectiveHours = Math.min(Math.max(1, hours), 168);
+        const startTime = new Date(Date.now() - effectiveHours * 60 * 60 * 1000).toISOString();
+
+        const timeline = await apiClient.getActivityTimeline({
+          start_time: startTime,
+          limit: 500,
+        });
+
+        // Filter to specific agent if requested
+        const activities = agent_name
+          ? timeline.activities.filter(a => a.agent_name === agent_name)
+          : timeline.activities;
+
+        // Aggregate by type and state
+        const byType: Record<string, Record<string, number>> = {};
+        const byAgent: Record<string, number> = {};
+
+        for (const activity of activities) {
+          const type = activity.activity_type;
+          const state = activity.activity_state;
+
+          if (!byType[type]) byType[type] = {};
+          byType[type][state] = (byType[type][state] || 0) + 1;
+
+          byAgent[activity.agent_name] = (byAgent[activity.agent_name] || 0) + 1;
+        }
+
+        console.log(`[get_agent_activity_summary] Summarized ${activities.length} activities${agent_name ? ` for '${agent_name}'` : ""} over ${effectiveHours}h`);
+
+        return JSON.stringify({
+          agent_name: agent_name || "all",
+          hours: effectiveHours,
+          total_activities: activities.length,
+          by_type: byType,
+          by_agent: agent_name ? undefined : byAgent,
+        }, null, 2);
+      },
+    },
+  };
+}

--- a/src/mcp-server/src/tools/index.ts
+++ b/src/mcp-server/src/tools/index.ts
@@ -7,6 +7,7 @@
 export { createAgentTools } from "./agents.js";
 export { createChatTools } from "./chat.js";
 export { createDocsTools } from "./docs.js";
+export { createExecutionTools } from "./executions.js";
 export { createSkillsTools } from "./skills.js";
 export { createSubscriptionTools } from "./subscriptions.js";
 export { createNeverminedTools } from "./nevermined.js";

--- a/src/mcp-server/src/types.ts
+++ b/src/mcp-server/src/types.ts
@@ -195,6 +195,35 @@ export interface ScheduleExecution {
   context_used?: number;
   context_max?: number;
   cost?: number;
+  tool_calls?: string;
+  execution_log?: string;
+  model_used?: string;
+  claude_session_id?: string;
+  source_agent_name?: string;
+  source_user_email?: string;
+}
+
+// Execution Query Types (MCP-007)
+
+export interface ActivityTimelineResponse {
+  count: number;
+  start_time?: string;
+  end_time?: string;
+  activity_types?: string[];
+  activities: ActivityEntry[];
+}
+
+export interface ActivityEntry {
+  id: string;
+  agent_name: string;
+  activity_type: string;
+  activity_state: string;
+  started_at: string;
+  completed_at?: string;
+  duration_ms?: number;
+  triggered_by: string;
+  details?: string;
+  error?: string;
 }
 
 export interface ScheduleToggleResult {


### PR DESCRIPTION
## Summary

- Three new MCP tools (`list_recent_executions`, `get_execution_result`, `get_agent_activity_summary`) enabling agents to query execution history and poll for async task results
- Closes the async agent-to-agent collaboration loop: `chat_with_agent(async=true)` returns `execution_id`, then `get_execution_result(id)` polls until complete — bypassing the 60-second MCP timeout
- No backend changes — all tools wrap existing REST endpoints with the same auth pattern as existing 59 tools
- Total MCP tools: 59 → 62

## Changes

**MCP Server (5 files):**
- `src/mcp-server/src/tools/executions.ts` — NEW: 3 tools with agent-scoped access control
- `src/mcp-server/src/client.ts` — Added `getExecution()`, `getExecutionLog()`, `getActivityTimeline()`
- `src/mcp-server/src/types.ts` — Added `ActivityTimelineResponse`, `ActivityEntry`, extended `ScheduleExecution`
- `src/mcp-server/src/server.ts` — Register 3 new tools
- `src/mcp-server/src/tools/index.ts` — Export

**Documentation (8 files):**
- `docs/memory/changelog.md`, `requirements.md`, `architecture.md` — Feature documented
- `docs/requirements/MCP_EXECUTION_QUERY_TOOLS.md` — Status → Implemented
- `docs/memory/feature-flows/mcp-orchestration.md` — Added MCP polling examples
- `docs/KNOWN_ISSUES.md` — Updated 60s timeout workaround with `get_execution_result`
- `CLAUDE.md`, `README.md` — Updated tool counts

## Test plan

- [x] TypeScript compiles cleanly
- [x] MCP server starts with 62 tools registered
- [x] Level 1: All 3 tools return correct data via MCP Streamable HTTP protocol
- [x] Level 2: mem-agent async polls trinity-system through 90-second task (4 polls)
- [x] Level 2: mem-agent async polls trinity-system through 180-second task (6 polls, ~3.5 min total)
- [x] Auth: Agent-scoped keys can only access self or permitted agents

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)