### PR TITLE
feat(settings): add Remove buttons for stored API keys + Slack (#459)

### DIFF
--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -152,6 +152,18 @@
                       </svg>
                       Save
                     </button>
+                    <button
+                      v-if="anthropicKeyStatus.configured && anthropicKeyStatus.source === 'settings'"
+                      @click="removeAnthropicKey"
+                      :disabled="removingApiKey"
+                      class="inline-flex items-center px-4 py-2 border border-red-300 dark:border-red-700 rounded-md shadow-sm text-sm font-medium text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <svg v-if="removingApiKey" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      Remove
+                    </button>
                   </div>
                   <!-- Status/Result -->
                   <div class="mt-2 flex items-center text-sm">
@@ -244,6 +256,18 @@
                         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>
                       Save
+                    </button>
+                    <button
+                      v-if="githubPatStatus.configured && githubPatStatus.source === 'settings'"
+                      @click="removeGithubPat"
+                      :disabled="removingGithubPat"
+                      class="inline-flex items-center px-4 py-2 border border-red-300 dark:border-red-700 rounded-md shadow-sm text-sm font-medium text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <svg v-if="removingGithubPat" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      Remove
                     </button>
                   </div>
                   <!-- Status/Result -->
@@ -440,6 +464,18 @@
                       <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
                     Save Credentials
+                  </button>
+                  <button
+                    v-if="slackHasStoredCredentials"
+                    @click="removeSlackSettings"
+                    :disabled="removingSlackSettings"
+                    class="inline-flex items-center px-4 py-2 border border-red-300 dark:border-red-700 rounded-md shadow-sm text-sm font-medium text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <svg v-if="removingSlackSettings" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    Remove Credentials
                   </button>
                   <span v-if="slackSaveSuccess" class="text-sm text-green-600 dark:text-green-400">
                     ✓ Saved
@@ -1611,16 +1647,26 @@ Example:
         </div>
       </div>
     </main>
+
+    <ConfirmDialog
+      v-model:visible="confirmDialog.visible"
+      :title="confirmDialog.title"
+      :message="confirmDialog.message"
+      :confirm-text="confirmDialog.confirmText"
+      :variant="confirmDialog.variant"
+      @confirm="confirmDialog.onConfirm"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useSettingsStore } from '../stores/settings'
 import NavBar from '../components/NavBar.vue'
+import ConfirmDialog from '../components/ConfirmDialog.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -1705,6 +1751,27 @@ const githubPatStatus = ref({
   source: null
 })
 const githubPatPropagation = ref(null)
+const removingApiKey = ref(false)
+const removingGithubPat = ref(false)
+const removingSlackSettings = ref(false)
+
+const slackHasStoredCredentials = computed(() => {
+  const s = slackSettings.value
+  return Boolean(
+    (s?.client_id?.configured && s.client_id.source === 'settings') ||
+    (s?.client_secret?.configured && s.client_secret.source === 'settings') ||
+    (s?.signing_secret?.configured && s.signing_secret.source === 'settings')
+  )
+})
+
+const confirmDialog = reactive({
+  visible: false,
+  title: '',
+  message: '',
+  confirmText: 'Confirm',
+  variant: 'danger',
+  onConfirm: () => {}
+})
 
 // Slack Integration state (SLACK-001)
 const slackClientId = ref('')
@@ -1972,6 +2039,51 @@ async function saveGithubPat() {
   }
 }
 
+function removeAnthropicKey() {
+  confirmDialog.title = 'Remove Anthropic API Key'
+  confirmDialog.message = 'Remove the stored Anthropic API key? Agents will fall back to the ANTHROPIC_API_KEY environment variable if set, otherwise they will stop working until a key is re-added.'
+  confirmDialog.confirmText = 'Remove'
+  confirmDialog.variant = 'danger'
+  confirmDialog.onConfirm = async () => {
+    removingApiKey.value = true
+    error.value = null
+    try {
+      await axios.delete('/api/settings/api-keys/anthropic')
+      await loadApiKeyStatus()
+      anthropicKey.value = ''
+      apiKeyTestResult.value = null
+    } catch (e) {
+      error.value = e.response?.data?.detail || 'Failed to remove API key'
+    } finally {
+      removingApiKey.value = false
+    }
+  }
+  confirmDialog.visible = true
+}
+
+function removeGithubPat() {
+  confirmDialog.title = 'Remove GitHub PAT'
+  confirmDialog.message = 'Remove the stored GitHub Personal Access Token? Agents will fall back to the GITHUB_PAT environment variable if set. Repository creation and push will fail until a PAT is re-added.'
+  confirmDialog.confirmText = 'Remove'
+  confirmDialog.variant = 'danger'
+  confirmDialog.onConfirm = async () => {
+    removingGithubPat.value = true
+    error.value = null
+    try {
+      await axios.delete('/api/settings/api-keys/github')
+      await loadApiKeyStatus()
+      githubPat.value = ''
+      githubPatTestResult.value = null
+      githubPatPropagation.value = null
+    } catch (e) {
+      error.value = e.response?.data?.detail || 'Failed to remove GitHub PAT'
+    } finally {
+      removingGithubPat.value = false
+    }
+  }
+  confirmDialog.visible = true
+}
+
 // Public URL methods
 async function loadPublicUrl() {
   try {
@@ -2047,6 +2159,29 @@ async function saveSlackSettings() {
   } finally {
     savingSlackSettings.value = false
   }
+}
+
+function removeSlackSettings() {
+  confirmDialog.title = 'Remove Slack Credentials'
+  confirmDialog.message = 'Remove the stored Slack OAuth credentials (client ID, client secret, signing secret)? Slack integration will fall back to environment variables if configured; otherwise Slack channels will stop working until credentials are re-added.'
+  confirmDialog.confirmText = 'Remove'
+  confirmDialog.variant = 'danger'
+  confirmDialog.onConfirm = async () => {
+    removingSlackSettings.value = true
+    error.value = null
+    try {
+      await axios.delete('/api/settings/slack')
+      await loadSlackSettings()
+      slackClientId.value = ''
+      slackClientSecret.value = ''
+      slackSigningSecret.value = ''
+    } catch (e) {
+      error.value = e.response?.data?.detail || 'Failed to remove Slack credentials'
+    } finally {
+      removingSlackSettings.value = false
+    }
+  }
+  confirmDialog.visible = true
 }
 
 async function loadSlackTransportStatus() {


### PR DESCRIPTION
Closes #459.

## Summary

Settings page lets admins save/test Anthropic API Key, GitHub PAT, and Slack OAuth credentials, but exposed **no UI to clear** them once stored. The only workaround was hitting the backend `DELETE` endpoints directly or editing the DB. Peer sections (MCP URL, Email Whitelist, GitHub Templates, Trinity Prompt) all have inline Remove/Clear/Reset — this closes the gap for the three remaining secret-bearing sections.

## Changes

`src/frontend/src/views/Settings.vue` (only file):
- **Anthropic API Key** — `Remove` button next to `Save`, visible when `anthropicKeyStatus.configured && source === 'settings'` → `DELETE /api/settings/api-keys/anthropic`
- **GitHub PAT** — same pattern → `DELETE /api/settings/api-keys/github`
- **Slack Credentials** — `Remove Credentials` button next to `Save Credentials`, visible when any of `client_id` / `client_secret` / `signing_secret` is stored in settings (not env) → `DELETE /api/settings/slack` (wipes all three)
- All three flow through a shared `ConfirmDialog` (reuses `components/ConfirmDialog.vue`, pattern from `views/ApiKeys.vue::revokeKey`)
- Status refreshed via `loadApiKeyStatus()` / `loadSlackSettings()` — no page reload required
- Env-var fallbacks stay uneditable from UI (button only shows for settings-sourced values — matching the existing convention that env keys display "from environment" and are not touchable)

**No backend work** — DELETE endpoints already exist (`routers/settings.py:196, 355, 592`), admin-gated, audit-logged, return `{success, deleted, fallback_configured}`.

## Audit of other Settings sections (per AC checklist)

| Section | Status |
|---|---|
| MCP Server URL | `resetMcpUrl` exists — verified |
| Trinity Prompt | `clearPrompt` blanks + saves (backend accepts empty) — verified |
| Skills Library | Save handler auto-routes empty input → `deleteSetting` — verified |
| GitHub Templates | Inline remove + reset — already present |
| Email Whitelist | Inline `removeEmailFromWhitelist` — already present |
| SSH Access | Toggle, no stored secret |
| Agent Quotas | Integer config, not secrets |
| Subscriptions | Managed via separate UI |
| **Anthropic / GitHub / Slack** | **Fixed by this PR** |

## Test plan

- [x] `DELETE /api/settings/api-keys/anthropic` — verified on running local stack: returns `{success: true, deleted: true, fallback_configured: true}`, status endpoint flips to `configured: true, source: env`
- [x] `DELETE /api/settings/api-keys/github` — same
- [x] `DELETE /api/settings/slack` — verified: returns `{success: true, deleted: [], fallback_configured: false}` (already empty in local)
- [x] Vite transform compiles `Settings.vue` cleanly (HTTP 200, no syntax errors on hot reload)
- [x] Conditional rendering: button is `v-if="...source === 'settings'"` → hidden when key comes from env, shown when stored in DB
- [x] Manual smoke in browser at `http://localhost/settings`: save key → Remove button appears → click → confirm dialog → click Remove → status flips to env/unconfigured without reload

## Notes

Single-file diff (+136 / −1). No schema change, no migration, no new route, no new dependency. The UI-only patch is self-contained.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>