### PR TITLE
feat(git): self-hosted git URL support (#387)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,12 @@ GITHUB_CLIENT_SECRET=
 # This will be auto-uploaded to Redis on startup for local development
 GITHUB_PAT=
 
+# Self-hosted git support (#387)
+# Optional overrides — default to github.com / api.github.com (standard GitHub).
+# Set both when targeting GitHub Enterprise Server, Gitea, or a dev harness.
+# TRINITY_GIT_BASE_URL=https://git.example.com
+# TRINITY_GIT_API_BASE=https://git.example.com/api/v1
+
 # Notion OAuth (for Notion MCP)
 # Get from: https://www.notion.so/my-integrations
 NOTION_CLIENT_ID=

--- a/docker-compose.gitea.yml
+++ b/docker-compose.gitea.yml
@@ -1,0 +1,47 @@
+# Dev-only overlay: local gitea for git-sync reproduction scenarios.
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.gitea.yml up -d
+#
+# Pairs with the TRINITY_GIT_BASE_URL env override and the scripts in
+# tests/integration/git_sync/. Not intended for production.
+
+services:
+  gitea:
+    image: gitea/gitea:1.22-rootless
+    container_name: trinity-gitea-dev
+    restart: unless-stopped
+    ports:
+      - "3001:3000"  # avoids collisions with common dev ports (3000 is often node/web)
+    environment:
+      - GITEA__database__DB_TYPE=sqlite3
+      - GITEA__server__DOMAIN=trinity-gitea-dev
+      - GITEA__server__ROOT_URL=http://trinity-gitea-dev:3000/
+      - GITEA__server__SSH_DOMAIN=trinity-gitea-dev
+      - GITEA__security__INSTALL_LOCK=true
+      - GITEA__security__SECRET_KEY=dev-secret-not-for-prod
+      - GITEA__log__MODE=console
+      - GITEA__log__LEVEL=info
+      - GITEA__service__DISABLE_REGISTRATION=false
+      - GITEA__service__REQUIRE_SIGNIN_VIEW=false
+    volumes:
+      - gitea-data:/var/lib/gitea
+      - gitea-config:/etc/gitea
+    networks:
+      - trinity-network
+    labels:
+      - "trinity.platform=dev-infra"
+      - "trinity.service=gitea"
+
+  # Expose TRINITY_GIT_BASE_URL to the backend so new agents target gitea.
+  # NB: the patch to git_service.py/startup.sh reads this; without the patch
+  # this env var is inert.
+  backend:
+    environment:
+      - TRINITY_GIT_BASE_URL=${TRINITY_GIT_BASE_URL:-http://trinity-gitea-dev:3000}
+      - TRINITY_GIT_API_BASE=${TRINITY_GIT_API_BASE:-http://trinity-gitea-dev:3000/api/v1}
+      # Override GITHUB_PAT with gitea PAT for the repro harness
+      - GITHUB_PAT=${GITEA_PAT}
+
+volumes:
+  gitea-data:
+  gitea-config:

--- a/docker/base-image/startup.sh
+++ b/docker/base-image/startup.sh
@@ -17,8 +17,14 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
     echo "Initializing agent from GitHub repository: ${GITHUB_REPO}"
     cd /home/developer
 
-    # Clone the repository using PAT authentication
-    CLONE_URL="https://oauth2:${GITHUB_PAT}@github.com/${GITHUB_REPO}.git"
+    # Clone the repository using PAT authentication.
+    # TRINITY_GIT_BASE_URL defaults to https://github.com; overridable for
+    # self-hosted gitea / GHES / dev harnesses.
+    GIT_BASE_URL="${TRINITY_GIT_BASE_URL:-https://github.com}"
+    GIT_BASE_URL="${GIT_BASE_URL%/}"
+    GIT_HOST_PATH="${GIT_BASE_URL#*://}"
+    GIT_SCHEME="${GIT_BASE_URL%%://*}"
+    CLONE_URL="${GIT_SCHEME}://oauth2:${GITHUB_PAT}@${GIT_HOST_PATH}/${GITHUB_REPO}.git"
 
     # Check if GIT_SYNC_ENABLED - if so, keep .git directory for bidirectional sync
     if [ "${GIT_SYNC_ENABLED}" = "true" ]; then
@@ -34,7 +40,7 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
             echo "Current branch: ${CURRENT_BRANCH} (preserved from previous run)"
             # Update remote URL with current PAT (may have changed since last start)
             if [ -n "${GITHUB_PAT}" ]; then
-                git remote set-url origin "https://oauth2:${GITHUB_PAT}@github.com/${GITHUB_REPO}.git"
+                git remote set-url origin "${CLONE_URL}"
             fi
             git fetch origin 2>&1 || echo "Note: Could not fetch from remote"
 

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -408,6 +408,10 @@ async def create_agent_internal(
         env_vars['GITHUB_PAT'] = github_pat_for_agent
         # Phase 7: Enable git sync for GitHub-native agents
         env_vars['GIT_SYNC_ENABLED'] = 'true'
+        # Dev/self-host: propagate optional git base-URL override to agent container
+        _git_base = os.getenv('TRINITY_GIT_BASE_URL')
+        if _git_base:
+            env_vars['TRINITY_GIT_BASE_URL'] = _git_base
 
         # Source mode (default): Track source branch directly for pull-only sync
         # Legacy mode: Create a unique working branch for bidirectional sync

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -8,6 +8,7 @@ Handles:
 - Initializing git in agent containers
 """
 import httpx
+import os
 import uuid
 import logging
 from dataclasses import dataclass
@@ -22,6 +23,18 @@ logger = logging.getLogger(__name__)
 def generate_instance_id() -> str:
     """Generate a unique instance ID for an agent."""
     return uuid.uuid4().hex[:8]
+
+
+def _git_remote_url(github_pat: str, github_repo: str) -> str:
+    """Build an authenticated git remote URL.
+
+    Defaults to GitHub. Dev/self-host deployments can override the base via
+    TRINITY_GIT_BASE_URL (e.g., "http://trinity-gitea-dev:3000" for a local
+    gitea in the test harness). The base URL must include the scheme.
+    """
+    base = os.getenv("TRINITY_GIT_BASE_URL", "https://github.com").rstrip("/")
+    scheme, _, host_path = base.partition("://")
+    return f"{scheme}://oauth2:{github_pat}@{host_path}/{github_repo}.git"
 
 
 def generate_working_branch(agent_name: str, instance_id: str) -> str:
@@ -339,8 +352,8 @@ async def initialize_git_in_container(
         ('git config --global init.defaultBranch main', True),
         ('git init', True),
         (f'git remote get-url origin >/dev/null 2>&1 && '
-         f'git remote set-url origin https://oauth2:{github_pat}@github.com/{github_repo}.git || '
-         f'git remote add origin https://oauth2:{github_pat}@github.com/{github_repo}.git', True),
+         f'git remote set-url origin {_git_remote_url(github_pat, github_repo)} || '
+         f'git remote add origin {_git_remote_url(github_pat, github_repo)}', True),
         ('git fetch origin', False),  # Optional — remote may be empty
     ]
 

--- a/src/backend/services/github_service.py
+++ b/src/backend/services/github_service.py
@@ -9,6 +9,7 @@ Handles all GitHub API interactions:
 """
 import httpx
 import logging
+import os
 from dataclasses import dataclass
 from typing import Optional, Tuple
 from enum import Enum
@@ -64,7 +65,7 @@ class GitHubService:
     Centralizes all GitHub REST API calls.
     """
 
-    API_BASE = "https://api.github.com"
+    API_BASE = os.getenv("TRINITY_GIT_API_BASE", "https://api.github.com")
     API_VERSION = "2022-11-28"
 
     def __init__(self, pat: str):

--- a/tests/unit/test_self_hosted_git_url.py
+++ b/tests/unit/test_self_hosted_git_url.py
@@ -1,0 +1,239 @@
+"""
+Tests for TRINITY_GIT_BASE_URL / TRINITY_GIT_API_BASE overrides (#387).
+
+Acceptance criteria from the issue:
+- `TRINITY_GIT_BASE_URL` (default `https://github.com`) — scheme+host for
+  clone/push URLs.
+- `TRINITY_GIT_API_BASE` (default `https://api.github.com`) — API endpoint.
+- Backward compatibility: when env vars unset, behavior unchanged.
+
+Covered surfaces:
+- `src/backend/services/git_service.py:_git_remote_url`
+- `src/backend/services/github_service.py:GitHubService.API_BASE`
+- `src/backend/services/agent_service/crud.py` env propagation
+- `docker/base-image/startup.sh` bash URL composition
+"""
+import importlib
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_STARTUP_SH = _PROJECT_ROOT / "docker" / "base-image" / "startup.sh"
+_CRUD_PY = _PROJECT_ROOT / "src" / "backend" / "services" / "agent_service" / "crud.py"
+
+
+# ---------------------------------------------------------------------------
+# git_service._git_remote_url — Python helper
+# ---------------------------------------------------------------------------
+
+
+def _load_git_service():
+    """Import services.git_service with heavy deps mocked.
+
+    Mirrors the pattern in tests/unit/test_github_init_push.py.
+    Re-imports on every call so env-var changes take effect.
+    """
+    mock_modules = {}
+    for mod in [
+        "docker", "docker.errors", "docker.types",
+        "redis", "redis.asyncio",
+        "database",
+        "services.docker_service",
+    ]:
+        mock_modules[mod] = Mock()
+
+    mock_modules["database"].db = Mock()
+    mock_modules["database"].AgentGitConfig = Mock
+    mock_modules["database"].GitSyncResult = Mock
+
+    with patch.dict("sys.modules", mock_modules):
+        for key in list(sys.modules.keys()):
+            if key.startswith("services.git_service"):
+                del sys.modules[key]
+        import services.git_service as gs
+    return gs
+
+
+@pytest.fixture
+def unset_git_env(monkeypatch):
+    """Guarantee TRINITY_GIT_* env vars are unset for the test body."""
+    monkeypatch.delenv("TRINITY_GIT_BASE_URL", raising=False)
+    monkeypatch.delenv("TRINITY_GIT_API_BASE", raising=False)
+
+
+def test_git_remote_url_default_is_github(unset_git_env):
+    """#387 backward-compat: default composition still points at github.com."""
+    gs = _load_git_service()
+    url = gs._git_remote_url("ghp_fake", "owner/repo")
+    assert url == "https://oauth2:ghp_fake@github.com/owner/repo.git"
+
+
+def test_git_remote_url_respects_gitea_override(monkeypatch):
+    """Dev/self-host: gitea base URL is honored end-to-end."""
+    monkeypatch.setenv("TRINITY_GIT_BASE_URL", "http://trinity-gitea-dev:3000")
+    gs = _load_git_service()
+    url = gs._git_remote_url("ghp_fake", "owner/repo")
+    assert url == "http://oauth2:ghp_fake@trinity-gitea-dev:3000/owner/repo.git"
+
+
+def test_git_remote_url_preserves_https_override(monkeypatch):
+    """GHES override keeps the https scheme (no forced downgrade)."""
+    monkeypatch.setenv("TRINITY_GIT_BASE_URL", "https://ghes.example.com")
+    gs = _load_git_service()
+    url = gs._git_remote_url("ghp_fake", "owner/repo")
+    assert url == "https://oauth2:ghp_fake@ghes.example.com/owner/repo.git"
+
+
+def test_git_remote_url_strips_trailing_slash(monkeypatch):
+    """A trailing slash in the base URL must not produce `//owner/...`."""
+    monkeypatch.setenv("TRINITY_GIT_BASE_URL", "https://gitea.example.com/")
+    gs = _load_git_service()
+    url = gs._git_remote_url("ghp_fake", "owner/repo")
+    assert url == "https://oauth2:ghp_fake@gitea.example.com/owner/repo.git"
+
+
+# ---------------------------------------------------------------------------
+# github_service.GitHubService.API_BASE — class attr bound at import time
+# ---------------------------------------------------------------------------
+
+
+def _reload_github_service():
+    """Fresh import of services.github_service (API_BASE is bound at import)."""
+    for key in list(sys.modules.keys()):
+        if key.startswith("services.github_service"):
+            del sys.modules[key]
+    backend = str(_PROJECT_ROOT / "src" / "backend")
+    if backend not in sys.path:
+        sys.path.insert(0, backend)
+    return importlib.import_module("services.github_service")
+
+
+def test_github_service_api_base_default(unset_git_env):
+    """Default API_BASE is the public GitHub API."""
+    ghs = _reload_github_service()
+    assert ghs.GitHubService.API_BASE == "https://api.github.com"
+
+
+def test_github_service_api_base_override(monkeypatch):
+    """TRINITY_GIT_API_BASE swaps the API endpoint at import time."""
+    monkeypatch.setenv(
+        "TRINITY_GIT_API_BASE", "http://trinity-gitea-dev:3000/api/v1"
+    )
+    ghs = _reload_github_service()
+    assert (
+        ghs.GitHubService.API_BASE == "http://trinity-gitea-dev:3000/api/v1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# crud.py env propagation — source-level assertion
+# ---------------------------------------------------------------------------
+#
+# Rationale: create_agent_internal pulls in half the backend (DB, Docker,
+# templating). A full unit test would need extensive fixtures for a
+# 3-line change. Pin the behavior via source inspection instead — a
+# refactor that removes the propagation still breaks this test.
+
+
+def test_crud_propagates_base_url_env():
+    text = _CRUD_PY.read_text()
+    assert (
+        "os.getenv('TRINITY_GIT_BASE_URL')" in text
+        or 'os.getenv("TRINITY_GIT_BASE_URL")' in text
+    ), "crud.py no longer reads TRINITY_GIT_BASE_URL"
+    assert (
+        "env_vars['TRINITY_GIT_BASE_URL']" in text
+        or 'env_vars["TRINITY_GIT_BASE_URL"]' in text
+    ), "crud.py no longer writes TRINITY_GIT_BASE_URL into agent env_vars"
+
+
+# ---------------------------------------------------------------------------
+# startup.sh — bash URL composition
+# ---------------------------------------------------------------------------
+#
+# We extract the exact composition snippet from startup.sh and run it in a
+# fresh bash with controlled env. If the snippet drifts, the test breaks —
+# which is the point.
+
+_COMPOSE_SNIPPET = r'''
+GIT_BASE_URL="${TRINITY_GIT_BASE_URL:-https://github.com}"
+GIT_BASE_URL="${GIT_BASE_URL%/}"
+GIT_HOST_PATH="${GIT_BASE_URL#*://}"
+GIT_SCHEME="${GIT_BASE_URL%%://*}"
+CLONE_URL="${GIT_SCHEME}://oauth2:${GITHUB_PAT}@${GIT_HOST_PATH}/${GITHUB_REPO}.git"
+printf '%s' "$CLONE_URL"
+'''
+
+
+def _run_snippet(env_overrides):
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "GITHUB_PAT": "p",
+        "GITHUB_REPO": "o/r",
+    }
+    env.update(env_overrides)
+    result = subprocess.run(
+        ["bash", "-c", _COMPOSE_SNIPPET],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_startup_snippet_matches_startup_sh():
+    """Guard: the snippet under test still matches the real script."""
+    sh = _STARTUP_SH.read_text()
+    assert 'GIT_BASE_URL="${TRINITY_GIT_BASE_URL:-https://github.com}"' in sh
+    assert 'GIT_BASE_URL="${GIT_BASE_URL%/}"' in sh
+    assert 'GIT_HOST_PATH="${GIT_BASE_URL#*://}"' in sh
+    assert 'GIT_SCHEME="${GIT_BASE_URL%%://*}"' in sh
+    assert (
+        'CLONE_URL="${GIT_SCHEME}://oauth2:${GITHUB_PAT}@${GIT_HOST_PATH}/${GITHUB_REPO}.git"'
+        in sh
+    )
+
+
+def test_startup_sh_default_clone_url():
+    """#387 backward-compat: unset env yields the classic GitHub URL."""
+    out = _run_snippet({})
+    assert out == "https://oauth2:p@github.com/o/r.git"
+
+
+def test_startup_sh_respects_base_url_override():
+    """Dev/self-host: gitea base URL flows all the way to CLONE_URL."""
+    out = _run_snippet(
+        {"TRINITY_GIT_BASE_URL": "http://trinity-gitea-dev:3000"}
+    )
+    assert out == "http://oauth2:p@trinity-gitea-dev:3000/o/r.git"
+
+
+def test_startup_sh_strips_trailing_slash_in_base_url():
+    """No `//o/r` when the operator leaves a trailing slash."""
+    out = _run_snippet(
+        {"TRINITY_GIT_BASE_URL": "https://gitea.example.com/"}
+    )
+    assert out == "https://oauth2:p@gitea.example.com/o/r.git"
+
+
+def test_startup_sh_shellcheck_clean():
+    """shellcheck must still be happy with startup.sh (skipped if not installed)."""
+    if shutil.which("shellcheck") is None:
+        pytest.skip("shellcheck not installed")
+    result = subprocess.run(
+        ["shellcheck", str(_STARTUP_SH)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"shellcheck failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Adds two env-var overrides so Trinity can target GitHub Enterprise Server, Gitea, or a local dev harness instead of hardcoded `github.com` / `api.github.com`:

- `TRINITY_GIT_BASE_URL` (default `https://github.com`) — scheme+host used to compose authenticated clone/push URLs.
- `TRINITY_GIT_API_BASE` (default `https://api.github.com`) — API endpoint used by `GitHubService` for repo validation, branch checks, and repo creation.

Unblocks local reproduction of the git-sync issues tracked under epic #381 (P1–P7) and doubles as a feature for self-hosted users.

Closes abilityai/trinity#387
Refs abilityai/trinity#381

## What changed

| File | Change |
|---|---|
| `src/backend/services/git_service.py` | New `_git_remote_url(pat, repo)` helper reads `TRINITY_GIT_BASE_URL`, preserves scheme, strips trailing slash. `initialize_git_in_container` switches from hardcoded `github.com` literals to the helper. |
| `src/backend/services/github_service.py` | `GitHubService.API_BASE = os.getenv("TRINITY_GIT_API_BASE", "https://api.github.com")`. |
| `src/backend/services/agent_service/crud.py` | Propagates `TRINITY_GIT_BASE_URL` (when set) into `env_vars` for agent containers. |
| `docker/base-image/startup.sh` | Composes `CLONE_URL` from the env var; reuses the composed URL on the `set-url origin` path so both branches stay in sync. |
| `docker-compose.gitea.yml` | New dev-only overlay running `gitea/gitea:1.22-rootless` on `:3001`, wires the env vars into `backend`. |
| `.env.example` | Documents the two new overrides. |
| `tests/unit/test_self_hosted_git_url.py` | 11 unit + bash tests covering defaults, overrides, trailing slash, and `startup.sh` composition. |

~130 lines net (incl. tests). Zero schema change.

## Before / after

Authenticated remote URL composition for `owner/repo` with PAT `p`:

| Config | Before | After |
|---|---|---|
| Env unset (default) | `https://oauth2:p@github.com/owner/repo.git` | `https://oauth2:p@github.com/owner/repo.git` ✅ unchanged |
| `TRINITY_GIT_BASE_URL=http://trinity-gitea-dev:3000` | same as above (override ignored) | `http://oauth2:p@trinity-gitea-dev:3000/owner/repo.git` |
| `TRINITY_GIT_BASE_URL=https://ghes.example.com/` | same as above | `https://oauth2:p@ghes.example.com/owner/repo.git` (trailing slash stripped) |

`GitHubService.API_BASE`:

| Config | Value |
|---|---|
| Env unset (default) | `https://api.github.com` ✅ unchanged |
| `TRINITY_GIT_API_BASE=http://trinity-gitea-dev:3000/api/v1` | `http://trinity-gitea-dev:3000/api/v1` |

## Backward compatibility

When both env vars are unset, behavior is unchanged. The default-path tests (`test_git_remote_url_default_is_github`, `test_github_service_api_base_default`, `test_startup_sh_default_clone_url`) pin this.

## Test plan

- [x] `python3.12 -m pytest tests/unit/test_self_hosted_git_url.py -v` → **11 passed, 1 skipped** (shellcheck not installed locally)
- [x] `python3.12 -m pytest tests/unit/test_github_init_push.py tests/unit/test_git_pull_branch.py -v` → **13 passed** (regression on the two git-service unit suites)
- [x] Fresh-shell sanity check of the `startup.sh` composition snippet with env unset → `https://oauth2:p@github.com/o/r.git`
- [x] Same snippet with `TRINITY_GIT_BASE_URL=http://trinity-gitea-dev:3000` → `http://oauth2:p@trinity-gitea-dev:3000/o/r.git`
- [ ] `shellcheck docker/base-image/startup.sh` — test skips cleanly when binary missing; CI with shellcheck will run it.
- [ ] Full live round-trip through `docker-compose.gitea.yml` — not re-run in this PR (was Tier-2 verified in the proposal behind this issue; Docker not available in my local PR-prep environment).

## Out of scope

- No schema changes.
- No other git-sync sub-issues (S1–S7 / #382–#390) — S0 only.
- No upstream push of anything other than this branch.