### PR TITLE
fix(agent-runtime): reap claude subprocess tree via process groups (#407)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -27,6 +27,12 @@ from ..utils.credential_sanitizer import (
     sanitize_dict,
     sanitize_subprocess_line,
 )
+from ..utils.subprocess_pgroup import (
+    capture_pgid as _capture_pgid,
+    terminate_process_group as _terminate_process_group,
+    safe_close_pipes as _safe_close_pipes,
+    drain_reader_threads as _drain_reader_threads,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -560,35 +566,44 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
         # Mark session as potentially running (will be set to running when first tool starts)
         logger.info(f"Starting Claude Code with streaming: {' '.join(cmd[:5])}...")
 
-        # Use Popen for real-time streaming instead of blocking run()
+        # Use Popen for real-time streaming instead of blocking run().
+        # Issue #407: start_new_session=True puts claude (and hook children
+        # it spawns) into their own process group so we can reap the whole
+        # tree on exit — hook grandchildren can otherwise outlive claude
+        # and wedge readline() forever via inherited pipe FDs.
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            bufsize=1  # Line buffered
+            bufsize=1,  # Line buffered
+            start_new_session=True,
         )
+        # Issue #407: capture pgid now — after wait() reaps the parent,
+        # the pid is gone and we lose the ability to signal the group.
+        process_pgid = _capture_pgid(process)
 
         # Register process for potential termination
         registry = get_process_registry()
         registry.register(execution_id, process, metadata={
             "type": "chat",
-            "message_preview": prompt[:100]
+            "message_preview": prompt[:100],
+            "pgid": process_pgid,
         })
 
         # Write prompt to stdin and close it
         process.stdin.write(prompt)
         process.stdin.close()
 
-        # Helper function that reads subprocess output (runs in thread pool)
-        def read_subprocess_output():
-            """Blocking function to read subprocess output line by line"""
+        stderr_lines: List[str] = []
+
+        def read_stdout():
+            """Read stdout (stream-json); parse and publish log entries."""
             try:
                 for line in iter(process.stdout.readline, ''):
                     if not line:
                         break
-                    # Capture raw JSON for full execution log (same as execute_headless_task)
                     try:
                         raw_msg = json.loads(line.strip())
                         if not isinstance(raw_msg, dict):
@@ -597,22 +612,41 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
                         # SECURITY: Sanitize credentials from output before storing
                         raw_msg = sanitize_dict(raw_msg)
                         raw_messages.append(raw_msg)
-                        # Publish to live streaming subscribers
                         registry.publish_log_entry(execution_id, raw_msg)
                     except json.JSONDecodeError:
                         pass
-                    # SECURITY: Sanitize the line before processing
                     sanitized_line = sanitize_subprocess_line(line)
-                    # Process each line immediately - updates session_activity in real-time
                     process_stream_line(sanitized_line, execution_log, metadata, tool_start_times, response_parts)
             except Exception as e:
                 logger.error(f"Error reading Claude output: {e}")
 
-            # Wait for process to complete and get stderr
-            stderr = process.stderr.read()
-            # SECURITY: Sanitize stderr output
-            stderr = sanitize_text(stderr) if stderr else stderr
+        def read_stderr():
+            """Read stderr line by line (captured for error reporting)."""
+            try:
+                for line in iter(process.stderr.readline, ''):
+                    if not line:
+                        break
+                    stderr_lines.append(line)
+            except Exception as e:
+                logger.error(f"Error reading Claude stderr: {e}")
+
+        def read_subprocess_output():
+            """Runs in thread pool. Starts stdout/stderr reader threads, waits
+            for subprocess, drains readers with process-group cleanup if
+            hook grandchildren still hold pipes open (Issue #407)."""
+            stdout_thread = threading.Thread(target=read_stdout, daemon=True)
+            stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+            stdout_thread.start()
+            stderr_thread.start()
+
             return_code = process.wait()
+            _drain_reader_threads(
+                process, stdout_thread, stderr_thread,
+                grace=5, pgid=process_pgid,
+            )
+
+            stderr = ''.join(stderr_lines)
+            stderr = sanitize_text(stderr) if stderr else stderr
             return stderr, return_code
 
         # Run the blocking subprocess reading in a thread pool to allow FastAPI
@@ -838,8 +872,6 @@ async def execute_headless_task(
 
     Returns: (response_text, execution_log, metadata, session_id)
     """
-    import signal
-
     # Issue #81: Default to "sonnet" when model is not specified.
     # Without this, Claude Code uses the agent's ~/.claude/settings.json model,
     # which may be incompatible with the assigned subscription (e.g., haiku on
@@ -927,21 +959,30 @@ async def execute_headless_task(
 
         logger.info(f"[Headless Task] Starting task {task_session_id}: {' '.join(cmd[:5])}...")
 
-        # Use Popen for real-time streaming
+        # Use Popen for real-time streaming.
+        # Issue #407: start_new_session=True puts claude (and any hooks it
+        # spawns) into their own process group so we can reap the whole tree
+        # on exit/timeout. Without this, hook grandchildren can outlive
+        # claude, keep pipe FDs open, and wedge readline() forever.
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            bufsize=1  # Line buffered
+            bufsize=1,  # Line buffered
+            start_new_session=True,
         )
+        # Issue #407: capture pgid now — after wait() reaps the parent,
+        # the pid is gone and we lose the ability to signal the group.
+        process_pgid = _capture_pgid(process)
 
         # Register process for potential termination
         registry = get_process_registry()
         registry.register(task_session_id, process, metadata={
             "type": "task",
-            "message_preview": prompt[:100]
+            "message_preview": prompt[:100],
+            "pgid": process_pgid,
         })
 
         # Write prompt to stdin and close it
@@ -953,46 +994,47 @@ async def execute_headless_task(
         auth_abort_event = threading.Event()
         auth_abort_reason: List[str] = []  # Capture the auth failure message
 
-        # Helper function that reads subprocess output (runs in thread pool)
-        def read_subprocess_output_with_timeout():
-            """Blocking function to read subprocess output line by line with timeout"""
+        # Issue #407: box for capturing exceptions from the stdout reader
+        # thread (e.g. permission-mode RuntimeError) so the main executor
+        # function can re-raise after joining.
+        stdout_exc: List[BaseException] = []
 
-            # Read stderr in separate thread (verbose output with thinking/tool calls)
-            # Issue #285: Also scan for auth failure patterns and abort early
-            def read_stderr():
-                try:
-                    for line in iter(process.stderr.readline, ''):
-                        if not line:
-                            break
-                        stripped = line.rstrip('\n')
-                        verbose_output_lines.append(stripped)
+        def read_stderr():
+            """Read stderr line by line; scan for auth failures."""
+            try:
+                for line in iter(process.stderr.readline, ''):
+                    if not line:
+                        break
+                    stripped = line.rstrip('\n')
+                    verbose_output_lines.append(stripped)
 
-                        # Issue #285: Check for auth failure patterns in real-time
-                        # If detected, signal abort immediately instead of waiting for timeout
-                        if _is_auth_failure_message(stripped):
-                            logger.warning(
-                                f"[Headless Task] Auth failure detected in stderr: {stripped[:200]}"
+                    # Issue #285: detect auth failures in real time
+                    if _is_auth_failure_message(stripped):
+                        logger.warning(
+                            f"[Headless Task] Auth failure detected in stderr: {stripped[:200]}"
+                        )
+                        auth_abort_reason.append(stripped)
+                        auth_abort_event.set()
+                        # Kill the whole process group so stdout's readline()
+                        # gets EOF and we unwind cleanly (Issue #407).
+                        try:
+                            _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid)
+                        except Exception as kill_err:
+                            logger.error(
+                                f"[Headless Task] Failed to kill process on auth abort: {kill_err}"
                             )
-                            auth_abort_reason.append(stripped)
-                            auth_abort_event.set()
-                            # Kill the process immediately
-                            try:
-                                process.kill()
-                            except Exception as kill_err:
-                                logger.error(f"[Headless Task] Failed to kill process on auth abort: {kill_err}")
-                            break
-                except Exception as e:
-                    logger.error(f"[Headless Task] Error reading stderr: {e}")
+                        break
+            except Exception as e:
+                logger.error(f"[Headless Task] Error reading stderr: {e}")
 
-            stderr_thread = threading.Thread(target=read_stderr)
-            stderr_thread.start()
-
-            # Read stdout (stream-json for metadata)
+        def read_stdout():
+            """Read stdout (stream-json); parse and publish log entries."""
+            nonlocal permission_mode_validated
             try:
                 for line in iter(process.stdout.readline, ''):
                     if not line:
                         break
-                    # Issue #285: Check if stderr thread detected auth failure
+                    # Issue #285: stderr thread detected auth failure
                     if auth_abort_event.is_set():
                         logger.info(f"[Headless Task] Stdout loop exiting due to auth abort")
                         break
@@ -1020,11 +1062,10 @@ async def execute_headless_task(
                                 logger.error(
                                     f"[Headless Task] CRITICAL: Permission bypass not active! "
                                     f"permissionMode={perm_mode} (expected bypassPermissions). "
-                                    f"Killing process to prevent silent timeout. "
+                                    f"Killing process tree to prevent silent timeout. "
                                     f"Task: {task_session_id}"
                                 )
-                                process.kill()
-                                process.wait()
+                                _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid)
                                 raise RuntimeError(
                                     f"Permission bypass failed: permissionMode={perm_mode}. "
                                     f"This may be caused by a stale Claude Code session process "
@@ -1042,23 +1083,80 @@ async def execute_headless_task(
             except Exception as e:
                 logger.error(f"[Headless Task] Error reading stdout: {e}")
 
-            # Wait for stderr thread and process to complete
-            stderr_thread.join(timeout=5)
-            return_code = process.wait()
+        def _run_stdout():
+            try:
+                read_stdout()
+            except BaseException as e:  # noqa: BLE001 — captured for main thread re-raise
+                stdout_exc.append(e)
+                # Wake the main thread's process.wait() by killing the group
+                try:
+                    _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid)
+                except Exception:
+                    pass
+
+        def read_subprocess_output_with_timeout():
+            """Runs in thread pool. Waits for subprocess with bounded timeout,
+            then drains reader threads (killing process-group stragglers if
+            they hold pipes open — Issue #407)."""
+            stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+            stdout_thread = threading.Thread(target=_run_stdout, daemon=True)
+            stderr_thread.start()
+            stdout_thread.start()
+
+            # Bounded wait on the subprocess itself. If claude hangs, we
+            # never wedge the executor thread for more than timeout_seconds.
+            try:
+                return_code = process.wait(timeout=timeout_seconds)
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    f"[Headless Task] Task {task_session_id} timed out after {timeout_seconds}s "
+                    f"— killing process group"
+                )
+                _terminate_process_group(process, graceful_timeout=5, pgid=process_pgid)
+                _drain_reader_threads(
+                    process, stdout_thread, stderr_thread,
+                    grace=3, pgid=process_pgid,
+                )
+                raise
+
+            # Subprocess exited. Drain readers — if a hook grandchild still
+            # holds a pipe, the helper will close the pipe FDs so the
+            # reader threads can exit.
+            _drain_reader_threads(
+                process, stdout_thread, stderr_thread,
+                grace=5, pgid=process_pgid,
+            )
+
+            # Re-raise permission-mode failure captured by stdout thread
+            if stdout_exc:
+                raise stdout_exc[0]
+
             return return_code
 
-        # Run with timeout using asyncio
+        # Run with timeout using asyncio. The inner function already bounds
+        # its wait on the subprocess; the outer wait_for is a safety net
+        # with a small grace period for drain/cleanup.
         loop = asyncio.get_event_loop()
         try:
             try:
                 return_code = await asyncio.wait_for(
                     loop.run_in_executor(None, read_subprocess_output_with_timeout),
-                    timeout=timeout_seconds
+                    timeout=timeout_seconds + 60
                 )
             except asyncio.TimeoutError:
-                # Kill the process on timeout
-                process.kill()
-                process.wait()
+                # Inner machinery should have raised first; safety net.
+                logger.error(
+                    f"[Headless Task] Outer timeout on task {task_session_id} "
+                    f"— killing process group as last resort"
+                )
+                _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid)
+                _safe_close_pipes(process)
+                raise HTTPException(
+                    status_code=504,
+                    detail=f"Task execution timed out after {timeout_seconds} seconds"
+                )
+            except subprocess.TimeoutExpired:
+                # Inner process.wait() timed out; tree has already been killed.
                 logger.error(f"[Headless Task] Task {task_session_id} timed out after {timeout_seconds}s")
                 raise HTTPException(
                     status_code=504,

--- a/docker/base-image/agent_server/services/process_registry.py
+++ b/docker/base-image/agent_server/services/process_registry.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from typing import Dict, Optional, List, AsyncIterator
 from threading import Lock
 
+from ..utils.subprocess_pgroup import signal_process_tree as _signal_process_tree
+
 logger = logging.getLogger(__name__)
 
 
@@ -111,21 +113,33 @@ class ProcessRegistry:
                 del self._processes[execution_id]
                 return {"success": False, "reason": "already_finished", "returncode": returncode}
 
+        # Read pgid from the entry metadata (captured at register time)
+        # so we can signal the full process group even if the parent has
+        # already been reaped (Issue #407).
+        pgid = (entry.get("metadata") or {}).get("pgid")
+
         # Terminate outside lock to avoid blocking other operations
         try:
             # Graceful termination first (SIGINT = Ctrl+C)
-            # Claude Code handles SIGINT gracefully, finishing current tool
-            logger.info(f"[ProcessRegistry] Sending SIGINT to execution {execution_id}")
-            process.send_signal(signal.SIGINT)
+            # Claude Code handles SIGINT gracefully, finishing current tool.
+            # Issue #407: signal the whole process group so hook
+            # grandchildren don't linger holding our pipe FDs.
+            logger.info(f"[ProcessRegistry] Sending SIGINT to execution {execution_id} (process group)")
+            _signal_process_tree(process, signal.SIGINT, pgid=pgid)
 
             try:
                 process.wait(timeout=graceful_timeout)
                 logger.info(f"[ProcessRegistry] Execution {execution_id} terminated gracefully")
             except subprocess.TimeoutExpired:
                 # Force kill if graceful didn't work
-                logger.warning(f"[ProcessRegistry] Force killing execution {execution_id}")
-                process.kill()
-                process.wait(timeout=2)
+                logger.warning(f"[ProcessRegistry] Force killing execution {execution_id} (process group)")
+                _signal_process_tree(process, signal.SIGKILL, pgid=pgid)
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    logger.error(
+                        f"[ProcessRegistry] Execution {execution_id} did not exit after SIGKILL"
+                    )
 
             returncode = process.returncode
 

--- a/docker/base-image/agent_server/utils/subprocess_pgroup.py
+++ b/docker/base-image/agent_server/utils/subprocess_pgroup.py
@@ -1,0 +1,194 @@
+"""Process-group lifecycle helpers for Claude Code subprocess management.
+
+Issue #407: Claude Code spawns hooks (bash-guardrail.py, file-guardrail.py,
+output-scanner.py, …) as child subprocesses that inherit our stdout/stderr
+pipes. If a hook — or any grandchild it forks — outlives claude itself, the
+inherited pipe write-ends stay open and our readline() blocks forever, even
+though ``claude`` is already a ``<defunct>`` zombie. Result: agent-server
+wedges at ~83% CPU and stops serving HTTP.
+
+Fix: launch claude with ``start_new_session=True`` so it becomes its own
+process-group leader, and kill the entire group on shutdown. That reaps
+hook grandchildren too, which closes the inherited pipe FDs and lets our
+reader threads unwind naturally.
+
+Important: the caller must capture the pgid **right after** ``Popen()``
+(via ``capture_pgid``) and pass it to every helper that operates on the
+group. Once ``process.wait()`` / ``process.poll()`` reaps the parent, the
+pid is gone and ``os.getpgid(pid)`` raises — but the process group itself
+lives on in the kernel as long as it has any member (the grandchildren we
+need to kill).
+
+This module is kept free of package-relative imports so it can be
+unit-tested without loading the rest of ``agent_server``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def capture_pgid(process: subprocess.Popen) -> Optional[int]:
+    """Return the process group id for ``process``.
+
+    Must be called before the process is reaped (``wait()`` / ``poll()``
+    collecting the exit status) — afterwards the pid is gone and
+    ``os.getpgid`` raises ``ProcessLookupError``.
+
+    Returns ``None`` on error; helpers fall back to single-process
+    signaling in that case.
+    """
+    try:
+        return os.getpgid(process.pid)
+    except (ProcessLookupError, PermissionError, OSError):
+        return None
+
+
+def _signal_group_or_process(
+    process: subprocess.Popen,
+    pgid: Optional[int],
+    sig: int,
+) -> None:
+    """Send ``sig`` to the process group if ``pgid`` is known, otherwise
+    fall back to signaling the single process. Silent on ESRCH / EPERM."""
+    if pgid is not None:
+        try:
+            os.killpg(pgid, sig)
+            return
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    try:
+        process.send_signal(sig)
+    except (ProcessLookupError, OSError):
+        pass
+
+
+def terminate_process_group(
+    process: subprocess.Popen,
+    graceful_timeout: int = 5,
+    *,
+    pgid: Optional[int] = None,
+) -> None:
+    """Terminate the subprocess AND its entire process group.
+
+    Sends SIGTERM to the group, waits up to ``graceful_timeout`` seconds
+    for the direct child to exit, then sends SIGKILL to the group.
+
+    If ``pgid`` is not provided, it's looked up from ``process.pid`` —
+    which only works while the process is still alive or is a zombie.
+    After ``process.wait()`` has reaped it, callers MUST pass the pgid
+    they captured at spawn time, otherwise the helper falls back to
+    signaling the single (already-reaped) pid and grandchildren are
+    left running.
+
+    Safe to call on already-exited processes and safe to call multiple
+    times.
+    """
+    if pgid is None:
+        pgid = capture_pgid(process)
+
+    # Always attempt a SIGTERM on the group — even if the direct child is
+    # already reaped, grandchildren may still be alive in the group.
+    _signal_group_or_process(process, pgid, signal.SIGTERM)
+
+    if process.poll() is None:
+        try:
+            process.wait(timeout=graceful_timeout)
+        except subprocess.TimeoutExpired:
+            pass
+
+    # SIGKILL the group unconditionally. If it's already empty, the
+    # kernel returns ESRCH and we swallow it.
+    _signal_group_or_process(process, pgid, signal.SIGKILL)
+
+    if process.poll() is None:
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "[Subprocess] pid=%s did not exit after SIGKILL", process.pid
+            )
+
+
+def safe_close_pipes(process: subprocess.Popen) -> None:
+    """Close subprocess stdout/stderr without raising.
+
+    Used to unblock reader threads that are stuck on readline() because a
+    surviving grandchild still holds the write end of the pipe open.
+    Closing our read end causes readline() to raise ValueError or return
+    EOF, which lets the thread exit.
+    """
+    for pipe in (process.stdout, process.stderr):
+        if pipe is None:
+            continue
+        try:
+            pipe.close()
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+
+
+def drain_reader_threads(
+    process: subprocess.Popen,
+    *threads: Optional[threading.Thread],
+    grace: int = 5,
+    pgid: Optional[int] = None,
+) -> None:
+    """Join subprocess reader threads with a bounded timeout.
+
+    If any thread is still alive after ``grace`` seconds, a surviving
+    process-group member is holding a pipe write end open. Kill the
+    group (via ``pgid`` if provided, else looked up) and force-close
+    our pipe FDs so readline() returns and threads exit.
+
+    Callers that have already reaped the parent via ``process.wait()``
+    must pass ``pgid`` — after reaping, the pid is gone and we'd
+    otherwise lose the ability to signal grandchildren.
+    """
+    alive_threads = [t for t in threads if t is not None]
+    for t in alive_threads:
+        t.join(timeout=grace)
+
+    stuck = [t for t in alive_threads if t.is_alive()]
+    if not stuck:
+        return
+
+    logger.warning(
+        "[Subprocess] Reader thread(s) stuck after process exit "
+        "(pid=%s, stuck_count=%s) — killing process group and closing pipes to unwind",
+        process.pid, len(stuck),
+    )
+    terminate_process_group(process, graceful_timeout=1, pgid=pgid)
+    safe_close_pipes(process)
+    for t in stuck:
+        t.join(timeout=2)
+
+    still_alive = [t for t in stuck if t.is_alive()]
+    if still_alive:
+        logger.error(
+            "[Subprocess] %s reader thread(s) leaked for pid=%s after "
+            "close+killpg; continuing anyway",
+            len(still_alive), process.pid,
+        )
+
+
+def signal_process_tree(
+    process: subprocess.Popen,
+    sig: int,
+    *,
+    pgid: Optional[int] = None,
+) -> None:
+    """Send ``sig`` to the subprocess's process group if it is a group
+    leader; otherwise fall back to signaling the single process.
+
+    Used by ProcessRegistry.terminate() to propagate SIGINT/SIGKILL to
+    the full tree instead of just the subprocess parent.
+    """
+    if pgid is None:
+        pgid = capture_pgid(process)
+    _signal_group_or_process(process, pgid, sig)

--- a/docs/memory/feature-flows/execution-termination.md
+++ b/docs/memory/feature-flows/execution-termination.md
@@ -82,7 +82,7 @@ Thread-safe registry for tracking running subprocess handles.
 | `list_running()` | List all currently running executions |
 | `cleanup_finished()` | Remove entries for finished processes |
 
-**Termination Flow** (lines 54-110):
+**Termination Flow**:
 ```python
 def terminate(self, execution_id: str, graceful_timeout: int = 5) -> dict:
     # 1. Check if process exists
@@ -93,14 +93,18 @@ def terminate(self, execution_id: str, graceful_timeout: int = 5) -> dict:
     if process.poll() is not None:
         return {"success": False, "reason": "already_finished", "returncode": ...}
 
-    # 3. Graceful termination (SIGINT = Ctrl+C)
-    process.send_signal(signal.SIGINT)
+    # 3. Graceful termination (SIGINT = Ctrl+C) — signal the whole
+    #    process group via captured pgid so hook grandchildren go too
+    #    (Issue #407). Falls back to signaling just the parent if pgid
+    #    is unknown.
+    pgid = (entry.get("metadata") or {}).get("pgid")
+    _signal_process_tree(process, signal.SIGINT, pgid=pgid)
 
     try:
         process.wait(timeout=graceful_timeout)  # Wait 5 seconds
     except subprocess.TimeoutExpired:
-        # 4. Force kill if graceful didn't work
-        process.kill()
+        # 4. Force kill the group if graceful didn't work
+        _signal_process_tree(process, signal.SIGKILL, pgid=pgid)
         process.wait(timeout=2)
 
     return {"success": True, "returncode": process.returncode}
@@ -469,12 +473,16 @@ When termination succeeds:
 
 ## Signal Handling
 
-| Signal | Purpose | Timeout |
-|--------|---------|---------|
-| `SIGINT` | Graceful termination (Ctrl+C) | 5 seconds |
-| `SIGKILL` | Force kill (after SIGINT timeout) | 2 seconds |
+| Signal | Purpose | Scope | Timeout |
+|--------|---------|-------|---------|
+| `SIGINT` | Graceful termination (Ctrl+C) | Full process group | 5 seconds |
+| `SIGKILL` | Force kill (after SIGINT timeout) | Full process group | 2 seconds |
 
 Claude Code handles SIGINT gracefully, finishing its current operation before exiting. This allows tools like `Write` or `Bash` to complete their current action.
+
+**Process-group semantics (Issue #407)**: The claude subprocess is launched with `start_new_session=True` so it leads its own process group. Hook subprocesses (bash-guardrail, file-guardrail, output-scanner, …) and any grandchildren they fork are in the same group. Termination sends signals to the group via `os.killpg(pgid, …)` so hook grandchildren don't outlive claude and keep our stdout/stderr pipes open (which previously caused `readline()` to wedge, leaving a `<defunct>` zombie and pinning agent-server CPU until the container was restarted).
+
+The pgid is captured at spawn time (before `process.wait()` reaps the parent — after that, `os.getpgid(pid)` raises) and stored in the registry entry metadata so termination can signal the full tree even after the parent has exited. See `docker/base-image/agent_server/utils/subprocess_pgroup.py` for the helper functions (`capture_pgid`, `terminate_process_group`, `signal_process_tree`, `drain_reader_threads`).
 
 ---
 

--- a/tests/unit/test_subprocess_pgroup.py
+++ b/tests/unit/test_subprocess_pgroup.py
@@ -1,0 +1,404 @@
+"""Regression tests for Issue #407: agent-server spin after claude becomes defunct.
+
+The production bug: Claude Code spawns hooks (bash-guardrail.py,
+file-guardrail.py, output-scanner.py, …) as subprocesses that inherit the
+parent's stdout/stderr pipes. When claude exits but a hook grandchild
+outlives it and keeps the write end of a pipe open, our reader's
+``readline()`` never sees EOF and the agent-server executor thread wedges
+— visibly spinning at ~83% CPU with claude as a ``<defunct>`` zombie.
+
+These tests verify the process-group-based fix in
+``docker/base-image/agent_server/utils/subprocess_pgroup.py``:
+
+- ``terminate_process_group`` reaps the full tree (parent + grandchildren)
+  so pipe write-ends close and readers unwind.
+- ``drain_reader_threads`` kills the group and force-closes pipes when
+  readers are stuck after the direct child has exited.
+- Helpers are safe to call on already-exited processes.
+
+Module under test: docker/base-image/agent_server/utils/subprocess_pgroup.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# Import the subprocess_pgroup module directly (it has no package-relative
+# imports, so we can add its parent dir to sys.path and import it flat).
+_project_root = Path(__file__).resolve().parents[2]
+_agent_utils_path = str(_project_root / 'docker' / 'base-image' / 'agent_server' / 'utils')
+if _agent_utils_path not in sys.path:
+    sys.path.insert(0, _agent_utils_path)
+
+import subprocess_pgroup  # noqa: E402
+from subprocess_pgroup import (  # noqa: E402
+    capture_pgid,
+    drain_reader_threads,
+    safe_close_pipes,
+    signal_process_tree,
+    terminate_process_group,
+)
+
+
+# ---------------------------------------------------------------------------
+# Harness: a parent process that forks a grandchild which keeps stderr open
+# after the parent exits. Mirrors the production pattern where claude spawns
+# hook children that outlive it.
+# ---------------------------------------------------------------------------
+
+# This script is spawned with text=True, line-buffered, stdout/stderr PIPE.
+# On stdin "go\n", parent forks a grandchild that holds stderr open for a
+# long time. Then parent exits with code 0. Result: parent is <defunct>
+# until reaped, grandchild still writes to stderr periodically → the parent
+# process.wait() succeeds but readline() on stderr keeps returning data
+# (or just blocks) forever.
+_HARNESS_SCRIPT = r"""
+import os
+import sys
+import time
+
+# Wait for "go" then fork grandchild that keeps stderr open, then exit parent.
+sys.stdin.readline()
+
+pid = os.fork()
+if pid == 0:
+    # Grandchild: keep stderr open and write heartbeats.
+    # No stdin; stdout/stderr are inherited from the parent (the test
+    # harness's Popen pipes).
+    try:
+        for _ in range(600):  # up to 60s of heartbeats at 0.1s cadence
+            sys.stderr.write("hb\n")
+            sys.stderr.flush()
+            time.sleep(0.1)
+    finally:
+        sys.stderr.close()
+    os._exit(0)
+
+# Parent: do not wait on the grandchild; exit immediately.
+sys.stdout.write("ready\n")
+sys.stdout.flush()
+sys.exit(0)
+"""
+
+
+def _spawn_harness() -> subprocess.Popen:
+    """Spawn the harness with its own process group (mirrors production)."""
+    return subprocess.Popen(
+        [sys.executable, "-u", "-c", _HARNESS_SCRIPT],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        start_new_session=True,
+    )
+
+
+def _signal_harness_go(proc: subprocess.Popen) -> None:
+    """Tell the harness parent to fork a grandchild and exit."""
+    assert proc.stdin is not None
+    proc.stdin.write("go\n")
+    proc.stdin.flush()
+    proc.stdin.close()
+
+
+def _wait_for_parent_exit(proc: subprocess.Popen, timeout: float = 5.0) -> int:
+    """Wait for the HARNESS PARENT to exit (grandchild may still be alive)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        rc = proc.poll()
+        if rc is not None:
+            return rc
+        time.sleep(0.05)
+    raise AssertionError(f"Harness parent pid={proc.pid} did not exit in {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestTerminateProcessGroup:
+    """terminate_process_group() reaps the whole tree via the process group."""
+
+    def test_kills_parent_and_grandchild(self):
+        """The grandchild that holds stderr open must be killed too.
+
+        Without killpg, the grandchild would keep running (and keep the
+        inherited stderr FD open), causing readline() to block forever.
+        """
+        proc = _spawn_harness()
+        # Capture the pgid EARLY via the helper, before anything reaps
+        # the parent — mirrors production use (capture_pgid right after
+        # Popen, pass through to terminate_process_group).
+        pgid = capture_pgid(proc)
+        assert pgid is not None and pgid > 0
+        try:
+            _signal_harness_go(proc)
+            parent_rc = _wait_for_parent_exit(proc)
+            assert parent_rc == 0
+
+            # At this point: parent is reaped, grandchild is alive in
+            # the (still-valid) process group. terminate_process_group
+            # must reap the grandchild via the captured pgid.
+            start = time.monotonic()
+            terminate_process_group(proc, graceful_timeout=2, pgid=pgid)
+            elapsed = time.monotonic() - start
+
+            # Must not hang: SIGTERM → 2s wait → SIGKILL → reaped.
+            assert elapsed < 5.0, f"terminate took {elapsed:.2f}s — too slow"
+
+            # Parent must be reaped.
+            assert proc.poll() is not None
+
+            # No process in the old group should still exist.
+            # Give the kernel a beat to clean up.
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                try:
+                    os.killpg(pgid, 0)  # signal 0 = existence check
+                except (ProcessLookupError, PermissionError, OSError):
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail(f"process group {pgid} still exists after terminate_process_group")
+        finally:
+            # Best-effort cleanup if the test failed mid-way.
+            try:
+                terminate_process_group(proc, graceful_timeout=1)
+            except Exception:
+                pass
+
+    def test_safe_on_already_exited(self):
+        """Calling on a process that already exited is a no-op."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "pass"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        proc.wait(timeout=5)
+        # Must not raise.
+        terminate_process_group(proc, graceful_timeout=1)
+
+    def test_idempotent(self):
+        """Calling multiple times is safe."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            terminate_process_group(proc, graceful_timeout=1)
+            # Already terminated — second call must be a no-op.
+            terminate_process_group(proc, graceful_timeout=1)
+            assert proc.poll() is not None
+        finally:
+            try:
+                proc.kill()
+                proc.wait(timeout=1)
+            except Exception:
+                pass
+
+
+
+@pytest.mark.unit
+class TestDrainReaderThreads:
+    """drain_reader_threads() unwinds readers stuck on pipe held by grandchild."""
+
+    def test_unwinds_reader_stuck_on_grandchild_pipe(self):
+        """The production #407 scenario reproduced end-to-end.
+
+        Harness parent exits after forking a grandchild that keeps stderr
+        open. Without the fix, the stderr reader's readline() returns data
+        forever (never sees EOF). drain_reader_threads() must notice the
+        reader is still alive after grace, kill the grandchild via the
+        process group, force-close the pipe, and let the reader thread
+        exit.
+        """
+        proc = _spawn_harness()
+        pgid = capture_pgid(proc)
+        assert pgid is not None
+        lines: list[str] = []
+        start_event = threading.Event()
+
+        def read_stderr():
+            start_event.set()
+            try:
+                assert proc.stderr is not None
+                for line in iter(proc.stderr.readline, ''):
+                    if not line:
+                        break
+                    lines.append(line)
+            except Exception:
+                # Closing the pipe from the main thread raises ValueError
+                # inside readline in some Python versions — acceptable.
+                pass
+
+        stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+        stderr_thread.start()
+        start_event.wait(timeout=2)
+
+        try:
+            _signal_harness_go(proc)
+            parent_rc = _wait_for_parent_exit(proc)
+            assert parent_rc == 0
+
+            # Give the reader a moment to pick up heartbeat lines, so we
+            # know the pipe is still producing data (grandchild is alive).
+            time.sleep(0.3)
+            assert stderr_thread.is_alive(), \
+                "stderr reader should still be running — grandchild holds pipe open"
+
+            # Now drain. Helper must kill the grandchild + close the pipe,
+            # so the reader thread exits.
+            start = time.monotonic()
+            drain_reader_threads(proc, stderr_thread, grace=2, pgid=pgid)
+            elapsed = time.monotonic() - start
+
+            assert elapsed < 6.0, f"drain took {elapsed:.2f}s — too slow"
+            assert not stderr_thread.is_alive(), \
+                "stderr reader thread still alive after drain — helper did not unwind it"
+        finally:
+            try:
+                terminate_process_group(proc, graceful_timeout=1, pgid=pgid)
+            except Exception:
+                pass
+
+    def test_fast_path_when_readers_already_exited(self):
+        """If threads finished on their own, drain is fast and non-destructive."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "print('hi')"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            out_lines: list[str] = []
+
+            def read_stdout():
+                assert proc.stdout is not None
+                for line in iter(proc.stdout.readline, ''):
+                    if not line:
+                        break
+                    out_lines.append(line)
+
+            t = threading.Thread(target=read_stdout, daemon=True)
+            t.start()
+            proc.wait(timeout=5)
+            t.join(timeout=2)
+            assert not t.is_alive(), "reader should have exited on its own"
+
+            # Drain should be a cheap no-op.
+            start = time.monotonic()
+            drain_reader_threads(proc, t, grace=2)
+            assert time.monotonic() - start < 1.0
+            assert out_lines == ["hi\n"]
+        finally:
+            try:
+                terminate_process_group(proc, graceful_timeout=1)
+            except Exception:
+                pass
+
+
+@pytest.mark.unit
+class TestSafeClosePipes:
+    """safe_close_pipes() never raises."""
+
+    def test_closes_open_pipes(self):
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            safe_close_pipes(proc)
+            assert proc.stdout is None or proc.stdout.closed
+            assert proc.stderr is None or proc.stderr.closed
+        finally:
+            terminate_process_group(proc, graceful_timeout=1)
+
+    def test_safe_when_pipes_already_closed(self):
+        """Idempotent — calling on already-closed pipes does not raise."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "pass"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        proc.wait(timeout=5)
+        proc.stdout.close()
+        proc.stderr.close()
+        # Must not raise.
+        safe_close_pipes(proc)
+
+    def test_safe_with_none_pipes(self):
+        class Dummy:
+            stdout = None
+            stderr = None
+
+        safe_close_pipes(Dummy())
+
+
+@pytest.mark.unit
+class TestSignalProcessTree:
+    """signal_process_tree() signals via pgid with fallback."""
+
+    def test_signals_process_group(self):
+        """SIGTERM via signal_process_tree should kill a grandchild too."""
+        proc = _spawn_harness()
+        pgid = capture_pgid(proc)
+        assert pgid is not None
+        try:
+            _signal_harness_go(proc)
+            _wait_for_parent_exit(proc)
+
+            import signal as _sig
+            signal_process_tree(proc, _sig.SIGKILL, pgid=pgid)
+
+            # Parent pid may still be a zombie until reaped, but the
+            # process group should be empty.
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                try:
+                    os.killpg(pgid, 0)
+                except (ProcessLookupError, PermissionError, OSError):
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail(f"process group {pgid} still exists after SIGKILL via signal_process_tree")
+            # Reap the zombie to keep the test host tidy.
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                pass
+        finally:
+            try:
+                terminate_process_group(proc, graceful_timeout=1)
+            except Exception:
+                pass
+
+    def test_safe_when_pid_gone(self):
+        """If the process is already gone, signaling is a no-op, not an error."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "pass"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        proc.wait(timeout=5)
+        import signal as _sig
+        # Must not raise.
+        signal_process_tree(proc, _sig.SIGTERM)


### PR DESCRIPTION
## Summary

Fixes #407 — agent-server spinning at ~83% CPU after `claude` CLI subprocess becomes `<defunct>` and all HTTP endpoints hang until the container is restarted.

- Launch `claude` with `start_new_session=True` and kill the entire process group on every exit path, so hook grandchildren (bash-guardrail, file-guardrail, output-scanner, …) can't outlive `claude` and wedge `readline()` via inherited pipe FDs.
- Restructure the task-path reader so both stdout and stderr read in threads; the main executor waits on the subprocess with a bounded timeout and drains readers with a grace period. If readers are still stuck, drain helper kills the group and force-closes pipes so `readline()` unwinds.
- Capture the pgid **at spawn time** (before `wait()` reaps the parent) and thread it through every cleanup callsite — after reap, `os.getpgid(pid)` raises, but the process group itself persists as long as any member does (the grandchildren we need to kill).
- `ProcessRegistry.terminate()` now signals the full tree via the stored pgid, preserving termination semantics even after the parent has been reaped.
- Helpers extracted to `docker/base-image/agent_server/utils/subprocess_pgroup.py` so they're testable without loading the rest of `agent_server`.

## Root cause

From the issue: parent `python3 /app/agent-server.py` pinned at ~83% CPU with a `[claude] <defunct>` zombie beneath it. Last log line before the hang: `[ProcessRegistry] Registered execution <id>`. Claude CLI had already exited, but a hook grandchild kept the inherited stderr FD open — so our `readline()` never saw EOF, the executor thread wedged, and FastAPI stopped serving.

Analysis and code read both point at the same fix shape: process-group lifecycle + bounded waits + thread drain. No code change is a regression from the last release; exposure grew after `max_turns_task` was raised 20→50 (#361, 2d before the report) because tasks now do more hook-invoking tool calls before cap.

## Test plan

- [x] New regression test `tests/unit/test_subprocess_pgroup.py` (10 cases, all passing). Covers the production pattern end-to-end: harness parent forks a grandchild that keeps stderr open, exits, and the helper must kill the grandchild via the captured pgid and unwind the stuck reader within a bounded time. Also exercises idempotency, already-exited safety, and `signal_process_tree` fallback paths.
- [x] Adjacent subprocess/orchestration unit tests still pass (`test_error_classification`, `test_credential_sanitizer_agent`, `test_otel_trace_logging`, `test_orphaned_execution_recovery`).
- [x] Base image rebuilds cleanly (`./scripts/deploy/build-base-image.sh`).
- [x] Imports resolve inside the base image (`python3 -c "from agent_server.utils.subprocess_pgroup import ..."` and `from agent_server.services.claude_code import execute_headless_task`).
- [ ] Deploy + validate against a scheduled task that hits the 50-turn cap (the original repro trigger).

## Broader architectural question

The symptom class (#285 false-positive auth detection on stderr regex, #407 subprocess zombie/wedge) is downstream of running `claude` as a CLI subprocess and hand-parsing `stream-json` with threads + asyncio bridges. Whether to migrate this module to the Claude Agent SDK instead is tracked separately in #409 — not in scope here.

Closes #407
Related #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)