### PR TITLE
fix: resolve test suite failures (Epic #342)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -718,6 +718,15 @@ def _diagnose_exit_failure(return_code: int, metadata: Optional['ExecutionMetada
     if metadata and metadata.error_type == "rate_limit":
         return _format_rate_limit_error(metadata)
 
+    # Check for billing errors (e.g., credit balance too low)
+    if metadata and metadata.error_type == "billing_error":
+        error_msg = metadata.error_message or "Billing error"
+        return (
+            f"{error_msg}. "
+            f"To resolve: (1) add credits to your Anthropic account at console.anthropic.com, "
+            f"or (2) assign a subscription token with available usage in Settings → Subscriptions."
+        )
+
     # Check for model access errors detected during stream parsing
     if metadata and metadata.error_message and _is_model_access_error(metadata.error_message):
         return (

--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -542,7 +542,7 @@ class SubscriptionOperations:
         Get subscription with fewest assigned agents (round-robin).
 
         Tie-break: alphabetical by name.
-        Skips subscriptions that are currently rate-limited.
+        Skips subscriptions that are currently rate-limited or have invalid tokens.
         Used for auto-assignment on agent creation (#74).
 
         Returns:
@@ -559,8 +559,14 @@ class SubscriptionOperations:
             """)
             for row in cursor.fetchall():
                 sub = self._row_to_subscription(row)
-                if not self.is_subscription_rate_limited(sub.id):
-                    return sub
+                # Skip rate-limited subscriptions
+                if self.is_subscription_rate_limited(sub.id):
+                    continue
+                # Skip subscriptions with invalid/legacy tokens (#340)
+                token = self.get_subscription_token(sub.id)
+                if not token:
+                    continue
+                return sub
             return None
 
     def select_best_alternative_subscription(

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -322,6 +322,11 @@ class DeployLocalRequest(BaseModel):
     """Request to deploy a local agent."""
     archive: str  # Base64-encoded tar.gz
     name: Optional[str] = None  # Override name from template.yaml
+    credentials: Optional[Dict[str, str]] = None  # Optional credentials to inject {KEY: value}
+
+
+# Maximum credentials allowed per deploy-local request
+MAX_DEPLOY_CREDENTIALS = 100
 
 
 class DeployLocalResponse(BaseModel):
@@ -329,6 +334,8 @@ class DeployLocalResponse(BaseModel):
     status: str  # "success" or "error"
     agent: Optional[AgentStatus] = None
     versioning: Optional[VersioningInfo] = None
+    credentials_imported: Optional[Dict[str, str]] = None  # Files found in archive
+    credentials_injected: Optional[int] = None  # Count of credentials injected
     error: Optional[str] = None
     code: Optional[str] = None  # Error code for machine-readable errors
 

--- a/src/backend/routers/subscriptions.py
+++ b/src/backend/routers/subscriptions.py
@@ -257,6 +257,7 @@ async def assign_subscription_to_agent(
 
         container = get_agent_container(agent_name)
         restart_result = None
+        injection_result = None
 
         if container:
             agent_status = get_agent_status_from_container(container)
@@ -265,12 +266,18 @@ async def assign_subscription_to_agent(
                     await container_stop(container)
                     await start_agent_internal(agent_name)
                     restart_result = "success"
+                    injection_result = {"status": "success"}
                     logger.info(
                         f"Restarted agent '{agent_name}' to apply subscription token"
                     )
                 except Exception as e:
                     logger.error(f"Failed to restart agent '{agent_name}' for subscription: {e}")
                     restart_result = f"failed: {e}"
+                    injection_result = {"status": "failed", "error": str(e)}
+            else:
+                injection_result = {"status": "agent_not_running"}
+        else:
+            injection_result = {"status": "agent_not_running"}
 
         return {
             "success": True,
@@ -278,6 +285,7 @@ async def assign_subscription_to_agent(
             "agent_name": agent_name,
             "subscription_name": subscription_name,
             "restart_result": restart_result,
+            "injection_result": injection_result,
         }
 
     except ValueError as e:

--- a/src/backend/services/agent_service/deploy.py
+++ b/src/backend/services/agent_service/deploy.py
@@ -20,6 +20,7 @@ from models import (
     DeployLocalRequest,
     DeployLocalResponse,
     VersioningInfo,
+    MAX_DEPLOY_CREDENTIALS,
 )
 from database import db
 from services.template_service import is_trinity_compatible
@@ -229,6 +230,16 @@ async def deploy_local_agent_logic(
                 }
             )
 
+        # 1b. Validate credential count limit
+        if body.credentials and len(body.credentials) > MAX_DEPLOY_CREDENTIALS:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Too many credentials: {len(body.credentials)} exceeds limit of {MAX_DEPLOY_CREDENTIALS}",
+                    "code": "TOO_MANY_CREDENTIALS"
+                }
+            )
+
         # 2. Extract archive to temp directory
         temp_dir = Path(tempfile.mkdtemp(prefix="trinity-deploy-"))
         try:
@@ -359,6 +370,35 @@ async def deploy_local_agent_logic(
             runtime_model=runtime_model
         )
 
+        # 9b. Process credentials before agent creation
+        credentials_imported = {}
+        credentials_injected = 0
+
+        # Check for credential files in archive
+        env_file = dest_path / ".env"
+        if env_file.exists():
+            credentials_imported[".env"] = "from_archive"
+
+        mcp_file = dest_path / ".mcp.json"
+        if mcp_file.exists():
+            credentials_imported[".mcp.json"] = "from_archive"
+
+        # Write credentials from request to template directory
+        # These will be copied to the agent workspace during creation
+        if body.credentials:
+            env_content = "\n".join(f"{k}={v}" for k, v in body.credentials.items())
+            # Append to existing .env or create new one
+            if env_file.exists():
+                existing = env_file.read_text()
+                # Append with newline separator
+                env_file.write_text(existing.rstrip() + "\n" + env_content + "\n")
+                credentials_imported[".env"] = "merged"
+            else:
+                env_file.write_text(env_content + "\n")
+                credentials_imported[".env"] = "created"
+            credentials_injected = len(body.credentials)
+            logger.info(f"Wrote {credentials_injected} credentials to template for agent {version_name}")
+
         agent_status = await create_agent_fn(
             agent_config,
             current_user,
@@ -376,6 +416,8 @@ async def deploy_local_agent_logic(
                 previous_version_stopped=previous_stopped,
                 new_version=version_name
             ),
+            credentials_imported=credentials_imported,
+            credentials_injected=credentials_injected,
         )
 
     except HTTPException:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -342,10 +342,10 @@ class TestAgentNotifications:
     def test_get_agent_notifications_success(
         self,
         api_client: TrinityApiClient,
-        created_agent: str
+        created_agent: dict
     ):
         """Get notifications for existing agent returns 200."""
-        response = api_client.get(f"/api/agents/{created_agent}/notifications")
+        response = api_client.get(f"/api/agents/{created_agent['name']}/notifications")
         assert_status(response, 200)
         data = assert_json_response(response)
         assert_has_fields(data, ["count", "notifications"])
@@ -358,14 +358,14 @@ class TestAgentNotifications:
     def test_count_agent_notifications_success(
         self,
         api_client: TrinityApiClient,
-        created_agent: str
+        created_agent: dict
     ):
         """Count pending notifications for existing agent returns 200."""
-        response = api_client.get(f"/api/agents/{created_agent}/notifications/count")
+        response = api_client.get(f"/api/agents/{created_agent['name']}/notifications/count")
         assert_status(response, 200)
         data = response.json()
         assert_has_fields(data, ["agent_name", "pending_count"])
-        assert data["agent_name"] == created_agent
+        assert data["agent_name"] == created_agent["name"]
         assert isinstance(data["pending_count"], int)
 
     def test_count_agent_notifications_not_found(self, api_client: TrinityApiClient):

--- a/tests/test_parallel_task.py
+++ b/tests/test_parallel_task.py
@@ -741,12 +741,12 @@ class TestAsyncModeUnifiedExecutor:
       - save_to_session guarded on SUCCESS (E1 fix)
     """
 
-    def test_async_mode_at_capacity_returns_429_upfront(
+    def test_async_mode_at_capacity_queues_task(
         self,
         api_client: TrinityApiClient,
         created_agent,
     ):
-        """Issue #95 T1: async-at-capacity returns 429 synchronously, not 202+FAILED on poll."""
+        """BACKLOG-001: async-at-capacity queues task instead of returning 429."""
         agent_name = created_agent["name"]
 
         # Prior tests may still hold slots. Raise capacity briefly so any
@@ -785,18 +785,20 @@ class TestAsyncModeUnifiedExecutor:
                 pytest.skip("Slots still occupied from prior tests — rerun isolated")
             assert_status(first, 200)
 
-            # Second async task should be rejected with 429 *synchronously*
+            # BACKLOG-001: Second async task should be queued (not rejected 429)
             second = api_client.post(
                 f"/api/agents/{agent_name}/task",
-                json={"message": "Should be rejected.", "async_mode": True},
+                json={"message": "Should be queued.", "async_mode": True},
                 timeout=10.0,
             )
-            assert_status(second, 429), (
-                "async-at-capacity must return 429 upfront (not 202 with FAILED-on-poll) — "
-                "preserves existing client retry contract through issue #95 refactor"
+            assert_status(second, 200), (
+                "BACKLOG-001: async-at-capacity should queue task with status 200"
             )
-            detail = (second.json() or {}).get("detail", "")
-            assert "capacity" in detail.lower()
+            data = second.json() or {}
+            # Task should be queued, not rejected
+            assert data.get("status") == "queued" or "execution_id" in data, (
+                f"Expected 'queued' status or execution_id, got: {data}"
+            )
         finally:
             # Restore default capacity
             api_client.put(

--- a/tests/unit/test_slack_watchdog.py
+++ b/tests/unit/test_slack_watchdog.py
@@ -59,10 +59,18 @@ _transports.base = _base
 
 # Import via importlib to load the .py file directly
 import importlib.util
+import os
+
+# Use __file__-relative path to work regardless of cwd (#341)
+_slack_socket_path = os.path.join(
+    os.path.dirname(__file__),
+    "..", "..",  # from tests/unit to project root
+    "src", "backend", "adapters", "transports", "slack_socket.py"
+)
 
 _spec = importlib.util.spec_from_file_location(
     "adapters.transports.slack_socket",
-    "src/backend/adapters/transports/slack_socket.py",
+    _slack_socket_path,
 )
 _mod = importlib.util.module_from_spec(_spec)
 sys.modules["adapters.transports.slack_socket"] = _mod


### PR DESCRIPTION
## Summary

Fixes 7 distinct test failures identified in Epic #342. All tests now pass.

## Changes

| Issue | Problem | Fix |
|-------|---------|-----|
| #335 | `UnboundLocalError: execution_id` in agent container | Fixed by rebuilding base image with correct code |
| #336 | Exit code 1 "General error" hides billing errors | Added `billing_error` detection in `_diagnose_exit_failure()` |
| #337 | Deploy-local missing response fields | Added `credentials_imported` and `credentials_injected` to response |
| #338 | Test expects 429 at capacity, now queues | Updated test to expect 200 with `status: "queued"` per BACKLOG-001 |
| #339 | Agent notification endpoints return 404 | Fixed test to use `created_agent["name"]` instead of dict directly |
| #340 | Subscription assignment missing injection_result | Added `injection_result` field; fixed auto-assign to skip invalid tokens |
| #341 | Slack watchdog test collection error | Changed relative path to `__file__`-based path |

## Files Modified

- `docker/base-image/agent_server/services/claude_code.py` - billing_error handling
- `src/backend/db/subscriptions.py` - Skip subscriptions with invalid/legacy tokens
- `src/backend/models.py` - Added credential fields to deploy-local models
- `src/backend/routers/subscriptions.py` - Added `injection_result` to response
- `src/backend/services/agent_service/deploy.py` - Credential injection support
- `tests/test_notifications.py` - Fixed `created_agent` fixture usage
- `tests/test_parallel_task.py` - Updated at-capacity test expectations
- `tests/unit/test_slack_watchdog.py` - Fixed relative path

## Test Plan

- [x] `test_notifications.py::TestAgentNotifications` (4 tests) - PASS
- [x] `test_subscriptions.py::TestCredentialInjection::test_injection_on_assignment` - PASS
- [x] `test_subscriptions.py::TestSubscriptionAutoAssign::test_round_robin_distribution` - PASS
- [x] `test_parallel_task.py::test_async_mode_at_capacity_queues_task` - PASS
- [x] `unit/test_slack_watchdog.py` (28 tests) - PASS
- [x] Smoke tests: 677 passed, 22 skipped, 0 failed

Closes #342, #335, #336, #337, #338, #339, #340, #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)