### PR TITLE
fix(api-keys): clipboard fallback + error feedback (#677)

### DIFF
--- a/src/frontend/e2e/api-keys-copy.spec.js
+++ b/src/frontend/e2e/api-keys-copy.spec.js
@@ -1,0 +1,85 @@
+// Regression test for #677 — API Keys page Copy buttons must reach the
+// clipboard. Prior to the fix, the buttons called `navigator.clipboard.writeText`
+// with no fallback and swallowed every rejection silently.
+//
+// This test creates a fresh API key, clicks both copy actions in the
+// "Your MCP API Key is Ready!" modal, and reads the clipboard back to
+// verify the content actually landed.
+
+import { test, expect } from '@playwright/test'
+
+test.describe('@interactive api-keys copy buttons (#677)', () => {
+  test.beforeEach(async ({ context }) => {
+    // Headless browsers gate clipboard read by default — opt in for the test.
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+  })
+
+  test('Copy Config button writes MCP JSON to clipboard', async ({ page }) => {
+    await page.goto('/api-keys')
+
+    await page.getByRole('button', { name: /create api key/i }).first().click()
+
+    const keyName = `e2e-copy-${Date.now()}`
+    await page.getByPlaceholder('My Claude Code Key').fill(keyName)
+    await page.getByRole('button', { name: 'Create', exact: true }).click()
+
+    // The "Your MCP API Key is Ready!" modal renders the Copy Config button.
+    const copyConfigBtn = page.getByRole('button', { name: /copy config/i })
+    await expect(copyConfigBtn).toBeVisible({ timeout: 10000 })
+
+    await copyConfigBtn.click()
+
+    // Visual confirmation flips to "Copied!" only on success.
+    await expect(page.getByRole('button', { name: /copied!/i })).toBeVisible({
+      timeout: 3000,
+    })
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboardText).toContain('"mcpServers"')
+    expect(clipboardText).toContain('"trinity"')
+    expect(clipboardText).toContain('Bearer trinity_mcp_')
+
+    // Cleanup — close modal, then revoke + delete the test key.
+    await page.getByRole('button', { name: /i've copied the configuration/i }).click()
+    await cleanupKey(page, keyName)
+  })
+
+  test('Copy key icon button writes raw key to clipboard', async ({ page }) => {
+    await page.goto('/api-keys')
+
+    await page.getByRole('button', { name: /create api key/i }).first().click()
+
+    const keyName = `e2e-copy-key-${Date.now()}`
+    await page.getByPlaceholder('My Claude Code Key').fill(keyName)
+    await page.getByRole('button', { name: 'Create', exact: true }).click()
+
+    const copyKeyBtn = page.getByTitle('Copy key')
+    await expect(copyKeyBtn).toBeVisible({ timeout: 10000 })
+
+    await copyKeyBtn.click()
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboardText).toMatch(/^trinity_mcp_/)
+    // Sanity: API keys are 44 chars (trinity_mcp_ + 32-char random).
+    expect(clipboardText.length).toBeGreaterThan(20)
+
+    await page.getByRole('button', { name: /i've copied the configuration/i }).click()
+    await cleanupKey(page, keyName)
+  })
+})
+
+async function cleanupKey(page, keyName) {
+  // The list refreshes after the modal closes — find the row by name and delete.
+  const row = page.locator('li', { has: page.getByText(keyName, { exact: true }) }).first()
+  if (await row.count() === 0) return
+
+  // Revoke first if still active, then delete. Both buttons trigger a confirm dialog.
+  const revokeBtn = row.getByRole('button', { name: /revoke/i })
+  if (await revokeBtn.isVisible().catch(() => false)) {
+    await revokeBtn.click()
+    await page.getByRole('button', { name: /^confirm$/i }).click().catch(() => {})
+    await page.waitForTimeout(200)
+  }
+  await row.getByRole('button', { name: /delete/i }).click()
+  await page.getByRole('button', { name: /^confirm$/i }).click().catch(() => {})
+}

--- a/src/frontend/src/utils/clipboard.js
+++ b/src/frontend/src/utils/clipboard.js
@@ -1,0 +1,65 @@
+/**
+ * Copy text to clipboard with a fallback for hostile environments.
+ *
+ * `navigator.clipboard.writeText()` rejects when the document doesn't have
+ * focus (modal overlays), permission is denied, or the page is served over
+ * a non-secure context other than localhost. In those cases we fall back
+ * to a synthetic <textarea> + document.execCommand('copy') flow.
+ *
+ * @param {string} text - The text to copy.
+ * @returns {Promise<boolean>} - true if copy succeeded, false otherwise.
+ */
+export async function copyToClipboard(text) {
+  if (text == null) return false
+  const value = String(text)
+
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value)
+      return true
+    } catch (err) {
+      console.warn('navigator.clipboard.writeText failed, falling back:', err)
+    }
+  }
+
+  return execCommandFallback(value)
+}
+
+function execCommandFallback(text) {
+  if (typeof document === 'undefined') return false
+  const ta = document.createElement('textarea')
+  ta.value = text
+  // Off-screen but still in the document so execCommand can read selection.
+  ta.setAttribute('readonly', '')
+  ta.style.position = 'fixed'
+  ta.style.top = '0'
+  ta.style.left = '0'
+  ta.style.width = '1px'
+  ta.style.height = '1px'
+  ta.style.padding = '0'
+  ta.style.border = 'none'
+  ta.style.outline = 'none'
+  ta.style.boxShadow = 'none'
+  ta.style.background = 'transparent'
+  ta.style.opacity = '0'
+
+  const previouslyFocused = document.activeElement
+  document.body.appendChild(ta)
+
+  try {
+    ta.focus()
+    ta.select()
+    ta.setSelectionRange(0, text.length)
+    const ok = document.execCommand('copy')
+    return !!ok
+  } catch (err) {
+    console.error('execCommand("copy") fallback failed:', err)
+    return false
+  } finally {
+    document.body.removeChild(ta)
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      try { previouslyFocused.focus() } catch (_) { /* noop */ }
+    }
+  }
+}
+

--- a/src/frontend/src/views/ApiKeys.vue
+++ b/src/frontend/src/views/ApiKeys.vue
@@ -313,6 +313,7 @@ import axios from 'axios'
 import NavBar from '../components/NavBar.vue'
 import ConfirmDialog from '../components/ConfirmDialog.vue'
 import { useAuthStore } from '../stores/auth'
+import { copyToClipboard } from '../utils/clipboard'
 
 const authStore = useAuthStore()
 
@@ -528,27 +529,27 @@ const deleteKey = (keyId) => {
 }
 
 const copyApiKey = async () => {
-  try {
-    await navigator.clipboard.writeText(createdApiKey.value)
-    copied.value = true
-    setTimeout(() => {
-      copied.value = false
-    }, 2000)
-  } catch (error) {
-    console.error('Failed to copy:', error)
+  const ok = await copyToClipboard(createdApiKey.value)
+  if (!ok) {
+    alert('Failed to copy API key. Please select the key text and copy it manually.')
+    return
   }
+  copied.value = true
+  setTimeout(() => {
+    copied.value = false
+  }, 2000)
 }
 
 const copyMcpConfig = async () => {
-  try {
-    await navigator.clipboard.writeText(getMcpConfig(createdApiKey.value))
-    copiedConfig.value = true
-    setTimeout(() => {
-      copiedConfig.value = false
-    }, 2000)
-  } catch (error) {
-    console.error('Failed to copy config:', error)
+  const ok = await copyToClipboard(getMcpConfig(createdApiKey.value))
+  if (!ok) {
+    alert('Failed to copy config. Please select the config text and copy it manually.')
+    return
   }
+  copiedConfig.value = true
+  setTimeout(() => {
+    copiedConfig.value = false
+  }, 2000)
 }
 
 const closeKeyModal = () => {


### PR DESCRIPTION
## Summary

Fixes #677 — both copy actions on `/api-keys` (Copy Config, Copy key icon) failed silently in any context where `navigator.clipboard.writeText()` rejects (modal focus trap, denied permission, non-secure context). Errors were swallowed in `console.error`, the "Copied!" visual state could flip on failure, and there was no user-facing fallback.

## Change

- **New utility** `src/frontend/src/utils/clipboard.js` — `copyToClipboard(text)` tries `navigator.clipboard.writeText` first, falls back to a synthetic off-screen `<textarea>` + `document.execCommand('copy')`, restores prior focus, returns a boolean for caller-driven UX.
- **`ApiKeys.vue`** — `copyApiKey` / `copyMcpConfig` now route through the utility. Visual feedback (`copied = true` / green check) only fires on confirmed success. Total failure surfaces an `alert()` instructing the user to copy manually (matches the existing error pattern in this view).
- **e2e regression** `src/frontend/e2e/api-keys-copy.spec.js` — grants `clipboard-read`/`clipboard-write`, creates a fresh key, clicks both copy actions, asserts the clipboard contents (MCP JSON for Copy Config; raw `trinity_mcp_*` for Copy key), and cleans up the test key.

## Scope

Issue scope is the API Keys page only, so the 8 other call sites of `navigator.clipboard.writeText()` across the frontend are left for a follow-up migration.

## Test plan

- [x] Live browser verification: admin login → /api-keys → create key → click Copy Config → clipboard contains `{ "mcpServers": { "trinity": { ... "Bearer trinity_mcp_..." } } }` ✅
- [x] Live browser verification: click Copy key icon → clipboard contains `trinity_mcp_*` ✅
- [x] Visual feedback: "Copied!" text + green check appear in both cases ✅
- [x] No console errors during the flow ✅
- [x] e2e spec covers both buttons + cleans up test key

🤖 Generated with [Claude Code](https://claude.com/claude-code)