### PR TITLE
fix(agent-runtime): guard content_block isinstance in process_stream_line (#542)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -220,6 +220,8 @@ def parse_stream_json_output(output: str) -> tuple[str, List[ExecutionLogEntry],
             message_content = msg.get("message", {}).get("content", [])
 
             for content_block in message_content:
+                if not isinstance(content_block, dict):
+                    continue  # stream-json content arrays can contain plain strings
                 block_type = content_block.get("type")
 
                 if block_type == "tool_use":
@@ -397,6 +399,8 @@ def process_stream_line(line: str, execution_log: List[ExecutionLogEntry], metad
             logger.debug(f"Processing {msg_type} message with {len(message_content)} content blocks")
 
         for content_block in message_content:
+            if not isinstance(content_block, dict):
+                continue  # stream-json content arrays can contain plain strings
             block_type = content_block.get("type")
 
             if block_type == "tool_use":


### PR DESCRIPTION
## Summary
- Add `isinstance(content_block, dict)` guard at the top of the `content_block` loop in `process_stream_line` (real-time streaming path) and `parse_stream_json_output` (batch path)
- Prevents `AttributeError: 'str' object has no attribute 'get'` crash when Claude Code stream-json emits a string element inside a message `content` array
- Mirrors the identical guard already present on the `error_content` loop a few lines above

## Changes
- `docker/base-image/agent_server/services/claude_code.py` — 4 lines added (+2 guards)

## Test Plan
- [ ] Scheduled task that previously crashed with `'str' object has no attribute 'get'` now completes successfully
- [ ] Normal tasks unaffected (guard is a no-op when all content blocks are dicts)
- [ ] Existing tests pass

Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)