### PR TITLE
fix(access): scope role on first email login to whitelist intent (#314)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -127,7 +127,7 @@ The test suite covers:
 
 ### Smoke Tests (Fast, No Agent Required)
 - **Authentication** (test_auth.py) - Login, token validation, auth modes [SMOKE]
-- **Email Authentication** (test_email_auth.py) - Email-based login, OTP codes [SMOKE]
+- **Email Authentication** (test_email_auth.py) - Email-based login, OTP codes, whitelist CRUD, `default_role` plumbing (#314) [SMOKE]
 - **Templates** (test_templates.py) - Template listing [SMOKE]
 - **MCP Keys** (test_mcp_keys.py) - API key management [SMOKE]
 - **First-Time Setup** (test_setup.py) - Setup status, admin password validation [SMOKE]
@@ -138,7 +138,7 @@ The test suite covers:
 - **Agent Lifecycle** (test_agent_lifecycle.py) - CRUD, start/stop, logs
 - **Agent Chat** (test_agent_chat.py) - Message sending, history, sessions, in-memory activity, model selection
 - **Agent Files** (test_agent_files.py) - File browser, downloads
-- **Agent Sharing** (test_agent_sharing.py) - Share/unshare agents
+- **Agent Sharing** (test_agent_sharing.py) - Share/unshare agents, whitelist auto-add with `default_role="user"` (#314)
 - **Agent Permissions** (test_agent_permissions.py) - Agent-to-agent permission CRUD, defaults, cascade delete (Req 9.10)
 - **Agent Git** (test_agent_git.py) - Git sync operations
 - **Agent Metrics** (test_agent_metrics.py) - Custom metrics endpoint (Req 9.9)
@@ -251,7 +251,18 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 
 | Test File | Description | Tests Added |
 |-----------|-------------|-------------|
+| `test_email_auth.py`, `test_agent_sharing.py` | `TestEmailWhitelistDefaultRole` + `TestShareWhitelistDefaultRole` — whitelist `default_role` plumbing; first-login role no longer hardcoded to `creator` (#314) | 5 tests (all smoke) |
 | `test_public_links.py` | `TestUnifiedAccessPolicy` class — public web chat now honors agent-level `require_email` / `open_access` (unified with Slack/Telegram, #311 follow-up) | 6 tests (all smoke) |
+
+**Whitelist default_role** (`test_email_auth.py::TestEmailWhitelistDefaultRole`, `test_agent_sharing.py::TestShareWhitelistDefaultRole`):
+
+- `test_whitelist_entry_exposes_default_role` — list response includes `default_role` field on every row
+- `test_add_whitelist_defaults_to_user_role` — POST without `default_role` lands `"user"` (safer default)
+- `test_add_whitelist_admin_can_grant_creator` — admin passing `default_role="creator"` is honored
+- `test_add_whitelist_rejects_invalid_role` — unknown role returns 4xx, row is not persisted
+- `test_share_adds_whitelist_entry_with_user_role` — `POST /api/agents/{name}/share` auto-whitelists the recipient with `default_role="user"` (prevents silent promotion to `creator`)
+
+
 
 **Unified public-chat access policy** (`test_public_links.py::TestUnifiedAccessPolicy`):
 

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1256,7 +1256,8 @@ Users authenticate to the Trinity web UI and API.
 
 - Email whitelist controls who can login via email
 - Admin login always available for 'admin' user
-- **4-tier role hierarchy** (ROLE-001): `user` < `operator` < `creator` < `admin`. New email users default to `creator`. Agent creation requires `creator` or above. Enforced via `require_role()` dependency factory in `dependencies.py`.
+- **4-tier role hierarchy** (ROLE-001): `user` < `operator` < `creator` < `admin`. Agent creation requires `creator` or above. Enforced via `require_role()` dependency factory in `dependencies.py`.
+- **Whitelist-driven role on first login** (#314): New email users inherit the `default_role` recorded on their `email_whitelist` row (fallback `user` if no row or NULL). Callsites pass explicit intent — `/share` and access-request approvals → `user` (chat-only grant); public `/api/access/request` self-signup → `user`; admin whitelist UI → caller-specified, defaults to `user`. Owners promote collaborators to `creator` explicitly via `PUT /api/users/{username}/role`. This closes a privilege-escalation where any access grant silently promoted the recipient to `creator` on first web login.
 
 ### 2. MCP API Keys (User → MCP Server)
 

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-13 | #314 | Whitelist-driven role on first email login — fixes silent promotion to `creator` for cross-channel access grants | [email-authentication.md](feature-flows/email-authentication.md), [agent-sharing.md](feature-flows/agent-sharing.md), [cli-tool.md](feature-flows/cli-tool.md) |
 | 2026-04-12 | #311 | Unified cross-channel access control — verified email as identity, per-agent policy, access requests | [unified-channel-access-control.md](feature-flows/unified-channel-access-control.md) |
 | 2026-04-12 | #309 | Telegram webhook back-fill when `public_chat_url` is saved (self-healing config order) | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-11 | #297 | Telegram group chat support — @mention triggers, welcome messages, per-group config | [telegram-integration.md](feature-flows/telegram-integration.md) |

--- a/docs/memory/feature-flows/agent-sharing.md
+++ b/docs/memory/feature-flows/agent-sharing.md
@@ -200,7 +200,7 @@ async def share_agent_endpoint(
     email_auth_setting = db.get_setting_value("email_auth_enabled", str(EMAIL_AUTH_ENABLED).lower())
     if email_auth_setting.lower() == "true":
         try:
-            db.add_to_whitelist(share_request.email, current_user.username, source="agent_sharing")
+            db.add_to_whitelist(share_request.email, current_user.username, source="agent_sharing", default_role="user")  # #314: chat-only grant
         except Exception:
             pass  # Already whitelisted or error - continue anyway
 
@@ -386,7 +386,7 @@ When email auth is enabled, shared emails are automatically added to the whiteli
 ```python
 if email_auth_setting.lower() == "true":
     try:
-        db.add_to_whitelist(share_request.email, current_user.username, source="agent_sharing")
+        db.add_to_whitelist(share_request.email, current_user.username, source="agent_sharing", default_role="user")  # #314: chat-only grant
     except Exception:
         pass  # Already whitelisted or error - continue anyway
 ```

--- a/docs/memory/feature-flows/cli-tool.md
+++ b/docs/memory/feature-flows/cli-tool.md
@@ -117,7 +117,7 @@ Request:  {"email": "user@example.com"}
 Response: {"success": true, "message": "Access granted", "already_registered": false}
 ```
 
-- Auto-adds email to whitelist via `db.add_to_whitelist(email, added_by="admin", source="cli")`
+- Auto-adds email to whitelist via `db.add_to_whitelist(email, added_by="admin", source="cli", default_role="user")` — #314 defaults public self-signup to `user`; owners promote via `PUT /api/users/{username}/role`.
 - Idempotent: returns `already_registered: true` if exists
 - Rate limited: reuses `check_login_rate_limit(client_ip)` — 5 req / 10 min per IP
 - Requires: setup completed, email auth enabled

--- a/docs/memory/feature-flows/email-authentication.md
+++ b/docs/memory/feature-flows/email-authentication.md
@@ -483,9 +483,10 @@ async function removeEmailFromWhitelist(email) {
 CREATE TABLE IF NOT EXISTS email_whitelist (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     email TEXT UNIQUE NOT NULL,
-    added_by TEXT NOT NULL,          -- User ID who added this email
-    added_at TEXT NOT NULL,          -- ISO timestamp
-    source TEXT NOT NULL,            -- "manual" or "agent_sharing"
+    added_by TEXT NOT NULL,                           -- User ID who added this email
+    added_at TEXT NOT NULL,                           -- ISO timestamp
+    source TEXT NOT NULL,                             -- "manual" | "agent_sharing" | "access_request" | "cli"
+    default_role TEXT NOT NULL DEFAULT 'user',        -- Role assigned on first email login (#314)
     FOREIGN KEY (added_by) REFERENCES users(id)
 )
 ```
@@ -517,7 +518,8 @@ CREATE INDEX idx_email_login_codes_code ON email_login_codes(code)
 | Method | Line | Purpose |
 |--------|------|---------|
 | `is_email_whitelisted(email)` | 27-35 | Check if email is in whitelist |
-| `add_to_whitelist(email, added_by, source)` | 37-67 | Add email to whitelist |
+| `add_to_whitelist(email, added_by, source, *, default_role)` | 37-90 | Add email to whitelist (default_role is a required kwarg, #314) |
+| `get_whitelist_default_role(email)` | 92-103 | Read default_role for a whitelisted email |
 | `remove_from_whitelist(email)` | 69-83 | Remove email from whitelist |
 | `list_whitelist(limit)` | 85-104 | Get all whitelisted emails with metadata |
 | `create_login_code(email, expiry_minutes)` | 110-145 | Generate 6-digit code with 10 min expiry |
@@ -700,8 +702,9 @@ Add email to whitelist.
 **Business Logic:**
 1. Parse request and lowercase email (lines 460-463)
 2. Add to whitelist (lines 466-467)
-   - `db.add_to_whitelist(email, current_user.username, source)`
-   - Returns `False` if already exists
+   - `db.add_to_whitelist(email, current_user.username, source, default_role=add_request.default_role)`
+   - `default_role` is a required keyword-only kwarg (defaults to `"user"` on the Pydantic request model); see #314.
+   - Returns `False` if already exists; raises `ValueError` if `default_role` is unknown.
 3. If duplicate: return 409 Conflict (lines 469-472)
 4. Return success (line 475)
 
@@ -738,7 +741,8 @@ if email_auth_setting.lower() == "true":
         db.add_to_whitelist(
             share_request.email,
             current_user.username,
-            source="agent_sharing"
+            source="agent_sharing",
+            default_role="user",  # chat-only grant — #314
         )
     except Exception:
         # Already whitelisted or error - continue anyway

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -915,8 +915,13 @@ class DatabaseManager:
     def is_email_whitelisted(self, email: str):
         return self._email_auth_ops.is_email_whitelisted(email)
 
-    def add_to_whitelist(self, email: str, added_by: str, source: str = "manual"):
-        return self._email_auth_ops.add_to_whitelist(email, added_by, source)
+    def add_to_whitelist(self, email: str, added_by: str, source: str, *, default_role: str):
+        return self._email_auth_ops.add_to_whitelist(
+            email, added_by, source, default_role=default_role
+        )
+
+    def get_whitelist_default_role(self, email: str):
+        return self._email_auth_ops.get_whitelist_default_role(email)
 
     def remove_from_whitelist(self, email: str):
         return self._email_auth_ops.remove_from_whitelist(email)

--- a/src/backend/db/email_auth.py
+++ b/src/backend/db/email_auth.py
@@ -12,6 +12,11 @@ from datetime import datetime, timedelta
 from typing import Optional, List
 from db.connection import get_db_connection
 
+# Valid role values for new users. Kept local to avoid a circular import with
+# dependencies.py (which imports from database, which imports from this module).
+# Must stay in sync with dependencies.ROLE_HIERARCHY.
+_VALID_DEFAULT_ROLES = {"user", "operator", "creator", "admin"}
+
 
 class EmailAuthOperations:
     """Handles email-based authentication operations."""
@@ -34,18 +39,36 @@ class EmailAuthOperations:
             )
             return cursor.fetchone() is not None
 
-    def add_to_whitelist(self, email: str, added_by: str, source: str = "manual") -> bool:
+    def add_to_whitelist(
+        self,
+        email: str,
+        added_by: str,
+        source: str,
+        *,
+        default_role: str,
+    ) -> bool:
         """
         Add an email to the whitelist.
 
         Args:
             email: Email address to whitelist
             added_by: Username of user adding this email
-            source: Source of addition (manual, agent_sharing, etc.)
+            source: Source of addition (manual, agent_sharing, access_request, cli)
+            default_role: Role assigned on first email login. Required keyword-only
+                so every callsite makes the role decision deliberately (#314).
 
         Returns:
             True if added, False if already exists
+
+        Raises:
+            ValueError: If default_role is not a recognized role.
         """
+        if default_role not in _VALID_DEFAULT_ROLES:
+            raise ValueError(
+                f"Invalid default_role: {default_role!r}. "
+                f"Must be one of {sorted(_VALID_DEFAULT_ROLES)}"
+            )
+
         with get_db_connection() as conn:
             cursor = conn.cursor()
 
@@ -59,12 +82,25 @@ class EmailAuthOperations:
                 raise ValueError(f"User not found: {added_by}")
 
             cursor.execute("""
-                INSERT INTO email_whitelist (email, added_by, added_at, source)
-                VALUES (?, ?, ?, ?)
-            """, (email.lower(), user["id"], datetime.utcnow().isoformat(), source))
+                INSERT INTO email_whitelist (email, added_by, added_at, source, default_role)
+                VALUES (?, ?, ?, ?, ?)
+            """, (email.lower(), user["id"], datetime.utcnow().isoformat(), source, default_role))
 
             conn.commit()
             return True
+
+    def get_whitelist_default_role(self, email: str) -> Optional[str]:
+        """Return the default_role for a whitelisted email, or None if not found."""
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT default_role FROM email_whitelist WHERE LOWER(email) = ?",
+                (email.lower(),),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+            return row["default_role"] if row["default_role"] else None
 
     def remove_from_whitelist(self, email: str) -> bool:
         """
@@ -93,7 +129,8 @@ class EmailAuthOperations:
                     w.added_by,
                     u.username as added_by_username,
                     w.added_at,
-                    w.source
+                    w.source,
+                    w.default_role
                 FROM email_whitelist w
                 LEFT JOIN users u ON w.added_by = u.id
                 ORDER BY w.added_at DESC
@@ -228,11 +265,21 @@ class EmailAuthOperations:
         Get or create a user account for email authentication.
 
         Email becomes the username. No password is set (email auth only).
+
+        New users inherit the role recorded on their whitelist row, falling
+        back to "user" when no whitelist entry exists (safer default — see
+        #314). Previously this hardcoded "creator", which silently promoted
+        anyone whitelisted via access grants to full agent-creation rights.
         """
         # Try to get existing user by email
         user = self._user_ops.get_user_by_email(email)
         if user:
             return user
+
+        # Resolve intended role from whitelist row; "user" if no row or NULL.
+        role = self.get_whitelist_default_role(email) or "user"
+        if role not in _VALID_DEFAULT_ROLES:
+            role = "user"
 
         # Create new user
         now = datetime.utcnow().isoformat()
@@ -245,7 +292,7 @@ class EmailAuthOperations:
             cursor.execute("""
                 INSERT INTO users (username, email, role, created_at, updated_at)
                 VALUES (?, ?, ?, ?, ?)
-            """, (username, email.lower(), "creator", now, now))
+            """, (username, email.lower(), role, now, now))
 
             conn.commit()
 

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -1073,6 +1073,30 @@ def _migrate_public_link_require_email_unified(cursor, conn):
     conn.commit()
 
 
+def _migrate_email_whitelist_default_role(cursor, conn):
+    """Add default_role column to email_whitelist (#314).
+
+    Before: `get_or_create_email_user()` hardcoded new email users to role
+    `creator`, so anyone whitelisted via access-request approval, /share, or
+    the public CLI self-signup endpoint silently gained agent-creation rights.
+
+    After: whitelist rows carry the intended role. Access-based grants default
+    to `user`; only admin-initiated whitelisting can request `creator`. This
+    migration sets existing rows to `'user'` — a deliberate downgrade of the
+    buggy default going forward. It does NOT touch `users.role`, so users who
+    have already logged in and been promoted keep their current role.
+    """
+    cursor.execute("PRAGMA table_info(email_whitelist)")
+    columns = {row[1] for row in cursor.fetchall()}
+
+    if "default_role" not in columns:
+        cursor.execute(
+            "ALTER TABLE email_whitelist ADD COLUMN default_role TEXT NOT NULL DEFAULT 'user'"
+        )
+
+    conn.commit()
+
+
 def _migrate_telegram_group_configs(cursor, conn):
     """Create Telegram group configuration table (TGRAM-GROUP)."""
 
@@ -1146,4 +1170,5 @@ MIGRATIONS = [
     ("telegram_group_configs", _migrate_telegram_group_configs),
     ("access_control", _migrate_access_control),
     ("public_link_require_email_unified", _migrate_public_link_require_email_unified),
+    ("email_whitelist_default_role", _migrate_email_whitelist_default_role),
 ]

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -113,6 +113,7 @@ TABLES = {
             added_by TEXT NOT NULL,
             added_at TEXT NOT NULL,
             source TEXT NOT NULL,
+            default_role TEXT NOT NULL DEFAULT 'user',
             FOREIGN KEY (added_by) REFERENCES users(id)
         )
     """,

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -446,13 +446,15 @@ class EmailWhitelistEntry(BaseModel):
     added_by: str  # User ID
     added_by_username: Optional[str] = None
     added_at: datetime
-    source: str  # "manual", "agent_sharing"
+    source: str  # "manual", "agent_sharing", "access_request", "cli"
+    default_role: str = "user"  # Role assigned on first email login (#314)
 
 
 class EmailWhitelistAdd(BaseModel):
     """Request to add an email to the whitelist."""
     email: str
     source: str = "manual"
+    default_role: str = "user"  # Role assigned on first email login (#314)
 
 
 class EmailLoginRequest(BaseModel):

--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -481,7 +481,10 @@ async def request_access(request: Request):
         return {"success": True, "message": "Access granted", "already_registered": True}
 
     try:
-        db.add_to_whitelist(email, added_by="admin", source="cli")
+        # Public self-signup — default to `user`. Owners who want a collaborator
+        # to create agents can promote them via `PUT /api/users/{username}/role`.
+        # Granting `creator` here would recreate the bug fixed in #314.
+        db.add_to_whitelist(email, added_by="admin", source="cli", default_role="user")
     except Exception as e:
         logger.error(f"Failed to add {email} to whitelist: {e}")
         record_login_attempt(client_ip, success=False)

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -787,7 +787,12 @@ async def add_email_to_whitelist(
 
     # Add to whitelist
     try:
-        added = db.add_to_whitelist(email, current_user.username, source=add_request.source)
+        added = db.add_to_whitelist(
+            email,
+            current_user.username,
+            source=add_request.source,
+            default_role=add_request.default_role,
+        )
 
         if not added:
             raise HTTPException(

--- a/src/backend/routers/sharing.py
+++ b/src/backend/routers/sharing.py
@@ -79,7 +79,8 @@ async def share_agent_endpoint(
             db.add_to_whitelist(
                 share_request.email,
                 current_user.username,
-                source="agent_sharing"
+                source="agent_sharing",
+                default_role="user",  # chat-only grant; don't promote to creator (#314)
             )
         except Exception:
             # Already whitelisted or error - continue anyway
@@ -208,6 +209,7 @@ async def decide_access_request_endpoint(
                     existing["email"],
                     current_user.username,
                     source="access_request",
+                    default_role="user",  # chat-only grant; don't promote to creator (#314)
                 )
             except Exception:
                 pass

--- a/tests/test_agent_sharing.py
+++ b/tests/test_agent_sharing.py
@@ -160,3 +160,53 @@ class TestUnshareAgent:
 
         # May return 404 or 400
         assert_status_in(response, [200, 204, 400, 404])
+
+
+class TestShareWhitelistDefaultRole:
+    """#314: sharing an agent auto-whitelists the recipient with default_role='user'.
+
+    Prevents the privilege escalation where /share silently promoted the
+    recipient to `creator` on their first Trinity web login.
+    """
+
+    def test_share_adds_whitelist_entry_with_user_role(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """POST /api/agents/{name}/share creates a whitelist entry with default_role='user'."""
+        # Requires admin to inspect whitelist
+        list_response = api_client.get("/api/settings/email-whitelist")
+        if list_response.status_code == 403:
+            pytest.skip("User is not admin - cannot inspect whitelist")
+
+        # Requires email auth enabled (whitelist insert is gated on that flag)
+        auth_mode = api_client.get("/api/auth/mode").json()
+        if not auth_mode.get("email_auth_enabled"):
+            pytest.skip("Email auth not enabled — /share does not whitelist")
+
+        share_email = "test-share-default-role@example.com"
+        # Clean slate
+        api_client.delete(f"/api/agents/{created_agent['name']}/share/{share_email}")
+        api_client.delete(f"/api/settings/email-whitelist/{share_email}")
+
+        try:
+            share_response = api_client.post(
+                f"/api/agents/{created_agent['name']}/share",
+                json={"email": share_email},
+            )
+            if share_response.status_code not in [200, 201]:
+                pytest.skip(f"Share call failed: {share_response.status_code}")
+
+            whitelist = api_client.get("/api/settings/email-whitelist").json()["whitelist"]
+            entry = next((e for e in whitelist if e["email"] == share_email), None)
+            assert entry is not None, (
+                f"Expected {share_email} in whitelist after /share"
+            )
+            assert entry["default_role"] == "user", (
+                f"Expected default_role='user' for share recipient, "
+                f"got {entry['default_role']} — this recreates the #314 bug"
+            )
+        finally:
+            api_client.delete(f"/api/agents/{created_agent['name']}/share/{share_email}")
+            api_client.delete(f"/api/settings/email-whitelist/{share_email}")

--- a/tests/test_email_auth.py
+++ b/tests/test_email_auth.py
@@ -370,6 +370,125 @@ class TestEmailWhitelistCRUD:
             api_client.delete(f"/api/settings/email-whitelist/{test_email}")
 
 
+class TestEmailWhitelistDefaultRole:
+    """Tests for #314: whitelist rows carry a `default_role` that drives
+    the role assigned on first email login.
+
+    Critical invariants:
+    - Whitelist entries have a `default_role` field (defaults to `"user"`).
+    - Admin can override by passing `default_role` in POST body.
+    - Invalid role values are rejected.
+    - Public self-signup via `/api/access/request` defaults to `"user"`
+      (prevents privilege escalation).
+    """
+
+    def test_whitelist_entry_exposes_default_role(self, api_client: TrinityApiClient):
+        """Entries listed via GET /api/settings/email-whitelist include default_role."""
+        list_response = api_client.get("/api/settings/email-whitelist")
+        if list_response.status_code == 403:
+            pytest.skip("User is not admin - cannot inspect whitelist")
+
+        assert_status(list_response, 200)
+        whitelist = list_response.json()["whitelist"]
+
+        if not whitelist:
+            pytest.skip("Whitelist is empty; nothing to inspect")
+
+        for entry in whitelist:
+            assert "default_role" in entry, (
+                f"entry missing default_role: {entry}"
+            )
+            assert entry["default_role"] in {"user", "operator", "creator", "admin"}
+
+    def test_add_whitelist_defaults_to_user_role(self, api_client: TrinityApiClient):
+        """POST with no default_role assigns 'user' (safer default, #314)."""
+        test_email = "test-default-role-user@example.com"
+
+        list_response = api_client.get("/api/settings/email-whitelist")
+        if list_response.status_code == 403:
+            pytest.skip("User is not admin")
+
+        try:
+            # Ensure clean slate
+            api_client.delete(f"/api/settings/email-whitelist/{test_email}")
+
+            response = api_client.post(
+                "/api/settings/email-whitelist",
+                json={"email": test_email, "source": "manual"},
+            )
+            assert_status(response, 200)
+
+            listed = api_client.get("/api/settings/email-whitelist").json()["whitelist"]
+            entry = next((e for e in listed if e["email"] == test_email), None)
+            assert entry is not None, "Added email not found in list"
+            assert entry["default_role"] == "user"
+        finally:
+            api_client.delete(f"/api/settings/email-whitelist/{test_email}")
+
+    def test_add_whitelist_admin_can_grant_creator(self, api_client: TrinityApiClient):
+        """Admin explicitly whitelisting with default_role='creator' is honored."""
+        test_email = "test-default-role-creator@example.com"
+
+        list_response = api_client.get("/api/settings/email-whitelist")
+        if list_response.status_code == 403:
+            pytest.skip("User is not admin")
+
+        try:
+            api_client.delete(f"/api/settings/email-whitelist/{test_email}")
+
+            response = api_client.post(
+                "/api/settings/email-whitelist",
+                json={
+                    "email": test_email,
+                    "source": "manual",
+                    "default_role": "creator",
+                },
+            )
+            assert_status(response, 200)
+
+            listed = api_client.get("/api/settings/email-whitelist").json()["whitelist"]
+            entry = next((e for e in listed if e["email"] == test_email), None)
+            assert entry is not None
+            assert entry["default_role"] == "creator"
+        finally:
+            api_client.delete(f"/api/settings/email-whitelist/{test_email}")
+
+    def test_add_whitelist_rejects_invalid_role(self, api_client: TrinityApiClient):
+        """POST with an unknown default_role is rejected (400-class error)."""
+        test_email = "test-default-role-invalid@example.com"
+
+        list_response = api_client.get("/api/settings/email-whitelist")
+        if list_response.status_code == 403:
+            pytest.skip("User is not admin")
+
+        try:
+            api_client.delete(f"/api/settings/email-whitelist/{test_email}")
+
+            response = api_client.post(
+                "/api/settings/email-whitelist",
+                json={
+                    "email": test_email,
+                    "source": "manual",
+                    "default_role": "superuser",
+                },
+            )
+            # Service raises ValueError → router translates to 400; FastAPI may
+            # also surface it as 422 or 500 depending on handler. All non-2xx
+            # is acceptable — we just must not silently accept the row.
+            assert response.status_code >= 400, (
+                f"Expected rejection of invalid role, got {response.status_code}: "
+                f"{response.text}"
+            )
+
+            # Belt-and-suspenders: confirm nothing landed in the whitelist.
+            listed = api_client.get("/api/settings/email-whitelist").json()["whitelist"]
+            assert not any(e["email"] == test_email for e in listed), (
+                "Invalid role should not have been persisted"
+            )
+        finally:
+            api_client.delete(f"/api/settings/email-whitelist/{test_email}")
+
+
 class TestEmailAuthDisabled:
     """Tests for behavior when email auth is disabled."""
 


### PR DESCRIPTION
## Summary

Closes the privilege-escalation where anyone whitelisted via `/share`, access-request approval, or the public `/api/access/request` endpoint was silently promoted to `creator` on their first Trinity web login — letting them spin up their own agents on the platform.

- Add `default_role` column to `email_whitelist` (migration #40); `get_or_create_email_user()` reads it on first login instead of hardcoding `"creator"`, with `"user"` as the safer fallback.
- `add_to_whitelist()` now requires an explicit `default_role` kwarg — new callsites must make the role decision deliberately.
- Access-based grants (`/share`, access-request approval, public `/api/access/request`) pass `default_role="user"`. Admin whitelist UI passes through caller-specified, defaulting to `"user"`.

## Deviation from issue

The issue proposed `default_role="creator"` for `/api/access/request` (source="cli"). That endpoint is unauthenticated and rate-limited by IP — granting `creator` there would recreate the exact bug being fixed. This PR uses `"user"` and documents that owners promote via `PUT /api/users/{username}/role`.

## Test plan

- [x] New tests pass: `pytest tests/test_email_auth.py::TestEmailWhitelistDefaultRole tests/test_agent_sharing.py::TestShareWhitelistDefaultRole -v` — 5/5 pass
- [x] Related regression suite green: `pytest test_email_auth.py test_agent_sharing.py test_access_control.py test_channel_access_control.py test_cli_access_request.py` — 81/81 pass
- [x] Migration verified on live DB: `default_role` column added, existing rows backfilled to `'user'`, `schema_migrations` row recorded
- [x] Invalid role values rejected at service layer (`ValueError` → 400)
- [x] `docs/memory/architecture.md` role hierarchy section updated; feature flow docs (`email-authentication.md`, `agent-sharing.md`, `cli-tool.md`) reflect new signature

## Out of scope (follow-ups)

- Admin UI for per-row `default_role` editing
- Audit endpoint to surface users auto-promoted before this fix landed (their `users.role` is unchanged — migration doesn't touch the `users` table)

Closes #314

Generated with [Claude Code](https://claude.com/claude-code)