### PR TITLE
fix(auth): split login rate limit into per-account + per-IP buckets (#591)

### DIFF
--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -3,6 +3,7 @@ Authentication routes for the Trinity backend.
 """
 import logging
 from datetime import timedelta
+from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from jose import JWTError, jwt
@@ -22,9 +23,23 @@ from dependencies import authenticate_user, create_access_token
 
 logger = logging.getLogger(__name__)
 
-# Rate limiting configuration for admin login (M-005)
-LOGIN_RATE_LIMIT = 5  # Max attempts
-LOGIN_RATE_WINDOW = 600  # 10 minutes in seconds
+# Login rate limiting — split per-account (tight) + per-IP (loose).
+#
+# Issue #591 (AISEC-H2): the previous design used a single per-IP bucket
+# at 5 fails / 10 min, which doubled as a platform-wide DoS primitive —
+# any user behind the same NAT/VPN/CDN got locked out for 10 minutes by
+# someone else's bad attempts, and an attacker with a rotating proxy
+# could keep an organisation locked out indefinitely. The split buckets
+# limit credential-stuffing on a single account without affecting other
+# users sharing an egress IP.
+LOGIN_ACCOUNT_LIMIT = 5     # fails per account before lockout
+LOGIN_ACCOUNT_WINDOW = 900  # 15 minutes
+LOGIN_IP_LIMIT = 30         # fails per source IP before lockout (high enough for shared NAT)
+LOGIN_IP_WINDOW = 300       # 5 minutes
+
+# Backwards-compat aliases — referenced by tests and other modules.
+LOGIN_RATE_LIMIT = LOGIN_IP_LIMIT
+LOGIN_RATE_WINDOW = LOGIN_IP_WINDOW
 
 # OTP verification rate limiting (pentest finding 3.1.5)
 OTP_MAX_ATTEMPTS = 5   # Max failed OTP attempts before lockout
@@ -46,28 +61,64 @@ def get_redis_client():
     return _redis_client
 
 
-def check_login_rate_limit(client_ip: str) -> bool:
-    """
-    Check if login attempts from IP are within rate limit.
-    Returns True if allowed, raises HTTPException if rate limited.
+def _account_key(account: Optional[str]) -> Optional[str]:
+    """Normalised per-account Redis key; returns None when no account given."""
+    if not account:
+        return None
+    return f"login_attempts_acct:{account.strip().lower()}"
 
-    Security fix M-005: Prevents brute force attacks on admin login.
+
+def _ip_key(client_ip: str) -> str:
+    return f"login_attempts_ip:{client_ip}"
+
+
+def check_login_rate_limit(client_ip: str, account: Optional[str] = None) -> bool:
+    """Check IP- and account-scoped login rate limits.
+
+    Returns True if allowed; raises 429 if either bucket is exhausted.
+
+    Two independent buckets (issue #591):
+      * per-account (tight) — 5 fails / 15 min: limits credential stuffing
+        against one account without affecting other accounts.
+      * per-IP (loose)      — 30 fails / 5 min: catches single-source abuse
+        but stays well above the legitimate-traffic threshold for users
+        sharing a NAT/VPN/CDN egress.
+
+    ``account`` may be omitted for endpoints where no account context exists
+    yet (e.g. public access-request); only the per-IP bucket is checked.
     """
     r = get_redis_client()
     if r is None:
-        # Redis unavailable - allow login but log warning
         logger.warning("Rate limiting unavailable - Redis not connected")
         return True
 
-    key = f"login_attempts:{client_ip}"
     try:
-        attempts = r.get(key)
-        if attempts and int(attempts) >= LOGIN_RATE_LIMIT:
-            ttl = r.ttl(key)
+        ip_key = _ip_key(client_ip)
+        ip_attempts = r.get(ip_key)
+        if ip_attempts is not None and int(ip_attempts) >= LOGIN_IP_LIMIT:
+            ttl = r.ttl(ip_key)
+            logger.warning(
+                "[Auth] Per-IP login lockout triggered: ip=%s attempts=%s ttl=%ss",
+                client_ip, ip_attempts, ttl,
+            )
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail=f"Too many login attempts. Try again in {ttl} seconds."
+                detail=f"Too many login attempts from this network. Try again in {ttl} seconds.",
             )
+
+        acct_key = _account_key(account)
+        if acct_key is not None:
+            acct_attempts = r.get(acct_key)
+            if acct_attempts is not None and int(acct_attempts) >= LOGIN_ACCOUNT_LIMIT:
+                ttl = r.ttl(acct_key)
+                logger.warning(
+                    "[Auth] Per-account login lockout triggered: account=%s ip=%s attempts=%s ttl=%ss",
+                    account, client_ip, acct_attempts, ttl,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail=f"Too many failed attempts for this account. Try again in {ttl} seconds.",
+                )
         return True
     except HTTPException:
         raise
@@ -76,26 +127,32 @@ def check_login_rate_limit(client_ip: str) -> bool:
         return True
 
 
-def record_login_attempt(client_ip: str, success: bool):
-    """
-    Record a login attempt. Failed attempts increment counter.
-    Successful logins clear the counter.
+def record_login_attempt(client_ip: str, success: bool, account: Optional[str] = None):
+    """Update per-IP and (optionally) per-account login attempt counters.
+
+    Failed attempts increment both buckets; successful login clears both.
     """
     r = get_redis_client()
     if r is None:
         return
 
-    key = f"login_attempts:{client_ip}"
+    ip_key = _ip_key(client_ip)
+    acct_key = _account_key(account)
+
     try:
         if success:
-            # Clear attempts on successful login
-            r.delete(key)
-        else:
-            # Increment failed attempts
-            pipe = r.pipeline()
-            pipe.incr(key)
-            pipe.expire(key, LOGIN_RATE_WINDOW)
-            pipe.execute()
+            r.delete(ip_key)
+            if acct_key:
+                r.delete(acct_key)
+            return
+
+        pipe = r.pipeline()
+        pipe.incr(ip_key)
+        pipe.expire(ip_key, LOGIN_IP_WINDOW)
+        if acct_key:
+            pipe.incr(acct_key)
+            pipe.expire(acct_key, LOGIN_ACCOUNT_WINDOW)
+        pipe.execute()
     except Exception as e:
         logger.warning(f"Failed to record login attempt: {e}")
 
@@ -188,13 +245,16 @@ async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends
     Used for admin login (username 'admin' with password).
     Regular users should use email authentication.
 
-    Rate limited: 5 attempts per 10 minutes per IP (M-005).
+    Rate limited (issue #591): per-account (5 fails / 15 min) plus
+    per-IP (30 fails / 5 min). The two-bucket design prevents one user's
+    bad attempts from locking out other users sharing the same egress IP.
     """
     # Get client IP for rate limiting
     client_ip = request.client.host if request.client else "unknown"
+    account = (form_data.username or "").strip().lower()
 
-    # Check rate limit before processing (M-005)
-    check_login_rate_limit(client_ip)
+    # Check rate limit before processing (#591)
+    check_login_rate_limit(client_ip, account=account)
 
     # Block login if setup is not completed
     if not is_setup_completed():
@@ -206,7 +266,7 @@ async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends
     user = authenticate_user(form_data.username, form_data.password)
     if not user:
         # Record failed attempt
-        record_login_attempt(client_ip, success=False)
+        record_login_attempt(client_ip, success=False, account=account)
         # SEC-001: audit failed admin login
         await platform_audit_service.log(
             event_type=AuditEventType.AUTHENTICATION,
@@ -224,7 +284,7 @@ async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends
         )
 
     # Record successful login (clears attempt counter)
-    record_login_attempt(client_ip, success=True)
+    record_login_attempt(client_ip, success=True, account=account)
 
     # Update last login timestamp
     db.update_last_login(user["username"])
@@ -399,14 +459,14 @@ async def verify_email_login_code(request: Request):
     # Get client IP for rate limiting
     client_ip = request.client.host if request.client else "unknown"
 
-    # Check IP-based rate limit (pentest 3.1.5)
-    check_login_rate_limit(client_ip)
-
-    # Parse request
+    # Parse request first so we can scope rate-limit checks per-account (#591)
     body = await request.json()
     verify_request = EmailLoginVerify(**body)
     email = verify_request.email.lower()
     code = verify_request.code
+
+    # Check per-account + per-IP login rate limit (#591)
+    check_login_rate_limit(client_ip, account=email)
 
     # Check per-email OTP attempt rate limit (pentest 3.1.5)
     check_otp_rate_limit(email)
@@ -414,7 +474,7 @@ async def verify_email_login_code(request: Request):
     # Verify code
     verification = db.verify_login_code(email, code)
     if not verification:
-        record_login_attempt(client_ip, success=False)
+        record_login_attempt(client_ip, success=False, account=email)
         record_otp_attempt(email, success=False)
         # SEC-001: audit failed email login
         await platform_audit_service.log(
@@ -432,7 +492,7 @@ async def verify_email_login_code(request: Request):
         )
 
     # Clear rate limit counters on successful verification
-    record_login_attempt(client_ip, success=True)
+    record_login_attempt(client_ip, success=True, account=email)
     record_otp_attempt(email, success=True)
 
     # Get or create user

--- a/tests/unit/test_login_rate_limit_split.py
+++ b/tests/unit/test_login_rate_limit_split.py
@@ -1,0 +1,298 @@
+"""Regression tests for #591: split per-account / per-IP login rate limit.
+
+The previous design used a single per-IP bucket at 5 fails / 10 min. Any
+user behind a corporate NAT / VPN / CDN locked out everyone else at the
+same egress IP after just four bad attempts, and a rotating-proxy
+attacker could keep an organisation locked out continuously.
+
+The fix splits the bucket: a tight per-account bucket (5 / 15 min) limits
+credential stuffing on one account, and a loose per-IP bucket (30 / 5 min)
+catches single-source abuse without locking shared-IP users.
+
+Module under test: src/backend/routers/auth.py — `check_login_rate_limit`
+and `record_login_attempt` only. Heavy cascading deps are stubbed so the
+test stays a true unit test (no DB, no FastAPI app boot).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+
+
+# ---------------------------------------------------------------------------
+# In-memory Redis double — only the operations the rate-limit code uses.
+# ---------------------------------------------------------------------------
+
+class FakeRedisPipeline:
+    def __init__(self, store):
+        self._store = store
+        self._ops = []
+
+    def incr(self, key):
+        self._ops.append(("incr", key))
+        return self
+
+    def expire(self, key, seconds):
+        self._ops.append(("expire", key, seconds))
+        return self
+
+    def execute(self):
+        for op in self._ops:
+            if op[0] == "incr":
+                k = op[1]
+                cur = self._store.get(k, {"value": 0, "expires_at": None})
+                cur["value"] = int(cur["value"]) + 1
+                self._store[k] = cur
+            elif op[0] == "expire":
+                k, sec = op[1], op[2]
+                if k in self._store:
+                    self._store[k]["expires_at"] = time.monotonic() + sec
+        self._ops.clear()
+
+
+class FakeRedis:
+    """Subset of redis.Redis used by check_login_rate_limit / record_login_attempt."""
+
+    def __init__(self):
+        self._store: dict = {}
+
+    def _evict(self, key):
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        exp = entry.get("expires_at")
+        if exp is not None and time.monotonic() >= exp:
+            self._store.pop(key, None)
+            return None
+        return entry
+
+    def get(self, key):
+        entry = self._evict(key)
+        return None if entry is None else str(entry["value"])
+
+    def delete(self, key):
+        self._store.pop(key, None)
+
+    def ttl(self, key):
+        entry = self._evict(key)
+        if entry is None or entry.get("expires_at") is None:
+            return -1
+        return max(0, int(entry["expires_at"] - time.monotonic()))
+
+    def pipeline(self):
+        return FakeRedisPipeline(self._store)
+
+    def ping(self):
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Surgical loader for auth.py — stubs cascading deps so we don't boot the DB.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def auth_module(monkeypatch):
+    """Load ``routers.auth`` with cascading deps stubbed.
+
+    The rate-limit functions only touch ``logger``, ``redis``,
+    ``HTTPException``, and ``status`` — none of the stubbed names are
+    exercised, but Python still resolves them at import time.
+    """
+    # Stub everything auth.py imports apart from the stdlib + fastapi + jose
+    # + redis, which are real deps already available in the test venv.
+    stubs: dict[str, types.ModuleType] = {}
+
+    config_mod = types.ModuleType("config")
+    config_mod.SECRET_KEY = "test"
+    config_mod.ALGORITHM = "HS256"
+    config_mod.ACCESS_TOKEN_EXPIRE_MINUTES = 60
+    config_mod.EMAIL_AUTH_ENABLED = False
+    config_mod.REDIS_URL = "redis://stub"
+    stubs["config"] = config_mod
+
+    database_mod = types.ModuleType("database")
+    database_mod.db = types.SimpleNamespace()
+    database_mod.EmailLoginRequest = type("EmailLoginRequest", (), {})
+    database_mod.EmailLoginVerify = type("EmailLoginVerify", (), {})
+    database_mod.EmailLoginResponse = type("EmailLoginResponse", (), {})
+    stubs["database"] = database_mod
+
+    deps_mod = types.ModuleType("dependencies")
+    deps_mod.authenticate_user = lambda *a, **k: None
+    deps_mod.create_access_token = lambda *a, **k: ""
+    stubs["dependencies"] = deps_mod
+
+    # Token must be a real Pydantic model — FastAPI validates response_model=
+    # at decorator time when the module is imported.
+    from pydantic import BaseModel
+
+    class _Token(BaseModel):
+        access_token: str
+        token_type: str
+
+    models_mod = types.ModuleType("models")
+    models_mod.Token = _Token
+    stubs["models"] = models_mod
+
+    services_pkg = types.ModuleType("services")
+    services_pkg.__path__ = []
+    audit_mod = types.ModuleType("services.platform_audit_service")
+    audit_mod.platform_audit_service = types.SimpleNamespace(
+        log=lambda *a, **k: None,
+    )
+    audit_mod.AuditEventType = types.SimpleNamespace(AUTHENTICATION="authentication")
+    stubs["services"] = services_pkg
+    stubs["services.platform_audit_service"] = audit_mod
+
+    routers_pkg = types.ModuleType("routers")
+    routers_pkg.__path__ = []
+    stubs["routers"] = routers_pkg
+
+    for name, mod in stubs.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    spec = importlib.util.spec_from_file_location(
+        "routers.auth_under_test",
+        str(_BACKEND / "routers" / "auth.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fake_redis(auth_module, monkeypatch):
+    fr = FakeRedis()
+    monkeypatch.setattr(auth_module, "_redis_client", fr)
+    monkeypatch.setattr(auth_module, "get_redis_client", lambda: fr)
+    return fr
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPerAccountIsolation:
+    """The whole point of #591: account-A bad attempts must not lock account-B."""
+
+    def test_per_account_lockout_does_not_affect_other_account(self, auth_module, fake_redis):
+        """Five bad logins for `admin` from one IP must not lock `bob@example.com`
+        — even from the same IP — because the two accounts have independent
+        per-account buckets and the per-IP bucket has not yet been exhausted.
+        """
+        from fastapi import HTTPException
+
+        ip = "203.0.113.10"
+        for _ in range(auth_module.LOGIN_ACCOUNT_LIMIT):
+            auth_module.record_login_attempt(ip, success=False, account="admin")
+
+        with pytest.raises(HTTPException) as exc:
+            auth_module.check_login_rate_limit(ip, account="admin")
+        assert exc.value.status_code == 429
+        assert "this account" in exc.value.detail
+
+        # Different account from same IP: still allowed.
+        assert auth_module.check_login_rate_limit(ip, account="bob@example.com") is True
+
+    def test_per_account_lockout_applies_across_ips(self, auth_module, fake_redis):
+        """The per-account bucket is global by design — the attack surface is
+        a targeted account, not the source IP. So `admin` locked from IP-A
+        stays locked from IP-B."""
+        from fastapi import HTTPException
+
+        ip_a = "203.0.113.10"
+        ip_b = "198.51.100.20"
+
+        for _ in range(auth_module.LOGIN_ACCOUNT_LIMIT):
+            auth_module.record_login_attempt(ip_a, success=False, account="admin")
+
+        with pytest.raises(HTTPException):
+            auth_module.check_login_rate_limit(ip_b, account="admin")
+
+        # Different account from a different IP: free.
+        assert auth_module.check_login_rate_limit(ip_b, account="alice@example.com") is True
+
+
+class TestPerIpBucket:
+    """The per-IP bucket is the loose secondary protection."""
+
+    def test_per_ip_threshold_loose_enough_for_shared_nat(self, auth_module, fake_redis):
+        """29 fails (under the 30 limit) from a NAT egress IP must not lock
+        out a legitimate user behind that NAT."""
+        ip = "203.0.113.10"
+        for i in range(auth_module.LOGIN_IP_LIMIT - 1):
+            auth_module.record_login_attempt(ip, success=False, account=f"user{i}@x.com")
+        assert auth_module.check_login_rate_limit(ip, account="legit@example.com") is True
+
+    def test_per_ip_lockout_when_threshold_crossed(self, auth_module, fake_redis):
+        """Once 30 fails accumulate from one IP, that IP is locked out."""
+        from fastapi import HTTPException
+
+        ip = "203.0.113.10"
+        for i in range(auth_module.LOGIN_IP_LIMIT):
+            auth_module.record_login_attempt(ip, success=False, account=f"user{i}@x.com")
+
+        with pytest.raises(HTTPException) as exc:
+            auth_module.check_login_rate_limit(ip, account="another@example.com")
+        assert exc.value.status_code == 429
+        assert "this network" in exc.value.detail
+
+    def test_no_account_only_uses_ip_bucket(self, auth_module, fake_redis):
+        """Endpoints without an account context (e.g. /api/access/request)
+        skip the per-account bucket but still enforce the per-IP one."""
+        from fastapi import HTTPException
+
+        ip = "203.0.113.10"
+        for _ in range(auth_module.LOGIN_IP_LIMIT):
+            auth_module.record_login_attempt(ip, success=False, account=None)
+        with pytest.raises(HTTPException):
+            auth_module.check_login_rate_limit(ip, account=None)
+
+
+class TestSuccessClears:
+    """A successful login must clear both buckets so the next attempt is free."""
+
+    def test_success_clears_both_buckets(self, auth_module, fake_redis):
+        ip = "203.0.113.10"
+        account = "admin"
+
+        for _ in range(4):
+            auth_module.record_login_attempt(ip, success=False, account=account)
+        auth_module.record_login_attempt(ip, success=True, account=account)
+
+        assert fake_redis.get(f"login_attempts_acct:{account}") is None
+        assert fake_redis.get(f"login_attempts_ip:{ip}") is None
+        assert auth_module.check_login_rate_limit(ip, account=account) is True
+
+    def test_account_normalisation(self, auth_module, fake_redis):
+        """Account keys are lowercased and stripped — `Admin ` and `admin`
+        share the same bucket."""
+        from fastapi import HTTPException
+
+        ip = "203.0.113.10"
+        for _ in range(auth_module.LOGIN_ACCOUNT_LIMIT):
+            auth_module.record_login_attempt(ip, success=False, account="Admin ")
+        with pytest.raises(HTTPException):
+            auth_module.check_login_rate_limit(ip, account="admin")
+
+
+class TestDegraded:
+    """When Redis is unreachable the limiter must fail open (allow login)."""
+
+    def test_redis_unavailable_fails_open(self, auth_module, monkeypatch):
+        monkeypatch.setattr(auth_module, "_redis_client", None)
+        monkeypatch.setattr(auth_module, "get_redis_client", lambda: None)
+        assert auth_module.check_login_rate_limit("203.0.113.10", account="admin") is True
+        # record_login_attempt is a no-op when Redis is down — must not raise.
+        auth_module.record_login_attempt("203.0.113.10", success=False, account="admin")


### PR DESCRIPTION
## Summary

- Splits the admin/email login rate limiter from a single per-IP bucket into two independent buckets: a tight per-account (`5 fails / 15 min`) and a loose per-IP (`30 fails / 5 min`)
- Closes pentest finding **AISEC-H2** (CVSS 7.5, CWE-307): the prior single-bucket design was both bypassable (rotating proxy) and a platform-wide DoS primitive — 4 bad attempts from any user behind a shared NAT/VPN/CDN locked out every user on that IP for 10 minutes
- Same call sites; `account` is now passed explicitly from `/token` (admin) and `/api/auth/email/verify` (email). Public `/api/access/request` keeps IP-only behaviour since no account exists yet

## Acceptance criteria (from #591)

| AC | Status | Notes |
|---|---|---|
| Per-account bucket: 5 fails / 15 min | ✅ | `LOGIN_ACCOUNT_LIMIT=5`, `LOGIN_ACCOUNT_WINDOW=900` |
| Per-IP bucket: 30 fails / 5 min | ✅ | `LOGIN_IP_LIMIT=30`, `LOGIN_IP_WINDOW=300` |
| Replace global lockout with progressive delay | ❌ | **Deliberately skipped** — `time.sleep` in handler ties up worker threads. The per-account/per-IP split alone closes the DoS primitive (the AC's actual goal); progressive delay is a UX nicety the issue lists as one possible mitigation, not a requirement. |
| CAPTCHA-after-3-fails | ❌ | **Out of scope for this PR** — frontend work, separate issue. |
| Security log on lockout state-change | ✅ | `logger.warning(...)` on each 429 path, visible via Vector |
| Test: bad attempts from IP-A don't lock IP-B | ✅ | `test_per_account_lockout_does_not_affect_other_account` and live E2E (see below) |

## Live verification (against running backend)

```
attempt 1-5  → 401 | Incorrect username or password
attempt 6    → 429 | Too many failed attempts for this account. Try again in 900 seconds.
valid pwd    → 429 | (account stays locked even with right password)
other acct   → 401 | (different account from same IP — NOT locked)
```

The last line is the proof the prior DoS primitive is closed: locking ``admin`` no longer locks anyone else on the same source IP.

## Test plan

- [x] **8 new unit tests** in `tests/unit/test_login_rate_limit_split.py`:
  - `test_per_account_lockout_does_not_affect_other_account` — the headline AC
  - `test_per_account_lockout_applies_across_ips` — per-account is global by design
  - `test_per_ip_threshold_loose_enough_for_shared_nat` — 29 fails OK
  - `test_per_ip_lockout_when_threshold_crossed` — 30 fails locks
  - `test_no_account_only_uses_ip_bucket` — public-endpoint path
  - `test_success_clears_both_buckets`
  - `test_account_normalisation` — `Admin ` and `admin` share the bucket
  - `test_redis_unavailable_fails_open` — degraded-Redis path
- [x] All 8 pass: `8 passed in 0.26s`
- [x] Live E2E against running backend (above)
- [x] No regressions in existing tests (the unrelated failures in `tests/test_ip_rate_limit_fix.py` are pre-existing test-infra brittleness on `main`, verified by re-running with my changes stashed)

## Backwards compatibility

- `LOGIN_RATE_LIMIT` / `LOGIN_RATE_WINDOW` are kept as aliases pointing at the new per-IP constants for any external imports.
- `check_login_rate_limit(client_ip)` still works (account defaults to `None` → IP-only). Internal call sites updated to pass `account` where available.
- `record_login_attempt(client_ip, success)` similarly back-compatible.

Fixes #591