### PR TITLE
feat(git): parallel-history detection at modal open (S2, #385)

### DIFF
--- a/docker/base-image/agent_server/routers/git.py
+++ b/docker/base-image/agent_server/routers/git.py
@@ -3,7 +3,7 @@ Git sync endpoints for GitHub bidirectional sync.
 """
 import subprocess
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -176,6 +176,43 @@ async def get_git_status():
                 behind = int(parts[0])
                 ahead = int(parts[1])
 
+        # Parallel-history detection (S2, issue #385): surface the common
+        # ancestor between HEAD and origin/<pull_branch> so the frontend can
+        # distinguish "simple behind" from "parallel history" (where both
+        # Pull First and Force Push are wrong answers).
+        common_ancestor_sha = ""
+        common_ancestor_age_days = None
+        merge_base_result = subprocess.run(
+            ["git", "merge-base", "HEAD", f"origin/{pull_branch}"],
+            capture_output=True,
+            text=True,
+            cwd=str(home_dir),
+            timeout=10
+        )
+        if merge_base_result.returncode == 0:
+            common_ancestor_sha = merge_base_result.stdout.strip()
+            if common_ancestor_sha:
+                ancestor_date_result = subprocess.run(
+                    ["git", "log", "-1", "--format=%cI", common_ancestor_sha],
+                    capture_output=True,
+                    text=True,
+                    cwd=str(home_dir),
+                    timeout=10
+                )
+                if ancestor_date_result.returncode == 0:
+                    date_str = ancestor_date_result.stdout.strip()
+                    if date_str:
+                        try:
+                            ancestor_dt = datetime.fromisoformat(date_str)
+                            if ancestor_dt.tzinfo is None:
+                                ancestor_dt = ancestor_dt.replace(tzinfo=timezone.utc)
+                            delta = datetime.now(timezone.utc) - ancestor_dt
+                            common_ancestor_age_days = delta.days
+                        except ValueError:
+                            logger.warning(
+                                f"Could not parse common-ancestor date: {date_str!r}"
+                            )
+
         # Get remote URL (without credentials)
         remote_result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
@@ -196,12 +233,15 @@ async def get_git_status():
         return {
             "git_enabled": True,
             "branch": current_branch,
+            "pull_branch": pull_branch,
             "remote_url": remote_url,
             "last_commit": last_commit,
             "changes": changes,
             "changes_count": len(changes),
             "ahead": ahead,
             "behind": behind,
+            "common_ancestor_sha": common_ancestor_sha,
+            "common_ancestor_age_days": common_ancestor_age_days,
             "sync_status": "up_to_date" if ahead == 0 and len(changes) == 0 else "pending_sync"
         }
 

--- a/docs/memory/feature-flows/github-sync.md
+++ b/docs/memory/feature-flows/github-sync.md
@@ -630,6 +630,68 @@ When a conflict is detected (HTTP 409 response), the UI shows a modal with optio
 +---------------------------------------------+
 ```
 
+### Parallel-history modal (S2, #385)
+
+When the agent's branch and `origin/<pull_branch>` have diverged with no recent
+common ancestor, the standard Pull First / Force Push options would both lose
+data. The frontend detects this at modal-open time (no new endpoint, no extra
+round-trip) and renders a different modal variant.
+
+**Predicate** (`src/frontend/src/composables/useGitSync.js:44-55`):
+
+```javascript
+const PARALLEL_HISTORY_STALE_DAYS = 30
+const isParallelHistory = computed(() => {
+  const s = gitStatus.value
+  if (!s) return false
+  if ((s.behind || 0) <= 0) return false
+  const noAncestor = !s.common_ancestor_sha
+  const staleAncestor = typeof s.common_ancestor_age_days === 'number'
+    && s.common_ancestor_age_days >= PARALLEL_HISTORY_STALE_DAYS
+  return noAncestor || staleAncestor
+})
+```
+
+**Label-agnostic copy**: a sibling `pullBranch` computed
+(`useGitSync.js:36-38`) echoes the backend `pull_branch` field; all modal copy
+uses `{{ pullBranchLabel }}` so working-branch agents (`trinity/*` -> `main`)
+and non-default upstreams (`master`, `trunk`, ...) all render correctly.
+
+**Modal variant** (`src/frontend/src/components/GitConflictModal.vue:106-184`):
+purely additive sibling `<div v-if="show && isParallelHistory">`. The original
+Pull/Push variant has its outer `v-if` narrowed to
+`show && !isParallelHistory` (line 2) so the new variant takes priority — no
+existing branches were rewritten.
+
+| Element | Description |
+|---------|-------------|
+| Title | "Your agent cannot sync" |
+| Body | Plain-English divergence explanation, references `{{ pullBranchLabel }}` |
+| Primary button | "Adopt latest upstream (preserve my state)" -> emits `resolve('adopt_upstream_preserve_state')` |
+| Secondary button | "Force push anyway" with destructive warning -> emits `resolve('force_push')` |
+
+**Recovery dispatch**: `resolveConflict()` in `useGitSync.js:165-182` short-
+circuits the `adopt_upstream_preserve_state` strategy to a dedicated resolver,
+`adoptUpstreamPreserveState()` (lines 189-220), which calls
+`agentsStore.adoptUpstreamPreserveState(agentName)` -> `POST
+/api/agents/{name}/git/reset-to-main-preserve-state`.
+
+**Deferred dependency on #384**: the S3 endpoint is not yet live. The resolver
+handles two not-yet-wired states explicitly (no silent no-op): if the store
+method is missing it surfaces "Adopt-upstream action requires backend endpoint
+from issue #384 (not yet available)."; on HTTP 404 it surfaces "Adopt-upstream
+endpoint not available yet (blocked on issue #384)."
+
+**Wiring**: `src/frontend/src/views/AgentDetail.vue` forwards `pullBranch` and
+`isParallelHistory` from the composable into the `<GitConflictModal>` mount.
+
+### Regression tests (S2, #385)
+
+| File | Scope |
+|------|-------|
+| `tests/git-sync/test_p2_parallel_history_detection.sh` | Drives the real FastAPI handler in-process and asserts `pull_branch`, `common_ancestor_sha`, `common_ancestor_age_days` are present and well-formed in the `/api/git/status` response. |
+| `tests/git-sync/test_s2_usegitsync.test.js` | Vitest scenarios for the `isParallelHistory` predicate (no ancestor, stale ancestor, recent ancestor, behind=0 short-circuit). |
+
 ### API Request Format
 
 ```json
@@ -728,10 +790,26 @@ def _get_pull_branch(current_branch: str, home_dir: Path) -> str:
 
 | Endpoint | Line Range | Description |
 |----------|------------|-------------|
-| `GET /api/git/status` | 33-155 | Get repository status, branch, changes, ahead/behind (uses `_get_pull_branch` for behind count) |
-| `POST /api/git/sync` | 158-407 | Stage, commit, push with strategy support (`pull_first` pulls from `pull_branch`) |
+| `GET /api/git/status` | 86-251 | Get repository status, branch, changes, ahead/behind (uses `_get_pull_branch` for behind count); also surfaces `pull_branch`, `common_ancestor_sha`, `common_ancestor_age_days` for parallel-history detection (S2, #385) |
+| `POST /api/git/sync` | 254-407 | Stage, commit, push with strategy support (`pull_first` pulls from `pull_branch`) |
 | `GET /api/git/log` | 410-457 | Get recent commit history |
 | `POST /api/git/pull` | 460-659 | Pull from remote with conflict strategies (targets `pull_branch`) |
+
+#### `GET /api/git/status` — parallel-history fields (S2, #385)
+
+In addition to the existing `branch`, `ahead`, `behind`, `changes_count`, etc., the
+status response now carries three fields used by the frontend to distinguish a
+"simple behind" state from parallel histories where neither Pull First nor Force
+Push is the right answer:
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `pull_branch` | string | `_get_pull_branch(current_branch, home_dir)` (line 70-83); returned at line 235 | Effective upstream branch — `main` for `trinity/*` working branches, otherwise the current branch. Lets the frontend keep copy label-agnostic (no hardcoded "main"). |
+| `common_ancestor_sha` | string | `git merge-base HEAD origin/<pull_branch>` (line 184-192); returned at line 242 | Empty string when no merge-base exists (truly disjoint histories). |
+| `common_ancestor_age_days` | int \| null | `git log -1 --format=%cI <sha>` parsed to days (line 194-213); returned at line 243 | `null` when the ancestor date can't be parsed (logged as a warning). |
+
+`ahead` and `behind` are unchanged — they still come from
+`git rev-list --left-right --count origin/<pull_branch>...HEAD` (line 163-176).
 
 ---
 
@@ -768,6 +846,7 @@ Working - Pull fix for working branches (2026-03-26)
 | Date | Changes |
 |------|---------|
 | 2026-04-19 | **S5 — operator-readable conflict diagnosis** (#386, PR #397): Added `ConflictClass` enum + pure `classify_conflict()` in `src/backend/services/git_service.py:28-130`, mirrored in new `docker/base-image/agent_server/utils/git_conflict.py`. New `conflict_class` field on `GitSyncResult` (`db_models.py:231`) and `X-Conflict-Class` response header on 409s (`routers/git.py:134-140, 212-218`). Agent-server collapsed 5 `HTTPException` sites behind a shared `_conflict_response()` helper (`docker/base-image/agent_server/routers/git.py:41-68`). `GitConflictModal.vue` picks per-class title/body/recommendation from a `COPY` lookup; raw stderr in an expandable `<details>`; pre-S5 fallback preserves old strings. Composable `useGitSync.js:87-93, 131-138` reads the header into the existing `gitConflict` ref. Regression coverage in `tests/git-sync/test_s5_conflict_classifier.py` (11 pytest cases) and `tests/git-sync/test_s5_modal.spec.js` (5 Vitest snapshots). |
+| 2026-04-19 | **S2 — Parallel-history detection at modal open** (#385, PR #395): `get_git_status()` in `docker/base-image/agent_server/routers/git.py` now also returns `pull_branch` (line 235), `common_ancestor_sha` (line 242), and `common_ancestor_age_days` (line 243), computed via `git merge-base HEAD origin/<pull_branch>` (line 184-192) and `git log -1 --format=%cI` (line 194-213). Existing `ahead`/`behind` are unchanged. Frontend `useGitSync.js` adds `pullBranch` (lines 36-38), `isParallelHistory` predicate (lines 44-55, threshold 30 days), and an `adoptUpstreamPreserveState()` resolver (lines 189-220) that POSTs to `/api/agents/{name}/git/reset-to-main-preserve-state` (S3 / #384, not yet live — surfaces a clear "blocked on #384" notification on 404 / missing store method). `GitConflictModal.vue` adds a sibling `<div v-if="show && isParallelHistory">` variant (lines 106-184) titled "Your agent cannot sync" with primary "Adopt latest upstream (preserve my state)" and secondary "Force push anyway"; the existing variant's outer `v-if` is narrowed to `show && !isParallelHistory` so the new branch takes priority. All copy uses `{{ pullBranchLabel }}` — no hardcoded "main". `AgentDetail.vue` forwards the two new reactives into the modal mount. Regression tests: `tests/git-sync/test_p2_parallel_history_detection.sh` (in-process FastAPI) and `tests/git-sync/test_s2_usegitsync.test.js` (Vitest predicate scenarios). |
 | 2026-04-16 | **Per-Agent GitHub PAT** (#347): Added per-agent PAT configuration. Agents can now use their own GitHub PAT instead of the global one. DB column `github_pat_encrypted` in `agent_git_config`, encrypted with AES-256-GCM. 3 new API endpoints (GET/PUT/DELETE), 2 MCP tools, GitPanel.vue settings UI. Helper `get_github_pat_for_agent()` provides fallback logic. |
 | 2026-03-26 | **Fix git pull for working branches** (#195): Added `_get_pull_branch()` helper that detects `trinity/*` branches and redirects pull/status to `origin/main`. Fixed `git fetch --dry-run` → `git fetch origin` in status endpoint. Fixed `initialize_git_in_container()` to preserve remote history via `git fetch + reset` instead of `git init + force push`. Tests in `tests/unit/test_git_pull_branch.py`. |
 | 2026-02-28 | **Git Branch Support** (GIT-002): Added complete data flow documentation with line numbers. URL syntax (`github:owner/repo@branch`) parses branch in crud.py:102-113. MCP types.ts:29 and agents.ts:201-207 expose `source_branch` parameter. template_service.py:22-41 passes branch to git clone. startup.sh:38-45 uses `-b` flag. Added testing checklist from requirements spec. |

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -434,6 +434,16 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
   - Frontend `COPY` lookup in `GitConflictModal.vue` renders per-class title/body/recommendation; raw git stderr lives inside an expandable `<details>` element.
   - Pre-S5 fallback preserved for older agent images that don't emit `conflict_class`.
 - **GitHub Issue**: #386 (Epic #381)
+
+### 11.4 Parallel-History Detection (S2)
+- **Status**: ✅ Implemented (2026-04-19)
+- **Description**: When the agent's working branch and the upstream pull-branch share no recent ancestor and both have diverging commits, render a different conflict modal that offers an "Adopt latest upstream (preserve my state)" recovery instead of the (always-wrong) Pull-First / Force-Push pair.
+- **Key Features**:
+  - `/api/git/status` returns `common_ancestor_sha`, `common_ancestor_age_days`, and `pull_branch` (label-agnostic copy).
+  - Frontend `isParallelHistory` predicate: `(no common ancestor OR ancestor age ≥ 30 days) AND behind > 0`.
+  - New sibling modal variant in `GitConflictModal.vue`; existing pull/push variants untouched.
+  - Primary recovery button calls the S3 endpoint owned by #384 (deferred dependency).
+- **GitHub Issue**: #385 (Epic #381)
 - **Flow**: `docs/memory/feature-flows/github-sync.md`
 
 ---

--- a/src/frontend/src/components/GitConflictModal.vue
+++ b/src/frontend/src/components/GitConflictModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="show" class="fixed z-50 inset-0 overflow-y-auto">
+  <div v-if="show && !isParallelHistory" class="fixed z-50 inset-0 overflow-y-auto">
     <div class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:p-0">
       <!-- Backdrop -->
       <div class="fixed inset-0 bg-gray-500 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-75 transition-opacity" @click="$emit('dismiss')"></div>
@@ -114,6 +114,85 @@
       </div>
     </div>
   </div>
+  <!-- S2 (issue #385): parallel-history variant. Rendered when the agent's
+       branch and origin/<pull_branch> share no recent common ancestor AND
+       behind > 0 — neither Pull First nor Force Push recovers. -->
+  <div v-if="show && isParallelHistory" class="fixed z-50 inset-0 overflow-y-auto">
+    <div class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:p-0">
+      <div class="fixed inset-0 bg-gray-500 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-75 transition-opacity" @click="$emit('dismiss')"></div>
+
+      <div class="inline-block align-middle bg-white dark:bg-gray-800 rounded-lg text-left shadow-xl transform transition-all sm:max-w-lg sm:w-full">
+        <div class="px-4 pt-5 pb-4 sm:p-6">
+          <div class="flex items-start">
+            <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-yellow-100 dark:bg-yellow-900/30">
+              <svg class="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+            <div class="ml-4 flex-1">
+              <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+                Your agent cannot sync
+              </h3>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Your agent's branch and <code class="font-mono text-xs">{{ pullBranchLabel }}</code> have diverged —
+                each side has commits the other doesn't. Pull First and Force Push would both lose data.
+              </p>
+              <p v-if="divergenceSummary" class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                {{ divergenceSummary }}
+              </p>
+            </div>
+          </div>
+
+          <div class="mt-6 space-y-3">
+            <button
+              @click="$emit('resolve', 'adopt_upstream_preserve_state')"
+              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-blue-500 dark:hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors group"
+            >
+              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 group-hover:bg-blue-200 dark:group-hover:bg-blue-900/50">
+                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              </div>
+              <div class="ml-4 text-left">
+                <p class="text-sm font-medium text-gray-900 dark:text-white">Adopt latest upstream (preserve my state)</p>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  Reset the agent's source files to <code class="font-mono">{{ pullBranchLabel }}</code> while keeping
+                  its workspace / persistent state intact. Recommended.
+                </p>
+              </div>
+            </button>
+
+            <button
+              @click="$emit('resolve', 'force_push')"
+              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-red-500 dark:hover:border-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors group"
+            >
+              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 group-hover:bg-red-200 dark:group-hover:bg-red-900/50">
+                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+                </svg>
+              </div>
+              <div class="ml-4 text-left">
+                <p class="text-sm font-medium text-gray-900 dark:text-white">Force push anyway</p>
+                <p class="text-xs text-red-600 dark:text-red-400 mt-0.5">
+                  Overwrites the remote working branch with your local history. Does NOT bring in
+                  {{ pullBranchLabel }}'s commits. Destructive.
+                </p>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <div class="bg-gray-50 dark:bg-gray-700/50 px-4 py-3 sm:px-6 flex justify-end">
+          <button
+            @click="$emit('dismiss')"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup>
@@ -137,6 +216,25 @@ const props = defineProps({
     //                             // WORKING_BRANCH_EXTERNAL_WRITE | UNKNOWN
     //   rawStderr?: string        // full git stderr, rendered inside <details>
     // }
+  },
+  // S2 (issue #385): when true, render the parallel-history variant instead
+  // of the default Pull First / Force Push modal. Read-only flag computed
+  // upstream in useGitSync.js.
+  isParallelHistory: {
+    type: Boolean,
+    default: false
+  },
+  // S2 (issue #385): label of the branch the agent pulls from (e.g. 'main',
+  // 'master', 'trunk'). Avoids hardcoding 'main' in user-facing copy.
+  pullBranch: {
+    type: String,
+    default: ''
+  },
+  // S2 (issue #385): optional human-readable summary like
+  // "main has 3 new commits; your agent has 2 local commits".
+  divergenceSummary: {
+    type: String,
+    default: ''
   }
 })
 
@@ -209,4 +307,5 @@ const copy = computed(() => {
 })
 
 const rawStderr = computed(() => props.conflict?.rawStderr || '')
+const pullBranchLabel = computed(() => props.pullBranch || 'upstream')
 </script>

--- a/src/frontend/src/composables/useGitSync.js
+++ b/src/frontend/src/composables/useGitSync.js
@@ -31,6 +31,29 @@ export function useGitSync(agentRef, agentsStore, showNotification) {
     return gitStatus.value?.behind || 0
   })
 
+  // S2 (issue #385): the branch name the agent pulls from (e.g. 'main',
+  // 'master', 'trunk'). Surfaced so UI copy stays label-agnostic.
+  const pullBranch = computed(() => {
+    return gitStatus.value?.pull_branch || gitStatus.value?.branch || ''
+  })
+
+  // S2 (issue #385): parallel-history predicate. When the agent's working
+  // branch and origin/<pull_branch> share no recent common ancestor AND the
+  // agent is behind, both 'Pull First' and 'Force Push' are wrong answers.
+  // The frontend uses this flag to render a different modal variant.
+  const PARALLEL_HISTORY_STALE_DAYS = 30
+  const isParallelHistory = computed(() => {
+    const s = gitStatus.value
+    if (!s) return false
+    const behind = s.behind || 0
+    if (behind <= 0) return false
+    const ancestorSha = s.common_ancestor_sha
+    const ancestorAge = s.common_ancestor_age_days
+    const noAncestor = !ancestorSha
+    const staleAncestor = typeof ancestorAge === 'number' && ancestorAge >= PARALLEL_HISTORY_STALE_DAYS
+    return noAncestor || staleAncestor
+  })
+
   const loadGitStatus = async () => {
     if (!agentRef.value || agentRef.value.status !== 'running' || !hasGitSync.value) return
     gitLoading.value = true
@@ -155,10 +178,56 @@ export function useGitSync(agentRef, agentsStore, showNotification) {
     showConflictModal.value = false
     const conflictType = gitConflict.value?.type
 
+    // S2 (issue #385): parallel-history recovery dispatches to the S3
+    // endpoint (issue #384). The endpoint may 404 until #384 lands — the
+    // error surface is the same as any other failed pull/sync.
+    if (strategy === 'adopt_upstream_preserve_state') {
+      await adoptUpstreamPreserveState()
+      return
+    }
+
     if (conflictType === 'pull') {
       await pullFromGithub(strategy)
     } else if (conflictType === 'sync') {
       await syncToGithub(strategy)
+    }
+  }
+
+  /**
+   * Call the S3 endpoint (issue #384, blocking) to adopt upstream source
+   * while preserving persistent workspace state. Intended recovery path
+   * when parallel-history is detected.
+   */
+  const adoptUpstreamPreserveState = async () => {
+    if (!agentRef.value) return
+    const agentName = agentRef.value.name
+    try {
+      const result = await agentsStore.adoptUpstreamPreserveState?.(agentName)
+      if (result?.success) {
+        showNotification(result.message || 'Adopted latest upstream', 'success')
+      } else if (result) {
+        showNotification(result.message || 'Adopt upstream failed', 'error')
+      } else {
+        // Store method not yet wired (waiting on #384). Surface a clear
+        // not-implemented error instead of a silent no-op.
+        showNotification(
+          'Adopt-upstream action requires backend endpoint from issue #384 (not yet available).',
+          'error'
+        )
+      }
+      await loadGitStatus()
+    } catch (err) {
+      console.error('Adopt upstream failed:', err)
+      const status = err.response?.status
+      const message = err.response?.data?.detail || err.message || 'Failed to adopt upstream'
+      if (status === 404) {
+        showNotification(
+          'Adopt-upstream endpoint not available yet (blocked on issue #384).',
+          'error'
+        )
+      } else {
+        showNotification(message, 'error')
+      }
     }
   }
 
@@ -201,6 +270,9 @@ export function useGitSync(agentRef, agentsStore, showNotification) {
     gitHasChanges,
     gitChangesCount,
     gitBehind,
+    // S2 (issue #385) parallel-history detection
+    pullBranch,
+    isParallelHistory,
     // Conflict state
     gitConflict,
     showConflictModal,

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -220,6 +220,8 @@
     <GitConflictModal
       :show="showConflictModal"
       :conflict="gitConflict"
+      :is-parallel-history="isParallelHistory"
+      :pull-branch="pullBranch"
       @resolve="resolveConflict"
       @dismiss="dismissConflict"
     />
@@ -357,6 +359,9 @@ const {
   gitBehind,
   gitConflict,
   showConflictModal,
+  // S2 (issue #385) parallel-history detection
+  isParallelHistory,
+  pullBranch,
   refreshGitStatus,
   syncToGithub,
   pullFromGithub,

--- a/tests/git-sync/.gitignore
+++ b/tests/git-sync/.gitignore
@@ -1,0 +1,4 @@
+# Vitest install for test_s2_usegitsync.test.js
+node_modules/
+package-lock.json
+__pycache__/

--- a/tests/git-sync/test_p2_parallel_history_detection.sh
+++ b/tests/git-sync/test_p2_parallel_history_detection.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# P2 — Parallel-history detection test.
+#
+# Sets up the P2 scenario (agent working branch and origin/main share only a
+# stale common ancestor) and asserts the agent-server's get_git_status() now
+# surfaces `common_ancestor_sha` and `common_ancestor_age_days` so the
+# frontend can detect parallel history before rendering the two-button modal.
+#
+# Runs the real get_git_status() code by invoking the FastAPI endpoint
+# in-process via python. No Docker, no network.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ROOT=/tmp/trinity-p2-detection
+rm -rf "$ROOT"
+mkdir -p "$ROOT"
+cd "$ROOT"
+
+PYTHON_BIN="${PYTHON_BIN:-${REPO_ROOT}/.venv-test/bin/python}"
+if [ ! -x "$PYTHON_BIN" ]; then
+  # Fallback: let the user set PYTHON_BIN to any python with fastapi.
+  PYTHON_BIN=python3
+fi
+
+echo "=== TEST P2 DETECTION: common_ancestor_sha in git status ==="
+echo "Using python: $PYTHON_BIN"
+echo
+
+# Pre-compute ISO 8601 dates (Apple Git chokes on 'N days ago' relative dates).
+BASE_DATE="$(date -u -v-90d +%Y-%m-%dT%H:%M:%S)"
+X_DATE="$(date -u -v-60d +%Y-%m-%dT%H:%M:%S)"
+XPRIME_DATE="$(date -u -v-1d +%Y-%m-%dT%H:%M:%S)"
+
+# 1. Bare repo + seed history: base -> X
+git init --bare -q -b main bare.git
+
+git clone -q bare.git seed
+(
+  cd seed
+  git config user.email seed@t.local; git config user.name Seed
+  git config commit.gpgsign false
+  echo "base" > README.md
+  git add .
+  GIT_AUTHOR_DATE="$BASE_DATE" GIT_COMMITTER_DATE="$BASE_DATE" \
+      git commit -qm "base"
+  echo "v1 config" > trader.conf
+  git add .
+  GIT_AUTHOR_DATE="$X_DATE" GIT_COMMITTER_DATE="$X_DATE" \
+      git commit -qm "Add polymarket trader configuration"
+  git push -q -u origin main
+
+  git checkout -qb trinity/polygon-vybe/abc12345
+  git push -q -u origin trinity/polygon-vybe/abc12345
+)
+rm -rf seed
+
+# 2. Rewriter force-pushes main to a parallel commit X' (same parent = base).
+git clone -q bare.git rewriter
+(
+  cd rewriter
+  git config user.email admin@t.local; git config user.name Admin
+  git config commit.gpgsign false
+  git checkout -q main
+  git reset --hard HEAD~1   # drop X, keep base
+  echo "v2 config with extra fields" > trader.conf
+  git add .
+  GIT_AUTHOR_DATE="$XPRIME_DATE" GIT_COMMITTER_DATE="$XPRIME_DATE" \
+      git commit -qm "Add polymarket trader configuration"
+  git push --force -q origin main
+)
+rm -rf rewriter
+
+# 3. Agent container workspace: clone working branch + add unpushed commit.
+git clone -q -b trinity/polygon-vybe/abc12345 bare.git home
+(
+  cd home
+  git config user.email a@t.local; git config user.name AgentVybe
+  git config commit.gpgsign false
+  echo "trade history + brier log" > workspace.txt
+  git add .
+  git commit -qm "Trinity sync: workspace state"
+  git fetch -q origin
+)
+
+# 4. Invoke the real get_git_status() handler in-process and assert on the
+#    new fields. The handler reads from /home/developer by default — we
+#    monkeypatch that path to our throwaway repo.
+export TEST_HOME="$ROOT/home"
+PYTHONPATH="$REPO_ROOT/docker/base-image:${PYTHONPATH:-}" \
+"$PYTHON_BIN" - <<'PYEOF'
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+test_home = Path(os.environ["TEST_HOME"])
+
+# Pre-import to resolve deps before we patch Path
+from agent_server.routers import git as git_router
+
+with patch.object(git_router, "Path") as PathMock:
+    def path_ctor(arg):
+        if arg == "/home/developer":
+            return test_home
+        return Path(arg)
+    PathMock.side_effect = path_ctor
+    result = asyncio.run(git_router.get_git_status())
+
+print(json.dumps(result, indent=2, default=str))
+
+assert result.get("git_enabled") is True, "git_enabled must be True"
+assert "common_ancestor_sha" in result, "missing common_ancestor_sha field"
+assert "common_ancestor_age_days" in result, "missing common_ancestor_age_days field"
+
+sha = result["common_ancestor_sha"]
+age = result["common_ancestor_age_days"]
+
+assert isinstance(sha, str) and len(sha) == 40, \
+    f"common_ancestor_sha must be a 40-char sha, got {sha!r}"
+assert isinstance(age, (int, float)), \
+    f"common_ancestor_age_days must be numeric, got {type(age).__name__}"
+assert age >= 30, \
+    f"common_ancestor_age_days must be >= 30 for parallel-history scenario, got {age}"
+
+assert "ahead" in result and "behind" in result, "ahead/behind must remain top-level"
+assert result["ahead"] >= 1, f"expected ahead >= 1, got {result['ahead']}"
+assert result["behind"] >= 1, f"expected behind >= 1, got {result['behind']}"
+
+assert "pull_branch" in result, "pull_branch must be returned so UI copy can avoid hardcoding 'main'"
+assert result["pull_branch"] == "main", \
+    f"pull_branch for trinity/* working branch should be 'main', got {result['pull_branch']!r}"
+
+print("\n[OK] common_ancestor_sha surfaced, age >= 30d, ahead/behind preserved, pull_branch echoed")
+PYEOF
+
+echo
+echo "=== PASS ==="

--- a/tests/git-sync/test_s2_usegitsync.test.js
+++ b/tests/git-sync/test_s2_usegitsync.test.js
@@ -1,0 +1,117 @@
+/**
+ * S2 — Parallel-history detection in useGitSync composable.
+ *
+ * Verifies that when the agent-server status response carries a stale or
+ * absent common-ancestor AND behind > 0, the composable flips an
+ * `isParallelHistory` flag so the parallel-history modal variant renders
+ * instead of the two-button Pull First / Force Push modal.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+
+// Import path is relative to this file: tests/git-sync/...
+import { useGitSync } from '../../src/frontend/src/composables/useGitSync.js'
+
+function makeHarness(statusPayload) {
+  const agentRef = ref({ name: 'polygon-vybe', status: 'running' })
+  const agentsStore = {
+    getGitStatus: vi.fn().mockResolvedValue(statusPayload),
+    syncToGithub: vi.fn(),
+    pullFromGithub: vi.fn(),
+  }
+  const showNotification = vi.fn()
+  const sync = useGitSync(agentRef, agentsStore, showNotification)
+  return { sync, agentsStore }
+}
+
+describe('useGitSync parallel-history detection', () => {
+  it('flips isParallelHistory when common_ancestor is stale AND behind>0', async () => {
+    const { sync } = makeHarness({
+      git_enabled: true,
+      branch: 'trinity/polygon-vybe/abc12345',
+      pull_branch: 'main',
+      ahead: 2,
+      behind: 1,
+      changes_count: 0,
+      common_ancestor_sha: '1111111111111111111111111111111111111111',
+      common_ancestor_age_days: 90,
+    })
+
+    await sync.loadGitStatus()
+    await nextTick()
+
+    expect(sync.isParallelHistory.value).toBe(true)
+  })
+
+  it('flips isParallelHistory when common_ancestor_sha is empty AND behind>0', async () => {
+    const { sync } = makeHarness({
+      git_enabled: true,
+      branch: 'trinity/polygon-vybe/abc12345',
+      pull_branch: 'main',
+      ahead: 1,
+      behind: 1,
+      changes_count: 0,
+      common_ancestor_sha: '',
+      common_ancestor_age_days: 0,
+    })
+
+    await sync.loadGitStatus()
+    await nextTick()
+
+    expect(sync.isParallelHistory.value).toBe(true)
+  })
+
+  it('does NOT flip isParallelHistory for a simple behind (recent shared ancestor)', async () => {
+    const { sync } = makeHarness({
+      git_enabled: true,
+      branch: 'trinity/polygon-vybe/abc12345',
+      pull_branch: 'main',
+      ahead: 0,
+      behind: 3,
+      changes_count: 0,
+      common_ancestor_sha: '2222222222222222222222222222222222222222',
+      common_ancestor_age_days: 1,
+    })
+
+    await sync.loadGitStatus()
+    await nextTick()
+
+    expect(sync.isParallelHistory.value).toBe(false)
+  })
+
+  it('does NOT flip isParallelHistory when behind is 0 even if ancestor is old', async () => {
+    const { sync } = makeHarness({
+      git_enabled: true,
+      branch: 'trinity/polygon-vybe/abc12345',
+      pull_branch: 'main',
+      ahead: 5,
+      behind: 0,
+      changes_count: 0,
+      common_ancestor_sha: '3333333333333333333333333333333333333333',
+      common_ancestor_age_days: 400,
+    })
+
+    await sync.loadGitStatus()
+    await nextTick()
+
+    expect(sync.isParallelHistory.value).toBe(false)
+  })
+
+  it('surfaces pull_branch from the status payload (for label-agnostic copy)', async () => {
+    const { sync } = makeHarness({
+      git_enabled: true,
+      branch: 'trinity/polygon-vybe/abc12345',
+      pull_branch: 'trunk',
+      ahead: 1,
+      behind: 1,
+      changes_count: 0,
+      common_ancestor_sha: '',
+      common_ancestor_age_days: 0,
+    })
+
+    await sync.loadGitStatus()
+    await nextTick()
+
+    expect(sync.pullBranch.value).toBe('trunk')
+  })
+})


### PR DESCRIPTION
Closes abilityai/trinity#385
Refs #381

## Summary

When an agent's working branch and `origin/main` share no recent ancestor and both have diverging commits ("parallel history"), Trinity's current two-button conflict modal (`Pull First` / `Force Push`) is wrong in both directions. The backend already computes `ahead`/`behind`; this PR wires through the missing piece — the common ancestor — and routes the frontend to a new third modal variant when the parallel-history class is detected.

## Changes

**Backend — `docker/base-image/agent_server/routers/git.py`**
- `get_git_status()` now runs `git merge-base HEAD origin/<pull_branch>` and returns:
  - `common_ancestor_sha` (string, empty if none)
  - `common_ancestor_age_days` (int, null if the ancestor date can't be parsed)
  - `pull_branch` (the effective upstream branch — e.g. `main` for `trinity/*` working branches)
- Existing `ahead` / `behind` field names are **untouched** — #386's P6 ahead/behind-tuple expansion is orthogonal and ships independently.

**Frontend composable — `src/frontend/src/composables/useGitSync.js`**
- New `pullBranch` computed (echoes backend — avoids hardcoding "main" in UI copy).
- New `isParallelHistory` computed. Predicate:
  `(common_ancestor_sha is empty OR common_ancestor_age_days >= 30) AND behind > 0`.
- `resolveConflict('adopt_upstream_preserve_state')` dispatches to a new helper that calls `POST /api/agents/{name}/git/reset-to-main-preserve-state`.

**Frontend modal — `src/frontend/src/components/GitConflictModal.vue`**
- Purely additive: new sibling `v-if="show && isParallelHistory"` block rendering a distinct variant with title **"Your agent cannot sync"**, plain-English divergence body, primary button **"Adopt latest upstream (preserve my state)"**, and a secondary **"Force push anyway"** with destructive warning.
- Existing Pull Conflict / Push Conflict branches are untouched except for narrowing the outer `v-if` to `show && !isParallelHistory` so the new variant takes priority. This is intentionally minimal so #386's broader modal redesign can rebase cleanly on top.
- All user-facing copy references `{{ pullBranchLabel }}` — no hardcoded "main".

**View wiring — `src/frontend/src/views/AgentDetail.vue`**
- Destructures the two new reactives and forwards them into the modal mount.

## Deferred dependency (#384)

The primary button calls `POST /api/agents/{name}/git/reset-to-main-preserve-state`, owned by issue **#384** (S3). That endpoint may 404 until #384 lands. When it does, `useGitSync.adoptUpstreamPreserveState()` surfaces a clear operator-facing notification (`"Adopt-upstream endpoint not available yet (blocked on issue #384)."`) instead of a silent no-op. Detection + routing are valuable on their own because they stop the two-button modal from rendering in the parallel-history case — which is the bottleneck UX gap today.

## Out of scope

- Conflict-class enum + operator-readable copy redesign (#386)
- S3 endpoint implementation (#384)
- Branch-ownership enforcement (#382)
- P6 ahead/behind-tuple expansion

## Test Plan

- [x] `bash tests/git-sync/test_p2_parallel_history_detection.sh` — builds a parallel-history repo (commit X on the agent's branch, commit X' with the same message but different SHA on `origin/main`, base commit 90 days ago), invokes the real FastAPI handler in-process via `python -c`, and asserts the response carries `common_ancestor_sha` (40-char SHA), `common_ancestor_age_days >= 30`, untouched `ahead`/`behind`, and `pull_branch == "main"`.
- [x] `cd tests/git-sync && npx vitest run test_s2_usegitsync.test.js` — 5 scenarios of the composable predicate:
  1. stale ancestor + behind > 0 → true
  2. empty ancestor + behind > 0 → true
  3. recent ancestor + behind > 0 → false
  4. stale ancestor + behind == 0 → false
  5. non-`main` pull_branch is surfaced as-is (label-agnostic check)

Both tests are in a new `tests/git-sync/` directory at repo root, following the issue description's "adapted from `/tmp/trinity-repro/p2_parallel_history.sh`" guidance. Vitest + vue are installed locally to the test dir via a self-contained `tests/git-sync/package.json` to avoid dragging frontend dev deps into repo root.

Manual smoke (post-merge, once #384 lands): parallel-history modal should show the new variant; primary button invokes the S3 endpoint; non-parallel conflicts render the existing modal unchanged.