### PR TITLE
fix(voice): cross-worker session 403 + audit kwargs TypeError (#704 #705)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -205,6 +205,8 @@ The test suite covers:
 - **Web Terminal** (test_web_terminal.py) - WebSocket terminal sessions
 - **Execution Streaming** (test_execution_streaming.py) - SSE streaming for execution logs
 - **Trinity Connect** (test_trinity_connect.py) - [NOT YET IMPLEMENTED] /ws/events endpoint, MCP key auth, filtered event broadcasts (Req SYNC-001)
+- **Voice Tool Execution** (unit/test_voice_tools.py) - `_execute_tool`, `_execute_and_respond`, tool declarations, panel tools (show_markdown/update_panel/append_to_panel/clear_panel), 512KB content cap, routing guard, session cancellation [UNIT] (19 tests)
+- **Voice Auth & Panel Ownership** (unit/test_voice_auth.py) - WS ownership gate (no-token/invalid-token/unknown-session/wrong-user/owner/admin), voice_stop auth, GET /panel ownership (missing-session/owner/wrong-agent/wrong-user/admin) [UNIT] (18 tests)
 
 ### Direct Agent Tests
 - **Agent Server Direct** (agent_server/) - Direct agent server tests [SKIPPED unless TEST_AGENT_NAME set]
@@ -234,10 +236,10 @@ The test suite covers:
 
 ## Test Suite Statistics
 
-**Total Tests**: ~2,271 tests across 125 test files
+**Total Tests**: ~2,283 tests across 125 test files
 **Smoke Tests**: ~578 tests (fast, no agent creation)
-**Unit Tests**: ~170 tests (no backend needed, rate limit detection, watchdog logic, context formula, OTel trace logging, file upload, voice transcription, inter-agent timeout, scheduler sync loop, team-share gate, WhatsApp adapter (67), subprocess pgroup (11), empty result classification (13))
-**Core Tests (not slow)**: ~2,112 tests
+**Unit Tests**: ~190 tests (no backend needed, rate limit detection, watchdog logic, context formula, OTel trace logging, file upload, voice transcription, voice tools+auth (45: 26 tools + 19 auth), inter-agent timeout, scheduler sync loop, team-share gate, WhatsApp adapter (67), subprocess pgroup (11), empty result classification (13))
+**Core Tests (not slow)**: ~2,124 tests
 **Slow Tests**: ~99 tests (chat execution, fleet ops, system agent ops, execution termination, WhatsApp live-backend integration)
 **WebSocket Tests**: ~10 tests (web terminal, execution streaming)
 
@@ -265,6 +267,30 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 - **Healthy**: >90% pass rate, 0 critical failures
 - **Warning**: 75-90% pass rate, <5 failures
 - **Critical**: <75% pass rate or >5 failures
+
+## Recent Test Additions (2026-05-07)
+
+| Test File | Description | Tests Added |
+|-----------|-------------|-------------|
+| `unit/test_voice_tools.py` | Voice Redis cross-worker fix (#704) — `TestRedisSessionFallback`: in-memory hit skips Redis, cross-worker Redis fallback reconstructs session, Redis miss returns None, Redis error degrades gracefully, remove_session deletes Redis key, create_session writes metadata with correct TTL, create_session Redis failure raises + clears memory; `REDIS_URL` added to config stub | +7 tests (file total 26) |
+| `unit/test_voice_auth.py` | Voice audit attribution fix (#705) — `TestVoiceAuditAttribution`: source-inspect regression guard verifying `actor_user=SimpleNamespace(...)` and absence of legacy `actor_type=`/`actor_id=`/`actor_email=` kwargs; `_FakeVoiceService` updated to use `AsyncMock` for `get_session`, `remove_session`, `create_session` (now async) | +1 test (file total 19) |
+| `unit/test_voice_tools.py` | Voice workspace (#699) — `TestExecutePanelTool`: all 4 panel tool handlers (`show_markdown`, `update_panel`, `append_to_panel`, `clear_panel`), 512 KB content cap on `append_to_panel`, routing guard (panel tools must not reach `_execute_tool`); config stub extended with `SECRET_KEY`, `ALGORITHM`, `VOICE_ENABLED` for cross-session stability | +7 tests (file total 19) |
+| `unit/test_voice_auth.py` | Voice workspace (#699) — `TestVoicePanelAuth`: missing session → 200 empty state (no 404 during teardown), owner access, wrong-agent 403, wrong-user 403, admin bypass; `_FakeVoiceSession` extended with `panel_state`; stub extended with `WORKSPACE_PANEL_INSTRUCTIONS` | +5 tests (file total 18) |
+
+**Voice Workspace Panel Tests (#699)** — panel tool execution and endpoint auth:
+
+Panel tools (`show_markdown`, `update_panel`, `append_to_panel`, `clear_panel`) are executed in-process via `_execute_panel_tool()` without touching the agent container. Key behaviors tested:
+- Each handler sets `panel_state["type"]` and `"content"` correctly
+- `append_to_panel` accumulates content and caps at `_PANEL_CONTENT_MAX = 524_288` (512 KB), keeping the tail
+- The `_execute_and_respond` routing guard verifies panel tools never reach `_execute_tool` (the agent container call)
+- `GET /panel` returns empty state (200, not 404) for a non-existent `session_id` — avoids poll errors during the teardown window when the session has just been removed
+- Ownership checks: `session.agent_name != name` → 403; `session.user_id != current_user.id` → 403; admin role bypasses ownership
+
+Run via: `pytest tests/unit/test_voice_tools.py tests/unit/test_voice_auth.py -v` (must run in this order — auth file depends on config stub from tools file).
+
+**Known cross-session collision (pre-existing, not introduced by #699)**: the 3 tests `TestToolDeclaration::test_run_task_declared`, `test_prompt_required`, `TestExecuteAndRespond::test_timeout_sends_error_response` fail when both files run together. Root cause: `test_voice_auth.py` replaces `sys.modules["services.gemini_voice"]` with a minimal stub during collection, dropping `_RUN_TASK_TOOL` and `asyncio` from the already-imported module. The 34 remaining tests all pass. New panel tests (7 + 5) all pass regardless.
+
+---
 
 ## Recent Test Additions (2026-05-05)
 

--- a/docs/memory/feature-flows/voice-chat.md
+++ b/docs/memory/feature-flows/voice-chat.md
@@ -199,6 +199,28 @@ Button hidden entirely when `voiceAvailable=false`.
 | Method | Truncation of last N messages injected into system prompt |
 | Fallback | Voice system prompt alone if no prior messages |
 
+### VOICE-009: Multi-Worker Session Reliability (#704)
+
+**Status**: ✅ Implemented (2026-05-07)
+
+Uvicorn runs `--workers 2` in production. HTTP requests (REST `/voice/start`, `/voice/stop`) and WebSocket connections round-robin across OS processes. Without a cross-worker session store, the WebSocket worker would have an empty `_sessions` dict and reject with 403.
+
+**Fix: Redis dual-write pattern**
+
+| Layer | Store | Purpose |
+|-------|-------|---------|
+| In-memory `_sessions` dict | Live state | Gemini connection, asyncio tasks, panel_state (unserializable) |
+| Redis key `voice_session:{id}` | Serializable metadata | Cross-worker auth lookup (agent_name, user_id, user_email, …) |
+
+- `create_session()` (now `async`) writes JSON metadata to Redis with TTL = `VOICE_MAX_DURATION + 60` (360s). If Redis write fails, in-memory state is rolled back and `RuntimeError` is raised — the client gets 500 at `/voice/start` rather than a session ID that will intermittently 403.
+- `get_session()` (now `async`) checks `_sessions` first; on cache miss, falls back to Redis, reconstructs a `VoiceSession` from the stored metadata, and registers it in the worker's `_sessions` for subsequent calls. Redis errors degrade gracefully to `None`.
+- `remove_session()` (now `async`) deletes the Redis key and pops from `_sessions`.
+- `_redis` client is lazy-initialized as `redis.asyncio` (async, non-blocking) reusing the existing platform Redis URL (`config.REDIS_URL`).
+
+**Key implementation:** `src/backend/services/gemini_voice.py` — `_get_redis()`, `_REDIS_SESSION_TTL`, async `create_session`/`get_session`/`remove_session`.
+
+---
+
 ### VOICE-007: Tool Calling (run_task)
 
 **Status**: ✅ Implemented (Phase 3 — shipped early)
@@ -212,7 +234,7 @@ Button hidden entirely when `voiceAvailable=false`.
 | Empty prompt | Falls back to "No prompt" |
 | Session tracking | `_pending_tool_tasks` dict on `VoiceSession`; all cancelled on `end_session()` |
 | WS events | `{type: "tool_call", tool_name: "run_task"}` and `{type: "tool_result", ...}` frames |
-| Audit | Platform audit log written on each tool call via `on_tool_call` callback |
+| Audit | Platform audit log written on each tool call via `on_tool_call` callback; `actor_user=types.SimpleNamespace(id=..., email=...)` pattern (#705 — legacy `actor_type=`/`actor_id=`/`actor_email=` kwargs caused silent TypeError) |
 
 ### VOICE-008: Workspace Mode + Canvas Panel (BETA)
 
@@ -338,8 +360,8 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 | **Frontend** | `src/frontend/src/composables/useVoiceSession.js` | `start(sessionId, voiceName, workspaceMode)` — passes `workspace_mode` to backend |
 | **Frontend** | `src/frontend/src/stores/sessions.js` | `voiceAvailable` state from feature flags |
 | **Frontend** | `src/frontend/src/utils/audio.js` | AudioWorklet-first capture/playback, `getAmplitude()` via `AnalyserNode` |
-| **Tests** | `tests/unit/test_voice_tools.py` | 19 unit tests: tool execution, panel tool handlers, content cap, routing guard |
-| **Tests** | `tests/unit/test_voice_auth.py` | 18 unit tests: WS auth, stop auth, panel ownership (owner/admin/wrong-user/wrong-agent/missing-session) |
+| **Tests** | `tests/unit/test_voice_tools.py` | 26 unit tests: tool execution, panel tool handlers, content cap, routing guard, Redis session fallback (#704) |
+| **Tests** | `tests/unit/test_voice_auth.py` | 19 unit tests: WS auth, stop auth, panel ownership, audit attribution kwargs (#705) |
 
 ---
 

--- a/src/backend/routers/voice.py
+++ b/src/backend/routers/voice.py
@@ -12,6 +12,7 @@ import asyncio
 import base64
 import json
 import logging
+import types
 from typing import Optional
 
 import httpx
@@ -24,7 +25,7 @@ from database import db
 from config import GEMINI_API_KEY, VOICE_ENABLED
 from services.gemini_voice import voice_service, WORKSPACE_PANEL_INSTRUCTIONS
 from services.docker_service import get_agent_container
-from services.platform_audit_service import platform_audit_service, AuditEventType, AuditActorType
+from services.platform_audit_service import platform_audit_service, AuditEventType
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +101,7 @@ async def voice_start(
 
     voice_name = request.voice_name or _get_voice_name(name)
 
-    session = voice_service.create_session(
+    session = await voice_service.create_session(
         agent_name=name,
         chat_session_id=chat_session_id,
         user_id=current_user.id,
@@ -128,7 +129,7 @@ async def voice_stop(
     # the session before any mutation happens — otherwise any authenticated
     # user with access to ANY agent could end and persist a transcript onto
     # someone else's session by passing its 128-bit id in the body.
-    preview = voice_service.get_session(request.voice_session_id)
+    preview = await voice_service.get_session(request.voice_session_id)
     if not preview:
         raise HTTPException(status_code=404, detail="Voice session not found")
     if preview.agent_name != name:
@@ -144,7 +145,7 @@ async def voice_stop(
     messages_saved = _save_transcript(session)
 
     # Clean up
-    voice_service.remove_session(request.voice_session_id)
+    await voice_service.remove_session(request.voice_session_id)
 
     return VoiceStopResponse(
         transcript=[
@@ -180,7 +181,7 @@ async def get_voice_panel(
     Returns empty state (not 404) when session has ended so the frontend
     poll loop doesn't raise errors during the teardown window.
     """
-    session = voice_service.get_session(session_id)
+    session = await voice_service.get_session(session_id)
     if not session:
         return {"type": "empty", "content": "", "title": None, "updated_at": None}
     if session.agent_name != name:
@@ -228,14 +229,14 @@ async def voice_websocket(
                   {"type": "transcript", "role": "user|assistant", "text": "..."}
                   {"type": "status", "state": "connecting|listening|speaking|ended"}
     """
-    session = voice_service.get_session(voice_session_id)
-    if not session:
-        await websocket.close(code=4004, reason="Voice session not found")
-        return
-
     # Authenticate via query param token (WebSocket can't use Authorization header)
     if not token:
         await websocket.close(code=4001, reason="Authentication required")
+        return
+
+    session = await voice_service.get_session(voice_session_id)
+    if not session:
+        await websocket.close(code=4004, reason="Voice session not found")
         return
 
     from jose import jwt, JWTError
@@ -308,17 +309,15 @@ async def voice_websocket(
             })
         except Exception:
             pass
-        await platform_audit_service.log(
+        asyncio.create_task(platform_audit_service.log(
             event_type=AuditEventType.EXECUTION,
             event_action="voice_tool_call",
-            actor_type=AuditActorType.USER,
-            actor_id=str(session.user_id),
-            actor_email=session.user_email,
+            source="api",
+            actor_user=types.SimpleNamespace(id=user["id"], email=user.get("email")),
             target_type="agent",
             target_id=session.agent_name,
             details={"tool": tool_name, "prompt_preview": str(args.get("prompt", ""))[:100]},
-            source="api",
-        )
+        ))
 
     async def on_tool_result(tool_name: str, result: str):
         try:
@@ -363,7 +362,7 @@ async def voice_websocket(
         session = await voice_service.end_session(voice_session_id)
         if session:
             _save_transcript(session)
-            voice_service.remove_session(voice_session_id)
+            await voice_service.remove_session(voice_session_id)
 
         # Cancel Gemini task
         if not gemini_task.done():

--- a/src/backend/services/gemini_voice.py
+++ b/src/backend/services/gemini_voice.py
@@ -10,6 +10,7 @@ Architecture:
 """
 
 import asyncio
+import json
 import logging
 import secrets
 from dataclasses import dataclass, field
@@ -19,7 +20,7 @@ from typing import Optional, Callable, Awaitable
 from google import genai
 from google.genai import types as genai_types
 
-from config import GEMINI_API_KEY, VOICE_MODEL, VOICE_MAX_DURATION
+from config import GEMINI_API_KEY, VOICE_MODEL, VOICE_MAX_DURATION, REDIS_URL
 
 logger = logging.getLogger(__name__)
 
@@ -168,12 +169,22 @@ class VoiceSession:
     _on_tool_result: Optional[Callable] = field(default=None, repr=False)  # (name, result) → None
 
 
+_REDIS_SESSION_TTL = VOICE_MAX_DURATION + 60  # grace buffer beyond max session length
+
+
 class GeminiVoiceService:
     """Manages Gemini Live API voice sessions."""
 
     def __init__(self):
         self._client: Optional[genai.Client] = None
         self._sessions: dict[str, VoiceSession] = {}
+        self._redis = None  # lazy-init async Redis client
+
+    async def _get_redis(self):
+        if self._redis is None:
+            import redis.asyncio as aioredis
+            self._redis = aioredis.from_url(REDIS_URL, decode_responses=True)
+        return self._redis
 
     def is_available(self) -> bool:
         """Check if Gemini voice is configured."""
@@ -187,7 +198,7 @@ class GeminiVoiceService:
             self._client = genai.Client(api_key=GEMINI_API_KEY)
         return self._client
 
-    def create_session(
+    async def create_session(
         self,
         agent_name: str,
         chat_session_id: str,
@@ -210,6 +221,28 @@ class GeminiVoiceService:
             workspace_mode=workspace_mode,
         )
         self._sessions[session_id] = session
+
+        # Persist metadata to Redis so any Uvicorn worker can validate the session.
+        # The active streaming state (Gemini connection, asyncio tasks) stays in-process.
+        metadata = {
+            "session_id": session_id,
+            "agent_name": agent_name,
+            "chat_session_id": chat_session_id,
+            "user_id": user_id,
+            "user_email": user_email,
+            "voice_name": voice_name,
+            "workspace_mode": workspace_mode,
+            "system_prompt": system_prompt,
+        }
+        try:
+            r = await self._get_redis()
+            await r.setex(f"voice_session:{session_id}", _REDIS_SESSION_TTL, json.dumps(metadata))
+        except Exception as e:
+            # Fail loudly: better to 500 at /voice/start than issue a session_id
+            # that will intermittently 403 when the WebSocket lands on another worker.
+            self._sessions.pop(session_id, None)
+            raise RuntimeError(f"Failed to persist voice session metadata to Redis: {e}") from e
+
         logger.info(f"Voice session created: {session_id} for agent {agent_name}")
         return session
 
@@ -534,13 +567,50 @@ class GeminiVoiceService:
         logger.info(f"Voice session {session_id} ended")
         return session
 
-    def get_session(self, session_id: str) -> Optional[VoiceSession]:
-        """Get a voice session by ID."""
-        return self._sessions.get(session_id)
+    async def get_session(self, session_id: str) -> Optional[VoiceSession]:
+        """Get a voice session by ID.
 
-    def remove_session(self, session_id: str):
-        """Remove a session from tracking."""
+        Checks in-process memory first. If not found (cross-worker scenario),
+        falls back to Redis metadata and reconstructs a VoiceSession so the
+        WebSocket handler on any worker can validate ownership and stream.
+        """
+        session = self._sessions.get(session_id)
+        if session is not None:
+            return session
+
+        # Cross-worker fallback: reconstruct from Redis metadata
+        try:
+            r = await self._get_redis()
+            raw = await r.get(f"voice_session:{session_id}")
+            if not raw:
+                return None
+            meta = json.loads(raw)
+        except Exception as e:
+            logger.warning(f"Redis fallback failed for voice session {session_id}: {e}")
+            return None
+
+        session = VoiceSession(
+            session_id=meta["session_id"],
+            agent_name=meta["agent_name"],
+            chat_session_id=meta["chat_session_id"],
+            user_id=meta["user_id"],
+            user_email=meta["user_email"],
+            system_prompt=meta["system_prompt"],
+            voice_name=meta.get("voice_name", "Kore"),
+            workspace_mode=meta.get("workspace_mode", False),
+        )
+        self._sessions[session_id] = session
+        logger.info(f"Voice session {session_id} reconstructed from Redis on worker")
+        return session
+
+    async def remove_session(self, session_id: str):
+        """Remove a session from tracking and clean up Redis metadata."""
         self._sessions.pop(session_id, None)
+        try:
+            r = await self._get_redis()
+            await r.delete(f"voice_session:{session_id}")
+        except Exception as e:
+            logger.warning(f"Failed to delete voice session Redis key {session_id}: {e}")
 
 
 # Singleton

--- a/tests/unit/test_voice_auth.py
+++ b/tests/unit/test_voice_auth.py
@@ -83,16 +83,15 @@ def _stub_voice_service():
         def __init__(self):
             self._sessions: dict = {}
             self.is_available = MagicMock(return_value=True)
-            self.create_session = MagicMock()
+            self.create_session = AsyncMock()
             self.connect_and_stream = AsyncMock()
             self.send_audio = AsyncMock()
-            self.remove_session = MagicMock(side_effect=lambda sid: self._sessions.pop(sid, None))
+            # get_session and remove_session are now async (fix for #704)
+            self.remove_session = AsyncMock(side_effect=lambda sid: self._sessions.pop(sid, None))
+            self.get_session = AsyncMock(side_effect=lambda sid: self._sessions.get(sid))
 
         def add(self, session):
             self._sessions[session.session_id] = session
-
-        def get_session(self, sid):
-            return self._sessions.get(sid)
 
         async def end_session(self, sid):
             return self._sessions.get(sid)
@@ -380,3 +379,43 @@ class TestVoicePanelAuth:
             current_user=_FakeUser(99, role="admin"),
         ))
         assert result["type"] == "html"
+
+
+# ── Audit attribution tests (#705) ──────────────────────────────────────────
+
+class TestVoiceAuditAttribution:
+    """
+    Tests that on_tool_call uses actor_user= (SimpleNamespace) not the legacy
+    actor_type/actor_id/actor_email kwargs that caused TypeError (fix for #705).
+    """
+
+    def test_on_tool_call_audit_uses_actor_user_not_legacy_kwargs(self):
+        """
+        Fix #705: the on_tool_call closure inside voice_websocket must pass
+        actor_user= to audit.log(), not the legacy actor_type=/actor_id=/actor_email=
+        kwargs that caused a TypeError and silently suppressed audit records.
+
+        Tests the source directly — the regression was a kwargs mismatch; source
+        inspection is the most reliable check and avoids async scheduling complexity.
+        """
+        import inspect
+        source = inspect.getsource(voice_router.voice_websocket)
+
+        # Must NOT contain the legacy invalid kwargs
+        assert "actor_type=" not in source, (
+            "Legacy actor_type= kwarg found in voice_websocket — this causes TypeError (#705)"
+        )
+        assert "actor_id=" not in source, (
+            "Legacy actor_id= kwarg found in voice_websocket — this causes TypeError (#705)"
+        )
+        assert "actor_email=" not in source, (
+            "Legacy actor_email= kwarg found in voice_websocket — this causes TypeError (#705)"
+        )
+
+        # Must use the correct actor_user= kwarg
+        assert "actor_user=" in source, (
+            "actor_user= is missing from audit.log() call in voice_websocket"
+        )
+        assert "SimpleNamespace" in source, (
+            "SimpleNamespace wrapper is missing from actor_user= in voice_websocket"
+        )

--- a/tests/unit/test_voice_tools.py
+++ b/tests/unit/test_voice_tools.py
@@ -9,6 +9,7 @@ Issue: https://github.com/abilityai/trinity/issues/581
 """
 
 import asyncio
+import json
 import sys
 import types
 import pytest
@@ -85,6 +86,7 @@ def _stub_config():
     config_mod.GEMINI_API_KEY = "test-key"
     config_mod.VOICE_MODEL = "test-model"
     config_mod.VOICE_MAX_DURATION = 300
+    config_mod.REDIS_URL = "redis://user:pass@localhost:6379"
     config_mod.DEFAULT_GITHUB_TEMPLATE_REPOS = []
     config_mod.GITHUB_PAT_CREDENTIAL_ID = "github-pat-templates"
     # Required by dependencies.py when test_voice_auth.py runs in the same session
@@ -441,3 +443,136 @@ class TestEndSession:
         task = _run(run())
         assert task.cancelled() or task.done()
         assert len(session._pending_tool_tasks) == 0
+
+
+# ── Tests: Redis cross-worker session fallback (#704) ────────────────────────
+
+class TestRedisSessionFallback:
+    """
+    Tests for get_session() Redis cross-worker fallback (fix for #704).
+
+    With --workers 2, POST /voice/start stores the session in Worker A's
+    _sessions dict.  The subsequent WebSocket may hit Worker B, which has an
+    empty _sessions.  get_session() now falls back to Redis metadata and
+    reconstructs a VoiceSession so the ownership gate works on any worker.
+    """
+
+    def _make_redis_mock(self, return_value=None, side_effect=None):
+        redis_mock = AsyncMock()
+        if side_effect:
+            redis_mock.get = AsyncMock(side_effect=side_effect)
+        else:
+            redis_mock.get = AsyncMock(return_value=return_value)
+        redis_mock.setex = AsyncMock()
+        redis_mock.delete = AsyncMock()
+        return redis_mock
+
+    def test_get_session_returns_in_memory_first(self, svc):
+        """In-memory session is returned directly without a Redis call."""
+        session = _make_session()
+        svc._sessions[session.session_id] = session
+
+        redis_mock = self._make_redis_mock(return_value=None)
+        svc._get_redis = AsyncMock(return_value=redis_mock)
+
+        result = _run(svc.get_session(session.session_id))
+        assert result is session
+        redis_mock.get.assert_not_awaited()
+
+    def test_get_session_falls_back_to_redis(self, svc):
+        """Session absent from memory is reconstructed from Redis metadata."""
+        metadata = {
+            "session_id": "vs_remote",
+            "agent_name": "remote-agent",
+            "chat_session_id": "cs_remote",
+            "user_id": 42,
+            "user_email": "remote@example.com",
+            "voice_name": "Puck",
+            "workspace_mode": True,
+            "system_prompt": "You are remote.",
+        }
+        redis_mock = self._make_redis_mock(return_value=json.dumps(metadata))
+        svc._get_redis = AsyncMock(return_value=redis_mock)
+
+        result = _run(svc.get_session("vs_remote"))
+
+        assert result is not None
+        assert result.session_id == "vs_remote"
+        assert result.agent_name == "remote-agent"
+        assert result.user_id == 42
+        assert result.workspace_mode is True
+        # Stored in memory so subsequent calls skip Redis
+        assert svc._sessions.get("vs_remote") is result
+
+    def test_get_session_redis_miss_returns_none(self, svc):
+        """Redis returning None (key expired/missing) → get_session() returns None."""
+        redis_mock = self._make_redis_mock(return_value=None)
+        svc._get_redis = AsyncMock(return_value=redis_mock)
+
+        result = _run(svc.get_session("vs_missing"))
+        assert result is None
+
+    def test_get_session_redis_error_returns_none(self, svc):
+        """Redis connection failure is swallowed; get_session() degrades to None."""
+        redis_mock = self._make_redis_mock(side_effect=Exception("Redis unreachable"))
+        svc._get_redis = AsyncMock(return_value=redis_mock)
+
+        result = _run(svc.get_session("vs_error"))
+        assert result is None
+
+    def test_remove_session_deletes_redis_key(self, svc):
+        """remove_session() deletes the Redis key in addition to clearing in-memory state."""
+        session = _make_session()
+        svc._sessions[session.session_id] = session
+
+        redis_mock = self._make_redis_mock()
+        svc._get_redis = AsyncMock(return_value=redis_mock)
+
+        _run(svc.remove_session(session.session_id))
+
+        assert session.session_id not in svc._sessions
+        redis_mock.delete.assert_awaited_once_with(f"voice_session:{session.session_id}")
+
+    def test_create_session_writes_redis(self, svc):
+        """create_session() writes metadata to Redis with TTL = VOICE_MAX_DURATION + 60."""
+        # Import constant from config stub (avoids cross-session stub collision with
+        # test_voice_auth.py which replaces services.gemini_voice in sys.modules)
+        import config as _cfg
+        expected_ttl = _cfg.VOICE_MAX_DURATION + 60
+
+        redis_mock = self._make_redis_mock()
+        svc._get_redis = AsyncMock(return_value=redis_mock)
+
+        session = _run(svc.create_session(
+            agent_name="my-agent",
+            chat_session_id="cs_1",
+            user_id=7,
+            user_email="test@example.com",
+            system_prompt="Be helpful.",
+        ))
+
+        redis_mock.setex.assert_awaited_once()
+        key, ttl, value = redis_mock.setex.call_args[0]
+        assert key == f"voice_session:{session.session_id}"
+        assert ttl == expected_ttl
+        stored = json.loads(value)
+        assert stored["user_id"] == 7
+        assert stored["agent_name"] == "my-agent"
+        assert stored["system_prompt"] == "Be helpful."
+
+    def test_create_session_redis_failure_raises(self, svc):
+        """Redis write failure raises RuntimeError; session must not remain in memory."""
+        redis_mock = AsyncMock()
+        redis_mock.setex = AsyncMock(side_effect=Exception("Redis down"))
+        svc._get_redis = AsyncMock(return_value=redis_mock)
+
+        with pytest.raises(RuntimeError, match="Failed to persist"):
+            _run(svc.create_session(
+                agent_name="agent",
+                chat_session_id="cs_1",
+                user_id=1,
+                user_email="u@example.com",
+                system_prompt="prompt",
+            ))
+
+        assert len(svc._sessions) == 0


### PR DESCRIPTION
## Summary

- **#704** — Voice WebSocket returns 403 intermittently in production (Uvicorn `--workers 2`). HTTP `/voice/start` and the WebSocket connection can land on different OS processes; each worker has its own in-memory `_sessions` dict. Fixed with a Redis dual-write: session metadata written to `voice_session:{id}` at creation with TTL = `VOICE_MAX_DURATION + 60` (360s); `get_session()` falls back to Redis on cache miss and reconstructs the `VoiceSession` object. Redis failure at `/voice/start` raises loudly instead of silently producing a broken session ID.

- **#705** — Every voice tool-call audit record was silently dropped. The `on_tool_call` callback passed legacy `actor_type=`/`actor_id=`/`actor_email=` kwargs that don't exist on `platform_audit_service.log()`, producing a `TypeError` that was swallowed. Fixed to use `actor_user=types.SimpleNamespace(id=..., email=...)` matching `_resolve_actor`'s contract; wrapped in `asyncio.create_task` so the audit write is fire-and-forget.

## Changes

- `src/backend/services/gemini_voice.py` — lazy async Redis client (`redis.asyncio`), `_REDIS_SESSION_TTL`, async `create_session`/`get_session`/`remove_session`
- `src/backend/routers/voice.py` — all `voice_service` call sites awaited; `on_tool_call` audit kwargs fixed with `types.SimpleNamespace`
- `tests/unit/test_voice_tools.py` — `TestRedisSessionFallback` (7 tests): in-memory hit, cross-worker Redis fallback, Redis miss, Redis error, `remove_session` deletes key, `create_session` writes with TTL, failure raises + rolls back
- `tests/unit/test_voice_auth.py` — `TestVoiceAuditAttribution` (1 test): source inspection verifying no legacy kwargs, presence of `actor_user=`/`SimpleNamespace`
- `.claude/agents/test-runner.md` — catalog updated (45 voice unit tests total)
- `docs/memory/feature-flows/voice-chat.md` — VOICE-009 section documenting Redis dual-write pattern

## Test Plan

- [ ] New unit tests pass: `cd tests && source .venv/bin/activate && python -m pytest tests/unit/test_voice_tools.py tests/unit/test_voice_auth.py -v` → 45 collected, 42 passed, 3 pre-existing cross-stub failures
- [ ] Manual: start voice session, verify WebSocket connects without 403
- [ ] Manual: trigger a `run_task` tool call, verify audit log receives the entry at `GET /api/audit-log`

Fixes #704
Fixes #705

Generated with [Claude Code](https://claude.com/claude-code)