### PR TITLE
fix: Add authentication to unauthenticated info disclosure endpoints (#180)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,7 +82,7 @@ services:
     # Production: no --reload flag
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --workers 2 --timeout-worker-healthcheck 120
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/setup/status"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -182,6 +182,24 @@ Added pluggable channel adapter architecture for external messaging platforms (S
 
 ---
 
+### 2026-03-27
+
+**fix: Add authentication to unauthenticated information disclosure endpoints (SEC-180, pentest 3.2.3)**
+
+Addresses pentest finding 3.2.3 (Medium, CVSS 5.1). Five endpoints previously exposed sensitive system information without authentication: telemetry host/container stats, platform version, health check, and OAuth provider configuration. All now require Bearer token authentication via `get_current_user`. The telemetry endpoints no longer follow the OpenTelemetry unauthenticated convention — this was an intentional reversal to address the information disclosure risk.
+
+**Backend:**
+- `src/backend/routers/telemetry.py` — Added `Depends(get_current_user)` to `/host` and `/containers`
+- `src/backend/main.py` — Added `Depends(get_current_user)` to `/health` and `/api/version`
+- `src/backend/routers/credentials.py` — Added `Depends(get_current_user)` to `/oauth/providers`
+- `docker-compose.prod.yml` — Updated backend healthcheck to use `/api/setup/status` (unauthenticated) since `/health` now requires auth
+
+**Frontend:**
+- `src/frontend/src/components/HostTelemetry.vue` — Added auth headers to telemetry fetch, handles 401 gracefully
+
+**Tests:**
+- `tests/test_telemetry.py` — Flipped no-auth tests to assert 401, added auth tests for version/health/OAuth
+
 ### 2026-03-23
 
 **feat: Voice Chat — real-time voice conversations with agents via Gemini Live API (VOICE-001)**

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-03-27 | SEC-180 | Auth added to telemetry, version, health, OAuth endpoints (pentest 3.2.3) | [host-telemetry.md](feature-flows/host-telemetry.md) |
 | 2026-03-26 | EVT-001 | Agent Event Subscriptions — lightweight pub/sub for inter-agent pipelines | [agent-event-subscriptions.md](feature-flows/agent-event-subscriptions.md) |
 | 2026-03-25 | #148 | Fix silent subscription registration failure — encryption key auto-generation, status endpoint, frontend warning | [subscription-management.md](feature-flows/subscription-management.md) |
 | 2026-03-25 | #74 | Auto-assign subscription to new agents (round-robin, rate-limit aware) | [subscription-management.md](feature-flows/subscription-management.md) |

--- a/docs/memory/feature-flows/host-telemetry.md
+++ b/docs/memory/feature-flows/host-telemetry.md
@@ -73,8 +73,9 @@ No Pinia store - component manages its own state:
 ### API Calls
 
 ```javascript
-// HostTelemetry.vue:30-35
+// HostTelemetry.vue:31-36 — requires auth headers (pentest 3.2.3)
 const hostRes = await fetch(`${API_BASE}/api/telemetry/host`, {
+  headers: authStore.authHeader,
   signal: AbortSignal.timeout(3000)
 })
 ```
@@ -104,7 +105,7 @@ app.include_router(telemetry_router)
 
 Returns host system statistics via psutil.
 
-**No authentication required** (follows OpenTelemetry pattern).
+**Requires authentication** (`Depends(get_current_user)`) — added per pentest finding 3.2.3.
 
 **Response Schema:**
 ```json
@@ -145,7 +146,7 @@ disk = psutil.disk_usage('/')
 
 Returns aggregate statistics across all running agent containers.
 
-**No authentication required**.
+**Requires authentication** (`Depends(get_current_user)`) — added per pentest finding 3.2.3.
 
 **Response Schema:**
 ```json
@@ -251,7 +252,7 @@ Dashboard.vue
 - **No WebSocket**: Pure polling model
 - **No Audit Logging**: Telemetry endpoints are read-only, high-frequency
 - **No Database**: Metrics are computed fresh each request
-- **No Authentication**: Public endpoints (infrastructure monitoring should be accessible)
+- **Authentication Required**: Bearer token via `get_current_user` (added per pentest 3.2.3)
 
 ---
 
@@ -280,10 +281,11 @@ signal: AbortSignal.timeout(3000)
 
 ## Security Considerations
 
-- **No Authentication Required**: Follows OTel pattern for infrastructure metrics
+- **Authentication Required**: Bearer token via `Depends(get_current_user)` — pentest finding 3.2.3 (CVSS 5.1) identified unauthenticated info disclosure risk. Previously followed OTel pattern (no auth).
 - **Read-Only**: No mutation endpoints
 - **Rate Limiting**: Not implemented (polling interval is client-controlled)
 - **No PII**: Only system metrics exposed
+- **Frontend 401 Handling**: Clears stale data on auth failure instead of showing frozen charts
 
 ---
 
@@ -312,11 +314,12 @@ signal: AbortSignal.timeout(3000)
 | 3 | Wait 5 seconds | Values update | Numbers change |
 | 4 | Check color coding | Values <50% are green | Color matches threshold |
 
-#### Test 2: API Direct Access
+#### Test 2: API Direct Access (requires auth)
 | Step | Action | Expected | Verify |
 |------|--------|----------|--------|
-| 1 | `curl http://localhost:8000/api/telemetry/host` | JSON response | Contains cpu, memory, disk |
-| 2 | `curl http://localhost:8000/api/telemetry/containers` | JSON response | Contains running_count, containers array |
+| 1 | `curl http://localhost:8000/api/telemetry/host` (no auth) | 401 Unauthorized | Auth enforced |
+| 2 | `curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/telemetry/host` | JSON response | Contains cpu, memory, disk |
+| 3 | `curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/telemetry/containers` | JSON response | Contains running_count, containers array |
 
 #### Test 3: Container Stats (OBS-012)
 | Step | Action | Expected | Verify |
@@ -347,4 +350,5 @@ No cleanup required - read-only endpoints.
 
 | Date | Change |
 |------|--------|
+| 2026-03-27 | Added authentication requirement per pentest finding 3.2.3 (#180) |
 | 2026-01-13 | Initial documentation |

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -625,15 +625,15 @@ async def websocket_events_endpoint(
 
 # Health check endpoint
 @app.get("/health")
-async def health_check():
-    """Health check endpoint."""
+async def health_check(current_user: User = Depends(get_current_user)):
+    """Health check endpoint. Requires authentication (pentest finding 3.2.3)."""
     return {"status": "healthy", "timestamp": datetime.now()}
 
 
 # Version endpoint
 @app.get("/api/version")
-async def get_version():
-    """Get Trinity platform version information."""
+async def get_version(current_user: User = Depends(get_current_user)):
+    """Get Trinity platform version information. Requires authentication (pentest finding 3.2.3)."""
     import os
     from pathlib import Path
 

--- a/src/backend/routers/credentials.py
+++ b/src/backend/routers/credentials.py
@@ -122,8 +122,8 @@ async def init_oauth(
 
 
 @router.get("/oauth/providers")
-async def list_oauth_providers():
-    """List available OAuth providers."""
+async def list_oauth_providers(current_user: User = Depends(get_current_user)):
+    """List available OAuth providers. Requires authentication (pentest finding 3.2.3)."""
     oauth_scopes = {
         "google": ["openid", "email", "profile", "drive"],
         "github": ["repo", "user"],

--- a/src/backend/routers/telemetry.py
+++ b/src/backend/routers/telemetry.py
@@ -11,8 +11,10 @@ import psutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import List, Dict, Any, Optional
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from dependencies import get_current_user
+from models import User
 from services.docker_service import docker_client, list_all_agents_fast
 
 # Module-level executor for Docker operations (blocking calls)
@@ -27,12 +29,12 @@ psutil.cpu_percent(interval=None)
 
 
 @router.get("/host")
-async def get_host_stats():
+async def get_host_stats(current_user: User = Depends(get_current_user)):
     """
     Get host system statistics using psutil.
 
     Returns CPU, memory, and disk usage metrics.
-    No authentication required (follows OTel pattern).
+    Requires authentication (pentest finding 3.2.3).
     """
     try:
         # CPU - use interval=None to get last computed value (non-blocking)
@@ -110,13 +112,13 @@ def _get_single_container_stats_sync(agent_name: str) -> Dict[str, Any]:
 
 
 @router.get("/containers")
-async def get_container_stats():
+async def get_container_stats(current_user: User = Depends(get_current_user)):
     """
     Get aggregate statistics across all running agent containers.
 
     Returns total CPU usage, memory consumption, and per-container breakdown.
     Uses parallel execution for better performance with multiple containers.
-    No authentication required (follows OTel pattern).
+    Requires authentication (pentest finding 3.2.3).
     """
     if not docker_client:
         raise HTTPException(status_code=503, detail="Docker not available")

--- a/src/frontend/src/components/HostTelemetry.vue
+++ b/src/frontend/src/components/HostTelemetry.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
+import { useAuthStore } from '@/stores/auth'
 import SparklineChart from './SparklineChart.vue'
 
 const API_BASE = import.meta.env.VITE_API_BASE || ''
+const authStore = useAuthStore()
 
 // History configuration: 60 samples at 5s intervals = 5 minutes
 const MAX_POINTS = 60
@@ -26,10 +28,16 @@ function initHistory() {
 
 async function fetchStats() {
   try {
-    // Fetch host stats
+    // Fetch host stats (requires authentication — pentest finding 3.2.3)
     const hostRes = await fetch(`${API_BASE}/api/telemetry/host`, {
+      headers: authStore.authHeader,
       signal: AbortSignal.timeout(3000)
     }).catch(() => null)
+
+    if (hostRes?.status === 401) {
+      hostStats.value = null
+      return
+    }
 
     if (hostRes?.ok) {
       hostStats.value = await hostRes.json()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -68,11 +68,10 @@ class TestHostTelemetry:
         # Timestamp should be an ISO format string
         assert isinstance(data["timestamp"], str)
 
-    def test_host_no_auth_required(self, unauthenticated_client: TrinityApiClient):
-        """GET /api/telemetry/host does not require authentication."""
-        # Telemetry follows OpenTelemetry pattern - no auth required
+    def test_host_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        """GET /api/telemetry/host requires authentication (pentest 3.2.3)."""
         response = unauthenticated_client.get("/api/telemetry/host", auth=False)
-        assert_status(response, 200)
+        assert_status(response, 401)
 
     def test_host_cpu_count_present(self, api_client: TrinityApiClient):
         """GET /api/telemetry/host includes CPU count."""
@@ -203,14 +202,54 @@ class TestContainerTelemetry:
         assert "timestamp" in data
         assert isinstance(data["timestamp"], str)
 
-    def test_containers_no_auth_required(
+    def test_containers_requires_auth(
         self,
         unauthenticated_client: TrinityApiClient
     ):
-        """GET /api/telemetry/containers does not require authentication."""
-        # Telemetry follows OpenTelemetry pattern - no auth required
+        """GET /api/telemetry/containers requires authentication (pentest 3.2.3)."""
         response = unauthenticated_client.get("/api/telemetry/containers", auth=False)
+        assert_status(response, 401)
+
+
+class TestEndpointAuthentication:
+    """Pentest 3.2.3: Verify previously-unauthenticated endpoints now require auth."""
+
+    def test_version_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        """GET /api/version requires authentication."""
+        response = unauthenticated_client.get("/api/version", auth=False)
+        assert_status(response, 401)
+
+    def test_health_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        """GET /health requires authentication."""
+        response = unauthenticated_client.get("/health", auth=False)
+        assert_status(response, 401)
+
+    def test_oauth_providers_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        """GET /api/oauth/providers requires authentication."""
+        response = unauthenticated_client.get("/api/oauth/providers", auth=False)
+        assert_status(response, 401)
+
+    def test_version_accessible_with_auth(self, api_client: TrinityApiClient):
+        """GET /api/version returns 200 with valid authentication."""
+        response = api_client.get("/api/version")
         assert_status(response, 200)
+        data = assert_json_response(response)
+        assert "version" in data
+        assert "platform" in data
+
+    def test_health_accessible_with_auth(self, api_client: TrinityApiClient):
+        """GET /health returns 200 with valid authentication."""
+        response = api_client.get("/health")
+        assert_status(response, 200)
+        data = assert_json_response(response)
+        assert "status" in data
+
+    def test_oauth_providers_accessible_with_auth(self, api_client: TrinityApiClient):
+        """GET /api/oauth/providers returns 200 with valid authentication."""
+        response = api_client.get("/api/oauth/providers")
+        assert_status(response, 200)
+        data = assert_json_response(response)
+        assert "providers" in data
 
 
 class TestTelemetryConsistency:


### PR DESCRIPTION
## Summary
- Add `Depends(get_current_user)` to 5 previously unauthenticated endpoints per pentest finding 3.2.3 (CVSS 5.1)
- Update `docker-compose.prod.yml` healthcheck to use `/api/setup/status` since `/health` now requires auth
- Update `HostTelemetry.vue` to send auth headers and handle 401 gracefully
- Add/update tests: flip "no auth required" → assert 401, add positive auth tests for version/health/OAuth

## Endpoints Secured
| Endpoint | File |
|----------|------|
| `GET /api/telemetry/host` | `routers/telemetry.py` |
| `GET /api/telemetry/containers` | `routers/telemetry.py` |
| `GET /api/version` | `main.py` |
| `GET /health` | `main.py` |
| `GET /api/oauth/providers` | `routers/credentials.py` |

Note: `GET /api/internal/health` listed in the issue is already secured via `verify_internal_secret` — no change needed.

## Concerns / Recommendations for Review

1. **`/health` + Docker healthcheck**: Adding auth to `/health` required updating `docker-compose.prod.yml:83` to use `/api/setup/status` instead. Please verify this works in your deployment environment.

2. **Consider `require_admin` for telemetry/version**: These endpoints expose CPU count, RAM capacity, disk capacity, container names, build date, and runtimes — data that only admins need. Currently uses `get_current_user` (any authenticated user) per issue description, but `require_admin` would be stronger.

3. **CSO audit found additional CRITICAL unauthenticated endpoints** not in the pentest report:
   - `POST /api/approvals/{id}/approve` and `/reject` — **zero auth on approve/reject workflow steps** (approvals.py imports `Depends` but never uses it)
   - `GET /api/approvals`, `GET /api/approvals/{id}` — enumerate all pending approvals
   - `POST /api/triggers/webhook/{trigger_id}` — invoke agent executions (has optional HMAC but no JWT)
   
   These should be filed as separate P0/P1 issues.

## Test Plan
- [ ] New tests pass: `pytest tests/test_telemetry.py -v`
- [ ] Existing tests unaffected
- [ ] Manual verification: unauthenticated curl returns 401 for all 5 endpoints
- [ ] Manual verification: authenticated curl returns 200 with valid data
- [ ] Frontend: dashboard telemetry panel works after login
- [ ] Docker healthcheck: `docker-compose.prod.yml` backend starts healthy

Closes #180

Generated with [Claude Code](https://claude.com/claude-code)