### PR TITLE
fix: MCP server healthcheck always fails (localhost → 127.0.0.1) (#142)

### DIFF
--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,11 @@
+### 2026-03-27
+
+**fix: MCP server healthcheck always fails — localhost resolves to IPv6 (#142)**
+
+The Dockerfile HEALTHCHECK used `localhost` which resolves to `[::1]` (IPv6) inside Alpine containers, but the Node.js server binds to `0.0.0.0:8080` (IPv4 only). Changed to `127.0.0.1` (explicit IPv4). Also bumped `start-period` from 5s to 10s.
+
+- `src/mcp-server/Dockerfile` — Fixed HEALTHCHECK to use `127.0.0.1` instead of `localhost`
+
 ### 2026-03-23
 
 **feat: Voice Chat — real-time voice conversations with agents via Gemini Live API (VOICE-001)**

--- a/src/mcp-server/Dockerfile
+++ b/src/mcp-server/Dockerfile
@@ -27,8 +27,8 @@ ENV MCP_PORT=8080
 ENV TRINITY_API_URL=http://backend:8000
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/mcp || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/mcp || exit 1
 
 # Run the server
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- Fix Docker HEALTHCHECK using `localhost` which resolves to IPv6 `[::1]` in Alpine, while Node.js binds IPv4 `0.0.0.0:8080`
- Changed to `127.0.0.1` (explicit IPv4 loopback) so the healthcheck connects successfully
- Bumped `start-period` from 5s to 10s for startup margin

## Changes
- `src/mcp-server/Dockerfile` — HEALTHCHECK: `localhost` → `127.0.0.1`, start-period 5s → 10s
- `docs/memory/changelog.md` — Added entry

## Test Plan
- [ ] `docker build -t trinity-mcp-server src/mcp-server/` succeeds
- [ ] After deploy, `docker ps | grep mcp-server` shows `(healthy)` instead of `(unhealthy)`
- [ ] `docker exec trinity-mcp-server wget -q -O - http://127.0.0.1:8080/mcp` returns success

Closes #142

Generated with [Claude Code](https://claude.com/claude-code)