### PR TITLE
feat(frontend): add state, brand, accent token families (#555)

### DIFF
--- a/src/frontend/scripts/check-design-tokens.mjs
+++ b/src/frontend/scripts/check-design-tokens.mjs
@@ -24,11 +24,25 @@ const FRONTEND_ROOT = resolve(__dirname, '..')
 // expected palette via a literal `colors.<name>` reference — that's the only
 // invariant this PR commits to.
 const EXPECTED_ALIASES = {
-  'status-success': 'green',
-  'status-warning': 'yellow',
-  'status-danger':  'red',
-  'status-info':    'blue',
-  'status-urgent':  'orange',
+  'status-success':   'green',
+  'status-warning':   'yellow',
+  'status-danger':    'red',
+  'status-info':      'blue',
+  'status-urgent':    'orange',
+  'state-autonomous': 'amber',
+  'state-locked':     'rose',
+  'brand-claude':     'orange',
+  'brand-gemini':     'blue',
+  'accent-purple':    'purple',
+}
+
+// Known token families. Reference scanner uses this to flag references like
+// `bg-status-foo-500` where `foo` isn't a defined token in the family.
+const KNOWN_FAMILIES = {
+  status: new Set(['success', 'warning', 'danger', 'info', 'urgent']),
+  state:  new Set(['autonomous', 'locked']),
+  brand:  new Set(['claude', 'gemini']),
+  accent: new Set(['purple']),
 }
 
 function checkPaletteEquivalence() {
@@ -43,7 +57,11 @@ function checkPaletteEquivalence() {
   return failures
 }
 
-const TOKEN_REFERENCE_RE = /(?:bg|text|border|ring|fill|stroke|from|to|via|focus:ring|focus:bg|focus:text|focus:border|hover:bg|hover:text|hover:border|hover:ring|dark:bg|dark:text|dark:border|dark:ring|dark:hover:bg|dark:hover:text)-status-([a-z]+)-(?:50|100|200|300|400|500|600|700|800|900|950)\b/g
+const FAMILY_RE = Object.keys(KNOWN_FAMILIES).join('|')
+const TOKEN_REFERENCE_RE = new RegExp(
+  `(?:bg|text|border|ring|fill|stroke|from|to|via|focus:ring|focus:bg|focus:text|focus:border|hover:bg|hover:text|hover:border|hover:ring|dark:bg|dark:text|dark:border|dark:ring|dark:hover:bg|dark:hover:text)-(${FAMILY_RE})-([a-z]+)-(?:50|100|200|300|400|500|600|700|800|900|950)\\b`,
+  'g'
+)
 
 function* walkVueAndJs(dir) {
   for (const entry of readdirSync(dir)) {
@@ -56,15 +74,15 @@ function* walkVueAndJs(dir) {
 }
 
 function checkTokenReferences() {
-  const knownTokens = new Set(Object.keys(EXPECTED_ALIASES).map(t => t.replace(/^status-/, '')))
   const failures = []
   for (const file of walkVueAndJs(join(FRONTEND_ROOT, 'src'))) {
     const content = readFileSync(file, 'utf8')
     for (const match of content.matchAll(TOKEN_REFERENCE_RE)) {
-      const family = match[1]
-      if (!knownTokens.has(family)) {
+      const [whole, family, variant] = match
+      const variants = KNOWN_FAMILIES[family]
+      if (!variants?.has(variant)) {
         const line = content.slice(0, match.index).split('\n').length
-        failures.push(`${file.replace(FRONTEND_ROOT + '/', '')}:${line}: unknown status family "${family}" in "${match[0]}"`)
+        failures.push(`${file.replace(FRONTEND_ROOT + '/', '')}:${line}: unknown ${family}-* token "${variant}" in "${whole}"`)
       }
     }
   }

--- a/src/frontend/src/components/AutonomyToggle.vue
+++ b/src/frontend/src/components/AutonomyToggle.vue
@@ -5,7 +5,7 @@
       class="font-medium whitespace-nowrap min-w-[3rem] text-right"
       :class="[
         labelSizeClass,
-        modelValue ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'
+        modelValue ? 'text-state-autonomous-600 dark:text-state-autonomous-400' : 'text-gray-500 dark:text-gray-400'
       ]"
     >
       {{ modelValue ? 'AUTO' : 'Manual' }}
@@ -20,7 +20,7 @@
       class="relative inline-flex items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
       :class="[
         sizeClasses,
-        modelValue ? 'bg-amber-500 focus:ring-amber-500' : 'bg-gray-300 dark:bg-gray-600 focus:ring-gray-400',
+        modelValue ? 'bg-state-autonomous-500 focus:ring-state-autonomous-500' : 'bg-gray-300 dark:bg-gray-600 focus:ring-gray-400',
         (disabled || loading) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
       ]"
     >

--- a/src/frontend/src/components/DashboardPanel.vue
+++ b/src/frontend/src/components/DashboardPanel.vue
@@ -510,7 +510,7 @@ const getStatusColors = (color) => {
     gray: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
     blue: 'bg-status-info-100 text-status-info-800 dark:bg-status-info-900/50 dark:text-status-info-300',
     orange: 'bg-status-urgent-100 text-status-urgent-800 dark:bg-status-urgent-900/50 dark:text-status-urgent-300',
-    purple: 'bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-300'
+    purple: 'bg-accent-purple-100 text-accent-purple-800 dark:bg-accent-purple-900/50 dark:text-accent-purple-300'
   }
   return colorMap[color] || colorMap.gray
 }

--- a/src/frontend/src/components/ReadOnlyToggle.vue
+++ b/src/frontend/src/components/ReadOnlyToggle.vue
@@ -5,7 +5,7 @@
       class="font-medium whitespace-nowrap min-w-[4.25rem] text-right"
       :class="[
         labelSizeClass,
-        modelValue ? 'text-rose-600 dark:text-rose-400' : 'text-gray-500 dark:text-gray-400'
+        modelValue ? 'text-state-locked-600 dark:text-state-locked-400' : 'text-gray-500 dark:text-gray-400'
       ]"
     >
       {{ modelValue ? 'Read-Only' : 'Editable' }}
@@ -20,7 +20,7 @@
       class="relative inline-flex items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
       :class="[
         sizeClasses,
-        modelValue ? 'bg-rose-500 focus:ring-rose-500' : 'bg-gray-300 dark:bg-gray-600 focus:ring-gray-400',
+        modelValue ? 'bg-state-locked-500 focus:ring-state-locked-500' : 'bg-gray-300 dark:bg-gray-600 focus:ring-gray-400',
         (disabled || loading) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
       ]"
     >

--- a/src/frontend/src/components/RuntimeBadge.vue
+++ b/src/frontend/src/components/RuntimeBadge.vue
@@ -100,14 +100,11 @@ const tooltipText = computed(() => {
 
 const badgeClasses = computed(() => {
   if (isClaudeRuntime.value) {
-    // Anthropic brand colors - coral/terracotta
-    return 'bg-orange-50 dark:bg-orange-950/50 text-orange-700 dark:text-orange-300 border border-orange-200 dark:border-orange-800'
+    return 'bg-brand-claude-50 dark:bg-brand-claude-950/50 text-brand-claude-700 dark:text-brand-claude-300 border border-brand-claude-200 dark:border-brand-claude-800'
   }
   if (isGeminiRuntime.value) {
-    // Google Gemini brand colors - blue/purple gradient feel
-    return 'bg-blue-50 dark:bg-blue-950/50 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800'
+    return 'bg-brand-gemini-50 dark:bg-brand-gemini-950/50 text-brand-gemini-700 dark:text-brand-gemini-300 border border-brand-gemini-200 dark:border-brand-gemini-800'
   }
-  // Fallback
   return 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
 })
 </script>

--- a/src/frontend/tailwind.config.js
+++ b/src/frontend/tailwind.config.js
@@ -9,15 +9,27 @@ export default {
   darkMode: 'class',
   theme: {
     extend: {
-      // Semantic status tokens — alias full palettes so every shade remains
-      // available (e.g. `bg-status-success-500`, `text-status-success-700
-      // dark:text-status-success-400`).
+      // Design-system tokens — each aliases a full Tailwind palette so every
+      // shade remains available (e.g. `bg-status-success-500`,
+      // `text-state-autonomous-700 dark:text-state-autonomous-300`).
+      //
+      //   status-*  health/result of an event (success, warning, danger, …)
+      //   state-*   an operating mode (autonomous, locked, …)
+      //   brand-*   third-party product identity (claude, gemini, …)
+      //   accent-*  decorative highlight that isn't status (named after the
+      //             literal color so future accents like `accent-green` join
+      //             cleanly without renaming).
       colors: {
-        'status-success': colors.green,
-        'status-warning': colors.yellow,
-        'status-danger':  colors.red,
-        'status-info':    colors.blue,
-        'status-urgent':  colors.orange,
+        'status-success':    colors.green,
+        'status-warning':    colors.yellow,
+        'status-danger':     colors.red,
+        'status-info':       colors.blue,
+        'status-urgent':     colors.orange,
+        'state-autonomous':  colors.amber,
+        'state-locked':      colors.rose,
+        'brand-claude':      colors.orange,
+        'brand-gemini':      colors.blue,
+        'accent-purple':     colors.purple,
       },
     },
   },


### PR DESCRIPTION
## Summary
Extends the design-system token system from #67 (PR #553) with three additional families for colors that don't fit the status taxonomy, and migrates the 4 components blocked by #67's status-only scope.

> ⚠️ **Stacked on #553.** Base is `feature/67-design-system-tokens`; GitHub will auto-rebase to `dev` once #553 merges. Review #553 first.

## New token families

| Family | Purpose |
|---|---|
| `state-*` | Agent operating modes (mutually exclusive at any time) |
| `brand-*` | Third-party product identity |
| `accent-*` | Decorative highlights, named after the literal color so future accents (`accent-green`, …) join cleanly |

| Token | Palette | Used by |
|---|---|---|
| `state-autonomous` | amber | `AutonomyToggle.vue` (AUTO mode) |
| `state-locked` | rose | `ReadOnlyToggle.vue` (ON mode) |
| `brand-claude` | orange | `RuntimeBadge.vue` (Claude Code runtime) |
| `brand-gemini` | blue | `RuntimeBadge.vue` (Gemini CLI runtime) |
| `accent-purple` | purple | `DashboardPanel.getStatusColors` purple slot |

All tokens are direct full-palette aliases — visual output is byte-identical to the raw classes they replace.

## Naming rationale
- **`state-` vs `status-`**: `status-*` is for a result of an event (success/warning/danger/etc.); `state-*` is for an operating mode the agent is currently in. Different semantic axis.
- **`brand-claude` not `brand-anthropic`**: User-facing product names, not vendor names. Anticipates future runtimes (e.g. `brand-openai`).
- **`accent-purple` not bare `accent`**: Avoids Tailwind's `accent-{color}` utility-class collision, and `accent-{literal-color}` lets future accents join without a rename.

## Validator updates
`scripts/check-design-tokens.mjs` (added in #553) now:
- Knows all 4 families via a `KNOWN_FAMILIES` map
- Scans for `bg/text/ring/dark:*-{status|state|brand|accent}-*-{shade}` and flags typos within any family
- Continues to enforce palette-alias equivalence in `tailwind.config.js`

Negative tests confirmed: `bg-state-autonomus-500` (typo) → caught with file:line; alias drift in config → caught with token:expected.

## Files
```
src/frontend/tailwind.config.js                +5 token aliases + namespace docs
src/frontend/scripts/check-design-tokens.mjs   +KNOWN_FAMILIES, family-aware regex
src/frontend/src/components/RuntimeBadge.vue   2 brand-* migrations
src/frontend/src/components/AutonomyToggle.vue 1 state-autonomous migration
src/frontend/src/components/ReadOnlyToggle.vue 1 state-locked migration
src/frontend/src/components/DashboardPanel.vue 1 accent-purple migration
```

6 files changed, +55/−28.

## Test plan
- [ ] CI: `frontend-build` (#553) + `check:tokens` pass on this PR
- [ ] Visual smoke: `RuntimeBadge` (orange/blue), `AutonomyToggle` (amber AUTO), `ReadOnlyToggle` (rose Read-Only), `DashboardPanel` purple widgets — all colors should look identical to before
- [ ] Dark mode toggle: above components still pair correctly

Fixes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)