### PR TITLE
fix(git): UI Push no longer commits runtime state (#462)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -263,6 +263,25 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 - **Warning**: 75-90% pass rate, <5 failures
 - **Critical**: <75% pass rate or >5 failures
 
+## Recent Test Additions (2026-04-25)
+
+| Test File | Description | Tests Added |
+|-----------|-------------|-------------|
+| `unit/test_github_init_gitignore.py` | Gitignore widen + migrate-on-push (#462) — full exclusion list coverage, idempotency, doc/constant sync, `git rm --cached` for newly-ignored files | 4 new tests (file total 6) |
+
+**Gitignore Widen + Migrate (#462)** (`unit/test_github_init_gitignore.py`):
+
+- `test_preserves_preexisting_gitignore` — existing `.gitignore` content is retained after init (pre-existing test)
+- `test_fresh_agent_ignores_env_and_mcp_json` — fresh agent gets `.env` and `.mcp.json` exclusions (pre-existing test)
+- `test_full_documented_exclusion_list_present` — all patterns in `_GITIGNORE_PATTERNS` constant are written to `.gitignore` (new)
+- `test_idempotent_double_run` — running `initialize_git_in_container` twice does not duplicate patterns (new)
+- `test_doc_and_constant_in_sync` — `_GITIGNORE_PATTERNS` constant matches the exclusion block in `TRINITY_COMPATIBLE_AGENT_GUIDE.md` (new)
+- `test_rm_cached_for_newly_ignored_files` — `sync_to_github` calls `git rm --cached` for files that are tracked but now match a `.gitignore` pattern (new)
+
+Pure unit tests over `git_service.py` stubs; no backend container required. Run via `pytest tests/unit/test_github_init_gitignore.py`.
+
+---
+
 ## Recent Test Additions (2026-04-23)
 
 | Test File | Description | Tests Added |

--- a/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
+++ b/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
@@ -125,35 +125,50 @@ OTHER_VAR=value
 
 ### 5. `.gitignore` (Required)
 
-Must exclude secrets, instance-specific files, and large content:
+Must exclude secrets, instance-specific files, and large content.
+
+> **Source of truth**: this list mirrors `_GITIGNORE_PATTERNS` in
+> `src/backend/services/git_service.py`. The Python constant is the
+> source of truth — the platform appends every entry to the agent's
+> `.gitignore` on init and again on every Push. A unit test
+> (`tests/unit/test_github_init_gitignore.py::test_doc_and_constant_in_sync`)
+> asserts the two stay in sync.
 
 ```gitignore
+# Shell init / history (instance-specific)
+.bash_logout
+.bashrc
+.profile
+.bash_history
+.sudo_as_admin_successful
+
 # Credentials - NEVER COMMIT
-.mcp.json
 .env
+.env.*
+.mcp.json
+credentials.json
 *.pem
 *.key
-credentials.json
+
+# Instance-specific directories - DO NOT COMMIT
+.cache/
+.local/
+.npm/
+.ssh/
+.trinity/
 
 # Large generated content - DO NOT COMMIT
 content/
 
-# Instance-specific directories - DO NOT COMMIT
-.npm/
-.ssh/
-.trinity/
-.cache/
-
-# Instance-specific files - DO NOT COMMIT
+# Claude Code - commit commands/skills/agents, exclude runtime data
 .claude.json
 .claude.json.backup
-.sudo_as_admin_successful
-
-# Claude Code - commit commands/skills/agents, exclude runtime data
 .claude/projects/
 .claude/statsig/
 .claude/todos/
 .claude/debug/
+.claude/sessions/
+.claude/shell-snapshots/
 # Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
 
 # Temporary files
@@ -179,6 +194,8 @@ content/
 - ❌ `.claude/statsig/` - Analytics
 - ❌ `.claude/todos/` - Temporary todo lists
 - ❌ `.claude/debug/` - Debug logs
+- ❌ `.claude/sessions/` - Per-session state
+- ❌ `.claude/shell-snapshots/` - Shell environment snapshots
 
 **Note on Skills**: Skills in templates are seeded to the **Platform Skills Library** on first deployment, then managed centrally. See [Platform Skills](#platform-skills).
 

--- a/docs/memory/feature-flows/github-repo-initialization.md
+++ b/docs/memory/feature-flows/github-repo-initialization.md
@@ -460,12 +460,19 @@ async def initialize_git_in_container(
     git_dir = "/home/developer/workspace" if workspace_has_content else "/home/developer"
 
     # Step 2: Append any missing _GITIGNORE_PATTERNS entries to .gitignore
-    # (issue #458). Runs for BOTH /home/developer and the legacy
+    # (issues #458 and #462). Runs for BOTH /home/developer and the legacy
     # /home/developer/workspace path. The merge is idempotent — each
     # pattern is gated by an exact-line `grep -qxF` check — so any
     # workspace-supplied `.gitignore` (e.g. written by `/trinity:onboard`)
-    # is preserved. Patterns: .bash_logout, .bashrc, .profile,
-    # .bash_history, .cache/, .local/, .npm/, .ssh/, .env, .env.*, .mcp.json.
+    # is preserved.
+    #
+    # _GITIGNORE_PATTERNS is the canonical exclusion list (single source
+    # of truth) — see src/backend/services/git_service.py and the mirrored
+    # block in docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md. The list covers
+    # shell init, credentials, instance-specific dirs/files, Claude Code
+    # runtime data, temp files, and local overrides. The same merge runs
+    # again on every Push via _migrate_workspace_gitignore (#462) so
+    # existing agents pick up new entries without re-init.
     execute_command_in_container(
         command=_build_gitignore_merge_command(git_dir),
         timeout=5,
@@ -1098,8 +1105,14 @@ sqlite3 ~/trinity-data/trinity.db "SELECT key, substr(value, 1, 10) || '...' FRO
 # - Two branches: main, trinity/test-agent/xxxxxxxx
 # - Commits on both branches
 # - Agent files: CLAUDE.md, .claude/, .trinity/
-# - .gitignore excludes: .bashrc, .cache/, .ssh/, .env, .env.*, .mcp.json
-# - .env and .mcp.json are NOT in the initial commit (#458)
+# - .gitignore covers the full _GITIGNORE_PATTERNS list — see the canonical
+#   constant in src/backend/services/git_service.py (also mirrored in
+#   docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md). The list spans shell init,
+#   credentials, instance-specific dirs/files, Claude Code runtime data,
+#   temp files, and local overrides.
+# - .env, .mcp.json, and Claude Code runtime files (.claude/sessions,
+#   .claude/shell-snapshots, .cache, .claude.json, etc.) are NOT in the
+#   initial commit (#458 + #462)
 ```
 
 **Verify in Database**:
@@ -1180,15 +1193,18 @@ sqlite3 ~/trinity-data/trinity.db "SELECT * FROM agent_git_config WHERE agent_na
 **Expected**:
 - System uses `/home/developer` directly (no workspace subdirectory)
 - Backend logs: `Using home directory: /home/developer`
-- `.gitignore` contains system file exclusions plus `.env`, `.env.*`, `.mcp.json` (#458)
-- Agent files (CLAUDE.md, .claude/, .trinity/) pushed to GitHub
+- `.gitignore` contains the full `_GITIGNORE_PATTERNS` canonical list — credentials, instance dirs/files, Claude Code runtime data, temp files (#458 + #462)
+- Agent files (CLAUDE.md, .claude/commands/, .claude/skills/, .claude/agents/, .trinity/) pushed to GitHub
 - `.env` and `.mcp.json` written by `inject_credentials` are excluded
+- Claude Code runtime (`.claude/sessions/`, `.claude/shell-snapshots/`, `.claude.json`, etc.) is excluded
 - Pre-existing workspace `.gitignore` rules (e.g. from `/trinity:onboard`) are preserved
+- The same merge runs on every subsequent Push via `_migrate_workspace_gitignore` (#462), so existing agents pick up new patterns automatically
 
 **LEGACY Case** (agents created before 2026-02):
 - If `/home/developer/workspace/` exists with content, that directory is used
 - Backend logs: `Using workspace directory: /home/developer/workspace`
 - `.gitignore` merge also runs here (#458 — previously skipped)
+- Detection logic shared with `_detect_git_dir`, used by both init and the post-init Push migration (#462)
 
 **Verify**:
 - Check GitHub repo contains agent files but not system files

--- a/docs/memory/feature-flows/github-sync.md
+++ b/docs/memory/feature-flows/github-sync.md
@@ -236,6 +236,8 @@ sequenceDiagram
 
     User->>UI: Click "Sync" button
     UI->>Backend: POST /api/agents/{name}/git/sync
+    Backend->>Container: docker exec — append missing _GITIGNORE_PATTERNS (#462)
+    Backend->>Container: docker exec — git rm --cached newly-ignored tracked files
     Backend->>Container: POST /api/git/sync
     Container->>Container: git add -A
     Container->>Container: git commit -m "Trinity sync: {timestamp}"
@@ -243,6 +245,32 @@ sequenceDiagram
     Container->>Backend: Return commit SHA (or 409 on stale lease)
     Backend->>UI: Show notification (or branch_ownership_collision modal)
 ```
+
+### Per-Push Gitignore Migration (#462)
+
+Before forwarding to the agent's `/api/git/sync`, the platform calls
+`_migrate_workspace_gitignore(agent_name)` in `services/git_service.py`.
+This runs two `docker exec` steps inside the agent container:
+
+1. **Append missing patterns**: `_build_gitignore_merge_command` idempotently
+   appends any `_GITIGNORE_PATTERNS` entries not already present in
+   `/home/developer/.gitignore`. Pre-existing user rules are preserved
+   (each pattern is gated by an exact-line `grep -qxF` check).
+2. **Untrack newly-ignored files**: `_build_rm_cached_ignored_command`
+   runs `git ls-files -ci --exclude-standard | xargs -0 git rm --cached`
+   so files that were force-tracked before a pattern was added (e.g.
+   `.cache/foo` from an old agent) are removed from the index. Working-tree
+   files are left on disk; only the index changes.
+
+The migration is **best effort** — failures are caught, logged at WARNING,
+and Push proceeds against whatever `.gitignore` already exists. Rationale:
+a transient docker exec glitch must not break an operator's Push.
+
+This means existing agents pick up new exclusion patterns automatically on
+their next Push, with no re-init or container rebuild required. The same
+shared `_detect_git_dir` helper used by `initialize_git_in_container`
+guarantees the migration targets the same path as init (`/home/developer`,
+or `/home/developer/workspace` for legacy pre-2026-02 agents).
 
 ---
 

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -497,6 +497,12 @@ async def sync_to_github(
             message="Agent must be running to sync"
         )
 
+    # #462: bring the workspace `.gitignore` up to the current canonical list
+    # and untrack any files that NOW match a rule. Runs on every Push so
+    # existing agents migrate without re-init or container rebuild. Best
+    # effort — failures are logged inside the helper and Push proceeds.
+    await _migrate_workspace_gitignore(agent_name)
+
     try:
         # Call the agent's internal sync endpoint
         async with httpx.AsyncClient(timeout=120.0) as client:
@@ -643,22 +649,53 @@ def delete_agent_git_config(agent_name: str) -> bool:
 # Git Initialization in Container
 # ============================================================================
 
-# Hardcoded patterns merged (append-if-missing) into the agent's `.gitignore`
-# at init time. Ordering is preserved in the file so operators reading it see
-# the legacy shell/cache entries first followed by the credential files that
-# `inject_credentials` writes (the trio the #458 bug report named).
+# Canonical exclusion list merged (append-if-missing) into every agent's
+# `.gitignore`. This is the single source of truth — the matching block in
+# `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md` mirrors it, and a unit test
+# (`test_doc_and_constant_in_sync`) keeps them aligned.
+#
+# Ordering is preserved in the file so operators reading it see entries
+# grouped by category. The list covers the runtime/instance noise the #462
+# bug report named (1,599 files leaked on a single Push) plus the credential
+# files `inject_credentials` writes (the #458 trio).
 _GITIGNORE_PATTERNS: Tuple[str, ...] = (
+    # Shell init / history (instance-specific)
     ".bash_logout",
     ".bashrc",
     ".profile",
     ".bash_history",
+    ".sudo_as_admin_successful",
+    # Credentials — NEVER COMMIT
+    ".env",
+    ".env.*",
+    ".mcp.json",
+    "credentials.json",
+    "*.pem",
+    "*.key",
+    # Instance-specific directories
     ".cache/",
     ".local/",
     ".npm/",
     ".ssh/",
-    ".env",
-    ".env.*",
-    ".mcp.json",
+    ".trinity/",
+    # Large generated content
+    "content/",
+    # Claude Code runtime — commit commands/skills/agents, exclude runtime data
+    ".claude.json",
+    ".claude.json.backup",
+    ".claude/projects/",
+    ".claude/statsig/",
+    ".claude/todos/",
+    ".claude/debug/",
+    ".claude/sessions/",
+    ".claude/shell-snapshots/",
+    # Temporary files
+    "*.log",
+    "*.tmp",
+    ".DS_Store",
+    # Local overrides
+    "*.local.md",
+    "*.local.json",
 )
 
 
@@ -674,6 +711,93 @@ def _build_gitignore_merge_command(git_dir: str) -> str:
         parts.append(f"(grep -qxF -- {q} .gitignore || echo {q} >> .gitignore)")
     script = " && ".join(parts)
     return f"bash -c {shlex.quote(script)}"
+
+
+def _build_rm_cached_ignored_command(git_dir: str) -> str:
+    """Build a bash command that ``git rm --cached``s any tracked files that
+    NOW match an ignore rule. Idempotent — `git ls-files -ci` returns the
+    empty set after the first successful run.
+
+    Two-pass: a non-NUL `git ls-files` to check emptiness via shell variable
+    (bash can't hold NUL bytes), then a NUL-delimited pipe to xargs so paths
+    with spaces or unicode survive the round-trip. Working-tree files are
+    left alone; only the index is touched.
+    """
+    script = (
+        f"cd {shlex.quote(git_dir)} && "
+        "ignored=$(git ls-files -ci --exclude-standard) && "
+        'if [ -n "$ignored" ]; then '
+        "git ls-files -ci -z --exclude-standard | "
+        "xargs -0 git rm --cached --quiet -r --; "
+        "fi"
+    )
+    return f"bash -c {shlex.quote(script)}"
+
+
+async def _detect_git_dir(container_name: str) -> str:
+    """Pick the directory git operations should run in for an agent container.
+
+    Standard path is ``/home/developer``. Returns ``/home/developer/workspace``
+    only for legacy agents (created before 2026-02) that have content under
+    that subdirectory. Mirrors the detection ``initialize_git_in_container``
+    has always used so init and the post-init migration agree.
+    """
+    check_workspace = await execute_command_in_container(
+        container_name=container_name,
+        command=(
+            'bash -c "[ -d /home/developer/workspace ] && '
+            'find /home/developer/workspace -mindepth 1 -maxdepth 1 | '
+            'head -1 | wc -l"'
+        ),
+        timeout=5,
+    )
+    workspace_has_content = (
+        check_workspace.get("exit_code") == 0
+        and "1" in check_workspace.get("output", "")
+    )
+    return "/home/developer/workspace" if workspace_has_content else "/home/developer"
+
+
+async def _migrate_workspace_gitignore(agent_name: str) -> None:
+    """Idempotently bring an existing agent's `.gitignore` up to the current
+    `_GITIGNORE_PATTERNS` and untrack any files that NOW match a rule.
+
+    Runs on every Push (#462) so existing agents adopt new patterns without
+    requiring a re-init or container rebuild. Errors are logged and swallowed
+    — a transient migration failure must not break an operator's Push.
+
+    No-op if the container has no `.git` directory (agent not initialized for
+    git sync).
+    """
+    container_name = f"agent-{agent_name}"
+    try:
+        git_dir = await _detect_git_dir(container_name)
+        # Bail if not git-initialized — the agent's /api/git/sync will
+        # return its own 400 in that case.
+        check_git = await execute_command_in_container(
+            container_name=container_name,
+            command=f'bash -c "[ -d {shlex.quote(git_dir)}/.git ]"',
+            timeout=5,
+        )
+        if check_git.get("exit_code") != 0:
+            return
+        # 1. Append missing patterns (idempotent).
+        await execute_command_in_container(
+            container_name=container_name,
+            command=_build_gitignore_merge_command(git_dir),
+            timeout=10,
+        )
+        # 2. Untrack any indexed files that now match an ignore rule.
+        await execute_command_in_container(
+            container_name=container_name,
+            command=_build_rm_cached_ignored_command(git_dir),
+            timeout=30,
+        )
+    except Exception as exc:
+        logger.warning(
+            f"_migrate_workspace_gitignore failed for {agent_name}: {exc}. "
+            "Push will proceed against the existing .gitignore."
+        )
 
 
 @dataclass
@@ -724,28 +848,13 @@ async def initialize_git_in_container(
     """
     container_name = f"agent-{agent_name}"
 
-    # Step 1: Determine git directory
-    # NOTE: All agents use /home/developer as their home directory.
-    # The /home/developer/workspace check is LEGACY support for agents created before 2026-02.
-    # New agents should never have a workspace subdirectory.
-    check_workspace = await execute_command_in_container(
-        container_name=container_name,
-        command='bash -c "[ -d /home/developer/workspace ] && find /home/developer/workspace -mindepth 1 -maxdepth 1 | head -1 | wc -l"',
-        timeout=5
-    )
-
-    workspace_has_content = (
-        check_workspace.get("exit_code") == 0 and
-        "1" in check_workspace.get("output", "")
-    )
-
-    if workspace_has_content:
-        # Legacy agent with workspace subdirectory
-        git_dir = "/home/developer/workspace"
+    # Step 1: Determine git directory (workspace for legacy agents, else home).
+    # Detection logic is shared with `_migrate_workspace_gitignore` so the
+    # post-init Push migration targets the same path.
+    git_dir = await _detect_git_dir(container_name)
+    if git_dir == "/home/developer/workspace":
         logger.info(f"[LEGACY] Using workspace directory with existing content: {git_dir}")
     else:
-        # Standard path for all current agents
-        git_dir = "/home/developer"
         logger.info(f"Using home directory: {git_dir}")
 
     # Step 2: Append any missing `_GITIGNORE_PATTERNS` entries to the

--- a/tests/unit/test_github_init_gitignore.py
+++ b/tests/unit/test_github_init_gitignore.py
@@ -105,3 +105,159 @@ def test_fresh_agent_ignores_env_and_mcp_json(tmp_path):
         assert p in lines, (
             f"pattern {p!r} not in .gitignore after fresh merge — got:\n{content}"
         )
+
+
+# ---------------------------------------------------------------------------
+# #462 regression coverage — the platform-injected `.gitignore` must cover the
+# full canonical list and existing agents must migrate on the next Push.
+# ---------------------------------------------------------------------------
+
+
+def test_full_documented_exclusion_list_present(tmp_path):
+    """Every entry in `_GITIGNORE_PATTERNS` must end up in `.gitignore`
+    after a fresh merge. Guards against accidental constant truncation.
+    """
+    gs = _load_git_service()
+    content = _run_merge(tmp_path)
+    lines = content.splitlines()
+
+    for pattern in gs._GITIGNORE_PATTERNS:
+        assert pattern in lines, (
+            f"pattern {pattern!r} from _GITIGNORE_PATTERNS missing — got:\n"
+            f"{content}"
+        )
+
+
+def test_idempotent_double_run(tmp_path):
+    """Running the merge twice must not duplicate any line. The append guard
+    is `grep -qxF` per pattern; a regression here would mean every Push
+    grows the file by one full copy of the canonical list.
+    """
+    _run_merge(tmp_path)
+    second = _run_merge(tmp_path)
+    lines = second.splitlines()
+
+    # Each pattern must appear exactly once.
+    gs = _load_git_service()
+    for pattern in gs._GITIGNORE_PATTERNS:
+        count = lines.count(pattern)
+        assert count == 1, (
+            f"pattern {pattern!r} appears {count} times after double run — "
+            f"merge is not idempotent. Full file:\n{second}"
+        )
+
+
+def test_doc_and_constant_in_sync():
+    """The `.gitignore` code block in `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md`
+    must contain every entry in `_GITIGNORE_PATTERNS`.
+
+    The Python constant is the source of truth. The doc is hand-written and
+    drifts; this test catches drift in CI before the doc gets out of date
+    again. A new entry in `_GITIGNORE_PATTERNS` requires a matching update
+    to the doc block (see `### 5. .gitignore (Required)` section).
+    """
+    import re
+    gs = _load_git_service()
+
+    doc_path = _project_root / "docs" / "TRINITY_COMPATIBLE_AGENT_GUIDE.md"
+    doc = doc_path.read_text()
+
+    # Find the first ```gitignore ... ``` fenced block in the file.
+    match = re.search(r"```gitignore\n(.*?)\n```", doc, flags=re.DOTALL)
+    assert match, (
+        f"no ```gitignore``` code block found in {doc_path} — did the "
+        "section get renamed or the fence language change?"
+    )
+    doc_lines = set(match.group(1).splitlines())
+
+    missing = [p for p in gs._GITIGNORE_PATTERNS if p not in doc_lines]
+    assert not missing, (
+        f"_GITIGNORE_PATTERNS entries missing from doc block: {missing}. "
+        f"Update the gitignore code block in {doc_path.name} to match "
+        "git_service.py — they are intentionally kept in sync."
+    )
+
+
+def test_rm_cached_for_newly_ignored_files(tmp_path):
+    """A file that was committed BEFORE its ignore rule existed must be
+    untracked (`git rm --cached`) by the migration helper, but its working
+    tree copy must remain on disk. Acceptance criterion #462.5: the fix
+    only helps existing agents if previously-tracked runtime files are
+    removed from the index too.
+    """
+    gs = _load_git_service()
+
+    # Fresh repo with deterministic identity so commits don't fail under CI.
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=10,
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("config", "commit.gpgsign", "false")
+
+    # Force-track files that the new patterns ignore. Use `-f` to bypass any
+    # ignore rule (simulating an old agent that committed these before the
+    # fix landed).
+    cache_file = tmp_path / ".cache" / "leaked"
+    session_file = tmp_path / ".claude" / "sessions" / "leaked"
+    keeper = tmp_path / "agent" / "skill.md"
+    for f, content in [
+        (cache_file, "old cache"),
+        (session_file, "old session"),
+        (keeper, "real value"),
+    ]:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content)
+
+    git("add", "-f", str(cache_file), str(session_file), str(keeper))
+    git("commit", "-q", "-m", "seed runtime files")
+
+    # Sanity: all three files start out tracked.
+    tracked_before = set(git("ls-files").stdout.splitlines())
+    assert ".cache/leaked" in tracked_before
+    assert ".claude/sessions/leaked" in tracked_before
+    assert "agent/skill.md" in tracked_before
+
+    # Run the real migration: gitignore merge + rm-cached for ignored files.
+    for build in (
+        gs._build_gitignore_merge_command,
+        gs._build_rm_cached_ignored_command,
+    ):
+        result = subprocess.run(
+            build(str(tmp_path)),
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, (
+            f"command failed: {build.__name__}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+
+    tracked_after = set(git("ls-files").stdout.splitlines())
+
+    # The runtime files must be untracked now.
+    assert ".cache/leaked" not in tracked_after, (
+        f".cache/leaked still tracked after migration; tracked={tracked_after}"
+    )
+    assert ".claude/sessions/leaked" not in tracked_after, (
+        f".claude/sessions/leaked still tracked; tracked={tracked_after}"
+    )
+    # The agent-value file must remain tracked.
+    assert "agent/skill.md" in tracked_after, (
+        f"agent/skill.md was wrongly untracked; tracked={tracked_after}"
+    )
+
+    # Working-tree files MUST still exist on disk — the migration only
+    # touches the index, never the user's files.
+    assert cache_file.exists(), "rm --cached must not delete the on-disk file"
+    assert session_file.exists(), "rm --cached must not delete the on-disk file"


### PR DESCRIPTION
## Summary

- Widen `_GITIGNORE_PATTERNS` in `git_service.py` from 11 to 30 entries to cover the full canonical list documented in `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md` (adds `.claude/sessions/`, `.claude/shell-snapshots/`, `.claude.json[.backup]`, `.sudo_as_admin_successful`, `.trinity/`, `content/`, `*.pem`, `*.key`, `credentials.json`, `*.log`, `*.tmp`, `.DS_Store`, `*.local.{md,json}`, plus the existing `.claude/{projects,statsig,todos,debug}/`).
- Migrate existing agents on every Push: new `_migrate_workspace_gitignore` helper runs the (already-idempotent) gitignore merge plus `git rm --cached` for files now matching an ignore rule, via `execute_command_in_container`. Works regardless of agent server code version inside the container — no rebuild required.
- Sync `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md` to the Python constant and add a single-source-of-truth note + parity test.

Closes #462. Related: #458 (#461) added the idempotent merge primitive this PR re-uses.

## Policy decision: keep `git add -A`

Acceptance criterion #3 asked us to pick option (a) keep `-A` or (b) switch to an allow-list. **Picked (a)** with rationale: with the canonical list widened and migrated onto every Push, `-A` is safe — it stages exactly the agent-value files. Switching to an explicit allow-list would require enumerating every legitimate path (skills, commands, agent configs, code, docs, `workspace/**`) and would silently drop new file types as features are added. Worth revisiting as a separate hardening if more \"forgot to ignore X\" bugs surface.

## Files

- `src/backend/services/git_service.py` — widened constant, new `_build_rm_cached_ignored_command` / `_detect_git_dir` / `_migrate_workspace_gitignore` helpers, migration call wired into `sync_to_github` immediately before the HTTP forward to the agent's `/api/git/sync`.
- `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md` — gitignore code block + Claude-Code runtime list synced to constant; SoT note added.
- `tests/unit/test_github_init_gitignore.py` — 4 new tests covering full-list presence, idempotency, doc/constant parity, and `git rm --cached` of force-tracked runtime files (working-tree files preserved).

## Test plan

- [x] `pytest tests/unit/test_github_init_gitignore.py -v` — all 6 pass (2 existing #458 regression tests + 4 new #462 tests).
- [ ] Manual: start an agent with git enabled, `touch ~/.cache/test-leak ~/.claude/sessions/test-leak ~/.claude.json`, click Push, verify the GitHub commit contains zero of those paths and that `/home/developer/.gitignore` contains the new entries.
- [ ] Manual (existing-agent migration): on an agent created BEFORE this fix, force-stage `.cache/x` (`git add -f`), commit, then click Push — confirm the resulting commit contains a `D .cache/x` line and the gitignore diff.

## Files NOT modified (deliberately)

- `docker/base-image/agent_server/routers/git.py` — kept the `git add -A` at line 693 and the auto-sync heartbeat at line 163. Platform-side migration handles correctness; touching agent-side would require base-image rebuild + agent re-creation, which isn't automatic in Trinity's ops model. Once the first post-upgrade Push migrates the workspace `.gitignore`, every subsequent in-container `git add -A` (Push or 15-min heartbeat) operates against the now-correct list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)