### PR TITLE
fix(git): append missing patterns to .gitignore on github init (#458)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-22 | #458 | `.gitignore` init fix — `initialize_git_in_container` now appends missing patterns instead of truncate-and-write; adds `.env`, `.env.*`, `.mcp.json` to the default list and runs for both `/home/developer` and legacy `/home/developer/workspace` (stops credential leak on first GitHub sync) | [github-repo-initialization.md](feature-flows/github-repo-initialization.md) |
 | 2026-04-21 | RELIABILITY-003 (#306) | WebSocket event bus on Redis Streams — replaces in-process broadcast with XADD/XREAD, adds reconnect replay via `?last-event-id=`, 3-failure eviction, MAXLEN trim (tunable) | [websocket-event-bus.md](feature-flows/websocket-event-bus.md) |
 | 2026-04-20 | #420 | Scheduler sync loop fix — `update_schedule_run_times` no longer bumps `updated_at`, stopping the self-triggering re-register of every schedule per tick | [scheduler-service.md](feature-flows/scheduler-service.md) |
 | 2026-04-20 | #418 | Inter-agent timeout honors per-agent `execution_timeout_seconds` — removed 600s hardcoded defaults in MCP `chat_with_agent`/`fan_out` tools and fan-out service; HTTP client ceiling bumped to platform max (7200s) | [fan-out.md](feature-flows/fan-out.md), [mcp-orchestration.md](feature-flows/mcp-orchestration.md), [parallel-headless-execution.md](feature-flows/parallel-headless-execution.md) |

--- a/docs/memory/feature-flows/github-repo-initialization.md
+++ b/docs/memory/feature-flows/github-repo-initialization.md
@@ -459,19 +459,17 @@ async def initialize_git_in_container(
     # Otherwise use home directory directly (new standard)
     git_dir = "/home/developer/workspace" if workspace_has_content else "/home/developer"
 
-    # Step 2: Create .gitignore (standard path - /home/developer)
-    if git_dir == "/home/developer":
-        gitignore_content = """# Exclude sensitive and temporary files
-.bash_logout
-.bashrc
-.profile
-.bash_history
-.cache/
-.local/
-.npm/
-.ssh/
-"""
-        execute_command_in_container(...)
+    # Step 2: Append any missing _GITIGNORE_PATTERNS entries to .gitignore
+    # (issue #458). Runs for BOTH /home/developer and the legacy
+    # /home/developer/workspace path. The merge is idempotent — each
+    # pattern is gated by an exact-line `grep -qxF` check — so any
+    # workspace-supplied `.gitignore` (e.g. written by `/trinity:onboard`)
+    # is preserved. Patterns: .bash_logout, .bashrc, .profile,
+    # .bash_history, .cache/, .local/, .npm/, .ssh/, .env, .env.*, .mcp.json.
+    execute_command_in_container(
+        command=_build_gitignore_merge_command(git_dir),
+        timeout=5,
+    )
 
     # Step 3-6: Git commands (lines 329-356)
     commands = [
@@ -1099,8 +1097,9 @@ sqlite3 ~/trinity-data/trinity.db "SELECT key, substr(value, 1, 10) || '...' FRO
 # - Private badge (if selected)
 # - Two branches: main, trinity/test-agent/xxxxxxxx
 # - Commits on both branches
-# - Agent files: CLAUDE.md, .claude/, .trinity/, .mcp.json
-# - .gitignore excludes: .bashrc, .cache/, .ssh/ (if using home directory)
+# - Agent files: CLAUDE.md, .claude/, .trinity/
+# - .gitignore excludes: .bashrc, .cache/, .ssh/, .env, .env.*, .mcp.json
+# - .env and .mcp.json are NOT in the initial commit (#458)
 ```
 
 **Verify in Database**:
@@ -1181,13 +1180,15 @@ sqlite3 ~/trinity-data/trinity.db "SELECT * FROM agent_git_config WHERE agent_na
 **Expected**:
 - System uses `/home/developer` directly (no workspace subdirectory)
 - Backend logs: `Using home directory: /home/developer`
-- `.gitignore` created with system file exclusions
-- Agent files (CLAUDE.md, .claude/, .trinity/, .mcp.json) pushed to GitHub
-- System files (.bashrc, .ssh/, .cache/) excluded via .gitignore
+- `.gitignore` contains system file exclusions plus `.env`, `.env.*`, `.mcp.json` (#458)
+- Agent files (CLAUDE.md, .claude/, .trinity/) pushed to GitHub
+- `.env` and `.mcp.json` written by `inject_credentials` are excluded
+- Pre-existing workspace `.gitignore` rules (e.g. from `/trinity:onboard`) are preserved
 
 **LEGACY Case** (agents created before 2026-02):
 - If `/home/developer/workspace/` exists with content, that directory is used
 - Backend logs: `Using workspace directory: /home/developer/workspace`
+- `.gitignore` merge also runs here (#458 — previously skipped)
 
 **Verify**:
 - Check GitHub repo contains agent files but not system files
@@ -1341,6 +1342,21 @@ docker exec agent-{name} bash -c "[ -d /home/developer/.git ] && echo exists || 
 - Fixed timeout issue: Increased frontend timeout to 120 seconds + console logging
 - Fixed verification: Git initialization verified before DB insert
 - Fixed system files: Created .gitignore to exclude .bashrc, .ssh/, etc.
+
+**Bug Fix 2026-04-22 (#458) — P0 credential leak**:
+- Previously `.gitignore` was written with `cat > .gitignore <<EOF` (truncate-
+  and-write), clobbering any pre-existing workspace `.gitignore` (including
+  rules written by `/trinity:onboard`), and the hardcoded list contained only
+  shell/cache entries — so `.env` and `.mcp.json` (written into the container
+  by `inject_credentials`) landed in the initial commit.
+- Fix in `services/git_service.py`: new `_GITIGNORE_PATTERNS` tuple plus
+  `_build_gitignore_merge_command()` helper. The merge uses `touch .gitignore`
+  followed by `grep -qxF <pattern> .gitignore || echo <pattern> >> .gitignore`
+  per entry — idempotent, append-only. The three new patterns beyond the
+  prior shell/cache list are `.env`, `.env.*`, and `.mcp.json` (the files the
+  #458 bug report named). Runs for BOTH `/home/developer` and the legacy
+  `/home/developer/workspace` path (previously the legacy branch skipped it).
+- Regression tests: `tests/unit/test_github_init_gitignore.py`.
 
 **Test Coverage**:
 - Settings UI: PAT configuration and testing

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -11,6 +11,7 @@ import asyncio
 import httpx
 import os
 import re
+import shlex
 import sqlite3
 import uuid
 import logging
@@ -642,6 +643,39 @@ def delete_agent_git_config(agent_name: str) -> bool:
 # Git Initialization in Container
 # ============================================================================
 
+# Hardcoded patterns merged (append-if-missing) into the agent's `.gitignore`
+# at init time. Ordering is preserved in the file so operators reading it see
+# the legacy shell/cache entries first followed by the credential files that
+# `inject_credentials` writes (the trio the #458 bug report named).
+_GITIGNORE_PATTERNS: Tuple[str, ...] = (
+    ".bash_logout",
+    ".bashrc",
+    ".profile",
+    ".bash_history",
+    ".cache/",
+    ".local/",
+    ".npm/",
+    ".ssh/",
+    ".env",
+    ".env.*",
+    ".mcp.json",
+)
+
+
+def _build_gitignore_merge_command(git_dir: str) -> str:
+    """Build a bash command that appends any missing ``_GITIGNORE_PATTERNS``
+    entries to ``{git_dir}/.gitignore`` without clobbering user-supplied
+    rules. Idempotent — each pattern is gated by an exact-line ``grep -qxF``
+    check, so a second run is a no-op.
+    """
+    parts = [f"cd {shlex.quote(git_dir)}", "touch .gitignore"]
+    for p in _GITIGNORE_PATTERNS:
+        q = shlex.quote(p)
+        parts.append(f"(grep -qxF -- {q} .gitignore || echo {q} >> .gitignore)")
+    script = " && ".join(parts)
+    return f"bash -c {shlex.quote(script)}"
+
+
 @dataclass
 class GitInitResult:
     """Result of git initialization in container."""
@@ -714,23 +748,17 @@ async def initialize_git_in_container(
         git_dir = "/home/developer"
         logger.info(f"Using home directory: {git_dir}")
 
-    # Step 2: Create .gitignore (if using home directory)
-    if git_dir == "/home/developer":
-        gitignore_content = """# Exclude sensitive and temporary files
-.bash_logout
-.bashrc
-.profile
-.bash_history
-.cache/
-.local/
-.npm/
-.ssh/
-"""
-        await execute_command_in_container(
-            container_name=container_name,
-            command=f'bash -c "cat > {git_dir}/.gitignore << \'GITIGNORE_EOF\'\n{gitignore_content}\nGITIGNORE_EOF\n"',
-            timeout=5
-        )
+    # Step 2: Append any missing `_GITIGNORE_PATTERNS` entries to the
+    # agent's `.gitignore`. Runs for BOTH `/home/developer` and the legacy
+    # `/home/developer/workspace` path — previously the legacy branch was
+    # skipped entirely, and the home path used `cat > .gitignore` which
+    # clobbered any workspace-supplied rules (including `.env` / `.mcp.json`
+    # added by `/trinity:onboard`). The merge is idempotent.
+    await execute_command_in_container(
+        container_name=container_name,
+        command=_build_gitignore_merge_command(git_dir),
+        timeout=5,
+    )
 
     # Step 3: Initialize git and try to preserve remote history
     # Commands marked required=True will abort on failure;

--- a/tests/unit/test_github_init_gitignore.py
+++ b/tests/unit/test_github_init_gitignore.py
@@ -1,0 +1,107 @@
+"""
+Regression tests for #458 — `initialize_git_in_container` .gitignore handling.
+
+The bug: the old code ran `cat > .gitignore <<EOF ...` which clobbered any
+workspace-supplied `.gitignore` (so `/trinity:onboard`'s ignore rules were
+lost) and listed only shell/cache entries (so `.env` and `.mcp.json`, which
+`inject_credentials` writes, were never ignored and got committed on the
+initial sync). The fix replaces that truncate-and-write with an
+append-if-missing merge that preserves existing rules and adds the three
+patterns the reporter named.
+
+These tests exercise the actual bash script returned by
+`_build_gitignore_merge_command` against a temp directory, which is honest:
+the only difference from production is the host filesystem vs. the agent
+container.
+"""
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+_project_root = Path(__file__).resolve().parents[2]
+backend_path = str(_project_root / "src" / "backend")
+if backend_path not in sys.path:
+    sys.path.insert(0, backend_path)
+
+
+def _load_git_service():
+    """Import git_service with heavy dependencies mocked out."""
+    mock_modules = {}
+    for mod in [
+        "docker", "docker.errors", "docker.types",
+        "redis", "redis.asyncio",
+        "database",
+        "services.docker_service",
+    ]:
+        mock_modules[mod] = Mock()
+    mock_modules["database"].db = Mock()
+    mock_modules["database"].AgentGitConfig = Mock
+    mock_modules["database"].GitSyncResult = Mock
+
+    with patch.dict("sys.modules", mock_modules):
+        for key in list(sys.modules.keys()):
+            if key.startswith("services.git_service"):
+                del sys.modules[key]
+        import services.git_service as gs
+    return gs
+
+
+def _run_merge(tmp_path: Path) -> str:
+    """Run the real merge command (produced by `_build_gitignore_merge_command`)
+    against ``tmp_path`` and return the resulting `.gitignore` contents.
+    """
+    gs = _load_git_service()
+    # The production helper hardcodes the path that the agent container
+    # passes in; for tests we just point it at the temp dir.
+    cmd = gs._build_gitignore_merge_command(str(tmp_path))
+    result = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, timeout=10
+    )
+    assert result.returncode == 0, (
+        f"merge command failed: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    return (tmp_path / ".gitignore").read_text()
+
+
+def test_preserves_preexisting_gitignore(tmp_path):
+    """A workspace `.gitignore` with user rules must survive the merge.
+
+    Regression guard for the primary #458 bug: the old `cat > .gitignore`
+    path clobbered anything `/trinity:onboard` (or the user) had written.
+    """
+    preexisting = "# user rules\nnode_modules/\nbuild/\n*.log\n"
+    (tmp_path / ".gitignore").write_text(preexisting)
+
+    content = _run_merge(tmp_path)
+
+    # Every user line still present, verbatim.
+    for line in ("# user rules", "node_modules/", "build/", "*.log"):
+        assert line in content.splitlines(), (
+            f"user rule {line!r} lost — got:\n{content}"
+        )
+    # And the three credential patterns the reporter named are now covered.
+    for p in (".env", ".env.*", ".mcp.json"):
+        assert p in content.splitlines(), (
+            f"credential pattern {p!r} missing after merge — got:\n{content}"
+        )
+
+
+def test_fresh_agent_ignores_env_and_mcp_json(tmp_path):
+    """With no pre-existing `.gitignore`, the merge must produce one that
+    ignores `.env`, `.env.*`, and `.mcp.json` — the files `inject_credentials`
+    writes and that #458 observed leaking on the initial commit.
+    """
+    assert not (tmp_path / ".gitignore").exists()
+
+    content = _run_merge(tmp_path)
+    lines = content.splitlines()
+
+    for p in (".env", ".env.*", ".mcp.json"):
+        assert p in lines, (
+            f"pattern {p!r} not in .gitignore after fresh merge — got:\n{content}"
+        )


### PR DESCRIPTION
## Summary
- `initialize_git_in_container` used `cat > .gitignore <<EOF` (truncate-and-write) with a shell/cache-only pattern list, so any workspace `.gitignore` was clobbered and `.env` / `.mcp.json` (written by `inject_credentials`) leaked on the initial commit to GitHub.
- Replaces the write with an append-if-missing merge (`touch .gitignore` + `grep -qxF <p> .gitignore || echo <p> >> .gitignore` per pattern). Idempotent; preserves any pre-existing workspace rules.
- Adds just the three patterns the bug report named — `.env`, `.env.*`, `.mcp.json` — alongside the existing 8 shell/cache entries. Runs for both `/home/developer` and the legacy `/home/developer/workspace` path (previously skipped).

Replaces PR #460 (auto-closed when the prior branch was deleted). That PR took a broader deny-list + base64 scaffolding; this is the narrow scope the bug report asked for.

## Changes
- `src/backend/services/git_service.py` — new `_GITIGNORE_PATTERNS` tuple + `_build_gitignore_merge_command()` helper, call site hoisted out of the `/home/developer`-only guard.
- `tests/unit/test_github_init_gitignore.py` — 2 tests that run the real bash command against a temp dir: (1) pre-existing `.gitignore` preserved; (2) fresh agent gets `.env` / `.env.*` / `.mcp.json` ignored.
- `docs/memory/feature-flows/github-repo-initialization.md` — code snippet, expected-state checklist, and bug-fix note updated.

## Test plan
- [x] `pytest tests/unit/test_github_init_gitignore.py -v` — both new tests pass.
- [x] `pytest tests/unit/test_github_init_push.py -v` — pre-existing 4 tests still pass.
- [ ] Manual: deploy an agent → `inject_credentials` writes `.env` and `.mcp.json` → `initialize_github_sync` → inspect the "Initial commit from Trinity Agent" on GitHub, verify `.env` and `.mcp.json` are NOT in the tree, `.gitignore` contains both patterns.
- [ ] Manual (preservation): pre-seed `/home/developer/.gitignore` with `node_modules/\nbuild/\n` → `initialize_github_sync` → verify those lines survived and the three credential patterns are appended.

Closes #458

Generated with [Claude Code](https://claude.com/claude-code)