### PR TITLE
fix(monitoring): degrade fleet-status to 'unknown' on NULL status row (#669)

### DIFF
--- a/docs/user-docs/operations/monitoring.md
+++ b/docs/user-docs/operations/monitoring.md
@@ -89,7 +89,9 @@ Agents can query monitoring data through these MCP tools:
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/monitoring/fleet-health` | GET | Fleet health summary |
+| `/api/monitoring/status` | GET | Fleet health summary |
+| `/api/monitoring/agents/{name}` | GET | Single-agent health detail |
+| `/api/monitoring/agents/{name}/check` | POST | Force immediate health check |
 | `/api/monitoring/cleanup-status` | GET | Cleanup service status (admin) |
 | `/api/monitoring/cleanup-trigger` | POST | Force a cleanup run (admin) |
 

--- a/src/backend/routers/monitoring.py
+++ b/src/backend/routers/monitoring.py
@@ -10,7 +10,8 @@ Provides endpoints for agent health monitoring:
 """
 
 import json
-from typing import Optional, List
+import logging
+from typing import Any, Dict, Optional, List
 from fastapi import APIRouter, Depends, HTTPException, Query, BackgroundTasks
 
 from database import db
@@ -36,9 +37,60 @@ from services.agent_service import get_accessible_agents
 
 router = APIRouter(prefix="/api/monitoring", tags=["monitoring"])
 
+logger = logging.getLogger(__name__)
+
+# Sort key: lower number = higher severity, surfaces first.
+_STATUS_SORT_ORDER = {"critical": 0, "unhealthy": 1, "degraded": 2, "unknown": 3, "healthy": 4}
+
 # WebSocket manager for broadcasting health events
 _websocket_manager = None
 _filtered_websocket_manager = None
+
+
+# ============================================================================
+# Builders (extracted for unit-test coverage — see #669)
+# ============================================================================
+
+def _coerce_status(raw: Any) -> str:
+    """Map any persisted status value (incl. NULL / non-str) to a known label.
+
+    The DB column is nullable, and partial health-check rows can land with
+    `status = NULL`. Without coercion, building `AgentHealthSummary(status=...)`
+    fails Pydantic validation (status is a required str) and the whole
+    fleet-status endpoint returns 500. See #669.
+    """
+    if isinstance(raw, str) and raw:
+        return raw
+    return "unknown"
+
+
+def _build_agent_summary(name: str, check: Optional[Dict[str, Any]]) -> AgentHealthSummary:
+    """Build an `AgentHealthSummary` from a (possibly absent / partial) row.
+
+    Tolerates `check is None` (no row at all), missing keys, NULL `status`,
+    and NULL `error_message`. All defects in stored data degrade to
+    `status="unknown"` instead of bubbling as a 500.
+    """
+    if not check:
+        return AgentHealthSummary(name=name, status="unknown", issues=["No health check data"])
+
+    error_message = check.get("error_message") or ""
+    issues = error_message.split("; ") if error_message else []
+
+    return AgentHealthSummary(
+        name=name,
+        status=_coerce_status(check.get("status")),
+        docker_status=check.get("container_status"),
+        network_reachable=check.get("reachable"),
+        runtime_available=check.get("runtime_available"),
+        last_check_at=check.get("checked_at"),
+        issues=issues,
+    )
+
+
+def _status_sort_key(summary: AgentHealthSummary) -> int:
+    """Sort key for fleet status — most severe first, unknowns in the middle."""
+    return _STATUS_SORT_ORDER.get(summary.status, 3)
 
 
 def set_websocket_manager(manager):
@@ -115,34 +167,25 @@ async def get_fleet_status(
             agents=[]
         )
 
-    # Get latest health checks from database
-    latest_checks = db.get_all_latest_health_checks(agent_names, "aggregate")
-    summary = db.get_health_summary(agent_names)
-
-    # Build agent summaries
-    agents = []
-    for name in agent_names:
-        check = latest_checks.get(name)
-        if check:
-            agents.append(AgentHealthSummary(
-                name=name,
-                status=check.get("status", "unknown"),
-                docker_status=check.get("container_status"),
-                network_reachable=check.get("reachable"),
-                runtime_available=check.get("runtime_available"),
-                last_check_at=check.get("checked_at"),
-                issues=check.get("error_message", "").split("; ") if check.get("error_message") else []
-            ))
-        else:
-            agents.append(AgentHealthSummary(
-                name=name,
-                status="unknown",
-                issues=["No health check data"]
-            ))
-
-    # Sort by status severity (critical first)
-    status_order = {"critical": 0, "unhealthy": 1, "degraded": 2, "unknown": 3, "healthy": 4}
-    agents.sort(key=lambda a: status_order.get(a.status, 3))
+    # #669: aggregator-side defects (NULL status, schema drift, partial rows)
+    # must not propagate as 500. Degrade to an "unknown" payload so MCP clients
+    # and the UI can render *something*.
+    try:
+        latest_checks = db.get_all_latest_health_checks(agent_names, "aggregate")
+        summary = db.get_health_summary(agent_names)
+        agents = [_build_agent_summary(name, latest_checks.get(name)) for name in agent_names]
+        agents.sort(key=_status_sort_key)
+    except Exception:
+        logger.exception("Fleet health aggregation failed for %d agents", len(agent_names))
+        return FleetHealthStatus(
+            enabled=get_monitoring_service().is_running,
+            last_check_at=None,
+            summary=FleetHealthSummary(total_agents=len(agent_names), unknown=len(agent_names)),
+            agents=[
+                AgentHealthSummary(name=n, status="unknown", issues=["Health aggregation failed"])
+                for n in agent_names
+            ],
+        )
 
     # Include circuit breaker states for admin users
     cb_data = None

--- a/tests/unit/test_fleet_status_resilience.py
+++ b/tests/unit/test_fleet_status_resilience.py
@@ -1,0 +1,192 @@
+"""Regression tests for #669 — `GET /api/monitoring/status` returns 500
+when one or more `agent_health_checks` rows have `status = NULL`.
+
+Root cause: the original build loop did
+    AgentHealthSummary(status=check.get("status", "unknown"), ...)
+
+`dict.get(key, default)` only returns the default when the key is *missing*.
+If the key exists with a `None` value (which happens whenever a partial
+health-check row is persisted), the call returns `None` and Pydantic v2
+rejects the model because `AgentHealthSummary.status: str` is required and
+non-optional. The whole fleet-status endpoint then 500s, even though the
+sibling per-agent endpoint (`/api/monitoring/agents/{name}`) recovers by
+triggering a fresh check for missing-aggregate rows.
+
+The fix extracts a single `_build_agent_summary(name, check)` helper that
+coerces `None`/missing/non-string status to `"unknown"` and tolerates a
+`None` `error_message`. The endpoint also wraps the aggregation in a
+defensive try/except returning an "unknown"-degraded payload (issue ask #1)
+so that any future schema drift surfaces as a structured response rather
+than a 500.
+
+Issue: https://github.com/abilityai/trinity/issues/669
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Issue #589: src/backend/config.py raises at import unless REDIS_URL carries
+# credentials. Stub it before any backend import lands.
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _load_monitoring_router():
+    """Load `routers.monitoring` with heavy deps stubbed.
+
+    `routers/monitoring.py` imports `database`, `services.monitoring_service`,
+    `services.agent_service`, `dependencies` — all of which transitively touch
+    `/data` (SQLite path), Redis, Docker. None of that matters for the pure
+    helper functions under test (`_build_agent_summary`, `_status_sort_key`).
+    """
+    # Stub `database` so `from database import db` returns a MagicMock.
+    sys.modules.setdefault("database", types.SimpleNamespace(db=MagicMock()))
+
+    # Stub `services` package + the two submodules monitoring.py imports.
+    services_stub = types.ModuleType("services")
+    services_stub.__path__ = [str(_BACKEND / "services")]
+    sys.modules.setdefault("services", services_stub)
+    sys.modules.setdefault(
+        "services.monitoring_service",
+        types.SimpleNamespace(
+            perform_health_check=AsyncMock(),
+            perform_fleet_health_check=AsyncMock(),
+            get_monitoring_service=MagicMock(),
+            start_monitoring_service=MagicMock(),
+            stop_monitoring_service=MagicMock(),
+            DEFAULT_CONFIG=MagicMock(),
+        ),
+    )
+    sys.modules.setdefault(
+        "services.agent_service",
+        types.SimpleNamespace(get_accessible_agents=MagicMock(return_value=[])),
+    )
+    sys.modules.setdefault(
+        "services.agent_client",
+        types.SimpleNamespace(get_all_circuit_states=MagicMock(return_value={})),
+    )
+
+    # `dependencies` imports the world; stub the three names monitoring uses.
+    sys.modules.setdefault(
+        "dependencies",
+        types.SimpleNamespace(
+            get_current_user=MagicMock(),
+            require_admin=MagicMock(),
+            AuthorizedAgentByName=str,  # FastAPI annotation placeholder
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "routers.monitoring", _BACKEND / "routers" / "monitoring.py"
+    )
+    routers_pkg = sys.modules.setdefault("routers", types.ModuleType("routers"))
+    routers_pkg.__path__ = [str(_BACKEND / "routers")]
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["routers.monitoring"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def fleet_helpers():
+    return _load_monitoring_router()
+
+
+@pytest.fixture(scope="module")
+def AgentHealthSummary():
+    return importlib.import_module("db_models").AgentHealthSummary
+
+
+# ---------------------------------------------------------------------------
+# _build_agent_summary — pure helper extracted from the build loop
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAgentSummary:
+    def test_full_check_row_passes_through(self, fleet_helpers, AgentHealthSummary):
+        check = {
+            "status": "healthy",
+            "container_status": "running",
+            "reachable": True,
+            "runtime_available": True,
+            "checked_at": "2026-05-06T00:00:00Z",
+            "error_message": "",
+        }
+        s = fleet_helpers._build_agent_summary("agent-a", check)
+        assert isinstance(s, AgentHealthSummary)
+        assert s.name == "agent-a"
+        assert s.status == "healthy"
+        assert s.docker_status == "running"
+        assert s.network_reachable is True
+        assert s.runtime_available is True
+        assert s.last_check_at == "2026-05-06T00:00:00Z"
+        assert s.issues == []
+
+    def test_status_none_coerces_to_unknown(self, fleet_helpers, AgentHealthSummary):
+        """The 500 trigger from #669: row with explicit NULL status."""
+        check = {
+            "status": None,
+            "container_status": "running",
+            "reachable": True,
+            "checked_at": "2026-05-06T00:00:00Z",
+            "error_message": None,
+        }
+        s = fleet_helpers._build_agent_summary("agent-b", check)
+        assert s.status == "unknown"
+        assert s.issues == []  # None error_message must not crash .split
+
+    def test_missing_status_key_coerces_to_unknown(self, fleet_helpers):
+        check = {"container_status": "running"}
+        s = fleet_helpers._build_agent_summary("agent-c", check)
+        assert s.status == "unknown"
+
+    def test_missing_check_returns_unknown_with_no_data_issue(self, fleet_helpers):
+        """When db lookup returns no row at all (None), we still must build a
+        valid AgentHealthSummary — the endpoint relied on this branch."""
+        s = fleet_helpers._build_agent_summary("agent-d", None)
+        assert s.status == "unknown"
+        assert s.issues == ["No health check data"]
+
+    def test_error_message_splits_on_semicolon(self, fleet_helpers):
+        check = {
+            "status": "degraded",
+            "error_message": "context high; runtime stalled",
+        }
+        s = fleet_helpers._build_agent_summary("agent-e", check)
+        assert s.issues == ["context high", "runtime stalled"]
+
+    def test_non_string_status_coerces_to_unknown(self, fleet_helpers):
+        """Defensive: if a row ever lands with a non-string status (e.g. int
+        from a botched migration), don't 500 — degrade to unknown."""
+        check = {"status": 0}
+        s = fleet_helpers._build_agent_summary("agent-f", check)
+        assert s.status == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# status_order sort tolerance — sort key must not raise on coerced status.
+# ---------------------------------------------------------------------------
+
+
+class TestStatusOrderSort:
+    def test_sort_tolerates_unknown(self, fleet_helpers):
+        items = [
+            fleet_helpers._build_agent_summary("a", {"status": "healthy"}),
+            fleet_helpers._build_agent_summary("b", {"status": None}),
+            fleet_helpers._build_agent_summary("c", {"status": "critical"}),
+        ]
+        items.sort(key=fleet_helpers._status_sort_key)
+        assert [i.name for i in items] == ["c", "b", "a"]


### PR DESCRIPTION
## Summary

`GET /api/monitoring/status` (the endpoint MCP `get_fleet_health` calls) returned 500 whenever any `agent_health_checks` row had `status = NULL`. The build loop did `check.get("status", "unknown")` — which only returns the default if the *key* is missing, not when the value is `None`. Pydantic v2 then rejected the model because `AgentHealthSummary.status: str` is required and non-optional.

The sibling per-agent endpoint dodged it by triggering a fresh check when no aggregate row existed, which is why `get_agent_health` worked while `get_fleet_health` 500'd in the production fleet from #669.

## Changes

- Extract `_build_agent_summary(name, check)` + `_coerce_status(raw)` so NULL/missing/non-str status degrades to `"unknown"`. Same defensive treatment for NULL `error_message` (would explode `.split("; ")`).
- Wrap the aggregator in `try/except` returning a structured `"unknown"`-degraded payload rather than 500 (issue ask #1). Future schema drift surfaces as data, not an outage.
- Reconcile `docs/user-docs/operations/monitoring.md` — listed path `/api/monitoring/fleet-health` doesn't exist; correct to `/api/monitoring/status`.

## Tests

7 new unit tests in `tests/unit/test_fleet_status_resilience.py`. Cover NULL status, missing key, missing row, NULL `error_message`, non-str status, and sort-key tolerance. Stubs heavy router deps so the test stays a true unit (no DB, no Redis, no FastAPI app boot).

```
$ .venv/bin/pytest tests/unit/test_fleet_status_resilience.py -q
7 passed
```

Wider unit-suite regression check passes for everything that ran on `dev` before — the 45 failures on `tests/unit/` are the pre-existing post-#589 cluster tracked in #660, not introduced here (verified by stashing the diff and re-running on clean `dev`).

## Does NOT fix

The underlying scheduler stoppage (8 of 9 agents in production going 2-3 months without a health refresh) needs prod logs to root-cause. Split into #675.

## Test plan

- [x] Unit tests pass (7/7 new)
- [x] Verified the pre-existing 45 unit failures are not introduced by this PR (clean on stashed-base)
- [ ] Live-verify on a running stack with at least one agent that has a NULL `status` row — call `/api/monitoring/status` and confirm 200 instead of 500
- [ ] Production sanity check — next time the fleet has agents with stale rollups, confirm MCP `get_fleet_health` returns a structured payload

Closes #669
Refs #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)