### PR TITLE
fix(executions): close CB probe executions on fast-fail and backend shutdown (#767)

### DIFF
--- a/src/backend/routers/internal.py
+++ b/src/backend/routers/internal.py
@@ -16,7 +16,8 @@ from pydantic import BaseModel
 from typing import Optional, Dict, List
 import logging
 
-from models import ActivityState, ActivityType, ShareFileRequest, ShareFileResponse
+from database import db
+from models import ActivityState, ActivityType, ShareFileRequest, ShareFileResponse, TaskExecutionStatus
 from services.activity_service import activity_service
 from services.task_execution_service import get_task_execution_service
 from services.platform_audit_service import platform_audit_service, AuditEventType
@@ -332,9 +333,6 @@ async def _execute_task_internal_background(task_service, request: InternalTaskE
     tracking, DB updates, and cleanup. This wrapper logs outcomes and ensures
     execution status is updated on any uncaught exception (fixes issue #90).
     """
-    from database import db
-    from models import TaskExecutionStatus
-
     try:
         result = await task_service.execute_task(
             agent_name=request.agent_name,
@@ -351,6 +349,28 @@ async def _execute_task_internal_background(task_service, request: InternalTaskE
             f"Async task completed for {request.agent_name}: "
             f"status={result.status}, execution_id={result.execution_id}"
         )
+    except asyncio.CancelledError:
+        # Python 3.11+: CancelledError is BaseException, bypasses except Exception.
+        # On backend shutdown, in-flight background tasks are cancelled; close the
+        # record synchronously so cleanup_service doesn't inflate duration (#767).
+        if request.execution_id:
+            try:
+                existing = db.get_execution(request.execution_id)
+                if existing and existing.status not in (
+                    TaskExecutionStatus.SUCCESS,
+                    TaskExecutionStatus.FAILED,
+                    TaskExecutionStatus.CANCELLED,
+                ):
+                    db.update_execution_status(
+                        execution_id=request.execution_id,
+                        status=TaskExecutionStatus.FAILED,
+                        error="Execution cancelled (backend shutdown)",
+                    )
+                    logger.info(f"Updated execution {request.execution_id} to FAILED on cancel")
+            except Exception as db_err:
+                logger.error(f"Failed to update execution status on cancel: {db_err}")
+        raise
+
     except Exception as e:
         # If an exception escapes TaskExecutionService, ensure execution is marked failed
         # to prevent stuck 'running' status (fixes issue #90)

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -29,6 +29,7 @@ import httpx
 from database import db
 from models import ActivityState, ActivityType, TaskExecutionStatus
 from services.activity_service import activity_service
+from services.agent_client import CircuitState
 from services.capacity_manager import CapacityFull, get_capacity_manager
 from utils.credential_sanitizer import sanitize_execution_log, sanitize_response
 from services.platform_prompt_service import (
@@ -58,6 +59,7 @@ class TaskExecutionErrorCode(str, Enum):
     BILLING = "billing"             # Rate limit, credit, or billing issue
     AGENT_ERROR = "agent_error"     # Agent returned non-zero exit code
     NETWORK = "network"             # HTTP/connection error to agent container
+    CIRCUIT_OPEN = "circuit_open"   # Circuit breaker open — agent known unhealthy (#767)
 
 
 @dataclass
@@ -366,7 +368,37 @@ class TaskExecutionService:
                 )
             except Exception as e:
                 logger.warning(f"[TaskExecService] Failed to track activity start: {e}")
-            # ---- 3b. Mark execution as dispatched ---------------------------
+            # ---- 3b. Circuit breaker fast-fail (precursor to #526) ----------
+            # Check the per-agent circuit breaker before marking dispatched.
+            # If the CB is open the agent is known-unhealthy; close the record
+            # immediately rather than letting it hang until cleanup (120 min).
+            circuit = CircuitState(agent_name)
+            if not circuit.allow_request():
+                error_msg = "Agent circuit breaker open — agent is unhealthy"
+                logger.warning(f"[TaskExecService] CB open, fast-failing execution {execution_id} for {agent_name}")
+                if execution_id:
+                    existing = db.get_execution(execution_id)
+                    if not existing or existing.status != TaskExecutionStatus.CANCELLED:
+                        db.update_execution_status(
+                            execution_id=execution_id,
+                            status=TaskExecutionStatus.FAILED,
+                            error=error_msg,
+                        )
+                if activity_id:
+                    await activity_service.complete_activity(
+                        activity_id=activity_id,
+                        status=ActivityState.FAILED,
+                        error=error_msg,
+                    )
+                return TaskExecutionResult(
+                    execution_id=execution_id or "",
+                    status=TaskExecutionStatus.FAILED,
+                    response="",
+                    error=error_msg,
+                    error_code=TaskExecutionErrorCode.CIRCUIT_OPEN,
+                )
+
+            # ---- 3c. Mark execution as dispatched ---------------------------
             # Set claude_session_id='dispatched' BEFORE calling the agent so
             # the no-session cleanup doesn't falsely mark long-running executions
             # as "Silent launch failure". Only truly orphaned executions (where
@@ -654,6 +686,27 @@ class TaskExecutionService:
                 response="",
                 error=error_msg,
             )
+
+        except asyncio.CancelledError:
+            # Python 3.11+: CancelledError is BaseException, bypasses except Exception.
+            # On backend shutdown, background tasks are cancelled; close the record
+            # immediately so cleanup_service doesn't inflate duration (#767).
+            if execution_id:
+                try:
+                    existing = db.get_execution(execution_id)
+                    if existing and existing.status not in (
+                        TaskExecutionStatus.SUCCESS,
+                        TaskExecutionStatus.FAILED,
+                        TaskExecutionStatus.CANCELLED,
+                    ):
+                        db.update_execution_status(
+                            execution_id=execution_id,
+                            status=TaskExecutionStatus.FAILED,
+                            error="Execution cancelled (backend shutdown)",
+                        )
+                except Exception:
+                    pass
+            raise
 
         finally:
             # ---- 8. Release slot (only if acquired) ----------------------

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -486,6 +486,17 @@
         "backend",
         "git"
       ]
+    },
+    {
+      "file": "test_cb_probe_execution_close.py",
+      "feature": "#767",
+      "added": "2026-05-11",
+      "categories": [
+        "unit",
+        "backend",
+        "executions",
+        "circuit-breaker"
+      ]
     }
   ]
 }

--- a/tests/test_cb_probe_execution_close.py
+++ b/tests/test_cb_probe_execution_close.py
@@ -1,0 +1,539 @@
+"""
+Unit tests for #767: CB probe executions left open until backend restart.
+
+Two bugs fixed:
+- Fix A: execute_task now fast-fails (closes the execution record) when the
+  circuit breaker is open, rather than attempting a long-running HTTP call
+  that would be left dangling until cleanup_service's 120-minute stale sweep.
+- Fix B: asyncio.CancelledError (Python 3.11+ BaseException) is now caught in
+  both execute_task and _execute_task_internal_background so that execution
+  records are closed synchronously on backend shutdown, preventing the cleanup
+  service from inflating failure duration.
+"""
+
+import asyncio
+import os
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mirror pattern from test_watchdog_unit.py
+# ---------------------------------------------------------------------------
+_backend_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "backend")
+)
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies before importing backend modules
+# ---------------------------------------------------------------------------
+_helpers_mod = types.ModuleType("utils.helpers")
+_helpers_mod.utc_now = lambda: datetime.utcnow()
+_helpers_mod.utc_now_iso = lambda: datetime.utcnow().isoformat() + "Z"
+_helpers_mod.iso_cutoff = lambda hours: datetime.utcnow().isoformat() + "Z"
+_helpers_mod.parse_iso_timestamp = lambda s: datetime.utcnow()
+_helpers_mod.to_utc_iso = lambda *a, **k: datetime.utcnow().isoformat() + "Z"
+sys.modules.setdefault("utils.helpers", _helpers_mod)
+
+_sanitizer_mod = types.ModuleType("utils.credential_sanitizer")
+_sanitizer_mod.sanitize_response = lambda x: x
+_sanitizer_mod.sanitize_execution_log = lambda x: x
+_sanitizer_mod.sanitize_text = lambda x: x
+sys.modules.setdefault("utils.credential_sanitizer", _sanitizer_mod)
+
+sys.modules.setdefault("database", MagicMock())
+
+# Stub redis to prevent connection attempts
+_redis_mod = types.ModuleType("redis")
+_redis_mod.Redis = MagicMock
+_redis_mod.ConnectionError = ConnectionError
+sys.modules.setdefault("redis", _redis_mod)
+
+# Stub APScheduler and other heavy deps
+for _stub in (
+    "apscheduler", "apscheduler.schedulers", "apscheduler.schedulers.asyncio",
+    "docker", "docker.errors", "docker.types",
+):
+    sys.modules.setdefault(_stub, MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_execution(status="running"):
+    ex = MagicMock()
+    ex.id = "exec-test-001"
+    ex.status = status
+    return ex
+
+
+# ===========================================================================
+# Fix A: Circuit breaker fast-fail
+# ===========================================================================
+
+class TestCircuitBreakerFastFail:
+    """execute_task closes the execution record immediately when CB is open."""
+
+    pytestmark = pytest.mark.unit
+
+    @pytest.fixture(autouse=True)
+    def _patch_env(self):
+        """Ensure backend config can load without real env vars."""
+        env_patch = {
+            "REDIS_URL": "redis://test:test@localhost:6379",
+            "REDIS_PASSWORD": "test",
+            "REDIS_BACKEND_PASSWORD": "test",
+            "SECRET_KEY": "test-secret-key",
+        }
+        with patch.dict(os.environ, env_patch, clear=False):
+            yield
+
+    def _make_task_service(self):
+        """Return a TaskExecutionService with all external deps mocked."""
+        from services.task_execution_service import TaskExecutionService, TaskExecutionStatus
+
+        svc = TaskExecutionService.__new__(TaskExecutionService)
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_cb_open_fails_execution_record(self):
+        """When CB is open, execute_task marks execution FAILED immediately."""
+        from services.task_execution_service import (
+            TaskExecutionService, TaskExecutionStatus, TaskExecutionErrorCode,
+        )
+
+        mock_db = MagicMock()
+        existing_exec = _make_execution("running")
+        mock_db.get_execution.return_value = existing_exec
+        mock_db.get_max_parallel_tasks.return_value = 3
+        mock_db.create_task_execution.return_value = existing_exec
+        mock_db.mark_execution_dispatched.return_value = None
+
+        mock_capacity = MagicMock()
+        admitted = MagicMock()
+        admitted.state = "admitted"
+        mock_capacity.acquire = AsyncMock(return_value=admitted)
+        mock_capacity.release = AsyncMock()
+
+        mock_activity_svc = MagicMock()
+        mock_activity_svc.track_activity = AsyncMock(return_value="act-001")
+        mock_activity_svc.complete_activity = AsyncMock()
+
+        mock_circuit = MagicMock()
+        mock_circuit.allow_request.return_value = False
+
+        with (
+            patch("services.task_execution_service.db", mock_db),
+            patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+            patch("services.task_execution_service.activity_service", mock_activity_svc),
+            patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+        ):
+            svc = TaskExecutionService()
+            result = await svc.execute_task(
+                agent_name="test-agent",
+                message="hello",
+                triggered_by="schedule",
+                execution_id="exec-test-001",
+            )
+
+        assert result.status == TaskExecutionStatus.FAILED
+        assert result.error_code == TaskExecutionErrorCode.CIRCUIT_OPEN
+        assert "circuit breaker" in result.error.lower()
+
+        mock_db.update_execution_status.assert_called_once()
+        call_kwargs = mock_db.update_execution_status.call_args
+        assert call_kwargs.kwargs.get("status") == TaskExecutionStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_cb_open_does_not_call_agent(self):
+        """When CB is open, agent_post_with_retry is never called."""
+        from services.task_execution_service import TaskExecutionService, TaskExecutionStatus
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution("running")
+        mock_db.get_max_parallel_tasks.return_value = 3
+        mock_db.create_task_execution.return_value = _make_execution("running")
+
+        mock_capacity = MagicMock()
+        admitted = MagicMock()
+        admitted.state = "admitted"
+        mock_capacity.acquire = AsyncMock(return_value=admitted)
+        mock_capacity.release = AsyncMock()
+
+        mock_circuit = MagicMock()
+        mock_circuit.allow_request.return_value = False
+
+        mock_post = AsyncMock()
+
+        with (
+            patch("services.task_execution_service.db", mock_db),
+            patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+            patch("services.task_execution_service.activity_service", MagicMock(
+                track_activity=AsyncMock(return_value="act-001"),
+                complete_activity=AsyncMock(),
+            )),
+            patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+            patch("services.task_execution_service.agent_post_with_retry", mock_post),
+        ):
+            svc = TaskExecutionService()
+            await svc.execute_task(
+                agent_name="test-agent",
+                message="hello",
+                triggered_by="schedule",
+                execution_id="exec-test-001",
+            )
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cb_open_does_not_mark_dispatched(self):
+        """When CB is open, execution is NOT marked dispatched (keeps caught by short-circuit cleanup)."""
+        from services.task_execution_service import TaskExecutionService
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution("running")
+        mock_db.get_max_parallel_tasks.return_value = 3
+        mock_db.create_task_execution.return_value = _make_execution("running")
+
+        mock_capacity = MagicMock()
+        admitted = MagicMock()
+        admitted.state = "admitted"
+        mock_capacity.acquire = AsyncMock(return_value=admitted)
+        mock_capacity.release = AsyncMock()
+
+        mock_circuit = MagicMock()
+        mock_circuit.allow_request.return_value = False
+
+        with (
+            patch("services.task_execution_service.db", mock_db),
+            patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+            patch("services.task_execution_service.activity_service", MagicMock(
+                track_activity=AsyncMock(return_value=None),
+                complete_activity=AsyncMock(),
+            )),
+            patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+        ):
+            svc = TaskExecutionService()
+            await svc.execute_task(
+                agent_name="test-agent",
+                message="hello",
+                triggered_by="schedule",
+                execution_id="exec-test-001",
+            )
+
+        mock_db.mark_execution_dispatched.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cb_closed_proceeds_normally(self):
+        """When CB is closed, execute_task calls agent_post_with_retry as usual."""
+        from services.task_execution_service import TaskExecutionService, TaskExecutionStatus
+        import httpx
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution("running")
+        mock_db.get_max_parallel_tasks.return_value = 3
+        mock_db.create_task_execution.return_value = _make_execution("running")
+
+        mock_capacity = MagicMock()
+        admitted = MagicMock()
+        admitted.state = "admitted"
+        mock_capacity.acquire = AsyncMock(return_value=admitted)
+        mock_capacity.release = AsyncMock()
+
+        mock_circuit = MagicMock()
+        mock_circuit.allow_request.return_value = True  # CB closed
+
+        # Simulate a successful agent response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "response": "done",
+            "session_id": "sess-001",
+            "metadata": {"cost_usd": 0.01, "input_tokens": 100, "context_window": 200000},
+            "execution_log": [],
+        }
+        mock_post = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("services.task_execution_service.db", mock_db),
+            patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+            patch("services.task_execution_service.activity_service", MagicMock(
+                track_activity=AsyncMock(return_value="act-001"),
+                complete_activity=AsyncMock(),
+            )),
+            patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+            patch("services.task_execution_service.agent_post_with_retry", mock_post),
+        ):
+            svc = TaskExecutionService()
+            result = await svc.execute_task(
+                agent_name="test-agent",
+                message="hello",
+                triggered_by="schedule",
+                execution_id="exec-test-001",
+            )
+
+        mock_post.assert_called_once()
+        assert result.status == TaskExecutionStatus.SUCCESS
+
+
+# ===========================================================================
+# Fix B: asyncio.CancelledError in execute_task
+# ===========================================================================
+
+class TestCancelledErrorInExecuteTask:
+    """execute_task closes the execution record when cancelled by backend shutdown."""
+
+    pytestmark = pytest.mark.unit
+
+    @pytest.fixture(autouse=True)
+    def _patch_env(self):
+        env_patch = {
+            "REDIS_URL": "redis://test:test@localhost:6379",
+            "REDIS_PASSWORD": "test",
+            "REDIS_BACKEND_PASSWORD": "test",
+            "SECRET_KEY": "test-secret-key",
+        }
+        with patch.dict(os.environ, env_patch, clear=False):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_marks_execution_failed(self):
+        """When execute_task is cancelled mid-flight, the open execution is closed."""
+        from services.task_execution_service import TaskExecutionService, TaskExecutionStatus
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution("running")
+        mock_db.get_max_parallel_tasks.return_value = 3
+        mock_db.create_task_execution.return_value = _make_execution("running")
+
+        mock_capacity = MagicMock()
+        admitted = MagicMock()
+        admitted.state = "admitted"
+        mock_capacity.acquire = AsyncMock(return_value=admitted)
+        mock_capacity.release = AsyncMock()
+
+        mock_circuit = MagicMock()
+        mock_circuit.allow_request.return_value = True
+
+        # Simulate cancellation during agent HTTP call
+        mock_post = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with (
+            patch("services.task_execution_service.db", mock_db),
+            patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+            patch("services.task_execution_service.activity_service", MagicMock(
+                track_activity=AsyncMock(return_value=None),
+                complete_activity=AsyncMock(),
+            )),
+            patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+            patch("services.task_execution_service.agent_post_with_retry", mock_post),
+        ):
+            svc = TaskExecutionService()
+            with pytest.raises(asyncio.CancelledError):
+                await svc.execute_task(
+                    agent_name="test-agent",
+                    message="hello",
+                    triggered_by="schedule",
+                    execution_id="exec-test-001",
+                )
+
+        # Execution must be closed with FAILED status
+        mock_db.update_execution_status.assert_called_once()
+        call_kwargs = mock_db.update_execution_status.call_args
+        assert call_kwargs.kwargs.get("status") == TaskExecutionStatus.FAILED
+        assert "cancelled" in (call_kwargs.kwargs.get("error") or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_is_reraised(self):
+        """CancelledError must propagate after cleanup so asyncio can cancel the task."""
+        from services.task_execution_service import TaskExecutionService
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution("running")
+        mock_db.get_max_parallel_tasks.return_value = 3
+        mock_db.create_task_execution.return_value = _make_execution("running")
+
+        mock_capacity = MagicMock()
+        admitted = MagicMock()
+        admitted.state = "admitted"
+        mock_capacity.acquire = AsyncMock(return_value=admitted)
+        mock_capacity.release = AsyncMock()
+
+        mock_circuit = MagicMock()
+        mock_circuit.allow_request.return_value = True
+        mock_post = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with (
+            patch("services.task_execution_service.db", mock_db),
+            patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+            patch("services.task_execution_service.activity_service", MagicMock(
+                track_activity=AsyncMock(return_value=None),
+                complete_activity=AsyncMock(),
+            )),
+            patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+            patch("services.task_execution_service.agent_post_with_retry", mock_post),
+        ):
+            svc = TaskExecutionService()
+            with pytest.raises(asyncio.CancelledError):
+                await svc.execute_task(
+                    agent_name="test-agent",
+                    message="hello",
+                    triggered_by="schedule",
+                    execution_id="exec-test-001",
+                )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_skips_already_terminal_execution(self):
+        """If execution is already terminal, cancel handler doesn't overwrite it."""
+        from services.task_execution_service import TaskExecutionService, TaskExecutionStatus
+
+        mock_db = MagicMock()
+        # Already marked CANCELLED by another path
+        mock_db.get_execution.return_value = _make_execution(TaskExecutionStatus.CANCELLED)
+        mock_db.get_max_parallel_tasks.return_value = 3
+        mock_db.create_task_execution.return_value = _make_execution("running")
+
+        mock_capacity = MagicMock()
+        admitted = MagicMock()
+        admitted.state = "admitted"
+        mock_capacity.acquire = AsyncMock(return_value=admitted)
+        mock_capacity.release = AsyncMock()
+
+        mock_circuit = MagicMock()
+        mock_circuit.allow_request.return_value = True
+        mock_post = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with (
+            patch("services.task_execution_service.db", mock_db),
+            patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+            patch("services.task_execution_service.activity_service", MagicMock(
+                track_activity=AsyncMock(return_value=None),
+                complete_activity=AsyncMock(),
+            )),
+            patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+            patch("services.task_execution_service.agent_post_with_retry", mock_post),
+        ):
+            svc = TaskExecutionService()
+            with pytest.raises(asyncio.CancelledError):
+                await svc.execute_task(
+                    agent_name="test-agent",
+                    message="hello",
+                    triggered_by="schedule",
+                    execution_id="exec-test-001",
+                )
+
+        mock_db.update_execution_status.assert_not_called()
+
+
+# ===========================================================================
+# Fix B2: asyncio.CancelledError in _execute_task_internal_background
+# ===========================================================================
+
+class TestCancelledErrorInBackground:
+    """_execute_task_internal_background closes execution on cancel."""
+
+    pytestmark = pytest.mark.unit
+
+    @pytest.mark.asyncio
+    async def test_background_cancelled_marks_execution_failed(self):
+        """When execute_task raises CancelledError, background wrapper closes the record."""
+        from models import TaskExecutionStatus
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution("running")
+
+        mock_task_service = MagicMock()
+        mock_task_service.execute_task = AsyncMock(side_effect=asyncio.CancelledError())
+
+        request = MagicMock()
+        request.agent_name = "test-agent"
+        request.message = "hello"
+        request.triggered_by = "schedule"
+        request.model = None
+        request.timeout_seconds = 900
+        request.allowed_tools = None
+        request.execution_id = "exec-bg-001"
+        request.attempt = 1
+        request.schedule_id = None
+        request.schedule_name = None
+        request.schedule_cron = None
+        request.schedule_next_run = None
+
+        with patch("routers.internal.db", mock_db):
+            import routers.internal as internal_mod
+            with pytest.raises(asyncio.CancelledError):
+                await internal_mod._execute_task_internal_background(mock_task_service, request)
+
+        mock_db.update_execution_status.assert_called_once()
+        call_kwargs = mock_db.update_execution_status.call_args
+        assert call_kwargs.kwargs.get("status") == TaskExecutionStatus.FAILED
+        assert "cancelled" in (call_kwargs.kwargs.get("error") or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_background_cancelled_reraises(self):
+        """CancelledError must propagate from the background wrapper."""
+        from models import TaskExecutionStatus
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution("running")
+
+        mock_task_service = MagicMock()
+        mock_task_service.execute_task = AsyncMock(side_effect=asyncio.CancelledError())
+
+        request = MagicMock()
+        request.agent_name = "test-agent"
+        request.message = "hello"
+        request.triggered_by = "schedule"
+        request.model = None
+        request.timeout_seconds = 900
+        request.allowed_tools = None
+        request.execution_id = "exec-bg-001"
+        request.attempt = 1
+        request.schedule_id = None
+        request.schedule_name = None
+        request.schedule_cron = None
+        request.schedule_next_run = None
+
+        with patch("routers.internal.db", mock_db):
+            import routers.internal as internal_mod
+            with pytest.raises(asyncio.CancelledError):
+                await internal_mod._execute_task_internal_background(mock_task_service, request)
+
+    @pytest.mark.asyncio
+    async def test_background_cancelled_skips_already_terminal(self):
+        """Cancel handler doesn't overwrite already-terminal execution in background."""
+        from models import TaskExecutionStatus
+
+        mock_db = MagicMock()
+        mock_db.get_execution.return_value = _make_execution(TaskExecutionStatus.SUCCESS)
+
+        mock_task_service = MagicMock()
+        mock_task_service.execute_task = AsyncMock(side_effect=asyncio.CancelledError())
+
+        request = MagicMock()
+        request.agent_name = "test-agent"
+        request.execution_id = "exec-bg-001"
+        request.message = "hello"
+        request.triggered_by = "schedule"
+        request.model = None
+        request.timeout_seconds = 900
+        request.allowed_tools = None
+        request.attempt = 1
+        request.schedule_id = None
+        request.schedule_name = None
+        request.schedule_cron = None
+        request.schedule_next_run = None
+
+        with patch("routers.internal.db", mock_db):
+            import routers.internal as internal_mod
+            with pytest.raises(asyncio.CancelledError):
+                await internal_mod._execute_task_internal_background(mock_task_service, request)
+
+        mock_db.update_execution_status.assert_not_called()


### PR DESCRIPTION
## Summary

- **Fix A (CB fast-fail)**: `execute_task` now checks `CircuitState.allow_request()` before marking an execution dispatched. When the circuit breaker is open, the execution record is closed immediately with `FAILED / CIRCUIT_OPEN` instead of hanging for up to 120 minutes until `cleanup_service`'s stale sweep. Adds `CIRCUIT_OPEN` to `TaskExecutionErrorCode`.
- **Fix B (shutdown cancellation)**: `asyncio.CancelledError` is a `BaseException` in Python 3.11+, so it bypasses all `except Exception` handlers. Added explicit `CancelledError` handlers in both `execute_task` and `_execute_task_internal_background` to synchronously close open execution records before the process exits — preventing `cleanup_service` from stamping `completed_at = restart_time` and creating artificially large red failure blocks on the timeline.
- **Cleanup**: `db` and `TaskExecutionStatus` imports promoted from function-local to module-level in `_execute_task_internal_background`, consistent with all other routers.

## Root cause

CB probe executions call `mark_execution_dispatched` (sets `claude_session_id = 'dispatched'`), which opts them out of the 60-second no-session cleanup. Only the 120-minute stale sweep catches them — and it stamps `completed_at = now()` regardless of when the execution actually started, creating long red blocks on the timeline. The `CancelledError` path has the same problem with an even longer potential gap (execution started hours before shutdown).

## Alignment

Precursor to Sprint D′ **#526 (dispatch circuit breaker)** in `docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md`. The CB check here is additive (the existing `agent_post_with_retry` path is unchanged); #526 will move the breaker upstream to `CapacityManager`.

## Test plan

- [x] `tests/test_cb_probe_execution_close.py` — 10 unit tests:
  - CB open → execution closed, agent not called, `mark_execution_dispatched` not called, `CIRCUIT_OPEN` error code returned
  - CB closed → proceeds normally to agent call
  - `CancelledError` in `execute_task` → execution closed, error re-raised, terminal state not overwritten
  - `CancelledError` in `_execute_task_internal_background` → execution closed, error re-raised, terminal state not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)