### PR TITLE
feat(web-chat): file upload for web and public chat (#364)

### DIFF
--- a/.claude/skills/cso/SKILL.md
+++ b/.claude/skills/cso/SKILL.md
@@ -132,13 +132,34 @@ For each workflow file in `.github/workflows/`:
 
 **Docker socket access**: Check if backend has Docker socket mounted and what permissions it has.
 
-**Severity**: CRITICAL for prod DB URLs with credentials in committed config. HIGH for root containers in prod / Docker socket access without read-only. MEDIUM for missing USER directive / exposed ports.
+**Redis authentication and network isolation**:
+- Check `redis.conf` or Docker env for `requirepass` — unauthenticated Redis reachable from the agent container network is CRITICAL (agents get full read/write to all task queues and secrets including other tenants')
+- Check if agent containers have direct TCP access to Redis (e.g., `redis:6379`) — they should reach the platform only via the backend HTTP API, not the Redis port directly
+- Check Redis keyspace for per-user isolation — if all users share a Redis namespace without user-scoped key prefixes, cross-tenant enumeration is possible even with auth
+
+**Docker `base_image` allowlist**:
+- Search agent creation code for the `base_image` field — verify it's validated against an allowlist (regex or explicit list), not accepted as free text from the API request body
+- An unvalidated `base_image` lets any authenticated user pull and execute arbitrary Docker images inside the agent network, giving access to Redis, the MCP server, and credential env vars
+
+**Setup/onboarding endpoint exposure**:
+- Check if the first-run setup endpoint (`/api/setup`, `/setup`, etc.) is network-accessible or bound to 127.0.0.1 only
+- If accessible from the public internet, check whether it uses a single-use bootstrapping token to prevent a race-condition hijack granting full admin control to an external caller
+
+**Severity**: CRITICAL for Redis without auth accessible from agent network. CRITICAL for unvalidated `base_image`. HIGH for setup endpoint reachable from public internet without a single-use token. HIGH for root containers in prod / Docker socket access without read-only. MEDIUM for missing USER directive / exposed ports.
 
 **FP rules**: `docker-compose.yml` for local dev with localhost = not a finding.
 
 ### Phase 6: Webhook & Integration Audit
 
 **Webhook routes**: Find files containing webhook/hook/callback route patterns. Check whether they also contain signature verification.
+
+**Internal endpoint auth completeness**:
+- For every route in the internal router (routes under `/api/internal/` or any "internal" prefix), verify each endpoint enforces the shared-secret header (`X-Internal-Secret`) — not just that the pattern exists in the file, but that every individual route uses it
+- Probe: send request to each internal endpoint without the header and confirm 401/403, not 200
+
+**Webhook trigger auth (not just signature)**:
+- For webhook trigger endpoints, check for the presence of `Depends(get_current_user)` or an equivalent auth gate — not just HMAC signature verification
+- Trigger routes have been found missing auth entirely while signature verification exists elsewhere in the same file; the two are independent checks
 
 **TLS verification disabled**: Search for `verify=False`, `VERIFY_NONE`, etc.
 
@@ -156,8 +177,9 @@ Trinity-specific AI security concerns:
 - **AI API keys in code**: Hardcoded API key assignments (not env vars)
 - **Credential injection safety**: Are injected credentials exposed to agent code in unexpected ways?
 - **Cost/resource attacks**: Can a user trigger unbounded LLM calls via agent chat?
+- **Agent container network reach**: From inside an agent container, check what internal services are directly reachable (Redis, MCP server backend port, etc.). Agent containers should reach the platform only through the backend HTTP API — direct TCP access to Redis, internal service ports, or other agents' containers outside the API layer is a CRITICAL isolation failure. Check `docker-compose.yml` network definitions and confirm agent containers cannot reach `redis:6379` or `mcp-server:8080` directly.
 
-**Severity**: CRITICAL for user input in system prompts / unsanitized LLM output rendered as HTML. HIGH for missing tool call validation / exposed AI API keys. MEDIUM for unbounded LLM calls.
+**Severity**: CRITICAL for user input in system prompts / unsanitized LLM output rendered as HTML. CRITICAL for agent containers with direct Redis or internal service access bypassing the API. HIGH for missing tool call validation / exposed AI API keys. MEDIUM for unbounded LLM calls.
 
 **FP rules**: User content in the user-message position of an AI conversation is NOT prompt injection.
 
@@ -178,10 +200,14 @@ For each OWASP category, perform targeted analysis. Scope file extensions to Pyt
 - Missing auth on routes (check FastAPI dependency injection for auth)
 - Direct object reference (can user A access user B's agents by changing IDs?)
 - Horizontal/vertical privilege escalation
+- **Internal router completeness**: Every endpoint in the internal router must use the shared-secret dependency — audit the full router, not a sample. No route should return 200 without the secret header.
+- **Role-permission consistency across ALL creation routes**: For each resource-creation endpoint (`POST /api/agents`, `/api/processes`, `/deploy-local`, webhook-triggered deployments, etc.), verify the same role-check dependency is used. The lowest-privilege role must not bypass the creation gate via any alternate route.
+- **File-write path policy completeness**: For any file-write API, verify the path-deny/allowlist is evaluated in full — not just basename matching. Specifically check: can `.mcp.json`, `.env`, `.credentials.enc`, or `.ssh/*` be reached via path traversal or a sibling endpoint (e.g., `/credentials/inject`) that enforces a shorter deny list?
 
 #### A02: Cryptographic Failures
 - Weak crypto (MD5, SHA1, DES, ECB) or hardcoded secrets
 - JWT implementation (algorithm, expiration, secret management)
+- **SSH key server-side generation**: Check if SSH private keys are generated server-side and returned in API responses. Flag as HIGH — clients should generate keypairs locally and submit only the public key. Server-generated private keys are exposed in transit and in API/access logs.
 
 #### A03: Injection
 - SQL injection: raw queries, string interpolation in SQL (check `database.py`)
@@ -192,6 +218,8 @@ For each OWASP category, perform targeted analysis. Scope file extensions to Pyt
 - Rate limits on authentication endpoints?
 - Account lockout after failed attempts?
 - Business logic validated server-side?
+- **Rate limiting quality**: Per-IP-only rate limits are bypassable via rotating proxies/Tor/IPv6 subnets. Check that rate limiting on auth endpoints (login, OTP, password reset) uses a per-account/per-email counter as the primary bucket. Also check that hard lockout on IP isn't itself a DoS primitive — progressive delay or CAPTCHA is safer than a hard block.
+- **OTP brute-force window**: For email OTP flows, verify the code space (6 digits = 1M possibilities) is protected by an attempt counter that survives process restarts (stored in Redis/DB, not in-memory), and that codes expire within 5–10 minutes.
 
 #### A05: Security Misconfiguration
 - CORS configuration (wildcard origins?)

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -11,6 +11,7 @@
 
 | Date | ID | Feature | Flow |
 |------|-----|---------|------|
+| 2026-04-30 | #364 | Web chat file upload — drag-drop/picker in ChatPanel and PublicChat; base64 JSON encoding; shared upload_service; images via vision blocks, non-images via Docker put_archive | [web-chat-file-upload.md](feature-flows/web-chat-file-upload.md) |
 | 2026-04-27 | #539 | fix: public chat context duplication — `build_public_chat_context()` now called before `add_public_chat_message(role="user")`, preventing current message appearing twice in every agent prompt | [public-agent-links.md](feature-flows/public-agent-links.md) |
 | 2026-04-26 | #428 | CapacityManager facade — single public surface for capacity (admit / release / overflow policy / status / reclaim) replacing ExecutionQueue + SlotService + BacklogService trio | [capacity-management.md](feature-flows/capacity-management.md) |
 | 2026-04-26 | #516, #520 | Agent error classification — `_classify_signal_exit()` (504 for SIGINT/SIGKILL/SIGTERM, was misread as 503 auth) and `_classify_empty_result()` (502 when clean exit drops the final result message, was silent 200 + watchdog reap) | [parallel-headless-execution.md](feature-flows/parallel-headless-execution.md), [task-execution-service.md](feature-flows/task-execution-service.md) |
@@ -310,6 +311,12 @@
 | API Keys Page | [api-keys-page.md](feature-flows/api-keys-page.md) | `/api-keys` page UI flow |
 | Agents Page UI | [agents-page-ui-improvements.md](feature-flows/agents-page-ui-improvements.md) | Horizontal row tiles with success rate bars, filtering, responsive breakpoints |
 | Alerts Page | [alerts-page.md](feature-flows/alerts-page.md) | Removed in #430 (process engine deletion; cost alerts were PE-only) |
+
+### File Management
+
+| Flow | Document | Description |
+|------|----------|-------------|
+| Web Chat File Upload | [web-chat-file-upload.md](feature-flows/web-chat-file-upload.md) | Drag-drop/picker for authenticated and public chat; shared upload_service (#364) |
 
 ### Chat & Sessions
 

--- a/docs/memory/feature-flows/parallel-headless-execution.md
+++ b/docs/memory/feature-flows/parallel-headless-execution.md
@@ -562,9 +562,14 @@ Note: Async mode on the `/api/agents/{name}/task` endpoint does **not** use `Tas
 class ParallelTaskRequest(BaseModel):
     # ... existing fields ...
     async_mode: Optional[bool] = False  # If true, return immediately with execution_id
+    files: Optional[List[WebFileUpload]] = None  # File attachments (#364)
 ```
 
-**Background Task Handler** (`src/backend/routers/chat.py:438-650`):
+**File upload** (#364): `execute_parallel_task` decodes files synchronously (before async/sync fork)
+via `upload_service.process_file_uploads()`. Images become vision blocks in `execute_task(images=)`;
+text files are written to `/home/developer/uploads/{user_id}/` before the execution ID is returned.
+
+**Background Task Handler** (`src/backend/routers/chat.py:608-800`):
 ```python
 async def _run_async_task_with_persistence(
     agent_name: str,
@@ -577,6 +582,7 @@ async def _run_async_task_with_persistence(
     subscription_id: Optional[str] = None,
     is_self_task: bool = False,
     self_task_activity_id: Optional[str] = None,
+    images: Optional[list] = None,  # (#364) pre-decoded vision blocks
 ):
     """
     Async /task background wrapper (issue #95).

--- a/docs/memory/feature-flows/slack-file-sharing.md
+++ b/docs/memory/feature-flows/slack-file-sharing.md
@@ -27,14 +27,16 @@ ChannelMessageRouter._handle_message_inner()
 Step 3b: File upload rate limit (5/min per user)
   ↓
 Step 7b: _handle_file_uploads(adapter, message, agent_name, container, session_id)
+  → downloads each file via adapter.download_file() → assembles raw_files list
+  → delegates to services/upload_service.process_file_uploads() (#364)
   ↓
-For each file:
+process_file_uploads() for each file:
   ├── Unsupported format? → skip with message
-  ├── _sanitize_filename(): NFKC + basename + safe-chars + 200-char
+  ├── sanitize_filename(): NFKC + basename + safe-chars + 200-char
   │     truncation + collision dedup (-1, -2, …) (#487)
-  ├── adapter.download_file() → bytes (channel-agnostic)
-  ├── Image? → base64 → "[File uploaded by {uploader}]: name (size) — image
-  │     attached inline\n![name](data:mime;base64,…)"
+  ├── size check against limit
+  ├── magic-byte MIME validation (python-magic, graceful fallback)
+  ├── Image? → base64 vision block → image_data list (via stream-json)
   └── Text?  → tar archive → container_put_archive to uploads/{session_id}/
               → "[File uploaded by {uploader}]: name (size) saved to {path}"
   ↓
@@ -68,22 +70,28 @@ No frontend changes. File handling is entirely backend (Slack → adapter → ro
 
 ### Message Router (`adapters/message_router.py`)
 - Step 3b: File upload rate limit (`_FILE_UPLOAD_RATE_LIMIT_MAX=5`, 60s window)
-- Step 7b: `_handle_file_uploads(verified_email=...)` — download, route by type,
-  copy/embed; returns `(descriptions, upload_dir, all_writes_failed)`
-- Filename sanitization (`_sanitize_filename`, #487): NFKC unicode normalize
-  → `os.path.basename` → safe-chars regex → `file_{id}` fallback (empty,
-  dot-only, or hidden dotfiles like `.env`) → 200-char truncation preserving
-  extension → collision dedup with `-1`, `-2`, … suffix
-- Session ID sanitization: `re.sub(r"[^a-zA-Z0-9_-]", "_", session_id)` for shell safety
+- Step 7b: `_handle_file_uploads(verified_email=...)` — downloads each file via
+  `adapter.download_file()`, then delegates to `upload_service.process_file_uploads()` (#364)
+  The inline validation/write logic was extracted to the shared service so web chat
+  (ChatPanel, PublicChat) reuses the same path
+- `_sanitize_filename()` and `_format_file_size()` in this file delegate to
+  `services/upload_service.sanitize_filename()` / `format_file_size()`
 - Chat injection format: `[File uploaded by {uploader}]: {name} ({size}) saved
   to {path}` — `uploader` is the verified email (Issue #311) or
   `adapter.get_source_identifier(message)`
-- Image budget: 5MB/image, 10MB total, excess skipped
-- Unsupported MIME rejection: PDF, ZIP, tar, gzip, rar, video/*, audio/*
-- Allowed tools: `Read` added only for non-image files
 - All-writes-failed handling: when every write attempt fails, reply via
   channel with explicit error and skip agent execution (#487 AC6)
 - Cleanup on all exit paths (success, task failure, exception, all-failed abort)
+
+### Upload Service (`services/upload_service.py`) — shared since #364
+- `process_file_uploads()` — core logic: sanitize, size-check, MIME-validate, image/file dispatch
+- `sanitize_filename()`: NFKC normalize → `os.path.basename` → safe-chars → hidden-dotfile
+  rejection → 200-char truncation → collision dedup with `-1`, `-2`, … suffix (#487)
+- Channel limits: `CHANNEL_MAX_FILES=10`, `CHANNEL_MAX_FILE_SIZE=10MB`
+- Image budget: `CHANNEL_MAX_IMAGE_SIZE=5MB`, `CHANNEL_MAX_TOTAL_IMAGE_SIZE=10MB`
+- Unsupported MIME rejection: PDF, ZIP, tar, gzip, rar, video/*, audio/*
+- Magic-byte MIME validation via python-magic (graceful fallback if unavailable)
+- Session ID sanitized with `re.sub(r"[^a-zA-Z0-9_-]", "_", session_id)` for shell safety
 
 ### Slack Service (`services/slack_service.py`)
 - `download_file(bot_token, url, max_size)`: GET with Authorization header, follow redirects, 10MB cap
@@ -153,3 +161,4 @@ No frontend changes. File handling is entirely backend (Slack → adapter → ro
 
 - [slack-channel-routing.md](slack-channel-routing.md) — Channel adapter abstraction (SLACK-002)
 - [slack-integration.md](slack-integration.md) — Original Slack integration (SLACK-001)
+- [web-chat-file-upload.md](web-chat-file-upload.md) — Web chat file upload (ChatPanel + PublicChat), uses same shared upload_service (#364)

--- a/docs/memory/feature-flows/web-chat-file-upload.md
+++ b/docs/memory/feature-flows/web-chat-file-upload.md
@@ -1,0 +1,306 @@
+# Feature: Web Chat File Upload
+
+## Overview
+Adds drag-and-drop / file-picker to authenticated chat (ChatPanel.vue) and public chat (PublicChat.vue), encoding files as base64 in the JSON request body and reusing the same validation/write infrastructure as the Telegram/Slack/WhatsApp channel adapters.
+
+## User Story
+As a user chatting with an agent, I want to attach files to my message so that the agent can visually analyze images or read text/CSV/JSON files I provide.
+
+## Entry Points
+- **UI (auth)**: `src/frontend/src/components/chat/ChatInput.vue` — paperclip button / drag-and-drop on wrapper div
+- **UI (public)**: `src/frontend/src/views/PublicChat.vue:745` — same ChatInput component embedded in public chat
+- **API (auth)**: `POST /api/agents/{name}/task`
+- **API (public)**: `POST /api/public/chat/{token}`
+
+## Frontend Layer
+
+### Components
+
+**`src/frontend/src/components/chat/ChatInput.vue`**
+
+Key state (lines 272-274):
+- `pendingFiles` ref — `[{name, mimetype, size, data_base64}]`
+- `fileInputRef` ref — hidden `<input type="file">`
+- `dragOver` ref — boolean for drag-over highlight
+
+Client-side limits (lines 226-227):
+```javascript
+const MAX_FILES = 3
+const MAX_FILE_BYTES = 5 * 1024 * 1024  // 5 MB
+```
+
+File encoding (lines 404-425):
+```javascript
+function encodeFile(file) {
+  return new Promise((resolve) => {
+    const reader = new FileReader()
+    reader.onload = (e) => resolve(e.target.result)  // data: URI
+    reader.readAsDataURL(file)
+  })
+}
+
+async function addFiles(fileList) {
+  // Reads each file via FileReader.readAsDataURL → data: URI string
+  // Parses MIME from data: URI prefix (not file.type — unreliable cross-browser)
+  // Checks size <= MAX_FILE_BYTES; alerts and skips oversized files
+  pendingFiles.value.push({ name, mimetype, size, data_base64 })
+}
+```
+
+Drop / picker handlers (lines 428-442):
+- `onFileInputChange` — triggered by hidden `<input>`; resets input value to allow re-selection
+- `onDrop` — handles `@drop.prevent` on wrapper div; delegates to `addFiles`
+- `removeFile(idx)` — removes chip from preview list
+
+Submit (lines 445-457):
+```javascript
+function handleSubmit() {
+  emit('submit', localMessage.value.trim(), [...pendingFiles.value])
+  pendingFiles.value = []
+}
+```
+
+**`src/frontend/src/components/ChatPanel.vue:606`**
+```javascript
+const sendMessage = async (userMessage, files = []) => {
+  const payload = {
+    message: contextPrompt,
+    async_mode: true,
+    files: files.length > 0 ? files : undefined,
+    // ...other fields
+  }
+  // POST /api/agents/{name}/task
+}
+```
+
+**`src/frontend/src/views/PublicChat.vue:745`**
+```javascript
+const sendMessage = async (userMessage, files = []) => {
+  const payload = {
+    message: userMessage,
+    async_mode: true,
+    files: files.length > 0 ? files : undefined,
+  }
+  // POST /api/public/chat/{token}
+}
+```
+
+### nginx
+`src/frontend/nginx.conf:8`:
+```nginx
+client_max_body_size 25m;
+```
+Required because 3 files × 5 MB each, base64-encoded in JSON, is approximately 21 MB. Without this directive nginx silently rejects the request with 413 before it reaches the backend.
+
+## Backend Layer
+
+### Models
+
+**`src/backend/db_models.py:430`** — `WebFileUpload`:
+```python
+class WebFileUpload(BaseModel):
+    name: str
+    mimetype: str
+    size: int
+    data_base64: str  # raw base64 or data: URI from FileReader.readAsDataURL()
+```
+
+**`src/backend/db_models.py:444`** — `PublicChatRequest.files`:
+```python
+files: Optional[List[WebFileUpload]] = None  # (#364)
+```
+
+**`src/backend/models.py:99`** — `ParallelTaskRequest.files`:
+```python
+files: Optional[List[WebFileUpload]] = None  # (#364)
+```
+
+### Endpoints
+
+**Authenticated chat** — `src/backend/routers/chat.py:858-894` (`execute_parallel_task`):
+- File processing block runs synchronously before the async/sync fork
+- `session_id` is `str(current_user.id)` (stable per user, scopes the upload directory)
+- `uploader` is `current_user.email or current_user.username`
+- On `all_writes_failed=True` → `502` with `"File upload failed: could not write to agent workspace."`
+- Appends file descriptions to `request.message` as a newline-joined block
+
+**Public chat** — `src/backend/routers/public.py:493-527` (`public_chat`):
+- Same pattern; `session_id` is `session_identifier` (the anonymous token or email)
+- `uploader` is `verified_email or f"anonymous ({client_ip})"`
+- File descriptions appended to `context_prompt` (not `chat_request.message`) so the stored user message doesn't contain the injection block
+- Images passed as `images=_pub_image_data` to both `_execute_public_chat_background` and `execute_task`
+
+### Shared Upload Service
+
+**`src/backend/services/upload_service.py`** — extracted from `adapters/message_router._handle_file_uploads()`.
+
+**`decode_web_file(f: dict) -> Optional[bytes]`** (line 345):
+- Strips `data:mime;base64,` prefix from FileReader output
+- Falls back to raw base64 if no prefix present
+- Returns `None` on decode failure
+
+**`sanitize_filename(name, file_id, used_names) -> str`** (line 62):
+- NFKC normalize → `os.path.basename` → strip unsafe chars via `[^\w.\-()]` regex
+- Rejects hidden filenames starting with `.` (e.g., `.env`, `.gitignore`)
+- Truncates to 200 chars (preserves extension up to 16 chars)
+- Collision dedup: appends `-1`, `-2`, … suffix
+
+**`process_file_uploads(raw_files, agent_name, container, session_id, uploader, source, ...) -> (descriptions, upload_dir, all_writes_failed, image_data)`** (line 119):
+
+```
+for each file (up to max_files):
+  1. sanitize_filename() — NFKC, path traversal, dedup
+  2. Reject unsupported MIME categories (PDF, ZIP, TAR, video/, audio/)
+  3. Actual size check against declared limit (TOCTOU defense)
+  4. Magic-byte MIME validation via python-magic (graceful fallback):
+     - Image MIME mislabel (JPEG vs PNG) → accept with detected MIME
+     - text/plain vs text/csv → accept
+     - Other mismatch → reject with "file type mismatch"
+  5a. If image → base64-encode → append to image_data list (vision blocks)
+  5b. If non-image → container mkdir -p + put_archive to /home/developer/uploads/{session_id}/
+  6. Emit platform_audit_service.log(event_type=EXECUTION, event_action="file_upload")
+```
+
+Returns:
+- `descriptions` — list of context strings injected into the agent prompt
+- `upload_dir` — container path for cleanup, or `None` if no non-image writes occurred
+- `all_writes_failed` — `True` when at least one write was attempted but all failed
+- `image_data` — `[{"media_type": str, "data": base64_str}]` for `execute_task(images=...)`
+
+**Constants** (lines 35-43):
+| Constant | Value |
+|----------|-------|
+| `WEB_MAX_FILES` | 3 |
+| `WEB_MAX_FILE_SIZE` | 5 MB |
+| `WEB_MAX_IMAGE_SIZE` | 5 MB |
+| `WEB_MAX_TOTAL_IMAGE_SIZE` | 10 MB |
+| `CHANNEL_MAX_FILES` | 10 |
+| `CHANNEL_MAX_FILE_SIZE` | 10 MB |
+
+### Business Logic
+
+1. Frontend encodes file via `FileReader.readAsDataURL` → `data: URI`
+2. `decode_web_file()` strips prefix → raw bytes
+3. `process_file_uploads()` validates, MIME-checks, and routes:
+   - Images → base64 collected in `image_data` list
+   - Non-images → written to `/home/developer/uploads/{session_id}/{filename}` in the running container via Docker `put_archive`
+4. File descriptions appended to the message text
+5. `task_execution_service.execute_task(images=image_data)` invokes Claude Code with `--input-format stream-json`, delivering images as vision content blocks (not embedded text)
+6. Text files are readable by the agent at `/home/developer/uploads/{session_id}/`
+
+### Docker Operations
+- `container_exec_run(container, f"mkdir -p {upload_dir}", user="developer")` — create upload directory
+- `container_put_archive(container, upload_dir, tar_bytes)` — write file into container via tar stream with uid/gid 1000, mode 0o644
+
+## Agent Layer
+
+Images are passed through to Claude Code via `--input-format stream-json` as content blocks. There is no agent-server endpoint involved; the backend writes files directly into the agent container (Docker SDK) and passes image bytes through the existing `execute_task` path.
+
+## Side Effects
+
+- **Audit log**: `platform_audit_service.log(event_type=EXECUTION, event_action="file_upload")` fires once per successfully processed file; records filename, size, MIME, storage type (`stream_json_vision` for images, `container_file` for non-images), uploader, sender_id, channel_id, agent_name
+- **No WebSocket broadcast** specific to file uploads; the enclosing chat execution broadcasts normally via activity tracking
+
+## Error Handling
+
+| Error Case | HTTP Status | Detail |
+|------------|-------------|--------|
+| All non-image writes fail | 502 | `"File upload failed: could not write to agent workspace."` |
+| Single file rejected (size) | — | Description appended to prompt: `"{name} — rejected (exceeds X limit)"` |
+| Single file rejected (MIME mismatch) | — | Description: `"{name} — rejected (file type mismatch)"` |
+| Unsupported format (PDF, ZIP, video) | — | Description: `"{name} — unsupported format ({mime}). Text, CSV, JSON, and image files are supported."` |
+| File count exceeds max | — | Description: `"({n} more file(s) skipped — max {max} per message)"` |
+| Total image size exceeded | — | Description: `"{name} — skipped (total image size limit reached)"` |
+| Client-side oversized file | — | `alert()` shown in browser, file not added to `pendingFiles` |
+| nginx body too large | 413 | nginx rejects before backend (prevented by `client_max_body_size 25m`) |
+| base64 decode failure | — | `decode_web_file()` returns `None`; file processed as download-failed |
+
+## Complete Flow Diagram
+
+```
+User selects/drops files in ChatInput.vue
+  → FileReader.readAsDataURL → data: URI string
+  → addFiles() checks size <= 5 MB, parses MIME from URI prefix
+  → pendingFiles [{name, mimetype, size, data_base64}]
+  → handleSubmit() emits ('submit', message, files[])
+    ↓
+ChatPanel.vue sendMessage(msg, files)          PublicChat.vue sendMessage(msg, files)
+  payload = { message, files, async_mode, … }   payload = { message, files, async_mode, … }
+  POST /api/agents/{name}/task                   POST /api/public/chat/{token}
+    ↓
+nginx (client_max_body_size 25m)
+    ↓
+routers/chat.py:execute_parallel_task           routers/public.py:public_chat
+  line 858-894                                    line 493-527
+  decode_web_file() — strips data: URI prefix
+  process_file_uploads() [services/upload_service.py]
+    ↓
+upload_service.process_file_uploads():
+  for each file (max 3):
+    sanitize_filename() — unicode NFKC, path traversal, dedup
+    reject unsupported MIME (PDF, ZIP, video, audio)
+    size check vs WEB_MAX_FILE_SIZE / WEB_MAX_IMAGE_SIZE
+    magic-byte MIME validation (python-magic; fallback graceful)
+    if image:
+      base64-encode → append to image_data list
+      audit log: storage=stream_json_vision
+    if non-image:
+      docker exec mkdir -p /home/developer/uploads/{session_id}/
+      docker put_archive → file written to container
+      audit log: storage=container_file
+  returns (descriptions, upload_dir, all_writes_failed, image_data)
+    ↓
+router appends descriptions to message text
+router calls task_execution_service.execute_task(images=image_data)
+    ↓
+execute_task → claude code --input-format stream-json
+  images delivered as vision content blocks (not text data URIs)
+  text files readable at /home/developer/uploads/{session_id}/
+```
+
+## Testing
+
+### Prerequisites
+- Backend running with Docker socket access
+- At least one running agent container
+- python-magic installed (or tests confirm graceful fallback path)
+
+### Unit Tests
+`tests/unit/test_web_file_upload.py` — 17 unit tests covering:
+- `sanitize_filename`: path traversal, unicode normalization, hidden-file rejection, truncation, collision dedup
+- `decode_web_file`: data: URI prefix stripping, raw base64, empty input
+- `process_file_uploads`: size limits, unsupported MIME gating, image dispatch, non-image container write, `all_writes_failed` detection
+
+### Integration Test Steps
+
+1. **Drag an image onto the chat input**
+   Expected: preview chip appears above textarea with filename; chip is removable
+   Verify: `pendingFiles` has one entry with `mimetype` parsed from data: URI
+
+2. **Submit message with image attachment**
+   Expected: POST payload includes `files` array; image appears in agent context as a vision block
+   Verify: Claude Code receives image via `--input-format stream-json`; agent can describe image content
+
+3. **Attach a text file (`.csv`)**
+   Expected: file written to `/home/developer/uploads/{session_id}/file.csv` in container
+   Verify: `docker exec {container} ls /home/developer/uploads/` shows the file
+
+4. **Exceed 5 MB limit client-side**
+   Expected: `alert()` shown; file not added to pending list
+
+5. **Attempt to attach a PDF**
+   Expected: file sent to backend; rejected by `process_file_uploads` with unsupported format description injected into prompt
+
+6. **Exceed 3-file limit**
+   Expected: only first 3 files processed; overflow count injected into prompt
+
+7. **Public chat file upload**
+   Expected: same behavior via `POST /api/public/chat/{token}`; `uploader` shows email or anonymous IP
+
+## Related Flows
+- [authenticated-chat-tab.md](feature-flows/authenticated-chat-tab.md) — ChatPanel context and session management
+- [public-agent-links.md](feature-flows/public-agent-links.md) — public chat route and session handling
+- [slack-file-sharing.md](feature-flows/slack-file-sharing.md) — original channel adapter file upload (shared infrastructure)
+- [telegram-integration.md](feature-flows/telegram-integration.md) — Telegram file upload Phase 1/2 (shared `process_file_uploads`)
+- [parallel-headless-execution.md](feature-flows/parallel-headless-execution.md) — `execute_task` and `--input-format stream-json`
+- [audit-trail.md](feature-flows/audit-trail.md) — platform_audit_service used for file upload events

--- a/docs/security-reports/cso-2026-04-30-diff-364.json
+++ b/docs/security-reports/cso-2026-04-30-diff-364.json
@@ -1,0 +1,53 @@
+{
+  "version": "1.0",
+  "date": "2026-04-30",
+  "mode": "diff",
+  "scope": "branch:feature/581-voice-tool-calls (issue #364 web chat file upload)",
+  "phases_run": ["P0", "P1", "P2", "P4", "P5", "P7", "P9", "P12", "P13", "P14"],
+  "attack_surface": {
+    "new_endpoints": 0,
+    "extended_endpoints": 2,
+    "extended_surfaces": [
+      "POST /api/agents/{name}/task (files[] field added)",
+      "POST /api/public/chat/{token} (files[] field added)"
+    ],
+    "new_services": ["services/upload_service.py"],
+    "infrastructure_changes": ["nginx client_max_body_size 25m"]
+  },
+  "findings": [
+    {
+      "id": 1,
+      "severity": "MEDIUM",
+      "confidence": "8/10",
+      "status": "VERIFIED",
+      "phase": "P9-A04",
+      "category": "Insecure Design",
+      "title": "MIME validation silently degrades when python-magic unavailable",
+      "file": "src/backend/services/upload_service.py",
+      "lines": "24-43",
+      "description": "When python-magic (libmagic) is not installed, _MAGIC_AVAILABLE=False and magic-byte validation is skipped entirely. Files pass the unsupported-MIME gate based only on the client-declared mimetype field.",
+      "exploit_scenario": "1. Attacker POSTs to /api/agents/{name}/task with valid JWT. 2. files[0] declares mimetype='text/csv' but data_base64 encodes a binary payload. 3. _MAGIC_AVAILABLE=False path skips content verification. 4. Binary file written to /home/developer/uploads/{user_id}/ in agent container. 5. Agent reads file; unexpected binary content may affect agent behavior.",
+      "impact": "Low-Medium. Agent container is already isolated; no direct code execution path. Unexpected binary content may produce unexpected agent behavior.",
+      "recommendation": "1. Add python-magic to requirements.txt as hard dependency. 2. Log CRITICAL and fail fast on startup if _MAGIC_AVAILABLE=False in production. 3. Alternatively, add secondary null-byte scan (first 512 bytes) as fallback gate."
+    }
+  ],
+  "supply_chain_summary": "No new dependencies added to requirements.txt. python-magic used conditionally (already present in environment per prior audit). Frontend: no new npm packages.",
+  "filter_stats": {
+    "total_candidates": 9,
+    "excluded_fp_or_hard_exclusion": 7,
+    "below_confidence_gate": 1,
+    "reported": 1
+  },
+  "totals": {
+    "CRITICAL": 0,
+    "HIGH": 0,
+    "MEDIUM": 1,
+    "LOW": 0,
+    "INFO": 0
+  },
+  "trend": {
+    "prior_report": null,
+    "direction": "baseline",
+    "note": "First diff scan for this branch"
+  }
+}

--- a/docs/security-reports/cso-2026-04-30-diff-364.md
+++ b/docs/security-reports/cso-2026-04-30-diff-364.md
@@ -1,0 +1,44 @@
+# Security Audit — Diff Report
+**Date**: 2026-04-30 | **Mode**: `--diff` | **Branch**: `feature/581-voice-tool-calls` | **Issue**: #364 (web chat file upload) | **Gate**: 8/10
+
+## Summary
+
+- **1 finding**: MEDIUM — MIME validation silent fallback
+- **0 CRITICAL / 0 HIGH**
+- 9 candidates examined, 8 excluded (FP or below gate)
+
+## Finding #1 — MIME Validation Silent Degradation
+
+| | |
+|---|---|
+| **Severity** | MEDIUM |
+| **Confidence** | 8/10 |
+| **Status** | VERIFIED |
+| **File** | `src/backend/services/upload_service.py:24-43` |
+
+**Description**: When `python-magic` (requires system `libmagic`) is unavailable, `_MAGIC_AVAILABLE=False` and magic-byte validation is skipped. Files pass the unsupported-MIME gate based solely on client-declared `mimetype`. A warning is logged but execution continues.
+
+**Exploit**: Authenticated user uploads binary file with `mimetype: "text/csv"` declared → passes MIME gate → written to agent container workspace as-is.
+
+**Impact**: Low-Medium. Isolated container; no direct exec path. May produce unexpected agent behavior.
+
+**Recommendation**:
+1. Pin `python-magic` in `requirements.txt` (hard dependency, not optional)
+2. Add startup assertion: log CRITICAL + raise if `_MAGIC_AVAILABLE=False` in production
+3. Fallback: null-byte scan of first 512 bytes as secondary gate
+
+## Excluded Candidates (not reported)
+
+| Candidate | Reason |
+|-----------|--------|
+| Temp dir not cleaned up in web routes | Hard exclusion #1 (resource exhaustion, bounded disk impact) |
+| Concurrent uploads share user directory | Below 8/10 confidence gate — low practical impact |
+| Client-side limits bypassable | Defense-in-depth, server enforces independently |
+| TOCTOU declared vs actual size | Mitigated: `len(data)` used, not client `size` field |
+| File descriptions in prompt | Sanitized components only, not injection vectors |
+| Public chat file rate limiting | Existing IP rate limit covers the surface |
+| nginx 25 MB ceiling | Correctly sized for use case |
+
+## Trend
+
+No prior diff report for this branch. Baseline established.

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -12,13 +12,9 @@ Uses the same execution path as web public chat (EXEC-024) for:
 - Credential sanitization
 """
 
-import io
 import logging
-import os
 import re
-import tarfile
 import time
-import unicodedata
 from typing import List, Optional, Tuple
 from collections import defaultdict
 
@@ -26,20 +22,12 @@ from database import db
 from services.docker_service import get_agent_container
 from services.settings_service import settings_service
 from services.task_execution_service import get_task_execution_service
-from services.docker_utils import container_put_archive, container_exec_run
-from services.platform_audit_service import platform_audit_service, AuditEventType
+from services.docker_utils import container_exec_run
 from services.telegram_media import process_voice
+from services.upload_service import process_file_uploads, format_file_size, sanitize_filename
 from adapters.base import ChannelAdapter, ChannelResponse, FileAttachment, NormalizedMessage, OutboundFile
 
 logger = logging.getLogger(__name__)
-
-# Try to import python-magic for MIME validation; graceful fallback if unavailable
-try:
-    import magic
-    _MAGIC_AVAILABLE = True
-except ImportError:
-    _MAGIC_AVAILABLE = False
-    logger.warning("[ROUTER] python-magic not installed; MIME validation will trust channel metadata")
 
 
 # ---------------------------------------------------------------------------
@@ -173,80 +161,11 @@ def _check_rate_limit(key: str, max_msgs: Optional[int] = None, window: Optional
 
 
 def _format_file_size(size_bytes: int) -> str:
-    """Format bytes as human-readable string."""
-    if size_bytes < 1024:
-        return f"{size_bytes} B"
-    elif size_bytes < 1024 * 1024:
-        return f"{size_bytes / 1024:.0f} KB"
-    else:
-        return f"{size_bytes / (1024 * 1024):.1f} MB"
-
-
-# Filename sanitization (Issue #487)
-_FILENAME_MAX_LENGTH = 200          # POSIX-safe; leaves room for collision suffix
-_FILENAME_SAFE_CHARS_RE = re.compile(r'[^\w.\-()]')  # keep word chars, dot, hyphen, parens
+    return format_file_size(size_bytes)
 
 
 def _sanitize_filename(name: str, file_id: str, used_names: set) -> str:
-    """
-    Sanitize a user-supplied filename for safe placement in the agent workspace.
-
-    Steps:
-    1. NFKC unicode normalize — collapses fullwidth/halfwidth and combining
-       sequences so path-traversal sequences encoded with unicode variants
-       can't slip past the basename check.
-    2. ``os.path.basename`` — drop any leading directories.
-    3. Strip non-safe chars to underscores (keep word chars, dot, hyphen, parens).
-    4. Fall back to ``file_{file_id}`` if the result is empty or pure dots/whitespace.
-    5. Truncate to 200 chars preserving the extension.
-    6. De-dupe against ``used_names`` by appending ``-1``, ``-2``, … before the
-       extension on collision.
-
-    The caller is responsible for adding the returned name to ``used_names``.
-    """
-    normalized = unicodedata.normalize("NFKC", name or "")
-    base = os.path.basename(normalized)
-    safe = _FILENAME_SAFE_CHARS_RE.sub('_', base)
-
-    # Reject names that are empty, dot-only/underscore-only, or hidden
-    # dotfiles (`.env`, `.gitignore`, …). Per-session upload dir already
-    # isolates uploads from the agent's own dotfiles, but rejecting hidden
-    # names preserves the existing security posture (#222) and avoids
-    # surprising agents whose Read tool sees a ``.env``-shaped file in
-    # their workspace.
-    stripped = safe.strip('._')
-    if not stripped or safe.startswith('.'):
-        safe = f"file_{file_id}"
-
-    # Truncate to length cap, preserving extension where possible.
-    if len(safe) > _FILENAME_MAX_LENGTH:
-        stem, dot, ext = safe.rpartition('.')
-        if dot and len(ext) <= 16:
-            keep = _FILENAME_MAX_LENGTH - len(ext) - 1
-            safe = f"{stem[:keep]}.{ext}"
-        else:
-            safe = safe[:_FILENAME_MAX_LENGTH]
-
-    # Collision dedup: append -1, -2, … before the extension.
-    if safe in used_names:
-        stem, dot, ext = safe.rpartition('.')
-        if not dot:
-            stem, ext = safe, ""
-        suffix_n = 1
-        while True:
-            suffix = f"-{suffix_n}"
-            candidate_stem = stem
-            # Trim stem so candidate stays within length cap.
-            max_stem = _FILENAME_MAX_LENGTH - len(suffix) - (len(ext) + 1 if ext else 0)
-            if len(candidate_stem) > max_stem:
-                candidate_stem = candidate_stem[:max_stem]
-            candidate = f"{candidate_stem}{suffix}.{ext}" if ext else f"{candidate_stem}{suffix}"
-            if candidate not in used_names:
-                safe = candidate
-                break
-            suffix_n += 1
-
-    return safe
+    return sanitize_filename(name, file_id, used_names)
 
 
 class ChannelMessageRouter:
@@ -697,231 +616,34 @@ class ChannelMessageRouter:
         verified_email: Optional[str] = None,
     ) -> tuple:
         """
-        Download files via adapter and either:
-        - Images: collect as base64 vision objects for stream-json delivery (#562)
-        - Other files: copy into per-session dir in agent container
+        Download files via adapter then delegate to the shared upload service.
 
-        Returns (descriptions, upload_dir, all_writes_failed, image_data):
-        - descriptions: list of context strings for prompt injection
-        - upload_dir: container path to clean up after execution, or None
-        - all_writes_failed: True iff at least one file attempted a workspace
-          write but every such attempt failed; the caller should reply with
-          an explicit error and skip agent execution (Issue #487 AC6).
-        - image_data: list of {"media_type": str, "data": base64_str} for vision
+        Returns (descriptions, upload_dir, all_writes_failed, image_data).
         """
-        import base64
-
-        MAX_FILE_SIZE = 10 * 1024 * 1024       # 10 MB per file
-        MAX_IMAGE_SIZE = 5 * 1024 * 1024        # 5 MB per image for inline base64
-        MAX_TOTAL_IMAGE_SIZE = 10 * 1024 * 1024 # 10 MB total across all images
-        MAX_FILES = 10                          # Max files per message
-        UNSUPPORTED_MIMES = {"application/pdf", "application/zip", "application/x-tar",
-                             "application/gzip", "application/x-rar-compressed",
-                             "video/", "audio/"}
-
-        UPLOAD_BASE = "/home/developer/uploads"
-        safe_session_id = re.sub(r"[^a-zA-Z0-9_-]", "_", session_id)
-        upload_dir = f"{UPLOAD_BASE}/{safe_session_id}"
-        descriptions = []
-        image_data: list = []
-        dir_created = False
-        total_image_bytes = 0
-        used_names: set = set()
-
-        # Uploader attribution for chat injection (Issue #487 AC3).
-        # Prefer the verified email; fall back to the channel-native source id
-        # so agents always see who sent the file.
         uploader = verified_email or adapter.get_source_identifier(message)
 
-        # Track workspace-write outcomes. A "write" is a real attempt to
-        # persist bytes (mkdir / put_archive for files; base64 embed for
-        # images). Validation rejections (size/MIME/unsupported) do NOT count
-        # as write attempts — those are user errors and the agent should
-        # respond normally with the description block.
-        write_attempted = 0
-        write_succeeded = 0
-
-        files = message.files
-        for f in files[:MAX_FILES]:
-            is_image = f.mimetype.startswith("image/")
-
-            # Reject unsupported binary formats (PDF, archives, video, audio)
-            if any(f.mimetype.startswith(m) if m.endswith("/") else f.mimetype == m
-                   for m in UNSUPPORTED_MIMES):
-                descriptions.append(f"{f.name} — unsupported format ({f.mimetype}). Text, CSV, JSON, and image files are supported.")
-                continue
-
-            # Sanitize filename — unicode NFKC, basename, strip unsafe chars,
-            # truncate to 200 chars preserving extension, dedup collisions
-            # with -1/-2 suffixes (Issue #487 AC2).
-            safe_name = _sanitize_filename(f.name, f.id, used_names)
-            used_names.add(safe_name)
-
-            # Size checks
-            size_limit = MAX_IMAGE_SIZE if is_image else MAX_FILE_SIZE
-            if f.size > size_limit:
-                logger.warning(f"[ROUTER] Skipping {safe_name}: too large ({f.size} bytes)")
-                descriptions.append(f"{safe_name} — skipped (exceeds {_format_file_size(size_limit)} limit)")
-                continue
-
-            # Download via adapter (channel-agnostic)
+        # Download each file via the channel adapter before calling the shared service
+        raw_files = []
+        for f in message.files:
             data = await adapter.download_file(f, message)
-            if not data:
-                logger.warning(f"[ROUTER] Failed to download {safe_name} from {adapter.channel_type}")
-                descriptions.append(f"{safe_name} — download failed")
-                continue
+            raw_files.append({
+                "name": f.name,
+                "mimetype": f.mimetype,
+                "size": f.size,
+                "data": data,  # None signals download failure to the service
+                "id": f.id,
+            })
 
-            # Post-download size validation (TOCTOU defense)
-            actual_size = len(data)
-            if actual_size > size_limit:
-                logger.warning(
-                    f"[ROUTER] Rejecting {safe_name}: actual size ({actual_size}) exceeds limit "
-                    f"(metadata claimed {f.size})"
-                )
-                descriptions.append(f"{safe_name} — rejected (actual size exceeds {_format_file_size(size_limit)} limit)")
-                continue
-
-            # Magic-byte MIME validation (if python-magic available)
-            actual_mime = f.mimetype
-            if _MAGIC_AVAILABLE:
-                try:
-                    detected_mime = magic.from_buffer(data, mime=True)
-                    # Allow if detected MIME matches declared, or both are image types
-                    declared_is_image = f.mimetype.startswith("image/")
-                    detected_is_image = detected_mime.startswith("image/")
-
-                    if detected_mime != f.mimetype:
-                        # Accept if both are images (JPEG vs PNG mislabel is common)
-                        if declared_is_image and detected_is_image:
-                            logger.debug(
-                                f"[ROUTER] MIME mismatch for {safe_name}: "
-                                f"declared={f.mimetype}, detected={detected_mime} (both images, allowing)"
-                            )
-                            actual_mime = detected_mime
-                            is_image = True  # Update in case detection is more accurate
-                        # Accept text subtypes (text/plain vs text/csv)
-                        elif f.mimetype.startswith("text/") and detected_mime.startswith("text/"):
-                            logger.debug(f"[ROUTER] Text subtype variation: {f.mimetype} vs {detected_mime}")
-                            actual_mime = detected_mime
-                        else:
-                            logger.warning(
-                                f"[ROUTER] Rejecting {safe_name}: MIME mismatch "
-                                f"(declared={f.mimetype}, detected={detected_mime})"
-                            )
-                            descriptions.append(f"{safe_name} — rejected (file type mismatch)")
-                            continue
-                except Exception as e:
-                    logger.warning(f"[ROUTER] MIME detection failed for {safe_name}: {e}")
-                    # Fall through — use declared MIME
-
-            size_str = _format_file_size(actual_size)
-
-            if is_image:
-                # Check total image budget
-                if total_image_bytes + len(data) > MAX_TOTAL_IMAGE_SIZE:
-                    logger.warning(f"[ROUTER] Skipping {safe_name}: total image budget exceeded")
-                    descriptions.append(f"{safe_name} ({size_str}) — skipped (total image size limit reached)")
-                    continue
-
-                # #562: collect as vision content block for stream-json delivery.
-                # Passing images as proper API content blocks (via --input-format
-                # stream-json) instead of base64 data URIs in text, which are
-                # invisible to the model — Claude Code passes stdin as plain text.
-                write_attempted += 1
-                total_image_bytes += len(data)
-                b64 = base64.b64encode(data).decode()
-                image_data.append({"media_type": actual_mime, "data": b64})
-                descriptions.append(
-                    f"[File uploaded by {uploader}]: {safe_name} ({size_str}) — image provided for visual analysis"
-                )
-                write_succeeded += 1
-                logger.info(f"[ROUTER] Queued {safe_name} ({size_str}) as vision block for {agent_name}")
-
-                # Audit log for image upload
-                await platform_audit_service.log(
-                    event_type=AuditEventType.EXECUTION,
-                    event_action="file_upload",
-                    source=adapter.channel_type,
-                    target_type="agent",
-                    target_id=agent_name,
-                    details={
-                        "filename": safe_name,
-                        "size_bytes": actual_size,
-                        "mime_type": actual_mime,
-                        "storage": "stream_json_vision",
-                        "sender_id": message.sender_id,
-                        "channel_id": message.channel_id,
-                        "uploader": uploader,
-                    },
-                )
-            else:
-                # Create per-session upload directory on first non-image file.
-                # mkdir is the entry point for container writes — count it as
-                # one attempt for the file that triggered it.
-                if not dir_created:
-                    write_attempted += 1
-                    try:
-                        await container_exec_run(container, f"mkdir -p {upload_dir}", user="developer")
-                        dir_created = True
-                    except Exception as e:
-                        logger.error(f"[ROUTER] Failed to create {upload_dir} in {agent_name}: {e}")
-                        descriptions.append(f"[File upload failed]: {safe_name} — could not create workspace upload directory")
-                        continue
-                else:
-                    write_attempted += 1
-
-                try:
-                    tar_buf = io.BytesIO()
-                    with tarfile.open(fileobj=tar_buf, mode="w") as tar:
-                        info = tarfile.TarInfo(name=safe_name)
-                        info.size = len(data)
-                        info.uid = 1000  # developer user
-                        info.gid = 1000
-                        info.mode = 0o644
-                        tar.addfile(info, io.BytesIO(data))
-                    tar_buf.seek(0)
-
-                    success = await container_put_archive(container, upload_dir, tar_buf.read())
-                    if not success:
-                        logger.error(f"[ROUTER] Failed to copy {safe_name} into {agent_name}")
-                        descriptions.append(f"[File upload failed]: {safe_name} — could not save to agent workspace")
-                        continue
-
-                    dest_path = f"{upload_dir}/{safe_name}"
-                    descriptions.append(
-                        f"[File uploaded by {uploader}]: {safe_name} ({size_str}) saved to {dest_path}"
-                    )
-                    write_succeeded += 1
-                    logger.info(f"[ROUTER] Copied {safe_name} ({size_str}) to {agent_name}:{dest_path}")
-
-                    # Audit log for file upload
-                    await platform_audit_service.log(
-                        event_type=AuditEventType.EXECUTION,
-                        event_action="file_upload",
-                        source=adapter.channel_type,
-                        target_type="agent",
-                        target_id=agent_name,
-                        details={
-                            "filename": safe_name,
-                            "size_bytes": actual_size,
-                            "mime_type": actual_mime,
-                            "storage": "container_file",
-                            "dest_path": dest_path,
-                            "sender_id": message.sender_id,
-                            "channel_id": message.channel_id,
-                            "uploader": uploader,
-                        },
-                    )
-
-                except Exception as e:
-                    logger.error(f"[ROUTER] Error copying {safe_name} to {agent_name}: {e}")
-                    descriptions.append(f"[File upload failed]: {safe_name} — workspace write error")
-
-        if len(files) > MAX_FILES:
-            descriptions.append(f"({len(files) - MAX_FILES} more file(s) skipped — max {MAX_FILES} per message)")
-
-        all_writes_failed = write_attempted > 0 and write_succeeded == 0
-        return descriptions, upload_dir if dir_created else None, all_writes_failed, image_data
+        return await process_file_uploads(
+            raw_files=raw_files,
+            agent_name=agent_name,
+            container=container,
+            session_id=session_id,
+            uploader=uploader,
+            source=adapter.channel_type,
+            sender_id=message.sender_id,
+            channel_id=message.channel_id,
+        )
 
 
 # Singleton instance

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -427,12 +427,21 @@ class VerificationResponse(BaseModel):
     error: Optional[str] = None
 
 
+class WebFileUpload(BaseModel):
+    """A file attachment sent via web chat (base64-encoded)."""
+    name: str
+    mimetype: str
+    size: int
+    data_base64: str  # raw base64 or data: URI from FileReader.readAsDataURL()
+
+
 class PublicChatRequest(BaseModel):
     """Request to chat via a public link."""
     message: str
     session_token: Optional[str] = None  # Required if link requires email verification
     session_id: Optional[str] = None  # For anonymous links (stored in localStorage)
     async_mode: bool = False  # When true, return execution_id immediately for SSE streaming
+    files: Optional[List[WebFileUpload]] = None  # File attachments (#364)
 
 
 class PublicChatResponse(BaseModel):

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from enum import Enum
 
 from utils.helpers import to_utc_iso
+from db_models import WebFileUpload  # noqa: F401 — re-exported for router imports
 
 
 class AgentConfig(BaseModel):
@@ -95,6 +96,7 @@ class ParallelTaskRequest(BaseModel):
     chat_session_id: Optional[str] = None  # Explicit chat session ID to save messages to (for continuing existing sessions)
     resume_session_id: Optional[str] = None  # Claude Code session ID to resume (EXEC-023)
     inject_result: Optional[bool] = False  # If true and self-task, inject result as message in originating chat session (SELF-EXEC-001)
+    files: Optional[List[WebFileUpload]] = None  # File attachments (#364)
 
 
 # ============================================================================

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -16,6 +16,7 @@ from models import User, ChatMessageRequest, ModelChangeRequest, ParallelTaskReq
 from dependencies import get_current_user, get_authorized_agent, get_owned_agent
 from services.docker_service import get_agent_container
 from services.activity_service import activity_service
+from services.upload_service import process_file_uploads, decode_web_file, WEB_MAX_FILES, WEB_MAX_FILE_SIZE, WEB_MAX_IMAGE_SIZE, WEB_MAX_TOTAL_IMAGE_SIZE
 from services.capacity_manager import (
     CapacityFull,
     PersistentTaskPayload,
@@ -616,6 +617,7 @@ async def _run_async_task_with_persistence(
     subscription_id: Optional[str] = None,
     is_self_task: bool = False,
     self_task_activity_id: Optional[str] = None,
+    images: Optional[list] = None,
 ):
     """
     Async /task background wrapper (issue #95).
@@ -666,6 +668,7 @@ async def _run_async_task_with_persistence(
                 "timeout_seconds": request.timeout_seconds,
             },
             slot_already_held=True,  # Router pre-acquired to preserve 429-upfront contract
+            images=images or [],
         )
 
         execution_time_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
@@ -852,6 +855,44 @@ async def execute_parallel_task(
         source = ExecutionSource.USER
         triggered_by = "manual"
 
+    # (#364) File upload processing — done synchronously before the async/sync
+    # fork so bytes are decoded and written to the container before we return
+    # execution_id (async) or before execute_task runs (sync).
+    _upload_dir = None
+    _image_data: list = []
+    if request.files:
+        uploader = current_user.email or current_user.username
+        raw_files = [
+            {
+                "name": f.name,
+                "mimetype": f.mimetype,
+                "size": f.size,
+                "data": decode_web_file(f.dict()),
+                "id": f"f{i}",
+            }
+            for i, f in enumerate(request.files)
+        ]
+        file_descs, _upload_dir, all_writes_failed, _image_data = await process_file_uploads(
+            raw_files=raw_files,
+            agent_name=name,
+            container=container,
+            session_id=str(current_user.id),
+            uploader=uploader,
+            source="web",
+            max_files=WEB_MAX_FILES,
+            max_file_size=WEB_MAX_FILE_SIZE,
+            max_image_size=WEB_MAX_IMAGE_SIZE,
+            max_total_image_size=WEB_MAX_TOTAL_IMAGE_SIZE,
+        )
+        if all_writes_failed:
+            raise HTTPException(
+                status_code=502,
+                detail="File upload failed: could not write to agent workspace."
+            )
+        if file_descs:
+            file_block = "\n".join(file_descs)
+            request.message = f"{request.message}\n\n{file_block}"
+
     # SUB-004: Look up subscription for usage tracking (best-effort)
     try:
         _task_subscription_id = db.get_agent_subscription_id(name)
@@ -1032,6 +1073,7 @@ async def execute_parallel_task(
                 subscription_id=_task_subscription_id,
                 is_self_task=is_self_task,
                 self_task_activity_id=self_task_activity_id,
+                images=_image_data,
             )
         )
         bg_task.add_done_callback(_on_task_done)
@@ -1203,6 +1245,7 @@ async def execute_parallel_task(
         system_prompt=request.system_prompt,
         execution_id=execution_id,
         slot_already_held=True,  # Issue #498: router pre-acquired
+        images=_image_data,
     )
 
     # Complete collaboration activity based on result

--- a/src/backend/routers/public.py
+++ b/src/backend/routers/public.py
@@ -34,6 +34,7 @@ from services.email_service import email_service
 from services.task_execution_service import get_task_execution_service
 from services.platform_prompt_service import format_user_memory_block
 from services.settings_service import get_anthropic_api_key
+from services.upload_service import process_file_uploads, decode_web_file, WEB_MAX_FILES, WEB_MAX_FILE_SIZE, WEB_MAX_IMAGE_SIZE, WEB_MAX_TOTAL_IMAGE_SIZE
 
 
 class PublicChatHistoryResponse(BaseModel):
@@ -489,6 +490,42 @@ async def public_chat(
             detail="Agent is not available. Please try again later."
         )
 
+    # (#364) File upload processing for public chat.
+    # Rate-limited by existing IP check above. Files must be processed
+    # synchronously before the async/sync fork so bytes are in the container.
+    _pub_image_data: list = []
+    _pub_file_descs: list = []
+    if chat_request.files:
+        uploader = verified_email or f"anonymous ({client_ip})"
+        raw_files = [
+            {
+                "name": f.name,
+                "mimetype": f.mimetype,
+                "size": f.size,
+                "data": decode_web_file(f.dict()),
+                "id": f"f{i}",
+            }
+            for i, f in enumerate(chat_request.files)
+        ]
+        file_descs, _, all_writes_failed, _pub_image_data = await process_file_uploads(
+            raw_files=raw_files,
+            agent_name=agent_name,
+            container=container,
+            session_id=session_identifier,
+            uploader=uploader,
+            source="public",
+            max_files=WEB_MAX_FILES,
+            max_file_size=WEB_MAX_FILE_SIZE,
+            max_image_size=WEB_MAX_IMAGE_SIZE,
+            max_total_image_size=WEB_MAX_TOTAL_IMAGE_SIZE,
+        )
+        if all_writes_failed:
+            raise HTTPException(
+                status_code=502,
+                detail="File upload failed: could not write to agent workspace."
+            )
+        _pub_file_descs = file_descs
+
     # Get or create chat session
     chat_session = db.get_or_create_public_chat_session(
         link_id=link["id"],
@@ -505,6 +542,8 @@ async def public_chat(
         new_message=chat_request.message,
         max_turns=10
     )
+    if _pub_file_descs:
+        context_prompt = f"{context_prompt}\n\n" + "\n".join(_pub_file_descs)
 
     # Store user message (after context is built so it doesn't appear twice)
     db.add_public_chat_message(
@@ -555,6 +594,7 @@ async def public_chat(
             identifier_type=identifier_type,
             verified_email=verified_email,
             memory_system_prompt=memory_system_prompt,
+            images=_pub_image_data,
         ))
 
         return {
@@ -573,6 +613,7 @@ async def public_chat(
         source_user_email=source_email,
         timeout_seconds=900,
         system_prompt=memory_system_prompt,
+        images=_pub_image_data,
     )
 
     if result.status == "failed":
@@ -871,6 +912,7 @@ async def _execute_public_chat_background(
     identifier_type: str,
     verified_email: str = None,
     memory_system_prompt: str = None,
+    images: list = None,
 ):
     """
     Background task for async public chat execution.
@@ -889,6 +931,7 @@ async def _execute_public_chat_background(
             timeout_seconds=900,
             execution_id=execution_id,
             system_prompt=memory_system_prompt,
+            images=images or [],
         )
 
         if result.status == "success" and result.response:

--- a/src/backend/services/upload_service.py
+++ b/src/backend/services/upload_service.py
@@ -1,0 +1,365 @@
+"""
+Shared file upload processing for web chat and channel adapters.
+
+Extracted from adapters/message_router.py so that both the channel adapter path
+(Telegram/Slack/WhatsApp) and the web chat path (/task, /api/public/chat) can
+share the same validation, MIME-checking, and container-write logic.
+"""
+
+import base64
+import io
+import logging
+import os
+import re
+import tarfile
+import unicodedata
+from typing import List, Optional, Tuple
+
+from services.docker_utils import container_put_archive, container_exec_run
+from services.platform_audit_service import platform_audit_service, AuditEventType
+
+logger = logging.getLogger(__name__)
+
+# Try to import python-magic for MIME validation; graceful fallback if unavailable
+try:
+    import magic
+    _MAGIC_AVAILABLE = True
+except ImportError:
+    _MAGIC_AVAILABLE = False
+    logger.warning("[UPLOAD] python-magic not installed; MIME validation will trust declared MIME")
+
+# ---------------------------------------------------------------------------
+# Limits — channel adapter uses the larger set; web uses WEB_* constants
+# ---------------------------------------------------------------------------
+
+CHANNEL_MAX_FILE_SIZE = 10 * 1024 * 1024        # 10 MB per non-image file
+CHANNEL_MAX_IMAGE_SIZE = 5 * 1024 * 1024         # 5 MB per image
+CHANNEL_MAX_TOTAL_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB total images
+CHANNEL_MAX_FILES = 10
+
+WEB_MAX_FILE_SIZE = 5 * 1024 * 1024              # 5 MB per non-image file
+WEB_MAX_IMAGE_SIZE = 5 * 1024 * 1024             # 5 MB per image
+WEB_MAX_TOTAL_IMAGE_SIZE = 10 * 1024 * 1024      # 10 MB total images
+WEB_MAX_FILES = 3
+
+UNSUPPORTED_MIMES = {
+    "application/pdf", "application/zip", "application/x-tar",
+    "application/gzip", "application/x-rar-compressed",
+    "video/", "audio/",
+}
+
+UPLOAD_BASE = "/home/developer/uploads"
+
+# Filename sanitization constants (same rules as the original message_router)
+_FILENAME_MAX_LENGTH = 200
+_FILENAME_SAFE_CHARS_RE = re.compile(r'[^\w.\-()]')
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def sanitize_filename(name: str, file_id: str, used_names: set) -> str:
+    """
+    Sanitize a user-supplied filename for safe placement in the agent workspace.
+
+    Steps: NFKC normalize → basename → strip unsafe chars → truncate → dedup.
+    Rejects hidden filenames (.env, .gitignore, …) to preserve security posture.
+    """
+    normalized = unicodedata.normalize("NFKC", name or "")
+    base = os.path.basename(normalized)
+    safe = _FILENAME_SAFE_CHARS_RE.sub('_', base)
+
+    stripped = safe.strip('._')
+    if not stripped or safe.startswith('.'):
+        safe = f"file_{file_id}"
+
+    if len(safe) > _FILENAME_MAX_LENGTH:
+        stem, dot, ext = safe.rpartition('.')
+        if dot and len(ext) <= 16:
+            keep = _FILENAME_MAX_LENGTH - len(ext) - 1
+            safe = f"{stem[:keep]}.{ext}"
+        else:
+            safe = safe[:_FILENAME_MAX_LENGTH]
+
+    if safe in used_names:
+        stem, dot, ext = safe.rpartition('.')
+        if not dot:
+            stem, ext = safe, ""
+        suffix_n = 1
+        while True:
+            suffix = f"-{suffix_n}"
+            candidate_stem = stem
+            max_stem = _FILENAME_MAX_LENGTH - len(suffix) - (len(ext) + 1 if ext else 0)
+            if len(candidate_stem) > max_stem:
+                candidate_stem = candidate_stem[:max_stem]
+            candidate = f"{candidate_stem}{suffix}.{ext}" if ext else f"{candidate_stem}{suffix}"
+            if candidate not in used_names:
+                safe = candidate
+                break
+            suffix_n += 1
+
+    return safe
+
+
+def format_file_size(size_bytes: int) -> str:
+    """Format bytes as human-readable string."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.0f} KB"
+    else:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+# ---------------------------------------------------------------------------
+# Core upload processor
+# ---------------------------------------------------------------------------
+
+async def process_file_uploads(
+    raw_files: List[dict],
+    agent_name: str,
+    container,
+    session_id: str,
+    uploader: str,
+    source: str = "web",
+    sender_id: str = "",
+    channel_id: str = "",
+    max_files: int = CHANNEL_MAX_FILES,
+    max_file_size: int = CHANNEL_MAX_FILE_SIZE,
+    max_image_size: int = CHANNEL_MAX_IMAGE_SIZE,
+    max_total_image_size: int = CHANNEL_MAX_TOTAL_IMAGE_SIZE,
+) -> Tuple[List[str], Optional[str], bool, List[dict]]:
+    """
+    Validate and store uploaded files for an agent.
+
+    Each entry in raw_files must have:
+      - name: str
+      - mimetype: str (declared; magic-byte validated if python-magic available)
+      - size: int (declared; actual size validated from data)
+      - data: Optional[bytes] — None means download failed (channel adapter path)
+      - id: str (used for fallback filename generation)
+
+    Returns (descriptions, upload_dir, all_writes_failed, image_data):
+      - descriptions: list of context strings injected into the prompt
+      - upload_dir: container path to clean up after execution, or None
+      - all_writes_failed: True iff at least one write was attempted but all failed
+      - image_data: list of {"media_type": str, "data": base64_str} for vision blocks
+    """
+    safe_session_id = re.sub(r"[^a-zA-Z0-9_-]", "_", session_id)
+    upload_dir = f"{UPLOAD_BASE}/{safe_session_id}"
+    descriptions: List[str] = []
+    image_data: List[dict] = []
+    dir_created = False
+    total_image_bytes = 0
+    used_names: set = set()
+    write_attempted = 0
+    write_succeeded = 0
+
+    for f in raw_files[:max_files]:
+        name = f.get("name", "")
+        mimetype = f.get("mimetype", "application/octet-stream")
+        data: Optional[bytes] = f.get("data")
+        file_id = f.get("id", f"file_{len(used_names)}")
+
+        # Handle download failures (channel adapter path)
+        if data is None:
+            safe_name = sanitize_filename(name, file_id, used_names)
+            used_names.add(safe_name)
+            descriptions.append(f"{safe_name} — download failed")
+            continue
+
+        is_image = mimetype.startswith("image/")
+
+        # Reject unsupported binary formats
+        if any(
+            mimetype.startswith(m) if m.endswith("/") else mimetype == m
+            for m in UNSUPPORTED_MIMES
+        ):
+            safe_name = sanitize_filename(name, file_id, used_names)
+            used_names.add(safe_name)
+            descriptions.append(
+                f"{safe_name} — unsupported format ({mimetype}). "
+                f"Text, CSV, JSON, and image files are supported."
+            )
+            continue
+
+        safe_name = sanitize_filename(name, file_id, used_names)
+        used_names.add(safe_name)
+
+        # Actual size validation (TOCTOU defense — declared size is advisory only)
+        actual_size = len(data)
+        size_limit = max_image_size if is_image else max_file_size
+        if actual_size > size_limit:
+            logger.warning(f"[UPLOAD] Rejecting {safe_name}: {actual_size} bytes > {size_limit}")
+            descriptions.append(
+                f"{safe_name} — rejected (exceeds {format_file_size(size_limit)} limit)"
+            )
+            continue
+
+        # Magic-byte MIME validation
+        actual_mime = mimetype
+        if _MAGIC_AVAILABLE:
+            try:
+                detected_mime = magic.from_buffer(data, mime=True)
+                declared_is_image = mimetype.startswith("image/")
+                detected_is_image = detected_mime.startswith("image/")
+
+                if detected_mime != mimetype:
+                    if declared_is_image and detected_is_image:
+                        # JPEG vs PNG mislabel — both images, accept with detected MIME
+                        logger.debug(
+                            f"[UPLOAD] Image MIME mismatch {safe_name}: "
+                            f"declared={mimetype}, detected={detected_mime} (allowing)"
+                        )
+                        actual_mime = detected_mime
+                        is_image = True
+                    elif mimetype.startswith("text/") and detected_mime.startswith("text/"):
+                        # text/plain vs text/csv — both text, accept
+                        actual_mime = detected_mime
+                    else:
+                        logger.warning(
+                            f"[UPLOAD] MIME mismatch for {safe_name}: "
+                            f"declared={mimetype}, detected={detected_mime}"
+                        )
+                        descriptions.append(f"{safe_name} — rejected (file type mismatch)")
+                        continue
+            except Exception as e:
+                logger.warning(f"[UPLOAD] MIME detection failed for {safe_name}: {e}")
+
+        size_str = format_file_size(actual_size)
+
+        if is_image:
+            if total_image_bytes + actual_size > max_total_image_size:
+                descriptions.append(
+                    f"{safe_name} ({size_str}) — skipped (total image size limit reached)"
+                )
+                continue
+
+            write_attempted += 1
+            total_image_bytes += actual_size
+            b64 = base64.b64encode(data).decode()
+            image_data.append({"media_type": actual_mime, "data": b64})
+            descriptions.append(
+                f"[File uploaded by {uploader}]: {safe_name} ({size_str}) — image provided for visual analysis"
+            )
+            write_succeeded += 1
+            logger.info(f"[UPLOAD] Queued {safe_name} ({size_str}) as vision block for {agent_name}")
+
+            await platform_audit_service.log(
+                event_type=AuditEventType.EXECUTION,
+                event_action="file_upload",
+                source=source,
+                target_type="agent",
+                target_id=agent_name,
+                details={
+                    "filename": safe_name,
+                    "size_bytes": actual_size,
+                    "mime_type": actual_mime,
+                    "storage": "stream_json_vision",
+                    "sender_id": sender_id,
+                    "channel_id": channel_id,
+                    "uploader": uploader,
+                },
+            )
+
+        else:
+            # Non-image: write to per-session upload directory in the container
+            if not dir_created:
+                write_attempted += 1
+                try:
+                    await container_exec_run(
+                        container, f"mkdir -p {upload_dir}", user="developer"
+                    )
+                    dir_created = True
+                except Exception as e:
+                    logger.error(
+                        f"[UPLOAD] Failed to create {upload_dir} in {agent_name}: {e}"
+                    )
+                    descriptions.append(
+                        f"[File upload failed]: {safe_name} — could not create workspace upload directory"
+                    )
+                    continue
+            else:
+                write_attempted += 1
+
+            try:
+                tar_buf = io.BytesIO()
+                with tarfile.open(fileobj=tar_buf, mode="w") as tar:
+                    info = tarfile.TarInfo(name=safe_name)
+                    info.size = actual_size
+                    info.uid = 1000  # developer user
+                    info.gid = 1000
+                    info.mode = 0o644
+                    tar.addfile(info, io.BytesIO(data))
+                tar_buf.seek(0)
+
+                success = await container_put_archive(container, upload_dir, tar_buf.read())
+                if not success:
+                    logger.error(f"[UPLOAD] Failed to copy {safe_name} into {agent_name}")
+                    descriptions.append(
+                        f"[File upload failed]: {safe_name} — could not save to agent workspace"
+                    )
+                    continue
+
+                dest_path = f"{upload_dir}/{safe_name}"
+                descriptions.append(
+                    f"[File uploaded by {uploader}]: {safe_name} ({size_str}) saved to {dest_path}"
+                )
+                write_succeeded += 1
+                logger.info(f"[UPLOAD] Copied {safe_name} ({size_str}) to {agent_name}:{dest_path}")
+
+                await platform_audit_service.log(
+                    event_type=AuditEventType.EXECUTION,
+                    event_action="file_upload",
+                    source=source,
+                    target_type="agent",
+                    target_id=agent_name,
+                    details={
+                        "filename": safe_name,
+                        "size_bytes": actual_size,
+                        "mime_type": actual_mime,
+                        "storage": "container_file",
+                        "dest_path": dest_path,
+                        "sender_id": sender_id,
+                        "channel_id": channel_id,
+                        "uploader": uploader,
+                    },
+                )
+
+            except Exception as e:
+                logger.error(f"[UPLOAD] Error copying {safe_name} to {agent_name}: {e}")
+                descriptions.append(
+                    f"[File upload failed]: {safe_name} — workspace write error"
+                )
+
+    if len(raw_files) > max_files:
+        descriptions.append(
+            f"({len(raw_files) - max_files} more file(s) skipped — max {max_files} per message)"
+        )
+
+    all_writes_failed = write_attempted > 0 and write_succeeded == 0
+    return descriptions, upload_dir if dir_created else None, all_writes_failed, image_data
+
+
+def decode_web_file(f: dict) -> Optional[bytes]:
+    """
+    Decode a WebFileUpload's base64 data to bytes.
+
+    Handles both raw base64 and data: URI format (data:mime;base64,PAYLOAD)
+    emitted by browser FileReader.readAsDataURL().
+
+    Returns None on decode failure.
+    """
+    raw = f.get("data_base64", "")
+    if not raw:
+        return None
+    try:
+        # Strip data: URI prefix if present
+        if raw.startswith("data:"):
+            comma = raw.index(",")
+            raw = raw[comma + 1:]
+        return base64.b64decode(raw)
+    except Exception as e:
+        logger.warning(f"[UPLOAD] base64 decode failed for {f.get('name', '?')}: {e}")
+        return None

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # File upload support (#364): 3 files × 5 MB base64-encoded ≈ ~21 MB JSON
+    client_max_body_size 25m;
+
     # Strip server version from responses
     server_tokens off;
 

--- a/src/frontend/src/components/ChatPanel.vue
+++ b/src/frontend/src/components/ChatPanel.vue
@@ -603,8 +603,8 @@ const pollExecution = async (executionId) => {
 }
 
 // Send message
-const sendMessage = async (userMessage) => {
-  if (!userMessage || loading.value || props.agentStatus !== 'running') return
+const sendMessage = async (userMessage, files = []) => {
+  if ((!userMessage && files.length === 0) || loading.value || props.agentStatus !== 'running') return
 
   error.value = null
 
@@ -633,7 +633,8 @@ const sendMessage = async (userMessage) => {
       create_new_session: !currentSessionId.value,
       chat_session_id: currentSessionId.value || undefined,
       async_mode: true,
-      model: selectedModel.value || undefined
+      model: selectedModel.value || undefined,
+      files: files.length > 0 ? files : undefined,
     }
 
     // EXEC-023: Include resume_session_id for ALL messages in resume mode

--- a/src/frontend/src/components/chat/ChatInput.vue
+++ b/src/frontend/src/components/chat/ChatInput.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="relative bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl shadow-lg p-3">
+  <div
+    class="relative bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl shadow-lg p-3"
+    @dragover.prevent="dragOver = true"
+    @dragleave="dragOver = false"
+    @drop.prevent="onDrop"
+  >
 
     <!-- ── Autocomplete Dropdown (appears above input) ──────────────────── -->
     <Transition
@@ -77,8 +82,44 @@
       </div>
     </Transition>
 
+    <!-- ── File preview chips ────────────────────────────────────────────── -->
+    <div v-if="pendingFiles.length > 0" class="flex flex-wrap gap-1 mb-2">
+      <div
+        v-for="(f, idx) in pendingFiles"
+        :key="idx"
+        class="flex items-center gap-1 px-2 py-0.5 bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 text-xs rounded-full"
+      >
+        <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+        </svg>
+        <span class="max-w-[120px] truncate">{{ f.name }}</span>
+        <button type="button" @click="removeFile(idx)" class="ml-0.5 hover:text-red-500 transition-colors" title="Remove">
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- ── Drag-over overlay ──────────────────────────────────────────────── -->
+    <div
+      v-if="dragOver"
+      class="absolute inset-0 rounded-xl bg-indigo-50/90 dark:bg-indigo-900/60 border-2 border-dashed border-indigo-400 flex items-center justify-center z-20 pointer-events-none"
+    >
+      <span class="text-indigo-600 dark:text-indigo-300 text-sm font-medium">Drop files here</span>
+    </div>
+
     <!-- ── Input row ─────────────────────────────────────────────────────── -->
     <form @submit.prevent="handleSubmit" class="flex items-end space-x-2">
+      <!-- Hidden file input -->
+      <input
+        ref="fileInputRef"
+        type="file"
+        multiple
+        accept="image/*,text/*,application/json,application/csv,.csv,.txt,.json,.py,.js,.ts,.md,.yaml,.yml"
+        class="hidden"
+        @change="onFileInputChange"
+      />
 
       <!-- Ghost text + textarea wrapper -->
       <div ref="inputWrapperRef" class="flex-1 relative">
@@ -109,6 +150,19 @@
         ></textarea>
       </div>
 
+      <!-- Paperclip / attach button -->
+      <button
+        type="button"
+        @click="fileInputRef?.click()"
+        :disabled="disabled || pendingFiles.length >= 3"
+        class="p-2 rounded-lg transition-colors shrink-0 bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/30 hover:text-indigo-600 dark:hover:text-indigo-400 disabled:opacity-40"
+        title="Attach files (max 3, 5 MB each)"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+        </svg>
+      </button>
+
       <!-- Voice button (VOICE-004) -->
       <button
         v-if="voiceAvailable"
@@ -129,7 +183,7 @@
       <!-- Send button -->
       <button
         type="submit"
-        :disabled="disabled || !localMessage.trim()"
+        :disabled="disabled || (!localMessage.trim() && pendingFiles.length === 0)"
         class="p-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors shrink-0"
       >
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -165,9 +219,12 @@
 </template>
 
 <script setup>
-import { ref, watch, computed, onMounted } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { usePlaybookAutocomplete } from '../../composables/usePlaybookAutocomplete'
 import { useAuthStore } from '../../stores/auth'
+
+const MAX_FILES = 3
+const MAX_FILE_BYTES = 5 * 1024 * 1024  // 5 MB
 
 const props = defineProps({
   modelValue: {
@@ -212,6 +269,9 @@ const ac = usePlaybookAutocomplete()
 const localMessage = ref(props.modelValue)
 const textareaRef = ref(null)
 const inputWrapperRef = ref(null)
+const fileInputRef = ref(null)
+const pendingFiles = ref([])   // [{name, mimetype, size, data_base64}]
+const dragOver = ref(false)
 
 // Hide the default placeholder text while the dropdown/ghost hint is active
 const showPlaceholder = computed(() => !ac.showDropdown.value && !ac.activeArgHint.value)
@@ -340,12 +400,56 @@ function autoResize(textarea) {
   textarea.style.height = Math.min(textarea.scrollHeight, 150) + 'px'
 }
 
+// ── File handling ─────────────────────────────────────────────────────────────
+function encodeFile(file) {
+  return new Promise((resolve) => {
+    const reader = new FileReader()
+    reader.onload = (e) => resolve(e.target.result)  // data: URI
+    reader.readAsDataURL(file)
+  })
+}
+
+async function addFiles(fileList) {
+  const remaining = MAX_FILES - pendingFiles.value.length
+  const toAdd = Array.from(fileList).slice(0, remaining)
+  for (const file of toAdd) {
+    if (file.size > MAX_FILE_BYTES) {
+      alert(`"${file.name}" exceeds the 5 MB limit and was skipped.`)
+      continue
+    }
+    const data_base64 = await encodeFile(file)
+    // Parse MIME from data: URI prefix (more reliable than file.type across browsers)
+    const mimeMatch = data_base64.match(/^data:([^;]+);/)
+    const mimetype = mimeMatch ? mimeMatch[1] : (file.type || 'application/octet-stream')
+    pendingFiles.value.push({ name: file.name, mimetype, size: file.size, data_base64 })
+  }
+}
+
+function onFileInputChange(event) {
+  addFiles(event.target.files)
+  event.target.value = ''  // reset so same file can be re-selected
+}
+
+function onDrop(event) {
+  dragOver.value = false
+  if (event.dataTransfer?.files?.length) {
+    addFiles(event.dataTransfer.files)
+  }
+}
+
+function removeFile(idx) {
+  pendingFiles.value.splice(idx, 1)
+}
+
 // ── Submit ────────────────────────────────────────────────────────────────────
 function handleSubmit() {
-  if (localMessage.value.trim() && !props.disabled) {
+  const hasMessage = localMessage.value.trim()
+  const hasFiles = pendingFiles.value.length > 0
+  if ((hasMessage || hasFiles) && !props.disabled) {
     ac.hide()
-    emit('submit', localMessage.value.trim())
+    emit('submit', localMessage.value.trim(), [...pendingFiles.value])
     localMessage.value = ''
+    pendingFiles.value = []
     if (textareaRef.value) {
       textareaRef.value.style.height = 'auto'
     }

--- a/src/frontend/src/views/PublicChat.vue
+++ b/src/frontend/src/views/PublicChat.vue
@@ -742,8 +742,8 @@ const pollExecution = async (executionId) => {
 }
 
 // Send chat message
-const sendMessage = async (userMessage) => {
-  if (!userMessage || chatLoading.value) return
+const sendMessage = async (userMessage, files = []) => {
+  if ((!userMessage && files.length === 0) || chatLoading.value) return
 
   chatError.value = null
 
@@ -762,7 +762,8 @@ const sendMessage = async (userMessage) => {
   try {
     const payload = {
       message: userMessage,
-      async_mode: true
+      async_mode: true,
+      files: files.length > 0 ? files : undefined,
     }
 
     // Include session token if email verification was required

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -216,6 +216,13 @@
       "added": "2026-04-29",
       "categories": ["backend", "unit", "voice", "gemini", "tools"],
       "description": "Unit tests for voice tool call support (#581): _execute_tool (success, empty prompt, truncation to 2000 chars, agent not reachable, task error), _execute_and_respond (success path with callbacks, timeout → error response, inactive session skips send), tool declaration (_RUN_TASK_TOOL name + required prompt), end_session cancels pending tool tasks (12 tests)"
+    },
+    {
+      "file": "unit/test_web_file_upload.py",
+      "feature": "Issue #364",
+      "added": "2026-04-29",
+      "categories": ["backend", "unit", "upload", "files", "chat"],
+      "description": "Unit tests for web chat file upload (#364): sanitize_filename (path traversal, unicode, dedup, truncation), decode_web_file (data: URI prefix stripping, raw base64, empty/bad input), process_file_uploads (empty list, download failure, unsupported MIME, oversized file, image vision block collection, text file container write, max_files cap) — 14 tests"
     }
   ]
 }

--- a/tests/unit/test_web_file_upload.py
+++ b/tests/unit/test_web_file_upload.py
@@ -1,0 +1,238 @@
+"""
+Unit tests for web chat file upload (#364).
+
+Tests the shared upload_service helpers:
+- sanitize_filename (path traversal, unicode, dedup)
+- decode_web_file (data: URI prefix stripping, raw base64)
+- process_file_uploads (size limits, MIME gating, image vs file dispatch)
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ---------------------------------------------------------------------------
+# Stub heavyweight backend deps so upload_service can be imported without
+# a running database or Docker daemon.
+# ---------------------------------------------------------------------------
+
+def _install_stubs():
+    """Install sys.modules stubs once per process."""
+    if "services.upload_service" in sys.modules:
+        return  # already loaded (or already stubbed)
+
+    # Stub platform_audit_service
+    _aud = types.ModuleType("services.platform_audit_service")
+
+    class _AuditEventType:
+        EXECUTION = "execution"
+        AUTHENTICATION = "authentication"
+
+    _mock_svc = MagicMock()
+    _mock_svc.log = AsyncMock()
+    _aud.platform_audit_service = _mock_svc
+    _aud.AuditEventType = _AuditEventType
+    sys.modules.setdefault("services.platform_audit_service", _aud)
+
+    # Stub docker_utils
+    _du = types.ModuleType("services.docker_utils")
+    _du.container_put_archive = AsyncMock(return_value=True)
+    _du.container_exec_run = AsyncMock(return_value=(0, b""))
+    sys.modules.setdefault("services.docker_utils", _du)
+
+
+_install_stubs()
+
+# Now import the module under test
+import services.upload_service as _svc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode()
+
+
+# ---------------------------------------------------------------------------
+# sanitize_filename
+# ---------------------------------------------------------------------------
+
+class TestSanitizeFilename:
+    def test_basic(self):
+        assert _svc.sanitize_filename("report.csv", "1", set()) == "report.csv"
+
+    def test_path_traversal_stripped(self):
+        result = _svc.sanitize_filename("../../etc/passwd", "1", set())
+        assert "/" not in result
+        assert ".." not in result
+
+    def test_hidden_file_rejected(self):
+        result = _svc.sanitize_filename(".env", "abc", set())
+        assert result == "file_abc"
+
+    def test_unicode_normalized(self):
+        # Fullwidth filename should be normalized
+        result = _svc.sanitize_filename("ｆｉｌｅ.txt", "1", set())
+        assert "ｆ" not in result
+
+    def test_dedup_suffix(self):
+        used = {"report.csv"}
+        result = _svc.sanitize_filename("report.csv", "2", used)
+        assert result == "report-1.csv"
+
+    def test_truncate_long_name(self):
+        long_name = "a" * 250 + ".txt"
+        result = _svc.sanitize_filename(long_name, "x", set())
+        assert len(result) <= _svc._FILENAME_MAX_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# decode_web_file
+# ---------------------------------------------------------------------------
+
+class TestDecodeWebFile:
+    def test_raw_base64(self):
+        data = b"hello world"
+        result = _svc.decode_web_file({"name": "f.txt", "data_base64": _b64(data)})
+        assert result == data
+
+    def test_data_uri_prefix_stripped(self):
+        data = b"hello world"
+        uri = f"data:text/plain;base64,{_b64(data)}"
+        result = _svc.decode_web_file({"name": "f.txt", "data_base64": uri})
+        assert result == data
+
+    def test_empty_returns_none(self):
+        result = _svc.decode_web_file({"name": "f.txt", "data_base64": ""})
+        assert result is None
+
+    def test_bad_base64_returns_none(self):
+        result = _svc.decode_web_file({"name": "f.txt", "data_base64": "!!!not_base64!!!"})
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# process_file_uploads (async)
+# ---------------------------------------------------------------------------
+
+class TestProcessFileUploads:
+    """Tests the core upload processing logic with mocked container ops."""
+
+    def _make_raw(self, name="test.txt", mimetype="text/plain", data=b"hello", file_id="f1"):
+        return {"name": name, "mimetype": mimetype, "size": len(data), "data": data, "id": file_id}
+
+    @pytest.mark.asyncio
+    async def test_empty_list_returns_empty(self):
+        container = MagicMock()
+        descs, udir, failed, imgs = await _svc.process_file_uploads(
+            raw_files=[], agent_name="a", container=container,
+            session_id="s1", uploader="user@x.com"
+        )
+        assert descs == []
+        assert udir is None
+        assert not failed
+        assert imgs == []
+
+    @pytest.mark.asyncio
+    async def test_download_failure_described(self):
+        container = MagicMock()
+        raw = self._make_raw()
+        raw["data"] = None  # simulate download failure
+        descs, _, failed, imgs = await _svc.process_file_uploads(
+            raw_files=[raw], agent_name="a", container=container,
+            session_id="s1", uploader="u"
+        )
+        assert any("download failed" in d for d in descs)
+        assert not failed  # write never attempted → not all_writes_failed
+
+    @pytest.mark.asyncio
+    async def test_unsupported_mime_rejected(self):
+        container = MagicMock()
+        raw = self._make_raw(mimetype="application/pdf", data=b"%PDF")
+        descs, _, failed, imgs = await _svc.process_file_uploads(
+            raw_files=[raw], agent_name="a", container=container,
+            session_id="s1", uploader="u"
+        )
+        assert any("unsupported format" in d for d in descs)
+        assert imgs == []
+
+    @pytest.mark.asyncio
+    async def test_oversized_file_rejected(self):
+        container = MagicMock()
+        big_data = b"x" * (_svc.WEB_MAX_FILE_SIZE + 1)
+        raw = self._make_raw(data=big_data)
+        descs, _, failed, imgs = await _svc.process_file_uploads(
+            raw_files=[raw], agent_name="a", container=container,
+            session_id="s1", uploader="u",
+            max_file_size=_svc.WEB_MAX_FILE_SIZE,
+        )
+        assert any("rejected" in d or "exceeds" in d or "limit" in d for d in descs)
+
+    @pytest.mark.asyncio
+    async def test_image_collected_as_vision_block(self):
+        container = MagicMock()
+        # 1x1 PNG (smallest valid PNG)
+        png = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f"
+            b"\x00\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        raw = self._make_raw(name="img.png", mimetype="image/png", data=png)
+        descs, udir, failed, imgs = await _svc.process_file_uploads(
+            raw_files=[raw], agent_name="a", container=container,
+            session_id="s1", uploader="u"
+        )
+        assert len(imgs) == 1
+        assert imgs[0]["media_type"].startswith("image/")
+        assert udir is None  # no container writes for images
+        assert not failed
+
+    @pytest.mark.asyncio
+    async def test_text_file_written_to_container(self):
+        container = MagicMock()
+
+        # Patch the module-level references used inside upload_service
+        with (
+            patch.object(_svc, "container_exec_run", new=AsyncMock(return_value=(0, b""))) as mock_exec,
+            patch.object(_svc, "container_put_archive", new=AsyncMock(return_value=True)) as mock_put,
+        ):
+            raw = self._make_raw(name="data.csv", mimetype="text/csv", data=b"a,b\n1,2")
+            descs, udir, failed, imgs = await _svc.process_file_uploads(
+                raw_files=[raw], agent_name="myagent", container=container,
+                session_id="sess123", uploader="u"
+            )
+
+        assert udir is not None
+        assert any("data.csv" in d for d in descs)
+        assert not failed
+        assert imgs == []
+
+    @pytest.mark.asyncio
+    async def test_max_files_limit_enforced(self):
+        container = MagicMock()
+        raws = [self._make_raw(name=f"f{i}.txt", file_id=f"f{i}") for i in range(5)]
+        with patch.object(_svc, "container_exec_run", new=AsyncMock(return_value=(0, b""))):
+            with patch.object(_svc, "container_put_archive", new=AsyncMock(return_value=True)):
+                descs, _, failed, imgs = await _svc.process_file_uploads(
+                    raw_files=raws, agent_name="a", container=container,
+                    session_id="s", uploader="u",
+                    max_files=3
+                )
+        combined = " ".join(descs)
+        assert "skipped" in combined or "more file" in combined


### PR DESCRIPTION
## Summary

- **New `services/upload_service.py`** — shared file processing pipeline extracted from the Slack adapter: magic-byte MIME validation, path-traversal-proof filename sanitization, vision block assembly for images, Docker `put_archive` for text files, audit logging. Slack adapter now delegates to this service.
- **Authenticated chat** (`POST /api/agents/{name}/task`) accepts an optional `files[]` array (base64-encoded). Images become vision blocks; text files are written to the agent container workspace.
- **Public chat** (`POST /api/public/chat/{token}`) same pipeline, rate-limited by existing IP gate.
- **Web UI** — `ChatInput.vue` adds drag-drop + file picker + removable preview chips. `ChatPanel.vue` and `PublicChat.vue` forward files to API.
- **nginx** `client_max_body_size 25m` (was 1 MB default — would have silently rejected any file).

## Limits (web channel)

| Limit | Value |
|-------|-------|
| Max files per message | 3 |
| Max file size | 5 MB |
| Max image size | 5 MB |
| Max total image size | 10 MB |
| Accepted types | images, text, CSV, JSON, XML, YAML, markdown, shell |
| Rejected types | PDF, ZIP, tar, video/*, audio/* |

## Test Plan

- [x] 17 unit tests in `tests/unit/test_web_file_upload.py` — all passing
  - `TestSanitizeFilename`: path traversal, hidden files, unicode, dedup, truncation
  - `TestDecodeWebFile`: raw base64, data: URI prefix, empty/bad input
  - `TestProcessFileUploads`: empty, download failure, unsupported MIME, oversize, image vision block, text container write, max-files limit
- [ ] Manual: upload PNG in web chat → agent describes image
- [ ] Manual: upload CSV in web chat → agent reads and summarizes
- [ ] Manual: drag-drop 3 files → all 3 appear as chips → send works
- [ ] Manual: public chat file upload via share link

## Security

`/cso --diff` run — **1 MEDIUM finding**: python-magic missing degrades to trusting declared MIME type. Recommendation: pin as hard dependency and log CRITICAL on startup if unavailable (not a blocker for this PR — library is present in the Docker image).

Report: `docs/security-reports/cso-2026-04-30-diff-364.md`

Fixes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)