### PR TITLE
feat(ui): add owner filter to Dashboard and Agents pages (#69)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-08 | #69 | Owner filter dropdown on Dashboard and Agents pages | [agents-page-ui-improvements.md](feature-flows/agents-page-ui-improvements.md), [agent-network.md](feature-flows/agent-network.md) |
 | 2026-04-06 | QUOTA-001 | Per-role agent creation quotas with admin exemption | [agent-quotas.md](feature-flows/agent-quotas.md) |
 | 2026-04-04 | DASH-001 | Dashboard reliability: DB-persisted cache, retry backoff, partial YAML tolerance, decoupled tab visibility | [dynamic-dashboards.md](feature-flows/dynamic-dashboards.md) |
 | 2026-04-04 | CLI-001 | CLI UX: URL normalization + retry, table default output, tag-driven auto-versioning | [cli-tool.md](feature-flows/cli-tool.md) |

--- a/docs/memory/feature-flows/agent-network.md
+++ b/docs/memory/feature-flows/agent-network.md
@@ -1,6 +1,8 @@
 # Feature: Agent Network
 
-> **Last Updated**: 2026-03-20 - Canonical edge deduplication: bidirectional agent connections now render as ONE line with arrowheads on appropriate ends, instead of TWO overlapping lines. New `getCanonicalEdgePair(x, y)` helper (line 128) returns alphabetically sorted pair. `fetchPermissionEdges()`, `createHistoricalEdges()`, `animateEdge()`, `clearEdgeAnimation()`, and `resetAllEdges()` all use canonical IDs and track `hasForward`/`hasReverse` in edge data for direction-aware `markerStart`/`markerEnd` arrowheads.
+> **Last Updated**: 2026-04-08 - Owner filter (#69): Added owner dropdown to Dashboard header controls. Network store gains `filterOwner` ref (persisted to localStorage) and `setFilterOwner()` action. On change, agents are filtered client-side before `convertAgentsToNodes()` — graph shows only selected owner's agents. Dropdown hidden when ≤1 distinct owner.
+>
+> **Previous (2026-03-20)** - Canonical edge deduplication: bidirectional agent connections now render as ONE line with arrowheads on appropriate ends, instead of TWO overlapping lines. New `getCanonicalEdgePair(x, y)` helper (line 128) returns alphabetically sorted pair. `fetchPermissionEdges()`, `createHistoricalEdges()`, `animateEdge()`, `clearEdgeAnimation()`, and `resetAllEdges()` all use canonical IDs and track `hasForward`/`hasReverse` in edge data for direction-aware `markerStart`/`markerEnd` arrowheads.
 >
 > **Previous (2026-03-18)** - Graph edges simplified to permission-only: `edges` computed now returns `permissionEdges.value` directly (old merge logic combining collaborationEdges + permissionEdges removed). `collaborationEdges` still exists in state and is populated by WebSocket events for live animation purposes, but is NOT rendered in the graph.
 >

--- a/docs/memory/feature-flows/agents-page-ui-improvements.md
+++ b/docs/memory/feature-flows/agents-page-ui-improvements.md
@@ -1,8 +1,8 @@
 # Feature: Agents Page UI Improvements
 
-> **Status**: Implemented (2025-12-07, Enhanced 2026-01-09, System Agent Consolidation 2026-01-13, Toggle UX 2026-01-26, Component Standardization 2026-02-12, Horizontal Row Tiles 2026-03-03, Two-Row Tiles + Persistent Filter 2026-03-03, Full Filtering 2026-03-03, Success Rate Bar 2026-03-03, Capacity Meter + Fixed Grid 2026-03-03, Agent Avatars 2026-03-07)
+> **Status**: Implemented (2025-12-07, Enhanced 2026-01-09, System Agent Consolidation 2026-01-13, Toggle UX 2026-01-26, Component Standardization 2026-02-12, Horizontal Row Tiles 2026-03-03, Two-Row Tiles + Persistent Filter 2026-03-03, Full Filtering 2026-03-03, Success Rate Bar 2026-03-03, Capacity Meter + Fixed Grid 2026-03-03, Agent Avatars 2026-03-07, Owner Filter 2026-04-08)
 > **Tested**: All features verified working
-> **Last Updated**: 2026-03-07 - Agent Avatars: Added `AgentAvatar` component (from `../components/AgentAvatar.vue`) to all three view modes (desktop, tablet, mobile) in Agents.vue. Each renders `<AgentAvatar :name="agent.name" :avatar-url="agent.avatar_url" size="sm" />` next to the agent name. Desktop: line 272, Tablet: line 442, Mobile: line 585.
+> **Last Updated**: 2026-04-08 - Owner Filter (#69): Added owner dropdown filter to Agents page header bar. Derives distinct owners from full agent list, filters with AND logic alongside name/status/tag filters. Hidden when ≤1 distinct owner. Persisted to localStorage (`trinity-agents-filter-owner`). Supports "Unassigned" option for orphaned agents.
 >
 > **Previous (2026-03-03)** - Capacity Meter + Fixed Grid Columns: Added CapacityMeter component to desktop and tablet layouts. Desktop: flex sibling alongside two-row content block (height=48, width=6), default fallback active=0/max=3. Tablet: between success bar and stats (height=28, width=10), conditional on slot data. Fixed grid column widths: Activity column 56px, Stats column 200px with `overflow-hidden` to prevent layout shifts from varying stats content.
 >

--- a/src/frontend/src/stores/network.js
+++ b/src/frontend/src/stores/network.js
@@ -102,11 +102,27 @@ export const useNetworkStore = defineStore('network', () => {
 
   // Filter tags for system views
   const filterTags = ref([])
+  // Filter by owner
+  const filterOwner = ref(localStorage.getItem('trinity-dashboard-filter-owner') || '')
 
   // Actions
   function setFilterTags(tags) {
     filterTags.value = tags || []
     fetchAgents() // Refetch when filter changes
+  }
+
+  function setFilterOwner(owner) {
+    filterOwner.value = owner || ''
+    if (owner) {
+      localStorage.setItem('trinity-dashboard-filter-owner', owner)
+    } else {
+      localStorage.removeItem('trinity-dashboard-filter-owner')
+    }
+    // Re-convert agents to nodes with owner filter applied
+    const filtered = filterOwner.value
+      ? agents.value.filter(a => (a.owner || null) === (filterOwner.value === '__unassigned__' ? null : filterOwner.value))
+      : agents.value
+    convertAgentsToNodes(filtered)
   }
 
   async function fetchAgents() {
@@ -117,7 +133,11 @@ export const useNetworkStore = defineStore('network', () => {
       }
       const response = await axios.get('/api/agents', { params })
       agents.value = response.data
-      convertAgentsToNodes(response.data)
+      // Apply client-side owner filter before converting to nodes
+      const filtered = filterOwner.value
+        ? response.data.filter(a => (a.owner || null) === (filterOwner.value === '__unassigned__' ? null : filterOwner.value))
+        : response.data
+      convertAgentsToNodes(filtered)
       await fetchPermissionEdges()
     } catch (error) {
       console.error('Failed to fetch agents:', error)
@@ -1635,6 +1655,7 @@ export const useNetworkStore = defineStore('network', () => {
     slotStats,
     schedules,
     filterTags,
+    filterOwner,
     // View mode / Replay state
     isTimelineMode,
     isPlaying,
@@ -1657,6 +1678,7 @@ export const useNetworkStore = defineStore('network', () => {
     fetchAgents,
     fetchPermissionEdges,
     setFilterTags,
+    setFilterOwner,
     fetchHistoricalCollaborations,
     fetchHistoricalCommunications: fetchHistoricalCollaborations, // Alias for new terminology
     createHistoricalEdges,

--- a/src/frontend/src/views/Agents.vue
+++ b/src/frontend/src/views/Agents.vue
@@ -60,6 +60,18 @@
             </option>
           </select>
 
+          <!-- Owner filter dropdown -->
+          <select
+            v-if="availableOwners.length > 1"
+            v-model="selectedOwner"
+            class="block rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2 px-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
+          >
+            <option value="">All Owners</option>
+            <option v-for="owner in availableOwners" :key="owner.name || '__unassigned__'" :value="owner.name || '__unassigned__'">
+              {{ owner.name || 'Unassigned' }} ({{ owner.count }})
+            </option>
+          </select>
+
           <!-- Clear all filters -->
           <button
             v-if="hasActiveFilters"
@@ -718,6 +730,7 @@ const initialFilterTag = legacyTag || (legacyTags ? JSON.parse(legacyTags)[0] ||
 if (legacyTag) localStorage.removeItem('trinity-agents-filter-tag')
 if (legacyTags) localStorage.removeItem('trinity-agents-filter-tags')
 const selectedFilterTagDropdown = ref(initialFilterTag)
+const selectedOwner = ref(localStorage.getItem('trinity-agents-filter-owner') || '')
 const selectedAgents = ref([])
 const showBulkAddTag = ref(false)
 const showBulkRemoveTag = ref(false)
@@ -748,14 +761,40 @@ watch(selectedFilterTagDropdown, (val) => {
   }
 })
 
+watch(selectedOwner, (val) => {
+  if (val) {
+    localStorage.setItem('trinity-agents-filter-owner', val)
+  } else {
+    localStorage.removeItem('trinity-agents-filter-owner')
+  }
+})
+
+// Derive distinct owners from the full (unfiltered) agent list
+const availableOwners = computed(() => {
+  const agents = isAdmin.value ? agentsStore.sortedAgentsWithSystem : agentsStore.sortedAgents
+  const counts = {}
+  for (const agent of agents) {
+    const owner = agent.owner || null
+    counts[owner] = (counts[owner] || 0) + 1
+  }
+  return Object.entries(counts)
+    .map(([name, count]) => ({ name: name === 'null' ? null : name, count }))
+    .sort((a, b) => {
+      if (a.name === null) return 1
+      if (b.name === null) return -1
+      return a.name.localeCompare(b.name)
+    })
+})
+
 const hasActiveFilters = computed(() => {
-  return filterName.value.trim() !== '' || filterStatus.value !== 'all' || selectedFilterTagDropdown.value !== ''
+  return filterName.value.trim() !== '' || filterStatus.value !== 'all' || selectedFilterTagDropdown.value !== '' || selectedOwner.value !== ''
 })
 
 function clearAllFilters() {
   filterName.value = ''
   filterStatus.value = 'all'
   selectedFilterTagDropdown.value = ''
+  selectedOwner.value = ''
 }
 
 // Total agent count before filtering (for "Showing X of Y")
@@ -787,6 +826,15 @@ const displayAgents = computed(() => {
       const tags = agentTags.value[agent.name] || []
       return tags.includes(selectedFilterTagDropdown.value)
     })
+  }
+
+  // Filter by owner
+  if (selectedOwner.value) {
+    if (selectedOwner.value === '__unassigned__') {
+      agents = agents.filter(agent => !agent.owner)
+    } else {
+      agents = agents.filter(agent => agent.owner === selectedOwner.value)
+    }
   }
 
   return agents

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -120,7 +120,20 @@
                 <span>Clouds</span>
               </button>
 
-              <span v-if="availableTags.length > 0" class="text-gray-300 dark:text-gray-600">|</span>
+              <!-- Owner filter dropdown -->
+              <select
+                v-if="availableOwners.length > 1"
+                v-model="selectedOwner"
+                @change="onOwnerFilterChange"
+                class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                <option value="">All Owners</option>
+                <option v-for="owner in availableOwners" :key="owner.name || '__unassigned__'" :value="owner.name || '__unassigned__'">
+                  {{ owner.name || 'Unassigned' }} ({{ owner.count }})
+                </option>
+              </select>
+
+              <span v-if="availableTags.length > 0 || availableOwners.length > 1" class="text-gray-300 dark:text-gray-600">|</span>
 
               <!-- Mode Toggle -->
               <div class="flex rounded-md border border-gray-300 dark:border-gray-600 p-0.5 bg-gray-50 dark:bg-gray-700">
@@ -536,6 +549,30 @@ const availableTags = ref([])
 const savedQuickTags = localStorage.getItem('trinity-dashboard-quick-tags')
 const selectedQuickTags = ref(savedQuickTags ? JSON.parse(savedQuickTags) : [])
 const showTagDropdown = ref(false)
+
+// Owner filter state (persisted to localStorage, synced with network store)
+const selectedOwner = ref(networkStore.filterOwner || '')
+
+// Derive distinct owners from the full (unfiltered) agent list
+const availableOwners = computed(() => {
+  const allAgents = agents.value
+  const counts = {}
+  for (const agent of allAgents) {
+    const owner = agent.owner || null
+    counts[owner] = (counts[owner] || 0) + 1
+  }
+  return Object.entries(counts)
+    .map(([name, count]) => ({ name: name === 'null' ? null : name, count }))
+    .sort((a, b) => {
+      if (a.name === null) return 1
+      if (b.name === null) return -1
+      return a.name.localeCompare(b.name)
+    })
+})
+
+function onOwnerFilterChange() {
+  networkStore.setFilterOwner(selectedOwner.value)
+}
 
 // Computed: First 5 tags for inline display
 const displayedTags = computed(() => availableTags.value.slice(0, 5))


### PR DESCRIPTION
## Summary
- Add owner filter dropdown to **Agents page** (next to tag filter) and **Dashboard** (next to Clouds button)
- Client-side AND-logic filtering — works with existing name/status/tag filters
- Derives distinct owners from full agent list, auto-hides when ≤1 owner
- Persists filter selection to localStorage across sessions
- Handles null/orphaned agents as "Unassigned" option

## Changes
- `src/frontend/src/stores/network.js` — `filterOwner` state + `setFilterOwner()` action
- `src/frontend/src/views/Agents.vue` — Owner dropdown + filter in `displayAgents` computed
- `src/frontend/src/views/Dashboard.vue` — Owner dropdown synced with network store
- `docs/memory/feature-flows/` — Updated agent-network.md, agents-page-ui-improvements.md, index

## Test Plan
- [x] Agents page: owner dropdown visible with 2+ owners, filters correctly
- [x] Dashboard: owner dropdown visible, graph updates to show only selected owner's agents
- [x] "All Owners" resets filter on both pages
- [x] Filter persists across page navigation (localStorage)
- [x] "Clear" button resets owner filter along with other filters
- [x] Single-user instance: dropdown hidden (≤1 owner)
- [x] Orphaned agents appear under "Unassigned" option

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)