### PR TITLE
fix(lifecycle): readiness probe gates post-start injections (#406)

### DIFF
--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -3,7 +3,11 @@ Agent Service Lifecycle - Agent start/stop and configuration management.
 
 Contains functions for starting, stopping, and reconfiguring agents.
 """
+import asyncio
 import logging
+import os
+import time
+
 import docker
 import httpx
 
@@ -25,6 +29,58 @@ from .helpers import check_shared_folder_mounts_match, check_api_key_env_matches
 from .read_only import inject_read_only_hooks
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Readiness Probe (#406)
+# =============================================================================
+
+# Docker reporting a container as "running" precedes the in-container FastAPI
+# server accepting connections by several seconds. Under multi-agent deploys,
+# the downstream credential-injection retry window exhausts before the server
+# is up. Gate post-start injections on HTTP readiness to close the race.
+
+AGENT_READINESS_TIMEOUT_S = int(os.getenv("AGENT_READINESS_TIMEOUT_S", "60"))
+AGENT_READINESS_POLL_INTERVAL_S = float(os.getenv("AGENT_READINESS_POLL_INTERVAL_S", "1.0"))
+
+
+async def wait_for_agent_ready(
+    agent_name: str,
+    timeout_s: int = AGENT_READINESS_TIMEOUT_S,
+    poll_interval_s: float = AGENT_READINESS_POLL_INTERVAL_S,
+) -> bool:
+    """Poll the agent's /health endpoint until it returns 200 or timeout.
+
+    Returns True if ready, False on timeout. Never raises — callers treat a
+    False return as "proceed anyway and let downstream retries cope."
+    """
+    url = f"http://agent-{agent_name}:8000/health"
+    deadline = time.monotonic() + timeout_s
+    attempt = 0
+    async with httpx.AsyncClient() as client:
+        while time.monotonic() < deadline:
+            attempt += 1
+            try:
+                r = await client.get(url, timeout=2.0)
+                if r.status_code == 200:
+                    if attempt > 1:
+                        logger.info(
+                            f"Agent {agent_name} became ready after {attempt} poll(s)"
+                        )
+                    return True
+            except (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout):
+                pass
+            except Exception as e:  # noqa: BLE001 — readiness probe must never bubble
+                logger.debug(
+                    f"Readiness probe for {agent_name} hit unexpected error: {e}"
+                )
+            await asyncio.sleep(poll_interval_s)
+
+    logger.warning(
+        f"Agent {agent_name} did not become ready within {timeout_s}s "
+        f"(polled {attempt} time(s)) — proceeding anyway"
+    )
+    return False
 
 
 # =============================================================================
@@ -229,6 +285,11 @@ async def start_agent_internal(agent_name: str) -> dict:
         }
         skills_status = "skipped"
     else:
+        # Gate post-start injections on HTTP readiness — Docker "running"
+        # precedes FastAPI "listening" by several seconds, and the downstream
+        # retry window is too short under multi-agent deploys (#406).
+        await wait_for_agent_ready(agent_name)
+
         # Inject assigned credentials from the Credentials page
         credentials_result = await inject_assigned_credentials(agent_name)
         credentials_status = credentials_result.get("status", "unknown")

--- a/tests/unit/test_agent_readiness_probe.py
+++ b/tests/unit/test_agent_readiness_probe.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for the agent readiness probe (#406).
+
+`wait_for_agent_ready` polls an agent's /health until 200 or timeout.
+Callers treat False as "proceed anyway and let downstream retries cope" —
+the probe itself must never raise.
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+
+import httpx
+import pytest
+
+# Resolve backend path whether the test runs from the repo
+# (repo/tests/unit/*.py → repo/src/backend) or inside a container where /app
+# is the backend root.
+_candidates = [
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "backend")),
+    "/app",
+]
+_backend = next(
+    (p for p in _candidates if os.path.isfile(os.path.join(p, "services", "agent_service", "lifecycle.py"))),
+    None,
+)
+assert _backend, "Could not locate backend path containing services/agent_service/lifecycle.py"
+if _backend not in sys.path:
+    sys.path.insert(0, _backend)
+
+# Load lifecycle module directly; loading through `services.*` would pull in
+# docker/db/redis init, which we don't need for a pure async function test.
+_spec = importlib.util.spec_from_file_location(
+    "agent_service_lifecycle",
+    os.path.join(_backend, "services", "agent_service", "lifecycle.py"),
+)
+# The module imports `from services.docker_service import ...` etc at top level,
+# so we stub those before exec_module instead of loading the package directly.
+
+
+@pytest.fixture
+def wait_for_agent_ready(monkeypatch):
+    """Load `wait_for_agent_ready` in isolation with its heavy deps stubbed out."""
+    import types
+    # Stub heavy imports the module pulls at top level.
+    stubs = {
+        "database": types.SimpleNamespace(db=None),
+        "services.docker_service": types.SimpleNamespace(
+            docker_client=None, get_agent_container=lambda _n: None
+        ),
+        "services.docker_utils": types.SimpleNamespace(
+            container_stop=None, container_remove=None, container_start=None,
+            container_reload=None, volume_get=None, volume_create=None,
+            containers_run=None,
+        ),
+        "services.agent_service.helpers": types.SimpleNamespace(
+            validate_base_image=None,
+            check_shared_folder_mounts_match=None,
+            check_api_key_env_matches=None,
+            check_github_pat_env_matches=None,
+            check_resource_limits_match=None,
+            check_full_capabilities_match=None,
+            check_guardrails_env_matches=None,
+        ),
+        "services.settings_service": types.SimpleNamespace(
+            get_anthropic_api_key=None, get_github_pat=None,
+            get_agent_full_capabilities=None,
+        ),
+        "services.skill_service": types.SimpleNamespace(skill_service=None),
+    }
+    for name, mod in stubs.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    # read_only is a relative import — can't stub via sys.modules easily.
+    # Instead, eval the module with an injected __name__ that avoids the relative
+    # import by loading just the function text.
+    src_path = os.path.join(_backend, "services", "agent_service", "lifecycle.py")
+
+    # Simplest: exec the file under a fake package context.
+    pkg = types.ModuleType("services.agent_service")
+    pkg.__path__ = [os.path.join(_backend, "services", "agent_service")]
+    monkeypatch.setitem(sys.modules, "services.agent_service", pkg)
+    monkeypatch.setitem(sys.modules, "services.agent_service.read_only",
+                        types.SimpleNamespace(inject_read_only_hooks=None))
+
+    spec = importlib.util.spec_from_file_location(
+        "services.agent_service.lifecycle", src_path,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.wait_for_agent_ready
+
+
+def _install_fake_httpx(monkeypatch, handler):
+    """Patch httpx.AsyncClient so it returns responses produced by `handler`."""
+    transport = httpx.MockTransport(handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, transport=transport, **kw)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+
+def test_returns_true_when_agent_ready_immediately(wait_for_agent_ready, monkeypatch):
+    def handler(req):
+        return httpx.Response(200, json={"status": "healthy"})
+
+    _install_fake_httpx(monkeypatch, handler)
+    result = asyncio.run(wait_for_agent_ready("bot", timeout_s=5, poll_interval_s=0.01))
+    assert result is True
+
+
+def test_returns_true_after_initial_connect_errors(wait_for_agent_ready, monkeypatch):
+    """Simulate FastAPI not listening for first 2 polls, then becomes ready."""
+    attempts = {"n": 0}
+
+    def handler(req):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise httpx.ConnectError("not listening yet")
+        return httpx.Response(200, json={"status": "healthy"})
+
+    _install_fake_httpx(monkeypatch, handler)
+    result = asyncio.run(wait_for_agent_ready("bot", timeout_s=5, poll_interval_s=0.01))
+    assert result is True
+    assert attempts["n"] == 3
+
+
+def test_returns_false_on_timeout(wait_for_agent_ready, monkeypatch):
+    def handler(req):
+        raise httpx.ConnectError("server never starts")
+
+    _install_fake_httpx(monkeypatch, handler)
+    result = asyncio.run(wait_for_agent_ready("bot", timeout_s=0.1, poll_interval_s=0.02))
+    assert result is False
+
+
+def test_unexpected_exception_swallowed(wait_for_agent_ready, monkeypatch):
+    """Any exception during poll (not just Connect/Read) must not bubble."""
+    attempts = {"n": 0}
+
+    def handler(req):
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            raise RuntimeError("weird transport error")
+        return httpx.Response(200, json={"status": "healthy"})
+
+    _install_fake_httpx(monkeypatch, handler)
+    result = asyncio.run(wait_for_agent_ready("bot", timeout_s=5, poll_interval_s=0.01))
+    assert result is True
+
+
+def test_non_200_response_keeps_polling(wait_for_agent_ready, monkeypatch):
+    """500/503 responses from startup should not be treated as ready."""
+    attempts = {"n": 0}
+
+    def handler(req):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            return httpx.Response(503)
+        return httpx.Response(200, json={"status": "healthy"})
+
+    _install_fake_httpx(monkeypatch, handler)
+    result = asyncio.run(wait_for_agent_ready("bot", timeout_s=5, poll_interval_s=0.01))
+    assert result is True
+    assert attempts["n"] == 3


### PR DESCRIPTION
## Summary

Closes #406.

Docker reports a container as \`running\` several seconds before the in-container FastAPI server accepts connections. The existing credential-injection retry loop (3 × 2s = ~6s) exhausts before the agent server is listening under multi-agent deploys, producing a flood of \`ConnectError\` log lines and a batch of failed scheduled executions in the first 1–5 minutes after deploy.

## Fix

Add \`wait_for_agent_ready(agent_name, timeout_s, poll_interval_s)\` in \`services/agent_service/lifecycle.py\`. Polls \`GET http://agent-{name}:8000/health\` at 1s intervals with a 60s default timeout. Gated between \`container_start\` and the credential / skill / read-only injection block in \`start_agent\`.

- On ready: silently returns \`True\` (no noise for happy path); logs informative line only if the probe needed more than one poll.
- On timeout: logs warning and returns \`False\` — caller proceeds anyway; existing retry loops remain as backstop.
- On unexpected exception during poll: swallowed by design. The probe must never raise.

Configurable via env:
- \`AGENT_READINESS_TIMEOUT_S\` (default \`60\`)
- \`AGENT_READINESS_POLL_INTERVAL_S\` (default \`1.0\`)

## Test plan

- [x] **Unit** (\`tests/unit/test_agent_readiness_probe.py\`): 5 tests — immediate-ready, ready-after-N-connect-errors, timeout path, unexpected-exception swallowed, non-200 responses keep polling. All pass.
- [x] **Live**: Created fresh blank agent and started it. Readiness probe ran silently (agent ready on first poll, expected). Credential inject reached the server with no \`ConnectError\` (pre-fix: flood of connect errors in startup window).

## Out of scope (noted)

While verifying, observed an unrelated pre-existing bug in \`inject_assigned_credentials\`: the \`if \"not found\" in str(e).lower():\` check was intended to short-circuit the retry loop when \`.credentials.enc\` doesn't exist, but the actual error text is \`\"No .credentials.enc file found in agent workspace\"\` — no literal \"not found\" substring. Result: blank agents retry 3× unnecessarily. Not fixed here (different root cause, different ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)