### PR TITLE
fix(execution): MCP sync task triggered_by=mcp attribution (#473)

### DIFF
--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -793,6 +793,9 @@ async def execute_parallel_task(
     if x_source_agent:
         source = ExecutionSource.AGENT
         triggered_by = "self_task" if is_self_task else "agent"
+    elif x_via_mcp:
+        source = ExecutionSource.USER
+        triggered_by = "mcp"
     else:
         source = ExecutionSource.USER
         triggered_by = "manual"

--- a/tests/test_self_execute.py
+++ b/tests/test_self_execute.py
@@ -154,11 +154,14 @@ class TestTriggeredByField:
     def test_triggered_by_self_task_for_self_calls(self):
         """triggered_by should be 'self_task' for self-calls."""
         x_source_agent = "my-agent"
+        x_via_mcp = "true"
         name = "my-agent"
         is_self_task = (x_source_agent is not None and x_source_agent == name)
 
         if x_source_agent:
             triggered_by = "self_task" if is_self_task else "agent"
+        elif x_via_mcp:
+            triggered_by = "mcp"
         else:
             triggered_by = "manual"
 
@@ -167,24 +170,46 @@ class TestTriggeredByField:
     def test_triggered_by_agent_for_other_agent_calls(self):
         """triggered_by should be 'agent' for agent-to-agent calls (not self)."""
         x_source_agent = "other-agent"
+        x_via_mcp = "true"
         name = "my-agent"
         is_self_task = (x_source_agent is not None and x_source_agent == name)
 
         if x_source_agent:
             triggered_by = "self_task" if is_self_task else "agent"
+        elif x_via_mcp:
+            triggered_by = "mcp"
         else:
             triggered_by = "manual"
 
         assert triggered_by == "agent"
 
-    def test_triggered_by_manual_for_user_calls(self):
-        """triggered_by should be 'manual' for user-initiated calls."""
+    def test_triggered_by_mcp_for_mcp_user_calls(self):
+        """triggered_by should be 'mcp' for MCP user calls (no source agent)."""
         x_source_agent = None
+        x_via_mcp = "true"
         name = "my-agent"
         is_self_task = (x_source_agent is not None and x_source_agent == name)
 
         if x_source_agent:
             triggered_by = "self_task" if is_self_task else "agent"
+        elif x_via_mcp:
+            triggered_by = "mcp"
+        else:
+            triggered_by = "manual"
+
+        assert triggered_by == "mcp"
+
+    def test_triggered_by_manual_for_user_calls(self):
+        """triggered_by should be 'manual' for direct API calls (no MCP, no source agent)."""
+        x_source_agent = None
+        x_via_mcp = None
+        name = "my-agent"
+        is_self_task = (x_source_agent is not None and x_source_agent == name)
+
+        if x_source_agent:
+            triggered_by = "self_task" if is_self_task else "agent"
+        elif x_via_mcp:
+            triggered_by = "mcp"
         else:
             triggered_by = "manual"
 


### PR DESCRIPTION
## Summary
- The `/task` endpoint always wrote `triggered_by = "manual"` for non-agent callers, even when the request came through MCP
- Added `elif x_via_mcp: triggered_by = "mcp"` branch to mirror the identical pattern already working in `/chat`
- Both sync and async execution paths are fixed (they share the same variable)

## Changes
- `src/backend/routers/chat.py` — 3-line fix at the `triggered_by` determination block in `execute_parallel_task`
- `tests/test_self_execute.py` — Added `test_triggered_by_mcp_for_mcp_user_calls`; updated existing tests to include `x_via_mcp` in the logic under test

## Test Plan
- [x] `TestTriggeredByField` (4 tests): `pytest tests/test_self_execute.py::TestTriggeredByField -v` — all pass
- [x] Full `test_self_execute.py` suite (22 tests) — all pass
- [ ] Manual: trigger a `/task` via MCP client, verify `schedule_executions.triggered_by = "mcp"` in DB

Fixes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)