### PR TITLE
fix(cli): URL normalization, table output default, tag-driven auto-versioning

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -16,12 +16,28 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/project/trinity-cli/
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          # cli-v0.2.0 → 0.2.0
+          VERSION="${GITHUB_REF_NAME#cli-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $VERSION"
+
+      - name: Inject version into pyproject.toml
+        working-directory: src/cli
+        run: |
+          sed -i 's/^version = .*/version = "${{ steps.version.outputs.version }}"/' pyproject.toml
+          grep '^version' pyproject.toml
 
       - name: Install build tools
         run: pip install build
@@ -34,3 +50,62 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: src/cli/dist/
+
+  update-homebrew:
+    name: Update Homebrew formula
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for PyPI availability
+        run: |
+          VERSION="${{ needs.publish.outputs.version }}"
+          URL="https://files.pythonhosted.org/packages/source/t/trinity-cli/trinity_cli-${VERSION}.tar.gz"
+          echo "Waiting for $URL ..."
+          for i in $(seq 1 30); do
+            if curl -sf --head "$URL" > /dev/null 2>&1; then
+              echo "Available after ${i}0 seconds"
+              break
+            fi
+            sleep 10
+          done
+
+      - name: Download sdist and compute sha256
+        id: hash
+        run: |
+          VERSION="${{ needs.publish.outputs.version }}"
+          URL="https://files.pythonhosted.org/packages/source/t/trinity-cli/trinity_cli-${VERSION}.tar.gz"
+          curl -sfL -o trinity_cli.tar.gz "$URL"
+          SHA256=$(sha256sum trinity_cli.tar.gz | cut -d' ' -f1)
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+          echo "SHA256: $SHA256"
+
+      - name: Update Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ needs.publish.outputs.version }}"
+          SHA256="${{ steps.hash.outputs.sha256 }}"
+
+          # Clone the tap repo
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/abilityai/homebrew-tap.git" tap
+          cd tap
+
+          FORMULA="Formula/trinity-cli.rb"
+          if [ ! -f "$FORMULA" ]; then
+            echo "Formula not found at $FORMULA, checking root..."
+            FORMULA="trinity-cli.rb"
+          fi
+
+          # Update version URL and sha256
+          sed -i "s|url \"https://files.pythonhosted.org/packages/source/t/trinity-cli/trinity_cli-.*\.tar\.gz\"|url \"https://files.pythonhosted.org/packages/source/t/trinity-cli/trinity_cli-${VERSION}.tar.gz\"|" "$FORMULA"
+          sed -i "0,/sha256 \"[a-f0-9]*\"/s|sha256 \"[a-f0-9]*\"|sha256 \"${SHA256}\"|" "$FORMULA"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$FORMULA"
+          git commit -m "trinity-cli ${VERSION}" || echo "No changes to commit"
+          git push

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -73,6 +73,17 @@ Environment variables take precedence over the config file.
 | `trinity logout` | Clear stored credentials |
 | `trinity status` | Show instance, user, and connection status |
 
+### Deploy
+
+| Command | Description |
+|---------|-------------|
+| `trinity deploy .` | Deploy current directory as an agent |
+| `trinity deploy ./path` | Deploy a specific directory |
+| `trinity deploy . --name bot` | Override agent name |
+| `trinity deploy --repo user/repo` | Deploy from a GitHub repo |
+
+On first deploy, writes `.trinity-remote.yaml` for tracking. Subsequent deploys update the same agent.
+
 ### Agents
 
 | Command | Description |
@@ -123,15 +134,15 @@ Environment variables take precedence over the config file.
 
 ## Output Formats
 
-All commands support `--format json` (default) and `--format table`:
+All commands support `--format table` (default) and `--format json`:
 
 ```bash
-# JSON (default) — good for piping and scripts
+# Table (default) — human-readable
 trinity agents list
-trinity agents list | jq '.[].name'
 
-# Table — human-readable
-trinity agents list --format table
+# JSON — for piping and scripts
+trinity agents list --format json
+trinity agents list --format json | jq '.[].name'
 ```
 
 ## Configuration

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -67,11 +67,11 @@ trinity profile list
 ## Output Formats
 
 ```bash
-# JSON (default)
+# Table (default, human-readable)
 trinity agents list
 
-# Table
-trinity agents list --format table
+# JSON (for piping/scripting)
+trinity agents list --format json
 ```
 
 ## Environment Variables

--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trinity-cli"
-version = "0.1.0"
+version = "0.0.0"  # Replaced at build time by CI from git tag (cli-vX.Y.Z)
 description = "CLI for the Trinity Autonomous Agent Orchestration Platform"
 readme = "README.md"
 license = "MIT"

--- a/src/cli/trinity_cli/__init__.py
+++ b/src/cli/trinity_cli/__init__.py
@@ -1,3 +1,8 @@
 """Trinity CLI — command-line interface for the Trinity Agent Platform."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("trinity-cli")
+except PackageNotFoundError:
+    __version__ = "dev"

--- a/src/cli/trinity_cli/commands/agents.py
+++ b/src/cli/trinity_cli/commands/agents.py
@@ -13,7 +13,7 @@ def agents():
 
 
 @agents.command("list")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def list_agents(fmt):
     """List all agents."""
     client = TrinityClient()
@@ -36,7 +36,7 @@ def list_agents(fmt):
 
 @agents.command("get")
 @click.argument("name")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def get_agent(name, fmt):
     """Get agent details."""
     client = TrinityClient()
@@ -47,7 +47,7 @@ def get_agent(name, fmt):
 @agents.command("create")
 @click.argument("name")
 @click.option("--template", default=None, help="Template (e.g. github:Org/repo)")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def create_agent(name, template, fmt):
     """Create a new agent."""
     client = TrinityClient()

--- a/src/cli/trinity_cli/commands/auth.py
+++ b/src/cli/trinity_cli/commands/auth.py
@@ -70,6 +70,16 @@ def _write_mcp_json(instance_url: str, mcp_api_key: str):
             gitignore.write_text(f"{marker}\n")
 
 
+def _normalize_url(url: str) -> str:
+    """Normalize a URL: add https:// if no scheme, strip trailing slash."""
+    url = url.strip().rstrip("/")
+    if not url:
+        return url
+    if not url.startswith(("http://", "https://")):
+        url = f"https://{url}"
+    return url
+
+
 def _get_profile_name(ctx: click.Context) -> str | None:
     """Extract the --profile value from the root context."""
     root = ctx.find_root()
@@ -87,9 +97,21 @@ def login(ctx, instance, profile_opt):
     url = instance or get_instance_url(profile_name)
     if not url:
         url = click.prompt("Trinity instance URL")
-    url = url.rstrip("/")
+    url = _normalize_url(url)
 
-    client = TrinityClient(base_url=url, token="none")
+    # Verify instance is reachable (with retry)
+    for attempt in range(3):
+        client = TrinityClient(base_url=url, token="none")
+        try:
+            client.get_unauthenticated("/api/auth/mode")
+            break
+        except Exception:
+            click.echo(f"Cannot reach {url}.", err=True)
+            if attempt < 2:
+                url = _normalize_url(click.prompt("Try a different URL"))
+            else:
+                click.echo("Giving up after 3 attempts.", err=True)
+                raise SystemExit(1)
 
     email = click.prompt("Email")
 
@@ -184,18 +206,22 @@ def init(ctx, profile_opt):
     for the instance (defaults to hostname).
     """
     url = click.prompt("Trinity instance URL", default="http://localhost:8000")
-    url = url.rstrip("/")
+    url = _normalize_url(url)
 
-    client = TrinityClient(base_url=url, token="none")
-
-    # Verify instance is reachable
-    try:
-        client.get_unauthenticated("/api/auth/mode")
-    except Exception:
-        click.echo(f"Cannot reach {url}. Check the URL and try again.", err=True)
-        raise SystemExit(1)
-
-    click.echo(f"Connected to {url}")
+    # Verify instance is reachable (with retry)
+    for attempt in range(3):
+        client = TrinityClient(base_url=url, token="none")
+        try:
+            client.get_unauthenticated("/api/auth/mode")
+            click.echo(f"Connected to {url}")
+            break
+        except Exception:
+            click.echo(f"Cannot reach {url}.", err=True)
+            if attempt < 2:
+                url = _normalize_url(click.prompt("Try a different URL"))
+            else:
+                click.echo("Giving up after 3 attempts.", err=True)
+                raise SystemExit(1)
 
     # Determine profile name
     profile_name = profile_opt or _get_profile_name(ctx) or profile_name_from_url(url)

--- a/src/cli/trinity_cli/commands/chat.py
+++ b/src/cli/trinity_cli/commands/chat.py
@@ -9,7 +9,7 @@ from ..output import format_output
 @click.command("chat")
 @click.argument("agent")
 @click.argument("message")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def chat_with_agent(agent, message, fmt):
     """Send a message to an agent.
 
@@ -33,7 +33,7 @@ def chat_history_group():
 
 @click.command("history")
 @click.argument("agent")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def chat_history(agent, fmt):
     """Get chat history for an agent."""
     client = TrinityClient()
@@ -44,7 +44,7 @@ def chat_history(agent, fmt):
 @click.command("logs")
 @click.argument("agent")
 @click.option("--tail", default=50, help="Number of log lines")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def logs(agent, tail, fmt):
     """View agent container logs.
 

--- a/src/cli/trinity_cli/commands/health.py
+++ b/src/cli/trinity_cli/commands/health.py
@@ -13,7 +13,7 @@ def health():
 
 
 @health.command("fleet")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def fleet_health(fmt):
     """Show fleet-wide health status."""
     client = TrinityClient()
@@ -23,7 +23,7 @@ def fleet_health(fmt):
 
 @health.command("agent")
 @click.argument("name")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def agent_health(name, fmt):
     """Show health status for a specific agent."""
     client = TrinityClient()

--- a/src/cli/trinity_cli/commands/schedules.py
+++ b/src/cli/trinity_cli/commands/schedules.py
@@ -14,7 +14,7 @@ def schedules():
 
 @schedules.command("list")
 @click.argument("agent")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def list_schedules(agent, fmt):
     """List schedules for an agent."""
     client = TrinityClient()

--- a/src/cli/trinity_cli/commands/skills.py
+++ b/src/cli/trinity_cli/commands/skills.py
@@ -13,7 +13,7 @@ def skills():
 
 
 @skills.command("list")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def list_skills(fmt):
     """List all available skills."""
     client = TrinityClient()
@@ -34,7 +34,7 @@ def list_skills(fmt):
 
 @skills.command("get")
 @click.argument("name")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def get_skill(name, fmt):
     """Get details for a specific skill."""
     client = TrinityClient()

--- a/src/cli/trinity_cli/commands/tags.py
+++ b/src/cli/trinity_cli/commands/tags.py
@@ -13,7 +13,7 @@ def tags():
 
 
 @tags.command("list")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def list_tags(fmt):
     """List all tags in use."""
     client = TrinityClient()
@@ -23,7 +23,7 @@ def list_tags(fmt):
 
 @tags.command("get")
 @click.argument("agent")
-@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="json", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format")
 def get_agent_tags(agent, fmt):
     """Get tags for a specific agent."""
     client = TrinityClient()

--- a/src/cli/trinity_cli/output.py
+++ b/src/cli/trinity_cli/output.py
@@ -1,6 +1,6 @@
 """Output formatting for Trinity CLI.
 
-JSON by default (for piping/scripting). --format table for humans.
+Table (human-readable) by default. Use --format json for piping/scripting.
 """
 
 import json
@@ -10,7 +10,7 @@ from typing import Any
 import click
 
 
-def format_output(data: Any, fmt: str = "json"):
+def format_output(data: Any, fmt: str = "table"):
     """Format and print data according to the chosen format."""
     if fmt == "json":
         click.echo(json.dumps(data, indent=2, default=str))


### PR DESCRIPTION
## Summary
- **URL fix**: `trinity init` / `trinity login` now handle bare domains (`trinity.ability.ai` → `https://trinity.ability.ai`) and retry up to 3 times instead of exiting
- **Output default**: Changed from JSON to human-readable table; `--format json` still works for scripting
- **Auto-versioning**: `git tag cli-v0.2.0 && git push --tags` now publishes to PyPI and auto-updates Homebrew formula (needs `HOMEBREW_TAP_TOKEN` secret — already configured)

## Changes
- `src/cli/trinity_cli/commands/auth.py` — `_normalize_url()` + retry loop
- `src/cli/trinity_cli/commands/*.py` (7 files) — default format → table
- `src/cli/trinity_cli/output.py` — default param update
- `.github/workflows/publish-cli.yml` — version injection from tag + Homebrew auto-update job
- `src/cli/pyproject.toml` — placeholder version (CI overwrites)
- `src/cli/trinity_cli/__init__.py` — runtime version from package metadata
- `docs/CLI.md` — add deploy command, update output docs
- `src/cli/README.md` — update output docs

## Test plan
- [ ] `trinity init` with bare domain like `trinity.ability.ai` normalizes to `https://`
- [ ] `trinity init` with bad URL prompts for retry instead of exiting
- [ ] `trinity agents list` shows table by default
- [ ] `trinity agents list --format json` still outputs JSON
- [ ] `trinity --version` shows version from package metadata
- [ ] After merge: `git tag cli-v0.2.0 && git push --tags` triggers PyPI + Homebrew update

🤖 Generated with [Claude Code](https://claude.com/claude-code)