### PR TITLE
fix(audit): log() not log_event() in proactive messages (#374)

### DIFF
--- a/src/backend/services/proactive_message_service.py
+++ b/src/backend/services/proactive_message_service.py
@@ -123,7 +123,7 @@ class ProactiveMessageService:
         except Exception as e:
             logger.warning(f"Rate limit increment failed: {e}")
 
-    def _audit_send(
+    async def _audit_send(
         self,
         agent_name: str,
         recipient_email: str,
@@ -134,14 +134,13 @@ class ProactiveMessageService:
     ) -> None:
         """Log proactive message send to audit trail."""
         try:
-            platform_audit_service.log_event(
+            await platform_audit_service.log(
                 event_type=AuditEventType.PROACTIVE_MESSAGE,
                 event_action="send",
-                actor_type="agent",
-                actor_id=agent_name,
+                source="proactive_message_service",
+                actor_agent_name=agent_name,
                 target_type="user",
                 target_id=recipient_email,
-                source="proactive_message_service",
                 details={
                     "channel": channel,
                     "success": success,
@@ -184,7 +183,7 @@ class ProactiveMessageService:
 
         # 1. Authorization check
         if not db.can_agent_message_email(agent_name, recipient_email):
-            self._audit_send(agent_name, recipient_email, channel, False, "not_authorized")
+            await self._audit_send(agent_name, recipient_email, channel, False, "not_authorized")
             raise NotAuthorizedError(
                 f"Agent '{agent_name}' is not authorized to message '{recipient_email}'. "
                 "Recipient must opt in via allow_proactive flag."
@@ -192,7 +191,7 @@ class ProactiveMessageService:
 
         # 2. Rate limit check
         if not self._check_rate_limit(agent_name, recipient_email):
-            self._audit_send(agent_name, recipient_email, channel, False, "rate_limited")
+            await self._audit_send(agent_name, recipient_email, channel, False, "rate_limited")
             raise RateLimitedError(
                 f"Rate limit exceeded: max {RATE_LIMIT_MAX_PER_HOUR} messages per hour to this recipient."
             )
@@ -211,7 +210,7 @@ class ProactiveMessageService:
                 )
                 if result.success:
                     self._increment_rate_limit(agent_name, recipient_email)
-                    self._audit_send(
+                    await self._audit_send(
                         agent_name, recipient_email, ch, True,
                         message_preview=message_preview
                     )
@@ -227,7 +226,7 @@ class ProactiveMessageService:
 
         # All channels failed
         error_msg = last_error or "No delivery channel available for recipient"
-        self._audit_send(agent_name, recipient_email, channel, False, error_msg)
+        await self._audit_send(agent_name, recipient_email, channel, False, error_msg)
         raise RecipientNotFoundError(error_msg)
 
     async def _deliver_via_channel(

--- a/tests/test_proactive_audit_unit.py
+++ b/tests/test_proactive_audit_unit.py
@@ -111,3 +111,51 @@ def test_audit_send_truncates_long_preview(proactive_service):
     )
     kwargs = audit.log.call_args.kwargs
     assert len(kwargs["details"]["message_preview"]) == 100
+
+
+def test_send_message_success_path_writes_success_audit(proactive_service, monkeypatch):
+    """End-to-end: send_message → successful delivery → audit with success=True.
+
+    Guards against regressions where the success-branch `await self._audit_send(...)`
+    at the end of `send_message` silently drops (e.g. if made sync again, or if
+    the call site forgets to await).
+    """
+    service, audit = proactive_service
+
+    # 1. Authorization passes.
+    from database import db as fake_db
+    fake_db.can_agent_message_email = MagicMock(return_value=True)
+
+    # 2. Rate limit passes (both helpers are sync; stub them).
+    monkeypatch.setattr(service, "_check_rate_limit", lambda a, e: True)
+    monkeypatch.setattr(service, "_increment_rate_limit", lambda a, e: None)
+
+    # 3. Delivery succeeds.
+    from services.proactive_message_service import DeliveryResult
+
+    async def _fake_deliver(agent_name, recipient_email, text, channel, reply_to_thread):
+        return DeliveryResult(success=True, channel=channel, message_id="msg-42")
+
+    monkeypatch.setattr(service, "_deliver_via_channel", _fake_deliver)
+
+    result = asyncio.run(
+        service.send_message(
+            agent_name="bot",
+            recipient_email="friend@example.com",
+            text="a successful hello",
+            channel="telegram",
+        )
+    )
+
+    assert result.success is True
+    assert result.message_id == "msg-42"
+
+    # Audit log called exactly once with success=True — not the failure paths.
+    audit.log.assert_awaited_once()
+    kwargs = audit.log.call_args.kwargs
+    assert kwargs["actor_agent_name"] == "bot"
+    assert kwargs["target_id"] == "friend@example.com"
+    assert kwargs["details"]["success"] is True
+    assert kwargs["details"]["error"] is None
+    assert kwargs["details"]["channel"] == "telegram"
+    assert kwargs["details"]["message_preview"] == "a successful hello"

--- a/tests/test_proactive_audit_unit.py
+++ b/tests/test_proactive_audit_unit.py
@@ -1,0 +1,113 @@
+"""
+Regression test for #374 — proactive message audit logging.
+
+Pre-fix: `proactive_message_service._audit_send` called
+`platform_audit_service.log_event(...)` which does not exist; the warning
+was swallowed and no audit row was ever written for proactive messages.
+
+Post-fix: `_audit_send` is async, awaits `platform_audit_service.log(...)`
+with the correct kwargs (`actor_agent_name` instead of `actor_type`/`actor_id`).
+"""
+
+import asyncio
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_backend_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "backend")
+)
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+
+@pytest.fixture
+def proactive_service(monkeypatch):
+    # Stub database.db — only used by other methods, not _audit_send.
+    fake_db_mod = types.ModuleType("database")
+    fake_db_mod.db = MagicMock()
+    monkeypatch.setitem(sys.modules, "database", fake_db_mod)
+
+    # Stub platform_audit_service with an AsyncMock for .log so we can assert call kwargs.
+    fake_audit_mod = types.ModuleType("services.platform_audit_service")
+
+    class _AuditEventType:
+        PROACTIVE_MESSAGE = "proactive_message"
+
+    fake_service = MagicMock()
+    fake_service.log = AsyncMock(return_value="evt-1")
+    fake_audit_mod.platform_audit_service = fake_service
+    fake_audit_mod.AuditEventType = _AuditEventType
+    monkeypatch.setitem(sys.modules, "services.platform_audit_service", fake_audit_mod)
+
+    # Fresh import so stubs take effect.
+    for mod in ("services.proactive_message_service", "proactive_message_service"):
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    from services.proactive_message_service import ProactiveMessageService
+
+    return ProactiveMessageService(), fake_service
+
+
+def test_audit_send_invokes_platform_audit_log(proactive_service):
+    """_audit_send must call platform_audit_service.log with actor_agent_name kwarg."""
+    service, audit = proactive_service
+    asyncio.run(
+        service._audit_send(
+            agent_name="research-bot",
+            recipient_email="alice@example.com",
+            channel="telegram",
+            success=True,
+            message_preview="hello",
+        )
+    )
+
+    audit.log.assert_awaited_once()
+    kwargs = audit.log.call_args.kwargs
+    assert kwargs["event_action"] == "send"
+    assert kwargs["source"] == "proactive_message_service"
+    assert kwargs["actor_agent_name"] == "research-bot"
+    assert kwargs["target_type"] == "user"
+    assert kwargs["target_id"] == "alice@example.com"
+    assert kwargs["details"]["channel"] == "telegram"
+    assert kwargs["details"]["success"] is True
+    # No legacy log_event / actor_type / actor_id keys.
+    assert "actor_type" not in kwargs
+    assert "actor_id" not in kwargs
+
+
+def test_audit_send_swallows_exceptions(proactive_service):
+    """Audit failures must never propagate to caller (best-effort contract)."""
+    service, audit = proactive_service
+    audit.log.side_effect = RuntimeError("db down")
+
+    # Should not raise.
+    asyncio.run(
+        service._audit_send(
+            agent_name="bot",
+            recipient_email="x@example.com",
+            channel="web",
+            success=False,
+            error="oops",
+        )
+    )
+
+
+def test_audit_send_truncates_long_preview(proactive_service):
+    service, audit = proactive_service
+    long_text = "x" * 500
+    asyncio.run(
+        service._audit_send(
+            agent_name="bot",
+            recipient_email="x@example.com",
+            channel="web",
+            success=True,
+            message_preview=long_text,
+        )
+    )
+    kwargs = audit.log.call_args.kwargs
+    assert len(kwargs["details"]["message_preview"]) == 100

--- a/tests/test_sharing_null_email_unit.py
+++ b/tests/test_sharing_null_email_unit.py
@@ -1,0 +1,165 @@
+"""
+Regression test for #417 — can_agent_message_email crashes on NULL owner email.
+
+Pre-fix: `owner_user.get("email", "").lower()` raised
+`AttributeError: 'NoneType' object has no attribute 'lower'` when the owner
+user's email column was NULL (admin user on fresh installs).
+
+Post-fix: coerces None → "" via `(... or "")` before `.lower()`.
+"""
+
+import os
+import sys
+import tempfile
+import sqlite3
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Resolve backend path whether the test runs from the repo
+# (repo/tests/*.py → repo/src/backend) or inside a container where /app is the
+# backend root.
+_candidates = [
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src", "backend")),
+    "/app",
+]
+_backend_path = next((p for p in _candidates if os.path.isdir(os.path.join(p, "db", "agent_settings"))), None)
+assert _backend_path, "Could not locate backend path containing db/agent_settings"
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+
+@pytest.fixture
+def sharing_mixin(monkeypatch):
+    """Isolate SharingMixin with an in-memory agent_sharing table."""
+    db_file = tempfile.NamedTemporaryFile(suffix="_share_test.db", delete=False)
+    db_file.close()
+    db_path = db_file.name
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE agent_sharing (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            shared_with_email TEXT NOT NULL,
+            shared_by_id TEXT NOT NULL,
+            shared_by_email TEXT,
+            allow_proactive INTEGER DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    class _Ctx:
+        def __enter__(self):
+            self.c = sqlite3.connect(db_path)
+            self.c.row_factory = sqlite3.Row
+            return self.c
+
+        def __exit__(self, *a):
+            self.c.close()
+
+    fake_conn_mod = types.ModuleType("db.connection")
+    fake_conn_mod.get_db_connection = lambda: _Ctx()
+    monkeypatch.setitem(sys.modules, "db.connection", fake_conn_mod)
+
+    # Stub db_models with permissive getattr — sharing.py and any transitive
+    # db/*.py imports will resolve symbols to MagicMock classes.
+    class _PermissiveModule(types.ModuleType):
+        def __getattr__(self, name):
+            return MagicMock
+
+    fake_models_mod = _PermissiveModule("db_models")
+    monkeypatch.setitem(sys.modules, "db_models", fake_models_mod)
+
+    # Direct file-load to bypass db/__init__.py (which imports many heavy modules).
+    import importlib.util
+    sharing_path = os.path.join(_backend_path, "db", "agent_settings", "sharing.py")
+    spec = importlib.util.spec_from_file_location("db_agent_settings_sharing", sharing_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    SharingMixin = mod.SharingMixin
+
+    class _SharingOps(SharingMixin):
+        """Concrete harness for the mixin."""
+
+        def __init__(self):
+            self._user_ops = MagicMock()
+            self._owner = None
+
+        def get_agent_owner(self, agent_name):
+            return self._owner
+
+    yield _SharingOps(), db_path
+    os.unlink(db_path)
+
+
+def test_null_owner_email_does_not_crash(sharing_mixin):
+    """NULL owner.email must not raise; must cleanly return False for non-owner."""
+    ops, _ = sharing_mixin
+    ops._owner = {"owner_username": "admin"}
+    ops._user_ops.get_user_by_username.return_value = {
+        "username": "admin",
+        "email": None,  # NULL column
+    }
+
+    # Must not raise AttributeError.
+    result = ops.can_agent_message_email("some-agent", "other@example.com")
+    assert result is False
+
+
+def test_owner_email_match_returns_true(sharing_mixin):
+    """Sanity check: real email match still works after the fix."""
+    ops, _ = sharing_mixin
+    ops._owner = {"owner_username": "alice"}
+    ops._user_ops.get_user_by_username.return_value = {
+        "username": "alice",
+        "email": "Alice@Example.com",
+    }
+
+    assert ops.can_agent_message_email("x", "alice@example.com") is True
+
+
+def test_missing_email_key_returns_false(sharing_mixin):
+    """dict without an 'email' key at all (defensive) must not crash."""
+    ops, _ = sharing_mixin
+    ops._owner = {"owner_username": "admin"}
+    ops._user_ops.get_user_by_username.return_value = {"username": "admin"}
+
+    assert ops.can_agent_message_email("x", "someone@example.com") is False
+
+
+def test_empty_recipient_email_returns_false(sharing_mixin):
+    ops, _ = sharing_mixin
+    assert ops.can_agent_message_email("x", "") is False
+
+
+def test_share_with_proactive_flag_admits_recipient(sharing_mixin):
+    """The allow_proactive path continues to work when owner email branch is False."""
+    ops, db_path = sharing_mixin
+    ops._owner = {"owner_username": "admin"}
+    ops._user_ops.get_user_by_username.return_value = {
+        "username": "admin",
+        "email": None,
+    }
+
+    # Insert a share with allow_proactive=1.
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO agent_sharing
+          (agent_name, shared_with_email, shared_by_id, allow_proactive, created_at)
+        VALUES (?, ?, ?, 1, datetime('now'))
+        """,
+        ("shared-agent", "friend@example.com", "1"),
+    )
+    conn.commit()
+    conn.close()
+
+    assert ops.can_agent_message_email("shared-agent", "friend@example.com") is True
+    assert ops.can_agent_message_email("shared-agent", "stranger@example.com") is False


### PR DESCRIPTION
## Summary

Closes #374.

`proactive_message_service._audit_send` called `platform_audit_service.log_event(...)` — a method that does not exist on `PlatformAuditService` (the real method is `log()`). The call was wrapped in `try/except` so the `AttributeError` surfaced only as a `WARNING: Failed to audit proactive message: 'PlatformAuditService' object has no attribute 'log_event'`, and **no audit row was ever written for a proactive message** — a silent coverage hole in the SEC-001 audit trail.

## Fix

- `_audit_send` is now `async` and awaits `platform_audit_service.log(...)`.
- Kwargs updated to match the real signature: `actor_agent_name="..."` replaces the non-existent `actor_type="agent"` + `actor_id=...` pair (actor resolution is now delegated to `log()`'s internal `_resolve_actor`).
- All four call sites in `send_message` now `await self._audit_send(...)`.

## Test plan

- [x] New regression unit test `tests/test_proactive_audit_unit.py` with 3 cases:
  - `log()` invoked with correct kwargs (`actor_agent_name`, `target_type`, `target_id`, `details`, no legacy `actor_type`/`actor_id`)
  - Audit failures never propagate to caller (best-effort contract)
  - `message_preview` truncated to 100 chars
- [x] All 3 pass locally.
- [ ] Live smoke: send a proactive message via Telegram, verify a row appears in `audit_log` with `event_type=proactive_message` (deferred — requires rebuilt backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)