### PR TITLE
fix(session-tab): lock cold-turn POSTs on a per-session key (#779)

### DIFF
--- a/src/backend/routers/sessions.py
+++ b/src/backend/routers/sessions.py
@@ -166,26 +166,40 @@ end
 
 
 class _ResumeLock:
-    """Async context manager for the per-(agent, uuid) lock.
+    """Async context manager for the per-session turn lock.
 
-    Acts as a no-op when ``claude_session_id`` is None (cold turn) or when
-    Redis is unavailable (degraded mode — log and proceed; lock contention
-    is an optimisation, not a correctness gate at the platform layer).
+    Two key shapes:
+      * **warm turn** — ``session_lock:{agent}:{claude_session_id}`` keyed by
+        the cached Claude UUID. Multiple sessions sharing the same UUID would
+        be a bug elsewhere, but for safety the agent is included.
+      * **cold turn** — ``session_lock:cold:{session_id}``. Issue #779: cold
+        turns previously short-circuited to ``key=None`` (no lock), so two
+        concurrent first-turn POSTs on a fresh session would race on
+        ``update_cached_claude_session_id`` and orphan one JSONL. Keying on
+        the session id serialises cold turns on the *same* session while
+        leaving cold turns on *different* sessions free to run in parallel.
+
+    Acts as a no-op when Redis is unavailable (degraded mode — log and
+    proceed; lock contention is an optimisation, not a correctness gate at
+    the platform layer).
     """
 
-    def __init__(self, agent_name: str, claude_session_id: Optional[str]):
+    def __init__(
+        self,
+        agent_name: str,
+        claude_session_id: Optional[str],
+        session_id: str,
+    ):
         self._key = (
             f"session_lock:{agent_name}:{claude_session_id}"
             if claude_session_id
-            else None
+            else f"session_lock:cold:{session_id}"
         )
         self._token = secrets.token_urlsafe(16)
         self._redis = None
         self._held = False
 
     async def __aenter__(self) -> "_ResumeLock":
-        if self._key is None:
-            return self
         self._redis = self._get_redis()
         if self._redis is None:
             logger.warning(
@@ -227,7 +241,7 @@ class _ResumeLock:
             await asyncio.sleep(_LOCK_POLL_INTERVAL_SECONDS)
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        if not self._held or self._redis is None or self._key is None:
+        if not self._held or self._redis is None:
             return
         try:
             await self._redis.eval(_LOCK_RELEASE_LUA, 1, self._key, self._token)
@@ -449,7 +463,7 @@ async def send_session_message(
     fallback_fired = False
     fallback_reason: Optional[str] = None
 
-    async with _ResumeLock(name, cached_uuid):
+    async with _ResumeLock(name, cached_uuid, session.id):
         # Step 4: cold or resume turn.
         result = await service.execute_task(
             agent_name=name,

--- a/tests/unit/test_session_cold_turn_lock.py
+++ b/tests/unit/test_session_cold_turn_lock.py
@@ -1,0 +1,197 @@
+"""
+Issue #779 regression pin — cold-turn POSTs must serialize on the same session.
+
+Before the fix, `_ResumeLock.__init__` short-circuited to `self._key = None`
+when `claude_session_id` was None (the cold-turn path), so the
+`async with _ResumeLock(...)` block was a no-op. Two concurrent first-turn
+POSTs on a fresh session would bypass the lock, race on
+`update_cached_claude_session_id`, and orphan one JSONL inside the agent
+container (Anthropic claude-code #20992).
+
+The fix keys the cold-turn lock on the session id
+(`session_lock:cold:{session_id}`), so cold turns on the *same* session
+block each other while cold turns on *different* sessions still run in
+parallel.
+
+This file pins:
+1. ``_ResumeLock.__init__`` takes ``session_id`` as a third required parameter.
+2. The cold-turn branch produces ``session_lock:cold:{session_id}`` — not
+   ``None``, not anything else.
+3. The warm-turn branch still uses the existing
+   ``session_lock:{agent}:{uuid}`` format.
+4. The single call site passes ``session.id`` as the third argument.
+5. ``self._key`` is no longer treated as nullable in ``__aenter__`` /
+   ``__aexit__`` (the dead-code guards are gone — they would otherwise
+   silently bypass the new cold-turn lock if some future refactor revived
+   a ``None`` key path).
+
+Style follows ``tests/unit/test_session_persistence_flag.py``: AST + regex
+on source, no live backend required.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SESSIONS_ROUTER_PY = _PROJECT_ROOT / "src" / "backend" / "routers" / "sessions.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror test_session_persistence_flag.py
+# ---------------------------------------------------------------------------
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing {path}"
+    return path.read_text()
+
+
+def _find_class(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found")
+
+
+def _find_method(cls: ast.ClassDef, name: str) -> ast.AsyncFunctionDef | ast.FunctionDef:
+    for node in cls.body:
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"method {name} not found on {cls.name}")
+
+
+def _function_source(source: str, func) -> str:
+    lines = source.splitlines()
+    return "\n".join(lines[func.lineno - 1 : func.end_lineno])
+
+
+# ---------------------------------------------------------------------------
+# 1. Constructor signature
+# ---------------------------------------------------------------------------
+
+
+def test_resume_lock_init_requires_session_id():
+    """``__init__`` must accept ``session_id`` so cold turns have a stable key.
+
+    Before #779: ``def __init__(self, agent_name, claude_session_id)``.
+    After  #779: ``def __init__(self, agent_name, claude_session_id, session_id)``.
+    """
+    tree = ast.parse(_read(_SESSIONS_ROUTER_PY))
+    cls = _find_class(tree, "_ResumeLock")
+    init = _find_method(cls, "__init__")
+
+    arg_names = [a.arg for a in init.args.args]
+    assert "session_id" in arg_names, (
+        f"_ResumeLock.__init__ must take session_id; got {arg_names!r}"
+    )
+    assert arg_names[:4] == ["self", "agent_name", "claude_session_id", "session_id"], (
+        f"_ResumeLock.__init__ positional args drifted; got {arg_names!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Cold-turn key formula
+# ---------------------------------------------------------------------------
+
+
+def test_resume_lock_cold_turn_uses_session_id_key():
+    """The cold-turn branch must build ``session_lock:cold:{session_id}``.
+
+    The bug shape we never want to see again: the cold-turn branch falling
+    back to ``None`` (or any other key that doesn't include session_id),
+    which would silently disable the lock for the very race window this
+    class exists to prevent (#779).
+    """
+    src = _read(_SESSIONS_ROUTER_PY)
+
+    # Positive: the cold-turn key literal is present, parameterised by session_id.
+    assert re.search(
+        r'f["\']session_lock:cold:\{session_id\}["\']',
+        src,
+    ), "cold-turn lock key must be f'session_lock:cold:{session_id}'"
+
+    # Negative: no path leaves ``self._key`` as ``None``. Any future refactor
+    # that wires a None-key fallback back into _ResumeLock would re-open #779.
+    tree = ast.parse(src)
+    cls = _find_class(tree, "_ResumeLock")
+    init = _find_method(cls, "__init__")
+    init_src = _function_source(src, init)
+    assert not re.search(r"self\._key\s*=\s*None", init_src), (
+        "self._key must never be set to None — that re-enables the #779 race"
+    )
+    # And in the conditional, `else None` shouldn't appear as the alternate
+    # branch for self._key.
+    assert not re.search(
+        r"self\._key\s*=\s*\([^)]*\belse\s+None\s*\)",
+        init_src,
+        flags=re.DOTALL,
+    ), "self._key cold-turn branch must not be `else None`"
+
+
+def test_resume_lock_warm_turn_key_unchanged():
+    """The warm-turn key shape stays the same — fix is purely additive."""
+    src = _read(_SESSIONS_ROUTER_PY)
+    assert re.search(
+        r'f["\']session_lock:\{agent_name\}:\{claude_session_id\}["\']',
+        src,
+    ), "warm-turn key must remain f'session_lock:{agent_name}:{claude_session_id}'"
+
+
+# ---------------------------------------------------------------------------
+# 3. Call-site passes session.id
+# ---------------------------------------------------------------------------
+
+
+def test_message_endpoint_passes_session_id_to_resume_lock():
+    """The single ``_ResumeLock(...)`` call must pass ``session.id`` so the
+    cold-turn key is bound to the persisted session row."""
+    src = _read(_SESSIONS_ROUTER_PY)
+
+    call_sites = re.findall(r"_ResumeLock\([^)]+\)", src)
+    assert len(call_sites) == 1, (
+        f"expected exactly one _ResumeLock(...) call site; found {len(call_sites)}: "
+        f"{call_sites!r}"
+    )
+
+    call = call_sites[0]
+    assert "session.id" in call, (
+        f"_ResumeLock call must pass session.id (third arg); got {call!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Dead-code guards on the None path are gone
+# ---------------------------------------------------------------------------
+
+
+def test_aenter_no_longer_short_circuits_on_none_key():
+    """``__aenter__`` previously had ``if self._key is None: return self`` —
+    the no-op cold-turn path. With the fix, self._key is never None, so the
+    guard is dead code AND would silently break the new cold-turn lock if
+    reintroduced. Pin its absence."""
+    src = _read(_SESSIONS_ROUTER_PY)
+    tree = ast.parse(src)
+    cls = _find_class(tree, "_ResumeLock")
+    aenter = _find_method(cls, "__aenter__")
+    body = _function_source(src, aenter)
+    assert "self._key is None" not in body, (
+        "__aenter__ must not short-circuit on self._key is None — #779 regression"
+    )
+
+
+def test_aexit_no_longer_short_circuits_on_none_key():
+    """Same for ``__aexit__``."""
+    src = _read(_SESSIONS_ROUTER_PY)
+    tree = ast.parse(src)
+    cls = _find_class(tree, "_ResumeLock")
+    aexit = _find_method(cls, "__aexit__")
+    body = _function_source(src, aexit)
+    assert "self._key is None" not in body, (
+        "__aexit__ must not short-circuit on self._key is None — #779 regression"
+    )


### PR DESCRIPTION
## Summary

`_ResumeLock.__init__` short-circuited to `self._key = None` on the cold-turn path (no cached Claude UUID yet), making `async with _ResumeLock(...)` a no-op for first turns. Two concurrent POSTs to a fresh session bypassed the lock entirely, raced on `update_cached_claude_session_id`, and orphaned one JSONL inside the agent container — the Anthropic claude-code #20992 corruption window the lock was added specifically to close.

Cold turns now lock on a per-session key (`session_lock:cold:{session_id}`). Same session → serialised; different sessions → still concurrent. Warm-turn key shape is unchanged.

Related to #779.

## Diff shape

```python
# Before
self._key = (
    f"session_lock:{agent_name}:{claude_session_id}"
    if claude_session_id
    else None
)

# After
self._key = (
    f"session_lock:{agent_name}:{claude_session_id}"
    if claude_session_id
    else f"session_lock:cold:{session_id}"
)
```

Plus:
- `__init__` takes `session_id` as a third required parameter
- Single call site `_ResumeLock(name, cached_uuid)` → `_ResumeLock(name, cached_uuid, session.id)`
- Dead-code `if self._key is None: return self` guards in `__aenter__` / `__aexit__` removed (would silently re-open the race if some future refactor reintroduced a None-key path)

## Why this is safe

- **Warm turns**: unchanged key, unchanged behaviour.
- **Cold turns, same session**: now serialise on `session_lock:cold:{session_id}`. Inherits the existing 30s wait ceiling + 429 escalation.
- **Cold turns, different sessions**: keys differ → no contention.
- **Resume-failure fallback path** (`_is_resume_not_found(result.error)`): only triggers when `cached_uuid` is set, so cold turns never enter it. Unaffected.
- **Key collision**: `session_lock:cold:{session_id}` vs `session_lock:{agent}:{uuid}` — different schemas, session ids are urlsafe tokens not UUIDs, safe.

## Test plan

- [x] New unit test `tests/unit/test_session_cold_turn_lock.py` — 6 AST/regex pins matching the house style of `test_session_persistence_flag.py`:
  - `__init__` takes `session_id` (positional, third)
  - Cold-turn key is `f"session_lock:cold:{session_id}"` (positive) and never `None` (negative)
  - Warm-turn key shape unchanged
  - Single call site passes `session.id`
  - `__aenter__` / `__aexit__` no longer contain `self._key is None`
- [x] All 6 pass
- [x] No regression in adjacent session unit tests (one pre-existing failure in `test_session_persistence_flag.py::test_execute_task_runtime_signature_inherits_default` is environmental — missing `docker` py-pkg in test venv, verified by `git stash` repro on `origin/dev`)
- [ ] Reviewer pass

## Files

| File | Change |
|---|---|
| `src/backend/routers/sessions.py` | `_ResumeLock` gains `session_id` param + cold-turn key; dead `is None` guards removed from `__aenter__` / `__aexit__`; call site updated |
| `tests/unit/test_session_cold_turn_lock.py` (new) | 6 AST/regex pins |

🤖 Generated with [Claude Code](https://claude.com/claude-code)