### PR TITLE
fix: Slack file download passes wrong arg to get_bot_token (#237)

### DIFF
--- a/src/backend/adapters/slack_adapter.py
+++ b/src/backend/adapters/slack_adapter.py
@@ -138,7 +138,7 @@ class SlackAdapter(ChannelAdapter):
 
     async def download_file(self, file: FileAttachment, message: NormalizedMessage) -> Optional[bytes]:
         """Download file from Slack using bot token."""
-        bot_token = self.get_bot_token(message.metadata.get("team_id"))
+        bot_token = self.get_bot_token(message)
         if not bot_token:
             logger.error(f"No bot token for file download: {file.name}")
             return None


### PR DESCRIPTION
## Summary

`SlackAdapter.download_file()` passed `message.metadata.get("team_id")` (a string) to `get_bot_token()`, which expects a `NormalizedMessage` object. All Slack file downloads failed silently — bot token lookup returned None.

## Fix

One line: `self.get_bot_token(message.metadata.get("team_id"))` → `self.get_bot_token(message)`

## Test plan

- [x] Code inspection: `get_bot_token(self, message: NormalizedMessage)` signature confirmed
- [ ] Upload file in Slack → agent receives and processes it

Fixes #237