### PR TITLE
feat(telegram): add group chat support — agents as community managers (#297)

### DIFF
--- a/.claude/skills/validate-config/SKILL.md
+++ b/.claude/skills/validate-config/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: validate-config
+description: Validate config hygiene — docker-compose env vars vs .env.example vs code references vs architecture docs. Flags missing, stale, or undocumented configuration.
+allowed-tools: [Read, Grep, Glob, Bash]
+user-invocable: true
+---
+
+# Validate Config
+
+## Purpose
+
+Check that configuration is consistent across all surfaces: docker-compose files, `.env.example`, backend code that reads env vars, and documentation. Report gaps where a variable is referenced but not documented, or documented but unused. No changes are made — read-only analysis.
+
+## State Dependencies
+
+| Source | Location | Read | Write | Description |
+|--------|----------|------|-------|-------------|
+| Docker Compose (local) | `docker-compose.yml` | R | | Local service definitions |
+| Docker Compose (prod) | `docker-compose.prod.yml` | R | | Production service definitions |
+| Env example | `.env.example` | R | | Documented env vars |
+| Backend config | `src/backend/config.py` | R | | Centralized config constants |
+| Backend code | `src/backend/` | R | | os.environ / os.getenv usage |
+| MCP server code | `src/mcp-server/src/` | R | | process.env usage |
+| Frontend code | `src/frontend/` | R | | VITE_ env var usage |
+| Architecture docs | `docs/memory/architecture.md` | R | | Documented config |
+
+## Process
+
+### Step 1: Extract Env Vars from .env.example
+
+Read `.env.example` and extract all variable names and their placeholder values.
+Build a set: `documented_vars`
+
+### Step 2: Extract Env Vars from docker-compose
+
+Read `docker-compose.yml` and `docker-compose.prod.yml`. Extract:
+- All `environment:` entries (both `KEY=value` and `KEY: value` forms)
+- All `${VAR}` and `${VAR:-default}` references
+- Which service uses which vars
+
+Build a map: `var_name -> [services that use it]`
+
+### Step 3: Extract Env Vars from Backend Code
+
+Grep `src/backend/` for:
+- `os.environ.get("VAR"` and `os.environ["VAR"]`
+- `os.getenv("VAR"`
+- `config.VAR` patterns where `config.py` reads from env
+
+Read `src/backend/config.py` specifically and extract all env var references.
+
+Build a set: `backend_vars`
+
+### Step 4: Extract Env Vars from MCP Server
+
+Grep `src/mcp-server/src/` for:
+- `process.env.VAR`
+- `process.env["VAR"]`
+
+Build a set: `mcp_vars`
+
+### Step 5: Extract Frontend Env Vars
+
+Grep `src/frontend/` for:
+- `import.meta.env.VITE_`
+
+Build a set: `frontend_vars`
+
+### Step 6: Cross-Reference
+
+**6a. Used but undocumented:**
+For each var in `backend_vars + mcp_vars + frontend_vars + docker_compose_vars`:
+- Check if it exists in `.env.example`
+- Flag missing ones (excluding well-known system vars like `PATH`, `HOME`, `NODE_ENV`)
+
+**6b. Documented but unused:**
+For each var in `.env.example`:
+- Check if it appears in any code or docker-compose file
+- Flag dead config entries
+
+**6c. Docker-compose vs .env.example:**
+For each `${VAR}` in docker-compose files:
+- Check if `.env.example` provides a value
+- Flag vars that docker-compose expects but .env.example doesn't define
+
+**6d. Local vs production divergence:**
+Compare `docker-compose.yml` and `docker-compose.prod.yml`:
+- Services present in one but not the other (expected — document why)
+- Env vars in one but not the other — flag as potential misconfiguration
+- Port mappings that conflict
+
+### Step 7: Check for Hardcoded Config
+
+Grep `src/backend/` for patterns that should be env vars:
+- Hardcoded port numbers (except well-known like 8000, 80, 443)
+- Hardcoded hostnames (except `localhost`, `127.0.0.1`, service names from docker-compose)
+- Hardcoded API URLs
+
+Flag as informational — not all are violations, but worth reviewing.
+
+### Step 8: Generate Report
+
+Output a summary:
+
+```
+## Config Validation Report
+
+### Env Var Coverage
+| Var | .env.example | docker-compose | Backend | MCP | Frontend | Status |
+|-----|-------------|----------------|---------|-----|----------|--------|
+| ADMIN_PASSWORD | Y | Y | Y | - | - | OK |
+| NEW_VAR | - | - | Y | - | - | UNDOCUMENTED |
+| OLD_VAR | Y | - | - | - | - | UNUSED |
+...
+
+### Issues
+
+#### Used but Undocumented (add to .env.example)
+- `VAR_NAME` — used in `src/backend/config.py:42`
+
+#### Documented but Unused (remove from .env.example)
+- `OLD_VAR` — not referenced anywhere in code
+
+#### Docker Compose Missing from .env.example
+- `${VAR}` in docker-compose.yml service `backend` — no .env.example entry
+
+#### Local vs Production Divergence
+- `VAR` in docker-compose.yml but not docker-compose.prod.yml
+
+#### Hardcoded Config (informational)
+- `src/backend/services/foo.py:88` — hardcoded URL `http://some-service:3000`
+
+**Result: X issues found (Y must-fix, Z informational)**
+```
+
+## Outputs
+
+- Markdown report printed to conversation
+- No files created or modified

--- a/.claude/skills/validate-schema/SKILL.md
+++ b/.claude/skills/validate-schema/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: validate-schema
+description: Validate database schema consistency — DDL in schema.py vs migrations.py vs architecture.md. Flags drift between the three sources of truth.
+allowed-tools: [Read, Grep, Glob, Bash]
+user-invocable: true
+---
+
+# Validate Schema
+
+## Purpose
+
+Check that the three places defining database schema are consistent: `db/schema.py` (DDL), `db/migrations.py` (ALTER/CREATE for upgrades), and `docs/memory/architecture.md` (documentation). Report drift with specific mismatches. No changes are made — read-only analysis.
+
+## State Dependencies
+
+| Source | Location | Read | Write | Description |
+|--------|----------|------|-------|-------------|
+| Schema DDL | `src/backend/db/schema.py` | R | | Authoritative table definitions |
+| Migrations | `src/backend/db/migrations.py` | R | | Schema evolution history |
+| Architecture docs | `docs/memory/architecture.md` | R | | Documented schema |
+
+## Process
+
+### Step 1: Extract Tables from schema.py
+
+Read `src/backend/db/schema.py` and extract:
+- All `CREATE TABLE` statements
+- Table names
+- Column names, types, constraints per table
+- All `CREATE INDEX` statements
+
+Build a map: `table_name -> { columns: [{name, type, constraints}], indexes: [name] }`
+
+### Step 2: Extract Tables from architecture.md
+
+Read the "Database Schema" section of `docs/memory/architecture.md` and extract:
+- All documented tables
+- Column names, types, constraints per table
+- Documented indexes
+
+Build the same map structure.
+
+### Step 3: Extract Migration Additions
+
+Read `src/backend/db/migrations.py` and extract:
+- All `ALTER TABLE ... ADD COLUMN` statements
+- All `CREATE TABLE IF NOT EXISTS` statements
+- All `CREATE INDEX IF NOT EXISTS` statements
+- Map each to the migration version that introduced it
+
+### Step 4: Cross-Reference — schema.py vs architecture.md
+
+For each table in schema.py:
+1. Check table exists in architecture.md docs
+2. Compare column lists — flag missing or extra columns in either direction
+3. Compare column types — flag type mismatches
+4. Compare indexes — flag missing indexes in docs
+
+For each table in architecture.md:
+1. Check table exists in schema.py — flag documented-but-nonexistent tables
+
+### Step 5: Cross-Reference — migrations.py vs schema.py
+
+For each migration that adds a column or table:
+1. Verify the column/table exists in schema.py's DDL
+2. Flag migrations that add something not reflected in schema.py (migration applied but DDL not updated)
+3. Flag columns in schema.py that have no corresponding migration and aren't in the original CREATE TABLE (column added to DDL but no migration to apply it to existing databases)
+
+### Step 6: Check for Ad-Hoc Schema
+
+Grep `src/backend/` (excluding `db/schema.py` and `db/migrations.py`) for:
+- `CREATE TABLE` — tables created outside the schema system
+- `ALTER TABLE` — schema changes outside the migration system
+- `ADD COLUMN` — ad-hoc column additions
+
+Flag any findings as violations of Architectural Invariant #3.
+
+### Step 7: Generate Report
+
+Output a summary:
+
+```
+## Schema Validation Report
+
+### Tables Summary
+| Table | schema.py | architecture.md | Migrations | Status |
+|-------|-----------|-----------------|------------|--------|
+| users | Y | Y | - | PASS/FAIL |
+...
+
+### Drift Findings
+
+#### schema.py vs architecture.md
+- **Table X**: Column `foo` in schema.py but missing from docs
+- **Table Y**: Type mismatch — schema says `INTEGER`, docs say `TEXT`
+
+#### migrations.py vs schema.py
+- **Migration v12**: Adds `bar` column to `users`, but schema.py DDL missing it
+- **schema.py**: Column `baz` in `agents` has no migration (added directly to DDL?)
+
+#### Ad-Hoc Schema
+- **File**: path/to/file.py:line — `CREATE TABLE` outside schema system
+
+**Result: X issues found (Y critical, Z informational)**
+```
+
+## Outputs
+
+- Markdown report printed to conversation
+- No files created or modified

--- a/README.md
+++ b/README.md
@@ -619,6 +619,19 @@ docker compose build backend
 docker compose up -d backend
 ```
 
+### Codebase Hygiene
+
+Weekly maintenance skills to keep the codebase clean and consistent:
+
+| Skill | What it checks |
+|-------|---------------|
+| `/validate-architecture` | 16 architectural invariants (layer separation, auth patterns, etc.) |
+| `/validate-schema` | Schema drift between `db/schema.py`, `db/migrations.py`, and `architecture.md` |
+| `/validate-config` | Env var consistency across `docker-compose.yml`, `.env.example`, and code |
+| `/refactor-audit` | Dead code, complexity hotspots, large files/functions |
+| `/cso --supply-chain` | Dependency freshness and known CVEs |
+| `/tidy` | Orphan files, misplaced configs, test artifacts |
+
 ### Releasing the CLI
 
 The CLI auto-publishes to PyPI and Homebrew on every push to `main` that changes `src/cli/`. The patch version auto-increments from the latest `cli-v*` tag.

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -373,6 +373,8 @@ Agents are invoked automatically by Claude Code when appropriate, or you can req
 | `/add-testing` | Add tests for a feature | In Progress |
 | `/validate-pr <number>` | Validate PR against methodology | Review |
 | `/validate-architecture` | Validate codebase against 16 architectural invariants | Weekly / Review |
+| `/validate-schema` | Check schema.py vs migrations.py vs architecture.md for drift | Weekly |
+| `/validate-config` | Check env vars across docker-compose, .env.example, and code | Weekly |
 | `/groom` | Backlog grooming — audit board, rank issues, review priorities | Todo |
 | `/sprint [issue-number]` | Full dev cycle (orchestrates all above) | All |
 
@@ -452,4 +454,6 @@ Skills in `.claude/skills/` define HOW to approach specific tasks:
 **Weekly maintenance:**
 
 - [ ] `/validate-architecture` — check codebase against architectural invariants
+- [ ] `/validate-schema` — check schema.py vs migrations.py vs architecture.md for drift
+- [ ] `/validate-config` — check env vars across docker-compose, .env.example, and code
 - [ ] `/groom` — audit backlog, rank issues, review priorities

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-11 | #297 | Telegram group chat support — @mention triggers, welcome messages, per-group config | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-10 | #296 | Telegram bot connection UI — TelegramChannelPanel in Agent Detail Sharing page | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-08 | #69 | Owner filter dropdown on Dashboard and Agents pages | [agents-page-ui-improvements.md](feature-flows/agents-page-ui-improvements.md), [agent-network.md](feature-flows/agent-network.md) |
 | 2026-04-06 | QUOTA-001 | Per-role agent creation quotas with admin exemption | [agent-quotas.md](feature-flows/agent-quotas.md) |
@@ -178,7 +179,7 @@
 | Slack Integration | [slack-integration.md](feature-flows/slack-integration.md) | Slack as delivery channel for public links (SLACK-001) |
 | Slack Channel Routing | [slack-channel-routing.md](feature-flows/slack-channel-routing.md) | Channel adapter abstraction + multi-agent Slack routing (SLACK-002) |
 | Slack File Sharing | [slack-file-sharing.md](feature-flows/slack-file-sharing.md) | Inbound file uploads: images via vision, text via container (SLACK-FILES) |
-| Telegram Integration | [telegram-integration.md](feature-flows/telegram-integration.md) | Per-agent Telegram bots with webhook transport (TELEGRAM-001) |
+| Telegram Integration | [telegram-integration.md](feature-flows/telegram-integration.md) | Per-agent Telegram bots with webhook transport, group chat support (TELEGRAM-001, TGRAM-GROUP) |
 | Nevermined x402 Payments | [nevermined-payments.md](feature-flows/nevermined-payments.md) | Per-agent paid API via x402 payment protocol (NVM-001) |
 
 ### Mobile & PWA

--- a/docs/memory/feature-flows/telegram-integration.md
+++ b/docs/memory/feature-flows/telegram-integration.md
@@ -1,7 +1,7 @@
-# Feature: Telegram Bot Integration (TELEGRAM-001)
+# Feature: Telegram Bot Integration (TELEGRAM-001, TGRAM-GROUP)
 
 ## Overview
-Per-agent Telegram bots with 1:1 agent-to-bot mapping, enabling users to chat with Trinity agents via Telegram text, photos, and documents. Agents are shareable via `t.me/BotUsername` links.
+Per-agent Telegram bots with 1:1 agent-to-bot mapping, enabling users to chat with Trinity agents via Telegram DMs and group chats. Agents are shareable via `t.me/BotUsername` links. In groups, agents respond to @mentions and direct replies.
 
 ## User Story
 As an agent owner, I want to connect a Telegram bot to my agent so that external users can interact with it via Telegram without needing a Trinity account.
@@ -9,9 +9,12 @@ As an agent owner, I want to connect a Telegram bot to my agent so that external
 ## Entry Points
 - **API (configure)**: `PUT /api/agents/{name}/telegram` — bind a bot token to an agent
 - **API (webhook)**: `POST /api/telegram/webhook/{webhook_secret}` — receive Telegram updates (public, no JWT)
-- **API (status)**: `GET /api/agents/{name}/telegram` — check binding status
+- **API (status)**: `GET /api/agents/{name}/telegram` — check binding status (includes group_count)
 - **API (delete)**: `DELETE /api/agents/{name}/telegram` — remove bot binding
 - **API (test)**: `POST /api/agents/{name}/telegram/test` — send test message or verify bot
+- **API (groups)**: `GET /api/agents/{name}/telegram/groups` — list group configs (TGRAM-GROUP)
+- **API (group update)**: `PUT /api/agents/{name}/telegram/groups/{id}` — update trigger mode / welcome settings
+- **API (group delete)**: `DELETE /api/agents/{name}/telegram/groups/{id}` — deactivate group config
 
 ## Architecture
 
@@ -104,8 +107,8 @@ Two routers are registered in `main.py:523-524`:
 - `_process_update(update, binding)` (line 79) — Commands are handled directly; regular messages go through `on_event()` → adapter → router pipeline.
 
 **Webhook lifecycle functions** (module-level):
-- `register_webhook(agent_name, public_url)` (line 120) — Calls Telegram `setWebhook` with URL + secret_token + `allowed_updates: ["message"]`. Updates `webhook_url` in DB on success.
-- `delete_webhook(agent_name)` (line 165) — Calls Telegram `deleteWebhook`.
+- `register_webhook(agent_name, public_url)` — Calls Telegram `setWebhook` with URL + secret_token + `allowed_updates: ["message", "my_chat_member", "chat_member"]`. Updates `webhook_url` in DB on success.
+- `delete_webhook(agent_name)` — Calls Telegram `deleteWebhook`.
 
 ### Adapter: `src/backend/adapters/telegram_adapter.py`
 
@@ -370,6 +373,113 @@ TelegramChannelPanel is imported and rendered between the Slack and Public Links
 <div class="border-t ..."></div>
 <PublicLinksPanel :agent-name="agentName" />
 ```
+
+## Group Chat Support (TGRAM-GROUP)
+
+### Overview
+
+Agents can participate in Telegram group chats. Bots respond to @mentions and direct replies in groups. Per-group configuration controls trigger mode and welcome messages. Added 2026-04-11.
+
+### Group Message Flow
+
+```
+Telegram Group Chat
+    |
+    v (HTTP POST — message update)
+TelegramWebhookTransport.handle_webhook()
+    |
+    v (inject _bot_id, _bot_username, _agent_name)
+TelegramWebhookTransport._process_update()
+    |  - Member events (my_chat_member, chat_member) → adapter.handle_member_event()
+    |  - Commands with @botname suffix → adapter.handle_command()
+    |  - Regular messages → on_event(update)
+    v
+TelegramAdapter.parse_message(update)
+    |  - Detect group vs private (chat.type in {"group", "supergroup"})
+    |  - Check @mention in entities → _is_bot_mentioned()
+    |  - Check reply_to_message → _is_reply_to_bot()
+    |  - If neither and trigger_mode != "all" → return None (skip)
+    |  - Strip @mention from text for cleaner agent input
+    v
+ChannelMessageRouter.handle_message()
+    |  - Rate limit with per-group key (telegram:{bot_id}:group:{chat_id})
+    |  - Silent drop on rate limit (no public error message in group)
+    |  - Fresh context per message (no prior session history — prevents context bleed)
+    |  - Execute via TaskExecutionService
+    v
+TelegramAdapter.send_response()
+    |  - Reply to triggering message via reply_parameters (threaded in group)
+    v
+User sees response as reply in group
+```
+
+### Trigger Rules
+
+| Condition | trigger_mode=mention | trigger_mode=all |
+|-----------|---------------------|-----------------|
+| @mention in entities | ✅ Process | ✅ Process |
+| Reply to bot's message | ✅ Process | ✅ Process |
+| Regular message (no mention) | ❌ Skip | ✅ Process |
+
+### Member Events
+
+**`my_chat_member`** — Bot's own status changes (no admin required):
+- Bot added to group (`left/kicked → member/administrator`) → `get_or_create_group_config()` with auto-activate
+- Bot removed from group (`member/administrator → left/kicked`) → `deactivate_group_config()`
+
+**`chat_member`** — Other users' status changes (requires bot admin):
+- User joins group → send welcome message if `welcome_enabled` and `welcome_text` set
+- Welcome text supports `{name}` placeholder for user's first name
+
+### Database: `telegram_group_configs`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | Auto-increment |
+| binding_id | INTEGER FK | References `telegram_bindings(id)` |
+| chat_id | TEXT | Telegram chat ID (negative for groups) |
+| chat_title | TEXT | Group name (updated on each interaction) |
+| chat_type | TEXT | `"group"` or `"supergroup"` |
+| trigger_mode | TEXT | `"mention"` (default) or `"all"` |
+| welcome_enabled | INTEGER | 0 or 1 |
+| welcome_text | TEXT | Welcome message template |
+| is_active | INTEGER | 1=active, 0=deactivated (bot removed) |
+| created_at | TEXT | ISO timestamp |
+| updated_at | TEXT | ISO timestamp |
+
+Unique constraint: `(binding_id, chat_id)`
+
+### Group Config API
+
+All endpoints require JWT + `OwnedAgentByName` (agent owner only):
+
+- `GET /api/agents/{name}/telegram/groups` — List active group configs
+- `PUT /api/agents/{name}/telegram/groups/{id}` — Update trigger_mode, welcome_enabled, welcome_text (ownership verified)
+- `DELETE /api/agents/{name}/telegram/groups/{id}` — Deactivate group config
+
+### Frontend: Group Config UI
+
+The `TelegramChannelPanel.vue` component shows group configurations when the bot is connected:
+
+- Group list with chat title and type badge
+- Trigger mode radio buttons (mention-only / all messages)
+- Welcome message toggle with text input (`{name}` placeholder)
+- Remove button per group (deactivates, doesn't delete)
+
+### Security Notes
+
+- **No new attack surface**: Group messages use the same webhook endpoint with the same dual-layer auth
+- **IDOR prevention**: Group config update verifies the config ID belongs to the requesting agent's binding
+- **Context bleed prevention**: Group messages get fresh context (no prior session history) — agent replies in a public group cannot leak prior DM conversation context
+- **Bot loop prevention**: Inherited from DM support — `parse_message()` skips messages from bots (`is_bot` check)
+- **Silent rate limiting**: Rate limit errors are not sent to groups (would be visible to all members)
+- **Membership not verified per message**: Telegram doesn't provide a cheap per-message membership check; this is standard bot behavior and is documented
+
+### Known Limitations
+
+- **"All messages" trigger mode requires BotFather privacy mode change**: By default, Telegram privacy mode is ON and bots only receive @mentions/replies. The "all messages" mode works if the bot admin disables privacy mode via BotFather (`/setprivacy` → Disable). This is a manual step not automatable via the Bot API.
+- **`chat_member` events require bot admin**: Welcome messages for user joins only work if the bot has admin rights in the group AND `chat_member` is in `allowed_updates`. If the bot isn't admin, events simply don't arrive — graceful degradation.
+- **No `edited_message` handling**: Edited messages in groups are not processed. In mention-only mode this is rare.
 
 ## Related Flows
 - [slack-integration.md](slack-integration.md) — Slack equivalent (SLACK-001)

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -711,6 +711,39 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
   - Phase 2: Voice transcription (Whisper API), notification forwarding
   - Phase 3: Inline keyboards for approve/reject, deep links with start parameters
 
+### 15.1e Telegram Group Chat Support (TGRAM-GROUP)
+- **Status**: ✅ Complete (2026-04-11)
+- **Requirement ID**: TGRAM-GROUP
+- **Priority**: P2
+- **Description**: Agents participate in Telegram group chats. Bots respond to @mentions and direct replies in groups. Per-group configuration for trigger mode and welcome messages.
+- **Key Features**:
+  - Group message handling: respond to @mentions of bot username in message entities
+  - Reply-to-bot detection: respond when user replies to bot's own messages
+  - Configurable trigger mode per group: "mention" (default, @mention-only) or "all" (all messages)
+  - New member welcome messages: configurable text with {name} placeholder
+  - Auto-created group configs on first interaction (no manual setup required)
+  - Bot added/removed from group detection via `my_chat_member` update events
+  - User join/leave detection via `chat_member` events (requires bot admin in group)
+  - Fresh context per group message (no prior session history to prevent context bleed)
+  - Silent rate limit drops in groups (no error messages visible to all members)
+  - Mention text stripped from agent input for cleaner prompts
+  - Commands support @botname suffix in groups (e.g., `/help@mybot`)
+  - Uses modern Telegram `reply_parameters` API for threaded replies
+- **Database Tables**:
+  - `telegram_group_configs` — Per-group settings (binding_id, chat_id, trigger_mode, welcome_enabled, welcome_text, is_active)
+- **API Endpoints**:
+  - `GET /api/agents/{name}/telegram/groups` — List group configs
+  - `PUT /api/agents/{name}/telegram/groups/{id}` — Update group config (trigger mode, welcome settings)
+  - `DELETE /api/agents/{name}/telegram/groups/{id}` — Remove group config (deactivates)
+- **Webhook Changes**:
+  - `allowed_updates` now includes `["message", "my_chat_member", "chat_member"]`
+- **Security**:
+  - Same webhook auth (URL secret + header token) — no new attack surface
+  - Group membership not re-verified per message (documented limitation)
+  - Bot loop prevention inherited from TGRAM-001 (`is_bot` check)
+- **Frontend**: TelegramChannelPanel extended with group list, trigger mode radio, welcome message config
+- **Flow**: `docs/memory/feature-flows/telegram-integration.md`
+
 ### 15.1d Public Chat Session Memory (PUB-006)
 - **Status**: ⏳ Not Started
 - **Requirement ID**: PUB-006

--- a/docs/user-docs/dev-announcements/2026-04-07-workshop-promo.md
+++ b/docs/user-docs/dev-announcements/2026-04-07-workshop-promo.md
@@ -1,0 +1,21 @@
+---
+date: 2026-04-07
+channels: discord:updates, slack:updates, telegram:updates
+---
+
+**Live Agent-Building Workshops — Starting Thursday**
+
+Every Tue & Thu at 8:30 AM PT / 11:30 AM ET. 45-60 min on Zoom. Recordings available.
+
+**What we build together:**
+- Autonomous agents that delegate to other agents
+- Fleet-wide scheduling, persistent memory, MCP integrations
+- Production-ready multi-agent systems — not theory
+
+**First session (Thu Apr 10):** Your First Trinity Agent in 30 Minutes
+
+One registration covers all April sessions.
+
+Prereq: familiarity with Claude Code, CoWork, or similar tools.
+
+**Register:** https://www.ability.ai/workshops

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -155,8 +155,12 @@ class ChannelMessageRouter:
 
         # 3. Rate limiting per channel user
         rate_key = adapter.get_rate_key(message)
+        is_group = message.metadata.get("is_group", False)
         if not _check_rate_limit(rate_key):
             logger.warning(f"[ROUTER:{channel}] Rate limited: {rate_key}")
+            # In groups, silently drop to avoid spamming the group with error messages
+            if is_group:
+                return
             await adapter.send_response(
                 message.channel_id,
                 ChannelResponse(
@@ -169,7 +173,7 @@ class ChannelMessageRouter:
 
         # 3b. File upload rate limiting (stricter than message rate limit)
         if message.files:
-            file_rate_key = f"slack-files:{message.metadata.get('team_id')}:{message.sender_id}"
+            file_rate_key = f"{channel}-files:{message.channel_id}:{message.sender_id}"
             if not _check_rate_limit(file_rate_key, max_msgs=_FILE_UPLOAD_RATE_LIMIT_MAX, window=_FILE_UPLOAD_RATE_LIMIT_WINDOW):
                 logger.warning(f"[ROUTER] File upload rate limited: {file_rate_key}")
                 await adapter.send_response(
@@ -213,8 +217,13 @@ class ChannelMessageRouter:
         logger.debug(f"[ROUTER:{channel}] Step 6 - session_id: {session_id}")
 
         # 7. Build context prompt (same as web public chat)
-        context_prompt = db.build_public_chat_context(session_id, message.text)
-        logger.debug(f"[ROUTER:{channel}] Step 7 - context built ({len(context_prompt)} chars)")
+        # In group chats, use fresh context (no prior history) to prevent
+        # leaking prior private conversation context into public group replies.
+        if is_group:
+            context_prompt = message.text
+        else:
+            context_prompt = db.build_public_chat_context(session_id, message.text)
+        logger.debug(f"[ROUTER:{channel}] Step 7 - context built ({len(context_prompt)} chars, group={is_group})")
 
         # 7b. Handle file uploads — download from Slack, copy into agent container
         upload_dir = None  # Track for cleanup
@@ -321,9 +330,12 @@ class ChannelMessageRouter:
 
         # 12. Send response to channel
         logger.debug(f"[ROUTER:{channel}] Step 12 - sending response")
+        response_metadata = {"bot_token": bot_token, "agent_name": agent_name}
+        if is_group:
+            response_metadata["is_group"] = True
         await adapter.send_response(
             message.channel_id,
-            ChannelResponse(text=send_text, files=outbound_files, metadata={"bot_token": bot_token, "agent_name": agent_name}),
+            ChannelResponse(text=send_text, files=outbound_files, metadata=response_metadata),
             thread_id=message.thread_id,
         )
 

--- a/src/backend/adapters/telegram_adapter.py
+++ b/src/backend/adapters/telegram_adapter.py
@@ -5,10 +5,12 @@ Handles Telegram-specific message parsing, response formatting (HTML),
 agent resolution via bot bindings, and bot commands.
 
 Supports:
-- Text messages → routed to bot-bound agent
+- Private chats (DMs) → routed to bot-bound agent
+- Group chats → @mention or reply-to-bot triggers (TGRAM-GROUP)
 - Photos, documents → downloaded and passed as context
 - /start, /help, /reset commands
 - Typing indicator via sendChatAction
+- Member events (bot added/removed, user join/leave)
 """
 
 import logging
@@ -28,6 +30,9 @@ TELEGRAM_MAX_MESSAGE_LENGTH = 4096
 # Telegram Bot API base URL
 TELEGRAM_API_BASE = "https://api.telegram.org"
 
+# Group chat types
+_GROUP_CHAT_TYPES = {"group", "supergroup"}
+
 
 class TelegramAdapter(ChannelAdapter):
     """Telegram implementation of ChannelAdapter with per-agent bot routing."""
@@ -42,6 +47,9 @@ class TelegramAdapter(ChannelAdapter):
 
     def get_rate_key(self, message: NormalizedMessage) -> str:
         bot_id = message.metadata.get("bot_id", "unknown")
+        # In groups, add a per-group rate key component
+        if message.metadata.get("is_group"):
+            return f"telegram:{bot_id}:group:{message.channel_id}"
         return f"telegram:{bot_id}:{message.sender_id}"
 
     def get_session_identifier(self, message: NormalizedMessage) -> str:
@@ -68,29 +76,56 @@ class TelegramAdapter(ChannelAdapter):
         Parse a Telegram Update into a NormalizedMessage.
 
         Handles:
-        - Text messages
+        - Private chat text messages
+        - Group chat messages (filtered by @mention or reply-to-bot)
         - Photo messages (caption + photo indicator)
         - Document messages (caption + document indicator)
-        - /start, /help, /reset commands
         """
         message = raw_event.get("message")
         if not message:
             return None
 
-        # Skip messages from bots
+        # Skip messages from bots (prevents bot loops)
         from_user = message.get("from", {})
         if from_user.get("is_bot", False):
             return None
 
         user_id = str(from_user.get("id", ""))
-        chat_id = str(message.get("chat", {}).get("id", ""))
+        chat = message.get("chat", {})
+        chat_id = str(chat.get("id", ""))
+        chat_type = chat.get("type", "private")
         username = from_user.get("username")
 
         if not user_id or not chat_id:
             return None
 
+        # Resolve bot → agent via the binding stored in metadata by transport
+        bot_id = raw_event.get("_bot_id", "")
+        bot_username = raw_event.get("_bot_username", "")
+        agent_name = raw_event.get("_agent_name", "")
+        is_group = chat_type in _GROUP_CHAT_TYPES
+
+        # Group chat filtering: only process @mentions or replies to bot
+        if is_group:
+            is_mentioned = self._is_bot_mentioned(message, bot_username)
+            is_reply = self._is_reply_to_bot(message, bot_id)
+
+            if not is_mentioned and not is_reply:
+                # Check trigger mode — if "all", process anyway
+                binding = db.get_telegram_binding(agent_name)
+                if binding:
+                    group_config = db.get_telegram_group_config(binding["id"], chat_id)
+                    if not group_config or group_config.get("trigger_mode") != "all":
+                        return None
+                else:
+                    return None
+
         # Extract text content
         text = message.get("text", "").strip()
+
+        # Strip @mention from text in groups for cleaner agent input
+        if is_group and bot_username and text:
+            text = re.sub(rf'@{re.escape(bot_username)}\b', '', text).strip()
 
         # Handle media messages — extract caption or description
         media_context = self._extract_media_context(message)
@@ -100,10 +135,6 @@ class TelegramAdapter(ChannelAdapter):
         if not text:
             return None
 
-        # Resolve bot → agent via the binding stored in metadata by transport
-        bot_id = raw_event.get("_bot_id", "")
-        agent_name = raw_event.get("_agent_name", "")
-
         return NormalizedMessage(
             sender_id=user_id,
             text=text,
@@ -112,8 +143,12 @@ class TelegramAdapter(ChannelAdapter):
             timestamp=str(message.get("date", "")),
             metadata={
                 "bot_id": bot_id,
+                "bot_username": bot_username,
                 "agent_name": agent_name,
                 "username": username,
+                "is_group": is_group,
+                "chat_type": chat_type,
+                "chat_title": chat.get("title"),
                 "has_photo": "photo" in message,
                 "has_document": "document" in message,
                 "raw_message": message,
@@ -142,24 +177,167 @@ class TelegramAdapter(ChannelAdapter):
         # Split long messages at paragraph boundaries
         chunks = self._split_message(html_text)
 
+        # In groups, always reply to the triggering message for threaded context
+        reply_to = thread_id if response.metadata.get("is_group") else None
+
         for chunk in chunks:
             await self._send_message(
                 bot_token=bot_token,
                 chat_id=channel_id,
                 text=chunk,
-                reply_to_message_id=thread_id,
+                reply_to_message_id=reply_to,
                 parse_mode="HTML",
             )
 
     async def get_agent_name(self, message: NormalizedMessage) -> Optional[str]:
         """Resolve which agent handles this message (set by transport layer)."""
-        return message.metadata.get("agent_name")
+        agent_name = message.metadata.get("agent_name")
+
+        # For group chats, auto-create group config on first interaction
+        if message.metadata.get("is_group") and agent_name:
+            binding = db.get_telegram_binding(agent_name)
+            if binding:
+                db.get_or_create_telegram_group_config(
+                    binding_id=binding["id"],
+                    chat_id=message.channel_id,
+                    chat_title=message.metadata.get("chat_title"),
+                    chat_type=message.metadata.get("chat_type", "group"),
+                )
+
+        return agent_name
 
     async def indicate_processing(self, message: NormalizedMessage) -> None:
         """Send typing indicator to Telegram chat."""
         bot_token = db.get_telegram_bot_token(message.metadata.get("agent_name", ""))
         if bot_token:
             await self._send_chat_action(bot_token, message.channel_id, "typing")
+
+    # =========================================================================
+    # Group chat helpers (TGRAM-GROUP)
+    # =========================================================================
+
+    @staticmethod
+    def _is_bot_mentioned(message: dict, bot_username: str) -> bool:
+        """Check if the bot is @mentioned in message entities."""
+        if not bot_username:
+            return False
+        entities = message.get("entities", [])
+        text = message.get("text", "")
+        for entity in entities:
+            if entity.get("type") == "mention":
+                offset = entity.get("offset", 0)
+                length = entity.get("length", 0)
+                mention_text = text[offset:offset + length]
+                # Mention text is "@username"
+                if mention_text.lower() == f"@{bot_username.lower()}":
+                    return True
+        return False
+
+    @staticmethod
+    def _is_reply_to_bot(message: dict, bot_id: str) -> bool:
+        """Check if this message is a reply to one of the bot's own messages."""
+        reply_to = message.get("reply_to_message")
+        if not reply_to:
+            return False
+        reply_from = reply_to.get("from", {})
+        # Compare as strings — bot_id is stored as TEXT in DB,
+        # Telegram sends integer IDs
+        return str(reply_from.get("id", "")) == str(bot_id)
+
+    # =========================================================================
+    # Member event handling (TGRAM-GROUP)
+    # =========================================================================
+
+    async def handle_member_event(
+        self,
+        update: dict,
+        binding: dict,
+    ) -> None:
+        """
+        Handle chat member updates (bot added/removed, user join/leave).
+
+        Events:
+        - my_chat_member: bot's own status changed in a chat
+        - chat_member: another user's status changed (requires bot admin)
+        """
+        my_member = update.get("my_chat_member")
+        other_member = update.get("chat_member")
+
+        if my_member:
+            await self._handle_bot_member_change(my_member, binding)
+        elif other_member:
+            await self._handle_user_member_change(other_member, binding)
+
+    async def _handle_bot_member_change(self, event: dict, binding: dict) -> None:
+        """Handle the bot being added to or removed from a group."""
+        chat = event.get("chat", {})
+        chat_id = str(chat.get("id", ""))
+        chat_type = chat.get("type", "")
+        chat_title = chat.get("title", "")
+
+        if chat_type not in _GROUP_CHAT_TYPES:
+            return
+
+        new_status = event.get("new_chat_member", {}).get("status", "")
+        old_status = event.get("old_chat_member", {}).get("status", "")
+
+        if new_status in ("member", "administrator") and old_status in ("left", "kicked"):
+            # Bot was added to group — create config
+            logger.info(f"Bot added to group '{chat_title}' (chat_id={chat_id}) for agent={binding['agent_name']}")
+            db.get_or_create_telegram_group_config(
+                binding_id=binding["id"],
+                chat_id=chat_id,
+                chat_title=chat_title,
+                chat_type=chat_type,
+            )
+        elif new_status in ("left", "kicked") and old_status in ("member", "administrator"):
+            # Bot was removed from group — deactivate config
+            logger.info(f"Bot removed from group '{chat_title}' (chat_id={chat_id}) for agent={binding['agent_name']}")
+            db.deactivate_telegram_group_config(binding["id"], chat_id)
+
+    async def _handle_user_member_change(self, event: dict, binding: dict) -> None:
+        """Handle a user joining or leaving a group (welcome messages)."""
+        chat = event.get("chat", {})
+        chat_id = str(chat.get("id", ""))
+        chat_type = chat.get("type", "")
+
+        if chat_type not in _GROUP_CHAT_TYPES:
+            return
+
+        new_status = event.get("new_chat_member", {}).get("status", "")
+        old_status = event.get("old_chat_member", {}).get("status", "")
+        user = event.get("new_chat_member", {}).get("user", {})
+
+        # Skip bot users
+        if user.get("is_bot", False):
+            return
+
+        # Only handle user joins
+        if new_status != "member" or old_status not in ("left", "kicked"):
+            return
+
+        # Check if welcome messages are enabled for this group
+        group_config = db.get_telegram_group_config(binding["id"], chat_id)
+        if not group_config or not group_config.get("welcome_enabled"):
+            return
+
+        welcome_text = group_config.get("welcome_text")
+        if not welcome_text:
+            return
+
+        # Personalize welcome message
+        user_name = user.get("first_name", "there")
+        personalized = welcome_text.replace("{name}", user_name)
+
+        bot_token = db.get_telegram_bot_token(binding["agent_name"])
+        if bot_token:
+            await self._send_message(
+                bot_token=bot_token,
+                chat_id=chat_id,
+                text=personalized,
+                parse_mode="HTML",
+            )
+            logger.info(f"Sent welcome message to {user_name} in group {chat_id}")
 
     # =========================================================================
     # Bot commands
@@ -176,6 +354,11 @@ class TelegramAdapter(ChannelAdapter):
         """
         text = message.text.strip()
         agent_name = message.metadata.get("agent_name", "Agent")
+
+        # In groups, commands may have @botname suffix (e.g., /help@mybot)
+        bot_username = message.metadata.get("bot_username", "")
+        if bot_username:
+            text = re.sub(rf'@{re.escape(bot_username)}$', '', text)
 
         if text == "/start" or text.startswith("/start "):
             return (
@@ -225,7 +408,10 @@ class TelegramAdapter(ChannelAdapter):
             "parse_mode": parse_mode,
         }
         if reply_to_message_id:
-            payload["reply_to_message_id"] = reply_to_message_id
+            payload["reply_parameters"] = {
+                "message_id": int(reply_to_message_id),
+                "allow_sending_without_reply": True,
+            }
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:

--- a/src/backend/adapters/transports/telegram_webhook.py
+++ b/src/backend/adapters/transports/telegram_webhook.py
@@ -4,6 +4,11 @@ Telegram webhook transport — inbound POST from Telegram Bot API.
 Receives updates at POST /api/telegram/webhook/{webhook_secret}.
 Validates via X-Telegram-Bot-Api-Secret-Token header.
 Processes asynchronously — returns 200 immediately.
+
+Supports:
+- message: text, media, commands
+- my_chat_member: bot added/removed from groups (TGRAM-GROUP)
+- chat_member: user join/leave for welcome messages (TGRAM-GROUP)
 """
 
 import asyncio
@@ -69,6 +74,7 @@ class TelegramWebhookTransport(ChannelTransport):
 
         # 5. Inject routing metadata for the adapter
         update["_bot_id"] = binding.get("bot_id", "")
+        update["_bot_username"] = binding.get("bot_username", "")
         update["_agent_name"] = binding["agent_name"]
 
         # 6. Process asynchronously — return 200 immediately
@@ -79,23 +85,26 @@ class TelegramWebhookTransport(ChannelTransport):
     async def _process_update(self, update: dict, binding: dict) -> None:
         """Process a Telegram update through the adapter → router pipeline."""
         try:
+            # Handle member events (bot added/removed, user join/leave)
+            if update.get("my_chat_member") or update.get("chat_member"):
+                await self.adapter.handle_member_event(update, binding)
+                return
+
             # Check for bot commands first
             message = update.get("message", {})
             text = message.get("text", "")
 
             if text.startswith("/"):
                 # Handle commands directly in the adapter
-                from adapters.telegram_adapter import TelegramAdapter
-                adapter = self.adapter
-                normalized = adapter.parse_message(update)
+                normalized = self.adapter.parse_message(update)
                 if normalized:
-                    command_response = await adapter.handle_command(normalized)
+                    command_response = await self.adapter.handle_command(normalized)
                     if command_response:
                         bot_token = db.get_telegram_bot_token(binding["agent_name"])
                         if bot_token:
                             # Handle /reset by clearing the session
-                            if text.strip() == "/reset":
-                                session_id = adapter.get_session_identifier(normalized)
+                            if text.strip().split("@")[0] == "/reset":
+                                session_id = self.adapter.get_session_identifier(normalized)
                                 session = db.get_or_create_public_chat_session(
                                     binding["agent_name"], session_id, "telegram"
                                 )
@@ -103,7 +112,7 @@ class TelegramWebhookTransport(ChannelTransport):
                                 if sid:
                                     db.clear_public_chat_session(sid)
 
-                            await adapter._send_message(
+                            await self.adapter._send_message(
                                 bot_token=bot_token,
                                 chat_id=str(message.get("chat", {}).get("id", "")),
                                 text=command_response,
@@ -122,6 +131,7 @@ async def register_webhook(agent_name: str, public_url: str) -> bool:
     Register a Telegram webhook URL for an agent's bot.
 
     Called on bot configuration and on backend startup (reconciliation).
+    Requests message and member update types for group support.
     """
     import httpx
 
@@ -142,7 +152,7 @@ async def register_webhook(agent_name: str, public_url: str) -> bool:
     payload = {
         "url": webhook_url,
         "secret_token": secret_token,
-        "allowed_updates": ["message"],
+        "allowed_updates": ["message", "my_chat_member", "chat_member"],
     }
 
     try:

--- a/src/backend/config/agent-templates/quota-deploy-20ad05/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-20ad05/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-20ad05/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-20ad05/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-20ad05
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-287e93/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-287e93/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-287e93/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-287e93/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-287e93
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-372ce6/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-372ce6/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-372ce6/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-372ce6/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-372ce6
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-4153f4/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-4153f4/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-4153f4/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-4153f4/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-4153f4
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-5322d2/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-5322d2/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-5322d2/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-5322d2/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-5322d2
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-53637f/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-53637f/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-53637f/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-53637f/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-53637f
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-6e4aad/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-6e4aad/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-6e4aad/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-6e4aad/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-6e4aad
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-7b90c4/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-7b90c4/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-7b90c4/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-7b90c4/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-7b90c4
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-7f1a41/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-7f1a41/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-7f1a41/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-7f1a41/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-7f1a41
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-939425/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-939425/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-939425/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-939425/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-939425
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-9a588e/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-9a588e/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-9a588e/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-9a588e/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-9a588e
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-c7e7d5/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-c7e7d5/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-c7e7d5/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-c7e7d5/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-c7e7d5
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-cc0270/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-cc0270/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-cc0270/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-cc0270/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-cc0270
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-e0becf/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-e0becf/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-e0becf/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-e0becf/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-e0becf
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-e3dbca/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-e3dbca/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-e3dbca/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-e3dbca/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-e3dbca
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-deploy-e7e06d/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-deploy-e7e06d/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-deploy-e7e06d/template.yaml
+++ b/src/backend/config/agent-templates/quota-deploy-e7e06d/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-deploy-e7e06d
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-4e19d0-2/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-4e19d0-2/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-4e19d0-2/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-4e19d0-2/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-4e19d0
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-4e19d0/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-4e19d0/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-4e19d0/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-4e19d0/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-4e19d0
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-5b3c37-2/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-5b3c37-2/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-5b3c37-2/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-5b3c37-2/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-5b3c37
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-5b3c37/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-5b3c37/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-5b3c37/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-5b3c37/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-5b3c37
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-9242f6-2/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-9242f6-2/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-9242f6-2/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-9242f6-2/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-9242f6
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-9242f6/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-9242f6/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-9242f6/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-9242f6/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-9242f6
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-c30592-2/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-c30592-2/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-c30592-2/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-c30592-2/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-c30592
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/config/agent-templates/quota-redeploy-c30592/CLAUDE.md
+++ b/src/backend/config/agent-templates/quota-redeploy-c30592/CLAUDE.md
@@ -1,0 +1,2 @@
+# Test Agent
+Quota test.

--- a/src/backend/config/agent-templates/quota-redeploy-c30592/template.yaml
+++ b/src/backend/config/agent-templates/quota-redeploy-c30592/template.yaml
@@ -1,0 +1,6 @@
+
+name: quota-redeploy-c30592
+display_name: Quota Test Agent
+resources:
+  cpu: "1"
+  memory: "2g"

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1381,6 +1381,23 @@ class DatabaseManager:
     def increment_telegram_message_count(self, chat_link_id):
         return self._telegram_channel_ops.increment_message_count(chat_link_id)
 
+    # Telegram Group Configs (TGRAM-GROUP)
+
+    def get_or_create_telegram_group_config(self, binding_id, chat_id, chat_title=None, chat_type="group"):
+        return self._telegram_channel_ops.get_or_create_group_config(binding_id, chat_id, chat_title, chat_type)
+
+    def get_telegram_group_config(self, binding_id, chat_id):
+        return self._telegram_channel_ops.get_group_config(binding_id, chat_id)
+
+    def get_telegram_groups_for_agent(self, agent_name):
+        return self._telegram_channel_ops.get_groups_for_agent(agent_name)
+
+    def update_telegram_group_config(self, group_config_id, trigger_mode=None, welcome_enabled=None, welcome_text=None):
+        return self._telegram_channel_ops.update_group_config(group_config_id, trigger_mode, welcome_enabled, welcome_text)
+
+    def deactivate_telegram_group_config(self, binding_id, chat_id):
+        return self._telegram_channel_ops.deactivate_group_config(binding_id, chat_id)
+
     # =========================================================================
     # Nevermined Payment Integration (delegated to db/nevermined.py) - NVM-001
     # =========================================================================

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -1004,6 +1004,37 @@ def _migrate_telegram_bindings(cursor, conn):
     conn.commit()
 
 
+def _migrate_telegram_group_configs(cursor, conn):
+    """Create Telegram group configuration table (TGRAM-GROUP)."""
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS telegram_group_configs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            binding_id INTEGER NOT NULL REFERENCES telegram_bindings(id),
+            chat_id TEXT NOT NULL,
+            chat_title TEXT,
+            chat_type TEXT DEFAULT 'group',
+            trigger_mode TEXT DEFAULT 'mention',
+            welcome_enabled INTEGER DEFAULT 0,
+            welcome_text TEXT,
+            is_active INTEGER DEFAULT 1,
+            created_at TEXT NOT NULL,
+            updated_at TEXT
+        )
+    """)
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_tg_group_binding_chat ON telegram_group_configs(binding_id, chat_id)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tg_group_chat_id ON telegram_group_configs(chat_id)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tg_group_active ON telegram_group_configs(is_active)"
+    )
+
+    conn.commit()
+
+
 # Ordered list of all migrations. Defined at module level (after all _migrate_* functions)
 # so run_all_migrations and the health check can both reference it.
 # IMPORTANT: append-only — never reorder or remove entries.
@@ -1043,4 +1074,5 @@ MIGRATIONS = [
     ("execution_fan_out_id", _migrate_execution_fan_out_id),
     ("telegram_bindings", _migrate_telegram_bindings),
     ("subscription_usage_tracking", _migrate_subscription_usage_tracking),
+    ("telegram_group_configs", _migrate_telegram_group_configs),
 ]

--- a/src/backend/db/telegram_channels.py
+++ b/src/backend/db/telegram_channels.py
@@ -174,10 +174,17 @@ class TelegramChannelOperations:
             conn.commit()
 
     def delete_binding(self, agent_name: str) -> bool:
-        """Delete a Telegram binding and associated chat links."""
+        """Delete a Telegram binding and associated chat links and group configs."""
         with get_db_connection() as conn:
             cursor = conn.cursor()
-            # Delete chat links first
+            # Delete group configs first
+            cursor.execute("""
+                DELETE FROM telegram_group_configs
+                WHERE binding_id IN (
+                    SELECT id FROM telegram_bindings WHERE agent_name = ?
+                )
+            """, (agent_name,))
+            # Delete chat links
             cursor.execute("""
                 DELETE FROM telegram_chat_links
                 WHERE binding_id IN (
@@ -245,8 +252,188 @@ class TelegramChannelOperations:
             conn.commit()
 
     # =========================================================================
+    # Group Config Operations (TGRAM-GROUP)
+    # =========================================================================
+
+    def get_or_create_group_config(
+        self,
+        binding_id: int,
+        chat_id: str,
+        chat_title: Optional[str] = None,
+        chat_type: str = "group",
+    ) -> dict:
+        """Get or create a group config. Auto-creates on first interaction."""
+        now = datetime.utcnow().isoformat()
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT id, binding_id, chat_id, chat_title, chat_type,
+                       trigger_mode, welcome_enabled, welcome_text,
+                       is_active, created_at, updated_at
+                FROM telegram_group_configs
+                WHERE binding_id = ? AND chat_id = ?
+            """, (binding_id, chat_id))
+            row = cursor.fetchone()
+
+            if row:
+                # Re-activate if inactive (bot removed then re-added) and update title
+                needs_update = False
+                if chat_title and chat_title != row[3]:
+                    needs_update = True
+                if not row[8]:  # is_active == 0
+                    needs_update = True
+
+                if needs_update:
+                    cursor.execute("""
+                        UPDATE telegram_group_configs
+                        SET chat_title = ?, is_active = 1, updated_at = ?
+                        WHERE id = ?
+                    """, (chat_title or row[3], now, row[0]))
+                    conn.commit()
+                    return {**self._row_to_group_config(row),
+                            "chat_title": chat_title or row[3],
+                            "is_active": True}
+                return self._row_to_group_config(row)
+
+            cursor.execute("""
+                INSERT INTO telegram_group_configs
+                (binding_id, chat_id, chat_title, chat_type,
+                 trigger_mode, welcome_enabled, is_active, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'mention', 0, 1, ?, ?)
+            """, (binding_id, chat_id, chat_title, chat_type, now, now))
+            conn.commit()
+
+            cursor.execute("""
+                SELECT id, binding_id, chat_id, chat_title, chat_type,
+                       trigger_mode, welcome_enabled, welcome_text,
+                       is_active, created_at, updated_at
+                FROM telegram_group_configs
+                WHERE binding_id = ? AND chat_id = ?
+            """, (binding_id, chat_id))
+            return self._row_to_group_config(cursor.fetchone())
+
+    def get_group_config(self, binding_id: int, chat_id: str) -> Optional[dict]:
+        """Get group config for a specific chat."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT id, binding_id, chat_id, chat_title, chat_type,
+                       trigger_mode, welcome_enabled, welcome_text,
+                       is_active, created_at, updated_at
+                FROM telegram_group_configs
+                WHERE binding_id = ? AND chat_id = ?
+            """, (binding_id, chat_id))
+            row = cursor.fetchone()
+        return self._row_to_group_config(row) if row else None
+
+    def get_groups_for_binding(self, binding_id: int) -> List[dict]:
+        """Get all group configs for a bot binding."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT id, binding_id, chat_id, chat_title, chat_type,
+                       trigger_mode, welcome_enabled, welcome_text,
+                       is_active, created_at, updated_at
+                FROM telegram_group_configs
+                WHERE binding_id = ? AND is_active = 1
+                ORDER BY chat_title
+            """, (binding_id,))
+            rows = cursor.fetchall()
+        return [self._row_to_group_config(row) for row in rows]
+
+    def get_groups_for_agent(self, agent_name: str) -> List[dict]:
+        """Get all group configs for an agent (via binding lookup)."""
+        binding = self.get_binding_by_agent(agent_name)
+        if not binding:
+            return []
+        return self.get_groups_for_binding(binding["id"])
+
+    def update_group_config(
+        self,
+        group_config_id: int,
+        trigger_mode: Optional[str] = None,
+        welcome_enabled: Optional[bool] = None,
+        welcome_text: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Update group config settings."""
+        now = datetime.utcnow().isoformat()
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            updates = ["updated_at = ?"]
+            values = [now]
+
+            if trigger_mode is not None:
+                updates.append("trigger_mode = ?")
+                values.append(trigger_mode)
+            if welcome_enabled is not None:
+                updates.append("welcome_enabled = ?")
+                values.append(1 if welcome_enabled else 0)
+            if welcome_text is not None:
+                updates.append("welcome_text = ?")
+                values.append(welcome_text)
+
+            values.append(group_config_id)
+            cursor.execute(f"""
+                UPDATE telegram_group_configs
+                SET {', '.join(updates)}
+                WHERE id = ?
+            """, values)
+            conn.commit()
+
+            cursor.execute("""
+                SELECT id, binding_id, chat_id, chat_title, chat_type,
+                       trigger_mode, welcome_enabled, welcome_text,
+                       is_active, created_at, updated_at
+                FROM telegram_group_configs
+                WHERE id = ?
+            """, (group_config_id,))
+            row = cursor.fetchone()
+        return self._row_to_group_config(row) if row else None
+
+    def deactivate_group_config(self, binding_id: int, chat_id: str) -> bool:
+        """Mark a group config as inactive (bot removed from group)."""
+        now = datetime.utcnow().isoformat()
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                UPDATE telegram_group_configs
+                SET is_active = 0, updated_at = ?
+                WHERE binding_id = ? AND chat_id = ?
+            """, (now, binding_id, chat_id))
+            deleted = cursor.rowcount > 0
+            conn.commit()
+        return deleted
+
+    def delete_groups_for_binding(self, binding_id: int) -> int:
+        """Delete all group configs for a binding (when bot is disconnected)."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM telegram_group_configs WHERE binding_id = ?",
+                (binding_id,)
+            )
+            count = cursor.rowcount
+            conn.commit()
+        return count
+
+    # =========================================================================
     # Row converters
     # =========================================================================
+
+    def _row_to_group_config(self, row) -> dict:
+        return {
+            "id": row[0],
+            "binding_id": row[1],
+            "chat_id": row[2],
+            "chat_title": row[3],
+            "chat_type": row[4],
+            "trigger_mode": row[5],
+            "welcome_enabled": bool(row[6]),
+            "welcome_text": row[7],
+            "is_active": bool(row[8]),
+            "created_at": row[9],
+            "updated_at": row[10],
+        }
 
     def _row_to_binding(self, row) -> dict:
         return {

--- a/src/backend/routers/telegram.py
+++ b/src/backend/routers/telegram.py
@@ -1,5 +1,5 @@
 """
-Telegram bot integration router (TELEGRAM-001).
+Telegram bot integration router (TELEGRAM-001, TGRAM-GROUP).
 
 Thin HTTP layer that delegates to the channel adapter abstraction.
 
@@ -7,14 +7,17 @@ Public Endpoints (no auth — validated by webhook secret + header token):
 - POST /api/telegram/webhook/{webhook_secret} — Receive Telegram updates
 
 Authenticated Endpoints:
-- GET    /api/agents/{name}/telegram       — Bot binding status
-- PUT    /api/agents/{name}/telegram       — Configure bot token
-- DELETE /api/agents/{name}/telegram       — Remove bot binding
-- POST   /api/agents/{name}/telegram/test  — Send test message
+- GET    /api/agents/{name}/telegram              — Bot binding status
+- PUT    /api/agents/{name}/telegram              — Configure bot token
+- DELETE /api/agents/{name}/telegram              — Remove bot binding
+- POST   /api/agents/{name}/telegram/test         — Send test message
+- GET    /api/agents/{name}/telegram/groups        — List group configs (TGRAM-GROUP)
+- PUT    /api/agents/{name}/telegram/groups/{id}   — Update group config
+- DELETE /api/agents/{name}/telegram/groups/{id}   — Remove group config
 """
 
 import logging
-from typing import Optional
+from typing import Optional, List
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request, Depends
@@ -68,7 +71,7 @@ async def handle_telegram_webhook(webhook_secret: str, request: Request):
 
 
 # =========================================================================
-# Authenticated Router (bot configuration)
+# Authenticated Router (bot configuration + group config)
 # =========================================================================
 
 auth_router = APIRouter(prefix="/api/agents", tags=["telegram"])
@@ -81,6 +84,7 @@ class TelegramBindingResponse(BaseModel):
     webhook_url: Optional[str] = None
     bot_link: Optional[str] = None
     configured: bool = False
+    group_count: int = 0
 
 
 class TelegramConfigureRequest(BaseModel):
@@ -90,6 +94,23 @@ class TelegramConfigureRequest(BaseModel):
 class TelegramTestRequest(BaseModel):
     chat_id: Optional[str] = None
     message: str = "Hello from Trinity! Your Telegram bot is configured correctly."
+
+
+class TelegramGroupConfigResponse(BaseModel):
+    id: int
+    chat_id: str
+    chat_title: Optional[str] = None
+    chat_type: str = "group"
+    trigger_mode: str = "mention"
+    welcome_enabled: bool = False
+    welcome_text: Optional[str] = None
+    is_active: bool = True
+
+
+class TelegramGroupConfigUpdateRequest(BaseModel):
+    trigger_mode: Optional[str] = None
+    welcome_enabled: Optional[bool] = None
+    welcome_text: Optional[str] = None
 
 
 @auth_router.get("/{agent_name}/telegram", response_model=TelegramBindingResponse)
@@ -103,6 +124,7 @@ async def get_telegram_binding(
         return TelegramBindingResponse(agent_name=agent_name, configured=False)
 
     bot_username = binding.get("bot_username")
+    groups = db.get_telegram_groups_for_agent(agent_name)
     return TelegramBindingResponse(
         agent_name=agent_name,
         bot_username=bot_username,
@@ -110,6 +132,7 @@ async def get_telegram_binding(
         webhook_url=binding.get("webhook_url"),
         bot_link=f"https://t.me/{bot_username}" if bot_username else None,
         configured=True,
+        group_count=len(groups),
     )
 
 
@@ -183,6 +206,7 @@ async def configure_telegram_bot(
         webhook_url=binding.get("webhook_url") if binding else None,
         bot_link=f"https://t.me/{bot_username}" if bot_username else None,
         configured=True,
+        group_count=0,
     )
 
 
@@ -199,7 +223,7 @@ async def delete_telegram_binding(
     from adapters.transports.telegram_webhook import delete_webhook
     await delete_webhook(agent_name)
 
-    # Delete from DB
+    # Delete from DB (cascades to group configs and chat links)
     db.delete_telegram_binding(agent_name)
 
     logger.info(f"Telegram bot removed for agent={agent_name}")
@@ -252,3 +276,78 @@ async def test_telegram_bot(
                 return {"ok": False, "message": result.get("description", "Failed to send")}
     except Exception as e:
         return {"ok": False, "message": str(e)}
+
+
+# =========================================================================
+# Group Config Endpoints (TGRAM-GROUP)
+# =========================================================================
+
+
+@auth_router.get(
+    "/{agent_name}/telegram/groups",
+    response_model=List[TelegramGroupConfigResponse],
+)
+async def list_telegram_groups(
+    agent_name: str,
+    current_user: User = Depends(get_current_user),
+):
+    """List all Telegram groups this agent's bot is in."""
+    groups = db.get_telegram_groups_for_agent(agent_name)
+    return [TelegramGroupConfigResponse(**g) for g in groups]
+
+
+@auth_router.put("/{agent_name}/telegram/groups/{group_config_id}")
+async def update_telegram_group(
+    agent_name: OwnedAgentByName,
+    group_config_id: int,
+    config: TelegramGroupConfigUpdateRequest,
+):
+    """Update a group's trigger mode or welcome message settings."""
+    # Validate trigger_mode if provided
+    if config.trigger_mode is not None and config.trigger_mode not in ("mention", "all"):
+        raise HTTPException(status_code=400, detail="trigger_mode must be 'mention' or 'all'")
+
+    # Validate welcome_text length
+    if config.welcome_text is not None and len(config.welcome_text) > 4096:
+        raise HTTPException(status_code=400, detail="welcome_text must be 4096 characters or less")
+
+    # Verify the group config belongs to this agent's binding
+    binding = db.get_telegram_binding(agent_name)
+    if not binding:
+        raise HTTPException(status_code=404, detail="No Telegram binding found")
+
+    # Check ownership: group config must belong to this agent's binding
+    groups = db.get_telegram_groups_for_agent(agent_name)
+    if not any(g["id"] == group_config_id for g in groups):
+        raise HTTPException(status_code=404, detail="Group config not found for this agent")
+
+    updated = db.update_telegram_group_config(
+        group_config_id=group_config_id,
+        trigger_mode=config.trigger_mode,
+        welcome_enabled=config.welcome_enabled,
+        welcome_text=config.welcome_text,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Group config not found")
+
+    return updated
+
+
+@auth_router.delete("/{agent_name}/telegram/groups/{group_config_id}")
+async def delete_telegram_group(
+    agent_name: OwnedAgentByName,
+    group_config_id: int,
+):
+    """Remove a group config (bot will ignore messages from this group)."""
+    binding = db.get_telegram_binding(agent_name)
+    if not binding:
+        raise HTTPException(status_code=404, detail="No Telegram binding found")
+
+    # Deactivate rather than delete — preserves history
+    groups = db.get_telegram_groups_for_agent(agent_name)
+    target = next((g for g in groups if g["id"] == group_config_id), None)
+    if not target:
+        raise HTTPException(status_code=404, detail="Group config not found")
+
+    db.deactivate_telegram_group_config(binding["id"], target["chat_id"])
+    return {"ok": True, "message": "Group config removed"}

--- a/src/frontend/src/components/TelegramChannelPanel.vue
+++ b/src/frontend/src/components/TelegramChannelPanel.vue
@@ -2,7 +2,7 @@
   <div>
     <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Telegram Bot</h3>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-      Connect a Telegram bot so users can chat with this agent via Telegram DMs.
+      Connect a Telegram bot so users can chat with this agent via Telegram DMs and group chats.
     </p>
 
     <!-- Loading -->
@@ -62,6 +62,90 @@
       <!-- Webhook Warning -->
       <div v-if="!binding.webhook_url" class="p-3 rounded-lg text-sm bg-yellow-50 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300">
         Bot connected but webhook not registered. Set a <router-link to="/settings" class="underline font-medium hover:text-yellow-800 dark:hover:text-yellow-200">Public URL in Settings</router-link> for Telegram messages to reach this agent.
+      </div>
+
+      <!-- Group Chats Section -->
+      <div v-if="groups.length > 0" class="mt-4">
+        <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Group Chats ({{ groups.length }})
+        </h4>
+        <div class="space-y-2">
+          <div
+            v-for="group in groups"
+            :key="group.id"
+            class="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700"
+          >
+            <div class="flex items-center justify-between mb-2">
+              <div class="flex items-center gap-2">
+                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                <span class="text-sm font-medium text-gray-900 dark:text-white">
+                  {{ group.chat_title || `Group ${group.chat_id}` }}
+                </span>
+                <span class="text-xs text-gray-400">{{ group.chat_type }}</span>
+              </div>
+              <button
+                @click="removeGroup(group)"
+                class="text-xs text-red-500 hover:text-red-700 dark:hover:text-red-400"
+              >
+                Remove
+              </button>
+            </div>
+
+            <!-- Trigger Mode -->
+            <div class="flex items-center gap-4 text-xs">
+              <label class="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  :name="`trigger-${group.id}`"
+                  value="mention"
+                  :checked="group.trigger_mode === 'mention'"
+                  @change="updateGroup(group, { trigger_mode: 'mention' })"
+                  class="text-indigo-600 focus:ring-indigo-500"
+                />
+                <span class="text-gray-600 dark:text-gray-400">@mention only</span>
+              </label>
+              <label class="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  :name="`trigger-${group.id}`"
+                  value="all"
+                  :checked="group.trigger_mode === 'all'"
+                  @change="updateGroup(group, { trigger_mode: 'all' })"
+                  class="text-indigo-600 focus:ring-indigo-500"
+                />
+                <span class="text-gray-600 dark:text-gray-400">All messages</span>
+              </label>
+            </div>
+
+            <!-- Welcome Message Toggle -->
+            <div class="mt-2">
+              <label class="flex items-center gap-1.5 cursor-pointer text-xs">
+                <input
+                  type="checkbox"
+                  :checked="group.welcome_enabled"
+                  @change="updateGroup(group, { welcome_enabled: !group.welcome_enabled })"
+                  class="rounded text-indigo-600 focus:ring-indigo-500"
+                />
+                <span class="text-gray-600 dark:text-gray-400">Welcome new members</span>
+              </label>
+              <div v-if="group.welcome_enabled" class="mt-1.5">
+                <input
+                  type="text"
+                  :value="group.welcome_text || ''"
+                  @blur="updateGroup(group, { welcome_text: $event.target.value })"
+                  placeholder="Welcome, {name}! I'm here to help."
+                  class="w-full text-xs px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                />
+                <p class="mt-0.5 text-xs text-gray-400">Use {name} for the user's first name</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-else-if="binding.configured && binding.webhook_url" class="mt-3 text-xs text-gray-400 dark:text-gray-500">
+        No group chats yet. Add the bot to a Telegram group to see it here.
       </div>
     </div>
 
@@ -125,6 +209,7 @@ const disconnecting = ref(false)
 const verifying = ref(false)
 const accessDenied = ref(false)
 const binding = ref({ configured: false })
+const groups = ref([])
 const botToken = ref('')
 const message = ref(null)
 
@@ -135,6 +220,9 @@ async function loadBinding() {
   try {
     const response = await api.get(`/api/agents/${props.agentName}/telegram`)
     binding.value = response.data
+    if (response.data.configured) {
+      await loadGroups()
+    }
   } catch (e) {
     if (e.response?.status === 403) {
       accessDenied.value = true
@@ -142,6 +230,15 @@ async function loadBinding() {
     binding.value = { configured: false }
   } finally {
     loading.value = false
+  }
+}
+
+async function loadGroups() {
+  try {
+    const response = await api.get(`/api/agents/${props.agentName}/telegram/groups`)
+    groups.value = response.data
+  } catch (e) {
+    groups.value = []
   }
 }
 
@@ -171,6 +268,7 @@ async function disconnectBot() {
     await api.delete(`/api/agents/${props.agentName}/telegram`)
     message.value = { type: 'success', text: 'Bot disconnected' }
     binding.value = { configured: false }
+    groups.value = []
     setTimeout(() => { message.value = null }, 3000)
   } catch (e) {
     const detail = e.response?.data?.detail || 'Failed to disconnect bot'
@@ -198,6 +296,35 @@ async function verifyBot() {
     message.value = { type: 'error', text: detail }
   } finally {
     verifying.value = false
+  }
+}
+
+async function updateGroup(group, updates) {
+  try {
+    const response = await api.put(
+      `/api/agents/${props.agentName}/telegram/groups/${group.id}`,
+      updates
+    )
+    // Update local state
+    const idx = groups.value.findIndex(g => g.id === group.id)
+    if (idx !== -1) {
+      groups.value[idx] = { ...groups.value[idx], ...response.data }
+    }
+  } catch (e) {
+    const detail = e.response?.data?.detail || 'Failed to update group config'
+    message.value = { type: 'error', text: detail }
+    setTimeout(() => { message.value = null }, 3000)
+  }
+}
+
+async function removeGroup(group) {
+  try {
+    await api.delete(`/api/agents/${props.agentName}/telegram/groups/${group.id}`)
+    groups.value = groups.value.filter(g => g.id !== group.id)
+  } catch (e) {
+    const detail = e.response?.data?.detail || 'Failed to remove group'
+    message.value = { type: 'error', text: detail }
+    setTimeout(() => { message.value = null }, 3000)
   }
 }
 


### PR DESCRIPTION
## Summary
- Enable agents to participate in Telegram group chats via @mentions and reply-to-bot triggers
- Per-group configuration for trigger mode (mention-only vs all messages) and welcome messages for new members
- Auto-creates group configs on first interaction; handles bot added/removed from groups via `my_chat_member` events

## Changes
- **Adapter** (`telegram_adapter.py`): Group detection, @mention parsing from entities, reply-to-bot detection, member event handling, command @botname suffix stripping
- **Transport** (`telegram_webhook.py`): Handle `my_chat_member` and `chat_member` updates, inject `_bot_username` metadata, updated `allowed_updates` for webhook
- **DB** (`migrations.py`, `telegram_channels.py`, `database.py`): New `telegram_group_configs` table with trigger mode, welcome message config, active state; cascading deletes
- **Router** (`telegram.py`): CRUD endpoints for group configs with IDOR-safe ownership verification
- **Message Router** (`message_router.py`): Silent rate-limit drops in groups, fresh context per group message (no session history bleed), channel-agnostic file upload rate keys
- **Frontend** (`TelegramChannelPanel.vue`): Group list with trigger mode radio buttons and welcome message configuration
- **Requirements** (`requirements.md`): Documented TGRAM-GROUP requirement

## Test Plan
- [ ] Bot responds to @mentions in group chats
- [ ] Bot responds to direct replies to its messages
- [ ] Bot ignores non-mentioned messages when trigger_mode=mention
- [ ] `my_chat_member` creates/deactivates group configs on bot add/remove
- [ ] Welcome messages sent on user join (when enabled)
- [ ] Group config UI shows groups with trigger mode and welcome config
- [ ] Rate limiting silently drops in groups (no public error messages)
- [ ] No session history context bleed in group replies
- [ ] Group config CRUD endpoints verify ownership (no IDOR)
- [ ] Bot re-added to group reactivates previously deactivated config

Closes #297

Generated with [Claude Code](https://claude.com/claude-code)