### PR TITLE
fix(tests): set credentialed REDIS_URL in scheduler config test fixtures (#755)

### DIFF
--- a/tests/scheduler_tests/test_config.py
+++ b/tests/scheduler_tests/test_config.py
@@ -9,16 +9,19 @@ from unittest.mock import patch
 from scheduler.config import SchedulerConfig
 
 
+_TEST_REDIS_URL = "redis://test:testpassword@localhost:6379"
+
+
 class TestSchedulerConfig:
     """Tests for SchedulerConfig."""
 
     def test_default_values(self):
         """Test that default config values are set correctly."""
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {"REDIS_URL": _TEST_REDIS_URL}, clear=True):
             config = SchedulerConfig()
 
             assert config.database_path == "/data/trinity.db"
-            assert config.redis_url == "redis://redis:6379"
+            assert config.redis_url == _TEST_REDIS_URL
             assert config.lock_timeout == 600
             assert config.lock_auto_renewal is True
             assert config.health_port == 8001
@@ -28,7 +31,7 @@ class TestSchedulerConfig:
         """Test that environment variables override defaults."""
         env = {
             "DATABASE_PATH": "/custom/path.db",
-            "REDIS_URL": "redis://custom:6380",
+            "REDIS_URL": "redis://test:testpassword@custom:6380",
             "LOCK_TIMEOUT": "120",
             "LOCK_AUTO_RENEWAL": "false",
             "HEALTH_PORT": "9000",
@@ -38,7 +41,7 @@ class TestSchedulerConfig:
             config = SchedulerConfig.from_env()
 
             assert config.database_path == "/custom/path.db"
-            assert config.redis_url == "redis://custom:6380"
+            assert config.redis_url == "redis://test:testpassword@custom:6380"
             assert config.lock_timeout == 120
             assert config.lock_auto_renewal is False
             assert config.health_port == 9000
@@ -46,18 +49,18 @@ class TestSchedulerConfig:
 
     def test_agent_timeout(self):
         """Test agent timeout configuration."""
-        with patch.dict(os.environ, {"AGENT_TIMEOUT": "1800"}, clear=True):
+        with patch.dict(os.environ, {"REDIS_URL": _TEST_REDIS_URL, "AGENT_TIMEOUT": "1800"}, clear=True):
             config = SchedulerConfig()
             assert config.agent_timeout == 1800.0
 
     def test_publish_events_default(self):
         """Test event publishing is enabled by default."""
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {"REDIS_URL": _TEST_REDIS_URL}, clear=True):
             config = SchedulerConfig()
             assert config.publish_events is True
 
     def test_publish_events_disabled(self):
         """Test event publishing can be disabled."""
-        with patch.dict(os.environ, {"PUBLISH_EVENTS": "false"}, clear=True):
+        with patch.dict(os.environ, {"REDIS_URL": _TEST_REDIS_URL, "PUBLISH_EVENTS": "false"}, clear=True):
             config = SchedulerConfig()
             assert config.publish_events is False


### PR DESCRIPTION
## Summary
- Adds `_TEST_REDIS_URL = "redis://test:testpassword@localhost:6379"` constant to `test_config.py`
- Injects it into each test's `patch.dict` env so `SchedulerConfig()` passes the credential validation added in Issue #589
- Updates `test_default_values` assertion and `test_env_override` REDIS_URL to use credentialed URLs

## Changes
- `tests/scheduler_tests/test_config.py` — 5 tests updated

## Test Plan
- [x] `pytest tests/scheduler_tests/test_config.py -v` → 5 passed, 0 failed
- [x] `pytest tests/scheduler_tests/ -v` → 162 passed, 0 failed

Fixes #755

Generated with [Claude Code](https://claude.com/claude-code)