### PR TITLE
fix(sharing): clear stale pending access_request on team share + Sharing UX (#446)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -139,6 +139,7 @@ The test suite covers:
 - **Agent Chat** (test_agent_chat.py) - Message sending, history, sessions, in-memory activity, model selection
 - **Agent Files** (test_agent_files.py) - File browser, downloads
 - **Agent Sharing** (test_agent_sharing.py) - Share/unshare agents, whitelist auto-add with `default_role="user"` (#314)
+- **Team Share Gate Unit** (test_team_share_gate_unit.py) - Isolated `SharingMixin` tests: team-shared email passes gate, mixed-case normalization, stale pending `access_requests` cleanup on `share_agent`, cleanup scope (#446) [UNIT]
 - **Channel Access Control** (test_channel_access_control.py) - Per-agent access policy (require_email, open_access, group_auth_mode), access requests inbox (#311) [SMOKE + Agent]
 - **Telegram Groups** (test_telegram_groups.py) - Trigger mode validation (mention/all/observe), proactive message endpoint validation (#349) [SMOKE + Agent]
 - **Agent Permissions** (test_agent_permissions.py) - Agent-to-agent permission CRUD, defaults, cascade delete, bulk edges endpoint (#359) (Req 9.10)
@@ -228,10 +229,10 @@ The test suite covers:
 
 ## Test Suite Statistics
 
-**Total Tests**: ~2,211 tests across 121 test files
+**Total Tests**: ~2,219 tests across 122 test files
 **Smoke Tests**: ~578 tests (fast, no agent creation)
-**Unit Tests**: ~90 tests (no backend needed, rate limit detection, watchdog logic, context formula, OTel trace logging, file upload, voice transcription, inter-agent timeout, scheduler sync loop)
-**Core Tests (not slow)**: ~2,076 tests
+**Unit Tests**: ~98 tests (no backend needed, rate limit detection, watchdog logic, context formula, OTel trace logging, file upload, voice transcription, inter-agent timeout, scheduler sync loop, team-share gate)
+**Core Tests (not slow)**: ~2,084 tests
 **Slow Tests**: ~89 tests (chat execution, fleet ops, system agent ops, execution termination)
 **WebSocket Tests**: ~10 tests (web terminal, execution streaming)
 
@@ -259,6 +260,28 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 - **Healthy**: >90% pass rate, 0 critical failures
 - **Warning**: 75-90% pass rate, <5 failures
 - **Critical**: <75% pass rate or >5 failures
+
+## Recent Test Additions (2026-04-22)
+
+| Test File | Description | Tests Added |
+|-----------|-------------|-------------|
+| `test_team_share_gate_unit.py` | Team-share gate regression for #446 — ensures team-shared emails pass the public-link gate and `share_agent` clears stale pending `access_requests` rows | 8 tests |
+
+**Team Share Gate (#446)** (`test_team_share_gate_unit.py`):
+
+Isolated unit tests over `SharingMixin` using an in-memory `agent_sharing` + `access_requests` SQLite DB (same harness style as `test_sharing_null_email_unit.py`). No backend container required; runs via `python -m pytest` inside the `trinity-backend` image (needs `utils.helpers`).
+
+Gate behavior:
+- `test_team_shared_email_passes_gate_lowercase` — baseline pass for lowercase input
+- `test_team_shared_email_passes_gate_mixed_case` — `Alice@Example.COM` and whitespace-padded input still match the lowercase allow-list (#446 casing defense-in-depth)
+- `test_non_shared_email_still_fails_gate` — no false positives
+- `test_empty_email_returns_false` — None / "" / "   " all rejected
+
+Stale-row cleanup on share:
+- `test_share_agent_clears_stale_pending_request` — adding a user to Team Sharing atomically deletes any pre-existing `status='pending'` row for the same `(agent, email)`
+- `test_share_agent_no_pending_row_is_noop_on_access_requests` — fresh share with no pending row is a safe no-op
+- `test_share_agent_does_not_clear_other_agents_pending` — cleanup scope is exactly `(this agent, this email, status='pending')`
+- `test_share_agent_normalizes_whitespace_and_case` — mixed-case / padded share input lands lowercase and still clears the matching lowercase pending row
 
 ## Recent Test Additions (2026-04-20)
 

--- a/docs/memory/feature-flows/agent-sharing.md
+++ b/docs/memory/feature-flows/agent-sharing.md
@@ -320,33 +320,42 @@ Both `is_agent_shared_with_email` and `email_has_agent_access` are exposed on th
 
 Access-policy storage lives on `agent_ownership` via `AccessPolicyMixin` (`db/agent_settings/access_policy.py`); access requests live in their own table via `db/access_requests.py`.
 
-### Share Agent (`db/agents.py:169-212`)
+### Share Agent (`db/agent_settings/sharing.py`)
+
+`share_agent` now normalizes the email (`.strip().lower()`) and, within the same transaction as the `agent_sharing` insert, deletes any stale pending `access_requests` row for the same `(agent_name, email)` so the owner's Pending list reflects reality after a manual Team Share add (#446). Approved/denied rows are left untouched as audit trail.
+
 ```python
-def share_agent(self, agent_name: str, owner_username: str, share_with_email: str) -> Optional[AgentShare]:
+def share_agent(self, agent_name, owner_username, share_with_email) -> Optional[AgentShare]:
     owner = self._user_ops.get_user_by_username(owner_username)
     if not owner:
         return None
-
-    # Check if user can share (owner or admin)
     if not self.can_user_share_agent(owner_username, agent_name):
         return None
 
-    # Prevent self-sharing
-    owner_email = owner.get("email") or ""
-    if owner_email and owner_email.lower() == share_with_email.lower():
+    normalized_email = (share_with_email or "").strip().lower()
+    if not normalized_email:
         return None
+
+    owner_email = (owner.get("email") or "").strip().lower()
+    if owner_email and owner_email == normalized_email:
+        return None  # self-share
 
     with get_db_connection() as conn:
         cursor = conn.cursor()
         try:
-            cursor.execute("""
-                INSERT INTO agent_sharing (agent_name, shared_with_email, shared_by_id, created_at)
-                VALUES (?, ?, ?, ?)
-            """, (agent_name, share_with_email.lower(), owner["id"], now))
+            cursor.execute(
+                "INSERT INTO agent_sharing (agent_name, shared_with_email, shared_by_id, created_at) VALUES (?, ?, ?, ?)",
+                (agent_name, normalized_email, owner["id"], now),
+            )
+            # #446: clear any stale pending access_request for same (agent, email)
+            cursor.execute(
+                "DELETE FROM access_requests WHERE agent_name = ? AND email = ? AND status = 'pending'",
+                (agent_name, normalized_email),
+            )
             conn.commit()
             return AgentShare(...)
         except sqlite3.IntegrityError:
-            return None  # Already shared
+            return None  # already shared
 ```
 
 ### Cascade Delete (`db/agents.py:117-128`)
@@ -455,6 +464,7 @@ Working - Agent sharing fully functional with email-based collaboration
 
 | Date | Changes |
 |------|---------|
+| 2026-04-22 | **#446 — team-share gate hardening + Sharing UX**. `share_agent` now deletes stale pending `access_requests` rows atomically with the share insert (manual Team Share now clears the owner's Pending list). Email normalization (`.strip().lower()`) added in `share_agent`, `is_agent_shared_with_email`, and `email_has_agent_access` as defense-in-depth. `SharingPanel.vue` restructured to distinguish **Identity Proof** (`require_email`) from **Authorization** (Team Sharing allow-list + approval queue); dead-end warning shown when `require_email=true && !open_access && shares.length===0`. New unit test file: `tests/test_team_share_gate_unit.py`. Canonical gate semantics continue to live in [unified-channel-access-control.md](unified-channel-access-control.md). |
 | 2026-04-12 | **Issue #311 — unified cross-channel access control**: `agent_sharing` is now the cross-channel allow-list (web + Telegram + Slack). Added 4 endpoints to `routers/sharing.py` for access policy (`require_email`, `open_access`) and pending access requests (approve/deny). `SharingPanel.vue` gained a Channel Access Policy section + Pending Access Requests list (direct axios, no composable). New `SharingMixin` helpers: `is_agent_shared_with_email`, `email_has_agent_access`. `delete_agent_ownership` now also cascades `access_requests`. Canonical primitive lives in [unified-channel-access-control.md](unified-channel-access-control.md). |
 | 2026-02-18 | **Public Links tab consolidated**: Public Links tab removed from AgentDetail.vue. SharingPanel.vue now includes PublicLinksPanel as embedded component (lines 79-83, 92). Updated tab visibility line numbers (506-509). Single "Sharing" tab now contains both Team Sharing and Public Links sections. |
 | 2026-01-30 | **Git Pull permission update**: Added Git Pull and Git Sync/Init columns to Access Levels table. Shared users can now pull from GitHub (was owner-only). |

--- a/docs/memory/feature-flows/unified-channel-access-control.md
+++ b/docs/memory/feature-flows/unified-channel-access-control.md
@@ -145,21 +145,24 @@ New ops class (not a mixin — `access_requests` is its own domain table):
 | `decide(request_id, approve, decided_by_user_id)` | Sets `status` to `approved` or `denied`, stamps `decided_by` and `decided_at`. |
 | `delete_for_agent(agent_name)` | Cascade delete on agent removal. |
 
-### Extended `AgentSharingMixin` (`src/backend/db/agent_settings/sharing.py:121-148`)
+### Extended `AgentSharingMixin` (`src/backend/db/agent_settings/sharing.py`)
 
-Two new helpers — both are lookups by **email** (not by username), which is the cross-channel identity:
+Two helpers — both are lookups by **email** (not by username), which is the cross-channel identity. Defensive input normalization (`.strip().lower()`) was added at the gate boundary (#446) so mixed-case session emails cannot slip past the allow-list match:
 
 ```python
 def is_agent_shared_with_email(self, agent_name, email) -> bool:
-    """Direct hit on agent_sharing.shared_with_email."""
+    """Direct hit on agent_sharing.shared_with_email (strip+lower input)."""
 
 def email_has_agent_access(self, agent_name, email) -> bool:
     """Cross-channel access check (#311).
     True if email is owner, admin, or in agent_sharing.
+    Normalizes email at the boundary (strip+lower) for #446.
     """
 ```
 
-`email_has_agent_access` is the single function the channel router calls to check authorization.
+`email_has_agent_access` is the single function the channel router calls to check authorization. Both gate call sites (`routers/public.py` and `adapters/message_router.py`) also normalize `verified_email` at the router boundary for #446 defense-in-depth and consistent logging.
+
+**Team share clears stale pending (#446)**: `share_agent` now atomically deletes any `access_requests` row with `status='pending'` for the same `(agent_name, email)` in the same transaction as the `agent_sharing` insert. This ensures the owner's Pending list reflects reality when an email is manually added to Team Sharing after a prior public-chat attempt. Approved/denied rows are left untouched as audit trail.
 
 ### Extended `TelegramChannelOperations` (`src/backend/db/telegram_channels.py:242-309`)
 
@@ -621,6 +624,7 @@ Working. Telegram, Slack, and web public-chat all run the same gate.
 
 | Date | Changes |
 |------|---------|
+| 2026-04-22 | **#446 — team-share gate hardening + Sharing UX**: (1) `share_agent` now deletes any stale pending `access_requests` row for the same `(agent, email)` atomically with the share insert, so a manual Team Share add clears the owner's Pending list. (2) Defense-in-depth email normalization (`.strip().lower()`) added in `email_has_agent_access`, `is_agent_shared_with_email`, `routers/public.py` gate, and both DM+group branches of `adapters/message_router.py` so mixed-case session emails can't bypass the allow-list. (3) `SharingPanel.vue` restructured: new framing banner distinguishes "Identity proof" (verify who the user is) from "Authorization" (allow-list + approval queue); "Team Sharing" heading tagged "— allow-list"; dead-end warning banner when `require_email=true && !open_access && shares.length===0`. New unit tests: `tests/test_team_share_gate_unit.py` (8 tests). |
 | 2026-04-12 | Initial implementation (#311). New migration `access_control`, `AccessPolicyMixin`, `AccessRequestOperations`, ABC additions, Telegram `/login` state machine, Slack `users.info` resolver, four owner endpoints, SharingPanel UI. |
 | 2026-04-13 | Web public-chat unified. `routers/public.py` now runs the same gate as `message_router.py`, keyed on `agent_ownership.require_email` instead of per-link `agent_public_links.require_email`. New migration `public_link_require_email_unified` ORs legacy per-link flags into the agent-level flag. Access requests from web use `channel="web"`. Closes the #252 follow-up. |
 | 2026-04-15 | Group authentication mode. New `group_auth_mode` field (`"none"` or `"any_verified"`) on access policy. When `any_verified`, groups require at least one verified member before the bot responds. New migration `group_auth_mode` adds column to `agent_ownership` and `verified_by_email`/`verified_at` to `telegram_group_configs`. New ABC methods: `is_group_verified()`, `set_group_verified()`, `prompt_group_auth()`. Router gate applies group auth when `is_group=True`. |

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -296,6 +296,10 @@ class ChannelMessageRouter:
                         logger.warning(f"[ROUTER:{channel}] resolve_verified_email error: {e}")
                         verified_email = None
 
+                    # #446 defensive normalization at router boundary.
+                    if verified_email:
+                        verified_email = verified_email.strip().lower() or None
+
                     if verified_email:
                         # Sender is verified — unlock the group
                         await adapter.set_group_verified(message, agent_name, verified_email)
@@ -318,6 +322,12 @@ class ChannelMessageRouter:
             except Exception as e:
                 logger.warning(f"[ROUTER:{channel}] resolve_verified_email error: {e}")
                 verified_email = None
+
+            # Defensive normalization (#446): downstream `email_has_agent_access`
+            # already lowercases, but normalizing at the router boundary keeps
+            # all gate checks and any logging consistent.
+            if verified_email:
+                verified_email = verified_email.strip().lower() or None
 
             require_email = policy.get("require_email", False)
             open_access = policy.get("open_access", False)

--- a/src/backend/db/agent_settings/sharing.py
+++ b/src/backend/db/agent_settings/sharing.py
@@ -34,6 +34,8 @@ class SharingMixin:
         Share an agent with another user by email.
         - Validates owner has permission to share
         - Creates sharing record with email (user doesn't need to exist yet)
+        - Clears any stale pending access_requests row for the same email+agent
+          so the owner's "Pending Access Requests" list reflects reality (#446).
         - Returns share details or None if failed
         """
         # Get owner and validate permission
@@ -45,9 +47,13 @@ class SharingMixin:
         if not self.can_user_share_agent(owner_username, agent_name):
             return None
 
+        normalized_email = (share_with_email or "").strip().lower()
+        if not normalized_email:
+            return None
+
         # Prevent self-sharing (check if owner's email matches target email)
-        owner_email = owner.get("email") or ""
-        if owner_email and owner_email.lower() == share_with_email.lower():
+        owner_email = (owner.get("email") or "").strip().lower()
+        if owner_email and owner_email == normalized_email:
             return None
 
         now = utc_now_iso()
@@ -58,14 +64,21 @@ class SharingMixin:
                 cursor.execute("""
                     INSERT INTO agent_sharing (agent_name, shared_with_email, shared_by_id, created_at)
                     VALUES (?, ?, ?, ?)
-                """, (agent_name, share_with_email.lower(), owner["id"], now))
+                """, (agent_name, normalized_email, owner["id"], now))
+                # #446: once the email is on the allow-list, any pending access
+                # request for the same (agent, email) is stale — drop it so the
+                # owner's Pending list doesn't double-prompt them.
+                cursor.execute("""
+                    DELETE FROM access_requests
+                    WHERE agent_name = ? AND email = ? AND status = 'pending'
+                """, (agent_name, normalized_email))
                 conn.commit()
                 share_id = cursor.lastrowid
 
                 return AgentShare(
                     id=share_id,
                     agent_name=agent_name,
-                    shared_with_email=share_with_email.lower(),
+                    shared_with_email=normalized_email,
                     shared_by_id=owner["id"],
                     shared_by_email=owner.get("email") or owner.get("username") or "unknown",
                     created_at=datetime.fromisoformat(now)
@@ -123,32 +136,36 @@ class SharingMixin:
 
     def is_agent_shared_with_email(self, agent_name: str, email: str) -> bool:
         """Check if an agent is shared with the given email directly."""
-        if not email:
+        normalized = (email or "").strip().lower()
+        if not normalized:
             return False
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
                 SELECT 1 FROM agent_sharing
                 WHERE agent_name = ? AND shared_with_email = ?
-            """, (agent_name, email.lower()))
+            """, (agent_name, normalized))
             return cursor.fetchone() is not None
 
     def email_has_agent_access(self, agent_name: str, email: str) -> bool:
         """Cross-channel access check (Issue #311).
 
         Returns True when the email is owner, admin, or in agent_sharing for
-        the given agent. Used by the channel router gate.
+        the given agent. Used by the channel router gate. Defensive
+        normalization (#446): strip + lowercase at the boundary so
+        mixed-case session emails can't bypass the allow-list match.
         """
-        if not email:
+        normalized = (email or "").strip().lower()
+        if not normalized:
             return False
-        user = self._user_ops.get_user_by_email(email)
+        user = self._user_ops.get_user_by_email(normalized)
         if user:
             if user.get("role") == "admin":
                 return True
             owner = self.get_agent_owner(agent_name)
             if owner and owner["owner_username"] == user["username"]:
                 return True
-        return self.is_agent_shared_with_email(agent_name, email)
+        return self.is_agent_shared_with_email(agent_name, normalized)
 
     def is_agent_shared_with_user(self, agent_name: str, username: str) -> bool:
         """Check if an agent is shared with a specific user (by their email)."""

--- a/src/backend/routers/public.py
+++ b/src/backend/routers/public.py
@@ -433,8 +433,10 @@ async def public_chat(
                 status_code=401,
                 detail="Invalid or expired session. Please verify your email again."
             )
-        verified_email = email
-        session_identifier = email.lower()
+        # Defensive normalization (#446): ensure gate compares lowercased emails
+        # even if the stored session email contained unexpected casing/whitespace.
+        verified_email = (email or "").strip().lower()
+        session_identifier = verified_email
         identifier_type = "email"
 
         # Unified cross-channel access gate (#311) — same logic as

--- a/src/frontend/src/components/SharingPanel.vue
+++ b/src/frontend/src/components/SharingPanel.vue
@@ -1,11 +1,20 @@
 <template>
   <div class="p-6 space-y-8">
+    <!-- Framing: identity vs. authorization (Issue #446) -->
+    <div class="rounded-lg bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-100 dark:border-indigo-900/40 p-4 text-sm text-indigo-900 dark:text-indigo-200">
+      Access to this agent has two layers:
+      <ul class="mt-2 list-disc pl-5 space-y-1">
+        <li><strong>Identity proof</strong> — "Require verified email" (below) forces every user to prove who they are via email verification before chatting. It is enforced on web, Slack, and Telegram.</li>
+        <li><strong>Authorization</strong> — "Team Sharing" (below) is the allow-list of emails who skip the owner-approval queue. Everyone else lands in Pending Access Requests until you approve them.</li>
+      </ul>
+    </div>
+
     <!-- Channel Access Policy (Issue #311) -->
     <div>
-      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Channel Access Policy</h3>
+      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Identity Proof</h3>
       <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Controls who can chat with this agent across web, Telegram, and Slack.
-        The team-sharing list below is the unified allow-list.
+        Require users to prove who they are before chatting, across web, Telegram, and Slack.
+        Identity proof alone does <em>not</em> grant access — see Team Sharing below.
       </p>
 
       <div class="space-y-3">
@@ -21,6 +30,7 @@
             <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Require verified email</div>
             <div class="text-xs text-gray-500 dark:text-gray-400">
               Telegram users must <code>/login</code>; Slack uses workspace email; web requires email verification.
+              This only proves who the user is — it does not authorize them to chat. Use Team Sharing or Open access below for authorization.
             </div>
           </div>
         </label>
@@ -34,13 +44,23 @@
             @change="updatePolicy({ open_access: $event.target.checked })"
           />
           <div>
-            <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Open access</div>
+            <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Open access (anyone verified)</div>
             <div class="text-xs text-gray-500 dark:text-gray-400">
               Anyone with a verified email may chat without owner approval.
-              Off = pending requests must be approved.
+              When off, only users in Team Sharing skip the pending-approval queue.
             </div>
           </div>
         </label>
+      </div>
+
+      <!-- Dead-end configuration warning (#446) -->
+      <div
+        v-if="policy.require_email && !policy.open_access && (!shares || shares.length === 0)"
+        class="mt-4 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40 p-3 text-sm text-amber-900 dark:text-amber-200"
+      >
+        <strong>Heads up:</strong> you've required verified email but haven't shared with anyone or enabled Open access.
+        Every verified user will land in Pending Access Requests and stay locked out until you approve them one by one.
+        Add emails to Team Sharing below, or enable Open access, to let people chat.
       </div>
 
       <!-- Pending access requests -->
@@ -48,6 +68,9 @@
         <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
           Pending access requests ({{ pendingRequests.length }})
         </h4>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+          Users who verified their identity but aren't in Team Sharing. Approving moves them into Team Sharing.
+        </p>
         <ul class="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg">
           <li v-for="req in pendingRequests" :key="req.id" class="px-4 py-3 flex items-center justify-between">
             <div>
@@ -77,9 +100,12 @@
 
     <!-- Team Sharing Section -->
     <div>
-      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Team Sharing</h3>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Share this agent with team members by entering their email address.
+      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Team Sharing <span class="text-sm font-normal text-gray-500 dark:text-gray-400">— allow-list</span></h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+        Pre-authorize team members by email. They still verify their identity on first chat, but they skip the owner-approval queue.
+      </p>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+        Applies uniformly across web, Slack, and Telegram. Entries are stored lowercase and matched case-insensitively.
       </p>
 
       <!-- Share Form -->

--- a/tests/test_team_share_gate_unit.py
+++ b/tests/test_team_share_gate_unit.py
@@ -1,0 +1,299 @@
+"""
+Regression tests for #446 — team-shared users must pass the public-link gate
+without being queued into access_requests, regardless of email casing.
+
+These are isolated unit tests over `SharingMixin` (mirrors the test style of
+`test_sharing_null_email_unit.py`). They cover:
+
+  1. `email_has_agent_access` returns True for a team-shared email even when
+     the gate receives the email in mixed case (casing defense-in-depth).
+  2. `share_agent` clears any pre-existing pending access_request row for
+     the same (agent, email), so the owner's Pending list doesn't
+     double-prompt them after a manual Team Share add.
+  3. Sharing a brand-new email with no pending row is still a no-op on the
+     access_requests table (no spurious deletes, no crashes).
+"""
+
+import os
+import sys
+import tempfile
+import sqlite3
+import types
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_candidates = [
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src", "backend")),
+    "/app",
+]
+_backend_path = next(
+    (p for p in _candidates if os.path.isdir(os.path.join(p, "db", "agent_settings"))),
+    None,
+)
+assert _backend_path, "Could not locate backend path containing db/agent_settings"
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+
+@pytest.fixture
+def sharing_harness(monkeypatch):
+    """SharingMixin wired to an in-memory agent_sharing + access_requests DB."""
+    db_file = tempfile.NamedTemporaryFile(suffix="_gate_test.db", delete=False)
+    db_file.close()
+    db_path = db_file.name
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE agent_sharing (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT NOT NULL,
+            shared_with_email TEXT NOT NULL,
+            shared_by_id TEXT NOT NULL,
+            shared_by_email TEXT,
+            allow_proactive INTEGER DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(agent_name, shared_with_email)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE access_requests (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            channel TEXT,
+            requested_at TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            decided_by INTEGER,
+            decided_at TEXT,
+            UNIQUE(agent_name, email)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    class _Ctx:
+        def __enter__(self):
+            self.c = sqlite3.connect(db_path)
+            self.c.row_factory = sqlite3.Row
+            return self.c
+
+        def __exit__(self, *a):
+            self.c.close()
+
+    fake_conn_mod = types.ModuleType("db.connection")
+    fake_conn_mod.get_db_connection = lambda: _Ctx()
+    monkeypatch.setitem(sys.modules, "db.connection", fake_conn_mod)
+
+    class _PermissiveModule(types.ModuleType):
+        def __getattr__(self, name):
+            return MagicMock
+
+    fake_models_mod = _PermissiveModule("db_models")
+    monkeypatch.setitem(sys.modules, "db_models", fake_models_mod)
+
+    import importlib.util
+
+    sharing_path = os.path.join(_backend_path, "db", "agent_settings", "sharing.py")
+    spec = importlib.util.spec_from_file_location(
+        "db_agent_settings_sharing_446", sharing_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    SharingMixin = mod.SharingMixin
+
+    class _SharingOps(SharingMixin):
+        def __init__(self):
+            self._user_ops = MagicMock()
+            self._owner = None
+
+        def get_agent_owner(self, agent_name):
+            return self._owner
+
+    yield _SharingOps(), db_path
+    os.unlink(db_path)
+
+
+def _seed_share(db_path: str, agent: str, email_lower: str, sharer_id: str = "1") -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO agent_sharing
+          (agent_name, shared_with_email, shared_by_id, created_at)
+        VALUES (?, ?, ?, datetime('now'))
+        """,
+        (agent, email_lower, sharer_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_pending_request(
+    db_path: str,
+    agent: str,
+    email_lower: str,
+    channel: str = "web",
+    rid: str = "req_1",
+) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO access_requests
+          (id, agent_name, email, channel, requested_at, status)
+        VALUES (?, ?, ?, ?, ?, 'pending')
+        """,
+        (rid, agent, email_lower, channel, datetime.utcnow().isoformat()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _count_pending(db_path: str, agent: str, email_lower: str) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM access_requests WHERE agent_name=? AND email=? AND status='pending'",
+            (agent, email_lower),
+        )
+        return cur.fetchone()[0]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# email_has_agent_access — gate behavior
+# ---------------------------------------------------------------------------
+
+
+def test_team_shared_email_passes_gate_lowercase(sharing_harness):
+    """Baseline: a team-shared email passes `email_has_agent_access`."""
+    ops, db_path = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    ops._user_ops.get_user_by_email.return_value = None
+    _seed_share(db_path, "agent-x", "alice@example.com")
+
+    assert ops.email_has_agent_access("agent-x", "alice@example.com") is True
+
+
+def test_team_shared_email_passes_gate_mixed_case(sharing_harness):
+    """#446: mixed-case session email still matches the lowercase allow-list."""
+    ops, db_path = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    ops._user_ops.get_user_by_email.return_value = None
+    _seed_share(db_path, "agent-x", "alice@example.com")
+
+    # Gate may be invoked with whatever casing the session/channel produced.
+    assert ops.email_has_agent_access("agent-x", "Alice@Example.COM") is True
+    assert ops.email_has_agent_access("agent-x", "  alice@example.com  ") is True
+
+
+def test_non_shared_email_still_fails_gate(sharing_harness):
+    """Non-shared emails must still return False (no casing leak)."""
+    ops, db_path = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    ops._user_ops.get_user_by_email.return_value = None
+    _seed_share(db_path, "agent-x", "alice@example.com")
+
+    assert ops.email_has_agent_access("agent-x", "bob@example.com") is False
+
+
+def test_empty_email_returns_false(sharing_harness):
+    ops, _ = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    assert ops.email_has_agent_access("agent-x", "") is False
+    assert ops.email_has_agent_access("agent-x", None) is False
+    assert ops.email_has_agent_access("agent-x", "   ") is False
+
+
+# ---------------------------------------------------------------------------
+# share_agent — stale pending cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_share_agent_clears_stale_pending_request(sharing_harness):
+    """#446: adding a Team Share drops any pre-existing pending access_request.
+
+    Scenario: user tried to chat before being shared, landing in the queue.
+    Owner then adds them to Team Sharing manually. The stale pending row
+    must be gone so the Pending list doesn't double-prompt the owner.
+    """
+    ops, db_path = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    ops._user_ops.get_user_by_username.return_value = {
+        "id": 1,
+        "username": "owner",
+        "email": "owner@example.com",
+        "role": "user",
+    }
+
+    _seed_pending_request(db_path, "agent-x", "alice@example.com")
+    assert _count_pending(db_path, "agent-x", "alice@example.com") == 1
+
+    share = ops.share_agent("agent-x", "owner", "Alice@Example.com")
+    assert share is not None
+    assert share.shared_with_email == "alice@example.com"
+    # Stale pending row must be deleted atomically with the share insert.
+    assert _count_pending(db_path, "agent-x", "alice@example.com") == 0
+
+
+def test_share_agent_no_pending_row_is_noop_on_access_requests(sharing_harness):
+    """Sharing a fresh email must not crash when there's nothing to delete."""
+    ops, db_path = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    ops._user_ops.get_user_by_username.return_value = {
+        "id": 1,
+        "username": "owner",
+        "email": "owner@example.com",
+        "role": "user",
+    }
+
+    share = ops.share_agent("agent-x", "owner", "bob@example.com")
+    assert share is not None
+    assert _count_pending(db_path, "agent-x", "bob@example.com") == 0
+
+
+def test_share_agent_does_not_clear_other_agents_pending(sharing_harness):
+    """Cleanup scope: only (this agent, this email) pending rows are cleared."""
+    ops, db_path = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    ops._user_ops.get_user_by_username.return_value = {
+        "id": 1,
+        "username": "owner",
+        "email": "owner@example.com",
+        "role": "user",
+    }
+
+    _seed_pending_request(db_path, "agent-x", "alice@example.com", rid="rx")
+    _seed_pending_request(db_path, "agent-y", "alice@example.com", rid="ry")
+
+    ops.share_agent("agent-x", "owner", "alice@example.com")
+
+    assert _count_pending(db_path, "agent-x", "alice@example.com") == 0
+    # Unrelated agent's pending row must remain untouched.
+    assert _count_pending(db_path, "agent-y", "alice@example.com") == 1
+
+
+def test_share_agent_normalizes_whitespace_and_case(sharing_harness):
+    """Sharing `  Alice@Example.COM  ` lands as `alice@example.com` and clears pending."""
+    ops, db_path = sharing_harness
+    ops._owner = {"owner_username": "owner"}
+    ops._user_ops.get_user_by_username.return_value = {
+        "id": 1,
+        "username": "owner",
+        "email": "owner@example.com",
+        "role": "user",
+    }
+
+    _seed_pending_request(db_path, "agent-x", "alice@example.com")
+
+    share = ops.share_agent("agent-x", "owner", "  Alice@Example.COM  ")
+    assert share is not None
+    assert share.shared_with_email == "alice@example.com"
+    assert _count_pending(db_path, "agent-x", "alice@example.com") == 0


### PR DESCRIPTION
## Summary
- **Gate hardening**: `share_agent` now atomically deletes any stale pending `access_requests` row for the same `(agent, email)` so manually adding someone to Team Sharing clears the Pending list (closes the reported "team-shared user stays queued" symptom).
- **Defense-in-depth**: every gate boundary (`email_has_agent_access`, `is_agent_shared_with_email`, `routers/public.py`, both DM + group paths in `adapters/message_router.py`) now normalizes `email.strip().lower()` so mixed-case session emails can't bypass the allow-list.
- **UX**: `SharingPanel.vue` restructured to make the two-layer model explicit — **Identity Proof** (`require_email` proves who they are) vs. **Authorization** (Team Sharing allow-list + pending approval). Adds a dead-end warning banner when `require_email=true && !open_access && shares.length===0`.

## Changes
- `src/backend/db/agent_settings/sharing.py` — `share_agent` clears stale pending rows; input normalized
- `src/backend/routers/public.py` — gate boundary normalization
- `src/backend/adapters/message_router.py` — DM + group branch normalization
- `src/frontend/src/components/SharingPanel.vue` — framing banner, renamed sections, dead-end warning
- `tests/test_team_share_gate_unit.py` — 8 new unit tests (casing, cleanup scope, no-op paths)
- Feature flow docs updated (`agent-sharing.md`, `unified-channel-access-control.md`)

## Test plan
- [x] `pytest tests/test_team_share_gate_unit.py` — 8/8 pass (run inside `trinity-backend`)
- [x] `pytest tests/test_sharing_null_email_unit.py` — 5/5 still pass (no regression)
- [x] Backend imports cleanly (`db.agent_settings.sharing`, `routers.public`, `adapters.message_router`)
- [x] Frontend HMR reloads `SharingPanel.vue` without errors
- [x] Visual: Sharing tab shows new framing banner + renamed sections
- [x] Visual: Enabling "Require verified email" with zero shares and Open access off surfaces the amber "Heads up" warning
- [ ] Manual end-to-end reproducer (optional): team-share + email-verify + public chat → 200, no new `access_requests` row

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)