### PR TITLE
refactor(frontend): migrate operator queue to design-system tokens (#554)

### DIFF
--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -94,11 +94,11 @@
     <!-- Stats -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
-        <div class="text-3xl font-bold text-red-600 dark:text-red-400">{{ notificationsStore.pendingCount }}</div>
+        <div class="text-3xl font-bold text-status-danger-600 dark:text-status-danger-400">{{ notificationsStore.pendingCount }}</div>
         <div class="text-xs text-gray-500 dark:text-gray-400">Pending</div>
       </div>
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
-        <div class="text-3xl font-bold text-green-600 dark:text-green-400">{{ acknowledgedCount }}</div>
+        <div class="text-3xl font-bold text-status-success-600 dark:text-status-success-400">{{ acknowledgedCount }}</div>
         <div class="text-xs text-gray-500 dark:text-gray-400">Acknowledged</div>
       </div>
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
@@ -159,8 +159,8 @@
           :key="notification.id"
           class="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
           :class="{
-            'bg-red-50 dark:bg-red-900/10': notification.status === 'pending' && notification.priority === 'urgent',
-            'bg-orange-50 dark:bg-orange-900/10': notification.status === 'pending' && notification.priority === 'high',
+            'bg-status-danger-50 dark:bg-status-danger-900/10': notification.status === 'pending' && notification.priority === 'urgent',
+            'bg-status-urgent-50 dark:bg-status-urgent-900/10': notification.status === 'pending' && notification.priority === 'high',
             'opacity-60': notification.status === 'dismissed'
           }"
         >
@@ -218,7 +218,7 @@
                 <span class="px-2 py-0.5 rounded" :class="getTypeBadge(notification.notification_type)">
                   {{ notification.notification_type }}
                 </span>
-                <span v-if="notification.status === 'acknowledged'" class="flex items-center gap-1 text-green-600 dark:text-green-400">
+                <span v-if="notification.status === 'acknowledged'" class="flex items-center gap-1 text-status-success-600 dark:text-status-success-400">
                   <CheckIcon class="w-3 h-3" />
                   Acknowledged
                 </span>
@@ -245,7 +245,7 @@
               <button
                 v-if="notification.status === 'pending'"
                 @click="acknowledge(notification.id)"
-                class="px-3 py-1.5 text-xs font-medium text-green-700 dark:text-green-300 bg-green-100 dark:bg-green-900/30 border border-green-300 dark:border-green-700 rounded hover:bg-green-200 dark:hover:bg-green-900/50"
+                class="px-3 py-1.5 text-xs font-medium text-status-success-700 dark:text-status-success-300 bg-status-success-100 dark:bg-status-success-900/30 border border-status-success-300 dark:border-status-success-700 rounded hover:bg-status-success-200 dark:hover:bg-status-success-900/50"
                 title="Acknowledge"
               >
                 <CheckIcon class="w-4 h-4" />
@@ -491,9 +491,9 @@ function getTypeIcon(type) {
 
 function getPriorityIconBg(priority) {
   const classes = {
-    urgent: 'bg-red-100 dark:bg-red-900/30',
-    high: 'bg-orange-100 dark:bg-orange-900/30',
-    normal: 'bg-blue-100 dark:bg-blue-900/30',
+    urgent: 'bg-status-danger-100 dark:bg-status-danger-900/30',
+    high: 'bg-status-urgent-100 dark:bg-status-urgent-900/30',
+    normal: 'bg-status-info-100 dark:bg-status-info-900/30',
     low: 'bg-gray-100 dark:bg-gray-700',
   }
   return classes[priority] || 'bg-gray-100 dark:bg-gray-700'
@@ -501,9 +501,9 @@ function getPriorityIconBg(priority) {
 
 function getPriorityIconColor(priority) {
   const classes = {
-    urgent: 'text-red-600 dark:text-red-400',
-    high: 'text-orange-600 dark:text-orange-400',
-    normal: 'text-blue-600 dark:text-blue-400',
+    urgent: 'text-status-danger-600 dark:text-status-danger-400',
+    high: 'text-status-urgent-600 dark:text-status-urgent-400',
+    normal: 'text-status-info-600 dark:text-status-info-400',
     low: 'text-gray-600 dark:text-gray-400',
   }
   return classes[priority] || 'text-gray-600 dark:text-gray-400'
@@ -511,9 +511,9 @@ function getPriorityIconColor(priority) {
 
 function getPriorityBadge(priority) {
   const classes = {
-    urgent: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300',
-    high: 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300',
-    normal: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
+    urgent: 'bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-700 dark:text-status-danger-300',
+    high: 'bg-status-urgent-100 dark:bg-status-urgent-900/30 text-status-urgent-700 dark:text-status-urgent-300',
+    normal: 'bg-status-info-100 dark:bg-status-info-900/30 text-status-info-700 dark:text-status-info-300',
     low: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
   }
   return classes[priority] || 'bg-gray-100 text-gray-700'
@@ -521,19 +521,19 @@ function getPriorityBadge(priority) {
 
 function getTypeBadge(type) {
   const classes = {
-    alert: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300',
-    info: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
-    status: 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300',
-    completion: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300',
-    question: 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300',
+    alert: 'bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-700 dark:text-status-danger-300',
+    info: 'bg-status-info-100 dark:bg-status-info-900/30 text-status-info-700 dark:text-status-info-300',
+    status: 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-700 dark:text-accent-purple-300',
+    completion: 'bg-status-success-100 dark:bg-status-success-900/30 text-status-success-700 dark:text-status-success-300',
+    question: 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-700 dark:text-status-warning-300',
   }
   return classes[type] || 'bg-gray-100 text-gray-700'
 }
 
 function getStatusBadge(status) {
   const classes = {
-    pending: 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300',
-    acknowledged: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300',
+    pending: 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-700 dark:text-status-warning-300',
+    acknowledged: 'bg-status-success-100 dark:bg-status-success-900/30 text-status-success-700 dark:text-status-success-300',
     dismissed: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
   }
   return classes[status] || 'bg-gray-100 text-gray-700'

--- a/src/frontend/src/components/operator/QueueCard.vue
+++ b/src/frontend/src/components/operator/QueueCard.vue
@@ -208,14 +208,14 @@ function submitAnswer() {
 }
 
 function optionClass(idx) {
-  if (idx === 0) return 'border-green-500 bg-green-50 text-green-700 dark:border-green-400 dark:bg-green-900/20 dark:text-green-300'
-  if (idx === 1) return 'border-red-500 bg-red-50 text-red-700 dark:border-red-400 dark:bg-red-900/20 dark:text-red-300'
+  if (idx === 0) return 'border-status-success-500 bg-status-success-50 text-status-success-700 dark:border-status-success-400 dark:bg-status-success-900/20 dark:text-status-success-300'
+  if (idx === 1) return 'border-status-danger-500 bg-status-danger-50 text-status-danger-700 dark:border-status-danger-400 dark:bg-status-danger-900/20 dark:text-status-danger-300'
   return 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/20 dark:text-blue-300'
 }
 
 function typePill(type) {
   return {
-    approval: 'bg-purple-50 text-purple-600 dark:bg-purple-900/20 dark:text-purple-400',
+    approval: 'bg-accent-purple-50 text-accent-purple-600 dark:bg-accent-purple-900/20 dark:text-accent-purple-400',
     question: 'bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400',
     alert: 'bg-amber-50 text-amber-600 dark:bg-amber-900/20 dark:text-amber-400'
   }[type] || ''
@@ -227,8 +227,8 @@ function typeLabel(type) {
 
 function priorityPill(priority) {
   return {
-    critical: 'bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-400',
-    high: 'bg-orange-50 text-orange-600 dark:bg-orange-900/20 dark:text-orange-400'
+    critical: 'bg-status-danger-50 text-status-danger-600 dark:bg-status-danger-900/20 dark:text-status-danger-400',
+    high: 'bg-status-urgent-50 text-status-urgent-600 dark:bg-status-urgent-900/20 dark:text-status-urgent-400'
   }[priority] || ''
 }
 

--- a/src/frontend/src/components/operator/QueueItemDetail.vue
+++ b/src/frontend/src/components/operator/QueueItemDetail.vue
@@ -97,10 +97,10 @@
       <!-- Already responded info -->
       <div v-if="item.status !== 'pending'" class="p-4 border-b border-gray-200 dark:border-gray-700">
         <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">Response</h3>
-        <div class="bg-green-50 dark:bg-green-900/20 rounded-lg p-3 space-y-1">
-          <p class="text-sm font-medium text-green-800 dark:text-green-300">{{ item.response }}</p>
-          <p v-if="item.response_text" class="text-sm text-green-700 dark:text-green-400">{{ item.response_text }}</p>
-          <p class="text-xs text-green-600 dark:text-green-500">
+        <div class="bg-status-success-50 dark:bg-status-success-900/20 rounded-lg p-3 space-y-1">
+          <p class="text-sm font-medium text-status-success-800 dark:text-status-success-300">{{ item.response }}</p>
+          <p v-if="item.response_text" class="text-sm text-status-success-700 dark:text-status-success-400">{{ item.response_text }}</p>
+          <p class="text-xs text-status-success-600 dark:text-status-success-500">
             by {{ item.responded_by_email }} &middot; {{ formatDate(item.responded_at) }}
           </p>
         </div>
@@ -227,14 +227,14 @@ function submitAcknowledge() {
 }
 
 function optionSelectedClass(idx) {
-  if (idx === 0) return 'border-green-500 bg-green-50 text-green-700 dark:border-green-400 dark:bg-green-900/30 dark:text-green-300'
-  if (idx === 1) return 'border-red-500 bg-red-50 text-red-700 dark:border-red-400 dark:bg-red-900/30 dark:text-red-300'
+  if (idx === 0) return 'border-status-success-500 bg-status-success-50 text-status-success-700 dark:border-status-success-400 dark:bg-status-success-900/30 dark:text-status-success-300'
+  if (idx === 1) return 'border-status-danger-500 bg-status-danger-50 text-status-danger-700 dark:border-status-danger-400 dark:bg-status-danger-900/30 dark:text-status-danger-300'
   return 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-300'
 }
 
 function typeBadge(type) {
   const badges = {
-    approval: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+    approval: 'bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-900/30 dark:text-accent-purple-400',
     question: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
     alert: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
   }
@@ -243,9 +243,9 @@ function typeBadge(type) {
 
 function priorityBadge(priority) {
   const badges = {
-    critical: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    high: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-    medium: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+    critical: 'bg-status-danger-100 text-status-danger-700 dark:bg-status-danger-900/30 dark:text-status-danger-400',
+    high: 'bg-status-urgent-100 text-status-urgent-700 dark:bg-status-urgent-900/30 dark:text-status-urgent-400',
+    medium: 'bg-status-warning-100 text-status-warning-700 dark:bg-status-warning-900/30 dark:text-status-warning-400',
     low: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
   }
   return badges[priority] || ''
@@ -253,7 +253,7 @@ function priorityBadge(priority) {
 
 function statusBadge(status) {
   const badges = {
-    responded: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+    responded: 'bg-status-success-100 text-status-success-700 dark:bg-status-success-900/30 dark:text-status-success-400',
     acknowledged: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
   }
   return badges[status] || ''

--- a/src/frontend/src/components/operator/QueueList.vue
+++ b/src/frontend/src/components/operator/QueueList.vue
@@ -102,8 +102,8 @@
             v-if="item.priority === 'critical' || item.priority === 'high'"
             class="flex-shrink-0 text-xs font-medium px-1.5 py-0.5 rounded"
             :class="{
-              'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400': item.priority === 'critical',
-              'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400': item.priority === 'high'
+              'bg-status-danger-100 text-status-danger-700 dark:bg-status-danger-900/30 dark:text-status-danger-400': item.priority === 'critical',
+              'bg-status-urgent-100 text-status-urgent-700 dark:bg-status-urgent-900/30 dark:text-status-urgent-400': item.priority === 'high'
             }"
           >
             {{ item.priority }}
@@ -122,10 +122,10 @@ const store = useOperatorQueueStore()
 
 function priorityColor(priority) {
   const colors = {
-    critical: 'bg-red-500 animate-pulse',
-    high: 'bg-orange-500',
-    medium: 'bg-yellow-500',
-    low: 'bg-blue-400'
+    critical: 'bg-status-danger-500 animate-pulse',
+    high: 'bg-status-urgent-500',
+    medium: 'bg-status-warning-500',
+    low: 'bg-status-info-400'
   }
   return colors[priority] || 'bg-gray-400'
 }
@@ -162,7 +162,7 @@ function typeIcon(type) {
 
 function typeIconColor(type) {
   const colors = {
-    approval: 'text-purple-500 dark:text-purple-400',
+    approval: 'text-accent-purple-500 dark:text-accent-purple-400',
     question: 'text-blue-500 dark:text-blue-400',
     alert: 'text-amber-500 dark:text-amber-400'
   }
@@ -171,9 +171,9 @@ function typeIconColor(type) {
 
 function statusBadge(status) {
   const badges = {
-    responded: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+    responded: 'bg-status-success-100 text-status-success-700 dark:bg-status-success-900/30 dark:text-status-success-400',
     acknowledged: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
-    expired: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400'
+    expired: 'bg-status-danger-100 text-status-danger-600 dark:bg-status-danger-900/30 dark:text-status-danger-400'
   }
   return badges[status] || ''
 }

--- a/src/frontend/src/components/operator/QueueStats.vue
+++ b/src/frontend/src/components/operator/QueueStats.vue
@@ -10,24 +10,24 @@
       </div>
       <div class="space-y-1">
         <div v-if="stats.byPriority.critical > 0" class="flex items-center gap-2">
-          <span class="w-2 h-2 rounded-full bg-red-500 animate-pulse"></span>
+          <span class="w-2 h-2 rounded-full bg-status-danger-500 animate-pulse"></span>
           <span class="text-xs text-gray-600 dark:text-gray-400 flex-1">Critical</span>
-          <span class="text-xs font-medium text-red-600 dark:text-red-400">{{ stats.byPriority.critical }}</span>
+          <span class="text-xs font-medium text-status-danger-600 dark:text-status-danger-400">{{ stats.byPriority.critical }}</span>
         </div>
         <div v-if="stats.byPriority.high > 0" class="flex items-center gap-2">
-          <span class="w-2 h-2 rounded-full bg-orange-500"></span>
+          <span class="w-2 h-2 rounded-full bg-status-urgent-500"></span>
           <span class="text-xs text-gray-600 dark:text-gray-400 flex-1">High</span>
-          <span class="text-xs font-medium text-orange-600 dark:text-orange-400">{{ stats.byPriority.high }}</span>
+          <span class="text-xs font-medium text-status-urgent-600 dark:text-status-urgent-400">{{ stats.byPriority.high }}</span>
         </div>
         <div v-if="stats.byPriority.medium > 0" class="flex items-center gap-2">
-          <span class="w-2 h-2 rounded-full bg-yellow-500"></span>
+          <span class="w-2 h-2 rounded-full bg-status-warning-500"></span>
           <span class="text-xs text-gray-600 dark:text-gray-400 flex-1">Medium</span>
-          <span class="text-xs font-medium text-yellow-600 dark:text-yellow-400">{{ stats.byPriority.medium }}</span>
+          <span class="text-xs font-medium text-status-warning-600 dark:text-status-warning-400">{{ stats.byPriority.medium }}</span>
         </div>
         <div v-if="stats.byPriority.low > 0" class="flex items-center gap-2">
-          <span class="w-2 h-2 rounded-full bg-blue-400"></span>
+          <span class="w-2 h-2 rounded-full bg-status-info-400"></span>
           <span class="text-xs text-gray-600 dark:text-gray-400 flex-1">Low</span>
-          <span class="text-xs font-medium text-blue-600 dark:text-blue-400">{{ stats.byPriority.low }}</span>
+          <span class="text-xs font-medium text-status-info-600 dark:text-status-info-400">{{ stats.byPriority.low }}</span>
         </div>
       </div>
     </div>

--- a/src/frontend/src/components/operator/ResolvedCard.vue
+++ b/src/frontend/src/components/operator/ResolvedCard.vue
@@ -16,7 +16,7 @@
 
         <!-- Response -->
         <div class="mt-2 flex items-center gap-2">
-          <span class="inline-flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+          <span class="inline-flex items-center gap-1 text-xs text-status-success-600 dark:text-status-success-400">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>


### PR DESCRIPTION
## Summary
First slice of the #554 sweep — migrates the 6 operator-queue components (`src/frontend/src/components/operator/`) from raw status colors to the semantic tokens introduced in #67 (PR #553) and #555 (PR #561). Visual output is unchanged.

> Refs #554 — this is one focused domain slice; the issue stays open for follow-up slices on agent views, settings, channels, etc.

## Migration scope

**56 sites migrated** across 6 files. Each callsite was reviewed for semantic intent (per the [I2 caveat](https://github.com/Abilityai/trinity/issues/554#issuecomment-4336981539)), not search-and-replaced.

| File | Sites |
|---|---|
| `NotificationsPanel.vue` | 22 (priority/type/status badges, counts, row backgrounds, ack button) |
| `QueueCard.vue` | 5 (option buttons, type/priority pills) |
| `QueueItemDetail.vue` | 11 (same as above + response box) |
| `QueueList.vue` | 9 (priority dots/labels, status badge) |
| `QueueStats.vue` | 8 (priority indicators) |
| `ResolvedCard.vue` | 1 (resolved indicator) |

## Token mapping

| Token | Used for |
|---|---|
| `status-success` | completion / acknowledged / approval option / responded |
| `status-danger` | critical priority / urgent / pending count / reject option / expired |
| `status-urgent` | high priority |
| `status-warning` | medium priority / question type / pending status |
| `status-info` | low / normal priority indicator |
| `accent-purple` | "approval" / "status" type categorical pills |

All tokens are 1:1 palette aliases — generated CSS is byte-identical to the raw classes they replace.

## Deferred — by design, not oversight

**38 raw color references remain in this folder.** Each falls into one of three categories that need their own design decision before they can be mass-migrated:

1. **Blue for primary actions** (~25 sites) — buttons (`bg-blue-600`), links (`text-blue-600`), focus rings (`focus:ring-blue-500`). Needs an `action-primary` token family.
2. **Blue for selected state** (~5 sites) — list-item highlight, expanded card border. Needs a `state-selected` token (similar to how `state-autonomous` was added in #555).
3. **Amber for "alert" type** (~6 sites) — would need to either map to `status-warning` (palette shift yellow vs amber → visible color change, violates #67 AC) or stay raw until the alert type gets its own token.
4. **Green for "Acknowledge Selected" bulk button** (~2 sites) — falls under category 1.

These are tracked in [#555 follow-up](https://github.com/Abilityai/trinity/issues/555) territory; flagging here so reviewers can confirm the deferral.

## Test plan
- [x] `npm run check:tokens` passes (verified locally)
- [x] `npm run build` succeeds (verified locally)
- [ ] CI: `frontend-build` workflow passes
- [ ] Visual smoke: open `/operator` (Operating Room) — Queue list dots, priority/status badges, expanded queue card option buttons, resolved cards. All colors should look identical to before.
- [ ] Dark mode: re-verify above

Refs #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)