### PR TITLE
fix(tests): fix sys.modules leaks causing 47 cross-file test errors (#752)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -167,7 +167,7 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 - `docker_service.py` - Docker container management
 - `docker_utils.py` - Docker utility helpers
 - `template_service.py` - GitHub template cloning and processing
-- `agent_client.py` - HTTP client for agent container communication (chat, session, injection)
+- `agent_client.py` - HTTP client for agent container communication (chat, session, injection); Redis-backed circuit breaker with exponential backoff + dormant state (#631)
 - `settings_service.py` - Centralized settings retrieval (API keys, ops config, agent quotas)
 
 *Execution & Scheduling:*

--- a/tests/test_ip_rate_limit_fix.py
+++ b/tests/test_ip_rate_limit_fix.py
@@ -26,11 +26,16 @@ BASE_URL = "http://localhost:8000"
 # Helpers to load the router module without a full FastAPI app
 # ---------------------------------------------------------------------------
 
-def _load_public_router():
-    """Import the public router and return its module."""
-    # Add backend to path
-    backend_path = os.path.join(os.path.dirname(__file__), "..", "src", "backend")
-    backend_path = os.path.abspath(backend_path)
+def _load_public_router(monkeypatch):
+    """Import the public router and return its module.
+
+    Uses ``monkeypatch`` for every ``sys.modules`` mutation so that pytest
+    automatically restores the original module state after each test.  Without
+    this, the minimal fastapi stub (which lacks ``status``, ``security``, etc.)
+    would leak into subsequent test files and cause ImportErrors in any module
+    that does ``from fastapi import status``.
+    """
+    backend_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src", "backend"))
     if backend_path not in sys.path:
         sys.path.insert(0, backend_path)
 
@@ -46,12 +51,12 @@ def _load_public_router():
         routers_pkg = types.ModuleType("routers")
         routers_pkg.__path__ = [os.path.join(backend_path, "routers")]
         routers_pkg.__package__ = "routers"
-        sys.modules["routers"] = routers_pkg
+        monkeypatch.setitem(sys.modules, "routers", routers_pkg)
 
-    # Stub fastapi unconditionally so that response_model= annotations on
-    # router decorators in routers/public.py don't trigger real Pydantic
-    # validation when loaded in a combined pytest session (where
-    # test_inter_agent_timeout_unit.py already imported the real FastAPI).
+    # Stub fastapi. routers/public.py only needs APIRouter, Depends,
+    # HTTPException, and Request at module load time.  We stub `dependencies`
+    # directly (below) so the transitive chain that needs fastapi.status and
+    # fastapi.security never runs.
     fastapi_mod = types.ModuleType("fastapi")
     fastapi_mod.APIRouter = MagicMock(return_value=MagicMock())
     fastapi_mod.HTTPException = Exception
@@ -59,21 +64,20 @@ def _load_public_router():
     fastapi_mod.Depends = MagicMock()
     fastapi_mod.exceptions = types.ModuleType("fastapi.exceptions")
     fastapi_mod.routing = types.ModuleType("fastapi.routing")
-    sys.modules["fastapi"] = fastapi_mod
-    sys.modules["fastapi.exceptions"] = fastapi_mod.exceptions
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi_mod)
+    monkeypatch.setitem(sys.modules, "fastapi.exceptions", fastapi_mod.exceptions)
 
     fr_mod = types.ModuleType("fastapi.responses")
     fr_mod.StreamingResponse = MagicMock()
-    sys.modules["fastapi.responses"] = fr_mod
+    monkeypatch.setitem(sys.modules, "fastapi.responses", fr_mod)
 
-    # Application-level stubs.
-    # Use setdefault for most stubs (don't overwrite stubs other test files
-    # installed for their own purposes), EXCEPT for `database` which must
-    # always be a MagicMock so that `from database import X` works when
-    # loading routers/public.py.  test_inter_agent_timeout_unit.py installs
-    # a types.SimpleNamespace (not a MagicMock) via setdefault, which does
-    # not support attribute-access style imports.
-    sys.modules["database"] = MagicMock()
+    # Stub application modules that routers/public.py imports directly.
+    # `database` and `dependencies` must be unconditional (not setdefault)
+    # because other test files may have installed incompatible stubs.
+    monkeypatch.setitem(sys.modules, "database", MagicMock())
+    monkeypatch.setitem(sys.modules, "dependencies", MagicMock())
+    monkeypatch.setitem(sys.modules, "models", MagicMock())
+
     stubs = {
         "routers.auth": MagicMock(
             check_login_rate_limit=MagicMock(),
@@ -84,13 +88,17 @@ def _load_public_router():
         "services.task_execution_service": MagicMock(),
         "services.platform_prompt_service": MagicMock(),
         "services.settings_service": MagicMock(),
+        "services.upload_service": MagicMock(),
     }
     for name, stub in stubs.items():
-        sys.modules.setdefault(name, stub)
+        # Use unconditional setitem (not setdefault) so that module-level stubs
+        # installed by other test files at import time don't shadow our stubs.
+        # monkeypatch restores the original value after each test.
+        monkeypatch.setitem(sys.modules, name, stub)
 
     # Force a fresh load of routers.public every call so module-level state
     # (e.g. _trusted_proxy_networks) is reset cleanly.
-    sys.modules.pop("routers.public", None)
+    monkeypatch.delitem(sys.modules, "routers.public", raising=False)
     import routers.public as pub  # noqa: E402
     return pub
 
@@ -103,8 +111,8 @@ class TestIsTrustedProxy:
     """Test the trusted-proxy network matching logic."""
 
     @pytest.fixture(autouse=True)
-    def load_module(self):
-        self.pub = _load_public_router()
+    def load_module(self, monkeypatch):
+        self.pub = _load_public_router(monkeypatch)
         # Reset cached networks so env changes are picked up
         self.pub._trusted_proxy_networks = None
 
@@ -163,8 +171,8 @@ class TestGetClientIp:
     """Test the _get_client_ip function against the pentest scenario."""
 
     @pytest.fixture(autouse=True)
-    def load_module(self):
-        self.pub = _load_public_router()
+    def load_module(self, monkeypatch):
+        self.pub = _load_public_router(monkeypatch)
         self.pub._trusted_proxy_networks = None
 
     def test_direct_connection_ignores_xff(self):
@@ -231,12 +239,14 @@ def auth_headers():
 class TestPerTokenRateLimit:
     """Verify the per-token secondary rate limit constant is configured."""
 
+    @pytest.fixture(autouse=True)
+    def load_module(self, monkeypatch):
+        self.pub = _load_public_router(monkeypatch)
+
     def test_max_messages_per_token_constant_exists(self):
-        pub = _load_public_router()
-        assert hasattr(pub, "MAX_CHAT_MESSAGES_PER_TOKEN")
-        assert pub.MAX_CHAT_MESSAGES_PER_TOKEN > 0
+        assert hasattr(self.pub, "MAX_CHAT_MESSAGES_PER_TOKEN")
+        assert self.pub.MAX_CHAT_MESSAGES_PER_TOKEN > 0
 
     def test_rate_limit_constants_reasonable(self):
         """Per-token limit must be >= per-IP limit (token covers all IPs)."""
-        pub = _load_public_router()
-        assert pub.MAX_CHAT_MESSAGES_PER_TOKEN >= pub.MAX_CHAT_MESSAGES_PER_IP
+        assert self.pub.MAX_CHAT_MESSAGES_PER_TOKEN >= self.pub.MAX_CHAT_MESSAGES_PER_IP

--- a/tests/unit/test_sync_health_service.py
+++ b/tests/unit/test_sync_health_service.py
@@ -16,6 +16,7 @@ import asyncio
 import importlib.util
 import sqlite3
 import sys
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -61,8 +62,18 @@ def tmp_db(tmp_path, monkeypatch):
     # DatabaseManager singleton especially) sees the new DB path.
     for modname in list(sys.modules):
         if modname == "database" or modname.startswith("db.") \
-                or modname == "services.sync_health_service":
+                or modname == "services.sync_health_service" \
+                or modname == "services.agent_client":
             sys.modules.pop(modname, None)
+    # Install a stub for services.agent_client. The real module requires
+    # docker/redis; all tests patch _fetch_git_status so AgentClient is never
+    # actually called. Using monkeypatch ensures the stub is removed after each
+    # test, preventing contamination of subsequent test files.
+    monkeypatch.setitem(
+        sys.modules,
+        "services.agent_client",
+        types.SimpleNamespace(AgentClient=MagicMock()),
+    )
     yield db_path
 
 


### PR DESCRIPTION
## Summary

- `test_ip_rate_limit_fix.py` permanently overwrote `sys.modules[\"fastapi\"]` with a stripped stub (no `status`, `security`, or other attrs) and never restored it, causing `ImportError: cannot import name 'status' from 'fastapi'` in every test that ran after it in the same session — 47 errors across the 7 files listed in #752
- `test_sync_health_service.py` failed after `test_fleet_status_resilience.py` because the latter installed a `SimpleNamespace` stub for `services.agent_client` without `AgentClient`, breaking `sync_health_service.py`'s module-level import

## Changes

- **`tests/test_ip_rate_limit_fix.py`**: Refactored `_load_public_router()` to accept `monkeypatch` and use `monkeypatch.setitem` for all `sys.modules` mutations (fastapi, fastapi.*, database, dependencies, models, all service stubs). Added missing `dependencies`, `models`, and `services.upload_service` stubs that were causing the transitive import chain to fail. Added autouse `load_module` fixture to `TestPerTokenRateLimit` (previously called `_load_public_router()` directly with no cleanup).
- **`tests/unit/test_sync_health_service.py`**: Extended `tmp_db` fixture to evict and re-stub `services.agent_client` via `monkeypatch`, ensuring a clean `AgentClient`-bearing stub is always present when `sync_health_service.py` is imported, regardless of what prior test files installed.

## Test Plan

- [x] All 7 previously-erroring files pass individually
- [x] All 60 tests pass when all 7 files run together: `pytest tests/test_ip_rate_limit_fix.py tests/unit/test_login_rate_limit_split.py tests/unit/test_webhook_rate_limit_inprocess.py tests/unit/test_webhook_rate_limit_toctou.py tests/unit/test_fleet_status_resilience.py tests/unit/test_sync_health_service.py tests/test_github_pat_propagation_unit.py`
- [x] `pytest tests/ --collect-only` reports 0 collection errors for all 7 files (only 3 pre-existing unrelated errors remain: trinity_cli ×2, twilio ×1)
- [x] No regressions in broader unit test suite

Fixes #752

Generated with [Claude Code](https://claude.com/claude-code)