### PR TITLE
refactor(git): route orphan cleanup through db layer (#451)

### DIFF
--- a/src/backend/routers/git.py
+++ b/src/backend/routers/git.py
@@ -347,7 +347,7 @@ async def initialize_github_sync(
         else:
             # Database record exists but git not initialized - clean up orphaned record
             print(f"Warning: Found orphaned git config for {agent_name}. Cleaning up and allowing re-initialization.")
-            db.execute_query("DELETE FROM agent_git_config WHERE agent_name = ?", (agent_name,))
+            db.delete_git_config(agent_name)
 
     # Get GitHub PAT from settings
     github_pat = get_github_pat()


### PR DESCRIPTION
## Summary

- Replaces raw `DELETE FROM agent_git_config` SQL in `src/backend/routers/git.py:350` with the existing `db.delete_git_config(agent_name)` method.
- Restores Architectural Invariant #1 (Three-Layer Backend: Router → Service → DB) for this router.
- The same router file already uses `db.delete_git_config()` at line 435 for the init-failure rollback path — this brings the orphan-cleanup branch in line with that canonical pattern.

## Why

Issue #451 (parent: #447 automated architecture validation) flagged this as the only Invariant #1 violation in `routers/git.py`. The fix is a literal substitution: `db.delete_git_config()` (defined at `database.py:789`, implemented at `db/schedules.py:1476`) executes the exact same parameterized SQL.

## Changes

- `src/backend/routers/git.py` — 1-line change inside `initialize_github_sync`'s orphan-cleanup branch.

## Test Plan

- [x] No raw SQL remains in `routers/git.py` — `grep -nE "execute_query|cursor|^\s*(SELECT|INSERT|UPDATE|DELETE)" src/backend/routers/git.py` returns no matches.
- [x] AST parses cleanly.
- [x] Identical SQL is invoked via the existing `db.delete_git_config()` path — no behavior change.
- [x] `/validate-architecture` no longer flags `routers/git.py:315` under Invariant #1.

Closes #451

Generated with [Claude Code](https://claude.com/claude-code)