### PR TITLE
feat: unified cross-channel access control (#311)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-12 | #311 | Unified cross-channel access control — verified email as identity, per-agent policy, access requests | [unified-channel-access-control.md](feature-flows/unified-channel-access-control.md) |
 | 2026-04-12 | #309 | Telegram webhook back-fill when `public_chat_url` is saved (self-healing config order) | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-11 | #297 | Telegram group chat support — @mention triggers, welcome messages, per-group config | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-10 | #296 | Telegram bot connection UI — TelegramChannelPanel in Agent Detail Sharing page | [telegram-integration.md](feature-flows/telegram-integration.md) |
@@ -157,7 +158,7 @@
 | Agent-to-Agent Collaboration | [agent-to-agent-collaboration.md](feature-flows/agent-to-agent-collaboration.md) | Inter-agent communication via MCP |
 | Agent Event Subscriptions | [agent-event-subscriptions.md](feature-flows/agent-event-subscriptions.md) | Lightweight pub/sub for inter-agent event pipelines |
 | Agent Permissions | [agent-permissions.md](feature-flows/agent-permissions.md) | Agent communication permissions |
-| Agent Sharing | [agent-sharing.md](feature-flows/agent-sharing.md) | Email-based sharing with access levels |
+| Agent Sharing | [agent-sharing.md](feature-flows/agent-sharing.md) | Cross-channel email allow-list (web/Slack/Telegram) with access policy and pending requests |
 | Agent Shared Folders | [agent-shared-folders.md](feature-flows/agent-shared-folders.md) | File collaboration via shared volumes |
 | Agent Tags & System Views | [agent-tags.md](feature-flows/agent-tags.md) | Tagging and saved filters (ORG-001) |
 | Tag Clouds | [tag-clouds.md](feature-flows/tag-clouds.md) | Visual grouping on Dashboard |
@@ -180,7 +181,8 @@
 | Slack Integration | [slack-integration.md](feature-flows/slack-integration.md) | Slack as delivery channel for public links (SLACK-001) |
 | Slack Channel Routing | [slack-channel-routing.md](feature-flows/slack-channel-routing.md) | Channel adapter abstraction + multi-agent Slack routing (SLACK-002) |
 | Slack File Sharing | [slack-file-sharing.md](feature-flows/slack-file-sharing.md) | Inbound file uploads: images via vision, text via container (SLACK-FILES) |
-| Telegram Integration | [telegram-integration.md](feature-flows/telegram-integration.md) | Per-agent Telegram bots with webhook transport, group chat support (TELEGRAM-001, TGRAM-GROUP) |
+| Telegram Integration | [telegram-integration.md](feature-flows/telegram-integration.md) | Per-agent Telegram bots with webhook transport, group chat support, and `/login` email verification (TELEGRAM-001, TGRAM-GROUP) |
+| Unified Channel Access Control | [unified-channel-access-control.md](feature-flows/unified-channel-access-control.md) | Cross-channel access gate keyed on verified email — policy, /login, access requests (#311) |
 | Nevermined x402 Payments | [nevermined-payments.md](feature-flows/nevermined-payments.md) | Per-agent paid API via x402 payment protocol (NVM-001) |
 
 ### Mobile & PWA

--- a/docs/memory/feature-flows/agent-sharing.md
+++ b/docs/memory/feature-flows/agent-sharing.md
@@ -1,16 +1,22 @@
 # Feature: Agent Sharing
 
 ## Overview
-Collaboration feature enabling agent owners to share agents with team members via email. Supports three access levels: Owner (full control), Shared (limited access), and Admin (full control over all agents). The Sharing tab now includes both Team Sharing and Public Links in a unified interface.
+Collaboration feature enabling agent owners to share agents with team members via email. Supports three access levels: Owner (full control), Shared (limited access), and Admin (full control over all agents). The Sharing tab now includes Team Sharing, Channel Access Policy, Pending Access Requests, Slack/Telegram channel bindings, and Public Links in a unified interface.
+
+> **Cross-channel allow-list (Issue #311)**: As of 2026-04-12, `agent_sharing` is the **unified cross-channel allow-list**, not a web-only construct. The same email shared on this page admits that user across Telegram, Slack, and web public links whenever the agent's access policy requires a verified email. See [unified-channel-access-control.md](unified-channel-access-control.md) for the gate semantics and channel adapter details.
 
 ## User Story
-As an agent owner, I want to share my agents with team members so that they can use the agents without having full ownership permissions.
+As an agent owner, I want to share my agents with team members so that they can use the agents from any channel (web, Slack, Telegram) without having full ownership permissions.
 
 ## Entry Points
 - **UI**: `src/frontend/src/views/AgentDetail.vue:429-432` - Sharing tab (owners only, hidden for system agents)
 - **API**: `POST /api/agents/{name}/share` - Share agent
 - **API**: `DELETE /api/agents/{name}/share/{email}` - Remove share
 - **API**: `GET /api/agents/{name}/shares` - List shares
+- **API**: `GET /api/agents/{name}/access-policy` - Get channel access policy (Issue #311)
+- **API**: `PUT /api/agents/{name}/access-policy` - Update channel access policy
+- **API**: `GET /api/agents/{name}/access-requests?status=pending` - List pending access requests
+- **API**: `POST /api/agents/{name}/access-requests/{id}/decide` - Approve/deny request
 
 ---
 
@@ -18,13 +24,15 @@ As an agent owner, I want to share my agents with team members so that they can 
 
 ### SharingPanel.vue (`src/frontend/src/components/SharingPanel.vue`)
 
-The sharing UI is implemented as a dedicated component with two sections: Team Sharing and Public Links.
+The sharing UI is implemented as a dedicated component with multiple stacked sections.
 
-**Component Structure** (132 lines total):
-- Lines 3-77: Team Sharing section (header, form, user list)
-- Lines 79-80: Divider between sections
-- Lines 82-83: Embedded `PublicLinksPanel` component
-- Line 92: Import of `PublicLinksPanel`
+**Component Structure** (~310 lines total):
+- Lines 3-74: **Channel Access Policy** section (Issue #311) — `require_email`, `open_access` checkboxes + Pending Access Requests list with Approve/Deny buttons
+- Lines 78-152: **Team Sharing** section (header, form, shared users list — the unified allow-list)
+- Lines 157-158: Embedded `SlackChannelPanel`
+- Lines 163-164: Embedded `TelegramChannelPanel`
+- Lines 169-170: Embedded `PublicLinksPanel`
+- Lines 181-183: Imports for the embedded channel panels
 
 **Team Sharing Section** (lines 3-77):
 ```vue
@@ -35,22 +43,36 @@ The sharing UI is implemented as a dedicated component with two sections: Team S
 </div>
 ```
 
-**Public Links Integration** (lines 79-83):
-```vue
-<!-- Divider -->
-<div class="border-t border-gray-200 dark:border-gray-700"></div>
-
-<!-- Public Links Section -->
-<PublicLinksPanel :agent-name="agentName" />
-```
-
-**Component Props** (lines 94-103):
+**Component Props** (lines 185-194):
 ```javascript
 const props = defineProps({
   agentName: { type: String, required: true },
   shares: { type: Array, default: () => [] }
 })
 ```
+
+**Channel Access Policy & Access Requests (Issue #311)** — wired via direct axios calls in `<script setup>` (no composable):
+```javascript
+// State (lines 226-230)
+const policy = ref({ require_email: false, open_access: false })
+const policyLoading = ref(false)
+const pendingRequests = ref([])
+const decisionLoading = ref(null)
+
+// loadPolicy        — GET  /api/agents/{name}/access-policy
+// updatePolicy      — PUT  /api/agents/{name}/access-policy   (merges partial change)
+// loadAccessRequests — GET  /api/agents/{name}/access-requests?status=pending
+// decideRequest      — POST /api/agents/{name}/access-requests/{id}/decide  { approve }
+// formatRequestedAt  — local date formatting helper
+
+// Refresh both on agent change (lines 305-308)
+watch(() => props.agentName, async (name) => {
+  if (!name) return
+  await Promise.all([loadPolicy(), loadAccessRequests()])
+}, { immediate: true })
+```
+
+After `decideRequest(req, true)` succeeds, `loadAccessRequests()` is re-run and `loadAgent()` is emitted so the Team Sharing list reflects the newly-added email.
 
 ### Composable (`src/frontend/src/composables/useAgentSharing.js`)
 
@@ -120,11 +142,17 @@ if (agent.value?.can_share && !isSystem) {
 
 ### Endpoints (`src/backend/routers/sharing.py`)
 
+All endpoints are gated by `OwnedAgentByName` (owner or admin).
+
 | Line | Endpoint | Method | Purpose |
 |------|----------|--------|---------|
-| 23-64 | `/api/agents/{agent_name}/share` | POST | Share agent with email |
-| 67-89 | `/api/agents/{agent_name}/share/{email}` | DELETE | Remove share |
-| 92-103 | `/api/agents/{agent_name}/shares` | GET | List shares |
+| 53-94 | `/api/agents/{agent_name}/share` | POST | Share agent with email |
+| 97-119 | `/api/agents/{agent_name}/share/{email}` | DELETE | Remove share |
+| 122-133 | `/api/agents/{agent_name}/shares` | GET | List shares |
+| 140-146 | `/api/agents/{agent_name}/access-policy` | GET | Get `{require_email, open_access}` (Issue #311) |
+| 149-157 | `/api/agents/{agent_name}/access-policy` | PUT | Update policy (delegates to `db.set_access_policy`) |
+| 160-168 | `/api/agents/{agent_name}/access-requests` | GET | List requests, defaults `status=pending` |
+| 171-221 | `/api/agents/{agent_name}/access-requests/{request_id}/decide` | POST | `{approve: bool}` — on approve, idempotently inserts into `agent_sharing` via `db.share_agent`, auto-whitelists email when email auth is enabled, and broadcasts `agent_shared` over WebSocket |
 
 ### Authorization via Dependencies (`src/backend/dependencies.py:258-285`)
 
@@ -269,18 +297,23 @@ CREATE TABLE IF NOT EXISTS agent_sharing (
 )
 ```
 
-### Operations (`db/agents.py`)
+### Operations (`db/agent_settings/sharing.py` — `SharingMixin`, composed into `AgentOperations`)
 
 | Method | Line | Purpose |
 |--------|------|---------|
-| `share_agent()` | 169-212 | Create share record |
-| `unshare_agent()` | 214-227 | Remove share record |
-| `get_agent_shares()` | 229-241 | List shares for agent |
-| `get_shared_agents()` | 243-258 | Get agents shared with user |
-| `is_agent_shared_with_user()` | 260-276 | Access check by email |
-| `can_user_share_agent()` | 278-288 | Authorization check |
-| `delete_agent_shares()` | 290-296 | Cascade delete shares |
-| `get_all_agent_metadata()` | 467-529 | Batch metadata query (N+1 fix) |
+| `share_agent()` | 30-73 | Create share record |
+| `unshare_agent()` | 75-88 | Remove share record |
+| `get_agent_shares()` | 90-102 | List shares for agent |
+| `get_shared_agents()` | 104-119 | Get agents shared with user |
+| `is_agent_shared_with_email()` | 121-131 | Direct email lookup, no user record needed (Issue #311) |
+| `email_has_agent_access()` | 133-148 | Composite gate: owner / admin / `agent_sharing` (used by channel router gate, Issue #311) |
+| `is_agent_shared_with_user()` | 150-166 | Access check by username |
+| `can_user_share_agent()` | 168-178 | Authorization check |
+| `delete_agent_shares()` | 180-186 | Cascade delete shares |
+
+Both `is_agent_shared_with_email` and `email_has_agent_access` are exposed on the `db` facade.
+
+Access-policy storage lives on `agent_ownership` via `AccessPolicyMixin` (`db/agent_settings/access_policy.py`); access requests live in their own table via `db/access_requests.py`.
 
 ### Share Agent (`db/agents.py:169-212`)
 ```python
@@ -311,15 +344,17 @@ def share_agent(self, agent_name: str, owner_username: str, share_with_email: st
             return None  # Already shared
 ```
 
-### Cascade Delete (`db/agents.py:290-296`)
-When an agent is deleted, all sharing records are removed via `delete_agent_ownership()` (line 103-112):
+### Cascade Delete (`db/agents.py:117-128`)
+When an agent is deleted, sharing records AND pending access requests are removed via `delete_agent_ownership()`:
 ```python
 def delete_agent_ownership(self, agent_name: str) -> bool:
-    """Remove agent ownership record and all sharing records."""
+    """Remove agent ownership record, all sharing records, and pending access requests."""
     with get_db_connection() as conn:
         cursor = conn.cursor()
         # Delete sharing records first (cascade)
         cursor.execute("DELETE FROM agent_sharing WHERE agent_name = ?", (agent_name,))
+        # Delete access requests (issue #311)
+        cursor.execute("DELETE FROM access_requests WHERE agent_name = ?", (agent_name,))
         # Delete ownership record
         cursor.execute("DELETE FROM agent_ownership WHERE agent_name = ?", (agent_name,))
 ```
@@ -415,6 +450,7 @@ Working - Agent sharing fully functional with email-based collaboration
 
 | Date | Changes |
 |------|---------|
+| 2026-04-12 | **Issue #311 — unified cross-channel access control**: `agent_sharing` is now the cross-channel allow-list (web + Telegram + Slack). Added 4 endpoints to `routers/sharing.py` for access policy (`require_email`, `open_access`) and pending access requests (approve/deny). `SharingPanel.vue` gained a Channel Access Policy section + Pending Access Requests list (direct axios, no composable). New `SharingMixin` helpers: `is_agent_shared_with_email`, `email_has_agent_access`. `delete_agent_ownership` now also cascades `access_requests`. Canonical primitive lives in [unified-channel-access-control.md](unified-channel-access-control.md). |
 | 2026-02-18 | **Public Links tab consolidated**: Public Links tab removed from AgentDetail.vue. SharingPanel.vue now includes PublicLinksPanel as embedded component (lines 79-83, 92). Updated tab visibility line numbers (506-509). Single "Sharing" tab now contains both Team Sharing and Public Links sections. |
 | 2026-01-30 | **Git Pull permission update**: Added Git Pull and Git Sync/Init columns to Access Levels table. Shared users can now pull from GitHub (was owner-only). |
 | 2026-01-23 | **Full verification**: Updated to use SharingPanel.vue component (not inline in AgentDetail.vue). Updated line numbers for routers/sharing.py (23-64, 67-89, 92-103). Added useAgentSharing.js composable documentation. Updated db/agents.py line numbers for sharing methods. Added OwnedAgentByName dependency documentation from dependencies.py. Documented tab visibility logic at AgentDetail.vue:428-432. Updated helpers.py reference for batch metadata query. |
@@ -422,8 +458,12 @@ Working - Agent sharing fully functional with email-based collaboration
 
 ---
 
+## See Also
+
+- **[unified-channel-access-control.md](unified-channel-access-control.md)** — Canonical reference for the cross-channel gate, `email_has_agent_access` semantics, and how Telegram/Slack/web public links resolve a verified email and consult `agent_sharing`. This flow only documents the sharing UX and API surface; gate implementation lives there.
+
 ## Related Flows
 
 - **Upstream**: Authentication (user identity)
-- **Downstream**: Public Agent Links (embedded in same tab via PublicLinksPanel)
-- **Related**: Agent Lifecycle (delete cascades shares), MCP Orchestration (agent-to-agent access control), Email Authentication (auto-whitelist)
+- **Downstream**: Public Agent Links (embedded in same tab via PublicLinksPanel), Telegram Integration, Slack Integration (all consume the unified allow-list)
+- **Related**: Agent Lifecycle (delete cascades shares + access requests), MCP Orchestration (agent-to-agent access control), Email Authentication (auto-whitelist)

--- a/docs/memory/feature-flows/slack-integration.md
+++ b/docs/memory/feature-flows/slack-integration.md
@@ -700,6 +700,62 @@ db.set_setting() for each provided field
 Reload status (refresh UI)
 ```
 
+## Unified Cross-Channel Access Control (#311)
+
+> **Canonical reference**: [unified-channel-access-control.md](unified-channel-access-control.md). This section only describes the Slack-specific pieces — the policy model, `access_requests` table, router gate, and approval UI live in that flow.
+
+Issue #311 introduced a single per-agent access policy shared across all channels (web public links, Slack, Telegram). Slack's role in that flow is minimal: the workspace OAuth token already proves user identity, so the adapter just looks up the sender's email via Slack's `users.info` API. No 6-digit verification round-trip is needed (unlike Telegram's `/login`), which makes Slack the simplest channel to wire in.
+
+### New adapter method: `resolve_verified_email`
+
+Added to `SlackAdapter` at `src/backend/adapters/slack_adapter.py:51-67`:
+
+```python
+async def resolve_verified_email(self, message: NormalizedMessage) -> Optional[str]:
+    bot_token = self.get_bot_token(message)
+    if not bot_token:
+        return None
+    try:
+        email = await slack_service.get_user_email(bot_token, message.sender_id)
+    except Exception as e:
+        logger.warning(f"Slack resolve_verified_email failed: {e}")
+        return None
+    return email.lower() if email else None
+```
+
+- `get_bot_token(message)` resolves the workspace token via `slack_workspaces` (new path) with `slack_link_connections` as a legacy fallback (see lines 69-81 in the same file).
+- `slack_service.get_user_email(bot_token, user_id)` calls Slack's `users.info` API (`services/slack_service.py:239-268`).
+- Emails are returned lowercased for case-insensitive matching against `agent_sharing.shared_with_email`.
+- No persistence — the adapter re-resolves live on every message. The workspace OAuth token is already durable state.
+
+### Router gate integration
+
+`ChannelMessageRouter._handle_message_inner` (`src/backend/adapters/message_router.py:210-264`) calls `adapter.resolve_verified_email` in step 5b of the gate. The returned email is used for:
+
+1. **Access check** — `db.email_has_agent_access(agent_name, email)` (owner / admin / `agent_sharing` row).
+2. **Open-access bypass** — admitted if the agent has `open_access=true`.
+3. **Access request path** — if neither of the above, `db.upsert_access_request(agent_name, email, "slack")` queues the request for owner approval; user gets "🔒 Your access request is pending approval".
+
+Channel-wide (non-DM) group messages bypass the gate entirely — see the "Group chat bypass" section of [unified-channel-access-control.md](unified-channel-access-control.md). Full gate semantics (require_email flag, legacy passthrough fallback) are documented there.
+
+### OAuth scope requirement
+
+For `resolve_verified_email` to return a value, the Slack app must be installed with the **`users:read.email`** OAuth scope (already present in the scope list at `slack_service.py:92-106` — `im:history,chat:write,users:read.email`).
+
+If the scope is missing, or the user has hidden their profile email, `users.info` returns `null` and `resolve_verified_email` returns `None`. When the agent's policy has `require_email=true`, the router then falls back to `adapter.prompt_auth` — the default text reply from the ABC — since `SlackAdapter` does not override `prompt_auth` (there's no Slack-native "send a verification code" flow the way Telegram has `/login`).
+
+### Relation to `slack_user_verifications`
+
+The existing `slack_user_verifications` + `slack_pending_verifications` tables (see Database Schema above) power the **per-public-link** email verification flow from SLACK-001 (used when a link has `require_email=true` but the workspace can't auto-resolve email).
+
+The #311 gate — for **workspace-connected agents** routed via the channel adapter (SLACK-002) — does not use these tables. It reads directly from the Slack API on each message. The tables remain in place for the legacy public-link path; no new per-message persistence is added.
+
+### See also
+
+- **[Unified Channel Access Control](unified-channel-access-control.md)** — canonical reference for policy columns, `access_requests` table, the router gate, `AccessPolicyMixin`, and approval UI.
+- **[Agent Sharing](agent-sharing.md)** — `agent_sharing` is the cross-channel allow-list; approving an access request inserts a row here.
+- **[Slack Channel Routing](slack-channel-routing.md)** (SLACK-002) — the `SlackAdapter` + channel binding model that #311 plugs into.
+
 ## Related
 
 - **[Public Agent Links](public-agent-links.md)** (15.1) - Base infrastructure, session persistence (PUB-005)
@@ -715,3 +771,4 @@ Reload status (refresh UI)
 | 2026-02-25 | Claude | Added Settings Configuration flow (admin UI for Slack credentials) |
 | 2026-03-01 | Claude | Fixed access checks to use `can_user_access_agent()`/`can_user_share_agent()` (Issue #48) |
 | 2026-03-12 | Claude | Fixed `initiate_slack_oauth()` to use `get_slack_signing_secret()` from settings_service instead of importing from config.py |
+| 2026-04-12 | Claude | Added `SlackAdapter.resolve_verified_email` for unified cross-channel access control (#311) — see [unified-channel-access-control.md](unified-channel-access-control.md) |

--- a/docs/memory/feature-flows/telegram-integration.md
+++ b/docs/memory/feature-flows/telegram-integration.md
@@ -487,7 +487,112 @@ The `TelegramChannelPanel.vue` component shows group configurations when the bot
 - **`chat_member` events require bot admin**: Welcome messages for user joins only work if the bot has admin rights in the group AND `chat_member` is in `allowed_updates`. If the bot isn't admin, events simply don't arrive — graceful degradation.
 - **No `edited_message` handling**: Edited messages in groups are not processed. In mention-only mode this is rare.
 
+## Access Control & `/login` Email Verification (#311)
+
+Part of the unified cross-channel access control primitive. Full design (policy columns on `agent_ownership`, router gate logic, access-request inbox, Slack/public parity) lives in [unified-channel-access-control.md](unified-channel-access-control.md) — this section documents the Telegram-specific pieces only.
+
+### Schema additions
+
+Migration `access_control` adds two columns to `telegram_chat_links`:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| verified_email | TEXT | The email bound to this Telegram user within this bot, or NULL if unverified |
+| verified_at | TEXT | ISO timestamp set when `set_verified_email` runs |
+
+The unique index remains `UNIQUE(binding_id, telegram_user_id)`.
+
+### New DB methods (`src/backend/db/telegram_channels.py`)
+
+Added to `TelegramChannelOperations`:
+
+- `get_chat_link(binding_id, telegram_user_id)` — lookup without auto-create (the existing `get_or_create_chat_link` upserts, which is wrong for a pure "is this user verified?" read)
+- `get_verified_email(binding_id, telegram_user_id) -> str | None`
+- `set_verified_email(binding_id, telegram_user_id, email)` — `INSERT OR IGNORE` to ensure the row exists, then `UPDATE` to set `verified_email` + `verified_at`
+- `clear_verified_email(binding_id, telegram_user_id)` — nulls both columns
+
+Exposed on the `Database` facade (`src/backend/database.py`):
+- `db.get_telegram_verified_email(...)`
+- `db.set_telegram_verified_email(...)`
+- `db.clear_telegram_verified_email(...)`
+
+### Adapter additions (`src/backend/adapters/telegram_adapter.py`)
+
+**`async resolve_verified_email(message) -> str | None`**
+Reads `db.get_telegram_verified_email(binding_id, telegram_user_id)` from the normalized message metadata. Used by the router gate before dispatching to an agent.
+
+**`async prompt_auth(message, agent_name, bot_token=None)`**
+Sends a Telegram-native HTML prompt instructing the user to verify with `/login your@email.com`. Called by the router gate when `require_email=True` and no verified email is bound.
+
+**`handle_command` — new commands**
+
+| Command | Behavior |
+|---------|----------|
+| `/login` (no args) | Sends usage instructions |
+| `/login <email>` | `db.create_login_code(email, 10)` → `EmailService.send_verification_code(email, code)` → stores `_PENDING_LOGINS[(binding_id, telegram_user_id)] = email` → replies "📧 Sent a 6-digit code" |
+| `/login <6-digit-code>` | Looks up pending email → `db.verify_login_code(email, code)` → on success `db.set_telegram_verified_email(binding_id, telegram_user_id, email)` + `_PENDING_LOGINS.pop(...)` → replies "✅ Verified" |
+| `/logout` | `db.clear_telegram_verified_email(...)` + `_PENDING_LOGINS.pop(...)` |
+| `/whoami` | Displays current verified email (or "not verified") |
+
+**`_PENDING_LOGINS`** is a module-level in-memory `dict[(binding_id, telegram_user_id) -> email]`. Login codes have a 10-minute TTL in `email_login_codes` (same table used by email authentication), so a backend restart mid-verification simply forces the user to re-issue `/login <email>` — no migration required, no persistent state to corrupt.
+
+### Router gate integration
+
+The unified gate lives in `adapters/message_router.py` at step 5b of `_handle_message_inner` (see [unified-channel-access-control.md](unified-channel-access-control.md) for the full policy matrix). For Telegram:
+
+- **1:1 DMs**: Gate calls `adapter.resolve_verified_email(message)` before step 9 (execution). If `None` and policy `require_email=True`, it invokes `adapter.prompt_auth(...)` and short-circuits — the message is not sent to the agent.
+- **Group chats**: The gate is **bypassed** for group messages. Groups are gated by bot membership (the group admin who added the bot is trusted), not per-user email verification. Trying to verify every group member via DM would be a poor UX and, for large groups, impractical.
+
+### `/login` state machine (DM)
+
+```
+stranger sends "hi"
+    |
+    v
+router step 5b: resolve_verified_email() → None
+    |
+    v
+policy.require_email=True → adapter.prompt_auth()
+    |
+    v
+user sends "/login user@example.com"
+    |
+    v
+handle_command:
+    db.create_login_code(email, ttl=10min)
+    EmailService.send_verification_code(email, code)
+    _PENDING_LOGINS[(binding_id, user_id)] = email
+    reply: "📧 Sent a 6-digit code to user@example.com"
+    |
+    v
+user sends "/login 123456"
+    |
+    v
+handle_command:
+    email = _PENDING_LOGINS[(binding_id, user_id)]
+    db.verify_login_code(email, "123456") → OK
+    db.set_telegram_verified_email(binding_id, user_id, email)
+    _PENDING_LOGINS.pop(...)
+    reply: "✅ Verified as user@example.com"
+    |
+    v
+user sends "what's the weather?"
+    |
+    v
+router step 5b: resolve_verified_email() → "user@example.com"
+    |
+    v
+gate admits (or issues access-request, per policy) → agent executes
+```
+
+### Transport
+
+No changes to `src/backend/adapters/transports/telegram_webhook.py`. The transport already dispatches `/`-prefixed messages to `adapter.handle_command` before the router pipeline, so `/login`, `/logout`, and `/whoami` are picked up for free.
+
 ## Related Flows
+- [unified-channel-access-control.md](unified-channel-access-control.md) — Cross-channel access primitive (policy, router gate, access requests) (#311)
+- [agent-sharing.md](agent-sharing.md) — Allow-list / ownership model the gate consults
+- [email-authentication.md](email-authentication.md) — Shared `email_login_codes` infrastructure and `EmailService.send_verification_code`
 - [slack-integration.md](slack-integration.md) — Slack equivalent (SLACK-001)
 - [slack-channel-routing.md](slack-channel-routing.md) — Channel adapter abstraction (SLACK-002)
 - [public-agent-links.md](public-agent-links.md) — Web-based public chat (shares session/execution infrastructure)

--- a/docs/memory/feature-flows/unified-channel-access-control.md
+++ b/docs/memory/feature-flows/unified-channel-access-control.md
@@ -1,0 +1,545 @@
+# Feature: Unified Channel Access Control (#311)
+
+## Overview
+A single cross-channel access control primitive for chatting with an agent. **Verified email is the unit of identity** — every channel adapter (web public links, Telegram, Slack, future channels) is responsible only for translating its native sender ID into a verified email. Everything downstream — the allow-list, pending access requests, and per-user persistent memory (MEM-001) — keys off that email.
+
+Before #311, each channel had its own ad-hoc access model:
+- Web public links: anonymous-by-default with optional CAPTCHA / email verification per link.
+- Telegram: bound 1:1 by chat_id, no notion of a verified user identity.
+- Slack: bound by workspace OAuth, but no per-user gate.
+
+After #311, all three channels share one gate, one allow-list (`agent_sharing`), and one approval queue (`access_requests`).
+
+## Design Principle
+> **An agent owner manages access by email, not by channel.** Approving `alice@example.com` admits her on Telegram, Slack, and web. Each adapter's job is to prove her email; the platform decides whether she is allowed.
+
+## User Story
+- As an agent owner, I want to gate my agent uniformly across channels so that approving a user once admits them everywhere.
+- As a user contacting an agent on Telegram, I want a clear way to verify my email so the owner can recognize me as the same person who emailed them.
+- As an agent owner, I want a queue of pending access requests across all channels so I can grant access without leaving Trinity.
+
+## Entry Points
+- **Channel inbound**: `src/backend/adapters/message_router.py:138` — `_handle_message_inner` (gate at lines 210-264)
+- **Telegram `/login` command**: `src/backend/adapters/telegram_adapter.py:436` — `handle_command`
+- **API (policy)**: `GET|PUT /api/agents/{name}/access-policy`
+- **API (requests)**: `GET /api/agents/{name}/access-requests`, `POST /api/agents/{name}/access-requests/{id}/decide`
+- **UI**: `src/frontend/src/components/SharingPanel.vue:3-74` — Channel Access Policy + pending requests panel
+
+---
+
+## Architecture
+
+```
+                        ┌──────────────────────────────────┐
+                        │ ChannelAdapter (per channel)     │
+                        │ resolve_verified_email(message)  │ ← channel-specific
+                        │ prompt_auth(message, agent, tok) │ ← channel-specific
+                        └────────────┬─────────────────────┘
+                                     │ verified_email | None
+                                     ▼
+                        ┌──────────────────────────────────┐
+                        │ ChannelMessageRouter (gate)      │
+                        │  1. require_email + no email →   │
+                        │     prompt_auth, return          │
+                        │  2. email + agent access  →      │
+                        │     proceed                      │
+                        │  3. email + open_access   →      │
+                        │     proceed                      │
+                        │  4. email + restrictive   →      │
+                        │     upsert_access_request, reply │
+                        │  5. no email + no policy  →      │
+                        │     legacy passthrough           │
+                        └────────────┬─────────────────────┘
+                                     │ proceed
+                                     ▼
+                        ┌──────────────────────────────────┐
+                        │ TaskExecutionService             │
+                        │ source_user_email = verified     │
+                        │ → MEM-001 keys per email         │
+                        └──────────────────────────────────┘
+```
+
+| Channel | `resolve_verified_email` source | `prompt_auth` UX |
+|---------|---------------------------------|------------------|
+| Telegram | `telegram_chat_links.verified_email` (set by `/login`) | HTML message with `/login` instructions |
+| Slack | `slack_service.get_user_email(bot_token, user_id)` (workspace OAuth) | Default text (rarely triggered — OAuth always resolves) |
+| Web public link (TBD #252) | TBD — existing per-link verification will plug in here | TBD |
+
+---
+
+## Database Layer
+
+### Migration: `access_control` (`src/backend/db/migrations.py:1007-1047`)
+
+Idempotent migration that:
+1. Adds two columns to `agent_ownership`:
+   ```sql
+   ALTER TABLE agent_ownership ADD COLUMN require_email INTEGER DEFAULT 0;
+   ALTER TABLE agent_ownership ADD COLUMN open_access INTEGER DEFAULT 0;
+   ```
+2. Adds two columns to `telegram_chat_links` to bind a verified email to a Telegram user:
+   ```sql
+   ALTER TABLE telegram_chat_links ADD COLUMN verified_email TEXT;
+   ALTER TABLE telegram_chat_links ADD COLUMN verified_at TEXT;
+   ```
+3. Creates the `access_requests` table:
+   ```sql
+   CREATE TABLE access_requests (
+       id TEXT PRIMARY KEY,
+       agent_name TEXT NOT NULL,
+       email TEXT NOT NULL,
+       channel TEXT,
+       requested_at TEXT NOT NULL,
+       status TEXT NOT NULL DEFAULT 'pending',  -- pending | approved | denied
+       decided_by INTEGER,
+       decided_at TEXT,
+       UNIQUE(agent_name, email)
+   );
+   CREATE INDEX idx_access_requests_agent ON access_requests(agent_name, status);
+   CREATE INDEX idx_access_requests_email ON access_requests(email);
+   ```
+
+The fresh-install table DDL also lives in `db/schema.py:651-663`, mirroring the migration.
+
+### `AccessPolicyMixin` (`src/backend/db/agent_settings/access_policy.py`)
+
+New mixin composed into `AgentOperations` (`db/agents.py:33-40`):
+
+| Method | Purpose |
+|--------|---------|
+| `get_access_policy(agent_name)` | Returns `{require_email: bool, open_access: bool}`. Defaults to `{False, False}` when the agent has no row. |
+| `set_access_policy(agent_name, require_email, open_access)` | Updates both flags atomically on `agent_ownership`. |
+
+This follows architectural invariant #2 (Mixin Composition for agent settings): each new agent setting is a new mixin, not a bigger class.
+
+### `AccessRequestOperations` (`src/backend/db/access_requests.py`)
+
+New ops class (not a mixin — `access_requests` is its own domain table):
+
+| Method | Behavior |
+|--------|----------|
+| `upsert_pending(agent_name, email, channel)` | Inserts a new pending request, or — on UNIQUE collision — resets an existing approved/denied row back to `pending` and refreshes timestamp + channel. Returns the row dict. |
+| `list_for_agent(agent_name, status="pending")` | Returns rows ordered by `requested_at DESC`. |
+| `get(request_id)` | Single-row lookup. |
+| `decide(request_id, approve, decided_by_user_id)` | Sets `status` to `approved` or `denied`, stamps `decided_by` and `decided_at`. |
+| `delete_for_agent(agent_name)` | Cascade delete on agent removal. |
+
+### Extended `AgentSharingMixin` (`src/backend/db/agent_settings/sharing.py:121-148`)
+
+Two new helpers — both are lookups by **email** (not by username), which is the cross-channel identity:
+
+```python
+def is_agent_shared_with_email(self, agent_name, email) -> bool:
+    """Direct hit on agent_sharing.shared_with_email."""
+
+def email_has_agent_access(self, agent_name, email) -> bool:
+    """Cross-channel access check (#311).
+    True if email is owner, admin, or in agent_sharing.
+    """
+```
+
+`email_has_agent_access` is the single function the channel router calls to check authorization.
+
+### Extended `TelegramChannelOperations` (`src/backend/db/telegram_channels.py:242-309`)
+
+| Method | Purpose |
+|--------|---------|
+| `get_chat_link(binding_id, telegram_user_id)` | Returns the chat link row (now including `verified_email`, `verified_at`). |
+| `get_verified_email(binding_id, telegram_user_id)` | Convenience: returns `verified_email` or None. |
+| `set_verified_email(binding_id, telegram_user_id, email)` | `INSERT OR IGNORE` the chat link row, then UPDATE `verified_email` + `verified_at`. |
+| `clear_verified_email(binding_id, telegram_user_id)` | `/logout` — nullifies both columns. |
+
+### Cascade on agent delete (`db/agents.py:117-128`)
+
+`delete_agent_ownership` now also deletes `access_requests` for the agent in the same transaction as `agent_sharing` and `agent_ownership`:
+
+```python
+cursor.execute("DELETE FROM agent_sharing WHERE agent_name = ?", (agent_name,))
+cursor.execute("DELETE FROM access_requests WHERE agent_name = ?", (agent_name,))  # #311
+cursor.execute("DELETE FROM agent_ownership WHERE agent_name = ?", (agent_name,))
+```
+
+### Database Facade (`src/backend/database.py`)
+
+New methods on the central `db` singleton:
+
+| Facade method | Delegates to |
+|---------------|--------------|
+| `get_access_policy(agent_name)` | `_agent_ops.get_access_policy` |
+| `set_access_policy(agent_name, require_email, open_access)` | `_agent_ops.set_access_policy` |
+| `email_has_agent_access(agent_name, email)` | `_agent_ops.email_has_agent_access` |
+| `upsert_access_request(agent_name, email, channel)` | `_access_request_ops.upsert_pending` |
+| `list_access_requests(agent_name, status)` | `_access_request_ops.list_for_agent` |
+| `get_access_request(request_id)` | `_access_request_ops.get` |
+| `decide_access_request(request_id, approve, decided_by_user_id)` | `_access_request_ops.decide` |
+| `delete_access_requests_for_agent(agent_name)` | `_access_request_ops.delete_for_agent` |
+| `get_telegram_verified_email(binding_id, telegram_user_id)` | `_telegram_ops.get_verified_email` |
+| `set_telegram_verified_email(binding_id, telegram_user_id, email)` | `_telegram_ops.set_verified_email` |
+| `clear_telegram_verified_email(binding_id, telegram_user_id)` | `_telegram_ops.clear_verified_email` |
+
+---
+
+## Channel Adapter Layer
+
+### `ChannelAdapter` ABC additions (`src/backend/adapters/base.py:169-212`)
+
+Two new methods on the base class — both have safe defaults, so existing adapters keep working without changes (architectural invariant #9):
+
+```python
+async def resolve_verified_email(self, message: NormalizedMessage) -> Optional[str]:
+    """
+    Translate the channel-native identity into a verified email, if known.
+
+    Returns lowercase email string, or None when the sender has not yet
+    proven an email. Default: None.
+    """
+    return None
+
+async def prompt_auth(
+    self,
+    message: NormalizedMessage,
+    agent_name: str,
+    bot_token: Optional[str] = None,
+) -> None:
+    """
+    Ask the sender to prove an email (channel-specific).
+    Default: send a generic text reply with /login instructions.
+    """
+```
+
+### Telegram (`src/backend/adapters/telegram_adapter.py`)
+
+**`resolve_verified_email`** (lines 202-212): looks up `verified_email` on the chat link via the agent's binding.
+
+```python
+binding = db.get_telegram_binding(agent_name)
+return db.get_telegram_verified_email(binding["id"], message.sender_id)
+```
+
+**`prompt_auth`** (lines 214-236): sends a Telegram-native HTML message:
+
+```
+🔒 This agent requires a verified email.
+
+Send /login your@email.com and I'll email you a 6-digit code.
+Then reply with /login 123456 to complete verification.
+```
+
+**`/login` state machine** — added to `handle_command` (lines 435-448) and dispatched to `_handle_login_command` (lines 450-519):
+
+```
+state                                   action
+─────────────────────────────────────────────────────────────────
+no pending login                        user sends `/login alice@x.com`
+                                        → db.create_login_code(email, 10min)
+                                        → EmailService.send_verification_code
+                                        → _PENDING_LOGINS[(binding_id, tg_user)] = email
+                                        → reply "📧 Sent code to alice@x.com"
+
+pending login                           user sends `/login 123456`
+                                        → db.verify_login_code(pending_email, code)
+                                        → db.set_telegram_verified_email(...)
+                                        → _PENDING_LOGINS.pop(...)
+                                        → reply "✅ Verified as alice@x.com"
+
+pending login (wrong code)              user sends `/login 999999`
+                                        → reply "❌ Invalid or expired code"
+                                        (pending kept; user can retry or restart)
+
+verified                                user sends `/logout`
+                                        → db.clear_telegram_verified_email(...)
+                                        → reply "👋 Logged out"
+
+any state                               user sends `/whoami`
+                                        → reply email or "not verified"
+```
+
+The pending-email state lives in an in-memory dict `_PENDING_LOGINS` (line 40) keyed by `(binding_id, telegram_user_id)`. It is **per-process** and lost on backend restart by design — users who lose state simply re-issue `/login email`. The verified email itself is persistent in `telegram_chat_links.verified_email`.
+
+### Slack (`src/backend/adapters/slack_adapter.py:51-67`)
+
+Slack is simpler — workspace OAuth already proves identity, so `users.info` returns a verified email directly:
+
+```python
+async def resolve_verified_email(self, message):
+    bot_token = self.get_bot_token(message)
+    email = await slack_service.get_user_email(bot_token, message.sender_id)
+    return email.lower() if email else None
+```
+
+No `prompt_auth` override is needed — the default text reply is the fallback for the rare case Slack doesn't return an email (e.g. workspace where bot lacks `users:read.email` scope).
+
+---
+
+## Router Gate (`src/backend/adapters/message_router.py:210-264`)
+
+The gate is inserted between step 5 (verification) and step 6 (session creation) in `_handle_message_inner`:
+
+```python
+# 5b. Unified cross-channel access gate (Issue #311).
+verified_email: Optional[str] = None
+if not is_group:                                    # group chats bypass — see below
+    try:
+        verified_email = await adapter.resolve_verified_email(message)
+    except Exception as e:
+        verified_email = None
+
+    policy = db.get_access_policy(agent_name)
+    require_email = policy.get("require_email", False)
+    open_access = policy.get("open_access", False)
+
+    if require_email and not verified_email:
+        await adapter.prompt_auth(message, agent_name, bot_token)
+        return
+
+    if verified_email and db.email_has_agent_access(agent_name, verified_email):
+        pass                                        # owner / admin / shared → proceed
+    elif open_access:
+        pass                                        # anyone w/ verified email → proceed
+    elif verified_email:
+        db.upsert_access_request(agent_name, verified_email, channel)
+        await adapter.send_response(
+            message.channel_id,
+            ChannelResponse(text="🔒 Your access request is pending approval. ..."),
+            thread_id=message.thread_id,
+        )
+        return
+    # else: no verified email and no policy set → legacy permissive (backward compat)
+```
+
+**After the gate**, the router uses the verified email as the source identifier so that cross-channel users converge on the same MEM-001 memory key:
+
+```python
+# Step 9 — execute task
+source_email = verified_email or adapter.get_source_identifier(message)
+```
+
+### Group chat bypass
+
+`is_group = message.metadata.get("is_group", False)` — Telegram group chats skip the entire gate. Group access is gated by the bot being added to the group (a manual operator action), not by per-user identity. This preserves the existing TGRAM-GROUP semantics where every group member can chat freely.
+
+### Backward compatibility
+
+If `require_email` and `open_access` are both `False` **and** the adapter returns no verified email, the gate falls through and the message proceeds as before. This means existing agents keep working without any opt-in step. Owners enable the gate explicitly via the new policy UI.
+
+---
+
+## API Endpoints
+
+All four are owner-only via the `OwnedAgentByName` dependency (architectural invariant #8).
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/agents/{name}/access-policy` | Owner | Returns `{require_email, open_access}` |
+| PUT | `/api/agents/{name}/access-policy` | Owner | Body: `{require_email, open_access}` |
+| GET | `/api/agents/{name}/access-requests?status=pending` | Owner | Lists access requests for the agent |
+| POST | `/api/agents/{name}/access-requests/{id}/decide` | Owner | Body: `{approve: bool}` |
+
+### Approve flow (`routers/sharing.py:171-220`)
+
+On approval the endpoint:
+1. Calls `db.decide_access_request(id, True, user_id)` to mark the request approved.
+2. Calls `db.share_agent(agent_name, current_user.username, email)` — idempotent insert into `agent_sharing`. Future messages from this email are admitted by `email_has_agent_access`.
+3. If `email_auth_enabled` setting is true, auto-adds the email to the platform whitelist with `source="access_request"`.
+4. Broadcasts a `agent_shared` WebSocket event so the Sharing panel refreshes for owners viewing it.
+
+### Pydantic models (`routers/sharing.py:22-42`)
+
+```python
+class AccessPolicy(BaseModel):
+    require_email: bool
+    open_access: bool
+
+class AccessPolicyUpdate(BaseModel):
+    require_email: bool
+    open_access: bool
+
+class AccessRequest(BaseModel):
+    id: str
+    agent_name: str
+    email: str
+    channel: str | None = None
+    requested_at: str
+    status: str
+
+class AccessRequestDecision(BaseModel):
+    approve: bool
+```
+
+These are co-located with the router (slight deviation from invariant #15) because they are scoped to the sharing surface area.
+
+---
+
+## Frontend Layer (`src/frontend/src/components/SharingPanel.vue`)
+
+The Sharing tab on `AgentDetail.vue` already housed Team Sharing + Public Links. #311 prepends a new "Channel Access Policy" section.
+
+### Layout (lines 3-74)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Channel Access Policy                                    │
+│  ☐ Require verified email                                │
+│      Telegram users must /login; Slack uses workspace    │
+│      email; web requires email verification.             │
+│  ☐ Open access                                           │
+│      Anyone with a verified email may chat without       │
+│      owner approval.                                     │
+│                                                          │
+│  Pending access requests (2)                             │
+│   ┌────────────────────────────────────────────────────┐ │
+│   │ alice@example.com                                  │ │
+│   │ via telegram · 2026-04-12 09:14                    │ │
+│   │                          [Approve] [Deny]          │ │
+│   └────────────────────────────────────────────────────┘ │
+├──────────────────────────────────────────────────────────┤
+│ Team Sharing                                             │
+│  user@example.com  [share]                               │
+│  (existing list)                                         │
+├──────────────────────────────────────────────────────────┤
+│ Public Links (existing PublicLinksPanel)                 │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Reactive state (lines 226-230)
+
+```javascript
+const policy = ref({ require_email: false, open_access: false })
+const policyLoading = ref(false)
+const pendingRequests = ref([])
+const decisionLoading = ref(null)
+```
+
+### API calls (lines 232-295)
+
+| Function | Endpoint |
+|----------|----------|
+| `loadPolicy()` | `GET /api/agents/{name}/access-policy` |
+| `updatePolicy(changes)` | `PUT /api/agents/{name}/access-policy` (merges changes into current policy) |
+| `loadAccessRequests()` | `GET /api/agents/{name}/access-requests?status=pending` |
+| `decideRequest(req, approve)` | `POST /api/agents/{name}/access-requests/{id}/decide` — on approve also calls `loadAgent()` to refresh the shares list |
+
+A `watch(() => props.agentName, ..., { immediate: true })` (lines 305-308) loads both the policy and pending requests when the agent changes.
+
+The component uses raw `axios` (matching the existing pattern in this file) rather than going through `agents.js` store — the policy/requests state is local to this panel and not consumed elsewhere.
+
+---
+
+## Architectural Invariants Touched
+
+| # | Invariant | How #311 honors it |
+|---|-----------|-------------------|
+| 2 | DB Layer: Class-per-domain with Mixin Composition | New `AccessPolicyMixin` composed into `AgentOperations`; new `AccessRequestOperations` is its own domain class because `access_requests` is its own table. |
+| 3 | Schema in `db/schema.py`, migrations in `db/migrations.py` | Both updated. Migration registered as `("access_control", _migrate_access_control)` in the migration list. |
+| 8 | Auth pattern: `Depends()` + `OwnedAgentByName` | All four new endpoints use `OwnedAgentByName` for owner-only access. |
+| 9 | Channel Adapter ABC | Added `resolve_verified_email` and `prompt_auth` to the ABC with safe defaults. Telegram and Slack override; new channels can override or inherit. |
+| 11 | WebSocket events for real-time | `agent_shared` event broadcast on approval so other owner sessions refresh. |
+| 13 | Credentials never stored in DB | Verified emails are persisted (they are identity, not secret). The 6-digit `/login` code reuses the existing `email_login_codes` table and `EmailService.send_verification_code` — no new credential storage. |
+
+---
+
+## Side Effects
+
+### WebSocket Broadcasts
+| Event | When | Payload |
+|-------|------|---------|
+| `agent_shared` | Access request approved (calls `db.share_agent` internally) | `{name, shared_with: email}` |
+
+### Email
+On `/login email`, an email is sent via `EmailService.send_verification_code` — same path as web email auth (see [email-authentication.md](email-authentication.md)).
+
+### Whitelist auto-add
+On approval, if `email_auth_enabled` is true, the email is added to the platform email whitelist with `source="access_request"` (parity with `/share` endpoint).
+
+### Auto-promotion to `agent_sharing`
+Approving an access request inserts the email into `agent_sharing` so all future messages from that email — across any channel — are admitted by the existing `email_has_agent_access` check, no further owner action needed.
+
+---
+
+## Error Handling
+
+| Error case | HTTP / Channel response |
+|-----------|------------------------|
+| `prompt_auth` triggered | Adapter-specific message asking to verify (return early) |
+| Verified email but not allowed (restrictive policy) | Channel reply: "🔒 Your access request is pending approval." |
+| `/login` with no arg | Telegram reply with usage instructions |
+| `/login {bad-email}` | Telegram reply: "That doesn't look like an email address." |
+| `/login {6-digit-code}` without pending | Telegram reply: "I don't have a pending login for you." |
+| `/login {wrong-code}` | Telegram reply: "❌ Invalid or expired code. Try again or request a new one." |
+| `decide` request not found / wrong agent | 404 |
+| `decide` user lookup fails | 403 |
+| `decide` DB update fails | 500 |
+| Channel `resolve_verified_email` raises | Treated as `None` (logged warning), gate continues with no email |
+
+---
+
+## Testing
+
+### Prerequisites
+- Backend running with #311 migration applied.
+- An agent with a Telegram bot bound (see [telegram-integration.md](telegram-integration.md)).
+- Email auth configured (`EMAIL_AUTH_ENABLED=true`) — required for Telegram `/login` verification codes to deliver.
+
+### Test 1: Telegram `/login` happy path
+1. As an unverified Telegram user, DM the bot. **Expected**: free passthrough (no policy set yet).
+2. As owner via UI: Sharing tab → check "Require verified email". **Expected**: policy persisted.
+3. DM the bot again. **Expected**: bot replies with `/login` instructions (`prompt_auth`).
+4. Send `/login alice@example.com`. **Expected**: bot replies "📧 Sent a 6-digit code"; email arrives.
+5. Send `/login 123456` (the code from the email). **Expected**: bot replies "✅ Verified as alice@example.com".
+6. Send a normal message. **Expected**: bot still replies "🔒 Your access request is pending approval".
+7. As owner: Sharing tab shows `alice@example.com` in pending requests. Click Approve.
+8. As alice on Telegram: send another message. **Expected**: real agent response.
+
+### Test 2: Open access
+1. Owner enables both "Require verified email" + "Open access".
+2. New user `bob@example.com` does the `/login` flow.
+3. After verification, send a message. **Expected**: real agent response (no approval needed). No row in `access_requests`.
+
+### Test 3: Slack workspace
+1. Owner enables "Require verified email" only.
+2. Slack user (in the workspace) DMs the bot. **Expected**: `slack_service.get_user_email` resolves their workspace email automatically; user immediately enters the gate without any `/login` step.
+3. Owner approves once → user can chat freely.
+
+### Test 4: Cross-channel identity
+1. Approve `alice@example.com` via the Telegram flow.
+2. Alice contacts the same agent on Slack (with the same email in her workspace profile). **Expected**: admitted immediately — no second approval; same MEM-001 memory thread.
+
+### Test 5: Group chat bypass
+1. Add the bot to a Telegram group.
+2. With "Require verified email" on, a non-verified group member @mentions the bot. **Expected**: gate is bypassed; agent responds normally.
+
+### Test 6: Cascade on agent deletion
+```bash
+# Delete an agent that had pending access requests
+curl -X DELETE http://localhost:8000/api/agents/my-agent -H "Authorization: Bearer $TOKEN"
+# Verify access_requests for that agent are gone
+sqlite3 ~/trinity-data/trinity.db "SELECT COUNT(*) FROM access_requests WHERE agent_name='my-agent';"
+# → 0
+```
+
+---
+
+## Related Flows
+
+- **MEM-001 per-user memory** ([public-agent-links.md](public-agent-links.md)) — keyed off `source_user_email`, which is now the verified email. Cross-channel users converge on one memory key automatically.
+- **Email authentication** ([email-authentication.md](email-authentication.md)) — the `/login` flow reuses `db.create_login_code`, `db.verify_login_code`, and `EmailService.send_verification_code` from the platform email auth path. The whitelist auto-add on approval matches the existing `/share` endpoint.
+- **Agent sharing** ([agent-sharing.md](agent-sharing.md)) — `agent_sharing` is the unified allow-list. Approving an access request just calls `db.share_agent`. The cross-channel `email_has_agent_access` helper extends `is_agent_shared_with_email` with owner+admin checks.
+- **Telegram integration** ([telegram-integration.md](telegram-integration.md)) — bindings and chat links remain the durable Telegram-side state; #311 only adds two columns and the `/login` command.
+- **Slack channel routing** ([slack-channel-routing.md](slack-channel-routing.md)) — the channel router gate runs uniformly; Slack just resolves email via OAuth.
+- **Role model** ([role-model.md](role-model.md)) — orthogonal. Roles control *platform* permissions (who can create agents). Access policy controls *per-agent* channel access.
+
+## Follow-ups
+
+- **#252 — apply the same gate to web public links.** The web public chat path currently has its own per-link verification model; the plan is to plug `resolve_verified_email` into a `WebAdapter` so the same gate applies.
+- **Access requests via UI for non-Telegram channels.** Pending requests already work uniformly server-side; we may want richer "where did this user come from" metadata in the requests panel.
+
+---
+
+## Status
+Working. Telegram and Slack adapters wired through; web public links to follow in #252.
+
+## Revision History
+
+| Date | Changes |
+|------|---------|
+| 2026-04-12 | Initial implementation (#311). New migration `access_control`, `AccessPolicyMixin`, `AccessRequestOperations`, ABC additions, Telegram `/login` state machine, Slack `users.info` resolver, four owner endpoints, SharingPanel UI. |

--- a/src/backend/adapters/base.py
+++ b/src/backend/adapters/base.py
@@ -166,6 +166,51 @@ class ChannelAdapter(ABC):
         """
         return True
 
+    async def resolve_verified_email(
+        self, message: NormalizedMessage
+    ) -> Optional[str]:
+        """
+        Translate the channel-native identity into a verified email, if known.
+
+        Unified cross-channel access control (Issue #311). Each channel is
+        responsible only for producing a verified email — everything else
+        (sharing checks, access requests, memory injection) runs off that key.
+
+        Returns the email as a lowercase string, or None when the sender has
+        not yet proven an email (the router will then prompt via
+        ``prompt_auth`` if the agent requires email).
+
+        Default: None. Override in concrete adapters.
+        """
+        return None
+
+    async def prompt_auth(
+        self,
+        message: NormalizedMessage,
+        agent_name: str,
+        bot_token: Optional[str] = None,
+    ) -> None:
+        """
+        Ask the sender to prove an email (channel-specific).
+
+        Called by the router when the agent requires a verified email and
+        the adapter couldn't resolve one. Default sends a generic text reply
+        with instructions; channels can override for richer UX (e.g. Telegram
+        ``/login`` hint, Slack DM, etc.).
+        """
+        text = (
+            "This agent requires a verified email to chat.\n"
+            "Send `/login your@email.com` to start verification."
+        )
+        await self.send_response(
+            message.channel_id,
+            ChannelResponse(
+                text=text,
+                metadata={"bot_token": bot_token, "agent_name": agent_name},
+            ),
+            thread_id=message.thread_id,
+        )
+
     async def download_file(self, file: "FileAttachment", message: NormalizedMessage) -> Optional[bytes]:
         """
         Download a file attachment's bytes.

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -207,6 +207,62 @@ class ChannelMessageRouter:
         if not verified:
             return
 
+        # 5b. Unified cross-channel access gate (Issue #311).
+        # Resolve a verified email via the adapter, then apply the agent's
+        # access policy. Group chats bypass — group context is gated by the
+        # bot being added to the group, not by per-user email.
+        verified_email: Optional[str] = None
+        if not is_group:
+            try:
+                verified_email = await adapter.resolve_verified_email(message)
+            except Exception as e:
+                logger.warning(f"[ROUTER:{channel}] resolve_verified_email error: {e}")
+                verified_email = None
+
+            policy = db.get_access_policy(agent_name)
+            require_email = policy.get("require_email", False)
+            open_access = policy.get("open_access", False)
+
+            if require_email and not verified_email:
+                logger.info(
+                    f"[ROUTER:{channel}] Access denied: agent={agent_name} requires email "
+                    f"and sender={message.sender_id} not verified"
+                )
+                await adapter.prompt_auth(message, agent_name, bot_token)
+                return
+
+            if verified_email and db.email_has_agent_access(agent_name, verified_email):
+                logger.debug(f"[ROUTER:{channel}] Access granted via owner/admin/sharing: {verified_email}")
+            elif open_access:
+                logger.debug(
+                    f"[ROUTER:{channel}] Access granted via open_access "
+                    f"(email={verified_email or 'none'})"
+                )
+            elif verified_email:
+                # Verified email + restrictive policy → record access request
+                try:
+                    db.upsert_access_request(agent_name, verified_email, channel)
+                except Exception as e:
+                    logger.error(f"[ROUTER:{channel}] Failed to upsert access_request: {e}")
+                logger.info(
+                    f"[ROUTER:{channel}] Pending access request: "
+                    f"agent={agent_name}, email={verified_email}"
+                )
+                await adapter.send_response(
+                    message.channel_id,
+                    ChannelResponse(
+                        text=(
+                            "🔒 Your access request is pending approval. "
+                            "I'll let you know once the agent owner responds."
+                        ),
+                        metadata={"bot_token": bot_token, "agent_name": agent_name},
+                    ),
+                    thread_id=message.thread_id,
+                )
+                return
+            # else: no verified email and policy not set → legacy permissive
+            # (preserves backward compat for agents that haven't opted in).
+
         # 6. Get/create session
         logger.debug(f"[ROUTER:{channel}] Step 6 - creating session")
         session_identifier = adapter.get_session_identifier(message)
@@ -241,7 +297,9 @@ class ChannelMessageRouter:
 
         # 9. Execute via TaskExecutionService (same path as web public chat)
         logger.debug(f"[ROUTER:{channel}] Step 9 - executing via TaskExecutionService")
-        source_email = adapter.get_source_identifier(message)
+        # Prefer the verified email (Issue #311) so MEM-001 keys cross-channel
+        # off the same identity. Fall back to the channel-native source id.
+        source_email = verified_email or adapter.get_source_identifier(message)
 
         # Security: restrict tools for public channel users
         # No file access (Read exposes .env/credentials), no Bash, no Write/Edit

--- a/src/backend/adapters/slack_adapter.py
+++ b/src/backend/adapters/slack_adapter.py
@@ -48,6 +48,24 @@ class SlackAdapter(ChannelAdapter):
     def get_source_identifier(self, message: NormalizedMessage) -> str:
         return f"slack:{message.metadata.get('team_id')}:{message.sender_id}"
 
+    async def resolve_verified_email(
+        self, message: NormalizedMessage
+    ) -> Optional[str]:
+        """Slack workspace email is already verified — fetch via users.info.
+
+        Issue #311. Cached per process for the lifetime of the message
+        (no persistence needed: the workspace OAuth token already proves identity).
+        """
+        bot_token = self.get_bot_token(message)
+        if not bot_token:
+            return None
+        try:
+            email = await slack_service.get_user_email(bot_token, message.sender_id)
+        except Exception as e:
+            logger.warning(f"Slack resolve_verified_email failed: {e}")
+            return None
+        return email.lower() if email else None
+
     def get_bot_token(self, message: NormalizedMessage) -> Optional[str]:
         team_id = message.metadata.get("team_id")
         if not team_id:

--- a/src/backend/adapters/telegram_adapter.py
+++ b/src/backend/adapters/telegram_adapter.py
@@ -21,6 +21,7 @@ import httpx
 
 from database import db
 from adapters.base import ChannelAdapter, NormalizedMessage, ChannelResponse
+from services.email_service import EmailService
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,11 @@ TELEGRAM_API_BASE = "https://api.telegram.org"
 
 # Group chat types
 _GROUP_CHAT_TYPES = {"group", "supergroup"}
+
+# Pending /login email per (binding_id, telegram_user_id) — cleared on verify/logout.
+# In-memory: codes are short-lived (10 min) and a backend restart simply forces
+# the user to re-issue /login.
+_PENDING_LOGINS: dict = {}
 
 
 class TelegramAdapter(ChannelAdapter):
@@ -188,6 +194,46 @@ class TelegramAdapter(ChannelAdapter):
                 reply_to_message_id=reply_to,
                 parse_mode="HTML",
             )
+
+    # =========================================================================
+    # Unified access control (Issue #311)
+    # =========================================================================
+
+    async def resolve_verified_email(
+        self, message: NormalizedMessage
+    ) -> Optional[str]:
+        """Look up the verified email bound to this Telegram user, if any."""
+        agent_name = message.metadata.get("agent_name")
+        if not agent_name:
+            return None
+        binding = db.get_telegram_binding(agent_name)
+        if not binding:
+            return None
+        return db.get_telegram_verified_email(binding["id"], message.sender_id)
+
+    async def prompt_auth(
+        self,
+        message: NormalizedMessage,
+        agent_name: str,
+        bot_token: Optional[str] = None,
+    ) -> None:
+        """Send a Telegram-native auth prompt with /login instructions."""
+        if not bot_token:
+            bot_token = db.get_telegram_bot_token(agent_name)
+        if not bot_token:
+            return
+        text = (
+            "🔒 This agent requires a verified email.\n\n"
+            "Send <code>/login your@email.com</code> and I'll email you a 6-digit code. "
+            "Then reply with <code>/login 123456</code> to complete verification."
+        )
+        await self._send_message(
+            bot_token=bot_token,
+            chat_id=message.channel_id,
+            text=text,
+            reply_to_message_id=message.thread_id,
+            parse_mode="HTML",
+        )
 
     async def get_agent_name(self, message: NormalizedMessage) -> Optional[str]:
         """Resolve which agent handles this message (set by transport layer)."""
@@ -386,7 +432,102 @@ class TelegramAdapter(ChannelAdapter):
             # Clear session — the transport/router will handle this
             return "Conversation history cleared. Let's start fresh!"
 
+        # /login state machine (Issue #311)
+        if text == "/login" or text.startswith("/login "):
+            return await self._handle_login_command(message, text)
+
+        if text == "/logout":
+            return await self._handle_logout_command(message)
+
+        if text == "/whoami":
+            email = await self.resolve_verified_email(message)
+            if email:
+                return f"You are verified as <code>{email}</code>."
+            return "You are not verified. Send <code>/login your@email.com</code> to verify."
+
         return None
+
+    async def _handle_login_command(
+        self, message: NormalizedMessage, text: str
+    ) -> Optional[str]:
+        """Handle /login {email} (request code) and /login {code} (verify)."""
+        agent_name = message.metadata.get("agent_name")
+        if not agent_name:
+            return "Login is unavailable for this chat."
+
+        binding = db.get_telegram_binding(agent_name)
+        if not binding:
+            return "Login is unavailable for this chat."
+
+        # /login with no argument
+        parts = text.split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            return (
+                "Usage:\n"
+                "<code>/login your@email.com</code> — request a verification code\n"
+                "<code>/login 123456</code> — confirm the code I emailed you"
+            )
+
+        arg = parts[1].strip()
+
+        # 6-digit code path
+        if arg.isdigit() and len(arg) == 6:
+            pending_email = _PENDING_LOGINS.get((binding["id"], message.sender_id))
+            if not pending_email:
+                return (
+                    "I don't have a pending login for you. Send "
+                    "<code>/login your@email.com</code> first."
+                )
+            result = db.verify_login_code(pending_email, arg)
+            if not result:
+                return "❌ Invalid or expired code. Try again or request a new one."
+            db.set_telegram_verified_email(binding["id"], message.sender_id, pending_email)
+            _PENDING_LOGINS.pop((binding["id"], message.sender_id), None)
+            return (
+                f"✅ Verified! You're now signed in as <code>{pending_email}</code>.\n"
+                "You can chat normally now."
+            )
+
+        # Email path
+        email = arg.lower()
+        if "@" not in email or " " in email or len(email) > 254:
+            return "That doesn't look like an email address. Try <code>/login you@example.com</code>."
+
+        try:
+            code_data = db.create_login_code(email, expiry_minutes=10)
+        except Exception as e:
+            logger.error(f"Failed to create login code for {email}: {e}")
+            return "Couldn't create a verification code. Please try again later."
+
+        try:
+            email_service = EmailService()
+            sent = await email_service.send_verification_code(email, code_data["code"])
+        except Exception as e:
+            logger.error(f"Failed to send verification email to {email}: {e}")
+            sent = False
+
+        _PENDING_LOGINS[(binding["id"], message.sender_id)] = email
+
+        if not sent:
+            return (
+                f"⚠️ I couldn't send the email to <code>{email}</code>. "
+                "Ask the agent owner to check email delivery."
+            )
+        return (
+            f"📧 Sent a 6-digit code to <code>{email}</code>.\n"
+            "Reply with <code>/login 123456</code> to finish verification."
+        )
+
+    async def _handle_logout_command(self, message: NormalizedMessage) -> str:
+        agent_name = message.metadata.get("agent_name")
+        if not agent_name:
+            return "Logout is unavailable for this chat."
+        binding = db.get_telegram_binding(agent_name)
+        if not binding:
+            return "Logout is unavailable for this chat."
+        db.clear_telegram_verified_email(binding["id"], message.sender_id)
+        _PENDING_LOGINS.pop((binding["id"], message.sender_id), None)
+        return "👋 Logged out. Send <code>/login your@email.com</code> to sign in again."
 
     # =========================================================================
     # Telegram API helpers

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -127,6 +127,7 @@ from db.nevermined import NeverminedOperations
 from db.operator_queue import OperatorQueueOperations
 from db.event_subscriptions import EventSubscriptionOperations
 from db.telegram_channels import TelegramChannelOperations
+from db.access_requests import AccessRequestOperations
 
 
 def init_database():
@@ -277,6 +278,7 @@ class DatabaseManager:
         self._operator_queue_ops = OperatorQueueOperations()
         self._event_subscription_ops = EventSubscriptionOperations()
         self._telegram_channel_ops = TelegramChannelOperations()
+        self._access_request_ops = AccessRequestOperations()
 
     # =========================================================================
     # User Management (delegated to db/users.py)
@@ -346,6 +348,16 @@ class DatabaseManager:
 
     def is_system_agent(self, agent_name: str):
         return self._agent_ops.is_system_agent(agent_name)
+
+    # Access policy (issue #311)
+    def get_access_policy(self, agent_name: str):
+        return self._agent_ops.get_access_policy(agent_name)
+
+    def set_access_policy(self, agent_name: str, require_email: bool, open_access: bool):
+        return self._agent_ops.set_access_policy(agent_name, require_email, open_access)
+
+    def email_has_agent_access(self, agent_name: str, email: str):
+        return self._agent_ops.email_has_agent_access(agent_name, email)
 
     # =========================================================================
     # Agent Sharing Management (delegated to db/agents.py)
@@ -1381,6 +1393,15 @@ class DatabaseManager:
     def increment_telegram_message_count(self, chat_link_id):
         return self._telegram_channel_ops.increment_message_count(chat_link_id)
 
+    def get_telegram_verified_email(self, binding_id, telegram_user_id):
+        return self._telegram_channel_ops.get_verified_email(binding_id, telegram_user_id)
+
+    def set_telegram_verified_email(self, binding_id, telegram_user_id, email):
+        return self._telegram_channel_ops.set_verified_email(binding_id, telegram_user_id, email)
+
+    def clear_telegram_verified_email(self, binding_id, telegram_user_id):
+        return self._telegram_channel_ops.clear_verified_email(binding_id, telegram_user_id)
+
     # Telegram Group Configs (TGRAM-GROUP)
 
     def get_or_create_telegram_group_config(self, binding_id, chat_id, chat_title=None, chat_type="group"):
@@ -1502,6 +1523,25 @@ class DatabaseManager:
 
     def list_agent_events(self, source_agent=None, event_type=None, limit=50):
         return self._event_subscription_ops.list_events(source_agent, event_type, limit)
+
+    # =========================================================================
+    # Access Requests (Issue #311)
+    # =========================================================================
+
+    def upsert_access_request(self, agent_name: str, email: str, channel: str = None):
+        return self._access_request_ops.upsert_pending(agent_name, email, channel)
+
+    def list_access_requests(self, agent_name: str, status: str = "pending"):
+        return self._access_request_ops.list_for_agent(agent_name, status)
+
+    def get_access_request(self, request_id: str):
+        return self._access_request_ops.get(request_id)
+
+    def decide_access_request(self, request_id: str, approve: bool, decided_by_user_id: int):
+        return self._access_request_ops.decide(request_id, approve, decided_by_user_id)
+
+    def delete_access_requests_for_agent(self, agent_name: str):
+        return self._access_request_ops.delete_for_agent(agent_name)
 
 
 # Global database manager instance

--- a/src/backend/db/access_requests.py
+++ b/src/backend/db/access_requests.py
@@ -1,0 +1,150 @@
+"""
+Database operations for per-agent access requests (Issue #311).
+
+When a user tries to talk to an agent across any channel without being
+owner / admin / shared / and the agent is not open-access, we record a
+pending request. Owners can approve (which inserts into agent_sharing)
+or deny.
+"""
+
+import secrets
+import sqlite3
+from datetime import datetime
+from typing import List, Optional
+
+from .connection import get_db_connection
+
+
+class AccessRequestOperations:
+    """Operations for access_requests table."""
+
+    @staticmethod
+    def _row_to_dict(row) -> dict:
+        return {
+            "id": row["id"],
+            "agent_name": row["agent_name"],
+            "email": row["email"],
+            "channel": row["channel"],
+            "requested_at": row["requested_at"],
+            "status": row["status"],
+            "decided_by": row["decided_by"],
+            "decided_at": row["decided_at"],
+        }
+
+    def upsert_pending(
+        self,
+        agent_name: str,
+        email: str,
+        channel: Optional[str] = None,
+    ) -> dict:
+        """Insert or refresh a pending access request for (agent_name, email).
+
+        If an approved/denied record exists and the user now has no access
+        anyway (e.g. share removed), we reset to pending so the owner sees it.
+        """
+        email = email.lower()
+        now = datetime.utcnow().isoformat()
+        rid = secrets.token_urlsafe(16)
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(
+                    """
+                    INSERT INTO access_requests
+                    (id, agent_name, email, channel, requested_at, status)
+                    VALUES (?, ?, ?, ?, ?, 'pending')
+                    """,
+                    (rid, agent_name, email, channel, now),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError:
+                # Already exists — refresh status to pending and update timestamp
+                cursor.execute(
+                    """
+                    UPDATE access_requests
+                    SET status = 'pending',
+                        requested_at = ?,
+                        channel = COALESCE(?, channel),
+                        decided_by = NULL,
+                        decided_at = NULL
+                    WHERE agent_name = ? AND email = ?
+                    """,
+                    (now, channel, agent_name, email),
+                )
+                conn.commit()
+
+            cursor.execute(
+                "SELECT * FROM access_requests WHERE agent_name = ? AND email = ?",
+                (agent_name, email),
+            )
+            row = cursor.fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def list_for_agent(
+        self,
+        agent_name: str,
+        status: Optional[str] = "pending",
+    ) -> List[dict]:
+        """List access requests for an agent, optionally filtered by status."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            if status:
+                cursor.execute(
+                    """
+                    SELECT * FROM access_requests
+                    WHERE agent_name = ? AND status = ?
+                    ORDER BY requested_at DESC
+                    """,
+                    (agent_name, status),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT * FROM access_requests
+                    WHERE agent_name = ?
+                    ORDER BY requested_at DESC
+                    """,
+                    (agent_name,),
+                )
+            rows = cursor.fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def get(self, request_id: str) -> Optional[dict]:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT * FROM access_requests WHERE id = ?", (request_id,))
+            row = cursor.fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def decide(
+        self,
+        request_id: str,
+        approve: bool,
+        decided_by_user_id: int,
+    ) -> Optional[dict]:
+        """Mark a request approved or denied. Returns updated row."""
+        now = datetime.utcnow().isoformat()
+        new_status = "approved" if approve else "denied"
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE access_requests
+                SET status = ?, decided_by = ?, decided_at = ?
+                WHERE id = ?
+                """,
+                (new_status, decided_by_user_id, now, request_id),
+            )
+            conn.commit()
+            cursor.execute("SELECT * FROM access_requests WHERE id = ?", (request_id,))
+            row = cursor.fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def delete_for_agent(self, agent_name: str) -> int:
+        """Delete all access requests for an agent (on agent deletion)."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM access_requests WHERE agent_name = ?", (agent_name,))
+            conn.commit()
+            return cursor.rowcount

--- a/src/backend/db/agent_settings/__init__.py
+++ b/src/backend/db/agent_settings/__init__.py
@@ -16,6 +16,7 @@ from .security import SecurityMixin
 from .autonomy import AutonomyMixin
 from .avatar import AvatarMixin
 from .metadata import MetadataMixin
+from .access_policy import AccessPolicyMixin
 
 __all__ = [
     'SharingMixin',
@@ -24,4 +25,5 @@ __all__ = [
     'AutonomyMixin',
     'AvatarMixin',
     'MetadataMixin',
+    'AccessPolicyMixin',
 ]

--- a/src/backend/db/agent_settings/access_policy.py
+++ b/src/backend/db/agent_settings/access_policy.py
@@ -1,0 +1,54 @@
+"""
+Agent access policy settings (Issue #311).
+
+Stores per-agent channel access policy:
+- require_email: gate requires a verified email on incoming messages
+- open_access: anyone with a verified email may talk (access_requests skipped)
+"""
+
+from db.connection import get_db_connection
+
+
+class AccessPolicyMixin:
+    """Mixin for per-agent access policy (require_email, open_access)."""
+
+    def get_access_policy(self, agent_name: str) -> dict:
+        """Return {'require_email': bool, 'open_access': bool} for an agent."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT COALESCE(require_email, 0) AS require_email,
+                       COALESCE(open_access, 0) AS open_access
+                FROM agent_ownership
+                WHERE agent_name = ?
+                """,
+                (agent_name,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return {"require_email": False, "open_access": False}
+        return {
+            "require_email": bool(row["require_email"]),
+            "open_access": bool(row["open_access"]),
+        }
+
+    def set_access_policy(
+        self,
+        agent_name: str,
+        require_email: bool,
+        open_access: bool,
+    ) -> bool:
+        """Update access policy for an agent."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE agent_ownership
+                SET require_email = ?, open_access = ?
+                WHERE agent_name = ?
+                """,
+                (1 if require_email else 0, 1 if open_access else 0, agent_name),
+            )
+            conn.commit()
+            return cursor.rowcount > 0

--- a/src/backend/db/agent_settings/sharing.py
+++ b/src/backend/db/agent_settings/sharing.py
@@ -118,6 +118,35 @@ class SharingMixin:
             """, (user_email.lower(),))
             return [row["agent_name"] for row in cursor.fetchall()]
 
+    def is_agent_shared_with_email(self, agent_name: str, email: str) -> bool:
+        """Check if an agent is shared with the given email directly."""
+        if not email:
+            return False
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT 1 FROM agent_sharing
+                WHERE agent_name = ? AND shared_with_email = ?
+            """, (agent_name, email.lower()))
+            return cursor.fetchone() is not None
+
+    def email_has_agent_access(self, agent_name: str, email: str) -> bool:
+        """Cross-channel access check (Issue #311).
+
+        Returns True when the email is owner, admin, or in agent_sharing for
+        the given agent. Used by the channel router gate.
+        """
+        if not email:
+            return False
+        user = self._user_ops.get_user_by_email(email)
+        if user:
+            if user.get("role") == "admin":
+                return True
+            owner = self.get_agent_owner(agent_name)
+            if owner and owner["owner_username"] == user["username"]:
+                return True
+        return self.is_agent_shared_with_email(agent_name, email)
+
     def is_agent_shared_with_user(self, agent_name: str, username: str) -> bool:
         """Check if an agent is shared with a specific user (by their email)."""
         user = self._user_ops.get_user_by_username(username)

--- a/src/backend/db/agents.py
+++ b/src/backend/db/agents.py
@@ -23,6 +23,7 @@ from .agent_settings import (
     AutonomyMixin,
     AvatarMixin,
     MetadataMixin,
+    AccessPolicyMixin,
 )
 
 # System agent name constant
@@ -36,6 +37,7 @@ class AgentOperations(
     AutonomyMixin,
     AvatarMixin,
     MetadataMixin,
+    AccessPolicyMixin,
 ):
     """Agent ownership, access control, and settings database operations.
 
@@ -113,11 +115,13 @@ class AgentOperations(
             return [row["agent_name"] for row in cursor.fetchall()]
 
     def delete_agent_ownership(self, agent_name: str) -> bool:
-        """Remove agent ownership record and all sharing records (when agent is deleted)."""
+        """Remove agent ownership record, all sharing records, and pending access requests."""
         with get_db_connection() as conn:
             cursor = conn.cursor()
             # Delete sharing records first (cascade)
             cursor.execute("DELETE FROM agent_sharing WHERE agent_name = ?", (agent_name,))
+            # Delete access requests (issue #311)
+            cursor.execute("DELETE FROM access_requests WHERE agent_name = ?", (agent_name,))
             # Delete ownership record
             cursor.execute("DELETE FROM agent_ownership WHERE agent_name = ?", (agent_name,))
             conn.commit()

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -1004,6 +1004,49 @@ def _migrate_telegram_bindings(cursor, conn):
     conn.commit()
 
 
+def _migrate_access_control(cursor, conn):
+    """Add unified channel access control (issue #311).
+
+    - agent_ownership: require_email (INTEGER), open_access (INTEGER)
+    - telegram_chat_links: verified_email (TEXT), verified_at (TEXT)
+    - access_requests: new table for pending per-agent access requests
+    """
+    # 1. agent_ownership columns
+    cursor.execute("PRAGMA table_info(agent_ownership)")
+    ao_cols = {row[1] for row in cursor.fetchall()}
+    if "require_email" not in ao_cols:
+        cursor.execute("ALTER TABLE agent_ownership ADD COLUMN require_email INTEGER DEFAULT 0")
+    if "open_access" not in ao_cols:
+        cursor.execute("ALTER TABLE agent_ownership ADD COLUMN open_access INTEGER DEFAULT 0")
+
+    # 2. telegram_chat_links columns
+    cursor.execute("PRAGMA table_info(telegram_chat_links)")
+    tcl_cols = {row[1] for row in cursor.fetchall()}
+    if "verified_email" not in tcl_cols:
+        cursor.execute("ALTER TABLE telegram_chat_links ADD COLUMN verified_email TEXT")
+    if "verified_at" not in tcl_cols:
+        cursor.execute("ALTER TABLE telegram_chat_links ADD COLUMN verified_at TEXT")
+
+    # 3. access_requests table
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS access_requests (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            channel TEXT,
+            requested_at TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            decided_by INTEGER,
+            decided_at TEXT,
+            UNIQUE(agent_name, email)
+        )
+    """)
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_access_requests_agent ON access_requests(agent_name, status)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_access_requests_email ON access_requests(email)")
+
+    conn.commit()
+
+
 def _migrate_telegram_group_configs(cursor, conn):
     """Create Telegram group configuration table (TGRAM-GROUP)."""
 
@@ -1075,4 +1118,5 @@ MIGRATIONS = [
     ("telegram_bindings", _migrate_telegram_bindings),
     ("subscription_usage_tracking", _migrate_subscription_usage_tracking),
     ("telegram_group_configs", _migrate_telegram_group_configs),
+    ("access_control", _migrate_access_control),
 ]

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -66,6 +66,8 @@ TABLES = {
             avatar_identity_prompt TEXT,
             avatar_updated_at TEXT,
             is_default_avatar INTEGER DEFAULT 0,
+            require_email INTEGER DEFAULT 0,
+            open_access INTEGER DEFAULT 0,
             FOREIGN KEY (owner_id) REFERENCES users(id),
             FOREIGN KEY (subscription_id) REFERENCES subscription_credentials(id)
         )
@@ -642,6 +644,23 @@ TABLES = {
             created_at TEXT NOT NULL
         )
     """,
+
+    # -------------------------------------------------------------------------
+    # Access Requests (Issue #311 - Unified Channel Access Control)
+    # -------------------------------------------------------------------------
+    "access_requests": """
+        CREATE TABLE IF NOT EXISTS access_requests (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            channel TEXT,
+            requested_at TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            decided_by INTEGER,
+            decided_at TEXT,
+            UNIQUE(agent_name, email)
+        )
+    """,
 }
 
 # =============================================================================
@@ -780,6 +799,10 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_event_subs_source_type ON agent_event_subscriptions(source_agent, event_type)",
     "CREATE INDEX IF NOT EXISTS idx_events_source ON agent_events(source_agent, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_events_type ON agent_events(event_type)",
+
+    # Access requests indexes (Issue #311)
+    "CREATE INDEX IF NOT EXISTS idx_access_requests_agent ON access_requests(agent_name, status)",
+    "CREATE INDEX IF NOT EXISTS idx_access_requests_email ON access_requests(email)",
 ]
 
 

--- a/src/backend/db/telegram_channels.py
+++ b/src/backend/db/telegram_channels.py
@@ -239,6 +239,75 @@ class TelegramChannelOperations:
             """, (binding_id, telegram_user_id))
             return self._row_to_chat_link(cursor.fetchone())
 
+    def get_chat_link(self, binding_id: int, telegram_user_id: str) -> Optional[dict]:
+        """Look up a chat link without creating it."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT id, binding_id, telegram_user_id, telegram_username,
+                       session_id, message_count, created_at, last_active,
+                       verified_email, verified_at
+                FROM telegram_chat_links
+                WHERE binding_id = ? AND telegram_user_id = ?
+            """, (binding_id, telegram_user_id))
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "binding_id": row[1],
+            "telegram_user_id": row[2],
+            "telegram_username": row[3],
+            "session_id": row[4],
+            "message_count": row[5],
+            "created_at": row[6],
+            "last_active": row[7],
+            "verified_email": row[8],
+            "verified_at": row[9],
+        }
+
+    def get_verified_email(self, binding_id: int, telegram_user_id: str) -> Optional[str]:
+        """Return the verified email for this Telegram user, or None."""
+        link = self.get_chat_link(binding_id, telegram_user_id)
+        return link["verified_email"] if link else None
+
+    def set_verified_email(
+        self,
+        binding_id: int,
+        telegram_user_id: str,
+        email: str,
+    ) -> bool:
+        """Persist a verified email onto the chat link (auto-creates the row)."""
+        now = datetime.utcnow().isoformat()
+        email = email.lower()
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            # Ensure row exists
+            cursor.execute("""
+                INSERT OR IGNORE INTO telegram_chat_links
+                (binding_id, telegram_user_id, message_count, created_at, last_active)
+                VALUES (?, ?, 0, ?, ?)
+            """, (binding_id, telegram_user_id, now, now))
+            cursor.execute("""
+                UPDATE telegram_chat_links
+                SET verified_email = ?, verified_at = ?
+                WHERE binding_id = ? AND telegram_user_id = ?
+            """, (email, now, binding_id, telegram_user_id))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def clear_verified_email(self, binding_id: int, telegram_user_id: str) -> bool:
+        """Unbind a verified email (logout)."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                UPDATE telegram_chat_links
+                SET verified_email = NULL, verified_at = NULL
+                WHERE binding_id = ? AND telegram_user_id = ?
+            """, (binding_id, telegram_user_id))
+            conn.commit()
+            return cursor.rowcount > 0
+
     def increment_message_count(self, chat_link_id: int) -> None:
         """Increment message count and update last_active."""
         now = datetime.utcnow().isoformat()

--- a/src/backend/routers/sharing.py
+++ b/src/backend/routers/sharing.py
@@ -2,7 +2,10 @@
 Agent sharing routes for the Trinity backend.
 """
 import json
+from typing import List
+
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
 
 from models import User
 from database import db, AgentShare, AgentShareRequest
@@ -10,6 +13,33 @@ from dependencies import get_current_user, OwnedAgentByName, CurrentUser
 from services.docker_service import get_agent_container
 
 router = APIRouter(prefix="/api/agents", tags=["sharing"])
+
+
+# ---------------------------------------------------------------------------
+# Models for unified access control (Issue #311)
+# ---------------------------------------------------------------------------
+
+class AccessPolicy(BaseModel):
+    require_email: bool
+    open_access: bool
+
+
+class AccessPolicyUpdate(BaseModel):
+    require_email: bool
+    open_access: bool
+
+
+class AccessRequest(BaseModel):
+    id: str
+    agent_name: str
+    email: str
+    channel: str | None = None
+    requested_at: str
+    status: str
+
+
+class AccessRequestDecision(BaseModel):
+    approve: bool
 
 # WebSocket manager will be injected from main.py
 manager = None
@@ -101,3 +131,91 @@ async def get_agent_shares_endpoint(
 
     shares = db.get_agent_shares(agent_name)
     return shares
+
+
+# ---------------------------------------------------------------------------
+# Unified channel access control (Issue #311)
+# ---------------------------------------------------------------------------
+
+@router.get("/{agent_name}/access-policy", response_model=AccessPolicy)
+async def get_access_policy_endpoint(
+    agent_name: OwnedAgentByName,
+    current_user: CurrentUser,
+):
+    """Get the per-agent channel access policy."""
+    return AccessPolicy(**db.get_access_policy(agent_name))
+
+
+@router.put("/{agent_name}/access-policy", response_model=AccessPolicy)
+async def update_access_policy_endpoint(
+    agent_name: OwnedAgentByName,
+    update: AccessPolicyUpdate,
+    current_user: CurrentUser,
+):
+    """Update the per-agent channel access policy (owner-only)."""
+    db.set_access_policy(agent_name, update.require_email, update.open_access)
+    return AccessPolicy(**db.get_access_policy(agent_name))
+
+
+@router.get("/{agent_name}/access-requests", response_model=List[AccessRequest])
+async def list_access_requests_endpoint(
+    agent_name: OwnedAgentByName,
+    current_user: CurrentUser,
+    status: str = "pending",
+):
+    """List access requests for this agent (owner-only)."""
+    rows = db.list_access_requests(agent_name, status)
+    return [AccessRequest(**r) for r in rows]
+
+
+@router.post("/{agent_name}/access-requests/{request_id}/decide", response_model=AccessRequest)
+async def decide_access_request_endpoint(
+    agent_name: OwnedAgentByName,
+    request_id: str,
+    decision: AccessRequestDecision,
+    current_user: CurrentUser,
+):
+    """Approve or deny a pending access request (owner-only).
+
+    Approval inserts the email into agent_sharing so future messages from
+    that user across any channel are admitted automatically.
+    """
+    existing = db.get_access_request(request_id)
+    if not existing or existing["agent_name"] != agent_name:
+        raise HTTPException(status_code=404, detail="Access request not found")
+
+    user = db.get_user_by_username(current_user.username)
+    if not user:
+        raise HTTPException(status_code=403, detail="User not found")
+
+    updated = db.decide_access_request(request_id, decision.approve, user["id"])
+    if not updated:
+        raise HTTPException(status_code=500, detail="Failed to update request")
+
+    if decision.approve:
+        # Insert into agent_sharing so the email is admitted on future messages.
+        # share_agent is idempotent (returns None if already shared).
+        db.share_agent(agent_name, current_user.username, existing["email"])
+
+        # Auto-add to whitelist if email auth is enabled (parity with /share endpoint)
+        from config import EMAIL_AUTH_ENABLED
+        email_auth_setting = db.get_setting_value(
+            "email_auth_enabled", str(EMAIL_AUTH_ENABLED).lower()
+        )
+        if email_auth_setting.lower() == "true":
+            try:
+                db.add_to_whitelist(
+                    existing["email"],
+                    current_user.username,
+                    source="access_request",
+                )
+            except Exception:
+                pass
+
+        if manager:
+            await manager.broadcast(json.dumps({
+                "event": "agent_shared",
+                "data": {"name": agent_name, "shared_with": existing["email"]},
+            }))
+
+    return AccessRequest(**updated)

--- a/src/frontend/src/components/SharingPanel.vue
+++ b/src/frontend/src/components/SharingPanel.vue
@@ -1,5 +1,80 @@
 <template>
   <div class="p-6 space-y-8">
+    <!-- Channel Access Policy (Issue #311) -->
+    <div>
+      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Channel Access Policy</h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Controls who can chat with this agent across web, Telegram, and Slack.
+        The team-sharing list below is the unified allow-list.
+      </p>
+
+      <div class="space-y-3">
+        <label class="flex items-start gap-3">
+          <input
+            type="checkbox"
+            class="mt-1"
+            :checked="policy.require_email"
+            :disabled="policyLoading"
+            @change="updatePolicy({ require_email: $event.target.checked })"
+          />
+          <div>
+            <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Require verified email</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+              Telegram users must <code>/login</code>; Slack uses workspace email; web requires email verification.
+            </div>
+          </div>
+        </label>
+
+        <label class="flex items-start gap-3">
+          <input
+            type="checkbox"
+            class="mt-1"
+            :checked="policy.open_access"
+            :disabled="policyLoading"
+            @change="updatePolicy({ open_access: $event.target.checked })"
+          />
+          <div>
+            <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Open access</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+              Anyone with a verified email may chat without owner approval.
+              Off = pending requests must be approved.
+            </div>
+          </div>
+        </label>
+      </div>
+
+      <!-- Pending access requests -->
+      <div v-if="pendingRequests.length > 0" class="mt-6">
+        <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
+          Pending access requests ({{ pendingRequests.length }})
+        </h4>
+        <ul class="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg">
+          <li v-for="req in pendingRequests" :key="req.id" class="px-4 py-3 flex items-center justify-between">
+            <div>
+              <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ req.email }}</p>
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                via {{ req.channel || 'unknown' }} · {{ formatRequestedAt(req.requested_at) }}
+              </p>
+            </div>
+            <div class="flex items-center gap-2">
+              <button
+                @click="decideRequest(req, true)"
+                :disabled="decisionLoading === req.id"
+                class="px-3 py-1 text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 disabled:opacity-50"
+              >Approve</button>
+              <button
+                @click="decideRequest(req, false)"
+                :disabled="decisionLoading === req.id"
+                class="px-3 py-1 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
+              >Deny</button>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="border-t border-gray-200 dark:border-gray-700"></div>
+
     <!-- Team Sharing Section -->
     <div>
       <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Team Sharing</h3>
@@ -97,8 +172,10 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, onMounted } from 'vue'
+import axios from 'axios'
 import { useAgentsStore } from '../stores/agents'
+import { useAuthStore } from '../stores/auth'
 import { useAgentSharing } from '../composables/useAgentSharing'
 import { useNotification } from '../composables'
 import PublicLinksPanel from './PublicLinksPanel.vue'
@@ -142,4 +219,91 @@ const {
   shareWithUser,
   removeShare
 } = useAgentSharing(agent, agentsStore, loadAgent, showNotification)
+
+// ---------------------------------------------------------------------------
+// Access policy + access requests (Issue #311)
+// ---------------------------------------------------------------------------
+const authStore = useAuthStore()
+const policy = ref({ require_email: false, open_access: false })
+const policyLoading = ref(false)
+const pendingRequests = ref([])
+const decisionLoading = ref(null)
+
+const loadPolicy = async () => {
+  try {
+    const { data } = await axios.get(
+      `/api/agents/${props.agentName}/access-policy`,
+      { headers: authStore.authHeader }
+    )
+    policy.value = data
+  } catch (err) {
+    console.error('Failed to load access policy:', err)
+  }
+}
+
+const updatePolicy = async (changes) => {
+  policyLoading.value = true
+  try {
+    const next = { ...policy.value, ...changes }
+    const { data } = await axios.put(
+      `/api/agents/${props.agentName}/access-policy`,
+      next,
+      { headers: authStore.authHeader }
+    )
+    policy.value = data
+    showNotification('Access policy updated', 'success')
+  } catch (err) {
+    console.error('Failed to update access policy:', err)
+    showNotification(err.response?.data?.detail || 'Failed to update policy', 'error')
+  } finally {
+    policyLoading.value = false
+  }
+}
+
+const loadAccessRequests = async () => {
+  try {
+    const { data } = await axios.get(
+      `/api/agents/${props.agentName}/access-requests`,
+      { headers: authStore.authHeader, params: { status: 'pending' } }
+    )
+    pendingRequests.value = data
+  } catch (err) {
+    console.error('Failed to load access requests:', err)
+  }
+}
+
+const decideRequest = async (req, approve) => {
+  decisionLoading.value = req.id
+  try {
+    await axios.post(
+      `/api/agents/${props.agentName}/access-requests/${req.id}/decide`,
+      { approve },
+      { headers: authStore.authHeader }
+    )
+    showNotification(
+      approve ? `Approved ${req.email}` : `Denied ${req.email}`,
+      'success'
+    )
+    await loadAccessRequests()
+    if (approve) await loadAgent()
+  } catch (err) {
+    console.error('Failed to decide request:', err)
+    showNotification(err.response?.data?.detail || 'Failed to update request', 'error')
+  } finally {
+    decisionLoading.value = null
+  }
+}
+
+const formatRequestedAt = (iso) => {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+watch(() => props.agentName, async (name) => {
+  if (!name) return
+  await Promise.all([loadPolicy(), loadAccessRequests()])
+}, { immediate: true })
 </script>

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -124,6 +124,13 @@
       "added": "2026-03-20",
       "categories": ["backend", "api", "auth", "roles"],
       "description": "Tests for 4-tier role model: list users, update roles, admin-only access, role validation"
+    },
+    {
+      "file": "test_channel_access_control.py",
+      "feature": "Issue #311",
+      "added": "2026-04-13",
+      "categories": ["backend", "api", "sharing", "channels"],
+      "description": "Tests for unified channel access control: access-policy GET/PUT, access-requests GET/decide, approve-inserts-share side-effect, deny-without-share side-effect"
     }
   ]
 }

--- a/tests/test_channel_access_control.py
+++ b/tests/test_channel_access_control.py
@@ -1,0 +1,482 @@
+"""
+Unified Channel Access Control Tests (test_channel_access_control.py)
+
+Tests for the per-agent channel access policy + access-requests inbox
+introduced by GitHub issue #311.
+
+Covers the four new endpoints on routers/sharing.py:
+- GET  /api/agents/{name}/access-policy
+- PUT  /api/agents/{name}/access-policy
+- GET  /api/agents/{name}/access-requests
+- POST /api/agents/{name}/access-requests/{id}/decide
+
+Feature flow: docs/memory/feature-flows/unified-channel-access-control.md
+"""
+
+import pytest
+
+from utils.api_client import TrinityApiClient
+from utils.assertions import (
+    assert_status,
+    assert_status_in,
+    assert_json_response,
+    assert_has_fields,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_policy(api_client: TrinityApiClient, agent_name: str) -> None:
+    """Restore default policy (both flags off) to avoid cross-test pollution."""
+    api_client.put(
+        f"/api/agents/{agent_name}/access-policy",
+        json={"require_email": False, "open_access": False},
+    )
+
+
+def _create_pending_request(agent_name: str, email: str) -> str | None:
+    """Seed a pending access_request directly in the backend container.
+
+    The public API doesn't expose a create endpoint for access_requests —
+    they're upserted by the router gate when a verified but non-shared user
+    tries to chat. Tests that need a pre-existing request seed one via a
+    small docker exec roundtrip. Returns the new request id, or None when
+    seeding isn't possible (pytest will skip dependent tests).
+    """
+    try:
+        import subprocess
+
+        cmd = [
+            "docker",
+            "exec",
+            "trinity-backend",
+            "python",
+            "-c",
+            (
+                "from database import db; "
+                f"r = db.upsert_access_request({agent_name!r}, {email!r}, 'telegram'); "
+                "print('RID=' + r['id'])"
+            ),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.startswith("RID="):
+                return line[4:]
+        return None
+    except Exception:
+        return None
+
+
+def _cleanup_request(agent_name: str, email: str) -> None:
+    """Best-effort cleanup: remove share + access_request row."""
+    try:
+        import subprocess
+
+        subprocess.run(
+            [
+                "docker",
+                "exec",
+                "trinity-backend",
+                "python",
+                "-c",
+                (
+                    "from database import db; "
+                    f"db.unshare_agent({agent_name!r}, 'admin', {email!r}); "
+                    "from db.connection import get_db_connection\n"
+                    "with get_db_connection() as c:\n"
+                    "    cur = c.cursor()\n"
+                    f"    cur.execute('DELETE FROM access_requests WHERE agent_name=? AND email=?', ({agent_name!r}, {email!r}))\n"
+                    "    c.commit()"
+                ),
+            ],
+            capture_output=True,
+            timeout=15,
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# GET /access-policy
+# ---------------------------------------------------------------------------
+
+
+class TestGetAccessPolicy:
+    """GET /api/agents/{name}/access-policy (#311)."""
+
+    @pytest.mark.smoke
+    def test_get_policy_requires_auth(
+        self,
+        unauthenticated_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = unauthenticated_client.get(
+            f"/api/agents/{created_agent['name']}/access-policy"
+        )
+        assert_status_in(response, [401, 403])
+
+    @pytest.mark.smoke
+    def test_get_policy_returns_shape(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = api_client.get(
+            f"/api/agents/{created_agent['name']}/access-policy"
+        )
+        assert_status(response, 200)
+        data = assert_json_response(response)
+        assert_has_fields(data, ["require_email", "open_access"])
+        assert isinstance(data["require_email"], bool)
+        assert isinstance(data["open_access"], bool)
+
+    @pytest.mark.smoke
+    def test_get_policy_default_values(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """New agents default to both flags off (legacy permissive behavior)."""
+        _reset_policy(api_client, created_agent["name"])
+        response = api_client.get(
+            f"/api/agents/{created_agent['name']}/access-policy"
+        )
+        assert_status(response, 200)
+        data = response.json()
+        assert data["require_email"] is False
+        assert data["open_access"] is False
+
+    @pytest.mark.smoke
+    def test_get_policy_nonexistent_agent_returns_404(
+        self,
+        api_client: TrinityApiClient,
+    ):
+        response = api_client.get(
+            "/api/agents/does-not-exist-xyz/access-policy"
+        )
+        assert_status_in(response, [403, 404])
+
+
+# ---------------------------------------------------------------------------
+# PUT /access-policy
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAccessPolicy:
+    """PUT /api/agents/{name}/access-policy (#311)."""
+
+    @pytest.mark.smoke
+    def test_put_policy_requires_auth(
+        self,
+        unauthenticated_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = unauthenticated_client.put(
+            f"/api/agents/{created_agent['name']}/access-policy",
+            json={"require_email": True, "open_access": False},
+        )
+        assert_status_in(response, [401, 403])
+
+    @pytest.mark.smoke
+    def test_put_policy_enables_require_email(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        agent_name = created_agent["name"]
+        try:
+            response = api_client.put(
+                f"/api/agents/{agent_name}/access-policy",
+                json={"require_email": True, "open_access": False},
+            )
+            assert_status(response, 200)
+            data = response.json()
+            assert data["require_email"] is True
+            assert data["open_access"] is False
+
+            # Verify persisted via GET
+            get_response = api_client.get(
+                f"/api/agents/{agent_name}/access-policy"
+            )
+            assert get_response.json()["require_email"] is True
+        finally:
+            _reset_policy(api_client, agent_name)
+
+    @pytest.mark.smoke
+    def test_put_policy_enables_open_access(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        agent_name = created_agent["name"]
+        try:
+            response = api_client.put(
+                f"/api/agents/{agent_name}/access-policy",
+                json={"require_email": False, "open_access": True},
+            )
+            assert_status(response, 200)
+            data = response.json()
+            assert data["open_access"] is True
+            assert data["require_email"] is False
+        finally:
+            _reset_policy(api_client, agent_name)
+
+    @pytest.mark.smoke
+    def test_put_policy_both_flags(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        agent_name = created_agent["name"]
+        try:
+            response = api_client.put(
+                f"/api/agents/{agent_name}/access-policy",
+                json={"require_email": True, "open_access": True},
+            )
+            assert_status(response, 200)
+            data = response.json()
+            assert data["require_email"] is True
+            assert data["open_access"] is True
+        finally:
+            _reset_policy(api_client, agent_name)
+
+    @pytest.mark.smoke
+    def test_put_policy_validates_required_fields(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """Both fields are required by the Pydantic model."""
+        response = api_client.put(
+            f"/api/agents/{created_agent['name']}/access-policy",
+            json={"require_email": True},
+        )
+        assert_status_in(response, [400, 422])
+
+    @pytest.mark.smoke
+    def test_put_policy_rejects_non_boolean(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = api_client.put(
+            f"/api/agents/{created_agent['name']}/access-policy",
+            json={"require_email": "yes please", "open_access": False},
+        )
+        assert_status_in(response, [400, 422])
+
+    @pytest.mark.smoke
+    def test_put_policy_nonexistent_agent_returns_404(
+        self,
+        api_client: TrinityApiClient,
+    ):
+        response = api_client.put(
+            "/api/agents/does-not-exist-xyz/access-policy",
+            json={"require_email": False, "open_access": False},
+        )
+        assert_status_in(response, [403, 404])
+
+
+# ---------------------------------------------------------------------------
+# GET /access-requests
+# ---------------------------------------------------------------------------
+
+
+class TestListAccessRequests:
+    """GET /api/agents/{name}/access-requests (#311)."""
+
+    @pytest.mark.smoke
+    def test_list_requires_auth(
+        self,
+        unauthenticated_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = unauthenticated_client.get(
+            f"/api/agents/{created_agent['name']}/access-requests"
+        )
+        assert_status_in(response, [401, 403])
+
+    @pytest.mark.smoke
+    def test_list_returns_array(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = api_client.get(
+            f"/api/agents/{created_agent['name']}/access-requests"
+        )
+        assert_status(response, 200)
+        data = assert_json_response(response)
+        assert isinstance(data, list)
+
+    @pytest.mark.smoke
+    def test_list_accepts_status_filter(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        for status in ("pending", "approved", "denied"):
+            response = api_client.get(
+                f"/api/agents/{created_agent['name']}/access-requests",
+                params={"status": status},
+            )
+            assert_status(response, 200)
+            assert isinstance(response.json(), list)
+
+    @pytest.mark.smoke
+    def test_list_nonexistent_agent_returns_404(
+        self,
+        api_client: TrinityApiClient,
+    ):
+        response = api_client.get(
+            "/api/agents/does-not-exist-xyz/access-requests"
+        )
+        assert_status_in(response, [403, 404])
+
+    @pytest.mark.smoke
+    def test_list_contains_seeded_request(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """A seeded pending request shows up in the listing."""
+        agent_name = created_agent["name"]
+        email = f"test-seeded-{agent_name[:10]}@example.com"
+
+        request_id = _create_pending_request(agent_name, email)
+        if not request_id:
+            pytest.skip("Cannot seed access_request (docker exec unavailable)")
+
+        try:
+            response = api_client.get(
+                f"/api/agents/{agent_name}/access-requests",
+                params={"status": "pending"},
+            )
+            assert_status(response, 200)
+            ids = [r["id"] for r in response.json()]
+            assert request_id in ids, f"Seeded id missing from list: {ids}"
+        finally:
+            _cleanup_request(agent_name, email)
+
+
+# ---------------------------------------------------------------------------
+# POST /access-requests/{id}/decide
+# ---------------------------------------------------------------------------
+
+
+class TestDecideAccessRequest:
+    """POST /api/agents/{name}/access-requests/{id}/decide (#311)."""
+
+    @pytest.mark.smoke
+    def test_decide_requires_auth(
+        self,
+        unauthenticated_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = unauthenticated_client.post(
+            f"/api/agents/{created_agent['name']}/access-requests/nonexistent/decide",
+            json={"approve": True},
+        )
+        assert_status_in(response, [401, 403])
+
+    @pytest.mark.smoke
+    def test_decide_nonexistent_request_returns_404(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = api_client.post(
+            f"/api/agents/{created_agent['name']}/access-requests/does-not-exist/decide",
+            json={"approve": True},
+        )
+        assert_status(response, 404)
+
+    @pytest.mark.smoke
+    def test_decide_validates_payload(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        response = api_client.post(
+            f"/api/agents/{created_agent['name']}/access-requests/anything/decide",
+            json={},
+        )
+        assert_status_in(response, [400, 422])
+
+    @pytest.mark.smoke
+    def test_approve_inserts_share_and_marks_approved(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """Approve adds email to agent_sharing and sets status=approved."""
+        agent_name = created_agent["name"]
+        email = f"test-approve-{agent_name[:10]}@example.com"
+
+        request_id = _create_pending_request(agent_name, email)
+        if not request_id:
+            pytest.skip("Cannot seed access_request (docker exec unavailable)")
+
+        try:
+            decide_resp = api_client.post(
+                f"/api/agents/{agent_name}/access-requests/{request_id}/decide",
+                json={"approve": True},
+            )
+            assert_status(decide_resp, 200)
+            decided = decide_resp.json()
+            assert decided["status"] == "approved"
+            assert decided["email"] == email
+
+            # Email should now be in the agent's shares
+            shares_resp = api_client.get(f"/api/agents/{agent_name}/shares")
+            assert_status(shares_resp, 200)
+            shares = shares_resp.json()
+            shares = shares if isinstance(shares, list) else shares.get("shares", [])
+            emails = [
+                s.get("shared_with_email") or s.get("email")
+                for s in shares
+            ]
+            assert email in emails, f"Email missing from shares: {emails}"
+        finally:
+            api_client.delete(f"/api/agents/{agent_name}/share/{email}")
+            _cleanup_request(agent_name, email)
+
+    @pytest.mark.smoke
+    def test_deny_marks_denied_without_sharing(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """Deny sets status=denied and does NOT insert into agent_sharing."""
+        agent_name = created_agent["name"]
+        email = f"test-deny-{agent_name[:10]}@example.com"
+
+        request_id = _create_pending_request(agent_name, email)
+        if not request_id:
+            pytest.skip("Cannot seed access_request (docker exec unavailable)")
+
+        try:
+            decide_resp = api_client.post(
+                f"/api/agents/{agent_name}/access-requests/{request_id}/decide",
+                json={"approve": False},
+            )
+            assert_status(decide_resp, 200)
+            assert decide_resp.json()["status"] == "denied"
+
+            shares_resp = api_client.get(f"/api/agents/{agent_name}/shares")
+            shares = shares_resp.json()
+            shares = shares if isinstance(shares, list) else shares.get("shares", [])
+            emails = [
+                s.get("shared_with_email") or s.get("email")
+                for s in shares
+            ]
+            assert email not in emails, \
+                f"Denied email unexpectedly in shares: {emails}"
+        finally:
+            _cleanup_request(agent_name, email)


### PR DESCRIPTION
## Summary

Implements the unified cross-channel access control primitive from #311: **one verified email, one allow-list, one gate**. Each adapter translates its native identifier into a verified email; everything downstream (sharing, access requests, per-user memory) keys off that single identity.

- Schema: `require_email` / `open_access` on `agent_ownership` (via `AccessPolicyMixin`), `verified_email` / `verified_at` on `telegram_chat_links`, new `access_requests` table.
- Adapters: `ChannelAdapter.resolve_verified_email` + `prompt_auth`; Telegram `/login` state machine (reuses `email_login_codes`); Slack via `users.info`.
- Router: single gate in `message_router` that checks owner/admin/`agent_sharing`, falls through to `open_access`, or upserts a pending access request. Group chats bypass; unpoliced agents retain legacy permissive behavior.
- Routes: `GET`/`PUT /api/agents/{name}/access-policy`, `GET /api/agents/{name}/access-requests`, `POST /api/agents/{name}/access-requests/{id}/decide` (approve inserts into `agent_sharing` + whitelists email).
- UI: `SharingPanel.vue` gains policy toggles and a pending-requests inbox.
- Docs: new canonical flow `docs/memory/feature-flows/unified-channel-access-control.md` + updates to `agent-sharing`, `telegram-integration`, `slack-integration` flows.

## Design notes

- `agent_sharing` becomes the cross-channel allow-list (same email admits the user on web, Telegram, and Slack).
- `public_user_memory` (MEM-001) now keys off the verified email automatically — the router uses `verified_email` as `source_user_email` when present.
- Backward compatibility: agents with both policy flags off retain the existing permissive behavior, so no live bots break on merge.
- Telegram `/login` uses the existing `email_login_codes` infrastructure (same 6-digit code table as web email auth).
- Slack has no `/login` step — the workspace OAuth token already proves identity, so `users.info` is called live (requires the `users:read.email` scope).

## Architectural invariants respected

- #2 (settings mixin): policy columns added via `AccessPolicyMixin`.
- #9 (Channel Adapter ABC): new method added to base class; adapters override.
- #8 (auth pattern): router uses `OwnedAgentByName` for owner-gated endpoints.
- ROLE-001 is untouched — end-user access control is orthogonal to platform roles.

## Test plan

- [x] 21 smoke tests in `tests/test_channel_access_control.py` — **21/21 passing** (15.6s)
- [x] Migration applied cleanly on running stack (`access_control` in `schema_migrations`)
- [x] DB roundtrip: `upsert_access_request` → `list_access_requests` → `decide_access_request(approve=True)` inserts into `agent_sharing`
- [x] `email_has_agent_access` returns True for admin, False for stranger
- [x] All four endpoints smoke-tested end-to-end against localhost backend
- [ ] Manual: Telegram `/login user@example.com` → code email → `/login 123456` → subsequent messages pass (not run — requires live bot)
- [ ] Manual: Slack DM with `require_email=True` fetches email via `users.info` (not run — requires live workspace)
- [ ] Follow-up PR: unify #252 (public-link web surface) onto this primitive

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)