### PR TITLE
docs(#411): Phase 1 canary harness design + catalog Phase 1 subset additions

### DIFF
--- a/docs/planning/CANARY_HARNESS_PHASE_1.md
+++ b/docs/planning/CANARY_HARNESS_PHASE_1.md
@@ -1,0 +1,130 @@
+# Canary Invariant Harness — Phase 1 Design
+
+**Date:** 2026-04-27
+**Status:** Proposal — implements Phase 1 of [#411](https://github.com/Abilityai/trinity/issues/411).
+**Reference:** [`docs/testing/orchestration-invariant-catalog.md`](../testing/orchestration-invariant-catalog.md)
+
+---
+
+## Scope
+
+Catalog's Phase 1 subset is 12 invariants. AC of #411 requires three running continuously on staging:
+
+- **S-01** — Slot↔row bijection
+- **E-02** — No phantom reversal
+- **L-03** — Delete cascades
+
+This doc covers the infrastructure to support those three plus the fleet they observe. The remaining 9 ship as follow-up PRs against the same snapshot collector — each is ~50 LOC.
+
+## Fleet
+
+Pre-seeded set of agents the canary observes. All run Claude Code (no architectural bypass exists); minimize cost via trivial prompts (e.g. `"reply ok"`).
+
+**Strawman** — template choices and counts not in catalog, open for review:
+
+| Agent | Schedules |
+|---|---|
+| `canary-1` | every 2min |
+| `canary-2` | every 5min |
+| `canary-3` | every 10min |
+| `canary-rotate-{ts}` | created+deleted hourly by canary skill |
+
+The rotation slot exists so L-03 fires on real deletes, not just vacuous orphan scans. Rotation is the only active behavior in Phase 1; everything else is observation.
+
+Naming follows catalog §Open Questions: `canary-*` prefix, dedicated synthetic operator user.
+
+## Snapshot collector
+
+Single async function gathering four sources roughly simultaneously:
+
+| Source | Access |
+|---|---|
+| SQLite | Backend API (per catalog rec for Phase 1 — enforces real code path) |
+| Redis | `ZRANGE`/`ZCARD`/`TTL`/`KEYS agent:slot:*` via MCP tool |
+| Docker | Container labels via backend API |
+| Agent registries | Parallel `GET /api/executions/running` via `asyncio.gather` |
+
+Returns a typed `Snapshot` dataclass. Reusable from unit tests. Phase 2's scenario runner uses the same primitive.
+
+Lives in `src/canary/snapshot.py`.
+
+## Invariant library
+
+Three pure functions: `check(snapshot) → list[ViolationReport]`. Each ~30-50 LOC.
+
+```
+src/canary/invariants/
+  s01_slot_row_bijection.py
+  e02_no_phantom_reversal.py
+  l03_delete_cascades.py
+```
+
+E-02 is about transitions, not state — implementation reads `update_execution_status` log lines from Vector since the last snapshot and asserts no terminal→non-terminal transitions.
+
+## Database migration
+
+```sql
+CREATE TABLE canary_violations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    invariant_id TEXT NOT NULL,
+    tier TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    snapshot_time TEXT NOT NULL,
+    observed_state TEXT NOT NULL,      -- JSON
+    signal_query TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_canary_violations_invariant ON canary_violations(invariant_id, snapshot_time DESC);
+CREATE INDEX idx_canary_violations_severity ON canary_violations(severity, snapshot_time DESC);
+```
+
+Versioned migration in `src/backend/db/migrations.py`. Read endpoint: `GET /api/canary/violations` (admin-only).
+
+## Canary agent template
+
+New template at `config/agent-templates/canary-invariant/`:
+
+- `template.yaml` — deletion-protected, owned by synthetic operator user
+- `CLAUDE.md` — operating instructions
+- `dashboard.yaml` — green/red widget per invariant + 24h violation trend
+- Scheduled skill `/check-invariants` every 5 min
+
+Deletion-protected mirrors the `trinity-system` pattern.
+
+## Alerts
+
+Three layers:
+
+1. **Persistent** — every violation written to `canary_violations`. Source of truth for trend queries.
+2. **Dashboard** — green/red per invariant + 24h sparklines via the agent's `dashboard.yaml`.
+3. **Push** — alert *only* on state transitions (green→red) and severity thresholds. Never on every check; otherwise operators learn to ignore them.
+
+Channel for push alerts: **TBD** (Slack / Telegram / email).
+
+## Rollout
+
+1. Migration + read endpoint
+2. Snapshot collector
+3. S-01, E-02, L-03 invariants + tests
+4. Canary agent template + scheduled skill
+5. Fleet seed script
+6. Push alert wiring (once channel decided)
+7. Deploy to staging; observe for 30 days
+
+Each step is a separate PR.
+
+## Acceptance criteria mapping
+
+- ✅ Catalog reviewed → S-03 and E-05 added to Phase 1 subset (same PR)
+- ✅ Phase 1 design doc reviewed → this doc
+- 🔲 `canary_violations` table + snapshot-collector → steps 1-2
+- 🔲 First 3 invariants running on staging → steps 3-5
+- 🔲 One real violation caught and alerted (or 30 days clean) → step 7
+
+## Open questions
+
+1. **Staging deploy access** — does it exist; how to provision canary + fleet
+2. **Alert channel** — Slack / Telegram / email
+3. **Fleet templates** — strawman above; better minimal options?
+4. **Snapshot retention** — keep raw snapshots for forensic replay or just violations

--- a/docs/planning/CANARY_HARNESS_PHASE_1.md
+++ b/docs/planning/CANARY_HARNESS_PHASE_1.md
@@ -8,72 +8,157 @@
 
 ## Scope
 
-Catalog's Phase 1 subset is 12 invariants. AC of #411 requires three running continuously on staging:
+Catalog's Phase 1 subset is 12 invariants. AC of #411 requires three running continuously on staging at deploy time (S-01, E-02, L-03); the remaining 9 ship as follow-up PRs against the same infrastructure.
 
-- **S-01** — Slot↔row bijection
-- **E-02** — No phantom reversal
-- **L-03** — Delete cascades
+This doc specifies the full Phase 1 design (all 12) so each follow-up is purely an additive code change.
 
-This doc covers the infrastructure to support those three plus the fleet they observe. The remaining 9 ship as follow-up PRs against the same snapshot collector — each is ~50 LOC.
+## Invariant coverage
 
-## Fleet
+Each row gives the check semantics and what the snapshot collector must capture for it.
 
-Pre-seeded agents the canary observes. All run Claude Code (no architectural bypass exists); minimize cost via trivial prompts (e.g. `"reply ok"`).
+| ID | Check (one-line) | Snapshot inputs |
+|---|---|---|
+| **S-01** | Per agent A: `Redis ZRANGE agent:slots:A` (minus drain sentinels < 5s old) == `SQL exec_ids WHERE agent_name=A AND status='running'` | Redis ZSET, SQL running rows |
+| **S-02** | Per agent A: `ZCARD agent:slots:A ≤ agent_ownership.max_parallel_tasks` | Redis ZCARD, SQL max_parallel |
+| **S-03** | Per slot member: `TTL agent:slot:A:{eid} ≥ timeout_seconds + 300` | Redis TTL, per-execution timeout (schedule override or agent default) |
+| **E-01** | `SQL count WHERE status='running' AND started_at < now() - (timeout + 300s)` == 0 | SQL running rows + timeouts |
+| **E-02** | No `update_execution_status` log line shows `terminal_state → non_terminal_state` since last snapshot | Vector log diff (`update_execution_status` lines) |
+| **E-05** | `SQL count WHERE status='running' AND started_at < now()-60s AND claude_session_id IS NULL` == 0 | SQL running rows |
+| **E-06** | For every SQL row `status='running' AND started_at < now()-60s`, exec_id appears in agent's `GET /api/executions/running` | SQL running rows + agent registry |
+| **B-01** | Per agent A: `backlog.get_queued_count(A) == SQL count WHERE status='queued' AND agent_name=A` | Backlog state, SQL queued rows |
+| **B-02** | If queued count > 0, then `ZCARD agent:slots:A == max_parallel_tasks` (or drain pending ≤60s) | SQL queued, Redis ZCARD, SQL max_parallel |
+| **L-03** | Orphan scan: no row in {agent_sharing, agent_schedules, schedule_executions (non-terminal), agent_permissions, agent_event_subscriptions, mcp_api_keys (scope='agent'), slack_channel_agents, agent_shared_folder_config, chat_sessions (active)} references an `agent_name` not in agent_ownership; no Redis `agent:slots:{name}` for missing agent | SQL multi-table joins, Redis KEYS |
+| **G-01** | After backend restart: no `status='running'` SQL row without matching agent registry entry, after startup-sweep + 5min grace | SQL running rows + agent registry (post-restart only) |
+| **R-01** | Per running agent container: `docker exec ps -eo stat,comm` shows zero zombie `claude` processes | Container exec output |
 
-Strictly necessary for the 3 required invariants:
+## Snapshot format
 
-| Agent | Settings | Schedule | Covers |
-|---|---|---|---|
-| `canary-tick` | default | every 1min, short prompt | S-01 (running state present at every 5-min snapshot), E-02 (transitions to audit) |
-| `canary-rotate-{ts}` | default | hourly create+delete by canary skill | L-03 (real deletes, not vacuous orphan scans) |
+Single typed dataclass returned by the collector. One snapshot per check cycle.
 
-Two agents. Cadence on `canary-tick` is 1 min so that *something* is always in `running` state when the canary snapshots every 5 min — otherwise S-01 has nothing to check.
+```python
+@dataclass
+class Snapshot:
+    timestamp: datetime
+    agents: list[AgentSnapshot]
+    transitions_since_last: list[StatusTransition]  # for E-02
+    orphan_refs: dict[str, list[OrphanRef]]         # for L-03; keyed by table
 
-Rotation is the only active behavior in Phase 1; everything else is observation.
+@dataclass
+class AgentSnapshot:
+    name: str
+    container_running: bool
+    max_parallel: int
+    execution_timeout_seconds: int
+    # Redis
+    slot_ids: set[str]
+    slot_ttls: dict[str, int]              # eid -> TTL seconds
+    # SQL
+    running_exec_ids: set[str]
+    queued_exec_ids: set[str]
+    overdue_running_ids: set[str]          # started_at < now() - (timeout+300)
+    no_session_running_ids: set[str]       # claude_session_id IS NULL > 60s
+    # Backlog service
+    backlog_queued_count: int
+    # Agent registry
+    registry_running_ids: set[str] | None  # None if agent unreachable this cycle
+    # Container exec
+    zombie_claude_count: int | None        # None if exec failed
 
-Naming follows catalog §Open Questions: `canary-*` prefix, dedicated synthetic operator user.
+@dataclass
+class StatusTransition:
+    execution_id: str
+    from_status: str
+    to_status: str
+    timestamp: datetime
+    log_source: str                        # vector log id
 
-Additional agents needed for the remaining 9 Phase 1 invariants (S-02, S-03, E-01, E-05, E-06, B-01, B-02, G-01, R-01) are added when those invariants ship — not Phase 1 v0 scope.
+@dataclass
+class OrphanRef:
+    table: str
+    column: str
+    referenced_agent_name: str
+    row_id: str
+```
 
-## Snapshot collector
+The collector lives at `src/canary/snapshot.py`. Public API:
 
-Single async function gathering four sources roughly simultaneously:
+```python
+async def collect_snapshot(
+    *,
+    since: datetime | None = None,    # for transitions_since_last
+    include_zombies: bool = True,
+) -> Snapshot
+```
 
-| Source | Access |
-|---|---|
-| SQLite | Backend API (per catalog rec for Phase 1 — enforces real code path) |
-| Redis | `ZRANGE`/`ZCARD`/`TTL`/`KEYS agent:slot:*` via MCP tool |
-| Docker | Container labels via backend API |
-| Agent registries | Parallel `GET /api/executions/running` via `asyncio.gather` |
+Reusable from unit tests by passing fixtures. Phase 2's scenario runner uses the same primitive.
 
-Returns a typed `Snapshot` dataclass. Reusable from unit tests. Phase 2's scenario runner uses the same primitive.
+### Snapshot sources
 
-Lives in `src/canary/snapshot.py`.
+| Source | Access | Used by |
+|---|---|---|
+| SQLite | Backend API (per catalog rec for Phase 1 — enforces real code path) | S-01, S-02, S-03, E-01, E-05, E-06, B-01, B-02, L-03, G-01 |
+| Redis | `ZRANGE`/`ZCARD`/`TTL`/`KEYS` via MCP tool | S-01, S-02, S-03, B-02, L-03 |
+| Agent registries | Parallel `GET /api/executions/running` via `asyncio.gather` | E-06, G-01 |
+| Container exec | `docker exec {name} ps -eo stat,comm` | R-01 |
+| Vector logs | Read JSON log file diff since last snapshot timestamp | E-02 |
+
+Agent-unreachable cases set the relevant fields to `None` rather than raising; affected invariants skip the cycle for that agent (mirrors the cleanup service's "skip-and-retry-next-cycle" pattern from PR #403).
 
 ## Invariant library
 
-Three pure functions: `check(snapshot) → list[ViolationReport]`. Each ~30-50 LOC.
+Twelve pure functions: `check(snapshot) → list[ViolationReport]`. Each ~30-50 LOC.
 
 ```
 src/canary/invariants/
   s01_slot_row_bijection.py
+  s02_no_overbooking.py
+  s03_slot_ttl.py
+  e01_terminal_closure.py
   e02_no_phantom_reversal.py
+  e05_dispatched_has_session.py
+  e06_no_completed_unreported.py
+  b01_queue_status_coherence.py
+  b02_queued_implies_full.py
   l03_delete_cascades.py
+  g01_no_restart_leak.py
+  r01_no_zombies.py
 ```
 
-E-02 is about transitions, not state — implementation reads `update_execution_status` log lines from Vector since the last snapshot and asserts no terminal→non-terminal transitions.
+`ViolationReport` matches the `canary_violations` schema below.
+
+## Fleet
+
+Pre-seeded agents the canary observes. All run Claude Code (no architectural bypass exists); minimize cost via trivial prompts.
+
+Fleet is designed against the invariant set: each agent exists for specific invariants.
+
+| Agent | Settings | Schedule | Exercises |
+|---|---|---|---|
+| `canary-burst` | `max_parallel=1`, default 15min timeout | every 30s, short prompt (`"reply ok"`) | S-01, S-02, B-01, B-02, E-02, E-05, R-01 |
+| `canary-long` | `max_parallel=2`, custom 45min timeout | every 5min, multi-tool prompt (~10–60s) | S-03, E-01, E-06, R-01 |
+| `canary-rotate-{ts}` | default | hourly create + delete by canary skill | L-03 |
+
+**Why these and not others:**
+- `canary-burst` cadence (30s) < expected task duration so backlog overflows — exercises B-01/B-02 organically.
+- `canary-long` is the only agent with non-default timeout — without it, S-03 has nothing to check.
+- `canary-rotate-{ts}` is the only active-mutation agent in Phase 1 (everything else is observation). Without it L-03 sits vacuously green.
+- G-01 (restart leak) needs a backend restart, not a fleet member.
+
+For the AC's 3-invariant initial deploy: only `canary-burst` + `canary-rotate-{ts}` are required (S-01 and E-02 fire on `canary-burst` traffic, L-03 on rotation). `canary-long` is added when S-03/E-01/E-06 invariants are wired up.
+
+Naming follows catalog §Open Questions: `canary-*` prefix, dedicated synthetic operator user.
 
 ## Database migration
 
 ```sql
 CREATE TABLE canary_violations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    invariant_id TEXT NOT NULL,
-    tier TEXT NOT NULL,
-    severity TEXT NOT NULL,
+    invariant_id TEXT NOT NULL,            -- 'S-01', 'E-02', 'L-03', ...
+    tier TEXT NOT NULL,                    -- 'A' or 'B'
+    severity TEXT NOT NULL,                -- 'critical', 'major', 'minor'
     snapshot_time TEXT NOT NULL,
-    observed_state TEXT NOT NULL,      -- JSON
-    signal_query TEXT,
+    observed_state TEXT NOT NULL,          -- JSON payload, invariant-specific
+    signal_query TEXT,                     -- the check that fired (debugging aid)
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -81,7 +166,7 @@ CREATE INDEX idx_canary_violations_invariant ON canary_violations(invariant_id, 
 CREATE INDEX idx_canary_violations_severity ON canary_violations(severity, snapshot_time DESC);
 ```
 
-Versioned migration in `src/backend/db/migrations.py`. Read endpoint: `GET /api/canary/violations` (admin-only).
+Versioned migration in `src/backend/db/migrations.py`. Read endpoint: `GET /api/canary/violations` (admin-only, supports filters by invariant_id / severity / time range).
 
 ## Canary agent template
 
@@ -89,44 +174,43 @@ New template at `config/agent-templates/canary-invariant/`:
 
 - `template.yaml` — deletion-protected, owned by synthetic operator user
 - `CLAUDE.md` — operating instructions
-- `dashboard.yaml` — green/red widget per invariant + 24h violation trend
-- Scheduled skill `/check-invariants` every 5 min
+- `dashboard.yaml` — green/red widget per invariant + 24h violation trend per invariant
+- Scheduled skill `/check-invariants` every 5 min: `collect_snapshot()` → run all enabled invariants → write violations + push alerts
 
 Deletion-protected mirrors the `trinity-system` pattern.
 
-## Alerts
+## Alert channel
 
 Three layers:
 
-1. **Persistent** — every violation written to `canary_violations`. Source of truth for trend queries.
+1. **Persistent** — every violation written to `canary_violations`. Source of truth for trend queries and forensic replay.
 2. **Dashboard** — green/red per invariant + 24h sparklines via the agent's `dashboard.yaml`.
 3. **Push** — alert *only* on state transitions (green→red) and severity thresholds. Never on every check; otherwise operators learn to ignore them.
 
-Channel for push alerts: **TBD** (Slack / Telegram / email).
+**Push channel: TBD.** Slack / Telegram / email. Needs to be decided before staging deploy. Existing Slack/Telegram channel adapters can be reused (no new transport needed).
 
 ## Rollout
 
 1. Migration + read endpoint
-2. Snapshot collector
-3. S-01, E-02, L-03 invariants + tests
-4. Canary agent template + scheduled skill
-5. Fleet seed script
-6. Push alert wiring (once channel decided)
-7. Deploy to staging; observe for 30 days
+2. Snapshot collector (full schema)
+3. S-01, E-02, L-03 invariants + tests + canary agent template + `canary-burst` and `canary-rotate` fleet
+4. Push alert wiring (channel decided)
+5. Deploy to staging; observe for 30 days → close AC
+6. (Follow-up PRs) S-02, S-03, E-01, E-05, E-06, B-01, B-02, G-01, R-01 invariants + add `canary-long` to fleet
 
 Each step is a separate PR.
 
 ## Acceptance criteria mapping
 
 - ✅ Catalog reviewed → S-03 and E-05 added to Phase 1 subset (same PR)
-- ✅ Phase 1 design doc reviewed → this doc
+- ✅ Phase 1 design doc reviewed → this doc covers all 12 invariants, snapshot format, alert channel
 - 🔲 `canary_violations` table + snapshot-collector → steps 1-2
 - 🔲 First 3 invariants running on staging → steps 3-5
-- 🔲 One real violation caught and alerted (or 30 days clean) → step 7
+- 🔲 One real violation caught and alerted (or 30 days clean) → step 5
 
 ## Open questions
 
 1. **Staging deploy access** — does it exist; how to provision canary + fleet
-2. **Alert channel** — Slack / Telegram / email
-3. **Fleet templates** — strawman above; better minimal options?
-4. **Snapshot retention** — keep raw snapshots for forensic replay or just violations
+2. **Push alert channel** — Slack / Telegram / email
+3. **Snapshot retention** — keep raw snapshots for forensic replay or just violations
+4. **Container exec for R-01** — `docker exec` from the canary agent requires Docker socket access; alternative is exposing a `GET /api/zombies` endpoint on the agent server. Open for review.

--- a/docs/planning/CANARY_HARNESS_PHASE_1.md
+++ b/docs/planning/CANARY_HARNESS_PHASE_1.md
@@ -18,20 +18,22 @@ This doc covers the infrastructure to support those three plus the fleet they ob
 
 ## Fleet
 
-Pre-seeded set of agents the canary observes. All run Claude Code (no architectural bypass exists); minimize cost via trivial prompts (e.g. `"reply ok"`).
+Pre-seeded agents the canary observes. All run Claude Code (no architectural bypass exists); minimize cost via trivial prompts (e.g. `"reply ok"`).
 
-**Strawman** — template choices and counts not in catalog, open for review:
+Strictly necessary for the 3 required invariants:
 
-| Agent | Schedules |
-|---|---|
-| `canary-1` | every 2min |
-| `canary-2` | every 5min |
-| `canary-3` | every 10min |
-| `canary-rotate-{ts}` | created+deleted hourly by canary skill |
+| Agent | Settings | Schedule | Covers |
+|---|---|---|---|
+| `canary-tick` | default | every 1min, short prompt | S-01 (running state present at every 5-min snapshot), E-02 (transitions to audit) |
+| `canary-rotate-{ts}` | default | hourly create+delete by canary skill | L-03 (real deletes, not vacuous orphan scans) |
 
-The rotation slot exists so L-03 fires on real deletes, not just vacuous orphan scans. Rotation is the only active behavior in Phase 1; everything else is observation.
+Two agents. Cadence on `canary-tick` is 1 min so that *something* is always in `running` state when the canary snapshots every 5 min — otherwise S-01 has nothing to check.
+
+Rotation is the only active behavior in Phase 1; everything else is observation.
 
 Naming follows catalog §Open Questions: `canary-*` prefix, dedicated synthetic operator user.
+
+Additional agents needed for the remaining 9 Phase 1 invariants (S-02, S-03, E-01, E-05, E-06, B-01, B-02, G-01, R-01) are added when those invariants ship — not Phase 1 v0 scope.
 
 ## Snapshot collector
 

--- a/docs/testing/orchestration-invariant-catalog.md
+++ b/docs/testing/orchestration-invariant-catalog.md
@@ -359,14 +359,16 @@ Running cleanup twice back-to-back produces an empty second report. Failure here
 
 ## Recommended starting subset
 
-Ten invariants cover ~80% of orchestration risk:
+Twelve invariants cover ~80% of orchestration risk:
 
 | ID | Invariant | Why |
 |----|-----------|-----|
 | S-01 | Slot–row bijection | Core orchestration consistency |
 | S-02 | No overbooking | Capacity guarantee |
+| S-03 | Slot TTL ≥ execution timeout | #226 |
 | E-01 | Terminal-state closure | No stuck executions |
 | E-02 | No phantom reversal | #378/#403 |
+| E-05 | Dispatched rows have session | #106 |
 | E-06 | No completed-but-not-reported | #129 |
 | B-01 | Queue-status coherence | Backlog integrity |
 | B-02 | No queued without slots-full | Drain liveness |


### PR DESCRIPTION
## Summary

Implements two of the AC items from #411:

- **Phase 1 design doc** — new `docs/planning/CANARY_HARNESS_PHASE_1.md` scoping the AC-required infrastructure (snapshot collector, `canary_violations` table, canary agent template, fleet, alerts) for the three required invariants (S-01, E-02, L-03).
- **Catalog correction** — Phase 1 starting subset expanded 10 → 12.

## Why S-03 and E-05 belong in Phase 1

Both bugs are explicitly cited in the catalog's `## Motivation` section as the bug class this harness exists to catch:

- **S-03 (slot TTL ≥ execution timeout)** — the catalog motivation lists *"Issue #219/#226 — slot TTL vs. execution timeout mismatch"* and the obvious-in-hindsight invariant *"Slot TTL must be ≥ execution timeout."* But the original 10-invariant Phase 1 subset had no detector for this — meaning #226 could recur on staging and the harness would not catch it.
- **E-05 (dispatched rows have session)** — Issue #106 is the same shape: silent launch failures sit `running` with `claude_session_id IS NULL`. The codebase already implements a 60s fast-fail path; E-05 verifies that path is working. Without it in Phase 1, the harness would only catch this class of bug after the 120-min stale timeout — same SLA as the bug.

Both checks are cheap (one Redis `TTL` per slot member; one SQL count) and have no dependency on Phase 2 active scenarios.

## Open questions (called out in the design doc)

1. Staging deploy access — does it exist; how to provision canary + fleet
2. Alert channel — Slack / Telegram / email
3. Fleet template choices — strawman in the doc, open to better minimal options
4. Snapshot retention — keep raw snapshots for forensic replay or just violations

(1) and (2) are blocking before implementation lands.

## Test plan

- [ ] Catalog change reviewed for accuracy of bug-to-invariant mapping
- [ ] Design doc reviewed end-to-end