### PR TITLE
fix(exec): detect auth failures in stderr and abort early (#285)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -9,6 +9,7 @@ import uuid
 import asyncio
 import subprocess
 import logging
+import threading
 from typing import List, Dict, Optional, Tuple
 from datetime import datetime
 from pathlib import Path
@@ -671,6 +672,35 @@ def _is_model_access_error(text: str) -> bool:
     ])
 
 
+def _is_auth_failure_message(text: str) -> bool:
+    """Check if a message indicates an authentication/token failure.
+
+    These patterns indicate the subscription token is expired, revoked,
+    or otherwise invalid. When detected during execution, we should
+    abort immediately rather than waiting for the full timeout.
+
+    Issue #285: Expired tokens can cause Claude Code to hang instead of
+    failing fast. Real-time detection in stderr allows early abort.
+    """
+    if not text:
+        return False
+    lower = text.lower()
+    return any(pattern in lower for pattern in [
+        "subscription token may be expired",
+        "token may be expired",
+        "token expired",
+        "token revoked",
+        "invalid token",
+        "authentication failed",
+        "auth failed",
+        "setup-token",  # "Generate a new one with 'claude setup-token'"
+        "oauth token",
+        "unauthorized",
+        "invalid credentials",
+        "credentials expired",
+    ])
+
+
 def _format_rate_limit_error(metadata: 'ExecutionMetadata') -> str:
     """Format a clear, actionable rate limit error message."""
     base_msg = metadata.error_message or "Subscription usage limit reached"
@@ -858,18 +888,39 @@ async def execute_headless_task(
         process.stdin.write(prompt)
         process.stdin.close()
 
+        # Issue #285: Event to signal auth failure detected in stderr
+        # When set, stdout loop should stop and process should be killed
+        auth_abort_event = threading.Event()
+        auth_abort_reason: List[str] = []  # Capture the auth failure message
+
         # Helper function that reads subprocess output (runs in thread pool)
         def read_subprocess_output_with_timeout():
             """Blocking function to read subprocess output line by line with timeout"""
-            import threading
 
             # Read stderr in separate thread (verbose output with thinking/tool calls)
+            # Issue #285: Also scan for auth failure patterns and abort early
             def read_stderr():
                 try:
                     for line in iter(process.stderr.readline, ''):
                         if not line:
                             break
-                        verbose_output_lines.append(line.rstrip('\n'))
+                        stripped = line.rstrip('\n')
+                        verbose_output_lines.append(stripped)
+
+                        # Issue #285: Check for auth failure patterns in real-time
+                        # If detected, signal abort immediately instead of waiting for timeout
+                        if _is_auth_failure_message(stripped):
+                            logger.warning(
+                                f"[Headless Task] Auth failure detected in stderr: {stripped[:200]}"
+                            )
+                            auth_abort_reason.append(stripped)
+                            auth_abort_event.set()
+                            # Kill the process immediately
+                            try:
+                                process.kill()
+                            except Exception as kill_err:
+                                logger.error(f"[Headless Task] Failed to kill process on auth abort: {kill_err}")
+                            break
                 except Exception as e:
                     logger.error(f"[Headless Task] Error reading stderr: {e}")
 
@@ -880,6 +931,10 @@ async def execute_headless_task(
             try:
                 for line in iter(process.stdout.readline, ''):
                     if not line:
+                        break
+                    # Issue #285: Check if stderr thread detected auth failure
+                    if auth_abort_event.is_set():
+                        logger.info(f"[Headless Task] Stdout loop exiting due to auth abort")
                         break
                     # Capture raw JSON for full execution log
                     try:
@@ -972,12 +1027,46 @@ async def execute_headless_task(
                     detail=error_detail
                 )
 
+            # Issue #285: Check for auth failure detected in stderr
+            # Return 503 (Service Unavailable) so backend can classify as AUTH error
+            if auth_abort_event.is_set():
+                auth_msg = auth_abort_reason[0] if auth_abort_reason else "Authentication failure detected"
+                # SECURITY: Sanitize before logging/returning (auth_abort_reason is captured pre-sanitization)
+                auth_msg = sanitize_text(auth_msg)
+                logger.error(f"[Headless Task] Auth abort: {auth_msg}")
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"Authentication failure: {auth_msg[:300]}. Check subscription token or API key configuration."
+                )
+
             # Check for errors
             if return_code != 0:
                 error_preview = verbose_transcript[:500] if verbose_transcript else ""
                 if not error_preview:
                     # Try to provide a meaningful fallback based on common failure patterns
                     error_preview = _diagnose_exit_failure(return_code, metadata)
+
+                # Issue #285: Check for auth failure patterns in stderr (fallback for cases
+                # where real-time detection didn't trigger, e.g., pattern in later lines)
+                if _is_auth_failure_message(error_preview) or _is_auth_failure_message(verbose_transcript):
+                    logger.error(f"[Headless Task] Auth failure (fallback detection): {error_preview[:200]}")
+                    raise HTTPException(
+                        status_code=503,
+                        detail=f"Authentication failure: {error_preview[:300]}. Check subscription token or API key configuration."
+                    )
+
+                # Issue #285: Heuristic fallback — if exit code != 0 AND zero tokens processed,
+                # likely an auth failure even if we didn't see the exact pattern
+                if metadata.input_tokens == 0 and metadata.output_tokens == 0:
+                    logger.warning(
+                        f"[Headless Task] Zero tokens processed with exit code {return_code} — "
+                        f"likely auth failure. Stderr: {error_preview[:200]}"
+                    )
+                    raise HTTPException(
+                        status_code=503,
+                        detail=f"Execution failed with no output (possible authentication issue): {error_preview[:300]}"
+                    )
+
                 # Also check if stderr contains a rate limit message
                 if _is_rate_limit_message(error_preview) or _is_rate_limit_message(verbose_transcript):
                     raise HTTPException(

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -409,6 +409,13 @@ class TaskExecutionService:
                 except Exception as switch_err:
                     logger.error(f"[SUB-003] Auto-switch check failed for '{agent_name}': {switch_err}")
 
+            # Issue #285: Detect auth failures (HTTP 503 from agent server)
+            # Return structured error code so callers can handle appropriately
+            error_code = None
+            if agent_status_code == 503:
+                logger.warning(f"[TaskExecService] Auth failure detected on {agent_name}: {error_msg[:200]}")
+                error_code = TaskExecutionErrorCode.AUTH
+
             if execution_id:
                 existing = db.get_execution(execution_id)
                 if not existing or existing.status != TaskExecutionStatus.CANCELLED:
@@ -428,6 +435,7 @@ class TaskExecutionService:
                 status=TaskExecutionStatus.FAILED,
                 response="",
                 error=error_msg,
+                error_code=error_code,  # Issue #285: Include auth error code
             )
 
         except Exception as e:

--- a/tests/test_auth_failure_detection.py
+++ b/tests/test_auth_failure_detection.py
@@ -1,0 +1,104 @@
+"""
+Tests for Issue #285: Expired Token Fast-Fail Detection
+
+Verifies that auth failure patterns in Claude Code stderr are detected
+and result in HTTP 503 responses with appropriate error codes.
+
+Related: docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md
+"""
+import pytest
+
+
+def _is_auth_failure_message(text: str) -> bool:
+    """
+    Check if a message indicates an authentication/token failure.
+
+    This is a copy of the function from claude_code.py for testing purposes.
+    The actual implementation lives in docker/base-image/agent_server/services/claude_code.py
+    """
+    if not text:
+        return False
+    lower = text.lower()
+    return any(pattern in lower for pattern in [
+        "subscription token may be expired",
+        "token may be expired",
+        "token expired",
+        "token revoked",
+        "invalid token",
+        "authentication failed",
+        "auth failed",
+        "setup-token",  # "Generate a new one with 'claude setup-token'"
+        "oauth token",
+        "unauthorized",
+        "invalid credentials",
+        "credentials expired",
+    ])
+
+
+class TestAuthFailurePatternMatcher:
+    """Unit tests for _is_auth_failure_message() pattern matcher."""
+
+    def test_expired_token_patterns(self):
+        """Test detection of expired token messages."""
+        # Patterns that should be detected
+        assert _is_auth_failure_message("Subscription token may be expired or revoked")
+        assert _is_auth_failure_message("Your token may be expired. Please re-authenticate.")
+        assert _is_auth_failure_message("Token expired")
+        assert _is_auth_failure_message("token revoked by user")
+        assert _is_auth_failure_message("Invalid token provided")
+        assert _is_auth_failure_message("Authentication failed: invalid credentials")
+        assert _is_auth_failure_message("Generate a new one with 'claude setup-token'")
+        assert _is_auth_failure_message("OAuth token invalid")
+        assert _is_auth_failure_message("Error: unauthorized")
+        assert _is_auth_failure_message("invalid credentials")
+        assert _is_auth_failure_message("credentials expired")
+
+    def test_non_auth_patterns(self):
+        """Test that non-auth messages are not flagged."""
+        # Patterns that should NOT be detected
+        assert not _is_auth_failure_message("")
+        assert not _is_auth_failure_message(None)
+        assert not _is_auth_failure_message("Task completed successfully")
+        assert not _is_auth_failure_message("Using model: claude-sonnet-4-5")
+        assert not _is_auth_failure_message("Processing tokens...")
+        assert not _is_auth_failure_message("Rate limit exceeded")  # Different error type
+        assert not _is_auth_failure_message("Out of usage")  # Rate limit, not auth
+
+    def test_case_insensitivity(self):
+        """Test that pattern matching is case-insensitive."""
+        assert _is_auth_failure_message("TOKEN EXPIRED")
+        assert _is_auth_failure_message("Authentication Failed")
+        assert _is_auth_failure_message("UNAUTHORIZED")
+
+
+class TestAuthFailureIntegration:
+    """Integration tests for auth failure flow (requires running backend)."""
+
+    @pytest.fixture
+    def auth_headers(self, get_auth_token):
+        """Get auth headers for API calls."""
+        token = get_auth_token()
+        return {"Authorization": f"Bearer {token}"}
+
+    @pytest.mark.skip(reason="Requires mock agent with auth failure - manual test")
+    def test_503_on_auth_failure(self, auth_headers):
+        """
+        Test that agent returns 503 on auth failure.
+
+        This test requires a mock agent that outputs auth failure to stderr.
+        Run manually with a specially configured test agent.
+        """
+        import httpx
+
+        # This would need a test agent configured to fail auth
+        response = httpx.post(
+            "http://localhost:8000/api/agents/test-auth-fail/task",
+            headers=auth_headers,
+            json={"message": "test"},
+            timeout=30.0,
+        )
+        # Should get 503 or the error should contain "auth" indicator
+        assert response.status_code in [503, 500]
+        if response.status_code == 500:
+            data = response.json()
+            assert "auth" in data.get("detail", "").lower() or "token" in data.get("detail", "").lower()


### PR DESCRIPTION
## Summary

- Add real-time auth failure detection in agent server stderr scanning
- Kill Claude Code process immediately when expired token patterns detected
- Return HTTP 503 so backend can classify as `error_code=AUTH`
- Add fallback heuristics: auth pattern in stderr, zero tokens processed

## Problem

When subscription tokens (CLAUDE_CODE_OAUTH_TOKEN) expire, Claude Code sometimes hangs instead of failing fast. This wastes execution slots for up to an hour before the watchdog recovers them. Issue #285 reports some executions fail in ~3 minutes (correct) while others hang for the full timeout (bug).

## Solution

Detect auth failure patterns in stderr **during** execution (not after) and abort immediately:
1. `_is_auth_failure_message()` pattern matcher scans for "token expired", "unauthorized", etc.
2. `read_stderr()` thread checks each line and sets abort event if pattern found
3. Process is killed immediately, HTTP 503 returned
4. Backend detects 503, sets `error_code=TaskExecutionErrorCode.AUTH`

## Test Plan

- [x] Unit tests for pattern matcher: `pytest tests/test_auth_failure_detection.py -v`
- [ ] Manual: Configure agent with expired token, verify fails in seconds not hours
- [ ] Verify watchdog still recovers executions that slip through

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)