### PR TITLE
fix: Subscription registration fails silently when CREDENTIAL_ENCRYPTION_KEY is not set (#148)

### DIFF
--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,5 +1,17 @@
 ### 2026-03-25
 
+**fix: Subscription registration fails silently when CREDENTIAL_ENCRYPTION_KEY is not set (#148)**
+
+Fresh Trinity deployments had no `CREDENTIAL_ENCRYPTION_KEY` configured, causing subscription registration to fail with a 500 error that was not clearly communicated to the user. Three fixes applied:
+
+1. `scripts/deploy/start.sh` now auto-generates `CREDENTIAL_ENCRYPTION_KEY` if missing from `.env`, so new deployments work out of the box.
+2. Backend adds `GET /api/subscriptions/encryption-status` endpoint and returns HTTP 503 with actionable instructions when the key is missing (instead of a generic 500).
+3. Frontend checks encryption status on page load and shows a yellow warning banner with setup instructions when not configured, disabling the Register button.
+
+- `scripts/deploy/start.sh` — Auto-generate CREDENTIAL_ENCRYPTION_KEY on startup if empty
+- `src/backend/routers/subscriptions.py` — Added `/encryption-status` endpoint; early validation in `register_subscription()` returns 503
+- `src/frontend/src/views/Settings.vue` — `encryptionConfigured` ref, warning banner, disabled button
+
 ✨ **Auto-assign subscription to new agents via round-robin (#74)**
 
 When creating a new agent, Trinity now automatically assigns a subscription using round-robin distribution (fewest agents first, alphabetical tie-break). Removes the manual step of assigning subscriptions after agent creation. Falls back to platform API key if no subscriptions exist or token decryption fails. System agents are unaffected (separate creation path).

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-03-25 | #148 | Fix silent subscription registration failure — encryption key auto-generation, status endpoint, frontend warning | [subscription-management.md](feature-flows/subscription-management.md) |
 | 2026-03-25 | #74 | Auto-assign subscription to new agents (round-robin, rate-limit aware) | [subscription-management.md](feature-flows/subscription-management.md) |
 | 2026-03-23 | VOICE-001 | Voice Chat — real-time voice conversations with agents via Gemini Live API | [voice-chat.md](feature-flows/voice-chat.md) |
 | 2026-03-21 | SUB-003 | Auto-switch subscriptions on repeated rate-limit errors — setting, tracking, orchestration | [subscription-auto-switch.md](feature-flows/subscription-auto-switch.md) |

--- a/docs/memory/feature-flows/subscription-management.md
+++ b/docs/memory/feature-flows/subscription-management.md
@@ -108,8 +108,9 @@ create_agent_internal()
 | **Agent Detail: AgentHeader subscription switcher** | `GET /api/subscriptions` | Load available subscriptions for dropdown (admin-only) |
 | **Agent Detail: AgentHeader subscription switcher** | `PUT /api/subscriptions/agents/{agent_name}?subscription_name={name}` | Assign subscription from dropdown |
 | **Agent Detail: AgentHeader subscription switcher** | `DELETE /api/subscriptions/agents/{agent_name}` | Revert to API Key from dropdown |
+| **Settings Page: Claude Subscriptions** | `GET /api/subscriptions/encryption-status` | Check if CREDENTIAL_ENCRYPTION_KEY is configured (shows warning banner if not) |
 | **Settings Page: Claude Subscriptions** | `GET /api/subscriptions` | List subscriptions (Settings UI) |
-| **Settings Page: Add Subscription** | `POST /api/subscriptions` | Register via token input |
+| **Settings Page: Add Subscription** | `POST /api/subscriptions` | Register via token input (returns 503 if encryption key missing) |
 | **Settings Page: Delete Button** | `DELETE /api/subscriptions/{id}` | Delete with cascade confirmation |
 | MCP Tool: `register_subscription` | `POST /api/subscriptions` | Register new subscription |
 | MCP Tool: `list_subscriptions` | `GET /api/subscriptions` | List all subscriptions with agents |
@@ -550,7 +551,20 @@ async registerSubscription(
 }
 ```
 
-### Backend Endpoint (`src/backend/routers/subscriptions.py:40-79`)
+### Encryption Status Check (`src/backend/routers/subscriptions.py:41-48`)
+
+```python
+@router.get("/encryption-status")
+async def get_encryption_status(current_user: User = Depends(get_current_user)):
+    """Check if credential encryption is configured for subscriptions."""
+    require_admin(current_user)
+    key = os.getenv("CREDENTIAL_ENCRYPTION_KEY")
+    return {"configured": bool(key and len(key) >= 64)}
+```
+
+Frontend calls this on Settings page load. If `configured: false`, a yellow warning banner is shown and the Register button is disabled.
+
+### Backend Endpoint (`src/backend/routers/subscriptions.py:51-99`)
 
 ```python
 @router.post("", response_model=SubscriptionCredential)
@@ -562,19 +576,13 @@ async def register_subscription(
     Token must start with `sk-ant-oat01-` (Claude Code OAuth access token)."""
     require_admin(current_user)
 
+    # Early validation — returns 503 with actionable instructions if key missing
+    encryption_key = os.getenv("CREDENTIAL_ENCRYPTION_KEY")
+    if not encryption_key:
+        raise HTTPException(status_code=503, detail="...")
+
     user = db.get_user_by_username(current_user.username)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-
-    subscription = db.create_subscription(
-        name=request.name,
-        token=request.token,
-        owner_id=user["id"],
-        subscription_type=request.subscription_type,
-        rate_limit_tier=request.rate_limit_tier,
-    )
-
-    logger.info(f"Registered subscription '{request.name}' by {current_user.username}")
+    subscription = db.create_subscription(...)
     return subscription
 ```
 

--- a/scripts/deploy/start.sh
+++ b/scripts/deploy/start.sh
@@ -16,6 +16,17 @@ if [ ! -f .env ]; then
     echo ""
 fi
 
+# Auto-generate CREDENTIAL_ENCRYPTION_KEY if not set
+if grep -qE '^CREDENTIAL_ENCRYPTION_KEY=$' .env 2>/dev/null || ! grep -q 'CREDENTIAL_ENCRYPTION_KEY' .env 2>/dev/null; then
+    NEW_KEY=$(openssl rand -hex 32)
+    if grep -q 'CREDENTIAL_ENCRYPTION_KEY' .env; then
+        sed -i.bak "s/^CREDENTIAL_ENCRYPTION_KEY=$/CREDENTIAL_ENCRYPTION_KEY=${NEW_KEY}/" .env && rm -f .env.bak
+    else
+        echo "CREDENTIAL_ENCRYPTION_KEY=${NEW_KEY}" >> .env
+    fi
+    echo "Auto-generated CREDENTIAL_ENCRYPTION_KEY"
+fi
+
 echo "Starting services..."
 docker compose up -d
 

--- a/src/backend/routers/subscriptions.py
+++ b/src/backend/routers/subscriptions.py
@@ -10,6 +10,7 @@ subscription is assigned, ANTHROPIC_API_KEY is removed from the container.
 """
 
 import logging
+import os
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import Optional, List
 
@@ -37,6 +38,16 @@ def require_admin(current_user: User):
 # Subscription CRUD
 # ============================================================================
 
+@router.get("/encryption-status")
+async def get_encryption_status(
+    current_user: User = Depends(get_current_user)
+):
+    """Check if credential encryption is configured for subscriptions."""
+    require_admin(current_user)
+    key = os.getenv("CREDENTIAL_ENCRYPTION_KEY")
+    return {"configured": bool(key and len(key) >= 64)}
+
+
 @router.post("", response_model=SubscriptionCredential)
 async def register_subscription(
     request: SubscriptionCredentialCreate,
@@ -52,6 +63,15 @@ async def register_subscription(
     Token must start with `sk-ant-oat01-` (Claude Code OAuth access token).
     """
     require_admin(current_user)
+
+    # Validate encryption key before attempting storage
+    encryption_key = os.getenv("CREDENTIAL_ENCRYPTION_KEY")
+    if not encryption_key:
+        raise HTTPException(
+            status_code=503,
+            detail="Subscription registration requires the CREDENTIAL_ENCRYPTION_KEY environment variable. "
+                   "Add it to your .env file (generate with: openssl rand -hex 32) and restart the backend."
+        )
 
     try:
         # Get the user's ID

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -390,6 +390,24 @@
 
             <div class="px-6 py-4">
               <div class="space-y-4">
+                <!-- Encryption Not Configured Warning -->
+                <div v-if="!encryptionConfigured" class="bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+                  <div class="flex">
+                    <div class="flex-shrink-0">
+                      <svg class="h-5 w-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                      </svg>
+                    </div>
+                    <div class="ml-3">
+                      <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-300">Encryption not configured</h3>
+                      <p class="mt-1 text-sm text-yellow-700 dark:text-yellow-400">
+                        Subscription storage requires <code class="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900 rounded text-xs">CREDENTIAL_ENCRYPTION_KEY</code> in your <code class="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900 rounded text-xs">.env</code> file.
+                        Generate with: <code class="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900 rounded text-xs">openssl rand -hex 32</code> and restart the backend.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
                 <!-- Add Subscription Form -->
                 <div class="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
                   <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Add Subscription</h3>
@@ -460,7 +478,7 @@
                     </button>
                     <button
                       @click="addSubscription"
-                      :disabled="!newSubscription.name || !newSubscription.token.startsWith('sk-ant-oat01-') || addingSubscription"
+                      :disabled="!newSubscription.name || !newSubscription.token.startsWith('sk-ant-oat01-') || addingSubscription || !encryptionConfigured"
                       class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <svg v-if="addingSubscription" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
@@ -1290,6 +1308,7 @@ const loadingSubscriptions = ref(false)
 const addingSubscription = ref(false)
 const deletingSubscription = ref(null)
 const expandedSubscriptions = ref(new Set())
+const encryptionConfigured = ref(true)
 const newSubscription = ref({
   name: '',
   type: 'max',
@@ -1900,6 +1919,17 @@ async function generateDefaultAvatars() {
 async function loadSubscriptions() {
   loadingSubscriptions.value = true
   try {
+    // Check encryption status first
+    try {
+      const statusResponse = await axios.get('/api/subscriptions/encryption-status', {
+        headers: authStore.authHeader
+      })
+      encryptionConfigured.value = statusResponse.data?.configured ?? true
+    } catch {
+      // Endpoint may not exist on older backends - assume configured
+      encryptionConfigured.value = true
+    }
+
     const response = await axios.get('/api/subscriptions', {
       headers: authStore.authHeader
     })


### PR DESCRIPTION
## Summary
- Auto-generate `CREDENTIAL_ENCRYPTION_KEY` in `start.sh` so new deployments work out of the box
- Add `GET /api/subscriptions/encryption-status` endpoint; return HTTP 503 with actionable instructions instead of generic 500
- Frontend checks encryption status on page load, shows yellow warning banner with setup steps, disables Register button

## Changes
- `scripts/deploy/start.sh` — auto-generate key if empty in `.env`
- `src/backend/routers/subscriptions.py` — new endpoint + early validation
- `src/frontend/src/views/Settings.vue` — encryption status check, warning banner, disabled button
- `docs/memory/changelog.md` — changelog entry

## Test Plan
- [x] Remove `CREDENTIAL_ENCRYPTION_KEY` from `.env`, run `./scripts/deploy/start.sh` — key auto-generated
- [x] `GET /api/subscriptions/encryption-status` returns `{"configured": true/false}`
- [x] With key unset: Settings shows yellow warning, Register button disabled
- [x] With key set: register subscription works normally
- [x] With key unset but POST forced: returns 503 with clear error message

Closes #148

Generated with [Claude Code](https://claude.com/claude-code)