### PR TITLE
fix(public-chat): build context before storing user message to prevent duplication (#539)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-27 | #539 | fix: public chat context duplication — `build_public_chat_context()` now called before `add_public_chat_message(role="user")`, preventing current message appearing twice in every agent prompt | [public-agent-links.md](feature-flows/public-agent-links.md) |
 | 2026-04-26 | #428 | CapacityManager facade — single public surface for capacity (admit / release / overflow policy / status / reclaim) replacing ExecutionQueue + SlotService + BacklogService trio | [capacity-management.md](feature-flows/capacity-management.md) |
 | 2026-04-26 | #516, #520 | Agent error classification — `_classify_signal_exit()` (504 for SIGINT/SIGKILL/SIGTERM, was misread as 503 auth) and `_classify_empty_result()` (502 when clean exit drops the final result message, was silent 200 + watchdog reap) | [parallel-headless-execution.md](feature-flows/parallel-headless-execution.md), [task-execution-service.md](feature-flows/task-execution-service.md) |
 | 2026-04-26 | #498 | Sync `/task` long-poll on backlog — sync parallel calls at capacity now spill to BACKLOG-001 (same backlog as async) and long-poll the open HTTP connection until terminal status (cap `2 × effective_timeout`); new `services/sync_waiter.py` owns the in-process registry + event/poll-fallback wait helper | [persistent-task-backlog.md](feature-flows/persistent-task-backlog.md), [parallel-headless-execution.md](feature-flows/parallel-headless-execution.md) |

--- a/docs/memory/feature-flows/public-agent-links.md
+++ b/docs/memory/feature-flows/public-agent-links.md
@@ -997,11 +997,12 @@ Determine session identifier:
 db.get_or_create_public_chat_session(link_id, identifier, type)
         |
         v
-db.add_public_chat_message(session_id, "user", message)
-        |
-        v
 db.build_public_chat_context(session_id, message, max_turns=10)
   -> "Previous conversation:\nUser: ...\nAssistant: ...\n\nCurrent message:\nUser: ..."
+  NOTE: context is built BEFORE the user message is stored (#539 fix).
+        |
+        v
+db.add_public_chat_message(session_id, "user", message)
         |
         v
 TaskExecutionService.execute_task(triggered_by="public")
@@ -1144,18 +1145,18 @@ class PublicChatMessage(BaseModel):
 - `build_public_chat_context()`
 - `delete_public_link_sessions()`
 
-**Chat Endpoint** (`routers/public.py:215-362`):
-1. Validate link token (line 231)
-2. Determine session identifier (lines 235-263)
+**Chat Endpoint** (`routers/public.py`):
+1. Validate link token
+2. Determine session identifier
    - Email links: validate session_token, extract email
    - Anonymous links: use provided session_id or generate new
-3. Rate limit check (lines 265-271)
-4. Check agent availability (lines 273-279)
-5. Get or create session (lines 284-288)
-6. Store user message (lines 290-295)
-7. Record usage (lines 297-302)
-8. Build context-enriched prompt (lines 304-309)
-9. **Execute via `TaskExecutionService.execute_task(triggered_by="public")`** (lines 311-322)
+3. Rate limit check
+4. Check agent availability
+5. Get or create session
+6. **Build context-enriched prompt** (#539: must happen BEFORE storing user message to avoid duplication)
+7. Store user message
+8. Record usage
+9. **Execute via `TaskExecutionService.execute_task(triggered_by="public")`**
    - Creates `schedule_executions` record
    - Acquires capacity slot (returns 429 if at capacity)
    - Tracks activity start (Dashboard timeline)
@@ -1775,6 +1776,7 @@ Summarization is triggered every 5th message per `(agent_name, user_email)` pair
 
 | Date | Changes |
 |------|---------|
+| 2026-04-27 | **fix #539 Context duplication**: `build_public_chat_context()` was called AFTER `add_public_chat_message(role="user")`, causing the current user message to appear twice in every agent prompt (once in "Previous conversation:", once in "Current message:"). Fixed by swapping the call order — context built first from prior history, user message stored after. Added 6 unit tests in `tests/unit/test_public_chat_context.py`. Updated PUB-005 data flow and backend implementation step ordering to reflect correct call order. |
 | 2026-02-19 | **CHAT-001 Shared Components Refactor**: PublicChat.vue now uses shared components from `components/chat/` (ChatMessages, ChatInput, ChatBubble, ChatLoadingIndicator). Shared with new ChatPanel.vue authenticated chat. Updated method line numbers, added Shared Chat Components section. File now 611 lines. |
 | 2026-02-18 | **Tab consolidation**: Public Links tab removed from AgentDetail.vue. PublicLinksPanel now embedded within SharingPanel.vue (lines 82-83, 92), accessible via "Sharing" tab. Updated Entry Points, Components table, Frontend Files table, and Related Flows sections. |
 | 2025-12-22 | Initial documentation |

--- a/src/backend/routers/public.py
+++ b/src/backend/routers/public.py
@@ -494,7 +494,17 @@ async def public_chat(
         identifier_type=identifier_type
     )
 
-    # Store user message
+    # Build context from prior history before storing the new user message.
+    # Must happen first — storing the user message then reading it back would
+    # include the current message in both "Previous conversation:" and
+    # "Current message:", sending it to the agent twice on every turn.
+    context_prompt = db.build_public_chat_context(
+        session_id=chat_session.id,
+        new_message=chat_request.message,
+        max_turns=10
+    )
+
+    # Store user message (after context is built so it doesn't appear twice)
     db.add_public_chat_message(
         session_id=chat_session.id,
         role="user",
@@ -506,13 +516,6 @@ async def public_chat(
         link_id=link["id"],
         email=verified_email,
         ip_address=client_ip
-    )
-
-    # Build context-enriched prompt with conversation history
-    context_prompt = db.build_public_chat_context(
-        session_id=chat_session.id,
-        new_message=chat_request.message,
-        max_turns=10
     )
 
     # MEM-001: Fetch per-user memory for email-verified sessions and inject into system prompt

--- a/tests/unit/test_public_chat_context.py
+++ b/tests/unit/test_public_chat_context.py
@@ -1,0 +1,216 @@
+"""
+Unit tests for public chat context building (fix for #539).
+
+The bug: user message was persisted to the DB *before* build_context_prompt
+was called, causing the current message to appear twice in every agent prompt —
+once in "Previous conversation:" and once in "Current message:".
+
+Tests exercise PublicChatOperations directly against a temporary SQLite DB
+(TRINITY_DB_PATH) so the real get_db_connection() is used but isolated.
+"""
+
+from __future__ import annotations
+
+import secrets
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: make src/backend importable without shadowing tests/utils.
+# ---------------------------------------------------------------------------
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+# ---------------------------------------------------------------------------
+# Minimal schema for the tables PublicChatOperations touches.
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS public_chat_sessions (
+    id TEXT PRIMARY KEY,
+    link_id TEXT NOT NULL,
+    session_identifier TEXT NOT NULL,
+    identifier_type TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    last_message_at TEXT NOT NULL,
+    message_count INTEGER DEFAULT 0,
+    total_cost REAL DEFAULT 0.0
+);
+CREATE TABLE IF NOT EXISTS public_chat_messages (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    cost REAL
+);
+"""
+
+
+@pytest.fixture()
+def ops(tmp_path, monkeypatch):
+    """
+    Provision a fresh SQLite file DB, point TRINITY_DB_PATH at it, and
+    return a PublicChatOperations instance ready to use.
+    """
+    db_path = tmp_path / "trinity_test.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_path))
+
+    # Evict any previously imported db.connection so the env var is re-read.
+    for mod in list(sys.modules):
+        if mod.startswith("db.") or mod == "db":
+            sys.modules.pop(mod, None)
+
+    conn = sqlite3.connect(str(db_path))
+    for stmt in _SCHEMA.strip().split(";"):
+        stmt = stmt.strip()
+        if stmt:
+            conn.execute(stmt)
+    conn.commit()
+    conn.close()
+
+    from db.public_chat import PublicChatOperations
+    return PublicChatOperations()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_session(ops, link_id: str = "link-1") -> str:
+    session = ops.get_or_create_session(link_id, secrets.token_urlsafe(8), "anonymous")
+    return session.id
+
+
+def _add_msg(ops, session_id: str, role: str, content: str) -> None:
+    ops.add_message(session_id, role, content)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestBuildContextPromptNoDuplication:
+    """Verify the current message never appears in both context sections."""
+
+    def test_empty_session_message_appears_once(self, ops):
+        """First message in a fresh session: should appear only in Current message."""
+        sid = _make_session(ops)
+        new_msg = "Hello, what can you do?"
+
+        ctx = ops.build_context_prompt(sid, new_msg, max_turns=10)
+
+        assert "Previous conversation:" not in ctx, (
+            "Expected no 'Previous conversation:' section in empty session context"
+        )
+        assert ctx.count(new_msg) == 1, (
+            f"New message should appear exactly once; got:\n{ctx}"
+        )
+        assert "Current message:" in ctx
+
+    def test_prior_history_new_message_appears_once(self, ops):
+        """With existing history, new message appears only in Current message."""
+        sid = _make_session(ops)
+        _add_msg(ops, sid, "user", "First question")
+        _add_msg(ops, sid, "assistant", "First answer")
+
+        new_msg = "Follow-up question"
+        ctx = ops.build_context_prompt(sid, new_msg, max_turns=10)
+
+        assert "Previous conversation:" in ctx
+        assert "First question" in ctx
+        assert "First answer" in ctx
+
+        # Parse out just the "Previous conversation:" section
+        prev_lines = []
+        in_prev = False
+        for line in ctx.splitlines():
+            if line.strip() == "Previous conversation:":
+                in_prev = True
+            elif line.strip() == "Current message:":
+                in_prev = False
+            elif in_prev:
+                prev_lines.append(line)
+
+        prev_text = "\n".join(prev_lines)
+        assert new_msg not in prev_text, (
+            f"New message must NOT appear in 'Previous conversation:':\n{prev_text}"
+        )
+        assert ctx.count(new_msg) == 1, (
+            f"New message should appear exactly once in full context:\n{ctx}"
+        )
+
+    def test_old_broken_order_produces_duplicate(self, ops):
+        """
+        Regression guard: storing user message BEFORE build_context_prompt
+        (the old broken order) causes the message to appear twice.
+
+        This test documents the bug so future readers understand why the
+        order in routers/public.py matters.
+        """
+        sid = _make_session(ops)
+        new_msg = "Bug-triggering question"
+
+        # OLD (broken) order: store first, then build
+        _add_msg(ops, sid, "user", new_msg)
+        ctx = ops.build_context_prompt(sid, new_msg, max_turns=10)
+
+        assert ctx.count(new_msg) == 2, (
+            "With the old broken order the message appears twice. "
+            "If this fails the context builder has been changed to de-dup internally "
+            "— update test_correct_order_no_duplication accordingly."
+        )
+
+    def test_correct_order_no_duplication(self, ops):
+        """
+        Fix validation: build context THEN store user message → appears once.
+
+        This mirrors the corrected call order in routers/public.py after #539.
+        """
+        sid = _make_session(ops)
+        _add_msg(ops, sid, "user", "Previous Q")
+        _add_msg(ops, sid, "assistant", "Previous A")
+
+        new_msg = "New question after fix"
+
+        # CORRECT ORDER: build context first, then store
+        ctx = ops.build_context_prompt(sid, new_msg, max_turns=10)
+        _add_msg(ops, sid, "user", new_msg)
+
+        assert ctx.count(new_msg) == 1
+        assert "Previous conversation:" in ctx
+        assert "Previous Q" in ctx
+
+    def test_public_link_mode_header_always_present(self, ops):
+        """The public-link sentinel header must be the first line."""
+        sid = _make_session(ops)
+        ctx = ops.build_context_prompt(sid, "anything", max_turns=10)
+        assert ctx.splitlines()[0] == "### Trinity: Public Link Access Mode"
+
+    def test_max_turns_respected(self, ops):
+        """Only the most recent max_turns exchanges appear in history."""
+        sid = _make_session(ops)
+        # Add 6 full turns (12 messages)
+        for i in range(6):
+            _add_msg(ops, sid, "user", f"Q{i}")
+            _add_msg(ops, sid, "assistant", f"A{i}")
+
+        # max_turns=2 → only last 4 messages (Q4, A4, Q5, A5)
+        ctx = ops.build_context_prompt(sid, "new", max_turns=2)
+
+        assert "Q5" in ctx and "A5" in ctx, "Most recent turn should be present"
+        assert "Q0" not in ctx, "Oldest turn should be pruned by max_turns"


### PR DESCRIPTION
## Summary

- Every public chat turn was sending the current user message **twice** to the agent — once inside "Previous conversation:" and once under "Current message:" — because the message was persisted to SQLite before `build_public_chat_context` read from it
- Fix: swap call order so context is built from prior history first, user message stored after
- Adds 6 unit tests, including a regression guard that documents the old broken order

## Changes

- `src/backend/routers/public.py` — reorder `build_public_chat_context` before `add_public_chat_message(role="user")` in the sync code path (async path was already building context from the same `context_prompt` variable so also benefits from this fix)
- `tests/unit/test_public_chat_context.py` — new unit tests covering the context builder: no-dup with empty session, no-dup with prior history, regression guard for old order, correct-order validation, header presence, max_turns pruning

## Test Plan

- [x] `pytest tests/unit/test_public_chat_context.py -v` → 6/6 passed
- [ ] Manual: send a public chat message, verify the agent doesn't receive a duplicate in its prompt (check agent logs or execution record `message` field)

Fixes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)