### PR TITLE
fix(tests): order-independence pin for S7 migration preflight (#763)

### DIFF
--- a/tests/git-sync/conftest.py
+++ b/tests/git-sync/conftest.py
@@ -7,7 +7,75 @@ backend-dependent fixtures with no-ops so pytest can collect and run the
 S7 unit tests in complete isolation.
 """
 
+import importlib.util
+import sys
+from pathlib import Path
+
 import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+
+
+def _restore_real_utils_helpers() -> None:
+    """Replace any stub `utils.helpers` in sys.modules with the real backend module.
+
+    Issue #763: `tests/test_validation.py:35` and `tests/test_watchdog_unit.py:54`
+    unconditionally assign `sys.modules["utils.helpers"] = _helpers_mod` at module
+    import time with a stub that has utc_now / utc_now_iso / to_utc_iso /
+    parse_iso_timestamp but is missing `iso_cutoff`. The top-level conftest preloads
+    the real `utils.helpers` first, but if either polluter is collected before this
+    directory, the real module is silently overwritten. Later, when
+    `TestMigrationPreflight` does `sys.modules.pop("db.migrations", None)` and
+    re-imports it, the chain hits `db/__init__.py` → `db/schedules.py` →
+    `from utils.helpers import iso_cutoff, ...` → ImportError, failing all 4
+    preflight tests.
+
+    Restoring the real module here is order-independent: works whether the polluter
+    ran before or after, and is idempotent (no-op when already real).
+    """
+    existing = sys.modules.get("utils.helpers")
+    helpers_path = _BACKEND / "utils" / "helpers.py"
+
+    if not helpers_path.exists():
+        return
+
+    # Already the real module? (presence of `iso_cutoff` is the discriminator.)
+    if existing is not None and hasattr(existing, "iso_cutoff"):
+        return
+
+    spec = importlib.util.spec_from_file_location("utils.helpers", str(helpers_path))
+    if spec is None or spec.loader is None:
+        return
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["utils.helpers"] = mod
+    spec.loader.exec_module(mod)
+
+
+def _evict_db_module_cache() -> None:
+    """Pop the `db.*` modules so the next import gets a fresh chain.
+
+    Required because `db/__init__.py` and `db/schedules.py` may already be
+    cached against the stub `utils.helpers` from a polluter test, even after
+    `_restore_real_utils_helpers()` puts the real module back. The test itself
+    pops `db.migrations`, but its import chain hits `db/__init__.py` first,
+    which is already cached with the bad import. Evict the whole `db` subtree
+    so the next `from db.migrations import …` reloads everything from disk.
+    """
+    for name in [n for n in sys.modules if n == "db" or n.startswith("db.")]:
+        del sys.modules[name]
+
+
+@pytest.fixture(autouse=True)
+def _pin_module_state_for_db_reimports():
+    """Order-independence pin for S7 migration preflight tests (#763).
+
+    Restores the real `utils.helpers` and evicts the `db.*` cache before
+    every test in this directory, defending against arbitrary earlier
+    tests that polluted `sys.modules`. Cheap and idempotent.
+    """
+    _restore_real_utils_helpers()
+    _evict_db_module_cache()
+    yield
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

4 tests in `tests/git-sync/test_s7_reserve_instance_id.py::TestMigrationPreflight` fail in the full integration suite but pass in isolation. Root cause is a `sys.modules` pollution + reimport ordering bug. Fixed in `tests/git-sync/conftest.py` with an autouse pin that restores the real `utils.helpers` and evicts the cached `db.*` subtree before every git-sync test.

Related to #763.

## Root cause

`tests/test_validation.py:35` and `tests/test_watchdog_unit.py:54` execute, at module import time:

```python
sys.modules["utils.helpers"] = _helpers_mod
```

The stub has `utc_now` / `utc_now_iso` / `to_utc_iso` / `parse_iso_timestamp` — but **no `iso_cutoff`**. The top-level `tests/conftest.py` preload installs the real `utils.helpers` first, but either polluter overwrites it permanently when collected ahead of `tests/git-sync/`.

`TestMigrationPreflight` then does:

```python
sys.modules.pop("db.migrations", None)
from db.migrations import _find_duplicate_working_branches
```

The reimport chain hits `db/__init__.py` → `db/schedules.py` → `from utils.helpers import iso_cutoff, ...` → `ImportError`, surfaced by the test as `pytest.fail("S7 migration helper ... is missing")`.

Verified by reproducing the exact ImportError outside pytest with `python -c "...install stub then reimport db.migrations..."`.

## Fix

Per the issue's recommendation, an order-independence pin in `tests/git-sync/conftest.py`:

1. **Autouse fixture restores the real `utils.helpers`** if the current `sys.modules` entry lacks `iso_cutoff` (the discriminator for the stub).
2. **Same fixture evicts cached `db` / `db.*` modules** so the next `from db.migrations import …` reloads `db/__init__.py` and `db/schedules.py` against the restored real `utils.helpers`.

Both steps are idempotent (no-op when state is already clean), cheap, and run before every git-sync test. Integration-tier counterpart to the unit-tier pin added by #714.

## Test plan

- [x] `test_s7_reserve_instance_id.py::TestMigrationPreflight` passes in isolation — `4 passed`
- [x] `test_validation.py → test_s7` passes — `23 passed, 3 skipped` (was 4 failures pre-fix)
- [x] `test_watchdog_unit.py → test_s7` passes — `39 passed`
- [x] Full `test_s7_reserve_instance_id.py` still passes — `12 passed`
- [x] `test_validation.py` / `test_watchdog_unit.py` collection errors are pre-existing and unrelated (verified via `git stash`)
- [ ] Reviewer pass

## Files

| File | Change |
|---|---|
| `tests/git-sync/conftest.py` | +68 lines: `_restore_real_utils_helpers()` and `_evict_db_module_cache()` helpers + autouse `_pin_module_state_for_db_reimports` fixture |

🤖 Generated with [Claude Code](https://claude.com/claude-code)