### PR TITLE
ci(schema): schema.py vs migrations.py parity gate (#713)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -170,6 +170,7 @@ The test suite covers:
 - **System Manifest** (test_systems.py) - Multi-agent deployment from YAML, permissions, folders, schedules, tags (Req 10.7, ORG-001)
 - **System Views** (test_system_views.py) - [TESTS NEEDED] System view CRUD, agent_count, auto-creation from manifest (ORG-001)
 - **Local Deployment** (test_deploy_local.py) - Deploy local agents via MCP (Req 11.2)
+- **Schema Parity** (unit/test_schema_parity.py) - Diff `init_schema()` vs full `init_database()` lifecycle on in-memory SQLite. Catches drift in tables/columns (with type comparison)/indexes/triggers (#713) [UNIT]
 - **Public Links** (test_public_links.py) - Public agent sharing; email verification is driven by agent-level access policy (#311 follow-up, 2026-04-13) (Req 11.3)
 - **Public User Memory** (test_public_user_memory.py) - Per-user persistent memory for email-verified public sessions (MEM-001) [SMOKE]
 - **Site Proxy** (test_site_proxy.py) - Agent website proxy via /site/{token}/{path}; link_type field, URL format, token validation, 502 on no web server, redirect (SITE-001, #633)
@@ -267,6 +268,16 @@ Use these thresholds to assess test health (based on **executed** tests, not inc
 - **Healthy**: >90% pass rate, 0 critical failures
 - **Warning**: 75-90% pass rate, <5 failures
 - **Critical**: <75% pass rate or >5 failures
+
+## Recent Test Additions (2026-05-09)
+
+| Test File | Description | Tests Added |
+|-----------|-------------|-------------|
+| `unit/test_schema_parity.py` | Schema drift CI gate (#713) — `TestSchemaParity` builds two in-memory SQLite snapshots: `schema_snapshot` (`init_schema()` only) and `production_snapshot` (full `init_database()` lifecycle: `run_all_migrations` → `init_schema` → `run_all_migrations`). Diffs tables/columns (with type drift)/indexes/triggers. Module-scoped fixtures so each DB is built once. The full lifecycle (vs `init_schema` → migrations) is required so short-circuit migrations like `_migrate_audit_log_table` (`migrations.py:1356-1364`) can't hide schema.py omissions of indexes/triggers. Triggers `schema_migrations` table is the only allow-listed difference. Out of scope: NOT NULL/DEFAULT/FK/CHECK constraint drift, trigger BODY drift, reverse-direction drift (schema.py edited without a migration). Wired into CI via `.github/workflows/schema-parity.yml` (path-filtered to `src/backend/db/**`, `src/backend/utils/helpers.py`, `tests/requirements-test.txt`). | 4 tests (file total 4) |
+
+Local: `pytest tests/unit/test_schema_parity.py -v` → expected 4 passed in ~0.2s. Synthetic-failure smoke (verified): commenting out `idx_audit_log_timestamp` from `schema.py` causes only `test_no_missing_indexes` to fail with a clear `schema.py drift detected` message naming the missing index.
+
+---
 
 ## Recent Test Additions (2026-05-07)
 

--- a/.github/workflows/schema-parity.yml
+++ b/.github/workflows/schema-parity.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     paths:
       - 'src/backend/db/**'
+      - 'src/backend/database.py'
       - 'src/backend/utils/helpers.py'
       - 'tests/unit/test_schema_parity.py'
       - 'tests/requirements-test.txt'
@@ -25,6 +26,7 @@ on:
     branches: [main, dev]
     paths:
       - 'src/backend/db/**'
+      - 'src/backend/database.py'
       - 'src/backend/utils/helpers.py'
       - 'tests/unit/test_schema_parity.py'
       - 'tests/requirements-test.txt'

--- a/.github/workflows/schema-parity.yml
+++ b/.github/workflows/schema-parity.yml
@@ -41,10 +41,12 @@ jobs:
       - name: Run schema parity check
         env:
           # Migration _migrate_slack_bot_token_encryption (migrations.py:1898)
-          # imports services.credential_encryption which checks
-          # CREDENTIAL_ENCRYPTION_KEY. Use a dummy in CI — in-memory DB never
-          # persists encrypted bytes, so the key is unused at runtime.
-          CREDENTIAL_ENCRYPTION_KEY: "test-ci-only-not-real-key-not-used"
+          # imports services.credential_encryption. The key is only accessed
+          # if the migration encrypts a row — which never happens on an empty
+          # in-memory DB. Use a valid-hex placeholder (64 chars of zeros) so
+          # any future code path that DOES call encrypt() produces a real
+          # test failure instead of a "key format" crypto error.
+          CREDENTIAL_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
           # Backend config.py raises at import if REDIS_URL lacks credentials
           # (#589/#645). Set creds-bearing dummies; same pattern tests/unit/conftest.py uses.
           REDIS_URL: "redis://test:test@redis:6379"

--- a/.github/workflows/schema-parity.yml
+++ b/.github/workflows/schema-parity.yml
@@ -1,0 +1,53 @@
+name: Schema Parity Gate
+
+# Issue #713: fail PRs that add a migration to src/backend/db/migrations.py
+# without updating src/backend/db/schema.py to match. Runs the
+# tests/unit/test_schema_parity.py pytest suite, which builds two in-memory
+# SQLite snapshots (schema-only vs full init_database lifecycle) and diffs
+# tables/columns/indexes/triggers.
+
+on:
+  pull_request:
+    paths:
+      - 'src/backend/db/**'
+      - 'src/backend/utils/helpers.py'
+      - 'tests/unit/test_schema_parity.py'
+      - 'tests/requirements-test.txt'
+      - '.github/workflows/schema-parity.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'src/backend/db/**'
+      - 'src/backend/utils/helpers.py'
+      - 'tests/unit/test_schema_parity.py'
+      - 'tests/requirements-test.txt'
+      - '.github/workflows/schema-parity.yml'
+
+jobs:
+  schema-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'tests/requirements-test.txt'
+
+      - name: Install test deps
+        run: pip install -r tests/requirements-test.txt
+
+      - name: Run schema parity check
+        env:
+          # Migration _migrate_slack_bot_token_encryption (migrations.py:1898)
+          # imports services.credential_encryption which checks
+          # CREDENTIAL_ENCRYPTION_KEY. Use a dummy in CI — in-memory DB never
+          # persists encrypted bytes, so the key is unused at runtime.
+          CREDENTIAL_ENCRYPTION_KEY: "test-ci-only-not-real-key-not-used"
+          # Backend config.py raises at import if REDIS_URL lacks credentials
+          # (#589/#645). Set creds-bearing dummies; same pattern tests/unit/conftest.py uses.
+          REDIS_URL: "redis://test:test@redis:6379"
+          REDIS_PASSWORD: "test"
+          REDIS_BACKEND_PASSWORD: "test"
+        run: pytest tests/unit/test_schema_parity.py -v --tb=short

--- a/.github/workflows/schema-parity.yml
+++ b/.github/workflows/schema-parity.yml
@@ -5,6 +5,13 @@ name: Schema Parity Gate
 # tests/unit/test_schema_parity.py pytest suite, which builds two in-memory
 # SQLite snapshots (schema-only vs full init_database lifecycle) and diffs
 # tables/columns/indexes/triggers.
+#
+# MAINTAINER NOTE: do NOT add this job to required-status-checks in branch
+# protection until it has been green for ~1 week of normal PR traffic.
+# Otherwise any path-filter false-negative (e.g. a future module move that
+# bypasses the filter) would brick PRs that don't touch DB files. The
+# workflow self-skips on unrelated PRs (no path match -> no run -> no
+# required check needed) so leaving it optional is safe.
 
 on:
   pull_request:

--- a/tests/unit/test_schema_parity.py
+++ b/tests/unit/test_schema_parity.py
@@ -1,0 +1,172 @@
+"""
+Schema Parity Test (test_schema_parity.py)
+
+Issue #713 — Fail PRs that add a migration without updating schema.py.
+
+Builds two in-memory SQLite snapshots and asserts they match:
+
+  DB_schema = init_schema(empty)                                # canonical declarative
+  DB_full   = run_all_migrations() + init_schema() + run_all_migrations()  # init_database() lifecycle
+
+If ``schema.py`` is faithful, the two snapshots are identical (modulo the
+``schema_migrations`` tracker table that ``run_all_migrations`` creates
+internally). Any drift fails with a clear message naming the offending
+table / column / index / trigger.
+
+The full ``init_database()`` lifecycle is required: many migrations
+short-circuit when their target table already exists (e.g.
+``_migrate_audit_log_table`` at ``migrations.py:1356-1364`` returns early
+when ``audit_log`` exists). Running migrations on an empty DB *first*
+forces each migration to create the full table+indexes+triggers it
+intended to, exposing schema.py omissions that the early-return would
+otherwise hide.
+"""
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+
+
+def _load_module(rel_path: str, name: str):
+    path = _BACKEND / rel_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_schema_mod = _load_module("db/schema.py", "schema_for_parity")
+_migrations_mod = _load_module("db/migrations.py", "migrations_for_parity")
+init_schema = _schema_mod.init_schema
+run_all_migrations = _migrations_mod.run_all_migrations
+
+pytestmark = pytest.mark.unit
+
+# Tracker table that ``run_all_migrations`` creates internally; ``schema.py``
+# is not expected to define it.
+INTERNAL_TABLES = {"schema_migrations"}
+
+
+def _snapshot(cursor: sqlite3.Cursor) -> dict:
+    """Return ``{tables, columns, indexes, triggers}`` for the open DB."""
+    tables = {
+        row[0]
+        for row in cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+    } - INTERNAL_TABLES
+
+    # PRAGMA table_info returns (cid, name, type, notnull, dflt_value, pk).
+    # Map name -> type, uppercased so "INTEGER" / "integer" / "Int" compare equal.
+    columns: dict[str, dict[str, str]] = {}
+    for table in tables:
+        cursor.execute(f"PRAGMA table_info({table})")
+        columns[table] = {row[1]: (row[2] or "").upper() for row in cursor.fetchall()}
+
+    indexes = {
+        row[0]
+        for row in cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name NOT LIKE 'sqlite_%' "
+            "AND tbl_name NOT IN ('schema_migrations')"
+        ).fetchall()
+        if row[0] is not None
+    }
+
+    triggers = {
+        row[0]
+        for row in cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' "
+            "AND tbl_name NOT IN ('schema_migrations')"
+        ).fetchall()
+    }
+
+    return {
+        "tables": tables,
+        "columns": columns,
+        "indexes": indexes,
+        "triggers": triggers,
+    }
+
+
+@pytest.fixture(scope="module")
+def schema_snapshot() -> dict:
+    """Snapshot of ``init_schema()`` on an empty DB — the canonical declarative state."""
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    init_schema(cur, conn)
+    return _snapshot(cur)
+
+
+@pytest.fixture(scope="module")
+def production_snapshot() -> dict:
+    """Snapshot of the full ``init_database()`` lifecycle:
+    ``run_all_migrations`` -> ``init_schema`` -> ``run_all_migrations``.
+
+    Mirrors ``src/backend/database.py:139-164`` exactly. The first migrations
+    pass on an empty DB lets every migration create the table+indexes+triggers
+    it intended to, exposing any short-circuit-hidden drift in schema.py.
+    """
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    run_all_migrations(cur, conn)
+    init_schema(cur, conn)
+    run_all_migrations(cur, conn)
+    return _snapshot(cur)
+
+
+class TestSchemaParity:
+    """``schema.py`` must be a faithful encoding of ``init_database()``'s end state."""
+
+    def test_no_missing_tables(self, schema_snapshot: dict, production_snapshot: dict) -> None:
+        missing = sorted(production_snapshot["tables"] - schema_snapshot["tables"])
+        assert not missing, (
+            "schema.py drift detected: tables exist after init_database() but "
+            f"not in init_schema(): {missing}. Add CREATE TABLE definitions "
+            "to src/backend/db/schema.py."
+        )
+
+    def test_no_missing_columns(self, schema_snapshot: dict, production_snapshot: dict) -> None:
+        missing_cols: list[str] = []
+        type_drift: list[str] = []
+        for table, prod_cols in production_snapshot["columns"].items():
+            schema_cols = schema_snapshot["columns"].get(table, {})
+            for col_name, prod_type in prod_cols.items():
+                if col_name not in schema_cols:
+                    missing_cols.append(f"{table}.{col_name} ({prod_type})")
+                elif schema_cols[col_name] != prod_type:
+                    type_drift.append(
+                        f"{table}.{col_name}: schema.py={schema_cols[col_name]} "
+                        f"vs migrations={prod_type}"
+                    )
+        assert not missing_cols, (
+            "schema.py drift detected: columns exist after init_database() but "
+            "not in init_schema():\n  " + "\n  ".join(missing_cols)
+            + "\nAdd them to the CREATE TABLE in src/backend/db/schema.py."
+        )
+        assert not type_drift, (
+            "schema.py drift detected: column types differ between "
+            "init_schema() and migrations:\n  " + "\n  ".join(type_drift)
+            + "\nUpdate src/backend/db/schema.py to match the migration's type."
+        )
+
+    def test_no_missing_indexes(self, schema_snapshot: dict, production_snapshot: dict) -> None:
+        missing = sorted(production_snapshot["indexes"] - schema_snapshot["indexes"])
+        assert not missing, (
+            "schema.py drift detected: indexes exist after init_database() but "
+            f"not in init_schema(): {missing}. Add CREATE INDEX statements "
+            "to src/backend/db/schema.py."
+        )
+
+    def test_no_missing_triggers(self, schema_snapshot: dict, production_snapshot: dict) -> None:
+        missing = sorted(production_snapshot["triggers"] - schema_snapshot["triggers"])
+        assert not missing, (
+            "schema.py drift detected: triggers exist after init_database() but "
+            f"not in init_schema(): {missing}. Add CREATE TRIGGER statements "
+            "to src/backend/db/schema.py."
+        )


### PR DESCRIPTION
## Summary

Closes #713 — adds a CI gate that fails any PR whose `init_database()` boot path produces tables, columns, indexes, or triggers that aren't declared in `init_schema()` alone.

Two artifacts:
- **`tests/unit/test_schema_parity.py`** — pytest, in-memory SQLite, marked `@pytest.mark.unit`. Picks up automatically in `tests/run-core.sh` line 21.
- **`.github/workflows/schema-parity.yml`** — path-filtered GitHub Actions job (runs on `src/backend/db/**`, `utils/helpers.py`, the test, the workflow, and `tests/requirements-test.txt`).

## How it works

Builds two in-memory SQLite snapshots and asserts equality:

| Snapshot | Build sequence |
|---|---|
| `DB_schema` | empty → `init_schema()` |
| `DB_full` | empty → `run_all_migrations()` → `init_schema()` → `run_all_migrations()` (mirrors `database.py:139-164`) |

If `schema.py` is faithful, the two are identical (modulo the `schema_migrations` tracker table). Diff covers tables, columns + types (via `PRAGMA table_info`), indexes, triggers.

**Why the full lifecycle, not just `init_schema → migrations`:** several migrations short-circuit when their target table already exists (e.g. `_migrate_audit_log_table` at `migrations.py:1356-1364` returns early on `audit_log` exists). Running migrations on an empty DB *first* forces them to create everything they intended — exposing schema.py omissions that the early-return would otherwise hide.

## Plan & dual-voice review

This was planned with `/autoplan` (Codex + Claude subagent dual voices for CEO + Eng phases). Codex flagged a CRITICAL bug in the original draft — `init_schema → migrations` ordering missed the audit_log short-circuit class. The plan was revised to mirror `init_database()` exactly. Other findings folded in: per-column type comparison (vs brittle DDL text parity), triggers in snapshot, expanded path filter.

## Out of scope (documented in the test docstring)

- Reverse-direction drift (schema.py edited without a corresponding migration) — different invariant; remains a code-review concern.
- Constraint-level drift (NOT NULL, DEFAULT, FK, CHECK) — `PRAGMA table_info` returns this data but adding it balloons false-positive rates from SQLite's stored-DDL formatting. Future work.
- Trigger BODY drift (existence is checked; body content is not).
- Collapsing the two-source-of-truth into one (Alembic, generated DDL) — explicitly out of scope per #713; will be filed as a P3 follow-up issue.

## Test plan

- [x] Local: `pytest tests/unit/test_schema_parity.py -v` → 4 passed in 1.59s (PR #712 already backfilled; no drift today)
- [x] Synthetic-failure smoke: comment out one `CREATE INDEX` in `schema.py` → only `test_no_missing_indexes` fails with `schema.py drift detected: indexes exist after init_database() but not in init_schema(): ['idx_audit_log_timestamp']` and a remediation hint pointing at `src/backend/db/schema.py`. Restore → 4 passed.
- [ ] CI: this PR's `Schema Parity Gate` job should run + pass.

## Maintainer note

Do **not** add `Schema Parity Gate` to the required-status-checks list in branch protection until it's been green for ~1 week. Otherwise any path-filter false-negative would brick PRs that don't touch DB files. The workflow self-skips on unrelated PRs (no path match → no run → no required check needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)