### PR TITLE
docs(architecture): correct health endpoint paths to /health (#565)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -360,7 +360,7 @@ docker exec trinity-vector sh -c "tail -50 /data/logs/agents.json" | jq .
 **Internal Server:** `agent-server.py`
 - FastAPI app on port 8000
 - `/api/chat` - Claude Code execution (messages persisted to database)
-- `/api/health` - Health check
+- `/health` - Health check
 - `/api/credentials/update` - Hot-reload credentials
 - `/api/chat/session` - Context window stats
 - `/api/files` - List workspace files (recursive tree structure)
@@ -620,7 +620,7 @@ picks up on its next poll. (#389 S1a)
 | DELETE | `/api/mcp/keys/{id}` | Delete API key |
 | GET | `/oauth/{provider}/authorize` | Start OAuth |
 | GET | `/oauth/{provider}/callback` | OAuth callback |
-| GET | `/api/health` | Health check |
+| GET | `/health` | Health check (unauthenticated, top-level — no `/api/` prefix) |
 
 ### Fleet Sync Audit (#390 / S6)
 


### PR DESCRIPTION
## Summary

`docs/memory/architecture.md` listed the health endpoint as `/api/health` in two places. Actual served path is `/health` for both the backend (`main.py:893`) and agent-server (`docker/base-image/agent_server/routers/info.py:67`).

\`\`\`
$ curl -s -o /dev/null -w \"%{http_code}\\n\" http://localhost:8000/health      # 200
$ curl -s -o /dev/null -w \"%{http_code}\\n\" http://localhost:8000/api/health  # 404
\`\`\`

- Line 363 (agent-server endpoint list): `/api/health` → `/health`
- Line 623 (Auth/Users/MCP endpoint table): `/api/health` → `/health` + note that it's unauthenticated and outside the `/api/` prefix.

Closes #565.

## Test plan
- [x] `grep '/api/health' docs/memory/architecture.md` returns no results
- [x] curl confirms `/health` → 200, `/api/health` → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)