### PR TITLE
fix(auth): require auth on /api/docs endpoints (#452)

### DIFF
--- a/src/backend/routers/docs.py
+++ b/src/backend/routers/docs.py
@@ -6,10 +6,13 @@ Provides endpoints for:
 - Serving markdown content
 - Documentation index
 """
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse, JSONResponse
 from pathlib import Path
 import json
+
+from models import User
+from dependencies import get_current_user
 
 router = APIRouter(prefix="/api/docs", tags=["Documentation"])
 
@@ -31,7 +34,7 @@ def get_docs_dir() -> Path:
 
 
 @router.get("/index")
-async def get_docs_index():
+async def get_docs_index(current_user: User = Depends(get_current_user)):
     """Get documentation index/navigation structure."""
     docs_dir = get_docs_dir()
     if not docs_dir:
@@ -49,7 +52,10 @@ async def get_docs_index():
 
 
 @router.get("/content/{slug:path}")
-async def get_doc_content(slug: str):
+async def get_doc_content(
+    slug: str,
+    current_user: User = Depends(get_current_user),
+):
     """Get documentation content by slug (supports .md and .json files)."""
     docs_dir = get_docs_dir()
     if not docs_dir:
@@ -100,7 +106,7 @@ async def get_doc_content(slug: str):
 
 
 @router.get("/list")
-async def list_docs():
+async def list_docs(current_user: User = Depends(get_current_user)):
     """List all available documentation files."""
     docs_dir = get_docs_dir()
     if not docs_dir:


### PR DESCRIPTION
## Summary

Adds `Depends(get_current_user)` to all three handlers in `src/backend/routers/docs.py` so the file no longer violates **Architectural Invariant #8** ("Auth Pattern: `Depends(get_current_user)` on every authenticated endpoint").

## Note on Reachability

While exploring, I confirmed that `routers/docs.py` is **not currently registered in `src/backend/main.py`** — the `/api/docs/*` endpoints are not reachable on the running API. All other Process Engine routers (`processes.py`, `triggers.py`, `approvals.py`, `audit.py`) have already been removed; `docs.py` is the lone survivor.

I flagged this and offered to delete the file (Option B), but the maintainer chose Option A from the issue (add auth) — keeps the change minimal and aligns the file with Invariant #8 if it is ever remounted.

## Changes

- `src/backend/routers/docs.py`:
  - Add `Depends`, `User`, `get_current_user` imports
  - Add `current_user: User = Depends(get_current_user)` to `get_docs_index`, `get_doc_content`, `list_docs`

Net diff: +10 / -4.

## Test Plan

- [x] File parses (verified via `ast.parse`)
- [x] Module imports cleanly inside `trinity-backend` container; all three routes show `current_user: User` in their endpoint annotations
- [x] No mypy errors introduced on `routers/docs.py` (pre-existing errors in unrelated files only)
- [x] No frontend consumer of `/api/docs/*` (verified via grep across `src/frontend/`); acceptance criterion #2 (frontend docs viewer still works) is vacuously satisfied
- [x] No tests reference `/api/docs/*` (verified via grep across `tests/`)
- [ ] After merge: `/validate-architecture` no longer flags `routers/docs.py` under Invariant #8

## Acceptance Criteria

- [x] All three `/api/docs/*` endpoints require authentication
- [x] Frontend docs viewer still works (no consumer exists, vacuously satisfied)
- [ ] `/validate-architecture` no longer flags `routers/docs.py` under Invariant #8 (post-merge check)

Closes #452