### PR TITLE
fix: Cleanup service fails execution records when reclaiming stale slots (#219)

### DIFF
--- a/docs/memory/feature-flows/cleanup-service.md
+++ b/docs/memory/feature-flows/cleanup-service.md
@@ -34,7 +34,8 @@ Dataclass holding results from a single cleanup cycle:
 - `orphaned_skipped: int` - Skipped executions finalized (Issue #106)
 - `stale_activities: int` - Activities marked failed
 - `stale_slots: int` - Redis slots cleaned
-- `total` property: Sum of all five fields
+- `stale_slot_executions: int` - Execution records failed when their slot was reclaimed (Issue #219)
+- `total` property: Sum of all six fields
 - `to_dict()` method: Serializes for API responses
 
 #### CleanupService class (line 48)
@@ -81,12 +82,17 @@ Five sequential operations, each wrapped in individual try/except:
    ```
    Calls `DatabaseManager.mark_stale_activities_failed()` which delegates to `ActivityOperations.mark_stale_activities_failed()`.
 
-5. **Cleanup stale Redis slots** (lines 116-122)
+5. **Cleanup stale Redis slots and fail execution records** (lines 123-148, Issue #219)
    ```python
    slot_service = get_slot_service()
-   count = await slot_service.cleanup_stale_slots()
+   reclaimed = await slot_service.cleanup_stale_slots()
+   report.stale_slots = sum(len(ids) for ids in reclaimed.values())
+   # Fail execution records whose slots were reclaimed
+   for agent_name, execution_ids in reclaimed.items():
+       for execution_id in execution_ids:
+           db.fail_stale_slot_execution(execution_id, error=...)
    ```
-   Calls `SlotService.cleanup_stale_slots()` which scans all `agent:slots:*` keys and removes entries older than 30 minutes.
+   Calls `SlotService.cleanup_stale_slots()` which scans all `agent:slots:*` keys, removes entries older than TTL, and returns a dict mapping agent names to reclaimed execution IDs. The cleanup service then fails the corresponding `schedule_executions` DB records using a guarded update (`WHERE status = 'running'`) to avoid overwriting executions that completed via another path.
 
 ### Startup Loop (`_cleanup_loop`, lines 114-137)
 
@@ -226,8 +232,32 @@ SET status = 'failed',
 WHERE id = ?
 ```
 
+#### fail_stale_slot_execution (ScheduleOperations) — Issue #219
+**File**: `src/backend/db/schedules.py:1103-1144`
+
+Marks a single execution as failed when its Redis slot is reclaimed. Uses a `WHERE status = 'running'` guard to prevent overwriting executions that already completed or failed via another path.
+
+**SQL** (guarded select):
+```sql
+SELECT started_at FROM schedule_executions WHERE id = ? AND status = 'running'
+```
+
+**SQL** (guarded update):
+```sql
+UPDATE schedule_executions
+SET status = 'failed',
+    completed_at = ?,
+    duration_ms = ?,
+    error = ?
+WHERE id = ? AND status = 'running'
+```
+
+**Delegation chain**:
+- `cleanup_service.run_cleanup()` -> `db.fail_stale_slot_execution(execution_id, error)`
+- `DatabaseManager.fail_stale_slot_execution()` -> `self._schedule_ops.fail_stale_slot_execution()`
+
 #### finalize_orphaned_skipped_executions (ScheduleOperations) — Issue #106
-**File**: `src/backend/db/schedules.py:1057-1075`
+**File**: `src/backend/db/schedules.py:1146-1170`
 
 **SQL** (single update — now sets terminal status, Issue #137):
 ```sql
@@ -268,18 +298,21 @@ WHERE id = ?
 ### Redis Operations
 
 #### cleanup_stale_slots (SlotService)
-**File**: `src/backend/services/slot_service.py:247-271`
+**File**: `src/backend/services/slot_service.py:259-295`
+
+**Returns**: `Dict[str, List[str]]` — mapping of agent_name to list of reclaimed execution IDs (Issue #219).
 
 **Logic**:
 1. Scans all keys matching `agent:slots:*` pattern via `SCAN`
-2. For each agent, calls `_cleanup_stale_slots_for_agent()` (line 223)
-3. Removes ZSET entries with score (timestamp) older than 30 minutes:
+2. For each agent, calls `_cleanup_stale_slots_for_agent()` which returns the reclaimed execution IDs
+3. Removes ZSET entries with score (timestamp) older than TTL:
    ```
    ZREMRANGEBYSCORE agent:slots:{name} -inf {cutoff_timestamp}
    ```
 4. Deletes corresponding metadata keys: `agent:slot:{name}:{execution_id}`
+5. Returns the execution IDs so the caller (cleanup service) can fail corresponding DB records
 
-**TTL**: `SLOT_TTL_SECONDS = 1800` (30 minutes, line 30)
+**TTL**: `DEFAULT_SLOT_TTL_SECONDS = 1200` (20 minutes, line 31)
 
 ## Side Effects
 - **Logging**: Each cleanup cycle logs results at INFO level when resources are cleaned
@@ -369,10 +402,11 @@ This is a purely backend service. The only "UI" is the two admin API endpoints u
 | `src/backend/db/schedules.py:971-1013` | `mark_stale_executions_failed()` |
 | `src/backend/db/schedules.py:570-590` | `mark_execution_dispatched()` — sets sentinel before agent call |
 | `src/backend/db/schedules.py:1036-1076` | `mark_no_session_executions_failed()` (Issue #106) |
-| `src/backend/db/schedules.py:1078-1100` | `finalize_orphaned_skipped_executions()` (Issue #106) |
+| `src/backend/db/schedules.py:1103-1144` | `fail_stale_slot_execution()` (Issue #219) |
+| `src/backend/db/schedules.py:1146-1170` | `finalize_orphaned_skipped_executions()` (Issue #106) |
 | `src/backend/db/activities.py:187-225` | `mark_stale_activities_failed()` |
 | `src/backend/database.py:682-688` | Delegation methods on DatabaseManager |
-| `src/backend/services/slot_service.py:247-271` | `cleanup_stale_slots()` Redis cleanup |
+| `src/backend/services/slot_service.py:259-295` | `cleanup_stale_slots()` Redis cleanup, returns reclaimed IDs (Issue #219) |
 | `src/backend/main.py:86,265-269,300-305` | Import, start in lifespan, stop on shutdown |
 | `src/backend/routers/monitoring.py:455-491` | `/cleanup-status` and `/cleanup-trigger` endpoints |
 | `tests/test_cleanup_service.py` | API integration tests for cleanup (Issue #106) |

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -708,6 +708,10 @@ class DatabaseManager:
         """Mark running executions with no claude_session_id as failed (Issue #106)."""
         return self._schedule_ops.mark_no_session_executions_failed(timeout_seconds)
 
+    def fail_stale_slot_execution(self, execution_id: str, error: str) -> bool:
+        """Mark a running execution as failed when its slot is reclaimed (#219)."""
+        return self._schedule_ops.fail_stale_slot_execution(execution_id, error)
+
     def finalize_orphaned_skipped_executions(self):
         """Finalize skipped executions missing completed_at (Issue #106)."""
         return self._schedule_ops.finalize_orphaned_skipped_executions()

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -1100,6 +1100,50 @@ class ScheduleOperations:
             conn.commit()
             return len(no_session_rows)
 
+    def fail_stale_slot_execution(self, execution_id: str, error: str) -> bool:
+        """Mark a single execution as failed if it is still running.
+
+        Used by the cleanup service when a stale Redis slot is reclaimed.
+        The WHERE status='running' guard prevents overwriting executions
+        that have already completed or failed via another path.
+
+        Args:
+            execution_id: The execution to fail.
+            error: Error message describing why the execution was failed.
+
+        Returns:
+            True if the execution was updated, False if it was not found
+            or was no longer in 'running' status.
+        """
+        now = utc_now_iso()
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+
+            cursor.execute(
+                "SELECT started_at FROM schedule_executions WHERE id = ? AND status = ?",
+                (execution_id, TaskExecutionStatus.RUNNING),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return False
+
+            completed_at = parse_iso_timestamp(now)
+            started_at = parse_iso_timestamp(row["started_at"])
+            duration_ms = int((completed_at - started_at).total_seconds() * 1000)
+
+            cursor.execute("""
+                UPDATE schedule_executions
+                SET status = ?,
+                    completed_at = ?,
+                    duration_ms = ?,
+                    error = ?
+                WHERE id = ? AND status = ?
+            """, (TaskExecutionStatus.FAILED, now, duration_ms, error,
+                  execution_id, TaskExecutionStatus.RUNNING))
+
+            conn.commit()
+            return cursor.rowcount > 0
+
     def finalize_orphaned_skipped_executions(self) -> int:
         """Finalize skipped executions that are missing completed_at.
 

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -35,11 +35,13 @@ class CleanupReport:
     orphaned_skipped: int = 0
     stale_activities: int = 0
     stale_slots: int = 0
+    stale_slot_executions: int = 0  # Issue #219: executions failed when their slot was reclaimed
 
     @property
     def total(self) -> int:
         return (self.stale_executions + self.no_session_executions +
-                self.orphaned_skipped + self.stale_activities + self.stale_slots)
+                self.orphaned_skipped + self.stale_activities + self.stale_slots +
+                self.stale_slot_executions)
 
     def to_dict(self) -> Dict:
         return {
@@ -48,6 +50,7 @@ class CleanupReport:
             "orphaned_skipped": self.orphaned_skipped,
             "stale_activities": self.stale_activities,
             "stale_slots": self.stale_slots,
+            "stale_slot_executions": self.stale_slot_executions,
             "total": self.total,
         }
 
@@ -120,11 +123,29 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error marking stale activities: {e}")
 
-        # 3. Cleanup stale Redis slots
+        # 3. Cleanup stale Redis slots and fail corresponding execution records (#219)
         try:
             slot_service = get_slot_service()
-            count = await slot_service.cleanup_stale_slots()
-            report.stale_slots = count
+            reclaimed = await slot_service.cleanup_stale_slots()
+            report.stale_slots = sum(len(ids) for ids in reclaimed.values())
+
+            # Fail execution records whose slots were reclaimed
+            for agent_name, execution_ids in reclaimed.items():
+                for execution_id in execution_ids:
+                    try:
+                        updated = db.fail_stale_slot_execution(
+                            execution_id=execution_id,
+                            error=f"Stale execution — slot TTL expired for agent '{agent_name}', cleaned by cleanup service",
+                        )
+                        if updated:
+                            report.stale_slot_executions += 1
+                            logger.info(
+                                f"[Cleanup] Failed execution {execution_id} for agent '{agent_name}' (slot reclaimed)"
+                            )
+                    except Exception as e:
+                        logger.error(
+                            f"[Cleanup] Error failing execution {execution_id} after slot reclaim: {e}"
+                        )
         except Exception as e:
             logger.error(f"[Cleanup] Error cleaning stale slots: {e}")
 

--- a/src/backend/services/slot_service.py
+++ b/src/backend/services/slot_service.py
@@ -18,7 +18,7 @@ Slot Rules:
 import json
 import logging
 from datetime import datetime
-from typing import Optional, Dict, List, Any
+from typing import Optional, Dict, List, Any, Tuple
 import redis
 import time
 
@@ -226,12 +226,17 @@ class SlotService:
 
         return result
 
-    async def _cleanup_stale_slots_for_agent(self, agent_name: str, slot_ttl: int = None) -> int:
+    async def _cleanup_stale_slots_for_agent(
+        self, agent_name: str, slot_ttl: int = None
+    ) -> List[str]:
         """Remove slots older than TTL for a single agent.
 
         Args:
             agent_name: Name of the agent
             slot_ttl: Slot TTL in seconds. If None, uses DEFAULT_SLOT_TTL_SECONDS.
+
+        Returns:
+            List of execution IDs whose slots were reclaimed.
         """
         slots_key = self._slots_key(agent_name)
         ttl = slot_ttl if slot_ttl is not None else DEFAULT_SLOT_TTL_SECONDS
@@ -242,7 +247,7 @@ class SlotService:
 
         if stale:
             # Remove stale slots
-            removed = self.redis.zremrangebyscore(slots_key, "-inf", cutoff)
+            self.redis.zremrangebyscore(slots_key, "-inf", cutoff)
 
             # Clean up metadata
             for execution_id in stale:
@@ -250,20 +255,21 @@ class SlotService:
                 self.redis.delete(metadata_key)
 
             logger.warning(
-                f"[Slots] Cleaned up {removed} stale slots for agent '{agent_name}'"
+                f"[Slots] Cleaned up {len(stale)} stale slots for agent '{agent_name}'"
             )
-            return removed
+            return list(stale)
 
-        return 0
+        return []
 
-    async def cleanup_stale_slots(self) -> int:
+    async def cleanup_stale_slots(self) -> Dict[str, List[str]]:
         """
         Remove slots older than TTL for all agents.
 
         Returns:
-            Total number of stale slots removed
+            Dict mapping agent_name to list of reclaimed execution IDs.
+            Empty dict if nothing was cleaned.
         """
-        total_removed = 0
+        reclaimed: Dict[str, List[str]] = {}
 
         # Find all agent slot keys
         pattern = f"{self.slots_prefix}*"
@@ -272,15 +278,17 @@ class SlotService:
             cursor, keys = self.redis.scan(cursor, match=pattern, count=100)
             for key in keys:
                 agent_name = key.replace(self.slots_prefix, "")
-                removed = await self._cleanup_stale_slots_for_agent(agent_name)
-                total_removed += removed
+                stale_ids = await self._cleanup_stale_slots_for_agent(agent_name)
+                if stale_ids:
+                    reclaimed[agent_name] = stale_ids
             if cursor == 0:
                 break
 
-        if total_removed > 0:
-            logger.info(f"[Slots] Cleanup removed {total_removed} stale slots total")
+        total = sum(len(ids) for ids in reclaimed.values())
+        if total > 0:
+            logger.info(f"[Slots] Cleanup removed {total} stale slots total")
 
-        return total_removed
+        return reclaimed
 
     async def get_active_count(self, agent_name: str) -> int:
         """Get count of active slots for an agent."""

--- a/tests/test_cleanup_service.py
+++ b/tests/test_cleanup_service.py
@@ -4,6 +4,7 @@ Cleanup Service Tests (test_cleanup_service.py)
 Tests for cleanup service behavior including:
 - Issue #106: No-session execution fast-fail
 - Issue #106: Orphaned skipped execution finalization
+- Issue #219: Slot-execution correlation (stale_slot_executions)
 - Cleanup report structure validation
 
 Feature Flow: docs/memory/feature-flows/cleanup-service.md
@@ -36,7 +37,7 @@ class TestCleanupStatus:
         assert_has_fields(data, ["running", "last_run_at"])
 
     def test_cleanup_status_report_fields(self, api_client: TrinityApiClient):
-        """Cleanup report includes Issue #106 fields for no-session and orphaned skipped."""
+        """Cleanup report includes Issue #106 and #219 fields."""
         response = api_client.get("/api/monitoring/cleanup-status")
         assert_status(response, 200)
         data = response.json()
@@ -44,9 +45,11 @@ class TestCleanupStatus:
         # last_report may be None if cleanup hasn't run yet
         if data.get("last_report"):
             report = data["last_report"]
-            # Verify new Issue #106 fields exist
+            # Verify Issue #106 fields exist
             assert "no_session_executions" in report, "Missing no_session_executions field"
             assert "orphaned_skipped" in report, "Missing orphaned_skipped field"
+            # Verify Issue #219 field exists
+            assert "stale_slot_executions" in report, "Missing stale_slot_executions field"
             # Verify existing fields still present
             assert "stale_executions" in report
             assert "stale_activities" in report
@@ -59,6 +62,7 @@ class TestCleanupStatus:
                 + report["orphaned_skipped"]
                 + report["stale_activities"]
                 + report["stale_slots"]
+                + report["stale_slot_executions"]
             )
             assert report["total"] == expected_total
 
@@ -76,8 +80,8 @@ class TestCleanupTrigger:
         assert data["status"] == "completed"
         assert "report" in data
 
-    def test_trigger_cleanup_report_has_issue_106_fields(self, api_client: TrinityApiClient):
-        """Triggered cleanup report includes no_session_executions and orphaned_skipped."""
+    def test_trigger_cleanup_report_has_issue_106_and_219_fields(self, api_client: TrinityApiClient):
+        """Triggered cleanup report includes no_session_executions, orphaned_skipped, and stale_slot_executions."""
         response = api_client.post("/api/monitoring/cleanup-trigger")
         assert_status(response, 200)
         data = response.json()
@@ -85,13 +89,16 @@ class TestCleanupTrigger:
         report = data["report"]
         assert "no_session_executions" in report, "Missing no_session_executions field"
         assert "orphaned_skipped" in report, "Missing orphaned_skipped field"
+        assert "stale_slot_executions" in report, "Missing stale_slot_executions field (#219)"
         assert isinstance(report["no_session_executions"], int)
         assert isinstance(report["orphaned_skipped"], int)
+        assert isinstance(report["stale_slot_executions"], int)
         assert report["no_session_executions"] >= 0
         assert report["orphaned_skipped"] >= 0
+        assert report["stale_slot_executions"] >= 0
 
-    def test_trigger_cleanup_total_includes_new_fields(self, api_client: TrinityApiClient):
-        """Cleanup total correctly sums all fields including Issue #106 additions."""
+    def test_trigger_cleanup_total_includes_all_fields(self, api_client: TrinityApiClient):
+        """Cleanup total correctly sums all fields including Issue #106 and #219 additions."""
         response = api_client.post("/api/monitoring/cleanup-trigger")
         assert_status(response, 200)
         report = response.json()["report"]
@@ -102,6 +109,7 @@ class TestCleanupTrigger:
             + report["orphaned_skipped"]
             + report["stale_activities"]
             + report["stale_slots"]
+            + report["stale_slot_executions"]
         )
         assert report["total"] == expected_total
 


### PR DESCRIPTION
## Summary
- Correlate stale Redis slot cleanup with `schedule_executions` DB records — when a slot is reclaimed, the corresponding execution is now marked as failed
- Add race-condition guard (`WHERE status='running'`) to prevent overwriting executions that completed via another path
- Add `stale_slot_executions` field to `CleanupReport` for observability

## Changes
- `src/backend/db/schedules.py` — New `fail_stale_slot_execution()` with guarded update
- `src/backend/services/slot_service.py` — `cleanup_stale_slots` returns `Dict[str, List[str]]` (agent→execution IDs)
- `src/backend/services/cleanup_service.py` — Step 3 wired to fail execution records; new report field
- `src/backend/database.py` — Delegation method
- `tests/test_cleanup_service.py` — Updated for new `stale_slot_executions` field
- `docs/memory/feature-flows/cleanup-service.md` — Feature flow updated

## Test Plan
- [x] `pytest tests/test_cleanup_service.py -v` — 7/7 pass
- [x] New `stale_slot_executions` field present in cleanup status and trigger responses
- [x] Total correctly sums all fields including new one
- [ ] Manual: trigger cleanup when stale slots exist, verify execution records are failed

## Notes
- Gap 2 from the issue (skipped executions) was dropped — `finalize_orphaned_skipped_executions` already handles this case
- Filed #226 for a related TTL mismatch bug discovered during review (separate scope)

Closes #219

Generated with [Claude Code](https://claude.com/claude-code)