### PR TITLE
refactor(frontend): sweep cross-cutting + chat + file-mgr + process + misc (#554)

### DIFF
--- a/src/frontend/src/components/AvatarGenerateModal.vue
+++ b/src/frontend/src/components/AvatarGenerateModal.vue
@@ -39,7 +39,7 @@
       <div class="text-xs text-gray-400 dark:text-gray-500 mt-1 text-right">{{ identityPrompt.length }}/500</div>
 
       <!-- Error message -->
-      <p v-if="error" class="text-sm text-red-500 mt-2">{{ error }}</p>
+      <p v-if="error" class="text-sm text-status-danger-500 mt-2">{{ error }}</p>
 
       <!-- Actions -->
       <div class="flex items-center justify-between mt-4">
@@ -47,7 +47,7 @@
           v-if="currentAvatarUrl"
           @click="removeAvatar"
           :disabled="generating || removing"
-          class="text-sm text-red-500 hover:text-red-600 disabled:text-gray-400 transition-colors"
+          class="text-sm text-status-danger-500 hover:text-status-danger-600 disabled:text-gray-400 transition-colors"
         >
           {{ removing ? 'Removing...' : 'Remove Avatar' }}
         </button>

--- a/src/frontend/src/components/ChatPanel.vue
+++ b/src/frontend/src/components/ChatPanel.vue
@@ -78,8 +78,8 @@
     <!-- Agent not running message -->
     <div v-if="agentStatus !== 'running'" class="flex-1 flex items-center justify-center">
       <div class="text-center p-8">
-        <div class="w-16 h-16 bg-yellow-100 dark:bg-yellow-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-          <svg class="w-8 h-8 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="w-16 h-16 bg-status-warning-100 dark:bg-status-warning-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-status-warning-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
         </div>
@@ -138,9 +138,9 @@
       </ChatMessages>
 
       <!-- Error message -->
-      <div v-if="error" class="mx-6 mb-2 p-3 rounded-lg" :class="isRateLimitError ? 'bg-amber-100 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800' : 'bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800'">
+      <div v-if="error" class="mx-6 mb-2 p-3 rounded-lg" :class="isRateLimitError ? 'bg-amber-100 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800' : 'bg-status-danger-100 dark:bg-status-danger-900/30 border border-status-danger-200 dark:border-status-danger-800'">
         <p v-if="isRateLimitError" class="text-sm font-medium text-amber-700 dark:text-amber-400 mb-1">Subscription Usage Limit</p>
-        <p class="text-sm" :class="isRateLimitError ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400'">{{ error }}</p>
+        <p class="text-sm" :class="isRateLimitError ? 'text-amber-600 dark:text-amber-400' : 'text-status-danger-600 dark:text-status-danger-400'">{{ error }}</p>
       </div>
 
       <!-- Voice overlay (VOICE-004) -->

--- a/src/frontend/src/components/ConfirmDialog.vue
+++ b/src/frontend/src/components/ConfirmDialog.vue
@@ -21,12 +21,12 @@
               <!-- Icon -->
               <div :class="[
                 'mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full sm:mx-0 sm:h-10 sm:w-10',
-                variant === 'danger' ? 'bg-red-100 dark:bg-red-900/50' : 'bg-yellow-100 dark:bg-yellow-900/50'
+                variant === 'danger' ? 'bg-status-danger-100 dark:bg-status-danger-900/50' : 'bg-status-warning-100 dark:bg-status-warning-900/50'
               ]">
                 <svg
                   :class="[
                     'h-6 w-6',
-                    variant === 'danger' ? 'text-red-600 dark:text-red-400' : 'text-yellow-600 dark:text-yellow-400'
+                    variant === 'danger' ? 'text-status-danger-600 dark:text-status-danger-400' : 'text-status-warning-600 dark:text-status-warning-400'
                   ]"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -57,8 +57,8 @@
               :class="[
                 'w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:ml-3 sm:w-auto sm:text-sm',
                 variant === 'danger'
-                  ? 'bg-red-600 hover:bg-red-700 focus:ring-red-500'
-                  : 'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500'
+                  ? 'bg-status-danger-600 hover:bg-status-danger-700 focus:ring-status-danger-500'
+                  : 'bg-status-warning-600 hover:bg-status-warning-700 focus:ring-status-warning-500'
               ]"
               @click="onConfirm"
               data-testid="confirm-dialog-confirm"

--- a/src/frontend/src/components/CreateAgentModal.vue
+++ b/src/frontend/src/components/CreateAgentModal.vue
@@ -35,9 +35,9 @@
                 </div>
 
                 <!-- Error state -->
-                <div v-else-if="templatesError" class="mt-2 p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg">
-                  <p class="text-sm text-red-600 dark:text-red-400">{{ templatesError }}</p>
-                  <button @click="fetchTemplates" type="button" class="mt-1 text-sm text-red-700 dark:text-red-300 underline">
+                <div v-else-if="templatesError" class="mt-2 p-3 bg-status-danger-50 dark:bg-status-danger-900/30 border border-status-danger-200 dark:border-status-danger-800 rounded-lg">
+                  <p class="text-sm text-status-danger-600 dark:text-status-danger-400">{{ templatesError }}</p>
+                  <button @click="fetchTemplates" type="button" class="mt-1 text-sm text-status-danger-700 dark:text-status-danger-300 underline">
                     Try again
                   </button>
                 </div>
@@ -187,7 +187,7 @@
               </div>
             </div>
 
-            <div v-if="error" class="mt-4 text-red-600 dark:text-red-400 text-sm">
+            <div v-if="error" class="mt-4 text-status-danger-600 dark:text-status-danger-400 text-sm">
               {{ error }}
             </div>
           </div>

--- a/src/frontend/src/components/EditorHelpPanel.vue
+++ b/src/frontend/src/components/EditorHelpPanel.vue
@@ -46,7 +46,7 @@
             <span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase w-16">Required</span>
             <span
               :class="helpContent.required
-                ? 'text-red-600 dark:text-red-400'
+                ? 'text-status-danger-600 dark:text-status-danger-400'
                 : 'text-gray-500 dark:text-gray-400'"
               class="text-xs font-medium"
             >

--- a/src/frontend/src/components/FileSharingPanel.vue
+++ b/src/frontend/src/components/FileSharingPanel.vue
@@ -85,7 +85,7 @@
               <button
                 @click="revoke(file)"
                 :disabled="revokingId === file.file_id"
-                class="px-2 py-1 text-xs font-medium rounded-md text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/40 hover:bg-red-100 dark:hover:bg-red-900/70 disabled:opacity-50"
+                class="px-2 py-1 text-xs font-medium rounded-md text-status-danger-700 dark:text-status-danger-300 bg-status-danger-50 dark:bg-status-danger-900/40 hover:bg-status-danger-100 dark:hover:bg-status-danger-900/70 disabled:opacity-50"
               >
                 {{ revokingId === file.file_id ? 'Revoking…' : 'Revoke' }}
               </button>

--- a/src/frontend/src/components/GitConflictModal.vue
+++ b/src/frontend/src/components/GitConflictModal.vue
@@ -9,8 +9,8 @@
         <div class="px-4 pt-5 pb-4 sm:p-6">
           <!-- Header with icon -->
           <div class="flex items-start">
-            <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-yellow-100 dark:bg-yellow-900/30">
-              <svg class="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-status-warning-100 dark:bg-status-warning-900/30">
+              <svg class="h-6 w-6 text-status-warning-600 dark:text-status-warning-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
             </div>
@@ -54,16 +54,16 @@
 
             <button
               @click="$emit('resolve', 'force_reset')"
-              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-red-500 dark:hover:border-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors group"
+              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-status-danger-500 dark:hover:border-status-danger-400 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/20 transition-colors group"
             >
-              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 group-hover:bg-red-200 dark:group-hover:bg-red-900/50">
+              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-600 dark:text-status-danger-400 group-hover:bg-status-danger-200 dark:group-hover:bg-status-danger-900/50">
                 <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                 </svg>
               </div>
               <div class="ml-4 text-left">
                 <p class="text-sm font-medium text-gray-900 dark:text-white">Force Replace Local</p>
-                <p class="text-xs text-red-600 dark:text-red-400 mt-0.5">Discard all local changes and reset to remote (destructive!)</p>
+                <p class="text-xs text-status-danger-600 dark:text-status-danger-400 mt-0.5">Discard all local changes and reset to remote (destructive!)</p>
               </div>
             </button>
           </div>
@@ -87,16 +87,16 @@
 
             <button
               @click="$emit('resolve', 'force_push')"
-              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-red-500 dark:hover:border-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors group"
+              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-status-danger-500 dark:hover:border-status-danger-400 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/20 transition-colors group"
             >
-              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 group-hover:bg-red-200 dark:group-hover:bg-red-900/50">
+              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-600 dark:text-status-danger-400 group-hover:bg-status-danger-200 dark:group-hover:bg-status-danger-900/50">
                 <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
                 </svg>
               </div>
               <div class="ml-4 text-left">
                 <p class="text-sm font-medium text-gray-900 dark:text-white">Force Push</p>
-                <p class="text-xs text-red-600 dark:text-red-400 mt-0.5">Overwrite remote with your local changes (destructive!)</p>
+                <p class="text-xs text-status-danger-600 dark:text-status-danger-400 mt-0.5">Overwrite remote with your local changes (destructive!)</p>
               </div>
             </button>
           </div>
@@ -124,8 +124,8 @@
       <div class="inline-block align-middle bg-white dark:bg-gray-800 rounded-lg text-left shadow-xl transform transition-all sm:max-w-lg sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6">
           <div class="flex items-start">
-            <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-yellow-100 dark:bg-yellow-900/30">
-              <svg class="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-status-warning-100 dark:bg-status-warning-900/30">
+              <svg class="h-6 w-6 text-status-warning-600 dark:text-status-warning-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
             </div>
@@ -164,16 +164,16 @@
 
             <button
               @click="$emit('resolve', 'force_push')"
-              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-red-500 dark:hover:border-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors group"
+              class="w-full flex items-start p-4 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-status-danger-500 dark:hover:border-status-danger-400 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/20 transition-colors group"
             >
-              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 group-hover:bg-red-200 dark:group-hover:bg-red-900/50">
+              <div class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-full bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-600 dark:text-status-danger-400 group-hover:bg-status-danger-200 dark:group-hover:bg-status-danger-900/50">
                 <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
                 </svg>
               </div>
               <div class="ml-4 text-left">
                 <p class="text-sm font-medium text-gray-900 dark:text-white">Force push anyway</p>
-                <p class="text-xs text-red-600 dark:text-red-400 mt-0.5">
+                <p class="text-xs text-status-danger-600 dark:text-status-danger-400 mt-0.5">
                   Overwrites the remote working branch with your local history. Does NOT bring in
                   {{ pullBranchLabel }}'s commits. Destructive.
                 </p>

--- a/src/frontend/src/components/HelpChatWidget.vue
+++ b/src/frontend/src/components/HelpChatWidget.vue
@@ -102,12 +102,12 @@
       </div>
 
       <!-- Error message -->
-      <div v-if="error" class="mx-4 mb-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+      <div v-if="error" class="mx-4 mb-2 p-3 bg-status-danger-50 dark:bg-status-danger-900/20 border border-status-danger-200 dark:border-status-danger-800 rounded-lg">
         <div class="flex items-center justify-between">
-          <p class="text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+          <p class="text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
           <button
             @click="retryLastMessage"
-            class="ml-2 text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 underline"
+            class="ml-2 text-xs text-status-danger-600 dark:text-status-danger-400 hover:text-status-danger-700 dark:hover:text-status-danger-300 underline"
           >
             Retry
           </button>

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -47,7 +47,7 @@
               <span
                 v-if="combinedOpsCount > 0"
                 class="ml-1 inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-bold leading-none text-white rounded-full"
-                :class="hasCriticalOpsItem ? 'bg-red-500 animate-pulse' : 'bg-orange-500'"
+                :class="hasCriticalOpsItem ? 'bg-status-danger-500 animate-pulse' : 'bg-status-urgent-500'"
               >
                 {{ combinedOpsCount > 99 ? '99+' : combinedOpsCount }}
               </span>
@@ -74,7 +74,7 @@
         <div class="flex items-center space-x-4">
           <!-- WebSocket Status -->
           <span class="text-sm text-gray-500 dark:text-gray-400">
-            <span class="inline-block h-2 w-2 rounded-full mr-1" :class="isConnected ? 'bg-green-400' : 'bg-gray-400 dark:bg-gray-600'"></span>
+            <span class="inline-block h-2 w-2 rounded-full mr-1" :class="isConnected ? 'bg-status-success-400' : 'bg-gray-400 dark:bg-gray-600'"></span>
             {{ isConnected ? 'Connected' : 'Disconnected' }}
           </span>
 

--- a/src/frontend/src/components/OnboardingChecklist.vue
+++ b/src/frontend/src/components/OnboardingChecklist.vue
@@ -28,7 +28,7 @@
     class="fixed bottom-4 right-4 z-[9999] w-80 bg-white dark:bg-gray-800 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 overflow-hidden transition-all duration-300"
     :class="[
       { 'h-auto': !isMinimized, 'h-14': isMinimized },
-      isCelebrating ? 'ring-2 ring-green-400 ring-offset-2 animate-celebrate' : ''
+      isCelebrating ? 'ring-2 ring-status-success-400 ring-offset-2 animate-celebrate' : ''
     ]"
   >
     <!-- Header -->
@@ -84,7 +84,7 @@
           class="flex items-start gap-3 p-2 rounded-lg transition-colors"
           :class="[
             item.completed
-              ? 'bg-green-50 dark:bg-green-900/20'
+              ? 'bg-status-success-50 dark:bg-status-success-900/20'
               : isCurrentStep(index)
                 ? 'bg-indigo-50 dark:bg-indigo-900/20 ring-1 ring-indigo-200 dark:ring-indigo-700'
                 : 'opacity-50',
@@ -95,7 +95,7 @@
           <div
             class="flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center mt-0.5"
             :class="item.completed
-              ? 'bg-green-500 text-white'
+              ? 'bg-status-success-500 text-white'
               : isCurrentStep(index)
                 ? 'border-2 border-indigo-500 dark:border-indigo-400'
                 : 'border-2 border-gray-300 dark:border-gray-600'"
@@ -106,7 +106,7 @@
             <p
               class="text-sm font-medium"
               :class="item.completed
-                ? 'text-green-700 dark:text-green-400 line-through'
+                ? 'text-status-success-700 dark:text-status-success-400 line-through'
                 : isCurrentStep(index)
                   ? 'text-gray-900 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400'"
@@ -156,7 +156,7 @@
           class="flex items-start gap-3 p-2 rounded-lg transition-colors"
           :class="[
             item.completed
-              ? 'bg-green-50 dark:bg-green-900/20'
+              ? 'bg-status-success-50 dark:bg-status-success-900/20'
               : allRequiredComplete
                 ? 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
                 : 'opacity-40'
@@ -165,7 +165,7 @@
           <div
             class="flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center mt-0.5"
             :class="item.completed
-              ? 'bg-green-500 text-white'
+              ? 'bg-status-success-500 text-white'
               : 'border-2 border-gray-300 dark:border-gray-600'"
           >
             <CheckIcon v-if="item.completed" class="h-3 w-3" />
@@ -174,7 +174,7 @@
             <p
               class="text-sm font-medium"
               :class="item.completed
-                ? 'text-green-700 dark:text-green-400 line-through'
+                ? 'text-status-success-700 dark:text-status-success-400 line-through'
                 : allRequiredComplete
                   ? 'text-gray-900 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400'"

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -91,12 +91,12 @@
             <span>Public</span>
           </span>
           <span class="flex items-center space-x-1" title="Schedule marker (shows next scheduled run time)">
-            <span class="text-purple-500 text-xs font-bold">▼</span>
+            <span class="text-accent-purple-500 text-xs font-bold">▼</span>
             <span>Next Run</span>
           </span>
         </div>
         <span v-if="isLiveMode" class="flex items-center space-x-1">
-          <span class="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse"></span>
+          <span class="w-1.5 h-1.5 rounded-full bg-status-success-500 animate-pulse"></span>
           <span>Live</span>
         </span>
         <span>{{ totalEvents }} events</span>
@@ -130,7 +130,7 @@
               'px-2 py-1.5 border-b border-r border-gray-200 dark:border-gray-700',
               'flex',
               row.isSystemAgent
-                ? 'bg-purple-50/80 dark:bg-purple-900/20'
+                ? 'bg-accent-purple-50/80 dark:bg-accent-purple-900/20'
                 : 'bg-white dark:bg-gray-800'
             ]"
             :style="{ height: rowHeight + 'px' }"
@@ -138,7 +138,7 @@
             <!-- Avatar (vertically centered, with border ring) -->
             <div class="flex-shrink-0 flex items-center mr-1.5">
               <div class="rounded-full border-2 overflow-hidden shadow-sm"
-                   :class="row.isSystemAgent ? 'border-purple-400 dark:border-purple-500' : 'border-indigo-400 dark:border-indigo-500'"
+                   :class="row.isSystemAgent ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-indigo-400 dark:border-indigo-500'"
               >
                 <AgentAvatar :name="row.name" :avatar-url="row.avatarUrl" size="lg" />
               </div>
@@ -164,7 +164,7 @@
                   </span>
                   <span
                     v-if="row.isSystemAgent"
-                    class="ml-1.5 px-1 py-0.5 text-[10px] font-semibold rounded bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300 flex-shrink-0"
+                    class="ml-1.5 px-1 py-0.5 text-[10px] font-semibold rounded bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-900/50 dark:text-accent-purple-300 flex-shrink-0"
                   >
                     SYS
                   </span>
@@ -949,8 +949,8 @@ function getActivityStateLabel(row) {
 }
 
 function getActivityStateColor(row) {
-  if (row.activityState === 'active') return 'text-green-600 dark:text-green-400'
-  if (row.activityState === 'idle') return 'text-green-600 dark:text-green-400'
+  if (row.activityState === 'active') return 'text-status-success-600 dark:text-status-success-400'
+  if (row.activityState === 'idle') return 'text-status-success-600 dark:text-status-success-400'
   return 'text-gray-500 dark:text-gray-400'
 }
 
@@ -965,15 +965,15 @@ function getRowSuccessPercent(row) {
 }
 
 function getSuccessBarClass(percent) {
-  if (percent >= 90) return 'bg-green-500'
-  if (percent >= 50) return 'bg-yellow-500'
-  return 'bg-red-500'
+  if (percent >= 90) return 'bg-status-success-500'
+  if (percent >= 50) return 'bg-status-warning-500'
+  return 'bg-status-danger-500'
 }
 
 function getSuccessRateClass(rate) {
-  if (rate >= 80) return 'text-green-600 dark:text-green-400'
-  if (rate >= 50) return 'text-yellow-600 dark:text-yellow-400'
-  return 'text-red-600 dark:text-red-400'
+  if (rate >= 80) return 'text-status-success-600 dark:text-status-success-400'
+  if (rate >= 50) return 'text-status-warning-600 dark:text-status-warning-400'
+  return 'text-status-danger-600 dark:text-status-danger-400'
 }
 
 function formatLastExecution(timestamp) {

--- a/src/frontend/src/components/TagsEditor.vue
+++ b/src/frontend/src/components/TagsEditor.vue
@@ -72,7 +72,7 @@
     </div>
 
     <!-- Error message -->
-    <p v-if="error" class="mt-1 text-xs text-red-500">{{ error }}</p>
+    <p v-if="error" class="mt-1 text-xs text-status-danger-500">{{ error }}</p>
   </div>
 </template>
 

--- a/src/frontend/src/components/TerminalPanelContent.vue
+++ b/src/frontend/src/components/TerminalPanelContent.vue
@@ -54,7 +54,7 @@
           <div v-if="canShare" class="mb-4 p-4 bg-gray-800 rounded-lg text-left">
             <div class="flex items-center justify-between mb-2">
               <span class="text-sm font-medium text-gray-300">Authentication</span>
-              <span v-if="apiKeySetting.restart_required" class="text-xs text-yellow-400">Restart required</span>
+              <span v-if="apiKeySetting.restart_required" class="text-xs text-status-warning-400">Restart required</span>
             </div>
             <div class="space-y-2">
               <label class="flex items-center space-x-3 cursor-pointer">
@@ -89,7 +89,7 @@
           <button
             @click="$emit('start-agent')"
             :disabled="actionLoading"
-            class="bg-green-600 hover:bg-green-700 disabled:bg-green-400 text-white text-sm font-medium py-2 px-4 rounded-lg"
+            class="bg-status-success-600 hover:bg-status-success-700 disabled:bg-status-success-400 text-white text-sm font-medium py-2 px-4 rounded-lg"
           >
             {{ actionLoading ? 'Starting...' : 'Start Agent' }}
           </button>

--- a/src/frontend/src/components/UnifiedActivityPanel.vue
+++ b/src/frontend/src/components/UnifiedActivityPanel.vue
@@ -11,7 +11,7 @@
             <span
               :class="[
                 'w-2 h-2 rounded-full',
-                activity.status === 'running' ? 'bg-blue-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-500'
+                activity.status === 'running' ? 'bg-status-info-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-500'
               ]"
             ></span>
             <span class="text-sm text-gray-600 dark:text-gray-300">
@@ -88,8 +88,8 @@
             <span
               :class="[
                 'w-2 h-2 rounded-full flex-shrink-0',
-                entry.status === 'running' ? 'bg-blue-500 animate-pulse' :
-                entry.success ? 'bg-green-500' : 'bg-red-500'
+                entry.status === 'running' ? 'bg-status-info-500 animate-pulse' :
+                entry.success ? 'bg-status-success-500' : 'bg-status-danger-500'
               ]"
             ></span>
 
@@ -146,8 +146,8 @@
             <span
               :class="[
                 'w-2 h-2 rounded-full',
-                selectedEntry.status === 'running' ? 'bg-blue-500 animate-pulse' :
-                selectedEntry.success ? 'bg-green-500' : 'bg-red-500'
+                selectedEntry.status === 'running' ? 'bg-status-info-500 animate-pulse' :
+                selectedEntry.success ? 'bg-status-success-500' : 'bg-status-danger-500'
               ]"
             ></span>
             <span class="font-medium text-gray-900 dark:text-white">{{ selectedEntry.tool }}</span>
@@ -172,7 +172,7 @@
             </span>
             <span v-if="selectedEntry.success !== null">
               Status:
-              <span :class="selectedEntry.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
+              <span :class="selectedEntry.success ? 'text-status-success-600 dark:text-status-success-400' : 'text-status-danger-600 dark:text-status-danger-400'">
                 {{ selectedEntry.success ? 'Success' : 'Error' }}
               </span>
             </span>

--- a/src/frontend/src/components/YamlEditor.vue
+++ b/src/frontend/src/components/YamlEditor.vue
@@ -4,11 +4,11 @@
     <div class="flex items-center justify-between mb-2 px-1">
       <div class="flex items-center gap-2">
         <span class="text-sm font-medium text-gray-700 dark:text-gray-200">YAML Editor</span>
-        <div v-if="errors.length > 0" class="flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
+        <div v-if="errors.length > 0" class="flex items-center gap-1 text-xs text-status-danger-600 dark:text-status-danger-400">
           <ExclamationCircleIcon class="h-3.5 w-3.5" />
           <span>{{ errors.length }} error{{ errors.length !== 1 ? 's' : '' }}</span>
         </div>
-        <div v-else-if="warnings.length > 0" class="flex items-center gap-1 text-xs text-yellow-600 dark:text-yellow-400">
+        <div v-else-if="warnings.length > 0" class="flex items-center gap-1 text-xs text-status-warning-600 dark:text-status-warning-400">
           <ExclamationTriangleIcon class="h-3.5 w-3.5" />
           <span>{{ warnings.length }} warning{{ warnings.length !== 1 ? 's' : '' }}</span>
         </div>
@@ -27,7 +27,7 @@
           title="Copy to clipboard"
         >
           <ClipboardDocumentIcon v-if="!copied" class="h-4 w-4" />
-          <CheckIcon v-else class="h-4 w-4 text-green-500" />
+          <CheckIcon v-else class="h-4 w-4 text-status-success-500" />
         </button>
       </div>
     </div>
@@ -44,11 +44,11 @@
       <div
         v-for="(error, index) in errors"
         :key="'error-' + index"
-        class="flex items-start gap-2 rounded-md border border-red-300 dark:border-red-700/50 bg-red-50 dark:bg-red-900/20 p-2 text-xs"
+        class="flex items-start gap-2 rounded-md border border-status-danger-300 dark:border-status-danger-700/50 bg-status-danger-50 dark:bg-status-danger-900/20 p-2 text-xs"
         @click="goToLine(error.line)"
       >
-        <ExclamationCircleIcon class="h-3.5 w-3.5 mt-0.5 flex-shrink-0 text-red-500" />
-        <div class="text-red-700 dark:text-red-300">
+        <ExclamationCircleIcon class="h-3.5 w-3.5 mt-0.5 flex-shrink-0 text-status-danger-500" />
+        <div class="text-status-danger-700 dark:text-status-danger-300">
           <span v-if="error.line" class="font-medium">Line {{ error.line }}:</span>
           {{ error.message }}
         </div>
@@ -56,11 +56,11 @@
       <div
         v-for="(warning, index) in warnings"
         :key="'warning-' + index"
-        class="flex items-start gap-2 rounded-md border border-yellow-300 dark:border-yellow-700/50 bg-yellow-50 dark:bg-yellow-900/20 p-2 text-xs"
+        class="flex items-start gap-2 rounded-md border border-status-warning-300 dark:border-status-warning-700/50 bg-status-warning-50 dark:bg-status-warning-900/20 p-2 text-xs"
         @click="goToLine(warning.line)"
       >
-        <ExclamationTriangleIcon class="h-3.5 w-3.5 mt-0.5 flex-shrink-0 text-yellow-500" />
-        <div class="text-yellow-700 dark:text-yellow-300">
+        <ExclamationTriangleIcon class="h-3.5 w-3.5 mt-0.5 flex-shrink-0 text-status-warning-500" />
+        <div class="text-status-warning-700 dark:text-status-warning-300">
           <span v-if="warning.line" class="font-medium">Line {{ warning.line }}:</span>
           {{ warning.message }}
         </div>

--- a/src/frontend/src/components/chat/ChatBubble.vue
+++ b/src/frontend/src/components/chat/ChatBubble.vue
@@ -26,12 +26,12 @@
       @click.stop="copyContent"
     >
       <svg v-if="!copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
-      <svg v-else class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+      <svg v-else class="w-4 h-4 text-status-success-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
     </button>
-    <div class="rounded-xl px-4 py-3 bg-purple-50 dark:bg-purple-900/20 text-gray-900 dark:text-white shadow-sm border border-purple-200 dark:border-purple-800 overflow-hidden">
+    <div class="rounded-xl px-4 py-3 bg-accent-purple-50 dark:bg-accent-purple-900/20 text-gray-900 dark:text-white shadow-sm border border-accent-purple-200 dark:border-accent-purple-800 overflow-hidden">
       <!-- Self-task header with collapse toggle -->
       <div
-        class="flex items-center gap-2 mb-2 text-purple-600 dark:text-purple-400 cursor-pointer"
+        class="flex items-center gap-2 mb-2 text-accent-purple-600 dark:text-accent-purple-400 cursor-pointer"
         @click="selfTaskExpanded = !selfTaskExpanded"
       >
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -74,7 +74,7 @@
       @click.stop="copyContent"
     >
       <svg v-if="!copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
-      <svg v-else class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+      <svg v-else class="w-4 h-4 text-status-success-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
     </button>
     <div class="rounded-xl px-4 py-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm overflow-hidden">
       <div v-if="source === 'voice'" class="flex items-center gap-1.5 mb-1 text-gray-400 dark:text-gray-500">

--- a/src/frontend/src/components/chat/ChatHistoryDropdown.vue
+++ b/src/frontend/src/components/chat/ChatHistoryDropdown.vue
@@ -41,7 +41,7 @@
         </div>
 
         <!-- Error state -->
-        <div v-else-if="error" class="px-3 py-3 text-xs text-red-500 dark:text-red-400">
+        <div v-else-if="error" class="px-3 py-3 text-xs text-status-danger-500 dark:text-status-danger-400">
           {{ error }}
         </div>
 

--- a/src/frontend/src/components/chat/ChatInput.vue
+++ b/src/frontend/src/components/chat/ChatInput.vue
@@ -93,7 +93,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
         </svg>
         <span class="max-w-[120px] truncate">{{ f.name }}</span>
-        <button type="button" @click="removeFile(idx)" class="ml-0.5 hover:text-red-500 transition-colors" title="Remove">
+        <button type="button" @click="removeFile(idx)" class="ml-0.5 hover:text-status-danger-500 transition-colors" title="Remove">
           <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -171,7 +171,7 @@
         :disabled="disabled || voiceActive"
         class="p-2 rounded-lg transition-colors shrink-0"
         :class="voiceActive
-          ? 'bg-red-500 hover:bg-red-600 text-white'
+          ? 'bg-status-danger-500 hover:bg-status-danger-600 text-white'
           : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/30 hover:text-indigo-600 dark:hover:text-indigo-400 disabled:opacity-50'"
         :title="voiceActive ? 'Voice session active' : 'Start voice conversation'"
       >

--- a/src/frontend/src/components/file-manager/FilePreview.vue
+++ b/src/frontend/src/components/file-manager/FilePreview.vue
@@ -14,10 +14,10 @@
     <!-- Error State -->
     <div v-else-if="previewError" class="flex-1 flex items-center justify-center">
       <div class="text-center">
-        <svg class="h-12 w-12 text-red-400 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg class="h-12 w-12 text-status-danger-400 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
         </svg>
-        <p class="mt-2 text-sm text-red-500">{{ previewError }}</p>
+        <p class="mt-2 text-sm text-status-danger-500">{{ previewError }}</p>
       </div>
     </div>
 

--- a/src/frontend/src/components/file-manager/FileTreeNode.vue
+++ b/src/frontend/src/components/file-manager/FileTreeNode.vue
@@ -6,7 +6,7 @@
       :class="[
         'flex items-center px-2 py-1 rounded cursor-pointer text-sm',
         isSelected ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-900 dark:text-indigo-100' : 'hover:bg-gray-100 dark:hover:bg-gray-700',
-        isMatched ? 'bg-yellow-50 dark:bg-yellow-900/20' : ''
+        isMatched ? 'bg-status-warning-50 dark:bg-status-warning-900/20' : ''
       ]"
     >
       <!-- Expand/Collapse Icon (folders only) -->

--- a/src/frontend/src/components/process/RoleMatrix.vue
+++ b/src/frontend/src/components/process/RoleMatrix.vue
@@ -93,7 +93,7 @@
             :key="step.id"
             :class="[
               'border-b border-gray-100 dark:border-gray-700/50 last:border-b-0',
-              !hasExecutor(step.id) && 'bg-red-50 dark:bg-red-900/10'
+              !hasExecutor(step.id) && 'bg-status-danger-50 dark:bg-status-danger-900/10'
             ]"
           >
             <!-- Step name -->
@@ -102,7 +102,7 @@
                 <span class="truncate max-w-[180px]" :title="step.name">{{ step.name }}</span>
                 <span
                   v-if="!hasExecutor(step.id)"
-                  class="px-1.5 py-0.5 text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 rounded"
+                  class="px-1.5 py-0.5 text-xs font-medium bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-700 dark:text-status-danger-400 rounded"
                   title="Step must have an executor"
                 >
                   No executor

--- a/src/frontend/src/components/process/TemplateSelector.vue
+++ b/src/frontend/src/components/process/TemplateSelector.vue
@@ -254,10 +254,10 @@ async function fetchCategories() {
 function getCategoryBadgeClass(category) {
   const badges = {
     general: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
-    business: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
-    devops: 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300',
+    business: 'bg-status-info-100 dark:bg-status-info-900/30 text-status-info-700 dark:text-status-info-300',
+    devops: 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-700 dark:text-accent-purple-300',
     analytics: 'bg-cyan-100 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300',
-    support: 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300',
+    support: 'bg-status-urgent-100 dark:bg-status-urgent-900/30 text-status-urgent-700 dark:text-status-urgent-300',
     content: 'bg-pink-100 dark:bg-pink-900/30 text-pink-700 dark:text-pink-300',
   }
   return badges[category] || badges.general

--- a/src/frontend/src/components/process/TrendChart.vue
+++ b/src/frontend/src/components/process/TrendChart.vue
@@ -30,8 +30,8 @@
           >
             <div class="font-medium">{{ formatDate(item.date) }}</div>
             <div v-if="chartType === 'executions'">
-              <span class="text-green-400">{{ item.completed_count }}</span> /
-              <span class="text-red-400">{{ item.failed_count }}</span>
+              <span class="text-status-success-400">{{ item.completed_count }}</span> /
+              <span class="text-status-danger-400">{{ item.failed_count }}</span>
             </div>
             <div v-else-if="chartType === 'cost'">
               ${{ item.total_cost.toFixed(2) }}
@@ -46,19 +46,19 @@
             <!-- Success/Completed bar (green) -->
             <div
               v-if="chartType === 'executions'"
-              class="w-full bg-green-500 dark:bg-green-400 rounded-t transition-all duration-300"
+              class="w-full bg-status-success-500 dark:bg-status-success-400 rounded-t transition-all duration-300"
               :style="{ height: getBarHeight(item.completed_count) + '%' }"
             ></div>
             <!-- Failed bar (red) - stacked on top -->
             <div
               v-if="chartType === 'executions' && item.failed_count > 0"
-              class="w-full bg-red-500 dark:bg-red-400 rounded-t transition-all duration-300"
+              class="w-full bg-status-danger-500 dark:bg-status-danger-400 rounded-t transition-all duration-300"
               :style="{ height: getBarHeight(item.failed_count) + '%' }"
             ></div>
             <!-- Cost bar (blue) -->
             <div
               v-if="chartType === 'cost'"
-              class="w-full bg-blue-500 dark:bg-blue-400 rounded-t transition-all duration-300"
+              class="w-full bg-status-info-500 dark:bg-status-info-400 rounded-t transition-all duration-300"
               :style="{ height: getCostBarHeight(item.total_cost) + '%' }"
             ></div>
             <!-- Success rate bar (gradient) -->
@@ -89,11 +89,11 @@
     <!-- Legend -->
     <div v-if="chartType === 'executions'" class="flex items-center justify-center gap-4 mt-4 text-xs">
       <div class="flex items-center gap-1">
-        <div class="w-3 h-3 bg-green-500 rounded"></div>
+        <div class="w-3 h-3 bg-status-success-500 rounded"></div>
         <span class="text-gray-600 dark:text-gray-400">Completed</span>
       </div>
       <div class="flex items-center gap-1">
-        <div class="w-3 h-3 bg-red-500 rounded"></div>
+        <div class="w-3 h-3 bg-status-danger-500 rounded"></div>
         <span class="text-gray-600 dark:text-gray-400">Failed</span>
       </div>
     </div>
@@ -156,9 +156,9 @@ function getCostBarHeight(value) {
 }
 
 function getSuccessRateColor(rate) {
-  if (rate >= 80) return 'bg-green-500 dark:bg-green-400'
-  if (rate >= 50) return 'bg-yellow-500 dark:bg-yellow-400'
-  return 'bg-red-500 dark:bg-red-400'
+  if (rate >= 80) return 'bg-status-success-500 dark:bg-status-success-400'
+  if (rate >= 50) return 'bg-status-warning-500 dark:bg-status-warning-400'
+  return 'bg-status-danger-500 dark:bg-status-danger-400'
 }
 
 function formatDate(dateStr) {

--- a/src/frontend/src/views/FileManager.vue
+++ b/src/frontend/src/views/FileManager.vue
@@ -8,7 +8,7 @@
     >
       <div
         class="px-4 py-3 rounded-md text-sm"
-        :class="notification.type === 'success' ? 'bg-green-100 dark:bg-green-900/50 border border-green-400 dark:border-green-700 text-green-700 dark:text-green-300' : 'bg-red-100 dark:bg-red-900/50 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-300'"
+        :class="notification.type === 'success' ? 'bg-status-success-100 dark:bg-status-success-900/50 border border-status-success-400 dark:border-status-success-700 text-status-success-700 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300'"
       >
         {{ notification.message }}
       </div>
@@ -80,7 +80,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
               </svg>
               <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Select an agent</p>
-              <p v-if="runningAgents.length === 0" class="mt-1 text-xs text-yellow-600 dark:text-yellow-400">
+              <p v-if="runningAgents.length === 0" class="mt-1 text-xs text-status-warning-600 dark:text-status-warning-400">
                 No running agents
               </p>
             </div>
@@ -90,7 +90,7 @@
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
               </svg>
             </div>
-            <div v-else-if="error" class="text-red-500 text-sm p-2">{{ error }}</div>
+            <div v-else-if="error" class="text-status-danger-500 text-sm p-2">{{ error }}</div>
             <div v-else-if="filteredTree.length === 0" class="text-gray-500 dark:text-gray-400 text-sm p-2 text-center">
               {{ searchQuery ? 'No matching files found' : 'This folder is empty' }}
             </div>
@@ -205,7 +205,7 @@
                     <button
                       @click="showDeleteConfirm = true"
                       :disabled="deleting || isDeleteProtected"
-                      class="inline-flex items-center px-3 py-2 border border-red-300 dark:border-red-600 rounded-md shadow-sm text-sm font-medium text-red-700 dark:text-red-400 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"
+                      class="inline-flex items-center px-3 py-2 border border-status-danger-300 dark:border-status-danger-600 rounded-md shadow-sm text-sm font-medium text-status-danger-700 dark:text-status-danger-400 bg-white dark:bg-gray-700 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-status-danger-500 disabled:opacity-50"
                       :title="isDeleteProtected ? 'Protected file cannot be deleted' : ''"
                     >
                       <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -216,10 +216,10 @@
                   </template>
                 </div>
               </div>
-              <p v-if="isDeleteProtected && !isEditing" class="mt-2 text-xs text-yellow-600 dark:text-yellow-400">
+              <p v-if="isDeleteProtected && !isEditing" class="mt-2 text-xs text-status-warning-600 dark:text-status-warning-400">
                 This is a protected system file and cannot be deleted.
               </p>
-              <p v-if="isEditing && hasUnsavedChanges" class="mt-2 text-xs text-orange-600 dark:text-orange-400">
+              <p v-if="isEditing && hasUnsavedChanges" class="mt-2 text-xs text-status-urgent-600 dark:text-status-urgent-400">
                 You have unsaved changes.
               </p>
             </div>
@@ -234,8 +234,8 @@
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" @click="showDeleteConfirm = false"></div>
         <div class="relative bg-white dark:bg-gray-800 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
           <div class="sm:flex sm:items-start">
-            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 dark:bg-red-900/30 sm:mx-0 sm:h-10 sm:w-10">
-              <svg class="h-6 w-6 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-status-danger-100 dark:bg-status-danger-900/30 sm:mx-0 sm:h-10 sm:w-10">
+              <svg class="h-6 w-6 text-status-danger-600 dark:text-status-danger-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
             </div>
@@ -258,7 +258,7 @@
             <button
               @click="deleteFile"
               :disabled="deleting"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-status-danger-600 text-base font-medium text-white hover:bg-status-danger-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-status-danger-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
             >
               <svg v-if="deleting" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>


### PR DESCRIPTION
## Summary
**Slice 7, stacked on #609.** Migrates 24 files spanning the entire pool of small-and-medium domain files. Net diff: +106 / -106 — every change is a 1:1 palette alias, byte-identical CSS.

> ⚠️ Stacked on #609 (slices 4+5+6 + Vite proxy fix). GitHub will auto-rebase to \`dev\` once #609 merges.

## Subdomains migrated

### Chat (4 files)
- \`ChatBubble\`, \`ChatPanel\`, \`ChatInput\`, \`ChatHistoryDropdown\` — error states, success indicators, self-task purple accent panel

### File manager (4 files)
- \`FileManager\` — toast notifications, delete confirmation modal, error states
- \`FileTreeNode\` — search-matched highlight (file-type icons stay raw — need decorative accent palette later)
- \`FilePreview\` — preview-error indicator
- \`FileSharingPanel\` — Revoke button

### Process domain (3 files)
- \`TrendChart\` — full chart series (success/failure bars, cost bar, success-rate threshold ladder)
- \`RoleMatrix\` — no-executor row + badge
- \`TemplateSelector\` — category badges (business→info, devops→accent-purple, support→urgent)

### Cross-cutting / modals (10 files)
- \`NavBar\` — Ops critical-pulse indicator, WebSocket connected dot
- \`GitConflictModal\` — warning header + all destructive (red) options
- \`ReplayTimeline\` — system-agent purple panel + badge, schedule arrow, live-feed dot, success-rate ladder
- \`UnifiedActivityPanel\` — running/success/fail indicators in both live row + detail modal
- \`OnboardingChecklist\` — full completed-state styling (ring, bg, indicator, line-through text)
- \`CreateAgentModal\` — templates-error and general error states
- \`ConfirmDialog\` — danger/warning variants (icons, text, confirm buttons)
- \`AvatarGenerateModal\` — error text, remove-avatar button
- \`HelpChatWidget\` — error banner + retry button
- \`ResourceModal\` — amber notice deferred (palette shift)

### Misc (4 files)
- \`YamlEditor\` — error/warning counts, banners, success checkmark
- \`EditorHelpPanel\` — required-field indicator
- \`TerminalPanelContent\` — restart-required notice, start-agent button
- \`TagsEditor\` — error message

## Deferred (consistent with prior slices)

| Pattern | Files affected | Token gap |
|---|---|---|
| Primary action buttons (indigo / bg-blue-600 / hover:bg-blue-700) | many | \`action-primary\` |
| Selected-state styling (NavBar tabs, OperatingRoom tabs) | NavBar | \`state-selected\` |
| Amber notices (ResourceModal, FileSharingPanel notice, RoleMatrix amber missing-role marker) | 3 | accent palette expansion |
| File-type icon colors in \`FileTreeNode\` (folder yellow, video purple, audio green, image blue, pdf red) | 1 | decorative \`accent-{color}\` family |
| Slack / Telegram / WhatsApp brand logo colors | 3 | \`brand-*\` extensions for non-runtime brands |

## Verification

\`\`\`
npm run check:tokens             ✓ (10 tokens equivalent; all references resolve)
npm run build                    ✓
npm run test:e2e:smoke           ✓ 7/7 passed (7.9s)
\`\`\`

## Test plan
- [ ] CI \`frontend-build\` passes
- [ ] CI \`frontend-e2e\` (\`@smoke\`) passes
- [ ] Visual smoke: NavBar Ops counter, GitConflictModal (open conflict), confirmation dialogs, OnboardingChecklist completed items

Refs #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)