### PR TITLE
fix: Add adapters/ to backend Dockerfile and deploy script

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -41,6 +41,7 @@ COPY ../../src/backend/logging_config.py /app/
 # Copy module directories
 COPY ../../src/backend/routers /app/routers/
 COPY ../../src/backend/services /app/services/
+COPY ../../src/backend/adapters /app/adapters/
 COPY ../../src/backend/utils /app/utils/
 COPY ../../src/backend/db /app/db/
 
@@ -50,8 +51,8 @@ COPY ../../config/process-templates /app/config/process-templates/
 
 # Ensure all files are readable
 RUN chmod -R 644 /app/*.py && \
-    chmod -R 755 /app/routers /app/services /app/utils /app/db && \
-    find /app/routers /app/services /app/utils /app/db -name "*.py" -exec chmod 644 {} \;
+    chmod -R 755 /app/routers /app/services /app/adapters /app/utils /app/db && \
+    find /app/routers /app/services /app/adapters /app/utils /app/db -name "*.py" -exec chmod 644 {} \;
 
 EXPOSE 8000
 

--- a/scripts/deploy/gcp-deploy.sh
+++ b/scripts/deploy/gcp-deploy.sh
@@ -93,7 +93,7 @@ sync_files() {
     mkdir -p "${TEMP_DIR}/src/backend"
     cp "${PROJECT_ROOT}/src/backend/"*.py "${TEMP_DIR}/src/backend/" 2>/dev/null || true
     # Copy routers, services, utils, db modules
-    for module in routers services utils db; do
+    for module in routers services adapters utils db; do
         if [ -d "${PROJECT_ROOT}/src/backend/${module}" ]; then
             rsync -a --exclude '__pycache__' "${PROJECT_ROOT}/src/backend/${module}" "${TEMP_DIR}/src/backend/"
         fi


### PR DESCRIPTION
The adapters/ module (channel adapters for Slack SLACK-002) was missing from both the Dockerfile COPY commands and gcp-deploy.sh sync list, causing ModuleNotFoundError on production deployments.

- docker/backend/Dockerfile: COPY adapters/ + chmod
- scripts/deploy/gcp-deploy.sh: add adapters to module sync list

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] I have tested this locally
- [ ] New tests added (if applicable)
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation (if applicable)
- [ ] I have not committed any sensitive data (API keys, credentials, etc.)
- [ ] I have added appropriate logging for new functionality

## Screenshots (if applicable)

Add screenshots to help explain your changes.
