### PR TITLE
fix(schedules): add missing Request import for webhook endpoints

### DIFF
--- a/src/backend/routers/schedules.py
+++ b/src/backend/routers/schedules.py
@@ -8,7 +8,7 @@ defined BEFORE dynamic routes like /{name}/schedules to avoid FastAPI matching
 "scheduler" as an agent name.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime


### PR DESCRIPTION
## Summary

- `routers/schedules.py` (line 478, 515) references `Request` as a type annotation on the webhook endpoints but never imports it.
- Result: backend fails to load with `NameError: name 'Request' is not defined` on fresh start / reload.
- One-line fix: add `Request` to the existing `from fastapi import …` line (line 11).

## Root cause

Regression from c630931 (WEBHOOK-001 / #291). The webhook handlers were added with `request: Request` annotations but the import was never updated.

## Test plan

- [x] `docker compose logs backend` now boots cleanly (no NameError)
- [x] `curl http://localhost:8000/api/auth/mode` returns 200
- [x] Authenticated agents/list request returns expected data

🤖 Generated with [Claude Code](https://claude.com/claude-code)