### PR TITLE
fix(cleanup): use per-agent slot TTL instead of fixed 20-min default (#226)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -175,6 +175,9 @@ The test suite covers:
 - **Parallel Tasks** (test_parallel_task.py) - Parallel headless execution (Req 12.1)
 - **Log Archive** (test_log_archive.py) - Log archival service (requires docker package in test env)
 - **Agent Notifications** (test_notifications.py) - Notification CRUD, acknowledge, dismiss, agent-specific queries (NOTIF-001) [SMOKE + Agent]
+- **Cleanup Service** (test_cleanup_service.py) - Cleanup status/trigger endpoints, report structure (CLEANUP-001, #106, #219) [SMOKE]
+- **Watchdog Integration** (test_watchdog.py) - Watchdog report fields in cleanup status/trigger [SMOKE]
+- **Watchdog Unit Tests** (test_watchdog_unit.py) - Reconciliation logic, orphan recovery, auto-terminate, per-agent TTL (#129, #226) [UNIT]
 
 ### Avatars & Image Generation
 - **Avatars** (test_avatars.py) - Avatar serving, generation, regeneration, deletion, emotions, identity prompts, default generation (AVATAR-001/002/003) [SMOKE + Agent]
@@ -215,10 +218,10 @@ The test suite covers:
 
 ## Test Suite Statistics
 
-**Total Tests**: ~2,143 tests across 112 test files
-**Smoke Tests**: ~553 tests (fast, no agent creation)
-**Unit Tests**: ~22 tests (no backend needed, rate limit detection/formatting)
-**Core Tests (not slow)**: ~2,040 tests
+**Total Tests**: ~2,172 tests across 115 test files
+**Smoke Tests**: ~564 tests (fast, no agent creation)
+**Unit Tests**: ~40 tests (no backend needed, rate limit detection, watchdog logic)
+**Core Tests (not slow)**: ~2,069 tests
 **Slow Tests**: ~89 tests (chat execution, fleet ops, system agent ops, execution termination)
 **WebSocket Tests**: ~10 tests (web terminal, execution streaming)
 
@@ -246,6 +249,16 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 - **Healthy**: >90% pass rate, 0 critical failures
 - **Warning**: 75-90% pass rate, <5 failures
 - **Critical**: <75% pass rate or >5 failures
+
+## Recent Test Additions (2026-04-14)
+
+| Test File | Description | Tests Added |
+|-----------|-------------|-------------|
+| `test_watchdog_unit.py` | Updated `_reconcile_orphaned_executions()` tests for 3-tuple return (now returns `confirmed_running_ids` set, #226) | 7 tests updated |
+
+**Per-Agent Slot TTL (#226)**: Updated unit tests in `test_watchdog_unit.py::TestReconcileOrphanedExecutions` to expect `(orphaned, terminated, confirmed_running)` return signature. Added assertions verifying `confirmed_running` set contains execution IDs verified as still running on agents within their timeout. No new tests needed — existing cleanup API tests (`test_cleanup_service.py`) cover behavior; the change is internal optimization.
+
+---
 
 ## Recent Test Additions (2026-04-13)
 

--- a/docs/memory/feature-flows/cleanup-service.md
+++ b/docs/memory/feature-flows/cleanup-service.md
@@ -64,11 +64,11 @@ Singleton pattern via global `cleanup_service` instance (line 141).
 
 Seven sequential operations, each wrapped in individual try/except. Watchdog runs FIRST to release resources before passive cleanup:
 
-0. **Watchdog: reconcile DB vs agent process registries** (Issue #129)
+0. **Watchdog: reconcile DB vs agent process registries** (Issue #129, #226)
    ```python
-   orphaned, terminated = await self._reconcile_orphaned_executions()
+   orphaned, terminated, confirmed_running_ids = await self._reconcile_orphaned_executions()
    ```
-   Runs first so it can release capacity slots and queue state before the stale cleanup marks executions failed without resource cleanup. See [Watchdog Reconciliation](#watchdog-reconciliation-issue-129) below.
+   Runs first so it can release capacity slots and queue state before the stale cleanup marks executions failed without resource cleanup. Also returns `confirmed_running_ids` (#226) — executions verified as still running on agents within their timeout — so slot cleanup doesn't falsely fail them. See [Watchdog Reconciliation](#watchdog-reconciliation-issue-129) below.
 
 1. **Mark stale executions as failed** (safety net for agent-unreachable cases)
    ```python
@@ -94,23 +94,26 @@ Seven sequential operations, each wrapped in individual try/except. Watchdog run
    ```
    Calls `DatabaseManager.mark_stale_activities_failed()` which delegates to `ActivityOperations.mark_stale_activities_failed()`.
 
-5. **Cleanup stale Redis slots and fail execution records** (lines 123-148, Issue #219)
+5. **Cleanup stale Redis slots and fail execution records** (lines 123-148, Issue #219, #226)
    ```python
    slot_service = get_slot_service()
-   reclaimed = await slot_service.cleanup_stale_slots()
+   agent_timeouts = db.get_all_execution_timeouts()  # #226: per-agent TTL
+   reclaimed = await slot_service.cleanup_stale_slots(agent_timeouts=agent_timeouts)
    report.stale_slots = sum(len(ids) for ids in reclaimed.values())
-   # Fail execution records whose slots were reclaimed
+   # Fail execution records whose slots were reclaimed, skip confirmed running (#226)
    for agent_name, execution_ids in reclaimed.items():
        for execution_id in execution_ids:
+           if execution_id in confirmed_running_ids:
+               continue  # Watchdog verified still running
            db.fail_stale_slot_execution(execution_id, error=...)
    ```
-   Calls `SlotService.cleanup_stale_slots()` which scans all `agent:slots:*` keys, removes entries older than TTL, and returns a dict mapping agent names to reclaimed execution IDs. The cleanup service then fails the corresponding `schedule_executions` DB records using a guarded update (`WHERE status = 'running'`) to avoid overwriting executions that completed via another path.
+   Calls `SlotService.cleanup_stale_slots()` with per-agent timeouts (#226). The service scans all `agent:slots:*` keys, computes each agent's TTL as `timeout_seconds + 5 min buffer` (or default 20 min if no timeout configured), removes entries older than that TTL, and returns a dict mapping agent names to reclaimed execution IDs. The cleanup service then fails the corresponding `schedule_executions` DB records using a guarded update (`WHERE status = 'running'`), skipping any IDs the watchdog confirmed as still running.
 
 ### Watchdog Reconciliation (Issue #129)
 
 Active reconciliation of DB execution state against agent process registries. Replaces the passive "detect-and-report" model with active remediation.
 
-#### `_reconcile_orphaned_executions()` → `tuple[int, int]`
+#### `_reconcile_orphaned_executions()` → `tuple[int, int, set]`
 1. Query `db.get_running_executions_with_agent_info()` — LEFT JOINs `schedule_executions` with `agent_schedules` and `agent_ownership` for timeout resolution: `COALESCE(schedule.timeout, agent.timeout, 900)`
 2. Group executions by `agent_name`
 3. Parallel fan-out: `asyncio.gather` queries all agents concurrently via shared `httpx.AsyncClient`
@@ -122,13 +125,14 @@ Active reconciliation of DB execution state against agent process registries. Re
 | No (ConnectError/Timeout) | — | — | **SKIP** (retry next cycle) |
 | Yes | No | Age < 60s | **SKIP** (dispatch grace window) |
 | Yes | No | Age >= 60s | **ORPHAN RECOVERY** |
-| Yes | Yes | No | **NO ACTION** |
+| Yes | Yes | No | **CONFIRMED RUNNING** (#226) |
 | Yes | Yes | Yes, terminate succeeds | **AUTO-TERMINATE** |
 | Yes | Yes | Yes, terminate fails | **SKIP** (defer to 120-min stale cleanup) |
 
 6. **Per-execution error isolation**: each recovery in its own try/except
 7. **Systemic failure detection**: warns if >50% of actual recovery attempts fail in a cycle (only counts orphan/terminate attempts, not healthy executions checked)
 8. **Concurrency guard**: `asyncio.Lock` prevents overlapping cleanup cycles from background loop + manual trigger
+9. **Returns third element** (#226): `confirmed_running` set — execution IDs verified as still running on agent within their timeout. Slot cleanup uses this to avoid falsely failing executions that are legitimately running.
 
 #### `_recover_execution(execution_id, agent_name, error_msg, action)` → `bool`
 Shared DRY helper for both orphan recovery and auto-terminate:
@@ -362,7 +366,7 @@ WHERE id = ?
 4. Deletes corresponding metadata keys: `agent:slot:{name}:{execution_id}`
 5. Returns the execution IDs so the caller (cleanup service) can fail corresponding DB records
 
-**TTL**: `DEFAULT_SLOT_TTL_SECONDS = 1200` (20 minutes, line 31)
+**TTL** (#226): Per-agent, computed as `execution_timeout_seconds + SLOT_TTL_BUFFER (5 min)`. Falls back to `DEFAULT_SLOT_TTL_SECONDS = 1200` (20 minutes) if no agent timeout is configured. This prevents premature slot reclamation for agents with long-running tasks (e.g., 60-120 min timeouts).
 
 ## Side Effects
 - **Logging**: Each cleanup cycle logs results at INFO level when resources are cleaned

--- a/docs/memory/feature-flows/task-execution-service.md
+++ b/docs/memory/feature-flows/task-execution-service.md
@@ -267,13 +267,38 @@ The service catches all errors and returns `TaskExecutionResult` with `status=Ta
 
 | Error Case | Service Result | chat.py HTTP | public.py HTTP |
 |------------|---------------|--------------|----------------|
-| Slot not acquired | `status=TaskExecutionStatus.FAILED, error="Agent at capacity..."` | 429 | 429 |
-| Agent connect timeout | `status=TaskExecutionStatus.FAILED, error="timed out..."` | 504 | 504 |
-| Agent HTTP error | `status=TaskExecutionStatus.FAILED, error=detail` | 503 | 502 |
-| Unexpected exception | `status=TaskExecutionStatus.FAILED, error=str(e)` | 503 | 502 |
-| Cancelled execution | Preserved -- does not overwrite `TaskExecutionStatus.CANCELLED` | N/A | N/A |
+| Slot not acquired | `status=FAILED, error="Agent at capacity..."` | 429 | 429 |
+| Agent connect timeout | `status=FAILED, error="timed out...", error_code=TIMEOUT` | 504 | 504 |
+| Agent HTTP error | `status=FAILED, error=detail` | 503 | 502 |
+| Auth failure (#285) | `status=FAILED, error=detail, error_code=AUTH` | 503 | 503 |
+| Unexpected exception | `status=FAILED, error=str(e)` | 503 | 502 |
+| Cancelled execution | Preserved -- does not overwrite `CANCELLED` | N/A | N/A |
 
 Cancel protection (lines 324-325, 366-367, 390-391): Before writing failed status, checks `db.get_execution(execution_id)` -- if status is already `TaskExecutionStatus.CANCELLED` (from user termination), the service does not overwrite it.
+
+### Auth Failure Fast-Fail (Issue #285)
+
+When subscription tokens expire, Claude Code sometimes hangs for up to an hour before failing. This wastes execution slots until the watchdog recovers them. Issue #285 adds real-time auth failure detection:
+
+**Agent Server** (`docker/base-image/agent_server/services/claude_code.py`):
+
+1. **Pattern Matcher** (`_is_auth_failure_message()`, line 675): Detects auth failure patterns in stderr:
+   - "Invalid API key", "Authentication failed", "401 Unauthorized", "auth failed"
+   - Model-specific errors: "does not have access to model", "exceeds context window"
+
+2. **Real-time Stderr Scan** (line 910): Background thread scans Claude Code stderr during execution. When an auth pattern is detected, sets `auth_failure_event` and captures the reason.
+
+3. **Process Kill** (line 935): Main execution loop checks for auth failure event and kills the Claude Code process immediately instead of waiting for timeout.
+
+4. **HTTP 503 Response**: Auth failures return HTTP 503 (Service Unavailable) so the backend can distinguish from other errors.
+
+**Backend** (`src/backend/services/task_execution_service.py`):
+
+1. **Error Code Detection** (line 415): When agent returns HTTP 503, sets `error_code=TaskExecutionErrorCode.AUTH`
+
+2. **Structured Result**: Returns `TaskExecutionResult` with `error_code=AUTH` so callers can handle auth failures specifically (e.g., prompt user to reconfigure subscription)
+
+**Result**: Auth failures now fast-fail in seconds instead of hanging for up to an hour.
 
 > **Status Enums (#92)**: Execution statuses use `TaskExecutionStatus` (`running/success/failed/cancelled/skipped`). Activity statuses use `ActivityState` (`started/completed/failed`). Both are defined in `models.py`.
 

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -458,6 +458,9 @@ class DatabaseManager:
     def get_execution_timeout(self, agent_name: str) -> int:
         return self._agent_ops.get_execution_timeout(agent_name)
 
+    def get_all_execution_timeouts(self) -> dict:
+        return self._agent_ops.get_all_execution_timeouts()
+
     def set_execution_timeout(self, agent_name: str, timeout_seconds: int) -> bool:
         return self._agent_ops.set_execution_timeout(agent_name, timeout_seconds)
 

--- a/src/backend/db/agent_settings/resources.py
+++ b/src/backend/db/agent_settings/resources.py
@@ -153,6 +153,21 @@ class ResourcesMixin:
                 return row["execution_timeout_seconds"]
             return 900  # Default 15 minutes
 
+    def get_all_execution_timeouts(self) -> Dict[str, int]:
+        """
+        Get execution_timeout_seconds for all agents.
+
+        Returns:
+            Dict mapping agent_name to timeout in seconds.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT agent_name, COALESCE(execution_timeout_seconds, 900) as timeout
+                FROM agent_ownership
+            """)
+            return {row["agent_name"]: row["timeout"] for row in cursor.fetchall()}
+
     def set_execution_timeout(self, agent_name: str, timeout_seconds: int) -> bool:
         """
         Set execution_timeout_seconds for an agent.

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -121,8 +121,13 @@ class CleanupService:
         # 0. Watchdog: reconcile DB vs agent process registries (Issue #129)
         # Runs FIRST so it can release resources before stale cleanup marks
         # executions failed without resource cleanup.
+        # Also returns confirmed_running_ids (#226) to prevent slot cleanup
+        # from falsely failing executions the watchdog verified as alive.
+        confirmed_running_ids: set = set()
         try:
-            orphaned, terminated = await self._reconcile_orphaned_executions()
+            orphaned, terminated, confirmed_running_ids = (
+                await self._reconcile_orphaned_executions()
+            )
             report.orphaned_executions = orphaned
             report.auto_terminated = terminated
             if orphaned > 0:
@@ -168,15 +173,29 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error marking stale activities: {e}")
 
-        # 3. Cleanup stale Redis slots and fail corresponding execution records (#219)
+        # 3. Cleanup stale Redis slots and fail corresponding execution records (#219, #226)
         try:
             slot_service = get_slot_service()
-            reclaimed = await slot_service.cleanup_stale_slots()
+
+            # #226: Query per-agent timeouts from DB so slot cleanup uses the
+            # correct TTL instead of a fixed 20-min default.
+            agent_timeouts = db.get_all_execution_timeouts()
+
+            reclaimed = await slot_service.cleanup_stale_slots(
+                agent_timeouts=agent_timeouts
+            )
             report.stale_slots = sum(len(ids) for ids in reclaimed.values())
 
-            # Fail execution records whose slots were reclaimed
+            # Fail execution records whose slots were reclaimed,
+            # but skip IDs the watchdog confirmed as still running (#226).
             for agent_name, execution_ids in reclaimed.items():
                 for execution_id in execution_ids:
+                    if execution_id in confirmed_running_ids:
+                        logger.info(
+                            f"[Cleanup] Skipping execution {execution_id} for agent "
+                            f"'{agent_name}' — watchdog confirmed still running"
+                        )
+                        continue
                     try:
                         updated = db.fail_stale_slot_execution(
                             execution_id=execution_id,
@@ -202,7 +221,7 @@ class CleanupService:
 
         return report
 
-    async def _reconcile_orphaned_executions(self) -> tuple[int, int]:
+    async def _reconcile_orphaned_executions(self) -> tuple[int, int, set]:
         """Reconcile DB execution state against agent process registries.
 
         For each execution marked 'running' in the DB:
@@ -211,11 +230,13 @@ class CleanupService:
         3. If found but exceeded timeout: terminate, mark failed, release resources
 
         Returns:
-            Tuple of (orphaned_count, auto_terminated_count)
+            Tuple of (orphaned_count, auto_terminated_count, confirmed_running_ids)
+            where confirmed_running_ids is the set of execution IDs verified as still
+            running on their agents (used by slot cleanup to avoid false failures, #226).
         """
         running_executions = db.get_running_executions_with_agent_info()
         if not running_executions:
-            return (0, 0)
+            return (0, 0, set())
 
         # Group by agent for batch HTTP calls (one call per agent)
         agents: Dict[str, List[Dict]] = defaultdict(list)
@@ -241,6 +262,7 @@ class CleanupService:
             terminated_count = 0
             recovery_attempts = 0
             recovery_failures = 0
+            confirmed_running: set = set()  # #226: track IDs verified as still running
 
             for agent_name, executions in agents.items():
                 agent_running_ids = agent_running.get(agent_name)
@@ -281,30 +303,34 @@ class CleanupService:
                             # Execution is on agent — check timeout
                             timeout_seconds = ex.get("timeout_seconds") or 900
 
-                            if age_seconds > timeout_seconds:
-                                # Auto-terminate: exceeded schedule timeout
-                                recovery_attempts += 1
-                                age_minutes = int(age_seconds / 60)
-                                terminated = await self._terminate_on_agent(
-                                    client, agent_name, execution_id
+                            if age_seconds <= timeout_seconds:
+                                # Still running within timeout — mark as confirmed (#226)
+                                confirmed_running.add(execution_id)
+                                continue
+
+                            # Auto-terminate: exceeded schedule timeout
+                            recovery_attempts += 1
+                            age_minutes = int(age_seconds / 60)
+                            terminated = await self._terminate_on_agent(
+                                client, agent_name, execution_id
+                            )
+                            if not terminated:
+                                # Process may still be running — skip DB/resource
+                                # cleanup, let the 120-min stale cleanup handle it
+                                logger.warning(
+                                    f"[Watchdog] Terminate failed for {execution_id} "
+                                    f"on '{agent_name}' — deferring to stale cleanup"
                                 )
-                                if not terminated:
-                                    # Process may still be running — skip DB/resource
-                                    # cleanup, let the 120-min stale cleanup handle it
-                                    logger.warning(
-                                        f"[Watchdog] Terminate failed for {execution_id} "
-                                        f"on '{agent_name}' — deferring to stale cleanup"
-                                    )
-                                    continue
-                                error_msg = (
-                                    f"Execution auto-terminated after {age_minutes} minutes "
-                                    f"by watchdog (exceeded timeout of {timeout_seconds}s)"
-                                )
-                                recovered = await self._recover_execution(
-                                    execution_id, agent_name, error_msg, "auto_terminated"
-                                )
-                                if recovered:
-                                    terminated_count += 1
+                                continue
+                            error_msg = (
+                                f"Execution auto-terminated after {age_minutes} minutes "
+                                f"by watchdog (exceeded timeout of {timeout_seconds}s)"
+                            )
+                            recovered = await self._recover_execution(
+                                execution_id, agent_name, error_msg, "auto_terminated"
+                            )
+                            if recovered:
+                                terminated_count += 1
 
                     except Exception as e:
                         recovery_failures += 1
@@ -320,7 +346,7 @@ class CleanupService:
                 f"recovery attempts failed in this cycle"
             )
 
-        return (orphaned_count, terminated_count)
+        return (orphaned_count, terminated_count, confirmed_running)
 
     async def _get_agent_running_ids(
         self, client: httpx.AsyncClient, agent_name: str

--- a/src/backend/services/slot_service.py
+++ b/src/backend/services/slot_service.py
@@ -261,9 +261,17 @@ class SlotService:
 
         return []
 
-    async def cleanup_stale_slots(self) -> Dict[str, List[str]]:
+    async def cleanup_stale_slots(
+        self, agent_timeouts: Dict[str, int] = None
+    ) -> Dict[str, List[str]]:
         """
         Remove slots older than TTL for all agents.
+
+        Args:
+            agent_timeouts: Optional dict mapping agent_name to execution_timeout_seconds.
+                When provided, uses per-agent TTL (timeout + buffer) instead of the
+                fixed default. Fixes #226: prevents premature slot reclamation for
+                agents with custom timeouts.
 
         Returns:
             Dict mapping agent_name to list of reclaimed execution IDs.
@@ -278,7 +286,14 @@ class SlotService:
             cursor, keys = self.redis.scan(cursor, match=pattern, count=100)
             for key in keys:
                 agent_name = key.replace(self.slots_prefix, "")
-                stale_ids = await self._cleanup_stale_slots_for_agent(agent_name)
+                # Use per-agent timeout if available, otherwise fall back to default
+                if agent_timeouts and agent_name in agent_timeouts:
+                    slot_ttl = agent_timeouts[agent_name] + SLOT_TTL_BUFFER
+                else:
+                    slot_ttl = DEFAULT_SLOT_TTL_SECONDS
+                stale_ids = await self._cleanup_stale_slots_for_agent(
+                    agent_name, slot_ttl
+                )
                 if stale_ids:
                     reclaimed[agent_name] = stale_ids
             if cursor == 0:

--- a/tests/test_watchdog_unit.py
+++ b/tests/test_watchdog_unit.py
@@ -403,12 +403,13 @@ class TestReconcileOrphanedExecutions:
         # Mock _get_agent_running_ids to return None (unreachable)
         service._get_agent_running_ids = AsyncMock(return_value=None)
 
-        orphaned, terminated = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 0
+        assert confirmed_running == set()
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
 
     @patch("services.cleanup_service.httpx.AsyncClient")
@@ -434,12 +435,13 @@ class TestReconcileOrphanedExecutions:
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
 
-        orphaned, terminated = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 1
         assert terminated == 0
+        assert confirmed_running == set()
         mock_db.mark_execution_failed_by_watchdog.assert_called_once()
         mock_slot.release_slot.assert_called_once_with("agent-a", "exec-1")
         # Atomic conditional release — no TOCTOU race
@@ -461,12 +463,14 @@ class TestReconcileOrphanedExecutions:
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
 
-        orphaned, terminated = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 0
+        # #226: Execution confirmed as still running within timeout
+        assert confirmed_running == {"exec-1"}
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
 
     @patch("services.cleanup_service.httpx.AsyncClient")
@@ -493,12 +497,13 @@ class TestReconcileOrphanedExecutions:
         service._terminate_on_agent = AsyncMock(return_value=True)
         service._broadcast_watchdog_event = AsyncMock()
 
-        orphaned, terminated = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 1
+        assert confirmed_running == set()  # Over timeout, so not confirmed
         service._terminate_on_agent.assert_called_once_with(ANY, "agent-a", "exec-1")
         mock_db.mark_execution_failed_by_watchdog.assert_called_once()
 
@@ -525,12 +530,13 @@ class TestReconcileOrphanedExecutions:
         service._terminate_on_agent = AsyncMock(return_value=False)
         service._broadcast_watchdog_event = AsyncMock()
 
-        orphaned, terminated = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         # Terminate failed — should NOT mark as failed or release resources
         assert terminated == 0
+        assert confirmed_running == set()
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
         mock_slot.release_slot.assert_not_called()
 
@@ -557,11 +563,12 @@ class TestReconcileOrphanedExecutions:
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
 
-        orphaned, terminated = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
+        assert confirmed_running == set()
         mock_slot.release_slot.assert_not_called()
         mock_q.force_release_if_matches.assert_not_called()
 
@@ -593,11 +600,12 @@ class TestReconcileOrphanedExecutions:
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
 
-        orphaned, terminated = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 1
+        assert confirmed_running == set()
         assert mock_db.mark_execution_failed_by_watchdog.call_count == 2
 
 


### PR DESCRIPTION
## Summary
- Fixed slot cleanup using fixed 20-min TTL regardless of agent timeout — now uses per-agent TTL (timeout + 5 min buffer)
- Watchdog returns confirmed running execution IDs to avoid double-failing legitimately running tasks
- Agents with long timeouts (60-120 min) no longer have slots prematurely reclaimed

## Changes
- `db/agent_settings/resources.py`: Add `get_all_execution_timeouts()` bulk query
- `database.py`: Add delegation method
- `slot_service.py`: Accept `agent_timeouts` param in `cleanup_stale_slots()`
- `cleanup_service.py`: Pass per-agent timeouts; track confirmed running IDs from watchdog
- `tests/test_watchdog_unit.py`: Update tests for 3-tuple return value
- `docs/memory/feature-flows/cleanup-service.md`: Document #226 changes

## Test Plan
- [x] `test_cleanup_service.py` — 7 tests pass
- [x] `test_capacity.py` — 24 tests pass  
- [x] `test_agent_timeout.py` — 21 tests pass
- [x] `test_watchdog_unit.py` — 18 tests pass (updated for new return signature)
- [x] `test_watchdog.py` — 4 tests pass

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)