### PR TITLE
fix(agent-runtime): bound _kill_orphan_pipe_writers to 10s to prevent drain stall (#649)

### DIFF
--- a/docker/base-image/agent_server/utils/subprocess_pgroup.py
+++ b/docker/base-image/agent_server/utils/subprocess_pgroup.py
@@ -30,6 +30,7 @@ import signal
 import stat as _stat
 import subprocess
 import threading
+import time
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -238,6 +239,7 @@ def drain_reader_threads(
     if not stuck:
         return
 
+    drain_start = time.monotonic()
     logger.warning(
         "[Subprocess] Reader thread(s) still busy after process exit "
         "(pid=%s, stuck_count=%s) — killing process group, then waiting "
@@ -253,39 +255,69 @@ def drain_reader_threads(
     # The orphan keeps the write FD open so the kernel never delivers EOF to
     # our reader.  Killing it releases all its FDs (stdout AND stderr write
     # ends), unblocking both reader threads simultaneously.
+    #
+    # Issue #649: run in a daemon thread with a hard 10-second timeout.
+    # Iterating /proc can block indefinitely when a process is in D state
+    # (uninterruptible sleep), causing the drain to stall for tens of minutes
+    # instead of the expected ~30 seconds.
     if process.stdout is not None and not process.stdout.closed:
         try:
-            orphans = _kill_orphan_pipe_writers(process.stdout.fileno(), pgid)
-            if orphans:
+            stdout_fd = process.stdout.fileno()
+        except Exception:
+            stdout_fd = None
+        if stdout_fd is not None:
+            _orphan_result: list[int] = [0]
+
+            def _run_orphan_killer() -> None:
+                try:
+                    _orphan_result[0] = _kill_orphan_pipe_writers(stdout_fd, pgid)
+                except Exception:
+                    pass  # best-effort; never fail the drain path
+
+            _orphan_thread = threading.Thread(target=_run_orphan_killer, daemon=True)
+            _orphan_thread.start()
+            _orphan_thread.join(timeout=10)
+
+            if _orphan_thread.is_alive():
+                logger.warning(
+                    "[Subprocess] _kill_orphan_pipe_writers still running after "
+                    "10s (pid=%s) — /proc scan may be blocked on a D-state process",
+                    process.pid,
+                )
+            elif _orphan_result[0]:
                 logger.info(
                     "[Subprocess] Killed %s orphan stdout pipe-writer(s) "
                     "outside pgid=%s (pid=%s) — likely npx MCP server(s)",
-                    orphans, pgid, process.pid,
+                    _orphan_result[0], pgid, process.pid,
                 )
-        except Exception:
-            pass  # best-effort; never fail the drain path
 
-    # All writers are now dead → kernel will EOF the pipe once the buffered
-    # tail is consumed → reader's readline() returns '' and the thread exits.
+    # All writers are now dead (or we timed out trying to kill them).
+    # Use wall-clock accounting: subtract time already spent so the caller's
+    # post_kill_grace budget is measured from when the warning fired, not from
+    # after the orphan scan.  If the orphan scan itself consumed more than
+    # post_kill_grace, clamp to 1 second so we still attempt a natural drain.
+    elapsed = time.monotonic() - drain_start
+    join_timeout = max(1.0, post_kill_grace - elapsed)
     for t in stuck:
-        t.join(timeout=post_kill_grace)
+        t.join(timeout=join_timeout)
 
     still_stuck = [t for t in stuck if t.is_alive()]
     if not still_stuck:
         logger.info(
             "[Subprocess] Reader thread(s) drained naturally after "
-            "grandchild termination (pid=%s)",
-            process.pid,
+            "grandchild termination (pid=%s, elapsed=%.1fs)",
+            process.pid, time.monotonic() - drain_start,
         )
         return
 
     # Genuine wedge — reader did not return even after grandchildren died
     # and the kernel should have EOF'd. Force-close and accept data loss.
+    elapsed = time.monotonic() - drain_start
     logger.error(
-        "[Subprocess] Reader thread(s) still stuck after %ss post-kill "
+        "[Subprocess] Reader thread(s) still stuck after %.1fs post-kill "
         "grace — force-closing pipes; some buffered data may be lost "
         "(pid=%s, stuck_count=%s)",
-        post_kill_grace, process.pid, len(still_stuck),
+        elapsed, process.pid, len(still_stuck),
     )
     safe_close_pipes(process)
     for t in still_stuck:

--- a/tests/unit/test_subprocess_pgroup.py
+++ b/tests/unit/test_subprocess_pgroup.py
@@ -486,6 +486,77 @@ class TestSignalProcessTree:
 
 
 @pytest.mark.unit
+class TestDrainOrphanKillerTimeout:
+    """Issue #649: drain_reader_threads must complete in bounded time even when
+    _kill_orphan_pipe_writers is slow (e.g. blocked on a D-state /proc entry)."""
+
+    def test_drain_bounded_when_orphan_killer_blocks(self, monkeypatch):
+        """Monkeypatch the orphan killer to simulate a blocked /proc scan.
+
+        Without the fix the drain would block for the orphan killer's full
+        sleep duration (100s).  With it, the 10-second daemon-thread cap
+        ensures drain_reader_threads returns in < 20 seconds regardless.
+
+        The reader thread simulates "stuck in processing" (a time.sleep) rather
+        than blocked on I/O, so safe_close_pipes completes without contending
+        on the BufferedReader lock — the scenario that exercises the orphan-
+        killer timeout specifically.
+        """
+        import subprocess_pgroup as spg
+
+        orphan_killer_started = threading.Event()
+
+        def _slow_orphan_killer(fd: int, our_pgid) -> int:
+            orphan_killer_started.set()
+            time.sleep(100)  # simulate /proc scan blocked on D-state process
+            return 0
+
+        monkeypatch.setattr(spg, "_kill_orphan_pipe_writers", _slow_orphan_killer)
+
+        # Process with a stdout pipe (needed so safe_close_pipes has a FD to close
+        # and the orphan-killer branch runs).
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            start_new_session=True,
+        )
+        pgid = capture_pgid(proc)
+        assert pgid is not None
+
+        # Reader that simulates being stuck in long CPU/processing work (not I/O
+        # blocked on the pipe), so safe_close_pipes does not contend on the
+        # BufferedReader lock and can complete without waiting.
+        def slow_processor():
+            time.sleep(120)
+
+        t = threading.Thread(target=slow_processor, daemon=True)
+        t.start()
+
+        try:
+            start = time.monotonic()
+            # grace=0 → immediately enters the stuck-reader path.
+            drain_reader_threads(proc, t, grace=0, post_kill_grace=5, pgid=pgid)
+            elapsed = time.monotonic() - start
+
+            # Orphan killer must have been called.
+            assert orphan_killer_started.is_set(), "_kill_orphan_pipe_writers was not called"
+
+            # Drain must complete within: 10s orphan timeout + 1s join + 2s join + 3s slack.
+            assert elapsed < 20.0, (
+                f"drain took {elapsed:.2f}s — orphan killer 10s cap not enforced"
+            )
+            # Thread is leaked (still sleeping) — that is the expected wedge outcome.
+            # The important assertion is that drain_reader_threads itself returned.
+        finally:
+            try:
+                terminate_process_group(proc, graceful_timeout=1, pgid=pgid)
+            except Exception:
+                pass
+
+
+@pytest.mark.unit
 @pytest.mark.skipif(sys.platform != "linux", reason="_kill_orphan_pipe_writers uses /proc (Linux only)")
 class TestKillOrphanPipeWriters:
     """_kill_orphan_pipe_writers() handles Issue #618: npx MCP servers in a


### PR DESCRIPTION
## Summary

- `drain_reader_threads` was stalling for 60+ minutes because `_kill_orphan_pipe_writers` blocks indefinitely when `/proc` scanning encounters a D-state process (uninterruptible sleep)
- The issue report attributed the delay to `t.join(timeout=30)` not firing, but validation showed `drain_reader_threads` runs in an executor thread where `Thread.join(timeout)` is correctly respected — the actual culprit is the orphan scan
- Fix: run `_kill_orphan_pipe_writers` in a daemon thread with a 10-second cap so a stuck `/proc` entry cannot push the drain past its deadline
- Also: use wall-clock accounting for the post-kill join (so time spent in terminate + orphan scan doesn't silently erode `post_kill_grace`), and log actual elapsed time instead of the expected value

## Changes

- `docker/base-image/agent_server/utils/subprocess_pgroup.py` — orphan killer now runs in daemon thread with 10s timeout; wall-clock accounting for join budget; elapsed time in error logs
- `tests/unit/test_subprocess_pgroup.py` — new `TestDrainOrphanKillerTimeout` class with regression test verifying the 10s cap is enforced

## Test Plan

- [x] New test `TestDrainOrphanKillerTimeout::test_drain_bounded_when_orphan_killer_blocks` passes: monkeypatches killer to sleep 100s, verifies drain completes in < 20s
- [x] All existing `TestDrainReaderThreads` tests pass (fast path, natural drain, buffered data preserved)
- [x] All existing `TestTerminateProcessGroup` / `TestSafeClosePipes` / `TestSignalProcessTree` tests pass
- [x] Linux-only `TestKillOrphanPipeWriters` tests skipped on macOS (not a regression)

Fixes #649

Generated with [Claude Code](https://claude.com/claude-code)