### PR TITLE
refactor(exec): route async /task through TaskExecutionService (#95)

### DIFF
--- a/docs/memory/feature-flows/authenticated-chat-tab.md
+++ b/docs/memory/feature-flows/authenticated-chat-tab.md
@@ -173,7 +173,7 @@ When `async_mode: true` is set on the `/task` endpoint:
 
 1. Backend creates execution record, acquires capacity slot
 2. Sets execution status to `"running"` in database
-3. Spawns `_execute_task_background()` via `asyncio.create_task()`
+3. Spawns `_run_async_task_with_persistence()` via `asyncio.create_task()`
 4. Returns immediately with `{ status: "accepted", execution_id: "..." }`
 5. Background task runs headless Claude Code and updates execution record on completion
 6. Background task persists to `chat_sessions` when `save_to_session=true` (passes `user_id` + `user_email`)
@@ -184,7 +184,7 @@ When `async_mode: true` is set on the `/task` endpoint:
 if request.async_mode:
     db.update_execution_status(execution_id=execution_id, status="running")
     asyncio.create_task(
-        _execute_task_background(
+        _run_async_task_with_persistence(
             agent_name=name,
             request=request,
             execution_id=execution_id,
@@ -441,7 +441,7 @@ POST /api/agents/{name}/task (async_mode=true, save_to_session=true, chat_sessio
     |
     +---> Backend creates execution record (status: "running")
     +---> Backend acquires capacity slot (CAPACITY-001)
-    +---> Backend spawns _execute_task_background()
+    +---> Backend spawns _run_async_task_with_persistence()
     +---> Returns immediately: { status: "accepted", execution_id }
     |
     v
@@ -629,7 +629,7 @@ Tasks | Chat | Dashboard | Schedules | Credentials | Skills | ...
 ### Modified
 - `src/frontend/src/views/AgentDetail.vue` - Added Chat tab
 - `src/frontend/src/views/PublicChat.vue` - Refactored to use shared components
-- `src/backend/routers/chat.py` - `_execute_task_background` now supports `save_to_session` + `user_id`/`user_email` args; SSE stream proxy endpoint; both async and sync paths use explicit `chat_session_id` when provided
+- `src/backend/routers/chat.py` - `_run_async_task_with_persistence` now supports `save_to_session` + `user_id`/`user_email` args; SSE stream proxy endpoint; both async and sync paths use explicit `chat_session_id` when provided
 - `src/backend/models.py` - `ParallelTaskRequest.async_mode` and `chat_session_id` fields
 - `src/backend/db/chat.py` - `get_chat_messages()` uses subquery for correct ASC ordering
 
@@ -724,10 +724,10 @@ When detected (lines 147-150):
 |------|--------|
 | 2026-03-14 | **Model selector in Chat tab**. Added `ModelSelector` component (compact mode) above the chat input area in `ChatPanel.vue`. Users can now select a model (e.g., Opus, Sonnet, Haiku) before sending messages. Selection is persisted to `localStorage` (`trinity_chat_model`) and passed as the `model` parameter in the `/task` payload. Empty selection uses the agent's default model. Reuses the existing `ModelSelector.vue` component already used by Tasks and Schedules panels. |
 | 2026-03-14 | **Message timestamps**. ChatBubble now accepts optional `timestamp` prop (line 41-44) with `formattedTime` computed (line 51-59). Today's messages show time only ("3:42 PM"), older messages show date + time ("Mar 14, 3:42 PM"). ChatMessages passes `msg.timestamp` to ChatBubble (line 24). ChatPanel includes `timestamp: new Date().toISOString()` when pushing local user/assistant messages (lines 515, 570). Backend-loaded messages include `timestamp` from `msg.timestamp` in `selectSession()` (line 306). |
-| 2026-03-14 | **Bug Fix: Messages saved to wrong session**. Frontend was not passing `currentSessionId` to backend. When continuing in an existing (possibly closed) session, backend's `get_or_create_chat_session()` found a different active session or created a new one. Fix: Added `chat_session_id` field to `ParallelTaskRequest` (models.py:95). Frontend now sends `chat_session_id: currentSessionId.value` in payload (ChatPanel.vue:534). Both async (`_execute_task_background`, chat.py:462-471) and sync (chat.py:803-810) backend paths use explicit session ID via `db.get_chat_session()`, falling back to `get_or_create_chat_session()` if not found. |
+| 2026-03-14 | **Bug Fix: Messages saved to wrong session**. Frontend was not passing `currentSessionId` to backend. When continuing in an existing (possibly closed) session, backend's `get_or_create_chat_session()` found a different active session or created a new one. Fix: Added `chat_session_id` field to `ParallelTaskRequest` (models.py:95). Frontend now sends `chat_session_id: currentSessionId.value` in payload (ChatPanel.vue:534). Both async (`_run_async_task_with_persistence`, chat.py:462-471) and sync (chat.py:803-810) backend paths use explicit session ID via `db.get_chat_session()`, falling back to `get_or_create_chat_session()` if not found. |
 | 2026-03-14 | **Bug Fix: Message ordering wrong after switching sessions**. `get_chat_messages()` in `db/chat.py` returned `ORDER BY timestamp DESC` but frontend displayed messages as-is. New messages pushed locally appeared at the end, but after switching sessions and back, loaded messages were reversed. Fix: Changed SQL to subquery `SELECT * FROM (... ORDER BY timestamp DESC LIMIT ?) sub ORDER BY timestamp ASC` (db/chat.py:157-164) so the most recent N messages are returned in chronological order. |
 | 2026-03-07 | **Rate limit error styling**. Added `isRateLimitError` computed property (line 193) that detects subscription/rate limit errors by keyword matching. Error display (lines 140-143) now uses amber styling (`bg-amber-100`, `text-amber-700`) with a "Subscription Usage Limit" header for these errors, distinguishing them from red generic errors. |
-| 2026-03-03 | **THINK-001: Dynamic Thinking Status**. Refactored `sendMessage()` from synchronous POST to async mode (`async_mode=true`). Added SSE stream subscription via `fetch` + `ReadableStream` for real-time status labels. New utility `execution-status.js` maps Claude Code `stream-json` events to human-readable labels ("Reading file...", "Searching code...", etc.). Added 500ms minimum display time per label to prevent flicker. Added 10s heartbeat timeout fallback to "Working...". Added polling loop (5s intervals) for execution completion. Updated `ChatLoadingIndicator.vue` with CSS fade transition animation (`:key` binding for re-render). Backend `_execute_task_background` now accepts `user_id`/`user_email` for session persistence in async mode. |
+| 2026-03-03 | **THINK-001: Dynamic Thinking Status**. Refactored `sendMessage()` from synchronous POST to async mode (`async_mode=true`). Added SSE stream subscription via `fetch` + `ReadableStream` for real-time status labels. New utility `execution-status.js` maps Claude Code `stream-json` events to human-readable labels ("Reading file...", "Searching code...", etc.). Added 500ms minimum display time per label to prevent flicker. Added 10s heartbeat timeout fallback to "Working...". Added polling loop (5s intervals) for execution completion. Updated `ChatLoadingIndicator.vue` with CSS fade transition animation (`:key` binding for re-render). Backend `_run_async_task_with_persistence` now accepts `user_id`/`user_email` for session persistence in async mode. |
 | 2026-02-27 | **Bug Fix (CHAT-002)**: Fixed chat message ordering issue. Replaced fragile flex spacer technique (`<div class="flex-1">` pushing content down) with `min-h-full flex flex-col justify-end` pattern in `ChatMessages.vue`. This provides reliable bottom-alignment without race conditions between spacer resizing and message rendering. |
 | 2026-02-21 | **Bug Fix (EXEC-023)**: Fixed resume mode context lost after first message. Since `/task` is stateless (no `--continue`), clearing `resumeSessionIdLocal` after first message caused subsequent messages to lose context. Fix: (1) Added `resumeBannerDismissed` flag for banner-only dismissal, (2) Keep `resumeSessionIdLocal` for ALL messages, (3) `dismissResumeMode()` only hides banner (session ID persists), (4) Clear resume mode only on "New Chat" or session switch. See lines 291-296, 416-418, 625-629. |
 | 2026-02-21 | **Bug Fix (EXEC-023)**: Fixed session auto-select overriding resume mode. Added `!isResumeMode.value` condition at line 345 in `loadSessions()`. Without this fix, `onMounted` -> `loadSessions()` would select an existing session even when ChatPanel was entered via "Continue as Chat" button, breaking the resume flow. |

--- a/docs/memory/feature-flows/parallel-capacity.md
+++ b/docs/memory/feature-flows/parallel-capacity.md
@@ -60,7 +60,7 @@ The frontend displays slot usage as a vertical capacity meter bar on the Agents 
 │  │  1. Create execution record in database (chat.py:602-613)       │     │
 │  │  2. Router acquires slot directly (chat.py:644-651)             │     │
 │  │  3. If full → 429 response (chat.py:653-663)                   │     │
-│  │  4. Spawn _execute_task_background() with release_slot=True     │     │
+│  │  4. Spawn _run_async_task_with_persistence() with release_slot=True     │     │
 │  │  5. Background task releases slot in finally (chat.py:554-557)  │     │
 │  │                                                                  │     │
 │  │  PUBLIC path (public.py:315-322 → task_execution_service.py):   │     │
@@ -171,7 +171,7 @@ Task completes (success or failure)
        │   task_execution_service.py:370-375 (finally block)
        │
        └── Async path:
-           _execute_task_background() → chat.py:554-557 (finally block)
+           _run_async_task_with_persistence() → chat.py:554-557 (finally block)
        │
        v
 ┌─────────────────────────────────────────────────┐
@@ -266,7 +266,7 @@ Every 5 seconds (agents store / network store):
 | `src/backend/routers/chat.py` | 642-663 | Async mode: router acquires slot directly |
 | `src/backend/routers/chat.py` | 653-663 | Async mode: 429 response when at capacity |
 | `src/backend/routers/chat.py` | 697 | Async mode: `release_slot=True` flag |
-| `src/backend/routers/chat.py` | 370-558 | `_execute_task_background()` with slot release in finally |
+| `src/backend/routers/chat.py` | 370-558 | `_run_async_task_with_persistence()` with slot release in finally |
 | `src/backend/routers/chat.py` | 554-557 | Async mode: slot release in `finally` block |
 | `src/backend/routers/chat.py` | 714-730 | Sync mode: delegates to TaskExecutionService |
 | `src/backend/routers/chat.py` | 746-750 | Sync mode: translates "at capacity" result to 429 |
@@ -540,7 +540,7 @@ As of EXEC-024, slot acquisition/release is handled by different code paths depe
 | Execution Mode | Slot Acquire | Slot Release |
 |----------------|-------------|--------------|
 | **Sync** (authenticated `/task`) | `TaskExecutionService.execute_task()` (line 164) | `TaskExecutionService` finally block (line 372) |
-| **Async** (authenticated `/task`, `async_mode=true`) | `chat.py` router directly (line 646) | `_execute_task_background()` finally (line 557) |
+| **Async** (authenticated `/task`, `async_mode=true`) | `chat.py` router directly (line 646) | `_run_async_task_with_persistence()` finally (line 557) |
 | **Public** (`/api/public/chat/{token}`) | `TaskExecutionService.execute_task()` (line 164) | `TaskExecutionService` finally block (line 372) |
 | **Scheduled** (cron/manual via scheduler) | `TaskExecutionService.execute_task()` via `POST /api/internal/execute-task` | `TaskExecutionService` finally block (line 372) |
 

--- a/docs/memory/feature-flows/parallel-headless-execution.md
+++ b/docs/memory/feature-flows/parallel-headless-execution.md
@@ -15,12 +15,12 @@
 | 2026-03-07 | **ExecutionMetadata Error Fields**: Added `error_type` and `error_message` fields to `ExecutionMetadata` model (`models.py:91-92`). Populated during stream parsing in `claude_code.py` from two sources: `result` messages with `is_error=true` (line 304-311, classifies as `rate_limit` or `execution_error`) and `assistant` messages with `error` field (line 341-349, uses Claude Code's classification directly). Enables the platform to distinguish rate limits from other failures for better error handling (429 vs 503). |
 | 2026-03-08 | **Session ID UUID Fix**: Fixed `--session-id` validation failure. Claude Code requires `--session-id` to be a valid UUID but `execution_id` (from `secrets.token_urlsafe(16)`) is a base64url string. Changed `claude_code.py:799` to always generate `uuid.uuid4()` for `--session-id` instead of reusing `execution_id`. The `execution_id` still tracks the task internally. |
 | 2026-03-06 | **Session Isolation + Permission Validation**: Fixed bug where headless tasks could run with `permissionMode: "default"` instead of `bypassPermissions`, causing all tool calls to be silently denied. Added `--no-session-persistence` and unique `--session-id` per headless task to prevent session file collision with interactive `/api/chat` sessions. Added `permissionMode` validation on the `init` stream-json message — kills process immediately and returns HTTP 503 if bypass not active. Flags skipped when `resume_session_id` is provided (EXEC-023 needs persistence). |
-| 2026-03-04 | **EXEC-024 Service Extraction**: Sync path of `POST /api/agents/{name}/task` refactored. The ~250 lines of inline execution logic (slot acquisition, activity tracking, agent call with retry, sanitization, execution record updates, error handling, slot release) extracted into `TaskExecutionService.execute_task()` in `src/backend/services/task_execution_service.py`. Sync path in `chat.py:810-827` now delegates to the service. `agent_post_with_retry()` moved to the service module and imported back into `chat.py` for use by `/chat` and `_execute_task_background`. Async mode path unchanged (still uses `_execute_task_background` inline). |
+| 2026-03-04 | **EXEC-024 Service Extraction**: Sync path of `POST /api/agents/{name}/task` refactored. The ~250 lines of inline execution logic (slot acquisition, activity tracking, agent call with retry, sanitization, execution record updates, error handling, slot release) extracted into `TaskExecutionService.execute_task()` in `src/backend/services/task_execution_service.py`. Sync path in `chat.py:810-827` now delegates to the service. `agent_post_with_retry()` moved to the service module and imported back into `chat.py` for use by `/chat` and `_run_async_task_with_persistence`. Async mode path unchanged (still uses `_run_async_task_with_persistence` inline). |
 | 2026-03-02 | **MODEL-001 Model Selection**: `model_used` field now recorded on every execution record via `db.create_task_execution(model_used=request.model)`. Backend `chat.py` passes model to execution record. TasksPanel sends `model` in POST body. See [model-selection.md](model-selection.md). |
 | 2026-02-17 | **Added PUB-003 use case**: Public Chat Agent Introduction uses `/api/task` to fetch agent intro. Cross-reference to public-agent-links.md added. |
 | 2026-02-21 | **Bug Fix (EXEC-023)**: Fixed `DatabaseManager.update_execution_status()` wrapper in `src/backend/database.py:1295-1299` - was missing `claude_session_id` parameter, causing task executions to fail storing session IDs for the "Continue Execution as Chat" feature. The underlying `db/schedules.py:update_execution_status()` (lines 559-610) already supported the parameter. |
 | 2026-02-20 | **Chat Session Persistence (CHAT-001)**: `/task` endpoint now supports `save_to_session`, `user_message`, `create_new_session` parameters for authenticated Chat tab. When `save_to_session=true`, messages persist to `chat_sessions` and `chat_messages` tables. Response includes `chat_session_id`. New `db.create_new_chat_session()` method closes existing sessions before creating new one. |
-| 2026-02-16 | **Security Fix (Credential Leakage Prevention)**: Agent-side and backend-side credential sanitization now prevents secrets from appearing in execution logs. Agent sanitizes subprocess output via `sanitize_subprocess_line()` and response text via `sanitize_text()` (claude_code.py:563, 611, 922, 996). Backend provides defense-in-depth via `sanitize_execution_log()` and `sanitize_response()` (now called from `TaskExecutionService` in `services/task_execution_service.py:272-278` for sync path, and from `_execute_task_background` in `chat.py:489-499` for async path). |
+| 2026-02-16 | **Security Fix (Credential Leakage Prevention)**: Agent-side and backend-side credential sanitization now prevents secrets from appearing in execution logs. Agent sanitizes subprocess output via `sanitize_subprocess_line()` and response text via `sanitize_text()` (claude_code.py:563, 611, 922, 996). Backend provides defense-in-depth via `sanitize_execution_log()` and `sanitize_response()` (now called from `TaskExecutionService` in `services/task_execution_service.py:272-278` for sync path, and from `_run_async_task_with_persistence` in `chat.py:489-499` for async path). |
 | 2026-02-15 | **Claude Max subscription support**: Headless task execution now supports Claude Max subscription authentication. If user ran `/login` in web terminal, the OAuth session stored in `~/.claude.json` is used instead of requiring `ANTHROPIC_API_KEY`. The mandatory API key check was removed from `execute_headless_task()` in `docker/base-image/agent_server/services/claude_code.py`. |
 | 2026-02-12 | **Test fix**: `test_parallel_task_does_not_show_in_queue` (in `tests/test_execution_queue.py`) now uses `async_mode: True` to avoid 30s timeout. The test verifies that parallel tasks bypass the execution queue. |
 | 2026-02-05 | **SSE streaming fix**: Documented nginx configuration required for live execution streaming. Added `proxy_buffering off`, `proxy_cache off`, `chunked_transfer_encoding on` directives. Added frontend implementation details using fetch with ReadableStream. |
@@ -107,7 +107,7 @@ POST /api/agents/{name}/task
 | 3. Broadcast collaboration event (if        |
 |    agent-to-agent)                          |
 | 4. If async_mode: spawn background task     |
-|    via _execute_task_background(), return    |
+|    via _run_async_task_with_persistence(), return    |
 |    immediately                              |
 | 5. If sync: delegate to                     |
 |    TaskExecutionService.execute_task()      |
@@ -196,7 +196,7 @@ POST /api/task
 | `services/task_execution_service.py` | 61-97 | `agent_post_with_retry()` HTTP helper with exponential backoff |
 | `services/task_execution_service.py` | 104-417 | `TaskExecutionService.execute_task()` — full sync execution lifecycle |
 | `routers/chat.py` | 21-24 | Imports `get_task_execution_service` and `agent_post_with_retry` from service |
-| `routers/chat.py` | 438-650 | `_execute_task_background()` helper for async mode (still inline) |
+| `routers/chat.py` | 438-650 | `_run_async_task_with_persistence()` helper for async mode (still inline) |
 | `routers/chat.py` | 652-917 | POST /api/agents/{name}/task endpoint |
 | `routers/chat.py` | 810-827 | Sync path delegation to `TaskExecutionService.execute_task()` |
 | `routers/chat.py` | 842-857 | Translates `TaskExecutionResult.status == "failed"` to HTTP errors |
@@ -218,7 +218,7 @@ As of EXEC-024, the sync and async execution paths diverge:
 
 | Aspect | Sync (`async_mode=false`) | Async (`async_mode=true`) |
 |--------|---------------------------|---------------------------|
-| Execution logic | `TaskExecutionService.execute_task()` in `services/task_execution_service.py` | `_execute_task_background()` inline in `routers/chat.py:438-650` |
+| Execution logic | `TaskExecutionService.execute_task()` in `services/task_execution_service.py` | `_run_async_task_with_persistence()` inline in `routers/chat.py:438-650` |
 | Slot management | Service acquires/releases slots internally | Router acquires slot before spawning; background task releases in `finally` |
 | Activity tracking | Service tracks start/completion internally | Router tracks start; background task completes activities |
 | Result handling | Returns `TaskExecutionResult`; router translates to HTTP | Background task updates DB directly |
@@ -280,7 +280,7 @@ Same request/response as agent server, with additional parameters:
 **Backend Features**:
 - Authentication via JWT token
 - Access control validation
-- Activity tracking (sync: via `TaskExecutionService`; async: via `_execute_task_background`)
+- Activity tracking (sync: via `TaskExecutionService`; async: via `_run_async_task_with_persistence`)
 - Audit logging
 - **Slot management** - Capacity-limited parallel execution via `SlotService` (CAPACITY-001)
 - **Execution log persistence** - Full transcript saved to `schedule_executions.execution_log`
@@ -495,14 +495,14 @@ When `async_mode=true` is specified:
 1. **Backend acquires capacity slot** (CAPACITY-001)
 2. **Backend creates execution record** with `status="running"`
 3. **Tracks activity** (CHAT_START with async_mode: true)
-4. **Spawns background task** via `asyncio.create_task(_execute_task_background(...))`
+4. **Spawns background task** via `asyncio.create_task(_run_async_task_with_persistence(...))`
 5. **Returns immediately** with `execution_id` for polling
 6. **Background task executes** the Claude Code command (via `agent_post_with_retry`)
 7. **Updates execution record** when complete (success/failed)
 8. **Completes activities** asynchronously
 9. **Releases slot** in `finally` block
 
-Note: Async mode on the `/api/agents/{name}/task` endpoint does **not** use `TaskExecutionService`. It uses the inline `_execute_task_background()` function because it needs to manage its own activity IDs, collaboration tracking, and slot release timing. However, async mode on `/api/internal/execute-task` (used by the scheduler) **does** use `TaskExecutionService` inside its background coroutine — see [scheduler-service.md](scheduler-service.md).
+Note: Async mode on the `/api/agents/{name}/task` endpoint does **not** use `TaskExecutionService`. It uses the inline `_run_async_task_with_persistence()` function because it needs to manage its own activity IDs, collaboration tracking, and slot release timing. However, async mode on `/api/internal/execute-task` (used by the scheduler) **does** use `TaskExecutionService` inside its background coroutine — see [scheduler-service.md](scheduler-service.md).
 
 ### Architecture Diagram
 
@@ -522,7 +522,7 @@ Note: Async mode on the `/api/agents/{name}/task` endpoint does **not** use `Tas
 │  │  1. Acquire capacity slot (CAPACITY-001)                 │    │
 │  │  2. Create execution record (status="running")           │    │
 │  │  3. Track activities (CHAT_START)                        │    │
-│  │  4. asyncio.create_task(_execute_task_background(...))   │    │
+│  │  4. asyncio.create_task(_run_async_task_with_persistence(...))   │    │
 │  │  5. Return immediately:                                  │    │
 │  │     { status: "accepted", execution_id: "abc123" }       │    │
 │  └──────────────────────────┬──────────────────────────────┘    │
@@ -534,7 +534,7 @@ Note: Async mode on the `/api/agents/{name}/task` endpoint does **not** use `Tas
 │                        (Background task runs independently)      │
 │                                                                  │
 │  ┌──────────────────────────────────────────────────────────┐   │
-│  │  _execute_task_background()                               │   │
+│  │  _run_async_task_with_persistence()                               │   │
 │  │                                                           │   │
 │  │  - Calls agent container /api/task                        │   │
 │  │  - On success: db.update_execution_status("success")      │   │
@@ -556,7 +556,7 @@ class ParallelTaskRequest(BaseModel):
 
 **Background Task Handler** (`src/backend/routers/chat.py:438-650`):
 ```python
-async def _execute_task_background(
+async def _run_async_task_with_persistence(
     agent_name: str,
     request: ParallelTaskRequest,
     execution_id: str,
@@ -606,7 +606,7 @@ if request.async_mode:
 
     # Spawn background task (slot will be released when task completes)
     asyncio.create_task(
-        _execute_task_background(
+        _run_async_task_with_persistence(
             agent_name=name,
             request=request,
             execution_id=execution_id,
@@ -1130,4 +1130,4 @@ See [authenticated-chat-tab.md](authenticated-chat-tab.md) for full Chat tab doc
 3. ~~**Session Persistence**: Optional session persistence with TTL for resume~~ **IMPLEMENTED** (CHAT-001)
 4. **Batch API**: `POST /api/agents/{name}/batch` for multiple tasks
 5. **Priority Queue**: Priority parameter for urgent tasks
-6. **Async mode service migration**: Migrate `_execute_task_background()` to use `TaskExecutionService` for consistency (EXEC-024 follow-up)
+6. **Async mode service migration**: Migrate `_run_async_task_with_persistence()` to use `TaskExecutionService` for consistency (EXEC-024 follow-up)

--- a/docs/memory/feature-flows/task-execution-service.md
+++ b/docs/memory/feature-flows/task-execution-service.md
@@ -13,7 +13,7 @@ As the platform, I want task execution paths (authenticated sync tasks, public l
 | Path | Entry Point | Uses TaskExecutionService? | Notes |
 |------|------------|---------------------------|-------|
 | Sync parallel task | `POST /api/agents/{name}/task` (sync) | **Yes** | EXEC-024 delegation |
-| Async parallel task | `POST /api/agents/{name}/task` (async) | **No** | Inline `_execute_task_background()` in `chat.py:438` |
+| Async parallel task | `POST /api/agents/{name}/task` (async) | **Yes** | Issue #95: thin wrapper `_run_async_task_with_persistence` in `chat.py`. Router pre-acquires slot (preserves 429-upfront contract) then calls `execute_task(slot_already_held=True, ...)` |
 | Public link chat | `POST /api/public/chat/{token}` | **Yes** | Full lifecycle |
 | Scheduled execution | `POST /api/internal/execute-task` | **Yes** | Background coroutine wraps service call |
 | Interactive chat | `POST /api/agents/{name}/chat` | **No** | Direct agent HTTP call with inline retry in `chat.py` |
@@ -114,8 +114,18 @@ async def execute_task(
     allowed_tools: Optional[list] = None,
     system_prompt: Optional[str] = None,
     execution_id: Optional[str] = None,
+    fan_out_id: Optional[str] = None,
+    subscription_id: Optional[str] = None,
+    parent_activity_id: Optional[str] = None,       # Issue #95: CHAT_START parent linkage
+    extra_activity_details: Optional[dict] = None,  # Issue #95: merged into CHAT_START details
+    slot_already_held: bool = False,                # Issue #95: async path pre-acquires slot upfront
 ) -> TaskExecutionResult:
 ```
+
+**Issue #95 params** (added 2026-04-13):
+- `parent_activity_id`: set by the async `/task` router to the collaboration activity id so the CHAT_START is parented for agent-to-agent call graphs.
+- `extra_activity_details`: merged into the CHAT_START `details` dict. The async `/task` router passes `{parallel_mode: True, async_mode: True, model, timeout_seconds}` to keep the frontend Network view filter at `src/frontend/src/stores/network.js:255` working.
+- `slot_already_held`: when `True`, the service skips slot acquisition (but still releases in finally). The async `/task` router pre-acquires the slot synchronously so at-capacity returns HTTP 429 upfront, preserving the client contract. Other callers leave this `False` and the service both acquires and releases.
 
 **TIMEOUT-001**: When `timeout_seconds` is `None`, the service reads the agent's configured timeout via `db.get_execution_timeout(agent_name)`. Default agent timeout is 900 seconds (15 minutes).
 

--- a/docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md
+++ b/docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md
@@ -1,0 +1,248 @@
+# Orchestration & Multi-Agent Reliability Plan
+
+**Date:** 2026-04-13
+**Status:** Proposed sequencing for execution-time orchestration, event subscriptions, and multi-agent reliability.
+
+**Progress:** Sprint A — **#95 shipped** (PR pending on `feature/95-unified-async-executor`). Remaining Sprint A items (#285, #61, #226, #286, #132, #56) unblocked.
+
+---
+
+## Problem statement
+
+Trinity has accumulated ~20 issues touching execution-time orchestration. They exist because the current design has **parallel code paths for the same logical operation** (sync chat, async task, scheduler, fan-out, event subscriptions) that drift apart, and because **state-corruption bugs at the bottom of the stack** (orphaned processes, lost error context, fixed slot TTLs) make higher-level features unreliable.
+
+BACKLOG-001 (#260) is the marquee item, but it can't land cleanly until:
+1. The async execution path is unified with `TaskExecutionService` (#95).
+2. The lower-level bugs are fixed so the backlog doesn't inherit them.
+
+Shipping #260 on top of today's foundation would produce a *persistent* backlog of *corrupt* executions.
+
+---
+
+## Sequencing
+
+```
+Sprint A (unblock):     #95 ✅ DONE (PR pending)
+                        parallel: #285, #61, #226, #286, #132, #56  ← unblocked
+Sprint B (trace):       #305
+Sprint C (orchestrate): #260 → #271 → #294 → #264 → #291
+Sprint D (push telemetry): #306, #307
+Sprint E (scale):       #24, #18
+```
+
+`#95` lands alone because every other Tier 0 fix layers on top of the unified executor. The remaining Tier 0 issues are independent and can parallelize once `#95` ships.
+
+### Dependency edges to enforce on the board
+
+- `#260 blocked-by #95` — backlog drain must call unified executor, not re-implement launch logic.
+- `#271 blocked-by #285` — don't auto-retry zombies.
+- `#294 blocked-by #95` — validation session reuses the unified execution path.
+- `#260 blocks #271, #294, #264` — retry/validation/self-execute all benefit from uniform overflow semantics; landing them first creates divergent queue behavior.
+- Inside Sprint C, `#294` and `#264` are independent of each other once `#260` lands — parallelize them instead of serializing the whole tier.
+
+### Merge candidates (single PR surface)
+
+- **#226 + #61**: container process lifecycle. Both wire backend cleanup into the existing agent-side process registry. Same files, same review surface. *Caveat:* #226 is a one-call-site TTL fix; #61 is a larger cleanup→terminate wiring. If review drags, split so the TTL fix isn't held hostage.
+- **#305 + #286**: tracing + preserved error context. Both change how we record "what went wrong"; landing together lets the `cleanup_reason` field carry the trace ID.
+
+---
+
+## Tier 0 — Fix state-corruption bugs (Sprint A)
+
+**Goal:** Make execution state authoritative and correct. No new features.
+
+| # | Title | Why it's here |
+|---|-------|---------------|
+| ~~#95~~ ✅ | ~~Route async task mode through `TaskExecutionService`~~ | **Shipped** on `feature/95-unified-async-executor`. `_execute_task_background()` deleted. Async `/task` now delegates to `execute_task(slot_already_held=True)` via `_run_async_task_with_persistence` thin wrapper. 429-upfront preserved via router-side pre-acquire. Service gained `parent_activity_id`, `extra_activity_details`, `slot_already_held` params. Sync+async share `_persist_chat_session` helper. E3 fix: `subscription_id` now snapshotted on pre-created execution record. |
+| #285 | Expired subscription tokens cause hour-long zombie executions | Root cause of most "stuck" complaints. Define a structured exit-code / event contract from `agent_server` so the backend fast-fails on auth errors without regex on stderr. |
+| #61 | Backend cleanup doesn't invoke agent termination | Agent already has SIGINT→SIGKILL in `docker/base-image/agent_server/services/process_registry.py:84-140`. Gap is that backend timeout/cleanup paths don't always call the agent's `/api/executions/{id}/terminate`. Wire the existing endpoint, don't build new PID infrastructure. |
+| #226 | Stale-slot cleanup ignores per-agent TTL on the standalone path | `acquire_slot()` already passes `timeout_seconds + buffer` to per-agent cleanup (`slot_service.py:102-105`). The standalone `cleanup_stale_slots()` (line 264) doesn't thread it through and falls back to `DEFAULT_SLOT_TTL_SECONDS`. One-call-site fix. |
+| #286 | Cleanup overwrites real error | Add `cleanup_reason` column distinct from `error`. Schema change touches **all three** kill paths in `cleanup_service.py` (stale-slot, watchdog reconcile, orphan recovery) plus the execution-history UI. Bigger surface than it looks. |
+| #132 | APScheduler skips triggers when `max_instances=1` reached | Scheduler is a separate microservice at `src/scheduler/` (port 8001), not in the backend. Fire-and-forget dispatch already exists (`src/scheduler/service.py:823`, `SCHED-ASYNC-001`). The remaining work is tuning the skip-on-overlap policy: bump `max_instances`, add coalescing, or evict the prior run via the new termination wiring (#61). Rescope before estimating. |
+| #56 | Consistent context usage tracking | ~35 call sites across `chat.py`, `fan_out.py`, `schedules.py`, `agent_client.py` with three formulas (`input+output`, `session.context_tokens`, direct `context_used` passthrough). Split the work: pick source-of-truth field + fix `agent_client.py` contract in Tier 0; migrate remaining callers in Tier 1. Not a single-day fix. |
+
+### Architectural shift
+
+**Before:** Two execution code paths (sync + async) with duplicated slot/activity/sanitization logic. Backend cleanup doesn't call the agent's existing terminate endpoint, leaving processes running. Cleanup overwrites diagnostic data. Scheduler skips triggers silently when prior runs overlap.
+
+**After:** Single `TaskExecutionService` funnel. Backend timeout calls agent terminate → existing SIGINT→SIGKILL path runs. Slot TTL comes from per-slot metadata on every cleanup path. Cleanup preserves original error via new `cleanup_reason` column. Scheduler skip-on-overlap is replaced with eviction or coalescing.
+
+### Verification gates before exiting Tier 0
+
+- ✅ Grep for `_execute_task_background` returns zero hits outside docs (shipped in #95). Shadow-run deemed unnecessary for the async-path refactor: sync-mode already delegated to `execute_task()` pre-#95, and public/internal async paths had been using the same `execute_task(execution_id=...)` pattern in production; the refactor is a code-path unification rather than a semantics change. Parity tests cover the two observable invariants (429-upfront, `parallel_mode` activity flag).
+- Integration test: force a 5-second timeout on a real agent task, assert (a) zero orphan `claude` processes inside the container, (b) execution row has `cleanup_reason` populated and `error` preserved, (c) slot is released within TTL+buffer.
+- Execution history rows show distinct `error` and `cleanup_reason` fields across all three cleanup paths.
+- Scheduler log has zero "max_instances reached → skipped" events across a 24h soak.
+
+---
+
+## Tier 1 — Tracing (Sprint B)
+
+**Goal:** Get a single trace ID across hops before shipping orchestration features, so failures are diagnosable. Heartbeat and WS rewrite are deferred to Sprint D — they're bigger surfaces than #260 itself, and gating reliability work on a WebSocket rewrite is the wrong tradeoff.
+
+| # | Title | Why it's here |
+|---|-------|---------------|
+| #305 | OpenTelemetry distributed tracing (RELIABILITY-002) | OTel Collector already in `docker-compose.yml`. ~30 lines + 3 packages. Enables single trace ID across Agent A → B → C. Pairs with #286 so `cleanup_reason` carries the trace ID. |
+
+### Considerations
+
+- **Sampling**: start at 10% for high-volume endpoints. Full sampling only in dev.
+
+---
+
+## Tier 2 — Orchestration primitives (Sprint C)
+
+**Goal:** Ship the user-visible reliability features on top of the now-solid foundation.
+
+| # | Title | Why it's here |
+|---|-------|---------------|
+| #260 | Persistent task backlog (BACKLOG-001) | Async requests at capacity go to `status=queued` instead of 429. `SlotService.release_slot` publishes via Redis pub/sub (`PUBLISH slot:released:{agent}`) → any subscribing worker calls `BacklogService.drain_next` and claims the next row atomically. **Do not ship an in-process callback** — see multi-worker note below. |
+| #271 | Retry mechanism for scheduled executions | Pairs with #285 (need fast-fail first). Retries flow through backlog, not bypass it. Scheduler `date` trigger survives restart. |
+| #294 | Business task validation (VALIDATE-001) | Clean-context auditor session after execution. Reuses unified executor (#95). Writes `business_status` separate from technical `status`. |
+| #264 | Self-execute during chat (SELF-EXEC-001) | Thin layer: detect source==target, flag `X-Self-Task`, optionally `inject_result` back into chat session. Uses backlog for overflow. |
+| #291 | Agent webhook triggers (WEBHOOK-001) | External → agent dispatch. HMAC-signed URL. **Distinct from existing process-engine webhooks** (`routers/triggers.py`) which trigger BPMN process executions. Before building, decide: reuse the process-engine trigger surface (lower surface area) or ship a parallel agent-scoped trigger surface (clearer mental model, but exactly the parallel-paths problem this plan exists to fix). Default recommendation: reuse, with an `agent_task` shortcut process. |
+
+### Architectural shift
+
+**Before:** Overflow = 429 hard reject. Retry = none. Validation = none. Scheduler, webhooks, MCP, UI each have subtly different failure modes.
+
+**After:** A single invariant — *every* trigger type (user chat, schedule, webhook, retry, validation, self-execute, fan-out, event subscription) produces the same shape:
+
+```
+(trigger) ─► execution record (pending|queued)
+             ─► TaskExecutionService
+                ├─ slot acquired (or enqueued)
+                ├─ traced
+                ├─ PID tracked
+                ├─ heartbeat monitored
+                └─ terminal with preserved error
+```
+
+Retry and validation are **not new infrastructure** — they're just new trigger sources that produce more execution records. That's the architectural payoff.
+
+### Considerations
+
+- **Backlog depth cap**: default 50, hard cap 200. Unbounded queues mask capacity problems.
+- **FIFO only for v1**: priority can come later. Don't ship two ordering systems before one is proven.
+- **Stale expiry**: 24h. Queued items older than that are unlikely to still be relevant.
+- **Retry should enqueue, not dispatch directly**: ensures retries respect capacity and the "one path" invariant.
+- **Validation session is an agent call to itself**: no new execution machinery needed — it's just a task with an auditor prompt. Keeps the surface small.
+- **Multi-worker drain coordination**: with multiple uvicorn workers, the worker that releases a slot may not hold the in-process queue. The release → drain handoff must go through Redis pub/sub (`PUBLISH slot:released:{agent}`) and any worker that subscribes can claim the next row via `SELECT … FOR UPDATE` / atomic UPDATE. Don't ship an in-process callback — it works in dev and silently stalls in production.
+
+---
+
+## Tier 3 — Push telemetry (Sprint D)
+
+**Goal:** Move the remaining polling loops to push, now that the executor and queue are stable.
+
+| # | Title | Why it's here |
+|---|-------|---------------|
+| #306 | Redis Streams event bus for WebSocket (RELIABILITY-003) | Replaces in-process `ConnectionManager.broadcast()` (`main.py:125-130`, currently `except: pass`). `XADD`/`XREAD` with reconnect replay. Bigger surface than #260 itself — explicit `lastEventId` work on the frontend. |
+| #307 | Agent heartbeat push (RELIABILITY-004) | Flip 30s polling (`monitoring_service.py:654`) → 5s push. Feeds monitoring + (future) circuit breaker. Uses existing Redis. |
+
+### Considerations
+
+- **Redis memory**: stream trim via `MAXLEN ~10000`. Without this, a burst of activity blows up Redis.
+- **Backward compat**: WebSocket event shape must not change. Frontend needs `lastEventId` support but old events should still render.
+
+## Tier 4 — Scale (later)
+
+| # | Title |
+|---|-------|
+| #24 | Horizontal agent scalability (pools + load balancing) |
+| #18 | Unified Executions Dashboard (EXEC-022) |
+
+### Why last
+
+- Horizontal scaling only pays off after backlog (Tier 2) is the scheduling authority and heartbeat (Tier 3) tells the router which instances are live. Otherwise scaling multiplies broken parts.
+- Unified dashboard is low engineering risk but benefits from Redis Streams (#306) for live updates and consistent execution records (Tier 0) for meaningful aggregation.
+
+---
+
+## Already shipped (do not re-plan)
+
+- **EVT-001** (#169, closed) — `routers/event_subscriptions.py`, SQLite-backed pub/sub, permission-gated, template interpolation.
+- **Fan-out** (#230, closed) — `services/fan_out_service.py` + `routers/fan_out.py`, barrier-wait, per-task status.
+- **Cleanup watchdog** (#129/#94, closed) — active reconciliation + passive stale recovery in `cleanup_service.py`.
+- **Event Bus #22** (closed) — subsumed by EVT-001 SQLite path; upgrade to Redis Streams covered by #306.
+- **Agent process termination** — `docker/base-image/agent_server/services/process_registry.py` already implements SIGINT→SIGKILL with wait. #61 wires backend cleanup into this existing endpoint, not new infrastructure.
+- **Scheduler async dispatch (`SCHED-ASYNC-001`)** — `src/scheduler/service.py:823` already does fire-and-forget + DB polling. #132 is a tuning task on top of this, not a rewrite.
+
+### Out of scope (intentionally separate)
+
+- **Process Engine** has its own execution surface: `process_engine/engine/handlers/agent_task.py` calls `AgentClient.chat()` directly, bypassing `TaskExecutionService`, slot service, and cleanup service. It is intentionally outside this consolidation. Slot/timeout/PID work in Tier 0 does not apply to process steps. *Known limitation:* a process kicking off many parallel `agent_task` steps will not respect agent capacity. **File a tracking issue** (suggested title: "Process Engine `agent_task` should funnel through TaskExecutionService") so this surfaces in grooming rather than rotting inside this doc.
+
+---
+
+## Architecture snapshots
+
+### Today
+
+```
+HTTP sync chat   ─► routers/chat.py
+HTTP async task  ─► routers/chat.py ─► _execute_task_background()  ◄── duplicate path
+MCP chat_with_agent ─► TaskExecutionService
+MCP fan_out      ─► TaskExecutionService
+Schedule         ─► APScheduler ─► HTTP /task ─► poll status up-to-1h (blocks!)
+Event emit       ─► SQLite row ─► trigger matching subs
+Webhook          ─── none ───
+
+Slot ZSET (fixed 20-min TTL) ◄── cleanup overwrites errors
+Container (orphaned claude PID accumulates on timeout)
+WebSocket: in-process broadcast, except: pass, no replay
+Tracing: none. Heartbeat: 30s backend poll.
+```
+
+### After Tier 0 + 1
+
+```
+All entry paths ─► TaskExecutionService (single path)
+                      ├─ execute_task()        (sync)
+                      └─ execute_task_async()  (background)
+                      ├─ traceparent propagated
+                      ├─ PID tracked
+                      └─ activities, sanitization, timeout kill
+
+agent container ── heartbeat push 5s ──► Redis (TTL 15s)
+                ── stderr scanner ──► fast-fail on auth error
+                ── OTel trace ──► collector
+
+Slot ZSET (per-agent TTL from metadata)
+cleanup_service preserves error + cleanup_reason + kills PID
+APScheduler fire-and-forget, async status consumer
+WebSocket ◄── Redis Streams (XADD/XREAD) with replay
+```
+
+### After Tier 2
+
+```
+request at capacity ─► try slot.acquire()
+                        ├─ success → execute
+                        ├─ slot full → backlog.enqueue() → 202 queued
+                        └─ backlog full → 429
+
+slot.release_slot() ── callback ──► backlog.drain_next()
+                                    ├─ atomic claim (SELECT + UPDATE)
+                                    └─ TaskExecutionService.execute_task_async()
+
+New triggers, all funnel into the same executor:
+  • Webhook         ─► schedule dispatch (HMAC-signed URL)
+  • Self-execute    ─► X-Self-Task, optional inject_result
+  • Retry           ─► new execution with retry_of_execution_id
+  • Validation      ─► auditor session, writes business_status
+  • Event sub       ─► (already funnels)
+  • Fan-out         ─► (already funnels)
+```
+
+---
+
+## What to do next on the board
+
+1. ~~Add `blocked-by` links: #260 ← #95, #271 ← #285, #294 ← #95.~~ #95 landed; #260 and #294 now have only the remaining Tier 0 dependencies (none direct from #95).
+2. ~~Bump #95 to `status-ready` with a "do this first, alone" note.~~ ✅ Done — PR pending merge.
+3. Merge-candidate tag on #226 + #61 (single PR for container process lifecycle, both wire backend cleanup into the existing agent terminate endpoint).
+4. Merge-candidate tag on #305 + #286 (trace ID in `cleanup_reason`).
+5. Confirm scope cuts for #260: FIFO-only v1, depth 50 default, 24h expiry. Defer priority levels and WebSocket completion pings to v2.
+6. Rescope #132 against `src/scheduler/service.py` — fire-and-forget already exists; the open work is the skip-on-overlap policy.
+7. Re-estimate #56 — at least 5–7 distinct call sites with three formulas; not "trivial."
+8. Decide #291 direction: reuse process-engine triggers (recommended) vs. parallel agent-scoped trigger surface.

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -448,230 +448,182 @@ async def chat_with_agent(
             await slot_service.release_slot(name, execution.id)
 
 
-async def _execute_task_background(
+async def _persist_chat_session(
+    agent_name: str,
+    request: ParallelTaskRequest,
+    result,  # TaskExecutionResult
+    user_id: int,
+    user_email: str,
+    subscription_id: Optional[str] = None,
+    execution_time_ms: Optional[int] = None,
+):
+    """
+    Persist a /task execution to the authenticated chat session (THINK-001).
+
+    Shared by the sync and async branches of execute_parallel_task. Only persists
+    on SUCCESS — avoids writing empty assistant messages for FAILED/CANCELLED
+    executions. Returns the session id (or None on failure).
+    """
+    if result.status != TaskExecutionStatus.SUCCESS:
+        return None
+
+    try:
+        if request.create_new_session:
+            session = db.create_new_chat_session(
+                agent_name=agent_name,
+                user_id=user_id,
+                user_email=user_email,
+                subscription_id=subscription_id,
+            )
+        elif request.chat_session_id:
+            session = db.get_chat_session(request.chat_session_id)
+            if not session:
+                session = db.get_or_create_chat_session(
+                    agent_name=agent_name,
+                    user_id=user_id,
+                    user_email=user_email,
+                )
+        else:
+            session = db.get_or_create_chat_session(
+                agent_name=agent_name,
+                user_id=user_id,
+                user_email=user_email,
+            )
+
+        original_user_message = request.user_message or request.message
+        db.add_chat_message(
+            session_id=session.id,
+            agent_name=agent_name,
+            user_id=user_id,
+            user_email=user_email,
+            role="user",
+            content=original_user_message,
+        )
+        db.add_chat_message(
+            session_id=session.id,
+            agent_name=agent_name,
+            user_id=user_id,
+            user_email=user_email,
+            role="assistant",
+            content=result.response or "",
+            cost=result.cost,
+            context_used=result.context_used,
+            context_max=result.context_max,
+            execution_time_ms=execution_time_ms,
+        )
+        logger.debug(f"[Task] Saved to chat session {session.id} for agent '{agent_name}'")
+        return session.id
+    except Exception as e:
+        logger.warning(f"[Task] Failed to save to chat session for agent '{agent_name}': {e}")
+        return None
+
+
+async def _run_async_task_with_persistence(
     agent_name: str,
     request: ParallelTaskRequest,
     execution_id: str,
-    task_activity_id: str,
     collaboration_activity_id: Optional[str],
     x_source_agent: Optional[str],
-    release_slot: bool = False,
     user_id: Optional[int] = None,
     user_email: Optional[str] = None,
-    subscription_id: Optional[str] = None
+    subscription_id: Optional[str] = None,
 ):
     """
-    Background task execution for async mode.
-    Runs the task and updates execution record/activities when complete.
+    Async /task background wrapper (issue #95).
 
-    Args:
-        release_slot: If True, release the slot when task completes (CAPACITY-001)
-        user_id: User ID for session persistence (THINK-001)
-        user_email: User email for session persistence (THINK-001)
+    Delegates the full execution lifecycle to TaskExecutionService (single path
+    for slot / activity / sanitization / retry / release) and layers on the
+    chat-endpoint-specific post-task side effects:
+      - authenticated chat_session persistence (THINK-001)
+      - chat_response_ready WebSocket broadcast
+      - collaboration activity completion (agent-to-agent call)
+
+    Caller (execute_parallel_task async branch) has already pre-acquired the
+    capacity slot so that 429-at-capacity is returned synchronously. The
+    service will release the slot in its finally block.
     """
-    slot_service = get_slot_service() if release_slot else None
-    try:
-        # TIMEOUT-001: Use agent's configured timeout if not explicitly provided
-        effective_timeout = request.timeout_seconds
-        if effective_timeout is None:
-            effective_timeout = db.get_execution_timeout(agent_name)
+    start_time = datetime.utcnow()
+    task_service = get_task_execution_service()
+    triggered_by = "agent" if x_source_agent else "manual"
 
-        payload = {
-            "message": request.message,
+    # Service tracks CHAT_START with parent_activity_id=collaboration_activity_id
+    # and merges extra_activity_details (parallel_mode/async_mode) so the Network
+    # view filter at src/frontend/src/stores/network.js:255 still includes this
+    # execution.
+    result = await task_service.execute_task(
+        agent_name=agent_name,
+        message=request.message,
+        triggered_by=triggered_by,
+        source_user_id=user_id,
+        source_user_email=user_email,
+        source_agent_name=x_source_agent,
+        model=request.model,
+        timeout_seconds=request.timeout_seconds,
+        resume_session_id=request.resume_session_id,
+        allowed_tools=request.allowed_tools,
+        system_prompt=request.system_prompt,
+        execution_id=execution_id,
+        subscription_id=subscription_id,
+        parent_activity_id=collaboration_activity_id,
+        extra_activity_details={
+            "parallel_mode": True,
+            "async_mode": True,
             "model": request.model,
-            "allowed_tools": request.allowed_tools,
-            "system_prompt": request.system_prompt,
-            "timeout_seconds": effective_timeout,
-            "execution_id": execution_id,
-            "resume_session_id": request.resume_session_id  # EXEC-023: Claude Code session resume
-        }
+            "timeout_seconds": request.timeout_seconds,
+        },
+        slot_already_held=True,  # Router pre-acquired to preserve 429-upfront contract
+    )
 
-        start_time = datetime.utcnow()
+    execution_time_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
 
-        # Issue #279: Mark execution as dispatched BEFORE calling the agent so
-        # the no-session cleanup doesn't falsely mark it as "Silent launch failure".
-        # Without this, claude_session_id stays NULL and cleanup kills the execution
-        # after 60s even though the agent call is still in-flight.
-        if execution_id:
-            try:
-                db.mark_execution_dispatched(execution_id)
-            except Exception as e:
-                logger.warning(f"[Task Async] Failed to mark execution dispatched: {e}")
-
-        response = await agent_post_with_retry(
-            agent_name,
-            "/api/task",
-            payload,
-            max_retries=3,
-            retry_delay=1.0,
-            timeout=float(effective_timeout) + 10
+    # ---- Post-task: chat session persistence (THINK-001) ----
+    chat_session_id = None
+    if request.save_to_session and user_id and user_email:
+        chat_session_id = await _persist_chat_session(
+            agent_name=agent_name,
+            request=request,
+            result=result,
+            user_id=user_id,
+            user_email=user_email,
+            subscription_id=subscription_id,
+            execution_time_ms=execution_time_ms,
         )
-        response.raise_for_status()
-
-        response_data = response.json()
-        execution_time_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
-        metadata = response_data.get("metadata", {})
-
-        # SECURITY: Sanitize credentials from execution logs and response
-        sanitized_resp = sanitize_response(response_data.get("response"))
-        context_used = metadata.get("input_tokens", 0) + metadata.get("output_tokens", 0)
-
-        # Update execution record with success
-        if execution_id:
-            execution_log = response_data.get("execution_log", [])
-            execution_log_json = json.dumps(execution_log) if execution_log else None
-            execution_log_json = sanitize_execution_log(execution_log_json)
-
-            db.update_execution_status(
-                execution_id=execution_id,
-                status=TaskExecutionStatus.SUCCESS,
-                response=sanitized_resp,
-                context_used=context_used if context_used > 0 else None,
-                context_max=metadata.get("context_window") or 200000,
-                cost=metadata.get("cost_usd"),
-                tool_calls=execution_log_json,
-                execution_log=execution_log_json
-            )
-
-        # THINK-001: Persist to chat session if requested (for authenticated Chat tab async mode)
-        if request.save_to_session and user_id and user_email:
+        if chat_session_id and _websocket_manager:
             try:
-                if request.create_new_session:
-                    session = db.create_new_chat_session(
-                        agent_name=agent_name,
-                        user_id=user_id,
-                        user_email=user_email,
-                        subscription_id=subscription_id
-                    )
-                elif request.chat_session_id:
-                    # Use the explicit session ID from the frontend
-                    session = db.get_chat_session(request.chat_session_id)
-                    if not session:
-                        # Session not found, fall back to get_or_create
-                        session = db.get_or_create_chat_session(
-                            agent_name=agent_name,
-                            user_id=user_id,
-                            user_email=user_email
-                        )
-                else:
-                    session = db.get_or_create_chat_session(
-                        agent_name=agent_name,
-                        user_id=user_id,
-                        user_email=user_email
-                    )
-
-                original_user_message = request.user_message or request.message
-                db.add_chat_message(
-                    session_id=session.id,
-                    agent_name=agent_name,
-                    user_id=user_id,
-                    user_email=user_email,
-                    role="user",
-                    content=original_user_message
-                )
-
-                db.add_chat_message(
-                    session_id=session.id,
-                    agent_name=agent_name,
-                    user_id=user_id,
-                    user_email=user_email,
-                    role="assistant",
-                    content=sanitized_resp or "",
-                    cost=metadata.get("cost_usd"),
-                    context_used=context_used if context_used > 0 else None,
-                    context_max=metadata.get("context_window") or 200000,
-                    execution_time_ms=execution_time_ms
-                )
-
-                # Broadcast chat_session_id via WebSocket so frontend can update
-                if _websocket_manager:
-                    await _websocket_manager.broadcast(json.dumps({
-                        "type": "chat_response_ready",
-                        "execution_id": execution_id,
-                        "agent_name": agent_name,
-                        "chat_session_id": session.id,
-                        "timestamp": datetime.utcnow().isoformat()
-                    }))
-
-                logger.debug(f"[Task Async] Saved to chat session {session.id} for agent '{agent_name}'")
+                await _websocket_manager.broadcast(json.dumps({
+                    "type": "chat_response_ready",
+                    "execution_id": execution_id,
+                    "agent_name": agent_name,
+                    "chat_session_id": chat_session_id,
+                    "timestamp": datetime.utcnow().isoformat(),
+                }))
             except Exception as e:
-                logger.warning(f"[Task Async] Failed to save to chat session for agent '{agent_name}': {e}")
+                logger.warning(f"[Task Async] chat_response_ready broadcast failed: {e}")
 
-        # Complete activities
-        await activity_service.complete_activity(
-            activity_id=task_activity_id,
-            status=ActivityState.COMPLETED,
-            details={
-                "cost_usd": metadata.get("cost_usd"),
-                "execution_time_ms": execution_time_ms,
-                "tool_count": len(response_data.get("execution_log", [])),
-                "async_mode": True
-            }
-        )
-
-        if collaboration_activity_id:
+    # ---- Post-task: complete collaboration activity ----
+    if collaboration_activity_id:
+        try:
             await activity_service.complete_activity(
                 activity_id=collaboration_activity_id,
-                status=ActivityState.COMPLETED,
+                status=(
+                    ActivityState.COMPLETED
+                    if result.status == TaskExecutionStatus.SUCCESS
+                    else ActivityState.FAILED
+                ),
                 details={
-                    "response_length": len(response_data.get("response", "")),
+                    "response_length": len(result.response or ""),
                     "execution_time_ms": execution_time_ms,
-                    "execution_id": execution_id
-                }
+                    "execution_id": execution_id,
+                },
+                error=(result.error if result.status == TaskExecutionStatus.FAILED else None),
             )
+        except Exception as e:
+            logger.warning(f"[Task Async] collaboration activity completion failed: {e}")
 
-        logger.info(f"[Task Async] Completed background task for agent '{agent_name}', execution_id={execution_id}")
-
-    except Exception as e:
-        # Extract detailed error from HTTP response body if available
-        error_msg = str(e)
-        if hasattr(e, 'response') and e.response is not None:
-            try:
-                error_data = e.response.json()
-                if "detail" in error_data:
-                    error_msg = error_data["detail"]
-            except Exception:
-                if hasattr(e.response, 'text') and e.response.text:
-                    error_msg = e.response.text[:500]
-        logger.error(f"[Task Async] Background task failed for agent '{agent_name}': {error_msg}")
-
-        # SUB-003: Check for rate-limit auto-switch on background task failures
-        agent_status_code = getattr(getattr(e, 'response', None), 'status_code', None)
-        if agent_status_code == 429:
-            try:
-                from services.subscription_auto_switch import handle_rate_limit_error
-                await handle_rate_limit_error(agent_name=agent_name, error_message=error_msg)
-            except Exception as switch_err:
-                logger.error(f"[SUB-003] Auto-switch check failed for '{agent_name}': {switch_err}")
-
-        # Update execution record with failure
-        if execution_id:
-            existing = db.get_execution(execution_id)
-            if not existing or existing.status != TaskExecutionStatus.CANCELLED:
-                db.update_execution_status(
-                    execution_id=execution_id,
-                    status=TaskExecutionStatus.FAILED,
-                    error=error_msg
-                )
-
-        # Complete activities with failure
-        await activity_service.complete_activity(
-            activity_id=task_activity_id,
-            status=ActivityState.FAILED,
-            error=error_msg
-        )
-
-        if collaboration_activity_id:
-            await activity_service.complete_activity(
-                activity_id=collaboration_activity_id,
-                status=ActivityState.FAILED,
-                error=error_msg
-            )
-
-    finally:
-        # Release slot when task completes (CAPACITY-001)
-        if slot_service and release_slot:
-            await slot_service.release_slot(agent_name, execution_id)
+    logger.info(
+        f"[Task Async] Completed background task for agent '{agent_name}', "
+        f"execution_id={execution_id}, status={result.status}"
+    )
 
 
 @router.post("/{name}/task")
@@ -721,7 +673,10 @@ async def execute_parallel_task(
     except Exception:
         _task_subscription_id = None
 
-    # Create execution record in database (persisted task history)
+    # Create execution record in database (persisted task history).
+    # Issue #95 (E3): pass subscription_id so the pre-created execution record
+    # snapshots the subscription at creation time (service only snapshots when
+    # it creates the record itself).
     execution = db.create_task_execution(
         agent_name=name,
         message=request.message,
@@ -731,7 +686,8 @@ async def execute_parallel_task(
         source_agent_name=x_source_agent,
         source_mcp_key_id=x_mcp_key_id,
         source_mcp_key_name=x_mcp_key_name,
-        model_used=request.model
+        model_used=request.model,
+        subscription_id=_task_subscription_id,
     )
     execution_id = execution.id if execution else None
 
@@ -762,11 +718,12 @@ async def execute_parallel_task(
             }
         )
 
-    # Async mode: acquire slot here, spawn background task which releases it
+    # Async mode: pre-acquire slot synchronously so at-capacity returns 429 upfront
+    # (preserves existing client contract), then delegate the lifecycle to
+    # TaskExecutionService via _run_async_task_with_persistence (issue #95).
     if request.async_mode:
         slot_service = get_slot_service()
         max_parallel_tasks = db.get_max_parallel_tasks(name)
-        # TIMEOUT-001: Use agent's configured timeout for slot TTL
         effective_timeout = request.timeout_seconds
         if effective_timeout is None:
             effective_timeout = db.get_execution_timeout(name)
@@ -775,47 +732,21 @@ async def execute_parallel_task(
             execution_id=execution_id or f"temp-{datetime.utcnow().timestamp()}",
             max_parallel_tasks=max_parallel_tasks,
             message_preview=request.message[:100] if request.message else "",
-            timeout_seconds=effective_timeout
+            timeout_seconds=effective_timeout,
         )
-
         if not slot_acquired:
             if execution_id:
                 db.update_execution_status(
                     execution_id=execution_id,
                     status=TaskExecutionStatus.FAILED,
-                    error=f"Agent at capacity ({max_parallel_tasks}/{max_parallel_tasks} parallel tasks running)"
+                    error=f"Agent at capacity ({max_parallel_tasks}/{max_parallel_tasks} parallel tasks running)",
                 )
             raise HTTPException(
                 status_code=429,
-                detail=f"Agent '{name}' is at capacity ({max_parallel_tasks} parallel tasks). Try again later."
+                detail=f"Agent '{name}' is at capacity ({max_parallel_tasks} parallel tasks). Try again later.",
             )
 
-        # Track parallel task activity (belongs to target agent)
-        task_activity_id = await activity_service.track_activity(
-            agent_name=name,
-            activity_type=ActivityType.CHAT_START,
-            user_id=current_user.id,
-            triggered_by=triggered_by,
-            parent_activity_id=collaboration_activity_id,
-            related_execution_id=execution_id,
-            details={
-                "message_preview": request.message[:100],
-                "source_agent": x_source_agent,
-                "parallel_mode": True,
-                "async_mode": True,
-                "model": request.model,
-                "timeout_seconds": request.timeout_seconds,
-                "execution_id": execution_id
-            }
-        )
-
-        # Update execution status to running
-        if execution_id:
-            db.update_execution_status(execution_id=execution_id, status=TaskExecutionStatus.RUNNING)
-
-        # Spawn background task (slot will be released when task completes)
-        # Issue #279: Add done callback to surface any unhandled exceptions
-        # that would otherwise be silently swallowed by asyncio.
+        # Issue #279: done callback surfaces unhandled BG task exceptions.
         def _on_task_done(task: asyncio.Task):
             if task.cancelled():
                 logger.warning(f"[Task Async] Background task cancelled for agent '{name}', execution_id={execution_id}")
@@ -823,29 +754,26 @@ async def execute_parallel_task(
                 logger.error(f"[Task Async] Unhandled exception in background task for agent '{name}', execution_id={execution_id}: {exc}")
 
         bg_task = asyncio.create_task(
-            _execute_task_background(
+            _run_async_task_with_persistence(
                 agent_name=name,
                 request=request,
                 execution_id=execution_id,
-                task_activity_id=task_activity_id,
                 collaboration_activity_id=collaboration_activity_id,
                 x_source_agent=x_source_agent,
-                release_slot=True,  # CAPACITY-001: Release slot when background task completes
-                user_id=current_user.id,  # THINK-001: Pass user context for session persistence
+                user_id=current_user.id,
                 user_email=current_user.email or current_user.username,
-                subscription_id=_task_subscription_id,  # SUB-004: Usage tracking
+                subscription_id=_task_subscription_id,
             )
         )
         bg_task.add_done_callback(_on_task_done)
 
-        # Return immediately with execution_id for polling
         logger.info(f"[Task Async] Started background task for agent '{name}', execution_id={execution_id}")
         return {
             "status": "accepted",
             "execution_id": execution_id,
             "agent_name": name,
             "message": "Task accepted. Poll GET /api/agents/{name}/executions/{execution_id} for results.",
-            "async_mode": True
+            "async_mode": True,
         }
 
     # ---- Sync mode: delegate to TaskExecutionService (EXEC-024) ----
@@ -900,58 +828,20 @@ async def execute_parallel_task(
     # Build response from service result
     response_data = result.raw_response
 
-    # Persist to chat session if requested (for authenticated Chat tab)
+    # Persist to chat session if requested (for authenticated Chat tab).
+    # Shared helper with the async branch (issue #95): guards on SUCCESS so
+    # FAILED/CANCELLED executions don't write empty assistant messages.
     if request.save_to_session:
-        try:
-            if request.create_new_session:
-                session = db.create_new_chat_session(
-                    agent_name=name,
-                    user_id=current_user.id,
-                    user_email=current_user.email or current_user.username,
-                    subscription_id=_task_subscription_id,  # SUB-004
-                )
-            elif request.chat_session_id:
-                session = db.get_chat_session(request.chat_session_id)
-                if not session:
-                    session = db.get_or_create_chat_session(
-                        agent_name=name,
-                        user_id=current_user.id,
-                        user_email=current_user.email or current_user.username
-                    )
-            else:
-                session = db.get_or_create_chat_session(
-                    agent_name=name,
-                    user_id=current_user.id,
-                    user_email=current_user.email or current_user.username
-                )
-
-            original_user_message = request.user_message or request.message
-
-            db.add_chat_message(
-                session_id=session.id,
-                agent_name=name,
-                user_id=current_user.id,
-                user_email=current_user.email or current_user.username,
-                role="user",
-                content=original_user_message
-            )
-
-            db.add_chat_message(
-                session_id=session.id,
-                agent_name=name,
-                user_id=current_user.id,
-                user_email=current_user.email or current_user.username,
-                role="assistant",
-                content=result.response,
-                cost=result.cost,
-                context_used=result.context_used,
-                context_max=result.context_max,
-            )
-
-            response_data["chat_session_id"] = session.id
-            logger.debug(f"[Task] Saved to chat session {session.id} for agent '{name}'")
-        except Exception as e:
-            logger.warning(f"[Task] Failed to save to chat session for agent '{name}': {e}")
+        chat_session_id = await _persist_chat_session(
+            agent_name=name,
+            request=request,
+            result=result,
+            user_id=current_user.id,
+            user_email=current_user.email or current_user.username,
+            subscription_id=_task_subscription_id,
+        )
+        if chat_session_id:
+            response_data["chat_session_id"] = chat_session_id
 
     # Add database execution ID to response for frontend tracking
     response_data["task_execution_id"] = execution_id

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -145,6 +145,9 @@ class TaskExecutionService:
         execution_id: Optional[str] = None,
         fan_out_id: Optional[str] = None,
         subscription_id: Optional[str] = None,
+        parent_activity_id: Optional[str] = None,
+        extra_activity_details: Optional[dict] = None,
+        slot_already_held: bool = False,
     ) -> TaskExecutionResult:
         """
         Execute a task on an agent container with full lifecycle management.
@@ -167,7 +170,9 @@ class TaskExecutionService:
         """
         slot_service = get_slot_service()
         activity_id: Optional[str] = None
-        slot_acquired = False  # Track whether slot was acquired for proper cleanup
+        # If caller already acquired the slot (async /task path preserves 429-upfront
+        # contract by pre-flighting capacity), we still own releasing it in finally.
+        slot_acquired = slot_already_held
 
         # TIMEOUT-001: Use agent's configured timeout if not explicitly provided
         if timeout_seconds is None:
@@ -204,44 +209,49 @@ class TaskExecutionService:
         # stuck in 'running' status with NULL session_id and duration_ms.
         try:
             # ---- 2. Acquire capacity slot ------------------------------------
-            max_parallel_tasks = db.get_max_parallel_tasks(agent_name)
-            slot_acquired = await slot_service.acquire_slot(
-                agent_name=agent_name,
-                execution_id=execution_id or f"temp-{datetime.utcnow().timestamp()}",
-                max_parallel_tasks=max_parallel_tasks,
-                message_preview=message[:100] if message else "",
-                timeout_seconds=timeout_seconds,  # TIMEOUT-001: Pass for dynamic slot TTL
-            )
-
-            if not slot_acquired:
-                error_msg = f"Agent at capacity ({max_parallel_tasks}/{max_parallel_tasks} parallel tasks running)"
-                if execution_id:
-                    db.update_execution_status(
-                        execution_id=execution_id,
-                        status=TaskExecutionStatus.FAILED,
-                        error=error_msg,
-                    )
-                return TaskExecutionResult(
-                    execution_id=execution_id or "",
-                    status=TaskExecutionStatus.FAILED,
-                    response="",
-                    error=error_msg,
+            if not slot_already_held:
+                max_parallel_tasks = db.get_max_parallel_tasks(agent_name)
+                slot_acquired = await slot_service.acquire_slot(
+                    agent_name=agent_name,
+                    execution_id=execution_id or f"temp-{datetime.utcnow().timestamp()}",
+                    max_parallel_tasks=max_parallel_tasks,
+                    message_preview=message[:100] if message else "",
+                    timeout_seconds=timeout_seconds,  # TIMEOUT-001: Pass for dynamic slot TTL
                 )
 
+                if not slot_acquired:
+                    error_msg = f"Agent at capacity ({max_parallel_tasks}/{max_parallel_tasks} parallel tasks running)"
+                    if execution_id:
+                        db.update_execution_status(
+                            execution_id=execution_id,
+                            status=TaskExecutionStatus.FAILED,
+                            error=error_msg,
+                        )
+                    return TaskExecutionResult(
+                        execution_id=execution_id or "",
+                        status=TaskExecutionStatus.FAILED,
+                        response="",
+                        error=error_msg,
+                    )
+
             # ---- 3. Track activity start -------------------------------------
+            activity_details = {
+                "message_preview": message[:100] if message else "",
+                "source_agent": source_agent_name,
+                "execution_id": execution_id,
+                "triggered_by": triggered_by,
+            }
+            if extra_activity_details:
+                activity_details.update(extra_activity_details)
             try:
                 activity_id = await activity_service.track_activity(
                     agent_name=agent_name,
                     activity_type=ActivityType.CHAT_START,
                     user_id=source_user_id,
                     triggered_by=triggered_by,
+                    parent_activity_id=parent_activity_id,
                     related_execution_id=execution_id,
-                    details={
-                        "message_preview": message[:100] if message else "",
-                        "source_agent": source_agent_name,
-                        "execution_id": execution_id,
-                        "triggered_by": triggered_by,
-                    },
+                    details=activity_details,
                 )
             except Exception as e:
                 logger.warning(f"[TaskExecService] Failed to track activity start: {e}")

--- a/tests/test_parallel_task.py
+++ b/tests/test_parallel_task.py
@@ -730,3 +730,142 @@ class TestAsyncModeActivities:
         current_count = data.get("count", 0)
         assert current_count > initial_count, \
             f"Should have new activity for async task (before: {initial_count}, after: {current_count})"
+
+
+class TestAsyncModeUnifiedExecutor:
+    """Issue #95: async /task routes through TaskExecutionService.
+
+    Verifies that the refactor preserves observable behavior:
+      - 429 upfront at capacity (T1 decision)
+      - parallel_mode flag on CHAT_START activity (H2 fix — network.js filter)
+      - save_to_session guarded on SUCCESS (E1 fix)
+    """
+
+    def test_async_mode_at_capacity_returns_429_upfront(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """Issue #95 T1: async-at-capacity returns 429 synchronously, not 202+FAILED on poll."""
+        agent_name = created_agent["name"]
+
+        # Prior tests may still hold slots. Raise capacity briefly so any
+        # straggler slot doesn't block this test, then pin to 1.
+        api_client.put(
+            f"/api/agents/{agent_name}/capacity",
+            json={"max_parallel_tasks": 10},
+        )
+        # Wait for slots to drain
+        for _ in range(20):
+            cap = api_client.get(f"/api/agents/{agent_name}/capacity")
+            if cap.status_code == 200 and cap.json().get("active_slots", 0) == 0:
+                break
+            time.sleep(1)
+
+        cap_resp = api_client.put(
+            f"/api/agents/{agent_name}/capacity",
+            json={"max_parallel_tasks": 1},
+        )
+        if cap_resp.status_code not in (200, 204):
+            pytest.skip(f"Could not pin capacity (status {cap_resp.status_code})")
+
+        try:
+            # Fire-and-forget first async task to consume the slot
+            first = api_client.post(
+                f"/api/agents/{agent_name}/task",
+                json={
+                    "message": "Long-running: enumerate primes up to 10000 slowly.",
+                    "async_mode": True,
+                },
+                timeout=10.0,
+            )
+            if first.status_code == 503:
+                pytest.skip("Agent not ready")
+            if first.status_code == 429:
+                pytest.skip("Slots still occupied from prior tests — rerun isolated")
+            assert_status(first, 200)
+
+            # Second async task should be rejected with 429 *synchronously*
+            second = api_client.post(
+                f"/api/agents/{agent_name}/task",
+                json={"message": "Should be rejected.", "async_mode": True},
+                timeout=10.0,
+            )
+            assert_status(second, 429), (
+                "async-at-capacity must return 429 upfront (not 202 with FAILED-on-poll) — "
+                "preserves existing client retry contract through issue #95 refactor"
+            )
+            detail = (second.json() or {}).get("detail", "")
+            assert "capacity" in detail.lower()
+        finally:
+            # Restore default capacity
+            api_client.put(
+                f"/api/agents/{agent_name}/capacity",
+                json={"max_parallel_tasks": 3},
+            )
+
+    @pytest.mark.slow
+    @pytest.mark.requires_agent
+    def test_async_mode_activity_has_parallel_mode_flag(
+        self,
+        api_client: TrinityApiClient,
+        created_agent,
+    ):
+        """Issue #95 H2: CHAT_START activity retains parallel_mode=True so the
+        Network view filter at src/frontend/src/stores/network.js:255 still
+        includes async /task executions after the refactor.
+        """
+        agent_name = created_agent["name"]
+
+        resp = api_client.post(
+            f"/api/agents/{agent_name}/task",
+            json={"message": "What is 2+2?", "async_mode": True},
+            timeout=10.0,
+        )
+        if resp.status_code == 503:
+            pytest.skip("Agent not ready")
+        if resp.status_code == 429:
+            pytest.skip("Agent at capacity from prior test")
+        assert_status(resp, 200)
+        execution_id = resp.json()["execution_id"]
+
+        # Poll activities until we find the CHAT_START for this execution
+        import json as _json
+        found = None
+        for _ in range(15):
+            time.sleep(1)
+            acts_resp = api_client.get(f"/api/agents/{agent_name}/activities")
+            if acts_resp.status_code != 200:
+                continue
+            for a in acts_resp.json().get("activities", []):
+                if a.get("activity_type") != "chat_start":
+                    continue
+                details = a.get("details")
+                if isinstance(details, str):
+                    try:
+                        details = _json.loads(details)
+                    except Exception:
+                        details = {}
+                if (details or {}).get("execution_id") == execution_id:
+                    found = details
+                    break
+            if found is not None:
+                break
+
+        assert found is not None, (
+            f"CHAT_START activity for async execution {execution_id} not found"
+        )
+        assert found.get("parallel_mode") is True, (
+            f"parallel_mode flag missing from async CHAT_START details: {found}. "
+            "This would cause the Network view (network.js:255) to filter out "
+            "this execution — regression from issue #95 refactor."
+        )
+        assert found.get("async_mode") is True, (
+            f"async_mode flag missing from async CHAT_START details: {found}"
+        )
+
+    # Note: the E3 fix (passing subscription_id into db.create_task_execution
+    # on the async path) is a DB-write concern. The execution-detail endpoint
+    # doesn't serialize subscription_id, so it can't be asserted at the API
+    # surface without a new DB-direct fixture. Covered by code inspection at
+    # src/backend/routers/chat.py:688 where subscription_id is now passed.


### PR DESCRIPTION
## Summary

- Delete `_execute_task_background` (~220 lines of duplicated lifecycle) from `src/backend/routers/chat.py`. Async `/task` now delegates to `TaskExecutionService.execute_task` via a thin `_run_async_task_with_persistence` wrapper, matching the pattern already used by `public.py` and `internal.py` async paths.
- Add three parameters to `TaskExecutionService.execute_task()`: `parent_activity_id`, `extra_activity_details`, `slot_already_held`. These preserve async-specific behaviors (collaboration parent linkage, `parallel_mode` flag for the Network-view filter, router-side pre-acquire for the 429-upfront contract).
- Extract a shared `_persist_chat_session` helper used by both sync and async branches of `execute_parallel_task`. Guarded on `status == SUCCESS` to avoid empty assistant messages on FAILED/CANCELLED. Fixes a subscription_id snapshot gap (E3) by passing `subscription_id` into `db.create_task_execution` on the async path.

## Preserved behavior

- **429-at-capacity returned synchronously** — the router pre-acquires the slot and passes `slot_already_held=True` so the service skips its own acquire but still releases in `finally`.
- **`parallel_mode: True` on CHAT_START activity** — required by `src/frontend/src/stores/network.js:255`, preserved via `extra_activity_details`.
- **Collaboration activity parenting** — CHAT_START now linked to the collaboration activity via the new `parent_activity_id` param.
- **save_to_session + `chat_response_ready` WebSocket broadcast** — moved into the shared helper, still fires on the async path.

## Test Plan

- [x] New parity tests in `tests/test_parallel_task.py::TestAsyncModeUnifiedExecutor`:
  - `test_async_mode_at_capacity_returns_429_upfront` — confirms 429 contract preserved.
  - `test_async_mode_activity_has_parallel_mode_flag` — confirms Network-view filter still matches.
- [x] Existing `TestAsyncMode*` classes still pass (no regression).
- [x] Backend restarts clean; `execute_parallel_task` async branch serves 202 + `execution_id` within 1s.
- [x] `grep -r "_execute_task_background"` returns zero hits in `src/`.
- [ ] Reviewer manual verify: async task from the UI's Tasks tab completes, appears in Network timeline, `chat_response_ready` WebSocket event fires when `save_to_session=True`.

## Context

First Tier 0 item from `docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md`. Unblocks the remaining Sprint A fixes (#285, #61, #226, #286, #132, #56) and the Sprint C orchestration work (#260, #294) that layer on the unified executor.

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)