### PR TITLE
feat(ui): add allow_proactive toggle to SharingPanel (#376)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-17 | #376 | Proactive messaging UI toggle — SharingPanel shows allow_proactive switch per shared user | [proactive-messaging.md](feature-flows/proactive-messaging.md), [agent-sharing.md](feature-flows/agent-sharing.md) |
 | 2026-04-16 | #321 | Proactive agent messaging — agents send messages to users by verified email via Telegram/Slack/web | [proactive-messaging.md](feature-flows/proactive-messaging.md) |
 | 2026-04-16 | #354 | Telegram file upload Phase 1 — photo/document extraction, download, size/MIME validation | [telegram-integration.md](feature-flows/telegram-integration.md) |
 | 2026-04-15 | #311 | Group auth mode — require at least one verified member before bot responds in Telegram groups | [unified-channel-access-control.md](feature-flows/unified-channel-access-control.md), [telegram-integration.md](feature-flows/telegram-integration.md) |

--- a/docs/memory/feature-flows/agent-sharing.md
+++ b/docs/memory/feature-flows/agent-sharing.md
@@ -26,22 +26,27 @@ As an agent owner, I want to share my agents with team members so that they can 
 
 The sharing UI is implemented as a dedicated component with multiple stacked sections.
 
-**Component Structure** (~310 lines total):
+**Component Structure** (~370 lines total):
 - Lines 3-74: **Channel Access Policy** section (Issue #311) — `require_email`, `open_access` checkboxes + Pending Access Requests list with Approve/Deny buttons
-- Lines 78-152: **Team Sharing** section (header, form, shared users list — the unified allow-list)
+- Lines 78-152: **Team Sharing** section (header, form, shared users list with proactive toggle — the unified allow-list)
 - Lines 157-158: Embedded `SlackChannelPanel`
 - Lines 163-164: Embedded `TelegramChannelPanel`
 - Lines 169-170: Embedded `PublicLinksPanel`
 - Lines 181-183: Imports for the embedded channel panels
 
-**Team Sharing Section** (lines 3-77):
+**Team Sharing Section** (lines 78-152):
 ```vue
 <div>
   <h3 class="text-lg font-medium ...">Team Sharing</h3>
-  <!-- Share form (lines 11-30) -->
-  <!-- Shared users list (lines 40-76) -->
+  <!-- Share form (lines 86-105) -->
+  <!-- Shared users list with proactive toggle (lines 116-152) -->
 </div>
 ```
+
+Each shared user row includes:
+- User avatar and email
+- **Proactive toggle** (Issue #376) — enables `allow_proactive` flag for proactive messaging
+- Remove button
 
 **Component Props** (lines 185-194):
 ```javascript

--- a/docs/memory/feature-flows/proactive-messaging.md
+++ b/docs/memory/feature-flows/proactive-messaging.md
@@ -1,8 +1,8 @@
 # Proactive Agent Messaging
 
-> **Issue**: #321
+> **Issue**: #321, #376
 > **Status**: Implemented
-> **Last Updated**: 2026-04-16
+> **Last Updated**: 2026-04-17
 
 ## Overview
 
@@ -54,6 +54,48 @@ Enables agents to send proactive messages to specific users by verified email ac
 │   │ sendMessage     │       │ chat.postMessage│       │ DB persist      │  │
 │   └─────────────────┘       └─────────────────┘       └─────────────────┘  │
 └─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Frontend Layer
+
+### SharingPanel Toggle (#376)
+
+The `allow_proactive` flag is managed via a toggle switch in the Team Sharing section of the Sharing tab.
+
+**Location**: `src/frontend/src/components/SharingPanel.vue`
+
+**UI Structure** (lines 124-149):
+```vue
+<li v-for="share in shares" :key="share.id">
+  <div class="flex items-center gap-4">
+    <!-- Proactive messaging toggle -->
+    <label title="Agent can/cannot send proactive messages">
+      <span>Proactive</span>
+      <switch :checked="share.allow_proactive" @click="toggleProactive(share)" />
+    </label>
+    <button @click="removeShare(...)">Remove</button>
+  </div>
+</li>
+```
+
+**Toggle Handler** (lines 224-240):
+```javascript
+const toggleProactive = async (share) => {
+  await axios.put(
+    `/api/agents/${props.agentName}/shares/proactive`,
+    { email: share.shared_with_email, allow_proactive: !share.allow_proactive },
+    { headers: authStore.authHeader }
+  )
+  share.allow_proactive = !share.allow_proactive
+  showNotification(share.allow_proactive ? 'Proactive messaging enabled' : 'Proactive messaging disabled', 'success')
+}
+```
+
+**Model** (`src/backend/db_models.py:53-60`):
+```python
+class AgentShare(BaseModel):
+    # ... other fields
+    allow_proactive: bool = False  # Can agent send proactive messages to this user
 ```
 
 ## Data Flow

--- a/src/backend/db/agent_settings/sharing.py
+++ b/src/backend/db/agent_settings/sharing.py
@@ -24,7 +24,8 @@ class SharingMixin:
             shared_with_email=row["shared_with_email"],
             shared_by_id=row["shared_by_id"],
             shared_by_email=row["shared_by_email"] or "unknown",
-            created_at=datetime.fromisoformat(row["created_at"])
+            created_at=datetime.fromisoformat(row["created_at"]),
+            allow_proactive=bool(row["allow_proactive"]) if "allow_proactive" in row.keys() else False
         )
 
     def share_agent(self, agent_name: str, owner_username: str, share_with_email: str) -> Optional[AgentShare]:
@@ -93,6 +94,7 @@ class SharingMixin:
             cursor = conn.cursor()
             cursor.execute("""
                 SELECT s.id, s.agent_name, s.shared_with_email, s.shared_by_id, s.created_at,
+                       s.allow_proactive,
                        COALESCE(sb.email, sb.username) as shared_by_email
                 FROM agent_sharing s
                 JOIN users sb ON s.shared_by_id = sb.id

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -57,6 +57,7 @@ class AgentShare(BaseModel):
     shared_by_id: int
     shared_by_email: str  # Email or username of who shared it
     created_at: datetime
+    allow_proactive: bool = False  # Can agent send proactive messages to this user
 
 
 class AgentShareRequest(BaseModel):

--- a/src/frontend/src/components/SharingPanel.vue
+++ b/src/frontend/src/components/SharingPanel.vue
@@ -138,14 +138,38 @@
                 </p>
               </div>
             </div>
-            <button
-              @click="removeShare(share.shared_with_email)"
-              :disabled="unshareLoading === share.shared_with_email"
-              class="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 text-sm font-medium disabled:opacity-50"
-            >
-              <span v-if="unshareLoading === share.shared_with_email">Removing...</span>
-              <span v-else>Remove</span>
-            </button>
+            <div class="flex items-center gap-4">
+              <!-- Proactive messaging toggle -->
+              <label class="flex items-center gap-2 cursor-pointer" :title="share.allow_proactive ? 'Agent can send proactive messages' : 'Agent cannot send proactive messages'">
+                <span class="text-xs text-gray-500 dark:text-gray-400">Proactive</span>
+                <button
+                  type="button"
+                  role="switch"
+                  :aria-checked="share.allow_proactive"
+                  @click="toggleProactive(share)"
+                  :disabled="proactiveLoading === share.shared_with_email"
+                  :class="[
+                    share.allow_proactive ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600',
+                    'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
+                  ]"
+                >
+                  <span
+                    :class="[
+                      share.allow_proactive ? 'translate-x-4' : 'translate-x-0',
+                      'pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out'
+                    ]"
+                  />
+                </button>
+              </label>
+              <button
+                @click="removeShare(share.shared_with_email)"
+                :disabled="unshareLoading === share.shared_with_email"
+                class="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 text-sm font-medium disabled:opacity-50"
+              >
+                <span v-if="unshareLoading === share.shared_with_email">Removing...</span>
+                <span v-else>Remove</span>
+              </button>
+            </div>
           </li>
         </ul>
       </div>
@@ -219,6 +243,30 @@ const {
   shareWithUser,
   removeShare
 } = useAgentSharing(agent, agentsStore, loadAgent, showNotification)
+
+// Proactive messaging toggle
+const proactiveLoading = ref(null)
+
+const toggleProactive = async (share) => {
+  proactiveLoading.value = share.shared_with_email
+  try {
+    await axios.put(
+      `/api/agents/${props.agentName}/shares/proactive`,
+      { email: share.shared_with_email, allow_proactive: !share.allow_proactive },
+      { headers: authStore.authHeader }
+    )
+    share.allow_proactive = !share.allow_proactive
+    showNotification(
+      share.allow_proactive ? 'Proactive messaging enabled' : 'Proactive messaging disabled',
+      'success'
+    )
+  } catch (err) {
+    console.error('Failed to update proactive setting:', err)
+    showNotification(err.response?.data?.detail || 'Failed to update setting', 'error')
+  } finally {
+    proactiveLoading.value = null
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Access policy + access requests (Issue #311)


### PR DESCRIPTION
## Summary
- Add `allow_proactive` field to `AgentShare` model response
- Include proactive toggle switch in Team Sharing list for each shared user
- Toggle updates via `PUT /api/agents/{name}/shares/proactive` endpoint
- Shows tooltip explaining current proactive messaging status

## Changes
- `src/backend/db_models.py` — add `allow_proactive: bool` to `AgentShare`
- `src/backend/db/agent_settings/sharing.py` — include column in query and model mapping
- `src/frontend/src/components/SharingPanel.vue` — add toggle UI with API integration

## Test Plan
- [x] API tests pass: `pytest test_proactive_messaging.py` (18 passed)
- [x] Sharing tests pass: `pytest test_agent_sharing.py` (8 passed)
- [x] Manual verification: toggle works in UI, persists to database

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)