### PR TITLE
feat(tracing): add OpenTelemetry distributed tracing for multi-agent calls (#305)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -179,6 +179,7 @@ The test suite covers:
 - **Watchdog Integration** (test_watchdog.py) - Watchdog report fields in cleanup status/trigger [SMOKE]
 - **Watchdog Unit Tests** (test_watchdog_unit.py) - Reconciliation logic, orphan recovery, auto-terminate, per-agent TTL (#129, #226) [UNIT]
 - **Context Used Formula** (unit/test_context_used_formula.py) - Verify context_used = input_tokens only, not input+output (#56) [UNIT]
+- **OTel Trace Logging** (unit/test_otel_trace_logging.py) - Trace ID injection in logs, span context correlation (#305, RELIABILITY-002) [UNIT]
 
 ### Avatars & Image Generation
 - **Avatars** (test_avatars.py) - Avatar serving, generation, regeneration, deletion, emotions, identity prompts, default generation (AVATAR-001/002/003) [SMOKE + Agent]
@@ -219,9 +220,9 @@ The test suite covers:
 
 ## Test Suite Statistics
 
-**Total Tests**: ~2,172 tests across 115 test files
+**Total Tests**: ~2,175 tests across 116 test files
 **Smoke Tests**: ~564 tests (fast, no agent creation)
-**Unit Tests**: ~43 tests (no backend needed, rate limit detection, watchdog logic, context formula)
+**Unit Tests**: ~46 tests (no backend needed, rate limit detection, watchdog logic, context formula, OTel trace logging)
 **Core Tests (not slow)**: ~2,069 tests
 **Slow Tests**: ~89 tests (chat execution, fleet ops, system agent ops, execution termination)
 **WebSocket Tests**: ~10 tests (web terminal, execution streaming)
@@ -255,8 +256,11 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 
 | Test File | Description | Tests Added |
 |-----------|-------------|-------------|
+| `unit/test_otel_trace_logging.py` | Trace ID injection in logs for log-trace correlation (#305) | 3 tests |
 | `unit/test_context_used_formula.py` | Verify context_used equals input_tokens only (#56) | 3 tests |
 | `test_watchdog_unit.py` | Updated `_reconcile_orphaned_executions()` tests for 3-tuple return (now returns `confirmed_running_ids` set, #226) | 7 tests updated |
+
+**OTel Trace Logging (#305)**: Added `tests/unit/test_otel_trace_logging.py` to verify the JsonFormatter injects `trace_id` and `span_id` into log entries when an OpenTelemetry span is active. Tests verify correct format (32 hex for trace_id, 16 hex for span_id), absence of trace context when no span is active, and preservation of standard log fields. Part of RELIABILITY-002.
 
 **Context Used Formula (#56)**: Added `tests/unit/test_context_used_formula.py` to verify `context_used` equals `input_tokens` only, not `input_tokens + output_tokens`. Per Claude Code SDK, `input_tokens` represents the full context window fill at final turn. Tests verify the formula, edge cases (missing tokens), and percentage calculation sanity.
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -29,7 +29,13 @@ RUN pip install --no-cache-dir \
     "slack_sdk[socket-mode]==3.41.0" \
     aiohttp \
     slackify-markdown \
-    tenacity==9.0.0
+    tenacity==9.0.0 \
+    opentelemetry-api==1.29.0 \
+    opentelemetry-sdk==1.29.0 \
+    opentelemetry-exporter-otlp==1.29.0 \
+    opentelemetry-instrumentation-fastapi==0.50b0 \
+    opentelemetry-instrumentation-httpx==0.50b0 \
+    opentelemetry-instrumentation-redis==0.50b0
 
 # Copy all backend source files
 COPY ../../src/backend/main.py /app/

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -227,6 +227,14 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 **Logging (`logging_config.py`):**
 - Structured JSON logging for production
 - Captured by Vector via Docker stdout/stderr
+- OpenTelemetry trace ID included in log entries for log-trace correlation (RELIABILITY-002)
+
+**OpenTelemetry Tracing (`main.py`):**
+- Auto-instrumentation for FastAPI, httpx, and Redis (RELIABILITY-002)
+- `traceparent` header propagated through inter-agent calls
+- Traces exported to OTel Collector via OTLP/gRPC (`trinity-otel-collector:4317`)
+- Configurable sampling via `OTEL_SAMPLE_RATE` (default 10%)
+- Enabled via `OTEL_ENABLED=1` environment variable
 
 **Utilities (`utils/`):**
 - `helpers.py` - Shared helper functions

--- a/docs/memory/feature-flows/opentelemetry-integration.md
+++ b/docs/memory/feature-flows/opentelemetry-integration.md
@@ -826,7 +826,161 @@ curl http://localhost:8889/metrics | grep trinity_claude_code
 
 ---
 
-**Last Updated**: 2026-01-23 (Line numbers verified)
+## Distributed Tracing (RELIABILITY-002)
+
+### Overview
+
+Backend auto-instrumentation for distributed tracing across multi-agent request flows. Enables end-to-end request correlation: when Agent A calls the backend which calls Agent B, all operations share a single trace ID.
+
+### Architecture
+
+```
+Request (User)                    Agent A                    Agent B
+     │                               │                          │
+     │ ──traceparent──►              │                          │
+     │                               │                          │
+     ▼                               ▼                          ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Trinity Backend                              │
+│  FastAPI (auto-instrumented) → httpx (auto-instrumented) → Agent    │
+│                    │                                                 │
+│                    │ traceparent header propagated                  │
+│                    ▼                                                 │
+│              OTLP/gRPC                                               │
+└────────────────────┬────────────────────────────────────────────────┘
+                     │
+                     ▼
+          ┌──────────────────┐
+          │  OTel Collector  │
+          │  :4317 (gRPC)    │
+          └──────────────────┘
+```
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_ENABLED` | `0` | Set to `1` to enable tracing |
+| `OTEL_SAMPLE_RATE` | `0.1` | Fraction of requests to sample (10% default) |
+| `OTEL_COLLECTOR_ENDPOINT` | `http://trinity-otel-collector:4317` | Collector gRPC endpoint |
+
+### Backend Implementation
+
+**File**: `src/backend/main.py` (lines 247-289)
+
+```python
+def setup_opentelemetry(app: FastAPI) -> bool:
+    """Initialize OTel distributed tracing."""
+    if os.getenv("OTEL_ENABLED", "0") != "1":
+        return False
+
+    # Configure sampling (10% default)
+    sample_rate = float(os.getenv("OTEL_SAMPLE_RATE", "0.1"))
+    sampler = TraceIdRatioBased(sample_rate)
+
+    # Create resource with service metadata
+    resource = Resource.create({
+        "service.name": "trinity-backend",
+        "service.version": "1.0.0",
+        "deployment.environment": os.getenv("ENVIRONMENT", "development"),
+    })
+
+    # Set up tracer provider
+    provider = TracerProvider(resource=resource, sampler=sampler)
+    trace.set_tracer_provider(provider)
+
+    # Configure OTLP exporter
+    endpoint = os.getenv("OTEL_COLLECTOR_ENDPOINT", "http://trinity-otel-collector:4317")
+    exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+
+    # Auto-instrument frameworks
+    FastAPIInstrumentor.instrument_app(app)
+    HTTPXClientInstrumentor().instrument()
+    RedisInstrumentor().instrument()
+
+    return True
+```
+
+**Called at**: App creation time, before middleware/routers (line 542)
+
+### Log-Trace Correlation
+
+**File**: `src/backend/logging_config.py` (lines 24-29)
+
+```python
+# Add OpenTelemetry trace context for log-trace correlation
+span = trace.get_current_span()
+span_context = span.get_span_context()
+if span_context.is_valid:
+    log_entry["trace_id"] = format(span_context.trace_id, "032x")
+    log_entry["span_id"] = format(span_context.span_id, "016x")
+```
+
+**Result**: All JSON log entries during a request include `trace_id` and `span_id`:
+
+```json
+{
+  "timestamp": "2026-04-14T12:19:35.623530Z",
+  "level": "INFO",
+  "logger": "services.execution_queue",
+  "message": "[Queue] Agent 'trinity-system' execution started",
+  "trace_id": "48b5fef080ff82fb283c308f2f3d408a",
+  "span_id": "23dbd607a019b726"
+}
+```
+
+### Dependencies
+
+**File**: `docker/backend/Dockerfile` (lines 33-38)
+
+```dockerfile
+opentelemetry-api==1.29.0 \
+opentelemetry-sdk==1.29.0 \
+opentelemetry-exporter-otlp==1.29.0 \
+opentelemetry-instrumentation-fastapi==0.50b0 \
+opentelemetry-instrumentation-httpx==0.50b0 \
+opentelemetry-instrumentation-redis==0.50b0
+```
+
+### Testing
+
+```bash
+# Enable tracing
+export OTEL_ENABLED=1
+
+# Restart backend
+docker compose up -d backend
+
+# Check startup log
+docker compose logs backend | grep "OpenTelemetry tracing"
+# Expected: "OpenTelemetry tracing enabled (sample rate: 10%)"
+
+# Make a request that triggers logging
+curl -X POST http://localhost:8000/api/agents/trinity-system/chat \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "hello"}'
+
+# Check logs for trace_id
+docker compose logs backend --since 10s | grep trace_id
+
+# Check collector is receiving traces
+docker compose logs otel-collector --since 30s | grep Traces
+# Expected: "Traces" with "spans": N
+```
+
+### Error Handling
+
+| Error | Behavior |
+|-------|----------|
+| Collector unreachable | Traces buffered, dropped after timeout; app continues |
+| Invalid config | Logs warning, tracing disabled; app starts normally |
+| OTEL_ENABLED=0 | No initialization, no overhead |
+
+---
+
+**Last Updated**: 2026-04-14 (Added Distributed Tracing section for RELIABILITY-002)
 
 ---
 
@@ -834,6 +988,7 @@ curl http://localhost:8889/metrics | grep trinity_claude_code
 
 | Date | Changes |
 |------|---------|
+| 2026-04-14 | Added Distributed Tracing section (RELIABILITY-002): backend auto-instrumentation for FastAPI/httpx/Redis, trace_id in logs, 10% sampling |
 | 2026-01-23 | Updated line numbers for crud.py (308-316), docker-compose.yml (207-228), observability.py, main.py (289), Dashboard.vue (357, 371, 35-56, 340, 430-431), ObservabilityPanel.vue (185 lines). Added system_agent_service.py and ops.py to files modified. Added health_check endpoint port 13133 to docker-compose. Updated otel-collector.yaml to show health_check extension and telemetry config. |
 | 2025-12-30 | Line numbers verified |
 | 2025-12-20 | Initial Phase 1, 2, and 2.5 implementation complete |

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -423,9 +423,9 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
 - **Flow**: `docs/memory/feature-flows/system-agent-ui.md`
 
 ### 12.5 OpenTelemetry Integration
-- **Status**: ✅ Implemented (2025-12-20)
-- **Description**: OTel metrics export from Claude Code agents
-- **Key Features**: Cost, tokens, productivity metrics in Dashboard
+- **Status**: ✅ Implemented (2025-12-20, extended 2026-04-14)
+- **Description**: OTel metrics export from Claude Code agents + backend distributed tracing
+- **Key Features**: Cost, tokens, productivity metrics in Dashboard; trace_id in logs for multi-agent request correlation (RELIABILITY-002)
 - **Flow**: `docs/memory/feature-flows/opentelemetry-integration.md`
 
 ### 12.6 System-Wide Trinity Prompt

--- a/docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md
+++ b/docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-13
 **Status:** Proposed sequencing for execution-time orchestration, event subscriptions, and multi-agent reliability.
 
-**Progress:** Sprint A — **7/7 complete**: #95 (PR #320), #285 (PR #322), #226 (PR #323), #286 (PR #324), #61 (PR #326), #132 (PR #328), #56 (PR #329). **Sprint B next: #305.**
+**Progress:** Sprint A — **7/7 complete**. Sprint B — **1/1 complete**: #305 (PR #330). **Sprint C next: #260.**
 
 ---
 
@@ -23,7 +23,7 @@ Shipping #260 on top of today's foundation would produce a *persistent* backlog 
 
 ```
 Sprint A (unblock):     #95 ✅, #285 ✅, #226 ✅, #286 ✅, #61 ✅, #132 ✅, #56 ✅  ← COMPLETE
-Sprint B (trace):       #305
+Sprint B (trace):       #305 ✅  ← COMPLETE
 Sprint C (orchestrate): #260 → #271 → #294 → #264 → #291
 Sprint D (push telemetry): #306, #307
 Sprint E (scale):       #24, #18
@@ -81,7 +81,7 @@ Sprint E (scale):       #24, #18
 
 | # | Title | Why it's here |
 |---|-------|---------------|
-| #305 | OpenTelemetry distributed tracing (RELIABILITY-002) | OTel Collector already in `docker-compose.yml`. ~30 lines + 3 packages. Enables single trace ID across Agent A → B → C. Pairs with #286 so `cleanup_reason` carries the trace ID. |
+| ~~#305~~ ✅ | ~~OpenTelemetry distributed tracing (RELIABILITY-002)~~ | **Shipped** in PR #330. Auto-instrumentation for FastAPI/httpx/Redis. Trace ID in logs. 10% default sampling. Enabled via `OTEL_ENABLED=1`. |
 
 ### Considerations
 

--- a/src/backend/logging_config.py
+++ b/src/backend/logging_config.py
@@ -1,10 +1,14 @@
 """
 Structured logging configuration for Trinity.
 Logs go to stdout and are captured by Vector.
+
+Includes OpenTelemetry trace ID for log-trace correlation (RELIABILITY-002).
 """
 import logging
 import json
 from datetime import datetime
+
+from opentelemetry import trace
 
 
 class JsonFormatter(logging.Formatter):
@@ -17,6 +21,13 @@ class JsonFormatter(logging.Formatter):
             "logger": record.name,
             "message": record.getMessage(),
         }
+
+        # Add OpenTelemetry trace context for log-trace correlation
+        span = trace.get_current_span()
+        span_context = span.get_span_context()
+        if span_context.is_valid:
+            log_entry["trace_id"] = format(span_context.trace_id, "032x")
+            log_entry["span_id"] = format(span_context.span_id, "016x")
 
         # Add extra fields if present
         if hasattr(record, "event_type"):

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -14,9 +14,11 @@ Refactored for better concern separation:
 """
 import asyncio
 import json
+import os
 from datetime import datetime
 from typing import List
 from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Depends, Request, Query
 from fastapi.middleware.cors import CORSMiddleware
 import httpx
@@ -25,6 +27,17 @@ from config import CORS_ORIGINS, VOICE_ENABLED, GEMINI_API_KEY
 from models import User
 from dependencies import get_current_user
 from services.docker_service import docker_client, list_all_agents_fast
+
+# OpenTelemetry imports for distributed tracing (RELIABILITY-002)
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.instrumentation.redis import RedisInstrumentor
 
 # Import routers
 from routers.auth import router as auth_router
@@ -231,6 +244,49 @@ set_websocket_publisher_broadcast(manager.broadcast)
 set_cleanup_ws_manager(manager)
 
 
+def setup_opentelemetry(app: FastAPI) -> bool:
+    """
+    Initialize OpenTelemetry distributed tracing (RELIABILITY-002).
+
+    Auto-instruments FastAPI, httpx, and Redis for trace propagation.
+    Traces are exported to the OTel Collector via OTLP/gRPC.
+
+    Returns True if initialization succeeded, False otherwise.
+    """
+    if os.getenv("OTEL_ENABLED", "0") != "1":
+        return False
+
+    try:
+        # Configure sampling: 10% in production, 100% in development
+        sample_rate = float(os.getenv("OTEL_SAMPLE_RATE", "0.1"))
+        sampler = TraceIdRatioBased(sample_rate)
+
+        # Create resource with service metadata
+        resource = Resource.create({
+            "service.name": "trinity-backend",
+            "service.version": "1.0.0",
+            "deployment.environment": os.getenv("ENVIRONMENT", "development"),
+        })
+
+        # Set up tracer provider with sampling and resource
+        provider = TracerProvider(resource=resource, sampler=sampler)
+        trace.set_tracer_provider(provider)
+
+        # Configure OTLP exporter to collector
+        endpoint = os.getenv("OTEL_COLLECTOR_ENDPOINT", "http://trinity-otel-collector:4317")
+        exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+
+        # Auto-instrument frameworks (injects traceparent headers automatically)
+        FastAPIInstrumentor.instrument_app(app)
+        HTTPXClientInstrumentor().instrument()
+        RedisInstrumentor().instrument()
+
+        return True
+    except Exception as e:
+        # Log but don't fail startup — tracing is optional
+        print(f"OpenTelemetry initialization failed: {e}")
+        return False
 
 
 @asynccontextmanager
@@ -238,6 +294,13 @@ async def lifespan(app: FastAPI):
     """Application lifespan handler."""
     # Set up structured JSON logging (captured by Vector)
     setup_logging()
+
+    # Report OpenTelemetry status (RELIABILITY-002)
+    if _otel_enabled:
+        sample_rate = float(os.getenv("OTEL_SAMPLE_RATE", "0.1"))
+        logger.info(f"OpenTelemetry tracing enabled (sample rate: {sample_rate * 100:.0f}%)")
+    else:
+        logger.info("OpenTelemetry tracing disabled (set OTEL_ENABLED=1 to enable)")
 
     # Print setup token if first-time setup is not yet complete (SEC #177).
     # Only someone with access to server logs can read this token and complete setup,
@@ -473,6 +536,10 @@ app = FastAPI(
     version="2.0.0",
     lifespan=lifespan
 )
+
+# Initialize OpenTelemetry distributed tracing (RELIABILITY-002)
+# Must be called after app creation but before middleware/routers
+_otel_enabled = setup_opentelemetry(app)
 
 # Add CORS middleware
 app.add_middleware(

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -12,3 +12,6 @@ pydantic>=2.10.0
 fastapi>=0.115.0
 pyyaml>=6.0.0
 python-jose[cryptography]>=3.3.0
+# OpenTelemetry for trace logging tests
+opentelemetry-api>=1.29.0
+opentelemetry-sdk>=1.29.0

--- a/tests/unit/test_otel_trace_logging.py
+++ b/tests/unit/test_otel_trace_logging.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for OpenTelemetry trace ID injection in logs.
+
+Issue: https://github.com/abilityai/trinity/issues/305
+Module: src/backend/logging_config.py
+
+When OpenTelemetry tracing is active, the JsonFormatter should inject
+trace_id and span_id into log entries for log-trace correlation.
+"""
+
+import json
+import logging
+import os
+import pytest
+import sys
+
+# Add src/backend to path for logging_config import
+_backend_path = os.path.join(os.path.dirname(__file__), "..", "..", "src", "backend")
+if _backend_path not in sys.path:
+    sys.path.insert(0, os.path.abspath(_backend_path))
+
+# Check if OpenTelemetry is available
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+
+
+@pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry packages not installed")
+class TestTraceIdLogging:
+    """Verify trace_id and span_id are injected into logs correctly."""
+
+    def test_log_includes_trace_id_when_span_active(self):
+        """
+        Log entries should include trace_id and span_id when inside an active span.
+
+        RELIABILITY-002: Log-trace correlation requires trace context in logs.
+        """
+        # Set up a tracer provider
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+        tracer = trace.get_tracer(__name__)
+
+        from logging_config import JsonFormatter
+
+        # Create a logger with our formatter
+        formatter = JsonFormatter()
+
+        # Start a span and create a log record
+        with tracer.start_as_current_span("test_span") as span:
+            span_context = span.get_span_context()
+
+            record = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="test.py",
+                lineno=1,
+                msg="Test message",
+                args=(),
+                exc_info=None,
+            )
+
+            # Format the record
+            output = formatter.format(record)
+            log_data = json.loads(output)
+
+            # Verify trace_id and span_id are present
+            assert "trace_id" in log_data, "trace_id should be in log entry"
+            assert "span_id" in log_data, "span_id should be in log entry"
+
+            # Verify format: trace_id is 32 hex chars, span_id is 16 hex chars
+            assert len(log_data["trace_id"]) == 32, "trace_id should be 32 hex characters"
+            assert len(log_data["span_id"]) == 16, "span_id should be 16 hex characters"
+
+            # Verify they match the actual span context
+            expected_trace_id = format(span_context.trace_id, "032x")
+            expected_span_id = format(span_context.span_id, "016x")
+            assert log_data["trace_id"] == expected_trace_id
+            assert log_data["span_id"] == expected_span_id
+
+    def test_log_excludes_trace_id_when_no_span(self):
+        """
+        Log entries should NOT include trace_id when no span is active.
+
+        This prevents polluting logs with invalid trace context.
+        """
+        # Reset tracer provider to ensure no active span
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+
+        from logging_config import JsonFormatter
+
+        formatter = JsonFormatter()
+
+        # Create a log record outside any span
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message without span",
+            args=(),
+            exc_info=None,
+        )
+
+        output = formatter.format(record)
+        log_data = json.loads(output)
+
+        # trace_id and span_id should NOT be present (invalid span context)
+        # Note: get_current_span() returns a non-recording span with invalid context
+        assert "trace_id" not in log_data or log_data.get("trace_id") is None, \
+            "trace_id should not be in log entry when no span is active"
+
+    def test_log_preserves_standard_fields(self):
+        """
+        JsonFormatter should preserve standard log fields alongside trace context.
+        """
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+        tracer = trace.get_tracer(__name__)
+
+        from logging_config import JsonFormatter
+
+        formatter = JsonFormatter()
+
+        with tracer.start_as_current_span("test_span"):
+            record = logging.LogRecord(
+                name="test.module",
+                level=logging.WARNING,
+                pathname="test.py",
+                lineno=42,
+                msg="Warning message",
+                args=(),
+                exc_info=None,
+            )
+
+            output = formatter.format(record)
+            log_data = json.loads(output)
+
+            # Standard fields should be present
+            assert "timestamp" in log_data
+            assert log_data["level"] == "WARNING"
+            assert log_data["logger"] == "test.module"
+            assert log_data["message"] == "Warning message"
+
+            # Trace fields should also be present
+            assert "trace_id" in log_data
+            assert "span_id" in log_data


### PR DESCRIPTION
## Summary
- Add OTel auto-instrumentation for FastAPI, httpx, and Redis
- Initialize SDK with configurable sampling (default 10%, via `OTEL_SAMPLE_RATE`)
- Inject `trace_id` and `span_id` into structured JSON logs for log-trace correlation
- Export traces to existing OTel Collector (`trinity-otel-collector:4317`)

Traces propagate through inter-agent calls via `traceparent` header, enabling end-to-end request tracing across Agent A → Backend → Agent B.

## Changes
- `docker/backend/Dockerfile` — 6 new OTel packages
- `src/backend/main.py` — OTel SDK initialization (~40 lines)
- `src/backend/logging_config.py` — trace_id in JSON log entries
- `docs/memory/architecture.md` — document new tracing capability

## Test Plan
- [x] Backend starts with `OTEL_ENABLED=1`
- [x] OTel Collector receives traces (confirmed via debug exporter)
- [x] `trace_id` appears in JSON log entries during request handling
- [x] Syntax validation passes
- [ ] Manual: verify trace propagation through agent-to-agent call

## Configuration
```bash
OTEL_ENABLED=1                    # Enable tracing (default: 0)
OTEL_SAMPLE_RATE=0.1              # Sample 10% of requests (default)
OTEL_COLLECTOR_ENDPOINT=http://trinity-otel-collector:4317
```

Closes #305

🤖 Generated with [Claude Code](https://claude.ai/code)