### PR TITLE
feat(ui): add Telegram bot connection UI to Sharing page (#296)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-10 | #296 | Telegram bot connection UI — TelegramChannelPanel in Agent Detail Sharing page | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-08 | #69 | Owner filter dropdown on Dashboard and Agents pages | [agents-page-ui-improvements.md](feature-flows/agents-page-ui-improvements.md), [agent-network.md](feature-flows/agent-network.md) |
 | 2026-04-06 | QUOTA-001 | Per-role agent creation quotas with admin exemption | [agent-quotas.md](feature-flows/agent-quotas.md) |
 | 2026-04-04 | DASH-001 | Dashboard reliability: DB-persisted cache, retry backoff, partial YAML tolerance, decoupled tab visibility | [dynamic-dashboards.md](feature-flows/dynamic-dashboards.md) |

--- a/docs/memory/feature-flows/telegram-integration.md
+++ b/docs/memory/feature-flows/telegram-integration.md
@@ -310,6 +310,67 @@ The message router restricts public channel users to `WebSearch,WebFetch` by def
    **Expected**: Webhook deleted from Telegram, binding removed from DB
    **Verify**: `GET /api/agents/{agent}/telegram` returns `configured: false`
 
+## Frontend Layer
+
+### Component: `src/frontend/src/components/TelegramChannelPanel.vue`
+
+Self-contained panel rendered in the Agent Detail → Sharing tab via `SharingPanel.vue`. Mirrors the `SlackChannelPanel.vue` pattern.
+
+**Props**: `agentName` (String, required)
+
+**States**: `loading`, `connecting`, `disconnecting`, `verifying`, `accessDenied`
+
+**Data model**:
+```javascript
+binding = {
+  configured: boolean,
+  bot_username: string,
+  bot_id: string,
+  webhook_url: string | null,
+  bot_link: string | null
+}
+```
+
+**UI States**:
+
+| State | Display |
+|-------|---------|
+| Loading | Spinner |
+| Access denied (403) | "Only the agent owner can manage..." |
+| Disconnected | Token input (`type="password"`) + "Connect Bot" button + BotFather link |
+| Connected | Green dot, `@bot_username`, t.me link, Verify + Disconnect buttons |
+| Connected (no webhook) | Yellow warning: "Bot connected but webhook not registered..." |
+
+**API calls** (via `api.js` — Invariant #7):
+- `GET /api/agents/{name}/telegram` → load binding status
+- `PUT /api/agents/{name}/telegram` → connect bot (sends `{ bot_token }`)
+- `DELETE /api/agents/{name}/telegram` → disconnect bot
+- `POST /api/agents/{name}/telegram/test` → verify bot (calls getMe)
+
+**Security**:
+- Token input is `type="password"` (masked in DOM)
+- `botToken` ref cleared to `''` immediately on successful connect
+- No `console.error(e)` that could leak token via axios error object
+- Backend never returns token in GET response
+
+**Error handling**:
+- 409 → "This bot is already bound to agent '{name}'" (surfaces agent name from backend)
+- 400 → Invalid token format or failed getMe validation
+- 502 → Telegram API unreachable
+- Generic fallback for unexpected errors
+
+### Integration: `src/frontend/src/components/SharingPanel.vue`
+
+TelegramChannelPanel is imported and rendered between the Slack and Public Links sections:
+
+```vue
+<SlackChannelPanel :agent-name="agentName" />
+<div class="border-t ..."></div>
+<TelegramChannelPanel :agent-name="agentName" />
+<div class="border-t ..."></div>
+<PublicLinksPanel :agent-name="agentName" />
+```
+
 ## Related Flows
 - [slack-integration.md](slack-integration.md) — Slack equivalent (SLACK-001)
 - [slack-channel-routing.md](slack-channel-routing.md) — Channel adapter abstraction (SLACK-002)

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -674,11 +674,12 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
 - **Flow**: `docs/memory/feature-flows/slack-file-sharing.md`
 
 ### 15.1c Telegram Bot Integration (TGRAM-001)
-- **Status**: 🚧 In Progress (2026-03-31)
+- **Status**: ✅ Complete (2026-04-10)
 - **Requirement ID**: TGRAM-001
 - **Priority**: P2
 - **Description**: Per-agent Telegram bot integration. Each agent gets its own Telegram bot (1:1 via @BotFather), shareable via `t.me/BotUsername` links. Reuses the `ChannelAdapter` abstraction proven by SLACK-002.
 - **Key Features**:
+  - Frontend UI: `TelegramChannelPanel.vue` in Agent Detail → Sharing tab (connect, verify, disconnect, webhook warning)
   - Per-agent bots (one bot per agent, token encrypted via AES-256-GCM)
   - Bidirectional text chat (users message bot → agent responds via HTML formatting)
   - Photo and document support (download, text extraction for plain text files)

--- a/src/frontend/src/components/SharingPanel.vue
+++ b/src/frontend/src/components/SharingPanel.vue
@@ -85,6 +85,12 @@
     <!-- Divider -->
     <div class="border-t border-gray-200 dark:border-gray-700"></div>
 
+    <!-- Telegram Bot Section -->
+    <TelegramChannelPanel :agent-name="agentName" />
+
+    <!-- Divider -->
+    <div class="border-t border-gray-200 dark:border-gray-700"></div>
+
     <!-- Public Links Section -->
     <PublicLinksPanel :agent-name="agentName" />
   </div>
@@ -97,6 +103,7 @@ import { useAgentSharing } from '../composables/useAgentSharing'
 import { useNotification } from '../composables'
 import PublicLinksPanel from './PublicLinksPanel.vue'
 import SlackChannelPanel from './SlackChannelPanel.vue'
+import TelegramChannelPanel from './TelegramChannelPanel.vue'
 
 const props = defineProps({
   agentName: {

--- a/src/frontend/src/components/TelegramChannelPanel.vue
+++ b/src/frontend/src/components/TelegramChannelPanel.vue
@@ -1,0 +1,206 @@
+<template>
+  <div>
+    <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Telegram Bot</h3>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      Connect a Telegram bot so users can chat with this agent via Telegram DMs.
+    </p>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>
+      Loading...
+    </div>
+
+    <!-- Access Denied -->
+    <div v-else-if="accessDenied" class="text-sm text-gray-500 dark:text-gray-400">
+      Only the agent owner can manage Telegram bot settings.
+    </div>
+
+    <!-- Connected State -->
+    <div v-else-if="binding.configured" class="space-y-3">
+      <div class="p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <span class="inline-block w-2.5 h-2.5 rounded-full bg-green-500"></span>
+            <div>
+              <p class="text-sm font-medium text-gray-900 dark:text-white">
+                @{{ binding.bot_username }}
+              </p>
+              <a
+                v-if="binding.bot_link"
+                :href="binding.bot_link"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+              >
+                {{ binding.bot_link }}
+              </a>
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            <button
+              @click="verifyBot"
+              :disabled="verifying"
+              class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 disabled:opacity-50"
+            >
+              {{ verifying ? 'Verifying...' : 'Verify' }}
+            </button>
+            <button
+              @click="disconnectBot"
+              :disabled="disconnecting"
+              class="text-sm text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 disabled:opacity-50"
+            >
+              {{ disconnecting ? 'Removing...' : 'Disconnect' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Webhook Warning -->
+      <div v-if="!binding.webhook_url" class="p-3 rounded-lg text-sm bg-yellow-50 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300">
+        Bot connected but webhook not registered. Set a public URL in Settings for Telegram messages to reach this agent.
+      </div>
+    </div>
+
+    <!-- Disconnected State — Token Input -->
+    <div v-else>
+      <form @submit.prevent="connectBot" class="space-y-3">
+        <div>
+          <label for="telegram-token" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Bot Token
+          </label>
+          <input
+            id="telegram-token"
+            v-model="botToken"
+            type="password"
+            placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+            :disabled="connecting"
+            class="w-full max-w-lg px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-900"
+          />
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Get a token from <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" class="text-indigo-600 dark:text-indigo-400 hover:underline">@BotFather</a> on Telegram.
+          </p>
+        </div>
+        <button
+          type="submit"
+          :disabled="connecting || !botToken.trim()"
+          class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <svg v-if="connecting" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          {{ connecting ? 'Connecting...' : 'Connect Bot' }}
+        </button>
+      </form>
+    </div>
+
+    <!-- Messages -->
+    <div v-if="message" :class="[
+      'mt-3 p-3 rounded-lg text-sm',
+      message.type === 'success' ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300' : 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300'
+    ]">
+      {{ message.text }}
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import api from '../api'
+
+const props = defineProps({
+  agentName: {
+    type: String,
+    required: true
+  }
+})
+
+const loading = ref(true)
+const connecting = ref(false)
+const disconnecting = ref(false)
+const verifying = ref(false)
+const accessDenied = ref(false)
+const binding = ref({ configured: false })
+const botToken = ref('')
+const message = ref(null)
+
+async function loadBinding() {
+  loading.value = true
+  message.value = null
+  accessDenied.value = false
+  try {
+    const response = await api.get(`/api/agents/${props.agentName}/telegram`)
+    binding.value = response.data
+  } catch (e) {
+    if (e.response?.status === 403) {
+      accessDenied.value = true
+    }
+    binding.value = { configured: false }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function connectBot() {
+  connecting.value = true
+  message.value = null
+  try {
+    const response = await api.put(`/api/agents/${props.agentName}/telegram`, {
+      bot_token: botToken.value.trim()
+    })
+    botToken.value = ''
+    binding.value = response.data
+    message.value = { type: 'success', text: `Bot @${response.data.bot_username} connected` }
+    setTimeout(() => { message.value = null }, 3000)
+  } catch (e) {
+    const detail = e.response?.data?.detail || 'Failed to connect bot'
+    message.value = { type: 'error', text: detail }
+  } finally {
+    connecting.value = false
+  }
+}
+
+async function disconnectBot() {
+  disconnecting.value = true
+  message.value = null
+  try {
+    await api.delete(`/api/agents/${props.agentName}/telegram`)
+    message.value = { type: 'success', text: 'Bot disconnected' }
+    binding.value = { configured: false }
+    setTimeout(() => { message.value = null }, 3000)
+  } catch (e) {
+    const detail = e.response?.data?.detail || 'Failed to disconnect bot'
+    message.value = { type: 'error', text: detail }
+  } finally {
+    disconnecting.value = false
+  }
+}
+
+async function verifyBot() {
+  verifying.value = true
+  message.value = null
+  try {
+    const response = await api.post(`/api/agents/${props.agentName}/telegram/test`, {
+      message: 'Verification check'
+    })
+    if (response.data.ok) {
+      message.value = { type: 'success', text: response.data.message }
+    } else {
+      message.value = { type: 'error', text: response.data.message || 'Verification failed' }
+    }
+    setTimeout(() => { message.value = null }, 3000)
+  } catch (e) {
+    const detail = e.response?.data?.detail || 'Failed to verify bot'
+    message.value = { type: 'error', text: detail }
+  } finally {
+    verifying.value = false
+  }
+}
+
+watch(() => props.agentName, () => loadBinding())
+onMounted(() => loadBinding())
+</script>


### PR DESCRIPTION
## Summary
- Add `TelegramChannelPanel.vue` component to the Agent Detail Sharing page for connecting/managing Telegram bots per agent
- Mirrors the existing Slack channel panel pattern with bot token input, status display, verify, and disconnect flows
- Uses `api.js` auth client (Invariant #7), password input for token handling, webhook status warning banner

## Changes
- **New**: `src/frontend/src/components/TelegramChannelPanel.vue` — Self-contained panel component
- **Modified**: `src/frontend/src/components/SharingPanel.vue` — Import and render Telegram panel

## Key Decisions
- Bot token input uses `type="password"` and ref is cleared immediately on success (security)
- Shows webhook warning banner when bot is connected but `webhook_url` is null (common self-hosted issue)
- "Verify" button calls `getMe` (labeled accurately — does not send a message without chat_id)
- Requires explicit disconnect before reconnecting (prevents silent webhook_secret regeneration)
- Active chats display deferred — no backend endpoint exists for `telegram_chat_links` yet

## Test Plan
- [ ] Navigate to Agent Detail → Sharing tab → Telegram Bot section visible
- [ ] Paste a BotFather token → "Connect Bot" → shows @username and t.me link
- [ ] Click "Verify" → shows "Bot @username is operational" success message
- [ ] Click "Disconnect" → returns to token input state
- [ ] Paste a token already bound to another agent → shows 409 error with agent name
- [ ] Connect bot without public URL configured → yellow webhook warning banner appears
- [ ] Token input is `type="password"` (masked)
- [ ] Dark mode renders correctly

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)