### PR TITLE
fix(agent-server): recover lost result metadata + harden per-line reader (#630)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -894,19 +894,31 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
                 for line in iter(process.stdout.readline, ''):
                     if not line:
                         break
+                    # Issue #630: per-line try/except so one bad line does
+                    # not kill the reader and cost us the result line later
+                    # in the stream.
                     try:
-                        raw_msg = json.loads(line.strip())
-                        if not isinstance(raw_msg, dict):
-                            # stream-json can emit string literals; skip them
-                            continue
-                        # SECURITY: Sanitize credentials from output before storing
-                        raw_msg = sanitize_dict(raw_msg)
-                        raw_messages.append(raw_msg)
-                        registry.publish_log_entry(execution_id, raw_msg)
-                    except json.JSONDecodeError:
-                        pass
-                    sanitized_line = sanitize_subprocess_line(line)
-                    process_stream_line(sanitized_line, execution_log, metadata, tool_start_times, response_parts)
+                        try:
+                            raw_msg = json.loads(line.strip())
+                        except json.JSONDecodeError:
+                            raw_msg = None
+
+                        if isinstance(raw_msg, dict):
+                            # SECURITY: Sanitize credentials from output before storing
+                            raw_msg = sanitize_dict(raw_msg)
+                            raw_messages.append(raw_msg)
+                            try:
+                                registry.publish_log_entry(execution_id, raw_msg)
+                            except Exception as pub_err:  # noqa: BLE001
+                                logger.warning(
+                                    f"publish_log_entry failed (continuing): {pub_err}"
+                                )
+                        sanitized_line = sanitize_subprocess_line(line)
+                        process_stream_line(sanitized_line, execution_log, metadata, tool_start_times, response_parts)
+                    except Exception as line_err:  # noqa: BLE001
+                        logger.warning(
+                            f"Per-line stdout processing error (continuing): {line_err}"
+                        )
             except Exception as e:
                 logger.error(f"Error reading Claude output: {e}")
 
@@ -1220,6 +1232,82 @@ def _classify_signal_exit(
     return (504, detail)
 
 
+def _recover_metadata_from_raw_messages(
+    metadata: Optional['ExecutionMetadata'],
+    raw_messages: Optional[List[Dict]],
+) -> bool:
+    """Back-fill ``metadata`` from a ``{"type": "result"}`` entry in
+    ``raw_messages`` when ``process_stream_line`` failed to populate it.
+
+    Issue #630: even when the reader thread successfully appends the result
+    line to ``raw_messages``, ``process_stream_line`` may not run for that
+    line if the reader is interrupted between the append and the parse
+    (registry publish raising, permission-validation re-raise, any other
+    in-loop exception). In that case ``metadata.cost_usd`` /
+    ``duration_ms`` stay ``None`` even though Claude completed cleanly and
+    the final stats are sitting in ``raw_messages[-1]``.
+
+    This recovery pass scans ``raw_messages`` from the end (the result line
+    is always last) and copies the fields ``process_stream_line`` would
+    have set: ``cost_usd``, ``duration_ms``, ``num_turns``, and the token
+    counters from ``usage`` / ``modelUsage``. ``error_type`` / response
+    text are not back-filled — those drive control flow and would change
+    behaviour beyond this defensive recovery.
+
+    Returns ``True`` if recovery populated metadata, ``False`` otherwise.
+    Safe to call when metadata is already populated — short-circuits.
+    """
+    if metadata is None or not raw_messages:
+        return False
+    if metadata.cost_usd is not None or metadata.duration_ms is not None:
+        return False
+
+    for msg in reversed(raw_messages):
+        if not isinstance(msg, dict) or msg.get("type") != "result":
+            continue
+
+        cost = msg.get("total_cost_usd")
+        dur = msg.get("duration_ms")
+        if cost is None and dur is None:
+            return False  # malformed result entry — nothing to recover
+
+        metadata.cost_usd = cost
+        metadata.duration_ms = dur
+        metadata.num_turns = msg.get("num_turns")
+
+        usage = msg.get("usage", {}) if isinstance(msg.get("usage"), dict) else {}
+        if usage:
+            metadata.input_tokens = usage.get("input_tokens", metadata.input_tokens) or metadata.input_tokens
+            metadata.output_tokens = usage.get("output_tokens", metadata.output_tokens) or metadata.output_tokens
+            metadata.cache_creation_tokens = (
+                usage.get("cache_creation_input_tokens", metadata.cache_creation_tokens)
+                or metadata.cache_creation_tokens
+            )
+            metadata.cache_read_tokens = (
+                usage.get("cache_read_input_tokens", metadata.cache_read_tokens)
+                or metadata.cache_read_tokens
+            )
+
+        model_usage = msg.get("modelUsage", {})
+        if isinstance(model_usage, dict):
+            for _, model_data in model_usage.items():
+                if not isinstance(model_data, dict):
+                    continue
+                if "contextWindow" in model_data:
+                    metadata.context_window = model_data["contextWindow"]
+                model_in = model_data.get("inputTokens")
+                if isinstance(model_in, int) and model_in > metadata.input_tokens:
+                    metadata.input_tokens = model_in
+                model_out = model_data.get("outputTokens")
+                if isinstance(model_out, int) and model_out > metadata.output_tokens:
+                    metadata.output_tokens = model_out
+                break  # first model wins, mirrors process_stream_line
+
+        return True
+
+    return False
+
+
 def _classify_empty_result(
     metadata: Optional['ExecutionMetadata'] = None,
     raw_message_count: int = 0,
@@ -1249,6 +1337,13 @@ def _classify_empty_result(
     None (populated only by that line). Derive honest counts from
     raw_messages when available so the 502 detail is accurate. (#531)
 
+    Issue #630: before classifying, attempt
+    ``_recover_metadata_from_raw_messages`` — covers the case where the
+    result line *was* parsed and appended to raw_messages but
+    process_stream_line failed to run for it (reader-thread exit between
+    append and parse). When recovery succeeds, metadata is populated and
+    the function falls through to the success path.
+
     Returns ``(status_code, detail)`` for empty-result exits, or ``None``
     if metadata looks well-formed (caller proceeds with the normal
     response-building path).
@@ -1256,6 +1351,14 @@ def _classify_empty_result(
     if metadata is None:
         return None
     if metadata.cost_usd is not None or metadata.duration_ms is not None:
+        return None
+
+    if _recover_metadata_from_raw_messages(metadata, raw_messages):
+        logger.warning(
+            "[Headless Task] Recovered result metadata from raw_messages "
+            "(stream parser missed the result line; cost=%s duration=%sms turns=%s)",
+            metadata.cost_usd, metadata.duration_ms, metadata.num_turns,
+        )
         return None
 
     # tool_count is accumulated per-message during parsing (line ~1467), so
@@ -1504,52 +1607,75 @@ async def execute_headless_task(
                     if auth_abort_event.is_set():
                         logger.info(f"[Headless Task] Stdout loop exiting due to auth abort")
                         break
-                    # Capture raw JSON for full execution log
-                    try:
-                        raw_msg = json.loads(line.strip())
-                        if not isinstance(raw_msg, dict):
-                            # stream-json can emit string literals; skip them
-                            continue
-                        # SECURITY: Sanitize credentials from output before storing
-                        raw_msg = sanitize_dict(raw_msg)
-                        raw_messages.append(raw_msg)
-                        # Publish to live streaming subscribers
-                        registry.publish_log_entry(task_session_id, raw_msg)
 
-                        # Validate permissionMode on init message (first message from Claude Code).
-                        # If permission bypass isn't active, kill immediately instead of timing out
-                        # after hours with zero work completed (all tool calls silently denied).
-                        # Claude Code emits {"type": "system", "subtype": "init", ...} — see Appendix B
-                        # of docs/planning/SESSION_TAB_2026-04.md.
-                        if (
-                            raw_msg.get("type") == "system"
-                            and raw_msg.get("subtype") == "init"
-                            and not permission_mode_validated
-                        ):
-                            perm_mode = raw_msg.get("permissionMode", "unknown")
-                            if perm_mode == "bypassPermissions":
-                                permission_mode_validated = True
-                                logger.info(f"[Headless Task] Permission mode confirmed: {perm_mode}")
-                            else:
-                                logger.error(
-                                    f"[Headless Task] CRITICAL: Permission bypass not active! "
-                                    f"permissionMode={perm_mode} (expected bypassPermissions). "
-                                    f"Killing process tree to prevent silent timeout. "
-                                    f"Task: {task_session_id}"
+                    # Issue #630: each line is processed inside a per-line
+                    # try/except so a single failure (publish_log_entry
+                    # raising, process_stream_line tripping on weird input,
+                    # any non-RuntimeError exception) does not kill the
+                    # reader. If the reader exits early the result line
+                    # later in the stream is lost and the execution is
+                    # misclassified as "completed without a result message".
+                    # RuntimeError (permission-mode failure) is intentional
+                    # — keep the existing fast-fail behaviour.
+                    try:
+                        try:
+                            raw_msg = json.loads(line.strip())
+                        except json.JSONDecodeError:
+                            raw_msg = None
+
+                        if isinstance(raw_msg, dict):
+                            # SECURITY: Sanitize credentials from output before storing
+                            raw_msg = sanitize_dict(raw_msg)
+                            raw_messages.append(raw_msg)
+                            # Publish to live streaming subscribers — isolate
+                            # so subscriber-side breakage cannot back-pressure
+                            # the reader.
+                            try:
+                                registry.publish_log_entry(task_session_id, raw_msg)
+                            except Exception as pub_err:  # noqa: BLE001
+                                logger.warning(
+                                    f"[Headless Task] publish_log_entry failed (continuing): {pub_err}"
                                 )
-                                _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid)
-                                raise RuntimeError(
-                                    f"Permission bypass failed: permissionMode={perm_mode}. "
-                                    f"This may be caused by a stale Claude Code session process "
-                                    f"or project settings overriding the CLI flag. "
-                                    f"Try restarting the agent container."
-                                )
-                    except json.JSONDecodeError:
-                        pass
-                    # SECURITY: Sanitize the line before processing
-                    sanitized_line = sanitize_subprocess_line(line)
-                    # Process each line for metadata/tool tracking
-                    process_stream_line(sanitized_line, execution_log, metadata, tool_start_times, response_parts)
+
+                            # Validate permissionMode on init message (first message from Claude Code).
+                            # If permission bypass isn't active, kill immediately instead of timing out
+                            # after hours with zero work completed (all tool calls silently denied).
+                            # Claude Code emits {"type": "system", "subtype": "init", ...} — see Appendix B
+                            # of docs/planning/SESSION_TAB_2026-04.md.
+                            if (
+                                raw_msg.get("type") == "system"
+                                and raw_msg.get("subtype") == "init"
+                                and not permission_mode_validated
+                            ):
+                                perm_mode = raw_msg.get("permissionMode", "unknown")
+                                if perm_mode == "bypassPermissions":
+                                    permission_mode_validated = True
+                                    logger.info(f"[Headless Task] Permission mode confirmed: {perm_mode}")
+                                else:
+                                    logger.error(
+                                        f"[Headless Task] CRITICAL: Permission bypass not active! "
+                                        f"permissionMode={perm_mode} (expected bypassPermissions). "
+                                        f"Killing process tree to prevent silent timeout. "
+                                        f"Task: {task_session_id}"
+                                    )
+                                    _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid)
+                                    raise RuntimeError(
+                                        f"Permission bypass failed: permissionMode={perm_mode}. "
+                                        f"This may be caused by a stale Claude Code session process "
+                                        f"or project settings overriding the CLI flag. "
+                                        f"Try restarting the agent container."
+                                    )
+
+                        # SECURITY: Sanitize the line before processing
+                        sanitized_line = sanitize_subprocess_line(line)
+                        # Process each line for metadata/tool tracking
+                        process_stream_line(sanitized_line, execution_log, metadata, tool_start_times, response_parts)
+                    except RuntimeError:
+                        raise  # Re-raise permission-mode failures
+                    except Exception as line_err:  # noqa: BLE001
+                        logger.warning(
+                            f"[Headless Task] Per-line stdout processing error (continuing): {line_err}"
+                        )
             except RuntimeError:
                 raise  # Re-raise permission mode failures
             except Exception as e:

--- a/tests/unit/test_claude_code_result_recovery.py
+++ b/tests/unit/test_claude_code_result_recovery.py
@@ -1,0 +1,239 @@
+"""
+Unit tests for #630: result-line recovery and per-line reader hardening.
+
+The bug: when an agent has stdio MCP servers, the read_stdout thread can
+exit early (publish_log_entry raising, sanitize hiccup, anything that's
+not a JSONDecodeError). If that happens, the trailing
+``{"type": "result"}`` line either never gets parsed by
+``process_stream_line`` even though it sits in ``raw_messages``, or never
+makes it to ``raw_messages`` at all. metadata.cost_usd / duration_ms stay
+None, _classify_empty_result fires, the execution is recorded as a 502
+"completed without a result message" failure even though Claude finished
+cleanly.
+
+Two defensive layers are exercised here:
+
+1. ``_recover_metadata_from_raw_messages`` — back-fills metadata when
+   raw_messages contains a result entry the stream parser missed.
+2. ``_classify_empty_result`` — calls the recovery first; only emits 502
+   if recovery cannot find anything.
+
+The reader-thread per-line isolation is exercised separately by
+``test_read_stdout_continues_after_publish_failure``: a mocked publisher
+raises on every call, but the reader still appends every well-formed
+JSON line it sees and the result line eventually wins.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# tests/unit/conftest.py preloads the real agent_server package; just import.
+from agent_server.models import ExecutionMetadata  # noqa: E402
+from agent_server.services.claude_code import (  # noqa: E402
+    _classify_empty_result,
+    _recover_metadata_from_raw_messages,
+)
+
+
+def _result_msg(**overrides):
+    msg = {
+        "type": "result",
+        "total_cost_usd": 0.0123,
+        "duration_ms": 4567,
+        "num_turns": 7,
+        "usage": {
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 100,
+        },
+        "modelUsage": {
+            "claude-opus": {
+                "contextWindow": 200_000,
+                "inputTokens": 1500,
+                "outputTokens": 250,
+            }
+        },
+    }
+    msg.update(overrides)
+    return msg
+
+
+# ── _recover_metadata_from_raw_messages ─────────────────────────────────────
+
+class TestRecoverMetadata:
+
+    def test_no_op_when_metadata_already_populated(self):
+        m = ExecutionMetadata(cost_usd=0.5, duration_ms=100)
+        assert _recover_metadata_from_raw_messages(m, [_result_msg()]) is False
+        assert m.cost_usd == 0.5  # unchanged
+
+    def test_no_op_when_raw_messages_empty(self):
+        m = ExecutionMetadata()
+        assert _recover_metadata_from_raw_messages(m, []) is False
+        assert _recover_metadata_from_raw_messages(m, None) is False
+
+    def test_no_op_when_no_result_entry(self):
+        m = ExecutionMetadata()
+        raw = [
+            {"type": "init"},
+            {"type": "assistant", "message": {"content": []}},
+            {"type": "user", "message": {"content": []}},
+        ]
+        assert _recover_metadata_from_raw_messages(m, raw) is False
+        assert m.cost_usd is None
+
+    def test_populates_from_result_entry(self):
+        m = ExecutionMetadata()
+        ok = _recover_metadata_from_raw_messages(m, [{"type": "init"}, _result_msg()])
+        assert ok is True
+        assert m.cost_usd == 0.0123
+        assert m.duration_ms == 4567
+        assert m.num_turns == 7
+        assert m.cache_creation_tokens == 50
+        assert m.cache_read_tokens == 100
+        # modelUsage's inputTokens (1500) wins over usage.input_tokens (1000)
+        assert m.input_tokens == 1500
+        assert m.output_tokens == 250
+        assert m.context_window == 200_000
+
+    def test_picks_last_result_when_multiple(self):
+        """Recovery scans from the end — the trailing result is authoritative."""
+        m = ExecutionMetadata()
+        first = _result_msg(total_cost_usd=0.001)
+        last = _result_msg(total_cost_usd=0.999)
+        _recover_metadata_from_raw_messages(m, [first, {"type": "assistant"}, last])
+        assert m.cost_usd == 0.999
+
+    def test_skips_malformed_result_with_no_cost_or_duration(self):
+        m = ExecutionMetadata()
+        broken = {"type": "result"}  # no total_cost_usd, no duration_ms
+        assert _recover_metadata_from_raw_messages(m, [broken]) is False
+        assert m.cost_usd is None
+
+    def test_handles_partial_result_just_cost(self):
+        m = ExecutionMetadata()
+        partial = {"type": "result", "total_cost_usd": 0.5}  # no duration
+        assert _recover_metadata_from_raw_messages(m, [partial]) is True
+        assert m.cost_usd == 0.5
+        assert m.duration_ms is None  # genuinely missing
+
+    def test_handles_non_dict_entries(self):
+        m = ExecutionMetadata()
+        raw = ["string entry", 42, None, _result_msg()]
+        assert _recover_metadata_from_raw_messages(m, raw) is True
+        assert m.cost_usd == 0.0123
+
+    def test_handles_missing_usage_block(self):
+        m = ExecutionMetadata()
+        msg = {"type": "result", "total_cost_usd": 0.1, "duration_ms": 100}
+        assert _recover_metadata_from_raw_messages(m, [msg]) is True
+        # Token defaults preserved when usage missing
+        assert m.input_tokens == 0
+        assert m.output_tokens == 0
+
+
+# ── _classify_empty_result wired with recovery ─────────────────────────────
+
+class TestClassifyEmptyResultRecovery:
+
+    def test_recovery_short_circuits_502(self):
+        """End-to-end: result line is in raw_messages → classify returns None
+        (success path) instead of 502."""
+        m = ExecutionMetadata()
+        result = _classify_empty_result(
+            metadata=m,
+            raw_message_count=3,
+            raw_messages=[{"type": "init"}, {"type": "assistant"}, _result_msg()],
+        )
+        assert result is None
+        assert m.cost_usd == 0.0123  # recovered
+
+    def test_returns_502_when_no_result_in_raw_messages(self):
+        """When the result line is genuinely lost, classify still returns 502."""
+        m = ExecutionMetadata()
+        result = _classify_empty_result(
+            metadata=m,
+            raw_message_count=2,
+            raw_messages=[{"type": "init"}, {"type": "assistant"}],
+        )
+        assert result is not None
+        status, _ = result
+        assert status == 502
+
+    def test_returns_none_when_metadata_already_populated(self):
+        m = ExecutionMetadata(cost_usd=0.5, duration_ms=100)
+        assert _classify_empty_result(metadata=m, raw_messages=[]) is None
+
+    def test_returns_none_when_metadata_is_none(self):
+        assert _classify_empty_result(metadata=None) is None
+
+
+# ── Reader-thread per-line isolation ────────────────────────────────────────
+
+class TestReadStdoutPerLineIsolation:
+    """Verify that a publish-side failure does not kill the reader thread.
+
+    This test exercises the structure of read_stdout: previously, any
+    Exception raised inside the per-line block (other than JSONDecodeError)
+    propagated out of the for loop, killed the reader, and silently dropped
+    every subsequent line — including the trailing result line.
+
+    We can't easily import the nested closures without spinning up the full
+    headless task path, so we re-implement the per-line policy here and
+    assert the contract: result line is captured even when intermediate
+    publishes raise.
+    """
+
+    def test_per_line_exception_does_not_kill_reader(self):
+        """Simulate the patched read_stdout structure: publish raises every
+        time, but the reader still reaches the result line and metadata is
+        recoverable from raw_messages."""
+        import json
+
+        raw_messages: list = []
+        published: list = []
+
+        def fake_publish(msg):
+            published.append(msg)
+            raise RuntimeError("subscriber explosion")
+
+        def per_line(line: str) -> None:
+            try:
+                try:
+                    raw_msg = json.loads(line.strip())
+                except json.JSONDecodeError:
+                    raw_msg = None
+                if isinstance(raw_msg, dict):
+                    raw_messages.append(raw_msg)
+                    try:
+                        fake_publish(raw_msg)
+                    except Exception:
+                        pass  # mirror the patched code: log and continue
+            except Exception:
+                pass
+
+        lines = [
+            json.dumps({"type": "init"}) + "\n",
+            json.dumps({"type": "assistant", "message": {"content": []}}) + "\n",
+            json.dumps(_result_msg()) + "\n",
+        ]
+        for ln in lines:
+            per_line(ln)
+
+        # All three lines reached raw_messages despite publish raising every time.
+        assert len(raw_messages) == 3
+        assert raw_messages[-1]["type"] == "result"
+        assert len(published) == 3  # publisher was attempted on every line
+
+        # And recovery successfully back-fills metadata from the captured tail.
+        m = ExecutionMetadata()
+        assert _recover_metadata_from_raw_messages(m, raw_messages) is True
+        assert m.cost_usd == 0.0123


### PR DESCRIPTION
## Summary

Partial fix for #630. Targets two concrete failure paths that produce the "Execution completed without a result message after 0 tool calls / N turns" 502, while being upfront about what this PR does **not** fix.

Background: Claude emits a final `{"type": "result", ...}` line that populates `metadata.cost_usd`/`duration_ms`/`num_turns` via `process_stream_line`. When those stay `None`, `_classify_empty_result` records a 502 — even when Claude finished cleanly.

## What this fixes

**1. Per-line reader isolation in `read_stdout` (headless + chat paths)**

The current reader catches only `JSONDecodeError`. Anything else (e.g. `registry.publish_log_entry` raising due to a slow/disconnected subscriber, sanitize tripping on weird input) propagates out of the for loop, kills the reader thread, and silently drops every subsequent line — including the trailing `result` line.

Fix: each per-line block now runs inside `try/except`. Non-`RuntimeError` exceptions are logged with "(continuing)" and the reader keeps consuming. `RuntimeError` (permission-mode failure) still propagates intentionally — it's the existing fast-fail path for #285.

**2. Result-metadata recovery from `raw_messages`**

Even when the reader successfully appends the `result` line to `raw_messages`, `process_stream_line` may not run for it if the reader is interrupted between the append and the call. New helper `_recover_metadata_from_raw_messages` scans `raw_messages` from the end, locates a `{"type": "result"}` entry, and back-fills `cost_usd`, `duration_ms`, `num_turns`, and the token counters — matching the field set `process_stream_line` would have populated. `_classify_empty_result` calls recovery before classifying, so the 502 only fires when the result line is genuinely lost.

## What this does NOT fix

The issue body suggests three fixes; this PR addresses #1 in spirit (the recovery scan is "check after drain, before declaring failure"). The other two:

- **Fix 2 (kill same-pgid pipe holders)** — already happens. `terminate_process_group` does `killpg(pgid, SIGKILL)` which reaches every same-pgid process. The orphan killer in `_kill_orphan_pipe_writers` is for `setsid()`-escaped different-pgid processes only (the #618 case).
- **Fix 3 (close-on-exec for stdout)** — right intent, wrong layer. `FD_CLOEXEC` triggers on `exec()`, not `fork()`. Preventing MCP-child stdout pollution requires either (a) Claude Code itself closing fd 1 before `posix_spawn`-ing MCP servers, or (b) wrapping each `.mcp.json` `command` to redirect stdout. Both are outside agent-server's reach and would land as separate work.

When the result line itself is **corrupted on the wire** (interleaved writes from MCP children sharing inherited stdout fds), recovery cannot help — the line never makes it into `raw_messages` because `json.loads` failed. That case still surfaces as a 502 with the existing "Likely cause: a tool or child subprocess inherited stdout..." detail. The hardened reader at least guarantees we don't *also* lose the result line via reader-thread death.

## Tests

`tests/unit/test_claude_code_result_recovery.py` — 14 tests, all passing on `./.venv/bin/pytest`:

- `_recover_metadata_from_raw_messages`: no-op when already populated / empty raw_messages / no result entry; populates from result entry; picks last result when multiple; skips malformed result; handles partial result (just cost); ignores non-dict entries; handles missing `usage` block.
- `_classify_empty_result`: recovery short-circuits the 502; still 502 when no result in raw_messages; no-op when metadata already populated; no-op when metadata is None.
- Reader isolation: publisher raising on every line still yields all `raw_messages` and recovery succeeds.

```bash
./.venv/bin/pytest tests/unit/test_claude_code_result_recovery.py -v
# 14 passed in 0.32s
```

Sibling `tests/unit/test_subprocess_pgroup.py` also still passes (14/14) — the surrounding subprocess-pgroup machinery is untouched.

## Test plan

- [x] Unit: recovery helper covers happy path, no-op cases, malformed inputs, multi-result, modelUsage tiebreaker
- [x] Unit: `_classify_empty_result` short-circuits when recovery succeeds, still 502 when result genuinely lost
- [x] Unit: per-line reader isolation contract — publisher raising every iteration still leaves complete `raw_messages`
- [x] Sibling `test_subprocess_pgroup.py` unaffected (14/14 pass)
- [x] Manual: hard to reproduce reliably without an agent that has flaky stdio MCP servers + a long task. The existing `test_subprocess_pgroup.py` exercises the drain machinery; this PR's defensive layer activates only on the failure path which we'd need to inject artificially. Open to suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)