### PR TITLE
fix(agent-server): wall-clock timeout on chat-mode subprocess (#313)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -56,6 +56,7 @@ _GUARDRAILS_RUNTIME_PATH = "/opt/trinity/guardrails-runtime.json"
 _GUARDRAILS_BASELINE_PATH = "/opt/trinity/guardrails-baseline.json"
 _DEFAULT_MAX_TURNS_CHAT = 50
 _DEFAULT_MAX_TURNS_TASK = 50
+_DEFAULT_EXECUTION_TIMEOUT_SEC = 1800  # GUARD-003 (#313): 30 min wall clock for chat
 
 
 def _load_guardrails() -> dict:
@@ -529,6 +530,12 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
         if disallowed_tools:
             cmd.extend(["--disallowedTools", ",".join(disallowed_tools)])
             logger.info(f"[Chat] Guardrails disallow tools: {disallowed_tools}")
+        # GUARD-003 (#313): wall-clock cap so a stuck claude subprocess
+        # (billing error, stalled stream, max-turns evasion) doesn't hang
+        # the chat session until the container is killed externally.
+        timeout_seconds = int(
+            guardrails.get("execution_timeout_sec") or _DEFAULT_EXECUTION_TIMEOUT_SEC
+        )
 
         # Add MCP config if .mcp.json exists (for agent-to-agent collaboration via Trinity MCP)
         mcp_config_path = Path.home() / ".mcp.json"
@@ -632,14 +639,28 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
 
         def read_subprocess_output():
             """Runs in thread pool. Starts stdout/stderr reader threads, waits
-            for subprocess, drains readers with process-group cleanup if
-            hook grandchildren still hold pipes open (Issue #407)."""
+            for subprocess (bounded by timeout_seconds — GUARD-003 #313),
+            drains readers with process-group cleanup if hook grandchildren
+            still hold pipes open (Issue #407)."""
             stdout_thread = threading.Thread(target=read_stdout, daemon=True)
             stderr_thread = threading.Thread(target=read_stderr, daemon=True)
             stdout_thread.start()
             stderr_thread.start()
 
-            return_code = process.wait()
+            try:
+                return_code = process.wait(timeout=timeout_seconds)
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    f"[Chat] Session {execution_id} timed out after {timeout_seconds}s "
+                    f"— killing process group"
+                )
+                _terminate_process_group(process, graceful_timeout=5, pgid=process_pgid)
+                _drain_reader_threads(
+                    process, stdout_thread, stderr_thread,
+                    grace=3, pgid=process_pgid,
+                )
+                raise
+
             _drain_reader_threads(
                 process, stdout_thread, stderr_thread,
                 grace=5, pgid=process_pgid,
@@ -650,10 +671,33 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
             return stderr, return_code
 
         # Run the blocking subprocess reading in a thread pool to allow FastAPI
-        # to handle other requests (like /api/activity polling) during execution
+        # to handle other requests (like /api/activity polling) during execution.
+        # Outer asyncio.wait_for is a safety net with a small grace period for
+        # drain/cleanup after the inner process.wait() already bounded itself.
         loop = asyncio.get_event_loop()
         try:
-            stderr_output, return_code = await loop.run_in_executor(_executor, read_subprocess_output)
+            try:
+                stderr_output, return_code = await asyncio.wait_for(
+                    loop.run_in_executor(_executor, read_subprocess_output),
+                    timeout=timeout_seconds + 60
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"[Chat] Outer timeout on session {execution_id} "
+                    f"— killing process group as last resort"
+                )
+                _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid)
+                _safe_close_pipes(process)
+                raise HTTPException(
+                    status_code=504,
+                    detail=f"Chat execution timed out after {timeout_seconds} seconds"
+                )
+            except subprocess.TimeoutExpired:
+                logger.error(f"[Chat] Session {execution_id} timed out after {timeout_seconds}s")
+                raise HTTPException(
+                    status_code=504,
+                    detail=f"Chat execution timed out after {timeout_seconds} seconds"
+                )
 
             # Check for rate limit detected during stream parsing (takes priority)
             if metadata.error_type == "rate_limit":

--- a/tests/unit/test_chat_wallclock_timeout.py
+++ b/tests/unit/test_chat_wallclock_timeout.py
@@ -1,0 +1,159 @@
+"""Regression tests for #313: chat mode wall-clock timeout (GUARD-003 follow-up).
+
+Before this fix, `execute_claude_code` called `process.wait()` with no timeout
+and `run_in_executor` without `asyncio.wait_for`. A stalled Claude CLI
+subprocess (billing error, stuck stream, hook grandchild wedge not caught by
+`--max-turns`) would hang the chat session until the container was killed
+externally.
+
+Fix mirrors the existing task-mode pattern in `execute_headless_task`:
+- Read `execution_timeout_sec` from guardrails config with a 30-min default.
+- Inner `process.wait(timeout=...)` bounds the subprocess thread.
+- Outer `asyncio.wait_for(..., timeout=+60)` is a safety net.
+- On timeout, kill the process group and raise HTTP 504.
+
+These tests validate the fix is wired correctly without importing the full
+`claude_code` module (its relative imports require the whole agent_server
+package to be loadable). Source-level assertions catch accidental reverts.
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CLAUDE_CODE_PY = (
+    _PROJECT_ROOT
+    / "docker"
+    / "base-image"
+    / "agent_server"
+    / "services"
+    / "claude_code.py"
+)
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    assert _CLAUDE_CODE_PY.is_file(), f"missing {_CLAUDE_CODE_PY}"
+    return _CLAUDE_CODE_PY.read_text()
+
+
+@pytest.fixture(scope="module")
+def tree(source: str) -> ast.Module:
+    return ast.parse(source)
+
+
+def _find_function(tree: ast.Module, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name} not found")
+
+
+def _function_source(source: str, func: ast.AsyncFunctionDef) -> str:
+    lines = source.splitlines()
+    return "\n".join(lines[func.lineno - 1 : func.end_lineno])
+
+
+# ---------------------------------------------------------------------------
+# Module-level constant regression guards
+# ---------------------------------------------------------------------------
+
+
+def test_default_timeout_constant_is_30_minutes(tree: ast.Module) -> None:
+    """The default wall-clock cap is 30 minutes (1800 s) per issue spec."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "_DEFAULT_EXECUTION_TIMEOUT_SEC"
+        ):
+            assert isinstance(node.value, ast.Constant), "default must be literal"
+            assert node.value.value == 1800, f"expected 1800, got {node.value.value!r}"
+            return
+    raise AssertionError("_DEFAULT_EXECUTION_TIMEOUT_SEC constant not defined")
+
+
+# ---------------------------------------------------------------------------
+# execute_claude_code wiring
+# ---------------------------------------------------------------------------
+
+
+def test_chat_reads_guardrails_execution_timeout(source: str, tree: ast.Module) -> None:
+    """Chat mode must resolve timeout from the shared guardrails field."""
+    body = _function_source(source, _find_function(tree, "execute_claude_code"))
+    assert 'guardrails.get("execution_timeout_sec")' in body, (
+        "chat mode must read execution_timeout_sec from guardrails"
+    )
+    assert "_DEFAULT_EXECUTION_TIMEOUT_SEC" in body, (
+        "chat mode must fall back to the default constant"
+    )
+
+
+def test_chat_has_inner_process_wait_timeout(source: str, tree: ast.Module) -> None:
+    """Inner process.wait must be bounded by timeout_seconds."""
+    body = _function_source(source, _find_function(tree, "execute_claude_code"))
+    assert "process.wait(timeout=timeout_seconds)" in body, (
+        "inner subprocess wait must pass the timeout"
+    )
+    assert "subprocess.TimeoutExpired" in body, (
+        "inner wait must handle TimeoutExpired"
+    )
+    assert "_terminate_process_group(process" in body, (
+        "timeout handler must kill the process group"
+    )
+
+
+def test_chat_has_outer_asyncio_wait_for(source: str, tree: ast.Module) -> None:
+    """Outer wait_for is the async safety net with a 60s grace buffer."""
+    body = _function_source(source, _find_function(tree, "execute_claude_code"))
+    assert "asyncio.wait_for(" in body, (
+        "chat mode must wrap the executor call in asyncio.wait_for"
+    )
+    assert "timeout_seconds + 60" in body, (
+        "outer timeout must exceed inner by 60s for drain/cleanup"
+    )
+    assert "asyncio.TimeoutError" in body, (
+        "outer handler must catch asyncio.TimeoutError"
+    )
+
+
+def test_chat_timeout_returns_http_504(source: str, tree: ast.Module) -> None:
+    """Both timeout paths must raise HTTPException(504)."""
+    body = _function_source(source, _find_function(tree, "execute_claude_code"))
+    # Count 504 raises — expect at least 2 (one per timeout path).
+    count = body.count("status_code=504")
+    assert count >= 2, f"expected ≥2 HTTP 504 raises in chat mode, found {count}"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural check on the underlying subprocess primitive
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_wait_timeout_raises_timeoutexpired() -> None:
+    """Sanity: `process.wait(timeout=X)` raises TimeoutExpired — the primitive
+    the fix relies on. Guards against a platform-specific regression.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(5)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    start = time.monotonic()
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            proc.wait(timeout=0.3)
+        elapsed = time.monotonic() - start
+        # Primitive is cheap — timeout should fire well before the sleep ends.
+        assert elapsed < 1.0, f"wait(timeout=0.3) took {elapsed:.2f}s"
+    finally:
+        proc.kill()
+        proc.wait(timeout=2.0)


### PR DESCRIPTION
## Summary

Closes #313. GUARD-003 follow-up — chat mode now has the wall-clock timeout that task mode already had.

## Root cause

`execute_claude_code` in `docker/base-image/agent_server/services/claude_code.py` called:

```python
return_code = process.wait()                    # no timeout
stderr_output, return_code = await loop.run_in_executor(...)  # no asyncio.wait_for
```

If the Claude CLI subprocess stalls — billing error, stuck stream, hook grandchild wedge that `--max-turns` doesn't catch — the chat session hangs until the container is killed externally. Task mode (`execute_headless_task`) correctly uses `asyncio.wait_for` + `process.kill()`; chat mode silently lacked the parity.

## Fix

Mirror task mode's two-layer pattern:

- **New constant**: `_DEFAULT_EXECUTION_TIMEOUT_SEC = 1800` (30 min).
- **Guardrails read**: `timeout_seconds = int(guardrails.get("execution_timeout_sec") or _DEFAULT_EXECUTION_TIMEOUT_SEC)`. Field already exists in the shared guardrails schema (`agent_config.py:497`, range 60–7200).
- **Inner bound**: `process.wait(timeout=timeout_seconds)`. On `subprocess.TimeoutExpired`: `_terminate_process_group(graceful_timeout=5)` → drain readers → re-raise.
- **Outer safety net**: `asyncio.wait_for(..., timeout=timeout_seconds + 60)`. On `asyncio.TimeoutError`: `_terminate_process_group(graceful_timeout=2)` + `_safe_close_pipes`. Both timeout paths raise `HTTPException(504)`.
- `registry.unregister(execution_id)` still runs via the existing `finally` block.

## Test plan

- [x] `tests/unit/test_chat_wallclock_timeout.py` — 6/6 pass in 0.32s.
  - AST-level regression guards: default constant (1800), guardrails read wired, inner `process.wait(timeout=…)` + `TimeoutExpired` handling, outer `asyncio.wait_for` + `asyncio.TimeoutError` handling, ≥2 HTTP 504 raises.
  - Behavioural smoke: `subprocess.Popen.wait(timeout=0.3)` raises `TimeoutExpired` on this platform (guards against a primitive-level regression).
- [x] Python syntax check clean.
- [x] /review pre-landing pass: 0 critical, 1 non-blocking informational (timeout source-of-truth note).

## Scope

- `docker/base-image/agent_server/services/claude_code.py` — 49+/5-.
- `tests/unit/test_chat_wallclock_timeout.py` — new, 159 lines.

No router, DB schema, or external API change. No behaviour change when the subprocess completes before the timeout.

## Notes

The unit tests are source-AST regression guards rather than runtime tests of the full `execute_claude_code`. Reason: the module has relative imports (`from ..models`, `from ..state`) that require the full `agent_server` package to be importable. The helpers the fix composes (`_terminate_process_group`, `_drain_reader_threads`, `_safe_close_pipes`) are already behaviourally covered by `tests/unit/test_subprocess_pgroup.py`, and the pattern mirrors the production-proven task-mode code. Behavioural regression of the full chat-mode timeout path would require the agent-container integration harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)