### PR TITLE
chore(claude-config): fix frontmatter, stale Process Engine + Auth0 refs

### DIFF
--- a/.claude/agents/agent-template-validator.md
+++ b/.claude/agents/agent-template-validator.md
@@ -1,3 +1,10 @@
+---
+name: agent-template-validator
+description: Validates agent template structure and configuration. Invoke when creating, updating, or debugging an agent template, or before publishing a template to GitHub.
+tools: Read, Glob, Bash
+model: inherit
+---
+
 # Agent Template Validator
 
 Validates agent template structure and configuration.
@@ -8,10 +15,6 @@ Validates agent template structure and configuration.
 - Updating existing template
 - Debugging template deployment issues
 - Before publishing template to GitHub
-
-## Tools
-
-Read, Glob, Bash
 
 ## Required Files Check
 

--- a/.claude/agents/security-analyzer.md
+++ b/.claude/agents/security-analyzer.md
@@ -1,3 +1,10 @@
+---
+name: security-analyzer
+description: Analyzes code for security vulnerabilities using OWASP Top 10. Invoke before production deployment, after authentication/authorization changes, after adding new API endpoints, or when handling credentials.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
 # Security Analyzer
 
 Analyzes code for security vulnerabilities based on OWASP Top 10.
@@ -9,10 +16,6 @@ Analyzes code for security vulnerabilities based on OWASP Top 10.
 - After adding authentication/authorization changes
 - After adding new API endpoints
 - When handling credentials or secrets
-
-## Tools
-
-Read, Grep, Glob, Bash
 
 ## OWASP Top 10 Checklist
 
@@ -109,7 +112,7 @@ grep -r "logger.*password\|print.*secret\|console.log.*token" src/
 1. **Read architecture.md** to understand the stack and security boundaries
 
 2. **Identify security boundaries:**
-   - Auth0 authentication (external)
+   - Email-code + admin-password authentication (see `auth.py`)
    - Backend JWT verification
    - Container isolation
    - Redis credential storage

--- a/.claude/skills/capture-screenshots/SKILL.md
+++ b/.claude/skills/capture-screenshots/SKILL.md
@@ -180,40 +180,7 @@ Pick the first available agent (e.g., `acme-scout`).
 2. Wait for template list to load
 3. Take screenshot: `docs/screenshots/18-templates.png`
 
-### Step 19: Processes List
-
-1. Navigate to `http://localhost/processes`
-2. Wait for processes to load
-3. Take screenshot: `docs/screenshots/19-processes-list.png`
-
-### Step 20: Process Editor
-
-1. Click on an existing process (e.g., the first one) to open it
-2. Wait for the process editor/viewer to render
-3. Take screenshot: `docs/screenshots/20-process-editor.png`
-4. Navigate back to processes list
-
-### Step 21: Process Wizard
-
-1. Navigate to `http://localhost/processes/wizard`
-2. Take screenshot: `docs/screenshots/21-process-wizard.png`
-
-### Step 22: Process Dashboard
-
-1. Navigate to `http://localhost/process-dashboard`
-2. Take screenshot: `docs/screenshots/22-process-dashboard.png`
-
-### Step 23: Executions
-
-1. Navigate to `http://localhost/executions`
-2. Take screenshot: `docs/screenshots/23-executions.png`
-
-### Step 24: Approvals
-
-1. Navigate to `http://localhost/approvals`
-2. Take screenshot: `docs/screenshots/24-approvals.png`
-
-### Step 25: Operating Room
+### Step 19: Operating Room
 
 1. Navigate to `http://localhost/operating-room`
 2. Take screenshot of default tab (Needs Response): `docs/screenshots/25-operating-room.png`
@@ -222,18 +189,18 @@ Pick the first available agent (e.g., `acme-scout`).
 5. Click "Cost Alerts" tab
 6. Take screenshot: `docs/screenshots/27-operating-room-cost-alerts.png`
 
-### Step 26: Health Monitoring
+### Step 20: Health Monitoring
 
 1. Navigate to `http://localhost/monitoring`
 2. Wait for health data to load
 3. Take screenshot: `docs/screenshots/28-monitoring.png`
 
-### Step 27: API Keys
+### Step 21: API Keys
 
 1. Navigate to `http://localhost/api-keys`
 2. Take screenshot: `docs/screenshots/29-api-keys.png`
 
-### Step 28: Settings
+### Step 22: Settings
 
 1. Navigate to `http://localhost/settings`
 2. Take screenshot of default view: `docs/screenshots/30-settings.png`
@@ -241,19 +208,14 @@ Pick the first available agent (e.g., `acme-scout`).
    - `docs/screenshots/31-settings-ssh.png`
    - `docs/screenshots/32-settings-skills.png`
 
-### Step 29: Process Documentation
-
-1. Navigate to `http://localhost/processes/docs`
-2. Take screenshot: `docs/screenshots/33-process-docs.png`
-
-### Step 30: Create Agent Dialog
+### Step 23: Create Agent Dialog
 
 1. Navigate to `http://localhost/agents`
 2. Click "Create Agent" button
 3. Take screenshot of the creation dialog/form: `docs/screenshots/34-create-agent.png`
 4. Close/cancel the dialog
 
-### Step 31: Summary
+### Step 24: Summary
 
 After all screenshots are captured, list them:
 
@@ -287,15 +249,10 @@ Always use lowercase, hyphens for spaces. The numeric prefix ensures consistent 
 - [ ] Agents list captured
 - [ ] All agent detail tabs captured (Tasks through Info)
 - [ ] Templates page captured
-- [ ] Processes list + editor + wizard captured
-- [ ] Process dashboard captured
-- [ ] Executions captured
-- [ ] Approvals captured
 - [ ] Operating Room (all tabs) captured
 - [ ] Monitoring captured
 - [ ] API Keys captured
 - [ ] Settings captured
-- [ ] Process docs captured
 - [ ] Create Agent dialog captured
 - [ ] Summary printed
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -61,7 +61,7 @@ git commit -m "$(cat <<'EOF'
 
 Closes #N
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude <noreply@anthropic.com>
 EOF
 )"
 ```

--- a/.claude/skills/create-demo-agent-fleet/SKILL.md
+++ b/.claude/skills/create-demo-agent-fleet/SKILL.md
@@ -11,6 +11,8 @@ automation: gated
 
 Create and configure a demo agent fleet to showcase Trinity's capabilities.
 
+> **Note**: Process Engine is dormant (see `docs/memory/architecture.md` — "OUT OF SCOPE"). The Acme Consulting option's business-process steps (create/publish/execute processes, `/api/processes*` endpoints, `/processes` UI) are non-functional. Agent deployment, shared folders, schedules, and agent-to-agent collaboration still work.
+
 ## State Dependencies
 
 | Source | Location | Read | Write | Description |
@@ -36,7 +38,6 @@ Create and configure a demo agent fleet to showcase Trinity's capabilities.
 A business-focused 3-agent consulting team demonstrating:
 - Agent-to-agent collaboration via MCP
 - File-based collaboration via shared folders
-- Business process orchestration (Process Engine)
 - Scheduled automation
 
 | Agent | Template | Role |

--- a/.claude/skills/generate-user-docs/SKILL.md
+++ b/.claude/skills/generate-user-docs/SKILL.md
@@ -105,7 +105,6 @@ docs/user-docs/
 │   ├── voice-chat.md                 # Voice via Gemini Live API
 │   ├── image-generation.md           # Platform image generation
 │   ├── agent-avatars.md              # AI-generated avatars
-│   ├── process-engine.md             # BPMN workflows, process templates
 │   └── dynamic-dashboards.md         # Custom agent dashboards
 └── api-reference/
     ├── authentication.md             # JWT tokens, API keys, auth flow

--- a/.claude/skills/process-miner/SKILL.md
+++ b/.claude/skills/process-miner/SKILL.md
@@ -13,6 +13,8 @@ automation: manual
 
 # Process Miner Skill
 
+> **Note**: This skill emits Trinity Process YAML definitions. The Process Engine that consumes them is dormant (see `docs/memory/architecture.md` — "OUT OF SCOPE"). The mining/analysis outputs are still useful as standalone reports; the YAML definitions won't run until the Process Engine is reactivated.
+
 You are a Process Mining specialist. Your job is to analyze Claude Code execution logs (JSONL transcripts) and discover **HIGH-LEVEL SEMANTIC PATTERNS** — not just tool sequences, but the actual business workflows and user intents the agent handles.
 
 ## State Dependencies

--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: test-runner
+description: Run the full Trinity API test suite, analyze results, and generate a comprehensive testing report. Use before merging a PR, after implementing a new feature, or when debugging test failures.
+allowed-tools: [Agent, Bash, Read, Write, Grep, Glob]
+user-invocable: true
+argument-hint: "[<filter>] [--verbose] [--failing]"
+automation: manual
+---
+
 # Test Runner
 
 Run the full Trinity API test suite, analyze results, and generate a comprehensive testing report.


### PR DESCRIPTION
## Summary

Cleanup in `.claude/` surfaced by an external ability-review audit (2026-04-18).

- Add YAML frontmatter to `security-analyzer.md`, `agent-template-validator.md`, `test-runner/SKILL.md` (previously undiscoverable)
- Replace Auth0 boundary in `security-analyzer.md` with current email-code/admin auth (Auth0 removed 2026-01-01)
- Generalize `commit/SKILL.md` Co-Authored-By to `Claude` (was pinning stale 4.5)
- Annotate Process Engine as dormant in `create-demo-agent-fleet` and `process-miner`; remove PE entry from `generate-user-docs` tree and 7 broken routes (processes/executions/approvals/process-docs) from `capture-screenshots`

Docs-only, no code paths touched.

## Test plan
- [x] No code changes — `.claude/` config only
- [x] Step numbering in `capture-screenshots` verified contiguous (19→24)
- [x] Frontmatter matches existing convention (agents: `name/description/tools/model`; skills: `name/description/allowed-tools/user-invocable/automation`)