### PR TITLE
ci(unit-suite): add per-PR + nightly regression gates (#715)

### DIFF
--- a/.github/workflows/backend-unit-nightly.yml
+++ b/.github/workflows/backend-unit-nightly.yml
@@ -235,59 +235,72 @@ jobs:
             }
 
             for (const p of paths) {
-              const status = JSON.parse(fs.readFileSync(p, 'utf8'));
-              const pr = status.pr_number;
-              const diffPath = `diff-pr${pr}.md`;
+              try {
+                const status = JSON.parse(fs.readFileSync(p, 'utf8'));
+                const pr = status.pr_number;
+                const diffPath = `diff-pr${pr}.md`;
 
-              let body;
-              if (status.merge_conflict) {
-                body = `${marker}\n⚠️ **Nightly unit-suite check skipped — merge conflict against \`dev\`.**\n\nResolve by running \`git merge dev\` locally and pushing the result. The next nightly run will re-test once the conflict is gone.`;
-              } else if (status.regression) {
-                let diffMd = '_diff artifact missing_';
-                if (fs.existsSync(diffPath)) {
-                  diffMd = fs.readFileSync(diffPath, 'utf8');
+                let body;
+                if (status.merge_conflict) {
+                  body = `${marker}\n⚠️ **Nightly unit-suite check skipped — merge conflict against \`dev\`.**\n\nResolve by running \`git merge dev\` locally and pushing the result. The next nightly run will re-test once the conflict is gone.`;
+                } else if (status.regression) {
+                  let diffMd = '_diff artifact missing_';
+                  if (fs.existsSync(diffPath)) {
+                    diffMd = fs.readFileSync(diffPath, 'utf8');
+                  }
+                  body = `${marker}\n⚠️ **Nightly unit-suite found regressions when this PR is merged into \`dev\`.**\n\n<details>\n<summary>Regression details (head_sha: \`${status.head_sha}\`)</summary>\n\n${diffMd}\n\n</details>\n\n_Reproduce locally:_ \`git merge dev && tests/run-core.sh\``;
+                } else {
+                  body = `${marker}\n✅ **Nightly unit-suite clean** when this PR is merged into \`dev\` (head_sha: \`${status.head_sha}\`).`;
                 }
-                body = `${marker}\n⚠️ **Nightly unit-suite found regressions when this PR is merged into \`dev\`.**\n\n<details>\n<summary>Regression details (head_sha: \`${status.head_sha}\`)</summary>\n\n${diffMd}\n\n</details>\n\n_Reproduce locally:_ \`git merge dev && tests/run-core.sh\``;
-              } else {
-                body = `${marker}\n✅ **Nightly unit-suite clean** when this PR is merged into \`dev\` (head_sha: \`${status.head_sha}\`).`;
-              }
 
-              // Find existing sticky comment by marker (paginated).
-              const existing = await github.paginate(
-                github.rest.issues.listComments,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr,
-                  per_page: 100,
-                }
-              );
-              const sticky = existing.find(c => (c.body || '').includes(marker));
+                // Find existing sticky comment by marker (paginated).
+                // Bot-author filter is required — without it, a user comment
+                // that quotes the marker would match, and the subsequent
+                // updateComment call would 403 (bots can only edit their
+                // own comments) and we'd never create a fresh sticky.
+                const existing = await github.paginate(
+                  github.rest.issues.listComments,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr,
+                    per_page: 100,
+                  }
+                );
+                const sticky = existing.find(c =>
+                  (c.body || '').includes(marker)
+                  && c.user
+                  && (c.user.type === 'Bot' || c.user.login === 'github-actions[bot]')
+                );
 
-              if (sticky) {
-                // Skip if body is unchanged — avoids no-op churn.
-                if (sticky.body === body) {
-                  core.info(`PR #${pr}: comment unchanged, skipping.`);
-                  continue;
+                if (sticky) {
+                  // Skip if body is unchanged — avoids no-op churn.
+                  if (sticky.body === body) {
+                    core.info(`PR #${pr}: comment unchanged, skipping.`);
+                    continue;
+                  }
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: sticky.id,
+                    body,
+                  });
+                  core.info(`PR #${pr}: updated sticky comment ${sticky.id}.`);
+                } else if (status.regression || status.merge_conflict) {
+                  // Only create on bad news. Don't spam every PR with a
+                  // green sticky comment on its first night.
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr,
+                    body,
+                  });
+                  core.info(`PR #${pr}: created sticky comment.`);
+                } else {
+                  core.info(`PR #${pr}: clean and no prior comment — nothing to post.`);
                 }
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: sticky.id,
-                  body,
-                });
-                core.info(`PR #${pr}: updated sticky comment ${sticky.id}.`);
-              } else if (status.regression || status.merge_conflict) {
-                // Only create on bad news. Don't spam every PR with a
-                // green sticky comment on its first night.
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr,
-                  body,
-                });
-                core.info(`PR #${pr}: created sticky comment.`);
-              } else {
-                core.info(`PR #${pr}: clean and no prior comment — nothing to post.`);
+              } catch (err) {
+                // Per-PR failure must not take out the rest of the matrix.
+                core.warning(`Failed to process ${p}: ${err.message}`);
               }
             }

--- a/.github/workflows/backend-unit-nightly.yml
+++ b/.github/workflows/backend-unit-nightly.yml
@@ -1,0 +1,293 @@
+name: backend-unit-nightly
+
+# Nightly fleet sweep over open PRs targeting `dev` (issue #715).
+#
+# For each open PR, attempts the merge into a scratch commit and runs the
+# 3-seed unit-suite diff. If the PR introduces new failures (or hits a merge
+# conflict), posts a sticky comment on the PR.
+#
+# Architecture (Codex finding 5 — untrusted PR code must never share a job
+# with a write-capable token):
+#
+#   discover (RO, lists open PRs)
+#       └─> test (RO, no creds, runs untrusted PR code)
+#               └─> comment (write, no checkout of PR code)
+#
+# Artifacts (diff Markdown + status JSON) are how `test` hands work to
+# `comment` without ever sharing a write token with the PR code.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # 06:00 UTC = 07:00 London
+  workflow_dispatch:
+
+# No top-level permissions — each job declares its own narrow scope.
+permissions: {}
+
+concurrency:
+  group: backend-unit-nightly
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    name: discover open PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
+      has_prs: ${{ steps.list.outputs.has_prs }}
+    steps:
+      - id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          prs=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --base dev \
+            --state open \
+            --limit 50 \
+            --json number,headRefName,headRefOid)
+          count=$(echo "$prs" | jq 'length')
+          if [ "$count" = "0" ]; then
+            echo "has_prs=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          matrix=$(echo "$prs" | jq -c '{include: [.[] | {
+            pr_number: .number,
+            head_ref: .headRefName,
+            head_sha: .headRefOid
+          }]}')
+          {
+            echo "has_prs=true"
+            echo "matrix<<MATRIX_EOF"
+            echo "$matrix"
+            echo "MATRIX_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  test:
+    name: pytest (PR #${{ matrix.pr_number }})
+    needs: discover
+    if: needs.discover.outputs.has_prs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - name: Checkout origin/dev (no PR creds)
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fetch PR head via fork-safe ref
+        # `pull/N/head` is GitHub's internal ref that works for both
+        # same-repo and fork PRs. `origin/<headRefName>` would only work
+        # for same-repo branches and could collide with base-repo branch
+        # names. (Codex finding 5 / 11.)
+        run: |
+          git fetch --depth=1 origin pull/${{ matrix.pr_number }}/head:pr-head
+
+      - name: Attempt merge into dev
+        id: merge
+        run: |
+          git config user.email "ci@trinity.local"
+          git config user.name  "trinity-ci"
+          if ! git merge --no-edit --no-ff pr-head; then
+            echo "merge_conflict=true" >> "$GITHUB_OUTPUT"
+            git merge --abort || true
+          else
+            echo "merge_conflict=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: tests/requirements-test.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements-test.txt 'pytest-randomly>=3.15.0'
+
+      - name: Diff-script self-test
+        run: python scripts/ci/diff-pytest-failures.py --self-test
+
+      - name: Run unit suite (base = origin/dev, head = merge commit)
+        if: steps.merge.outputs.merge_conflict == 'false'
+        run: |
+          set -euo pipefail
+          # Snapshot the merge commit so we can come back to it.
+          MERGE_SHA=$(git rev-parse HEAD)
+
+          # Base run = origin/dev tip, before merge.
+          git switch --detach origin/dev
+          for seed in 12345 67890 99999; do
+            ( cd tests && python -m pytest unit/ -m "not slow" \
+                -p randomly --randomly-seed=$seed \
+                --junit-xml="$GITHUB_WORKSPACE/junit-base-pr${{ matrix.pr_number }}-$seed.xml" \
+                --tb=no -q || true )
+          done
+
+          # Head run = merge commit.
+          git switch --detach "$MERGE_SHA"
+          for seed in 12345 67890 99999; do
+            ( cd tests && python -m pytest unit/ -m "not slow" \
+                -p randomly --randomly-seed=$seed \
+                --junit-xml="$GITHUB_WORKSPACE/junit-head-pr${{ matrix.pr_number }}-$seed.xml" \
+                --tb=no -q || true )
+          done
+
+      - name: Run regression diff
+        if: steps.merge.outputs.merge_conflict == 'false'
+        id: diff
+        run: |
+          set +e
+          python scripts/ci/diff-pytest-failures.py \
+            --base junit-base-pr${{ matrix.pr_number }}-*.xml \
+            --head junit-head-pr${{ matrix.pr_number }}-*.xml \
+            --out "diff-pr${{ matrix.pr_number }}.md"
+          rc=$?
+          if [ $rc -eq 0 ]; then
+            echo "regression=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "regression=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write status JSON
+        if: always()
+        run: |
+          merge_conflict='${{ steps.merge.outputs.merge_conflict }}'
+          regression='${{ steps.diff.outputs.regression }}'
+          # Default regression to "false" when merge conflicted (no diff ran).
+          if [ -z "$regression" ]; then regression="false"; fi
+          jq -n \
+            --arg pr "${{ matrix.pr_number }}" \
+            --arg head_sha "${{ matrix.head_sha }}" \
+            --arg merge_conflict "$merge_conflict" \
+            --arg regression "$regression" \
+            '{pr_number: ($pr|tonumber), head_sha: $head_sha,
+              merge_conflict: ($merge_conflict == "true"),
+              regression: ($regression == "true")}' \
+            > "status-pr${{ matrix.pr_number }}.json"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-pr-${{ matrix.pr_number }}
+          path: |
+            diff-pr${{ matrix.pr_number }}.md
+            status-pr${{ matrix.pr_number }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  comment:
+    name: post sticky comments
+    needs: [discover, test]
+    if: always() && needs.discover.outputs.has_prs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write           # PR conversation comments are issue comments
+      pull-requests: write
+    steps:
+      - name: Download all nightly artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-pr-*
+          merge-multiple: true
+
+      - name: List artifacts
+        id: list
+        run: |
+          set -euo pipefail
+          ls -la
+          # Enumerate status JSONs so the next step can iterate.
+          paths=$(ls status-pr*.json 2>/dev/null || true)
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$paths" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky comment per PR
+        uses: actions/github-script@v7
+        env:
+          PATHS: ${{ steps.list.outputs.paths }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const marker = '<!-- nightly-unit-suite -->';
+
+            const paths = (process.env.PATHS || '').split('\n').map(s => s.trim()).filter(Boolean);
+            if (paths.length === 0) {
+              core.info('No status JSONs found — nothing to comment on.');
+              return;
+            }
+
+            for (const p of paths) {
+              const status = JSON.parse(fs.readFileSync(p, 'utf8'));
+              const pr = status.pr_number;
+              const diffPath = `diff-pr${pr}.md`;
+
+              let body;
+              if (status.merge_conflict) {
+                body = `${marker}\n⚠️ **Nightly unit-suite check skipped — merge conflict against \`dev\`.**\n\nResolve by running \`git merge dev\` locally and pushing the result. The next nightly run will re-test once the conflict is gone.`;
+              } else if (status.regression) {
+                let diffMd = '_diff artifact missing_';
+                if (fs.existsSync(diffPath)) {
+                  diffMd = fs.readFileSync(diffPath, 'utf8');
+                }
+                body = `${marker}\n⚠️ **Nightly unit-suite found regressions when this PR is merged into \`dev\`.**\n\n<details>\n<summary>Regression details (head_sha: \`${status.head_sha}\`)</summary>\n\n${diffMd}\n\n</details>\n\n_Reproduce locally:_ \`git merge dev && tests/run-core.sh\``;
+              } else {
+                body = `${marker}\n✅ **Nightly unit-suite clean** when this PR is merged into \`dev\` (head_sha: \`${status.head_sha}\`).`;
+              }
+
+              // Find existing sticky comment by marker (paginated).
+              const existing = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr,
+                  per_page: 100,
+                }
+              );
+              const sticky = existing.find(c => (c.body || '').includes(marker));
+
+              if (sticky) {
+                // Skip if body is unchanged — avoids no-op churn.
+                if (sticky.body === body) {
+                  core.info(`PR #${pr}: comment unchanged, skipping.`);
+                  continue;
+                }
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: sticky.id,
+                  body,
+                });
+                core.info(`PR #${pr}: updated sticky comment ${sticky.id}.`);
+              } else if (status.regression || status.merge_conflict) {
+                // Only create on bad news. Don't spam every PR with a
+                // green sticky comment on its first night.
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr,
+                  body,
+                });
+                core.info(`PR #${pr}: created sticky comment.`);
+              } else {
+                core.info(`PR #${pr}: clean and no prior comment — nothing to post.`);
+              }
+            }

--- a/.github/workflows/backend-unit-nightly.yml
+++ b/.github/workflows/backend-unit-nightly.yml
@@ -88,6 +88,18 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Stash trusted diff script (pre-merge)
+        # Workspace is unmodified origin/dev at this point. Copy the
+        # diff utility to a stable path BEFORE the merge so that a
+        # malicious PR modifying scripts/ci/diff-pytest-failures.py
+        # can't make the gate silently green by always-exit-0.
+        # CSO finding (defense-in-depth): nightly comments are the
+        # cross-PR signal reviewers consume, so the diff script must
+        # be tamper-evident relative to the PR being tested.
+        run: |
+          mkdir -p "$HOME/.ci-tools"
+          cp scripts/ci/diff-pytest-failures.py "$HOME/.ci-tools/diff-pytest-failures.py"
+
       - name: Fetch PR head via fork-safe ref
         # `pull/N/head` is GitHub's internal ref that works for both
         # same-repo and fork PRs. `origin/<headRefName>` would only work
@@ -119,8 +131,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r tests/requirements-test.txt 'pytest-randomly>=3.15.0'
 
-      - name: Diff-script self-test
-        run: python scripts/ci/diff-pytest-failures.py --self-test
+      - name: Diff-script self-test (trusted copy)
+        run: python "$HOME/.ci-tools/diff-pytest-failures.py" --self-test
 
       - name: Run unit suite (base = origin/dev, head = merge commit)
         if: steps.merge.outputs.merge_conflict == 'false'
@@ -147,12 +159,12 @@ jobs:
                 --tb=no -q || true )
           done
 
-      - name: Run regression diff
+      - name: Run regression diff (trusted copy)
         if: steps.merge.outputs.merge_conflict == 'false'
         id: diff
         run: |
           set +e
-          python scripts/ci/diff-pytest-failures.py \
+          python "$HOME/.ci-tools/diff-pytest-failures.py" \
             --base junit-base-pr${{ matrix.pr_number }}-*.xml \
             --head junit-head-pr${{ matrix.pr_number }}-*.xml \
             --out "diff-pr${{ matrix.pr_number }}.md"

--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -1,0 +1,124 @@
+name: backend-unit-test
+
+# Per-PR unit-suite regression gate (issue #715).
+#
+# Runs the backend unit suite under three pytest-randomly seeds against both
+# `base` (the PR's target branch tip) and `head` (the PR's merge commit), then
+# diffs the union of failing test IDs. Fails the check if `head` introduces
+# any new failing test ID that was not failing in `base` under any seed, or
+# if any pytest run produced no JUnit XML (fail-closed on infra failure).
+#
+# Trigger manually via the Actions tab (workflow_dispatch) for backfill.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [dev, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: backend-unit-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (${{ matrix.side }}, seed ${{ matrix.seed }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        side: [base, head]
+        seed: [12345, 67890, 99999]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `pull_request` checks out the synthetic merge commit by default
+          # (perfect for `side: head`). For `side: base` we explicitly fetch
+          # and detach onto the target-branch tip below.
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Switch to base branch tip (when side=base)
+        if: matrix.side == 'base'
+        run: |
+          git fetch --depth=1 origin "${{ github.base_ref || 'dev' }}"
+          git switch --detach FETCH_HEAD
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: tests/requirements-test.txt
+
+      - name: Install test dependencies
+        # pytest-randomly is installed in-workflow only — adding it to
+        # tests/requirements-test.txt would silently randomize
+        # tests/run-core.sh and any local contributor pytest invocation,
+        # because pytest auto-discovers installed plugins.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements-test.txt 'pytest-randomly>=3.15.0'
+
+      - name: Diff-script self-test
+        run: python scripts/ci/diff-pytest-failures.py --self-test
+
+      - name: Run unit suite
+        # || true: the existing 34 failures + 17 errors documented in #660
+        # produce a non-zero pytest exit. The diff job (`diff` below) is
+        # what fails this workflow on regression.
+        run: |
+          cd tests
+          python -m pytest unit/ -m "not slow" \
+            -p randomly --randomly-seed=${{ matrix.seed }} \
+            --junit-xml="$GITHUB_WORKSPACE/junit-${{ matrix.side }}-${{ matrix.seed }}.xml" \
+            --tb=no -q || true
+
+      - name: Upload JUnit XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-${{ matrix.side }}-${{ matrix.seed }}
+          path: junit-${{ matrix.side }}-${{ matrix.seed }}.xml
+          if-no-files-found: error
+          retention-days: 14
+
+  diff:
+    name: regression diff
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Download all JUnit artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: junit-*
+          merge-multiple: true
+
+      - name: Diff base vs head
+        run: |
+          python scripts/ci/diff-pytest-failures.py \
+            --base junit-base-12345.xml \
+                   junit-base-67890.xml \
+                   junit-base-99999.xml \
+            --head junit-head-12345.xml \
+                   junit-head-67890.xml \
+                   junit-head-99999.xml \
+            --out "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -38,17 +38,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # `pull_request` checks out the synthetic merge commit by default
-          # (perfect for `side: head`). For `side: base` we explicitly fetch
-          # and detach onto the target-branch tip below.
+          # `pull_request` checks out the synthetic merge commit by default.
+          # We capture the diff script before any branch switch so it
+          # survives the base-side checkout below (where scripts/ci/ may
+          # not yet exist on the target branch).
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Switch to base branch tip (when side=base)
-        if: matrix.side == 'base'
+      - name: Stash diff script (survives branch switch)
         run: |
-          git fetch --depth=1 origin "${{ github.base_ref || 'dev' }}"
-          git switch --detach FETCH_HEAD
+          mkdir -p "$HOME/.ci-tools"
+          cp scripts/ci/diff-pytest-failures.py "$HOME/.ci-tools/diff-pytest-failures.py"
 
       - uses: actions/setup-python@v5
         with:
@@ -66,7 +66,13 @@ jobs:
           pip install -r tests/requirements-test.txt 'pytest-randomly>=3.15.0'
 
       - name: Diff-script self-test
-        run: python scripts/ci/diff-pytest-failures.py --self-test
+        run: python "$HOME/.ci-tools/diff-pytest-failures.py" --self-test
+
+      - name: Switch to base branch tip (when side=base)
+        if: matrix.side == 'base'
+        run: |
+          git fetch --depth=1 origin "${{ github.base_ref || 'dev' }}"
+          git switch --detach FETCH_HEAD
 
       - name: Run unit suite
         # || true: the existing 34 failures + 17 errors documented in #660

--- a/scripts/ci/diff-pytest-failures.py
+++ b/scripts/ci/diff-pytest-failures.py
@@ -1,0 +1,300 @@
+"""JUnit XML regression diff for the unit-suite CI gate (issue #715).
+
+Compares the union of failing tests in --base XMLs against the union in --head
+XMLs. Exits 1 if --head introduces any new failing test ID OR if any input XML
+is missing/unparseable/empty (fail-closed on infrastructure failure).
+
+Test identity is (classname, name, kind) where kind is "failure" (assertion)
+or "error" (collection / fixture crash). Tracking kind separately matters
+because the unit suite has 17 collection errors today and "known failure
+flips to collection error" is a real regression class.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+import textwrap
+import xml.etree.ElementTree as ET
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+TestId = tuple[str, str, str]  # (classname, name, kind)
+
+
+@dataclass
+class XmlSummary:
+    path: Path
+    failures: set[TestId] = field(default_factory=set)
+    pass_count: int = 0
+    fail_count: int = 0
+    error_count: int = 0
+    skip_count: int = 0
+    total: int = 0
+    parse_error: str | None = None
+
+
+def _parse_one(path: Path) -> XmlSummary:
+    """Parse a single JUnit XML. Returns a summary with failures set populated.
+
+    A summary with parse_error set OR total == 0 is treated as infrastructure
+    failure by the caller.
+    """
+    summary = XmlSummary(path=path)
+    if not path.exists():
+        summary.parse_error = f"file does not exist: {path}"
+        return summary
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as exc:
+        summary.parse_error = f"unparseable XML: {exc}"
+        return summary
+
+    root = tree.getroot()
+    testcases = list(root.iter("testcase"))
+    summary.total = len(testcases)
+
+    for tc in testcases:
+        classname = tc.get("classname", "")
+        name = tc.get("name", "")
+        failure = tc.find("failure")
+        error = tc.find("error")
+        skipped = tc.find("skipped")
+        if failure is not None:
+            summary.failures.add((classname, name, "failure"))
+            summary.fail_count += 1
+        elif error is not None:
+            summary.failures.add((classname, name, "error"))
+            summary.error_count += 1
+        elif skipped is not None:
+            summary.skip_count += 1
+        else:
+            summary.pass_count += 1
+    return summary
+
+
+def _format_test_id(test_id: TestId) -> str:
+    classname, name, kind = test_id
+    sigil = "F" if kind == "failure" else "E"
+    full = f"{classname}::{name}" if classname else name
+    return f"[{sigil}] {full}"
+
+
+def _render_summary(
+    base_summaries: list[XmlSummary],
+    head_summaries: list[XmlSummary],
+    regressions: set[TestId],
+    fixes: set[TestId],
+    infra_failures: list[str],
+) -> str:
+    lines = ["# Backend unit-suite regression diff", ""]
+
+    if infra_failures:
+        lines.append("## ⚠️ Infrastructure failures")
+        lines.append("")
+        for msg in infra_failures:
+            lines.append(f"- {msg}")
+        lines.append("")
+
+    lines.append("## Per-XML totals")
+    lines.append("")
+    lines.append("| Side | Path | Total | Pass | Fail | Error | Skip |")
+    lines.append("|---|---|---:|---:|---:|---:|---:|")
+    for label, summaries in (("base", base_summaries), ("head", head_summaries)):
+        for s in summaries:
+            lines.append(
+                f"| {label} | `{s.path.name}` | {s.total} | {s.pass_count} | "
+                f"{s.fail_count} | {s.error_count} | {s.skip_count} |"
+            )
+    lines.append("")
+
+    if regressions:
+        lines.append(f"## ❌ New failures introduced by HEAD ({len(regressions)})")
+        lines.append("")
+        lines.append("Tests failing under HEAD that did not fail under BASE in any seed:")
+        lines.append("")
+        for test_id in sorted(regressions):
+            lines.append(f"- {_format_test_id(test_id)}")
+        lines.append("")
+    else:
+        lines.append("## ✅ No new failures")
+        lines.append("")
+
+    if fixes:
+        lines.append(f"## 🟢 Failures fixed by HEAD ({len(fixes)})")
+        lines.append("")
+        for test_id in sorted(fixes):
+            lines.append(f"- {_format_test_id(test_id)}")
+        lines.append("")
+
+    lines.append(
+        "_Legend: [F] = assertion failure, [E] = collection or fixture error._"
+    )
+    lines.append(
+        "_Identity = (classname, name, kind); union taken across all input XMLs._"
+    )
+    return "\n".join(lines)
+
+
+def diff(
+    base_paths: Iterable[Path],
+    head_paths: Iterable[Path],
+) -> tuple[str, int]:
+    """Returns (summary_markdown, exit_code)."""
+    base_paths = list(base_paths)
+    head_paths = list(head_paths)
+    base_summaries = [_parse_one(p) for p in base_paths]
+    head_summaries = [_parse_one(p) for p in head_paths]
+
+    infra_failures: list[str] = []
+    for s in (*base_summaries, *head_summaries):
+        if s.parse_error is not None:
+            infra_failures.append(f"`{s.path}`: {s.parse_error}")
+        elif s.total == 0:
+            infra_failures.append(f"`{s.path}`: zero testcases — pytest likely crashed before collection")
+
+    base_known: set[TestId] = set().union(*(s.failures for s in base_summaries)) if base_summaries else set()
+    head_known: set[TestId] = set().union(*(s.failures for s in head_summaries)) if head_summaries else set()
+
+    regressions = head_known - base_known
+    fixes = base_known - head_known
+
+    summary_md = _render_summary(
+        base_summaries, head_summaries, regressions, fixes, infra_failures
+    )
+
+    if infra_failures or regressions:
+        return summary_md, 1
+    return summary_md, 0
+
+
+def _write_xml(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).strip())
+
+
+def _build_xml(testcases: str) -> str:
+    return f'<?xml version="1.0" encoding="utf-8"?><testsuite>{testcases}</testsuite>'
+
+
+def _run_self_test() -> int:
+    """In-process tests covering the load-bearing edge cases."""
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        # Case 1: clean diff (identical sets) → exit 0
+        passing = _build_xml('<testcase classname="t" name="ok"/>')
+        with_failure = _build_xml(
+            '<testcase classname="t" name="bad"><failure/></testcase>'
+            '<testcase classname="t" name="ok"/>'
+        )
+        (tmp_path / "base1.xml").write_text(with_failure)
+        (tmp_path / "head1.xml").write_text(with_failure)
+        _, code = diff([tmp_path / "base1.xml"], [tmp_path / "head1.xml"])
+        if code != 0:
+            failures.append(f"case 1 (identical): expected 0, got {code}")
+
+        # Case 2: head introduces a new failure → exit 1
+        head2 = _build_xml(
+            '<testcase classname="t" name="bad"><failure/></testcase>'
+            '<testcase classname="t" name="new_bad"><failure/></testcase>'
+        )
+        (tmp_path / "head2.xml").write_text(head2)
+        md, code = diff([tmp_path / "base1.xml"], [tmp_path / "head2.xml"])
+        if code != 1:
+            failures.append(f"case 2 (new failure): expected 1, got {code}")
+        if "new_bad" not in md:
+            failures.append("case 2: regression list missing new_bad")
+
+        # Case 3: head fixes a failure → exit 0
+        _, code = diff([tmp_path / "head2.xml"], [tmp_path / "base1.xml"])
+        if code != 0:
+            failures.append(f"case 3 (fix only): expected 0, got {code}")
+
+        # Case 4: failure flips to error in head → exit 1 (different kind = different identity)
+        head4 = _build_xml(
+            '<testcase classname="t" name="bad"><error/></testcase>'
+            '<testcase classname="t" name="ok"/>'
+        )
+        (tmp_path / "head4.xml").write_text(head4)
+        md, code = diff([tmp_path / "base1.xml"], [tmp_path / "head4.xml"])
+        if code != 1:
+            failures.append(f"case 4 (failure→error): expected 1, got {code}")
+        if "[E] t::bad" not in md:
+            failures.append("case 4: regression list missing [E] t::bad")
+
+        # Case 5: missing XML → infra failure → exit 1
+        _, code = diff([tmp_path / "does-not-exist.xml"], [tmp_path / "base1.xml"])
+        if code != 1:
+            failures.append(f"case 5 (missing): expected 1, got {code}")
+
+        # Case 6: unparseable XML → infra failure → exit 1
+        (tmp_path / "broken.xml").write_text("this is not xml <<<")
+        _, code = diff([tmp_path / "broken.xml"], [tmp_path / "base1.xml"])
+        if code != 1:
+            failures.append(f"case 6 (unparseable): expected 1, got {code}")
+
+        # Case 7: zero testcases (pytest crashed before collection) → infra failure → exit 1
+        (tmp_path / "empty.xml").write_text(_build_xml(""))
+        _, code = diff([tmp_path / "empty.xml"], [tmp_path / "base1.xml"])
+        if code != 1:
+            failures.append(f"case 7 (zero testcases): expected 1, got {code}")
+
+        # Case 8: union de-noising — failure under base seed B is "known" → not a regression
+        base8a = _build_xml('<testcase classname="t" name="flake"><failure/></testcase>')
+        base8b = _build_xml('<testcase classname="t" name="flake"/>')
+        head8 = _build_xml('<testcase classname="t" name="flake"><failure/></testcase>')
+        (tmp_path / "base8a.xml").write_text(base8a)
+        (tmp_path / "base8b.xml").write_text(base8b)
+        (tmp_path / "head8.xml").write_text(head8)
+        _, code = diff(
+            [tmp_path / "base8a.xml", tmp_path / "base8b.xml"], [tmp_path / "head8.xml"]
+        )
+        if code != 0:
+            failures.append(f"case 8 (union de-noise): expected 0, got {code}")
+
+    if failures:
+        print("SELF-TEST FAILURES:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("self-test OK (8/8 cases pass)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base", nargs="*", type=Path, default=[], help="Baseline JUnit XML files"
+    )
+    parser.add_argument(
+        "--head", nargs="*", type=Path, default=[], help="Head (PR) JUnit XML files"
+    )
+    parser.add_argument(
+        "--out", type=Path, default=None, help="Write Markdown summary to this path"
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run in-process correctness tests on synthetic XMLs and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_test()
+
+    if not args.base or not args.head:
+        parser.error("--base and --head are required (unless --self-test)")
+
+    summary_md, exit_code = diff(args.base, args.head)
+    print(summary_md)
+    if args.out is not None:
+        args.out.write_text(summary_md + "\n")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #715.

## Summary

Two new GitHub Actions workflows that surface the dev-merge residual
class of regressions earlier than reviewer time, plus a small JUnit XML
diff utility they share.

- `backend-unit-test.yml` — per-PR gate. Runs the backend unit suite
  under three `pytest-randomly` seeds against both the PR's base-branch
  tip and its merge commit, then diffs the union of failing test IDs.
  Fails the check on new failures or missing JUnit XML (fail-closed on
  infrastructure failure).
- `backend-unit-nightly.yml` — cron 06:00 UTC sweep over open PRs
  targeting `dev`. Split into three jobs so untrusted PR code never
  shares a job with a write-capable token: `discover` (read-only) →
  `test` (read-only, no creds, fetches `pull/N/head` for fork-safe
  resolution) → `comment` (write, no PR-code checkout). Posts sticky
  regression comments idempotently via `github-script` + paginated
  marker search.
- `scripts/ci/diff-pytest-failures.py` — stdlib-only JUnit XML diff.
  Tracks `<failure>` and `<error>` kinds separately, fails closed on
  missing/unparseable/empty XMLs, ships an in-process `--self-test`
  mode (8 cases covering identity, regression, fix-only, kind-flip,
  missing, unparseable, empty, and union de-noising). The workflows
  invoke `--self-test` before the real diff to fail early on broken
  tooling.

`pytest-randomly` is installed in-workflow only — adding it to
`tests/requirements-test.txt` would silently randomize
`tests/run-core.sh` since pytest auto-discovers installed plugins.

## Out of scope (per #715)

Fixing the 34 unit-test failures + 17 collection errors in the existing
baseline. Those belong to the #660 follow-up; this gate is the entry
point that surfaces them. The diff is informational on the existing
baseline (`base_known` ≈ `head_known`) until #660 progresses.

## Test plan

- [ ] `python3 scripts/ci/diff-pytest-failures.py --self-test` exits 0 locally
- [ ] On this PR: `backend-unit-test / test (base, *)` and `(head, *)` matrix legs all start in parallel
- [ ] `backend-unit-test / diff` aggregator runs and posts a step summary with regressions table
- [ ] Overall check is green (calibration: PR is CI-only, introduces no test regressions)
- [ ] Manually trigger nightly via Actions tab `workflow_dispatch` after merge — confirm `discover` lists open PRs, `test` matrix runs per-PR, `comment` posts sticky entries
- [ ] Re-trigger nightly to validate sticky-comment idempotency (existing comment is updated, not duplicated)

Plan archived at `~/.claude/plans/system-instruction-you-are-working-playful-stream.md`; reviewed via `/autoplan` (Codex eng voice, NEEDS-REWORK → 10 findings addressed; consensus + audit trail in plan footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)