### PR TITLE
fix(voice): workspace panel flicker + Chart.js rendering in update_panel (#707)

### DIFF
--- a/docs/memory/feature-flows/voice-chat.md
+++ b/docs/memory/feature-flows/voice-chat.md
@@ -53,13 +53,13 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 │  │  bg-black               │  │  bg-gray-900 (canvas)         │   │
 │  │                         │  │                               │   │
 │  │  <canvas> orb (same     │  │  Panel content rendered via   │   │
-│  │   particle system as    │  │  show_markdown / update_panel │   │
-│  │   VoiceOverlay)         │  │  (DOMPurify-sanitized HTML or │   │
-│  │                         │  │   renderMarkdown())           │   │
-│  │  Status label           │  │                               │   │
-│  │  Tool name badge        │  │  Polled every 300ms via       │   │
-│  │  [Mute] [Start/End]     │  │  GET /voice/{sid}/panel       │   │
-│  │  Voice selector         │  │                               │   │
+│  │   particle system as    │  │  show_markdown → renderMarkdown│  │
+│  │   VoiceOverlay)         │  │  update_panel → DOMPurify +   │   │
+│  │                         │  │  _execScripts (Chart.js ok)   │   │
+│  │  Status label           │  │  Chart.js 4 pre-loaded        │   │
+│  │  Tool name badge        │  │                               │   │
+│  │  [Mute] [Start/End]     │  │  Polled 300ms; updated_at     │   │
+│  │  Voice selector         │  │  gate + in-flight guard       │   │
 │  └─────────────────────────┘  └───────────────────────────────┘   │
 └────────────────────────────────────────────────────────────────────┘
          │
@@ -249,8 +249,11 @@ Uvicorn runs `--workers 2` in production. HTTP requests (REST `/voice/start`, `/
 | Panel tools | `show_markdown`, `update_panel`, `append_to_panel`, `clear_panel` — handled in-process via `_execute_panel_tool()`, never forwarded to agent container |
 | Panel state | `VoiceSession.panel_state` dict (in-memory); type ∈ {empty, markdown, html}; content capped at `_PANEL_CONTENT_MAX=524288` (512 KB) |
 | Panel endpoint | `GET /api/agents/{name}/voice/{session_id}/panel` — returns empty state for missing sessions (no 404 during teardown window); ownership-gated (user_id + agent_name check, admin bypass) |
-| Frontend poll | `setInterval(fetchPanel, 300)` — stops on session end via `watch(voice.isActive)` |
-| XSS protection | `show_markdown` → `renderMarkdown()` (DOMPurify-wrapped); `update_panel`/`append_to_panel` → `DOMPurify.sanitize()` |
+| Frontend poll | `setInterval(fetchPanel, 300)` — in-flight guard (`panelFetching` flag) prevents overlapping requests; skips state update when `updated_at` unchanged (prevents 3×/sec Vue re-renders and preserves content after session ends) |
+| Content preservation | Panel content preserved on session end (poll stops, state not reset); reset on new session **start** via `resetPanelState()` |
+| HTML rendering | `update_panel`/`append_to_panel` → `ref="htmlPanelEl"` + `renderHtmlPanel()`: `DOMPurify.sanitize(html, {ADD_TAGS:['script']})` then `_execScripts()` re-clones `<script>` nodes as live DOM elements so Chart.js `new Chart(...)` calls execute |
+| Chart.js | Chart.js 4.4.0 pre-loaded globally via `injectChartJs()` on mount (CDN `<script>` tag injected once into `document.head`, guarded by `#chartjs-cdn` id check) |
+| XSS protection | `show_markdown` → `renderMarkdown()` (DOMPurify-wrapped); `update_panel` HTML — DOMPurify strips event handlers and `javascript:` hrefs; `<script>` tags are re-executed (Chart.js init) — trade-off: accepted per issue #707 security review, same trust level as agent MCP calls |
 | BETA indicator | Amber "BETA" badge in header button and page header |
 
 ---
@@ -392,18 +395,19 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 - ⏳ Multi-language voice with auto-detection
 - ⏳ Voice cloning / custom voice per agent
 
-### Phase 4: Workspace Mode ✅ Complete (2026-05-07, issue #699, BETA)
+### Phase 4: Workspace Mode ✅ Complete (2026-05-07, issue #699/#707, BETA)
 
 - ✅ Separate full-page workspace at `/agents/:name/workspace`
 - ✅ Split layout: orb (left) + canvas panel (right)
 - ✅ 4 panel tools: `show_markdown`, `update_panel`, `append_to_panel`, `clear_panel`
-- ✅ Panel content rendered safely (DOMPurify sanitization)
 - ✅ `voice_available` feature flag gates workspace button in AgentHeader
 - ✅ Panel ownership gate on REST endpoint
 - ✅ 512 KB content cap on accumulated `append_to_panel` content
-- ⏳ Persist panel state across session end
+- ✅ Panel flicker fixed: `updated_at` change-detection gate + in-flight fetch guard (#707)
+- ✅ Panel content preserved on session end; reset on new session start (#707)
+- ✅ Chart.js 4 pre-loaded; `update_panel` HTML with `<script>` tags executes correctly (#707)
 - ⏳ Export panel content as PDF/markdown
-- ⏳ Agent-controlled canvas with richer widgets (charts, code blocks)
+- ⏳ Multi-page / tabbed canvas
 
 ---
 

--- a/src/backend/services/gemini_voice.py
+++ b/src/backend/services/gemini_voice.py
@@ -103,6 +103,10 @@ Guidelines:
 - Use `show_markdown` by default. Reach for `update_panel` only when structure genuinely adds value.
 - Don't mirror every voice response in the panel — use it when structured content helps.
 - Clear when the topic changes significantly.
+
+Chart.js rule (for `update_panel` HTML):
+- Chart.js 4 is PRE-LOADED globally in the workspace. NEVER add a CDN `<script src>` tag for it — doing so causes a race condition and produces a blank chart.
+- Use `new Chart(...)` directly. Always give the canvas a fixed height: `<canvas id="c" style="max-height:380px"></canvas>`.
 """
 
 # Single tool declaration for all voice sessions

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -184,7 +184,7 @@
           <!-- HTML content -->
           <div
             v-else-if="panelState.type === 'html'"
-            v-html="sanitizedHtml"
+            ref="htmlPanelEl"
             class="text-gray-300 text-sm leading-relaxed"
           />
         </div>
@@ -195,7 +195,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
@@ -213,7 +213,9 @@ const voice = useVoiceSession(agentName)
 const agent = ref(null)
 const selectedVoice = ref('Kore')
 const panelState = ref({ type: 'empty', content: '', title: null, updated_at: null })
+const htmlPanelEl = ref(null)
 let panelPollTimer = null
+let panelFetching = false
 
 const VOICES = [
   { id: 'Kore',    label: 'Kore — Firm' },
@@ -230,10 +232,6 @@ const renderedContent = computed(() =>
   panelState.value.type === 'markdown' ? renderMarkdown(panelState.value.content || '') : ''
 )
 
-const sanitizedHtml = computed(() =>
-  panelState.value.type === 'html' ? DOMPurify.sanitize(panelState.value.content || '') : ''
-)
-
 const panelUpdatedAgo = computed(() => {
   if (!panelState.value.updated_at) return null
   const secs = Math.round((Date.now() - new Date(panelState.value.updated_at).getTime()) / 1000)
@@ -242,13 +240,47 @@ const panelUpdatedAgo = computed(() => {
   return `${Math.round(secs / 60)}m ago`
 })
 
+// ── HTML panel rendering ─────────────────────────────────────────────────────
+
+// Re-execute <script> tags after innerHTML assignment — v-html and innerHTML
+// both skip script execution. We clone each script node as a live element so
+// Chart.js initialisation code in update_panel HTML runs correctly.
+// Chart.js 4 is pre-loaded globally (see injectChartJs), so agents must NOT
+// add their own CDN <script src> tags.
+function _execScripts(container) {
+  Array.from(container.querySelectorAll('script')).forEach(old => {
+    const s = document.createElement('script')
+    Array.from(old.attributes).forEach(a => s.setAttribute(a.name, a.value))
+    s.textContent = old.textContent
+    old.replaceWith(s)
+  })
+}
+
+function renderHtmlPanel(html) {
+  const el = htmlPanelEl.value
+  if (!el) return
+  el.innerHTML = DOMPurify.sanitize(html, { ADD_TAGS: ['script'], ADD_ATTR: ['type'] })
+  _execScripts(el)
+}
+
+// Re-render HTML panel when panelState content changes
+watch(() => panelState.value, (state) => {
+  if (state.type === 'html') nextTick(() => renderHtmlPanel(state.content || ''))
+}, { deep: true })
+
 // ── Session lifecycle ────────────────────────────────────────────────────────
+
+function resetPanelState() {
+  panelState.value = { type: 'empty', content: '', title: null, updated_at: null }
+}
 
 async function toggleSession() {
   if (voice.isActive.value) {
     stopPanelPoll()
     await voice.stop()
+    // Content preserved in panelState — user can still read what the agent wrote
   } else {
+    resetPanelState()  // Clear previous session's content before starting new one
     await voice.start(null, selectedVoice.value, true) // workspace_mode = true
     startPanelPoll()
   }
@@ -270,19 +302,27 @@ function stopPanelPoll() {
 
 async function fetchPanel() {
   const sid = voice.voiceSessionId.value
-  if (!sid) return
+  if (!sid || panelFetching) return
+  panelFetching = true
   try {
     const r = await axios.get(
       `/api/agents/${agentName}/voice/${sid}/panel`,
       { headers: authStore.authHeader }
     )
-    panelState.value = r.data
+    // Only update state when content has actually changed — prevents 3x/sec
+    // Vue re-renders and avoids overwriting preserved content with empty state
+    // when the session ends and the backend returns the default empty response.
+    if (r.data.updated_at !== panelState.value.updated_at) {
+      panelState.value = r.data
+    }
   } catch (_) {
     // Ignore poll errors (session may have just ended)
+  } finally {
+    panelFetching = false
   }
 }
 
-// Stop poll when session ends naturally
+// Stop poll when session ends naturally (content is preserved in panelState)
 watch(() => voice.isActive.value, (active) => {
   if (!active) stopPanelPoll()
 })
@@ -516,7 +556,16 @@ function resizeCanvas() {
 
 watch(() => voice.status.value, (s) => { targetHueShift = STATE_HUE[s] ?? 0 })
 
+function injectChartJs() {
+  if (document.getElementById('chartjs-cdn')) return
+  const s = document.createElement('script')
+  s.id = 'chartjs-cdn'
+  s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js'
+  document.head.appendChild(s)
+}
+
 onMounted(async () => {
+  injectChartJs()
   await fetchAgent()
   currentSprites = buildSprites(0)
   initParticles()


### PR DESCRIPTION
## Summary

- **Panel flicker fixed**: `fetchPanel()` now compares `updated_at` timestamps and skips the Vue state write when content hasn't changed — eliminates 3×/sec re-renders. An in-flight guard (`panelFetching` flag) prevents overlapping 300ms requests.
- **Content preservation fixed**: Panel state is preserved on session end (user can keep reading); reset on new session **start** via `resetPanelState()`.
- **Charts fixed**: Replaced `v-html="sanitizedHtml"` with `ref="htmlPanelEl"` + `renderHtmlPanel()` — DOMPurify sanitizes then `_execScripts()` re-clones `<script>` nodes as live DOM so `new Chart(...)` calls in `update_panel` HTML execute correctly. Chart.js 4.4.0 pre-loaded globally via `injectChartJs()` on mount.
- **Instructions updated**: `WORKSPACE_PANEL_INSTRUCTIONS` documents the Chart.js pre-loaded rule (never add CDN `<script src>` tag).

## Changes

- `src/frontend/src/views/AgentWorkspace.vue` — all frontend fixes
- `src/backend/services/gemini_voice.py` — `WORKSPACE_PANEL_INSTRUCTIONS` docstring
- `docs/memory/feature-flows/voice-chat.md` — VOICE-008 section updated

## Test Plan

- [ ] Start workspace voice session — panel renders without flicker during active session
- [ ] Agent calls `show_markdown` — content appears and stays visible
- [ ] Agent calls `update_panel` with Chart.js HTML (`new Chart(...)`) — chart renders correctly
- [ ] End session — last panel content remains visible (not replaced by empty placeholder)
- [ ] Start new session — panel clears and shows empty state placeholder
- [ ] Rapid `update_panel` calls — no chart flicker or double-render

Fixes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)