### PR TITLE
fix(telegram): back-fill webhooks when public_chat_url is saved (#309)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-12 | #309 | Telegram webhook back-fill when `public_chat_url` is saved (self-healing config order) | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-11 | #297 | Telegram group chat support — @mention triggers, welcome messages, per-group config | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-10 | #296 | Telegram bot connection UI — TelegramChannelPanel in Agent Detail Sharing page | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-08 | #69 | Owner filter dropdown on Dashboard and Agents pages | [agents-page-ui-improvements.md](feature-flows/agents-page-ui-improvements.md), [agent-network.md](feature-flows/agent-network.md) |

--- a/docs/memory/feature-flows/telegram-integration.md
+++ b/docs/memory/feature-flows/telegram-integration.md
@@ -88,7 +88,7 @@ Two routers are registered in `main.py:523-524`:
 
 **Authenticated router** (`/api/agents`):
 - `GET /{agent_name}/telegram` (line 95) — Returns binding status (bot_username, bot_id, webhook_url, bot_link, configured flag). No token decryption.
-- `PUT /{agent_name}/telegram` (line 116) — Configure bot. Validates token format (`id:secret`), calls `getMe` API, checks bot_id uniqueness across agents, creates encrypted binding, registers webhook if `public_chat_url` is set.
+- `PUT /{agent_name}/telegram` (line 116) — Configure bot. Validates token format (`id:secret`), calls `getMe` API, checks bot_id uniqueness across agents, creates encrypted binding, registers webhook if `public_chat_url` is set. If `public_chat_url` is unset, the binding is still created (the UI "Connected (no webhook)" state handles this), and the response includes a `warning` field explaining that delivery will start automatically once the URL is saved. Back-fill is triggered by saving the setting — see "Back-fill on setting save" below.
 - `DELETE /{agent_name}/telegram` (line 190) — Calls Telegram `deleteWebhook`, then deletes binding + chat links from DB.
 - `POST /{agent_name}/telegram/test` (line 211) — Without `chat_id`: verifies bot via `getMe`. With `chat_id`: sends test message.
 
@@ -170,6 +170,12 @@ On backend startup:
 5. **Webhook reconciliation**: If `public_chat_url` is set, iterate all bindings and call `register_webhook()` for each. This ensures webhooks are re-registered after backend restarts or URL changes.
 
 On shutdown (`main.py:432-437`): calls `transport.stop()`.
+
+### Back-fill on `public_chat_url` save (`routers/settings.py`)
+
+When an admin saves `public_chat_url` via `PUT /api/settings/{key}`, the handler calls `_backfill_telegram_webhooks(new_url)` after the setting write succeeds. The helper iterates `db.get_all_telegram_bindings()` and invokes `register_webhook(agent_name, new_url)` for each. This is idempotent (Telegram's `setWebhook` replaces any existing registration) and self-healing — bindings created before a public URL was configured automatically start receiving messages as soon as the URL is saved, without requiring the admin to remove and re-add the bot.
+
+Failures during back-fill are logged (`logger.warning`) but not raised: the setting write has already succeeded, and a single bad binding (network blip, expired token) must not block others or the API response. The reconciliation loop in `main.py` startup re-runs on the next backend restart and catches any stragglers.
 
 ## Data Layer
 

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -1087,9 +1087,39 @@ async def update_setting(
     try:
         setting = db.set_setting(key, body.value)
 
+        # Back-fill Telegram webhooks when public_chat_url becomes available.
+        # Why: bindings created before public_chat_url was set have webhook_url IS NULL
+        # and receive no messages. Re-registering is idempotent (setWebhook on Telegram).
+        if key == "public_chat_url" and body.value:
+            await _backfill_telegram_webhooks(body.value)
+
         return setting
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update setting: {str(e)}")
+
+
+async def _backfill_telegram_webhooks(public_url: str) -> None:
+    """Re-register Telegram webhooks for all bindings after public_chat_url changes.
+
+    Idempotent: Telegram's setWebhook replaces any existing registration.
+    Failures are logged but not raised — the setting write has already succeeded
+    and a single bad binding must not block others or the response.
+    """
+    try:
+        from adapters.transports.telegram_webhook import register_webhook
+        bindings = db.get_all_telegram_bindings()
+    except Exception as e:
+        logger.warning(f"Telegram webhook back-fill skipped: {e}")
+        return
+
+    for binding in bindings:
+        agent_name = binding.get("agent_name", "<unknown>")
+        try:
+            await register_webhook(agent_name, public_url)
+        except Exception as e:
+            logger.warning(
+                f"Telegram webhook back-fill failed for agent={agent_name}: {e}"
+            )
 
 
 @router.delete("/{key}")

--- a/src/backend/routers/telegram.py
+++ b/src/backend/routers/telegram.py
@@ -85,6 +85,7 @@ class TelegramBindingResponse(BaseModel):
     bot_link: Optional[str] = None
     configured: bool = False
     group_count: int = 0
+    warning: Optional[str] = None
 
 
 class TelegramConfigureRequest(BaseModel):
@@ -191,11 +192,22 @@ async def configure_telegram_bot(
     # Register webhook if public URL is available
     from services.settings_service import settings_service
     public_url = settings_service.get_setting("public_chat_url", "")
+    warning: Optional[str] = None
     if public_url:
         from adapters.transports.telegram_webhook import register_webhook
         await register_webhook(agent_name, public_url)
         # Refresh binding to get updated webhook_url
         binding = db.get_telegram_binding(agent_name)
+    else:
+        warning = (
+            "Bot connected, but webhook not registered: 'public_chat_url' is not "
+            "set in Settings. The bot will start receiving messages automatically "
+            "once a public URL is saved."
+        )
+        logger.warning(
+            f"Telegram bot configured for agent={agent_name} without public_chat_url — "
+            "webhook registration deferred until the setting is saved"
+        )
 
     logger.info(f"Telegram bot configured for agent={agent_name} bot=@{bot_username}")
 
@@ -207,6 +219,7 @@ async def configure_telegram_bot(
         bot_link=f"https://t.me/{bot_username}" if bot_username else None,
         configured=True,
         group_count=0,
+        warning=warning,
     )
 
 

--- a/tests/unit/test_telegram_webhook_backfill.py
+++ b/tests/unit/test_telegram_webhook_backfill.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for Telegram webhook back-fill on public_chat_url save (#309).
+
+Verifies:
+- Setting public_chat_url to a non-empty value re-registers webhooks for
+  every existing Telegram binding.
+- Setting public_chat_url to an empty value does NOT trigger re-registration.
+- A failing register_webhook call for one binding does not break others.
+- Back-fill handles a missing db.get_all_telegram_bindings (fresh install)
+  without raising.
+
+Modules: src/backend/routers/settings.py
+Issue: https://github.com/abilityai/trinity/issues/309
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_project_root = Path(__file__).resolve().parents[2]
+_settings_py = _project_root / "src" / "backend" / "routers" / "settings.py"
+
+# Modules this test stubs into sys.modules — must be restored after each test
+# so other test files (e.g. test_webhook_signature.py) get clean imports.
+_STUBBED_MODULE_NAMES = [
+    "models",
+    "database",
+    "dependencies",
+    "services",
+    "services.settings_service",
+    "adapters",
+    "adapters.transports",
+    "adapters.transports.telegram_webhook",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot sys.modules before each test and restore after.
+
+    Prevents stubbed modules from leaking into other test files in the same
+    pytest session.
+    """
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+def _load_settings_module():
+    """Load routers/settings.py as a standalone module with stubbed deps.
+
+    Avoids triggering the real routers/__init__.py import chain, which pulls
+    in the entire backend. We stub the module-level imports that settings.py
+    reaches for, then load the source file directly.
+    """
+    stubs = {}
+
+    # Stub the sibling backend modules that settings.py imports at top level.
+    def _stub(name, **attrs):
+        mod = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(mod, k, v)
+        stubs[name] = mod
+        return mod
+
+    from pydantic import BaseModel
+
+    class _User(BaseModel):
+        username: str = "admin"
+
+    class _SystemSetting(BaseModel):
+        key: str
+        value: str = ""
+
+    class _SystemSettingUpdate(BaseModel):
+        value: str = ""
+
+    _stub("models", User=_User)
+
+    db_stub = MagicMock()
+    db_stub.set_setting = MagicMock(return_value=_SystemSetting(key="public_chat_url"))
+    db_stub.get_all_telegram_bindings = MagicMock(return_value=[])
+    _stub(
+        "database",
+        db=db_stub,
+        SystemSetting=_SystemSetting,
+        SystemSettingUpdate=_SystemSettingUpdate,
+    )
+
+    _stub("dependencies", get_current_user=MagicMock())
+
+    _stub(
+        "services.settings_service",
+        get_anthropic_api_key=MagicMock(),
+        get_github_pat=MagicMock(),
+        get_google_api_key=MagicMock(),
+        get_ops_setting=MagicMock(),
+        settings_service=MagicMock(),
+        OPS_SETTINGS_DEFAULTS={},
+        OPS_SETTINGS_DESCRIPTIONS={},
+        AGENT_QUOTA_DEFAULTS={},
+        AGENT_QUOTA_DESCRIPTIONS={},
+    )
+    _stub("services", __path__=[])
+
+    # Stub adapters.transports.telegram_webhook before load so the function
+    # can import it lazily without hitting the real backend.
+    adapters = _stub("adapters", __path__=[])
+    transports = _stub("adapters.transports", __path__=[])
+    telegram_webhook = _stub(
+        "adapters.transports.telegram_webhook",
+        register_webhook=AsyncMock(return_value=True),
+    )
+    adapters.transports = transports
+    transports.telegram_webhook = telegram_webhook
+
+    # Keep stubs in sys.modules beyond load: _backfill_telegram_webhooks
+    # imports adapters.transports.telegram_webhook lazily at call time.
+    sys.modules.update(stubs)
+    spec = importlib.util.spec_from_file_location(
+        "_trinity_settings_under_test", _settings_py
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, db_stub, telegram_webhook
+
+
+class TestTelegramBackfill:
+    """Back-fill behavior when public_chat_url is saved."""
+
+    @pytest.mark.asyncio
+    async def test_backfill_registers_all_bindings(self):
+        """Every existing binding gets register_webhook called with the new URL."""
+        module, db_stub, telegram_webhook = _load_settings_module()
+
+        bindings = [
+            {"agent_name": "agent-a", "webhook_url": None},
+            {"agent_name": "agent-b", "webhook_url": None},
+            {"agent_name": "agent-c", "webhook_url": "https://stale.example.com/..."},
+        ]
+        db_stub.get_all_telegram_bindings.return_value = bindings
+
+        register_mock = AsyncMock(return_value=True)
+        telegram_webhook.register_webhook = register_mock
+
+        await module._backfill_telegram_webhooks("https://new.example.com")
+
+        assert register_mock.await_count == 3
+        called_agents = {call.args[0] for call in register_mock.await_args_list}
+        assert called_agents == {"agent-a", "agent-b", "agent-c"}
+        for call in register_mock.await_args_list:
+            assert call.args[1] == "https://new.example.com"
+
+    @pytest.mark.asyncio
+    async def test_backfill_no_bindings_is_noop(self):
+        """Empty binding list produces no calls and no errors."""
+        module, db_stub, telegram_webhook = _load_settings_module()
+        db_stub.get_all_telegram_bindings.return_value = []
+
+        register_mock = AsyncMock(return_value=True)
+        telegram_webhook.register_webhook = register_mock
+
+        await module._backfill_telegram_webhooks("https://new.example.com")
+
+        assert register_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_backfill_continues_past_failures(self):
+        """One failing binding does not block others from being registered."""
+        module, db_stub, telegram_webhook = _load_settings_module()
+
+        bindings = [
+            {"agent_name": "agent-a", "webhook_url": None},
+            {"agent_name": "agent-bad", "webhook_url": None},
+            {"agent_name": "agent-c", "webhook_url": None},
+        ]
+        db_stub.get_all_telegram_bindings.return_value = bindings
+
+        async def flaky(agent_name, public_url):
+            if agent_name == "agent-bad":
+                raise RuntimeError("Telegram API unreachable")
+            return True
+
+        register_mock = AsyncMock(side_effect=flaky)
+        telegram_webhook.register_webhook = register_mock
+
+        # Must not raise
+        await module._backfill_telegram_webhooks("https://new.example.com")
+
+        # All three were attempted — the bad one did not short-circuit the loop
+        assert register_mock.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_backfill_swallows_db_errors(self):
+        """DB failure during back-fill is logged but does not raise.
+
+        The setting write has already succeeded; the back-fill is best-effort.
+        """
+        module, db_stub, telegram_webhook = _load_settings_module()
+        db_stub.get_all_telegram_bindings.side_effect = RuntimeError("db down")
+
+        register_mock = AsyncMock(return_value=True)
+        telegram_webhook.register_webhook = register_mock
+
+        # Must not raise
+        await module._backfill_telegram_webhooks("https://new.example.com")
+
+        assert register_mock.await_count == 0


### PR DESCRIPTION
## Summary

- When a Telegram bot is configured before `public_chat_url` is set, return a `warning` field instead of silently skipping webhook registration
- When `public_chat_url` is saved later, iterate all Telegram bindings and re-register each webhook (idempotent, mirrors startup reconciliation in `main.py`)
- Closes #309

## Changes

- `src/backend/routers/telegram.py` — Add `warning` field to `TelegramBindingResponse`; populate it when `public_chat_url` is unset at bot-config time
- `src/backend/routers/settings.py` — Add `_backfill_telegram_webhooks()` helper; call it after `PUT /api/settings/public_chat_url` succeeds
- `tests/unit/test_telegram_webhook_backfill.py` — 4 unit tests (all bindings registered, no-op on empty list, continues past per-binding failures, swallows DB errors)
- `docs/memory/feature-flows/telegram-integration.md` — Document the back-fill behavior

## Why Slack Is Not Affected

Slack `get_oauth_url()` already raises `ValueError` at install-time if `public_chat_url` is unset (fail-loud). Slack's event subscription URL is set via the Slack App manifest on the Slack side, not via our API, so there is no equivalent back-fill target here.

## Test Plan

- [x] `python -m pytest tests/unit/test_telegram_webhook_backfill.py -v` — 4 passed
- [x] Full unit suite still green: `python -m pytest tests/unit/ --ignore=tests/unit/test_slack_watchdog.py` — 437 passed
- [ ] Manual verification on a running backend:
  - [ ] Unset `public_chat_url`; `PUT /api/agents/{name}/telegram` with a valid bot token → response has `warning`, `webhook_url` is null
  - [ ] `PUT /api/settings/public_chat_url` with a reachable URL → check `telegram_bindings.webhook_url` is populated and Telegram `getWebhookInfo` returns the new URL

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)