### PR TITLE
fix(scheduler): unhang poll-timeout test via configurable grace buffer (#415)

### DIFF
--- a/src/scheduler/config.py
+++ b/src/scheduler/config.py
@@ -57,6 +57,12 @@ class SchedulerConfig:
         "POLL_INTERVAL", "10"
     )))  # seconds between DB polls while waiting for task completion
 
+    # Grace seconds added to task timeout for slot acquisition + finalize.
+    # Extracted from a literal so tests can override via config patching (#415).
+    poll_deadline_buffer: float = field(default_factory=lambda: float(os.getenv(
+        "POLL_DEADLINE_BUFFER", "60"
+    )))
+
     # Misfire grace time — how long after a missed trigger APScheduler will
     # still execute the job.  Default 30s is far too low for weekly cron jobs
     # whose container may restart.  3600s (1 hour) gives ample runway.

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -942,8 +942,8 @@ class SchedulerService:
         Raises:
             Exception if polling deadline exceeded.
         """
-        # Deadline = task timeout + 60s buffer for slot acquisition and cleanup
-        deadline = time.monotonic() + float(timeout_seconds) + 60
+        # Deadline = task timeout + grace buffer for slot acquisition and cleanup
+        deadline = time.monotonic() + float(timeout_seconds) + config.poll_deadline_buffer
         poll_count = 0
 
         while time.monotonic() < deadline:

--- a/tests/scheduler_tests/test_async_dispatch.py
+++ b/tests/scheduler_tests/test_async_dispatch.py
@@ -164,6 +164,7 @@ class TestDBPolling:
 
         with patch("scheduler.service.config") as mock_config:
             mock_config.poll_interval = 0.01  # Fast polling for tests
+            mock_config.poll_deadline_buffer = 60
 
             result = await service._poll_execution_completion(
                 execution_id=execution.id,
@@ -199,6 +200,7 @@ class TestDBPolling:
 
         with patch("scheduler.service.config") as mock_config:
             mock_config.poll_interval = 0.01
+            mock_config.poll_deadline_buffer = 60
 
             result = await service._poll_execution_completion(
                 execution_id=execution.id,
@@ -244,6 +246,7 @@ class TestDBPolling:
         with patch.object(db_with_data, "get_execution", side_effect=get_execution_with_delay), \
              patch("scheduler.service.config") as mock_config:
             mock_config.poll_interval = 0.01
+            mock_config.poll_deadline_buffer = 60
 
             result = await service._poll_execution_completion(
                 execution_id=execution.id,
@@ -275,11 +278,12 @@ class TestDBPolling:
 
         with patch("scheduler.service.config") as mock_config:
             mock_config.poll_interval = 0.01
+            mock_config.poll_deadline_buffer = 0  # disable grace buffer (#415)
 
             with pytest.raises(Exception, match="Polling deadline exceeded"):
                 await service._poll_execution_completion(
                     execution_id=execution.id,
-                    timeout_seconds=0,  # Immediate deadline (0 + 60s buffer is tiny with 0.01s poll)
+                    timeout_seconds=0,  # Immediate deadline with buffer=0
                 )
 
 
@@ -588,6 +592,7 @@ class TestFireAndForget:
         with patch("httpx.AsyncClient") as mock_client_cls, \
              patch("scheduler.service.config") as mock_config:
             mock_config.poll_interval = 0.01
+            mock_config.poll_deadline_buffer = 60
             mock_client = AsyncMock()
             mock_client.post.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)


### PR DESCRIPTION
## Summary

Closes #415.

`tests/scheduler_tests/test_async_dispatch.py::TestDBPolling::test_poll_timeout_raises_exception` hung for the full 60s pytest-timeout window on every scheduler test run. Test-only failure — production behavior unchanged.

## Root cause

`_poll_execution_completion` computed its deadline with a **hardcoded 60s grace buffer**:

```python
# src/scheduler/service.py:946 (before)
deadline = time.monotonic() + float(timeout_seconds) + 60
```

The test passed `timeout_seconds=0` expecting "immediate deadline," but the literal pushed the deadline 60s into the future. pytest-timeout (60s cap) fired first and killed the loop before the service's own `Polling deadline exceeded` exception could be raised.

The test's existing `patch("scheduler.service.config")` block couldn't help — the buffer was a literal, not a config read.

## Fix

Extract the literal to `SchedulerConfig.poll_deadline_buffer` (env override `POLL_DEADLINE_BUFFER`, default `60` to preserve current production behavior). The target test now sets `mock_config.poll_deadline_buffer = 0` and trips the deadline on the first iteration (~10ms total).

Companion tests in the same file that patch `scheduler.service.config` for other reasons now explicitly set `poll_deadline_buffer = 60` so `float + MagicMock` doesn't raise `TypeError`.

## Test plan

- [x] `tests/scheduler_tests/test_async_dispatch.py` — **15/15 pass in 0.73s** (was: 14 pass + 1 hang hitting 60s timeout).
- [x] Target test isolated: `TestDBPolling::test_poll_timeout_raises_exception` passes in 0.13s.
- [x] Production deadline math unchanged when `POLL_DEADLINE_BUFFER` unset (default 60 = old literal).

## Scope

- `src/scheduler/config.py` — new field + env plumbing.
- `src/scheduler/service.py` — one-line read swap.
- `tests/scheduler_tests/test_async_dispatch.py` — 5 patch sites updated.

No router, DB schema, or external API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)