### PR TITLE
fix(monitoring): correct get_accessible_agents call signature (#682)

### DIFF
--- a/src/backend/routers/monitoring.py
+++ b/src/backend/routers/monitoring.py
@@ -153,7 +153,7 @@ async def get_fleet_status(
 
     # Filter to accessible agents (unless admin)
     if current_user.role != "admin":
-        accessible = get_accessible_agents(current_user.email, all_agent_names)
+        accessible = get_accessible_agents(current_user)
         accessible_names = {a["name"] for a in accessible}
         agent_names = [n for n in all_agent_names if n in accessible_names]
     else:

--- a/tests/unit/test_monitoring_router_signatures.py
+++ b/tests/unit/test_monitoring_router_signatures.py
@@ -1,0 +1,250 @@
+"""
+Regression tests for monitoring router call-site signatures (#682).
+
+Bug: `routers/monitoring.py` was calling
+`get_accessible_agents(current_user.email, all_agent_names)` after the
+helper was refactored to `get_accessible_agents(current_user: User)`.
+Admins skipped the call (early-branch), so the bug only surfaced for
+non-admin users as a 500 TypeError on `GET /api/monitoring/status`.
+
+These tests pin two things:
+
+1. The canonical helper signature stays `(current_user: User) -> list`.
+2. `get_fleet_status` invokes the helper with a single positional
+   `User` arg and returns a 200-shape `FleetHealthStatus` for a
+   non-admin caller — i.e. the historical TypeError can no longer fire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import inspect
+import os
+import sys
+import tempfile
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Point the backend at an ephemeral SQLite file BEFORE any backend module
+# imports — database.py tries to mkdir /data on import otherwise.
+_TMP_DB = Path(tempfile.gettempdir()) / "trinity_test_monitoring_router.db"
+os.environ.setdefault("TRINITY_DB_PATH", str(_TMP_DB))
+
+def _find_backend_root() -> Path:
+    """Locate the backend source tree across host and in-container layouts."""
+    candidates = [
+        Path(__file__).resolve().parent.parent.parent / "src" / "backend",  # host
+        Path("/app"),  # trinity-backend container
+    ]
+    env_override = os.environ.get("TRINITY_BACKEND_PATH")
+    if env_override:
+        candidates.insert(0, Path(env_override))
+    for c in candidates:
+        if (c / "routers" / "monitoring.py").exists():
+            return c
+    raise RuntimeError(
+        "Cannot locate backend source tree (set TRINITY_BACKEND_PATH)"
+    )
+
+
+_BACKEND = _find_backend_root()
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _stub_passlib():
+    """passlib import path resolution stub — bcrypt isn't needed here."""
+    if "passlib" in sys.modules:
+        return
+    passlib = types.ModuleType("passlib")
+    context = types.ModuleType("passlib.context")
+
+    class _CryptContext:
+        def __init__(self, **_):
+            pass
+
+        def hash(self, pw):
+            return f"stub${pw}"
+
+        def verify(self, pw, hashed):
+            return hashed == f"stub${pw}"
+
+    context.CryptContext = _CryptContext
+    sys.modules["passlib"] = passlib
+    sys.modules["passlib.context"] = context
+
+
+_stub_passlib()
+
+
+pytestmark = pytest.mark.unit
+
+
+# ── Importlib-load routers/monitoring.py without dragging in routers/__init__ ─
+
+def _load_monitoring_router():
+    """Load routers/monitoring.py directly.
+
+    Going through `from routers import monitoring` would import 50+
+    unrelated routers via routers/__init__.py.
+    """
+    path = _BACKEND / "routers" / "monitoring.py"
+    spec = importlib.util.spec_from_file_location("routers.monitoring", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["routers.monitoring"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+monitoring_router = _load_monitoring_router()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+class _FakeAgent:
+    """Stand-in for the dataclass returned by list_all_agents_fast()."""
+
+    def __init__(self, name: str, status: str = "running"):
+        self.name = name
+        self.status = status
+
+
+def _make_user(role: str, *, username: str = "u", user_id: int = 1, email: str = "u@x.test"):
+    """Construct a real db_models.User instance."""
+    from db_models import User  # backend's pydantic User
+
+    now = datetime.now(timezone.utc)
+    return User(
+        id=user_id,
+        username=username,
+        role=role,
+        email=email,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Signature pin ────────────────────────────────────────────────────────────
+
+class TestGetAccessibleAgentsSignature:
+    """The helper must accept exactly one User argument.
+
+    If this changes, every router call site needs auditing.
+    """
+
+    def test_helper_takes_single_user_param(self):
+        from services.agent_service.helpers import get_accessible_agents
+
+        sig = inspect.signature(get_accessible_agents)
+        params = list(sig.parameters.values())
+        assert len(params) == 1, (
+            f"get_accessible_agents must take exactly one parameter, "
+            f"got {[p.name for p in params]}"
+        )
+        assert params[0].name == "current_user"
+
+
+# ── Behavioural regression for #682 ─────────────────────────────────────────
+
+class TestGetFleetStatusNonAdmin:
+    """`get_fleet_status` must work for non-admin users (#682)."""
+
+    def test_non_admin_does_not_raise_type_error(self, monkeypatch):
+        """The bug was: 500 TypeError on the non-admin branch."""
+        # Stub list_all_agents_fast to return a fixed fleet.
+        agents = [_FakeAgent("agent-a"), _FakeAgent("agent-b")]
+
+        fake_docker = types.ModuleType("services.docker_service")
+        fake_docker.list_all_agents_fast = MagicMock(return_value=agents)
+        monkeypatch.setitem(sys.modules, "services.docker_service", fake_docker)
+
+        # Spy on get_accessible_agents to verify call shape, return a subset.
+        captured_calls = []
+
+        def fake_get_accessible(*args, **kwargs):
+            captured_calls.append((args, kwargs))
+            return [{"name": "agent-a"}]  # alice owns just agent-a
+
+        monkeypatch.setattr(monitoring_router, "get_accessible_agents", fake_get_accessible)
+
+        # Stub db calls for the non-admin path.
+        fake_db = MagicMock()
+        fake_db.get_all_latest_health_checks = MagicMock(return_value={})
+        fake_db.get_health_summary = MagicMock(
+            return_value={"healthy": 0, "degraded": 0, "unhealthy": 0, "critical": 0, "unknown": 1}
+        )
+        monkeypatch.setattr(monitoring_router, "db", fake_db)
+
+        # Stub the monitoring service.
+        fake_service = MagicMock()
+        fake_service.is_running = False
+        monkeypatch.setattr(monitoring_router, "get_monitoring_service", lambda: fake_service)
+
+        non_admin = _make_user("user", username="alice", email="alice@example.test")
+
+        # Pre-fix this raised TypeError. Post-fix it returns FleetHealthStatus.
+        result = _run(monitoring_router.get_fleet_status(current_user=non_admin))
+
+        # 1. No exception, valid response shape.
+        assert result.summary.total_agents == 1
+        assert [a.name for a in result.agents] == ["agent-a"]
+
+        # 2. Helper called exactly once with one positional arg, the User itself
+        #    (not user.email and not a separate agent-list parameter).
+        assert len(captured_calls) == 1
+        args, kwargs = captured_calls[0]
+        assert kwargs == {}
+        assert len(args) == 1, (
+            f"get_accessible_agents called with {len(args)} positional args; "
+            f"the #682 regression was passing 2. Args: {args!r}"
+        )
+        assert args[0] is non_admin
+
+    def test_admin_branch_skips_helper_and_keeps_full_fleet(self, monkeypatch):
+        """Admins must not hit get_accessible_agents — they see everything."""
+        agents = [_FakeAgent("agent-a"), _FakeAgent("agent-b")]
+
+        fake_docker = types.ModuleType("services.docker_service")
+        fake_docker.list_all_agents_fast = MagicMock(return_value=agents)
+        monkeypatch.setitem(sys.modules, "services.docker_service", fake_docker)
+
+        helper_calls = []
+
+        def fake_get_accessible(*args, **kwargs):
+            helper_calls.append((args, kwargs))
+            return []
+
+        monkeypatch.setattr(monitoring_router, "get_accessible_agents", fake_get_accessible)
+
+        fake_db = MagicMock()
+        fake_db.get_all_latest_health_checks = MagicMock(return_value={})
+        fake_db.get_health_summary = MagicMock(
+            return_value={"healthy": 0, "degraded": 0, "unhealthy": 0, "critical": 0, "unknown": 2}
+        )
+        monkeypatch.setattr(monitoring_router, "db", fake_db)
+
+        fake_service = MagicMock()
+        fake_service.is_running = True
+        monkeypatch.setattr(monitoring_router, "get_monitoring_service", lambda: fake_service)
+
+        # Admin path also touches services.agent_client.get_all_circuit_states.
+        fake_client = types.ModuleType("services.agent_client")
+        fake_client.get_all_circuit_states = MagicMock(return_value={})
+        monkeypatch.setitem(sys.modules, "services.agent_client", fake_client)
+
+        admin = _make_user("admin", username="admin")
+
+        result = _run(monitoring_router.get_fleet_status(current_user=admin))
+
+        assert helper_calls == [], "admins must bypass get_accessible_agents"
+        assert {a.name for a in result.agents} == {"agent-a", "agent-b"}


### PR DESCRIPTION
## Summary

Fixes #682 — `GET /api/monitoring/status` returned **500 TypeError** for non-admin users because `routers/monitoring.py:104` was calling `get_accessible_agents(current_user.email, all_agent_names)` after the helper was refactored to accept a single `User`.

```
TypeError: get_accessible_agents() takes 1 positional argument but 2 were given
```

Every other call site (`agents.py`, `notifications.py`, `systems.py`, `fleet.py`, `activities.py`, `permissions.py`, `stats.py`) already used the new signature — this was the lone straggler. Admins were unaffected because the call sits inside an `if current_user.role != "admin":` branch.

## Change

One-line fix at `src/backend/routers/monitoring.py:104`:

```diff
- accessible = get_accessible_agents(current_user.email, all_agent_names)
+ accessible = get_accessible_agents(current_user)
```

## Regression test

`tests/unit/test_monitoring_router_signatures.py` — three cases:

1. **Signature pin** — `inspect.signature(get_accessible_agents)` must report exactly one `current_user` parameter. If the helper changes, all router call sites need re-auditing.
2. **Non-admin path** — spy on the helper, call `get_fleet_status` with a `role="user"` User, assert: no exception, valid `FleetHealthStatus` shape, helper called with **one** positional arg (the User itself, not `user.email` and not a separate agent-list parameter).
3. **Admin path** — verify admins bypass the helper entirely and still see the full fleet.

Verified the test FAILS on the pre-fix code and PASSES after.

## Test plan

- [x] Local repro: `curl -H "Authorization: Bearer <non-admin JWT>" /api/monitoring/status` → 200 (was 500)
- [x] Admin path unchanged: `/api/monitoring/status` as admin → 200, full fleet
- [x] New unit test passes
- [x] New unit test fails on the pre-fix code (regression coverage confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)