### PR TITLE
fix(config): clean stale Auth0 / AUDIT_URL, document SMTP/SendGrid/FRONTEND_URL (#481)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,16 @@ EMAIL_PROVIDER=console
 # Get from: https://resend.com/api-keys
 RESEND_API_KEY=
 
+# SendGrid API (when EMAIL_PROVIDER=sendgrid)
+# Get from: https://app.sendgrid.com/settings/api_keys
+SENDGRID_API_KEY=
+
+# SMTP provider (when EMAIL_PROVIDER=smtp)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+
 # From address for verification emails
 SMTP_FROM=noreply@your-domain.com
 
@@ -108,8 +118,13 @@ GEMINI_API_KEY=
 # ===========================================
 
 REDIS_URL=redis://redis:6379
-AUDIT_URL=http://audit-logger:8001
 BACKEND_URL=http://localhost:8000
+
+# Public-facing frontend URL — REQUIRED in production
+# Used for: OAuth post-auth redirects (Slack, etc.), SSH host auto-detection,
+# public chat link generation
+# Example: https://trinity.your-domain.com
+FRONTEND_URL=
 
 # ===========================================
 # REDIS SECURITY (Optional but recommended for production)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,8 +40,6 @@ services:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}  # For Gemini-powered agents
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # For platform image generation (IMG-001)
       - GITHUB_PAT=${GITHUB_PAT}
-      - AUTH0_DOMAIN=${AUTH0_DOMAIN}
-      - AUTH0_ALLOWED_DOMAIN=${AUTH0_ALLOWED_DOMAIN:-ability.ai}
       # Host paths for volumes (used when creating agent containers)
       - HOST_TEMPLATES_PATH=${HOST_TEMPLATES_PATH:-${PWD}/config/agent-templates}
       # OpenTelemetry Configuration (Optional)
@@ -94,9 +92,6 @@ services:
       dockerfile: ../../docker/frontend/Dockerfile.prod
       args:
         - VITE_API_URL=${VITE_API_URL:-http://localhost:8000}
-        - VITE_AUTH0_DOMAIN=${AUTH0_DOMAIN:-dev-10tz4lo7hcoijxav.us.auth0.com}
-        - VITE_AUTH0_CLIENT_ID=${VITE_AUTH0_CLIENT_ID:-bFeIEm4WAwaalgSnxsfS1V6vd4gOk0li}
-        - VITE_AUTH0_ALLOWED_DOMAIN=${AUTH0_ALLOWED_DOMAIN:-ability.ai}
     image: trinity-frontend:prod
     container_name: trinity-frontend
     restart: unless-stopped

--- a/docker/frontend/Dockerfile.prod
+++ b/docker/frontend/Dockerfile.prod
@@ -17,15 +17,9 @@ COPY . .
 
 # Build arguments (injected at build time)
 ARG VITE_API_URL=http://localhost:8000
-ARG VITE_AUTH0_DOMAIN=dev-10tz4lo7hcoijxav.us.auth0.com
-ARG VITE_AUTH0_CLIENT_ID=bFeIEm4WAwaalgSnxsfS1V6vd4gOk0li
-ARG VITE_AUTH0_ALLOWED_DOMAIN=ability.ai
 
 # Set environment variables for Vite build
 ENV VITE_API_URL=${VITE_API_URL}
-ENV VITE_AUTH0_DOMAIN=${VITE_AUTH0_DOMAIN}
-ENV VITE_AUTH0_CLIENT_ID=${VITE_AUTH0_CLIENT_ID}
-ENV VITE_AUTH0_ALLOWED_DOMAIN=${VITE_AUTH0_ALLOWED_DOMAIN}
 
 # Build the application
 RUN npm run build


### PR DESCRIPTION
## Summary

Closes #481 — config validation found 5 must-fix issues in `.env.example` and `docker-compose.prod.yml`. This PR fixes all five:

- **Removes stale Auth0 config** from `docker-compose.prod.yml` and `docker/frontend/Dockerfile.prod`. Auth0 was removed 2026-01-01 (replaced by email auth) but the env vars / build args lingered. The build-arg fallbacks were also leaking a **real Auth0 domain + client ID** into a public repo — fixed.
- **Drops `AUDIT_URL`** from `.env.example` — references a removed `audit-logger` service, not used anywhere in the backend.
- **Adds `FRONTEND_URL`** to `.env.example` — read by `services/slack_service.py` (OAuth redirects), `services/ssh_service.py` (SSH host auto-detect), and `routers/public_links.py`. Operators following the template were silently breaking OAuth + SSH.
- **Documents SMTP fields** (`SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD`) and **`SENDGRID_API_KEY`** so the advertised `EMAIL_PROVIDER=smtp` and `EMAIL_PROVIDER=sendgrid` modes are actually configurable from the template.

## Changes

- `docker-compose.prod.yml` — removed `AUTH0_DOMAIN`, `AUTH0_ALLOWED_DOMAIN`, `VITE_AUTH0_*` build args (5 lines)
- `docker/frontend/Dockerfile.prod` — removed `VITE_AUTH0_*` ARG/ENV declarations (6 lines)
- `.env.example` — removed `AUDIT_URL`, added `FRONTEND_URL`, `SMTP_*`, `SENDGRID_API_KEY` (net +5 lines)

Net: 16 insertions, 12 deletions across 3 files. No code logic touched.

## Out of scope

The validation report flagged additional informational items (`GOOGLE_API_KEY` alias, `VOICE_*`, `SLACK_APP_TOKEN`, `OTEL_SAMPLE_RATE`, `LOG_RETENTION_DAYS`, etc.) that are not in the must-fix list. Those should be a follow-up issue.

## Test Plan

- [x] `rg 'AUTH0|AUDIT_URL' docker-compose.prod.yml docker/frontend/Dockerfile.prod .env.example` returns zero hits
- [x] `docker compose -f docker-compose.prod.yml config -q` validates clean (only blank-string warnings for unset env vars, no schema errors)
- [x] `rg 'VITE_AUTH0|AUTH0' src/` returns zero hits — confirms no frontend source still depends on the removed build args
- [x] `git diff` review confirms only the planned lines changed

No code logic changes → existing test suite unaffected; agents with existing `.env` files keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)