### PR TITLE
fix(git-init): push workspace to GitHub when remote already has main (#256)

### DIFF
--- a/docs/memory/feature-flows/github-repo-initialization.md
+++ b/docs/memory/feature-flows/github-repo-initialization.md
@@ -12,6 +12,7 @@ As a **Trinity platform user**, I want to **enable GitHub synchronization for an
 
 | Date | Changes |
 |------|---------|
+| 2026-04-10 | Fix (#256): `initialize_git_in_container` now pushes after commit in the `remote_has_main` code path. Previously the workspace was committed locally inside the container but never reached GitHub when the target repo already had a `main` branch, making the UI report success while no files synced. |
 | 2026-02-11 | Added LEGACY notes for workspace path checks - new agents (2026-02+) use `/home/developer` directly, workspace checks exist for backward compatibility with pre-2026-02 agents |
 | 2026-01-23 | Verified line numbers against current implementation, updated MCP tool lines (530-604), verified git_service.py structure |
 | 2025-12-31 | Refactored to clean architecture with service layer |

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -367,14 +367,17 @@ async def initialize_git_in_container(
     remote_has_main = check_main.get("exit_code", 1) == 0
 
     if remote_has_main:
-        # Preserve remote history: reset to origin/main, then commit local changes
+        # Preserve remote history: reset index to origin/main, then stage
+        # the current workspace on top of it and fast-forward push.
         commit_commands = [
             'git reset origin/main',
             'git add .',
             'git commit -m "Initial commit from Trinity Agent" || echo "Nothing to commit"',
+            # Always set upstream; no-op when there is nothing new to push.
+            'git push -u origin main',
         ]
     else:
-        # Empty repo: fall back to force push (creates initial history)
+        # Empty repo: force push creates the initial history.
         commit_commands = [
             'git add .',
             'git commit -m "Initial commit from Trinity Agent" || echo "Nothing to commit"',

--- a/tests/unit/test_github_init_push.py
+++ b/tests/unit/test_github_init_push.py
@@ -1,0 +1,200 @@
+"""
+Tests for GitHub sync initialization command sequence (#256).
+
+Verifies that `initialize_git_in_container` pushes the initial commit to
+GitHub in both code paths:
+
+- Empty remote: force push creates initial history (pre-existing behavior)
+- Remote already has main: fast-forward push sends the agent's workspace
+  on top of origin/main (bug fix — push was previously missing)
+
+Module: src/backend/services/git_service.py
+"""
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+_project_root = Path(__file__).resolve().parents[2]
+backend_path = str(_project_root / "src" / "backend")
+if backend_path not in sys.path:
+    sys.path.insert(0, backend_path)
+
+
+def _load_git_service():
+    """Import git_service with heavy dependencies mocked out."""
+    mock_modules = {}
+    for mod in [
+        "docker", "docker.errors", "docker.types",
+        "redis", "redis.asyncio",
+        "database",
+        "services.docker_service",
+    ]:
+        mock_modules[mod] = Mock()
+
+    # `database` exposes `db`, `AgentGitConfig`, `GitSyncResult` at import time
+    mock_modules["database"].db = Mock()
+    mock_modules["database"].AgentGitConfig = Mock
+    mock_modules["database"].GitSyncResult = Mock
+
+    with patch.dict("sys.modules", mock_modules):
+        # Force reimport
+        for key in list(sys.modules.keys()):
+            if key.startswith("services.git_service"):
+                del sys.modules[key]
+        import services.git_service as gs
+    return gs
+
+
+class _FakeExec:
+    """Records commands and returns canned results for git operations."""
+
+    def __init__(self, remote_has_main: bool, commit_succeeds: bool = True):
+        self.remote_has_main = remote_has_main
+        self.commit_succeeds = commit_succeeds
+        self.calls: list[str] = []
+
+    async def __call__(self, container_name: str, command: str, timeout: int = 60):
+        # Capture the raw git command (the bit after `cd <dir> && `)
+        inner = command
+        if " && " in command:
+            inner = command.split(" && ", 1)[1].rstrip('"')
+        self.calls.append(inner)
+
+        # Workspace content check — pretend /home/developer/workspace is empty
+        if "find /home/developer/workspace" in command:
+            return {"exit_code": 0, "output": "0"}
+
+        # .gitignore write
+        if "GITIGNORE_EOF" in command:
+            return {"exit_code": 0, "output": ""}
+
+        # origin/main existence check
+        if "git rev-parse --verify origin/main" in inner:
+            return {
+                "exit_code": 0 if self.remote_has_main else 1,
+                "output": "abc123" if self.remote_has_main else "fatal: needed a revision"
+            }
+
+        # Commit may legitimately have nothing to commit
+        if inner.startswith("git commit") and not self.commit_succeeds:
+            return {"exit_code": 0, "output": "Nothing to commit"}
+
+        # Final verification
+        if "git rev-parse --git-dir" in inner:
+            return {"exit_code": 0, "output": ".git"}
+
+        # Everything else: success
+        return {"exit_code": 0, "output": ""}
+
+
+@pytest.mark.asyncio
+async def test_empty_remote_force_pushes():
+    """Initial push happens when origin/main doesn't exist yet."""
+    gs = _load_git_service()
+    fake = _FakeExec(remote_has_main=False)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs.initialize_git_in_container(
+            agent_name="test-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    assert result.success, f"expected success, got error: {result.error}"
+    # The bug: the old behaviour for empty-remote was already correct,
+    # this test just pins it so a refactor doesn't regress it.
+    assert any("git push -u origin main --force" in c for c in fake.calls), \
+        f"expected force push to empty remote, got: {fake.calls}"
+
+
+@pytest.mark.asyncio
+async def test_existing_remote_pushes_after_commit():
+    """
+    Regression test for #256.
+
+    When the remote already has a main branch, the old code reset to
+    origin/main, committed the workspace, and then did nothing — the
+    commit never reached GitHub. The fix adds a `git push -u origin main`
+    after the commit so the agent's workspace actually lands on GitHub.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(remote_has_main=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs.initialize_git_in_container(
+            agent_name="test-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    assert result.success, f"expected success, got error: {result.error}"
+
+    # Fast-forward push (not --force) to preserve any existing history
+    push_calls = [c for c in fake.calls if c.startswith("git push")]
+    assert push_calls, \
+        f"BUG: no git push issued on remote-has-main path. Calls: {fake.calls}"
+    assert any(c == "git push -u origin main" for c in push_calls), \
+        f"expected fast-forward 'git push -u origin main', got: {push_calls}"
+    assert not any("--force" in c for c in push_calls), \
+        f"must not force-push when remote has history, got: {push_calls}"
+
+
+@pytest.mark.asyncio
+async def test_existing_remote_reset_precedes_commit():
+    """Command order: reset → add → commit → push (remote-has-main path)."""
+    gs = _load_git_service()
+    fake = _FakeExec(remote_has_main=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        await gs.initialize_git_in_container(
+            agent_name="test-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    # Find the indices of the four operations in commit_commands
+    def idx(substr):
+        for i, c in enumerate(fake.calls):
+            if substr in c:
+                return i
+        return -1
+
+    reset_i = idx("git reset origin/main")
+    add_i = idx("git add .")
+    commit_i = idx("git commit -m")
+    push_i = idx("git push -u origin main")
+
+    assert reset_i >= 0 and add_i >= 0 and commit_i >= 0 and push_i >= 0, \
+        f"missing expected commands, got: {fake.calls}"
+    assert reset_i < add_i < commit_i < push_i, \
+        f"commands out of order: reset@{reset_i} add@{add_i} commit@{commit_i} push@{push_i}"
+
+
+@pytest.mark.asyncio
+async def test_existing_remote_nothing_to_commit_still_pushes():
+    """
+    Edge case: workspace is already identical to origin/main.
+
+    The commit step reports 'Nothing to commit' (exit 0 via the `|| echo`
+    fallback). The subsequent push is a no-op against an up-to-date remote,
+    but we still issue it so upstream tracking gets set.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(remote_has_main=True, commit_succeeds=False)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs.initialize_git_in_container(
+            agent_name="test-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    assert result.success
+    assert any(c == "git push -u origin main" for c in fake.calls), \
+        "push should run even when there was nothing new to commit"


### PR DESCRIPTION
## Summary

Fixes #256. `initialize_github_sync` silently succeeded without actually pushing the agent's workspace to GitHub whenever the target repo already had a `main` branch (e.g., a README).

## Root cause

`initialize_git_in_container` in `services/git_service.py` had two code paths depending on whether `origin/main` existed:

- **Empty remote** (no `main`): ended with `git push -u origin main --force` ✓
- **Remote has `main`**: did `git reset origin/main` → `git add .` → `git commit` — and then **nothing**. No push.

The commit lived inside the container forever. The DB row was written, the UI reported success, but GitHub never saw the workspace. This triggered in two very common scenarios:
1. Pre-created a GitHub repo with a README, then tried to initialize Trinity sync against it
2. Pointed at any existing repo that already had history

## Fix

Added `git push -u origin main` to the `remote_has_main` command list — fast-forward push (not `--force`), since we're one commit ahead of `origin/main` and want to preserve any history already on the remote. Push runs even on the "nothing to commit" path so upstream tracking still gets set.

```diff
     if remote_has_main:
-        # Preserve remote history: reset to origin/main, then commit local changes
+        # Preserve remote history: reset index to origin/main, then stage
+        # the current workspace on top of it and fast-forward push.
         commit_commands = [
             'git reset origin/main',
             'git add .',
             'git commit -m "Initial commit from Trinity Agent" || echo "Nothing to commit"',
+            # Always set upstream; no-op when there is nothing new to push.
+            'git push -u origin main',
         ]
```

## Test plan

### Unit tests (`tests/unit/test_github_init_push.py`, 4 new tests)

- [x] `test_empty_remote_force_pushes` — regression pin for the previously-working empty-repo path
- [x] `test_existing_remote_pushes_after_commit` — the fix: push now happens in the `remote_has_main` branch
- [x] `test_existing_remote_reset_precedes_commit` — command order: reset → add → commit → push
- [x] `test_existing_remote_nothing_to_commit_still_pushes` — push runs even when commit was a no-op

Verified that 3 of 4 tests fail against the pre-fix code and all 4 pass with the fix.

### Manual end-to-end (verified firsthand against real GitHub)

- [x] **Case A — the bug path**: pre-created `YOUR_USER/trinity-256-test --add-readme`, created a fresh blank Trinity agent, ran Initialize GitHub Sync against it. Confirmed the agent's workspace commit now appears on GitHub on top of the README commit. (Before the fix: the UI reported success but only the README existed remotely.)
- [x] **Case B — regression check**: pre-created an empty repo (no `--add-readme`), ran init, confirmed the empty-remote force-push path still produces a single `Initial commit from Trinity Agent` on `main` with the workspace contents.

## Notes / follow-ups (out of scope for this PR)

- `https://oauth2:{PAT}@github.com/...` embeds the PAT in the remote URL. On git errors, git often writes the remote URL to stderr, which then flows into the HTTPException detail and server logs. Blast radius is low (gated on `OwnedAgentByName`, so the leak is to the PAT owner themselves) but worth fixing separately via `git credential.helper` / `GIT_ASKPASS`.
- `"Nothing to commit"` string-matching to detect no-op commits is fragile but pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)