### PR TITLE
fix(security): override git User-Agent on skills library sync (#184)

### DIFF
--- a/src/backend/services/skill_service.py
+++ b/src/backend/services/skill_service.py
@@ -31,6 +31,15 @@ logger = logging.getLogger(__name__)
 # Local path for skills library clone
 SKILLS_LIBRARY_PATH = Path("/data/skills-library")
 
+# Issue #184 (UnderDefense pentest 3.3.1): override git's default
+# User-Agent (`git/<version> (libcurl/...)`) on every HTTP-bearing git
+# subcommand so outbound requests don't fingerprint the backend stack.
+# The SSRF allowlist (#179) already locks the destination to github.com,
+# but defense-in-depth: even if the allowlist is ever loosened, the UA
+# stays generic. Constant intentionally has no version suffix to avoid
+# yet another version string drifting against VERSION / package.json.
+_GIT_HTTP_UA_ARGS = ["-c", "http.useragent=Trinity-Skills-Sync"]
+
 class SkillService:
     """
     Service for managing skills library and skill assignments.
@@ -127,7 +136,10 @@ class SkillService:
         """Clone the skills library repository."""
         self.library_path.parent.mkdir(parents=True, exist_ok=True)
 
-        cmd = ["git", "clone", "--branch", branch, "--depth", "1", url, str(self.library_path)]
+        cmd = [
+            "git", *_GIT_HTTP_UA_ARGS,
+            "clone", "--branch", branch, "--depth", "1", url, str(self.library_path),
+        ]
 
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=120)
@@ -146,7 +158,7 @@ class SkillService:
         try:
             # Fetch and reset to remote branch
             subprocess.run(
-                ["git", "fetch", "origin", branch],
+                ["git", *_GIT_HTTP_UA_ARGS, "fetch", "origin", branch],
                 cwd=self.library_path,
                 check=True,
                 capture_output=True,

--- a/tests/unit/test_skill_service_user_agent.py
+++ b/tests/unit/test_skill_service_user_agent.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for #184: skill_service git subprocesses must override
+git's default User-Agent so outbound HTTP doesn't fingerprint the
+backend stack.
+
+Git's default UA is `git/<version> (libcurl/<version> ...)` which
+leaks the runtime versions to whatever endpoint git hits. Even with
+the SSRF allowlist (#179) restricting destinations to github.com, the
+defense-in-depth principle is to override the UA on every git
+subcommand that talks HTTP.
+
+We assert two things:
+1. `_git_clone` invocation includes `-c http.useragent=Trinity-Skills-Sync`
+   between the `git` argv[0] and the `clone` subcommand (this is the only
+   correct position for the `-c` flag).
+2. `_git_pull`'s fetch invocation includes the same flag.
+
+The local-only `git rev-parse` and `git reset --hard` calls intentionally
+do not need the flag (they don't make HTTP), so we don't assert it there.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+_TMP_DB = Path(tempfile.gettempdir()) / "trinity_test_skill_ua.db"
+os.environ.setdefault("TRINITY_DB_PATH", str(_TMP_DB))
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# Stub heavy dependencies so we can import skill_service without dragging in
+# the full backend (database, agent_client → tenacity, passlib, etc.). The
+# helpers under test only use subprocess + module-level constants — none of
+# the stubbed imports are exercised at runtime here.
+import types as _types  # noqa: E402
+
+for mod_name, attrs in [
+    ("database", {"db": MagicMock()}),
+    (
+        "services.settings_service",
+        {
+            "get_skills_library_url": lambda: "https://github.com/owner/repo",
+            "get_skills_library_branch": lambda: "main",
+            "get_github_pat": lambda: None,
+        },
+    ),
+    (
+        "services.agent_client",
+        {"get_agent_client": MagicMock(), "AgentClientError": Exception},
+    ),
+]:
+    if mod_name not in sys.modules:
+        m = _types.ModuleType(mod_name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[mod_name] = m
+
+
+import importlib.util as _ilu  # noqa: E402
+
+_skill_path = _BACKEND / "services" / "skill_service.py"
+_spec = _ilu.spec_from_file_location("services.skill_service", str(_skill_path))
+skill_service_mod = _ilu.module_from_spec(_spec)
+sys.modules["services.skill_service"] = skill_service_mod
+_spec.loader.exec_module(skill_service_mod)
+
+
+def _captured_cmd(call_args_list, sentinel):
+    """Return the cmd argv from the subprocess.run call whose argv contains
+    sentinel (e.g. 'clone' or 'fetch')."""
+    for call in call_args_list:
+        cmd = call.args[0] if call.args else call.kwargs.get("args") or []
+        if sentinel in cmd:
+            return cmd
+    raise AssertionError(f"No subprocess.run call contained {sentinel!r}")
+
+
+class TestSkillServiceGitUserAgent:
+
+    def test_clone_includes_user_agent_override(self, tmp_path):
+        svc = skill_service_mod.SkillService()
+        svc.library_path = tmp_path / "skills-library"
+
+        with patch.object(skill_service_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = svc._git_clone("https://github.com/owner/repo", "main")
+
+        assert result["success"] is True
+        cmd = _captured_cmd(mock_run.call_args_list, "clone")
+
+        # `-c key=value` must come BEFORE the subcommand, immediately after argv[0]
+        assert cmd[0] == "git"
+        assert "-c" in cmd, f"expected -c flag in cmd, got: {cmd}"
+        c_idx = cmd.index("-c")
+        assert cmd[c_idx + 1] == "http.useragent=Trinity-Skills-Sync"
+        # And the -c block is positioned before the clone subcommand
+        assert cmd.index("clone") > c_idx + 1
+
+    def test_pull_fetch_includes_user_agent_override(self, tmp_path):
+        svc = skill_service_mod.SkillService()
+        svc.library_path = tmp_path / "skills-library"
+        svc.library_path.mkdir(parents=True)
+
+        with patch.object(skill_service_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = svc._git_pull("main")
+
+        assert result["success"] is True
+
+        # The HTTP-bearing call is `git fetch` — must carry the UA flag.
+        fetch_cmd = _captured_cmd(mock_run.call_args_list, "fetch")
+        assert fetch_cmd[0] == "git"
+        assert "-c" in fetch_cmd
+        c_idx = fetch_cmd.index("-c")
+        assert fetch_cmd[c_idx + 1] == "http.useragent=Trinity-Skills-Sync"
+        assert fetch_cmd.index("fetch") > c_idx + 1
+
+    def test_pull_reset_does_not_need_user_agent(self, tmp_path):
+        """`git reset --hard` is a local-only operation — no HTTP, no UA leak,
+        no need to thread the flag through. This is documentation as much as
+        a test: if someone adds the flag here later, they should at least
+        consider whether reset has started doing remote calls."""
+        svc = skill_service_mod.SkillService()
+        svc.library_path = tmp_path / "skills-library"
+        svc.library_path.mkdir(parents=True)
+
+        with patch.object(skill_service_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            svc._git_pull("main")
+
+        reset_cmd = _captured_cmd(mock_run.call_args_list, "reset")
+        # Either way is acceptable; this asserts the current minimal-scope choice.
+        assert "-c" not in reset_cmd or reset_cmd.index("-c") > reset_cmd.index("reset")
+
+    def test_get_current_commit_does_not_need_user_agent(self, tmp_path):
+        """`git rev-parse HEAD` is a local query — same reasoning as reset."""
+        svc = skill_service_mod.SkillService()
+        svc.library_path = tmp_path / "skills-library"
+        svc.library_path.mkdir(parents=True)
+
+        with patch.object(skill_service_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="abc123def456\n", stderr="")
+            sha = svc._get_current_commit()
+
+        assert sha == "abc123def456"
+        rev_cmd = _captured_cmd(mock_run.call_args_list, "rev-parse")
+        assert "-c" not in rev_cmd or rev_cmd.index("-c") > rev_cmd.index("rev-parse")


### PR DESCRIPTION
## Summary

Closes #184. UnderDefense pentest 3.3.1 flagged the backend for leaking the underlying tech stack via outbound `User-Agent`. The pentest cited `POST /api/skills/library/sync` as the exemplar — that endpoint shells out to `git`, so the leaked UA is `git/<version> (libcurl/<version> ...)`, verified live with `GIT_TRACE_CURL=1`.

## Fix

Add `-c http.useragent=Trinity-Skills-Sync` to the two HTTP-bearing git invocations in `services/skill_service.py`:

- `_git_clone` → before the `clone` subcommand
- `_git_pull` → before the `fetch` subcommand

Position matters: git's `-c key=value` only takes effect when placed between the program name and the subcommand. Tests assert this.

The local-only `git reset --hard` and `git rev-parse HEAD` calls are deliberately left untouched — they make no HTTP and threading the flag through them would suggest otherwise.

## Why a static string

`Trinity-Skills-Sync` with no version suffix to avoid yet another version string drifting against `VERSION` / `package.json` / `pyproject`. Generic enough to identify "Trinity skills syncer" without revealing python/git/libcurl versions.

## Practical exposure

The SSRF allowlist (#179) already locks the destination to `github.com`, so today the only party that sees this UA is GitHub — they know it's `git` regardless. This PR is defense-in-depth: if the allowlist is ever loosened (or a future feature lets agents probe other URLs through this path), the UA stays generic.

## Tests

`tests/unit/test_skill_service_user_agent.py` — 4 tests, all passing:

```bash
./.venv/bin/pytest tests/unit/test_skill_service_user_agent.py -v
# 4 passed in 0.03s
```

- `test_clone_includes_user_agent_override` — clone cmd contains `-c http.useragent=Trinity-Skills-Sync` before `clone`
- `test_pull_fetch_includes_user_agent_override` — same for fetch
- `test_pull_reset_does_not_need_user_agent` — documentation that local ops are intentionally untouched
- `test_get_current_commit_does_not_need_user_agent` — same

## Live verification

```
$ GIT_TRACE_CURL=1 git -c http.useragent=Trinity-Skills-Sync ls-remote https://github.com/octocat/Hello-World 2>&1 | grep -i user-agent
http.c:845              == Info: [HTTP/2] [1] [user-agent: Trinity-Skills-Sync]
http.c:804              => Send header: User-Agent: Trinity-Skills-Sync

$ GIT_TRACE_CURL=1 git ls-remote https://github.com/octocat/Hello-World 2>&1 | grep -i user-agent
http.c:845              == Info: [HTTP/2] [1] [user-agent: git/2.43.0]
http.c:804              => Send header: User-Agent: git/2.43.0
```

## Test plan

- [x] Unit: clone subprocess argv contains the UA flag at the right position
- [x] Unit: fetch subprocess argv contains the UA flag at the right position
- [x] Unit: local-only reset and rev-parse subprocess argv do NOT carry the flag
- [x] Live: \`GIT_TRACE_CURL=1\` confirms wire UA changes from \`git/2.43.0\` to \`Trinity-Skills-Sync\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)