### PR TITLE
fix(security): operator-queue access control — scope items to accessible agents (#470)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1694,8 +1694,8 @@ class DatabaseManager:
     def mark_operator_queue_expired(self):
         return self._operator_queue_ops.mark_expired()
 
-    def get_operator_queue_stats(self):
-        return self._operator_queue_ops.get_stats()
+    def get_operator_queue_stats(self, **kwargs):
+        return self._operator_queue_ops.get_stats(**kwargs)
 
     def get_operator_queue_responded_for_agent(self, agent_name):
         return self._operator_queue_ops.get_responded_items_for_agent(agent_name)

--- a/src/backend/db/operator_queue.py
+++ b/src/backend/db/operator_queue.py
@@ -6,7 +6,7 @@ Supports listing, filtering, responding, and statistics.
 """
 
 import json
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Set
 from datetime import datetime
 
 from .connection import get_db_connection
@@ -108,10 +108,24 @@ class OperatorQueueOperations:
         since: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
+        accessible_agent_names: Optional[Set[str]] = None,
     ) -> List[Dict]:
-        """List queue items with optional filters."""
+        """List queue items with optional filters.
+
+        accessible_agent_names: if None, no access filter (admin). If a set,
+        only items whose agent_name is in the set are returned. Empty set
+        short-circuits to [] (user has no accessible agents).
+        """
+        if accessible_agent_names is not None and len(accessible_agent_names) == 0:
+            return []
+
         query = f"SELECT {self._SELECT_COLS} FROM operator_queue WHERE 1=1"
         params = []
+
+        if accessible_agent_names is not None:
+            placeholders = ",".join(["?"] * len(accessible_agent_names))
+            query += f" AND agent_name IN ({placeholders})"
+            params.extend(sorted(accessible_agent_names))
 
         if status:
             query += " AND status = ?"
@@ -240,59 +254,81 @@ class OperatorQueueOperations:
             conn.commit()
             return cursor.rowcount
 
-    def get_stats(self) -> Dict:
-        """Get queue statistics."""
+    def get_stats(self, accessible_agent_names: Optional[Set[str]] = None) -> Dict:
+        """Get queue statistics.
+
+        accessible_agent_names: if None, no access filter (admin). If a set,
+        only items for accessible agents are counted. Empty set returns zeros.
+        """
+        if accessible_agent_names is not None and len(accessible_agent_names) == 0:
+            return {
+                "by_status": {},
+                "by_type": {},
+                "by_priority": {},
+                "by_agent": {},
+                "pending_count": 0,
+                "avg_response_seconds": None,
+                "responded_today": 0,
+            }
+
+        # Build access filter fragment applied to every sub-query
+        access_filter = ""
+        access_params: List = []
+        if accessible_agent_names is not None:
+            placeholders = ",".join(["?"] * len(accessible_agent_names))
+            access_filter = f" AND agent_name IN ({placeholders})"
+            access_params = sorted(accessible_agent_names)
+
         with get_db_connection() as conn:
             cursor = conn.cursor()
 
             # Counts by status
-            cursor.execute("""
-                SELECT status, COUNT(*) FROM operator_queue
-                GROUP BY status
-            """)
+            cursor.execute(
+                f"SELECT status, COUNT(*) FROM operator_queue WHERE 1=1{access_filter} GROUP BY status",
+                access_params,
+            )
             by_status = {row[0]: row[1] for row in cursor.fetchall()}
 
             # Counts by type (pending only)
-            cursor.execute("""
-                SELECT type, COUNT(*) FROM operator_queue
-                WHERE status = 'pending'
-                GROUP BY type
-            """)
+            cursor.execute(
+                f"SELECT type, COUNT(*) FROM operator_queue WHERE status = 'pending'{access_filter} GROUP BY type",
+                access_params,
+            )
             by_type = {row[0]: row[1] for row in cursor.fetchall()}
 
             # Counts by priority (pending only)
-            cursor.execute("""
-                SELECT priority, COUNT(*) FROM operator_queue
-                WHERE status = 'pending'
-                GROUP BY priority
-            """)
+            cursor.execute(
+                f"SELECT priority, COUNT(*) FROM operator_queue WHERE status = 'pending'{access_filter} GROUP BY priority",
+                access_params,
+            )
             by_priority = {row[0]: row[1] for row in cursor.fetchall()}
 
             # Counts by agent (pending only)
-            cursor.execute("""
-                SELECT agent_name, COUNT(*) FROM operator_queue
-                WHERE status = 'pending'
-                GROUP BY agent_name
-            """)
+            cursor.execute(
+                f"SELECT agent_name, COUNT(*) FROM operator_queue WHERE status = 'pending'{access_filter} GROUP BY agent_name",
+                access_params,
+            )
             by_agent = {row[0]: row[1] for row in cursor.fetchall()}
 
             # Average response time (for responded items)
-            cursor.execute("""
-                SELECT AVG(
+            cursor.execute(
+                f"""SELECT AVG(
                     (julianday(responded_at) - julianday(created_at)) * 86400
                 ) FROM operator_queue
-                WHERE responded_at IS NOT NULL
-            """)
+                WHERE responded_at IS NOT NULL{access_filter}""",
+                access_params,
+            )
             avg_row = cursor.fetchone()
             avg_response_seconds = round(avg_row[0], 1) if avg_row[0] else None
 
             # Items responded today
             today = datetime.utcnow().strftime("%Y-%m-%d")
-            cursor.execute("""
-                SELECT COUNT(*) FROM operator_queue
+            cursor.execute(
+                f"""SELECT COUNT(*) FROM operator_queue
                 WHERE responded_at IS NOT NULL
-                  AND responded_at >= ?
-            """, (today,))
+                  AND responded_at >= ?{access_filter}""",
+                [today] + access_params,
+            )
             responded_today = cursor.fetchone()[0]
 
         return {

--- a/src/backend/routers/operator_queue.py
+++ b/src/backend/routers/operator_queue.py
@@ -7,7 +7,7 @@ operator_queue_service background poller.
 """
 
 import json
-from typing import Optional
+from typing import Optional, Set
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
@@ -39,6 +39,29 @@ class OperatorResponse(BaseModel):
 
 
 # ============================================================================
+# Access control helper
+# ============================================================================
+
+def _accessible_set(current_user: User) -> Optional[Set[str]]:
+    """Return the set of agent names the user may access in the operator queue.
+
+    Returns None for admins (no filter — sees everything).
+    Returns a set (possibly empty) for regular users.
+    """
+    if current_user.role == "admin":
+        return None
+    user_email = current_user.email or ""
+    names = db.get_accessible_agent_names(user_email, is_admin=False)
+    return set(names)
+
+
+def _assert_agent_accessible(agent_name: str, accessible: Optional[Set[str]]) -> None:
+    """Raise 403 if the user cannot access the given agent."""
+    if accessible is not None and agent_name not in accessible:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
+# ============================================================================
 # Endpoints
 # ============================================================================
 
@@ -54,6 +77,7 @@ async def list_queue_items(
     current_user: User = Depends(get_current_user),
 ):
     """List operator queue items with optional filters."""
+    accessible = _accessible_set(current_user)
     items = db.list_operator_queue_items(
         status=status,
         type=type,
@@ -62,6 +86,7 @@ async def list_queue_items(
         since=since,
         limit=limit,
         offset=offset,
+        accessible_agent_names=accessible,
     )
     return {"items": items, "count": len(items)}
 
@@ -71,7 +96,8 @@ async def get_queue_stats(
     current_user: User = Depends(get_current_user),
 ):
     """Get queue statistics (counts by status, type, priority, agent)."""
-    return db.get_operator_queue_stats()
+    accessible = _accessible_set(current_user)
+    return db.get_operator_queue_stats(accessible_agent_names=accessible)
 
 
 @router.get("/{item_id}")
@@ -83,6 +109,8 @@ async def get_queue_item(
     item = db.get_operator_queue_item(item_id)
     if not item:
         raise HTTPException(status_code=404, detail="Queue item not found")
+    accessible = _accessible_set(current_user)
+    _assert_agent_accessible(item["agent_name"], accessible)
     return item
 
 
@@ -93,10 +121,12 @@ async def respond_to_queue_item(
     current_user: User = Depends(get_current_user),
 ):
     """Submit an operator response to a pending queue item."""
-    # Check item exists
     existing = db.get_operator_queue_item(item_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Queue item not found")
+
+    accessible = _accessible_set(current_user)
+    _assert_agent_accessible(existing["agent_name"], accessible)
 
     if existing["status"] != "pending":
         raise HTTPException(
@@ -137,6 +167,9 @@ async def cancel_queue_item(
     if not existing:
         raise HTTPException(status_code=404, detail="Queue item not found")
 
+    accessible = _accessible_set(current_user)
+    _assert_agent_accessible(existing["agent_name"], accessible)
+
     if existing["status"] != "pending":
         raise HTTPException(
             status_code=400,
@@ -155,6 +188,8 @@ async def get_agent_queue_items(
     current_user: User = Depends(get_current_user),
 ):
     """Get queue items for a specific agent."""
+    accessible = _accessible_set(current_user)
+    _assert_agent_accessible(agent_name, accessible)
     items = db.list_operator_queue_items(
         agent_name=agent_name,
         status=status,

--- a/src/frontend/src/views/Agents.vue
+++ b/src/frontend/src/views/Agents.vue
@@ -230,9 +230,10 @@
         <!-- Agents List -->
         <div class="flex flex-col gap-1.5">
           <!-- Column Header (lg+ only) -->
-          <div class="hidden lg:grid lg:grid-cols-[auto_auto_1fr_46px_22rem_180px_auto_auto] lg:gap-x-4 items-center px-4 py-2 text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+          <div class="hidden lg:grid lg:grid-cols-[auto_auto_auto_1fr_46px_22rem_180px_auto_auto] lg:gap-x-4 items-center pl-8 pr-4 py-2 text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider">
             <div class="w-4"></div>
             <div class="w-3"></div>
+            <div class="w-2"></div>
             <div>Name</div>
             <div>Status</div>
             <div>Controls</div>
@@ -246,7 +247,7 @@
             v-for="agent in displayAgents"
             :key="agent.name"
             :class="[
-              'bg-white dark:bg-gray-800 rounded-lg',
+              'relative overflow-visible bg-white dark:bg-gray-800 rounded-lg',
               'transition-colors duration-150 hover:bg-gray-50 dark:hover:bg-gray-750',
               agent.is_system
                 ? 'border-l-3 border-l-purple-500'
@@ -256,12 +257,20 @@
                 : ''
             ]"
           >
+            <!-- Avatar: half out of the box (all breakpoints) -->
+            <div class="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10">
+              <div class="rounded-full border-2 shadow-md overflow-hidden"
+                   :class="agent.is_system ? 'border-purple-400 dark:border-purple-500' : 'border-indigo-400 dark:border-indigo-500'">
+                <AgentAvatar :name="agent.name" :avatar-url="agent.avatar_url" size="md" />
+              </div>
+            </div>
+
             <!-- Desktop layout (lg+) -->
-            <div class="hidden lg:flex px-4 py-3">
+            <div class="hidden lg:flex pl-8 pr-4 py-3">
               <!-- Two-row content block -->
               <div class="flex flex-col flex-1 min-w-0">
               <!-- Main grid (Row 1) -->
-              <div class="grid grid-cols-[auto_auto_1fr_46px_22rem_180px_auto_auto] gap-x-4 items-center">
+              <div class="grid grid-cols-[auto_auto_auto_1fr_46px_22rem_180px_auto_auto] gap-x-4 items-center">
                 <!-- Checkbox -->
                 <input
                   type="checkbox"
@@ -279,16 +288,14 @@
                   :style="{ backgroundColor: getStatusDotColor(agent.name) }"
                 ></div>
 
-                <!-- #389 Sync health dot (visible only for git-enabled agents) -->
+                <!-- #389 Sync health dot (always in grid to preserve column positions) -->
                 <div
-                  v-if="syncHealthEntry(agent.name)"
-                  :class="['w-2 h-2 rounded-full flex-shrink-0', syncHealthColorClass(agent.name)]"
-                  :title="syncHealthLabel(agent.name)"
+                  :class="['w-2 h-2 rounded-full flex-shrink-0', syncHealthEntry(agent.name) ? syncHealthColorClass(agent.name) : 'invisible']"
+                  :title="syncHealthEntry(agent.name) ? syncHealthLabel(agent.name) : ''"
                 ></div>
 
                 <!-- Name + badges -->
                 <div class="flex items-center min-w-0 gap-2">
-                  <AgentAvatar :name="agent.name" :avatar-url="agent.avatar_url" size="sm" />
                   <router-link
                     :to="`/agents/${agent.name}`"
                     class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-indigo-600 dark:hover:text-indigo-400"
@@ -412,7 +419,7 @@
               </div>
 
               <!-- Bottom row: tags (always rendered for uniform height) -->
-              <div class="flex items-center gap-1 pl-[3.625rem] min-h-[1.375rem] pt-1">
+              <div class="flex items-center gap-1 pl-[5.125rem] min-h-[1.375rem] pt-1">
                 <template v-if="getAgentTags(agent.name).length > 0">
                   <span
                     v-for="tag in getAgentTags(agent.name).slice(0, 3)"
@@ -443,7 +450,7 @@
             </div>
 
             <!-- Tablet layout (md, < lg) -->
-            <div class="hidden md:flex md:flex-col lg:hidden px-4 py-3 gap-2">
+            <div class="hidden md:flex md:flex-col lg:hidden pl-8 pr-4 py-3 gap-2">
               <div class="flex items-center gap-3">
                 <input
                   type="checkbox"
@@ -458,7 +465,6 @@
                   ]"
                   :style="{ backgroundColor: getStatusDotColor(agent.name) }"
                 ></div>
-                <AgentAvatar :name="agent.name" :avatar-url="agent.avatar_url" size="sm" />
                 <router-link
                   :to="`/agents/${agent.name}`"
                   class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-indigo-600 dark:hover:text-indigo-400"
@@ -499,7 +505,7 @@
                   </router-link>
                 </div>
               </div>
-              <div class="flex items-center gap-3 pl-[3.25rem]">
+              <div class="flex items-center gap-3 pl-[3.125rem]">
                 <div class="flex items-center gap-2">
                   <RunningStateToggle
                     :model-value="agent.status === 'running'"
@@ -567,7 +573,7 @@
                 </div>
               </div>
               <!-- Tags row (tablet) -->
-              <div v-if="getAgentTags(agent.name).length > 0" class="flex items-center gap-1 pl-[3.25rem]">
+              <div v-if="getAgentTags(agent.name).length > 0" class="flex items-center gap-1 pl-[3.125rem]">
                 <span
                   v-for="tag in getAgentTags(agent.name).slice(0, 3)"
                   :key="tag"
@@ -586,7 +592,7 @@
             </div>
 
             <!-- Mobile layout (< md) -->
-            <div class="flex flex-col md:hidden px-4 py-3 gap-2">
+            <div class="flex flex-col md:hidden pl-8 pr-4 py-3 gap-2">
               <div class="flex items-center gap-3">
                 <input
                   type="checkbox"
@@ -601,7 +607,6 @@
                   ]"
                   :style="{ backgroundColor: getStatusDotColor(agent.name) }"
                 ></div>
-                <AgentAvatar :name="agent.name" :avatar-url="agent.avatar_url" size="sm" />
                 <router-link
                   :to="`/agents/${agent.name}`"
                   class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-indigo-600 dark:hover:text-indigo-400 flex-1 min-w-0"

--- a/tests/test_operator_queue.py
+++ b/tests/test_operator_queue.py
@@ -3,16 +3,18 @@ Operator Queue Tests (test_operator_queue.py)
 
 Tests for the Operating Room / Operator Queue API endpoints (OPS-001).
 Covers list, get, respond, cancel, stats, agent-specific queries,
-authentication, and input validation.
+authentication, input validation, and cross-user access isolation (#470).
 
 Feature Flow: operating-room.md
 """
 
+import os
+import subprocess
 import pytest
 import uuid
 from datetime import datetime, timezone
 
-from utils.api_client import TrinityApiClient
+from utils.api_client import TrinityApiClient, ApiConfig
 from utils.assertions import (
     assert_status,
     assert_json_response,
@@ -468,3 +470,204 @@ class TestAgentQueueItems:
         assert_status(response, 200)
         data = response.json()
         assert len(data["items"]) <= 1
+
+
+# ============================================================================
+# Cross-User Access Isolation Tests (#470)
+# ============================================================================
+
+_BACKEND_CONTAINER = os.getenv("TRINITY_BACKEND_CONTAINER", "trinity-backend")
+_ISO_USERNAME = f"testuser-opq-{uuid.uuid4().hex[:8]}"
+_ISO_PASSWORD = "test-opq-password-470"
+_ISO_EMAIL = f"{_ISO_USERNAME}@test.example.com"
+_ISO_AGENT = f"test-opq-agent-{uuid.uuid4().hex[:6]}"
+_ISO_ITEM_ID = f"test-opq-item-{uuid.uuid4().hex[:12]}"
+
+
+def _exec_backend(python_code: str) -> str:
+    result = subprocess.run(
+        ["docker", "exec", _BACKEND_CONTAINER, "python3", "-c", python_code],
+        capture_output=True, text=True, timeout=15,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Backend exec failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+@pytest.fixture(scope="module")
+def _iso_setup(api_client: TrinityApiClient):
+    """Set up cross-user isolation fixtures.
+
+    Creates:
+    - A non-admin user (role='user') directly in the DB
+    - A fake agent ownership row for a sentinel agent owned by admin
+    - A queue item for that sentinel agent
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Create non-admin user
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+from passlib.context import CryptContext
+ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pw = ctx.hash("{_ISO_PASSWORD}")
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+conn.execute(
+    "INSERT OR IGNORE INTO users (username, password_hash, role, email, created_at, updated_at) "
+    "VALUES (?, ?, 'user', ?, datetime('now'), datetime('now'))",
+    ("{_ISO_USERNAME}", pw, "{_ISO_EMAIL}"),
+)
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+    # Register fake agent ownership under admin's user id
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+admin_id = conn.execute("SELECT id FROM users WHERE username='admin'").fetchone()[0]
+conn.execute(
+    "INSERT OR IGNORE INTO agent_ownership (agent_name, owner_id, created_at) VALUES (?, ?, datetime('now'))",
+    ("{_ISO_AGENT}", admin_id),
+)
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+    # Insert a queue item belonging to that agent
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+conn.execute(
+    "INSERT OR IGNORE INTO operator_queue "
+    "(id, agent_name, type, status, priority, title, question, created_at) "
+    "VALUES (?, ?, 'approval', 'pending', 'high', 'Test item 470', 'Proceed?', ?)",
+    ("{_ISO_ITEM_ID}", "{_ISO_AGENT}", "{now}"),
+)
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+    # Build the non-admin client
+    cfg = ApiConfig(
+        base_url=os.getenv("TRINITY_API_URL", "http://localhost:8000"),
+        username=_ISO_USERNAME,
+        password=_ISO_PASSWORD,
+    )
+    non_admin = TrinityApiClient(cfg)
+    non_admin.authenticate()
+
+    yield {"admin": api_client, "non_admin": non_admin, "item_id": _ISO_ITEM_ID, "agent": _ISO_AGENT}
+
+    non_admin.close()
+
+    # Teardown: remove queue item, agent ownership, user
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+conn.execute("DELETE FROM operator_queue WHERE id = ?", ("{_ISO_ITEM_ID}",))
+conn.execute("DELETE FROM agent_ownership WHERE agent_name = ?", ("{_ISO_AGENT}",))
+conn.execute("DELETE FROM users WHERE username = ?", ("{_ISO_USERNAME}",))
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+
+class TestOperatorQueueAccessControl:
+    """Cross-user isolation — fixes the pentest finding in issue #470.
+
+    A non-admin user must not be able to read or act on queue items that
+    belong to agents they do not own or have been shared on.
+    """
+
+    pytestmark = pytest.mark.smoke
+
+    def test_non_admin_list_excludes_foreign_items(self, _iso_setup):
+        """Non-admin list must not include items from unowned agents."""
+        non_admin = _iso_setup["non_admin"]
+        item_id = _iso_setup["item_id"]
+
+        response = non_admin.get("/api/operator-queue?limit=500")
+        assert_status(response, 200)
+        data = response.json()
+        ids = {item["id"] for item in data["items"]}
+        assert item_id not in ids, "Non-admin must not see items from unowned agents"
+
+    def test_non_admin_get_item_returns_403(self, _iso_setup):
+        """Non-admin GET /{id} for unowned agent's item returns 403."""
+        non_admin = _iso_setup["non_admin"]
+        item_id = _iso_setup["item_id"]
+
+        response = non_admin.get(f"/api/operator-queue/{item_id}")
+        assert_status(response, 403)
+
+    def test_non_admin_respond_returns_403(self, _iso_setup):
+        """Non-admin POST /{id}/respond for unowned agent's item returns 403."""
+        non_admin = _iso_setup["non_admin"]
+        item_id = _iso_setup["item_id"]
+
+        response = non_admin.post(
+            f"/api/operator-queue/{item_id}/respond",
+            json={"response": "approve"},
+        )
+        assert_status(response, 403)
+
+    def test_non_admin_cancel_returns_403(self, _iso_setup):
+        """Non-admin POST /{id}/cancel for unowned agent's item returns 403."""
+        non_admin = _iso_setup["non_admin"]
+        item_id = _iso_setup["item_id"]
+
+        response = non_admin.post(f"/api/operator-queue/{item_id}/cancel")
+        assert_status(response, 403)
+
+    def test_non_admin_agent_items_returns_403(self, _iso_setup):
+        """Non-admin GET /agents/{name} for unowned agent returns 403."""
+        non_admin = _iso_setup["non_admin"]
+        agent = _iso_setup["agent"]
+
+        response = non_admin.get(f"/api/operator-queue/agents/{agent}")
+        assert_status(response, 403)
+
+    def test_non_admin_stats_excludes_foreign_agents(self, _iso_setup):
+        """Non-admin stats by_agent must not reveal unowned agent names."""
+        non_admin = _iso_setup["non_admin"]
+        agent = _iso_setup["agent"]
+
+        response = non_admin.get("/api/operator-queue/stats")
+        assert_status(response, 200)
+        data = response.json()
+        assert agent not in data.get("by_agent", {}), \
+            "Stats by_agent must not leak unowned agent names"
+
+    def test_admin_still_sees_all_items(self, _iso_setup):
+        """Admin retains full visibility of all queue items (regression)."""
+        admin = _iso_setup["admin"]
+        item_id = _iso_setup["item_id"]
+
+        response = admin.get(f"/api/operator-queue/{item_id}")
+        assert_status(response, 200)
+        data = response.json()
+        assert data["id"] == item_id
+
+    def test_admin_stats_includes_all_agents(self, _iso_setup):
+        """Admin stats by_agent includes items from all agents (regression)."""
+        admin = _iso_setup["admin"]
+        agent = _iso_setup["agent"]
+
+        response = admin.get("/api/operator-queue/stats")
+        assert_status(response, 200)
+        data = response.json()
+        assert agent in data.get("by_agent", {}), \
+            "Admin stats must include the test agent"


### PR DESCRIPTION
## Summary

- Fixes High-severity broken access control (pentest finding 3.1.3 Broken Access Control [User]): `GET /api/operator-queue` and related endpoints were returning items for **all agents on the platform** regardless of requester ownership
- All 6 operator-queue endpoints now enforce user-scoped filtering: list, stats, get, respond, cancel, and `/agents/{name}`
- Admin users retain full visibility (no regression)
- Unblocks the Letter of Attestation (A grade) from the security vendor

## Changes

- `src/backend/db/operator_queue.py` — `list_items()` and `get_stats()` accept `accessible_agent_names: Optional[Set[str]]`; empty set short-circuits before SQL executes (prevents `IN ()` syntax error); all 5 stats sub-queries apply the filter so `by_agent` never leaks foreign agent names
- `src/backend/routers/operator_queue.py` — `_accessible_set()` helper computes user's allowed agents via `db.get_accessible_agent_names()`; `_assert_agent_accessible()` raises 403 on unauthorized access; applied to all 6 endpoints
- `src/backend/database.py` — `get_operator_queue_stats()` passes `**kwargs` through to support the new param
- `tests/test_operator_queue.py` — 8 new tests in `TestOperatorQueueAccessControl`: non-admin list/get/respond/cancel/agents/stats isolation + admin regression

## Test Plan

- [x] All 42 existing tests pass, 3 skipped (no live pending items): `pytest tests/test_operator_queue.py -v`
- [x] 8 new isolation tests pass: non-admin gets 403/filtered-list on all endpoints; admin sees everything
- [x] Manual: non-admin user's list returns only their own agents' items; stats `by_agent` contains no foreign agents

Closes #470

> Note: also includes a separate UI commit (`feat(agents): overflow-visible avatar`) that was an unrelated pre-existing working-tree change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)