### PR TITLE
fix(cleanup): preserve original error context when recovering stale executions (#286)

### DIFF
--- a/docker/base-image/agent_server/routers/chat.py
+++ b/docker/base-image/agent_server/routers/chat.py
@@ -295,6 +295,37 @@ async def get_execution_status(execution_id: str):
     return status
 
 
+@router.get("/api/executions/{execution_id}/last-error")
+async def get_execution_last_error(execution_id: str):
+    """
+    Get the last error from an execution's log buffer.
+
+    Used by the cleanup service to preserve error context when marking
+    stale executions as failed. Returns the most recent error found
+    in the execution's log buffer (if any).
+
+    Returns:
+        - 200: {"error_type": str, "error_message": str} if error found
+        - 200: {"error_type": null, "error_message": null} if no error
+        - 404: Execution not found in buffer
+    """
+    registry = get_process_registry()
+
+    # Check if execution exists (running or recently completed with buffer)
+    if not registry.is_execution_running(execution_id):
+        buffered = registry.get_buffered_logs(execution_id)
+        if buffered is None:
+            raise HTTPException(status_code=404, detail="Execution not found")
+
+    # Extract last error from buffer
+    error_info = registry.get_last_error(execution_id)
+    if error_info:
+        return error_info
+
+    # No error found in buffer
+    return {"error_type": None, "error_message": None}
+
+
 # ============================================================================
 # Live Execution Streaming Endpoints
 # ============================================================================

--- a/docker/base-image/agent_server/services/process_registry.py
+++ b/docker/base-image/agent_server/services/process_registry.py
@@ -303,6 +303,79 @@ class ProcessRegistry:
         with self._lock:
             return execution_id in self._processes
 
+    def get_last_error(self, execution_id: str) -> Optional[dict]:
+        """
+        Extract the last error from an execution's log buffer.
+
+        Scans the log buffer for error indicators:
+        - Messages with is_error=True
+        - Messages with error_type set
+        - Result messages indicating failure
+
+        Args:
+            execution_id: The execution ID
+
+        Returns:
+            Dict with error_type and error_message, or None if no error found
+        """
+        with self._lock:
+            if execution_id not in self._log_buffers:
+                return None
+
+            buffer = self._log_buffers[execution_id]
+            if not buffer:
+                return None
+
+            # Scan buffer in reverse (most recent first) for error indicators
+            last_error_type = None
+            last_error_message = None
+
+            for entry in reversed(buffer):
+                if not isinstance(entry, dict):
+                    continue
+
+                # Check for is_error flag on result messages
+                if entry.get("is_error"):
+                    last_error_type = "execution_error"
+                    last_error_message = entry.get("result", "")
+                    break
+
+                # Check for error field on assistant messages
+                if entry.get("error"):
+                    last_error_type = entry.get("error")
+                    # Try to extract error text from message content
+                    message = entry.get("message", {})
+                    content = message.get("content", [])
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            last_error_message = block.get("text", "")
+                            break
+                    if last_error_type:
+                        break
+
+                # Check for tool_result with is_error
+                if entry.get("type") == "assistant" or entry.get("type") == "user":
+                    message = entry.get("message", {})
+                    content = message.get("content", [])
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_result":
+                            if block.get("is_error"):
+                                last_error_type = "tool_error"
+                                result_content = block.get("content", [])
+                                for item in result_content:
+                                    if isinstance(item, dict) and item.get("type") == "text":
+                                        last_error_message = item.get("text", "")
+                                        break
+                                break
+
+            if last_error_type or last_error_message:
+                return {
+                    "error_type": last_error_type,
+                    "error_message": last_error_message[:2000] if last_error_message else None
+                }
+
+            return None
+
 
 # Global instance
 _process_registry: Optional[ProcessRegistry] = None

--- a/docs/memory/feature-flows/cleanup-service.md
+++ b/docs/memory/feature-flows/cleanup-service.md
@@ -26,6 +26,8 @@ EXECUTION_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to s
 ACTIVITY_STALE_TIMEOUT_MINUTES = 120   # SCHED-ASYNC-001: increased from 30 to support long-running tasks
 NO_SESSION_TIMEOUT_SECONDS = 60       # Issue #106: fast-fail executions without Claude session
 WATCHDOG_HTTP_TIMEOUT = 5.0           # Issue #129: timeout for agent HTTP calls during reconciliation
+ERROR_FETCH_TIMEOUT = 2.0             # Issue #286: timeout for fetching error context from agent
+MAX_ERROR_MESSAGE_LENGTH = 2000       # Issue #286: truncate combined error messages
 ```
 
 #### WebSocket Manager Injection (Issue #129)
@@ -134,12 +136,23 @@ Active reconciliation of DB execution state against agent process registries. Re
 8. **Concurrency guard**: `asyncio.Lock` prevents overlapping cleanup cycles from background loop + manual trigger
 9. **Returns third element** (#226): `confirmed_running` set — execution IDs verified as still running on agent within their timeout. Slot cleanup uses this to avoid falsely failing executions that are legitimately running.
 
-#### `_recover_execution(execution_id, agent_name, error_msg, action)` → `bool`
+#### `_get_execution_error(client, agent_name, execution_id)` → `Optional[str]` (Issue #286)
+Fetches original error context from agent before marking execution failed:
+1. `GET http://agent-{name}:8000/api/executions/{id}/last-error` — queries agent's log buffer for error info
+2. Returns formatted error string (`[error_type] error_message`) or None if unavailable
+3. Sanitizes error message via `sanitize_text()` to remove credential patterns
+4. Uses short timeout (`ERROR_FETCH_TIMEOUT = 2.0s`) to avoid blocking cleanup
+5. Gracefully handles agent unreachability — returns None on ConnectError/TimeoutException
+
+#### `_recover_execution(execution_id, agent_name, error_msg, action, client=None)` → `bool`
 Shared DRY helper for both orphan recovery and auto-terminate:
-1. `db.mark_execution_failed_by_watchdog()` — conditional UPDATE with `WHERE status='running'` race guard. Returns False if execution already completed (no-op).
-2. `slot_service.release_slot()` — idempotent Redis ZREM
-3. `queue.force_release_if_matches()` — atomic Lua script: GET running key, compare execution ID, conditional DELETE. Prevents TOCTOU race where a new execution could start between check and release.
-4. `_broadcast_watchdog_event()` — WebSocket JSON event: `{"type": "watchdog_recovery", "agent_name", "execution_id", "action", "reason", "timestamp"}`
+1. **Issue #286**: If `client` provided, calls `_get_execution_error()` to fetch original error context
+2. Combines original error with cleanup reason: `"{original_error}. Cleanup: {cleanup_reason}"`
+3. Truncates combined message to `MAX_ERROR_MESSAGE_LENGTH = 2000` to prevent DB bloat
+4. `db.mark_execution_failed_by_watchdog()` — conditional UPDATE with `WHERE status='running'` race guard. Returns False if execution already completed (no-op).
+5. `slot_service.release_slot()` — idempotent Redis ZREM
+6. `queue.force_release_if_matches()` — atomic Lua script: GET running key, compare execution ID, conditional DELETE. Prevents TOCTOU race where a new execution could start between check and release.
+7. `_broadcast_watchdog_event()` — WebSocket JSON event with combined error: `{"type": "watchdog_recovery", "agent_name", "execution_id", "action", "reason", "timestamp"}`
 
 #### `_terminate_on_agent(client, agent_name, execution_id)` → `bool`
 `POST http://agent-{name}:8000/api/executions/{id}/terminate`. Returns True if HTTP 2xx (agent confirmed termination), False otherwise. Callers only proceed with DB/resource cleanup on success — failed terminations are deferred to the 120-min stale cleanup safety net.
@@ -468,6 +481,8 @@ This is a purely backend service. The only "UI" is the two admin API endpoints u
 | `src/backend/services/execution_queue.py` | `force_release()` used by watchdog for queue state cleanup |
 | `src/backend/main.py` | Import, start in lifespan, stop on shutdown, wire WS manager |
 | `src/backend/routers/monitoring.py` | `/cleanup-status` and `/cleanup-trigger` endpoints |
+| `docker/base-image/agent_server/routers/chat.py` | `/api/executions/{id}/last-error` endpoint for error context retrieval (Issue #286) |
+| `docker/base-image/agent_server/services/process_registry.py` | `get_last_error()` method scans log buffer for errors (Issue #286) |
 | `tests/test_cleanup_service.py` | API integration tests for cleanup (Issue #106) |
 | `tests/test_watchdog.py` | API integration tests for watchdog fields (Issue #129) |
-| `tests/test_watchdog_unit.py` | Unit tests for watchdog reconciliation logic (Issue #129) |
+| `tests/test_watchdog_unit.py` | Unit tests for watchdog reconciliation logic (Issue #129), error context tests (Issue #286) |

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -25,6 +25,7 @@ from models import TaskExecutionStatus
 from services.slot_service import get_slot_service
 from services.execution_queue import get_execution_queue
 from utils.helpers import utc_now, utc_now_iso, parse_iso_timestamp
+from utils.credential_sanitizer import sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,8 @@ ACTIVITY_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to su
 NO_SESSION_TIMEOUT_SECONDS = 60  # Issue #106: fast-fail executions that never got a Claude session
 WATCHDOG_HTTP_TIMEOUT = 5.0  # Timeout for agent HTTP calls during reconciliation
 WATCHDOG_MIN_AGE_SECONDS = 60  # Don't orphan-recover executions younger than this (dispatch window)
+ERROR_FETCH_TIMEOUT = 2.0  # Issue #286: short timeout for fetching error context from agent
+MAX_ERROR_MESSAGE_LENGTH = 2000  # Issue #286: truncate combined error messages
 
 # WebSocket manager (injected from main.py)
 _ws_manager = None
@@ -295,7 +298,7 @@ class CleanupService:
                                 "— recovered by watchdog"
                             )
                             recovered = await self._recover_execution(
-                                execution_id, agent_name, error_msg, "orphan_recovered"
+                                execution_id, agent_name, error_msg, "orphan_recovered", client
                             )
                             if recovered:
                                 orphaned_count += 1
@@ -327,7 +330,7 @@ class CleanupService:
                                 f"by watchdog (exceeded timeout of {timeout_seconds}s)"
                             )
                             recovered = await self._recover_execution(
-                                execution_id, agent_name, error_msg, "auto_terminated"
+                                execution_id, agent_name, error_msg, "auto_terminated", client
                             )
                             if recovered:
                                 terminated_count += 1
@@ -381,27 +384,97 @@ class CleanupService:
             logger.warning(f"[Watchdog] Error checking agent '{agent_name}': {e}")
             return None
 
+    async def _get_execution_error(
+        self, client: httpx.AsyncClient, agent_name: str, execution_id: str
+    ) -> Optional[str]:
+        """Fetch the last error from an agent's execution log buffer.
+
+        Issue #286: Preserves original error context when cleanup recovers
+        stale executions. Queries the agent's /api/executions/{id}/last-error
+        endpoint to retrieve error details before they're lost.
+
+        Args:
+            client: Shared httpx client for the reconciliation cycle.
+            agent_name: The agent to query.
+            execution_id: The execution to get error for.
+
+        Returns:
+            Error message string if found, None otherwise.
+        """
+        try:
+            response = await client.get(
+                f"http://agent-{agent_name}:8000/api/executions/{execution_id}/last-error",
+                timeout=ERROR_FETCH_TIMEOUT,
+            )
+            if response.status_code == 200:
+                data = response.json()
+                error_type = data.get("error_type")
+                error_message = data.get("error_message")
+
+                if error_type or error_message:
+                    # Sanitize to remove any credential patterns
+                    parts = []
+                    if error_type:
+                        parts.append(f"[{error_type}]")
+                    if error_message:
+                        sanitized = sanitize_text(error_message)
+                        parts.append(sanitized)
+                    return " ".join(parts) if parts else None
+
+            return None
+        except (httpx.ConnectError, httpx.TimeoutException):
+            logger.debug(
+                f"[Watchdog] Could not fetch error context for {execution_id} "
+                f"from agent '{agent_name}' (unreachable)"
+            )
+            return None
+        except Exception as e:
+            logger.debug(
+                f"[Watchdog] Error fetching error context for {execution_id}: {e}"
+            )
+            return None
+
     async def _recover_execution(
         self,
         execution_id: str,
         agent_name: str,
         error_msg: str,
         action: str,
+        client: Optional[httpx.AsyncClient] = None,
     ) -> bool:
         """Mark execution as failed and release all associated resources.
 
         Shared helper for both orphan recovery and auto-terminate paths (DRY).
 
+        Issue #286: Now attempts to fetch original error context from the agent
+        before marking the execution as failed, preserving diagnostic info.
+
         Args:
             execution_id: The execution to recover.
             agent_name: The agent the execution belongs to.
-            error_msg: Descriptive error message.
+            error_msg: Descriptive error message (cleanup reason).
             action: Event action type ("orphan_recovered" or "auto_terminated").
+            client: Optional httpx client for fetching error context from agent.
 
         Returns:
             True if recovery succeeded, False if execution already transitioned.
         """
-        updated = db.mark_execution_failed_by_watchdog(execution_id, error_msg)
+        # Issue #286: Try to fetch original error context from agent before marking failed
+        original_error = None
+        if client:
+            original_error = await self._get_execution_error(client, agent_name, execution_id)
+
+        # Combine original error with cleanup reason
+        if original_error:
+            combined_error = f"{original_error}. Cleanup: {error_msg}"
+        else:
+            combined_error = error_msg
+
+        # Truncate to prevent DB bloat
+        if len(combined_error) > MAX_ERROR_MESSAGE_LENGTH:
+            combined_error = combined_error[:MAX_ERROR_MESSAGE_LENGTH - 3] + "..."
+
+        updated = db.mark_execution_failed_by_watchdog(execution_id, combined_error)
         if not updated:
             # Race condition: execution completed normally between check and update
             return False
@@ -422,8 +495,8 @@ class CleanupService:
         except Exception as e:
             logger.warning(f"[Watchdog] Error releasing queue for agent '{agent_name}': {e}")
 
-        # Broadcast WebSocket event
-        await self._broadcast_watchdog_event(action, agent_name, execution_id, error_msg)
+        # Broadcast WebSocket event with combined error (includes original context)
+        await self._broadcast_watchdog_event(action, agent_name, execution_id, combined_error)
 
         logger.info(
             f"[Watchdog] {action}: execution {execution_id} on agent '{agent_name}'"

--- a/tests/test_watchdog_unit.py
+++ b/tests/test_watchdog_unit.py
@@ -53,6 +53,11 @@ _helpers_mod.parse_iso_timestamp = _parse_iso_timestamp
 _helpers_mod.to_utc_iso = _MagicMock(return_value="2025-01-01T00:00:00Z")
 sys.modules["utils.helpers"] = _helpers_mod
 
+# Issue #286: Mock credential_sanitizer for cleanup_service import
+_sanitizer_mod = _types.ModuleType("utils.credential_sanitizer")
+_sanitizer_mod.sanitize_text = lambda x: x  # Pass-through for tests
+sys.modules["utils.credential_sanitizer"] = _sanitizer_mod
+
 sys.modules.setdefault("database", _MagicMock())
 
 
@@ -662,3 +667,223 @@ class TestBroadcastWatchdogEvent:
             assert "timestamp" in event
         finally:
             cs_module._ws_manager = original
+
+
+# ---------------------------------------------------------------------------
+# Error Context Preservation tests (Issue #286)
+# ---------------------------------------------------------------------------
+
+class TestGetExecutionError:
+    """Tests for _get_execution_error() — Issue #286."""
+
+    pytestmark = pytest.mark.unit
+
+    def _make_service(self):
+        from services.cleanup_service import CleanupService
+        return CleanupService()
+
+    def test_returns_error_from_agent(self):
+        """Returns formatted error when agent responds with error info."""
+        service = self._make_service()
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "error_type": "auth_failure",
+            "error_message": "Invalid API key"
+        }
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        result = asyncio.run(
+            service._get_execution_error(mock_client, "agent-a", "exec-1")
+        )
+
+        assert result == "[auth_failure] Invalid API key"
+        mock_client.get.assert_called_once()
+        assert "/api/executions/exec-1/last-error" in mock_client.get.call_args[0][0]
+
+    def test_returns_none_when_no_error(self):
+        """Returns None when agent has no error to report."""
+        service = self._make_service()
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "error_type": None,
+            "error_message": None
+        }
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        result = asyncio.run(
+            service._get_execution_error(mock_client, "agent-a", "exec-1")
+        )
+
+        assert result is None
+
+    def test_returns_none_on_connect_error(self):
+        """Returns None when agent is unreachable."""
+        import httpx
+        service = self._make_service()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+
+        result = asyncio.run(
+            service._get_execution_error(mock_client, "agent-down", "exec-1")
+        )
+
+        assert result is None
+
+    def test_returns_none_on_timeout(self):
+        """Returns None when agent request times out."""
+        import httpx
+        service = self._make_service()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("Request timed out"))
+
+        result = asyncio.run(
+            service._get_execution_error(mock_client, "agent-slow", "exec-1")
+        )
+
+        assert result is None
+
+    def test_handles_error_type_only(self):
+        """Handles case where error_type is set but error_message is None."""
+        service = self._make_service()
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "error_type": "rate_limit",
+            "error_message": None
+        }
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        result = asyncio.run(
+            service._get_execution_error(mock_client, "agent-a", "exec-1")
+        )
+
+        assert result == "[rate_limit]"
+
+
+class TestRecoverExecutionWithErrorContext:
+    """Tests for _recover_execution() with error context — Issue #286."""
+
+    pytestmark = pytest.mark.unit
+
+    def _make_service(self):
+        from services.cleanup_service import CleanupService
+        return CleanupService()
+
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_slot_service")
+    @patch("services.cleanup_service.get_execution_queue")
+    def test_combines_original_error_with_cleanup_reason(self, mock_queue_fn, mock_slot_fn, mock_db):
+        """Combines original error context with cleanup reason."""
+        mock_db.mark_execution_failed_by_watchdog.return_value = True
+        mock_slot = AsyncMock()
+        mock_slot_fn.return_value = mock_slot
+        mock_q = AsyncMock()
+        mock_queue_fn.return_value = mock_q
+
+        service = self._make_service()
+        service._get_execution_error = AsyncMock(return_value="[auth_failure] Token expired")
+        service._broadcast_watchdog_event = AsyncMock()
+
+        mock_client = AsyncMock()
+
+        result = asyncio.run(
+            service._recover_execution(
+                "exec-1", "agent-a", "recovered by watchdog", "orphan_recovered", mock_client
+            )
+        )
+
+        assert result is True
+        # Verify combined error message was passed to DB
+        mock_db.mark_execution_failed_by_watchdog.assert_called_once()
+        error_arg = mock_db.mark_execution_failed_by_watchdog.call_args[0][1]
+        assert "[auth_failure] Token expired" in error_arg
+        assert "recovered by watchdog" in error_arg
+
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_slot_service")
+    @patch("services.cleanup_service.get_execution_queue")
+    def test_uses_cleanup_reason_when_no_original_error(self, mock_queue_fn, mock_slot_fn, mock_db):
+        """Uses cleanup reason alone when no original error is available."""
+        mock_db.mark_execution_failed_by_watchdog.return_value = True
+        mock_slot = AsyncMock()
+        mock_slot_fn.return_value = mock_slot
+        mock_q = AsyncMock()
+        mock_queue_fn.return_value = mock_q
+
+        service = self._make_service()
+        service._get_execution_error = AsyncMock(return_value=None)
+        service._broadcast_watchdog_event = AsyncMock()
+
+        mock_client = AsyncMock()
+
+        result = asyncio.run(
+            service._recover_execution(
+                "exec-1", "agent-a", "recovered by watchdog", "orphan_recovered", mock_client
+            )
+        )
+
+        assert result is True
+        error_arg = mock_db.mark_execution_failed_by_watchdog.call_args[0][1]
+        assert error_arg == "recovered by watchdog"
+
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_slot_service")
+    @patch("services.cleanup_service.get_execution_queue")
+    def test_truncates_long_error_messages(self, mock_queue_fn, mock_slot_fn, mock_db):
+        """Truncates combined error message to prevent DB bloat."""
+        mock_db.mark_execution_failed_by_watchdog.return_value = True
+        mock_slot = AsyncMock()
+        mock_slot_fn.return_value = mock_slot
+        mock_q = AsyncMock()
+        mock_queue_fn.return_value = mock_q
+
+        service = self._make_service()
+        # Create a very long error message
+        long_error = "x" * 3000
+        service._get_execution_error = AsyncMock(return_value=long_error)
+        service._broadcast_watchdog_event = AsyncMock()
+
+        mock_client = AsyncMock()
+
+        asyncio.run(
+            service._recover_execution(
+                "exec-1", "agent-a", "cleanup reason", "orphan_recovered", mock_client
+            )
+        )
+
+        error_arg = mock_db.mark_execution_failed_by_watchdog.call_args[0][1]
+        # Should be truncated to MAX_ERROR_MESSAGE_LENGTH (2000) + "..."
+        assert len(error_arg) <= 2003
+        assert error_arg.endswith("...")
+
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_slot_service")
+    @patch("services.cleanup_service.get_execution_queue")
+    def test_works_without_client(self, mock_queue_fn, mock_slot_fn, mock_db):
+        """Works correctly when no client is provided (fallback path)."""
+        mock_db.mark_execution_failed_by_watchdog.return_value = True
+        mock_slot = AsyncMock()
+        mock_slot_fn.return_value = mock_slot
+        mock_q = AsyncMock()
+        mock_queue_fn.return_value = mock_q
+
+        service = self._make_service()
+        service._get_execution_error = AsyncMock()
+        service._broadcast_watchdog_event = AsyncMock()
+
+        result = asyncio.run(
+            service._recover_execution(
+                "exec-1", "agent-a", "cleanup reason only", "orphan_recovered", None
+            )
+        )
+
+        assert result is True
+        # _get_execution_error should NOT be called when client is None
+        service._get_execution_error.assert_not_called()
+        error_arg = mock_db.mark_execution_failed_by_watchdog.call_args[0][1]
+        assert error_arg == "cleanup reason only"


### PR DESCRIPTION
## Summary
- Adds `/api/executions/{id}/last-error` endpoint to agent server that extracts error context from log buffer
- Updates cleanup service watchdog to fetch original error before marking executions failed
- Combines original error with cleanup reason for full diagnostic context
- Sanitizes error messages to prevent credential leakage

## Changes
- `docker/base-image/agent_server/routers/chat.py` - New endpoint
- `docker/base-image/agent_server/services/process_registry.py` - `get_last_error()` method
- `src/backend/services/cleanup_service.py` - `_get_execution_error()` and updated `_recover_execution()`
- `tests/test_watchdog_unit.py` - 9 new unit tests
- `docs/memory/feature-flows/cleanup-service.md` - Updated documentation

## Test Plan
- [x] Unit tests pass: `pytest tests/test_watchdog_unit.py -v` (27 tests)
- [ ] Integration test: trigger a stale execution with a known error and verify error context preserved
- [ ] Manual verification: check cleanup logs show combined error messages

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)