### PR TITLE
refactor: Clean up dead code — unused imports across 4 files (#126)

### DIFF
--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,14 @@
+### 2026-03-27
+
+**refactor: Clean up dead code — unused imports across 4 files (#126)**
+
+Removed 11 unused imports detected by Vulture (80%+ confidence). Verified via grep that none are re-exported or referenced by other modules.
+
+- `src/backend/database.py` — Removed 8 unused re-exports: `AgentOwnership`, `AgentPermissionInfo`, `EmailWhitelistEntry`, `HealthCheckRecord`, `HealthCheckType`, `McpAgentKeyCreate`, `SharedFolderConfigUpdate`, `SharedFolderInfo`
+- `src/backend/routers/monitoring.py` — Removed unused `HealthCheckRecord` import
+- `src/backend/services/monitoring_service.py` — Removed unused `HealthCheckType` import
+- `src/backend/services/process_engine/events/websocket_publisher.py` — Removed unused `asdict` import
+
 ### 2026-03-26
 
 🔒 **fix(security): Broken access control — user-level horizontal privilege escalation (#174)**

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -29,13 +29,11 @@ from pathlib import Path
 from db_models import (
     UserCreate,
     User,
-    AgentOwnership,
     AgentShare,
     AgentShareRequest,
     McpApiKeyCreate,
     McpApiKey,
     McpApiKeyWithSecret,
-    McpAgentKeyCreate,
     ScheduleCreate,
     Schedule,
     ScheduleExecution,
@@ -44,11 +42,8 @@ from db_models import (
     ChatSession,
     ChatMessage,
     AgentPermission,
-    AgentPermissionInfo,
     SharedFolderConfig,
-    SharedFolderConfigUpdate,
     SharedFolderMount,
-    SharedFolderInfo,
     SystemSetting,
     SystemSettingUpdate,
     # Public Agent Links (Phase 12.2)
@@ -66,7 +61,6 @@ from db_models import (
     PublicChatSession,
     PublicChatMessage,
     # Email Authentication (Phase 12.4)
-    EmailWhitelistEntry,
     EmailWhitelistAdd,
     EmailLoginRequest,
     EmailLoginVerify,
@@ -90,7 +84,6 @@ from db_models import (
     AgentEventList,
     # Monitoring Models (MON-001)
     AgentHealthStatus,
-    HealthCheckType,
     DockerHealthCheck,
     NetworkHealthCheck,
     BusinessHealthCheck,
@@ -99,7 +92,6 @@ from db_models import (
     FleetHealthSummary,
     FleetHealthStatus,
     MonitoringConfig,
-    HealthCheckRecord,
 )
 
 # Re-export connection utilities

--- a/src/backend/routers/monitoring.py
+++ b/src/backend/routers/monitoring.py
@@ -22,7 +22,6 @@ from db_models import (
     FleetHealthSummary,
     AgentHealthDetail,
     AgentHealthSummary,
-    HealthCheckRecord,
 )
 from services.monitoring_service import (
     perform_health_check,

--- a/src/backend/services/monitoring_service.py
+++ b/src/backend/services/monitoring_service.py
@@ -22,7 +22,6 @@ import httpx
 from database import db
 from db_models import (
     AgentHealthStatus,
-    HealthCheckType,
     DockerHealthCheck,
     NetworkHealthCheck,
     BusinessHealthCheck,

--- a/src/backend/services/process_engine/events/websocket_publisher.py
+++ b/src/backend/services/process_engine/events/websocket_publisher.py
@@ -7,7 +7,6 @@ Part of the Process-Driven Platform feature.
 
 import json
 import logging
-from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Callable, Optional, Set
 


### PR DESCRIPTION
## Summary
- Removed 11 unused imports across 4 backend files, detected by Vulture at 80%+ confidence
- Each import verified via grep to confirm it's not re-exported or referenced by other modules
- Zero functional changes — only dead import removal

## Changes
- `src/backend/database.py` — 8 unused re-exports removed
- `src/backend/routers/monitoring.py` — 1 unused import removed
- `src/backend/services/monitoring_service.py` — 1 unused import removed
- `src/backend/services/process_engine/events/websocket_publisher.py` — 1 unused import removed
- `docs/memory/changelog.md` — Added entry

## Test Plan
- [x] All 4 files pass Python syntax check (`py_compile`)
- [x] No re-export consumers found via codebase-wide grep
- [ ] Existing tests unaffected (no test venv in workspace; CI will validate)

Closes #126

Generated with [Claude Code](https://claude.com/claude-code)