### PR TITLE
fix(deploy): rebuild stale platform images automatically in start.sh (#557)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,6 +24,8 @@ cp .env.example .env
 ./scripts/deploy/build-base-image.sh
 
 # 4. Start all services
+# (auto-rebuilds platform images whose Dockerfile or pinned deps changed since
+#  the last build — see "Stale-image detection" below)
 ./scripts/deploy/start.sh
 
 # 5. Access the platform
@@ -156,6 +158,17 @@ docker logs agent-myagent
 **Agent creation fails**
 - Check if `trinity-agent-base` image exists: `docker images | grep trinity-agent-base`
 - Rebuild: `./scripts/deploy/build-base-image.sh`
+
+**Stale platform images after a `git pull`**
+`start.sh` runs `scripts/deploy/_check_stale_images.py` before bringing
+services up. It compares each platform image's creation time against the
+mtime of its Dockerfile and pinned dependency files
+(`requirements.txt`, `package.json`, `package-lock.json`); any service
+whose tracked files are newer than its image is rebuilt automatically.
+If you see a `ModuleNotFoundError` on startup despite `up -d` reporting
+success, it means the detector couldn't run (Python 3 missing on PATH)
+— rebuild manually with `docker compose build <service>` and re-run
+`start.sh`.
 
 **Redis connection errors**
 - Ensure Redis is running: `docker compose ps redis`

--- a/scripts/deploy/_check_stale_images.py
+++ b/scripts/deploy/_check_stale_images.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Print platform services whose Docker images are stale (#557).
+
+For each service in ``SERVICES``, compare the image's ``.Created``
+timestamp against the latest mtime among the service's tracked files
+(Dockerfile, requirements.txt, package.json, package-lock.json). Stale
+service names go to stdout, one per line; human-readable reasons go to
+stderr. ``start.sh`` consumes stdout to decide what to ``docker compose
+build`` before ``up -d``.
+
+Tracked files are the ones whose changes imply a new image is required
+— Dockerfiles (because they pin installed deps inline) and dependency
+manifests that the Dockerfile copies in. Plain source files are not
+tracked: source is bind-mounted at runtime, so source-only changes do
+not require a rebuild.
+
+Exit code is always 0 — a failure here must not block ``start.sh``.
+"""
+from __future__ import annotations
+
+import datetime
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Each entry: service name → (image:tag, [files whose changes imply rebuild]).
+# Paths are relative to the project root.
+SERVICES: dict[str, tuple[str, list[str]]] = {
+    "backend": (
+        "trinity-backend:latest",
+        [
+            "docker/backend/Dockerfile",
+        ],
+    ),
+    "frontend": (
+        "trinity-frontend:latest",
+        [
+            "docker/frontend/Dockerfile",
+            "src/frontend/package.json",
+            "src/frontend/package-lock.json",
+        ],
+    ),
+    "mcp-server": (
+        "trinity-mcp-server:latest",
+        [
+            "src/mcp-server/Dockerfile",
+            "src/mcp-server/package.json",
+            "src/mcp-server/package-lock.json",
+        ],
+    ),
+    "scheduler": (
+        "trinity-scheduler:latest",
+        [
+            "docker/scheduler/Dockerfile",
+            "docker/scheduler/requirements.txt",
+        ],
+    ),
+}
+
+
+def _image_created_at(image: str) -> datetime.datetime | None:
+    """Return the image's creation time, or ``None`` if the image is missing.
+
+    Docker emits RFC 3339 with timezone offset and nanosecond precision
+    (e.g. ``2026-04-13T12:00:00.123456789+00:00``). ``fromisoformat``
+    handles the offset in Python 3.11+ but only accepts ≤6 fractional
+    digits, so trim nanos defensively.
+    """
+    try:
+        out = subprocess.check_output(
+            ["docker", "image", "inspect", image, "--format", "{{.Created}}"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    if not out:
+        return None
+    if "." in out:
+        head, _, tail = out.partition(".")
+        # tail looks like "123456789+00:00" or "123456789Z"
+        for sep in ("+", "-", "Z"):
+            if sep in tail:
+                idx = tail.index(sep)
+                frac, suffix = tail[:idx], tail[idx:]
+                out = f"{head}.{frac[:6]}{suffix}"
+                break
+        else:
+            out = f"{head}.{tail[:6]}"
+    try:
+        return datetime.datetime.fromisoformat(out)
+    except ValueError:
+        return None
+
+
+def _file_mtime(path: Path) -> datetime.datetime | None:
+    try:
+        ts = path.stat().st_mtime
+    except OSError:
+        return None
+    return datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc)
+
+
+def main() -> int:
+    for service, (image, file_paths) in SERVICES.items():
+        img_dt = _image_created_at(image)
+        if img_dt is None:
+            print(
+                f"  {service}: image {image} missing → will build",
+                file=sys.stderr,
+            )
+            print(service)
+            continue
+
+        for rel in file_paths:
+            f_dt = _file_mtime(PROJECT_ROOT / rel)
+            if f_dt is None:
+                continue
+            if f_dt > img_dt:
+                print(
+                    f"  {service}: {rel} modified at {f_dt.isoformat()} "
+                    f"after image build at {img_dt.isoformat()}",
+                    file=sys.stderr,
+                )
+                print(service)
+                break
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy/start.sh
+++ b/scripts/deploy/start.sh
@@ -36,6 +36,26 @@ if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "trinity-agent-
     echo ""
 fi
 
+# Detect stale platform images (#557): rebuild services whose Dockerfile or
+# pinned dependency files have been modified after the current image was
+# built. Without this, source-only pulls that add new Python/Node deps fail
+# at startup with `ModuleNotFoundError` while compose keeps respawning the
+# crash-looping worker — and `up -d` reports success.
+if command -v python3 >/dev/null 2>&1; then
+    echo "Checking for stale platform images..."
+    STALE_SERVICES=$(python3 scripts/deploy/_check_stale_images.py)
+    if [ -n "$STALE_SERVICES" ]; then
+        echo ""
+        echo "Rebuilding stale platform images: $(echo $STALE_SERVICES | tr '\n' ' ')"
+        # shellcheck disable=SC2086
+        docker compose build $STALE_SERVICES
+        echo ""
+    fi
+else
+    echo "⚠️  python3 not found on PATH; skipping stale-image detection (#557)."
+    echo "   If services fail to start with import errors, run 'docker compose build' manually."
+fi
+
 echo "Starting services..."
 docker compose up -d
 

--- a/tests/unit/test_stale_image_detector.py
+++ b/tests/unit/test_stale_image_detector.py
@@ -1,0 +1,203 @@
+"""Regression tests for #557: stale-image detection in start.sh.
+
+The detector compares each platform image's ``.Created`` timestamp
+against the latest mtime of its tracked dep-bearing files. The function
+under test is ``scripts/deploy/_check_stale_images.py``'s ``main()`` —
+covered here by mocking the docker subprocess and the filesystem mtime
+on a tmp project root.
+"""
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "deploy" / "_check_stale_images.py"
+
+
+@pytest.fixture
+def detector(monkeypatch, tmp_path):
+    """Load the detector module with PROJECT_ROOT pointed at a clean tmp tree."""
+    spec = importlib.util.spec_from_file_location("stale_image_detector", str(_SCRIPT))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(module, "PROJECT_ROOT", tmp_path)
+
+    # Build the tracked file tree under tmp_path so file mtimes are real.
+    for _, file_paths in module.SERVICES.values():
+        for rel in file_paths:
+            target = tmp_path / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("placeholder")
+    return module, tmp_path
+
+
+def _set_mtime(path: Path, when: datetime.datetime) -> None:
+    ts = when.timestamp()
+    os.utime(path, (ts, ts))
+
+
+def _mock_docker_inspect(timestamps: dict[str, str | None]):
+    """Patch ``subprocess.check_output`` to return a stub creation time per image.
+
+    ``timestamps`` maps image:tag → RFC3339 string (or ``None`` to simulate
+    a missing image — raises CalledProcessError).
+    """
+    def fake(cmd, *args, **kwargs):
+        # cmd is ['docker', 'image', 'inspect', '<image>', '--format', '{{.Created}}']
+        image = cmd[3]
+        ts = timestamps.get(image)
+        if ts is None:
+            raise subprocess.CalledProcessError(1, cmd)
+        return ts
+    return patch.object(subprocess, "check_output", side_effect=fake)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStaleImageDetector:
+    """Detector returns service names exactly when their tracked files are
+    newer than the image creation time."""
+
+    def test_all_fresh_emits_nothing(self, detector, capsys):
+        """No service should be flagged when every tracked file is older
+        than its image."""
+        module, root = detector
+        # Files were created just now; pin them in the past.
+        old = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        for _, file_paths in module.SERVICES.values():
+            for rel in file_paths:
+                _set_mtime(root / rel, old)
+
+        # Image creation time AFTER all file mtimes.
+        new = datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc)
+        timestamps = {
+            image: new.isoformat()
+            for image, _ in module.SERVICES.values()
+        }
+        with _mock_docker_inspect(timestamps):
+            module.main()
+
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "", (
+            f"Detector flagged services with no stale files: {captured.out!r}"
+        )
+
+    def test_dockerfile_newer_than_image_flags_service(self, detector, capsys):
+        """The exact #557 scenario: Dockerfile was modified after the image
+        was built, so the service must be flagged for rebuild."""
+        module, root = detector
+        old = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        for _, file_paths in module.SERVICES.values():
+            for rel in file_paths:
+                _set_mtime(root / rel, old)
+
+        # Push the backend Dockerfile into the future, after image creation.
+        future = datetime.datetime(2026, 4, 30, tzinfo=datetime.timezone.utc)
+        _set_mtime(root / "docker/backend/Dockerfile", future)
+
+        img_time = datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc)
+        timestamps = {
+            image: img_time.isoformat()
+            for image, _ in module.SERVICES.values()
+        }
+        with _mock_docker_inspect(timestamps):
+            module.main()
+
+        flagged = capsys.readouterr().out.strip().splitlines()
+        assert flagged == ["backend"]
+
+    def test_requirements_change_flags_scheduler(self, detector, capsys):
+        """Scheduler ships a separate requirements.txt — adding a dep there
+        without touching the Dockerfile must still trigger a rebuild."""
+        module, root = detector
+        old = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        for _, file_paths in module.SERVICES.values():
+            for rel in file_paths:
+                _set_mtime(root / rel, old)
+
+        future = datetime.datetime(2026, 4, 30, tzinfo=datetime.timezone.utc)
+        _set_mtime(root / "docker/scheduler/requirements.txt", future)
+
+        img_time = datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc)
+        timestamps = {
+            image: img_time.isoformat()
+            for image, _ in module.SERVICES.values()
+        }
+        with _mock_docker_inspect(timestamps):
+            module.main()
+
+        flagged = capsys.readouterr().out.strip().splitlines()
+        assert flagged == ["scheduler"]
+
+    def test_missing_image_flags_service(self, detector, capsys):
+        """First-time deploy: no image exists yet → must build."""
+        module, _root = detector
+        # All images present except backend.
+        img_time = datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc)
+        timestamps: dict[str, str | None] = {
+            image: img_time.isoformat()
+            for image, _ in module.SERVICES.values()
+        }
+        timestamps["trinity-backend:latest"] = None  # simulate missing image
+
+        with _mock_docker_inspect(timestamps):
+            module.main()
+
+        flagged = capsys.readouterr().out.strip().splitlines()
+        assert "backend" in flagged
+
+    def test_npm_lockfile_change_flags_frontend(self, detector, capsys):
+        """A `package-lock.json` bump (no Dockerfile change) must also fire."""
+        module, root = detector
+        old = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        for _, file_paths in module.SERVICES.values():
+            for rel in file_paths:
+                _set_mtime(root / rel, old)
+
+        future = datetime.datetime(2026, 4, 30, tzinfo=datetime.timezone.utc)
+        _set_mtime(root / "src/frontend/package-lock.json", future)
+
+        img_time = datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc)
+        timestamps = {
+            image: img_time.isoformat()
+            for image, _ in module.SERVICES.values()
+        }
+        with _mock_docker_inspect(timestamps):
+            module.main()
+
+        flagged = capsys.readouterr().out.strip().splitlines()
+        assert flagged == ["frontend"]
+
+    def test_handles_nanosecond_precision_timestamp(self, detector, capsys):
+        """Docker emits 9-digit fractional seconds; Python's fromisoformat
+        accepts at most 6. The detector must trim cleanly."""
+        module, root = detector
+        old = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        for _, file_paths in module.SERVICES.values():
+            for rel in file_paths:
+                _set_mtime(root / rel, old)
+
+        # Nanosecond-precision RFC3339 — a real Docker output format.
+        ts = "2026-04-13T12:00:00.123456789+00:00"
+        timestamps = {
+            image: ts for image, _ in module.SERVICES.values()
+        }
+        with _mock_docker_inspect(timestamps):
+            rc = module.main()
+
+        assert rc == 0
+        flagged = capsys.readouterr().out.strip()
+        assert flagged == "", "Nothing should be flagged when files are old"


### PR DESCRIPTION
## Summary

- `start.sh` was running `docker compose up -d` without checking whether platform images were stale relative to their Dockerfiles. After a `git pull` that added a new Python or Node dependency, self-hosted developers ended up with new source bind-mounted into an old image — uvicorn crashed at import with `ModuleNotFoundError`, compose kept respawning the worker, port 8000 never bound, and `up -d` reported success.
- Adds `scripts/deploy/_check_stale_images.py`: per-service comparison of image `.Created` against the latest mtime of its Dockerfile and pinned dependency files. Tracked files are only the ones whose changes imply a new image is required — plain source is bind-mounted at runtime, so the happy path stays fast (no rebuild penalty when nothing dep-bearing changed).
- Wires `start.sh` to run the detector before `up -d`; if any service is stale, `docker compose build <those-services>` runs first.

## Implementation choice (vs the three options in the issue)

Issue offered three approaches:
1. Always pass `--build` — simplest, slow on warm caches
2. **Detect Dockerfile-newer-than-image — only rebuild affected services** ← chosen
3. `BUILD_VERSION` marker — production-style, more invasive

Picked option 2 because AC #2 explicitly says \"fresh clones with up-to-date images don't pay a noticeable rebuild penalty\" — option 1 fails that. Option 3 needs Dockerfile changes across 4 services + a startup check; option 2 is one new Python file plus a 20-line block in `start.sh`.

## Acceptance criteria (from #557)

| AC | Status | Notes |
|---|---|---|
| `start.sh` brings up healthy backend after a Dockerfile change without `docker compose build` first | ✅ | Detector flags `backend`, `start.sh` rebuilds it |
| Happy path: no rebuild when source matches image | ✅ | Tracked files are dep-bearing only; source-only changes don't trigger rebuild |
| Print what's being rebuilt and why | ✅ | Detector emits human-readable reasons to stderr (file path + mtime + image build time); start.sh echoes the list of services |
| Same protection for frontend, mcp-server, scheduler | ✅ | All four services covered (with their respective `package.json` / `package-lock.json` / `requirements.txt`) |
| Document behaviour in `DEPLOYMENT.md` | ✅ | Added section under Troubleshooting + comment in Quick Start |

## Test plan

- [x] **6 unit tests** in `tests/unit/test_stale_image_detector.py`:
  - `test_all_fresh_emits_nothing` — no false positives
  - `test_dockerfile_newer_than_image_flags_service` — exact #557 scenario
  - `test_requirements_change_flags_scheduler` — separate requirements.txt
  - `test_missing_image_flags_service` — first-deploy path
  - `test_npm_lockfile_change_flags_frontend` — lockfile-only bump
  - `test_handles_nanosecond_precision_timestamp` — Docker emits 9-digit fractional seconds; Python's `fromisoformat` accepts ≤6
- [x] All 6 pass: `6 passed in 0.03s`
- [x] **End-to-end on the working tree**: detector flagged `backend` (stale Dockerfile) and `frontend` (stale package.json); bash captured both names cleanly into `$STALE_SERVICES`; rebuild command would run on exactly those two services. Diagnostic lines (file mtime + image build time) printed via stderr to the user.

## Failure modes

- **Python 3 missing on PATH**: detector skipped, one-line warning printed, fallback to old behaviour. The `command -v python3` guard in `start.sh` keeps this hands-off.
- **Detector crashes**: detector script always returns exit 0 (designed to fail open) — no impact on `start.sh`.
- **Docker daemon unreachable**: `_image_created_at` returns `None` → service flagged as missing → rebuild triggered, which would also fail on the next line. No degradation vs the current behaviour.

Fixes #557