### PR TITLE
fix(tests): scheduler conftest passes uncredentialed REDIS_URL after #589 (#659)

### DIFF
--- a/tests/scheduler_tests/conftest.py
+++ b/tests/scheduler_tests/conftest.py
@@ -298,7 +298,7 @@ def test_config(initialized_db: str):
     from scheduler.config import SchedulerConfig
     return SchedulerConfig(
         database_path=initialized_db,
-        redis_url="redis://localhost:6379",
+        redis_url="redis://test:test@localhost:6379",
         lock_timeout=60,
         lock_auto_renewal=False,
         health_port=8099,


### PR DESCRIPTION
## Summary
- Fixes the `test_config` fixture in `tests/scheduler_tests/conftest.py` to use a credentialed Redis URL (`redis://test:test@localhost:6379`) after #589 introduced a runtime validation that rejects bare `redis://` URLs.

## Changes
- `tests/scheduler_tests/conftest.py`: one-line fix on line 301

## Test Plan
- [ ] All 5 scheduler config tests pass: `test_default_values`, `test_env_override`, `test_agent_timeout`, `test_publish_events_default`, `test_publish_events_disabled`
- [ ] No other scheduler tests regress

Fixes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)