### PR TITLE
fix(timestamps): emit UTC with Z suffix across backend (#79)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -96,6 +96,7 @@ from db_models import (
 
 # Re-export connection utilities
 from db.connection import get_db_connection, DB_PATH
+from utils.helpers import utc_now_iso
 
 # Import schema and migration utilities
 from db.migrations import run_all_migrations
@@ -190,7 +191,7 @@ def _ensure_admin_user(cursor, conn):
             print("         Set ADMIN_PASSWORD environment variable to create admin user")
             return
 
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         # Hash password using bcrypt
         from passlib.context import CryptContext
         pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -230,7 +231,7 @@ def _ensure_admin_user(cursor, conn):
             cursor.execute("""
                 UPDATE users SET password_hash = ?, updated_at = ?
                 WHERE username = ?
-            """, (hashed, datetime.utcnow().isoformat(), admin_username))
+            """, (hashed, utc_now_iso(), admin_username))
             conn.commit()
 
 

--- a/src/backend/db/access_requests.py
+++ b/src/backend/db/access_requests.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from .connection import get_db_connection
+from utils.helpers import utc_now_iso
 
 
 class AccessRequestOperations:
@@ -43,7 +44,7 @@ class AccessRequestOperations:
         anyway (e.g. share removed), we reset to pending so the owner sees it.
         """
         email = email.lower()
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         rid = secrets.token_urlsafe(16)
 
         with get_db_connection() as conn:
@@ -124,7 +125,7 @@ class AccessRequestOperations:
         decided_by_user_id: int,
     ) -> Optional[dict]:
         """Mark a request approved or denied. Returns updated row."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         new_status = "approved" if approve else "denied"
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/agent_settings/sharing.py
+++ b/src/backend/db/agent_settings/sharing.py
@@ -10,6 +10,7 @@ from typing import Optional, List
 
 from db.connection import get_db_connection
 from db_models import AgentShare
+from utils.helpers import utc_now_iso
 
 
 class SharingMixin:
@@ -49,7 +50,7 @@ class SharingMixin:
         if owner_email and owner_email.lower() == share_with_email.lower():
             return None
 
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/agents.py
+++ b/src/backend/db/agents.py
@@ -27,6 +27,7 @@ from .agent_settings import (
     AccessPolicyMixin,
     GitPATMixin,
 )
+from utils.helpers import utc_now_iso
 
 # System agent name constant
 SYSTEM_AGENT_NAME = "trinity-system"
@@ -74,7 +75,7 @@ class AgentOperations(
                 cursor.execute("""
                     INSERT INTO agent_ownership (agent_name, owner_id, created_at, is_system)
                     VALUES (?, ?, ?, ?)
-                """, (agent_name, user["id"], datetime.utcnow().isoformat(), 1 if is_system else 0))
+                """, (agent_name, user["id"], utc_now_iso(), 1 if is_system else 0))
                 conn.commit()
                 return True
             except sqlite3.IntegrityError:

--- a/src/backend/db/chat.py
+++ b/src/backend/db/chat.py
@@ -10,6 +10,7 @@ from typing import Optional, List
 
 from .connection import get_db_connection
 from db_models import ChatSession, ChatMessage
+from utils.helpers import utc_now_iso
 
 
 class ChatOperations:
@@ -85,7 +86,7 @@ class ChatOperations:
 
             # Create a new session
             session_id = secrets.token_urlsafe(16)
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             cursor.execute("""
                 INSERT INTO chat_sessions (
@@ -125,7 +126,7 @@ class ChatOperations:
 
             # Create message
             message_id = secrets.token_urlsafe(16)
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             cursor.execute("""
                 INSERT INTO chat_messages (
@@ -272,7 +273,7 @@ class ChatOperations:
 
             # Create a new session
             session_id = secrets.token_urlsafe(16)
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             cursor.execute("""
                 INSERT INTO chat_sessions (

--- a/src/backend/db/email_auth.py
+++ b/src/backend/db/email_auth.py
@@ -11,6 +11,7 @@ import secrets
 from datetime import datetime, timedelta
 from typing import Optional, List
 from db.connection import get_db_connection
+from utils.helpers import utc_now_iso
 
 # Valid role values for new users. Kept local to avoid a circular import with
 # dependencies.py (which imports from database, which imports from this module).
@@ -84,7 +85,7 @@ class EmailAuthOperations:
             cursor.execute("""
                 INSERT INTO email_whitelist (email, added_by, added_at, source, default_role)
                 VALUES (?, ?, ?, ?, ?)
-            """, (email.lower(), user["id"], datetime.utcnow().isoformat(), source, default_role))
+            """, (email.lower(), user["id"], utc_now_iso(), source, default_role))
 
             conn.commit()
             return True
@@ -216,7 +217,7 @@ class EmailAuthOperations:
                 UPDATE email_login_codes
                 SET verified = 1, used_at = ?
                 WHERE id = ?
-            """, (datetime.utcnow().isoformat(), code_record["id"]))
+            """, (utc_now_iso(), code_record["id"]))
 
             conn.commit()
 
@@ -282,7 +283,7 @@ class EmailAuthOperations:
             role = "user"
 
         # Create new user
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
 

--- a/src/backend/db/event_subscriptions.py
+++ b/src/backend/db/event_subscriptions.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from db.connection import get_db_connection
 from db_models import EventSubscription, EventSubscriptionCreate, AgentEvent
+from utils.helpers import utc_now_iso
 
 
 class EventSubscriptionOperations:
@@ -29,7 +30,7 @@ class EventSubscriptionOperations:
     ) -> EventSubscription:
         """Create a new event subscription."""
         sub_id = f"esub_{secrets.token_urlsafe(12)}"
-        now = datetime.utcnow().isoformat() + "Z"
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -142,7 +143,7 @@ class EventSubscriptionOperations:
         if not updates:
             return self.get_subscription(subscription_id)
 
-        now = datetime.utcnow().isoformat() + "Z"
+        now = utc_now_iso()
         updates.append("updated_at = ?")
         params.append(now)
         params.append(subscription_id)
@@ -217,7 +218,7 @@ class EventSubscriptionOperations:
     ) -> AgentEvent:
         """Persist an emitted event."""
         event_id = f"evt_{secrets.token_urlsafe(12)}"
-        now = datetime.utcnow().isoformat() + "Z"
+        now = utc_now_iso()
         payload_json = json.dumps(payload) if payload else None
 
         with get_db_connection() as conn:

--- a/src/backend/db/mcp_keys.py
+++ b/src/backend/db/mcp_keys.py
@@ -12,6 +12,7 @@ from typing import Optional, List, Dict
 
 from .connection import get_db_connection
 from db_models import McpApiKey, McpApiKeyCreate, McpApiKeyWithSecret
+from utils.helpers import utc_now_iso
 
 
 class McpKeyOperations:
@@ -69,7 +70,7 @@ class McpKeyOperations:
         key_id = self._generate_id()
         api_key = self._generate_mcp_api_key()
         key_hash = self._hash_api_key(api_key)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -123,7 +124,7 @@ class McpKeyOperations:
         key_id = self._generate_id()
         api_key = self._generate_mcp_api_key()
         key_hash = self._hash_api_key(api_key)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         key_name = f"agent-{agent_name}-key"
 
         with get_db_connection() as conn:
@@ -217,7 +218,7 @@ class McpKeyOperations:
                 return None
 
             # Update usage statistics
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
             cursor.execute("""
                 UPDATE mcp_api_keys
                 SET last_used_at = ?, usage_count = usage_count + 1

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -42,6 +42,7 @@ Migration Order (as of 2026-02-28):
 import logging
 import sqlite3
 from datetime import datetime, timezone
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -513,7 +514,7 @@ def _migrate_setup_completed_backfill(cursor, conn):
         cursor.execute("""
             INSERT OR REPLACE INTO system_settings (key, value, updated_at)
             VALUES ('setup_completed', 'true', ?)
-        """, (datetime.utcnow().isoformat(),))
+        """, (utc_now_iso(),))
         conn.commit()
         print("Setup marked as completed.")
 

--- a/src/backend/db/nevermined.py
+++ b/src/backend/db/nevermined.py
@@ -11,6 +11,7 @@ from typing import Optional, List
 
 from .connection import get_db_connection
 from db_models import NeverminedConfig, NeverminedPaymentLog
+from utils.helpers import utc_now_iso
 
 
 class NeverminedOperations:
@@ -76,7 +77,7 @@ class NeverminedOperations:
         """Create or update Nevermined config for an agent. Encrypts the API key."""
         encryption_service = self._get_encryption_service()
         encrypted = encryption_service.encrypt({"nvm_api_key": nvm_api_key})
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -163,7 +164,7 @@ class NeverminedOperations:
 
     def set_enabled(self, agent_name: str, enabled: bool) -> bool:
         """Enable or disable Nevermined payments for an agent."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
@@ -203,7 +204,7 @@ class NeverminedOperations:
     ) -> NeverminedPaymentLog:
         """Log a payment action (verify, settle, settle_failed, reject)."""
         log_id = str(uuid.uuid4())
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/notifications.py
+++ b/src/backend/db/notifications.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from db.connection import get_db_connection
 from db_models import Notification, NotificationCreate
+from utils.helpers import utc_now_iso
 
 
 class NotificationOperations:
@@ -33,7 +34,7 @@ class NotificationOperations:
             The created notification
         """
         notification_id = f"notif_{secrets.token_urlsafe(12)}"
-        now = datetime.utcnow().isoformat() + "Z"
+        now = utc_now_iso()
 
         # Serialize metadata to JSON if provided
         metadata_json = json.dumps(data.metadata) if data.metadata else None
@@ -195,7 +196,7 @@ class NotificationOperations:
         Returns:
             The updated notification or None if not found
         """
-        now = datetime.utcnow().isoformat() + "Z"
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -234,7 +235,7 @@ class NotificationOperations:
         Returns:
             The updated notification or None if not found
         """
-        now = datetime.utcnow().isoformat() + "Z"
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/permissions.py
+++ b/src/backend/db/permissions.py
@@ -11,6 +11,7 @@ from typing import Optional, List
 
 from .connection import get_db_connection
 from db_models import AgentPermission
+from utils.helpers import utc_now_iso
 
 
 class PermissionOperations:
@@ -122,7 +123,7 @@ class PermissionOperations:
 
         Returns the created permission or None if it already exists.
         """
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -168,7 +169,7 @@ class PermissionOperations:
         """
         with get_db_connection() as conn:
             cursor = conn.cursor()
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             # Remove all existing permissions for this source
             cursor.execute("""

--- a/src/backend/db/public_chat.py
+++ b/src/backend/db/public_chat.py
@@ -13,6 +13,7 @@ from typing import Optional, List
 
 from .connection import get_db_connection
 from db_models import PublicChatSession, PublicChatMessage
+from utils.helpers import utc_now_iso
 
 # Header injected into every public chat request so agents know they're serving a public user
 PUBLIC_LINK_MODE_HEADER = "### Trinity: Public Link Access Mode"
@@ -82,7 +83,7 @@ class PublicChatOperations:
 
             # Create new session
             session_id = secrets.token_urlsafe(16)
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             cursor.execute("""
                 INSERT INTO public_chat_sessions (
@@ -147,7 +148,7 @@ class PublicChatOperations:
 
             # Create message
             message_id = secrets.token_urlsafe(16)
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             cursor.execute("""
                 INSERT INTO public_chat_messages (

--- a/src/backend/db/public_links.py
+++ b/src/backend/db/public_links.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional, List
 
 from db.connection import get_db_connection
+from utils.helpers import utc_now_iso
 
 
 def _utcnow() -> datetime:
@@ -53,7 +54,7 @@ class PublicLinkOperations:
         """
         link_id = secrets.token_urlsafe(16)
         token = secrets.token_urlsafe(24)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -346,7 +347,7 @@ class PublicLinkOperations:
         """Record a chat usage for a public link."""
         with get_db_connection() as conn:
             cursor = conn.cursor()
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             # Check for existing usage record
             cursor.execute("""
@@ -464,7 +465,7 @@ class PublicLinkOperations:
         memory_text, message_count, created_at, updated_at.
         """
         email = user_email.lower()
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -503,7 +504,7 @@ class PublicLinkOperations:
         Returns the new message_count.
         """
         email = user_email.lower()
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -528,7 +529,7 @@ class PublicLinkOperations:
         Returns True if the record was found and updated.
         """
         email = user_email.lower()
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/settings.py
+++ b/src/backend/db/settings.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Dict, Any
 
 from .connection import get_db_connection
 from db_models import SystemSetting
+from utils.helpers import utc_now_iso
 
 
 class SettingsOperations:
@@ -64,7 +65,7 @@ class SettingsOperations:
         Creates the setting if it doesn't exist, updates if it does.
         Returns the updated setting.
         """
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/shared_folders.py
+++ b/src/backend/db/shared_folders.py
@@ -11,6 +11,7 @@ from typing import Optional, List
 
 from .connection import get_db_connection
 from db_models import SharedFolderConfig
+from utils.helpers import utc_now_iso
 
 
 class SharedFolderOperations:
@@ -65,7 +66,7 @@ class SharedFolderOperations:
         Only updates the fields that are provided (not None).
         Returns the updated configuration.
         """
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/skills.py
+++ b/src/backend/db/skills.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 
 from .connection import get_db_connection
 from db_models import AgentSkill
+from utils.helpers import utc_now_iso
 
 
 class SkillsOperations:
@@ -89,7 +90,7 @@ class SkillsOperations:
         Returns:
             AgentSkill object if created, None if already exists
         """
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -150,7 +151,7 @@ class SkillsOperations:
         Returns:
             Number of skills assigned
         """
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()

--- a/src/backend/db/slack.py
+++ b/src/backend/db/slack.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 from typing import Optional, List
 
 from db.connection import get_db_connection
+from utils.helpers import utc_now_iso
 
 
 class SlackOperations:
@@ -31,7 +32,7 @@ class SlackOperations:
     ) -> dict:
         """Create a new Slack connection for a public link."""
         connection_id = secrets.token_urlsafe(16)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -219,7 +220,7 @@ class SlackOperations:
     ) -> dict:
         """Create a user verification record."""
         verification_id = secrets.token_urlsafe(16)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -251,7 +252,7 @@ class SlackOperations:
                 FROM slack_pending_verifications
                 WHERE slack_user_id = ? AND slack_team_id = ?
                 AND expires_at > ?
-            """, (slack_user_id, slack_team_id, datetime.utcnow().isoformat()))
+            """, (slack_user_id, slack_team_id, utc_now_iso()))
             row = cursor.fetchone()
 
         if not row:
@@ -351,7 +352,7 @@ class SlackOperations:
             cursor.execute("""
                 DELETE FROM slack_pending_verifications
                 WHERE expires_at < ?
-            """, (datetime.utcnow().isoformat(),))
+            """, (utc_now_iso(),))
             conn.commit()
             return cursor.rowcount
 

--- a/src/backend/db/slack_channels.py
+++ b/src/backend/db/slack_channels.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Optional, List
 
 from db.connection import get_db_connection
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,7 @@ class SlackChannelOperations:
     ) -> dict:
         """Create or update a workspace connection. Bot token is encrypted at rest."""
         workspace_id = secrets.token_urlsafe(16)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         encrypted_token = self._encrypt_token(bot_token)
 
         with get_db_connection() as conn:
@@ -145,7 +146,7 @@ class SlackChannelOperations:
     ) -> dict:
         """Bind a Slack channel to an agent."""
         binding_id = secrets.token_urlsafe(16)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -278,7 +279,7 @@ class SlackChannelOperations:
         agent_name: str,
     ) -> None:
         """Record that the bot responded in a thread (enables reply-without-mention)."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""

--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -15,6 +15,7 @@ from typing import Optional, List, Dict, Any
 
 from .connection import get_db_connection
 from db_models import SubscriptionCredential, SubscriptionUsage, SubscriptionUsageWindow, SubscriptionWithAgents
+from utils.helpers import utc_now_iso
 
 
 class SubscriptionOperations:
@@ -91,7 +92,7 @@ class SubscriptionOperations:
         encryption_service = self._get_encryption_service()
         encrypted = encryption_service.encrypt({"token": token})
 
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -482,7 +483,7 @@ class SubscriptionOperations:
         Returns the count of consecutive rate-limit events for this pair
         (events within the last 2 hours, no successful execution in between).
         """
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         event_id = str(uuid.uuid4())
 
         with get_db_connection() as conn:

--- a/src/backend/db/system_views.py
+++ b/src/backend/db/system_views.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from db.connection import get_db_connection
 from db_models import SystemView, SystemViewCreate, SystemViewUpdate
+from utils.helpers import utc_now_iso
 
 
 class SystemViewOperations:
@@ -29,7 +30,7 @@ class SystemViewOperations:
             The created SystemView
         """
         view_id = f"sv_{secrets.token_urlsafe(12)}"
-        now = datetime.utcnow().isoformat() + "Z"
+        now = utc_now_iso()
 
         # Normalize and validate tags
         filter_tags = sorted(set(t.lower().strip() for t in data.filter_tags if t.strip()))
@@ -169,7 +170,7 @@ class SystemViewOperations:
             return self.get_view(view_id)
 
         updates.append("updated_at = ?")
-        params.append(datetime.utcnow().isoformat() + "Z")
+        params.append(utc_now_iso())
         params.append(view_id)
 
         with get_db_connection() as conn:

--- a/src/backend/db/tags.py
+++ b/src/backend/db/tags.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 from db.connection import get_db_connection
 from db_models import AgentTagList, TagWithCount
+from utils.helpers import utc_now_iso
 
 
 class TagOperations:
@@ -50,7 +51,7 @@ class TagOperations:
             )
 
             # Insert new tags
-            now = datetime.utcnow().isoformat() + "Z"
+            now = utc_now_iso()
             for tag in normalized:
                 cursor.execute(
                     "INSERT INTO agent_tags (agent_name, tag, created_at) VALUES (?, ?, ?)",
@@ -77,7 +78,7 @@ class TagOperations:
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
-            now = datetime.utcnow().isoformat() + "Z"
+            now = utc_now_iso()
 
             # Use INSERT OR IGNORE to handle duplicates
             cursor.execute(

--- a/src/backend/db/telegram_channels.py
+++ b/src/backend/db/telegram_channels.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Optional, List
 
 from db.connection import get_db_connection
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ class TelegramChannelOperations:
         """Create or update a Telegram bot binding for an agent."""
         webhook_secret = secrets.token_urlsafe(32)
         telegram_secret_token = secrets.token_urlsafe(32)
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         encrypted_token = self._encrypt_token(bot_token)
 
         with get_db_connection() as conn:
@@ -152,7 +153,7 @@ class TelegramChannelOperations:
 
     def update_webhook_url(self, agent_name: str, webhook_url: str) -> None:
         """Update the registered webhook URL for a binding."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
@@ -223,7 +224,7 @@ class TelegramChannelOperations:
             if row:
                 return self._row_to_chat_link(row)
 
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
             cursor.execute("""
                 INSERT INTO telegram_chat_links
                 (binding_id, telegram_user_id, telegram_username, message_count, created_at, last_active)
@@ -278,7 +279,7 @@ class TelegramChannelOperations:
         email: str,
     ) -> bool:
         """Persist a verified email onto the chat link (auto-creates the row)."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         email = email.lower()
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -345,7 +346,7 @@ class TelegramChannelOperations:
 
     def increment_message_count(self, chat_link_id: int) -> None:
         """Increment message count and update last_active."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
@@ -367,7 +368,7 @@ class TelegramChannelOperations:
         chat_type: str = "group",
     ) -> dict:
         """Get or create a group config. Auto-creates on first interaction."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
@@ -464,7 +465,7 @@ class TelegramChannelOperations:
         welcome_text: Optional[str] = None,
     ) -> Optional[dict]:
         """Update group config settings."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             updates = ["updated_at = ?"]
@@ -501,7 +502,7 @@ class TelegramChannelOperations:
 
     def deactivate_group_config(self, binding_id: int, chat_id: str) -> bool:
         """Mark a group config as inactive (bot removed from group)."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
@@ -555,7 +556,7 @@ class TelegramChannelOperations:
 
     def set_group_verified(self, binding_id: int, chat_id: str, email: str) -> bool:
         """Mark a group as verified by the given email."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
@@ -568,7 +569,7 @@ class TelegramChannelOperations:
 
     def clear_group_verification(self, binding_id: int, chat_id: str) -> bool:
         """Clear verification status for a group (e.g., when verified user leaves)."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""

--- a/src/backend/db/users.py
+++ b/src/backend/db/users.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, List, Any
 
 from .connection import get_db_connection
 from db_models import UserCreate
+from utils.helpers import utc_now_iso
 
 
 class UserOperations:
@@ -64,7 +65,7 @@ class UserOperations:
 
     def create_user(self, user_data: UserCreate) -> Dict:
         """Create a new user."""
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
@@ -116,7 +117,7 @@ class UserOperations:
                 return self.get_user_by_username(username)
 
             set_clauses.append("updated_at = ?")
-            params.append(datetime.utcnow().isoformat())
+            params.append(utc_now_iso())
             params.append(username)
 
             cursor.execute(f"""
@@ -141,7 +142,7 @@ class UserOperations:
         """
         with get_db_connection() as conn:
             cursor = conn.cursor()
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
 
             # Try to update existing user
             cursor.execute("""
@@ -164,7 +165,7 @@ class UserOperations:
         """Update user's last login timestamp."""
         with get_db_connection() as conn:
             cursor = conn.cursor()
-            now = datetime.utcnow().isoformat()
+            now = utc_now_iso()
             cursor.execute("""
                 UPDATE users SET last_login = ?, updated_at = ? WHERE username = ?
             """, (now, now, username))
@@ -195,7 +196,7 @@ class UserOperations:
                 cursor.execute("""
                     UPDATE users SET auth0_sub = ?, name = ?, picture = ?, updated_at = ?
                     WHERE username = ?
-                """, (auth0_sub, name, picture, datetime.utcnow().isoformat(), email))
+                """, (auth0_sub, name, picture, utc_now_iso(), email))
                 conn.commit()
             return self.get_user_by_username(email)
 
@@ -231,7 +232,7 @@ class UserOperations:
             cursor = conn.cursor()
             cursor.execute("""
                 UPDATE users SET role = ?, updated_at = ? WHERE username = ?
-            """, (role, datetime.now().isoformat(), username))
+            """, (role, utc_now_iso(), username))
             conn.commit()
             if cursor.rowcount == 0:
                 return None

--- a/src/backend/logging_config.py
+++ b/src/backend/logging_config.py
@@ -9,6 +9,7 @@ import json
 from datetime import datetime
 
 from opentelemetry import trace
+from utils.helpers import utc_now_iso
 
 
 class JsonFormatter(logging.Formatter):
@@ -16,7 +17,7 @@ class JsonFormatter(logging.Formatter):
 
     def format(self, record):
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": utc_now_iso(),
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -27,6 +27,7 @@ from config import CORS_ORIGINS, VOICE_ENABLED, GEMINI_API_KEY
 from models import User
 from dependencies import get_current_user
 from services.docker_service import docker_client, list_all_agents_fast
+from utils.helpers import utc_now_iso
 
 # OpenTelemetry imports for distributed tracing (RELIABILITY-002)
 from opentelemetry import trace
@@ -757,7 +758,7 @@ async def health_check():
             status_code=503,
             content={
                 "status": "unhealthy",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": utc_now_iso(),
                 "migrations": {"applied": applied, "expected": expected},
             },
         )

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -66,6 +66,7 @@ from services.agent_service import (
     # Autonomy (global view)
     get_all_autonomy_status_logic,
 )
+from utils.helpers import utc_now_iso
 
 router = APIRouter(prefix="/api/agents", tags=["agents"])
 
@@ -266,7 +267,7 @@ async def get_all_agent_slots(
 
     return BulkSlotState(
         agents=slot_states,
-        timestamp=datetime.utcnow().isoformat() + "Z"
+        timestamp=utc_now_iso()
     )
 
 

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -30,6 +30,7 @@ from services.platform_prompt_service import (
     get_platform_system_prompt,
     is_execution_context_enabled,
 )
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ async def broadcast_collaboration_event(source_agent: str, target_agent: str, ac
             "source_agent": source_agent,
             "target_agent": target_agent,
             "action": action,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": utc_now_iso()
         }
         await _websocket_manager.broadcast(json.dumps(event))
     else:
@@ -618,7 +619,7 @@ async def _run_async_task_with_persistence(
                     "execution_id": execution_id,
                     "agent_name": agent_name,
                     "chat_session_id": chat_session_id,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utc_now_iso(),
                 }))
             except Exception as e:
                 logger.warning(f"[Task Async] chat_response_ready broadcast failed: {e}")
@@ -702,7 +703,7 @@ async def _run_async_task_with_persistence(
                     "activity_type": "self_task",
                     "activity_state": "completed" if result.status == TaskExecutionStatus.SUCCESS else "failed",
                     "action": f"Background task completed",
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utc_now_iso(),
                     "details": {
                         "execution_id": execution_id,
                         "chat_session_id": request.chat_session_id,
@@ -831,7 +832,7 @@ async def execute_parallel_task(
                     "activity_type": "self_task",
                     "activity_state": "started",
                     "action": f"Background task: {request.message[:50]}...",
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utc_now_iso(),
                     "details": {
                         "execution_id": execution_id,
                         "chat_session_id": request.chat_session_id,

--- a/src/backend/routers/ops.py
+++ b/src/backend/routers/ops.py
@@ -24,6 +24,7 @@ from services.docker_service import get_agent_container, docker_client, list_all
 from services.docker_utils import container_stop, container_start
 from services.agent_client import get_agent_client
 from db.agents import SYSTEM_AGENT_NAME
+from utils.helpers import utc_now_iso
 
 router = APIRouter(prefix="/api/ops", tags=["operations"])
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ async def get_fleet_status(
     )
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_now_iso(),
         "summary": {
             "total": total,
             "running": running,
@@ -210,7 +211,7 @@ async def get_fleet_health(
         overall = "healthy"
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_now_iso(),
         "overall": overall,
         "critical_issues": critical_issues,
         "warnings": warnings,
@@ -317,7 +318,7 @@ async def restart_fleet(
             failures += 1
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_now_iso(),
         "summary": {
             "total": len(agents),
             "successes": successes,
@@ -410,7 +411,7 @@ async def stop_fleet(
             failures += 1
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_now_iso(),
         "summary": {
             "total": len(agents),
             "successes": successes,
@@ -487,7 +488,7 @@ async def list_all_schedules(
     agents_with_schedules = len(set(s.agent_name for s in schedules))
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_now_iso(),
         "summary": {
             "total": total,
             "enabled": enabled,
@@ -710,7 +711,7 @@ async def list_alerts(
     # For now, return placeholder - check fleet health for issues
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_now_iso(),
         "alerts": [],
         "message": "Alerts feature coming soon. Check fleet health for current issues."
     }
@@ -785,7 +786,7 @@ async def get_ops_costs(
                     "enabled": True,
                     "available": False,
                     "error": f"OTel Collector returned status {response.status_code}",
-                    "timestamp": datetime.utcnow().isoformat()
+                    "timestamp": utc_now_iso()
                 }
 
             # Parse Prometheus metrics
@@ -831,7 +832,7 @@ async def get_ops_costs(
             result = {
                 "enabled": True,
                 "available": True,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_now_iso(),
 
                 # Summary
                 "summary": {
@@ -869,14 +870,14 @@ async def get_ops_costs(
             "enabled": True,
             "available": False,
             "error": "Cannot connect to OTel Collector. Is it running?",
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": utc_now_iso()
         }
     except httpx.TimeoutException:
         return {
             "enabled": True,
             "available": False,
             "error": "OTel Collector request timed out",
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": utc_now_iso()
         }
     except Exception as e:
         logger.error(f"Failed to fetch cost metrics: {e}")
@@ -884,7 +885,7 @@ async def get_ops_costs(
             "enabled": True,
             "available": False,
             "error": f"Failed to fetch metrics: {str(e)}",
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": utc_now_iso()
         }
 
 
@@ -995,7 +996,7 @@ async def get_auth_report(
     ]
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_now_iso(),
         "summary": {
             "total_agents": len(agents) - len([a for a in agents if db.get_agent_owner(a.name) and db.get_agent_owner(a.name).get("is_system")]),
             "using_subscription": len(subscription_agents),

--- a/src/backend/routers/processes.py
+++ b/src/backend/routers/processes.py
@@ -36,6 +36,7 @@ import secrets
 from datetime import datetime
 from croniter import croniter
 import pytz
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -795,7 +796,7 @@ def _register_process_schedules(definition: ProcessDefinition) -> int:
             )
         """)
 
-        now = datetime.utcnow().isoformat()
+        now = utc_now_iso()
 
         for trigger in schedule_triggers:
             if not trigger.enabled:

--- a/src/backend/routers/telemetry.py
+++ b/src/backend/routers/telemetry.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from dependencies import get_current_user
 from models import User
 from services.docker_service import docker_client, list_all_agents_fast
+from utils.helpers import utc_now_iso
 
 # Module-level executor for Docker operations (blocking calls)
 # Limited to 4 workers to avoid overwhelming Docker daemon
@@ -62,7 +63,7 @@ async def get_host_stats(current_user: User = Depends(get_current_user)):
                 "used_gb": round(disk.used / (1024**3), 1),
                 "total_gb": round(disk.total / (1024**3), 1)
             },
-            "timestamp": datetime.utcnow().isoformat() + "Z"
+            "timestamp": utc_now_iso()
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error getting host stats: {str(e)}")
@@ -134,7 +135,7 @@ async def get_container_stats(current_user: User = Depends(get_current_user)):
                 "total_cpu_percent": 0,
                 "total_memory_mb": 0,
                 "containers": [],
-                "timestamp": datetime.utcnow().isoformat() + "Z"
+                "timestamp": utc_now_iso()
             }
 
         # Fetch all container stats in PARALLEL using thread pool
@@ -168,7 +169,7 @@ async def get_container_stats(current_user: User = Depends(get_current_user)):
             "total_cpu_percent": round(total_cpu_percent, 1),
             "total_memory_mb": round(total_memory_mb, 1),
             "containers": sorted(processed_stats, key=lambda x: x.get('cpu', 0), reverse=True),
-            "timestamp": datetime.utcnow().isoformat() + "Z"
+            "timestamp": utc_now_iso()
         }
 
     except Exception as e:

--- a/src/backend/services/activity_service.py
+++ b/src/backend/services/activity_service.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional, Callable, Any
 from datetime import datetime
 from models import ActivityType, ActivityState, ActivityCreate
 from database import db
+from utils.helpers import utc_now_iso
 
 
 class ActivityService:
@@ -189,7 +190,7 @@ class ActivityService:
             "activity_type": activity_type,
             "activity_state": activity_state,
             "action": action,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_now_iso(),
             "details": details or {},
             "error": error
         }

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -31,7 +31,7 @@ from services.template_service import (
 from services import git_service
 from services.settings_service import get_anthropic_api_key, get_github_pat, get_agent_full_capabilities, get_agent_quota_for_role
 from services.github_service import GitHubService, GitHubError
-from utils.helpers import sanitize_agent_name
+from utils.helpers import sanitize_agent_name, utc_now_iso
 from .helpers import validate_base_image
 from .lifecycle import RESTRICTED_CAPABILITIES, FULL_CAPABILITIES
 
@@ -558,7 +558,7 @@ async def create_agent_internal(
                     'trinity.ssh-port': str(config.port),
                     'trinity.cpu': config.resources['cpu'],
                     'trinity.memory': config.resources['memory'],
-                    'trinity.created': datetime.now().isoformat(),
+                    'trinity.created': utc_now_iso(),
                     'trinity.template': config.template or '',
                     'trinity.agent-runtime': config.runtime or 'claude-code',
                     'trinity.full-capabilities': str(full_capabilities).lower(),

--- a/src/backend/services/archive_storage.py
+++ b/src/backend/services/archive_storage.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, Dict, List, Any
 from datetime import datetime
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,7 @@ class LocalArchiveStorage(ArchiveStorage):
                 "storage_type": "local",
                 "path": str(dest_path),
                 "size": file_size,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_now_iso(),
             }
 
         except Exception as e:

--- a/src/backend/services/docker_service.py
+++ b/src/backend/services/docker_service.py
@@ -2,9 +2,9 @@
 Docker service for managing agent containers.
 """
 from typing import List, Optional
-from datetime import datetime
 import docker
 from models import AgentStatus
+from utils.helpers import parse_iso_timestamp, utc_now
 
 
 # Initialize Docker client
@@ -73,7 +73,7 @@ def get_agent_status_from_container(container) -> AgentStatus:
         type=labels.get("trinity.agent-type", "unknown"),
         status=normalized_status,
         port=int(labels.get("trinity.ssh-port", "0")),
-        created=datetime.fromisoformat(labels.get("trinity.created", datetime.now().isoformat())),
+        created=parse_iso_timestamp(labels["trinity.created"]) if labels.get("trinity.created") else utc_now(),
         resources={
             "cpu": labels.get("trinity.cpu", "2"),
             "memory": labels.get("trinity.memory", "4g")
@@ -144,7 +144,7 @@ def list_all_agents_fast() -> List[AgentStatus]:
                 type=labels.get("trinity.agent-type", "unknown"),
                 status=normalized_status,
                 port=int(labels.get("trinity.ssh-port", "0")),
-                created=datetime.fromisoformat(labels.get("trinity.created", datetime.now().isoformat())),
+                created=parse_iso_timestamp(labels["trinity.created"]) if labels.get("trinity.created") else utc_now(),
                 resources={
                     "cpu": labels.get("trinity.cpu", "2"),
                     "memory": labels.get("trinity.memory", "4g")

--- a/src/backend/services/log_archive_service.py
+++ b/src/backend/services/log_archive_service.py
@@ -17,6 +17,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from .archive_storage import get_archive_storage
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ class LogArchiveService:
                             metadata = {
                                 "original_size": str(original_size),
                                 "compressed_size": str(compressed_size),
-                                "archived_at": datetime.utcnow().isoformat(),
+                                "archived_at": utc_now_iso(),
                                 "retention_days": str(retention_days),
                                 "original_file": log_file.name,
                             }

--- a/src/backend/services/process_engine/events/webhook_publisher.py
+++ b/src/backend/services/process_engine/events/webhook_publisher.py
@@ -28,6 +28,7 @@ from ..domain.events import (
     ApprovalRequested,
 )
 from ..events.bus import EventBus
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +152,7 @@ class WebhookEventPublisher:
         # Build base payload
         payload = {
             "event_type": event_type,
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": utc_now_iso(),
         }
 
         # Add event-specific data

--- a/src/backend/services/process_engine/events/websocket_publisher.py
+++ b/src/backend/services/process_engine/events/websocket_publisher.py
@@ -24,6 +24,7 @@ from ..domain.events import (
     CompensationFailed,
 )
 from ..events.bus import EventBus
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ class WebSocketEventPublisher:
         message = {
             "type": "process_event",
             "event_type": event_type,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_now_iso(),
         }
 
         # Add event-specific data

--- a/src/backend/services/slot_service.py
+++ b/src/backend/services/slot_service.py
@@ -24,6 +24,7 @@ import redis
 import time
 
 from dataclasses import dataclass
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ class SlotService:
         metadata_key = self._metadata_key(agent_name, execution_id)
         slot_number = current_count + 1  # Assign next available slot number
         self.redis.hset(metadata_key, mapping={
-            "started_at": datetime.utcnow().isoformat(),
+            "started_at": utc_now_iso(),
             "message_preview": message_preview[:100] if message_preview else "",
             "slot_number": str(slot_number),
             "timeout_seconds": str(timeout_seconds)

--- a/src/backend/services/system_agent_service.py
+++ b/src/backend/services/system_agent_service.py
@@ -23,6 +23,7 @@ from services.docker_service import (
 from services.docker_utils import container_reload, container_start, containers_run
 from services.settings_service import get_anthropic_api_key
 from services.agent_service.lifecycle import FULL_CAPABILITIES
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +223,7 @@ class SystemAgentService:
             'trinity.ssh-port': str(ssh_port),  # Required for port tracking
             'trinity.cpu': str(resources.get('cpu', '4')),
             'trinity.memory': resources.get('memory', '8g'),
-            'trinity.created': datetime.utcnow().isoformat(),
+            'trinity.created': utc_now_iso(),
             'trinity.template': SYSTEM_AGENT_TEMPLATE,
             'trinity.is-system': 'true',  # Mark as system agent
         }

--- a/src/backend/services/validation_service.py
+++ b/src/backend/services/validation_service.py
@@ -31,6 +31,7 @@ from typing import Optional
 from database import db
 from models import BusinessStatus
 from services.task_execution_service import TaskExecutionService, TaskExecutionResult
+from utils.helpers import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -379,7 +380,7 @@ class ValidationService:
                     "items": validation_result.items,
                     "recommendation": validation_result.recommendation,
                 },
-                "created_at": datetime.utcnow().isoformat() + "Z",
+                "created_at": utc_now_iso(),
             }
 
             # Read existing queue, append, write back


### PR DESCRIPTION
## Summary
Backend emitted naive ISO timestamps from `datetime.utcnow().isoformat()` in 41 modules — no `Z` suffix, no offset. JavaScript `new Date(str)` then parsed them as **local time**, so timestamps rendered in the server's timezone instead of the client's (the bug reported against the Payments tab and elsewhere).

- Mass-replace `datetime.utcnow().isoformat()` → `utc_now_iso()` helper (which appends `Z`) across 38 modules.
- Replace 3 stray `datetime.now().isoformat()` callsites (agent create docker label, user role update, health check).
- `docker_service.py` reads `trinity.created` label via `parse_iso_timestamp`, so legacy naive labels are tagged UTC and emitted with `+00:00` on serialization.
- Strip redundant `+ "Z"` suffixes where the old code appended Z manually — helper already includes it. Without this, logs printed `...ZZ`.

`utc_now_iso()` and `parse_iso_timestamp()` already existed in `utils/helpers.py`; this PR completes the mass adoption. Going forward, new backend code should use the helper.

Closes #79

## Verification
API now returns UTC-marked timestamps:
```
/api/agents         -> "2026-04-10T08:30:00.842757+00:00"   (was no tz)
/api/activities/... -> "2026-04-17T11:58:00.091554Z"        (was no tz)
logs                -> "2026-04-21T10:42:24.745640Z"        (was "ZZ" briefly during debug, now single Z)
```

Both `...Z` and `...+00:00` round-trip correctly through `new Date(str).toLocaleString()` in the browser — frontend now displays every timestamp in the viewer's local zone.

## Test plan
- [ ] Backend starts cleanly (verified locally: `docker compose restart backend` — no errors)
- [ ] `GET /api/agents` returns `created` with timezone marker
- [ ] `GET /api/activities/timeline` returns `started_at` with `Z`
- [ ] Log lines carry single `Z` (not `ZZ`)
- [ ] Open Payments tab (NeverminedPanel.vue) in a different browser timezone (or via DevTools timezone override) and confirm log entries display in local time
- [ ] Same check on chat timestamps, schedule history, agent created-at, credential last-updated
- [ ] `datetime.fromisoformat(label)` paths still handle both `...Z` (new writes) and naive (legacy docker labels) — `parse_iso_timestamp` covers both

## Follow-ups (out of scope for this PR)
- DB rows written before this PR remain naive; frontend `new Date(str)` will still mis-parse those as local. Options: one-off backfill migration OR frontend `parseUTC` adoption sweep (utility already exists at `src/frontend/src/utils/timestamps.js`). The latter is mechanical and ~30 files.
- A couple of `(datetime.utcnow() - timedelta(...)).isoformat() + "Z"` patterns in `db/monitoring.py` weren't touched — they emit single Z correctly but could be standardized via `to_utc_iso(datetime_obj)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)