### PR TITLE
fix(git): prevent .env and .mcp.json leak on initialize_github_sync (#458)

### DIFF
--- a/docs/memory/feature-flows/github-repo-initialization.md
+++ b/docs/memory/feature-flows/github-repo-initialization.md
@@ -459,19 +459,24 @@ async def initialize_git_in_container(
     # Otherwise use home directory directly (new standard)
     git_dir = "/home/developer/workspace" if workspace_has_content else "/home/developer"
 
-    # Step 2: Create .gitignore (standard path - /home/developer)
-    if git_dir == "/home/developer":
-        gitignore_content = """# Exclude sensitive and temporary files
-.bash_logout
-.bashrc
-.profile
-.bash_history
-.cache/
-.local/
-.npm/
-.ssh/
-"""
-        execute_command_in_container(...)
+    # Step 2: Merge the credential deny-list into .gitignore (issue #458).
+    # Runs for BOTH /home/developer AND the legacy /home/developer/workspace
+    # path. Idempotent — preserves any pre-existing user-supplied rules and
+    # only appends missing entries. Hard-fails initialization on error so we
+    # never reach `git add .` on a half-configured agent.
+    #
+    # DEFAULT_GITIGNORE_DENYLIST (in services/git_service.py) currently covers:
+    #   credentials:  .env, .env.*, !.env.example, .mcp.json, credentials.json,
+    #                 token.json, *.pem, *.key, *.p12, *.pfx,
+    #                 .aws/credentials, .config/gcloud/
+    #   shell/cache:  .bash_logout, .bashrc, .profile, .bash_history,
+    #                 .cache/, .local/, .npm/, .ssh/
+    gitignore_result = execute_command_in_container(
+        command=_build_gitignore_merge_command(git_dir),
+        timeout=10,
+    )
+    if gitignore_result["exit_code"] != 0:
+        return GitInitResult(success=False, error="Failed to write deny-list")
 
     # Step 3-6: Git commands (lines 329-356)
     commands = [
@@ -1099,8 +1104,10 @@ sqlite3 ~/trinity-data/trinity.db "SELECT key, substr(value, 1, 10) || '...' FRO
 # - Private badge (if selected)
 # - Two branches: main, trinity/test-agent/xxxxxxxx
 # - Commits on both branches
-# - Agent files: CLAUDE.md, .claude/, .trinity/, .mcp.json
-# - .gitignore excludes: .bashrc, .cache/, .ssh/ (if using home directory)
+# - Agent files: CLAUDE.md, .claude/, .trinity/
+# - .gitignore excludes credentials (.env*, .mcp.json, *.pem, *.key, ...)
+#   and shell/cache noise (.bashrc, .cache/, .ssh/, ...)
+# - .env and .mcp.json are NOT present (deny-listed, #458)
 ```
 
 **Verify in Database**:
@@ -1181,13 +1188,17 @@ sqlite3 ~/trinity-data/trinity.db "SELECT * FROM agent_git_config WHERE agent_na
 **Expected**:
 - System uses `/home/developer` directly (no workspace subdirectory)
 - Backend logs: `Using home directory: /home/developer`
-- `.gitignore` created with system file exclusions
-- Agent files (CLAUDE.md, .claude/, .trinity/, .mcp.json) pushed to GitHub
-- System files (.bashrc, .ssh/, .cache/) excluded via .gitignore
+- `.gitignore` contains the Trinity-managed credential deny-list (#458)
+- Agent files (CLAUDE.md, .claude/, .trinity/) pushed to GitHub
+- Credentials (`.env`, `.mcp.json`, `*.pem`, `*.key`, ...) excluded — NEVER committed
+- Shell/cache files (.bashrc, .ssh/, .cache/) excluded via .gitignore
+- If the agent workspace already had a `.gitignore`, its entries are preserved
+  (deny-list is appended under a `# Trinity-managed credential deny-list` header)
 
 **LEGACY Case** (agents created before 2026-02):
 - If `/home/developer/workspace/` exists with content, that directory is used
 - Backend logs: `Using workspace directory: /home/developer/workspace`
+- The credential deny-list is applied there too (#458 — previously skipped)
 
 **Verify**:
 - Check GitHub repo contains agent files but not system files
@@ -1341,6 +1352,21 @@ docker exec agent-{name} bash -c "[ -d /home/developer/.git ] && echo exists || 
 - Fixed timeout issue: Increased frontend timeout to 120 seconds + console logging
 - Fixed verification: Git initialization verified before DB insert
 - Fixed system files: Created .gitignore to exclude .bashrc, .ssh/, etc.
+
+**Bug Fix 2026-04-22 (#458) — P0 credential leak**:
+- `initialize_git_in_container` previously wrote a narrow `.gitignore`
+  (shell/cache only) with `cat > .gitignore` — clobbering any workspace
+  deny-list and not listing `.env` / `.mcp.json`. Any agent with injected
+  credentials leaked them on the initial commit to GitHub.
+- Fix: new `DEFAULT_GITIGNORE_DENYLIST` module constant covers `.env`,
+  `.env.*`, `!.env.example`, `.mcp.json`, `credentials.json`, `token.json`,
+  `*.pem`, `*.key`, `*.p12`, `*.pfx`, `.aws/credentials`, `.config/gcloud/`
+  in addition to the existing shell/cache entries.
+- `_build_gitignore_merge_command` now **appends missing entries** to any
+  pre-existing `.gitignore` (idempotent, exact-line match) instead of
+  overwriting, and runs for the legacy `/home/developer/workspace` path
+  too (previously skipped).
+- Regression tests: `tests/unit/test_github_init_gitignore.py`.
 
 **Test Coverage**:
 - Settings UI: PAT configuration and testing

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -8,6 +8,7 @@ Handles:
 - Initializing git in agent containers
 """
 import asyncio
+import base64
 import httpx
 import os
 import re
@@ -642,6 +643,78 @@ def delete_agent_git_config(agent_name: str) -> bool:
 # Git Initialization in Container
 # ============================================================================
 
+# Credential-leak deny-list merged into the agent's `.gitignore` at init time
+# (#458). Order matters — credentials must come before shell/cache entries so
+# any operator skimming the file sees the important patterns first.
+DEFAULT_GITIGNORE_DENYLIST: Tuple[str, ...] = (
+    # --- credentials & secrets (the fix for #458) ---
+    ".env",
+    ".env.*",
+    "!.env.example",
+    ".mcp.json",
+    "credentials.json",
+    "token.json",
+    "*.pem",
+    "*.key",
+    "*.p12",
+    "*.pfx",
+    ".aws/credentials",
+    ".config/gcloud/",
+    # --- legacy shell/cache noise (preserved from pre-#458 behavior) ---
+    ".bash_logout",
+    ".bashrc",
+    ".profile",
+    ".bash_history",
+    ".cache/",
+    ".local/",
+    ".npm/",
+    ".ssh/",
+)
+
+_GITIGNORE_MANAGED_HEADER = "# Trinity-managed credential deny-list (issue #458)"
+
+
+def _build_gitignore_merge_command(git_dir: str) -> str:
+    """Build a bash command that merges ``DEFAULT_GITIGNORE_DENYLIST`` into the
+    agent's existing ``.gitignore`` without clobbering user-supplied rules.
+
+    The full inner script is base64-encoded to avoid all shell-quoting hazards
+    (both the patterns themselves — ``!``, ``*``, ``/`` — and the bash-builtin
+    quoting inside the script body). The script is idempotent: every pattern
+    is append-only and gated by an exact-line ``grep -qxF`` check, so running
+    the command twice produces the same file.
+    """
+    blob = "\n".join(DEFAULT_GITIGNORE_DENYLIST)
+    b64_patterns = base64.b64encode(blob.encode("utf-8")).decode("ascii")
+    header = _GITIGNORE_MANAGED_HEADER
+    script = f"""set -e
+cd {git_dir}
+touch .gitignore
+PATTERNS=$(echo '{b64_patterns}' | base64 -d)
+HEADER_ADDED=0
+while IFS= read -r pattern; do
+  [ -z "$pattern" ] && continue
+  if ! grep -qxF -- "$pattern" .gitignore; then
+    if [ "$HEADER_ADDED" = "0" ]; then
+      if [ -s .gitignore ]; then
+        last_byte=$(tail -c1 .gitignore)
+        if [ -n "$last_byte" ]; then
+          echo "" >> .gitignore
+        fi
+      fi
+      if ! grep -qxF -- '{header}' .gitignore; then
+        echo '{header}' >> .gitignore
+      fi
+      HEADER_ADDED=1
+    fi
+    printf '%s\\n' "$pattern" >> .gitignore
+  fi
+done <<< "$PATTERNS"
+"""
+    b64_script = base64.b64encode(script.encode("utf-8")).decode("ascii")
+    return f"bash -c 'echo {b64_script} | base64 -d | bash'"
+
+
 @dataclass
 class GitInitResult:
     """Result of git initialization in container."""
@@ -714,22 +787,24 @@ async def initialize_git_in_container(
         git_dir = "/home/developer"
         logger.info(f"Using home directory: {git_dir}")
 
-    # Step 2: Create .gitignore (if using home directory)
-    if git_dir == "/home/developer":
-        gitignore_content = """# Exclude sensitive and temporary files
-.bash_logout
-.bashrc
-.profile
-.bash_history
-.cache/
-.local/
-.npm/
-.ssh/
-"""
-        await execute_command_in_container(
-            container_name=container_name,
-            command=f'bash -c "cat > {git_dir}/.gitignore << \'GITIGNORE_EOF\'\n{gitignore_content}\nGITIGNORE_EOF\n"',
-            timeout=5
+    # Step 2: Merge the credential deny-list into `.gitignore` (#458).
+    # Runs for BOTH the standard /home/developer path AND the legacy
+    # /home/developer/workspace path — previously the legacy branch skipped
+    # this entirely, leaking secrets on any initial sync.
+    # The merge is idempotent and preserves any pre-existing user rules.
+    gitignore_result = await execute_command_in_container(
+        container_name=container_name,
+        command=_build_gitignore_merge_command(git_dir),
+        timeout=10,
+    )
+    if gitignore_result.get("exit_code", 0) != 0:
+        return GitInitResult(
+            success=False,
+            git_dir=git_dir,
+            error=(
+                "Failed to write credential deny-list to .gitignore: "
+                f"{gitignore_result.get('output', '')}"
+            ),
         )
 
     # Step 3: Initialize git and try to preserve remote history

--- a/tests/unit/test_github_init_gitignore.py
+++ b/tests/unit/test_github_init_gitignore.py
@@ -1,0 +1,380 @@
+"""
+Tests for the .gitignore merge step of `initialize_git_in_container` (#458).
+
+Regression context: the previous implementation `cat > .gitignore <<EOF`
+overwrote any workspace `.gitignore` with a narrow shell/cache deny-list
+that did NOT include credentials. Agents that had `.env` / `.mcp.json`
+injected after deploy therefore leaked those files on the initial commit.
+
+This module pins the fix:
+
+1. A comprehensive credential deny-list is always present in the generated
+   `.gitignore`, regardless of what the workspace started with.
+2. Pre-existing `.gitignore` rules supplied by the user/skill are preserved.
+3. The merge runs for the legacy `/home/developer/workspace` path too —
+   the old code skipped it entirely.
+4. The merge script itself is idempotent, safe under edge cases (no trailing
+   newline, partial overlap), and reachable via the helper we expose.
+
+Module: src/backend/services/git_service.py
+"""
+import base64
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+_project_root = Path(__file__).resolve().parents[2]
+_backend_path = str(_project_root / "src" / "backend")
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+
+def _load_git_service():
+    """Import git_service with heavy deps mocked (same pattern as
+    tests/unit/test_github_init_push.py)."""
+    mock_modules = {}
+    for mod in [
+        "docker", "docker.errors", "docker.types",
+        "redis", "redis.asyncio",
+        "database",
+        "services.docker_service",
+    ]:
+        mock_modules[mod] = Mock()
+    mock_modules["database"].db = Mock()
+    mock_modules["database"].AgentGitConfig = Mock
+    mock_modules["database"].GitSyncResult = Mock
+
+    with patch.dict("sys.modules", mock_modules):
+        for key in list(sys.modules.keys()):
+            if key.startswith("services.git_service"):
+                del sys.modules[key]
+        import services.git_service as gs
+    return gs
+
+
+# ---------------------------------------------------------------------------
+# Helper / constant coverage
+# ---------------------------------------------------------------------------
+
+def test_default_denylist_covers_acceptance_criteria():
+    """Acceptance criteria on #458: these patterns MUST be in the deny-list.
+
+    Adding a new credential pattern to `DEFAULT_GITIGNORE_DENYLIST` is fine;
+    removing any of these is not.
+    """
+    gs = _load_git_service()
+    required = {
+        ".env", ".env.*", ".mcp.json", "credentials.json",
+        "token.json", "*.pem", "*.key",
+    }
+    missing = required - set(gs.DEFAULT_GITIGNORE_DENYLIST)
+    assert not missing, f"deny-list missing required patterns: {missing}"
+
+
+def test_default_denylist_negates_env_example():
+    """`.env.example` is a committable template — deny-list must whitelist it."""
+    gs = _load_git_service()
+    assert "!.env.example" in gs.DEFAULT_GITIGNORE_DENYLIST
+
+
+def test_default_denylist_orders_credentials_before_cache():
+    """Credentials come first so an operator skimming the file sees the
+    important patterns before the shell/cache noise."""
+    gs = _load_git_service()
+    denylist = gs.DEFAULT_GITIGNORE_DENYLIST
+    env_idx = denylist.index(".env")
+    bashrc_idx = denylist.index(".bashrc")
+    assert env_idx < bashrc_idx, \
+        "credentials must appear before shell/cache entries in the deny-list"
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests: run the generated bash against a real tmp directory
+# ---------------------------------------------------------------------------
+
+def _run_merge_command(git_service_module, target_dir: Path) -> None:
+    """Execute `_build_gitignore_merge_command` against an actual directory.
+
+    The helper returns a `bash -c '...'` string; we run it with
+    `subprocess.run(..., shell=True)` to exercise the exact quoting path
+    production hits. Any shell-quoting bug would surface here.
+    """
+    cmd = git_service_module._build_gitignore_merge_command(str(target_dir))
+    result = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, timeout=10
+    )
+    assert result.returncode == 0, \
+        f"merge script failed: stderr={result.stderr!r} stdout={result.stdout!r}"
+
+
+def test_merge_creates_denylist_when_gitignore_missing(tmp_path):
+    """AC #1: .env/.mcp.json/etc. must be ignored even if the workspace has
+    no `.gitignore` at all."""
+    gs = _load_git_service()
+    _run_merge_command(gs, tmp_path)
+
+    gi = (tmp_path / ".gitignore").read_text()
+    for required in (
+        ".env", ".env.*", ".mcp.json", "credentials.json",
+        "token.json", "*.pem", "*.key",
+    ):
+        assert required in gi, f"{required!r} missing from generated .gitignore"
+
+
+def test_merge_preserves_existing_user_rules(tmp_path):
+    """AC #2: user-supplied rules (via skill or manual edit) must survive."""
+    gs = _load_git_service()
+    (tmp_path / ".gitignore").write_text(
+        "# My rules\nnode_modules/\n*.log\n!important.log\n"
+    )
+    _run_merge_command(gs, tmp_path)
+
+    gi = (tmp_path / ".gitignore").read_text()
+    assert "# My rules" in gi
+    assert "node_modules/" in gi
+    assert "*.log" in gi
+    assert "!important.log" in gi
+    # ...alongside the managed deny-list:
+    assert ".env" in gi
+    assert ".mcp.json" in gi
+
+
+def test_merge_does_not_duplicate_when_user_already_has_entry(tmp_path):
+    """Idempotency: if the user's `.gitignore` already lists `.env`, we don't
+    add a second copy."""
+    gs = _load_git_service()
+    (tmp_path / ".gitignore").write_text(".env\n")
+    _run_merge_command(gs, tmp_path)
+
+    gi = (tmp_path / ".gitignore").read_text()
+    assert gi.count(".env\n") == 1, \
+        f"`.env` duplicated in merged file:\n{gi}"
+
+
+def test_merge_is_idempotent(tmp_path):
+    """Running the merge twice must produce the exact same file."""
+    gs = _load_git_service()
+    _run_merge_command(gs, tmp_path)
+    first = (tmp_path / ".gitignore").read_text()
+    _run_merge_command(gs, tmp_path)
+    second = (tmp_path / ".gitignore").read_text()
+    assert first == second
+
+
+def test_merge_handles_no_trailing_newline(tmp_path):
+    """Edge case: a hand-edited `.gitignore` may lack a trailing newline.
+    The merge must insert one before appending the managed block so the
+    first existing rule and the managed header don't collide on one line."""
+    gs = _load_git_service()
+    (tmp_path / ".gitignore").write_bytes(b"node_modules/")  # no \n
+    _run_merge_command(gs, tmp_path)
+
+    gi = (tmp_path / ".gitignore").read_text()
+    assert "node_modules/\n" in gi, \
+        "existing rule must end with a newline after merge"
+
+
+def test_merge_adds_managed_header_only_once(tmp_path):
+    """The 'Trinity-managed credential deny-list' header appears at most once,
+    even across multiple merge runs."""
+    gs = _load_git_service()
+    _run_merge_command(gs, tmp_path)
+    _run_merge_command(gs, tmp_path)
+    _run_merge_command(gs, tmp_path)
+
+    gi = (tmp_path / ".gitignore").read_text()
+    header_count = gi.count(gs._GITIGNORE_MANAGED_HEADER)
+    assert header_count == 1, \
+        f"managed header appears {header_count} times, expected 1"
+
+
+def test_command_is_safe_from_shell_injection(tmp_path):
+    """The generated command must not break even if patterns contained shell
+    metacharacters. Our deny-list has `*.pem`, `!.env.example`, `$`-free
+    entries — base64 encoding of both the patterns AND the script body
+    guarantees the shell sees only `[A-Za-z0-9+/=]`."""
+    gs = _load_git_service()
+    cmd = gs._build_gitignore_merge_command(str(tmp_path))
+
+    # Outer form is `bash -c 'echo <b64> | base64 -d | bash'`. The bit between
+    # `echo ` and ` |` must be pure base64.
+    assert cmd.startswith("bash -c 'echo "), cmd
+    b64_segment = cmd.split("echo ", 1)[1].split(" |", 1)[0]
+    assert b64_segment and all(
+        c.isalnum() or c in "+/=" for c in b64_segment
+    ), f"non-base64 chars leaked into command: {b64_segment!r}"
+
+    # And the decoded script must mention the git_dir we passed, nothing else.
+    decoded = base64.b64decode(b64_segment).decode("utf-8")
+    assert f"cd {tmp_path}" in decoded
+
+
+# ---------------------------------------------------------------------------
+# Call-site integration: initialize_git_in_container must invoke the merge
+# on BOTH the /home/developer path AND the legacy /home/developer/workspace path
+# ---------------------------------------------------------------------------
+
+class _RecordingExec:
+    """Records every command and returns success. Used to assert that the
+    .gitignore merge ran against the right git_dir."""
+
+    def __init__(self, workspace_has_content: bool, remote_has_main: bool = False):
+        self.workspace_has_content = workspace_has_content
+        self.remote_has_main = remote_has_main
+        self.calls: list[str] = []
+
+    async def __call__(self, container_name: str, command: str, timeout: int = 60):
+        self.calls.append(command)
+
+        # Workspace probe
+        if "find /home/developer/workspace" in command:
+            return {
+                "exit_code": 0,
+                "output": "1" if self.workspace_has_content else "0",
+            }
+
+        # origin/main existence check
+        if "git rev-parse --verify origin/main" in command:
+            return {
+                "exit_code": 0 if self.remote_has_main else 1,
+                "output": "",
+            }
+
+        # Final verify
+        if "git rev-parse --git-dir" in command:
+            return {"exit_code": 0, "output": ".git"}
+
+        return {"exit_code": 0, "output": ""}
+
+
+@pytest.mark.asyncio
+async def test_gitignore_merge_runs_for_home_directory():
+    """Standard-path agents (/home/developer) must get the deny-list."""
+    gs = _load_git_service()
+    fake = _RecordingExec(workspace_has_content=False)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs.initialize_git_in_container(
+            agent_name="test-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    assert result.success, f"init failed: {result.error}"
+    # The merge command is `bash -c 'echo <b64> | base64 -d | bash'`.
+    # It must reference /home/developer inside the decoded script.
+    merge_calls = [
+        c for c in fake.calls
+        if c.startswith("bash -c 'echo ") and "base64 -d | bash" in c
+    ]
+    assert len(merge_calls) == 1, \
+        f"expected exactly one gitignore merge call, got: {merge_calls}"
+
+    b64_segment = merge_calls[0].split("echo ", 1)[1].split(" |", 1)[0]
+    decoded = base64.b64decode(b64_segment).decode("utf-8")
+    assert "cd /home/developer" in decoded
+    assert "cd /home/developer/workspace" not in decoded
+
+
+@pytest.mark.asyncio
+async def test_gitignore_merge_runs_for_legacy_workspace_path():
+    """Bug fix (#458 AC #3): the legacy /home/developer/workspace branch must
+    also get the deny-list. The old code skipped this path entirely."""
+    gs = _load_git_service()
+    fake = _RecordingExec(workspace_has_content=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs.initialize_git_in_container(
+            agent_name="legacy-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    assert result.success, f"init failed: {result.error}"
+
+    merge_calls = [
+        c for c in fake.calls
+        if c.startswith("bash -c 'echo ") and "base64 -d | bash" in c
+    ]
+    assert len(merge_calls) == 1, \
+        f"BUG: legacy workspace path did not run the gitignore merge. " \
+        f"Calls: {fake.calls}"
+
+    b64_segment = merge_calls[0].split("echo ", 1)[1].split(" |", 1)[0]
+    decoded = base64.b64decode(b64_segment).decode("utf-8")
+    assert "cd /home/developer/workspace" in decoded
+
+
+@pytest.mark.asyncio
+async def test_gitignore_merge_runs_before_git_add():
+    """Ordering: the `.gitignore` must exist before `git add .` stages the
+    working tree, otherwise injected credentials are already in the index."""
+    gs = _load_git_service()
+    fake = _RecordingExec(workspace_has_content=False, remote_has_main=False)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        await gs.initialize_git_in_container(
+            agent_name="test-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    def first_index(predicate):
+        for i, c in enumerate(fake.calls):
+            if predicate(c):
+                return i
+        return -1
+
+    merge_i = first_index(
+        lambda c: c.startswith("bash -c 'echo ") and "base64 -d | bash" in c
+    )
+    add_i = first_index(lambda c: "git add ." in c)
+
+    assert merge_i >= 0, "gitignore merge was never invoked"
+    assert add_i >= 0, "git add was never invoked"
+    assert merge_i < add_i, \
+        f"gitignore merge must run before `git add .` " \
+        f"(merge@{merge_i}, add@{add_i})"
+
+
+@pytest.mark.asyncio
+async def test_merge_failure_aborts_initialization():
+    """If the merge command itself fails (bad container state, permissions),
+    we must abort before committing — we'd rather leave the repo uninitialized
+    than commit credentials on a half-configured agent."""
+    gs = _load_git_service()
+
+    class _FailingExec:
+        def __init__(self):
+            self.calls = []
+
+        async def __call__(self, container_name, command, timeout=60):
+            self.calls.append(command)
+            if "find /home/developer/workspace" in command:
+                return {"exit_code": 0, "output": "0"}
+            if "bash -c 'echo " in command and "base64 -d | bash" in command:
+                return {"exit_code": 1, "output": "permission denied"}
+            return {"exit_code": 0, "output": ""}
+
+    fake = _FailingExec()
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs.initialize_git_in_container(
+            agent_name="test-agent",
+            github_repo="owner/repo",
+            github_pat="ghp_fake",
+            create_working_branch=False,
+        )
+
+    assert not result.success
+    assert "deny-list" in (result.error or "").lower() \
+        or ".gitignore" in (result.error or "").lower(), \
+        f"unclear error message: {result.error}"
+    # Confirm we did NOT go on to run `git add` after the failure
+    assert not any("git add ." in c for c in fake.calls), \
+        "init must abort before `git add` when .gitignore write fails"


### PR DESCRIPTION
## Summary

- **P0 credential exfiltration fix.** `initialize_github_sync` previously committed `.env` and `.mcp.json` to GitHub on every first sync, regardless of whether the workspace had a `.gitignore`.
- The hardcoded `.gitignore` shipped by `git_service.initialize_git_in_container` covered only shell/cache files and used `cat > .gitignore`, clobbering any user-supplied rules. The legacy `/home/developer/workspace` path skipped the `.gitignore` write entirely.
- Now: a comprehensive credential deny-list is **merged** (append-only, idempotent, exact-line deduped) into any pre-existing `.gitignore`, on both the standard and legacy paths.

## Changes

**`src/backend/services/git_service.py`**
- New `DEFAULT_GITIGNORE_DENYLIST` module constant: credentials first (`.env`, `.env.*`, `!.env.example`, `.mcp.json`, `credentials.json`, `token.json`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `.aws/credentials`, `.config/gcloud/`), then existing shell/cache entries (preserved for backwards compat).
- New `_build_gitignore_merge_command(git_dir)` helper: generates a bash script that appends only missing entries to any existing `.gitignore`, using `grep -qxF` for exact-line matching. Inner script body and pattern list are both base64-encoded so shell metacharacters in patterns (`!`, `*`, `/`) can't reach the shell.
- Call site hoisted out of the `if git_dir == "/home/developer":` block so the legacy `/home/developer/workspace` path also gets the deny-list.
- Merge failure now aborts init with a descriptive error before `git add .` runs — better than committing credentials on a half-configured agent.

**`tests/unit/test_github_init_gitignore.py`** (new, 14 tests)
- Execute the generated bash against real tmp dirs (catches shell-quoting bugs production would hit).
- Cover all acceptance criteria: no `.gitignore` → deny-list written; existing user rules preserved; legacy workspace path covered; idempotency across re-runs; no-trailing-newline edge case; merge runs before `git add .`; failure aborts init.

**`docs/memory/feature-flows/github-repo-initialization.md`**
- Updated the .gitignore step pseudocode, the verify-on-GitHub bullet list, the testing-status section, and added a "Bug Fix 2026-04-22 (#458)" entry.

## Test Plan

- [x] `pytest tests/unit/test_github_init_gitignore.py -v` → 14/14 pass
- [x] `pytest tests/unit/test_github_init_push.py tests/unit/test_github_pat_recreation.py tests/unit/test_git_pull_branch.py tests/test_github_pat_propagation_unit.py` → 31/31 pass (no regressions)
- [x] Manual smoke: ran the generated bash against a tmp dir — fresh-file case, existing-user-rules case, partial-overlap case, no-trailing-newline case, idempotency re-run all produced correct output.
- [ ] End-to-end verification on a real agent: deploy agent → `inject_credentials` → `initialize_github_sync` → inspect initial commit tree — asserts `.env` and `.mcp.json` absent. (Cannot run from this sandbox; suggest running before merge.)

## Acceptance Criteria (from #458)

- [x] `.env`, `.env.*`, `.mcp.json`, `credentials.json`, `token.json`, `*.pem`, `*.key` never committed
- [x] Existing workspace `.gitignore` preserved (appended to, not overwritten)
- [x] Legacy `/home/developer/workspace` branch also writes the deny-list
- [x] Regression test: deploy → inject → init → assert no secrets in tree (unit-test equivalent via command inspection + tmp-dir execution)
- [x] Regression test: pre-existing `.gitignore` → user rules and deny-list both present

## Notes

- The `!.env.example` negation ensures committable env templates still work.
- Shell-injection surface is zero: `git_dir` is one of two hardcoded constants, and the outer command form is `bash -c 'echo <base64> | base64 -d | bash'` where the encoded segment is `[A-Za-z0-9+/=]` only.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)