### PR TITLE
refactor(frontend): migrate ApiKeys + tier e2e tests by @smoke tag (#554/#556)

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -73,11 +73,13 @@ jobs:
           # every route to /setup. Mark setup complete directly.
           docker exec trinity-backend python3 -c "from database import db; db.set_setting('setup_completed', 'true'); print('setup_completed=true')"
 
-      - name: Run Playwright tests
+      - name: Run Playwright smoke tests
         env:
           ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD || 'CiTestPassword!1' }}
           E2E_BASE_URL: http://localhost
-        run: npm run test:e2e
+        # Only @smoke-tagged specs run in CI. @visual / @interactive specs
+        # are local-only until their flake/baseline story is sorted (#596).
+        run: npm run test:e2e:smoke
 
       - name: Collect Trinity logs on failure
         if: failure()

--- a/src/frontend/e2e/README.md
+++ b/src/frontend/e2e/README.md
@@ -19,12 +19,36 @@ caches the session in `e2e/.auth/admin.json` (gitignored).
 ## Useful flags
 
 ```bash
+npm run test:e2e:smoke      # only @smoke-tagged tests (CI parity)
 npm run test:e2e:headed     # run with visible browser
 npm run test:e2e:ui         # interactive Playwright UI
 npm run test:e2e:update     # update visual regression snapshots
 ```
 
 After a run, the HTML report is at `e2e/playwright-report/index.html`.
+
+## Spec tags
+
+Each test gets a tag in its name to control where it runs:
+
+| Tag | Runs in CI? | Purpose |
+|---|---|---|
+| `@smoke` | ✅ always | Cross-page health checks. Fast (~5s), zero flakiness. Must always pass. |
+| `@visual` | ❌ local only | Visual regression / screenshot baselines. Deferred until cross-platform baseline capture is sorted (issue #596). |
+| `@interactive` | ❌ local only | Forms, modals, multi-step flows. Local-only until stabilised. |
+
+CI runs `npm run test:e2e:smoke` (filters by `@smoke`). To promote a spec to CI, simply rename it to include `@smoke` — no workflow changes needed.
+
+```js
+// CI + local
+test('@smoke dashboard renders', async ({ page }) => { ... })
+
+// Local only (until visual regression infra lands — #596)
+test('@visual /monitoring summary cards', async ({ page }) => { ... })
+
+// Local only (interactive flow)
+test('@interactive create agent end-to-end', async ({ page }) => { ... })
+```
 
 ## CI
 

--- a/src/frontend/e2e/smoke.spec.js
+++ b/src/frontend/e2e/smoke.spec.js
@@ -1,7 +1,16 @@
 import { test, expect } from '@playwright/test'
 
+// Spec tag convention (#556 follow-up):
+//   @smoke       — must always pass; runs in CI on every `ui`-labelled PR.
+//   @visual      — visual regression / screenshot baselines; CI runs only
+//                  once cross-platform baselines exist (#596).
+//   @interactive — exercises forms, modals, multi-step flows; expensive,
+//                  usually local-only until the test is stabilised.
+//
+// CI runs `npm run test:e2e:smoke` (filters by @smoke). Locally,
+// `npm run test:e2e` runs everything.
 test.describe('smoke', () => {
-  test('dashboard renders for authenticated admin', async ({ page }) => {
+  test('@smoke dashboard renders for authenticated admin', async ({ page }) => {
     await page.goto('/')
     // Top nav has Dashboard, Agents, Templates, Health, Ops, Keys, Settings.
     await expect(page.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible({ timeout: 10000 })
@@ -9,12 +18,12 @@ test.describe('smoke', () => {
     await expect(page.getByRole('link', { name: 'Settings', exact: true })).toBeVisible()
   })
 
-  test('agents page loads', async ({ page }) => {
+  test('@smoke agents page loads', async ({ page }) => {
     await page.goto('/agents')
     await expect(page.getByText(/agent|create/i).first()).toBeVisible({ timeout: 10000 })
   })
 
-  test('operating room page loads', async ({ page }) => {
+  test('@smoke operating room page loads', async ({ page }) => {
     await page.goto('/operating-room')
     // Either a queue list, filters, an empty state, or the title.
     await expect(
@@ -22,16 +31,24 @@ test.describe('smoke', () => {
     ).toBeVisible({ timeout: 10000 })
   })
 
-  test('templates page loads', async ({ page }) => {
+  test('@smoke templates page loads', async ({ page }) => {
     await page.goto('/templates')
     await expect(page.getByText(/template/i).first()).toBeVisible({ timeout: 10000 })
   })
 
-  test('monitoring page loads', async ({ page }) => {
+  test('@smoke monitoring page loads', async ({ page }) => {
     await page.goto('/monitoring')
     // Header, summary cards, or empty state — any of these confirms the route mounted.
     await expect(
       page.getByText(/monitoring|fleet|healthy|degraded|no agents/i).first()
+    ).toBeVisible({ timeout: 10000 })
+  })
+
+  test('@smoke api keys page loads', async ({ page }) => {
+    await page.goto('/api-keys')
+    // Header, info banner, list, or empty state — any confirms the route mounted.
+    await expect(
+      page.getByText(/mcp api keys|connect to mcp|no api keys|create api key/i).first()
     ).toBeVisible({ timeout: 10000 })
   })
 })

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,6 +7,7 @@
     "preview": "vite preview",
     "check:tokens": "node scripts/check-design-tokens.mjs",
     "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test --grep @smoke",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:update": "playwright test --update-snapshots"

--- a/src/frontend/src/views/ApiKeys.vue
+++ b/src/frontend/src/views/ApiKeys.vue
@@ -23,19 +23,19 @@
         </div>
 
         <!-- MCP Connection Info -->
-        <div class="bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-6">
+        <div class="bg-status-info-50 dark:bg-status-info-900/30 border border-status-info-200 dark:border-status-info-800 rounded-lg p-4 mb-6">
           <div class="flex">
             <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="h-5 w-5 text-status-info-400" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
               </svg>
             </div>
             <div class="ml-3 flex-1">
-              <h3 class="text-sm font-medium text-blue-800 dark:text-blue-300">Connect to MCP Server</h3>
-              <p class="text-sm text-blue-700 dark:text-blue-400 mt-1">
-                Add this to your <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">.mcp.json</code> configuration:
+              <h3 class="text-sm font-medium text-status-info-800 dark:text-status-info-300">Connect to MCP Server</h3>
+              <p class="text-sm text-status-info-700 dark:text-status-info-400 mt-1">
+                Add this to your <code class="bg-status-info-100 dark:bg-status-info-800 px-1 rounded">.mcp.json</code> configuration:
               </p>
-              <pre class="mt-2 bg-blue-100 dark:bg-blue-800 rounded p-3 text-xs overflow-x-auto text-blue-900 dark:text-blue-100">{
+              <pre class="mt-2 bg-status-info-100 dark:bg-status-info-800 rounded p-3 text-xs overflow-x-auto text-status-info-900 dark:text-status-info-100">{
   "mcpServers": {
     "trinity": {
       "type": "http",
@@ -71,8 +71,8 @@
                 <div class="flex items-center flex-1">
                   <div class="flex-shrink-0">
                     <div class="h-10 w-10 rounded-full flex items-center justify-center"
-                         :class="key.is_active ? 'bg-green-100 dark:bg-green-900/50' : 'bg-red-100 dark:bg-red-900/50'">
-                      <svg class="h-6 w-6" :class="key.is_active ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                         :class="key.is_active ? 'bg-status-success-100 dark:bg-status-success-900/50' : 'bg-status-danger-100 dark:bg-status-danger-900/50'">
+                      <svg class="h-6 w-6" :class="key.is_active ? 'text-status-success-600 dark:text-status-success-400' : 'text-status-danger-600 dark:text-status-danger-400'" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
                       </svg>
                     </div>
@@ -81,11 +81,11 @@
                     <div class="flex items-center">
                       <h3 class="text-sm font-medium text-gray-900 dark:text-white">{{ key.name }}</h3>
                       <span class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
-                            :class="key.is_active ? 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300' : 'bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-300'">
+                            :class="key.is_active ? 'bg-status-success-100 dark:bg-status-success-900/50 text-status-success-800 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 text-status-danger-800 dark:text-status-danger-300'">
                         {{ key.is_active ? 'Active' : 'Revoked' }}
                       </span>
                       <!-- Scope badge for admin visibility -->
-                      <span v-if="key.scope === 'agent'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-300">
+                      <span v-if="key.scope === 'agent'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-purple-100 dark:bg-accent-purple-900/50 text-accent-purple-800 dark:text-accent-purple-300">
                         Agent
                       </span>
                       <span v-else-if="key.scope === 'system'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-900/50 text-orange-800 dark:text-orange-300">
@@ -118,13 +118,13 @@
                   <button
                     v-if="key.is_active"
                     @click="revokeKey(key.id)"
-                    class="inline-flex items-center px-3 py-1.5 border border-yellow-300 dark:border-yellow-600 shadow-sm text-xs font-medium rounded text-yellow-700 dark:text-yellow-300 bg-white dark:bg-gray-700 hover:bg-yellow-50 dark:hover:bg-yellow-900/30"
+                    class="inline-flex items-center px-3 py-1.5 border border-status-warning-300 dark:border-status-warning-600 shadow-sm text-xs font-medium rounded text-status-warning-700 dark:text-status-warning-300 bg-white dark:bg-gray-700 hover:bg-status-warning-50 dark:hover:bg-status-warning-900/30"
                   >
                     Revoke
                   </button>
                   <button
                     @click="deleteKey(key.id)"
-                    class="inline-flex items-center px-3 py-1.5 border border-red-300 dark:border-red-600 shadow-sm text-xs font-medium rounded text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/30"
+                    class="inline-flex items-center px-3 py-1.5 border border-status-danger-300 dark:border-status-danger-600 shadow-sm text-xs font-medium rounded text-status-danger-700 dark:text-status-danger-300 bg-white dark:bg-gray-700 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/30"
                   >
                     Delete
                   </button>
@@ -195,21 +195,21 @@
         <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
           <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="flex items-center mb-4">
-              <div class="flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 dark:bg-green-900/50">
-                <svg class="h-6 w-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div class="flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-status-success-100 dark:bg-status-success-900/50">
+                <svg class="h-6 w-6 text-status-success-600 dark:text-status-success-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                 </svg>
               </div>
               <h3 class="ml-4 text-lg font-medium text-gray-900 dark:text-white">Your MCP API Key is Ready!</h3>
             </div>
 
-            <div class="bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4">
+            <div class="bg-status-warning-50 dark:bg-status-warning-900/30 border border-status-warning-200 dark:border-status-warning-800 rounded-lg p-4 mb-4">
               <div class="flex">
-                <svg class="h-5 w-5 text-yellow-400 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <svg class="h-5 w-5 text-status-warning-400 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
                 </svg>
                 <div class="ml-3">
-                  <p class="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+                  <p class="text-sm font-medium text-status-warning-800 dark:text-status-warning-300">
                     Copy the configuration below before closing - the key won't be shown again!
                   </p>
                 </div>
@@ -228,7 +228,7 @@
                     @click="copyMcpConfig"
                     class="inline-flex items-center px-3 py-1 text-xs font-medium rounded-md"
                     :class="copiedConfig
-                      ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300'
+                      ? 'bg-status-success-100 dark:bg-status-success-900/50 text-status-success-700 dark:text-status-success-300'
                       : 'bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-200 dark:hover:bg-indigo-900'"
                   >
                     <svg v-if="!copiedConfig" class="h-3.5 w-3.5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -274,7 +274,7 @@
                     <svg v-if="!copied" class="h-5 w-5 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                     </svg>
-                    <svg v-else class="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg v-else class="h-5 w-5 text-status-success-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                     </svg>
                   </button>


### PR DESCRIPTION
## Summary
**Two changes folded into one PR** (per request — the e2e tagging belongs alongside the next sweep slice):

1. **#554 slice 3** — Migrate \`/api-keys\` view to design-system tokens. 19 raw color refs → status/accent tokens.
2. **#556 follow-up** — Establish a tag-and-grep convention for the e2e suite so CI runs only the cheap reliable subset (@smoke), with @visual / @interactive specs reserved for local runs.

## Part 1 — ApiKeys migration (slice 3)

| Element | Token |
|---|---|
| Active / Revoked indicator + badge | \`status-success\` / \`status-danger\` |
| Revoke button | \`status-warning\` |
| Delete button | \`status-danger\` |
| "Connect to MCP Server" info banner (icon, headings, code blocks) | \`status-info\` |
| "Copy before closing" warning banner | \`status-warning\` |
| Modal success checkmark + "Copied!" state | \`status-success\` |
| "Agent" scope tag | \`accent-purple\` |

**Deferred (same pattern as slice 1 & 2):**
- Indigo primary action buttons ("Create API Key", "Create", "I've copied") — needs \`action-primary\` token
- "System" scope tag (orange) — needs \`accent-orange\` or \`brand-system\` token

## Part 2 — e2e tag convention

Three tiers, controlled by test name prefix and \`--grep\`:

| Tag | Runs in CI? | Purpose |
|---|---|---|
| \`@smoke\` | ✅ always | Cross-page health checks. Fast (~5s), zero flakiness. |
| \`@visual\` | ❌ local-only | Screenshot baselines. Promoted to CI once cross-platform infra lands (#596). |
| \`@interactive\` | ❌ local-only | Forms / modals / multi-step. Promoted once stable. |

**Changes:**
- \`smoke.spec.js\` — every test renamed with \`@smoke\` prefix; new \`@smoke api keys page loads\` test added.
- \`package.json\` — new \`test:e2e:smoke\` script (\`playwright test --grep @smoke\`).
- \`frontend-e2e.yml\` — CI step switched from \`test:e2e\` to \`test:e2e:smoke\`.
- \`e2e/README.md\` — convention documented.

**Why this matters:** without tagging, the only options when a test starts flaking are "fix it right now" or "disable CI entirely". With tagging, the answer is "rename to \`@interactive\` and file a follow-up". Future visual regression specs (#596) get added as \`@visual\` and don't block CI until they're ready.

## Files
\`\`\`
src/frontend/src/views/ApiKeys.vue   38 lines, 19 token replacements
src/frontend/e2e/smoke.spec.js       6 tests now @smoke-tagged + 1 new (api-keys)
src/frontend/package.json            adds test:e2e:smoke script
src/frontend/e2e/README.md           tag convention table
.github/workflows/frontend-e2e.yml   runs the @smoke filter
\`\`\`

5 files, +69 / −25.

## Test plan
- [x] \`npm run check:tokens\` passes (10 tokens, all references resolve)
- [x] \`npm run build\` succeeds
- [ ] CI \`frontend-build\` passes
- [ ] CI \`frontend-e2e\` passes — smoke subset (5 → 6 tests with the new \`/api-keys\`)
- [ ] Visual smoke at http://localhost/api-keys — colors should look identical to before

Refs #554 #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)