### PR TITLE
fix(cleanup): use per-agent slot TTL instead of fixed 20-min default (#226)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-10 | #226 | Per-agent slot TTL + watchdog coordination to prevent false execution failures | [cleanup-service.md](feature-flows/cleanup-service.md), [parallel-capacity.md](feature-flows/parallel-capacity.md) |
 | 2026-04-08 | #69 | Owner filter dropdown on Dashboard and Agents pages | [agents-page-ui-improvements.md](feature-flows/agents-page-ui-improvements.md), [agent-network.md](feature-flows/agent-network.md) |
 | 2026-04-06 | QUOTA-001 | Per-role agent creation quotas with admin exemption | [agent-quotas.md](feature-flows/agent-quotas.md) |
 | 2026-04-04 | DASH-001 | Dashboard reliability: DB-persisted cache, retry backoff, partial YAML tolerance, decoupled tab visibility | [dynamic-dashboards.md](feature-flows/dynamic-dashboards.md) |

--- a/docs/memory/feature-flows/cleanup-service.md
+++ b/docs/memory/feature-flows/cleanup-service.md
@@ -94,23 +94,27 @@ Seven sequential operations, each wrapped in individual try/except. Watchdog run
    ```
    Calls `DatabaseManager.mark_stale_activities_failed()` which delegates to `ActivityOperations.mark_stale_activities_failed()`.
 
-5. **Cleanup stale Redis slots and fail execution records** (lines 123-148, Issue #219)
+5. **Cleanup stale Redis slots and fail execution records** (lines 176-213, Issue #219, #226)
    ```python
    slot_service = get_slot_service()
-   reclaimed = await slot_service.cleanup_stale_slots()
+   agent_timeouts = db.get_all_execution_timeouts()  # #226: per-agent TTL
+   reclaimed = await slot_service.cleanup_stale_slots(agent_timeouts=agent_timeouts)
    report.stale_slots = sum(len(ids) for ids in reclaimed.values())
-   # Fail execution records whose slots were reclaimed
+   # Fail execution records whose slots were reclaimed,
+   # but skip IDs the watchdog confirmed as still running (#226)
    for agent_name, execution_ids in reclaimed.items():
        for execution_id in execution_ids:
+           if execution_id in confirmed_running_ids:
+               continue  # Watchdog verified alive
            db.fail_stale_slot_execution(execution_id, error=...)
    ```
-   Calls `SlotService.cleanup_stale_slots()` which scans all `agent:slots:*` keys, removes entries older than TTL, and returns a dict mapping agent names to reclaimed execution IDs. The cleanup service then fails the corresponding `schedule_executions` DB records using a guarded update (`WHERE status = 'running'`) to avoid overwriting executions that completed via another path.
+   Calls `SlotService.cleanup_stale_slots(agent_timeouts)` which scans all `agent:slots:*` keys, removes entries older than per-agent TTL (agent timeout + 5 min buffer, #226), and returns a dict mapping agent names to reclaimed execution IDs. The cleanup service then fails the corresponding `schedule_executions` DB records using a guarded update (`WHERE status = 'running'`), skipping any execution IDs the watchdog confirmed are still running on their agents.
 
 ### Watchdog Reconciliation (Issue #129)
 
 Active reconciliation of DB execution state against agent process registries. Replaces the passive "detect-and-report" model with active remediation.
 
-#### `_reconcile_orphaned_executions()` → `tuple[int, int]`
+#### `_reconcile_orphaned_executions()` → `tuple[int, int, set]`
 1. Query `db.get_running_executions_with_agent_info()` — LEFT JOINs `schedule_executions` with `agent_schedules` and `agent_ownership` for timeout resolution: `COALESCE(schedule.timeout, agent.timeout, 900)`
 2. Group executions by `agent_name`
 3. Parallel fan-out: `asyncio.gather` queries all agents concurrently via shared `httpx.AsyncClient`
@@ -122,7 +126,7 @@ Active reconciliation of DB execution state against agent process registries. Re
 | No (ConnectError/Timeout) | — | — | **SKIP** (retry next cycle) |
 | Yes | No | Age < 60s | **SKIP** (dispatch grace window) |
 | Yes | No | Age >= 60s | **ORPHAN RECOVERY** |
-| Yes | Yes | No | **NO ACTION** |
+| Yes | Yes | No | **CONFIRMED RUNNING** (#226: added to confirmed_running set, slot cleanup skips DB failure) |
 | Yes | Yes | Yes, terminate succeeds | **AUTO-TERMINATE** |
 | Yes | Yes | Yes, terminate fails | **SKIP** (defer to 120-min stale cleanup) |
 
@@ -348,21 +352,24 @@ WHERE id = ?
 ### Redis Operations
 
 #### cleanup_stale_slots (SlotService)
-**File**: `src/backend/services/slot_service.py:259-295`
+**File**: `src/backend/services/slot_service.py:264-302`
 
 **Returns**: `Dict[str, List[str]]` — mapping of agent_name to list of reclaimed execution IDs (Issue #219).
 
+**Args** (#226): `agent_timeouts: Dict[str, int]` — optional mapping of agent_name to execution_timeout_seconds. When provided, uses per-agent TTL (timeout + 5 min buffer) instead of the fixed default.
+
 **Logic**:
 1. Scans all keys matching `agent:slots:*` pattern via `SCAN`
-2. For each agent, calls `_cleanup_stale_slots_for_agent()` which returns the reclaimed execution IDs
-3. Removes ZSET entries with score (timestamp) older than TTL:
+2. For each agent, computes slot TTL: `agent_timeouts[name] + SLOT_TTL_BUFFER` if available, else `DEFAULT_SLOT_TTL_SECONDS` (#226)
+3. Calls `_cleanup_stale_slots_for_agent(agent_name, slot_ttl)` which returns the reclaimed execution IDs
+4. Removes ZSET entries with score (timestamp) older than TTL:
    ```
    ZREMRANGEBYSCORE agent:slots:{name} -inf {cutoff_timestamp}
    ```
-4. Deletes corresponding metadata keys: `agent:slot:{name}:{execution_id}`
-5. Returns the execution IDs so the caller (cleanup service) can fail corresponding DB records
+5. Deletes corresponding metadata keys: `agent:slot:{name}:{execution_id}`
+6. Returns the execution IDs so the caller (cleanup service) can fail corresponding DB records
 
-**TTL**: `DEFAULT_SLOT_TTL_SECONDS = 1200` (20 minutes, line 31)
+**TTL**: Per-agent (`execution_timeout_seconds + 300`), falling back to `DEFAULT_SLOT_TTL_SECONDS = 1200` (20 minutes) for agents not in the map (#226)
 
 ## Side Effects
 - **Logging**: Each cleanup cycle logs results at INFO level when resources are cleaned

--- a/docs/memory/feature-flows/parallel-capacity.md
+++ b/docs/memory/feature-flows/parallel-capacity.md
@@ -235,7 +235,7 @@ Every 5 seconds (agents store / network store):
 | `src/backend/services/slot_service.py` | 130-152 | release_slot() - Slot release and cleanup |
 | `src/backend/services/slot_service.py` | 154-199 | get_slot_state() - Detailed slot info |
 | `src/backend/services/slot_service.py` | 201-221 | get_all_slot_states() - Bulk query for Dashboard |
-| `src/backend/services/slot_service.py` | 247-271 | cleanup_stale_slots() - 30-min TTL enforcement |
+| `src/backend/services/slot_service.py` | 264-302 | cleanup_stale_slots(agent_timeouts) - Per-agent TTL enforcement (#226) |
 
 ### REST API Endpoints
 

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -446,6 +446,9 @@ class DatabaseManager:
     def get_execution_timeout(self, agent_name: str) -> int:
         return self._agent_ops.get_execution_timeout(agent_name)
 
+    def get_all_execution_timeouts(self) -> dict:
+        return self._agent_ops.get_all_execution_timeouts()
+
     def set_execution_timeout(self, agent_name: str, timeout_seconds: int) -> bool:
         return self._agent_ops.set_execution_timeout(agent_name, timeout_seconds)
 

--- a/src/backend/db/agent_settings/resources.py
+++ b/src/backend/db/agent_settings/resources.py
@@ -153,6 +153,21 @@ class ResourcesMixin:
                 return row["execution_timeout_seconds"]
             return 900  # Default 15 minutes
 
+    def get_all_execution_timeouts(self) -> dict:
+        """
+        Get execution_timeout_seconds for all agents.
+
+        Returns:
+            Dict mapping agent_name to timeout in seconds.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT agent_name, COALESCE(execution_timeout_seconds, 900) as timeout
+                FROM agent_ownership
+            """)
+            return {row["agent_name"]: row["timeout"] for row in cursor.fetchall()}
+
     def set_execution_timeout(self, agent_name: str, timeout_seconds: int) -> bool:
         """
         Set execution_timeout_seconds for an agent.

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -121,8 +121,13 @@ class CleanupService:
         # 0. Watchdog: reconcile DB vs agent process registries (Issue #129)
         # Runs FIRST so it can release resources before stale cleanup marks
         # executions failed without resource cleanup.
+        # Also returns confirmed_running_ids (#226) to prevent slot cleanup
+        # from falsely failing executions the watchdog verified as alive.
+        confirmed_running_ids: set = set()
         try:
-            orphaned, terminated = await self._reconcile_orphaned_executions()
+            orphaned, terminated, confirmed_running_ids = (
+                await self._reconcile_orphaned_executions()
+            )
             report.orphaned_executions = orphaned
             report.auto_terminated = terminated
             if orphaned > 0:
@@ -168,15 +173,29 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error marking stale activities: {e}")
 
-        # 3. Cleanup stale Redis slots and fail corresponding execution records (#219)
+        # 3. Cleanup stale Redis slots and fail corresponding execution records (#219, #226)
         try:
             slot_service = get_slot_service()
-            reclaimed = await slot_service.cleanup_stale_slots()
+
+            # #226: Query per-agent timeouts from DB so slot cleanup uses the
+            # correct TTL instead of a fixed 20-min default.
+            agent_timeouts = db.get_all_execution_timeouts()
+
+            reclaimed = await slot_service.cleanup_stale_slots(
+                agent_timeouts=agent_timeouts
+            )
             report.stale_slots = sum(len(ids) for ids in reclaimed.values())
 
-            # Fail execution records whose slots were reclaimed
+            # Fail execution records whose slots were reclaimed,
+            # but skip IDs the watchdog confirmed as still running (#226).
             for agent_name, execution_ids in reclaimed.items():
                 for execution_id in execution_ids:
+                    if execution_id in confirmed_running_ids:
+                        logger.info(
+                            f"[Cleanup] Skipping execution {execution_id} for agent "
+                            f"'{agent_name}' — watchdog confirmed still running"
+                        )
+                        continue
                     try:
                         updated = db.fail_stale_slot_execution(
                             execution_id=execution_id,
@@ -202,7 +221,7 @@ class CleanupService:
 
         return report
 
-    async def _reconcile_orphaned_executions(self) -> tuple[int, int]:
+    async def _reconcile_orphaned_executions(self) -> tuple[int, int, set]:
         """Reconcile DB execution state against agent process registries.
 
         For each execution marked 'running' in the DB:
@@ -211,11 +230,13 @@ class CleanupService:
         3. If found but exceeded timeout: terminate, mark failed, release resources
 
         Returns:
-            Tuple of (orphaned_count, auto_terminated_count)
+            Tuple of (orphaned_count, auto_terminated_count, confirmed_running_ids)
+            where confirmed_running_ids is the set of execution IDs verified as still
+            running on their agents (used by slot cleanup to avoid false failures, #226).
         """
         running_executions = db.get_running_executions_with_agent_info()
         if not running_executions:
-            return (0, 0)
+            return (0, 0, set())
 
         # Group by agent for batch HTTP calls (one call per agent)
         agents: Dict[str, List[Dict]] = defaultdict(list)
@@ -241,6 +262,7 @@ class CleanupService:
             terminated_count = 0
             recovery_attempts = 0
             recovery_failures = 0
+            confirmed_running: set = set()  # #226: track IDs verified as still running
 
             for agent_name, executions in agents.items():
                 agent_running_ids = agent_running.get(agent_name)
@@ -281,30 +303,34 @@ class CleanupService:
                             # Execution is on agent — check timeout
                             timeout_seconds = ex.get("timeout_seconds") or 900
 
-                            if age_seconds > timeout_seconds:
-                                # Auto-terminate: exceeded schedule timeout
-                                recovery_attempts += 1
-                                age_minutes = int(age_seconds / 60)
-                                terminated = await self._terminate_on_agent(
-                                    client, agent_name, execution_id
+                            if age_seconds <= timeout_seconds:
+                                # Still running within timeout — mark as confirmed (#226)
+                                confirmed_running.add(execution_id)
+                                continue
+
+                            # Auto-terminate: exceeded schedule timeout
+                            recovery_attempts += 1
+                            age_minutes = int(age_seconds / 60)
+                            terminated = await self._terminate_on_agent(
+                                client, agent_name, execution_id
+                            )
+                            if not terminated:
+                                # Process may still be running — skip DB/resource
+                                # cleanup, let the 120-min stale cleanup handle it
+                                logger.warning(
+                                    f"[Watchdog] Terminate failed for {execution_id} "
+                                    f"on '{agent_name}' — deferring to stale cleanup"
                                 )
-                                if not terminated:
-                                    # Process may still be running — skip DB/resource
-                                    # cleanup, let the 120-min stale cleanup handle it
-                                    logger.warning(
-                                        f"[Watchdog] Terminate failed for {execution_id} "
-                                        f"on '{agent_name}' — deferring to stale cleanup"
-                                    )
-                                    continue
-                                error_msg = (
-                                    f"Execution auto-terminated after {age_minutes} minutes "
-                                    f"by watchdog (exceeded timeout of {timeout_seconds}s)"
-                                )
-                                recovered = await self._recover_execution(
-                                    execution_id, agent_name, error_msg, "auto_terminated"
-                                )
-                                if recovered:
-                                    terminated_count += 1
+                                continue
+                            error_msg = (
+                                f"Execution auto-terminated after {age_minutes} minutes "
+                                f"by watchdog (exceeded timeout of {timeout_seconds}s)"
+                            )
+                            recovered = await self._recover_execution(
+                                execution_id, agent_name, error_msg, "auto_terminated"
+                            )
+                            if recovered:
+                                terminated_count += 1
 
                     except Exception as e:
                         recovery_failures += 1
@@ -320,7 +346,7 @@ class CleanupService:
                 f"recovery attempts failed in this cycle"
             )
 
-        return (orphaned_count, terminated_count)
+        return (orphaned_count, terminated_count, confirmed_running)
 
     async def _get_agent_running_ids(
         self, client: httpx.AsyncClient, agent_name: str

--- a/src/backend/services/slot_service.py
+++ b/src/backend/services/slot_service.py
@@ -261,9 +261,17 @@ class SlotService:
 
         return []
 
-    async def cleanup_stale_slots(self) -> Dict[str, List[str]]:
+    async def cleanup_stale_slots(
+        self, agent_timeouts: Dict[str, int] = None
+    ) -> Dict[str, List[str]]:
         """
         Remove slots older than TTL for all agents.
+
+        Args:
+            agent_timeouts: Optional dict mapping agent_name to execution_timeout_seconds.
+                When provided, uses per-agent TTL (timeout + buffer) instead of the
+                fixed default. Fixes #226: prevents premature slot reclamation for
+                agents with custom timeouts.
 
         Returns:
             Dict mapping agent_name to list of reclaimed execution IDs.
@@ -278,7 +286,14 @@ class SlotService:
             cursor, keys = self.redis.scan(cursor, match=pattern, count=100)
             for key in keys:
                 agent_name = key.replace(self.slots_prefix, "")
-                stale_ids = await self._cleanup_stale_slots_for_agent(agent_name)
+                # Use per-agent timeout if available, otherwise fall back to default
+                if agent_timeouts and agent_name in agent_timeouts:
+                    slot_ttl = agent_timeouts[agent_name] + SLOT_TTL_BUFFER
+                else:
+                    slot_ttl = DEFAULT_SLOT_TTL_SECONDS
+                stale_ids = await self._cleanup_stale_slots_for_agent(
+                    agent_name, slot_ttl
+                )
                 if stale_ids:
                     reclaimed[agent_name] = stale_ids
             if cursor == 0:


### PR DESCRIPTION
## Summary
- Periodic slot cleanup now queries per-agent `execution_timeout_seconds` from DB instead of using a fixed 20-min TTL, preventing premature slot reclamation for agents with custom timeouts
- Watchdog reconciliation returns confirmed-running execution IDs; slot cleanup skips DB failure marking for those IDs, preventing false "failed" status on actively running tasks
- Added `get_all_execution_timeouts()` bulk DB query for efficient per-agent timeout lookup

## Changes
- `src/backend/services/slot_service.py` — `cleanup_stale_slots()` accepts `agent_timeouts` map
- `src/backend/services/cleanup_service.py` — wires watchdog confirmed-running set to slot cleanup
- `src/backend/db/agent_settings/resources.py` — bulk timeout query
- `src/backend/database.py` — delegate new method
- `docs/memory/feature-flows/cleanup-service.md` — updated flow docs
- `docs/memory/feature-flows/parallel-capacity.md` — updated slot cleanup reference

## Test Plan
- [x] All modified files pass syntax check
- [x] `get_all_execution_timeouts()` returns correct data from live DB
- [x] Manual cleanup trigger returns correct report (no errors, same structure)
- [x] Existing `test_cleanup_service.py` API contract unchanged
- [x] Verify agent with custom timeout (30 min) no longer gets false "failed" status — injected 25-min-old slot survived cleanup (per-agent TTL = 35 min), while 40-min-old slot was correctly reclaimed

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)