### PR TITLE
fix(agent-client): circuit breaker half-open recovery (#687)

### DIFF
--- a/src/backend/services/agent_client.py
+++ b/src/backend/services/agent_client.py
@@ -43,7 +43,11 @@ class CircuitState:
 
     def record_failure(self):
         self.failure_count += 1
-        self.last_failure_time = time.monotonic()
+        # Don't reset the cooldown clock once open — continuous probe failures
+        # would otherwise keep last_failure_time near zero, preventing the
+        # half-open transition (root cause of #687).
+        if self.state != "open":
+            self.last_failure_time = time.monotonic()
         if self.failure_count >= self.failure_threshold:
             if self.state != "open":
                 logger.warning(

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -142,6 +142,43 @@ class TestCircuitState:
         assert d["state"] == "open"
         assert d["cooldown_remaining"] > 0
 
+    def test_open_circuit_does_not_reset_cooldown_clock_on_subsequent_failures(self):
+        """Subsequent failures while open must not advance last_failure_time (#687).
+
+        Before the fix, every record_failure() call reset last_failure_time even
+        when the circuit was already open. This made the cooldown timer restart on
+        every probe failure, so the half-open state was unreachable under load.
+        """
+        circuit = CircuitState(
+            agent_name="test", failure_threshold=1, cooldown_seconds=30.0
+        )
+        circuit.record_failure()
+        assert circuit.state == "open"
+        clock_at_open = circuit.last_failure_time
+
+        time.sleep(0.01)
+        circuit.record_failure()
+        circuit.record_failure()
+
+        assert circuit.last_failure_time == clock_at_open
+
+    def test_continuous_failures_while_open_still_allow_half_open_recovery(self):
+        """Circuit must enter half-open after cooldown even with ongoing probe failures (#687)."""
+        circuit = CircuitState(
+            agent_name="test", failure_threshold=1, cooldown_seconds=0.05
+        )
+        circuit.record_failure()
+        assert circuit.state == "open"
+
+        # Simulate cleanup / scheduler probes failing while circuit is open
+        circuit.record_failure()
+        circuit.record_failure()
+        circuit.record_failure()
+
+        time.sleep(0.1)
+        assert circuit.allow_request() is True
+        assert circuit.state == "half-open"
+
 
 # ============================================================================
 # Circuit Registry Tests


### PR DESCRIPTION
## Summary

- `record_failure()` was resetting `last_failure_time` on every call, even when the circuit was already open
- Continuous probe failures (cleanup re-verify, scheduler) kept the cooldown timer perpetually near zero → half-open state was unreachable → circuit stayed open until backend restart → zombie executions
- Fix: don't update `last_failure_time` once the circuit is open; cooldown clock now starts when the circuit first opens and isn't disturbed by subsequent failures

## Changes

- `src/backend/services/agent_client.py` — one-line guard in `record_failure()`: `if self.state != "open": self.last_failure_time = ...`
- `tests/unit/test_circuit_breaker.py` — two new regression tests covering the specific failure mode

## Test Plan

- [x] `test_open_circuit_does_not_reset_cooldown_clock_on_subsequent_failures` — asserts `last_failure_time` is frozen once open
- [x] `test_continuous_failures_while_open_still_allow_half_open_recovery` — asserts half-open is reachable after cooldown despite ongoing failures
- [x] All 27 circuit breaker tests pass

Fixes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)