### PR TITLE
fix(webhooks): import Request in schedules router

### DIFF
--- a/src/backend/routers/schedules.py
+++ b/src/backend/routers/schedules.py
@@ -8,7 +8,7 @@ defined BEFORE dynamic routes like /{name}/schedules to avoid FastAPI matching
 "scheduler" as an agent name.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime


### PR DESCRIPTION
## Summary

One-line import fix that unblocks `dev` deploys. The WEBHOOK-001 work added `request: Request` parameters to two endpoints in `src/backend/routers/schedules.py` without importing `Request` from `fastapi`, causing the backend module to fail at import time:

```
NameError: name 'Request' is not defined  (routers/schedules.py:478)
```

Result: backend container never starts, all dependent services fail health checks.

## Root cause

Introduced in commits `c630931` / `8fdf736` (PR #484 / WEBHOOK-001). The integration tests in `tests/test_webhook_triggers.py` exercise both buggy endpoints but never caught it — the backend never starts, so test setup fails before any assertion runs.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('src/backend/routers/schedules.py').read())"` — syntax OK
- [ ] Build images, start backend, confirm health check passes
- [ ] Run `tests/test_webhook_triggers.py` end-to-end

## Follow-ups

- Pre-merge CI should fail on backend import errors before integration tests
- PR #484 (against `main`) is now stale and will be closed; this fix + the WEBHOOK feature will reach main via the next `dev → main` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)