### PR TITLE
fix(voice): test regression + Chart.js bundling + model default (#723)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}  # For Gemini-powered agents
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # For platform image generation (IMG-001)
+      - VOICE_MODEL=${VOICE_MODEL:-}  # Gemini Live model override (default: gemini-2.5-flash-native-audio-preview-12-2025)
       - GITHUB_PAT=${GITHUB_PAT:-}
       - HOST_TEMPLATES_PATH=${PWD}/config/agent-templates
       # OpenTelemetry Configuration (Optional)

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -109,7 +109,7 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "") or os.getenv("GOOGLE_API_KEY", 
 
 # Voice Chat Configuration (VOICE-001)
 VOICE_ENABLED = os.getenv("VOICE_ENABLED", "true").lower() == "true"
-VOICE_MODEL = os.getenv("VOICE_MODEL", "gemini-2.5-flash-native-audio-preview-12-2025")
+VOICE_MODEL = os.getenv("VOICE_MODEL", "models/gemini-3.1-flash-live-preview")
 VOICE_MAX_DURATION = int(os.getenv("VOICE_MAX_DURATION", "300"))  # seconds
 
 # Default GitHub Template Repositories

--- a/src/backend/services/gemini_voice.py
+++ b/src/backend/services/gemini_voice.py
@@ -105,7 +105,7 @@ Guidelines:
 - Clear when the topic changes significantly.
 
 Chart.js rule (for `update_panel` HTML):
-- Chart.js 4 is PRE-LOADED globally in the workspace. NEVER add a CDN `<script src>` tag for it — doing so causes a race condition and produces a blank chart.
+- Chart.js 4 is available as `window.Chart` in the workspace (bundled, no CDN needed). NEVER add a `<script src>` tag for it.
 - Use `new Chart(...)` directly. Always give the canvas a fixed height: `<canvas id="c" style="max-height:380px"></canvas>`.
 """
 

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -203,6 +203,7 @@ import { useVoiceSession } from '../composables/useVoiceSession'
 import { renderMarkdown } from '../utils/markdown'
 import DOMPurify from 'dompurify'
 import AgentAvatar from '../components/AgentAvatar.vue'
+import Chart from 'chart.js/auto'
 
 const route = useRoute()
 const authStore = useAuthStore()
@@ -309,10 +310,10 @@ async function fetchPanel() {
       `/api/agents/${agentName}/voice/${sid}/panel`,
       { headers: authStore.authHeader }
     )
-    // Only update state when content has actually changed — prevents 3x/sec
-    // Vue re-renders and avoids overwriting preserved content with empty state
-    // when the session ends and the backend returns the default empty response.
-    if (r.data.updated_at !== panelState.value.updated_at) {
+    // Only update when the agent has actually called a panel tool (updated_at
+    // is non-null) AND the timestamp changed. A null updated_at means "session
+    // not found or no tool ever called" — never overwrite real content with it.
+    if (r.data.updated_at !== null && r.data.updated_at !== panelState.value.updated_at) {
       panelState.value = r.data
     }
   } catch (_) {
@@ -556,16 +557,9 @@ function resizeCanvas() {
 
 watch(() => voice.status.value, (s) => { targetHueShift = STATE_HUE[s] ?? 0 })
 
-function injectChartJs() {
-  if (document.getElementById('chartjs-cdn')) return
-  const s = document.createElement('script')
-  s.id = 'chartjs-cdn'
-  s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js'
-  document.head.appendChild(s)
-}
-
 onMounted(async () => {
-  injectChartJs()
+  // Expose Chart globally so agent update_panel HTML snippets can call new Chart(...)
+  if (!window.Chart) window.Chart = Chart
   await fetchAgent()
   currentSprites = buildSprites(0)
   initParticles()

--- a/tests/unit/test_voice_auth.py
+++ b/tests/unit/test_voice_auth.py
@@ -27,6 +27,11 @@ import pytest
 # imports — otherwise database.py tries to mkdir /data on import.
 _TMP_DB = Path(tempfile.gettempdir()) / "trinity_test_voice_auth.db"
 os.environ.setdefault("TRINITY_DB_PATH", str(_TMP_DB))
+# Fix cross-module SECRET_KEY mismatch: test_voice_tools.py's _stub_config()
+# replaces sys.modules["config"] with a stub that hardcodes this same value.
+# Setting it here ensures the real config (loaded during collection) and the
+# stub (activated during tests) both sign/verify JWTs with the same key.
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-unit-tests")
 
 _BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
 if str(_BACKEND) not in sys.path:
@@ -105,8 +110,22 @@ def _stub_voice_service():
 
 def _stub_docker_service():
     mod = types.ModuleType("services.docker_service")
+    mod.docker_client = None
     mod.get_agent_container = MagicMock(return_value=None)
+    mod.get_agent_status_from_container = MagicMock()
+    mod.list_all_agents = MagicMock(return_value=[])
+    mod.get_agent_by_name = MagicMock(return_value=None)
+    mod.get_next_available_port = MagicMock(return_value=2222)
     sys.modules["services.docker_service"] = mod
+
+
+def _stub_template_service():
+    mod = types.ModuleType("services.template_service")
+    mod.get_github_template = MagicMock()
+    mod.clone_github_repo = MagicMock()
+    mod.extract_agent_credentials = MagicMock()
+    mod.generate_credential_files = MagicMock()
+    sys.modules["services.template_service"] = mod
 
 
 def _stub_platform_audit():
@@ -128,6 +147,7 @@ def _stub_platform_audit():
 
 _voice_service, _FakeVoiceSession = _stub_voice_service()
 _stub_docker_service()
+_stub_template_service()
 _stub_platform_audit()
 
 

--- a/tests/unit/test_voice_tools.py
+++ b/tests/unit/test_voice_tools.py
@@ -119,6 +119,11 @@ _stub_genai()
 _stub_config()
 _stub_services_package()
 
+# Evict any stale stub registered by test_voice_auth.py when both files run in
+# the same pytest session — that module installs a fake services.gemini_voice
+# for isolation, and without this eviction the real class is unreachable.
+sys.modules.pop("services.gemini_voice", None)
+
 # Now we can import the service
 from services.gemini_voice import (  # noqa: E402
     GeminiVoiceService, VoiceSession, _TOOL_PROMPT_MAX, _PANEL_CONTENT_MAX,


### PR DESCRIPTION
## Summary

- **#723 fix**: 45 voice unit tests now collect and pass — three test isolation bugs fixed in `test_voice_auth.py` and `test_voice_tools.py`
- **Chart.js CDN → bundle**: `AgentWorkspace.vue` now imports Chart.js from the npm package; removes the unreliable CDN script injection that caused blank charts under load
- **Panel refresh guard**: `fetchPanel` no longer overwrites existing panel content with the empty-state response returned after a session ends
- **VOICE_MODEL env passthrough**: `docker-compose.yml` exposes `VOICE_MODEL` so the default can be overridden without a code change; default updated to `models/gemini-3.1-flash-live-preview`

## Root causes fixed (#723)

| Bug | Root cause | Fix |
|-----|-----------|-----|
| `test_voice_auth.py` collection `ImportError` | `_stub_docker_service()` was missing `docker_client` + 4 other attrs; `services/__init__.py` cascade-failed during DB migration init | Add missing attrs + `_stub_template_service()` |
| `test_voice_auth.py` ownership tests 4001 instead of 4003 | `test_voice_tools.py` module-level `_stub_config()` replaced `sys.modules["config"]` with a stub with a different `SECRET_KEY`; JWT signature mismatch | Set `SECRET_KEY` env var in `test_voice_auth.py` before config loads, matching the stub's hardcoded value |
| `test_voice_tools.py` `ImportError: GeminiVoiceService` | Stale `services.gemini_voice` stub from `test_voice_auth.py` left in `sys.modules` blocked real import | One-line `sys.modules.pop` eviction before the import |

## Test Plan
- [x] `test_voice_auth.py` + `test_voice_tools.py`: 45/45 passed (verified in container)
- [x] No secrets in diff
- [x] No unrelated files staged

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)