### PR TITLE
fix: Pass FRONTEND_URL to backend container + remove silent localhost…

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,8 @@ services:
       - OTEL_METRIC_EXPORT_INTERVAL=${OTEL_METRIC_EXPORT_INTERVAL:-60000}
       # Public external access URL (Tailscale Funnel, Cloudflare Tunnel, etc.)
       - PUBLIC_CHAT_URL=${PUBLIC_CHAT_URL:-}
+      # Frontend URL for post-OAuth redirects
+      - FRONTEND_URL=${FRONTEND_URL:-}
       # Internal API shared secret (C-003) - for scheduler/agent communication
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
     volumes:

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -38,7 +38,7 @@ if _redis_password and "://@" not in _redis_base_url and "://:" not in _redis_ba
 else:
     REDIS_URL = _redis_base_url
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
-FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost")  # Port 80 default (Docker)
+FRONTEND_URL = os.getenv("FRONTEND_URL", "")  # Set in .env or docker-compose for OAuth redirects
 
 # External URL for public chat links (Tailscale Funnel, Cloudflare Tunnel, etc.)
 # When set, enables "Copy External Link" button in PublicLinksPanel

--- a/src/backend/services/slack_service.py
+++ b/src/backend/services/slack_service.py
@@ -460,7 +460,10 @@ class SlackService:
         source: str = "agent"
     ) -> str:
         """Get the redirect URL after OAuth completion."""
-        base_url = FRONTEND_URL or "http://localhost"
+        base_url = FRONTEND_URL
+        if not base_url:
+            logger.error("FRONTEND_URL not configured — OAuth redirect will fail. Set FRONTEND_URL in .env")
+            base_url = "http://localhost"
         if source == "platform":
             if success:
                 return f"{base_url}/settings?slack=installed"


### PR DESCRIPTION
… fallback

FRONTEND_URL was not listed in docker-compose.prod.yml environment section, so the .env value never reached the container. OAuth callback redirected to http://localhost even when FRONTEND_URL was configured.

- docker-compose.prod.yml: add FRONTEND_URL=${FRONTEND_URL:-} to backend env
- config.py: remove http://localhost default (empty string instead)
- slack_service.py: log error when FRONTEND_URL not set instead of silent fallback

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] I have tested this locally
- [ ] New tests added (if applicable)
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation (if applicable)
- [ ] I have not committed any sensitive data (API keys, credentials, etc.)
- [ ] I have added appropriate logging for new functionality

## Screenshots (if applicable)

Add screenshots to help explain your changes.
