### PR TITLE
fix(orchestration): honor per-agent timeout on inter-agent tasks (#418)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -185,6 +185,7 @@ The test suite covers:
 - **OTel Trace Logging** (unit/test_otel_trace_logging.py) - Trace ID injection in logs, span context correlation (#305, RELIABILITY-002) [UNIT]
 - **File Upload** (unit/test_file_upload.py) - Telegram file extraction, download, message router validation, parse_message with files (#354) [UNIT]
 - **Telegram Voice** (unit/test_telegram_voice.py) - Voice transcription validation (duration/size limits), formatting, placeholder constants (#318) [UNIT]
+- **Inter-Agent Timeout** (test_inter_agent_timeout_unit.py) - FanOutRequest Optional timeout, per-subtask None dispatch, conditional asyncio.timeout wrap (#418) [UNIT]
 
 ### Avatars & Image Generation
 - **Avatars** (test_avatars.py) - Avatar serving, generation, regeneration, deletion, emotions, identity prompts, default generation (AVATAR-001/002/003) [SMOKE + Agent]
@@ -226,10 +227,10 @@ The test suite covers:
 
 ## Test Suite Statistics
 
-**Total Tests**: ~2,200 tests across 119 test files
+**Total Tests**: ~2,207 tests across 120 test files
 **Smoke Tests**: ~578 tests (fast, no agent creation)
-**Unit Tests**: ~79 tests (no backend needed, rate limit detection, watchdog logic, context formula, OTel trace logging, file upload, voice transcription)
-**Core Tests (not slow)**: ~2,069 tests
+**Unit Tests**: ~86 tests (no backend needed, rate limit detection, watchdog logic, context formula, OTel trace logging, file upload, voice transcription, inter-agent timeout)
+**Core Tests (not slow)**: ~2,076 tests
 **Slow Tests**: ~89 tests (chat execution, fleet ops, system agent ops, execution termination)
 **WebSocket Tests**: ~10 tests (web terminal, execution streaming)
 
@@ -257,6 +258,24 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 - **Healthy**: >90% pass rate, 0 critical failures
 - **Warning**: 75-90% pass rate, <5 failures
 - **Critical**: <75% pass rate or >5 failures
+
+## Recent Test Additions (2026-04-20)
+
+| Test File | Description | Tests Added |
+|-----------|-------------|-------------|
+| `test_inter_agent_timeout_unit.py` | Inter-agent timeout honors per-agent config (#418) | 7 tests |
+
+**Inter-Agent Timeout Fix (#418)** (`test_inter_agent_timeout_unit.py`):
+
+- `test_fan_out_request_allows_omitted_timeout` — FanOutRequest accepts no `timeout_seconds`, defaults to None
+- `test_fan_out_request_accepts_explicit_timeout` — Explicit value round-trips
+- `test_fan_out_request_rejects_out_of_range_timeout` — Validator rejects <10 / >3600
+- `test_fan_out_request_accepts_none_explicitly` — `timeout_seconds=None` short-circuits validator
+- `test_fan_out_service_forwards_none_per_subtask_without_outer_deadline` — Each sub-task gets `timeout_seconds=None` (per-agent config applies)
+- `test_fan_out_service_forwards_none_per_subtask_with_outer_deadline` — Outer deadline wraps gather, but per-subtask timeout stays None
+- `test_fan_out_service_outer_deadline_actually_applies` — When outer deadline exceeded, tasks marked `error_code="timeout"`
+
+Pure unit tests — mock `TaskExecutionService` and stub `database`/`models` modules. No backend container required.
 
 ## Recent Test Additions (2026-04-18)
 

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-20 | #418 | Inter-agent timeout honors per-agent `execution_timeout_seconds` — removed 600s hardcoded defaults in MCP `chat_with_agent`/`fan_out` tools and fan-out service; HTTP client ceiling bumped to platform max (7200s) | [fan-out.md](feature-flows/fan-out.md), [mcp-orchestration.md](feature-flows/mcp-orchestration.md), [parallel-headless-execution.md](feature-flows/parallel-headless-execution.md) |
 | 2026-04-19 | #211 | Auto-propagate global GitHub PAT to running agents on update — per-agent PAT holders and agents without `GITHUB_PAT` in `.env` are skipped; delete does NOT propagate | [github-sync.md](feature-flows/github-sync.md), [platform-settings.md](feature-flows/platform-settings.md) |
 | 2026-04-19 | #378 | Cleanup service Phase 3 just-in-time re-verify + parallel per-agent fan-out — eliminates phantom stale-slot failures for still-running tasks; adds residual-race observability log | [cleanup-service.md](feature-flows/cleanup-service.md) |
 | 2026-04-18 | DOCS-QA-001 | Trinity Docs Q&A — public Vertex AI Search endpoint + in-app floating help widget (#391) | [trinity-docs-qa.md](feature-flows/trinity-docs-qa.md) |

--- a/docs/memory/feature-flows/fan-out.md
+++ b/docs/memory/feature-flows/fan-out.md
@@ -1,7 +1,10 @@
 # Feature: Fan-Out Parallel Task Dispatch (FANOUT-001)
 
 ## Overview
-Dispatches N independent tasks to an agent in parallel (throttled by asyncio semaphore), collects results with an overall deadline, and returns aggregated per-task results. Each subtask follows the standard TaskExecutionService path for full dashboard observability.
+Dispatches N independent tasks to an agent in parallel (throttled by asyncio semaphore), collects results with an optional overall deadline, and returns aggregated per-task results. Each subtask follows the standard TaskExecutionService path for full dashboard observability.
+
+## Recent Changes
+- **Issue #418 (feature/418-inter-agent-timeout)**: `timeout_seconds` is now optional and governs only the outer fan-out-wide deadline. Individual subtasks are always bounded by the target agent's configured `execution_timeout_seconds` (TIMEOUT-001). Previously a hardcoded 600s default capped every subtask regardless of per-agent configuration.
 
 ## User Story
 As an agent orchestrator, I want to fan out multiple independent tasks to an agent in parallel so that embarrassingly parallel workloads (batch predictions, parallel analysis, ensemble methods) complete faster than sequential execution.
@@ -19,15 +22,15 @@ No frontend UI entry point exists; this is an API/MCP-only feature.
 
 ### Tool Definition
 - `src/mcp-server/src/tools/chat.ts:351-457` -- `fan_out` tool
-- Parameters: `agent_name`, `tasks[]`, `timeout_seconds`, `max_concurrency`, `model`, `system_prompt`, `allowed_tools`
+- Parameters: `agent_name`, `tasks[]`, `timeout_seconds` (optional; no default — when omitted, no outer deadline is applied and each sub-task is bounded by the target agent's configured `execution_timeout_seconds`), `max_concurrency`, `model`, `system_prompt`, `allowed_tools`
 - Access control: calls `checkAgentAccess()` (same rules as `chat_with_agent`)
 - Delegates to `TrinityClient.fanOut()`
 
 ### Client Method
 - `src/mcp-server/src/client.ts:610-704` -- `fanOut()` method
 - Sets headers: `Authorization`, `X-Via-MCP`, `X-Source-Agent`, `X-MCP-Key-ID`, `X-MCP-Key-Name`
-- Builds request body with `tasks`, `agent`, `timeout_seconds`, `max_concurrency`, `policy`, `model`, `system_prompt`, `allowed_tools`
-- HTTP timeout = `timeout_seconds + 30` (buffer for overhead)
+- Builds request body with `tasks`, `agent`, `max_concurrency`, `policy`, `model`, `system_prompt`, `allowed_tools`; `timeout_seconds` is conditionally spread in only when the caller provided it, so the backend sees `None` on omission and falls back to per-agent `execution_timeout_seconds`
+- HTTP ceiling = `(options?.timeout_seconds ?? 7200) + 60` seconds — covers the platform max per-agent timeout (7200s) + 60s buffer so the HTTP fetch doesn't abort before the backend finishes (#418)
 - Calls `POST /api/agents/{name}/fan-out`
 
 ## Backend Layer
@@ -39,11 +42,11 @@ No frontend UI entry point exists; this is an API/MCP-only feature.
 ### Request Validation (Pydantic)
 ```python
 class FanOutRequest(BaseModel):
-    tasks: List[FanOutTask]          # 1-50 tasks, unique IDs
-    agent: str = "self"              # v1: self-only
-    timeout_seconds: int = 600       # 10-3600
-    max_concurrency: int = 3         # 1-10
-    policy: str = "best-effort"      # only value supported
+    tasks: List[FanOutTask]                    # 1-50 tasks, unique IDs
+    agent: str = "self"                        # v1: self-only
+    timeout_seconds: Optional[int] = None      # 10-3600 when set; None = per-agent default (#418)
+    max_concurrency: int = 3                   # 1-10
+    policy: str = "best-effort"                # only value supported
     model: Optional[str]
     system_prompt: Optional[str]
     allowed_tools: Optional[List[str]]
@@ -52,7 +55,7 @@ class FanOutRequest(BaseModel):
 - Task IDs: regex `^[a-zA-Z0-9_-]{1,64}$`, must be unique
 - Max tasks: 50 (`MAX_TASKS`)
 - Max concurrency: 10 (`MAX_CONCURRENCY`)
-- Timeout range: 10-3600 seconds
+- Timeout range: 10-3600 seconds (or `None` for per-agent default, #418). The validator short-circuits and returns `None` when the field is omitted.
 - Policy: only `"best-effort"` supported in v1
 - Cross-agent fan-out (`agent != "self"` and `agent != name`): returns 400
 
@@ -78,13 +81,15 @@ class FanOutRequest(BaseModel):
 3. Create `asyncio.Semaphore(max_concurrency)` for throttling
 4. Define `run_subtask()` coroutine for each task:
    - Acquires semaphore
-   - Calls `task_service.execute_task()` with `triggered_by="fan_out"` and `fan_out_id=fan_out_id`
+   - Calls `task_service.execute_task()` with `triggered_by="fan_out"`, `fan_out_id=fan_out_id`, and **`timeout_seconds=None`** so TaskExecutionService resolves the target agent's configured `execution_timeout_seconds` (TIMEOUT-001, #418)
    - Maps result to `FanOutTaskResult` (completed or failed)
    - Catches `CancelledError` (deadline exceeded) and general exceptions
-5. Dispatch all coroutines via `asyncio.gather(*coroutines, return_exceptions=True)` wrapped in `asyncio.timeout(timeout_seconds)`
-6. On `TimeoutError`: mark unfinished tasks as failed with `error_code="timeout"`
+5. Dispatch all coroutines via `asyncio.gather(*coroutines, return_exceptions=True)`. The gather is **conditionally wrapped** in `asyncio.timeout(timeout_seconds)` only when the caller supplied an outer deadline (#418). Without a deadline, the gather runs unwrapped — each subtask is still individually bounded by per-agent `execution_timeout_seconds`.
+6. On `TimeoutError`: mark unfinished tasks as failed with `error_code="timeout"` (only reachable when outer deadline was set)
 7. Build ordered results matching input task order
 8. Return `FanOutResult` with aggregate counts
+
+Log line format: `[FanOut] Starting {fan_out_id}: {N} tasks on '{agent}' (concurrency={max_concurrency}, deadline={deadline_desc})` where `deadline_desc` is either `"{N}s"` or `"per-agent"`.
 
 ### Data Models
 ```python
@@ -152,12 +157,13 @@ class FanOutResult:
 | Duplicate task IDs | 422 | "Duplicate task IDs: {dupes}" |
 | Invalid task ID format | 422 | "Task ID must be 1-64 alphanumeric..." |
 | Concurrency out of range | 422 | "max_concurrency must be between 1 and 10" |
-| Timeout out of range | 422 | "timeout_seconds must be between 10 and 3600" |
+| Timeout out of range | 422 | "timeout_seconds must be between 10 and 3600" (only validated when field is set; `None`/omitted is accepted) |
 | Unsupported policy | 422 | "Only 'best-effort' policy is supported" |
 | Cross-agent target | 400 | "Fan-out target must be 'self' or '{name}'" |
 | Agent not found | 404 | From `get_authorized_agent` dependency |
 | Auth failure | 401 | From `get_current_user` dependency |
-| Overall deadline exceeded | 200 | `status: "deadline_exceeded"`, unfinished tasks get `error_code: "timeout"` |
+| Overall deadline exceeded | 200 | `status: "deadline_exceeded"`, unfinished tasks get `error_code: "timeout"` (only reachable when `timeout_seconds` was explicitly set) |
+| Per-subtask timeout (per-agent config) | 200 | Per-task `status: "failed"` with `error_code: "timeout"` from TaskExecutionService; other subtasks continue |
 | Individual subtask failure | 200 | Per-task `status: "failed"` with `error` and `error_code` |
 
 ## Request/Response Example
@@ -227,7 +233,7 @@ POST /api/agents/my-agent/fan-out
 ## Architecture Notes
 - Concurrency is managed by `asyncio.Semaphore` -- safe because asyncio is single-threaded (no preemption between awaits)
 - `asyncio.gather(return_exceptions=True)` ensures all coroutines complete even if one raises
-- `asyncio.timeout()` wraps the entire gather for the overall deadline
+- `asyncio.timeout()` wraps the entire gather for the overall deadline **only when `timeout_seconds` is set**; otherwise the gather runs unwrapped and each subtask is bounded by per-agent `execution_timeout_seconds` (#418)
 - Results dict is safe for concurrent writes in asyncio's cooperative model
 - v1 is self-only (agent fans out to itself); cross-agent fan-out is a future extension
 

--- a/docs/memory/feature-flows/mcp-orchestration.md
+++ b/docs/memory/feature-flows/mcp-orchestration.md
@@ -381,6 +381,9 @@ console.log(`Registered ${totalTools} tools`);
 | `chat_with_agent` | 132-270 | `{agent_name, message, parallel?, model?, allowed_tools?, system_prompt?, timeout_seconds?}` | `POST /api/agents/{name}/chat` or `/task` |
 | `get_chat_history` | 275-292 | `{agent_name}` | `GET /api/agents/{name}/chat/history` |
 | `get_agent_logs` | 297-326 | `{agent_name, lines?}` | `GET /api/agents/{name}/logs` |
+| `fan_out` | 390-590 | `{agent_name, tasks[], timeout_seconds?, max_concurrency?, model?, system_prompt?, allowed_tools?}` | `POST /api/agents/{name}/fan-out` |
+
+> **Per-agent timeout fallback (#418, 2026-04-20)**: For `chat_with_agent` (when `parallel=true`) and `fan_out`, `timeout_seconds` is fully optional with **no default**. When omitted, the backend falls back to the target agent's configured `execution_timeout_seconds` (TIMEOUT-001; default 900s, max 7200s). Previously, the Zod schema defaulted to `600`, which silently capped inter-agent invocations below the per-agent setting.
 
 ### System Tools (`src/mcp-server/src/tools/systems.ts`)
 
@@ -440,7 +443,9 @@ chat_with_agent({
   model: "sonnet",             // Optional: model override
   allowed_tools: ["Read"],     // Optional: tool restrictions
   system_prompt: "Be concise", // Optional: additional instructions
-  timeout_seconds: 300         // Optional: timeout (default 5 min)
+  timeout_seconds: 300         // Optional. Omit to use the target agent's
+                               // configured execution_timeout_seconds
+                               // (TIMEOUT-001; default 900s, max 7200s).
 })
 ```
 
@@ -469,7 +474,8 @@ chat_with_agent({
   message: "Process large dataset",
   parallel: true,              // Required for async mode
   async: true,                 // Return immediately with execution_id
-  timeout_seconds: 3600        // Long-running task
+  timeout_seconds: 3600        // Optional. Omit to use worker-1's configured
+                               // execution_timeout_seconds (TIMEOUT-001).
 })
 // Returns immediately:
 // {
@@ -661,11 +667,39 @@ async chat(name: string, message: string, sourceAgent?: string): Promise<ChatRes
 }
 ```
 
-### Parallel Task Execution (lines 393-445)
+### Parallel Task Execution (`client.task`, lines 511-600)
 ```typescript
 async task(name: string, message: string, options?: TaskOptions, sourceAgent?: string): Promise<ChatResponse> {
   // Stateless execution, no queue, can run N tasks concurrently
+  // HTTP ceiling covers platform max per-agent timeout (7200s) + buffer so the
+  // client never aborts before the backend resolves per-agent timeout (#418).
+  const timeout = options?.async_mode
+    ? 30
+    : (options?.timeout_seconds ?? 7200) + 60;
   const response = await fetch(`${this.baseUrl}/api/agents/${name}/task`, ...);
+}
+```
+
+### Fan-Out (`client.fanOut`, lines 621-720)
+```typescript
+async fanOut(name: string, tasks: FanOutTask[], options?: FanOutOptions): Promise<FanOutResult> {
+  // Only include timeout_seconds if caller provided it, so the backend can
+  // fall back to the target agent's configured execution_timeout_seconds (#418).
+  const body: Record<string, unknown> = {
+    tasks,
+    agent: options?.agent || "self",
+    max_concurrency: options?.max_concurrency || 3,
+    policy: options?.policy || "best-effort",
+    model: options?.model,
+    system_prompt: options?.system_prompt,
+    allowed_tools: options?.allowed_tools,
+  };
+  if (options?.timeout_seconds !== undefined) {
+    body.timeout_seconds = options.timeout_seconds;
+  }
+  // HTTP ceiling matches platform max per-agent timeout (7200s) + buffer.
+  const timeout = (options?.timeout_seconds ?? 7200) + 60;
+  const response = await fetch(`${this.baseUrl}/api/agents/${name}/fan-out`, ...);
 }
 ```
 
@@ -1025,6 +1059,7 @@ curl http://localhost:8000/api/agents/user2-agent | jq .owner  # Should be user2
 
 | Date | Changes |
 |------|---------|
+| 2026-04-20 | **Inter-agent timeout fix (#418)**: Removed Zod `.default(600)` from `timeout_seconds` on `chat_with_agent` (`parallel=true`) and `fan_out` in `src/mcp-server/src/tools/chat.ts`. When omitted, backend now falls back to the target agent's configured `execution_timeout_seconds` (TIMEOUT-001; default 900s, max 7200s). `client.ts` HTTP fetch ceilings in `task()` and `fanOut()` raised from `(timeout \|\| 600) + 10` to `(timeout ?? 7200) + 60` so the client never aborts before the backend. `fanOut()` now conditionally spreads `timeout_seconds` so the backend sees `None` and triggers per-agent fallback. |
 | 2026-02-22 | **Subscription tools (SUB-001)**: Tool count updated from 45 to 51. Added 6 subscription management tools: `register_subscription`, `list_subscriptions`, `assign_subscription`, `clear_agent_subscription`, `get_agent_auth`, `delete_subscription`. See [subscription-management.md](subscription-management.md) for full documentation. |
 | 2026-02-20 | **Notification tools (NOTIF-001)**: Tool count updated from 44 to 45. Added `send_notification` tool. |
 | 2026-02-20 | **Schedule tools: Per-schedule execution config**: `create_agent_schedule` and `update_agent_schedule` now support `timeout_seconds` and `allowed_tools` parameters for per-schedule execution configuration. Added dedicated Schedule Tools section with parameter table. |

--- a/docs/memory/feature-flows/parallel-headless-execution.md
+++ b/docs/memory/feature-flows/parallel-headless-execution.md
@@ -3,13 +3,14 @@
 > **Requirement**: 12.1 - Parallel Headless Execution
 > **Status**: Implemented
 > **Created**: 2025-12-22
-> **Updated**: 2026-04-17 (Issue #361 max-turns error fix)
+> **Updated**: 2026-04-20 (Issue #418 inter-agent timeout fix)
 > **Verified**: 2026-02-05
 
 ## Revision History
 
 | Date | Changes |
 |------|---------|
+| 2026-04-20 | **Issue #418 - Inter-agent timeout ceiling fix**: Removed hardcoded 600s timeout assumption from the MCP parallel/task path so per-agent `execution_timeout_seconds` (TIMEOUT-001, default 900s, max 7200s) is honored end-to-end. `src/mcp-server/src/tools/chat.ts` — `chat_with_agent` Zod schema no longer applies `.default(600)` to `timeout_seconds`; when callers omit it, `undefined` now flows through to the backend, which resolves the target agent's configured timeout. `src/mcp-server/src/client.ts:563-565` — `client.task()` HTTP fetch ceiling changed from `(timeout_seconds \|\| 600) + 10` to `(timeout_seconds ?? 7200) + 60`, so the fetch client doesn't abort before a long-running agent-configured task finishes. Async mode still uses a fixed 30s HTTP ceiling (unchanged). |
 | 2026-04-17 | **Issue #361 - Max-turns error fix**: Fixed max_turns termination being misclassified as authentication failure. Added detection for `terminal_reason="max_turns"` and `subtype="error_max_turns"` in result messages (`claude_code.py:329-336`). Max-turns errors now return HTTP 422 with clear "Task exceeded turn limit" message instead of HTTP 503 "Authentication failure". Also raised `max_turns_task` default from 20 to 50 in both `claude_code.py:52` and `guardrails-baseline.json:65`. |
 | 2026-03-26 | **Line number refresh**: Updated all file/line references to match current codebase after upstream shifts (~92 lines in backend `chat.py`, model extraction in `models.py`, agent server reorganisation). |
 | 2026-03-11 | **Issue #81 - Default Model for Headless Tasks**: Fixed misleading "token expired" error when agent's `~/.claude/settings.json` contains a model incompatible with the assigned subscription. `execute_headless_task()` now defaults to `model="sonnet"` when model is None (`claude_code.py:768-770`). Added `_is_model_access_error()` helper (`claude_code.py:657-674`) to detect subscription/model access errors. Enhanced `_diagnose_exit_failure()` (`claude_code.py:685-700`) to provide actionable error messages when model access fails. Terminal WebSocket sessions always passed `model=sonnet` via URL param, but headless tasks didn't specify `--model` flag, causing Claude Code to use agent settings which might be incompatible. |
@@ -209,9 +210,10 @@ POST /api/task
 
 | File | Line | Purpose |
 |------|------|---------|
-| `src/client.ts` | 499-560 | task() method with async_mode option |
-| `src/tools/chat.ts` | 132-284 | chat_with_agent tool with parallel and async parameters |
-| `src/tools/chat.ts` | 187-195 | async parameter definition |
+| `src/client.ts` | 511-587 | `task()` method with async_mode option. HTTP fetch ceiling: `(timeout_seconds ?? 7200) + 60` for sync, 30s for async (Issue #418). |
+| `src/tools/chat.ts` | 132-211 | `chat_with_agent` tool with parallel and async parameters. `timeout_seconds` Zod schema has no default — undefined flows through to backend (Issue #418). |
+| `src/tools/chat.ts` | 180-187 | `timeout_seconds` parameter definition (agent-configured fallback). |
+| `src/tools/chat.ts` | 188-195 | `async` parameter definition. |
 
 ### Sync vs Async Code Paths (EXEC-024)
 
@@ -238,7 +240,9 @@ The router (`chat.py:652-917`) still handles: container validation, execution re
   "model": "sonnet|opus|haiku",  // Optional: Model override
   "allowed_tools": ["Read"],     // Optional: Tool restrictions
   "system_prompt": "string",     // Optional: Additional instructions
-  "timeout_seconds": 900,        // Optional: Timeout (default 15 min)
+  "timeout_seconds": 900,        // Optional: Timeout. If omitted, backend resolves the target
+                                 //   agent's configured execution_timeout_seconds (TIMEOUT-001,
+                                 //   default 900s / 15 min, max 7200s / 2h).
   "max_turns": 50,               // Optional: Max agentic turns (runaway prevention)
   "execution_id": "uuid"         // Optional: Database execution ID for process registry
 }
@@ -324,7 +328,7 @@ Retrieve the full execution log for any task execution.
 | model | string | null | Model override (parallel only) |
 | allowed_tools | string[] | null | Tool restrictions (parallel only) |
 | system_prompt | string | null | Additional instructions (parallel only) |
-| timeout_seconds | number | 300 | Timeout in seconds (parallel only) |
+| timeout_seconds | number | agent-configured (default 900s, max 7200s) | Execution timeout in seconds (parallel only). If omitted, backend resolves target agent's `execution_timeout_seconds` (TIMEOUT-001). Issue #418 removed the prior hardcoded 600s MCP ceiling. |
 | max_turns | number | null | Max agentic turns for runaway prevention (parallel only) |
 | async | boolean | false | Fire-and-forget mode - return immediately with execution_id (parallel only) |
 
@@ -652,17 +656,25 @@ if result.status == "failed":
         raise HTTPException(status_code=503, ...)
 ```
 
-**MCP Client** (`src/mcp-server/src/client.ts:499-560`):
+**MCP Client** (`src/mcp-server/src/client.ts:511-587`):
 ```typescript
 async task(name: string, message: string, options?: {
   // ... existing options ...
   async_mode?: boolean;  // If true, return immediately with execution_id
 }, sourceAgent?: string) {
-  // Async mode returns immediately; sync mode waits for full execution
-  const timeout = options?.async_mode ? 30 : (options?.timeout_seconds || 600) + 10;
+  // Async mode returns immediately; sync mode waits for full execution.
+  // Issue #418: When timeout_seconds is omitted, backend resolves the target
+  // agent's configured execution_timeout_seconds (TIMEOUT-001, max 7200s).
+  // The HTTP fetch ceiling must cover the platform's max per-agent timeout
+  // plus a buffer, so fetch doesn't abort before the backend finishes.
+  const timeout = options?.async_mode
+    ? 30
+    : (options?.timeout_seconds ?? 7200) + 60;
   // ...
 }
 ```
+
+Note: Previously this ceiling was `(timeout_seconds || 600) + 10`, which capped inter-agent task duration at ~10 minutes and ignored per-agent `execution_timeout_seconds` whenever the caller omitted the parameter. Issue #418 lifted the ceiling to cover the platform max (7200s / 2h) with a 60s buffer.
 
 **MCP Tool** (`src/mcp-server/src/tools/chat.ts:187-195`):
 ```typescript
@@ -796,7 +808,7 @@ for agent in get_all_agents():
 |--------|------------------------|-------------------------|
 | Return time | After task completes | Immediately |
 | Response | Full result with execution_log | execution_id only |
-| HTTP timeout | timeout_seconds + 10 | 30 seconds |
+| HTTP timeout (MCP client → backend) | `timeout_seconds + 60` when explicit; `7200 + 60` (2h + 60s buffer) fallback when omitted (Issue #418) | 30 seconds (unchanged) |
 | Result retrieval | In response | Poll endpoint |
 | Error handling | Exception in response | Poll for error status |
 | Connection held | Yes, for duration | No, released immediately |

--- a/src/backend/routers/fan_out.py
+++ b/src/backend/routers/fan_out.py
@@ -53,7 +53,10 @@ class FanOutRequest(BaseModel):
     """Request model for fan-out parallel task execution."""
     tasks: List[FanOutTask]
     agent: str = "self"
-    timeout_seconds: int = 600
+    # Optional overall fan-out deadline. When None, no outer deadline is
+    # applied — each sub-task is still bounded by the target agent's
+    # configured execution_timeout_seconds (TIMEOUT-001).
+    timeout_seconds: Optional[int] = None
     max_concurrency: int = 3
     policy: str = "best-effort"
     model: Optional[str] = None
@@ -83,7 +86,9 @@ class FanOutRequest(BaseModel):
 
     @field_validator("timeout_seconds")
     @classmethod
-    def validate_timeout(cls, v: int) -> int:
+    def validate_timeout(cls, v: Optional[int]) -> Optional[int]:
+        if v is None:
+            return v
         if v < 10 or v > 3600:
             raise ValueError("timeout_seconds must be between 10 and 3600")
         return v

--- a/src/backend/services/fan_out_service.py
+++ b/src/backend/services/fan_out_service.py
@@ -72,7 +72,7 @@ class FanOutService:
         agent_name: str,
         tasks: List[FanOutTaskInput],
         max_concurrency: int = 3,
-        timeout_seconds: int = 600,
+        timeout_seconds: Optional[int] = None,
         model: Optional[str] = None,
         system_prompt: Optional[str] = None,
         allowed_tools: Optional[list] = None,
@@ -90,7 +90,10 @@ class FanOutService:
             agent_name: Target agent (typically self).
             tasks: List of tasks to execute.
             max_concurrency: Max concurrent subtasks (semaphore size).
-            timeout_seconds: Overall deadline for the entire fan-out.
+            timeout_seconds: Optional overall deadline for the entire fan-out.
+                When None, no outer deadline is applied — each sub-task is
+                still bounded by the target agent's configured
+                execution_timeout_seconds (TIMEOUT-001).
             model: Model override for subtasks.
             system_prompt: System prompt for subtasks.
             allowed_tools: Tool restrictions for subtasks.
@@ -105,9 +108,10 @@ class FanOutService:
         # Safe for concurrent writes: asyncio is single-threaded, no preemption between awaits.
         results: dict[str, FanOutTaskResult] = {}
 
+        deadline_desc = f"{timeout_seconds}s" if timeout_seconds is not None else "per-agent"
         logger.info(
             f"[FanOut] Starting {fan_out_id}: {len(tasks)} tasks on '{agent_name}' "
-            f"(concurrency={max_concurrency}, timeout={timeout_seconds}s)"
+            f"(concurrency={max_concurrency}, deadline={deadline_desc})"
         )
 
         async def run_subtask(task: FanOutTaskInput) -> None:
@@ -115,6 +119,11 @@ class FanOutService:
             start = datetime.utcnow()
             async with semaphore:
                 try:
+                    # Per-subtask timeout: pass None so TaskExecutionService
+                    # resolves the target agent's configured
+                    # execution_timeout_seconds (TIMEOUT-001). The optional
+                    # overall `timeout_seconds` parameter governs the outer
+                    # fan-out deadline, not the individual task ceiling.
                     result = await task_service.execute_task(
                         agent_name=agent_name,
                         message=task.message,
@@ -125,7 +134,7 @@ class FanOutService:
                         source_mcp_key_id=source_mcp_key_id,
                         source_mcp_key_name=source_mcp_key_name,
                         model=model,
-                        timeout_seconds=timeout_seconds,
+                        timeout_seconds=None,
                         system_prompt=system_prompt,
                         allowed_tools=allowed_tools,
                         fan_out_id=fan_out_id,
@@ -170,14 +179,20 @@ class FanOutService:
                         duration_ms=elapsed_ms,
                     )
 
-        # Dispatch all tasks with overall deadline.
-        # return_exceptions=True ensures all coroutines complete even if one raises
-        # an unexpected error — individual failures are handled inside run_subtask.
+        # Dispatch all tasks. When an overall deadline is set, wrap in
+        # asyncio.timeout so slow subtasks get cancelled once the deadline
+        # hits. Without a deadline, each subtask is still individually
+        # bounded by the target agent's execution_timeout_seconds.
+        # return_exceptions=True ensures all coroutines complete even if one
+        # raises — individual failures are handled inside run_subtask.
         deadline_exceeded = False
         coroutines = [run_subtask(t) for t in tasks]
 
         try:
-            async with asyncio.timeout(timeout_seconds):
+            if timeout_seconds is not None:
+                async with asyncio.timeout(timeout_seconds):
+                    await asyncio.gather(*coroutines, return_exceptions=True)
+            else:
                 await asyncio.gather(*coroutines, return_exceptions=True)
         except TimeoutError:
             deadline_exceeded = True

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -556,8 +556,13 @@ export class TrinityClient {
       chat_session_id: options?.chat_session_id,
     };
 
-    // Async mode returns immediately; sync mode waits for full execution
-    const timeout = options?.async_mode ? 30 : (options?.timeout_seconds || 600) + 10;
+    // Async mode returns immediately; sync mode waits for full execution.
+    // When timeout_seconds is omitted, backend resolves the target agent's
+    // configured execution_timeout_seconds (max 7200s). Use platform max + buffer
+    // as the HTTP client ceiling so we don't abort before the backend does.
+    const timeout = options?.async_mode
+      ? 30
+      : (options?.timeout_seconds ?? 7200) + 60;
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout * 1000);
@@ -661,19 +666,24 @@ export class TrinityClient {
       headers["X-MCP-Key-Name"] = mcpKeyInfo.keyName;
     }
 
-    const body = {
+    // Only include timeout_seconds if caller provided it, so the backend can
+    // fall back to the target agent's configured execution_timeout_seconds.
+    const body: Record<string, unknown> = {
       tasks,
       agent: options?.agent || "self",
-      timeout_seconds: options?.timeout_seconds || 600,
       max_concurrency: options?.max_concurrency || 3,
       policy: options?.policy || "best-effort",
       model: options?.model,
       system_prompt: options?.system_prompt,
       allowed_tools: options?.allowed_tools,
     };
+    if (options?.timeout_seconds !== undefined) {
+      body.timeout_seconds = options.timeout_seconds;
+    }
 
-    // Overall timeout: the fan-out timeout + buffer for HTTP overhead
-    const timeout = (options?.timeout_seconds || 600) + 30;
+    // HTTP ceiling: when no explicit fan-out timeout, cover the platform max
+    // per-agent timeout (7200s) + buffer so we don't abort before the backend.
+    const timeout = (options?.timeout_seconds ?? 7200) + 60;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout * 1000);
 

--- a/src/mcp-server/src/tools/chat.ts
+++ b/src/mcp-server/src/tools/chat.ts
@@ -180,9 +180,10 @@ export function createChatTools(client: TrinityClient, requireApiKey: boolean) {
         timeout_seconds: z
           .number()
           .optional()
-          .default(600)
           .describe(
-            "Execution timeout in seconds (default: 600). Only applies when parallel=true."
+            "Execution timeout in seconds. If omitted, uses the target agent's " +
+            "configured execution_timeout_seconds (default 900s, max 7200s). " +
+            "Only applies when parallel=true."
           ),
         async: z
           .boolean()
@@ -408,8 +409,11 @@ export function createChatTools(client: TrinityClient, requireApiKey: boolean) {
         timeout_seconds: z
           .number()
           .optional()
-          .default(600)
-          .describe("Overall deadline in seconds for the entire fan-out (default: 600, max: 3600)"),
+          .describe(
+            "Overall deadline in seconds for the entire fan-out (max: 3600). " +
+            "If omitted, no outer deadline is applied — each sub-task is still " +
+            "bounded by the target agent's configured execution_timeout_seconds."
+          ),
         max_concurrency: z
           .number()
           .optional()

--- a/tests/test_inter_agent_timeout_unit.py
+++ b/tests/test_inter_agent_timeout_unit.py
@@ -1,0 +1,258 @@
+"""
+Inter-agent timeout unit tests (test_inter_agent_timeout_unit.py)
+
+Issue #418. Verifies that the inter-agent execution path honours the target
+agent's configured `execution_timeout_seconds` (TIMEOUT-001) instead of a
+hardcoded 600s ceiling. Covers:
+
+- FanOutRequest model accepts omitted / None `timeout_seconds` and validates it.
+- FanOutService dispatches each sub-task with `timeout_seconds=None` so the
+  TaskExecutionService resolves the per-agent config, regardless of whether
+  an outer fan-out deadline is set.
+- When no outer deadline is set, the asyncio.timeout() wrap is skipped.
+- When an outer deadline is set, the wrap is applied but sub-tasks still
+  receive `timeout_seconds=None`.
+
+Runs as a pure unit test — no backend container required.
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Add backend to path so relative imports inside the target modules resolve.
+_backend_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "backend")
+)
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+
+# Stub database and utils so fan_out_service can be imported without a
+# running backend.
+_fake_db = MagicMock()
+sys.modules.setdefault("database", types.SimpleNamespace(db=_fake_db))
+
+if "utils.helpers" not in sys.modules:
+    _helpers = types.ModuleType("utils.helpers")
+    _helpers.utc_now = lambda: datetime.utcnow()
+    _helpers.utc_now_iso = lambda: datetime.utcnow().isoformat() + "Z"
+    _helpers.to_utc_iso = lambda v: str(v)
+    _helpers.parse_iso_timestamp = lambda s: datetime.fromisoformat(s.rstrip("Z"))
+    sys.modules["utils.helpers"] = _helpers
+
+
+# Load fan_out_service directly by file path to bypass services/__init__.py
+# which imports unrelated modules that need a full backend env.
+if "services" not in sys.modules:
+    sys.modules["services"] = types.ModuleType("services")
+
+# Stub task_execution_service before fan_out_service imports it.
+_fake_tes = types.ModuleType("services.task_execution_service")
+_fake_tes.get_task_execution_service = MagicMock()
+_fake_tes.TaskExecutionResult = MagicMock  # sentinel, only name is used by type hint
+_fake_tes.TaskExecutionErrorCode = MagicMock  # ditto
+sys.modules["services.task_execution_service"] = _fake_tes
+
+_fos_path = os.path.join(_backend_path, "services", "fan_out_service.py")
+_spec = importlib.util.spec_from_file_location(
+    "services.fan_out_service", _fos_path
+)
+fos = importlib.util.module_from_spec(_spec)
+sys.modules["services.fan_out_service"] = fos
+_spec.loader.exec_module(fos)  # type: ignore[union-attr]
+
+FanOutService = fos.FanOutService
+FanOutTaskInput = fos.FanOutTaskInput
+
+
+# Load the FanOutRequest pydantic model. Needs `dependencies` and `models`
+# stubbed because routers/fan_out.py imports them at module load.
+_fake_deps = types.ModuleType("dependencies")
+_fake_deps.get_authorized_agent = lambda: None
+_fake_deps.get_current_user = lambda: None
+sys.modules.setdefault("dependencies", _fake_deps)
+
+_fake_models = types.ModuleType("models")
+_fake_models.User = MagicMock  # only referenced as a type hint
+sys.modules.setdefault("models", _fake_models)
+
+_fo_router_path = os.path.join(_backend_path, "routers", "fan_out.py")
+if "routers" not in sys.modules:
+    sys.modules["routers"] = types.ModuleType("routers")
+_spec2 = importlib.util.spec_from_file_location(
+    "routers.fan_out", _fo_router_path
+)
+fo_router = importlib.util.module_from_spec(_spec2)
+sys.modules["routers.fan_out"] = fo_router
+_spec2.loader.exec_module(fo_router)  # type: ignore[union-attr]
+
+FanOutRequest = fo_router.FanOutRequest
+
+
+# Override the backend-requiring autouse fixtures from the package conftest.
+@pytest.fixture(scope="session")
+def api_client():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+
+
+# ---------------------------------------------------------------------------
+# FanOutRequest model
+# ---------------------------------------------------------------------------
+
+
+def test_fan_out_request_allows_omitted_timeout():
+    """Issue #418: timeout_seconds is optional and defaults to None."""
+    req = FanOutRequest(tasks=[{"id": "t1", "message": "hi"}])
+    assert req.timeout_seconds is None
+
+
+def test_fan_out_request_accepts_explicit_timeout():
+    req = FanOutRequest(
+        tasks=[{"id": "t1", "message": "hi"}],
+        timeout_seconds=300,
+    )
+    assert req.timeout_seconds == 300
+
+
+def test_fan_out_request_rejects_out_of_range_timeout():
+    with pytest.raises(Exception):
+        FanOutRequest(
+            tasks=[{"id": "t1", "message": "hi"}],
+            timeout_seconds=5,
+        )
+    with pytest.raises(Exception):
+        FanOutRequest(
+            tasks=[{"id": "t1", "message": "hi"}],
+            timeout_seconds=10_000,
+        )
+
+
+def test_fan_out_request_accepts_none_explicitly():
+    """Explicit None round-trips — no validator error."""
+    req = FanOutRequest(
+        tasks=[{"id": "t1", "message": "hi"}],
+        timeout_seconds=None,
+    )
+    assert req.timeout_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# FanOutService — per-subtask timeout forwarding
+# ---------------------------------------------------------------------------
+
+
+def _make_success_result():
+    """Build a minimal TaskExecutionResult-shaped object."""
+    r = MagicMock()
+    r.status = "success"
+    r.response = "ok"
+    r.execution_id = "exec_1"
+    r.cost = None
+    r.context_used = None
+    r.error = None
+    r.error_code = None
+    return r
+
+
+def _install_mock_task_service(call_log: list):
+    """Install a mock task execution service that records each call."""
+    async def _execute_task(**kwargs):
+        call_log.append(kwargs)
+        return _make_success_result()
+
+    svc = MagicMock()
+    svc.execute_task = AsyncMock(side_effect=_execute_task)
+    fos.get_task_execution_service = lambda: svc
+    return svc
+
+
+def test_fan_out_service_forwards_none_per_subtask_without_outer_deadline():
+    """Issue #418: each sub-task is dispatched with timeout_seconds=None so
+    TaskExecutionService resolves the agent's configured timeout."""
+    calls: list = []
+    _install_mock_task_service(calls)
+
+    service = FanOutService()
+    tasks = [FanOutTaskInput(id=f"t{i}", message=f"task {i}") for i in range(3)]
+
+    result = asyncio.run(
+        service.execute(
+            agent_name="delegate-1",
+            tasks=tasks,
+            max_concurrency=3,
+            timeout_seconds=None,
+        )
+    )
+
+    assert result.total == 3
+    assert result.completed == 3
+    assert len(calls) == 3
+    for call in calls:
+        assert call["timeout_seconds"] is None, (
+            "Per-subtask timeout must be None so the agent's configured "
+            "execution_timeout_seconds is used (TIMEOUT-001)"
+        )
+        assert call["agent_name"] == "delegate-1"
+
+
+def test_fan_out_service_forwards_none_per_subtask_with_outer_deadline():
+    """Outer fan-out deadline wraps the gather, but each sub-task is still
+    dispatched with timeout_seconds=None (per-agent config applies)."""
+    calls: list = []
+    _install_mock_task_service(calls)
+
+    service = FanOutService()
+    tasks = [FanOutTaskInput(id="t1", message="one")]
+
+    result = asyncio.run(
+        service.execute(
+            agent_name="delegate-2",
+            tasks=tasks,
+            max_concurrency=1,
+            timeout_seconds=300,
+        )
+    )
+
+    assert result.total == 1
+    assert result.completed == 1
+    assert len(calls) == 1
+    assert calls[0]["timeout_seconds"] is None
+
+
+def test_fan_out_service_outer_deadline_actually_applies():
+    """Pre-existing behaviour: when outer deadline is set and subtasks
+    exceed it, remaining tasks are marked deadline-exceeded."""
+    async def _slow_task(**kwargs):
+        await asyncio.sleep(5)
+        return _make_success_result()
+
+    svc = MagicMock()
+    svc.execute_task = AsyncMock(side_effect=_slow_task)
+    fos.get_task_execution_service = lambda: svc
+
+    service = FanOutService()
+    tasks = [FanOutTaskInput(id="t1", message="slow")]
+
+    result = asyncio.run(
+        service.execute(
+            agent_name="delegate-3",
+            tasks=tasks,
+            max_concurrency=1,
+            timeout_seconds=1,
+        )
+    )
+
+    assert result.status == "deadline_exceeded"
+    assert result.results[0].error_code == "timeout"


### PR DESCRIPTION
## Summary

Closes #418.

Inter-agent task invocations (MCP `chat_with_agent` with `parallel=true`, `fan_out`, and scheduled fan-out calls) were being killed at ~610s regardless of the target agent's configured `execution_timeout_seconds` (default 900s, max 7200s). Root cause was **upstream** of `TaskExecutionService` — three layers of hardcoded 600s defaults prevented `None` from reaching the service's per-agent resolution (TIMEOUT-001).

The reporter's 80-minute incident (~120 failed sub-executions across 7 delegate agents on one parent schedule) is explained by the Zod `.default(600)` on the MCP tool schema filling in 600 before the backend could fall back to the per-agent config.

## Changes

**MCP server (TypeScript):**
- `src/mcp-server/src/tools/chat.ts` — dropped `.default(600)` from `timeout_seconds` on both `chat_with_agent` and `fan_out` tools. Descriptions updated to document the per-agent fallback.
- `src/mcp-server/src/client.ts` — when caller omits `timeout_seconds`, `client.task()` and `client.fanOut()` now omit it from the request body (conditional spread) and use `(timeout_seconds ?? 7200) + 60` as the HTTP ceiling so `fetch()` doesn't abort before the backend.

**Backend (Python):**
- `src/backend/routers/fan_out.py` — `FanOutRequest.timeout_seconds` is now `Optional[int] = None`; validator short-circuits on `None`.
- `src/backend/services/fan_out_service.py` — separates outer fan-out deadline from per-subtask timeout. Each sub-task dispatches with `timeout_seconds=None` so `TaskExecutionService` resolves per-agent config. `asyncio.timeout()` only wraps the gather when an outer deadline is set.

**Tests & docs:**
- New `tests/test_inter_agent_timeout_unit.py` — 7 unit tests covering `FanOutRequest` validation (Optional, None, out-of-range) and `FanOutService` per-subtask `None` dispatch (with and without outer deadline). Runs without a backend.
- Synced `docs/memory/feature-flows/fan-out.md`, `mcp-orchestration.md`, `parallel-headless-execution.md` and added #418 entry to the feature-flows index.

## Backwards compatibility

- Callers that pass an explicit `timeout_seconds` see no behavior change.
- Older MCP clients (pre-fix) still include `timeout_seconds=600` in their request body — backend honors the explicit value as before.
- Per-agent `execution_timeout_seconds` configuration surface (TIMEOUT-001) unchanged.

## Test Plan
- [x] `pytest tests/test_inter_agent_timeout_unit.py -v` — 7 passed in 1.14s
- [x] `npx tsc --noEmit` clean in `src/mcp-server/`
- [ ] Manual verification on a long-running inter-agent task (>10 min) once deployed: agent-B's `execution_timeout_seconds=1800` is now respected when agent-A invokes via `chat_with_agent(parallel=true)` without explicit `timeout_seconds`.

Generated with [Claude Code](https://claude.com/claude-code)