### PR TITLE
fix(tests): update orphaned-recovery mocks to CapacityManager (#533)

### DIFF
--- a/tests/unit/test_orphaned_execution_recovery.py
+++ b/tests/unit/test_orphaned_execution_recovery.py
@@ -24,7 +24,9 @@ _BACKEND = os.path.abspath(os.path.join(
 
 # ── Shared mocks ──────────────────────────────────────────────────────────
 _mock_db = MagicMock()
-_mock_slot_service = AsyncMock()
+_mock_capacity = AsyncMock()
+_mock_capacity.release = AsyncMock()
+_mock_capacity.release_if_matches = AsyncMock(return_value=True)
 _mock_docker_svc = MagicMock()
 _mock_agent_client = AsyncMock()
 _AgentClientError = type('AgentClientError', (Exception,), {})
@@ -32,7 +34,7 @@ _AgentClientError = type('AgentClientError', (Exception,), {})
 _SYS_MOCKS = {
     'database': Mock(db=_mock_db),
     'models': Mock(TaskExecutionStatus=Mock(RUNNING='running', FAILED='failed')),
-    'services.slot_service': Mock(get_slot_service=Mock(return_value=_mock_slot_service)),
+    'services.capacity_manager': Mock(get_capacity_manager=Mock(return_value=_mock_capacity)),
     'services.docker_service': _mock_docker_svc,
     'services.agent_client': Mock(
         get_agent_client=Mock(return_value=_mock_agent_client),
@@ -85,7 +87,9 @@ def _set_agent_registry(execution_ids: list[str]):
 @pytest.fixture(autouse=True)
 def _reset_mocks():
     _mock_db.reset_mock()
-    _mock_slot_service.reset_mock()
+    _mock_capacity.reset_mock()
+    _mock_capacity.release.reset_mock()
+    _mock_capacity.release_if_matches.reset_mock()
     _mock_docker_svc.reset_mock()
     _mock_agent_client.reset_mock()
 
@@ -116,7 +120,7 @@ class TestRecoverOrphanedExecutions:
         assert kw["execution_id"] == "exec-1"
         assert kw["status"] == "failed"
         assert "orphaned" in kw["error"]
-        _mock_slot_service.release_slot.assert_awaited_once_with("agent-alpha", "exec-1")
+        _mock_capacity.release.assert_awaited_once_with("agent-alpha", "exec-1")
 
     def test_not_in_registry_marks_orphaned(self):
         _mock_db.get_running_executions.return_value = [
@@ -129,7 +133,7 @@ class TestRecoverOrphanedExecutions:
             result = _run(_recover_fn())
 
         assert result["recovered"] == 1
-        _mock_slot_service.release_slot.assert_awaited_once_with("agent-beta", "exec-2")
+        _mock_capacity.release.assert_awaited_once_with("agent-beta", "exec-2")
 
     def test_in_registry_left_alone(self):
         _mock_db.get_running_executions.return_value = [


### PR DESCRIPTION
## Summary
- Replace stale `services.slot_service` sys-mock with `services.capacity_manager` mock in `test_orphaned_execution_recovery.py`
- Update assertions from `release_slot` → `release` to match the CapacityManager API
- All 6 tests now pass (4 were failing with `'Mock' object can't be awaited`)

## Changes
- `tests/unit/test_orphaned_execution_recovery.py` — swap mock module and update two assertions

## Test Plan
- [x] All 6 tests pass: `pytest tests/unit/test_orphaned_execution_recovery.py -v`
- [x] No runtime code changed — test-only fix

Fixes #533

Generated with [Claude Code](https://claude.com/claude-code)