### PR TITLE
feat(dashboard): command + response/error preview on timeline hover (#514)

### DIFF
--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -481,6 +481,8 @@ class TaskExecutionService:
                         "cost_usd": metadata.get("cost_usd"),
                         "execution_time_ms": execution_time_ms,
                         "tool_count": len(response_data.get("execution_log", [])),
+                        # #514: short preview surfaced on dashboard timeline hover
+                        "response_preview": (sanitized_resp or "")[:200],
                     },
                 )
 

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -326,7 +326,8 @@
                 class="transition-all duration-300 cursor-pointer hover:opacity-90 hover:stroke-white hover:stroke-2"
                 @click="navigateToExecution(activity)"
               >
-                <title>{{ getBarTooltip(activity) }} (Click to open in new tab)</title>
+                <title>{{ getBarTooltip(activity) }}
+(Click to open in new tab)</title>
               </rect>
             </g>
 
@@ -665,7 +666,11 @@ const agentRows = computed(() => {
       scheduleName: event.schedule_name,
       // For navigation to execution details
       executionId: event.execution_id,
-      agentName: event.source_agent
+      agentName: event.source_agent,
+      // #514: previews + error text for hover tooltip
+      commandPreview: event.command_preview || '',
+      responsePreview: event.response_preview || '',
+      errorText: event.error || ''
     })
   })
 
@@ -721,7 +726,11 @@ const agentRows = computed(() => {
         scheduleName: act.scheduleName,
         // For navigation to execution details
         executionId: act.executionId,
-        agentName: act.agentName
+        agentName: act.agentName,
+        // #514: previews carried through to getBarTooltip
+        commandPreview: act.commandPreview,
+        responsePreview: act.responsePreview,
+        errorText: act.errorText
       }
     })
 
@@ -1093,7 +1102,29 @@ function getBarTooltip(activity) {
     ? `~${formatDuration(activity.durationMs)}`
     : formatDuration(activity.durationMs)
 
-  return `${prefix} ${status} - ${duration}`.trim().replace('  ', ' ')
+  // Header line — same as before.
+  const header = `${prefix} ${status} - ${duration}`.trim().replace('  ', ' ')
+
+  // #514: optional command + response/error preview lines.
+  const lines = [header]
+  const cmd = previewLine(activity.commandPreview)
+  if (cmd) lines.push(`Cmd: ${cmd}`)
+  if (activity.hasError && activity.errorText) {
+    lines.push(`Error: ${previewLine(activity.errorText)}`)
+  } else {
+    const resp = previewLine(activity.responsePreview)
+    if (resp) lines.push(`Out: ${resp}`)
+  }
+  return lines.join('\n')
+}
+
+// #514: collapse newlines, trim, truncate to 80 chars with an ellipsis.
+// Empty/whitespace-only input returns empty so the tooltip line is skipped.
+function previewLine(text) {
+  if (!text) return ''
+  const collapsed = String(text).replace(/\s+/g, ' ').trim()
+  if (!collapsed) return ''
+  return collapsed.length > 80 ? collapsed.slice(0, 80) + '…' : collapsed
 }
 
 // Schedule marker helper functions

--- a/src/frontend/src/stores/network.js
+++ b/src/frontend/src/stores/network.js
@@ -272,7 +272,13 @@ export const useNetworkStore = defineStore('network', () => {
               activity_type: activity.activity_type,
               triggered_by: activity.triggered_by,
               schedule_name: details.schedule_name || null,
-              error: activity.error
+              error: activity.error,
+              // #514: previews surfaced on timeline hover. Backend stores
+              // first 100 chars of command in details.message_preview at
+              // activity start; first 200 chars of sanitized response in
+              // details.response_preview on completion.
+              command_preview: details.message_preview || '',
+              response_preview: details.response_preview || ''
             }
           } catch (e) {
             console.warn('Failed to parse activity details:', e)


### PR DESCRIPTION
## Summary

Timeline bars on the dashboard now surface a preview on hover so it's possible to scan executions without clicking each one. Tooltip is three lines:

- **Header**: trigger type, status, duration (unchanged)
- **Cmd**: first 80 chars of the originating message
- **Out** *or* **Error**: first 80 chars of the response on success, or the error text on failure

## Pipeline

- **Backend** (`services/task_execution_service.py`): on success completion, merge `details.response_preview = sanitized_resp[:200]` into the `chat_start` activity row. Failed activities already populate `activity.error` via the existing `complete_activity(error=...)` calls.
- **Store** (`stores/network.js`): timeline mapper now exposes `command_preview` (from `details.message_preview`, already populated at start), `response_preview`, and the existing `error` on every event.
- **Component** (`components/ReplayTimeline.vue`): threads the new fields through `agentActivityMap` and `bars`. `getBarTooltip` renders the new lines via `previewLine()` — collapses whitespace, truncates to 80 chars with an ellipsis, drops the line entirely when input is empty so the tooltip stays compact.

Uses the existing SVG `<title>` primitive (same as the schedule-marker tooltip), so newline rendering is consistent. No new API round-trip — the preview data piggybacks on `/api/activities/timeline` via the existing `details` JSON field.

## Acceptance criteria

- [x] Hover shows two preview lines (cmd + response/error). Empty payloads silently skip the line so short tasks stay tidy.
- [x] Failed executions show `Error: …` in place of `Out: …`.
- [x] Works for chat, scheduled, agent-triggered, MCP, paid, and public executions — all funnel through `task_execution_service.execute_task`.
- [x] No additional API round-trip — preview ships in the existing timeline payload.
- [x] Long content truncated at 80 chars with `…`; whitespace collapsed.
- [x] Mobile graceful degradation: SVG `<title>` is hover-only; tap on a bar still opens the execution detail page (existing behaviour).

## Test plan

- [x] Backend write path verified: triggered an execution, queried the DB row → `details.response_preview` present after my change (synthetic preview rendered for visual smoke, then cleaned up).
- [x] API serves it: `GET /api/activities/timeline` returns `details.response_preview` in the activity payload.
- [x] Frontend build passes (`vite build` clean).
- [x] **Visual eyeball** required by reviewer: dashboard → Timeline mode → hover an execution bar. Confirm three lines render with `\\n` newlines.

## Notes for reviewer

I exercised the data pipeline end-to-end against the running stack. The visual tooltip rendering itself wasn't browser-tested in this session — the SVG `<title>` newline pattern is already proven by the schedule-marker tooltip in the same component, and the build is clean, but please give it a 5-second eyeball before merging.

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)