### PR TITLE
feat(voice): agent workspace page with canvas panel and Gemini panel tools (#699)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -518,6 +518,15 @@ picks up on its next poll. (#389 S1a)
 
 **Note**: Route ordering is critical. `/context-stats` and `/autonomy-status` must be defined BEFORE `/{name}` catch-all route to avoid 404 errors.
 
+### Voice (5 endpoints)
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/agents/{name}/voice/start` | Start Gemini Live voice session; accepts `workspace_mode` to enable panel tools |
+| POST | `/api/agents/{name}/voice/stop` | Stop active voice session |
+| GET | `/api/agents/{name}/voice/prompt` | Get per-agent voice system prompt |
+| PUT | `/api/agents/{name}/voice/prompt` | Set per-agent voice system prompt |
+| GET | `/api/agents/{name}/voice/{session_id}/panel` | Canvas panel state for workspace mode (ownership-gated; returns empty state when session gone, #699) |
+
 ### Activities (1 endpoint)
 | Method | Path | Description |
 |--------|------|-------------|
@@ -714,7 +723,7 @@ Rate limiting: dual-bucket (120 req/min per IP + 300 req/min per token). Request
 | GET | `/api/settings/mcp-url` | Get configured MCP server URL (any auth user) |
 | PUT | `/api/settings/mcp-url` | Set MCP server URL (admin-only) |
 | DELETE | `/api/settings/mcp-url` | Reset to auto-detect (admin-only) |
-| GET | `/api/settings/feature-flags` | Public-safe feature flags for UI gating (any auth user). Currently exposes `session_tab_enabled` (SESSION_TAB Phase 3). |
+| GET | `/api/settings/feature-flags` | Public-safe feature flags for UI gating (any auth user). Exposes `session_tab_enabled` (SESSION_TAB Phase 3) and `voice_available` (`VOICE_ENABLED && bool(GEMINI_API_KEY)`, #699). |
 | GET | `/api/settings/agent-defaults/resources` | Get fleet-wide default CPU/memory for new containers (admin-only, RES-001) |
 | PUT | `/api/settings/agent-defaults/resources` | Set fleet-wide default CPU/memory; valid CPU: 1/2/4/8/16; valid memory: 1g–32g (admin-only, RES-001) |
 

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -75,6 +75,7 @@
 | 2026-03-25 | #148 | Fix silent subscription registration failure — encryption key auto-generation, status endpoint, frontend warning | [subscription-management.md](feature-flows/subscription-management.md) |
 | 2026-03-25 | #76 | Configurable MCP Server URL in Admin Settings | [platform-settings.md](feature-flows/platform-settings.md), [api-keys-page.md](feature-flows/api-keys-page.md) |
 | 2026-03-25 | #74 | Auto-assign subscription to new agents (round-robin, rate-limit aware) | [subscription-management.md](feature-flows/subscription-management.md) |
+| 2026-05-07 | #699 | Voice Workspace (BETA) — full-page workspace with orb + canvas panel; panel tools (show_markdown/update_panel/append_to_panel/clear_panel); `voice_available` feature flag | [voice-chat.md](feature-flows/voice-chat.md) |
 | 2026-03-23 | VOICE-001 | Voice Chat — real-time voice conversations with agents via Gemini Live API | [voice-chat.md](feature-flows/voice-chat.md) |
 | 2026-03-23 | SLACK-002 | Channel adapter abstraction + multi-agent Slack routing | [slack-channel-routing.md](feature-flows/slack-channel-routing.md) |
 | 2026-03-21 | SUB-003 | Auto-switch subscriptions on repeated rate-limit errors — setting, tracking, orchestration | [subscription-auto-switch.md](feature-flows/subscription-auto-switch.md) |
@@ -190,7 +191,7 @@
 | Playbooks Tab | [playbooks-tab.md](feature-flows/playbooks-tab.md) | Invoke agent skills from UI (PLAYBOOK-001) |
 | Authenticated Chat Tab | [authenticated-chat-tab.md](feature-flows/authenticated-chat-tab.md) | Simple chat UI with dynamic status labels (CHAT-001, THINK-001) |
 | Playbook Autocomplete | [playbook-autocomplete.md](feature-flows/playbook-autocomplete.md) | Slash-command autocomplete for playbooks in chat input |
-| Voice Chat | [voice-chat.md](feature-flows/voice-chat.md) | Real-time voice conversations via Gemini Live API (VOICE-001) |
+| Voice Chat + Workspace | [voice-chat.md](feature-flows/voice-chat.md) | Voice conversations via Gemini Live API; Workspace mode with canvas panel tools (BETA) |
 | Execution Log Viewer | [execution-log-viewer.md](feature-flows/execution-log-viewer.md) | Modal for viewing execution transcripts |
 | Execution Detail Page | [execution-detail-page.md](feature-flows/execution-detail-page.md) | Dedicated page for execution details |
 | Continue Execution as Chat | [continue-execution-as-chat.md](feature-flows/continue-execution-as-chat.md) | Resume executions as interactive chat (EXEC-023) |

--- a/docs/memory/feature-flows/voice-chat.md
+++ b/docs/memory/feature-flows/voice-chat.md
@@ -1,7 +1,7 @@
 # Voice Chat — Gemini 2.5 Flash Native Audio
 
-**Status**: ✅ Phase 1 + Tool Calling Complete
-**Date**: 2026-04-29
+**Status**: ✅ Phase 1 + Tool Calling + Workspace Mode (BETA) Complete
+**Date**: 2026-05-07
 **Priority**: P1
 
 ---
@@ -24,65 +24,62 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 
 ## Architecture
 
+### Standard Mode (Chat Tab overlay)
+
 ```
 ┌────────────────────────────────────────────────────────────┐
 │                     Browser (Agent Detail)                  │
 │                                                            │
 │  ┌──────────────┐    ┌──────────────────────────────────┐  │
 │  │  Chat Panel  │    │  VoiceOverlay.vue (canvas orb)   │  │
-│  │  (existing)  │    │                                  │  │
-│  │              │    │  Canvas orb — value noise + curl │  │
-│  │  ... msgs    │    │  noise particles (220, 3 layers)  │  │
-│  │              │    │  State hues: idle/connecting=0°   │  │
-│  │              │    │  listening=+90° (green)           │  │
-│  │              │    │  speaking=+210° (indigo)          │  │
-│  │              │    │  tool_calling=amber badge overlay │  │
+│  │  (existing)  │    │  Canvas orb — value noise + curl │  │
+│  │  ... msgs    │    │  State hues + tool_calling badge  │  │
 │  │              │    │  [Mute] [End Call]                │  │
 │  └──────────────┘    └──────────────┬───────────────────┘  │
-│                                     │                       │
-│                    useVoiceSession.js composable            │
-│                    (amplitude polling @ 30ms,               │
-│                     tool_call / tool_result WS handlers)    │
-│                                     │ WebSocket             │
 └─────────────────────────────────────┼───────────────────────┘
-                                      │
-                                      ▼
-                          ┌───────────────────────┐
-                          │   Trinity Backend      │
-                          │                        │
-                          │  routers/voice.py      │
-                          │  POST voice/start      │
-                          │  WS /ws/voice/{id}     │
-                          │                        │
-                          │  services/gemini_voice │
-                          │  VoiceSession          │
-                          │  _execute_and_respond()│
-                          │  (30s timeout)         │
-                          │                        │
-                          │  on_tool_call →        │
-                          │    WS frame + audit log│
-                          │  on_tool_result →      │
-                          │    WS frame            │
-                          └────────────┬───────────┘
-                                       │
-                          ┌────────────┴───────────┐
-                          │                        │
-                          ▼                        ▼
-              ┌───────────────────┐   ┌────────────────────┐
-              │  Gemini Live API  │   │  Agent Container   │
-              │  (Vertex AI)      │   │  (Claude Code)     │
-              │                   │   │                    │
-              │  tools=[          │   │  agent_client      │
-              │   run_task fn     │   │  .task(prompt)     │
-              │  ]                │   │                    │
-              └───────────────────┘   └────────────────────┘
+                                      │ useVoiceSession.js (workspace_mode=false)
+                                      │ WebSocket
+                                      ▼ Trinity Backend
+```
+
+### Workspace Mode (Separate page `/agents/:name/workspace`, BETA)
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                    /agents/:name/workspace                          │
+│                                                                    │
+│  ┌─────────────────────────┐  ┌───────────────────────────────┐   │
+│  │  Left Panel (40%)       │  │  Right Panel (60%)            │   │
+│  │  bg-black               │  │  bg-gray-900 (canvas)         │   │
+│  │                         │  │                               │   │
+│  │  <canvas> orb (same     │  │  Panel content rendered via   │   │
+│  │   particle system as    │  │  show_markdown / update_panel │   │
+│  │   VoiceOverlay)         │  │  (DOMPurify-sanitized HTML or │   │
+│  │                         │  │   renderMarkdown())           │   │
+│  │  Status label           │  │                               │   │
+│  │  Tool name badge        │  │  Polled every 300ms via       │   │
+│  │  [Mute] [Start/End]     │  │  GET /voice/{sid}/panel       │   │
+│  │  Voice selector         │  │                               │   │
+│  └─────────────────────────┘  └───────────────────────────────┘   │
+└────────────────────────────────────────────────────────────────────┘
+         │
+         │ useVoiceSession.js (workspace_mode=true)
+         │ WebSocket (same as standard mode)
+         ▼
+   Trinity Backend (routers/voice.py)
+         │
+         ├─ Panel tools handled in-process (_execute_panel_tool)
+         │   show_markdown, update_panel, append_to_panel, clear_panel
+         │   → session.panel_state (in-memory, capped at 512 KB)
+         │
+         └─ run_task → Agent Container (Claude Code)
 ```
 
 ---
 
 ## User Flow
 
-### Starting a Voice Session
+### Starting a Voice Session (Standard Mode)
 
 1. User is on Agent Detail page, Chat tab (authenticated)
 2. User clicks **"Talk"** button (microphone icon) next to the chat input
@@ -108,6 +105,23 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 2. Backend closes Gemini session, cancels any pending `_pending_tool_tasks`
 3. Transcript saved as `ChatMessage` rows in existing `chat_messages` table
 4. Chat panel refreshes showing voice conversation inline with text messages
+
+### Starting a Voice Session (Workspace Mode)
+
+1. User is on Agent Detail page (agent must be running)
+2. **Workspace button** in AgentHeader (shown only when `voice_available=true` from feature flags)
+3. Router navigates to `/agents/:name/workspace` — `AgentWorkspace.vue`
+4. Same `POST /api/agents/{name}/voice/start` with `workspace_mode: true`
+5. Backend appends `WORKSPACE_PANEL_INSTRUCTIONS` to the system prompt (describes 4 panel tools)
+6. WebSocket established; panel poll starts at 300ms interval
+7. Agent may call panel tools during conversation — panel content updated in-memory
+8. Frontend polls `GET /api/agents/{name}/voice/{session_id}/panel` and re-renders canvas
+
+### Feature Flag: voice_available
+
+`GET /api/settings/feature-flags` returns `voice_available: VOICE_ENABLED && bool(GEMINI_API_KEY)`.
+Stored in `sessions.js` Pinia store as `voiceAvailable`. Passed as prop to `AgentHeader.vue`.
+Button hidden entirely when `voiceAvailable=false`.
 
 ---
 
@@ -200,6 +214,23 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 | WS events | `{type: "tool_call", tool_name: "run_task"}` and `{type: "tool_result", ...}` frames |
 | Audit | Platform audit log written on each tool call via `on_tool_call` callback |
 
+### VOICE-008: Workspace Mode + Canvas Panel (BETA)
+
+**Status**: ✅ Implemented (2026-05-07, issue #699)
+
+| Requirement | Detail |
+|-------------|--------|
+| Entry point | "Workspace" button in `AgentHeader.vue` (hidden when `voice_available=false`) |
+| Route | `/agents/:name/workspace` → `AgentWorkspace.vue` |
+| Layout | Left 40% (orb + controls) + Right 60% (canvas panel) |
+| `workspace_mode` flag | Passed in `POST /voice/start` body; appends `WORKSPACE_PANEL_INSTRUCTIONS` to system prompt |
+| Panel tools | `show_markdown`, `update_panel`, `append_to_panel`, `clear_panel` — handled in-process via `_execute_panel_tool()`, never forwarded to agent container |
+| Panel state | `VoiceSession.panel_state` dict (in-memory); type ∈ {empty, markdown, html}; content capped at `_PANEL_CONTENT_MAX=524288` (512 KB) |
+| Panel endpoint | `GET /api/agents/{name}/voice/{session_id}/panel` — returns empty state for missing sessions (no 404 during teardown window); ownership-gated (user_id + agent_name check, admin bypass) |
+| Frontend poll | `setInterval(fetchPanel, 300)` — stops on session end via `watch(voice.isActive)` |
+| XSS protection | `show_markdown` → `renderMarkdown()` (DOMPurify-wrapped); `update_panel`/`append_to_panel` → `DOMPurify.sanitize()` |
+| BETA indicator | Amber "BETA" badge in header button and page header |
+
 ---
 
 ## WebSocket Message Types
@@ -207,6 +238,7 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 **Client → Server:**
 ```json
 { "type": "audio", "data": "<base64 PCM audio>" }
+{ "type": "end" }
 ```
 
 **Server → Client:**
@@ -214,9 +246,11 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 { "type": "audio", "data": "<base64 PCM audio>" }
 { "type": "transcript", "role": "user|assistant", "text": "..." }
 { "type": "status", "state": "listening|speaking|processing" }
-{ "type": "tool_call", "tool_name": "run_task" }
+{ "type": "tool_call", "tool_name": "run_task|show_markdown|..." }
 { "type": "tool_result", "tool_name": "run_task", "result": "..." }
 ```
+
+Panel tool calls (`show_markdown`, `update_panel`, etc.) appear as `tool_call` WS frames but do NOT send `tool_result` frames to the browser — they're resolved in-process on the backend and Gemini is notified internally. The frontend polls the panel state separately via REST.
 
 ---
 
@@ -228,7 +262,8 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 ```json
 {
   "session_id": "optional - existing chat session to continue",
-  "voice_name": "optional - Gemini voice name"
+  "voice_name": "optional - Gemini voice name",
+  "workspace_mode": false
 }
 ```
 
@@ -236,7 +271,7 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 ```json
 {
   "voice_session_id": "vs_abc123",
-  "websocket_url": "wss://localhost:8000/ws/voice/vs_abc123",
+  "websocket_url": "/ws/voice/vs_abc123",
   "chat_session_id": "cs_xyz789"
 }
 ```
@@ -250,6 +285,20 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
   "messages_saved": 12,
   "duration_seconds": 45,
   "cost": 0.003
+}
+```
+
+### GET /api/agents/{name}/voice/{session_id}/panel
+
+Returns current canvas panel state. Returns empty state (not 404) for non-existent sessions to avoid poll errors during teardown. Auth: `get_authorized_agent` dep + `session.user_id == current_user.id` check (admin bypass).
+
+**Response:**
+```json
+{
+  "type": "empty|markdown|html",
+  "content": "...",
+  "title": "optional title or null",
+  "updated_at": "ISO-Z timestamp or null"
 }
 ```
 
@@ -280,12 +329,17 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 
 | Layer | File | Purpose |
 |-------|------|---------|
-| **Backend** | `src/backend/routers/voice.py` | Voice endpoints + WebSocket handler, `_get_voice_system_prompt()`, `on_tool_call`/`on_tool_result` callbacks |
-| **Backend** | `src/backend/services/gemini_voice.py` | `VoiceSession`, `_RUN_TASK_TOOL` declaration, `_execute_tool()`, `_execute_and_respond()`, `_pending_tool_tasks` |
-| **Frontend** | `src/frontend/src/components/chat/VoiceOverlay.vue` | Canvas orb (value noise + curl noise particles, state hues, amber tool badge) |
-| **Frontend** | `src/frontend/src/composables/useVoiceSession.js` | Session state (`toolName`, `amplitude`, `isToolCalling`), WS message handlers, amplitude polling |
+| **Backend** | `src/backend/routers/voice.py` | Voice endpoints + WebSocket handler, `/panel` endpoint, `_get_voice_system_prompt()`, `on_tool_call`/`on_tool_result` callbacks |
+| **Backend** | `src/backend/services/gemini_voice.py` | `VoiceSession` (+ `workspace_mode`, `panel_state`), `_RUN_TASK_TOOL`, `_PANEL_TOOLS`, `_execute_panel_tool()`, `WORKSPACE_PANEL_INSTRUCTIONS` |
+| **Backend** | `src/backend/routers/settings.py` | `voice_available` feature flag in `GET /api/settings/feature-flags` |
+| **Frontend** | `src/frontend/src/views/AgentWorkspace.vue` | Full workspace page (orb + canvas panel, particle system inlined, panel polling) |
+| **Frontend** | `src/frontend/src/components/chat/VoiceOverlay.vue` | Standard mode orb overlay (unchanged) |
+| **Frontend** | `src/frontend/src/components/AgentHeader.vue` | Workspace button (`goToWorkspace()`, shown when `voiceAvailable=true`) |
+| **Frontend** | `src/frontend/src/composables/useVoiceSession.js` | `start(sessionId, voiceName, workspaceMode)` — passes `workspace_mode` to backend |
+| **Frontend** | `src/frontend/src/stores/sessions.js` | `voiceAvailable` state from feature flags |
 | **Frontend** | `src/frontend/src/utils/audio.js` | AudioWorklet-first capture/playback, `getAmplitude()` via `AnalyserNode` |
-| **Tests** | `tests/unit/test_voice_tools.py` | 12 unit tests: `_execute_tool`, `_execute_and_respond`, tool declaration, session cancellation |
+| **Tests** | `tests/unit/test_voice_tools.py` | 19 unit tests: tool execution, panel tool handlers, content cap, routing guard |
+| **Tests** | `tests/unit/test_voice_auth.py` | 18 unit tests: WS auth, stop auth, panel ownership (owner/admin/wrong-user/wrong-agent/missing-session) |
 
 ---
 
@@ -315,6 +369,19 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 - ✅ 30s timeout with error recovery
 - ⏳ Multi-language voice with auto-detection
 - ⏳ Voice cloning / custom voice per agent
+
+### Phase 4: Workspace Mode ✅ Complete (2026-05-07, issue #699, BETA)
+
+- ✅ Separate full-page workspace at `/agents/:name/workspace`
+- ✅ Split layout: orb (left) + canvas panel (right)
+- ✅ 4 panel tools: `show_markdown`, `update_panel`, `append_to_panel`, `clear_panel`
+- ✅ Panel content rendered safely (DOMPurify sanitization)
+- ✅ `voice_available` feature flag gates workspace button in AgentHeader
+- ✅ Panel ownership gate on REST endpoint
+- ✅ 512 KB content cap on accumulated `append_to_panel` content
+- ⏳ Persist panel state across session end
+- ⏳ Export panel content as PDF/markdown
+- ⏳ Agent-controlled canvas with richer widgets (charts, code blocks)
 
 ---
 

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -1942,10 +1942,16 @@ Standalone mobile-friendly admin page for managing agents on the go. Designed as
 - **Key Features**: Single `run_task` tool declaration sent to Gemini Live API; non-blocking `asyncio.create_task` dispatch with 30s timeout; prompt injection mitigation (`_TOOL_PROMPT_MAX = 2000` chars); `_pending_tool_tasks` dict with cancellation on session end; canvas orb in `VoiceOverlay.vue` with `isToolCalling` state (no CDN dependencies); platform audit log on every tool call
 - **Architecture**: Gemini → `tool_call` WS message → `_execute_and_respond()` → `POST /api/agents/{name}/chat` → Gemini `tool_response`
 
+### 29.8 Voice Workspace (VOICE-008)
+- **Status**: ✅ Implemented (#699)
+- **Description**: Full-page workspace at `/agents/:name/workspace` with split layout — orb + controls left, agent-controlled canvas panel right; gated behind `voice_available` feature flag
+- **Key Features**: 4 in-process panel tools (`show_markdown`, `update_panel`, `append_to_panel`, `clear_panel`); 300ms poll via `GET /voice/{session_id}/panel`; DOMPurify sanitization; 512 KB content cap; `workspace_mode` param on `voice/start`; BETA-badged button in AgentHeader
+
 ### Phase Roadmap
 1. **Phase 1 (MVP)**: Authenticated chat only, basic overlay, transcript on session end, manual voice prompt ✅
 2. **Phase 2 (Polish)**: Real-time waveform, incremental transcript, auto-generate voice prompt from CLAUDE.md ✅
 3. **Phase 3 (Advanced)**: Tool calling (run_task), canvas orb ✅ — multi-language auto-detection, custom voice per agent (deferred)
+4. **Phase 4 (Workspace)**: Full-page workspace with canvas panel tools, feature-flag gated (BETA) ✅
 
 ---
 

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -122,8 +122,10 @@ async def get_public_feature_flags(
     Auth required (any role) — these flags reveal nothing sensitive but we
     still keep them out of the unauthenticated surface.
     """
+    from config import GEMINI_API_KEY, VOICE_ENABLED
     return {
         "session_tab_enabled": settings_service.is_session_tab_enabled(),
+        "voice_available": VOICE_ENABLED and bool(GEMINI_API_KEY),
     }
 
 

--- a/src/backend/routers/voice.py
+++ b/src/backend/routers/voice.py
@@ -22,7 +22,7 @@ from models import User
 from dependencies import get_current_user, get_authorized_agent
 from database import db
 from config import GEMINI_API_KEY, VOICE_ENABLED
-from services.gemini_voice import voice_service
+from services.gemini_voice import voice_service, WORKSPACE_PANEL_INSTRUCTIONS
 from services.docker_service import get_agent_container
 from services.platform_audit_service import platform_audit_service, AuditEventType, AuditActorType
 
@@ -36,6 +36,7 @@ router = APIRouter(tags=["voice"])
 class VoiceStartRequest(BaseModel):
     session_id: Optional[str] = None  # Existing chat session to continue
     voice_name: Optional[str] = None  # Gemini voice name (e.g. "Kore", "Puck")
+    workspace_mode: bool = False       # Enable canvas panel tools
 
 
 class VoiceStartResponse(BaseModel):
@@ -94,6 +95,8 @@ async def voice_start(
     combined_prompt = voice_prompt
     if context_summary:
         combined_prompt += f"\n\n## Conversation so far:\n{context_summary}"
+    if request.workspace_mode:
+        combined_prompt += WORKSPACE_PANEL_INSTRUCTIONS
 
     voice_name = request.voice_name or _get_voice_name(name)
 
@@ -104,6 +107,7 @@ async def voice_start(
         user_email=current_user.email or current_user.username,
         system_prompt=combined_prompt,
         voice_name=voice_name,
+        workspace_mode=request.workspace_mode,
     )
 
     return VoiceStartResponse(
@@ -163,6 +167,27 @@ async def voice_status(
         "available": voice_service.is_available(),
         "voice_prompt_set": bool(db.get_voice_system_prompt(name)),
     }
+
+
+@router.get("/api/agents/{name}/voice/{session_id}/panel")
+async def get_voice_panel(
+    session_id: str,
+    name: str = Depends(get_authorized_agent),
+    current_user: User = Depends(get_current_user),
+):
+    """Return the current canvas panel state for a workspace voice session.
+
+    Returns empty state (not 404) when session has ended so the frontend
+    poll loop doesn't raise errors during the teardown window.
+    """
+    session = voice_service.get_session(session_id)
+    if not session:
+        return {"type": "empty", "content": "", "title": None, "updated_at": None}
+    if session.agent_name != name:
+        raise HTTPException(status_code=403, detail="Session does not belong to this agent")
+    if session.user_id != current_user.id and current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Not authorized for this voice session")
+    return session.panel_state
 
 
 @router.get("/api/agents/{name}/voice/prompt")

--- a/src/backend/services/gemini_voice.py
+++ b/src/backend/services/gemini_voice.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import secrets
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Optional, Callable, Awaitable
 
 from google import genai
@@ -28,6 +29,80 @@ OUTPUT_SAMPLE_RATE = 24000  # 24kHz PCM output from Gemini
 
 # Max chars for tool call prompts (prevent injection via very long args)
 _TOOL_PROMPT_MAX = 2000
+# Max bytes stored in panel_state["content"] to bound memory per session
+_PANEL_CONTENT_MAX = 524_288  # 512 KB
+
+_PANEL_TOOL_NAMES = {"show_markdown", "update_panel", "append_to_panel", "clear_panel"}
+
+_PANEL_TOOLS = genai_types.Tool(
+    function_declarations=[
+        genai_types.FunctionDeclaration(
+            name="show_markdown",
+            description=(
+                "Display markdown content in the visual canvas panel visible to the user. "
+                "Use for notes, summaries, analysis, action items, frameworks. "
+                "This is your default panel tool — use it most often."
+            ),
+            parameters=genai_types.Schema(
+                type=genai_types.Type.OBJECT,
+                properties={
+                    "content": genai_types.Schema(type=genai_types.Type.STRING, description="Markdown content to display"),
+                    "title": genai_types.Schema(type=genai_types.Type.STRING, description="Optional panel title"),
+                },
+                required=["content"],
+            ),
+        ),
+        genai_types.FunctionDeclaration(
+            name="update_panel",
+            description="Replace the canvas panel with custom HTML for richer layouts, tables, or structured data.",
+            parameters=genai_types.Schema(
+                type=genai_types.Type.OBJECT,
+                properties={
+                    "html": genai_types.Schema(type=genai_types.Type.STRING, description="HTML content to display"),
+                    "title": genai_types.Schema(type=genai_types.Type.STRING, description="Optional panel title"),
+                },
+                required=["html"],
+            ),
+        ),
+        genai_types.FunctionDeclaration(
+            name="append_to_panel",
+            description="Append HTML to the existing panel without clearing it. Use to build content incrementally.",
+            parameters=genai_types.Schema(
+                type=genai_types.Type.OBJECT,
+                properties={
+                    "html": genai_types.Schema(type=genai_types.Type.STRING, description="HTML to append to the panel"),
+                },
+                required=["html"],
+            ),
+        ),
+        genai_types.FunctionDeclaration(
+            name="clear_panel",
+            description="Clear the canvas panel when moving to a new topic.",
+            parameters=genai_types.Schema(
+                type=genai_types.Type.OBJECT,
+                properties={},
+            ),
+        ),
+    ]
+)
+
+WORKSPACE_PANEL_INSTRUCTIONS = """
+## Visual Canvas
+
+You have a visual canvas panel visible to the user on the right side of the screen. Use it proactively alongside your voice responses.
+
+Panel tools:
+- `show_markdown(content, title?)` — Render markdown. Use most often for notes, summaries, action items, analysis.
+- `update_panel(html, title?)` — Replace panel with HTML for richer layouts.
+- `append_to_panel(html)` — Add to existing panel without clearing.
+- `clear_panel()` — Clear when shifting to a new topic.
+
+Guidelines:
+- The panel is a persistent whiteboard — voice is transient, the panel is the artefact.
+- Use `show_markdown` by default. Reach for `update_panel` only when structure genuinely adds value.
+- Don't mirror every voice response in the panel — use it when structured content helps.
+- Clear when the topic changes significantly.
+"""
 
 # Single tool declaration for all voice sessions
 _RUN_TASK_TOOL = genai_types.Tool(
@@ -72,7 +147,11 @@ class VoiceSession:
     user_email: str
     system_prompt: str
     voice_name: str = "Kore"
+    workspace_mode: bool = False
     transcript: list = field(default_factory=list)
+    panel_state: dict = field(default_factory=lambda: {
+        "type": "empty", "content": "", "title": None, "updated_at": None
+    })
     _gemini_session: object = field(default=None, repr=False)
     _send_task: object = field(default=None, repr=False)
     _receive_task: object = field(default=None, repr=False)
@@ -116,6 +195,7 @@ class GeminiVoiceService:
         user_email: str,
         system_prompt: str,
         voice_name: str = "Kore",
+        workspace_mode: bool = False,
     ) -> VoiceSession:
         """Create a new voice session (does not connect yet)."""
         session_id = f"vs_{secrets.token_urlsafe(16)}"
@@ -127,6 +207,7 @@ class GeminiVoiceService:
             user_email=user_email,
             system_prompt=system_prompt,
             voice_name=voice_name,
+            workspace_mode=workspace_mode,
         )
         self._sessions[session_id] = session
         logger.info(f"Voice session created: {session_id} for agent {agent_name}")
@@ -161,6 +242,10 @@ class GeminiVoiceService:
 
         client = self._get_client()
 
+        tools = [_RUN_TASK_TOOL]
+        if session.workspace_mode:
+            tools.append(_PANEL_TOOLS)
+
         config = genai_types.LiveConnectConfig(
             response_modalities=["AUDIO"],
             system_instruction=session.system_prompt,
@@ -171,7 +256,7 @@ class GeminiVoiceService:
                     )
                 )
             ),
-            tools=[_RUN_TASK_TOOL],
+            tools=tools,
         )
 
         try:
@@ -310,6 +395,39 @@ class GeminiVoiceService:
                 VoiceTranscriptEntry(role="assistant", text=current_assistant_text.strip())
             )
 
+    def _execute_panel_tool(self, session: VoiceSession, tool_name: str, args: dict) -> str:
+        """Handle panel tools in-process (no agent container call)."""
+        now = datetime.now(timezone.utc).isoformat()
+        if tool_name == "show_markdown":
+            session.panel_state = {
+                "type": "markdown",
+                "content": args.get("content", ""),
+                "title": args.get("title"),
+                "updated_at": now,
+            }
+        elif tool_name == "update_panel":
+            session.panel_state = {
+                "type": "html",
+                "content": args.get("html", ""),
+                "title": args.get("title"),
+                "updated_at": now,
+            }
+        elif tool_name == "append_to_panel":
+            combined = session.panel_state.get("content", "") + args.get("html", "")
+            if len(combined) > _PANEL_CONTENT_MAX:
+                combined = combined[-_PANEL_CONTENT_MAX:]
+            session.panel_state = {
+                "type": session.panel_state.get("type", "html"),
+                "content": combined,
+                "title": session.panel_state.get("title"),
+                "updated_at": now,
+            }
+        elif tool_name == "clear_panel":
+            session.panel_state = {
+                "type": "empty", "content": "", "title": None, "updated_at": now,
+            }
+        return "Panel updated."
+
     async def _execute_and_respond(self, session: VoiceSession, call_id: str, fc):
         """Execute a Gemini tool call and send the response back. Runs as a background task."""
         tool_name = getattr(fc, 'name', 'run_task')
@@ -319,10 +437,13 @@ class GeminiVoiceService:
             if session._on_tool_call:
                 await session._on_tool_call(tool_name, args)
 
-            result = await asyncio.wait_for(
-                self._execute_tool(session.agent_name, tool_name, args),
-                timeout=30.0,
-            )
+            if tool_name in _PANEL_TOOL_NAMES:
+                result = self._execute_panel_tool(session, tool_name, args)
+            else:
+                result = await asyncio.wait_for(
+                    self._execute_tool(session.agent_name, tool_name, args),
+                    timeout=30.0,
+                )
         except asyncio.TimeoutError:
             result = "Tool execution timed out after 30 seconds."
             logger.warning(f"Voice tool call timed out: {tool_name} session={session.session_id}")

--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -147,6 +147,23 @@
         </div>
         <!-- Right: Primary Actions -->
         <div class="flex items-center space-x-3">
+          <!-- Workspace button (voice + canvas, BETA) -->
+          <button
+            v-if="voiceAvailable"
+            @click="goToWorkspace"
+            :disabled="agent.status !== 'running'"
+            class="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-colors"
+            :class="agent.status === 'running'
+              ? 'text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-700'
+              : 'text-gray-300 dark:text-gray-600 border border-gray-200 dark:border-gray-700 cursor-not-allowed'"
+            title="Open Workspace — voice + canvas (Beta)"
+          >
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4M12 15a3 3 0 003-3V5a3 3 0 00-6 0v7a3 3 0 003 3z" />
+            </svg>
+            Workspace
+            <span class="px-1 py-0.5 text-[10px] font-semibold rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 leading-none">BETA</span>
+          </button>
           <!-- Running State Toggle -->
           <RunningStateToggle
             :model-value="agent.status === 'running'"
@@ -416,6 +433,7 @@
 
 <script setup>
 import { ref, computed, nextTick } from 'vue'
+import { useRouter } from 'vue-router'
 import AgentAvatar from './AgentAvatar.vue'
 import RuntimeBadge from './RuntimeBadge.vue'
 import SparklineChart from './SparklineChart.vue'
@@ -536,6 +554,10 @@ const props = defineProps({
   tokenStats: {
     type: Object,
     default: null
+  },
+  voiceAvailable: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -556,6 +578,12 @@ const emit = defineEmits([
   'cycle-emotion',
   'change-subscription'
 ])
+
+const router = useRouter()
+
+function goToWorkspace() {
+  router.push(`/agents/${props.agent.name}/workspace`)
+}
 
 // Name editing functions
 function startEditName() {

--- a/src/frontend/src/composables/useVoiceSession.js
+++ b/src/frontend/src/composables/useVoiceSession.js
@@ -46,8 +46,9 @@ export function useVoiceSession(agentName) {
    * Start a voice session.
    * @param {string|null} sessionId - Existing chat session to continue
    * @param {string|null} voiceName - Gemini voice name override
+   * @param {boolean} workspaceMode - Enable canvas panel tools
    */
-  async function start(sessionId = null, voiceName = null) {
+  async function start(sessionId = null, voiceName = null, workspaceMode = false) {
     if (active.value) return
     error.value = null
     transcriptEntries.value = []
@@ -58,7 +59,7 @@ export function useVoiceSession(agentName) {
     try {
       const response = await axios.post(
         `/api/agents/${agentName}/voice/start`,
-        { session_id: sessionId, voice_name: voiceName },
+        { session_id: sessionId, voice_name: voiceName, workspace_mode: workspaceMode },
         { headers: authStore.authHeader }
       )
 

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -45,6 +45,12 @@ const routes = [
     meta: { requiresAuth: true }
   },
   {
+    path: '/agents/:name/workspace',
+    name: 'AgentWorkspace',
+    component: () => import('../views/AgentWorkspace.vue'),
+    meta: { requiresAuth: true }
+  },
+  {
     path: '/agents/:name/executions/:executionId',
     name: 'ExecutionDetail',
     component: () => import('../views/ExecutionDetail.vue'),

--- a/src/frontend/src/stores/sessions.js
+++ b/src/frontend/src/stores/sessions.js
@@ -27,6 +27,7 @@ export const useSessionsStore = defineStore('sessions', {
     // Feature-flag cache (resolved once per page load)
     featureFlagsLoaded: false,
     sessionTabEnabled: false,
+    voiceAvailable: false,
   }),
 
   getters: {
@@ -50,8 +51,10 @@ export const useSessionsStore = defineStore('sessions', {
           headers: authStore.authHeader,
         })
         this.sessionTabEnabled = !!r.data?.session_tab_enabled
+        this.voiceAvailable = !!r.data?.voice_available
       } catch {
         this.sessionTabEnabled = false
+        this.voiceAvailable = false
       } finally {
         this.featureFlagsLoaded = true
       }

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -65,6 +65,7 @@
             @change-subscription="changeSubscription"
             :has-avatar-prompt="!!avatarIdentityPrompt"
             :emotion-avatar-url="emotionAvatarUrl"
+            :voice-available="sessionsStore.voiceAvailable"
           />
 
           <!-- Tabs -->

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -1,0 +1,567 @@
+<template>
+  <div class="h-screen flex flex-col bg-gray-950 text-white overflow-hidden">
+
+    <!-- ── Slim header ─────────────────────────────────────────────────────── -->
+    <header class="flex-shrink-0 flex items-center gap-3 px-4 py-2.5 bg-gray-900 border-b border-gray-800">
+      <button
+        @click="$router.push(`/agents/${agentName}`)"
+        class="p-1.5 rounded hover:bg-gray-800 text-gray-400 hover:text-white transition-colors flex-shrink-0"
+        title="Back to agent"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+
+      <AgentAvatar :name="agentName" :avatar-url="agent?.avatar_url" size="sm" class="flex-shrink-0" />
+
+      <span class="font-semibold text-sm text-white truncate">{{ agentName }}</span>
+
+      <span
+        v-if="agent"
+        :class="[
+          'px-2 py-0.5 text-[11px] font-medium rounded-full flex-shrink-0',
+          agent.status === 'running'
+            ? 'bg-green-900/50 text-green-400'
+            : 'bg-gray-700 text-gray-400'
+        ]"
+      >{{ agent.status }}</span>
+
+      <span class="flex-1" />
+
+      <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-amber-900/40 text-amber-400 border border-amber-700/50 tracking-wide flex-shrink-0">
+        BETA
+      </span>
+    </header>
+
+    <!-- ── Split body ──────────────────────────────────────────────────────── -->
+    <div class="flex-1 flex overflow-hidden">
+
+      <!-- Left: voice panel ──────────────────────────────────────────────── -->
+      <div class="w-2/5 flex-shrink-0 flex flex-col bg-black relative">
+
+        <!-- Orb fills most of the panel -->
+        <div class="flex-1 relative">
+          <canvas ref="canvasEl" class="absolute inset-0 w-full h-full" />
+
+          <!-- Tool calling label -->
+          <Transition
+            enter-active-class="transition ease-out duration-200"
+            enter-from-class="opacity-0 translate-y-2"
+            enter-to-class="opacity-100 translate-y-0"
+            leave-active-class="transition ease-in duration-150"
+            leave-from-class="opacity-100 translate-y-0"
+            leave-to-class="opacity-0 translate-y-2"
+          >
+            <div
+              v-if="voice.isToolCalling.value"
+              class="absolute top-5 left-1/2 -translate-x-1/2 z-10 px-3 py-1 rounded-full text-xs font-medium tracking-widest uppercase"
+              style="background: rgba(245,158,11,0.18); border: 1px solid rgba(245,158,11,0.35); color: rgba(253,211,77,0.9);"
+            >
+              {{ voice.toolName.value ? voice.toolName.value.replace(/_/g, ' ') : 'working…' }}
+            </div>
+          </Transition>
+
+          <!-- Status indicator -->
+          <div class="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 flex items-center gap-2">
+            <div class="w-1.5 h-1.5 rounded-full transition-colors duration-300" :style="{ background: statusDotColor }" />
+            <span class="text-xs tracking-widest uppercase" :style="{ color: statusTextColor }">{{ statusLabel }}</span>
+          </div>
+
+          <!-- Error -->
+          <div
+            v-if="voice.error.value"
+            class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 px-4 py-2 rounded-lg text-sm text-center max-w-xs"
+            style="background: rgba(127,29,29,0.7); border: 1px solid rgba(239,68,68,0.4); color: rgba(252,165,165,0.9);"
+          >
+            {{ voice.error.value }}
+          </div>
+        </div>
+
+        <!-- Controls bar -->
+        <div class="flex-shrink-0 px-5 py-4 flex flex-col gap-3 border-t border-gray-900">
+          <!-- Voice selector -->
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-gray-500 w-10 flex-shrink-0">Voice</span>
+            <select
+              v-model="selectedVoice"
+              :disabled="voice.isActive.value"
+              class="flex-1 text-xs bg-gray-900 border border-gray-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-indigo-500 disabled:opacity-40"
+            >
+              <option v-for="v in VOICES" :key="v.id" :value="v.id">{{ v.label }}</option>
+            </select>
+          </div>
+
+          <!-- Start / Mute / Stop -->
+          <div class="flex items-center justify-center gap-4">
+            <!-- Mute (only when active) -->
+            <button
+              v-if="voice.isActive.value"
+              @click="voice.toggleMute()"
+              class="w-10 h-10 rounded-full flex items-center justify-center transition-colors"
+              :style="voice.muted.value
+                ? 'background: rgba(217,119,6,0.35); border: 1px solid rgba(217,119,6,0.5);'
+                : 'background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.15);'"
+              :title="voice.muted.value ? 'Unmute' : 'Mute mic'"
+            >
+              <svg v-if="!voice.muted.value" class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4M12 15a3 3 0 003-3V5a3 3 0 00-6 0v7a3 3 0 003 3z" />
+              </svg>
+              <svg v-else class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2" />
+              </svg>
+            </button>
+
+            <!-- Start / Stop -->
+            <button
+              @click="toggleSession"
+              :disabled="!agent || agent.status !== 'running'"
+              class="flex items-center gap-2 px-5 py-2.5 rounded-full font-medium text-sm transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              :style="voice.isActive.value
+                ? 'background: rgba(185,28,28,0.7); border: 1px solid rgba(220,38,38,0.5);'
+                : 'background: rgba(79,70,229,0.8); border: 1px solid rgba(99,102,241,0.5);'"
+            >
+              <svg v-if="!voice.isActive.value" class="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <circle cx="12" cy="12" r="8" />
+              </svg>
+              <svg v-else class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z" />
+              </svg>
+              <span class="text-white">{{ voice.isActive.value ? 'End Session' : 'Start' }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right: canvas panel ─────────────────────────────────────────────── -->
+      <div class="flex-1 flex flex-col bg-gray-900 border-l border-gray-800 overflow-hidden">
+
+        <!-- Canvas header -->
+        <div class="flex-shrink-0 flex items-center justify-between px-5 py-3 border-b border-gray-800">
+          <h2 class="text-sm font-medium text-gray-200">
+            {{ panelState.title || 'Canvas' }}
+          </h2>
+          <span v-if="panelUpdatedAgo" class="text-xs text-gray-600">{{ panelUpdatedAgo }}</span>
+        </div>
+
+        <!-- Canvas content -->
+        <div class="flex-1 overflow-auto p-6">
+          <!-- Empty state -->
+          <div v-if="!panelState.content" class="flex flex-col items-center justify-center h-full gap-4 text-center">
+            <div class="w-16 h-16 rounded-full border-2 border-gray-800 flex items-center justify-center">
+              <svg class="w-7 h-7 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+              </svg>
+            </div>
+            <p class="text-gray-600 text-sm max-w-xs">
+              {{ voice.isActive.value
+                ? 'The agent can display notes, summaries, and structured content here during your conversation.'
+                : 'Start a conversation — the agent will display structured content here in real time.' }}
+            </p>
+          </div>
+
+          <!-- Markdown content -->
+          <div
+            v-else-if="panelState.type === 'markdown'"
+            v-html="renderedContent"
+            class="prose prose-sm prose-invert max-w-none
+              prose-headings:text-gray-100 prose-headings:font-semibold
+              prose-p:text-gray-300 prose-p:leading-relaxed
+              prose-strong:text-gray-100
+              prose-code:text-amber-300 prose-code:bg-gray-800 prose-code:px-1 prose-code:rounded prose-code:text-xs
+              prose-pre:bg-gray-800 prose-pre:border prose-pre:border-gray-700
+              prose-ul:text-gray-300 prose-ol:text-gray-300
+              prose-li:marker:text-gray-500
+              prose-blockquote:border-indigo-500 prose-blockquote:text-gray-400
+              prose-a:text-indigo-400 hover:prose-a:text-indigo-300
+              prose-hr:border-gray-700
+              prose-table:text-sm
+              prose-th:text-gray-200 prose-th:bg-gray-800
+              prose-td:text-gray-300 prose-td:border-gray-700"
+          />
+
+          <!-- HTML content -->
+          <div
+            v-else-if="panelState.type === 'html'"
+            v-html="sanitizedHtml"
+            class="text-gray-300 text-sm leading-relaxed"
+          />
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
+import axios from 'axios'
+import { useAuthStore } from '../stores/auth'
+import { useVoiceSession } from '../composables/useVoiceSession'
+import { renderMarkdown } from '../utils/markdown'
+import DOMPurify from 'dompurify'
+import AgentAvatar from '../components/AgentAvatar.vue'
+
+const route = useRoute()
+const authStore = useAuthStore()
+// route.params.name is a plain string in Vue Router 4 setup()
+const agentName = route.params.name
+const voice = useVoiceSession(agentName)
+
+const agent = ref(null)
+const selectedVoice = ref('Kore')
+const panelState = ref({ type: 'empty', content: '', title: null, updated_at: null })
+let panelPollTimer = null
+
+const VOICES = [
+  { id: 'Kore',    label: 'Kore — Firm' },
+  { id: 'Zephyr',  label: 'Zephyr — Bright' },
+  { id: 'Puck',    label: 'Puck — Upbeat' },
+  { id: 'Aoede',   label: 'Aoede — Breezy' },
+  { id: 'Charon',  label: 'Charon — Informational' },
+  { id: 'Fenrir',  label: 'Fenrir — Excitable' },
+]
+
+// ── Computed ────────────────────────────────────────────────────────────────
+
+const renderedContent = computed(() =>
+  panelState.value.type === 'markdown' ? renderMarkdown(panelState.value.content || '') : ''
+)
+
+const sanitizedHtml = computed(() =>
+  panelState.value.type === 'html' ? DOMPurify.sanitize(panelState.value.content || '') : ''
+)
+
+const panelUpdatedAgo = computed(() => {
+  if (!panelState.value.updated_at) return null
+  const secs = Math.round((Date.now() - new Date(panelState.value.updated_at).getTime()) / 1000)
+  if (secs < 5)  return 'just now'
+  if (secs < 60) return `${secs}s ago`
+  return `${Math.round(secs / 60)}m ago`
+})
+
+// ── Session lifecycle ────────────────────────────────────────────────────────
+
+async function toggleSession() {
+  if (voice.isActive.value) {
+    stopPanelPoll()
+    await voice.stop()
+  } else {
+    await voice.start(null, selectedVoice.value, true) // workspace_mode = true
+    startPanelPoll()
+  }
+}
+
+// ── Panel polling ────────────────────────────────────────────────────────────
+
+function startPanelPoll() {
+  stopPanelPoll()
+  panelPollTimer = setInterval(fetchPanel, 300)
+}
+
+function stopPanelPoll() {
+  if (panelPollTimer !== null) {
+    clearInterval(panelPollTimer)
+    panelPollTimer = null
+  }
+}
+
+async function fetchPanel() {
+  const sid = voice.voiceSessionId.value
+  if (!sid) return
+  try {
+    const r = await axios.get(
+      `/api/agents/${agentName}/voice/${sid}/panel`,
+      { headers: authStore.authHeader }
+    )
+    panelState.value = r.data
+  } catch (_) {
+    // Ignore poll errors (session may have just ended)
+  }
+}
+
+// Stop poll when session ends naturally
+watch(() => voice.isActive.value, (active) => {
+  if (!active) stopPanelPoll()
+})
+
+// ── Agent fetch ──────────────────────────────────────────────────────────────
+
+async function fetchAgent() {
+  try {
+    const r = await axios.get(`/api/agents/${agentName}`, {
+      headers: authStore.authHeader,
+    })
+    agent.value = r.data
+  } catch (_) {}
+}
+
+// ── Orb animation ────────────────────────────────────────────────────────────
+// Verbatim from VoiceOverlay.vue — self-contained in this page.
+
+const canvasEl = ref(null)
+let rafHandle = null
+let frameCount = 0
+
+function _hash(n) {
+  return Math.abs(Math.sin(n * 127.1 + 311.7) * 43758.5453) % 1
+}
+function noise(x, y = 0, z = 0) {
+  const ix = Math.floor(x), iy = Math.floor(y), iz = Math.floor(z)
+  const fx = x - ix, fy = y - iy, fz = z - iz
+  const ux = fx * fx * (3 - 2 * fx), uy = fy * fy * (3 - 2 * fy), uz = fz * fz * (3 - 2 * fz)
+  const h = (a, b, c) => _hash(a + b * 57 + c * 113)
+  return (
+    h(ix,   iy,   iz)   * (1-ux)*(1-uy)*(1-uz) +
+    h(ix+1, iy,   iz)   * ux    *(1-uy)*(1-uz) +
+    h(ix,   iy+1, iz)   * (1-ux)*uy    *(1-uz) +
+    h(ix+1, iy+1, iz)   * ux    *uy    *(1-uz) +
+    h(ix,   iy,   iz+1) * (1-ux)*(1-uy)*uz     +
+    h(ix+1, iy,   iz+1) * ux    *(1-uy)*uz     +
+    h(ix,   iy+1, iz+1) * (1-ux)*uy    *uz     +
+    h(ix+1, iy+1, iz+1) * ux    *uy    *uz
+  )
+}
+function curl(x, y, t, ox, oy) {
+  const eps = 1.5, sc = 0.0035
+  const dy = noise(x*sc+ox, (y+eps)*sc+oy, t) - noise(x*sc+ox, (y-eps)*sc+oy, t)
+  const dx = noise((x+eps)*sc+ox, y*sc+oy, t) - noise((x-eps)*sc+ox, y*sc+oy, t)
+  return { x: dy/(eps*sc*2), y: -dx/(eps*sc*2) }
+}
+function hsbToRgb(h, s, b) {
+  h /= 360; s /= 100; b /= 100
+  let r, g, bv
+  const i = Math.floor(h*6), f = h*6-i
+  const pp=b*(1-s), q=b*(1-f*s), tv=b*(1-(1-f)*s)
+  switch(i%6) {
+    case 0: r=b;  g=tv; bv=pp; break
+    case 1: r=q;  g=b;  bv=pp; break
+    case 2: r=pp; g=b;  bv=tv; break
+    case 3: r=pp; g=q;  bv=b;  break
+    case 4: r=tv; g=pp; bv=b;  break
+    case 5: r=b;  g=pp; bv=q;  break
+  }
+  return [Math.round(r*255), Math.round(g*255), Math.round(bv*255)]
+}
+function buildSprites(hueShift) {
+  const cfgs = [
+    {h:29,s:44},{h:33,s:40},{h:38,s:35},
+    {h:39,s:23},{h:43,s:19},{h:47,s:15},
+    {h:45,s:13},{h:50,s:10},{h:55,s:7},
+  ]
+  return cfgs.map(({ h, s }) => {
+    const sz = 128, cx = 64, r = 61
+    const c = document.createElement('canvas')
+    c.width = c.height = sz
+    const ctx = c.getContext('2d')
+    const hFinal = ((h + hueShift) % 360 + 360) % 360
+    const [rv, gv, bv] = hsbToRgb(hFinal, s, 90)
+    const grad = ctx.createRadialGradient(cx, cx, 0, cx, cx, r)
+    grad.addColorStop(0,    `rgba(${rv},${gv},${bv},0.94)`)
+    grad.addColorStop(0.32, `rgba(${rv},${gv},${bv},0.52)`)
+    grad.addColorStop(0.62, `rgba(${rv},${gv},${bv},0.16)`)
+    grad.addColorStop(0.86, `rgba(${rv},${gv},${bv},0.03)`)
+    grad.addColorStop(1,    `rgba(${rv},${gv},${bv},0)`)
+    ctx.fillStyle = grad
+    ctx.beginPath(); ctx.arc(cx, cx, r, 0, Math.PI*2); ctx.fill()
+    return c
+  })
+}
+function lerp(a, b, t) { return a + (b-a)*t }
+function rnd(lo, hi) { return Math.random()*(hi-lo)+lo }
+
+class Smoke {
+  constructor(idx, sprites) {
+    this.sprites = sprites
+    this.type = idx % 3
+    this.spriteIdx = this.type*3 + Math.floor(Math.random()*3)
+    this.nox = rnd(0,100); this.noy = rnd(0,100); this.nosh = rnd(0,2000)
+    this.rot = rnd(0, Math.PI*2); this.rotSpd = rnd(-0.012, 0.012)
+    this.vx = rnd(-0.4,0.4); this.vy = rnd(-0.4,0.4)
+    this.reset(true)
+  }
+  reset(init = false) {
+    const a = rnd(0, Math.PI*2)
+    let r
+    if      (this.type===0) r = init ? rnd(18,145) : rnd(15,46)
+    else if (this.type===1) r = init ? rnd(44,235) : rnd(38,76)
+    else                    r = init ? rnd(78,315) : rnd(68,112)
+    this.x = Math.cos(a)*r; this.y = Math.sin(a)*r
+    this.life = init ? rnd(0.3,1.0) : 1.0
+    if      (this.type===0) { this.baseSize=rnd(32,70); this.aspect=rnd(0.72,1.30); this.decay=rnd(0.0015,0.004) }
+    else if (this.type===1) { this.baseSize=rnd(13,43); this.aspect=rnd(0.26,0.62); this.decay=rnd(0.0013,0.0034) }
+    else                    { this.baseSize=rnd(4,15);  this.aspect=rnd(0.16,0.50); this.decay=rnd(0.001,0.0026) }
+    this.sz = this.baseSize; this.ia = init ? 1.0 : 0.0
+  }
+  update(energy, bv, mv, hv, fc) {
+    const te = this.type===0 ? bv : (this.type===1 ? mv : hv)
+    const t = fc * 0.0022
+    const c = curl(this.x, this.y, t, this.nox, this.noy)
+    const cs = 5 + energy*12 + te*8
+    const dist = Math.max(Math.sqrt(this.x*this.x + this.y*this.y), 1)
+    const push = 1.2 + energy*3.5 + te*2.5
+    this.vx = lerp(this.vx, c.x*cs + (this.x/dist)*push, 0.06)
+    this.vy = lerp(this.vy, c.y*cs + (this.y/dist)*push, 0.06)
+    this.x += this.vx*0.5; this.y += this.vy*0.5
+    const ss = this.type===2 ? 3.5 : (this.type===1 ? 1.8 : 0.55)
+    this.rotSpd += (noise(this.nosh + fc*0.004) - 0.5) * 0.0007
+    this.rotSpd = Math.max(-0.042, Math.min(0.042, this.rotSpd))
+    this.rot += this.rotSpd * ss * (1 + te*2.2)
+    const spd = Math.sqrt(this.vx*this.vx + this.vy*this.vy)
+    this.sz = this.baseSize * Math.max(0.18, 1.2/(1+spd*0.38)) * (0.5 + te*0.42 + energy*0.2)
+    this.ia = Math.min(1.0, this.ia + 0.045)
+    this.life -= this.decay
+    if (this.life <= 0 || Math.sqrt(this.x*this.x+this.y*this.y) > 445) this.reset()
+  }
+  draw(ctx, spread, size, brightness) {
+    const dist = Math.sqrt(this.x*this.x + this.y*this.y)
+    const fs = this.type===0 ? 95 : (this.type===1 ? 135 : 160)
+    const fe = this.type===0 ? 195 : (this.type===1 ? 250 : 285)
+    const tF = Math.max(0, Math.min(1, (dist-fs)/(fe-fs)))
+    const alpha = this.life * this.ia * (1 - tF*tF*(3-2*tF)) * (this.type===2 ? 0.22 : 0.15) * brightness
+    if (alpha <= 0.001) return
+    const w = this.sz * size * (0.42 + this.life*0.58)
+    ctx.save()
+    ctx.translate(this.x*spread, this.y*spread)
+    ctx.rotate(this.rot)
+    ctx.scale(1, this.aspect)
+    ctx.globalAlpha = alpha
+    ctx.drawImage(this.sprites[this.spriteIdx], -w, -w, w*2, w*2)
+    ctx.restore()
+  }
+}
+
+const STATE_HUE = {
+  idle: 0, connecting: 0, listening: 90, speaking: 210, tool_calling: 0, error: -30,
+}
+
+let particles = []
+let currentSprites = null
+let currentHueShift = 0
+let targetHueShift = 0
+
+function rebuildSprites(hueShift) {
+  currentSprites = buildSprites(hueShift)
+  currentHueShift = hueShift
+  for (const p of particles) p.sprites = currentSprites
+}
+function initParticles(count = 220) {
+  particles = []
+  for (let i = 0; i < count; i++) particles.push(new Smoke(i, currentSprites))
+}
+function drawCore(ctx, size, fc) {
+  const R = size
+  ctx.save()
+  const glow = ctx.createRadialGradient(0,0,R*0.15, 0,0,R*5.8)
+  glow.addColorStop(0,    `rgba(215,148,45,0.13)`)
+  glow.addColorStop(0.28, `rgba(190,122,35,0.06)`)
+  glow.addColorStop(0.6,  `rgba(160,98,25,0.02)`)
+  glow.addColorStop(1,    `rgba(130,72,18,0)`)
+  ctx.fillStyle = glow
+  ctx.beginPath(); ctx.arc(0,0,R*5.8,0,Math.PI*2); ctx.fill()
+  const t = fc * 0.012
+  const wA = noise(t)*0.08+0.96, wB = noise(t+50)*0.06+0.97
+  const tilt = noise(t*0.4) * Math.PI * 0.35
+  const sph = ctx.createRadialGradient(-R*0.26,-R*0.30, 0, 0,0, R*1.55)
+  sph.addColorStop(0,    `rgba(255,252,215,0.94)`)
+  sph.addColorStop(0.10, `rgba(255,238,165,0.88)`)
+  sph.addColorStop(0.26, `rgba(248,200,95,0.76)`)
+  sph.addColorStop(0.42, `rgba(215,152,52,0.54)`)
+  sph.addColorStop(0.58, `rgba(175,105,30,0.28)`)
+  sph.addColorStop(0.72, `rgba(150,85,22,0.10)`)
+  sph.addColorStop(0.88, `rgba(130,70,18,0.03)`)
+  sph.addColorStop(1,    `rgba(110,58,14,0)`)
+  ctx.fillStyle = sph
+  ctx.beginPath(); ctx.ellipse(0,0, R*wA*1.55, R*wB*1.55, tilt, 0, Math.PI*2); ctx.fill()
+  ctx.restore()
+}
+
+function renderFrame() {
+  const canvas = canvasEl.value
+  if (!canvas) return
+  const W = canvas.width, H = canvas.height
+  const ctx = canvas.getContext('2d')
+  frameCount++
+  if (Math.abs(currentHueShift - targetHueShift) > 1) {
+    const next = Math.round(lerp(currentHueShift, targetHueShift, 0.05))
+    if (next !== currentHueShift) rebuildSprites(next)
+  }
+  const amp = voice.amplitude?.value ?? 0
+  const energy = Math.min(1, amp * 2.5)
+  const bass = energy * 0.8, mid = energy * 0.5, high = energy * 0.3
+  ctx.fillStyle = '#000'
+  ctx.fillRect(0, 0, W, H)
+  ctx.save()
+  ctx.translate(W/2, H/2)
+  for (const p of particles) {
+    p.update(energy, bass, mid, high, frameCount)
+    p.draw(ctx, 1.1, 1.1, 1.0)
+  }
+  drawCore(ctx, 45 + energy * 20, frameCount)
+  ctx.restore()
+  rafHandle = requestAnimationFrame(renderFrame)
+}
+
+function resizeCanvas() {
+  const canvas = canvasEl.value
+  if (!canvas) return
+  const { width, height } = canvas.getBoundingClientRect()
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width
+    canvas.height = height
+  }
+}
+
+watch(() => voice.status.value, (s) => { targetHueShift = STATE_HUE[s] ?? 0 })
+
+onMounted(async () => {
+  await fetchAgent()
+  currentSprites = buildSprites(0)
+  initParticles()
+  resizeCanvas()
+  rafHandle = requestAnimationFrame(renderFrame)
+  window.addEventListener('resize', resizeCanvas)
+})
+
+onUnmounted(() => {
+  if (rafHandle !== null) cancelAnimationFrame(rafHandle)
+  stopPanelPoll()
+  window.removeEventListener('resize', resizeCanvas)
+  if (voice.isActive.value) voice.stop()
+})
+
+// ── Status display ────────────────────────────────────────────────────────────
+
+const statusDotColor = computed(() => {
+  switch (voice.status.value) {
+    case 'connecting':   return 'rgba(200,150,65,0.7)'
+    case 'listening':    return 'rgba(74,222,128,0.8)'
+    case 'speaking':     return 'rgba(129,140,248,0.9)'
+    case 'tool_calling': return 'rgba(245,158,11,0.9)'
+    case 'error':        return 'rgba(239,68,68,0.8)'
+    default:             return 'rgba(200,150,65,0.2)'
+  }
+})
+const statusTextColor = computed(() => {
+  switch (voice.status.value) {
+    case 'connecting':   return 'rgba(255,210,130,0.5)'
+    case 'listening':    return 'rgba(134,239,172,0.6)'
+    case 'speaking':     return 'rgba(199,210,254,0.7)'
+    case 'tool_calling': return 'rgba(253,211,77,0.7)'
+    default:             return 'rgba(255,210,130,0.2)'
+  }
+})
+const statusLabel = computed(() => {
+  if (voice.muted.value && voice.isListening.value) return 'muted'
+  switch (voice.status.value) {
+    case 'connecting':   return 'connecting'
+    case 'listening':    return 'listening'
+    case 'speaking':     return 'speaking'
+    case 'tool_calling': return 'working'
+    case 'error':        return 'error'
+    default:             return 'ready'
+  }
+})
+</script>

--- a/tests/unit/test_voice_auth.py
+++ b/tests/unit/test_voice_auth.py
@@ -77,6 +77,7 @@ def _stub_voice_service():
             self.chat_session_id = "cs_test"
             self.transcript = []
             self._duration_seconds = 0.0
+            self.panel_state = {"type": "empty", "content": "", "title": None, "updated_at": None}
 
     class _FakeVoiceService:
         def __init__(self):
@@ -98,6 +99,7 @@ def _stub_voice_service():
 
     mod.VoiceSession = _FakeVoiceSession
     mod.voice_service = _FakeVoiceService()
+    mod.WORKSPACE_PANEL_INSTRUCTIONS = ""
     sys.modules["services.gemini_voice"] = mod
     return mod.voice_service, _FakeVoiceSession
 
@@ -316,3 +318,65 @@ class TestVoiceStopAuth:
         monkeypatch.setattr(voice_router, "_save_transcript", lambda s: 0)
         result = _run(voice_router.voice_stop(req, name="alice-agent", current_user=_FakeUser(99, role="admin")))
         assert result.messages_saved == 0
+
+
+# ── GET /panel ownership tests ───────────────────────────────────────────────
+
+class TestVoicePanelAuth:
+    """Tests for GET /api/agents/{name}/voice/{session_id}/panel ownership gate."""
+
+    def test_missing_session_returns_empty_state(self, monkeypatch):
+        """Non-existent session_id returns empty state (200), not 404."""
+        result = _run(voice_router.get_voice_panel(
+            session_id="vs_does_not_exist",
+            name="alice-agent",
+            current_user=_FakeUser(1),
+        ))
+        assert result["type"] == "empty"
+        assert result["content"] == ""
+
+    def test_owner_gets_panel_state(self, alice_session, monkeypatch):
+        """Session owner gets the panel state back."""
+        # Inject some panel state on the fake session
+        alice_session.panel_state = {
+            "type": "markdown", "content": "# Hello", "title": None, "updated_at": "ts"
+        }
+        result = _run(voice_router.get_voice_panel(
+            session_id="vs_alice",
+            name="alice-agent",
+            current_user=_FakeUser(1),
+        ))
+        assert result["type"] == "markdown"
+        assert result["content"] == "# Hello"
+
+    def test_wrong_agent_name_403(self, alice_session, monkeypatch):
+        """Session belongs to alice-agent but path says bob-agent — reject."""
+        with pytest.raises(HTTPException) as exc:
+            _run(voice_router.get_voice_panel(
+                session_id="vs_alice",
+                name="bob-agent",
+                current_user=_FakeUser(1),
+            ))
+        assert exc.value.status_code == 403
+
+    def test_other_user_403(self, alice_session, monkeypatch):
+        """Bob cannot read Alice's panel state."""
+        with pytest.raises(HTTPException) as exc:
+            _run(voice_router.get_voice_panel(
+                session_id="vs_alice",
+                name="alice-agent",
+                current_user=_FakeUser(2),
+            ))
+        assert exc.value.status_code == 403
+
+    def test_admin_reads_any_panel(self, alice_session, monkeypatch):
+        """Admin can read any user's panel state."""
+        alice_session.panel_state = {
+            "type": "html", "content": "<b>data</b>", "title": "T", "updated_at": "ts"
+        }
+        result = _run(voice_router.get_voice_panel(
+            session_id="vs_alice",
+            name="alice-agent",
+            current_user=_FakeUser(99, role="admin"),
+        ))
+        assert result["type"] == "html"

--- a/tests/unit/test_voice_tools.py
+++ b/tests/unit/test_voice_tools.py
@@ -87,6 +87,10 @@ def _stub_config():
     config_mod.VOICE_MAX_DURATION = 300
     config_mod.DEFAULT_GITHUB_TEMPLATE_REPOS = []
     config_mod.GITHUB_PAT_CREDENTIAL_ID = "github-pat-templates"
+    # Required by dependencies.py when test_voice_auth.py runs in the same session
+    config_mod.SECRET_KEY = "test-secret-key-for-unit-tests"
+    config_mod.ALGORITHM = "HS256"
+    config_mod.VOICE_ENABLED = True
     sys.modules["config"] = config_mod
 
 
@@ -114,7 +118,9 @@ _stub_config()
 _stub_services_package()
 
 # Now we can import the service
-from services.gemini_voice import GeminiVoiceService, VoiceSession, _TOOL_PROMPT_MAX  # noqa: E402
+from services.gemini_voice import (  # noqa: E402
+    GeminiVoiceService, VoiceSession, _TOOL_PROMPT_MAX, _PANEL_CONTENT_MAX,
+)
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -331,6 +337,84 @@ class TestToolDeclaration:
         from services.gemini_voice import _RUN_TASK_TOOL
         fd = _RUN_TASK_TOOL.function_declarations[0]
         assert "prompt" in (fd.parameters.required or [])
+
+
+# ── Tests: _execute_panel_tool ────────────────────────────────────────────────
+
+class TestExecutePanelTool:
+    """Tests for in-process panel tool execution (workspace mode canvas)."""
+
+    def test_show_markdown_sets_state(self, svc):
+        session = _make_session()
+        result = svc._execute_panel_tool(session, "show_markdown", {"content": "# Hello"})
+        assert result == "Panel updated."
+        assert session.panel_state["type"] == "markdown"
+        assert session.panel_state["content"] == "# Hello"
+        assert session.panel_state["title"] is None
+        assert session.panel_state["updated_at"] is not None
+
+    def test_show_markdown_with_title(self, svc):
+        session = _make_session()
+        svc._execute_panel_tool(session, "show_markdown", {"content": "body", "title": "My Title"})
+        assert session.panel_state["title"] == "My Title"
+
+    def test_update_panel_sets_html(self, svc):
+        session = _make_session()
+        svc._execute_panel_tool(session, "update_panel", {"html": "<b>bold</b>", "title": "Report"})
+        assert session.panel_state["type"] == "html"
+        assert session.panel_state["content"] == "<b>bold</b>"
+        assert session.panel_state["title"] == "Report"
+
+    def test_append_to_panel_concatenates(self, svc):
+        session = _make_session()
+        session.panel_state = {"type": "html", "content": "A", "title": None, "updated_at": None}
+        svc._execute_panel_tool(session, "append_to_panel", {"html": "B"})
+        assert session.panel_state["content"] == "AB"
+        assert session.panel_state["type"] == "html"
+
+    def test_append_to_panel_caps_at_max(self, svc):
+        session = _make_session()
+        # Pre-fill content just under the limit, then append enough to exceed it
+        session.panel_state = {
+            "type": "html",
+            "content": "x" * (_PANEL_CONTENT_MAX - 10),
+            "title": None,
+            "updated_at": None,
+        }
+        svc._execute_panel_tool(session, "append_to_panel", {"html": "y" * 100})
+        assert len(session.panel_state["content"]) == _PANEL_CONTENT_MAX
+        # The tail of the content should end with the appended "y"s
+        assert session.panel_state["content"].endswith("y" * 10)
+
+    def test_clear_panel_resets_state(self, svc):
+        session = _make_session()
+        session.panel_state = {"type": "html", "content": "old", "title": "t", "updated_at": "ts"}
+        svc._execute_panel_tool(session, "clear_panel", {})
+        assert session.panel_state["type"] == "empty"
+        assert session.panel_state["content"] == ""
+        assert session.panel_state["title"] is None
+
+    def test_panel_tool_routed_not_forwarded_to_agent(self, svc):
+        """Panel tools must not reach _execute_tool (no agent container call)."""
+        session = _make_session()
+        session._active = True
+        gemini_session = MagicMock()
+        gemini_session.send_tool_response = AsyncMock()
+        session._gemini_session = gemini_session
+        session._on_tool_call = None
+        session._on_tool_result = None
+
+        fc = MagicMock()
+        fc.id = "fc_panel"
+        fc.name = "show_markdown"
+        fc.args = {"content": "# Test"}
+
+        with patch.object(svc, "_execute_tool", AsyncMock()) as mock_exec:
+            _run(svc._execute_and_respond(session, "fc_panel", fc))
+            mock_exec.assert_not_awaited()
+
+        assert session.panel_state["type"] == "markdown"
+        gemini_session.send_tool_response.assert_awaited_once()
 
 
 # ── Tests: end_session cancels pending tool tasks ─────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `/agents/:name/workspace` — a full-page voice workspace with split layout: orb + controls (left 40%) and an agent-controlled canvas panel (right 60%)
- Introduces four in-process Gemini panel tools: `show_markdown`, `update_panel`, `append_to_panel`, `clear_panel` — handled entirely backend-side without delegating to the agent container
- Gates the workspace button behind a new `voice_available` feature flag (`GEMINI_API_KEY` + `VOICE_ENABLED`); surfaced via BETA-badged button in `AgentHeader`

## Changes

- `src/backend/services/gemini_voice.py` — `_PANEL_TOOLS`, `_execute_panel_tool()`, `WORKSPACE_PANEL_INSTRUCTIONS`, `panel_state` on `VoiceSession`, 512 KB content cap for `append_to_panel`
- `src/backend/routers/voice.py` — `workspace_mode` in `VoiceStartRequest`, new `GET /voice/{session_id}/panel` endpoint with ownership gate
- `src/backend/routers/settings.py` — `voice_available` in feature flags
- `src/frontend/src/views/AgentWorkspace.vue` — new workspace page (orb particle system inlined, panel polling at 300ms, DOMPurify sanitization for v-html)
- `src/frontend/src/components/AgentHeader.vue` — workspace button with BETA badge
- `src/frontend/src/composables/useVoiceSession.js` — `workspace_mode` param forwarded to backend
- `src/frontend/src/stores/sessions.js` — `voiceAvailable` state from feature flags
- `tests/unit/test_voice_tools.py` — 7 new panel-tool tests (all 4 handlers, content cap, routing guard)
- `tests/unit/test_voice_auth.py` — 5 new panel endpoint ownership tests

## Test Plan

- [ ] `pytest tests/unit/test_voice_tools.py -v` — 19 tests pass
- [ ] `pytest tests/unit/test_voice_auth.py -v` — 18 tests pass (must run after test_voice_tools.py in same session)
- [ ] Manual: visit `/agents/:name/workspace` with Gemini key configured — workspace button visible in AgentHeader
- [ ] Manual: start voice session, trigger `show_markdown` via agent — canvas panel updates within 300ms
- [ ] Manual: workspace button disabled when agent is not running
- [ ] Manual: workspace button hidden when `GEMINI_API_KEY` not set

Fixes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)