### PR TITLE
fix(tests): skip-when-unset guard for REDIS_BACKEND_PASSWORD (#764)

### DIFF
--- a/tests/security/README.md
+++ b/tests/security/README.md
@@ -1,0 +1,18 @@
+# Security integration tests
+
+Live-stack integration tests for Trinity security boundaries (Redis network isolation, ACLs, …). Most tests in this directory require:
+
+- The platform stack running locally (`./scripts/deploy/start.sh`)
+- The `docker` Python package installed in the test venv (module-level `pytest.importorskip("docker")` skips when absent)
+- Real Redis credentials available — either pre-exported in the shell or sourced from the project-root `.env` by `conftest.py`:
+  - `REDIS_PASSWORD` (admin user)
+  - `REDIS_BACKEND_PASSWORD` (backend ACL user, see [Network Topology in architecture.md](../../docs/memory/architecture.md#network-topology-issue-589))
+
+Tests that depend on a specific credential also gate it locally via a per-test fixture (e.g. `backend_password` in `test_redis_network_isolation.py`) — those tests skip with a clear message when the env var is missing, rather than crashing with `KeyError` (Issue #764).
+
+Run only this directory:
+
+```bash
+cd tests
+.venv/bin/python -m pytest security/ -m integration -v
+```

--- a/tests/security/test_redis_network_isolation.py
+++ b/tests/security/test_redis_network_isolation.py
@@ -25,6 +25,27 @@ def _client():
     return docker.from_env()
 
 
+@pytest.fixture
+def backend_password() -> str:
+    """Return the Redis ACL backend-user password, or skip if unset.
+
+    Issue #764: the session-scoped autouse fixture in `conftest.py` already
+    skips when this env var is missing, but only when ``.env`` is absent
+    AND nothing exported the value. A per-test fixture here makes the
+    requirement explicit at the call site and provides a clearer skip
+    reason in pytest output. Contributors who don't run the security tests
+    against a live stack see "skipped: REDIS_BACKEND_PASSWORD not set"
+    instead of a hard ``KeyError``.
+    """
+    pwd = os.environ.get("REDIS_BACKEND_PASSWORD")
+    if not pwd:
+        pytest.skip(
+            "REDIS_BACKEND_PASSWORD not set; "
+            "platform-network ACL test requires a running stack — see tests/security/README.md"
+        )
+    return pwd
+
+
 @pytest.mark.integration
 def test_agent_network_container_cannot_reach_redis():
     """Acceptance #3: a container on the agent network has no route to Redis."""
@@ -58,17 +79,16 @@ def test_redis_rejects_unauthenticated_connection():
 
 
 @pytest.mark.integration
-def test_platform_container_can_authenticate():
+def test_platform_container_can_authenticate(backend_password):
     """Sanity: the backend connection string works."""
     client = _client()
-    pwd = os.environ["REDIS_BACKEND_PASSWORD"]
     out = client.containers.run(
         "redis:7-alpine",
         command=[
             "redis-cli",
             "-h", "redis",
             "--user", "backend",
-            "-a", pwd,
+            "-a", backend_password,
             "--no-auth-warning",
             "PING",
         ],
@@ -79,17 +99,16 @@ def test_platform_container_can_authenticate():
 
 
 @pytest.mark.integration
-def test_backend_acl_blocks_flushall():
+def test_backend_acl_blocks_flushall(backend_password):
     """Acceptance #2: backend ACL user cannot wipe data."""
     client = _client()
-    pwd = os.environ["REDIS_BACKEND_PASSWORD"]
     out = client.containers.run(
         "redis:7-alpine",
         command=[
             "redis-cli",
             "-h", "redis",
             "--user", "backend",
-            "-a", pwd,
+            "-a", backend_password,
             "--no-auth-warning",
             "FLUSHALL",
         ],
@@ -100,17 +119,16 @@ def test_backend_acl_blocks_flushall():
 
 
 @pytest.mark.integration
-def test_backend_acl_blocks_config_get():
+def test_backend_acl_blocks_config_get(backend_password):
     """Acceptance #2: backend ACL user cannot read CONFIG (would leak admin password)."""
     client = _client()
-    pwd = os.environ["REDIS_BACKEND_PASSWORD"]
     out = client.containers.run(
         "redis:7-alpine",
         command=[
             "redis-cli",
             "-h", "redis",
             "--user", "backend",
-            "-a", pwd,
+            "-a", backend_password,
             "--no-auth-warning",
             "CONFIG", "GET", "requirepass",
         ],


### PR DESCRIPTION
## Summary

- Adds a per-test `backend_password` pytest fixture in `tests/security/test_redis_network_isolation.py`. The 3 ACL tests now request it as a parameter; when `REDIS_BACKEND_PASSWORD` is missing they skip with a clear reason instead of crashing with `KeyError`.
- Adds `tests/security/README.md` documenting the env-var requirement (live stack + `docker` Python package + `REDIS_PASSWORD` / `REDIS_BACKEND_PASSWORD` either pre-exported or available in project-root `.env`).

Related to #764.

## Why a per-test fixture when conftest already handles this?

`tests/security/conftest.py` has a session-scoped autouse fixture (`_load_redis_env`) that calls `pytest.skip(...)` when `REDIS_BACKEND_PASSWORD` is absent. That catches the missing-env case in most situations, but:

- It only catches when `.env` is absent AND nothing exported the value. Edge cases (dotenv module missing in venv, conftest not auto-loaded, partial env exports) can let a test through into `os.environ["..."]` and hit `KeyError`.
- The per-test fixture makes the requirement explicit at the call site, matches the issue's recommended Option 1, and produces a clearer skip reason in pytest output (`"REDIS_BACKEND_PASSWORD not set; platform-network ACL test requires a running stack — see tests/security/README.md"`).

Defense-in-depth, not a replacement for the session fixture.

## Test plan

- [x] AST parse OK; all 3 test signatures take the `backend_password` fixture
- [x] `pytest.fixture` decorator wires correctly
- [x] No regression to the 2 tests in the same file that don't need the password (`test_agent_network_container_cannot_reach_redis`, `test_redis_rejects_unauthenticated_connection`) — they remain parameter-less
- [ ] Reviewer pass

## Files

| File | Change |
|---|---|
| `tests/security/test_redis_network_isolation.py` | New `backend_password` fixture (lines 28-46), 3 tests refactored to use it |
| `tests/security/README.md` | New — documents env-var requirement, links to architecture.md §Network Topology |

🤖 Generated with [Claude Code](https://claude.com/claude-code)