### PR TITLE
fix(tests): handle bare-list response from public-links endpoint (#766)

### DIFF
--- a/tests/test_public_chat_history.py
+++ b/tests/test_public_chat_history.py
@@ -76,7 +76,12 @@ class TestPublicSessionsEndpoints:
         if links_resp.status_code != 200:
             pytest.skip(f"Could not get public links for agent {agent_name}")
 
-        links = links_resp.json().get("links", [])
+        # The endpoint is declared `response_model=List[PublicLinkWithUrl]` in
+        # routers/public_links.py — bare list, no envelope. Tolerate either
+        # shape so the test doesn't break if a future refactor wraps the
+        # payload (Issue #766).
+        payload = links_resp.json()
+        links = payload["links"] if isinstance(payload, dict) else payload
         if not links:
             pytest.skip(f"No public links for agent {agent_name}")
 


### PR DESCRIPTION
## Summary

`tests/test_public_chat_history.py::TestPublicSessionsEndpoints::test_sessions_returns_list_shape` assumed `GET /api/agents/{name}/public-links` returned `{links: [...]}` and called `.get("links", [])` on the response, but the endpoint is declared `response_model=List[PublicLinkWithUrl]` in `src/backend/routers/public_links.py:110` — bare list, no envelope. Result: `AttributeError: 'list' object has no attribute 'get'`.

Fix tolerates either shape so the test stays resilient to a future refactor that adds an envelope.

Related to #766.

## Test plan

- [x] Endpoint contract confirmed: `routers/public_links.py:110` — `response_model=List[PublicLinkWithUrl]`
- [x] Local stack: with no public link present, test now reaches the documented "no public links" skip path at line 86 (was failing before reaching that path)
- [x] Local stack: with a manually created public link, the test PASSES end-to-end (verified by creating link, running the test, deleting link)
- [x] Other 5 tests in `test_public_chat_history.py` unaffected — `5 passed, 1 skipped`

## Files

| File | Change |
|---|---|
| `tests/test_public_chat_history.py` | One assignment replaced with `payload["links"] if isinstance(payload, dict) else payload` + 3-line comment explaining the contract |

🤖 Generated with [Claude Code](https://claude.com/claude-code)