### PR TITLE
feat(validation): add post-execution business task validation (VALIDATE-001)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-14 | VALIDATE-001 (#294) | Business task validation — post-execution clean-context auditor verifies task completion | [business-validation.md](feature-flows/business-validation.md) |
 | 2026-04-14 | SELF-EXEC-001 (#264) | Agent self-execute — background task on itself during chat, optional result injection | [self-execute.md](feature-flows/self-execute.md) |
 | 2026-04-13 | BACKLOG-001 (#260) | Persistent async task backlog — async `/task` spills to SQLite FIFO at capacity, drains on slot release, restart-durable | [persistent-task-backlog.md](feature-flows/persistent-task-backlog.md) |
 | 2026-04-13 | #314 | Whitelist-driven role on first email login — fixes silent promotion to `creator` for cross-channel access grants | [email-authentication.md](feature-flows/email-authentication.md), [agent-sharing.md](feature-flows/agent-sharing.md), [cli-tool.md](feature-flows/cli-tool.md) |
@@ -120,6 +121,7 @@
 | Parallel Capacity | [parallel-capacity.md](feature-flows/parallel-capacity.md) | Per-agent parallel execution slot tracking |
 | Persistent Task Backlog | [persistent-task-backlog.md](feature-flows/persistent-task-backlog.md) | SQLite-backed FIFO backlog for async tasks at capacity (BACKLOG-001) |
 | Task Execution Service | [task-execution-service.md](feature-flows/task-execution-service.md) | Unified execution lifecycle for all task callers (EXEC-024) |
+| Business Validation | [business-validation.md](feature-flows/business-validation.md) | Post-execution auditor verifies task completion (VALIDATE-001) |
 | Fan-Out | [fan-out.md](feature-flows/fan-out.md) | Parallel task dispatch and result collection via semaphore (FANOUT-001) |
 
 ### Dashboard & Monitoring

--- a/docs/memory/feature-flows/business-validation.md
+++ b/docs/memory/feature-flows/business-validation.md
@@ -1,0 +1,226 @@
+# Business Task Validation (VALIDATE-001)
+
+Post-execution validation feature that runs a clean-context Claude session to verify business task completion.
+
+## Overview
+
+After a scheduled task completes successfully (technical status), an optional validation phase runs to verify that the business task was actually completed correctly. This separates technical success (Claude ran without errors) from business success (the intended work was done).
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        Validation Flow                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Scheduler Service              Backend                 Agent Container  │
+│  ┌─────────────────┐           ┌──────────────────┐    ┌─────────────┐ │
+│  │ _poll_and_      │           │ ValidationService│    │   Claude    │ │
+│  │  finalize()     │ ──(1)──►  │ validate_        │    │    Code     │ │
+│  │                 │   POST    │  execution()     │    │             │ │
+│  │                 │ /internal │                  │    │             │ │
+│  │                 │ /validate │                  │    │             │ │
+│  │                 │           │   ┌──────────┐   │    │             │ │
+│  │                 │           │   │ Build    │   │    │             │ │
+│  │                 │           │   │ Auditor  │───┼────►             │ │
+│  │                 │           │   │ Prompt   │   │(2) │             │ │
+│  │                 │           │   └──────────┘   │    │             │ │
+│  │                 │           │                  │    │             │ │
+│  │                 │           │   ┌──────────┐   │    │             │ │
+│  │                 │           │   │ Parse    │◄──┼────┤  JSON or    │ │
+│  │                 │           │   │ Response │   │(3) │  Text       │ │
+│  │                 │           │   └──────────┘   │    │  Response   │ │
+│  │                 │           │                  │    │             │ │
+│  │                 │           │   ┌──────────┐   │    │             │ │
+│  │                 │  ◄──(4)── │   │ Update   │   │    │             │ │
+│  │                 │   status  │   │ Business │   │    │             │ │
+│  │                 │           │   │ Status   │   │    │             │ │
+│  │                 │           │   └──────────┘   │    └─────────────┘ │
+│  └─────────────────┘           └──────────────────┘                     │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Data Model
+
+### Schedule Fields (validation config)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `validation_enabled` | bool | false | Enable post-execution validation |
+| `validation_prompt` | text | null | Custom auditor prompt (uses default if null) |
+| `validation_timeout_seconds` | int | 120 | Timeout for validation execution |
+
+### Execution Fields (validation tracking)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `business_status` | enum | pending_validation, validated, failed_validation, skipped |
+| `validated_at` | timestamp | When validation completed |
+| `validation_execution_id` | FK | Points to the validation execution record |
+| `validates_execution_id` | FK | Set on validation execution, points back to original |
+
+### BusinessStatus Enum
+
+```python
+class BusinessStatus(str, Enum):
+    PENDING_VALIDATION = "pending_validation"  # Waiting for validation
+    VALIDATED = "validated"                    # Validation passed
+    FAILED_VALIDATION = "failed_validation"    # Validation failed
+    SKIPPED = "skipped"                        # Validation not configured
+```
+
+## Key Files
+
+| Layer | File | Purpose |
+|-------|------|---------|
+| Backend | `src/backend/services/validation_service.py` | Core validation logic |
+| Backend | `src/backend/routers/internal.py` | `/validate-execution` endpoint |
+| Backend | `src/backend/routers/schedules.py` | Schedule/execution response models |
+| Backend | `src/backend/db/schedules.py` | DB operations for validation |
+| Backend | `src/backend/models.py` | BusinessStatus enum |
+| Scheduler | `src/scheduler/service.py` | Triggers validation after execution |
+| Tests | `tests/test_validation.py` | Unit and integration tests |
+
+## Validation Prompt
+
+The default prompt uses explicit auditor framing:
+
+```
+You are an AUDITOR, not an executor. Your task is to VALIDATE whether
+the previous execution successfully completed its intended work.
+
+## Important Context
+- This is a POST-EXECUTION validation session
+- You are reviewing work that was ALREADY ATTEMPTED by this agent
+- Your job is to VERIFY completion, not to DO the work
+
+## Original Task
+{original_message}
+
+## Execution Output
+{execution_response}
+
+## Your Validation Task
+1. Check if work was actually completed (not just claimed)
+2. Verify artifacts/files/changes exist
+3. Check for completeness
+4. Look for errors, partial completions, or hallucinated success
+
+## Response Format
+{
+  "status": "pass" | "fail" | "partial",
+  "summary": "One sentence summary",
+  "items": [{"check": "...", "result": "pass|fail", "evidence": "..."}],
+  "recommendation": "Action if failed (optional)"
+}
+```
+
+## Response Parsing
+
+The service parses validation responses with fallback:
+
+1. **JSON extraction**: Look for `{...}` in response
+2. **Markdown code blocks**: Extract from ```json blocks
+3. **Text inference**: Analyze for pass/fail indicators
+4. **Default**: Return PARTIAL if unclear
+
+## Validation Flow
+
+1. **Scheduler completes execution** successfully (status=completed)
+2. **Check `validation_enabled`** on schedule
+3. **Call backend** `POST /api/internal/validate-execution`
+4. **Backend creates** validation execution record (linked via `validates_execution_id`)
+5. **Build auditor prompt** with original message + execution response
+6. **Run validation** via TaskExecutionService (clean context)
+7. **Parse response** into ValidationResult
+8. **Update original execution** `business_status` and `validation_execution_id`
+9. **On failure**: Add to operator queue for human review
+
+## Operator Queue Integration
+
+When validation fails:
+
+```json
+{
+  "id": "val_{execution_id}_{timestamp}",
+  "type": "alert",
+  "priority": "high",
+  "status": "pending",
+  "title": "Validation Failed",
+  "question": "Execution validation failed: {summary}",
+  "context": {
+    "execution_id": "...",
+    "validation_status": "fail",
+    "summary": "...",
+    "items": [...],
+    "recommendation": "..."
+  }
+}
+```
+
+## API Endpoints
+
+### Internal (scheduler -> backend)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/internal/validate-execution` | Trigger validation |
+
+Request:
+```json
+{
+  "execution_id": "exec-123",
+  "agent_name": "my-agent",
+  "schedule_id": "sched-456",
+  "original_message": "Create README file",
+  "execution_response": "I created README.md...",
+  "custom_prompt": null,
+  "timeout_seconds": 120
+}
+```
+
+### Schedule CRUD (include validation config)
+
+| Method | Path | Fields |
+|--------|------|--------|
+| POST | `/api/agents/{name}/schedules` | `validation_enabled`, `validation_prompt`, `validation_timeout_seconds` |
+| PUT | `/api/agents/{name}/schedules/{id}` | Same fields |
+| GET | `/api/agents/{name}/schedules/{id}` | Returns validation config |
+
+### Execution (include business status)
+
+| Method | Path | Fields |
+|--------|------|--------|
+| GET | `/api/agents/{name}/executions` | `business_status`, `validation_execution_id` |
+| GET | `/api/agents/{name}/executions/{id}` | Full validation fields |
+
+## Database Schema
+
+```sql
+-- Schedule: validation config
+ALTER TABLE agent_schedules ADD COLUMN validation_enabled INTEGER DEFAULT 0;
+ALTER TABLE agent_schedules ADD COLUMN validation_prompt TEXT;
+ALTER TABLE agent_schedules ADD COLUMN validation_timeout_seconds INTEGER DEFAULT 120;
+
+-- Execution: validation tracking
+ALTER TABLE schedule_executions ADD COLUMN business_status TEXT;
+ALTER TABLE schedule_executions ADD COLUMN validated_at TEXT;
+ALTER TABLE schedule_executions ADD COLUMN validation_execution_id TEXT;
+ALTER TABLE schedule_executions ADD COLUMN validates_execution_id TEXT;
+
+-- Indexes
+CREATE INDEX idx_executions_business_status ON schedule_executions(business_status);
+CREATE INDEX idx_executions_validates ON schedule_executions(validates_execution_id);
+```
+
+## Related Features
+
+- [Scheduling](scheduling.md) - Cron-based task scheduling
+- [Operator Queue](operator-queue.md) - Human review queue for failures
+- [Activity Stream](activity-stream.md) - Activity tracking
+
+## Issue Reference
+
+- GitHub Issue: #294
+- Feature ID: VALIDATE-001

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -395,6 +395,20 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
   - Identity captured at enqueue and replayed at drain (no re-auth, matches scheduler pattern)
 - **Flow**: `docs/memory/feature-flows/persistent-task-backlog.md`
 
+### 10.9 Business Task Validation (VALIDATE-001)
+- **Status**: ✅ Implemented (2026-04-14)
+- **Requirement ID**: VALIDATE-001
+- **GitHub Issue**: #294
+- **Description**: Post-execution validation phase that runs a clean-context Claude session with auditor framing to verify business task completion. Separates technical success (Claude ran without errors) from business success (intended work was done).
+- **Key Features**:
+  - Per-schedule `validation_enabled`, `validation_prompt`, `validation_timeout_seconds` config
+  - `business_status` field on executions: `pending_validation`, `validated`, `failed_validation`, `skipped`
+  - Linked validation execution records via `validates_execution_id` / `validation_execution_id`
+  - Default auditor prompt with explicit framing and JSON response format
+  - Fallback text inference when JSON parsing fails
+  - Operator queue notification on validation failure
+- **Flow**: `docs/memory/feature-flows/business-validation.md`
+
 ---
 
 ## 11. GitHub Integration

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -36,6 +36,7 @@ Migration Order (as of 2026-02-28):
 29. subscription_rate_limit_tracking - SUB-003 rate-limit event tracking for auto-switch
 30. execution_fan_out_id - FANOUT-001 fan-out operation linkage
 31. scheduler_retry_support - RETRY-001 scheduler retry mechanism
+32. validation_support - VALIDATE-001 post-execution business validation
 """
 import logging
 import sqlite3
@@ -1208,6 +1209,54 @@ def _migrate_scheduler_retry_support(cursor, conn):
     conn.commit()
 
 
+def _migrate_validation_support(cursor, conn):
+    """VALIDATE-001: Post-execution business validation.
+
+    Adds:
+    - agent_schedules.validation_enabled: enable validation for this schedule (default 0)
+    - agent_schedules.validation_prompt: custom auditor instructions
+    - agent_schedules.validation_timeout_seconds: timeout for validation task (default 120)
+    - schedule_executions.business_status: validation result (pending_validation, validated, failed_validation, skipped)
+    - schedule_executions.validated_at: when validation completed
+    - schedule_executions.validation_execution_id: FK to the validation execution
+    - schedule_executions.validates_execution_id: FK to execution being validated (for validation records)
+    """
+    # agent_schedules columns
+    cursor.execute("PRAGMA table_info(agent_schedules)")
+    as_cols = {row[1] for row in cursor.fetchall()}
+
+    if "validation_enabled" not in as_cols:
+        cursor.execute("ALTER TABLE agent_schedules ADD COLUMN validation_enabled INTEGER DEFAULT 0")
+    if "validation_prompt" not in as_cols:
+        cursor.execute("ALTER TABLE agent_schedules ADD COLUMN validation_prompt TEXT")
+    if "validation_timeout_seconds" not in as_cols:
+        cursor.execute("ALTER TABLE agent_schedules ADD COLUMN validation_timeout_seconds INTEGER DEFAULT 120")
+
+    # schedule_executions columns
+    cursor.execute("PRAGMA table_info(schedule_executions)")
+    se_cols = {row[1] for row in cursor.fetchall()}
+
+    if "business_status" not in se_cols:
+        cursor.execute("ALTER TABLE schedule_executions ADD COLUMN business_status TEXT")
+    if "validated_at" not in se_cols:
+        cursor.execute("ALTER TABLE schedule_executions ADD COLUMN validated_at TEXT")
+    if "validation_execution_id" not in se_cols:
+        cursor.execute("ALTER TABLE schedule_executions ADD COLUMN validation_execution_id TEXT")
+    if "validates_execution_id" not in se_cols:
+        cursor.execute("ALTER TABLE schedule_executions ADD COLUMN validates_execution_id TEXT")
+
+    # Indexes for validation queries
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_executions_business_status "
+        "ON schedule_executions(business_status)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_executions_validates "
+        "ON schedule_executions(validates_execution_id)"
+    )
+    conn.commit()
+
+
 # Ordered list of all migrations. Defined at module level (after all _migrate_* functions)
 # so run_all_migrations and the health check can both reference it.
 # IMPORTANT: append-only — never reorder or remove entries.
@@ -1253,4 +1302,5 @@ MIGRATIONS = [
     ("email_whitelist_default_role", _migrate_email_whitelist_default_role),
     ("backlog_support", _migrate_backlog_support),
     ("scheduler_retry_support", _migrate_scheduler_retry_support),
+    ("validation_support", _migrate_validation_support),
 ]

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -92,7 +92,11 @@ class ScheduleOperations:
             model=row["model"] if "model" in row_keys else None,
             # Retry configuration (RETRY-001)
             max_retries=row["max_retries"] if "max_retries" in row_keys and row["max_retries"] is not None else 1,
-            retry_delay_seconds=row["retry_delay_seconds"] if "retry_delay_seconds" in row_keys and row["retry_delay_seconds"] is not None else 60
+            retry_delay_seconds=row["retry_delay_seconds"] if "retry_delay_seconds" in row_keys and row["retry_delay_seconds"] is not None else 60,
+            # Validation configuration (VALIDATE-001)
+            validation_enabled=bool(row["validation_enabled"]) if "validation_enabled" in row_keys and row["validation_enabled"] is not None else False,
+            validation_prompt=row["validation_prompt"] if "validation_prompt" in row_keys else None,
+            validation_timeout_seconds=row["validation_timeout_seconds"] if "validation_timeout_seconds" in row_keys and row["validation_timeout_seconds"] is not None else 120
         )
 
     @staticmethod
@@ -140,6 +144,12 @@ class ScheduleOperations:
             retry_of_execution_id=row["retry_of_execution_id"] if "retry_of_execution_id" in row_keys else None,
             retry_scheduled_at=parse_iso_timestamp(row["retry_scheduled_at"])
                 if "retry_scheduled_at" in row_keys and row["retry_scheduled_at"] else None,
+            # Validation tracking (VALIDATE-001)
+            business_status=row["business_status"] if "business_status" in row_keys else None,
+            validated_at=parse_iso_timestamp(row["validated_at"])
+                if "validated_at" in row_keys and row["validated_at"] else None,
+            validation_execution_id=row["validation_execution_id"] if "validation_execution_id" in row_keys else None,
+            validates_execution_id=row["validates_execution_id"] if "validates_execution_id" in row_keys else None,
         )
 
     @staticmethod
@@ -202,12 +212,16 @@ class ScheduleOperations:
                 max_retries = max(0, min(5, schedule_data.max_retries))
                 retry_delay_seconds = max(30, min(600, schedule_data.retry_delay_seconds))
 
+                # Clamp validation timeout to valid range (VALIDATE-001)
+                validation_timeout_seconds = max(30, min(600, schedule_data.validation_timeout_seconds))
+
                 cursor.execute("""
                     INSERT INTO agent_schedules (
                         id, agent_name, name, cron_expression, message, enabled,
                         timezone, description, owner_id, created_at, updated_at, next_run_at,
-                        timeout_seconds, allowed_tools, model, max_retries, retry_delay_seconds
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        timeout_seconds, allowed_tools, model, max_retries, retry_delay_seconds,
+                        validation_enabled, validation_prompt, validation_timeout_seconds
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     schedule_id,
                     agent_name,
@@ -225,7 +239,10 @@ class ScheduleOperations:
                     allowed_tools_json,
                     schedule_data.model,
                     max_retries,
-                    retry_delay_seconds
+                    retry_delay_seconds,
+                    1 if schedule_data.validation_enabled else 0,
+                    schedule_data.validation_prompt,
+                    validation_timeout_seconds
                 ))
                 conn.commit()
 
@@ -246,7 +263,10 @@ class ScheduleOperations:
                     allowed_tools=schedule_data.allowed_tools,
                     model=schedule_data.model,
                     max_retries=max_retries,
-                    retry_delay_seconds=retry_delay_seconds
+                    retry_delay_seconds=retry_delay_seconds,
+                    validation_enabled=schedule_data.validation_enabled,
+                    validation_prompt=schedule_data.validation_prompt,
+                    validation_timeout_seconds=validation_timeout_seconds
                 )
             except sqlite3.IntegrityError:
                 return None
@@ -321,7 +341,8 @@ class ScheduleOperations:
             allowed_fields = [
                 "name", "cron_expression", "message", "enabled", "timezone",
                 "description", "timeout_seconds", "allowed_tools", "model",
-                "max_retries", "retry_delay_seconds"  # RETRY-001
+                "max_retries", "retry_delay_seconds",  # RETRY-001
+                "validation_enabled", "validation_prompt", "validation_timeout_seconds"  # VALIDATE-001
             ]
 
             for key, value in updates.items():
@@ -336,6 +357,12 @@ class ScheduleOperations:
                         value = max(0, min(5, int(value)))
                     elif key == "retry_delay_seconds":
                         # Clamp to valid range (RETRY-001)
+                        value = max(30, min(600, int(value)))
+                    elif key == "validation_enabled":
+                        # Convert to integer for SQLite (VALIDATE-001)
+                        value = 1 if value else 0
+                    elif key == "validation_timeout_seconds":
+                        # Clamp to valid range (VALIDATE-001)
                         value = max(30, min(600, int(value)))
                     set_clauses.append(f"{key} = ?")
                     params.append(value)
@@ -962,7 +989,7 @@ class ScheduleOperations:
                     duration_ms, message, triggered_by, context_used, context_max, cost,
                     source_user_id, source_user_email, source_agent_name,
                     source_mcp_key_id, source_mcp_key_name, claude_session_id, model_used,
-                    fan_out_id
+                    fan_out_id, business_status, validation_execution_id
                 FROM schedule_executions
                 WHERE agent_name = ?
                 ORDER BY started_at DESC
@@ -1529,3 +1556,146 @@ class ScheduleOperations:
                 ORDER BY agent_name
             """)
             return [self._row_to_git_config(row) for row in cursor.fetchall()]
+
+    # =========================================================================
+    # Business Validation (VALIDATE-001)
+    # =========================================================================
+
+    def create_validation_execution(
+        self,
+        validates_execution_id: str,
+        agent_name: str,
+        schedule_id: str,
+        message: str,
+        timeout_seconds: int = 120,
+    ) -> Optional[ScheduleExecution]:
+        """Create a validation execution record linked to the original execution.
+
+        Args:
+            validates_execution_id: The execution being validated.
+            agent_name: The agent running validation.
+            schedule_id: The schedule that triggered the original execution.
+            message: The validation prompt message.
+            timeout_seconds: Timeout for validation task.
+
+        Returns:
+            The created validation execution record.
+        """
+        execution_id = self._generate_id()
+        now = utc_now_iso()
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                INSERT INTO schedule_executions (
+                    id, schedule_id, agent_name, status, started_at, message, triggered_by,
+                    validates_execution_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                execution_id,
+                schedule_id,
+                agent_name,
+                TaskExecutionStatus.RUNNING,
+                now,
+                message,
+                "validation",  # New trigger type for validation
+                validates_execution_id,
+            ))
+            conn.commit()
+
+            return ScheduleExecution(
+                id=execution_id,
+                schedule_id=schedule_id,
+                agent_name=agent_name,
+                status=TaskExecutionStatus.RUNNING,
+                started_at=datetime.fromisoformat(now),
+                message=message,
+                triggered_by="validation",
+                validates_execution_id=validates_execution_id,
+            )
+
+    def update_business_status(
+        self,
+        execution_id: str,
+        business_status: str,
+        validation_execution_id: Optional[str] = None,
+    ) -> bool:
+        """Update the business validation status of an execution.
+
+        Args:
+            execution_id: The execution to update.
+            business_status: The new business status (pending_validation, validated, failed_validation, skipped).
+            validation_execution_id: Optional FK to the validation execution record.
+
+        Returns:
+            True if the row was updated.
+        """
+        now = utc_now_iso()
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+
+            if validation_execution_id:
+                cursor.execute("""
+                    UPDATE schedule_executions
+                    SET business_status = ?, validated_at = ?, validation_execution_id = ?
+                    WHERE id = ?
+                """, (business_status, now, validation_execution_id, execution_id))
+            else:
+                cursor.execute("""
+                    UPDATE schedule_executions
+                    SET business_status = ?, validated_at = ?
+                    WHERE id = ?
+                """, (business_status, now, execution_id))
+
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def get_executions_pending_validation(self, agent_name: str = None) -> List[ScheduleExecution]:
+        """Get executions that are pending validation.
+
+        Used for startup recovery to retry failed validation attempts.
+
+        Args:
+            agent_name: Optional filter by agent name.
+
+        Returns:
+            List of executions with business_status = 'pending_validation'.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+
+            if agent_name:
+                cursor.execute("""
+                    SELECT * FROM schedule_executions
+                    WHERE business_status = 'pending_validation' AND agent_name = ?
+                    ORDER BY started_at ASC
+                """, (agent_name,))
+            else:
+                cursor.execute("""
+                    SELECT * FROM schedule_executions
+                    WHERE business_status = 'pending_validation'
+                    ORDER BY started_at ASC
+                """)
+
+            return [self._row_to_schedule_execution(row) for row in cursor.fetchall()]
+
+    def get_validation_execution(self, validates_execution_id: str) -> Optional[ScheduleExecution]:
+        """Get the validation execution record for a given original execution.
+
+        Args:
+            validates_execution_id: The original execution ID.
+
+        Returns:
+            The validation execution record, or None if not found.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT * FROM schedule_executions
+                WHERE validates_execution_id = ?
+                ORDER BY started_at DESC
+                LIMIT 1
+            """, (validates_execution_id,))
+            row = cursor.fetchone()
+            return self._row_to_schedule_execution(row) if row else None

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -153,6 +153,9 @@ TABLES = {
             model TEXT,
             max_retries INTEGER DEFAULT 1,
             retry_delay_seconds INTEGER DEFAULT 60,
+            validation_enabled INTEGER DEFAULT 0,
+            validation_prompt TEXT,
+            validation_timeout_seconds INTEGER DEFAULT 120,
             FOREIGN KEY (owner_id) REFERENCES users(id)
         )
     """,
@@ -180,6 +183,10 @@ TABLES = {
             attempt_number INTEGER DEFAULT 1,
             retry_of_execution_id TEXT,
             retry_scheduled_at TEXT,
+            business_status TEXT,
+            validated_at TEXT,
+            validation_execution_id TEXT,
+            validates_execution_id TEXT,
             FOREIGN KEY (schedule_id) REFERENCES agent_schedules(id)
         )
     """,
@@ -699,6 +706,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_executions_status ON schedule_executions(status)",
     # PERF-001: Composite index for Tasks list queries
     "CREATE INDEX IF NOT EXISTS idx_executions_agent_started ON schedule_executions(agent_name, started_at DESC)",
+    # VALIDATE-001: Business status for validation results
+    "CREATE INDEX IF NOT EXISTS idx_executions_business_status ON schedule_executions(business_status)",
+    "CREATE INDEX IF NOT EXISTS idx_executions_validates ON schedule_executions(validates_execution_id)",
 
     # Git config indexes
     "CREATE INDEX IF NOT EXISTS idx_git_config_agent ON agent_git_config(agent_name)",

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -118,6 +118,10 @@ class ScheduleCreate(BaseModel):
     # Retry configuration (RETRY-001)
     max_retries: int = 1  # 0 = disabled, 1-5 range. Default 1 for resilience.
     retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
+    # Validation configuration (VALIDATE-001)
+    validation_enabled: bool = False  # Enable post-execution validation
+    validation_prompt: Optional[str] = None  # Custom auditor instructions (None = default prompt)
+    validation_timeout_seconds: int = 120  # Timeout for validation task (30-600 range)
 
 
 class Schedule(BaseModel):
@@ -141,6 +145,10 @@ class Schedule(BaseModel):
     # Retry configuration (RETRY-001)
     max_retries: int = 1  # 0 = disabled, 1-5 range
     retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
+    # Validation configuration (VALIDATE-001)
+    validation_enabled: bool = False  # Enable post-execution validation
+    validation_prompt: Optional[str] = None  # Custom auditor instructions (None = default prompt)
+    validation_timeout_seconds: int = 120  # Timeout for validation task (30-600 range)
 
 
 class ScheduleExecution(BaseModel):
@@ -183,6 +191,11 @@ class ScheduleExecution(BaseModel):
     attempt_number: int = 1                    # Which attempt this is (1 = first try)
     retry_of_execution_id: Optional[str] = None  # Links retry to original execution
     retry_scheduled_at: Optional[datetime] = None  # When retry is scheduled (for restart recovery)
+    # Validation tracking (VALIDATE-001)
+    business_status: Optional[str] = None       # pending_validation, validated, failed_validation, skipped
+    validated_at: Optional[datetime] = None     # When validation completed
+    validation_execution_id: Optional[str] = None  # FK to the validation execution record
+    validates_execution_id: Optional[str] = None   # FK to execution being validated (for validation records)
 
 
 # =========================================================================

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -197,6 +197,19 @@ class TaskExecutionStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+class BusinessStatus(str, Enum):
+    """
+    Business validation status for task executions (VALIDATE-001).
+
+    Separate from technical TaskExecutionStatus — an execution can complete
+    successfully (technical status) but fail business validation.
+    """
+    PENDING_VALIDATION = "pending_validation"  # Execution completed, awaiting validation
+    VALIDATED = "validated"                     # Validation passed
+    FAILED_VALIDATION = "failed_validation"    # Validation found incomplete/incorrect work
+    SKIPPED = "skipped"                        # Validation not configured for this schedule
+
+
 class QueueItemStatus(str, Enum):
     """Status of an execution request in the in-memory/Redis execution queue."""
     QUEUED = "queued"

--- a/src/backend/routers/internal.py
+++ b/src/backend/routers/internal.py
@@ -290,3 +290,90 @@ async def _execute_task_internal_background(task_service, request: InternalTaskE
                     logger.info(f"Updated execution {request.execution_id} to FAILED")
             except Exception as db_err:
                 logger.error(f"Failed to update execution status: {db_err}")
+
+
+# =============================================================================
+# Validation Endpoints (VALIDATE-001)
+# =============================================================================
+
+class ValidateExecutionRequest(BaseModel):
+    """Request model for triggering execution validation."""
+    execution_id: str
+    agent_name: str
+    schedule_id: str
+    original_message: str
+    execution_response: str
+    custom_prompt: Optional[str] = None
+    timeout_seconds: int = 120
+
+
+@router.post("/validate-execution")
+async def validate_execution(request: ValidateExecutionRequest):
+    """Trigger validation for a completed execution.
+
+    Called by the scheduler service after a successful execution
+    when validation is enabled for the schedule.
+
+    Returns:
+        dict with validation status and result.
+    """
+    from services.validation_service import get_validation_service
+
+    logger.info(
+        f"Received validation request for execution {request.execution_id} "
+        f"on agent '{request.agent_name}'"
+    )
+
+    validation_service = get_validation_service()
+
+    # Run validation in background to not block the scheduler
+    asyncio.create_task(
+        _run_validation_background(
+            validation_service=validation_service,
+            execution_id=request.execution_id,
+            agent_name=request.agent_name,
+            schedule_id=request.schedule_id,
+            original_message=request.original_message,
+            execution_response=request.execution_response,
+            custom_prompt=request.custom_prompt,
+            timeout_seconds=request.timeout_seconds,
+        )
+    )
+
+    return {
+        "status": "accepted",
+        "message": f"Validation triggered for execution {request.execution_id}",
+    }
+
+
+async def _run_validation_background(
+    validation_service,
+    execution_id: str,
+    agent_name: str,
+    schedule_id: str,
+    original_message: str,
+    execution_response: str,
+    custom_prompt: str = None,
+    timeout_seconds: int = 120,
+):
+    """Run validation in background.
+
+    This allows the internal endpoint to return immediately while
+    validation runs asynchronously.
+    """
+    try:
+        result = await validation_service.validate_execution(
+            execution_id=execution_id,
+            agent_name=agent_name,
+            schedule_id=schedule_id,
+            original_message=original_message,
+            execution_response=execution_response,
+            custom_prompt=custom_prompt,
+            timeout_seconds=timeout_seconds,
+        )
+        logger.info(
+            f"Validation completed for execution {execution_id}: "
+            f"status={result.status.value}, summary={result.summary}"
+        )
+    except Exception as e:
+        logger.error(f"Validation failed for execution {execution_id}: {e}")

--- a/src/backend/routers/schedules.py
+++ b/src/backend/routers/schedules.py
@@ -84,6 +84,10 @@ class ScheduleUpdateRequest(BaseModel):
     timeout_seconds: Optional[int] = None
     allowed_tools: Optional[List[str]] = None
     model: Optional[str] = None  # Model override (MODEL-001)
+    # Validation configuration (VALIDATE-001)
+    validation_enabled: Optional[bool] = None
+    validation_prompt: Optional[str] = None
+    validation_timeout_seconds: Optional[int] = None
 
 
 class ScheduleResponse(BaseModel):
@@ -103,6 +107,10 @@ class ScheduleResponse(BaseModel):
     timeout_seconds: int = 900
     allowed_tools: Optional[List[str]] = None
     model: Optional[str] = None  # Model override (MODEL-001)
+    # Validation configuration (VALIDATE-001)
+    validation_enabled: bool = False
+    validation_prompt: Optional[str] = None
+    validation_timeout_seconds: int = 120
 
     class Config:
         from_attributes = True
@@ -139,6 +147,9 @@ class ExecutionSummary(BaseModel):
     model_used: Optional[str] = None
     # Fan-out linkage (small) - FANOUT-001
     fan_out_id: Optional[str] = None
+    # Validation tracking (small) - VALIDATE-001
+    business_status: Optional[str] = None  # pending_validation, validated, failed_validation, skipped
+    validation_execution_id: Optional[str] = None
 
     # EXCLUDED (large fields - fetch via /executions/{id}):
     # - response: Optional[str]      # Full response text
@@ -184,6 +195,11 @@ class ExecutionResponse(BaseModel):
     model_used: Optional[str] = None
     # Fan-out linkage - FANOUT-001
     fan_out_id: Optional[str] = None
+    # Validation tracking - VALIDATE-001
+    business_status: Optional[str] = None
+    validated_at: Optional[datetime] = None
+    validation_execution_id: Optional[str] = None
+    validates_execution_id: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/src/backend/services/validation_service.py
+++ b/src/backend/services/validation_service.py
@@ -1,0 +1,424 @@
+"""
+Validation Service — Post-execution business validation (VALIDATE-001).
+
+Runs a clean-context Claude session after task execution to verify
+that the business task was actually completed correctly.
+
+The validation session:
+- Runs on the same agent (has access to workspace, tools, state)
+- Uses a clean context (new Claude session, no carry-over from execution)
+- Receives explicit auditor framing — this is a validation exercise
+- Produces structured output: pass/fail with evidence
+
+Flow:
+    1. Execution completes successfully (technical status)
+    2. If schedule.validation_enabled:
+        a. Create validation execution record (linked to original)
+        b. Build auditor prompt with execution context
+        c. Run validation via TaskExecutionService
+        d. Parse response and update business_status
+        e. On failure: notify operator queue
+"""
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from database import db
+from models import BusinessStatus
+from services.task_execution_service import TaskExecutionService, TaskExecutionResult
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Default validation prompt template
+# ---------------------------------------------------------------------------
+
+DEFAULT_VALIDATION_PROMPT = """You are an AUDITOR, not an executor. Your task is to VALIDATE whether the previous execution successfully completed its intended work.
+
+## Important Context
+- This is a POST-EXECUTION validation session
+- You are reviewing work that was ALREADY ATTEMPTED by this agent in a previous execution
+- You have access to the same workspace, tools, and files as the executor
+- Your job is to VERIFY completion, not to DO the work
+
+## Original Task
+The agent was asked to perform:
+```
+{original_message}
+```
+
+## Execution Output
+The execution produced this response:
+```
+{execution_response}
+```
+
+## Your Validation Task
+1. Check if the work was actually completed (not just claimed to be done)
+2. Verify any artifacts, files, or changes mentioned in the response exist
+3. Check for completeness — were all parts of the task addressed?
+4. Look for errors, partial completions, or hallucinated success claims
+
+## Response Format
+Respond with a JSON object (and nothing else):
+```json
+{{
+  "status": "pass" | "fail" | "partial",
+  "summary": "One sentence summary of validation result",
+  "items": [
+    {{
+      "check": "What was verified",
+      "result": "pass" | "fail",
+      "evidence": "What was found or not found"
+    }}
+  ],
+  "recommendation": "Action to take if failed (optional)"
+}}
+```
+
+Begin your validation now. Remember: you are AUDITING, not executing."""
+
+
+# ---------------------------------------------------------------------------
+# Validation result types
+# ---------------------------------------------------------------------------
+
+class ValidationStatus(str, Enum):
+    """Result status from validation."""
+    PASS = "pass"
+    FAIL = "fail"
+    PARTIAL = "partial"
+    ERROR = "error"  # Validation itself failed (timeout, parse error, etc.)
+
+
+@dataclass
+class ValidationResult:
+    """Parsed result from validation execution."""
+    status: ValidationStatus
+    summary: str
+    items: list  # List of {check, result, evidence} dicts
+    recommendation: Optional[str] = None
+    raw_response: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Validation Service
+# ---------------------------------------------------------------------------
+
+class ValidationService:
+    """Service for running post-execution business validation."""
+
+    def __init__(self, task_execution_service: TaskExecutionService = None):
+        """Initialize validation service.
+
+        Args:
+            task_execution_service: Optional TaskExecutionService instance.
+                If not provided, creates a new one.
+        """
+        self._task_service = task_execution_service or TaskExecutionService()
+
+    async def validate_execution(
+        self,
+        execution_id: str,
+        agent_name: str,
+        schedule_id: str,
+        original_message: str,
+        execution_response: str,
+        custom_prompt: Optional[str] = None,
+        timeout_seconds: int = 120,
+    ) -> ValidationResult:
+        """Run validation on a completed execution.
+
+        Creates a validation execution record, runs the auditor session,
+        parses the result, and updates the original execution's business_status.
+
+        Args:
+            execution_id: The original execution to validate.
+            agent_name: The agent to run validation on.
+            schedule_id: The schedule that triggered the original execution.
+            original_message: The original task message.
+            execution_response: The response from the original execution.
+            custom_prompt: Optional custom auditor prompt (uses default if None).
+            timeout_seconds: Timeout for validation task.
+
+        Returns:
+            ValidationResult with status, summary, and item details.
+        """
+        # 1. Mark original execution as pending validation
+        db.update_business_status(execution_id, BusinessStatus.PENDING_VALIDATION)
+
+        # 2. Build the auditor prompt
+        validation_prompt = self._build_validation_prompt(
+            original_message=original_message,
+            execution_response=execution_response,
+            custom_prompt=custom_prompt,
+        )
+
+        # 3. Create validation execution record
+        validation_execution = db.create_validation_execution(
+            validates_execution_id=execution_id,
+            agent_name=agent_name,
+            schedule_id=schedule_id,
+            message=validation_prompt[:500] + "..." if len(validation_prompt) > 500 else validation_prompt,
+            timeout_seconds=timeout_seconds,
+        )
+
+        if not validation_execution:
+            logger.error(f"Failed to create validation execution for {execution_id}")
+            return ValidationResult(
+                status=ValidationStatus.ERROR,
+                summary="Failed to create validation execution record",
+                items=[],
+                raw_response=None,
+            )
+
+        validation_execution_id = validation_execution.id
+
+        try:
+            # 4. Run validation via TaskExecutionService
+            result = await self._task_service.execute_task(
+                agent_name=agent_name,
+                message=validation_prompt,
+                triggered_by="validation",
+                timeout_seconds=timeout_seconds,
+                execution_id=validation_execution_id,
+            )
+
+            # 5. Parse validation response
+            validation_result = self._parse_validation_response(result)
+
+            # 6. Update business status based on result
+            business_status = self._map_validation_to_business_status(validation_result.status)
+            db.update_business_status(
+                execution_id=execution_id,
+                business_status=business_status,
+                validation_execution_id=validation_execution_id,
+            )
+
+            # 7. Notify operator on failure
+            if validation_result.status in (ValidationStatus.FAIL, ValidationStatus.PARTIAL):
+                await self._notify_operator_on_failure(
+                    execution_id=execution_id,
+                    agent_name=agent_name,
+                    validation_result=validation_result,
+                )
+
+            return validation_result
+
+        except Exception as e:
+            logger.error(f"Validation failed for execution {execution_id}: {e}")
+
+            # Mark as failed validation
+            db.update_business_status(
+                execution_id=execution_id,
+                business_status=BusinessStatus.FAILED_VALIDATION,
+                validation_execution_id=validation_execution_id,
+            )
+
+            return ValidationResult(
+                status=ValidationStatus.ERROR,
+                summary=f"Validation error: {str(e)}",
+                items=[],
+                raw_response=None,
+            )
+
+    def _build_validation_prompt(
+        self,
+        original_message: str,
+        execution_response: str,
+        custom_prompt: Optional[str] = None,
+    ) -> str:
+        """Build the auditor prompt for validation.
+
+        Args:
+            original_message: The original task message.
+            execution_response: The response from the original execution.
+            custom_prompt: Optional custom prompt template.
+
+        Returns:
+            The formatted validation prompt.
+        """
+        template = custom_prompt or DEFAULT_VALIDATION_PROMPT
+
+        # Truncate response if too long (keep first 10K chars)
+        truncated_response = execution_response
+        if execution_response and len(execution_response) > 10000:
+            truncated_response = execution_response[:10000] + "\n\n[... response truncated for validation ...]"
+
+        return template.format(
+            original_message=original_message,
+            execution_response=truncated_response or "(no response)",
+        )
+
+    def _parse_validation_response(self, result: TaskExecutionResult) -> ValidationResult:
+        """Parse the validation response from Claude.
+
+        Attempts to extract JSON from the response. Falls back to text analysis
+        if JSON parsing fails.
+
+        Args:
+            result: The TaskExecutionResult from validation execution.
+
+        Returns:
+            Parsed ValidationResult.
+        """
+        raw_response = result.response or ""
+
+        # Check for execution failure
+        if result.status == "failed":
+            return ValidationResult(
+                status=ValidationStatus.ERROR,
+                summary=f"Validation execution failed: {result.error or 'Unknown error'}",
+                items=[],
+                raw_response=raw_response,
+            )
+
+        # Try to extract JSON from response
+        try:
+            # Look for JSON object in the response
+            json_match = re.search(r'\{[\s\S]*\}', raw_response)
+            if json_match:
+                data = json.loads(json_match.group())
+
+                status_str = data.get("status", "error").lower()
+                status = ValidationStatus(status_str) if status_str in [s.value for s in ValidationStatus] else ValidationStatus.ERROR
+
+                return ValidationResult(
+                    status=status,
+                    summary=data.get("summary", "No summary provided"),
+                    items=data.get("items", []),
+                    recommendation=data.get("recommendation"),
+                    raw_response=raw_response,
+                )
+
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning(f"Failed to parse validation JSON: {e}")
+
+        # Fallback: analyze text for pass/fail indicators
+        response_lower = raw_response.lower()
+
+        if any(word in response_lower for word in ["pass", "successful", "verified", "confirmed", "complete"]):
+            if not any(word in response_lower for word in ["fail", "error", "missing", "incomplete", "not found"]):
+                return ValidationResult(
+                    status=ValidationStatus.PASS,
+                    summary="Validation passed (inferred from text)",
+                    items=[],
+                    raw_response=raw_response,
+                )
+
+        if any(word in response_lower for word in ["fail", "error", "missing", "incomplete", "not found", "not done"]):
+            return ValidationResult(
+                status=ValidationStatus.FAIL,
+                summary="Validation failed (inferred from text)",
+                items=[],
+                raw_response=raw_response,
+            )
+
+        # Default to partial if unclear
+        return ValidationResult(
+            status=ValidationStatus.PARTIAL,
+            summary="Validation result unclear — manual review recommended",
+            items=[],
+            raw_response=raw_response,
+        )
+
+    def _map_validation_to_business_status(self, validation_status: ValidationStatus) -> str:
+        """Map validation status to business status.
+
+        Args:
+            validation_status: The validation result status.
+
+        Returns:
+            The corresponding BusinessStatus value.
+        """
+        mapping = {
+            ValidationStatus.PASS: BusinessStatus.VALIDATED,
+            ValidationStatus.FAIL: BusinessStatus.FAILED_VALIDATION,
+            ValidationStatus.PARTIAL: BusinessStatus.FAILED_VALIDATION,
+            ValidationStatus.ERROR: BusinessStatus.FAILED_VALIDATION,
+        }
+        return mapping.get(validation_status, BusinessStatus.FAILED_VALIDATION)
+
+    async def _notify_operator_on_failure(
+        self,
+        execution_id: str,
+        agent_name: str,
+        validation_result: ValidationResult,
+    ):
+        """Notify operator queue when validation fails.
+
+        Writes to the agent's operator-queue.json file for the
+        OperatorQueueSyncService to pick up.
+
+        Args:
+            execution_id: The original execution that failed validation.
+            agent_name: The agent name.
+            validation_result: The validation result details.
+        """
+        try:
+            from services.agent_client import AgentClient
+
+            # Build the notification payload
+            notification = {
+                "id": f"val_{execution_id}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}",
+                "type": "alert",
+                "priority": "high",
+                "status": "pending",
+                "title": "Validation Failed",
+                "question": f"Execution validation failed: {validation_result.summary}",
+                "context": {
+                    "execution_id": execution_id,
+                    "validation_status": validation_result.status.value,
+                    "summary": validation_result.summary,
+                    "items": validation_result.items,
+                    "recommendation": validation_result.recommendation,
+                },
+                "created_at": datetime.utcnow().isoformat() + "Z",
+            }
+
+            # Read existing queue, append, write back
+            client = AgentClient(agent_name)
+            queue_path = ".trinity/operator-queue.json"
+
+            try:
+                result = await client.read_file(queue_path)
+                if result.get("success") and result.get("content"):
+                    queue_data = json.loads(result["content"])
+                else:
+                    queue_data = []
+            except Exception:
+                queue_data = []
+
+            queue_data.append(notification)
+
+            await client.write_file(
+                queue_path,
+                json.dumps(queue_data, indent=2),
+                platform=True  # Allow writes to .trinity directory
+            )
+            logger.info(f"Added validation failure notification to operator queue for agent '{agent_name}'")
+
+        except Exception as e:
+            # Best effort — don't fail validation because notification failed
+            logger.warning(f"Failed to notify operator queue for agent '{agent_name}': {e}")
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_validation_service: Optional[ValidationService] = None
+
+
+def get_validation_service() -> ValidationService:
+    """Get the singleton ValidationService instance."""
+    global _validation_service
+    if _validation_service is None:
+        _validation_service = ValidationService()
+    return _validation_service

--- a/src/scheduler/database.py
+++ b/src/scheduler/database.py
@@ -78,7 +78,11 @@ class SchedulerDatabase:
             model=row["model"] if "model" in row_keys else None,
             # Retry configuration (RETRY-001)
             max_retries=row["max_retries"] if "max_retries" in row_keys and row["max_retries"] is not None else 1,
-            retry_delay_seconds=row["retry_delay_seconds"] if "retry_delay_seconds" in row_keys and row["retry_delay_seconds"] is not None else 60
+            retry_delay_seconds=row["retry_delay_seconds"] if "retry_delay_seconds" in row_keys and row["retry_delay_seconds"] is not None else 60,
+            # Validation configuration (VALIDATE-001)
+            validation_enabled=bool(row["validation_enabled"]) if "validation_enabled" in row_keys and row["validation_enabled"] is not None else False,
+            validation_prompt=row["validation_prompt"] if "validation_prompt" in row_keys else None,
+            validation_timeout_seconds=row["validation_timeout_seconds"] if "validation_timeout_seconds" in row_keys and row["validation_timeout_seconds"] is not None else 120
         )
 
     @staticmethod
@@ -112,7 +116,13 @@ class SchedulerDatabase:
             attempt_number=row["attempt_number"] if "attempt_number" in row_keys and row["attempt_number"] else 1,
             retry_of_execution_id=row["retry_of_execution_id"] if "retry_of_execution_id" in row_keys else None,
             retry_scheduled_at=datetime.fromisoformat(row["retry_scheduled_at"])
-                if "retry_scheduled_at" in row_keys and row["retry_scheduled_at"] else None
+                if "retry_scheduled_at" in row_keys and row["retry_scheduled_at"] else None,
+            # Validation tracking (VALIDATE-001)
+            business_status=row["business_status"] if "business_status" in row_keys else None,
+            validated_at=datetime.fromisoformat(row["validated_at"])
+                if "validated_at" in row_keys and row["validated_at"] else None,
+            validation_execution_id=row["validation_execution_id"] if "validation_execution_id" in row_keys else None,
+            validates_execution_id=row["validates_execution_id"] if "validates_execution_id" in row_keys else None
         )
 
     # =========================================================================

--- a/src/scheduler/models.py
+++ b/src/scheduler/models.py
@@ -51,6 +51,10 @@ class Schedule:
     # Retry configuration (RETRY-001)
     max_retries: int = 1  # 0 = disabled, 1-5 range
     retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
+    # Validation configuration (VALIDATE-001)
+    validation_enabled: bool = False  # Enable post-execution validation
+    validation_prompt: Optional[str] = None  # Custom auditor instructions
+    validation_timeout_seconds: int = 120  # Timeout for validation task
 
 
 @dataclass
@@ -82,6 +86,11 @@ class ScheduleExecution:
     attempt_number: int = 1  # Which attempt this is (1 = first try)
     retry_of_execution_id: Optional[str] = None  # Links retry to original execution
     retry_scheduled_at: Optional[datetime] = None  # When retry is scheduled (for restart recovery)
+    # Validation tracking (VALIDATE-001)
+    business_status: Optional[str] = None  # pending_validation, validated, failed_validation, skipped
+    validated_at: Optional[datetime] = None  # When validation completed
+    validation_execution_id: Optional[str] = None  # FK to validation execution
+    validates_execution_id: Optional[str] = None  # FK to execution being validated
 
 
 @dataclass

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -1019,6 +1019,12 @@ class SchedulerService:
                     "execution_id": execution_id,
                     "status": "success"
                 })
+
+                # VALIDATE-001: Check if validation is enabled and trigger it
+                await self._maybe_trigger_validation(
+                    execution=execution,
+                    agent_name=agent_name,
+                )
             else:
                 # Log auth failures specially for diagnostics
                 if error_msg:
@@ -1290,6 +1296,135 @@ class SchedulerService:
                 retry_at=retry_at,
                 next_attempt_number=(execution.attempt_number or 1) + 1
             )
+
+    # =========================================================================
+    # Validation Management (VALIDATE-001)
+    # =========================================================================
+
+    async def _maybe_trigger_validation(
+        self,
+        execution: ScheduleExecution,
+        agent_name: str,
+    ):
+        """Check if a successful execution should be validated and trigger it.
+
+        Called after _poll_and_finalize detects a success.
+
+        Args:
+            execution: The completed execution record.
+            agent_name: The agent name for logging.
+        """
+        if not execution:
+            return
+
+        # Skip validation for validation executions (prevent infinite loop)
+        if execution.triggered_by == "validation":
+            logger.debug(f"Execution {execution.id} is a validation execution, skipping validation")
+            return
+
+        # Skip if execution already has a validation (duplicate prevention)
+        if execution.validation_execution_id:
+            logger.debug(f"Execution {execution.id} already has validation {execution.validation_execution_id}")
+            return
+
+        # Get the schedule to check validation configuration
+        schedule = self.db.get_schedule(execution.schedule_id)
+        if not schedule:
+            logger.debug(f"Schedule {execution.schedule_id} not found, skipping validation")
+            return
+
+        # Check if validation is enabled
+        if not schedule.validation_enabled:
+            logger.debug(f"Schedule {schedule.id} has validation_enabled=False, skipping validation")
+            # Mark as skipped for visibility
+            self._update_business_status(execution.id, "skipped")
+            return
+
+        logger.info(
+            f"Triggering validation for execution {execution.id} "
+            f"(schedule {schedule.id}, agent {agent_name})"
+        )
+
+        # Trigger validation via backend API
+        try:
+            await self._call_backend_trigger_validation(
+                execution_id=execution.id,
+                agent_name=agent_name,
+                schedule_id=schedule.id,
+                original_message=execution.message,
+                execution_response=execution.response or "",
+                custom_prompt=schedule.validation_prompt,
+                timeout_seconds=schedule.validation_timeout_seconds,
+            )
+        except Exception as e:
+            logger.error(f"Failed to trigger validation for execution {execution.id}: {e}")
+            # Mark as failed validation if trigger fails
+            self._update_business_status(execution.id, "failed_validation")
+
+    async def _call_backend_trigger_validation(
+        self,
+        execution_id: str,
+        agent_name: str,
+        schedule_id: str,
+        original_message: str,
+        execution_response: str,
+        custom_prompt: str = None,
+        timeout_seconds: int = 120,
+    ) -> dict:
+        """Call the backend API to trigger validation.
+
+        Args:
+            execution_id: The execution to validate.
+            agent_name: The agent to run validation on.
+            schedule_id: The schedule ID.
+            original_message: The original task message.
+            execution_response: The response from the original execution.
+            custom_prompt: Optional custom auditor prompt.
+            timeout_seconds: Timeout for validation task.
+
+        Returns:
+            dict with validation result.
+        """
+        url = f"{config.backend_url}/api/internal/validate-execution"
+
+        payload = {
+            "execution_id": execution_id,
+            "agent_name": agent_name,
+            "schedule_id": schedule_id,
+            "original_message": original_message,
+            "execution_response": execution_response,
+            "custom_prompt": custom_prompt,
+            "timeout_seconds": timeout_seconds,
+        }
+
+        headers = {"X-Internal-Secret": config.internal_api_secret}
+
+        async with httpx.AsyncClient(timeout=float(timeout_seconds) + 30) as client:
+            response = await client.post(url, json=payload, headers=headers)
+
+            if response.status_code >= 400:
+                logger.error(
+                    f"Backend validation trigger failed: {response.status_code} - {response.text}"
+                )
+                response.raise_for_status()
+
+            return response.json()
+
+    def _update_business_status(self, execution_id: str, business_status: str):
+        """Update the business status of an execution in the database.
+
+        Args:
+            execution_id: The execution to update.
+            business_status: The new business status.
+        """
+        with self.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                UPDATE schedule_executions
+                SET business_status = ?, validated_at = ?
+                WHERE id = ?
+            """, (business_status, datetime.utcnow().isoformat(), execution_id))
+            conn.commit()
 
     # =========================================================================
     # Schedule Management (for runtime updates)

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -138,6 +138,13 @@
       "added": "2026-04-13",
       "categories": ["backend", "unit", "backlog", "async", "executions"],
       "description": "Unit tests for persistent async task backlog (#260): TaskExecutionStatus.QUEUED enum, migration (queued_at/backlog_metadata/max_backlog_depth/partial index), ScheduleOperations claim FIFO atomicity, cancel paths, stale expiry, BacklogService enqueue depth-cap, drain slot-first acquire + corrupt metadata failure, SlotService release callback fan-out."
+    },
+    {
+      "file": "test_validation.py",
+      "feature": "VALIDATE-001",
+      "added": "2026-04-14",
+      "categories": ["backend", "api", "scheduler", "validation"],
+      "description": "Tests for business task validation (#294): prompt building (placeholders, truncation, custom prompts), response parsing (JSON, markdown blocks, text fallback, failure indicators), business status mapping, schedule/execution model validation fields, API integration tests"
     }
   ]
 }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,358 @@
+"""
+Tests for Business Task Validation (VALIDATE-001).
+
+Tests the post-execution validation feature that runs a clean-context
+Claude session to verify business task completion.
+
+Related issue: #294
+"""
+
+import os
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path isolation and module pre-mocking
+# tests/utils/ shadows src/backend/utils/ — fix path order and pre-mock
+# ---------------------------------------------------------------------------
+
+_backend_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "backend")
+)
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+# Pre-mock utils.helpers (shadowed by tests/utils/)
+_helpers_mod = types.ModuleType("utils.helpers")
+_helpers_mod.utc_now = lambda: datetime.utcnow()
+_helpers_mod.utc_now_iso = lambda: datetime.utcnow().isoformat() + "Z"
+_helpers_mod.parse_iso_timestamp = lambda s: datetime.fromisoformat(s.rstrip("Z"))
+_helpers_mod.to_utc_iso = MagicMock(return_value="2025-01-01T00:00:00Z")
+sys.modules["utils.helpers"] = _helpers_mod
+
+# Pre-mock credential_sanitizer (Issue #286)
+_sanitizer_mod = types.ModuleType("utils.credential_sanitizer")
+_sanitizer_mod.sanitize_text = lambda x: x
+sys.modules["utils.credential_sanitizer"] = _sanitizer_mod
+
+# Pre-mock database module (tries to write to /data outside Docker)
+sys.modules.setdefault("database", MagicMock())
+
+# Pre-mock task execution service (has complex dependencies)
+_mock_task_service = MagicMock()
+sys.modules["services.task_execution_service"] = _mock_task_service
+
+# ---------------------------------------------------------------------------
+# Now safe to import validation service components
+# ---------------------------------------------------------------------------
+
+from services.validation_service import (
+    ValidationService,
+    ValidationResult,
+    ValidationStatus,
+    DEFAULT_VALIDATION_PROMPT,
+)
+from models import BusinessStatus
+
+
+class TestValidationPromptBuilding:
+    """Test validation prompt construction."""
+
+    def test_default_prompt_includes_placeholders(self):
+        """Default prompt should have placeholders for message and response."""
+        assert "{original_message}" in DEFAULT_VALIDATION_PROMPT
+        assert "{execution_response}" in DEFAULT_VALIDATION_PROMPT
+
+    def test_prompt_builder_formats_correctly(self):
+        """Prompt builder should substitute placeholders."""
+        service = ValidationService()
+        prompt = service._build_validation_prompt(
+            original_message="Create a README file",
+            execution_response="I created README.md with project documentation.",
+            custom_prompt=None,
+        )
+
+        assert "Create a README file" in prompt
+        assert "I created README.md" in prompt
+        assert "AUDITOR" in prompt  # Auditor framing
+
+    def test_prompt_builder_with_custom_prompt(self):
+        """Custom prompt should override default."""
+        service = ValidationService()
+        custom = "Check if {original_message} was done. Result: {execution_response}"
+        prompt = service._build_validation_prompt(
+            original_message="Test task",
+            execution_response="Done",
+            custom_prompt=custom,
+        )
+
+        assert "Check if Test task was done" in prompt
+        assert "AUDITOR" not in prompt  # Custom doesn't include default
+
+    def test_prompt_builder_truncates_long_response(self):
+        """Long responses should be truncated."""
+        service = ValidationService()
+        long_response = "x" * 20000  # 20K chars
+
+        prompt = service._build_validation_prompt(
+            original_message="Test",
+            execution_response=long_response,
+            custom_prompt=None,
+        )
+
+        assert "truncated" in prompt.lower()
+        assert len(prompt) < 25000  # Should be much smaller
+
+
+class TestValidationResponseParsing:
+    """Test parsing of validation responses from Claude."""
+
+    def test_parse_valid_json_pass(self):
+        """Should parse valid JSON with pass status."""
+        service = ValidationService()
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.response = '''
+        {
+            "status": "pass",
+            "summary": "All checks passed",
+            "items": [{"check": "File exists", "result": "pass", "evidence": "README.md found"}]
+        }
+        '''
+
+        result = service._parse_validation_response(mock_result)
+
+        assert result.status == ValidationStatus.PASS
+        assert "passed" in result.summary.lower()
+        assert len(result.items) == 1
+
+    def test_parse_valid_json_fail(self):
+        """Should parse valid JSON with fail status."""
+        service = ValidationService()
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.response = '''
+        {
+            "status": "fail",
+            "summary": "File not found",
+            "items": [{"check": "File exists", "result": "fail", "evidence": "No README.md"}],
+            "recommendation": "Create the file manually"
+        }
+        '''
+
+        result = service._parse_validation_response(mock_result)
+
+        assert result.status == ValidationStatus.FAIL
+        assert result.recommendation == "Create the file manually"
+
+    def test_parse_json_embedded_in_text(self):
+        """Should extract JSON from markdown code blocks."""
+        service = ValidationService()
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.response = '''
+        Here is my validation:
+
+        ```json
+        {"status": "pass", "summary": "Done", "items": []}
+        ```
+        '''
+
+        result = service._parse_validation_response(mock_result)
+
+        assert result.status == ValidationStatus.PASS
+
+    def test_parse_malformed_json_fallback(self):
+        """Should fall back to text analysis for malformed JSON."""
+        service = ValidationService()
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.response = "The task was verified successfully. All files exist."
+
+        result = service._parse_validation_response(mock_result)
+
+        # Should infer pass from "verified successfully"
+        assert result.status == ValidationStatus.PASS
+        assert "inferred" in result.summary.lower()
+
+    def test_parse_failure_indicators(self):
+        """Should detect failure indicators in text."""
+        service = ValidationService()
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.response = "The file is missing. Task not completed."
+
+        result = service._parse_validation_response(mock_result)
+
+        assert result.status == ValidationStatus.FAIL
+
+    def test_parse_execution_failure(self):
+        """Should return ERROR for execution failures."""
+        service = ValidationService()
+        mock_result = MagicMock()
+        mock_result.status = "failed"
+        mock_result.error = "Agent timeout"
+        mock_result.response = ""
+
+        result = service._parse_validation_response(mock_result)
+
+        assert result.status == ValidationStatus.ERROR
+        assert "timeout" in result.summary.lower()
+
+
+class TestBusinessStatusMapping:
+    """Test mapping validation status to business status."""
+
+    def test_pass_maps_to_validated(self):
+        """PASS should map to VALIDATED."""
+        service = ValidationService()
+        result = service._map_validation_to_business_status(ValidationStatus.PASS)
+        assert result == BusinessStatus.VALIDATED
+
+    def test_fail_maps_to_failed_validation(self):
+        """FAIL should map to FAILED_VALIDATION."""
+        service = ValidationService()
+        result = service._map_validation_to_business_status(ValidationStatus.FAIL)
+        assert result == BusinessStatus.FAILED_VALIDATION
+
+    def test_partial_maps_to_failed_validation(self):
+        """PARTIAL should map to FAILED_VALIDATION."""
+        service = ValidationService()
+        result = service._map_validation_to_business_status(ValidationStatus.PARTIAL)
+        assert result == BusinessStatus.FAILED_VALIDATION
+
+    def test_error_maps_to_failed_validation(self):
+        """ERROR should map to FAILED_VALIDATION."""
+        service = ValidationService()
+        result = service._map_validation_to_business_status(ValidationStatus.ERROR)
+        assert result == BusinessStatus.FAILED_VALIDATION
+
+
+@pytest.mark.integration
+class TestDatabaseOperations:
+    """Test database operations for validation.
+
+    These tests require a running backend with database access.
+    Skipped in unit test mode.
+    """
+
+    @pytest.mark.skip(reason="Requires running backend with database")
+    def test_create_validation_execution_links_to_original(self):
+        """Validation execution should link to original via validates_execution_id."""
+        pass
+
+    @pytest.mark.skip(reason="Requires running backend with database")
+    def test_update_business_status(self):
+        """Should update business_status on execution."""
+        pass
+
+    @pytest.mark.skip(reason="Requires running backend with database")
+    def test_get_executions_pending_validation(self):
+        """Should return executions with pending_validation status."""
+        pass
+
+
+class TestScheduleValidationConfig:
+    """Test schedule validation configuration."""
+
+    def test_schedule_model_has_validation_fields(self):
+        """Schedule model should have validation fields."""
+        from db_models import Schedule
+
+        # Check fields exist
+        fields = Schedule.__annotations__
+        assert "validation_enabled" in fields
+        assert "validation_prompt" in fields
+        assert "validation_timeout_seconds" in fields
+
+    def test_execution_model_has_business_status(self):
+        """Execution model should have business_status field."""
+        from db_models import ScheduleExecution
+
+        fields = ScheduleExecution.__annotations__
+        assert "business_status" in fields
+        assert "validated_at" in fields
+        assert "validation_execution_id" in fields
+        assert "validates_execution_id" in fields
+
+
+# Integration tests (require running backend)
+
+@pytest.mark.integration
+class TestValidationIntegration:
+    """Integration tests for validation flow.
+
+    These tests require a running backend and use the api_client fixture.
+    Run with: pytest tests/test_validation.py -m integration
+    """
+
+    @pytest.fixture
+    def test_schedule_with_validation(self, api_client, created_agent):
+        """Create a test schedule with validation enabled."""
+        from utils.api_client import TrinityApiClient
+
+        agent_name = created_agent["name"]
+
+        # Create schedule with validation enabled
+        response = api_client.post(
+            f"/api/agents/{agent_name}/schedules",
+            json={
+                "name": "test-validation-schedule",
+                "cron_expression": "0 0 1 1 *",  # Never runs (Jan 1 at midnight)
+                "message": "Test task",
+                "enabled": False,
+                "validation_enabled": True,
+                "validation_timeout_seconds": 60,
+            }
+        )
+        assert response.status_code == 201
+
+        schedule = response.json()
+        yield schedule
+
+        # Cleanup
+        api_client.delete(f"/api/agents/{agent_name}/schedules/{schedule['id']}")
+
+    def test_schedule_includes_validation_config(self, api_client, test_schedule_with_validation):
+        """Schedule response should include validation config."""
+        schedule = test_schedule_with_validation
+
+        assert schedule["validation_enabled"] == True
+        assert schedule["validation_timeout_seconds"] == 60
+
+    def test_update_schedule_validation_config(self, api_client, created_agent, test_schedule_with_validation):
+        """Should be able to update validation config."""
+        agent_name = created_agent["name"]
+        schedule = test_schedule_with_validation
+
+        response = api_client.put(
+            f"/api/agents/{agent_name}/schedules/{schedule['id']}",
+            json={
+                "validation_enabled": False,
+                "validation_prompt": "Custom validation instructions"
+            }
+        )
+        assert response.status_code == 200
+
+        updated = response.json()
+        assert updated["validation_enabled"] == False
+        assert updated["validation_prompt"] == "Custom validation instructions"
+
+    def test_execution_includes_business_status(self, api_client, created_agent):
+        """Execution response should include business_status."""
+        agent_name = created_agent["name"]
+
+        # List executions
+        response = api_client.get(f"/api/agents/{agent_name}/executions")
+        assert response.status_code == 200
+
+        # Verify business_status field exists in schema (may be null)
+        # This just validates the API contract includes the field
+        executions = response.json()
+        if executions:
+            # Check first execution has the field
+            assert "business_status" in executions[0] or executions[0].get("business_status") is None


### PR DESCRIPTION
## Summary

- Add post-execution validation phase that runs clean-context Claude session with auditor framing to verify business task completion
- Separate technical success (Claude ran without errors) from business success (intended work was done)
- Track validation via `business_status` field and linked validation execution records
- Notify operator queue when validation fails for human review

## Changes

**Backend:**
- `src/backend/services/validation_service.py` — Core validation service with auditor prompt
- `src/backend/routers/internal.py` — `/api/internal/validate-execution` endpoint
- `src/backend/routers/schedules.py` — Updated response models with validation fields
- `src/backend/db/schedules.py` — New DB operations for validation
- `src/backend/db/schema.py` — Validation columns in schedules/executions
- `src/backend/db/migrations.py` — Migration #32

**Scheduler:**
- `src/scheduler/service.py` — Trigger validation after successful execution

**Tests:**
- `tests/test_validation.py` — Unit tests (19 passed, 3 skipped)

**Docs:**
- `docs/memory/feature-flows/business-validation.md` — Feature flow documentation

## Test Plan

- [x] Unit tests pass: `pytest tests/test_validation.py -v` (19 passed)
- [x] Integration tests pass against running backend
- [ ] Manual verification: Create schedule with `validation_enabled=true`, trigger, verify validation runs

Closes #294

Generated with [Claude Code](https://claude.com/claude-code)