### PR TITLE
fix(security): public link brute force protection (#185)

### DIFF
--- a/src/backend/routers/public.py
+++ b/src/backend/routers/public.py
@@ -26,7 +26,7 @@ from database import (
     PublicChatResponse,
     PublicChatMessage
 )
-from routers.auth import check_login_rate_limit, record_login_attempt
+from routers.auth import check_login_rate_limit, record_login_attempt, get_redis_client
 from services.docker_service import get_agent_container
 from services.email_service import email_service
 from services.task_execution_service import get_task_execution_service
@@ -56,6 +56,11 @@ router = APIRouter(prefix="/api/public", tags=["public"])
 MAX_VERIFICATION_REQUESTS_PER_EMAIL = 3  # per 10 minutes
 MAX_CHAT_MESSAGES_PER_IP = 30  # per minute
 MAX_CHAT_MESSAGES_PER_TOKEN = 60  # per minute, per public link token
+PUBLIC_LINK_LOOKUP_RATE_LIMIT = 60  # max lookups per minute per IP (pentest 3.3.2)
+PUBLIC_LINK_LOOKUP_RATE_WINDOW = 60  # 1 minute in seconds
+
+# Generic error message for invalid tokens — prevents oracle-based enumeration (pentest 3.3.2)
+INVALID_LINK_MESSAGE = "Invalid or expired link"
 
 # Trusted proxy networks — only trust X-Forwarded-For / X-Real-IP from these.
 # Default: RFC-1918 private ranges (covers Docker bridge networks).
@@ -124,6 +129,53 @@ def _get_client_ip(request: Request) -> str:
     return direct_ip
 
 
+def check_public_link_rate_limit(client_ip: str) -> None:
+    """
+    Rate limit public link lookups per IP.
+    Shared counter across all public token endpoints.
+
+    Security fix for pentest finding 3.3.2: prevents automated scanning
+    of public link tokens. Defense-in-depth alongside 192-bit token entropy.
+
+    Fails open if Redis is unavailable (logs warning).
+    """
+    r = get_redis_client()
+    if r is None:
+        logger.warning("Public link rate limiting unavailable - Redis not connected")
+        return
+
+    key = f"public_link_lookups:{client_ip}"
+    try:
+        attempts = r.get(key)
+        if attempts and int(attempts) >= PUBLIC_LINK_LOOKUP_RATE_LIMIT:
+            raise HTTPException(
+                status_code=429,
+                detail="Too many requests. Please try again later."
+            )
+        pipe = r.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, PUBLIC_LINK_LOOKUP_RATE_WINDOW)
+        pipe.execute()
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Public link rate limit check failed: {e}")
+
+
+def _validate_public_link(token: str) -> dict:
+    """
+    Validate a public link token and return link data.
+    Raises a generic 404 for all failure modes to prevent oracle-based enumeration.
+
+    Security fix for pentest finding 3.3.2: normalizes error responses so
+    valid/invalid/disabled/expired tokens all return the same error.
+    """
+    is_valid, reason, link = db.is_public_link_valid(token)
+    if not is_valid:
+        raise HTTPException(status_code=404, detail=INVALID_LINK_MESSAGE)
+    return link
+
+
 @router.get("/link/{token}", response_model=PublicLinkInfo)
 async def get_public_link_info(token: str, request: Request):
     """
@@ -132,15 +184,21 @@ async def get_public_link_info(token: str, request: Request):
     Returns whether the link is valid and if email verification is required.
     Also includes agent metadata (name, description, status flags).
     Does NOT expose sensitive data like the link ID.
+
+    Security (pentest 3.3.2): rate limited per IP, normalized error responses.
     """
+    client_ip = _get_client_ip(request)
+    check_public_link_rate_limit(client_ip)
+
     is_valid, reason, link = db.is_public_link_valid(token)
 
     if not is_valid:
+        # Normalized response — same shape for all failure modes (pentest 3.3.2)
         return PublicLinkInfo(
             valid=False,
             require_email=False,
             agent_available=False,
-            reason=reason
+            reason="invalid_or_expired"
         )
 
     agent_name = link["agent_name"]
@@ -193,10 +251,9 @@ async def get_public_playbooks(token: str, request: Request):
     Proxies the request to the agent's internal skills endpoint.
     No authentication required — the link token is validated instead.
     """
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail=f"Invalid link: {reason}")
+    client_ip = _get_client_ip(request)
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(token)
 
     agent_name = link["agent_name"]
 
@@ -237,10 +294,9 @@ async def request_verification_code(
     Sends a 6-digit code to the provided email address.
     Rate limited to 3 requests per email per 10 minutes.
     """
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(verification.token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail=f"Invalid link: {reason}")
+    client_ip = _get_client_ip(request)
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(verification.token)
 
     if not link["require_email"]:
         raise HTTPException(
@@ -295,13 +351,10 @@ async def confirm_verification_code(
     Rate limited: 5 attempts per 10 minutes per IP (pentest 3.1.5).
     """
     # Check IP-based rate limit (pentest 3.1.5)
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = _get_client_ip(request)
     check_login_rate_limit(client_ip)
-
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(confirmation.token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail=f"Invalid link: {reason}")
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(confirmation.token)
 
     # Verify the code
     success, error, session_data = db.verify_code(
@@ -340,11 +393,8 @@ async def public_chat(
     Returns session_id for anonymous links to store in localStorage.
     """
     client_ip = _get_client_ip(request)
-
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail=f"Invalid link: {reason}")
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(token)
 
     # Determine session identifier and type
     session_identifier = None
@@ -559,11 +609,8 @@ async def get_agent_intro(
     For links requiring email verification, a valid session_token query param must be provided.
     """
     client_ip = _get_client_ip(request)
-
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail=f"Invalid link: {reason}")
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(token)
 
     # Verify session if email required
     if link["require_email"]:
@@ -642,10 +689,9 @@ async def get_public_chat_history(
     For anonymous links, provide session_id query param.
     Returns messages array for current session, or empty if no history.
     """
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail=f"Invalid link: {reason}")
+    client_ip = _get_client_ip(request)
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(token)
 
     # Determine session identifier
     session_identifier = None
@@ -718,10 +764,9 @@ async def clear_public_session(
     For anonymous links, provide session_id query param.
     Returns new_session_id for anonymous links to update localStorage.
     """
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail=f"Invalid link: {reason}")
+    client_ip = _get_client_ip(request)
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(token)
 
     # Determine session identifier
     session_identifier = None
@@ -913,10 +958,9 @@ async def public_stream_execution(
     Validates the public link token instead of JWT authentication.
     Proxies the SSE stream from the agent container to the frontend.
     """
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail="Invalid link")
+    client_ip = _get_client_ip(request)
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(token)
 
     agent_name = link["agent_name"]
     container = get_agent_container(agent_name)
@@ -972,10 +1016,9 @@ async def public_execution_status(
     Used by the frontend to poll for completion after async submission.
     Validates the public link token instead of JWT authentication.
     """
-    # Validate link token
-    is_valid, reason, link = db.is_public_link_valid(token)
-    if not is_valid:
-        raise HTTPException(status_code=404, detail="Invalid link")
+    client_ip = _get_client_ip(request)
+    check_public_link_rate_limit(client_ip)
+    link = _validate_public_link(token)
 
     agent_name = link["agent_name"]
 

--- a/tests/test_public_links.py
+++ b/tests/test_public_links.py
@@ -61,12 +61,13 @@ class TestPublicEndpoints:
     """Test public (unauthenticated) endpoints."""
 
     def test_get_invalid_link(self):
-        """Test getting info for non-existent link."""
+        """Test getting info for non-existent link returns normalized response (pentest 3.3.2)."""
         response = httpx.get(f"{BASE_URL}/api/public/link/invalid-token-12345")
         assert response.status_code == 200
         data = response.json()
         assert data["valid"] == False
-        assert data["reason"] == "not_found"
+        # Normalized reason — no oracle for valid/invalid/disabled/expired (pentest 3.3.2)
+        assert data["reason"] == "invalid_or_expired"
 
     def test_verify_request_invalid_link(self):
         """Test verification request for invalid link."""
@@ -91,6 +92,146 @@ class TestPublicEndpoints:
             json={"message": "Hello"}
         )
         assert response.status_code == 404
+
+
+class TestPublicLinkBruteForceProtection:
+    """Tests for pentest finding 3.3.2 — brute force protection on public links.
+
+    Verifies:
+    1. Error responses are normalized (no oracle for valid vs invalid tokens)
+    2. Rate limiting is enforced on all public token endpoints
+    """
+
+    @pytest.fixture(autouse=True)
+    def flush_rate_limits(self):
+        """Flush public link rate limit counters before each test."""
+        try:
+            import redis as _redis
+            r = _redis.from_url("redis://localhost:6379", decode_responses=True)
+            for key in r.scan_iter("public_link_lookups:*"):
+                r.delete(key)
+        except Exception:
+            pass
+        yield
+
+    def test_normalized_error_link_info(self):
+        """All invalid tokens return the same reason string (no oracle)."""
+        # Different fake tokens should all get the same response
+        for token in ["nonexistent-aaa", "nonexistent-bbb", "nonexistent-ccc"]:
+            response = httpx.get(f"{BASE_URL}/api/public/link/{token}")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["valid"] == False
+            assert data["reason"] == "invalid_or_expired"
+            # Should NOT contain "not_found", "disabled", or "expired"
+            assert "not_found" not in str(data)
+
+    def test_normalized_error_history(self):
+        """History endpoint returns generic 404 for invalid tokens."""
+        response = httpx.get(f"{BASE_URL}/api/public/history/nonexistent-token-xyz")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Invalid or expired link"
+
+    def test_normalized_error_session(self):
+        """Session endpoint returns generic 404 for invalid tokens."""
+        response = httpx.delete(
+            f"{BASE_URL}/api/public/session/nonexistent-token-xyz",
+            params={"session_id": "test"}
+        )
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Invalid or expired link"
+
+    def test_normalized_error_chat(self):
+        """Chat endpoint returns generic 404 for invalid tokens."""
+        response = httpx.post(
+            f"{BASE_URL}/api/public/chat/nonexistent-token-xyz",
+            json={"message": "test"}
+        )
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Invalid or expired link"
+
+    def test_normalized_error_intro(self):
+        """Intro endpoint returns generic 404 for invalid tokens."""
+        response = httpx.get(f"{BASE_URL}/api/public/intro/nonexistent-token-xyz")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Invalid or expired link"
+
+    def test_normalized_error_playbooks(self):
+        """Playbooks endpoint returns generic 404 for invalid tokens."""
+        response = httpx.get(f"{BASE_URL}/api/public/playbooks/nonexistent-token-xyz")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Invalid or expired link"
+
+    def test_normalized_error_execution_stream(self):
+        """Execution stream returns generic 404 for invalid tokens."""
+        response = httpx.get(f"{BASE_URL}/api/public/executions/nonexistent-token-xyz/fake-exec-id/stream")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Invalid or expired link"
+
+    def test_normalized_error_execution_status(self):
+        """Execution status returns generic 404 for invalid tokens."""
+        response = httpx.get(f"{BASE_URL}/api/public/executions/nonexistent-token-xyz/fake-exec-id/status")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Invalid or expired link"
+
+    def test_rate_limiting_enforced(self):
+        """Rate limiting triggers after threshold (60 req/min per IP)."""
+        # Flush rate limit counters first so test is self-contained
+        try:
+            import redis as _redis
+            r = _redis.from_url("redis://localhost:6379", decode_responses=True)
+            for key in r.scan_iter("public_link_lookups:*"):
+                r.delete(key)
+        except Exception:
+            pytest.skip("Redis not reachable for rate limit test")
+
+        # Send 61 rapid requests — the 61st should be rate-limited
+        responses = []
+        for i in range(62):
+            resp = httpx.get(f"{BASE_URL}/api/public/link/ratelimit-test-token-{i}")
+            responses.append(resp.status_code)
+            if resp.status_code == 429:
+                break
+
+        assert 429 in responses, "Rate limiting was not enforced after 60+ requests"
+
+    def test_consistent_error_shape_across_endpoints(self):
+        """All endpoints return identical error shape for invalid tokens."""
+        # Flush rate limit counter from previous tests
+        try:
+            import redis as _redis
+            r = _redis.from_url("redis://localhost:6379", decode_responses=True)
+            for key in r.scan_iter("public_link_lookups:*"):
+                r.delete(key)
+        except Exception:
+            pass  # If Redis not reachable, test may still work if under limit
+
+        token = "consistency-test-token"
+        endpoints = [
+            ("GET", f"/api/public/history/{token}"),
+            ("GET", f"/api/public/intro/{token}"),
+            ("GET", f"/api/public/playbooks/{token}"),
+            ("GET", f"/api/public/executions/{token}/fake-id/stream"),
+            ("GET", f"/api/public/executions/{token}/fake-id/status"),
+        ]
+
+        error_details = set()
+        for method, path in endpoints:
+            if method == "GET":
+                resp = httpx.get(f"{BASE_URL}{path}")
+            assert resp.status_code == 404, f"{path} returned {resp.status_code}: {resp.text}"
+            error_details.add(resp.json()["detail"])
+
+        # All endpoints should return the exact same error message
+        assert len(error_details) == 1, f"Inconsistent error messages: {error_details}"
+        assert error_details.pop() == "Invalid or expired link"
 
 
 class TestOwnerEndpointsNoAuth:
@@ -215,12 +356,12 @@ class TestPublicLinkLifecycle:
             assert updated_link["name"] == "Updated Link Name"
             assert updated_link["enabled"] == False
 
-            # 5. Verify public endpoint shows link as disabled
+            # 5. Verify public endpoint shows link as invalid (normalized reason)
             public_response = httpx.get(f"{BASE_URL}/api/public/link/{token}")
             assert public_response.status_code == 200
             public_info = public_response.json()
             assert public_info["valid"] == False
-            assert public_info["reason"] == "disabled"
+            assert public_info["reason"] == "invalid_or_expired"
 
             # 6. Re-enable the link
             enable_response = httpx.put(
@@ -244,10 +385,10 @@ class TestPublicLinkLifecycle:
             )
             assert delete_response.status_code == 200
 
-            # Verify link is gone
+            # Verify link is gone (normalized reason — no oracle)
             verify_deleted = httpx.get(f"{BASE_URL}/api/public/link/{token}")
             assert verify_deleted.json()["valid"] == False
-            assert verify_deleted.json()["reason"] == "not_found"
+            assert verify_deleted.json()["reason"] == "invalid_or_expired"
 
 
 class TestEmailVerification:


### PR DESCRIPTION
## Summary
- Add IP-based rate limiting (60 req/min) to all public link token endpoints using shared Redis counter
- Normalize error responses across all endpoints — valid/invalid/disabled/expired tokens all return identical "Invalid or expired link" message, eliminating the oracle
- Fix `verify/confirm` to use proxy-aware `_get_client_ip()` instead of raw `request.client.host`

## Changes
- `src/backend/routers/public.py` — Rate limiter, `_validate_public_link()` helper, normalized responses on 10 endpoints
- `tests/test_public_links.py` — 10 new security tests, 2 existing tests updated

## Test Plan
- [x] New tests pass: `pytest tests/test_public_links.py -v` (21 passed, 4 skipped)
- [x] Rate limiting verified: 429 returned after 60 requests/min
- [x] Error normalization verified: all endpoints return identical error shape
- [x] Existing tests updated and passing
- [ ] Manual verification: `curl /api/public/link/invalid-token` returns `"reason": "invalid_or_expired"`

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)