### PR TITLE
fix(files): drop redundant session_token gate on /api/files/{id} (#568)

### DIFF
--- a/src/backend/routers/files.py
+++ b/src/backend/routers/files.py
@@ -2,14 +2,13 @@
 Public download endpoint for outbound agent file sharing (FILES-001 Step 4).
 
 Resolves the token-scoped URLs minted by POST /api/internal/agent-files/share.
-Unauthenticated — the download token IS the auth credential. Agent-level
-`require_email` policy additionally requires a valid session_token.
+Unauthenticated — the 192-bit `sig` token IS the auth credential, minted at
+share time and known only to the recipient.
 
 Error matrix:
 - 404 — file_id does not exist
 - 401 — download_token missing or wrong (constant-time compare)
 - 410 — revoked or expired
-- 401 — agent requires email + session_token missing/invalid
 - 429 — IP rate limit
 - 500 — storage file missing on disk
 """
@@ -30,10 +29,7 @@ from database import db
 from services.agent_shared_files_service import STORAGE_ROOT
 from services.platform_audit_service import AuditEventType, platform_audit_service
 from routers.auth import get_redis_client
-from routers.public import (
-    _get_client_ip,
-    _agent_requires_email,
-)
+from routers.public import _get_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -110,13 +106,12 @@ async def _validate_download_request(
     request: Request,
     sig: Optional[str],
     download_token_alias: Optional[str],
-    session_token: Optional[str],
 ) -> tuple:
     """
     Shared validation for GET and HEAD requests.
 
     Returns ``(row, storage_path, headers, mime_type, client_ip)`` on success.
-    Raises HTTPException on any failure (401 / 404 / 410 / 500 / 429 / 403).
+    Raises HTTPException on any failure (401 / 404 / 410 / 500 / 429).
     """
     client_ip = _get_client_ip(request)
     _check_file_download_rate_limit(client_ip)  # 429 on limit (C5 — dedicated bucket)
@@ -145,15 +140,6 @@ async def _validate_download_request(
     if datetime.now(timezone.utc) > expires:
         raise HTTPException(status_code=410, detail="expired")
 
-    # Per-agent channel-access policy gate — same as public chat
-    agent_name = row["agent_name"]
-    if _agent_requires_email(agent_name):
-        if not session_token:
-            raise HTTPException(status_code=401, detail="session_token required")
-        valid, _email = db.validate_agent_session(agent_name, session_token)
-        if not valid:
-            raise HTTPException(status_code=401, detail="invalid or expired session_token")
-
     storage_path = os.path.join(STORAGE_ROOT, row["stored_filename"])
     if not os.path.exists(storage_path):
         logger.error(
@@ -178,14 +164,12 @@ async def download_shared_file(
     request: Request,
     sig: Optional[str] = None,
     download_token: Optional[str] = None,
-    session_token: Optional[str] = None,
 ):
     """
     Serve a file previously registered via POST /api/internal/agent-files/share.
 
     Query parameters:
-    - sig (required): minted at share time (192-bit entropy)
-    - session_token (required iff the agent has require_email=true)
+    - sig (required): 192-bit token minted at share time, sole auth credential.
 
     `download_token` is accepted as a legacy alias but deprecated —
     Trinity's credential sanitizer redacts `...TOKEN...=value` query
@@ -193,7 +177,7 @@ async def download_shared_file(
     URLs emit `?sig=...`.
     """
     row, storage_path, headers, mime_type, client_ip = await _validate_download_request(
-        file_id, request, sig, download_token, session_token,
+        file_id, request, sig, download_token,
     )
     agent_name = row["agent_name"]
 
@@ -237,18 +221,17 @@ async def head_shared_file(
     request: Request,
     sig: Optional[str] = None,
     download_token: Optional[str] = None,
-    session_token: Optional[str] = None,
 ):
     """
     HEAD handler for link previewers / CDNs that probe before GET.
 
     Runs the same validation as GET (rate limit, token, expiry, revoke,
-    policy gate, storage presence) and returns the same headers —
-    but no body, no download counter bump, no audit row. Follows RFC 7231
-    §4.3.2: HEAD is identical to GET except the server MUST NOT return
-    a message-body.
+    storage presence) and returns the same headers — but no body, no
+    download counter bump, no audit row. Follows RFC 7231 §4.3.2:
+    HEAD is identical to GET except the server MUST NOT return a
+    message-body.
     """
     _row, _storage_path, headers, mime_type, _client_ip = await _validate_download_request(
-        file_id, request, sig, download_token, session_token,
+        file_id, request, sig, download_token,
     )
     return Response(status_code=200, headers=headers, media_type=mime_type)

--- a/tests/unit/test_file_download_no_session_gate.py
+++ b/tests/unit/test_file_download_no_session_gate.py
@@ -1,0 +1,92 @@
+"""
+Regression test for #568.
+
+`/api/files/{id}` previously gated downloads behind a `session_token`
+check when the owning agent had `require_email=true`. Since
+`build_download_url` never appended a `session_token` (and the agent
+has no way to learn the recipient's value), file sharing was
+permanently broken for those agents.
+
+The 192-bit `sig` token minted at share time is the sole auth
+credential. This test pins the post-fix structure of `routers/files.py`
+via AST so we don't accidentally re-introduce the gate later.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+_FILES_PY = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src" / "backend" / "routers" / "files.py"
+)
+
+
+@pytest.fixture(scope="module")
+def files_ast() -> ast.Module:
+    return ast.parse(_FILES_PY.read_text())
+
+
+def _function(tree: ast.Module, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found in {_FILES_PY}")
+
+
+def test_validate_download_request_has_no_session_token_param(files_ast):
+    fn = _function(files_ast, "_validate_download_request")
+    arg_names = [a.arg for a in fn.args.args]
+    assert "session_token" not in arg_names, (
+        "_validate_download_request must not accept session_token (#568)"
+    )
+    assert arg_names == [
+        "file_id", "request", "sig", "download_token_alias",
+    ], f"unexpected signature: {arg_names}"
+
+
+def test_get_endpoint_has_no_session_token_param(files_ast):
+    fn = _function(files_ast, "download_shared_file")
+    arg_names = [a.arg for a in fn.args.args]
+    assert "session_token" not in arg_names, (
+        "GET /api/files/{id} must not accept session_token (#568)"
+    )
+
+
+def test_head_endpoint_has_no_session_token_param(files_ast):
+    fn = _function(files_ast, "head_shared_file")
+    arg_names = [a.arg for a in fn.args.args]
+    assert "session_token" not in arg_names
+
+
+def test_does_not_import_agent_requires_email(files_ast):
+    """The require_email gate is gone; the import must be too."""
+    for node in ast.walk(files_ast):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                assert alias.name != "_agent_requires_email", (
+                    "remove _agent_requires_email import — gate was deleted (#568)"
+                )
+
+
+def test_validate_does_not_call_session_or_require_email(files_ast):
+    """No call to validate_agent_session or _agent_requires_email anywhere."""
+    fn = _function(files_ast, "_validate_download_request")
+    banned = {"_agent_requires_email", "validate_agent_session"}
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = (
+                func.attr if isinstance(func, ast.Attribute)
+                else func.id if isinstance(func, ast.Name)
+                else None
+            )
+            assert name not in banned, (
+                f"{name} call must not appear in _validate_download_request (#568)"
+            )


### PR DESCRIPTION
## Summary

- `/api/files/{id}` was double-gating downloads: the 192-bit `sig` token (sole credential the agent can mint and pass to the recipient) **plus** a `session_token` enforced when the agent had `require_email=true`. `build_download_url` never appended `session_token`, so file sharing was permanently broken for any `require_email` agent — every link returned `401 session_token required`.
- Removes the `_agent_requires_email` import, the gate block, and the `session_token` query param from GET/HEAD `/api/files/{id}`. The `sig` is a 192-bit one-time token minted at share time and constant-time compared; layering the channel-access gate on top added no real auth and broke the feature.
- Adds an AST-based regression test (`tests/unit/test_file_download_no_session_gate.py`) that pins the new shape — fails if the gate, the import, or the param ever come back.

Closes #568.

## Test plan
- [x] `pytest unit/test_file_download_no_session_gate.py` — 5/5 pass
- [x] `pytest unit/test_agent_shared_files_migration.py unit/test_file_sharing_mixin.py` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)