### PR TITLE
fix(scheduler): translate cron day-of-week to APScheduler named days (#220)

### DIFF
--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -264,6 +264,11 @@ class SchedulerService:
           - "0 9 * * *" = Every day at 9:00 AM
           - "*/15 * * * *" = Every 15 minutes
           - "0 0 * * 0" = Every Sunday at midnight
+
+        Note: the raw day_of_week value uses Unix cron numbering (0=Sun,
+        1=Mon, …).  Callers that build an APScheduler CronTrigger must
+        first run the value through _cron_dow_to_apscheduler() to avoid
+        a one-day shift (see Issue #220).
         """
         parts = cron_expression.strip().split()
         if len(parts) != 5:
@@ -277,6 +282,43 @@ class SchedulerService:
             'day_of_week': parts[4]
         }
 
+    @staticmethod
+    def _cron_dow_to_apscheduler(dow: str) -> str:
+        """
+        Translate a Unix cron day-of-week field to APScheduler named-day format.
+
+        Unix cron:   0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat, 7=Sun
+        APScheduler: 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun
+
+        Passing raw cron numeric values straight to CronTrigger shifts every
+        schedule one day forward (e.g. cron '1'=Monday fires on Tuesday).
+        Converting to APScheduler's named abbreviations (mon, tue, …) removes
+        the ambiguity because the names mean the same thing in both systems.
+
+        Handles: wildcard (*), single value (1), comma list (1,3,5),
+        range (1-5).  Step expressions (*/2) are returned unchanged — they
+        are uncommon for day-of-week and can be addressed separately.
+        """
+        _NAMES = {
+            0: 'sun', 1: 'mon', 2: 'tue', 3: 'wed',
+            4: 'thu', 5: 'fri', 6: 'sat', 7: 'sun',
+        }
+
+        def _token(t: str) -> str:
+            try:
+                return _NAMES[int(t)]
+            except (ValueError, KeyError):
+                return t  # already a named day or unrecognised — leave as-is
+
+        if dow == '*' or '/' in dow:
+            return dow
+        if ',' in dow:
+            return ','.join(_token(t) for t in dow.split(','))
+        if '-' in dow:
+            lo, hi = dow.split('-', 1)
+            return f'{_token(lo)}-{_token(hi)}'
+        return _token(dow)
+
     def _add_job(self, schedule: Schedule):
         """Add a schedule as an APScheduler job."""
         if not self.scheduler:
@@ -288,9 +330,17 @@ class SchedulerService:
             # Parse cron expression
             cron_kwargs = self._parse_cron(schedule.cron_expression)
 
+            # Build APScheduler trigger kwargs, translating day_of_week from
+            # Unix cron convention (0=Sun, 1=Mon) to APScheduler named days
+            # to prevent a one-day shift on weekday-based schedules (Issue #220).
+            trigger_kwargs = dict(cron_kwargs)
+            trigger_kwargs['day_of_week'] = self._cron_dow_to_apscheduler(
+                cron_kwargs['day_of_week']
+            )
+
             # Create timezone-aware trigger
             timezone = pytz.timezone(schedule.timezone) if schedule.timezone else pytz.UTC
-            trigger = CronTrigger(timezone=timezone, **cron_kwargs)
+            trigger = CronTrigger(timezone=timezone, **trigger_kwargs)
 
             # Add the job
             self.scheduler.add_job(
@@ -946,9 +996,17 @@ class SchedulerService:
             # Parse cron expression
             cron_kwargs = self._parse_cron(schedule.cron_expression)
 
+            # Build APScheduler trigger kwargs, translating day_of_week from
+            # Unix cron convention (0=Sun, 1=Mon) to APScheduler named days
+            # to prevent a one-day shift on weekday-based schedules (Issue #220).
+            trigger_kwargs = dict(cron_kwargs)
+            trigger_kwargs['day_of_week'] = self._cron_dow_to_apscheduler(
+                cron_kwargs['day_of_week']
+            )
+
             # Create timezone-aware trigger
             timezone = pytz.timezone(schedule.timezone) if schedule.timezone else pytz.UTC
-            trigger = CronTrigger(timezone=timezone, **cron_kwargs)
+            trigger = CronTrigger(timezone=timezone, **trigger_kwargs)
 
             # Add the job
             self.scheduler.add_job(

--- a/tests/scheduler_tests/test_cron.py
+++ b/tests/scheduler_tests/test_cron.py
@@ -14,6 +14,7 @@ import os
 from datetime import datetime
 import pytest
 import pytz
+from apscheduler.triggers.cron import CronTrigger
 
 from scheduler.service import SchedulerService
 
@@ -136,3 +137,151 @@ class TestNextRunTime:
         # Depending on implementation, this may return None or raise
         # In our implementation, it returns None on error
         assert next_run is None
+
+
+class TestCronDowConversion:
+    """
+    Tests for _cron_dow_to_apscheduler (Issue #220).
+
+    Unix cron numbers day-of-week as 0=Sun, 1=Mon, … 6=Sat.
+    APScheduler numbers it as 0=Mon, 1=Tue, … 6=Sun.
+    Passing raw cron numbers to CronTrigger shifts every weekday schedule
+    by one day.  The fix converts numeric tokens to APScheduler named-day
+    abbreviations (mon, tue, …) which are unambiguous.
+    """
+
+    def setup_method(self):
+        self.service = SchedulerService.__new__(SchedulerService)
+
+    # --- single numeric values ---
+
+    def test_sunday_cron_0(self):
+        assert self.service._cron_dow_to_apscheduler('0') == 'sun'
+
+    def test_monday_cron_1(self):
+        assert self.service._cron_dow_to_apscheduler('1') == 'mon'
+
+    def test_tuesday_cron_2(self):
+        assert self.service._cron_dow_to_apscheduler('2') == 'tue'
+
+    def test_wednesday_cron_3(self):
+        assert self.service._cron_dow_to_apscheduler('3') == 'wed'
+
+    def test_thursday_cron_4(self):
+        assert self.service._cron_dow_to_apscheduler('4') == 'thu'
+
+    def test_friday_cron_5(self):
+        assert self.service._cron_dow_to_apscheduler('5') == 'fri'
+
+    def test_saturday_cron_6(self):
+        assert self.service._cron_dow_to_apscheduler('6') == 'sat'
+
+    def test_sunday_cron_7(self):
+        """Cron allows 7 as an alias for Sunday."""
+        assert self.service._cron_dow_to_apscheduler('7') == 'sun'
+
+    # --- wildcard ---
+
+    def test_wildcard(self):
+        assert self.service._cron_dow_to_apscheduler('*') == '*'
+
+    # --- comma-separated list ---
+
+    def test_comma_list(self):
+        """1,3,5 (Mon,Wed,Fri) → mon,wed,fri"""
+        assert self.service._cron_dow_to_apscheduler('1,3,5') == 'mon,wed,fri'
+
+    def test_comma_list_with_sunday(self):
+        """0,6 (Sun,Sat) → sun,sat"""
+        assert self.service._cron_dow_to_apscheduler('0,6') == 'sun,sat'
+
+    # --- range ---
+
+    def test_weekday_range(self):
+        """1-5 (Mon–Fri) → mon-fri"""
+        assert self.service._cron_dow_to_apscheduler('1-5') == 'mon-fri'
+
+    def test_full_week_range(self):
+        """0-6 → sun-sat"""
+        assert self.service._cron_dow_to_apscheduler('0-6') == 'sun-sat'
+
+    # --- named days passed through unchanged ---
+
+    def test_named_day_passthrough(self):
+        """Named days already in APScheduler format are left unchanged."""
+        assert self.service._cron_dow_to_apscheduler('mon') == 'mon'
+        assert self.service._cron_dow_to_apscheduler('fri') == 'fri'
+        assert self.service._cron_dow_to_apscheduler('sun') == 'sun'
+
+    # --- step expressions passed through unchanged ---
+
+    def test_step_passthrough(self):
+        assert self.service._cron_dow_to_apscheduler('*/2') == '*/2'
+
+
+class TestAPSchedulerDayOfWeek:
+    """
+    Integration-level check: verify that a CronTrigger built from a parsed
+    cron expression (after DOW translation) fires on the correct calendar
+    day (Issue #220).
+    """
+
+    def setup_method(self):
+        self.service = SchedulerService.__new__(SchedulerService)
+
+    def _next_fire(self, cron_expr: str, from_dt: datetime) -> datetime:
+        """Build a CronTrigger for cron_expr and return the next fire time."""
+        cron_kwargs = self.service._parse_cron(cron_expr)
+        trigger_kwargs = dict(cron_kwargs)
+        trigger_kwargs['day_of_week'] = self.service._cron_dow_to_apscheduler(
+            cron_kwargs['day_of_week']
+        )
+        trigger = CronTrigger(timezone=pytz.UTC, **trigger_kwargs)
+        return trigger.get_next_fire_time(None, from_dt)
+
+    def test_monday_schedule_fires_on_monday(self):
+        """'5 9 * * 1' must fire on a Monday, not a Tuesday."""
+        # Base time: Wednesday 2026-03-25 (unambiguous — well before target)
+        base = datetime(2026, 3, 25, 0, 0, 0, tzinfo=pytz.UTC)
+        nxt = self._next_fire('5 9 * * 1', base)
+        assert nxt.strftime('%A') == 'Monday', (
+            f"Expected Monday, got {nxt.strftime('%A %Y-%m-%d')}"
+        )
+        assert nxt == datetime(2026, 3, 30, 9, 5, 0, tzinfo=pytz.UTC)
+
+    def test_monday_schedule_does_not_skip_after_eu_dst(self):
+        """
+        Regression for Issue #220: weekly Monday schedule must not skip the
+        Monday immediately after the European DST transition (Mar 29 2026).
+
+        Without the fix, CronTrigger(day_of_week='1') fires on Tuesday Mar 31
+        instead of Monday Mar 30, and the displayed next_run_at (from croniter)
+        diverges from the actual APScheduler fire time, creating an apparent
+        two-week gap in the UI.
+        """
+        # Simulate the state just after EU DST (clocks sprang forward Mar 29)
+        after_dst = datetime(2026, 3, 29, 12, 0, 0, tzinfo=pytz.UTC)
+        nxt = self._next_fire('5 9 * * 1', after_dst)
+
+        assert nxt.strftime('%A') == 'Monday', (
+            f"Schedule skipped Monday; next fire is {nxt.strftime('%A %Y-%m-%d')}"
+        )
+        assert nxt.date() == datetime(2026, 3, 30).date(), (
+            f"Expected 2026-03-30, got {nxt.date()}"
+        )
+
+    def test_sunday_schedule_fires_on_sunday(self):
+        """'0 0 * * 0' (cron 0=Sun) must fire on Sunday."""
+        base = datetime(2026, 3, 25, 0, 0, 0, tzinfo=pytz.UTC)  # Wednesday
+        nxt = self._next_fire('0 0 * * 0', base)
+        assert nxt.strftime('%A') == 'Sunday', (
+            f"Expected Sunday, got {nxt.strftime('%A %Y-%m-%d')}"
+        )
+
+    def test_weekday_range_fires_on_weekdays(self):
+        """'0 9 * * 1-5' must fire on weekdays Mon–Fri."""
+        base = datetime(2026, 3, 28, 12, 0, 0, tzinfo=pytz.UTC)  # Saturday
+        nxt = self._next_fire('0 9 * * 1-5', base)
+        assert nxt.strftime('%A') == 'Monday', (
+            f"Expected Monday after Saturday, got {nxt.strftime('%A %Y-%m-%d')}"
+        )


### PR DESCRIPTION
## Summary
- **Root cause**: `_parse_cron()` passed raw Unix cron day-of-week numbers (0=Sun, 1=Mon) to APScheduler's `CronTrigger` which uses a different convention (0=Mon, 1=Tue), silently shifting every weekday schedule forward by one day
- **Fix**: Added `_cron_dow_to_apscheduler()` static method that converts numeric DOW tokens to named abbreviations (`mon`, `tue`, …) which are unambiguous in both systems
- **Applied** at both `CronTrigger` call sites: `_add_job()` and `_add_process_job()`

## Changes
- `src/scheduler/service.py` — new `_cron_dow_to_apscheduler()` method, applied in both job-adding methods, docstring note on `_parse_cron()`
- `tests/scheduler_tests/test_cron.py` — 19 new tests across 2 test classes:
  - `TestCronDowConversion` — unit tests for all token shapes (0-7, `*`, ranges, comma lists, named days, steps)
  - `TestAPSchedulerDayOfWeek` — integration tests confirming `CronTrigger` fires on the correct calendar day, including the DST regression case (Monday Mar 30, 2026)

## Test Plan
- [x] 31/31 tests pass: `pytest tests/scheduler_tests/test_cron.py -v`
- [x] Existing tests unaffected
- [x] DST regression test confirms Monday schedule fires on Monday (not Tuesday)
- [ ] After merge: restart scheduler service and verify `next_run_at` values recalculate correctly

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)