### PR TITLE
fix(files): use inline Content-Disposition on preview endpoint (#784)

### DIFF
--- a/docker/base-image/agent_server/routers/files.py
+++ b/docker/base-image/agent_server/routers/files.py
@@ -350,11 +350,13 @@ async def preview_file(path: str):
             # Default to binary for unknown types
             mime_type = "application/octet-stream"
 
-        # Return file with correct Content-Type for browser preview
+        # Return file with correct Content-Type for browser preview.
+        # Use inline disposition so text/media files render in the preview
+        # panel rather than triggering a download.
         return FileResponse(
             path=requested_path,
             media_type=mime_type,
-            filename=requested_path.name
+            headers={"Content-Disposition": f'inline; filename="{requested_path.name}"'}
         )
 
     except Exception as e:

--- a/tests/test_agent_files.py
+++ b/tests/test_agent_files.py
@@ -260,6 +260,9 @@ class TestPreviewFile:
         )
 
         assert_status_in(response, [200, 404])
+        if response.status_code == 200:
+            cd = response.headers.get("content-disposition", "")
+            assert cd.startswith("inline"), f"Expected inline disposition for preview, got: {cd!r}"
 
     def test_preview_nonexistent_file_returns_404(
         self,


### PR DESCRIPTION
## Summary
- `FileResponse(filename=...)` in the agent server sets `Content-Disposition: attachment`, causing the frontend FilesPanel to fail rendering text files and show "Failed to load text content"
- Fix: switch to an explicit `Content-Disposition: inline; filename="..."` header so preview content displays inline
- Applies to all file types served by the `/api/files/preview` endpoint (text, images, PDFs, etc.)

## Changes
- `docker/base-image/agent_server/routers/files.py` — remove `filename=` param from `FileResponse`, set `Content-Disposition: inline` via headers instead
- `tests/test_agent_files.py` — add assertion that a successful preview response carries an `inline` disposition

## Test Plan
- [ ] Existing preview tests pass: `pytest tests/test_agent_files.py -v -k preview`
- [ ] Manual: navigate to any agent's Files tab, click a `.md` or `.txt` file — content renders in the preview panel instead of "Failed to load text content"

Fixes #784

Generated with [Claude Code](https://claude.com/claude-code)