### PR TITLE
fix(SUB-003): subscription rate-limit — persist reset time, skip retries on 429, default max_retries=0 (#476)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -187,6 +187,7 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 *Auth & Credentials:*
 - `credential_encryption.py` - AES-256-GCM encryption for .credentials.enc files (CRED-002)
 - `subscription_service.py` - Subscription management (SUB-002)
+- `subscription_auto_switch.py` - Auto-switches agents to alternative subscriptions on repeated 429s; parses reset timestamp from Anthropic error body and persists as `rate_limited_until` (SUB-003, #476)
 - `ssh_service.py` - Ephemeral SSH credential generation
 - `email_service.py` - Email sending for verification codes
 

--- a/docs/memory/feature-flows/scheduler-service.md
+++ b/docs/memory/feature-flows/scheduler-service.md
@@ -691,18 +691,20 @@ Failed scheduled executions can be automatically retried with configurable delay
 
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
-| `max_retries` | 1 | 0-5 | Max retry attempts (0=disabled) |
+| `max_retries` | 0 | 0-5 | Max retry attempts (0=disabled, opt-in) |
 | `retry_delay_seconds` | 60 | 30-600 | Delay between retries |
 
-New schedules default to 1 retry. Existing schedules migrated with 0 (opt-in).
+Retries default to **disabled** (`max_retries=0`). Scheduled agents are typically stateful and idempotent — skipping a run is preferable to replaying a backlog of failures. Enable per schedule if the workload benefits from retry.
 
 ### Retry Flow
 
 ```
 Execution fails → _maybe_schedule_retry()
+    ├─ If error is rate-limit (429 / "rate limit" / "subscription usage limit"):
+    │       return immediately — next scheduled cron tick recovers, not a retry
     ├─ Check schedule.max_retries > 0
     ├─ Check attempt_number <= max_retries
-    ├─ Calculate delay (2x for 429/rate-limit, capped at 300s)
+    ├─ Calculate delay (base retry_delay_seconds)
     ├─ Persist: DB schedule_retry(execution_id, retry_scheduled_at)
     └─ Schedule: APScheduler DateTrigger → _execute_retry()
 
@@ -1075,6 +1077,7 @@ The embedded scheduler (`src/backend/services/scheduler_service.py`) has been co
 
 | Date | Change |
 |------|--------|
+| 2026-04-23 | **Retry default opt-in + rate-limit skip (#476)**: `max_retries` default changed 1→0 (retries are opt-in). `_maybe_schedule_retry()` now returns immediately on rate-limit errors (429 / "subscription usage limit") — next cron tick handles recovery instead of building a retry backlog during subscription outages. |
 | 2026-04-14 | **Automatic Retry (RETRY-001)**: Added Flow 10 documenting configurable retry mechanism for failed executions. New fields: max_retries, retry_delay_seconds, attempt_number, retry_of_execution_id, retry_scheduled_at. New status: pending_retry. |
 | 2026-03-26 | **Line number refresh + Process Schedules documentation**: Updated all line numbers to match current code. Added Flow 3 (Process Schedule Execution), process schedule sync documentation, process schedule database operations, and full service method reference table. |
 | 2026-03-13 | **Schedule Update Nullable Field Fix**: Changed `schedules.py:270` from `if v is not None` filter to `model_dump(exclude_unset=True)`. |

--- a/docs/memory/feature-flows/subscription-auto-switch.md
+++ b/docs/memory/feature-flows/subscription-auto-switch.md
@@ -8,6 +8,8 @@
 
 Automatically switches an agent to a different subscription when it encounters 2+ consecutive rate-limit (429) errors from the Claude API. Opt-in via system setting.
 
+When Anthropic's 429 response body includes a reset time (e.g. `"resets 8pm (America/New_York)"`), that timestamp is parsed and persisted as `rate_limited_until` on the subscription row. Subsequent calls to `is_subscription_rate_limited()` check this authoritative timestamp first, blocking the subscription until it actually resets rather than relying on a 2-hour rolling event window (which is shorter than Anthropic's real 5–8 hour reset cycle).
+
 ## Flow
 
 ```
@@ -25,6 +27,7 @@ Check: setting enabled? → No → return None
 Check: agent has subscription? → No → return None
     ↓ Yes
 Record rate-limit event, get consecutive count
+Parse reset time from 429 body → persist rate_limited_until on subscription row (if parseable)
     ↓
 Count < 2? → return None (wait for more)
     ↓ ≥ 2
@@ -55,6 +58,12 @@ Return switch result to caller → 429 response includes auto_switch info
 
 ## Database
 
+### subscription_credentials (relevant columns)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| rate_limited_until | TEXT | ISO 8601 UTC timestamp — authoritative reset time parsed from 429 body. NULL when not rate-limited or after expiry. Checked by `is_subscription_rate_limited()` before the event-count fallback. |
+
 ### subscription_rate_limit_events
 
 | Column | Type | Description |
@@ -82,13 +91,16 @@ Return switch result to caller → 429 response includes auto_switch info
 
 1. Exclude current subscription
 2. Order by agent_count ascending (load-balance)
-3. Skip any subscription with rate-limit events in last 2 hours
+3. Skip any subscription where `is_subscription_rate_limited()` returns True:
+   - **Primary check**: `rate_limited_until` is set and still in the future (authoritative)
+   - **Fallback**: 2+ rate-limit events in the last 2 hours (heuristic for cases where reset time wasn't parseable)
 4. Return first viable candidate, or None
 
 ## Edge Cases
 
 - **All subscriptions exhausted**: No switch, error surfaces as normal 429. `_perform_auto_switch` does **not** clear rate-limit events for the old subscription — those events are the signal that keeps `is_subscription_rate_limited()` truthful, so the just-drained sub is not offered as a candidate on the next cycle (issue #444).
+- **Slow ping-pong** (#476): The 2h event window was shorter than Anthropic's 5–8h reset window, causing repeated failed switches every 2 hours. Fixed by persisting `rate_limited_until` from the 429 body — the subscription is blocked until Anthropic's actual reset time.
 - **API key agents**: Auto-switch only applies to subscription-based agents
 - **Flip-flopping**: 2-consecutive-error requirement prevents immediate re-switch
 - **Concurrent switches**: SQLite serialization prevents races
-- **Cleanup**: Records older than 24h are eligible for cleanup; the 2h "is rate-limited" window drives candidate filtering independently of cleanup
+- **Cleanup**: `rate_limited_until` is cleared in-place by `is_subscription_rate_limited()` once it expires. Rate-limit event records older than 24h are eligible for cleanup; the event-count heuristic operates independently as a fallback when reset time was not parseable.

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -1319,11 +1319,12 @@ The Process Engine supports six step types:
 - **Preconditions**: Setting enabled + 2+ consecutive errors + alternative subscription available
 - **Key Features**:
   - System setting `auto_switch_subscriptions` (default OFF) with Settings UI toggle
-  - Rate-limit event tracking per (agent, subscription) with 2h window
-  - Best-alternative selection: prefer fewer assigned agents, skip recently rate-limited
+  - Rate-limit event tracking per (agent, subscription) with 2h window (fallback heuristic)
+  - `rate_limited_until` timestamp persisted from 429 body — authoritative gate that matches Anthropic's actual 5-8h reset window (#476)
+  - Best-alternative selection: prefer fewer assigned agents, skip rate-limited subs (durable timestamp checked first)
   - Activity event logged on auto-switch, notification sent to agent owner
   - Hooks into chat proxy 429 handler and background task failure path
-- **Database**: `subscription_rate_limit_events` table
+- **Database**: `subscription_rate_limit_events` table; `subscription_credentials.rate_limited_until` column (#476)
 - **Files**:
   - `src/backend/db/subscriptions.py` - Rate-limit tracking queries
   - `src/backend/services/subscription_auto_switch.py` - Auto-switch orchestration

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1292,6 +1292,9 @@ class DatabaseManager:
     def is_subscription_rate_limited(self, subscription_id: str):
         return self._subscription_ops.is_subscription_rate_limited(subscription_id)
 
+    def set_subscription_rate_limited_until(self, subscription_id: str, until_iso: str):
+        return self._subscription_ops.set_subscription_rate_limited_until(subscription_id, until_iso)
+
     def clear_rate_limit_events(self, agent_name: str, subscription_id: str):
         return self._subscription_ops.clear_rate_limit_events(agent_name, subscription_id)
 

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -1567,6 +1567,23 @@ def _migrate_whatsapp_bindings(cursor, conn):
     conn.commit()
 
 
+def _migrate_subscription_rate_limited_until(cursor, conn):
+    """Add rate_limited_until column to subscription_credentials (#476).
+
+    Persists the actual Anthropic reset timestamp from 429 responses so
+    is_subscription_rate_limited() can make an authoritative decision instead
+    of relying on the 2-hour rolling event window (which is shorter than
+    Anthropic's real 5-8 hour reset cycle).
+    """
+    cursor.execute("PRAGMA table_info(subscription_credentials)")
+    cols = {row[1] for row in cursor.fetchall()}
+    if "rate_limited_until" not in cols:
+        cursor.execute(
+            "ALTER TABLE subscription_credentials ADD COLUMN rate_limited_until TEXT"
+        )
+    conn.commit()
+
+
 def _migrate_agent_git_config_branch_ownership(cursor, conn):
     """Add partial UNIQUE index to agent_git_config enforcing branch ownership (S7 Layer 2 / #382).
 
@@ -1678,4 +1695,5 @@ MIGRATIONS = [
     ("agent_git_config_branch_ownership", _migrate_agent_git_config_branch_ownership),
     ("sync_health", _migrate_sync_health),
     ("whatsapp_bindings", _migrate_whatsapp_bindings),
+    ("subscription_rate_limited_until", _migrate_subscription_rate_limited_until),
 ]

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -97,7 +97,7 @@ class ScheduleOperations:
             allowed_tools=allowed_tools,
             model=row["model"] if "model" in row_keys else None,
             # Retry configuration (RETRY-001)
-            max_retries=row["max_retries"] if "max_retries" in row_keys and row["max_retries"] is not None else 1,
+            max_retries=row["max_retries"] if "max_retries" in row_keys and row["max_retries"] is not None else 0,
             retry_delay_seconds=row["retry_delay_seconds"] if "retry_delay_seconds" in row_keys and row["retry_delay_seconds"] is not None else 60,
             # Validation configuration (VALIDATE-001)
             validation_enabled=bool(row["validation_enabled"]) if "validation_enabled" in row_keys and row["validation_enabled"] is not None else False,

--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -10,7 +10,7 @@ Tokens are encrypted using the same AES-256-GCM system as other credentials.
 
 import uuid
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Dict, Any
 
 from .connection import get_db_connection
@@ -504,10 +504,45 @@ class SubscriptionOperations:
             """, (agent_name, subscription_id))
             return cursor.fetchone()["cnt"]
 
-    def is_subscription_rate_limited(self, subscription_id: str) -> bool:
-        """Check if a subscription has been rate-limited in the last 2 hours."""
+    def set_subscription_rate_limited_until(self, subscription_id: str, until_iso: str) -> None:
+        """Persist the authoritative reset timestamp from a 429 response body."""
         with get_db_connection() as conn:
             cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE subscription_credentials SET rate_limited_until = ? WHERE id = ?",
+                (until_iso, subscription_id)
+            )
+            conn.commit()
+
+    def is_subscription_rate_limited(self, subscription_id: str) -> bool:
+        """Check if a subscription is rate-limited.
+
+        Checks the durable rate_limited_until timestamp first (authoritative when
+        Anthropic's reset time was parseable from the 429 body). Falls back to the
+        2-hour event-count heuristic for cases where parsing failed.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT rate_limited_until FROM subscription_credentials WHERE id = ?",
+                (subscription_id,)
+            )
+            row = cursor.fetchone()
+            if row and row["rate_limited_until"]:
+                until = datetime.fromisoformat(row["rate_limited_until"])
+                # Ensure timezone-aware comparison
+                if until.tzinfo is None:
+                    until = until.replace(tzinfo=timezone.utc)
+                if datetime.now(timezone.utc) < until:
+                    return True
+                # Expired — clear it so it doesn't block indefinitely
+                cursor.execute(
+                    "UPDATE subscription_credentials SET rate_limited_until = NULL WHERE id = ?",
+                    (subscription_id,)
+                )
+                conn.commit()
+
+            # Fallback: event-count heuristic
             cursor.execute("""
                 SELECT COUNT(*) as cnt
                 FROM subscription_rate_limit_events

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -117,7 +117,7 @@ class ScheduleCreate(BaseModel):
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
     # Retry configuration (RETRY-001)
-    max_retries: int = 1  # 0 = disabled, 1-5 range. Default 1 for resilience.
+    max_retries: int = 0  # 0 = disabled (default), 1-5 = retry count
     retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
     # Validation configuration (VALIDATE-001)
     validation_enabled: bool = False  # Enable post-execution validation
@@ -144,7 +144,7 @@ class Schedule(BaseModel):
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
     # Retry configuration (RETRY-001)
-    max_retries: int = 1  # 0 = disabled, 1-5 range
+    max_retries: int = 0  # 0 = disabled (default), 1-5 = retry count
     retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
     # Validation configuration (VALIDATE-001)
     validation_enabled: bool = False  # Enable post-execution validation

--- a/src/backend/services/subscription_auto_switch.py
+++ b/src/backend/services/subscription_auto_switch.py
@@ -11,13 +11,43 @@ Preconditions (all must be true):
 4. At least one alternative subscription is available and not rate-limited
 """
 
+import re
 import logging
+from datetime import datetime, timedelta
 from typing import Optional, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from database import db
 from db_models import NotificationCreate
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_rate_limit_reset(error_message: str) -> Optional[str]:
+    """Parse 'resets 8pm (America/New_York)' from a 429 body → UTC ISO string, or None.
+
+    Anthropic includes the reset time in the error message. Persisting it lets
+    is_subscription_rate_limited() block the subscription until it actually resets
+    rather than relying on the 2-hour rolling window (which is too short).
+    """
+    match = re.search(
+        r'resets\s+(\d{1,2}(?::\d{2})?(?:am|pm)?)\s+\(([^)]+)\)',
+        error_message, re.IGNORECASE
+    )
+    if not match:
+        return None
+    time_str, tz_str = match.group(1), match.group(2)
+    try:
+        tz = ZoneInfo(tz_str)
+        today = datetime.now(tz).date()
+        fmt = "%I:%M%p" if ":" in time_str else "%I%p"
+        t = datetime.strptime(time_str.upper(), fmt)
+        reset_local = datetime.combine(today, t.time(), tzinfo=tz)
+        if reset_local <= datetime.now(tz):
+            reset_local += timedelta(days=1)
+        return reset_local.astimezone(ZoneInfo("UTC")).isoformat()
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
 
 
 async def handle_rate_limit_error(
@@ -42,12 +72,16 @@ async def handle_rate_limit_error(
     if not current_sub_id:
         return None
 
-    # 3. Record the rate-limit event and get consecutive count
+    # 3. Record the rate-limit event and persist the authoritative reset time if parseable
     consecutive_count = db.record_rate_limit_event(
         agent_name=agent_name,
         subscription_id=current_sub_id,
         error_message=error_message
     )
+    reset_until = _parse_rate_limit_reset(error_message)
+    if reset_until:
+        db.set_subscription_rate_limited_until(current_sub_id, reset_until)
+        logger.info(f"[SUB-003] Subscription {current_sub_id} rate-limited until {reset_until}")
 
     if consecutive_count < 2:
         logger.info(

--- a/src/scheduler/models.py
+++ b/src/scheduler/models.py
@@ -49,7 +49,7 @@ class Schedule:
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
     # Retry configuration (RETRY-001)
-    max_retries: int = 1  # 0 = disabled, 1-5 range
+    max_retries: int = 0  # 0 = disabled (default), 1-5 = retry count
     retry_delay_seconds: int = 60  # Seconds between retries (30-600 range)
     # Validation configuration (VALIDATE-001)
     validation_enabled: bool = False  # Enable post-execution validation

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -1107,6 +1107,19 @@ class SchedulerService:
             logger.debug(f"Schedule {execution.schedule_id} not found, skipping retry")
             return
 
+        # Never retry rate-limit failures — the subscription is exhausted and the
+        # next scheduled cron tick is the right recovery path, not an immediate retry.
+        if error_msg:
+            error_lower = error_msg.lower()
+            if ("429" in error_lower or "rate limit" in error_lower
+                    or "too many requests" in error_lower
+                    or "subscription usage limit" in error_lower):
+                logger.info(
+                    f"Execution {execution.id} failed due to rate limit — skipping retry, "
+                    "next scheduled run will recover"
+                )
+                return
+
         # Check if retries are enabled
         max_retries = schedule.max_retries
         if max_retries <= 0:
@@ -1124,13 +1137,6 @@ class SchedulerService:
 
         # Calculate retry delay
         retry_delay = schedule.retry_delay_seconds
-
-        # Check for rate limit (429) in error - use 2x delay, capped at 300s
-        if error_msg:
-            error_lower = error_msg.lower()
-            if "429" in error_lower or "rate limit" in error_lower or "too many requests" in error_lower:
-                retry_delay = min(300, retry_delay * 2)
-                logger.info(f"Rate limit detected, using 2x delay: {retry_delay}s")
 
         # Schedule the retry
         retry_at = datetime.utcnow() + timedelta(seconds=retry_delay)


### PR DESCRIPTION
## Summary

- **Persist `rate_limited_until`** — parse `"resets 8pm (America/New_York)"` from the 429 body and store in a new `subscription_credentials.rate_limited_until` column. `is_subscription_rate_limited()` checks this authoritative timestamp before falling back to the 2h event-count heuristic, preventing the slow ping-pong where Trinity considers an exhausted subscription viable again every 2 hours while Anthropic's actual window is 5–8h.
- **Never retry rate-limited executions** — `_maybe_schedule_retry()` now returns early on 429/rate-limit errors. The next cron tick is the correct recovery path; queuing retries during a subscription outage just floods the backlog with guaranteed-to-fail work.
- **Default `max_retries` from 1 → 0** — retries are now opt-in per schedule. Scheduled agents are typically stateful and idempotent; skipping a run is preferable to thundering-herd replay when many tasks fail simultaneously.

## Changes

- `db/migrations.py` — add `_migrate_subscription_rate_limited_until` (ALTER TABLE adds column, idempotent)
- `db/subscriptions.py` — `set_subscription_rate_limited_until()` setter + updated `is_subscription_rate_limited()` checks durable timestamp first
- `database.py` — expose new setter on facade
- `services/subscription_auto_switch.py` — `_parse_rate_limit_reset()` parser + wired into `handle_rate_limit_error()`
- `db_models.py` + `scheduler/models.py` + `db/schedules.py` — `max_retries` default 1 → 0
- `scheduler/service.py` — early return in `_maybe_schedule_retry()` for rate-limit errors

## Test Plan

- [ ] Existing subscription tests pass
- [ ] `is_subscription_rate_limited()` returns True when `rate_limited_until` is in the future
- [ ] `is_subscription_rate_limited()` clears expired `rate_limited_until` and falls back to event count
- [ ] `_parse_rate_limit_reset("resets 8pm (America/New_York)")` returns a future UTC ISO string
- [ ] `_maybe_schedule_retry()` returns without scheduling when error contains "429"
- [ ] New schedules default to `max_retries=0`

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)