### PR TITLE
feat(scheduler): retry mechanism for failed scheduled executions (#271)

### DIFF
--- a/docs/memory/feature-flows/scheduler-service.md
+++ b/docs/memory/feature-flows/scheduler-service.md
@@ -677,6 +677,69 @@ def _on_job_max_instances(self, event: JobExecutionEvent):
 
 ---
 
+## Flow 10: Automatic Retry (RETRY-001)
+
+**Location**: `src/scheduler/service.py:1074-1132`
+
+Failed scheduled executions can be automatically retried with configurable delay.
+
+### Configuration
+
+| Field | Default | Range | Description |
+|-------|---------|-------|-------------|
+| `max_retries` | 1 | 0-5 | Max retry attempts (0=disabled) |
+| `retry_delay_seconds` | 60 | 30-600 | Delay between retries |
+
+New schedules default to 1 retry. Existing schedules migrated with 0 (opt-in).
+
+### Retry Flow
+
+```
+Execution fails → _maybe_schedule_retry()
+    ├─ Check schedule.max_retries > 0
+    ├─ Check attempt_number <= max_retries
+    ├─ Calculate delay (2x for 429/rate-limit, capped at 300s)
+    ├─ Persist: DB schedule_retry(execution_id, retry_scheduled_at)
+    └─ Schedule: APScheduler DateTrigger → _execute_retry()
+
+_execute_retry() fires:
+    ├─ Clear retry_scheduled_at from original execution
+    ├─ Verify schedule still exists and enabled
+    ├─ Create new execution record (triggered_by="retry", attempt_number=N+1)
+    └─ Call _call_backend_execute_task()
+```
+
+### Execution Record Fields
+
+| Field | Purpose |
+|-------|---------|
+| `attempt_number` | Which attempt (1=first try, 2=first retry) |
+| `retry_of_execution_id` | Links to original execution for grouping |
+| `retry_scheduled_at` | When retry fires (for restart recovery) |
+
+### Restart Recovery
+
+On startup, `_recover_pending_retries()` queries executions with `status='pending_retry'` and reschedules their APScheduler jobs.
+
+### Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `pending_retry` | Failed, retry scheduled but not yet fired |
+| Retry → `running` | Retry in progress |
+| Retry → `success/failed` | Retry outcome |
+
+### Database Operations
+
+| Method | Purpose |
+|--------|---------|
+| `schedule_retry()` | Mark execution as pending_retry |
+| `get_pending_retries()` | List executions awaiting retry |
+| `clear_retry_scheduled()` | Clear after retry fires |
+| `get_original_execution_id()` | Traverse chain for UI grouping |
+
+---
+
 ## Database Operations
 
 **Location**: `src/scheduler/database.py`
@@ -1008,6 +1071,7 @@ The embedded scheduler (`src/backend/services/scheduler_service.py`) has been co
 
 | Date | Change |
 |------|--------|
+| 2026-04-14 | **Automatic Retry (RETRY-001)**: Added Flow 10 documenting configurable retry mechanism for failed executions. New fields: max_retries, retry_delay_seconds, attempt_number, retry_of_execution_id, retry_scheduled_at. New status: pending_retry. |
 | 2026-03-26 | **Line number refresh + Process Schedules documentation**: Updated all line numbers to match current code. Added Flow 3 (Process Schedule Execution), process schedule sync documentation, process schedule database operations, and full service method reference table. |
 | 2026-03-13 | **Schedule Update Nullable Field Fix**: Changed `schedules.py:270` from `if v is not None` filter to `model_dump(exclude_unset=True)`. |
 | 2026-03-11 | **Async Fire-and-Forget with DB Polling (SCHED-ASYNC-001, Issue #101)**: Replaced blocking HTTP call with async dispatch + DB polling. |

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -35,6 +35,7 @@ Migration Order (as of 2026-02-28):
 28. public_user_memory_table - MEM-001 per-user persistent memory for public link agents
 29. subscription_rate_limit_tracking - SUB-003 rate-limit event tracking for auto-switch
 30. execution_fan_out_id - FANOUT-001 fan-out operation linkage
+31. scheduler_retry_support - RETRY-001 scheduler retry mechanism
 """
 import logging
 import sqlite3
@@ -1164,6 +1165,49 @@ def _migrate_backlog_support(cursor, conn):
     conn.commit()
 
 
+def _migrate_scheduler_retry_support(cursor, conn):
+    """RETRY-001: Scheduler retry mechanism for failed executions.
+
+    Adds:
+    - agent_schedules.max_retries: max retry attempts (0=disabled, default 1 for new, 0 for existing)
+    - agent_schedules.retry_delay_seconds: delay between retries (default 60, range 30-600)
+    - schedule_executions.attempt_number: which attempt this is (1 = first try)
+    - schedule_executions.retry_of_execution_id: links retry to original execution
+    - schedule_executions.retry_scheduled_at: when retry is scheduled (for restart recovery)
+
+    Note: Existing schedules get max_retries=0 (opt-in) to avoid surprising behavior changes.
+    New schedules default to max_retries=1 (resilient by default).
+    """
+    # agent_schedules columns
+    cursor.execute("PRAGMA table_info(agent_schedules)")
+    as_cols = {row[1] for row in cursor.fetchall()}
+
+    if "max_retries" not in as_cols:
+        # Default 0 for existing schedules (opt-in), schema default 1 for new
+        cursor.execute("ALTER TABLE agent_schedules ADD COLUMN max_retries INTEGER DEFAULT 0")
+    if "retry_delay_seconds" not in as_cols:
+        cursor.execute("ALTER TABLE agent_schedules ADD COLUMN retry_delay_seconds INTEGER DEFAULT 60")
+
+    # schedule_executions columns
+    cursor.execute("PRAGMA table_info(schedule_executions)")
+    se_cols = {row[1] for row in cursor.fetchall()}
+
+    if "attempt_number" not in se_cols:
+        cursor.execute("ALTER TABLE schedule_executions ADD COLUMN attempt_number INTEGER DEFAULT 1")
+    if "retry_of_execution_id" not in se_cols:
+        cursor.execute("ALTER TABLE schedule_executions ADD COLUMN retry_of_execution_id TEXT")
+    if "retry_scheduled_at" not in se_cols:
+        cursor.execute("ALTER TABLE schedule_executions ADD COLUMN retry_scheduled_at TEXT")
+
+    # Index for finding pending retries on startup
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_executions_pending_retry "
+        "ON schedule_executions(retry_scheduled_at) "
+        "WHERE retry_scheduled_at IS NOT NULL AND status = 'pending_retry'"
+    )
+    conn.commit()
+
+
 # Ordered list of all migrations. Defined at module level (after all _migrate_* functions)
 # so run_all_migrations and the health check can both reference it.
 # IMPORTANT: append-only — never reorder or remove entries.
@@ -1208,4 +1252,5 @@ MIGRATIONS = [
     ("public_link_require_email_unified", _migrate_public_link_require_email_unified),
     ("email_whitelist_default_role", _migrate_email_whitelist_default_role),
     ("backlog_support", _migrate_backlog_support),
+    ("scheduler_retry_support", _migrate_scheduler_retry_support),
 ]

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -89,7 +89,10 @@ class ScheduleOperations:
             next_run_at=parse_iso_timestamp(row["next_run_at"]) if row["next_run_at"] else None,
             timeout_seconds=row["timeout_seconds"] if "timeout_seconds" in row_keys and row["timeout_seconds"] else 900,
             allowed_tools=allowed_tools,
-            model=row["model"] if "model" in row_keys else None
+            model=row["model"] if "model" in row_keys else None,
+            # Retry configuration (RETRY-001)
+            max_retries=row["max_retries"] if "max_retries" in row_keys and row["max_retries"] is not None else 1,
+            retry_delay_seconds=row["retry_delay_seconds"] if "retry_delay_seconds" in row_keys and row["retry_delay_seconds"] is not None else 60
         )
 
     @staticmethod
@@ -132,6 +135,11 @@ class ScheduleOperations:
             queued_at=parse_iso_timestamp(row["queued_at"])
                 if "queued_at" in row_keys and row["queued_at"] else None,
             backlog_metadata=row["backlog_metadata"] if "backlog_metadata" in row_keys else None,
+            # Retry tracking (RETRY-001)
+            attempt_number=row["attempt_number"] if "attempt_number" in row_keys and row["attempt_number"] else 1,
+            retry_of_execution_id=row["retry_of_execution_id"] if "retry_of_execution_id" in row_keys else None,
+            retry_scheduled_at=parse_iso_timestamp(row["retry_scheduled_at"])
+                if "retry_scheduled_at" in row_keys and row["retry_scheduled_at"] else None,
         )
 
     @staticmethod
@@ -190,12 +198,16 @@ class ScheduleOperations:
         with get_db_connection() as conn:
             cursor = conn.cursor()
             try:
+                # Clamp retry values to valid ranges (RETRY-001)
+                max_retries = max(0, min(5, schedule_data.max_retries))
+                retry_delay_seconds = max(30, min(600, schedule_data.retry_delay_seconds))
+
                 cursor.execute("""
                     INSERT INTO agent_schedules (
                         id, agent_name, name, cron_expression, message, enabled,
                         timezone, description, owner_id, created_at, updated_at, next_run_at,
-                        timeout_seconds, allowed_tools, model
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        timeout_seconds, allowed_tools, model, max_retries, retry_delay_seconds
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     schedule_id,
                     agent_name,
@@ -211,7 +223,9 @@ class ScheduleOperations:
                     next_run_at_iso,
                     schedule_data.timeout_seconds,
                     allowed_tools_json,
-                    schedule_data.model
+                    schedule_data.model,
+                    max_retries,
+                    retry_delay_seconds
                 ))
                 conn.commit()
 
@@ -230,7 +244,9 @@ class ScheduleOperations:
                     next_run_at=next_run_at,
                     timeout_seconds=schedule_data.timeout_seconds,
                     allowed_tools=schedule_data.allowed_tools,
-                    model=schedule_data.model
+                    model=schedule_data.model,
+                    max_retries=max_retries,
+                    retry_delay_seconds=retry_delay_seconds
                 )
             except sqlite3.IntegrityError:
                 return None
@@ -302,7 +318,11 @@ class ScheduleOperations:
 
             set_clauses = []
             params = []
-            allowed_fields = ["name", "cron_expression", "message", "enabled", "timezone", "description", "timeout_seconds", "allowed_tools", "model"]
+            allowed_fields = [
+                "name", "cron_expression", "message", "enabled", "timezone",
+                "description", "timeout_seconds", "allowed_tools", "model",
+                "max_retries", "retry_delay_seconds"  # RETRY-001
+            ]
 
             for key, value in updates.items():
                 if key in allowed_fields:
@@ -311,6 +331,12 @@ class ScheduleOperations:
                     elif key == "allowed_tools":
                         # Serialize allowed_tools to JSON
                         value = json.dumps(value) if value is not None else None
+                    elif key == "max_retries":
+                        # Clamp to valid range (RETRY-001)
+                        value = max(0, min(5, int(value)))
+                    elif key == "retry_delay_seconds":
+                        # Clamp to valid range (RETRY-001)
+                        value = max(30, min(600, int(value)))
                     set_clauses.append(f"{key} = ?")
                     params.append(value)
 

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -151,6 +151,8 @@ TABLES = {
             timeout_seconds INTEGER DEFAULT 900,
             allowed_tools TEXT,
             model TEXT,
+            max_retries INTEGER DEFAULT 1,
+            retry_delay_seconds INTEGER DEFAULT 60,
             FOREIGN KEY (owner_id) REFERENCES users(id)
         )
     """,
@@ -175,6 +177,9 @@ TABLES = {
             execution_log TEXT,
             model_used TEXT,
             subscription_id TEXT,
+            attempt_number INTEGER DEFAULT 1,
+            retry_of_execution_id TEXT,
+            retry_scheduled_at TEXT,
             FOREIGN KEY (schedule_id) REFERENCES agent_schedules(id)
         )
     """,

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -115,6 +115,9 @@ class ScheduleCreate(BaseModel):
     timeout_seconds: int = 900  # Default 15 minutes
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
+    # Retry configuration (RETRY-001)
+    max_retries: int = 1  # 0 = disabled, 1-5 range. Default 1 for resilience.
+    retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
 
 
 class Schedule(BaseModel):
@@ -135,6 +138,9 @@ class Schedule(BaseModel):
     timeout_seconds: int = 900  # Default 15 minutes
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
+    # Retry configuration (RETRY-001)
+    max_retries: int = 1  # 0 = disabled, 1-5 range
+    retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
 
 
 class ScheduleExecution(BaseModel):
@@ -173,6 +179,10 @@ class ScheduleExecution(BaseModel):
     # Persistent backlog (BACKLOG-001)
     queued_at: Optional[datetime] = None       # ISO timestamp for FIFO ordering when status=queued
     backlog_metadata: Optional[str] = None     # JSON blob of the full ParallelTaskRequest context
+    # Retry tracking (RETRY-001)
+    attempt_number: int = 1                    # Which attempt this is (1 = first try)
+    retry_of_execution_id: Optional[str] = None  # Links retry to original execution
+    retry_scheduled_at: Optional[datetime] = None  # When retry is scheduled (for restart recovery)
 
 
 # =========================================================================

--- a/src/frontend/src/components/SchedulesPanel.vue
+++ b/src/frontend/src/components/SchedulesPanel.vue
@@ -116,6 +116,39 @@
               </div>
             </div>
 
+            <!-- Retry Configuration (RETRY-001) -->
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Max Retries</label>
+                <select
+                  v-model="formData.max_retries"
+                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option :value="0">Disabled</option>
+                  <option :value="1">1 retry (default)</option>
+                  <option :value="2">2 retries</option>
+                  <option :value="3">3 retries</option>
+                  <option :value="5">5 retries</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Retry Delay</label>
+                <select
+                  v-model="formData.retry_delay_seconds"
+                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option :value="30">30 seconds</option>
+                  <option :value="60">1 minute (default)</option>
+                  <option :value="120">2 minutes</option>
+                  <option :value="300">5 minutes</option>
+                  <option :value="600">10 minutes</option>
+                </select>
+              </div>
+            </div>
+            <p class="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+              Auto-retry failed executions. Rate-limited (429) failures use 2x delay.
+            </p>
+
             <!-- Allowed Tools Section -->
             <div>
               <div class="flex items-center justify-between mb-2">
@@ -264,6 +297,13 @@
                 </svg>
                 {{ schedule.model }}
               </span>
+              <!-- RETRY-001: Retry configuration badge -->
+              <span v-if="schedule.max_retries > 0" class="flex items-center" :title="`Retry: ${schedule.max_retries}x, ${schedule.retry_delay_seconds}s delay`">
+                <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                {{ schedule.max_retries }}x retry
+              </span>
               <span v-if="schedule.next_run_at" class="flex items-center text-indigo-600 dark:text-indigo-400">
                 <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
@@ -410,10 +450,10 @@
                 <span
                   :class="[
                     'font-medium',
-                    exec.status === 'success' ? 'text-green-600' : exec.status === 'failed' ? 'text-red-600' : exec.status === 'skipped' ? 'text-purple-600' : 'text-yellow-600'
+                    exec.status === 'success' ? 'text-green-600' : exec.status === 'failed' ? 'text-red-600' : exec.status === 'skipped' ? 'text-purple-600' : exec.status === 'pending_retry' ? 'text-orange-600' : 'text-yellow-600'
                   ]"
                 >
-                  {{ exec.status }}
+                  {{ exec.status === 'pending_retry' ? 'retrying' : exec.status }}
                 </span>
               </div>
             </div>
@@ -623,7 +663,10 @@ const formData = ref({
   enabled: true,
   timeout_seconds: 900,
   allowed_tools: null,  // null = all tools allowed
-  model: 'claude-opus-4-5-20251101'  // MODEL-001
+  model: 'claude-opus-4-5-20251101',  // MODEL-001
+  // RETRY-001: Retry configuration
+  max_retries: 1,  // 0 = disabled, 1-5 range
+  retry_delay_seconds: 60  // Seconds between retries (30-600 range)
 })
 
 // Tool categories for allowed tools selection
@@ -749,7 +792,10 @@ function closeForm() {
     enabled: true,
     timeout_seconds: 900,
     allowed_tools: null,
-    model: 'claude-opus-4-5-20251101'
+    model: 'claude-opus-4-5-20251101',
+    // RETRY-001
+    max_retries: 1,
+    retry_delay_seconds: 60
   }
 }
 
@@ -765,7 +811,10 @@ function editSchedule(schedule) {
     enabled: schedule.enabled,
     timeout_seconds: schedule.timeout_seconds || 900,
     allowed_tools: schedule.allowed_tools || null,
-    model: schedule.model || 'claude-opus-4-6'
+    model: schedule.model || 'claude-opus-4-6',
+    // RETRY-001
+    max_retries: schedule.max_retries ?? 1,
+    retry_delay_seconds: schedule.retry_delay_seconds ?? 60
   }
 }
 

--- a/src/frontend/src/views/ExecutionList.vue
+++ b/src/frontend/src/views/ExecutionList.vue
@@ -357,6 +357,7 @@ function getStatusIcon(status) {
     paused: '⏸️',
     awaiting_approval: '🔔',
     skipped: '⏭️',
+    pending_retry: '🔁',  // RETRY-001
   }
   return icons[status] || '❓'
 }
@@ -371,6 +372,7 @@ function getStatusClasses(status) {
     paused: 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300',
     awaiting_approval: 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300',
     skipped: 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300',
+    pending_retry: 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300',  // RETRY-001
   }
   return classes[status] || 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
 }

--- a/src/mcp-server/src/tools/schedules.ts
+++ b/src/mcp-server/src/tools/schedules.ts
@@ -174,6 +174,22 @@ export function createScheduleTools(
           .string()
           .optional()
           .describe("Model override for this schedule's executions (e.g., 'claude-sonnet-4-20250514'). If omitted, uses agent default."),
+        max_retries: z
+          .number()
+          .int()
+          .min(0)
+          .max(5)
+          .optional()
+          .default(1)
+          .describe("Max retry attempts on failure (0-5). Default: 1. Set to 0 to disable retries."),
+        retry_delay_seconds: z
+          .number()
+          .int()
+          .min(30)
+          .max(600)
+          .optional()
+          .default(60)
+          .describe("Seconds between retry attempts (30-600). Default: 60. Rate-limited failures use 2x delay."),
       }),
       execute: async (
         args: {
@@ -187,6 +203,8 @@ export function createScheduleTools(
           timeout_seconds?: number;
           allowed_tools?: string[];
           model?: string;
+          max_retries?: number;
+          retry_delay_seconds?: number;
         },
         context?: { session?: McpAuthContext }
       ) => {
@@ -214,6 +232,8 @@ export function createScheduleTools(
           timeout_seconds: args.timeout_seconds,
           allowed_tools: args.allowed_tools,
           model: args.model,
+          max_retries: args.max_retries,
+          retry_delay_seconds: args.retry_delay_seconds,
         });
 
         console.log(`[create_agent_schedule] Created schedule '${schedule.name}' (${schedule.id}) for agent '${args.agent_name}'`);
@@ -301,6 +321,20 @@ export function createScheduleTools(
           .string()
           .optional()
           .describe("New model override for executions"),
+        max_retries: z
+          .number()
+          .int()
+          .min(0)
+          .max(5)
+          .optional()
+          .describe("New max retry attempts (0-5). If omitted, keeps current value."),
+        retry_delay_seconds: z
+          .number()
+          .int()
+          .min(30)
+          .max(600)
+          .optional()
+          .describe("New retry delay in seconds (30-600). If omitted, keeps current value."),
       }),
       execute: async (
         args: {
@@ -315,6 +349,8 @@ export function createScheduleTools(
           timeout_seconds?: number;
           allowed_tools?: string[];
           model?: string;
+          max_retries?: number;
+          retry_delay_seconds?: number;
         },
         context?: { session?: McpAuthContext }
       ) => {
@@ -343,6 +379,8 @@ export function createScheduleTools(
         if (args.timeout_seconds !== undefined) updates.timeout_seconds = args.timeout_seconds;
         if (args.allowed_tools !== undefined) updates.allowed_tools = args.allowed_tools;
         if (args.model !== undefined) updates.model = args.model;
+        if (args.max_retries !== undefined) updates.max_retries = args.max_retries;
+        if (args.retry_delay_seconds !== undefined) updates.retry_delay_seconds = args.retry_delay_seconds;
 
         const schedule = await apiClient.updateAgentSchedule(
           args.agent_name,

--- a/src/mcp-server/src/types.ts
+++ b/src/mcp-server/src/types.ts
@@ -165,6 +165,9 @@ export interface ScheduleCreate {
   timeout_seconds?: number;
   allowed_tools?: string[];
   model?: string;
+  // RETRY-001: Retry configuration
+  max_retries?: number;
+  retry_delay_seconds?: number;
 }
 
 export interface ScheduleUpdate {
@@ -177,20 +180,23 @@ export interface ScheduleUpdate {
   timeout_seconds?: number;
   allowed_tools?: string[];
   model?: string;
+  // RETRY-001: Retry configuration
+  max_retries?: number;
+  retry_delay_seconds?: number;
 }
 
 export interface ScheduleExecution {
   id: string;
   schedule_id: string;
   agent_name: string;
-  status: "pending" | "running" | "success" | "failed" | "cancelled";
+  status: "pending" | "running" | "success" | "failed" | "cancelled" | "skipped" | "pending_retry";
   started_at: string;
   completed_at?: string;
   duration_ms?: number;
   message: string;
   response?: string;
   error?: string;
-  triggered_by: "schedule" | "manual" | "mcp";
+  triggered_by: "schedule" | "manual" | "mcp" | "retry";
   context_used?: number;
   context_max?: number;
   cost?: number;
@@ -200,6 +206,10 @@ export interface ScheduleExecution {
   claude_session_id?: string;
   source_agent_name?: string;
   source_user_email?: string;
+  // RETRY-001: Retry tracking
+  attempt_number?: number;
+  retry_of_execution_id?: string;
+  retry_scheduled_at?: string;
 }
 
 // Execution Query Types (MCP-007)

--- a/src/scheduler/database.py
+++ b/src/scheduler/database.py
@@ -75,7 +75,10 @@ class SchedulerDatabase:
             next_run_at=datetime.fromisoformat(row["next_run_at"]) if row["next_run_at"] else None,
             timeout_seconds=row["timeout_seconds"] if "timeout_seconds" in row_keys and row["timeout_seconds"] else 900,
             allowed_tools=allowed_tools,
-            model=row["model"] if "model" in row_keys else None
+            model=row["model"] if "model" in row_keys else None,
+            # Retry configuration (RETRY-001)
+            max_retries=row["max_retries"] if "max_retries" in row_keys and row["max_retries"] is not None else 1,
+            retry_delay_seconds=row["retry_delay_seconds"] if "retry_delay_seconds" in row_keys and row["retry_delay_seconds"] is not None else 60
         )
 
     @staticmethod
@@ -104,7 +107,12 @@ class SchedulerDatabase:
             source_user_email=row["source_user_email"] if "source_user_email" in row_keys else None,
             source_agent_name=row["source_agent_name"] if "source_agent_name" in row_keys else None,
             source_mcp_key_id=row["source_mcp_key_id"] if "source_mcp_key_id" in row_keys else None,
-            source_mcp_key_name=row["source_mcp_key_name"] if "source_mcp_key_name" in row_keys else None
+            source_mcp_key_name=row["source_mcp_key_name"] if "source_mcp_key_name" in row_keys else None,
+            # Retry tracking (RETRY-001)
+            attempt_number=row["attempt_number"] if "attempt_number" in row_keys and row["attempt_number"] else 1,
+            retry_of_execution_id=row["retry_of_execution_id"] if "retry_of_execution_id" in row_keys else None,
+            retry_scheduled_at=datetime.fromisoformat(row["retry_scheduled_at"])
+                if "retry_scheduled_at" in row_keys and row["retry_scheduled_at"] else None
         )
 
     # =========================================================================
@@ -199,9 +207,21 @@ class SchedulerDatabase:
         agent_name: str,
         message: str,
         triggered_by: str = "schedule",
-        model_used: str = None
+        model_used: str = None,
+        attempt_number: int = 1,
+        retry_of_execution_id: str = None
     ) -> Optional[ScheduleExecution]:
-        """Create a new execution record."""
+        """Create a new execution record.
+
+        Args:
+            schedule_id: Schedule ID
+            agent_name: Agent name
+            message: Task message
+            triggered_by: Trigger source ("schedule", "manual", "retry")
+            model_used: Model override
+            attempt_number: Which attempt this is (1 = first try, RETRY-001)
+            retry_of_execution_id: Original execution ID for retries (RETRY-001)
+        """
         execution_id = self._generate_id()
         now = datetime.utcnow().isoformat()
 
@@ -210,8 +230,8 @@ class SchedulerDatabase:
             cursor.execute("""
                 INSERT INTO schedule_executions (
                     id, schedule_id, agent_name, status, started_at, message, triggered_by,
-                    model_used
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    model_used, attempt_number, retry_of_execution_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 execution_id,
                 schedule_id,
@@ -220,7 +240,9 @@ class SchedulerDatabase:
                 now,
                 message,
                 triggered_by,
-                model_used
+                model_used,
+                attempt_number,
+                retry_of_execution_id
             ))
             conn.commit()
 
@@ -231,7 +253,9 @@ class SchedulerDatabase:
                 status=ExecutionStatus.RUNNING,
                 started_at=datetime.fromisoformat(now),
                 message=message,
-                triggered_by=triggered_by
+                triggered_by=triggered_by,
+                attempt_number=attempt_number,
+                retry_of_execution_id=retry_of_execution_id
             )
 
     def create_skipped_execution(
@@ -368,6 +392,97 @@ class SchedulerDatabase:
                 LIMIT ?
             """, (limit,))
             return [self._row_to_execution(row) for row in cursor.fetchall()]
+
+    # =========================================================================
+    # Retry Operations (RETRY-001)
+    # =========================================================================
+
+    def schedule_retry(
+        self,
+        original_execution_id: str,
+        retry_scheduled_at: datetime
+    ) -> bool:
+        """Mark an execution as pending retry.
+
+        Updates the execution status to 'pending_retry' and records when the retry
+        is scheduled to fire. This persists the retry intent so it survives scheduler restart.
+
+        Args:
+            original_execution_id: The failed execution ID
+            retry_scheduled_at: When the retry is scheduled to fire
+
+        Returns:
+            True if update succeeded
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                UPDATE schedule_executions
+                SET status = ?, retry_scheduled_at = ?
+                WHERE id = ?
+            """, (
+                ExecutionStatus.PENDING_RETRY,
+                retry_scheduled_at.isoformat(),
+                original_execution_id
+            ))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def get_pending_retries(self) -> List[ScheduleExecution]:
+        """Get all executions with pending retries (for startup recovery).
+
+        Returns executions where:
+        - status = 'pending_retry'
+        - retry_scheduled_at is not null
+
+        The caller should reschedule APScheduler date triggers for these.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT * FROM schedule_executions
+                WHERE status = ? AND retry_scheduled_at IS NOT NULL
+                ORDER BY retry_scheduled_at ASC
+            """, (ExecutionStatus.PENDING_RETRY,))
+            return [self._row_to_execution(row) for row in cursor.fetchall()]
+
+    def clear_retry_scheduled(self, execution_id: str) -> bool:
+        """Clear the retry_scheduled_at after retry fires.
+
+        Called when the retry actually executes. The new execution record
+        will have its own status tracking.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                UPDATE schedule_executions
+                SET retry_scheduled_at = NULL
+                WHERE id = ?
+            """, (execution_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def get_original_execution_id(self, execution_id: str) -> Optional[str]:
+        """Traverse retry chain to find the original execution ID.
+
+        For grouping retry attempts in the UI.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            current_id = execution_id
+
+            # Follow the chain (max 5 hops to prevent infinite loops)
+            for _ in range(5):
+                cursor.execute(
+                    "SELECT retry_of_execution_id FROM schedule_executions WHERE id = ?",
+                    (current_id,)
+                )
+                row = cursor.fetchone()
+                if not row or not row["retry_of_execution_id"]:
+                    return current_id
+                current_id = row["retry_of_execution_id"]
+
+            return current_id
 
     # =========================================================================
     # Process Schedule Operations

--- a/src/scheduler/models.py
+++ b/src/scheduler/models.py
@@ -18,6 +18,7 @@ class ExecutionStatus(str, Enum):
     FAILED = "failed"
     CANCELLED = "cancelled"
     SKIPPED = "skipped"  # Added for Issue #46 - records when execution was dropped
+    PENDING_RETRY = "pending_retry"  # Added for RETRY-001 - retry scheduled but not yet fired
 
 
 class TriggerSource(str, Enum):
@@ -25,6 +26,7 @@ class TriggerSource(str, Enum):
     SCHEDULE = "schedule"
     MANUAL = "manual"
     API = "api"
+    RETRY = "retry"  # Added for RETRY-001 - automatic retry of failed execution
 
 
 @dataclass
@@ -46,6 +48,9 @@ class Schedule:
     timeout_seconds: int = 900  # Default 15 minutes
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
+    # Retry configuration (RETRY-001)
+    max_retries: int = 1  # 0 = disabled, 1-5 range
+    retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
 
 
 @dataclass
@@ -73,6 +78,10 @@ class ScheduleExecution:
     source_agent_name: Optional[str] = None
     source_mcp_key_id: Optional[str] = None
     source_mcp_key_name: Optional[str] = None
+    # Retry tracking (RETRY-001)
+    attempt_number: int = 1  # Which attempt this is (1 = first try)
+    retry_of_execution_id: Optional[str] = None  # Links retry to original execution
+    retry_scheduled_at: Optional[datetime] = None  # When retry is scheduled (for restart recovery)
 
 
 @dataclass

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Optional, List, Callable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -141,6 +141,9 @@ class SchedulerService:
         logger.info(f"Instance ID: {self._instance_id}")
         logger.info(f"Schedule sync interval: {config.schedule_reload_interval}s")
         logger.info(f"Misfire grace time: {config.misfire_grace_time}s")
+
+        # RETRY-001: Recover any pending retries from before restart
+        self._recover_pending_retries()
 
     def _get_missed_schedules(self, schedules: List[Schedule]) -> List[Schedule]:
         """
@@ -1045,6 +1048,12 @@ class SchedulerService:
                     "error": error_msg
                 })
 
+                # RETRY-001: Check if retry is eligible and schedule it
+                await self._maybe_schedule_retry(
+                    execution=execution,
+                    error_msg=error_msg
+                )
+
         except asyncio.CancelledError:
             logger.info(f"Background poll for execution {execution_id} cancelled (shutdown)")
             raise
@@ -1064,6 +1073,223 @@ class SchedulerService:
                     f"Execution {execution_id} may be stuck in 'running' state — "
                     "cleanup service will recover within 5 minutes"
                 )
+
+    # =========================================================================
+    # Retry Management (RETRY-001)
+    # =========================================================================
+
+    async def _maybe_schedule_retry(
+        self,
+        execution: ScheduleExecution,
+        error_msg: str = None
+    ):
+        """Check if a failed execution is eligible for retry and schedule it.
+
+        Called after _poll_and_finalize detects a failure.
+        """
+        if not execution:
+            return
+
+        # Don't retry skipped or cancelled executions
+        if execution.status in (ExecutionStatus.SKIPPED, ExecutionStatus.CANCELLED):
+            logger.debug(f"Execution {execution.id} status '{execution.status}' is not retriable")
+            return
+
+        # Get the schedule to check retry configuration
+        schedule = self.db.get_schedule(execution.schedule_id)
+        if not schedule:
+            logger.debug(f"Schedule {execution.schedule_id} not found, skipping retry")
+            return
+
+        # Check if retries are enabled
+        max_retries = schedule.max_retries
+        if max_retries <= 0:
+            logger.debug(f"Schedule {schedule.id} has max_retries=0, skipping retry")
+            return
+
+        # Check if we've exceeded retry limit
+        current_attempt = execution.attempt_number or 1
+        if current_attempt > max_retries:
+            logger.info(
+                f"Execution {execution.id} attempt {current_attempt} exceeds max_retries={max_retries}, "
+                "no more retries"
+            )
+            return
+
+        # Calculate retry delay
+        retry_delay = schedule.retry_delay_seconds
+
+        # Check for rate limit (429) in error - use 2x delay, capped at 300s
+        if error_msg:
+            error_lower = error_msg.lower()
+            if "429" in error_lower or "rate limit" in error_lower or "too many requests" in error_lower:
+                retry_delay = min(300, retry_delay * 2)
+                logger.info(f"Rate limit detected, using 2x delay: {retry_delay}s")
+
+        # Schedule the retry
+        retry_at = datetime.utcnow() + timedelta(seconds=retry_delay)
+
+        logger.info(
+            f"Scheduling retry for execution {execution.id} "
+            f"(attempt {current_attempt + 1}/{max_retries + 1}) at {retry_at.isoformat()}"
+        )
+
+        # Persist retry intent to DB (survives restart)
+        self.db.schedule_retry(execution.id, retry_at)
+
+        # Schedule APScheduler date trigger
+        self._schedule_retry_job(
+            execution=execution,
+            schedule=schedule,
+            retry_at=retry_at,
+            next_attempt_number=current_attempt + 1
+        )
+
+    def _schedule_retry_job(
+        self,
+        execution: ScheduleExecution,
+        schedule: Schedule,
+        retry_at: datetime,
+        next_attempt_number: int
+    ):
+        """Schedule an APScheduler date trigger for retry."""
+        from apscheduler.triggers.date import DateTrigger
+
+        # Find the original execution ID for linking
+        original_id = self.db.get_original_execution_id(execution.id)
+
+        job_id = f"retry_{execution.id}"
+
+        # Remove any existing retry job for this execution
+        try:
+            self.scheduler.remove_job(job_id)
+        except Exception:
+            pass
+
+        self.scheduler.add_job(
+            self._execute_retry,
+            trigger=DateTrigger(run_date=retry_at),
+            id=job_id,
+            kwargs={
+                "original_execution_id": original_id,
+                "failed_execution_id": execution.id,
+                "schedule_id": schedule.id,
+                "agent_name": schedule.agent_name,
+                "message": schedule.message,
+                "timeout_seconds": schedule.timeout_seconds,
+                "model": schedule.model,
+                "allowed_tools": schedule.allowed_tools,
+                "next_attempt_number": next_attempt_number,
+            },
+            replace_existing=True
+        )
+
+    async def _execute_retry(
+        self,
+        original_execution_id: str,
+        failed_execution_id: str,
+        schedule_id: str,
+        agent_name: str,
+        message: str,
+        timeout_seconds: int,
+        model: str,
+        allowed_tools: list,
+        next_attempt_number: int
+    ):
+        """Execute a scheduled retry.
+
+        Called by APScheduler when the date trigger fires.
+        """
+        logger.info(
+            f"Executing retry for schedule {schedule_id}, agent {agent_name}, "
+            f"attempt {next_attempt_number}"
+        )
+
+        # Clear the retry_scheduled_at from the failed execution
+        self.db.clear_retry_scheduled(failed_execution_id)
+
+        # Check if agent still exists (in case it was deleted while retry was pending)
+        schedule = self.db.get_schedule(schedule_id)
+        if not schedule or not schedule.enabled:
+            logger.warning(
+                f"Schedule {schedule_id} no longer exists or is disabled, "
+                "skipping retry execution"
+            )
+            return
+
+        # Create a new execution record for the retry
+        retry_execution = self.db.create_execution(
+            schedule_id=schedule_id,
+            agent_name=agent_name,
+            message=message,
+            triggered_by="retry",
+            model_used=model,
+            attempt_number=next_attempt_number,
+            retry_of_execution_id=original_execution_id
+        )
+
+        if not retry_execution:
+            logger.error(f"Failed to create retry execution record for schedule {schedule_id}")
+            return
+
+        # Execute the task via the backend
+        try:
+            await self._call_backend_execute_task(
+                agent_name=agent_name,
+                message=message,
+                triggered_by="retry",
+                timeout_seconds=timeout_seconds,
+                model=model,
+                allowed_tools=allowed_tools,
+                execution_id=retry_execution.id
+            )
+        except Exception as e:
+            logger.error(f"Retry execution failed for {retry_execution.id}: {e}")
+            self.db.update_execution_status(
+                execution_id=retry_execution.id,
+                status=ExecutionStatus.FAILED,
+                error=str(e)[:2000]
+            )
+
+    def _recover_pending_retries(self):
+        """Recover pending retries after scheduler restart.
+
+        Called during initialization to reschedule any retries that were
+        pending when the scheduler shut down.
+        """
+        pending = self.db.get_pending_retries()
+        if not pending:
+            return
+
+        logger.info(f"Recovering {len(pending)} pending retries after restart")
+
+        now = datetime.utcnow()
+        for execution in pending:
+            schedule = self.db.get_schedule(execution.schedule_id)
+            if not schedule or not schedule.enabled:
+                # Schedule deleted or disabled, clear the retry
+                logger.info(
+                    f"Schedule {execution.schedule_id} no longer valid, "
+                    f"clearing retry for execution {execution.id}"
+                )
+                self.db.clear_retry_scheduled(execution.id)
+                continue
+
+            retry_at = execution.retry_scheduled_at
+            if retry_at < now:
+                # Retry time has passed, execute immediately
+                retry_at = now + timedelta(seconds=5)
+                logger.info(
+                    f"Retry for execution {execution.id} was scheduled for "
+                    f"{execution.retry_scheduled_at}, executing in 5s"
+                )
+
+            self._schedule_retry_job(
+                execution=execution,
+                schedule=schedule,
+                retry_at=retry_at,
+                next_attempt_number=(execution.attempt_number or 1) + 1
+            )
 
     # =========================================================================
     # Schedule Management (for runtime updates)


### PR DESCRIPTION
## Summary

- Add configurable automatic retry for failed scheduled executions
- Default: 1 retry with 60s delay (new schedules). Existing schedules: 0 retries (opt-in via migration)
- Rate-limited (429) failures use 2x delay, capped at 300s
- Each retry creates a new execution record with full observability (linked via `retry_of_execution_id`)
- Retries survive scheduler restart (persisted to DB, recovered on startup)

## Changes

**Schema** (4 new columns across 2 tables):
- `agent_schedules`: `max_retries`, `retry_delay_seconds`
- `schedule_executions`: `attempt_number`, `retry_of_execution_id`, `retry_scheduled_at`

**Backend**: Migration, db operations, Pydantic models
**Scheduler**: Retry logic (`_maybe_schedule_retry`, `_execute_retry`, `_recover_pending_retries`)
**MCP**: `create_agent_schedule` and `update_agent_schedule` accept retry params
**Frontend**: Retry config in schedule form, `pending_retry` status styling

## Test Plan

- [ ] Create schedule with max_retries=2, trigger execution that fails
- [ ] Verify retry fires after configured delay
- [ ] Verify 429 errors use 2x delay
- [ ] Restart scheduler mid-retry, verify recovery
- [ ] Verify execution history shows attempt numbers and links

Closes #271

Generated with [Claude Code](https://claude.com/claude-code)