### PR TITLE
fix: prevent accidental schedule re-enable via MCP update, expose retry config (#741)

### DIFF
--- a/src/backend/routers/schedules.py
+++ b/src/backend/routers/schedules.py
@@ -85,6 +85,9 @@ class ScheduleUpdateRequest(BaseModel):
     timeout_seconds: Optional[int] = None
     allowed_tools: Optional[List[str]] = None
     model: Optional[str] = None  # Model override (MODEL-001)
+    # Retry configuration (RETRY-001)
+    max_retries: Optional[int] = None
+    retry_delay_seconds: Optional[int] = None
     # Validation configuration (VALIDATE-001)
     validation_enabled: Optional[bool] = None
     validation_prompt: Optional[str] = None

--- a/src/mcp-server/src/tools/schedules.ts
+++ b/src/mcp-server/src/tools/schedules.ts
@@ -306,7 +306,12 @@ export function createScheduleTools(
         message: z.string().optional().describe("New task message"),
         timezone: z.string().optional().describe("New timezone"),
         description: z.string().optional().describe("New description"),
-        enabled: z.boolean().optional().describe("Enable/disable schedule"),
+        enabled: z.boolean().optional().describe(
+          "Enable or disable the schedule. WARNING: only include this field if you explicitly intend to " +
+          "change the enabled state. Omitting it leaves the current state unchanged. " +
+          "Prefer toggle_agent_schedule for toggling; setting enabled=true here will re-enable a " +
+          "previously disabled schedule."
+        ),
         timeout_seconds: z
           .number()
           .int()


### PR DESCRIPTION
## Summary

- Expanded `enabled` field description in `update_agent_schedule` MCP tool to explicitly warn AI models against including `enabled: true` when updating other schedule fields — prevents silent re-enabling of intentionally disabled schedules
- Added `max_retries` and `retry_delay_seconds` to `ScheduleUpdateRequest` Pydantic model so MCP retry-config updates are no longer silently dropped before reaching the DB layer

## Changes

- `src/mcp-server/src/tools/schedules.ts` — warn AI models to omit `enabled` unless changing state; prefer `toggle_agent_schedule` for toggling
- `src/backend/routers/schedules.py` — add missing `max_retries` / `retry_delay_seconds` to `ScheduleUpdateRequest`

## Test Plan

- [ ] Update a disabled schedule's cron expression via MCP — confirm schedule stays disabled
- [ ] Update `max_retries` via MCP — confirm it persists in the DB
- [ ] Toggle a schedule via `toggle_agent_schedule` — confirm still works
- [ ] Existing schedule tests pass

Fixes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)