### PR TITLE
test(harness): repro scaffolding + negative results for #640 — 6 hypotheses falsified

### DIFF
--- a/tests/harness/640/README.md
+++ b/tests/harness/640/README.md
@@ -1,0 +1,144 @@
+# Repro harness for #640 — MCP stdio stdout pollution
+
+> **Status:** harness only. The fix at the agent-runtime layer is still
+> open. PR #662 is the diagnostic-instrumentation prerequisite.
+
+## What this harness is for
+
+Issue #640 is the open root-cause ticket behind a family of "long execution
+silently fails with null response" reports (#678, #630, #618, #548, #586).
+The hypothesis is: an stdio MCP server (or one of its descendants) writes
+to a file descriptor that ends up interleaving with Claude Code's own
+stdout, corrupting the `stream-json` line that carries the result block.
+
+PR #662's author tried to repro with `@upstash/context7-mcp@latest`, ran
+~1.5h, did not manifest the failure (issue body says ≥100 turns / 18min
+needed). What's missing is a **deterministic** repro: a controlled MCP
+server that exhibits each hypothesised leak path, so we can prove which
+one actually corrupts the wire and design a fix at the right layer.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `noisy_mcp_server.py` | Minimal stdio MCP server with `--leak <variant>` knobs. Self-contained, stdlib only. |
+| `run_repro.py` | Driver that hits an agent's chat API for N turns and measures null-cost / null-response rate. |
+| `README.md` | This file. |
+
+## Leak variants
+
+Each variant tests one hypothesis from the #640 issue body and the #662
+author's empirical notes:
+
+| Variant | Hypothesis tested |
+|---------|-------------------|
+| `none` | Control / baseline. Should produce 0% null-cost. |
+| `stderr-flood` | MCP child stderr noise — does it bleed onto stdout via Claude's stderr handling? |
+| `setsid-child` | Grandchild escapes Claude pgid kill (#618 fix family) and retains write end on protocol pipe. |
+| `proc-fd-write` | Process writes to its own fd 1 via `/proc/self/fd/1`, interleaving raw text with MCP frames. |
+| `delayed-stdout` | Partial-line writes that race Claude's reader at line boundary. |
+| `npm-wrapper` | Real-world `npx`-style: package-manager boilerplate on stdout BEFORE protocol handshake. Most likely culprit. |
+
+The simulator never writes to stdout/stderr for its own diagnostics —
+those are reserved for the wire. All instrumentation goes to a sidecar
+log file (default `/tmp/noisy-mcp-server.log`).
+
+## How to run
+
+### 1. Pick an agent
+
+You need an existing Trinity agent in your local stack. Either reuse one
+or create a fresh template-based agent. The agent's `.mcp.json` will be
+modified to attach this simulator.
+
+### 2. Wire the simulator into the agent's `.mcp.json`
+
+Inside the agent container (e.g. `docker exec -u developer <agent> bash`):
+
+```bash
+# Copy the simulator into the agent's home dir.
+docker cp tests/harness/640/noisy_mcp_server.py <agent>:/home/developer/noisy_mcp_server.py
+docker exec <agent> chmod +x /home/developer/noisy_mcp_server.py
+
+# Append to .mcp.json (variant=npm-wrapper is the most production-like).
+# Use jq or hand-edit to add:
+#   "noisy": {
+#     "command": "/home/developer/noisy_mcp_server.py",
+#     "args": ["--leak", "npm-wrapper", "--log-file", "/home/developer/noisy-mcp.log"]
+#   }
+docker exec <agent> python3 -c '
+import json, pathlib
+p = pathlib.Path("/home/developer/.mcp.json")
+cfg = json.loads(p.read_text())
+cfg.setdefault("mcpServers", {})["noisy"] = {
+    "command": "/home/developer/noisy_mcp_server.py",
+    "args": ["--leak", "npm-wrapper", "--log-file", "/home/developer/noisy-mcp.log"],
+}
+p.write_text(json.dumps(cfg, indent=2))
+'
+```
+
+### 3. Restart the agent so Claude picks up the new MCP
+
+```bash
+# Force agent-server to restart claude — easiest path is to reset the chat session.
+curl -X DELETE -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/agents/<agent>/chat/history
+```
+
+### 4. Drive the repro
+
+```bash
+./tests/harness/640/run_repro.py --agent <agent> --turns 50
+```
+
+The driver mints a JWT from `.env` `ADMIN_PASSWORD` if `--token` is not
+passed.
+
+### 5. Read the verdict
+
+The driver prints per-turn status and a summary:
+
+```
+============================================================
+Total turns         : 50
+Null cost           : 6 (12.0%)
+Null response       : 4 (8.0%)
+Mean turn duration  : 14.3s
+Max turn duration   : 78.1s
+
+First 5 failures:
+  turn 17: {'turn': 17, 'cost': None, ...}
+
+FAIL: null-cost rate 12.0% exceeds threshold 5.0%
+```
+
+Exit code 0 if null-cost rate is below the `--null-cost-fail-rate`
+threshold (default 5%), 1 otherwise. Once a fix lands the same harness
+becomes a regression gate — variants that pass on the fixed runtime but
+failed on the buggy runtime are the ones the fix actually addresses.
+
+## Caveats
+
+- The simulator runs as the agent user (`developer`, uid 1000). It needs
+  Python 3 in `$PATH` — already present in the base image.
+- `setsid-child` forks a grandchild that holds an open write end on the
+  protocol pipe. After Claude exits, this grandchild becomes the orphan
+  that PR #662's `_kill_orphan_pipe_writers` is designed to surface.
+  Verify by checking `/home/developer/noisy-mcp.log` for the
+  `setsid-child started pgid=…` line and then `/proc/<pid>/fd/` after a
+  failed run.
+- The `npm-wrapper` variant only fires once at startup. To stress this
+  path, you must reset the chat session between turns so Claude
+  re-spawns the MCP child. The driver currently does not — extend if
+  needed.
+- Until PR #662 lands, parse_failures aren't logged at WARNING level —
+  the driver measures the symptom (null cost / null response). Once #662
+  ships, also grep agent-server logs for `parse_failures=` to correlate.
+
+## Links
+
+- Issue #640 — root cause ticket
+- PR #662 — diagnostic instrumentation (prerequisite)
+- Issue #678 — production manifestation (24-min execution, null telemetry)
+- `docker/base-image/agent_server/services/claude_code.py` — spawn site
+- `docker/base-image/agent_server/utils/subprocess_pgroup.py` — orphan reaper

--- a/tests/harness/640/README.md
+++ b/tests/harness/640/README.md
@@ -135,10 +135,56 @@ failed on the buggy runtime are the ones the fix actually addresses.
   the driver measures the symptom (null cost / null response). Once #662
   ships, also grep agent-server logs for `parse_failures=` to correlate.
 
+## Results to date (2026-05-07 session)
+
+Six hypotheses tested via this harness + static inspection of
+`@anthropic-ai/claude-code` cli.js (v at agent base image as of branch).
+**All falsified.** Negative results below — preserved so future hunts
+don't re-walk the same paths.
+
+| # | Hypothesis | Method | Result |
+|---|-----------|--------|--------|
+| 1 | Node `child_process.spawn` leaks fd>2 to MCP child | Read spawn opts in cli.js | ✗ Node closes fd>2 by default; no MCP-spawn site disables it |
+| 2 | Claude has stray `process.stdout.write` in stream-json hot path | Grepped all 45 stdout writes for real-code (non-docstring) sites firing in `--print` mode | ✗ All real sites are subcommand-specific (mcp add, login, TUI keys, native-host) — none fire in stream-json hot path |
+| 3 | Claude bridges MCP child stderr → its own stdout | Read `m.stderr.on("data")` handler | ✗ Buffers in 64MB ring (`if($.length<67108864) $+=h.toString()`); never re-emits |
+| 4 | `npm`-bootstrap stdout boilerplate before MCP handshake | 50 turns w/ `npm-wrapper` variant | ✗ 0/50 null-cost; Claude tolerates pre-protocol garbage at handshake |
+| 5 | `setsid` grandchild retains protocol-pipe write end and pollutes during steady state | 50 turns w/ `setsid-child` variant; verified 53 grandchildren forked + escaped pgid | ✗ 0/50 null-cost; pollution lands on MCP-protocol pipe (claude-side), not agent-server's claude-stdout pipe — Claude skips non-JSON frames |
+| 6 | Userspace `/proc/self/fd/N` bypass of pipe isolation | Smoke test of `proc-fd-write` variant | ✗ Linux returns `ENXIO` when re-opening a pipe via `/proc/self/fd/*` — kernel-level isolation. Hypothesis impossible at user level. |
+
+### What this rules out
+
+The corruption mechanism behind #640 is **not** in any of:
+
+- Process-level fd inheritance / leak from claude → MCP child → grandchild
+- Claude's own stream-json output gating (no stray writes in hot path)
+- Userspace MCP-child output corruption (stdout AND stderr both isolated by SDK transport)
+- Linux `/proc/*/fd/*` bypass at the user-permission level
+
+### What's still open (real remaining hypothesis space)
+
+- **Race in Claude's own stdout line buffering** — concurrent emitter threads inside Claude's runtime, not external pollution. Would require LD_PRELOAD or claude-cli source patching to test.
+- **Specific package with shell-wrapped launch** (`bash -c "node x.js"`) where shell init writes to a fd we haven't simulated — need a real cmdline from a production failure to target.
+- **Load-state dependent**: bug only manifests after 100+ turns / 18+ min sustained load (per #640 issue body). Our 50-turn / ~6 min runs may not exhaust whatever Claude-internal buffer/timer accumulates.
+- **Specific cli.js version drift**: the cli.js inspected here may differ from production version that hit #640 / #678. Check version pinning.
+
+### Recommended next steps
+
+1. **Land PR #662** (diagnostic instrumentation) — the only realistic way to identify the actual leaking package is from real production logs once `parse_failures=N` and orphan-cmdline lines are surfaced.
+2. **Redeploy dev cluster fixes** (#657, #649, #618, #630, #531, #520) on the host running `ability-website`. Reduces frequency of #678-style failures even without root-cause fix.
+3. **Wait for next prod failure with #662 logs** — the orphan cmdline and `parse_failures` count will identify the actual leaking package.
+4. **Build a targeted variant from that real cmdline** — much cheaper than synthetic hypothesis-hunting.
+5. **Optionally: 200-turn run with this harness** to test the load-state-dependent hypothesis. ~$8 / 30 min.
+
+### Cost of this investigation
+
+- ~$4 of subscription compute (npm-wrapper + setsid-child runs at 50 turns each)
+- ~3 hours wall (harness scaffold + 2 variants + cli.js inspection)
+- Information delivered: 6 hypotheses falsified, harness committed as future regression gate
+
 ## Links
 
-- Issue #640 — root cause ticket
-- PR #662 — diagnostic instrumentation (prerequisite)
+- Issue #640 — root cause ticket (still open after this investigation)
+- PR #662 — diagnostic instrumentation (prerequisite for next prod-data-driven attempt)
 - Issue #678 — production manifestation (24-min execution, null telemetry)
-- `docker/base-image/agent_server/services/claude_code.py` — spawn site
+- `docker/base-image/agent_server/services/claude_code.py` — agent-server spawn site
 - `docker/base-image/agent_server/utils/subprocess_pgroup.py` — orphan reaper

--- a/tests/harness/640/noisy_mcp_server.py
+++ b/tests/harness/640/noisy_mcp_server.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Noisy stdio MCP server — repro harness for #640.
+
+A minimal MCP server that speaks just enough of the protocol for Claude Code
+to register it (`initialize`, `notifications/initialized`, `tools/list`,
+`tools/call`) and then deliberately leaks output via one of several
+hypothesised pollution paths.
+
+Usage:
+    noisy_mcp_server.py --leak <variant> [--rate HZ] [--burst N]
+
+Variants:
+    none           — clean baseline (no leak; control)
+    stderr-flood   — flood stderr with text outside MCP protocol
+    setsid-child   — fork a setsid grandchild that writes to stdout
+                     periodically (escapes claude pgid kill)
+    proc-fd-write  — open /proc/self/fd/1 from this process and
+                     interleave raw text with MCP responses
+    delayed-stdout — write a partial JSON line to stdout, sleep mid-line,
+                     finish — races claude's reader at line boundary
+    npm-wrapper    — simulate `npx` style: print informational text to
+                     stdout BEFORE protocol begins (deprecation warnings,
+                     "added N packages" — known npm bootstrap behaviour)
+
+Each variant tests one of the leak hypotheses listed in #640.
+
+The server logs every protocol action to a sidecar file (specified via
+--log-file) so we can correlate observed wire corruption with what this
+process actually wrote.
+
+Designed to be self-contained — no external deps beyond the Python stdlib —
+so it can be dropped into any agent template's `.mcp.json` without
+needing pip install in the container.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Logging — write to file, never to stdout/stderr (those are the wire).
+# ---------------------------------------------------------------------------
+
+_LOG_FH = None
+
+
+def log(msg: str) -> None:
+    if _LOG_FH is not None:
+        _LOG_FH.write(f"[{time.time():.3f}] [pid={os.getpid()}] {msg}\n")
+        _LOG_FH.flush()
+
+
+# ---------------------------------------------------------------------------
+# Leak variants — each spawned (or activated) at server start.
+# ---------------------------------------------------------------------------
+
+
+def leak_stderr_flood(rate_hz: float, burst: int) -> None:
+    """Periodically write garbage to stderr.
+
+    Hypothesis: claude reads child stderr as line-delimited diagnostic
+    output. If it gets dup'd onto stdout somewhere, parse failures occur.
+    """
+
+    def _worker():
+        log("stderr-flood worker started")
+        while True:
+            for _ in range(burst):
+                sys.stderr.write(f"NOISY MCP STDERR LINE pid={os.getpid()} t={time.time():.3f}\n")
+            sys.stderr.flush()
+            time.sleep(1.0 / rate_hz)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+
+
+def leak_setsid_child(rate_hz: float, burst: int) -> None:
+    """Fork a grandchild via setsid that writes to fd 1 (the MCP-protocol
+    pipe write end inherited from this process).
+
+    Hypothesis: a setsid grandchild escapes claude's pgid kill (the #618
+    failure mode) AND retains an open write handle to the protocol pipe,
+    so its writes interleave with this server's MCP responses, corrupting
+    the JSON stream Claude is parsing as MCP frames. If those corrupted
+    frames bleed back into Claude's own stdout stream toward agent-server,
+    that's the #640 wire corruption.
+    """
+    pid = os.fork()
+    if pid == 0:
+        # In grandchild — detach from parent's session.
+        os.setsid()
+        log(f"setsid-child started pgid={os.getpgid(0)}")
+        # Inherit fd 1 = MCP protocol pipe write end.
+        try:
+            while True:
+                for _ in range(burst):
+                    os.write(1, f"GRANDCHILD STDOUT POLLUTION pid={os.getpid()} t={time.time():.3f}\n".encode())
+                time.sleep(1.0 / rate_hz)
+        except BrokenPipeError:
+            log("setsid-child broken pipe — parent died")
+            os._exit(0)
+    else:
+        log(f"forked setsid-child pid={pid}")
+
+
+def leak_proc_fd_write(rate_hz: float, burst: int) -> None:
+    """From this process, open /proc/self/fd/1 and write raw text
+    interleaved with MCP responses.
+
+    Hypothesis: even when fd 1 is the MCP protocol pipe, writing raw text
+    via /proc/self/fd/1 (which dups the descriptor) corrupts the protocol
+    stream Claude is parsing.
+    """
+
+    def _worker():
+        try:
+            with open("/proc/self/fd/1", "wb", buffering=0) as f:
+                log("proc-fd-write opened /proc/self/fd/1")
+                while True:
+                    for _ in range(burst):
+                        f.write(f"PROC_FD_WRITE_POLLUTION pid={os.getpid()} t={time.time():.3f}\n".encode())
+                    time.sleep(1.0 / rate_hz)
+        except (BrokenPipeError, OSError) as e:
+            log(f"proc-fd-write ended: {e}")
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+
+
+def leak_delayed_stdout(rate_hz: float, burst: int) -> None:
+    """Write a partial line to stdout (no newline), sleep, then finish.
+
+    Hypothesis: if Claude's reader is reading at line granularity and the
+    line is mid-flight when it expects a JSON message, the partial reads
+    cause buffering issues / split frames.
+    """
+
+    def _worker():
+        while True:
+            for _ in range(burst):
+                # Write half a line, no newline — sit on the pipe.
+                os.write(1, b"PARTIAL_LINE_NO_NEWLINE_")
+                time.sleep(0.05)
+                os.write(1, f"finish_pid={os.getpid()}\n".encode())
+            time.sleep(1.0 / rate_hz)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+
+
+def leak_npm_wrapper() -> None:
+    """Print informational text to stdout BEFORE protocol begins.
+
+    This is the most likely real-world culprit: `npx -y some-pkg` prints
+    "npm warn deprecated foo" / "added 5 packages, audited 23 packages"
+    on stdout during package install. If Claude attempts to start protocol
+    before that boilerplate has cleared, the first MCP frames are
+    interleaved with package-manager output.
+    """
+    sys.stdout.write("npm warn deprecated some-pkg@1.0.0: use other-pkg instead\n")
+    sys.stdout.write("npm warn deprecated another-pkg@2.0.0: this package is no longer maintained\n")
+    sys.stdout.write("\n")
+    sys.stdout.write("added 5 packages, and audited 23 packages in 1s\n")
+    sys.stdout.write("\n")
+    sys.stdout.write("3 packages are looking for funding\n")
+    sys.stdout.write("  run `npm fund` for details\n")
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+    log("npm-wrapper bootstrap noise emitted")
+
+
+# ---------------------------------------------------------------------------
+# Minimal MCP protocol — just enough to register and respond to tool calls.
+# ---------------------------------------------------------------------------
+
+
+def write_response(msg_id: Any, result: Dict[str, Any]) -> None:
+    msg = {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    line = json.dumps(msg) + "\n"
+    sys.stdout.write(line)
+    sys.stdout.flush()
+    log(f"RESPONSE id={msg_id} bytes={len(line)}")
+
+
+def write_error(msg_id: Any, code: int, message: str) -> None:
+    msg = {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+    log(f"ERROR id={msg_id} code={code}")
+
+
+def handle(msg: Dict[str, Any]) -> None:
+    method = msg.get("method")
+    msg_id = msg.get("id")
+    log(f"REQUEST method={method} id={msg_id}")
+
+    if method == "initialize":
+        write_response(msg_id, {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "noisy-mcp-server", "version": "0.1.0"},
+        })
+    elif method == "notifications/initialized":
+        # No response on notifications.
+        pass
+    elif method == "tools/list":
+        write_response(msg_id, {"tools": [
+            {
+                "name": "echo",
+                "description": "Echo a string back. Cheap. Use for repro stress.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            },
+        ]})
+    elif method == "tools/call":
+        params = msg.get("params", {})
+        name = params.get("name")
+        if name == "echo":
+            text = params.get("arguments", {}).get("text", "")
+            write_response(msg_id, {"content": [{"type": "text", "text": text}]})
+        else:
+            write_error(msg_id, -32601, f"Unknown tool: {name}")
+    elif method is None:
+        # Probably a response to a server-initiated request — ignore.
+        pass
+    else:
+        write_error(msg_id, -32601, f"Method not found: {method}")
+
+
+def main() -> None:
+    global _LOG_FH
+
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--leak",
+        choices=["none", "stderr-flood", "setsid-child", "proc-fd-write", "delayed-stdout", "npm-wrapper"],
+        default="none",
+    )
+    p.add_argument("--rate", type=float, default=10.0, help="Leak rate in Hz")
+    p.add_argument("--burst", type=int, default=5, help="Lines per burst")
+    p.add_argument(
+        "--log-file",
+        default="/tmp/noisy-mcp-server.log",
+        help="Sidecar log file (NEVER write to stdout/stderr).",
+    )
+    args = p.parse_args()
+
+    _LOG_FH = open(args.log_file, "a")
+    log(f"=== START variant={args.leak} rate={args.rate} burst={args.burst} ===")
+
+    # npm-wrapper variant runs once at startup BEFORE protocol begins.
+    if args.leak == "npm-wrapper":
+        leak_npm_wrapper()
+    elif args.leak == "stderr-flood":
+        leak_stderr_flood(args.rate, args.burst)
+    elif args.leak == "setsid-child":
+        leak_setsid_child(args.rate, args.burst)
+    elif args.leak == "proc-fd-write":
+        leak_proc_fd_write(args.rate, args.burst)
+    elif args.leak == "delayed-stdout":
+        leak_delayed_stdout(args.rate, args.burst)
+
+    # Read MCP frames from stdin, write responses to stdout.
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError as e:
+            log(f"malformed input: {e}; line={line[:200]!r}")
+            continue
+        try:
+            handle(msg)
+        except Exception as e:
+            log(f"handler error: {e}")
+
+    log("=== STDIN CLOSED — server exiting ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/harness/640/run_repro.py
+++ b/tests/harness/640/run_repro.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Repro driver for #640 — drive N chat turns against an agent that has
+the noisy MCP attached and measure how often the wire-corruption failure
+mode fires.
+
+Until PR #662 lands in dev, the agent-server doesn't expose a
+`parse_failures` counter, so we measure the **observable symptom** instead:
+an execution that completes with `cost_usd = None` despite running for
+multiple turns. That's the exact symptom #678 hit in production.
+
+Usage:
+    run_repro.py --agent <name> --turns 50 [--token <jwt>] [--base-url <url>]
+
+Setup is documented in tests/harness/640/README.md — you must wire
+noisy_mcp_server.py into the target agent's .mcp.json BEFORE running this.
+
+Output:
+    Per-turn line of [N/M] cost=$X turn_id=… status=…
+    Final summary: success rate, null-cost rate, mean turn duration.
+
+Exit code 0 if null-cost rate < 5%, 1 otherwise — useful for CI gating
+once a fix lands.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+
+def _request(method: str, url: str, token: str, body: Optional[Dict] = None) -> Dict[str, Any]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body_txt = e.read().decode(errors="replace")[:500]
+        raise SystemExit(f"HTTP {e.code} on {method} {url}: {body_txt}")
+
+
+def get_admin_token(base_url: str) -> str:
+    """Mint a token from local admin password if --token not provided."""
+    env_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", ".env")
+    pw = None
+    if os.path.exists(env_path):
+        with open(env_path) as f:
+            for line in f:
+                if line.startswith("ADMIN_PASSWORD="):
+                    pw = line.split("=", 1)[1].strip()
+                    break
+    if not pw:
+        raise SystemExit("ADMIN_PASSWORD not in .env and no --token passed")
+
+    data = f"username=admin&password={pw}".encode()
+    req = urllib.request.Request(f"{base_url}/api/token", data=data, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Drive turns
+# ---------------------------------------------------------------------------
+
+
+# Cheap prompts that incentivise tool use without burning many tokens.
+PROMPTS = [
+    "Use the echo tool to echo back the word 'one'.",
+    "Echo 'two' via the echo tool.",
+    "Call echo with 'three'.",
+    "Echo 'four'.",
+    "Echo 'five'.",
+    "Echo 'six'.",
+    "Echo 'seven'.",
+    "Echo 'eight'.",
+    "Echo 'nine'.",
+    "Echo 'ten'.",
+]
+
+
+def run_turn(base_url: str, token: str, agent: str, prompt: str, timeout_s: int = 600) -> Dict[str, Any]:
+    t0 = time.time()
+    result = _request(
+        "POST",
+        f"{base_url}/api/agents/{agent}/chat",
+        token,
+        {"message": prompt, "timeout_seconds": timeout_s},
+    )
+    elapsed = time.time() - t0
+    return {"elapsed": elapsed, "result": result}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--agent", required=True, help="Target agent name (must already be running with noisy MCP attached)")
+    p.add_argument("--turns", type=int, default=50)
+    p.add_argument("--base-url", default="http://localhost:8000")
+    p.add_argument("--token", help="JWT (defaults to mint via .env ADMIN_PASSWORD)")
+    p.add_argument("--prompt-set", default="echo", help="(reserved for future prompt variants)")
+    p.add_argument("--null-cost-fail-rate", type=float, default=0.05,
+                   help="Exit 1 if null-cost rate exceeds this fraction (default 5%%)")
+    args = p.parse_args()
+
+    token = args.token or get_admin_token(args.base_url)
+
+    print(f"=== Repro #640 against agent '{args.agent}' over {args.turns} turns ===\n")
+
+    null_cost_count = 0
+    null_response_count = 0
+    durations: List[float] = []
+    failures: List[Dict[str, Any]] = []
+
+    for i in range(args.turns):
+        prompt = PROMPTS[i % len(PROMPTS)]
+        try:
+            r = run_turn(args.base_url, token, args.agent, prompt)
+        except SystemExit:
+            raise
+        except Exception as e:
+            print(f"[{i+1}/{args.turns}] EXCEPTION {type(e).__name__}: {e}")
+            failures.append({"turn": i + 1, "type": "exception", "error": str(e)})
+            continue
+
+        result = r["result"]
+        cost = result.get("cost_usd")
+        response_text = result.get("response")
+        durations.append(r["elapsed"])
+
+        is_null_cost = cost is None
+        is_null_response = not response_text
+
+        if is_null_cost:
+            null_cost_count += 1
+        if is_null_response:
+            null_response_count += 1
+
+        marker = "FAIL" if (is_null_cost or is_null_response) else "ok"
+        print(f"[{i+1}/{args.turns}] {marker:>4} cost=${cost} response_len={len(response_text or '')} elapsed={r['elapsed']:.1f}s")
+
+        if is_null_cost or is_null_response:
+            failures.append({
+                "turn": i + 1,
+                "cost": cost,
+                "response_len": len(response_text or ""),
+                "elapsed": r["elapsed"],
+                "metadata": {k: result.get(k) for k in ("error", "execution_id", "status")},
+            })
+
+    # ---- Summary ----------------------------------------------------------
+    print()
+    print("=" * 60)
+    print(f"Total turns         : {args.turns}")
+    print(f"Null cost           : {null_cost_count} ({null_cost_count/args.turns:.1%})")
+    print(f"Null response       : {null_response_count} ({null_response_count/args.turns:.1%})")
+    if durations:
+        print(f"Mean turn duration  : {statistics.mean(durations):.1f}s")
+        print(f"Max turn duration   : {max(durations):.1f}s")
+    print()
+
+    if failures:
+        print("First 5 failures:")
+        for f in failures[:5]:
+            print(f"  turn {f['turn']}: {f}")
+
+    null_rate = null_cost_count / args.turns
+    if null_rate > args.null_cost_fail_rate:
+        print(f"\nFAIL: null-cost rate {null_rate:.1%} exceeds threshold {args.null_cost_fail_rate:.1%}")
+        return 1
+    print(f"\nPASS: null-cost rate {null_rate:.1%} within threshold {args.null_cost_fail_rate:.1%}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/harness/640/run_repro.py
+++ b/tests/harness/640/run_repro.py
@@ -132,7 +132,15 @@ def main() -> int:
             continue
 
         result = r["result"]
-        cost = result.get("cost_usd")
+        meta = result.get("metadata") or {}
+        # /api/agents/{name}/chat puts cost / tool_count / error fields under
+        # `metadata`, not at the top level. The harness measures the symptom
+        # described in #678: an execution that completes with `cost_usd=None`
+        # despite running through multiple turns.
+        cost = meta.get("cost_usd")
+        tool_count = meta.get("tool_count")
+        num_turns = meta.get("num_turns")
+        error_type = meta.get("error_type")
         response_text = result.get("response")
         durations.append(r["elapsed"])
 
@@ -145,15 +153,23 @@ def main() -> int:
             null_response_count += 1
 
         marker = "FAIL" if (is_null_cost or is_null_response) else "ok"
-        print(f"[{i+1}/{args.turns}] {marker:>4} cost=${cost} response_len={len(response_text or '')} elapsed={r['elapsed']:.1f}s")
+        print(
+            f"[{i+1}/{args.turns}] {marker:>4} cost=${cost} tools={tool_count} "
+            f"turns={num_turns} response_len={len(response_text or '')} "
+            f"elapsed={r['elapsed']:.1f}s err={error_type}",
+            flush=True,
+        )
 
         if is_null_cost or is_null_response:
             failures.append({
                 "turn": i + 1,
                 "cost": cost,
+                "tool_count": tool_count,
+                "num_turns": num_turns,
                 "response_len": len(response_text or ""),
                 "elapsed": r["elapsed"],
-                "metadata": {k: result.get(k) for k in ("error", "execution_id", "status")},
+                "error_type": error_type,
+                "error_message": meta.get("error_message"),
             })
 
     # ---- Summary ----------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a deterministic repro harness for #640 (MCP stdio stdout pollution → reader-thread silent failures, manifesting as #678) and documents 6 falsified hypotheses from running the harness + statically inspecting claude-cli.

## What's in `tests/harness/640/`

| File | Purpose |
|------|---------|
| `noisy_mcp_server.py` | Stdlib-only stdio MCP server with `--leak <variant>` knob: `none`, `stderr-flood`, `setsid-child`, `proc-fd-write`, `delayed-stdout`, `npm-wrapper`. Self-contained, drop into any agent. |
| `run_repro.py` | Driver: N turns against an agent, measures null-cost/null-response rate, exits 1 if rate > threshold. CI-gateable once a fix lands. |
| `README.md` | Runbook + variant matrix + **falsification table** (results section). |

## Falsified hypotheses

| # | Hypothesis | Method | Result |
|---|-----------|--------|--------|
| 1 | Node spawn leaks fd>2 to MCP child | Inspect cli.js spawn opts | ✗ Node closes fd>2 by default; no MCP-spawn site disables it |
| 2 | Claude has stray stdout write in stream-json hot path | Grep all 45 stdout.write sites | ✗ All real-code sites are subcommand-specific (mcp add, login, TUI) |
| 3 | Claude bridges MCP child stderr → its stdout | Read `m.stderr.on("data")` handler | ✗ Buffers in 64MB ring, never re-emits |
| 4 | npm-bootstrap stdout boilerplate corrupts handshake | 50 turns w/ `npm-wrapper` | ✗ 0/50 null-cost |
| 5 | setsid grandchild retains pipe write end → steady-state pollution | 50 turns w/ `setsid-child`, 53 grandchildren forked + escaped pgid | ✗ 0/50 null-cost; pollution lands on MCP-pipe, not agent-server pipe |
| 6 | `/proc/self/fd/N` userspace bypass | Smoke test of `proc-fd-write` | ✗ Linux returns ENXIO — kernel-level isolation |

## Why the harness can't reproduce #640

Every leak path this harness exercises is on the **MCP protocol pipe** (claude-side), not the **agent-server claude-stdout pipe** (where #640's wire corruption manifests). Claude+SDK isolate MCP child stdio correctly via `stdio:["pipe","pipe","inherit"|"pipe"|"ignore"]` — no fd reaches agent-server's read pipe through a child path. So no userspace synthetic variant can corrupt the right wire.

## What's still open

Real remaining hypothesis space (untestable from the harness alone):

- **Race in Claude's own stdout line buffering** — concurrent emitter threads inside Claude itself
- **Specific package with shell-wrapped launch** (`bash -c "..."`) — need a real cmdline from prod failure
- **Load-state dependent** — bug only fires after 100+ turns / 18+ min (per #640 issue body); 50-turn runs don't exercise this
- **cli.js version drift** — production version that hit #640 may differ from what's bundled in current base image

## Next steps (not in this PR)

1. Land **#662** (diagnostic instrumentation) — only realistic way to identify the leaking package is real prod logs
2. Redeploy dev cluster fixes (#657, #649, #618, #630, #531, #520) on host running `ability-website`
3. Wait for next prod failure with #662 logs — orphan cmdlines + parse_failures will identify the actual leak
4. Build a targeted variant from that real cmdline

## Test plan

- [x] Harness scaffolds + smoke-tests cleanly (npm-wrapper, setsid-child, proc-fd-write, none variants verified to fire / not fire as designed)
- [x] Driver fixed to read `metadata.cost_usd` (was reading top-level `cost_usd` which is always None)
- [x] Negative results documented in README so future hunts don't re-walk same paths
- [ ] Operator-facing: harness used to reproduce or regression-gate a real fix (waits on prod-data-driven targeted variant)

## Cost

~$4 of subscription compute, ~3 hours wall. 6 hypotheses ruled out; harness committed as future regression gate.

Refs #640 (still open — root cause unknown; this PR closes the synthetic-hypothesis-hunting angle, not the bug)
Refs #662 (diagnostic instrumentation prerequisite)
Refs #678 (production manifestation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)