### PR TITLE
sec(ws): single-use ticket auth on /ws — drop JWT-in-URL leak (#550)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1505,9 +1505,17 @@ Agent starts → If .credentials.enc exists → Decrypt → Write files
 
 Internal endpoints (`/api/internal/`) used by the scheduler and agent containers require shared-secret authentication via `X-Internal-Secret` header. Falls back to `SECRET_KEY` if `INTERNAL_API_SECRET` env var is not set.
 
-### WebSocket Security (C-002)
+### WebSocket Security (C-002, #550)
 
-The `/ws` endpoint requires JWT authentication. Token provided via `?token=` query parameter or as first message (`Bearer <token>`, 5s timeout). Unauthenticated connections are rejected. The `/ws/events` endpoint requires MCP API key authentication (unchanged).
+The `/ws` endpoint uses **single-use opaque tickets** instead of a JWT in the URL. Browser flow:
+
+1. Authenticated client `POST /api/ws/ticket` (JWT in `Authorization` header) → backend mints a 32-byte urlsafe ticket, stores it in Redis with a 30s TTL, and returns it.
+2. Client connects to `/ws?ticket=<opaque>`. Backend atomically `GETDEL`s the Redis key (Redis 6.2+) — single-use — resolves it to the authenticated subject, and only then accepts the WebSocket.
+3. Reconnects re-mint a fresh ticket; the JWT never enters the WebSocket URL.
+
+This closes the JWT-leak surface flagged by the April 2026 remediation pentest (finding 3.2.1): nginx access logs, browser history, and upstream proxies no longer see the JWT. CSWSH is mitigated because the ticket endpoint requires the JWT in an `Authorization` header — a malicious page can't mint a ticket on the victim's behalf without an explicit cross-origin request, which CORS rejects. Implementation lives in `services/ws_ticket_service.py` + `routers/ws_tickets.py`.
+
+The `/ws/events` endpoint still uses `?token=trinity_mcp_xxx` (MCP API key) for compatibility with documented external scripts (`websocat`, `wscat`); MCP keys are scoped, named, and revocable so the leak surface is bounded relative to a JWT.
 
 **Reconnect replay (RELIABILITY-003, #306):** Both `/ws` and `/ws/events` accept an optional `?last-event-id=<stream_id>` query param. The value is regex-gated (`^\d+-\d+$`) by `validate_last_event_id()` in `services/event_bus.py` before reaching `XRANGE`; malformed input is ignored (no catchup). Catchup is capped at `REPLAY_GAP_LIMIT=5000` entries — a larger gap returns `{"type": "resync_required", "reason": "gap_too_large"}` instead of an unbounded `XRANGE`. Authorization (`accessible_agents` for `/ws/events`) is re-applied on replay, not just on live fan-out.
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -91,6 +91,7 @@ from routers.users import router as users_router
 from routers.debug import router as debug_router  # #306 soak instrumentation
 from routers.messages import router as messages_router  # Proactive Messaging (#321)
 from routers.webhooks import router as webhooks_router  # Webhook triggers (WEBHOOK-001, #291)
+from routers.ws_tickets import router as ws_tickets_router  # /ws ticket auth (#550)
 
 # Import activity service
 from services.activity_service import activity_service
@@ -746,51 +747,50 @@ app.include_router(event_subscriptions_router)  # Agent Event Subscriptions (EVT
 app.include_router(users_router)  # User Management (ROLE-001)
 app.include_router(debug_router)  # #306 soak dashboard
 app.include_router(webhooks_router)  # Webhook Triggers (WEBHOOK-001, #291)
+app.include_router(ws_tickets_router)  # WebSocket auth tickets (#550)
 
 
 # WebSocket endpoint
 @app.websocket("/ws")
 async def websocket_endpoint(
     websocket: WebSocket,
-    token: str = Query(default=None),
+    ticket: str = Query(default=None),
     last_event_id: Optional[str] = Query(default=None, alias="last-event-id"),
 ):
     """
     WebSocket endpoint for real-time updates.
 
-    Security (#178, C-002): Authentication is REQUIRED before accepting the
-    connection. The JWT token MUST be provided via query parameter:
-      /ws?token=<jwt_token>
+    Security (#178/C-002 + #550): authentication is REQUIRED before
+    ``websocket.accept()``. Clients first call ``POST /api/ws/ticket``
+    to mint a single-use 30-second opaque ticket, then connect to:
 
-    Connections without a valid token are rejected before websocket.accept()
-    to prevent any unauthenticated data leakage.
+        /ws?ticket=<opaque_ticket>
+
+    Switching from a long-lived JWT in the URL to an opaque single-use
+    ticket closes the JWT-leak surface (nginx logs, browser history,
+    upstream proxies) flagged by the April 2026 remediation pentest
+    (finding 3.2.1) and mitigates CSWSH — a malicious page can't mint
+    a ticket on the victim's behalf because the ticket endpoint requires
+    the JWT in an ``Authorization`` header.
 
     Reconnect replay (#306): clients may pass ``last-event-id=<stream_id>``
     to receive events missed during a disconnect. Malformed or too-old ids
-    produce a ``{"type": "resync_required"}`` message — the client must then
-    fetch current state via REST.
+    produce a ``{"type": "resync_required"}`` message — the client must
+    then fetch current state via REST.
     """
-    from jose import JWTError, jwt as jose_jwt
-    from config import SECRET_KEY, ALGORITHM
     from services.event_bus import validate_last_event_id
+    from services.ws_ticket_service import consume_ticket
 
-    # Reject immediately if no token provided — before accept()
-    if not token:
-        await websocket.close(code=4001, reason="Authentication required: provide ?token=<jwt>")
+    if not ticket:
+        await websocket.close(code=4001, reason="Authentication required: provide ?ticket=<opaque>")
         return
 
-    # Validate token before accepting the connection
-    try:
-        payload = jose_jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        username = payload.get("sub")
-        if not username:
-            await websocket.close(code=4001, reason="Invalid token: missing subject")
-            return
-    except JWTError:
-        await websocket.close(code=4001, reason="Invalid authentication token")
+    payload = consume_ticket(ticket)
+    if not payload or not payload.get("sub"):
+        await websocket.close(code=4001, reason="Invalid or expired WebSocket ticket")
         return
 
-    # Token validated — now accept the connection
+    # Ticket validated — now accept the connection
     await manager.connect(websocket, last_event_id=validate_last_event_id(last_event_id))
 
     try:

--- a/src/backend/routers/ws_tickets.py
+++ b/src/backend/routers/ws_tickets.py
@@ -1,0 +1,36 @@
+"""
+WebSocket auth ticket endpoint (#550).
+
+Browser clients call ``POST /api/ws/ticket`` (JWT in ``Authorization``
+header) and receive a short-lived opaque ticket they then present on
+``/ws?ticket=<ticket>``. See ``services/ws_ticket_service`` for the
+single-use Redis-backed exchange.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from dependencies import get_current_user
+from models import User
+from services.ws_ticket_service import mint_ticket
+
+router = APIRouter(prefix="/api/ws", tags=["websocket"])
+
+
+@router.post("/ticket")
+async def create_ws_ticket(current_user: User = Depends(get_current_user)) -> dict:
+    """Mint a single-use 30-second WebSocket auth ticket for the caller.
+
+    The ticket is opaque and unrelated to the JWT. Clients must call
+    this endpoint immediately before opening the WebSocket; if the
+    ticket isn't consumed within 30 seconds it expires and a new one
+    must be requested.
+    """
+    try:
+        ticket = mint_ticket(current_user.username, scope="user")
+    except RuntimeError as exc:
+        # Redis down — fail closed. Surface as 503 so the client retries.
+        raise HTTPException(status_code=503, detail=str(exc))
+
+    return {"ticket": ticket, "expires_in": 30}

--- a/src/backend/services/ws_ticket_service.py
+++ b/src/backend/services/ws_ticket_service.py
@@ -1,0 +1,112 @@
+"""
+WebSocket auth tickets (#550).
+
+Closes the JWT-in-URL leak on ``/ws`` by swapping the long-lived bearer
+token for a short-lived opaque ticket. Browser flow:
+
+    1. Client calls ``POST /api/ws/ticket`` (JWT-authed, normal Bearer).
+    2. Backend mints a 32-byte urlsafe ticket, stores it in Redis with
+       a 30-second TTL, and returns it.
+    3. Client connects to ``/ws?ticket=<ticket>``. Backend atomically
+       GETDELs the Redis key — single-use — and resolves it to the
+       authenticated subject before accepting the WebSocket.
+
+Why this matters:
+
+- The JWT no longer appears in nginx access logs, browser history,
+  or upstream proxy logs.
+- A leaked ticket is single-use and expires in 30s, so replay is
+  effectively impossible.
+- CSWSH is mitigated: a malicious page can't mint a ticket on behalf
+  of the victim because ``POST /api/ws/ticket`` requires the JWT in
+  an ``Authorization`` header (cross-origin requests would fail
+  CORS preflight or lack the header entirely).
+
+Redis is required. If Redis is unavailable ``mint_ticket`` raises;
+``consume_ticket`` returns ``None`` and the WebSocket connection is
+rejected. Failing closed is the right call for an auth path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+from typing import Optional
+
+from routers.auth import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+_TICKET_TTL_SECONDS = 30
+_TICKET_KEY_PREFIX = "ws_ticket:"
+
+
+def _key(ticket: str) -> str:
+    return f"{_TICKET_KEY_PREFIX}{ticket}"
+
+
+def mint_ticket(subject: str, *, scope: str = "user") -> str:
+    """Mint a single-use opaque WebSocket ticket.
+
+    Args:
+        subject: The authenticated principal (username for JWT users).
+        scope: Identifier for the auth surface — currently always
+            ``"user"`` for the browser ``/ws`` flow. Reserved for a
+            future ticket variant on ``/ws/events`` (MCP scope).
+
+    Returns:
+        The opaque ticket string. Hand to client; expect them to
+        present it back on the WebSocket URL within 30 seconds.
+
+    Raises:
+        RuntimeError: Redis unavailable. Auth must fail closed.
+    """
+    r = get_redis_client()
+    if r is None:
+        raise RuntimeError("Redis unavailable — cannot mint WebSocket ticket")
+
+    ticket = secrets.token_urlsafe(32)
+    payload = json.dumps({"sub": subject, "scope": scope})
+    r.setex(_key(ticket), _TICKET_TTL_SECONDS, payload)
+    return ticket
+
+
+def consume_ticket(ticket: str) -> Optional[dict]:
+    """Atomically exchange a ticket for its principal.
+
+    Uses Redis ``GETDEL`` (Redis 6.2+) so the ticket is single-use:
+    the same ticket can never authenticate two connections, even
+    under a race. Returns ``None`` if the ticket is missing,
+    expired, or already consumed.
+
+    Args:
+        ticket: The opaque ticket the client presented.
+
+    Returns:
+        ``{"sub": "<username>", "scope": "<scope>"}`` on success;
+        ``None`` on any failure mode (missing, expired, used,
+        Redis down, malformed).
+    """
+    if not ticket:
+        return None
+
+    r = get_redis_client()
+    if r is None:
+        logger.warning("Redis unavailable — rejecting WebSocket ticket exchange")
+        return None
+
+    try:
+        raw = r.getdel(_key(ticket))
+    except Exception as exc:
+        logger.warning("WebSocket ticket exchange failed: %s", exc)
+        return None
+
+    if not raw:
+        return None
+
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning("WebSocket ticket payload was not valid JSON")
+        return None

--- a/src/frontend/src/stores/network.js
+++ b/src/frontend/src/stores/network.js
@@ -535,7 +535,7 @@ export const useNetworkStore = defineStore('network', () => {
     nodes.value = result
   }
 
-  function connectWebSocket() {
+  async function connectWebSocket() {
     // Reset intentional disconnect flag when intentionally connecting
     intentionalDisconnect.value = false
 
@@ -545,15 +545,25 @@ export const useNetworkStore = defineStore('network', () => {
       return
     }
 
-    let wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws?token=${encodeURIComponent(token)}`
-    if (lastEventId.value) {
-      wsUrl += `&last-event-id=${encodeURIComponent(lastEventId.value)}`
-    }
-
     // Prevent duplicate connections
     if (websocket.value?.readyState === WebSocket.OPEN) {
       console.log('[Collaboration] WebSocket already connected')
       return
+    }
+
+    // #550: mint single-use ticket; JWT never enters the WebSocket URL.
+    let ticket
+    try {
+      const { data } = await axios.post('/api/ws/ticket')
+      ticket = data.ticket
+    } catch (err) {
+      console.error('[Collaboration] failed to mint WS ticket', err)
+      return
+    }
+
+    let wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws?ticket=${encodeURIComponent(ticket)}`
+    if (lastEventId.value) {
+      wsUrl += `&last-event-id=${encodeURIComponent(lastEventId.value)}`
     }
 
     try {

--- a/src/frontend/src/utils/websocket.js
+++ b/src/frontend/src/utils/websocket.js
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import axios from 'axios'
 import { useAgentsStore } from '../stores/agents'
 import { useNotificationsStore } from '../stores/notifications'
 import { useOperatorQueueStore } from '../stores/operatorQueue'
@@ -9,12 +10,19 @@ const isConnected = ref(false)
 // so a brief disconnect replays missed events rather than dropping them.
 let lastEventId = null
 
+// #550: mint a fresh single-use ticket immediately before each connect.
+// Tickets are 30s TTL and consumed on use, so reconnects always re-fetch.
+async function fetchWsTicket() {
+  const { data } = await axios.post('/api/ws/ticket')
+  return data.ticket
+}
+
 export function useWebSocket() {
   const agentsStore = useAgentsStore()
   const notificationsStore = useNotificationsStore()
   const operatorQueueStore = useOperatorQueueStore()
 
-  const connect = () => {
+  const connect = async () => {
     if (ws.value) return
 
     const token = localStorage.getItem('token')
@@ -23,7 +31,16 @@ export function useWebSocket() {
       return
     }
 
-    let wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws?token=${encodeURIComponent(token)}`
+    let ticket
+    try {
+      ticket = await fetchWsTicket()
+    } catch (err) {
+      console.error('WebSocket: failed to mint ticket, retrying in 5s', err)
+      setTimeout(connect, 5000)
+      return
+    }
+
+    let wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws?ticket=${encodeURIComponent(ticket)}`
     if (lastEventId) {
       wsUrl += `&last-event-id=${encodeURIComponent(lastEventId)}`
     }

--- a/tests/unit/test_ws_ticket_service.py
+++ b/tests/unit/test_ws_ticket_service.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for WebSocket ticket auth (#550).
+
+Covers ``services.ws_ticket_service``:
+
+- ``mint_ticket`` writes a ticket-keyed entry to Redis with the
+  configured TTL and returns the opaque token.
+- ``consume_ticket`` returns the principal exactly once (single-use
+  via ``GETDEL``).
+- Missing / malformed / expired tickets return ``None``.
+- Redis-down behavior fails closed (mint raises, consume returns
+  ``None``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+
+
+class _FakeRedis:
+    """In-memory stand-in for the live Redis client.
+
+    Implements the subset our service actually calls: ``setex``,
+    ``getdel``. TTLs are tracked but treated as a one-shot expire flag
+    (the ``expire_now`` helper).
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ttl: dict[str, int] = {}
+
+    def setex(self, key: str, ttl: int, value: str) -> None:
+        self.store[key] = value
+        self.ttl[key] = ttl
+
+    def getdel(self, key: str):
+        return self.store.pop(key, None)
+
+    def expire_now(self, key: str) -> None:
+        self.store.pop(key, None)
+        self.ttl.pop(key, None)
+
+
+@pytest.fixture
+def ticket_service(monkeypatch):
+    """Load ``services.ws_ticket_service`` with a stub ``routers.auth``.
+
+    Loading the module via the regular package path triggers FastAPI
+    + jose imports we don't want in a unit test. We stub the ``routers``
+    package and the only function the service needs from it
+    (``get_redis_client``).
+    """
+    fake = _FakeRedis()
+    routers_pkg = types.ModuleType("routers")
+    routers_pkg.__path__ = []
+    auth_stub = types.ModuleType("routers.auth")
+    auth_stub.get_redis_client = lambda: fake
+    monkeypatch.setitem(sys.modules, "routers", routers_pkg)
+    monkeypatch.setitem(sys.modules, "routers.auth", auth_stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "ws_ticket_service_under_test",
+        str(_BACKEND / "services" / "ws_ticket_service.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, fake, auth_stub
+
+
+def test_mint_writes_ticket_with_ttl(ticket_service):
+    module, fake, _ = ticket_service
+    ticket = module.mint_ticket("alice", scope="user")
+
+    assert isinstance(ticket, str) and len(ticket) >= 32
+    key = f"ws_ticket:{ticket}"
+    assert fake.store[key]
+    assert fake.ttl[key] == 30
+    payload = json.loads(fake.store[key])
+    assert payload == {"sub": "alice", "scope": "user"}
+
+
+def test_consume_returns_principal_then_invalidates(ticket_service):
+    module, _fake, _ = ticket_service
+    ticket = module.mint_ticket("bob")
+
+    first = module.consume_ticket(ticket)
+    second = module.consume_ticket(ticket)
+
+    assert first == {"sub": "bob", "scope": "user"}
+    assert second is None  # single-use: second exchange fails
+
+
+def test_consume_unknown_ticket_returns_none(ticket_service):
+    module, _fake, _ = ticket_service
+    assert module.consume_ticket("never-issued") is None
+    assert module.consume_ticket("") is None
+    assert module.consume_ticket(None) is None
+
+
+def test_consume_expired_ticket_returns_none(ticket_service):
+    module, fake, _ = ticket_service
+    ticket = module.mint_ticket("carol")
+    fake.expire_now(f"ws_ticket:{ticket}")
+
+    assert module.consume_ticket(ticket) is None
+
+
+def test_mint_raises_when_redis_unavailable(ticket_service, monkeypatch):
+    # The service binds ``get_redis_client`` at import time via
+    # ``from routers.auth import get_redis_client``, so we patch the
+    # name as it lives in the service module — not on the auth stub.
+    module, _fake, _auth_stub = ticket_service
+    monkeypatch.setattr(module, "get_redis_client", lambda: None)
+
+    with pytest.raises(RuntimeError, match="Redis unavailable"):
+        module.mint_ticket("alice")
+
+
+def test_consume_returns_none_when_redis_unavailable(ticket_service, monkeypatch):
+    module, _fake, _auth_stub = ticket_service
+    monkeypatch.setattr(module, "get_redis_client", lambda: None)
+
+    assert module.consume_ticket("anything") is None
+
+
+def test_consume_handles_malformed_payload(ticket_service):
+    module, fake, _ = ticket_service
+    fake.store["ws_ticket:badjson"] = "not-json"
+
+    assert module.consume_ticket("badjson") is None
+    # Even malformed, the GETDEL still removed the entry — defensive.
+    assert "ws_ticket:badjson" not in fake.store


### PR DESCRIPTION
## Summary

Closes the residual finding from the April 2026 UnderDefense remediation pentest (3.2.1, residual CVSS ~2.1): JWT in the WebSocket URL leaks into nginx access logs, browser history, and upstream proxies, and same-origin auto-cookie behavior opens a CSWSH surface.

### New flow

1. Browser `POST /api/ws/ticket` (JWT in `Authorization` header). Backend mints a 32-byte urlsafe opaque ticket, stores it in Redis with a 30s TTL, returns it.
2. Browser connects to `/ws?ticket=<opaque>`. Backend atomically `GETDEL`s the Redis key (single-use, Redis 6.2+) and resolves to the authenticated subject before `websocket.accept()`.
3. Reconnects mint a fresh ticket; **the JWT never enters the WebSocket URL**.

CSWSH is mitigated because `POST /api/ws/ticket` requires the JWT in an `Authorization` header — a malicious page can't mint a ticket on the victim's behalf without an explicit cross-origin request, which CORS rejects.

### Components

- `services/ws_ticket_service.py` — mint + atomic-`GETDEL` consume. Fails closed when Redis is down (mint raises 503; consume returns `None` → `/ws` closes 4001).
- `routers/ws_tickets.py` — `POST /api/ws/ticket` (JWT-authed).
- `main.py` `/ws` — drops `?token=` path entirely; requires `?ticket=`.
- Frontend (`utils/websocket.js` + `stores/network.js`) — fetch ticket via existing axios bearer-auth defaults, then connect with `?ticket=`. The two real `/ws` call sites are the only ones touched (`useProcessWebSocket.js` is dead code, `AgentTerminal`/`useVoiceSession` use different endpoints).

### Scope decision: /ws/events kept on ?token=

`/ws/events` (Trinity Connect for external listeners) keeps `?token=trinity_mcp_xxx` for compatibility with documented external scripts (`websocat`, `wscat`). MCP keys are scoped, named, and revocable so the leak surface is bounded relative to a JWT. If we want to ticket-gate that surface too, it's a separate follow-up — adding tickets there would require updating the Trinity Connect docs and any deployed scripts.

Closes #550.

## Test plan

- [x] Unit: `pytest unit/test_ws_ticket_service.py` — 7/7 pass (mint+GETDEL single-use, expired/missing/malformed handling, Redis-down fail-closed).
- [x] Live protocol smoke (run against the running stack):
  - `POST /api/ws/ticket` unauthed → 401 ✅
  - `POST /api/ws/ticket` with JWT → 43-char ticket ✅
  - `/ws` no params → 403 (rejected before accept) ✅
  - `/ws?ticket=<valid>` → connects, ping/pong works ✅
  - `/ws?ticket=<used>` (replay) → 403 ✅ (single-use proven)
- [x] Browser eyeball (DevTools Network → WS): dashboard shows "Connected" + "Live"; both Trinity WS connections (`websocket.js`, `network.js`) URL-show `?ticket=…` with no JWT; status 101.
- [x] Frontend build clean (`vite build`).

## Notes for reviewer

- Redis required (already a hard dependency). Failing closed on Redis-down is intentional — auth must not silently degrade.
- Old browser tabs with cached pre-#550 JS will hit `/ws?token=…` and get rejected with 403 → frontend already handles a clean reconnect via the existing `setTimeout(connect, 5000)` path. Worst case is one failed connect followed by hard refresh; no data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)