### PR TITLE
fix(tests): fix test import drift — 0 collection errors, all 3 target files pass (#725)

### DIFF
--- a/tests/unit/test_agent_readiness_probe.py
+++ b/tests/unit/test_agent_readiness_probe.py
@@ -66,6 +66,7 @@ def wait_for_agent_ready(monkeypatch):
         "services.settings_service": types.SimpleNamespace(
             get_anthropic_api_key=None, get_github_pat=None,
             get_agent_full_capabilities=None,
+            get_agent_default_resources=None,  # added to lifecycle.py import (#725)
         ),
         "services.skill_service": types.SimpleNamespace(skill_service=None),
     }

--- a/tests/unit/test_monitoring_router_signatures.py
+++ b/tests/unit/test_monitoring_router_signatures.py
@@ -89,32 +89,30 @@ pytestmark = pytest.mark.unit
 # ── Importlib-load routers/monitoring.py without dragging in routers/__init__ ─
 
 def _load_monitoring_router():
-    """Load routers/monitoring.py directly.
+    """Load routers/monitoring.py directly with scoped dependency stubs.
 
     Going through `from routers import monitoring` would import 50+
     unrelated routers via routers/__init__.py.
 
-    Two sets of tests collected alphabetically before this file install
-    minimal stubs in sys.modules that persist across collection:
+    Several test files collected alphabetically before this one permanently
+    install minimal stubs in sys.modules at collection time:
 
-    * test_inter_agent_timeout_unit.py installs a fake `dependencies` stub
-      (via setdefault) that lacks require_admin / AuthorizedAgentByName.
-    * test_start_agent_skip_inject.py registers services.agent_service as a
-      bare package stub that lacks get_accessible_agents.
+    * test_inter_agent_timeout_unit.py: fake `dependencies` without require_admin.
+    * test_start_agent_skip_inject.py: bare services.agent_service without get_accessible_agents.
+    * test_inject_assigned_credentials.py: fastapi Mock, so @router.get() returns
+      a Mock instead of the original function.
 
-    We use patch.dict to install correct, typed stubs for the duration of
-    exec_module so FastAPI's route registration doesn't see MagicMock types
-    as Pydantic field types (which raises FastAPIError).
+    We use patch.dict to install correct stubs for the duration of exec_module
+    and recover real fastapi by briefly evicting the polluted entry.
 
     Type notes:
-    - AuthorizedAgentByName is Annotated[str, Depends(func)] → use `str`.
+    - AuthorizedAgentByName is Annotated[str, Depends(func)] → use `str` so
+      FastAPI treats it as a plain path parameter, not an unresolvable Pydantic type.
     - require_admin is a Depends callable → use a plain lambda.
     """
     _deps = types.ModuleType("dependencies")
     _deps.get_current_user = lambda: None
     _deps.require_admin = lambda: None
-    # Annotated[str, Depends(…)] → plain str so FastAPI treats it as a
-    # regular path parameter instead of an unresolvable Pydantic type.
     _deps.AuthorizedAgentByName = str
     _deps.OwnedAgentByName = str
     _deps.get_authorized_agent = lambda: None
@@ -130,6 +128,15 @@ def _load_monitoring_router():
     _mon_svc.stop_monitoring_service = MagicMock()
     _mon_svc.DEFAULT_CONFIG = {}
 
+    # test_inject_assigned_credentials.py permanently overwrites sys.modules['fastapi']
+    # with a Mock at collection time (sys.modules.update), causing @router.get() to
+    # return a Mock instead of the original function.  Evict the polluted entry briefly
+    # so `import fastapi` reloads from disk; then restore the Mock for other tests.
+    _saved_fastapi = sys.modules.pop("fastapi", None)
+    import fastapi as _real_fastapi  # noqa: PLC0415
+    if _saved_fastapi is not None:
+        sys.modules["fastapi"] = _saved_fastapi
+
     path = _BACKEND / "routers" / "monitoring.py"
     spec = importlib.util.spec_from_file_location("routers.monitoring", str(path))
     mod = importlib.util.module_from_spec(spec)
@@ -138,6 +145,7 @@ def _load_monitoring_router():
         "dependencies": _deps,
         "services.agent_service": _agent_svc,
         "services.monitoring_service": _mon_svc,
+        "fastapi": _real_fastapi,
     }):
         spec.loader.exec_module(mod)
     return mod

--- a/tests/unit/test_monitoring_router_signatures.py
+++ b/tests/unit/test_monitoring_router_signatures.py
@@ -26,7 +26,7 @@ import tempfile
 import types
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -93,12 +93,53 @@ def _load_monitoring_router():
 
     Going through `from routers import monitoring` would import 50+
     unrelated routers via routers/__init__.py.
+
+    Two sets of tests collected alphabetically before this file install
+    minimal stubs in sys.modules that persist across collection:
+
+    * test_inter_agent_timeout_unit.py installs a fake `dependencies` stub
+      (via setdefault) that lacks require_admin / AuthorizedAgentByName.
+    * test_start_agent_skip_inject.py registers services.agent_service as a
+      bare package stub that lacks get_accessible_agents.
+
+    We use patch.dict to install correct, typed stubs for the duration of
+    exec_module so FastAPI's route registration doesn't see MagicMock types
+    as Pydantic field types (which raises FastAPIError).
+
+    Type notes:
+    - AuthorizedAgentByName is Annotated[str, Depends(func)] → use `str`.
+    - require_admin is a Depends callable → use a plain lambda.
     """
+    _deps = types.ModuleType("dependencies")
+    _deps.get_current_user = lambda: None
+    _deps.require_admin = lambda: None
+    # Annotated[str, Depends(…)] → plain str so FastAPI treats it as a
+    # regular path parameter instead of an unresolvable Pydantic type.
+    _deps.AuthorizedAgentByName = str
+    _deps.OwnedAgentByName = str
+    _deps.get_authorized_agent = lambda: None
+
+    _agent_svc = types.ModuleType("services.agent_service")
+    _agent_svc.get_accessible_agents = MagicMock()
+
+    _mon_svc = types.ModuleType("services.monitoring_service")
+    _mon_svc.perform_health_check = MagicMock()
+    _mon_svc.perform_fleet_health_check = MagicMock()
+    _mon_svc.get_monitoring_service = MagicMock()
+    _mon_svc.start_monitoring_service = MagicMock()
+    _mon_svc.stop_monitoring_service = MagicMock()
+    _mon_svc.DEFAULT_CONFIG = {}
+
     path = _BACKEND / "routers" / "monitoring.py"
     spec = importlib.util.spec_from_file_location("routers.monitoring", str(path))
     mod = importlib.util.module_from_spec(spec)
     sys.modules["routers.monitoring"] = mod
-    spec.loader.exec_module(mod)
+    with patch.dict(sys.modules, {
+        "dependencies": _deps,
+        "services.agent_service": _agent_svc,
+        "services.monitoring_service": _mon_svc,
+    }):
+        spec.loader.exec_module(mod)
     return mod
 
 
@@ -143,8 +184,37 @@ class TestGetAccessibleAgentsSignature:
     """
 
     def test_helper_takes_single_user_param(self):
-        from services.agent_service.helpers import get_accessible_agents
+        # Load helpers.py DIRECTLY via importlib, bypassing services/agent_service/
+        # __init__.py.  test_start_agent_skip_inject.py permanently registers
+        # sys.modules['services.agent_service'] as a bare stub, so a normal
+        # `from services.agent_service.helpers import …` picks up the stub's
+        # MagicMock attribute rather than the real function.
+        helpers_path = str(_BACKEND / "services" / "agent_service" / "helpers.py")
+        _spec = importlib.util.spec_from_file_location(
+            "agent_service_helpers_sigcheck", helpers_path
+        )
+        _hmod = importlib.util.module_from_spec(_spec)
+        _docker_stub = types.SimpleNamespace(
+            docker_client=MagicMock(),
+            list_all_agents=MagicMock(),
+            list_all_agents_fast=MagicMock(),
+            get_agent_container=MagicMock(),
+        )
+        _settings_stub = types.SimpleNamespace(
+            get_anthropic_api_key=lambda: "sk-test",
+            get_github_pat=lambda: None,
+            get_agent_full_capabilities=lambda: False,
+            settings_service=MagicMock(),
+        )
+        with patch.dict(sys.modules, {
+            "services.docker_service": _docker_stub,
+            "services.docker_utils": types.SimpleNamespace(volume_get=MagicMock()),
+            "services.settings_service": _settings_stub,
+            "database": types.SimpleNamespace(db=MagicMock()),
+        }):
+            _spec.loader.exec_module(_hmod)
 
+        get_accessible_agents = _hmod.get_accessible_agents
         sig = inspect.signature(get_accessible_agents)
         params = list(sig.parameters.values())
         assert len(params) == 1, (

--- a/tests/unit/test_skill_service_user_agent.py
+++ b/tests/unit/test_skill_service_user_agent.py
@@ -52,12 +52,21 @@ for mod_name, attrs in [
             "get_skills_library_url": lambda: "https://github.com/owner/repo",
             "get_skills_library_branch": lambda: "main",
             "get_github_pat": lambda: None,
+            # Additional attrs needed by services.agent_service.helpers/lifecycle
+            # when those modules are transitively imported in the same pytest run.
+            "get_anthropic_api_key": lambda: "sk-test",
+            "get_agent_full_capabilities": lambda: False,
+            "get_agent_default_resources": lambda: {"cpu": "2", "memory": "4g"},
+            "settings_service": MagicMock(),
         },
     ),
     (
         "services.agent_client",
         {"get_agent_client": MagicMock(), "AgentClientError": Exception},
     ),
+    # sys.modules["utils"] points to tests/utils/ (needed for api_client/cleanup),
+    # not src/backend/utils/, so url_validation.py isn't found automatically.
+    ("utils.url_validation", {"validate_skills_library_url": lambda url: url}),
 ]:
     if mod_name not in sys.modules:
         m = _types.ModuleType(mod_name)


### PR DESCRIPTION
## Summary

- Fixes all collection errors reported in #725 by addressing 3 groups of import drift
- `pytest --collect-only` on the unit suite now shows **0 errors, 1347 tests collected** (was 2+ collection errors)
- All tests in the 3 modified files pass both in isolation and in the full suite

## Root Causes Fixed

**Group 1 — `test_monitoring_router_signatures.py`**

Three separate pollution sources all converge on this file when the full suite runs:
1. `test_inter_agent_timeout_unit.py` permanently installs a sparse `dependencies` stub missing `require_admin` / `AuthorizedAgentByName`
2. `test_start_agent_skip_inject.py` permanently registers a bare `services.agent_service` stub missing `get_accessible_agents`
3. `test_inject_assigned_credentials.py` permanently overwrites `sys.modules['fastapi']` with a Mock, causing `@router.get()` to return a Mock instead of the real function

Fix: rewrite `_load_monitoring_router()` to use `patch.dict` with correct typed stubs, and recover real fastapi by briefly evicting the polluted entry before re-importing from disk. Load `helpers.py` directly in the signature-pin test to bypass the stub package.

**Group 2 — `test_skill_service_user_agent.py`**

`skill_service.py` imports `from utils.url_validation import validate_skills_library_url`, but `sys.modules["utils"]` points to `tests/utils/` (not `src/backend/utils/`) because the test conftest sets it up that way. Also, the `services.settings_service` stub was missing attrs needed when `lifecycle.py` is transitively loaded in the same session.

Fix: add `utils.url_validation` stub to the stubs loop; add missing `settings_service` attrs.

**Group 3 — `test_agent_readiness_probe.py`**

`lifecycle.py` imports `get_agent_default_resources` from `services.settings_service`, but the fixture stub only provided 3 of the 4 needed names.

Fix: add `get_agent_default_resources=None` to the fixture's stub.

## Test Plan
- [x] `pytest tests/unit/test_monitoring_router_signatures.py tests/unit/test_skill_service_user_agent.py tests/unit/test_agent_readiness_probe.py` → 12 passed
- [x] `pytest tests/unit/ --collect-only` → 1347 collected, 0 errors
- [x] `pytest tests/unit/ -k "test_monitoring_router"` (full suite, pollution present) → 3 passed
- [x] No new failures introduced (49 pre-existing failures unchanged, verified via diff)

Fixes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)