### PR TITLE
fix(scheduler): break updated_at feedback loop in sync (#420)

### DIFF
--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -461,19 +461,26 @@ class ScheduleOperations:
             return cursor.rowcount > 0
 
     def update_schedule_run_times(self, schedule_id: str, last_run_at: datetime = None, next_run_at: datetime = None) -> bool:
-        """Update schedule run timestamps."""
+        """Update schedule run timestamps.
+
+        #420: Bookkeeping-only update — must not bump `updated_at`, which the
+        scheduler's sync loop uses as a config-change signal.
+        """
+        updates: list[str] = []
+        params: list = []
+
+        if last_run_at:
+            updates.append("last_run_at = ?")
+            params.append(last_run_at.isoformat())
+        if next_run_at:
+            updates.append("next_run_at = ?")
+            params.append(next_run_at.isoformat())
+
+        if not updates:
+            return False
+
         with get_db_connection() as conn:
             cursor = conn.cursor()
-            updates = ["updated_at = ?"]
-            params = [utc_now_iso()]
-
-            if last_run_at:
-                updates.append("last_run_at = ?")
-                params.append(last_run_at.isoformat())
-            if next_run_at:
-                updates.append("next_run_at = ?")
-                params.append(next_run_at.isoformat())
-
             params.append(schedule_id)
             cursor.execute(f"""
                 UPDATE agent_schedules SET {", ".join(updates)} WHERE id = ?

--- a/src/scheduler/database.py
+++ b/src/scheduler/database.py
@@ -187,19 +187,29 @@ class SchedulerDatabase:
         last_run_at: datetime = None,
         next_run_at: datetime = None
     ) -> bool:
-        """Update schedule run timestamps."""
+        """Update schedule run timestamps.
+
+        #420: Do NOT touch `updated_at` here. This method persists bookkeeping
+        (last/next run) not config changes, and `_sync_agent_schedules` uses
+        `updated_at` as its change-detection signal. Bumping it here created a
+        feedback loop: _add_job → update_schedule_run_times → updated_at
+        bumped → next sync tick thinks config changed → _add_job again → ...
+        """
+        updates: list[str] = []
+        params: list = []
+
+        if last_run_at:
+            updates.append("last_run_at = ?")
+            params.append(last_run_at.isoformat())
+        if next_run_at:
+            updates.append("next_run_at = ?")
+            params.append(next_run_at.isoformat())
+
+        if not updates:
+            return False
+
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            updates = ["updated_at = ?"]
-            params = [datetime.utcnow().isoformat()]
-
-            if last_run_at:
-                updates.append("last_run_at = ?")
-                params.append(last_run_at.isoformat())
-            if next_run_at:
-                updates.append("next_run_at = ?")
-                params.append(next_run_at.isoformat())
-
             params.append(schedule_id)
             cursor.execute(f"""
                 UPDATE agent_schedules SET {", ".join(updates)} WHERE id = ?

--- a/tests/unit/test_scheduler_sync_loop.py
+++ b/tests/unit/test_scheduler_sync_loop.py
@@ -1,0 +1,171 @@
+"""
+Regression test for #420 — scheduler sync feedback loop.
+
+Pre-fix: `update_schedule_run_times` unconditionally bumped `updated_at`,
+which `_sync_agent_schedules` then detected as a config change, triggering
+`_add_job` which called `update_schedule_run_times`, looping forever at the
+sync-interval cadence (default 60s).
+
+Post-fix: `update_schedule_run_times` is bookkeeping-only. It must not touch
+`updated_at` — that column is the sync loop's config-change signal.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+
+
+def _load_scheduler_db_module():
+    """Direct-load scheduler/database.py — runs without backend deps."""
+    candidates = [
+        os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "scheduler")),
+        "/app/scheduler",
+    ]
+    sched_dir = next(
+        (p for p in candidates if os.path.isfile(os.path.join(p, "database.py"))), None
+    )
+    assert sched_dir, "Could not locate src/scheduler/database.py"
+
+    # Scheduler package has relative imports, so we need it on sys.path.
+    parent = os.path.dirname(sched_dir)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+
+    spec = importlib.util.spec_from_file_location(
+        "scheduler.database", os.path.join(sched_dir, "database.py"),
+        submodule_search_locations=[sched_dir],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Register the parent package first so relative imports resolve.
+    sys.modules.setdefault("scheduler", sys.modules.get("scheduler") or importlib.util.module_from_spec(
+        importlib.util.spec_from_file_location("scheduler", os.path.join(sched_dir, "__init__.py"))
+    ))
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        # Fallback: manually register module then execute
+        sys.modules["scheduler.database"] = mod
+        spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def scheduler_db(monkeypatch):
+    """Isolated SchedulerDatabase bound to a temp SQLite file."""
+    db_module = _load_scheduler_db_module()
+
+    db_file = tempfile.NamedTemporaryFile(suffix="_sched_test.db", delete=False)
+    db_file.close()
+    db_path = db_file.name
+
+    # Build minimal schema the scheduler expects.
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE agent_schedules (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            name TEXT NOT NULL,
+            cron_expression TEXT NOT NULL,
+            message TEXT NOT NULL,
+            enabled INTEGER DEFAULT 1,
+            timezone TEXT DEFAULT 'UTC',
+            description TEXT,
+            owner_id INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_run_at TEXT,
+            next_run_at TEXT,
+            model TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    # SchedulerDatabase accepts an explicit path, bypassing `config.database_path`.
+    db = db_module.SchedulerDatabase(database_path=db_path)
+
+    # Seed one schedule with a known updated_at.
+    baseline = datetime(2026, 1, 1, 12, 0, 0)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO agent_schedules
+            (id, agent_name, name, cron_expression, message, enabled, timezone,
+             owner_id, created_at, updated_at, last_run_at, next_run_at)
+        VALUES (?, ?, ?, ?, ?, 1, 'UTC', 1, ?, ?, NULL, NULL)
+        """,
+        ("sched-1", "agent-a", "Hourly", "0 * * * *", "ping",
+         baseline.isoformat(), baseline.isoformat()),
+    )
+    conn.commit()
+    conn.close()
+
+    yield db, db_path, baseline
+    os.unlink(db_path)
+
+
+def _get_updated_at(db_path: str, schedule_id: str) -> str:
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT updated_at FROM agent_schedules WHERE id = ?", (schedule_id,)
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    return row[0]
+
+
+def test_update_run_times_does_not_bump_updated_at(scheduler_db):
+    """#420 regression: run-time updates are bookkeeping; updated_at must stay."""
+    db, db_path, baseline = scheduler_db
+
+    next_run = baseline + timedelta(hours=1)
+    ok = db.update_schedule_run_times("sched-1", next_run_at=next_run)
+    assert ok is True
+
+    assert _get_updated_at(db_path, "sched-1") == baseline.isoformat(), (
+        "update_schedule_run_times must not modify updated_at — sync loop would "
+        "misread that as a config change and re-add the job every tick (#420)"
+    )
+
+
+def test_update_run_times_persists_next_run_at(scheduler_db):
+    """Sanity: the call still does its job for next_run_at."""
+    db, db_path, _ = scheduler_db
+    next_run = datetime(2026, 6, 1, 12, 0, 0)
+    db.update_schedule_run_times("sched-1", next_run_at=next_run)
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT next_run_at FROM agent_schedules WHERE id = ?", ("sched-1",)
+    ).fetchone()
+    conn.close()
+    assert row[0] == next_run.isoformat()
+
+
+def test_update_run_times_persists_last_run_at(scheduler_db):
+    """Sanity: the call still does its job for last_run_at."""
+    db, db_path, _ = scheduler_db
+    last_run = datetime(2026, 6, 1, 11, 0, 0)
+    db.update_schedule_run_times("sched-1", last_run_at=last_run)
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT last_run_at FROM agent_schedules WHERE id = ?", ("sched-1",)
+    ).fetchone()
+    conn.close()
+    assert row[0] == last_run.isoformat()
+
+
+def test_update_run_times_noop_when_both_args_none(scheduler_db):
+    """Defensive: calling with no args is a no-op, not a bare `UPDATE SET ,`."""
+    db, db_path, baseline = scheduler_db
+    result = db.update_schedule_run_times("sched-1")
+    assert result is False
+    assert _get_updated_at(db_path, "sched-1") == baseline.isoformat()


### PR DESCRIPTION
## Summary

Closes #420.

The scheduler re-registered every enabled schedule once per sync tick (60s), logging ~2 lines per schedule per minute. With 13 schedules in the field that was ~780 INFO lines/hour → ~120 MB/day of log noise, wasted CPU, and a latent hazard: any real scheduler bug gets buried under the flood.

## Root cause

Infinite feedback loop between `update_schedule_run_times` and `_sync_agent_schedules`:

1. **Sync tick** (every 60s) compares DB \`updated_at\` against in-memory \`_schedule_snapshot\` to detect config changes.
2. When \`_add_job\` runs (either on startup or on a detected change) it calls \`db.update_schedule_run_times(schedule.id, next_run_at=...)\` at \`service.py:374\` to persist the computed next-run.
3. \`update_schedule_run_times\` in \`database.py:193\` unconditionally bumped \`updated_at = now\` as part of a generic UPDATE-builder pattern.
4. Next sync tick sees \`DB.updated_at\` ≠ \`snapshot.updated_at\` → thinks config changed → calls \`_add_job\` again → bumps \`updated_at\` again → loop forever.

## Fix

\`update_schedule_run_times\` is now strictly bookkeeping: it updates \`last_run_at\` / \`next_run_at\` as requested and never touches \`updated_at\`. Legitimate config edits (cron, message, timezone, enabled) go through other methods (\`update_schedule\`, \`set_schedule_enabled\`) that correctly bump \`updated_at\` — sync's change detection still catches those.

Secondary: if called with both args \`None\`, the method now no-ops instead of emitting an invalid \`UPDATE SET , WHERE\`.

Applied to:
- \`src/scheduler/database.py\` (the actual running copy in trinity-scheduler)
- \`src/backend/db/schedules.py\` (dead-code backend copy — same bug, fixed for consistency)

## Test plan

- [x] **Unit** (\`tests/unit/test_scheduler_sync_loop.py\`): 4 tests — regression guard on \`updated_at\`, \`next_run_at\` persistence, \`last_run_at\` persistence, no-arg no-op. All pass.
- [x] **Live**: restarted \`trinity-scheduler\` with the fix, observed 3 sync cycles (~3 min).
  - Pre-fix: 58 \"Added schedule job\" lines in 30 min (1 schedule).
  - Post-fix: 1 startup Add, silent for 3 sync cycles.
  - \`updated_at\` frozen at \`2026-04-20T10:33:30\` through all 3 ticks.
  - \`next_run_at\` correctly updated to \`2026-04-20T10:39:00\` — bookkeeping still works.

## Out of scope

- The scheduler Docker image is baked — production deploy still needs a rebuild to pick up the fix. \`docker compose build trinity-scheduler && docker compose up -d trinity-scheduler\`.
- The snapshot-initialization race on startup (snapshot stores old \`updated_at\`, DB has new post-\`_add_job\`) is resolved by this fix since the DB value no longer diverges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)