### PR TITLE
feat(observability): event-bus soak counters for #306

### DIFF
--- a/docs/memory/feature-flows/websocket-event-bus.md
+++ b/docs/memory/feature-flows/websocket-event-bus.md
@@ -200,13 +200,30 @@ Log events (via stdlib `logging`, captured by Vector):
 - `stream_dispatcher: send failed for <id-prefix> (N/3): <err>` — per-attempt
 - `stream_dispatcher: evicting client <id-prefix> after 3 failures`
 
+### Soak counters (`GET /api/debug/event-bus-stats`, admin-only)
+
+In-memory counters for the #306 soak gates. Monotonic, reset on backend
+restart — compare deltas. Response shape:
+
+- `publisher` — `events_published`, `publish_failures`, `outbound_overflow`,
+  `outbound_queue_depth`, `fallback_buffer_depth`, `redis_ready`, `uptime_seconds`
+- `dispatcher` — `events_delivered`, `send_failures`, `drops_queue_full`,
+  `clients_evicted`, `resyncs_sent`, `client_count`, `last_stream_id`, `uptime_seconds`
+- `watchdog` — `cumulative_orphaned`, `cumulative_auto_terminated`, `last_run_at`
+  (running totals from `CleanupService`)
+
+Gate checks (see orchestration reliability plan, Tier 2.5):
+- Delivery ≥99.9%: `(drops_queue_full + clients_evicted + resyncs_sent) / events_published < 0.001`
+- Zero watchdog recoveries: `watchdog.cumulative_orphaned == 0`
+
 ---
 
 ## Key Files
 
 | Layer | File | Role |
 |-------|------|------|
-| Service | `src/backend/services/event_bus.py` | `EventBus`, `StreamDispatcher`, scope helpers, `validate_last_event_id` |
+| Service | `src/backend/services/event_bus.py` | `EventBus`, `StreamDispatcher`, scope helpers, `validate_last_event_id`, soak-counter `stats()` helpers |
+| Router | `src/backend/routers/debug.py` | Admin-only `GET /api/debug/event-bus-stats` for soak dashboard |
 | Entry | `src/backend/main.py:112-200` | `ConnectionManager` / `FilteredWebSocketManager` shims over the bus |
 | Entry | `src/backend/main.py:634+`, `main.py:697+` | `/ws` and `/ws/events` endpoints with `?last-event-id=` support |
 | Entry | `src/backend/main.py:285-294` | Lifespan `event_bus.start()` + `stream_dispatcher.start()` |

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -84,6 +84,7 @@ from routers.operator_queue import router as operator_queue_router, set_websocke
 from routers.voice import router as voice_router
 from routers.event_subscriptions import router as event_subscriptions_router, set_websocket_manager as set_event_subs_ws_manager, set_filtered_websocket_manager as set_event_subs_filtered_ws_manager
 from routers.users import router as users_router
+from routers.debug import router as debug_router  # #306 soak instrumentation
 from routers.messages import router as messages_router  # Proactive Messaging (#321)
 
 # Import activity service
@@ -629,6 +630,7 @@ app.include_router(operator_queue_router)  # Operator Queue (OPS-001)
 app.include_router(voice_router)  # Voice Chat (VOICE-001)
 app.include_router(event_subscriptions_router)  # Agent Event Subscriptions (EVT-001)
 app.include_router(users_router)  # User Management (ROLE-001)
+app.include_router(debug_router)  # #306 soak dashboard
 
 
 # WebSocket endpoint

--- a/src/backend/routers/debug.py
+++ b/src/backend/routers/debug.py
@@ -1,0 +1,43 @@
+"""
+Debug / observability endpoints.
+
+Admin-only. Cheap to expose — exposes in-memory counters only, no DB queries.
+Primary use case: #306 Redis Streams event bus soak dashboard (gates defined in
+``docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md``).
+
+Endpoints:
+    GET /api/debug/event-bus-stats — publisher/consumer counters + cumulative
+        watchdog orphan/auto-terminate totals since last process restart.
+"""
+
+import logging
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends
+
+from dependencies import require_admin
+from models import User
+from services.cleanup_service import cleanup_service
+from services.event_bus import event_bus, stream_dispatcher
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/debug", tags=["debug"])
+
+
+@router.get("/event-bus-stats")
+async def event_bus_stats(_: User = Depends(require_admin)) -> Dict[str, Any]:
+    """Return in-memory counters for the #306 soak dashboard.
+
+    All counters are monotonic and reset on backend restart — compare deltas
+    across snapshots, not absolute values.
+    """
+    return {
+        "publisher": event_bus.stats(),
+        "dispatcher": stream_dispatcher.stats(),
+        "watchdog": {
+            "cumulative_orphaned": cleanup_service.cumulative_orphaned,
+            "cumulative_auto_terminated": cleanup_service.cumulative_auto_terminated,
+            "last_run_at": cleanup_service.last_run_at,
+        },
+    }

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -92,6 +92,10 @@ class CleanupService:
         self._lock = asyncio.Lock()
         self.last_run_at: Optional[str] = None
         self.last_report: Optional[CleanupReport] = None
+        # Cumulative counters for the #306 soak dashboard. Monotonic, reset on
+        # process restart. Zero orphan recoveries over 2 weeks is the gate.
+        self.cumulative_orphaned: int = 0
+        self.cumulative_auto_terminated: int = 0
 
     def start(self):
         """Start the background cleanup loop."""
@@ -133,6 +137,8 @@ class CleanupService:
             )
             report.orphaned_executions = orphaned
             report.auto_terminated = terminated
+            self.cumulative_orphaned += orphaned
+            self.cumulative_auto_terminated += terminated
             if orphaned > 0:
                 logger.info(f"[Watchdog] Recovered {orphaned} orphaned executions")
             if terminated > 0:

--- a/src/backend/services/event_bus.py
+++ b/src/backend/services/event_bus.py
@@ -135,6 +135,11 @@ class EventBus:
         self._writer_task: Optional[asyncio.Task] = None
         self._redis: Optional["aioredis.Redis"] = None
         self._ready = False
+        # Soak-period counters (#306). Monotonic, reset on process restart.
+        self._started_at: float = time.time()
+        self.events_published: int = 0
+        self.publish_failures: int = 0
+        self.outbound_overflow: int = 0
 
     async def start(self) -> None:
         if self._writer_task is not None:
@@ -212,6 +217,7 @@ class EventBus:
             try:
                 self._outbound.put_nowait(envelope)
             except asyncio.QueueFull:
+                self.outbound_overflow += 1
                 logger.warning("event_bus: outbound queue full, dropping event")
 
     async def _writer_loop(self) -> None:
@@ -246,6 +252,18 @@ class EventBus:
             self._redis = None
             return None
 
+    def stats(self) -> Dict[str, Any]:
+        """Snapshot of publisher-side counters for the #306 soak dashboard."""
+        return {
+            "uptime_seconds": int(time.time() - self._started_at),
+            "events_published": self.events_published,
+            "publish_failures": self.publish_failures,
+            "outbound_overflow": self.outbound_overflow,
+            "outbound_queue_depth": self._outbound.qsize(),
+            "fallback_buffer_depth": len(self._fallback),
+            "redis_ready": self._ready,
+        }
+
     async def _xadd(self, envelope: Dict[str, Any]) -> None:
         redis = await self._get_redis()
         if redis is None:
@@ -262,8 +280,10 @@ class EventBus:
         }
         try:
             await redis.xadd(STREAM_KEY, fields, maxlen=STREAM_MAXLEN, approximate=True)
+            self.events_published += 1
         except Exception as e:
             # Force reconnect on next call.
+            self.publish_failures += 1
             logger.warning("event_bus: XADD failed: %s", e)
             try:
                 await redis.aclose()
@@ -288,6 +308,13 @@ class StreamDispatcher:
         self._last_stream_id: str = "$"   # start at live tip on boot
         self._lock = asyncio.Lock()
         self._shutting_down = False
+        # Soak-period counters (#306). Monotonic, reset on process restart.
+        self._started_at: float = time.time()
+        self.events_delivered: int = 0
+        self.send_failures: int = 0
+        self.drops_queue_full: int = 0
+        self.clients_evicted: int = 0
+        self.resyncs_sent: int = 0
 
     async def start(self) -> None:
         if self._reader_task is not None:
@@ -433,6 +460,7 @@ class StreamDispatcher:
                 slot.queue.put_nowait((entry_id, payload))
             except asyncio.QueueFull:
                 # Slow client — drop and require resync.
+                self.drops_queue_full += 1
                 if not slot.resync_pending:
                     slot.resync_pending = True
                     logger.warning("stream_dispatcher: client %s queue full, marking resync",
@@ -441,6 +469,7 @@ class StreamDispatcher:
                         slot.queue.put_nowait((entry_id, {"type": "resync_required",
                                                           "reason": "slow_consumer",
                                                           "_eid": entry_id}))
+                        self.resyncs_sent += 1
                     except asyncio.QueueFull:
                         pass  # will be evicted by consumer on next failure
 
@@ -454,6 +483,7 @@ class StreamDispatcher:
                 try:
                     await slot.send_func(payload)
                     slot.failure_count = 0
+                    self.events_delivered += 1
                     # Monotonic guard (#306 review C1): even though catchup's
                     # range is capped to avoid overlap with live fan-out, keep
                     # this defensive check so any future ordering bug can't
@@ -468,11 +498,13 @@ class StreamDispatcher:
                     raise
                 except Exception as e:
                     slot.failure_count += 1
+                    self.send_failures += 1
                     logger.info(
                         "stream_dispatcher: send failed for %s (%d/%d): %s",
                         client_id[:8], slot.failure_count, EVICT_AFTER_FAILURES, e,
                     )
                     if slot.failure_count >= EVICT_AFTER_FAILURES:
+                        self.clients_evicted += 1
                         logger.warning("stream_dispatcher: evicting client %s after %d failures",
                                        client_id[:8], EVICT_AFTER_FAILURES)
                         try:
@@ -561,6 +593,7 @@ class StreamDispatcher:
         slot.resync_pending = True
         try:
             slot.queue.put_nowait(("0-0", {"type": "resync_required", "reason": reason}))
+            self.resyncs_sent += 1
         except asyncio.QueueFull:
             pass
 
@@ -577,6 +610,19 @@ class StreamDispatcher:
             logger.warning("stream_dispatcher: Redis unavailable (%s)", e)
             self._redis = None
             return None
+
+    def stats(self) -> Dict[str, Any]:
+        """Snapshot of consumer-side counters for the #306 soak dashboard."""
+        return {
+            "uptime_seconds": int(time.time() - self._started_at),
+            "client_count": len(self._clients),
+            "events_delivered": self.events_delivered,
+            "send_failures": self.send_failures,
+            "drops_queue_full": self.drops_queue_full,
+            "clients_evicted": self.clients_evicted,
+            "resyncs_sent": self.resyncs_sent,
+            "last_stream_id": self._last_stream_id,
+        }
 
 
 def _id_greater_than(a: str, b: str) -> bool:


### PR DESCRIPTION
## Summary

- Adds in-memory counters on `EventBus` / `StreamDispatcher` / `CleanupService` so the Tier 2.5 soak gates from `ORCHESTRATION_RELIABILITY_2026-04.md` (delivery ≥99.9%, zero watchdog orphans) are measurable with one curl.
- New admin-only `GET /api/debug/event-bus-stats` returns publisher / dispatcher / watchdog snapshots. Counters are monotonic and reset on process restart — compare deltas, not absolutes.
- Instrumentation only — no behavior change.

## Test plan

- [ ] Boot backend, hit `curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/debug/event-bus-stats` — expect all three keys (`publisher`, `dispatcher`, `watchdog`) populated.
- [ ] Non-admin call returns 403.
- [ ] Trigger a WS broadcast, re-poll — `events_published` / `events_delivered` incremented.
- [ ] Disconnect a WS client mid-event, re-poll — counters reflect `send_failures` / eventual `clients_evicted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)