### PR TITLE
fix: honor per-agent execution_timeout_seconds on inter-agent calls (#418)

### DIFF
--- a/src/backend/services/fan_out_service.py
+++ b/src/backend/services/fan_out_service.py
@@ -90,7 +90,9 @@ class FanOutService:
             agent_name: Target agent (typically self).
             tasks: List of tasks to execute.
             max_concurrency: Max concurrent subtasks (semaphore size).
-            timeout_seconds: Overall deadline for the entire fan-out.
+            timeout_seconds: Overall deadline for the entire fan-out batch.
+                Per-subtask timeout is resolved independently from the target
+                agent's configured execution_timeout_seconds (#418).
             model: Model override for subtasks.
             system_prompt: System prompt for subtasks.
             allowed_tools: Tool restrictions for subtasks.
@@ -107,7 +109,7 @@ class FanOutService:
 
         logger.info(
             f"[FanOut] Starting {fan_out_id}: {len(tasks)} tasks on '{agent_name}' "
-            f"(concurrency={max_concurrency}, timeout={timeout_seconds}s)"
+            f"(concurrency={max_concurrency}, batch_deadline={timeout_seconds}s)"
         )
 
         async def run_subtask(task: FanOutTaskInput) -> None:
@@ -115,6 +117,11 @@ class FanOutService:
             start = datetime.utcnow()
             async with semaphore:
                 try:
+                    # #418: Don't pass the batch deadline as the per-subtask
+                    # timeout — execute_task resolves to the target agent's
+                    # configured execution_timeout_seconds when None (TIMEOUT-001).
+                    # The batch deadline below (asyncio.timeout) still caps the
+                    # total fan-out wall time.
                     result = await task_service.execute_task(
                         agent_name=agent_name,
                         message=task.message,
@@ -125,7 +132,7 @@ class FanOutService:
                         source_mcp_key_id=source_mcp_key_id,
                         source_mcp_key_name=source_mcp_key_name,
                         model=model,
-                        timeout_seconds=timeout_seconds,
+                        timeout_seconds=None,
                         system_prompt=system_prompt,
                         allowed_tools=allowed_tools,
                         fan_out_id=fan_out_id,

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -556,8 +556,16 @@ export class TrinityClient {
       chat_session_id: options?.chat_session_id,
     };
 
-    // Async mode returns immediately; sync mode waits for full execution
-    const timeout = options?.async_mode ? 30 : (options?.timeout_seconds || 600) + 10;
+    // Async mode returns immediately; sync mode waits for full execution.
+    //
+    // #418: When timeout_seconds isn't specified the backend falls back to the
+    // target agent's configured execution_timeout_seconds (TIMEOUT-001, default
+    // 900s, max 7200s). The client can't know the target's config, so use a
+    // generous fetch deadline that won't cut off before the backend does.
+    const DEFAULT_SYNC_FETCH_TIMEOUT_S = 7210;
+    const timeout = options?.async_mode
+      ? 30
+      : (options?.timeout_seconds ? options.timeout_seconds + 10 : DEFAULT_SYNC_FETCH_TIMEOUT_S);
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout * 1000);

--- a/src/mcp-server/src/tools/chat.ts
+++ b/src/mcp-server/src/tools/chat.ts
@@ -180,9 +180,10 @@ export function createChatTools(client: TrinityClient, requireApiKey: boolean) {
         timeout_seconds: z
           .number()
           .optional()
-          .default(600)
           .describe(
-            "Execution timeout in seconds (default: 600). Only applies when parallel=true."
+            "Execution timeout in seconds. If omitted, the backend uses the " +
+            "target agent's configured execution_timeout_seconds (TIMEOUT-001, " +
+            "default 900s). Only applies when parallel=true."
           ),
         async: z
           .boolean()

--- a/tests/unit/test_fanout_per_subtask_timeout.py
+++ b/tests/unit/test_fanout_per_subtask_timeout.py
@@ -1,0 +1,121 @@
+"""
+Unit test for #418 — FanOutService must not apply the batch deadline as the
+per-subtask timeout.
+
+Pre-fix: `execute()` passed its `timeout_seconds` (overall deadline) to each
+`execute_task` call, overriding the target agent's configured
+`execution_timeout_seconds`. A 600s batch deadline killed 1800s sub-tasks at
+610s.
+
+Post-fix: per-subtask timeout is left as `None` so TaskExecutionService falls
+back to the target agent's config (TIMEOUT-001 semantics). The batch deadline
+remains as the overall fan-out wall-clock cap.
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_candidates = [
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "backend")),
+    "/app",
+]
+_backend = next(
+    (p for p in _candidates if os.path.isfile(os.path.join(p, "services", "fan_out_service.py"))),
+    None,
+)
+assert _backend, "Could not locate backend path containing services/fan_out_service.py"
+if _backend not in sys.path:
+    sys.path.insert(0, _backend)
+
+
+@pytest.fixture
+def fan_out_service(monkeypatch):
+    """Load FanOutService with task_execution_service stubbed."""
+    # Stub task_execution_service so import resolution short-circuits.
+    fake_task_exec_mod = types.ModuleType("services.task_execution_service")
+
+    class _Result:
+        def __init__(self, status="success", response="ok"):
+            self.status = status
+            self.response = response
+            self.error = None
+            self.error_code = None
+            self.cost = 0.0
+            self.context_used = 0
+            self.execution_id = "exec-1"
+
+    fake_task_service = MagicMock()
+    fake_task_service.execute_task = AsyncMock(return_value=_Result())
+
+    fake_task_exec_mod.TaskExecutionResult = _Result
+    fake_task_exec_mod.TaskExecutionErrorCode = MagicMock()
+    fake_task_exec_mod.get_task_execution_service = lambda: fake_task_service
+    monkeypatch.setitem(sys.modules, "services.task_execution_service", fake_task_exec_mod)
+
+    # Direct-load fan_out_service to avoid pulling services/__init__.py.
+    spec = importlib.util.spec_from_file_location(
+        "services.fan_out_service",
+        os.path.join(_backend, "services", "fan_out_service.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.FanOutService(), mod.FanOutTaskInput, fake_task_service
+
+
+def test_per_subtask_timeout_is_none_not_batch_deadline(fan_out_service):
+    """
+    execute_task must receive timeout_seconds=None so the backend resolves it
+    to the target agent's execution_timeout_seconds (TIMEOUT-001), rather than
+    the fan-out batch deadline.
+    """
+    service, FanOutTaskInput, task_svc = fan_out_service
+    tasks = [
+        FanOutTaskInput(id="t1", message="m1"),
+        FanOutTaskInput(id="t2", message="m2"),
+    ]
+
+    asyncio.run(
+        service.execute(
+            agent_name="delegate",
+            tasks=tasks,
+            max_concurrency=2,
+            timeout_seconds=600,  # batch deadline — must NOT leak to subtasks
+        )
+    )
+
+    assert task_svc.execute_task.await_count == 2
+    for call in task_svc.execute_task.await_args_list:
+        assert call.kwargs["timeout_seconds"] is None, (
+            f"execute_task should get None per-subtask timeout, got "
+            f"{call.kwargs['timeout_seconds']} — this would reintroduce #418"
+        )
+        # Sanity: other fields still flow through.
+        assert call.kwargs["triggered_by"] == "fan_out"
+        assert call.kwargs["agent_name"] == "delegate"
+
+
+def test_subtasks_complete_within_batch_deadline(fan_out_service):
+    """Smoke test the happy path still returns a FanOutResult."""
+    service, FanOutTaskInput, _ = fan_out_service
+    tasks = [FanOutTaskInput(id="only", message="hi")]
+
+    result = asyncio.run(
+        service.execute(
+            agent_name="delegate",
+            tasks=tasks,
+            max_concurrency=1,
+            timeout_seconds=300,
+        )
+    )
+
+    assert result.completed == 1
+    assert result.failed == 0
+    # `results` is an ordered list, not a dict — find by id.
+    by_id = {r.id: r for r in result.results}
+    assert by_id["only"].status == "completed"


### PR DESCRIPTION
## Summary

Closes #418.

Three hardcoded \`600\` defaults silently overrode agents' configured \`execution_timeout_seconds\` (TIMEOUT-001) on every MCP \`chat_with_agent\` and fan-out invocation, killing long-running sub-tasks at ~610s regardless of what operators had configured via \`PUT /api/agents/{name}/timeout\`.

Reported incident: ~120 failed sub-executions across 7 delegate agents in one 80-minute window, all tied to a single parent schedule run, all showing \`duration_ms ≈ 610000\` with \`limit=600s\`.

## Root cause

Three independent layers each applied a hardcoded 600s default, shadowing the backend's correct fallback to the target agent's config:

1. **MCP tool zod schema** (\`src/mcp-server/src/tools/chat.ts\`): \`timeout_seconds.default(600)\` — every MCP \`chat_with_agent\` call without an explicit timeout sent \`600\`, which the backend then used verbatim (line 276 of \`task_execution_service.py\` only falls back to agent config when the value is \`None\`).
2. **MCP client fetch deadline** (\`src/mcp-server/src/client.ts\`): \`const timeout = (options?.timeout_seconds || 600) + 10\` — the HTTP \`fetch\` itself aborted at ~610s even if the backend was given a longer deadline.
3. **fan_out_service.execute**: passed its \`timeout_seconds\` (the overall batch deadline) as the per-subtask timeout, so a 600s batch cap became a 600s per-task cap.

## Fix

- **MCP tool**: drop \`.default(600)\`. \`timeout_seconds\` is now truly optional; omitting it sends \`undefined\` and the backend resolves via \`db.get_execution_timeout(target)\` (default 900s).
- **MCP client**: when no explicit timeout is passed, use a generous fetch deadline (\`7210s\` = backend max \`7200s\` + buffer) so the client doesn't cut off before the backend's per-agent resolved deadline fires. Explicit values still get \`+ 10s\` as before.
- **fan_out_service**: pass \`timeout_seconds=None\` to each \`execute_task\` call so every subtask resolves independently to the target agent's configured timeout. The batch deadline (\`asyncio.timeout\`) still caps overall fan-out wall time — semantics preserved.

## Test plan

- [x] **Unit** (\`tests/unit/test_fanout_per_subtask_timeout.py\`): 2 tests — (1) \`execute_task\` receives \`timeout_seconds=None\` per subtask regardless of batch deadline; (2) happy-path smoke test. Both pass.
- [x] **TypeScript typecheck** on MCP server: clean (no diagnostics).
- [x] **Live**: configured agent \`t418\` with \`execution_timeout_seconds=1800\`, POST \`/api/agents/t418/task\` without \`timeout_seconds\` in body. Backend log: \`[TaskExecService] Calling agent t418 /api/task (timeout=1810.0s, ...)\` — resolved to 1800 + 10s buffer, not 600. Pre-fix this would have been 610s whenever the caller omitted the field or was an MCP client with the stale default.

## Notes / out of scope

- The public chat path (\`src/backend/routers/public.py:567\`) still passes \`timeout_seconds=900\` explicitly. That's user-facing rather than inter-agent, so the behavior is intentional; leaving alone.
- \`routers/fan_out.py:56\` \`timeout_seconds: int = 600\` is the overall batch deadline from the HTTP request model — semantically correct, only the per-subtask propagation was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)