### PR TITLE
feat(frontend): Playwright e2e harness gated on `ui` label (#556)

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -1,0 +1,93 @@
+name: frontend-e2e
+
+# Runs only when a PR carries the `ui` label. Adds a browser test layer for
+# UI changes; gated to avoid spending ~5 min of CI on every backend PR.
+# Trigger manually by adding the `ui` label to a PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  e2e:
+    if: contains(github.event.pull_request.labels.*.name, 'ui')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: src/frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: src/frontend/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('src/frontend/package-lock.json') }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Trinity stack
+        working-directory: ${{ github.workspace }}
+        env:
+          ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || 'ci-test-password' }}
+          ANTHROPIC_API_KEY: ${{ secrets.E2E_ANTHROPIC_API_KEY || 'placeholder' }}
+        run: |
+          # Generate the minimum .env needed to boot. Real secrets are not
+          # required for e2e — login uses ADMIN_PASSWORD only.
+          cp .env.example .env
+          echo "ADMIN_PASSWORD=$ADMIN_PASSWORD" >> .env
+          echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" >> .env
+          echo "SECRET_KEY=$(openssl rand -hex 32)" >> .env
+          ./scripts/deploy/start.sh
+
+      - name: Wait for backend health
+        run: |
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+              echo "backend healthy"; exit 0
+            fi
+            sleep 2
+          done
+          echo "backend never became healthy"; exit 1
+
+      - name: Run Playwright tests
+        env:
+          ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || 'ci-test-password' }}
+          E2E_BASE_URL: http://localhost
+        run: npm run test:e2e
+
+      - name: Collect Trinity logs on failure
+        if: failure()
+        working-directory: ${{ github.workspace }}
+        run: |
+          docker compose logs --no-color --tail=200 backend frontend mcp-server > trinity-logs.txt || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: src/frontend/e2e/playwright-report/
+          retention-days: 14
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-artifacts
+          path: |
+            src/frontend/e2e/test-results/
+            trinity-logs.txt
+          retention-days: 14

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -284,6 +284,11 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
 - **Key Features**: Docker socket capture, VRL transforms, platform.json/agents.json output
 - **Flow**: `docs/memory/feature-flows/vector-logging.md`
 
+### 8.8 Frontend E2E Test Infrastructure
+- **Status**: ✅ Implemented (2026-04-29)
+- **Description**: Playwright-based smoke test harness for the Trinity frontend, gated on the `ui` PR label in CI (#556)
+- **Key Features**: Chromium-only smoke suite (dashboard, agents, operating room, templates), storage-state auth pattern (login once, reuse session), label-gated CI workflow (~5 min, opt-in), on-failure artifact upload (screenshots, videos, Trinity logs)
+
 ---
 
 ## 9. Agent Collaboration

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -1,0 +1,12 @@
+# Vite/Node
+node_modules
+dist
+.env
+.env.local
+
+# Playwright e2e
+/e2e/.auth/admin.json
+/e2e/test-results/
+/e2e/playwright-report/
+/e2e/blob-report/
+/playwright/.cache/

--- a/src/frontend/e2e/README.md
+++ b/src/frontend/e2e/README.md
@@ -1,0 +1,57 @@
+# Frontend E2E Tests
+
+Playwright-based end-to-end tests for the Trinity frontend (#556).
+
+## Run locally
+
+```bash
+# 1. Start a Trinity stack (the tests don't spin one up themselves)
+./scripts/deploy/start.sh
+
+# 2. Run the tests
+cd src/frontend
+ADMIN_PASSWORD=<your-admin-password> npm run test:e2e
+```
+
+`ADMIN_PASSWORD` is required — `e2e/auth.setup.js` uses it to log in once and
+caches the session in `e2e/.auth/admin.json` (gitignored).
+
+## Useful flags
+
+```bash
+npm run test:e2e:headed     # run with visible browser
+npm run test:e2e:ui         # interactive Playwright UI
+npm run test:e2e:update     # update visual regression snapshots
+```
+
+After a run, the HTML report is at `e2e/playwright-report/index.html`.
+
+## CI
+
+CI runs e2e only on PRs **labeled `ui`** — add the label to any frontend PR
+that should be exercised end-to-end. The workflow lives at
+`.github/workflows/frontend-e2e.yml` and stands up the full Trinity stack
+before running tests (~5 min total).
+
+To make e2e a required check on a PR, add the `ui` label and wait for the
+workflow to complete.
+
+## Adding tests
+
+- Smoke tests live in `e2e/smoke.spec.js` — the lightweight cross-page checks
+- New flows go in their own `*.spec.js` next to the smoke file
+- Visual regression: use `await expect(page).toHaveScreenshot()`. Snapshots
+  are committed in `e2e/<spec>.spec.js-snapshots/`. Run
+  `npm run test:e2e:update` after intentional UI changes, then commit the
+  updated PNGs.
+
+## Why this layer exists
+
+The frontend has no other automated test coverage today. E2E tests catch:
+- Login regressions
+- Top-level routing breakage
+- Auth boundary violations exposed via the UI
+- Color drift on the design system (with visual regression)
+
+Cheaper layers (Vitest unit tests, type checking) are tracked in #556
+Phase 1 / Phase 3 — separate follow-ups.

--- a/src/frontend/e2e/auth.setup.js
+++ b/src/frontend/e2e/auth.setup.js
@@ -1,0 +1,25 @@
+import { test as setup, expect } from '@playwright/test'
+
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD
+if (!ADMIN_PASSWORD) {
+  throw new Error('ADMIN_PASSWORD env var must be set for e2e tests')
+}
+
+setup('authenticate as admin', async ({ page }) => {
+  await page.goto('/')
+  // Email auth is the default landing form; the password field only appears
+  // after clicking the Admin Login fallback. Click it if visible (skipped
+  // when admin-only mode is configured and the password field is shown
+  // immediately).
+  const passwordVisible = await page.locator('#password').isVisible().catch(() => false)
+  if (!passwordVisible) {
+    await page.getByText('Admin Login', { exact: false }).click()
+  }
+  await page.locator('#password').fill(ADMIN_PASSWORD)
+  await page.getByRole('button', { name: /sign in as admin/i }).click()
+  // Login successful when the URL is no longer /login.
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 10000 })
+  // And the password field is gone.
+  await expect(page.locator('#password')).not.toBeVisible({ timeout: 5000 })
+  await page.context().storageState({ path: 'e2e/.auth/admin.json' })
+})

--- a/src/frontend/e2e/smoke.spec.js
+++ b/src/frontend/e2e/smoke.spec.js
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('smoke', () => {
+  test('dashboard renders for authenticated admin', async ({ page }) => {
+    await page.goto('/')
+    // Top nav has Dashboard, Agents, Templates, Health, Ops, Keys, Settings.
+    await expect(page.getByText(/^Dashboard$/i).first()).toBeVisible()
+    await expect(page.getByText(/^Agents$/i).first()).toBeVisible()
+    await expect(page.getByText(/^Settings$/i).first()).toBeVisible()
+  })
+
+  test('agents page loads', async ({ page }) => {
+    await page.goto('/agents')
+    await expect(page.getByText(/agent|create/i).first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('operating room page loads', async ({ page }) => {
+    await page.goto('/operating-room')
+    // Either a queue list, filters, an empty state, or the title.
+    await expect(
+      page.getByText(/operating|queue|priority|all types|no items/i).first()
+    ).toBeVisible({ timeout: 10000 })
+  })
+
+  test('templates page loads', async ({ page }) => {
+    await page.goto('/templates')
+    await expect(page.getByText(/template/i).first()).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "vue-router": "^4.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.15",
         "@types/js-yaml": "^4.0.9",
         "@vitejs/plugin-vue": "^5.2.1",
@@ -179,6 +180,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1720,6 +1736,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,7 +5,11 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check:tokens": "node scripts/check-design-tokens.mjs"
+    "check:tokens": "node scripts/check-design-tokens.mjs",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:update": "playwright test --update-snapshots"
   },
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
@@ -31,6 +35,7 @@
     "vue-router": "^4.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.15",
     "@types/js-yaml": "^4.0.9",
     "@vitejs/plugin-vue": "^5.2.1",

--- a/src/frontend/playwright.config.js
+++ b/src/frontend/playwright.config.js
@@ -1,0 +1,33 @@
+// Playwright config for Trinity frontend e2e tests (#556).
+// Tests run against a live Trinity stack — set E2E_BASE_URL to override the
+// default `http://localhost`. Locally, run `./scripts/deploy/start.sh` first.
+
+import { defineConfig, devices } from '@playwright/test'
+
+const STORAGE_STATE = 'e2e/.auth/admin.json'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [['github'], ['html', { outputFolder: 'e2e/playwright-report', open: 'never' }]]
+    : [['list'], ['html', { outputFolder: 'e2e/playwright-report', open: 'never' }]],
+  outputDir: 'e2e/test-results',
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'setup', testMatch: /.*\.setup\.js/ },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+      dependencies: ['setup'],
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
Phase 2 of #556. Adds Playwright as the frontend e2e test layer with a minimal smoke-test suite. CI runs only on PRs that carry the **\`ui\`** label (this PR has it, so the workflow exercises itself).

## What this adds

| File | Purpose |
|---|---|
| \`src/frontend/playwright.config.js\` | Chromium-only, configurable \`E2E_BASE_URL\`, HTML+list reporter, on-failure screenshots/videos/traces |
| \`src/frontend/e2e/auth.setup.js\` | Storage-state pattern: login once via the admin form, reuse session across all specs |
| \`src/frontend/e2e/smoke.spec.js\` | 4 smoke tests — dashboard, /agents, /operating-room, /templates |
| \`src/frontend/e2e/README.md\` | How to run locally + add new tests |
| \`src/frontend/.gitignore\` | Excludes session JSON + test artifacts |
| \`src/frontend/package.json\` | \`@playwright/test\` dev dep + \`test:e2e[:ui|:headed|:update]\` scripts |
| \`.github/workflows/frontend-e2e.yml\` | Label-gated CI workflow |

## CI strategy: opt-in via \`ui\` label

The workflow runs only when a PR has the \`ui\` label. Each run:
1. Starts the full Trinity docker-compose stack (~3–5 min)
2. Waits for backend health
3. Runs Playwright against \`http://localhost\`
4. Uploads HTML report + failure artifacts

This avoids spending ~5 min on every backend-only PR. To exercise e2e on a frontend PR, just add the \`ui\` label.

## Naming choice
Label is \`ui\` (single word, matches existing style like \`enhancement\`). Chosen over \`e2e\` / \`frontend\` / \`needs-visual-test\` for brevity and because it covers any UI change, not just visual regression.

## Out of scope (tracked in #556)
- **Phase 1** — Vitest unit/component tests
- **Phase 3** — \`vue-tsc\` type checking
- **Visual regression baselines** — will be added per-component in design-system sweep PRs (e.g. #569 follow-up). Playwright supports it via \`toHaveScreenshot()\`; harness is ready, baselines come with each migration.

## How to run locally
\`\`\`bash
./scripts/deploy/start.sh                          # bring up Trinity
cd src/frontend
ADMIN_PASSWORD=<your-password> npm run test:e2e    # run smoke
npm run test:e2e:headed                             # with visible browser
npm run test:e2e:ui                                 # interactive mode
\`\`\`

## CI secrets needed (one-time setup)
- \`E2E_ADMIN_PASSWORD\` — admin password for the CI Trinity stack (falls back to \`ci-test-password\` if unset)
- \`E2E_ANTHROPIC_API_KEY\` — placeholder is acceptable since smoke tests don't exercise agent execution

## Test plan
- [x] \`npm install -D @playwright/test\` succeeds
- [x] \`npx playwright install chromium\` succeeds
- [x] \`npm run test:e2e\` runs and reaches the login page (auth flow exercised; full pass requires stable backend — flaky locally due to docker-port-binding bug unrelated to this PR)
- [ ] **CI** runs the workflow on this PR with the \`ui\` label and reports green

Refs #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)