### PR TITLE
fix(db): add voice system prompt delegation to DatabaseManager (#373)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -568,6 +568,16 @@ class DatabaseManager:
         return self._agent_ops.has_agent_github_pat(agent_name)
 
     # =========================================================================
+    # Voice System Prompt (delegated to db/agents.py) - VOICE-005
+    # =========================================================================
+
+    def get_voice_system_prompt(self, agent_name: str):
+        return self._agent_ops.get_voice_system_prompt(agent_name)
+
+    def set_voice_system_prompt(self, agent_name: str, prompt: str):
+        return self._agent_ops.set_voice_system_prompt(agent_name, prompt)
+
+    # =========================================================================
     # MCP API Key Management (delegated to db/mcp_keys.py)
     # =========================================================================
 

--- a/src/backend/routers/voice.py
+++ b/src/backend/routers/voice.py
@@ -148,7 +148,7 @@ async def voice_status(
     return {
         "enabled": VOICE_ENABLED,
         "available": voice_service.is_available(),
-        "voice_prompt_set": bool(db.agents.get_voice_system_prompt(name)),
+        "voice_prompt_set": bool(db.get_voice_system_prompt(name)),
     }
 
 
@@ -158,7 +158,7 @@ async def get_voice_prompt(
     current_user: User = Depends(get_current_user),
 ):
     """Get the agent's voice system prompt."""
-    prompt = db.agents.get_voice_system_prompt(name)
+    prompt = db.get_voice_system_prompt(name)
     return {"voice_system_prompt": prompt}
 
 
@@ -170,7 +170,7 @@ async def set_voice_prompt(
 ):
     """Set the agent's voice system prompt."""
     prompt = (body or {}).get("voice_system_prompt", "")
-    db.agents.set_voice_system_prompt(name, prompt)
+    db.set_voice_system_prompt(name, prompt)
     return {"ok": True, "voice_system_prompt": prompt}
 
 
@@ -297,7 +297,7 @@ async def _get_voice_system_prompt(agent_name: str) -> str:
     3. Error if neither exists
     """
     # 1. Check DB override
-    prompt = db.agents.get_voice_system_prompt(agent_name)
+    prompt = db.get_voice_system_prompt(agent_name)
     if prompt:
         return prompt
 


### PR DESCRIPTION
## Summary
- Added missing `get_voice_system_prompt()` and `set_voice_system_prompt()` delegation methods to `DatabaseManager`
- Updated 4 call sites in `routers/voice.py` from `db.agents.*` to `db.*` pattern

## Root Cause
`routers/voice.py` was accessing `db.agents.get_voice_system_prompt()` but `DatabaseManager` uses the delegation pattern — methods are called directly on `db` (e.g., `db.get_agent_owner()`), not via a property accessor (`db.agents.*`).

## Test Plan
- [x] Python syntax verified
- [x] No remaining `db.agents` references in voice.py
- [ ] Manual: start backend, verify no AttributeError on voice endpoints

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)