### PR TITLE
Wire up status-in-dev label + PR-merge automation (#488)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -183,28 +183,42 @@ Validate tag format: `cli-v<semver>` if CLI scope changed, otherwise `v<semver>`
 
 ### Step 5: Draft Release Notes
 
-Generate from squash commits in range:
+**Primary source: issues labeled `status-in-dev`.**
+
+Every PR that lands on `dev` promotes its linked issues to `status-in-dev` (via `.github/workflows/issue-status-on-merge.yml`). That label set is the authoritative "what's shipping in this release" list. The commit range is used as a sanity check, not the primary source.
 
 ```bash
-git log "$RANGE" --format='- %s (%h)' --reverse
+# Authoritative shipping list — open issues labeled status-in-dev
+gh issue list --repo abilityai/trinity --state open \
+  --label status-in-dev --limit 100 \
+  --json number,title,labels,url
+
+# Sanity check: issue references in the commit range
+git log "$RANGE" --format='%s%n%b' \
+  | grep -oiE '(fix(es|ed)?|close[sd]?|resolve[sd]?) #[0-9]+' \
+  | grep -oE '#[0-9]+' | sort -u
 ```
 
-Group by conventional-commit prefix:
+Reconcile the two lists. Flag and discuss:
+- Issues in `status-in-dev` but NOT referenced in commits → label may be stale (leftover from a reverted change)
+- Issues referenced in commits but NOT in `status-in-dev` → the automation missed them (retroactively add the label, or include manually)
+
+Group release notes by issue type (read from issue labels `type-feature` / `type-bug` / `type-refactor` / `type-docs`):
 
 ```markdown
 # [VERSION]
 
 ## Features
-- feat: ... (#N) — [commit short sha]
+- #N Title (short description)
 
 ## Fixes
-- fix: ... (#N)
+- #N Title
 
 ## Refactors
-- refactor: ... (#N)
+- #N Title
 
 ## Documentation
-- docs: ... (#N)
+- #N Title
 
 ## Breaking Changes
 [if any from 2.8, list here]
@@ -213,17 +227,28 @@ Group by conventional-commit prefix:
 **Contributors**: [names]
 ```
 
+Include standalone commits (without a linked issue) under an "Other changes" heading if material.
+
 [APPROVAL GATE] — Present drafted notes. User edits or approves.
 
 ### Step 6: Open the Release PR
 
+The PR body MUST include a `Closes #N #M ...` line listing every issue in the release so GitHub auto-closes them when the release squash-merges to `main`. Build this from the `status-in-dev` list gathered in Step 5.
+
 ```bash
+# Build the "Closes" line from status-in-dev issues
+CLOSES_LINE=$(gh issue list --repo abilityai/trinity --state open \
+  --label status-in-dev --limit 100 --json number \
+  --jq '[.[].number] | map("#\(.)") | join(" ")')
+
 PR_BODY=$(cat <<EOF
 Release [VERSION] — cumulative changes since [LAST_TAG].
 
 [release notes]
 
 ---
+
+Closes ${CLOSES_LINE}
 
 Pre-release checklist passed [date]. Ready for squash-merge.
 
@@ -238,7 +263,7 @@ gh pr create --repo abilityai/trinity \
   --body "$PR_BODY"
 ```
 
-Capture the PR URL.
+Capture the PR URL. The `Closes` line ensures every `status-in-dev` issue auto-closes when the release lands on `main`.
 
 ### Step 7: Wait for CI
 

--- a/.github/workflows/issue-status-on-merge.yml
+++ b/.github/workflows/issue-status-on-merge.yml
@@ -1,0 +1,63 @@
+name: Issue Status on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  mark-in-dev:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark referenced issues as status-in-dev
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const haystack = `${pr.title || ''}\n${pr.body || ''}`;
+
+            // Match Fixes/Fixed/Closes/Closed/Resolves/Resolved #N (case-insensitive)
+            const pattern = /\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+#(\d+)/gi;
+            const issues = [...new Set([...haystack.matchAll(pattern)].map(m => parseInt(m[1], 10)))];
+
+            if (issues.length === 0) {
+              core.info('No Fixes/Closes/Resolves references found in PR — nothing to do.');
+              return;
+            }
+
+            core.info(`Promoting ${issues.length} issue(s) to status-in-dev: ${issues.join(', ')}`);
+
+            for (const num of issues) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  labels: ['status-in-dev']
+                });
+                core.info(`#${num}: added status-in-dev`);
+              } catch (e) {
+                core.warning(`#${num}: failed to add status-in-dev — ${e.message}`);
+                continue;
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  name: 'status-in-progress'
+                });
+                core.info(`#${num}: removed status-in-progress`);
+              } catch (e) {
+                // Label may not be present; that's fine.
+                if (e.status !== 404) {
+                  core.warning(`#${num}: failed to remove status-in-progress — ${e.message}`);
+                }
+              }
+            }

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -7,10 +7,10 @@
 
 ## Software Development Lifecycle (SDLC)
 
-Trinity follows a 4-stage lifecycle that maps 1:1 to the **Trinity Roadmap** GitHub Project board columns.
+Trinity follows a 4-stage lifecycle. Each stage maps 1:1 to an issue's location in the commit graph, tracked via `status-*` labels (the authoritative surface — `gh issue list --label status-in-dev` etc.). The GitHub Project board mirrors these for visual tracking but is optional.
 
 ```
- Todo → In Progress → Review → Done
+ Todo → In Progress → In Dev → Done
 ```
 
 ```
@@ -20,26 +20,32 @@ Trinity follows a 4-stage lifecycle that maps 1:1 to the **Trinity Roadmap** Git
 │          │                                                          │
 │ TODO     │  Issue created, triaged with priority + type labels      │
 │          │  Acceptance criteria defined before work begins           │
-│          │  GitHub Project: Todo                                    │
+│          │  Label: status-ready (optional) | Board: Todo            │
 │          │                                                          │
 ├──────────┼──────────────────────────────────────────────────────────┤
 │          │                                                          │
 │ IN       │  /claim → /autoplan → approve → /implement              │
 │ PROGRESS │  → /review → /cso --diff → /sync-feature-flows          │
-│          │  Label: status-in-progress                               │
-│          │  GitHub Project: In Progress                             │
+│          │  → open PR to dev, /validate-pr                          │
+│          │  Label: status-in-progress | Board: In Progress          │
+│          │  Code location: feature branch                           │
 │          │                                                          │
 ├──────────┼──────────────────────────────────────────────────────────┤
 │          │                                                          │
-│ REVIEW   │  PR opened, /review + /validate-pr pass                  │
-│          │  Code review approved, ready to merge                    │
-│          │  GitHub Project: In Progress                             │
+│ IN DEV   │  PR squash-merged to dev — feature is shippable          │
+│          │  Awaiting next release cut (dev → main)                  │
+│          │  Label: status-in-dev | Board: In Dev                    │
+│          │  Code location: origin/dev                               │
+│          │                                                          │
+│          │  Promoted automatically by                               │
+│          │  .github/workflows/issue-status-on-merge.yml             │
 │          │                                                          │
 ├──────────┼──────────────────────────────────────────────────────────┤
 │          │                                                          │
-│ DONE     │  PR merged to dev, issue closed                          │
-│          │  Docs up to date                                         │
-│          │  GitHub Project: Done                                    │
+│ DONE     │  Release PR (dev → main) squash-merged + tagged          │
+│          │  Issues auto-closed via `Closes #N` in release body      │
+│          │  Label: (none — issue closed) | Board: Done              │
+│          │  Code location: origin/main                              │
 │          │                                                          │
 └──────────┴──────────────────────────────────────────────────────────┘
 ```
@@ -304,13 +310,29 @@ Runs a scoped security audit on the branch changes only. Checks secrets, depende
 - Missing tests for new behavior
 - `requirements.md` not updated for new features
 
-### 4. Done
+### 4. In Dev (merged to dev, awaiting release)
 
-When the PR is approved and merged to `dev`:
+When the feature PR squash-merges to `dev`:
 
-1. Issue is **auto-closed** via `Fixes #N`
-2. Move to **Done** on the project board
-3. Remove status labels
+1. **Automation fires** (`.github/workflows/issue-status-on-merge.yml`)
+   - Parses `Fixes #N` / `Closes #N` from the PR body + title
+   - Adds `status-in-dev` to each referenced issue
+   - Removes `status-in-progress`
+2. Issue remains **open** — it ships when the next release cuts `dev` → `main`
+3. Board column (if used): **In Dev**
+
+Querying what's shipping in the next release:
+```bash
+gh issue list --repo abilityai/trinity --state open --label status-in-dev
+```
+
+### 4a. Done (released)
+
+The issue transitions to Done when the release PR squash-merges to `main` (see §4b):
+
+1. The release PR body includes `Closes #N #M ...` for every `status-in-dev` issue — GitHub auto-closes them on merge
+2. `status-in-dev` label remains on the closed issue (cosmetic, harmless — `--state open` queries ignore it)
+3. Board column: **Done**
 
 ### 4b. Release cut (`dev` → `main`)
 
@@ -370,15 +392,20 @@ The `publish-cli.yml` workflow automatically:
 
 ### Label ↔ Board Sync
 
-Keep these in sync at all times:
+Labels are the authoritative surface (`gh issue list --label ...`). The project board mirrors them:
 
-| Stage | Label | Board Column |
-|-------|-------|--------------|
-| Todo | *(none)* | Todo |
-| In Progress | `status-in-progress` | In Progress |
-| Blocked | `status-blocked` | In Progress |
-| Review | *(PR open)* | In Progress |
-| Done | *(none)* | Done |
+| Stage | Label | Board Column | Code location |
+|-------|-------|--------------|---------------|
+| Todo | *(none or `status-ready`)* | Todo | — |
+| In Progress | `status-in-progress` | In Progress | feature branch |
+| Blocked | `status-blocked` | In Progress | feature branch |
+| In Dev | `status-in-dev` | In Dev | `origin/dev` |
+| Done | *(issue closed)* | Done | `origin/main` |
+
+Transitions:
+- **Todo → In Progress**: `/claim` adds `status-in-progress` (via `.github/workflows/claim.yml`)
+- **In Progress → In Dev**: PR merge to `dev` adds `status-in-dev`, removes `status-in-progress` (via `.github/workflows/issue-status-on-merge.yml`)
+- **In Dev → Done**: Release PR (dev → main) includes `Closes #N` for each `status-in-dev` issue; GitHub auto-closes on merge
 
 ---
 


### PR DESCRIPTION
## Summary

- New label `status-in-dev` + GH Action that stamps it on PR merge to `dev` (parses `Fixes/Closes/Resolves #N`)
- `/release` skill now uses `status-in-dev` as the authoritative shipping list for release notes and emits `Closes #N` in the release PR body so issues auto-close on merge to `main`
- `DEVELOPMENT_WORKFLOW.md` SDLC updated: `Todo → In Progress → In Dev → Done` with 1:1 mapping to commit-graph location

Fixes #488

## Why

Before: an issue stayed `status-in-progress` from PR-open through the eventual release to `main` — there was no visible "merged to dev, awaiting release" state. `/release` drafted notes from raw commits, not from a curated list of shipped issues.

After: every issue's label reflects where its code actually lives in the commit graph. Release notes are built from `gh issue list --label status-in-dev`, and the release PR body auto-closes them.

## Test plan

- [ ] Merge this PR to `dev` (self-test: the workflow should stamp `status-in-dev` on #488 and remove `status-in-progress`)
- [ ] Next feature PR merge to `dev`: verify the Action fires and labels flip correctly
- [ ] Next `/release` run: verify release notes are drafted from `status-in-dev` and the PR body includes `Closes #N ...`
- [ ] After release merge to `main`: verify all `status-in-dev` issues auto-closed

## Out of scope

- Project board automation (workflow is label-first, not board-first)
- `status-review` label — exists but unused; left for a follow-up decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)