### PR TITLE
fix(chat): mark execution dispatched + persist real session_id (#686)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ tests/reports/coverage/
 
 # Test agent templates (created during automated tests)
 src/backend/config/agent-templates/test-*/
+src/backend/config/agent-templates/quota-*/
 
 # Agent template runtime artifacts (generated during execution)
 config/agent-templates/**/memory/

--- a/docs/memory/feature-flows/cleanup-service.md
+++ b/docs/memory/feature-flows/cleanup-service.md
@@ -1,5 +1,7 @@
 # Feature: Cleanup Service (CLEANUP-001)
 
+> **Updated 2026-05-11 (#686):** The interactive `chat_with_agent()` handler in `routers/chat.py` is now a second producer of the `claude_session_id='dispatched'` sentinel (parallel of #279). The no-session sweep's correctness assumption now extends to interactive `/chat` executions too. See the updated [`mark_execution_dispatched`](#mark_execution_dispatched-scheduleoperations) and [Fast-fail no-session executions](#cleanup-cycle-run_cleanup) sections.
+
 > **Updated 2026-04-26 (#428):** Stale-slot reclaim and watchdog release now go through [`CapacityManager`](capacity-management.md) — `capacity.reclaim_stale(agent_timeouts)` replaces `slot_service.cleanup_stale_slots(...)` and `capacity.release_if_matches(agent, exec_id)` replaces the prior pair of `slot_service.release_slot` + `execution_queue.force_release_if_matches`. Recovery (`_recover_execution`) calls `capacity.release(...)`. `ExecutionQueue` is gone; the TOCTOU-safe match check lives on the new facade.
 
 ## Overview
@@ -85,7 +87,7 @@ Nine sequential operations plus an hourly maintenance gate, each wrapped in indi
    ```python
    count = db.mark_no_session_executions_failed(NO_SESSION_TIMEOUT_SECONDS)
    ```
-   Marks `running` executions with `claude_session_id IS NULL` older than 60 seconds as failed. These are silent launch failures where the backend failed to dispatch to the agent. Note: `TaskExecutionService` sets `claude_session_id='dispatched'` before calling the agent (step 3b), so only executions that never reached dispatch are caught here.
+   Marks `running` executions with `claude_session_id IS NULL` older than 60 seconds as failed. These are silent launch failures where the backend failed to dispatch to the agent. Note: both `TaskExecutionService` (step 3b, for `/task` / public chat / scheduled executions) AND the `chat_with_agent()` handler in `routers/chat.py` (added in #686 as the parallel of #279, for interactive `/chat` executions) set `claude_session_id='dispatched'` before their agent HTTP calls — so only executions that never reached dispatch are caught here. Both `/task` and `/chat` codepaths are protected from this false-fail sweep.
 
 3. **Finalize orphaned skipped executions** (lines 98-105, Issue #106)
    ```python
@@ -327,7 +329,7 @@ WHERE id = ?
 #### mark_execution_dispatched (ScheduleOperations)
 **File**: `src/backend/db/schedules.py:570-590`
 
-Called by `TaskExecutionService` (step 3b) before the agent HTTP call. Sets `claude_session_id='dispatched'` so the no-session cleanup only catches executions that never reached dispatch.
+Called by two codepaths before the agent HTTP call: (1) `TaskExecutionService.execute_task()` step 3b (for `/task`, public chat, and scheduled executions), and (2) `chat_with_agent()` in `src/backend/routers/chat.py:313-321` (for interactive `/chat` executions, added in #686 as the parallel of #279). Sets `claude_session_id='dispatched'` so the no-session cleanup only catches executions that never reached dispatch. On success, `chat_with_agent()` overwrites the sentinel with the real Claude UUID derived from `response_data`/`session_data`/`metadata` via `db.update_execution_status(claude_session_id=real_session_id)` at `routers/chat.py:411-428` (#686 UC1) — for observability and `--resume`-style reattachment.
 
 **SQL**:
 ```sql

--- a/docs/memory/feature-flows/task-execution-service.md
+++ b/docs/memory/feature-flows/task-execution-service.md
@@ -1,5 +1,7 @@
 # Feature: Task Execution Service (EXEC-024)
 
+> **Updated 2026-05-11 (#686 UC1):** Interactive `/chat` endpoint now mirrors the service's dispatched-sentinel pattern + real-UUID persistence inline in `routers/chat.py` (parallel of #279). The dispatched-sentinel mechanism is no longer exclusive to `TaskExecutionService.execute_task()`.
+
 > **Updated 2026-04-26 (#428):** Slot acquisition/release now goes through [`CapacityManager`](capacity-management.md) (`acquire(overflow_policy="reject")` + `release()`) rather than calling `SlotService` directly. The `slot_already_held` parameter still applies — routers pre-acquire via `CapacityManager` and pass `slot_already_held=True` so the service's `finally` block remains the single release point.
 
 ## Overview
@@ -18,7 +20,7 @@ As the platform, I want task execution paths (authenticated sync tasks, public l
 | Async parallel task | `POST /api/agents/{name}/task` (async) | **Yes** | Issue #95: thin wrapper `_run_async_task_with_persistence` in `chat.py`. Router pre-acquires slot (preserves 429-upfront contract) then calls `execute_task(slot_already_held=True, ...)` |
 | Public link chat | `POST /api/public/chat/{token}` | **Yes** | Full lifecycle |
 | Scheduled execution | `POST /api/internal/execute-task` | **Yes** | Background coroutine wraps service call |
-| Interactive chat | `POST /api/agents/{name}/chat` | **No** | Direct agent HTTP call with inline retry in `chat.py` |
+| Interactive chat | `POST /api/agents/{name}/chat` | **No** | Direct agent HTTP call with inline retry in `chat.py`. Calls `db.mark_execution_dispatched()` and persists real `claude_session_id` on success inline (#686) — same protection as the service, just not via `execute_task()`. |
 | Process engine | Internal | **No** | Separate `ExecutionEngine` with own status enum |
 
 ## Entry Points
@@ -114,6 +116,8 @@ Step  Action                                    Line   Dependency
 ```
 
 > **Step 3b**: Sets `claude_session_id='dispatched'` before the agent HTTP call. This prevents the cleanup service's no-session check from falsely marking long-running executions as "Silent launch failure". Only executions that never reach dispatch (backend crash before step 3b) will be caught by the 60-second no-session cleanup.
+>
+> **Parallel codepath (#686, 2026-05-11):** The `/chat` endpoint in `src/backend/routers/chat.py` (lines 313-321) now performs the equivalent inline dispatched-mark via `db.mark_execution_dispatched(task_execution_id)` immediately before its agent HTTP call — parallel of #279. On success it also computes the real `claude_session_id` from `response_data.get("session_id")` (falling back to `session_data` then `metadata`) and passes it to `db.update_execution_status()`, replacing the 'dispatched' sentinel with the actual Claude session UUID (#686 UC1 closes the observability gap). Net effect: the no-session sweep protection now applies to interactive chat executions too, even though `/chat` does not go through `TaskExecutionService.execute_task()`.
 
 > **Fix #90**: The try block starts at step 2 (slot acquisition) to ensure any exception updates execution status to FAILED. The `slot_acquired` flag ensures we only release slots that were successfully acquired.
 

--- a/docs/security-reports/cso-diff-2026-05-12.md
+++ b/docs/security-reports/cso-diff-2026-05-12.md
@@ -1,0 +1,93 @@
+# CSO Security Audit
+
+**Mode**: diff
+**Scope**: `AndriiPasternak31/issue-686-plan` vs `origin/dev`
+**Date**: 2026-05-12
+**Commits**: 2 (`70d10381`, `df454459`)
+**Files**: 4 changed (+527/-4)
+- `src/backend/routers/chat.py` (+18/-2)
+- `tests/unit/test_chat_dispatched_marker.py` (new, +498)
+- `docs/memory/feature-flows/cleanup-service.md` (+4/-2)
+- `docs/memory/feature-flows/task-execution-service.md` (+4/-2)
+
+## Summary
+
+| Category           | CRITICAL | HIGH | MEDIUM | LOW | INFO |
+|--------------------|---------:|-----:|-------:|----:|-----:|
+| Secrets            | 0        | 0    | 0      | 0   | 0    |
+| Dependencies       | 0        | 0    | 0      | 0   | 0    |
+| Auth Boundaries    | 0        | 0    | 0      | 0   | 0    |
+| Injection          | 0        | 0    | 0      | 0   | 1    |
+| Platform Patterns  | 0        | 0    | 0      | 0   | 0    |
+| Configuration      | 0        | 0    | 0      | 1   | 0    |
+
+## Findings
+
+### CRITICAL
+None.
+
+### HIGH
+None.
+
+### MEDIUM
+None.
+
+### LOW
+
+**1. Untracked agent-template directories not in `.gitignore`**
+- `src/backend/config/agent-templates/quota-deploy-95cd1d/`
+- `src/backend/config/agent-templates/quota-deploy-b834a0/`
+- `src/backend/config/agent-templates/quota-redeploy-3a4953/`
+- `src/backend/config/agent-templates/quota-redeploy-3a4953-2/`
+
+Contents are trivial test residue (5-line `template.yaml` + 1-line `CLAUDE.md`, no secrets). Not currently staged, but `git check-ignore` returns "NOT IGNORED", so they will get swept up by `git add -A`. If committed, they pollute the template catalog and become discoverable agent templates. Housekeeping only — delete the local dirs before commit, or add `config/agent-templates/quota-*` to `.gitignore`.
+
+### INFORMATIONAL
+
+**1. Agent-controlled `claude_session_id` now persisted on the `/chat` path** (`routers/chat.py:411-428`)
+
+The new code reads `response_data.get("session_id")` (with fallbacks to `session_data` / `metadata`) and passes it to `db.update_execution_status(claude_session_id=…)`. The string originates from the agent container's HTTP response. It is bound as a SQL parameter (no interpolation), so there is no SQL injection. Existing sanitizers (`sanitize_execution_log`, `sanitize_response` at lines 352-354) are preserved untouched. Trust model is identical to the parallel `services/task_execution_service.py:401-410` path — no regression. Flag is informational only.
+
+## Detailed Scan Results
+
+### Secrets scan
+- `grep -E '(sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36}|AKIA[A-Z0-9]{16}|xoxb-|trinity_mcp_[A-Za-z0-9])'` on diffed files → no matches.
+- Generic `(password|secret|token|api_key)=` pattern → no matches outside legitimate identifiers (`claude_session_id`, `task_execution_id`, `webhook_secret` mentions in docs).
+- No `.env*` file changes in the diff.
+
+### Dependency audit
+- No `requirements.txt`, `pyproject.toml`, `package.json`, or lockfile changes in the diff. No new dependencies introduced.
+
+### Auth boundary review
+- `chat_with_agent` (line 77) retains both `Depends(get_authorized_agent)` (ownership/sharing/role gate) and `Depends(get_current_user)`. The two new code blocks at lines 313-321 and 411-428 live inside the existing auth-gated handler. No new routes added.
+
+### Injection vectors
+- `db.mark_execution_dispatched(task_execution_id)` — `task_execution_id` is a server-generated UUID (`uuid4()` at line 123 + `db.create_task_execution` at line 206). Not user-controlled.
+- `db.update_execution_status(..., claude_session_id=real_session_id)` — `real_session_id` comes from the agent's HTTP response, but is passed as a SQL bind parameter through `cursor.execute(SQL, params)`. Not interpolated.
+- No new `subprocess`, `os.system`, `eval`, `exec`, or `shell=True` usage in the diff.
+
+### Platform-specific patterns
+- Credential-sanitizer pipeline (`sanitize_execution_log(execution_log_json)`, `sanitize_execution_log(tool_calls_json)`, `sanitize_response(...)` at lines 353-358 of the post-change file) is preserved exactly.
+- `try`/`except` wrapper around `db.mark_execution_dispatched` swallows the exception with `logger.warning(...)` — intentional per the comment ("mirrors `services/task_execution_service.py:401-410`, fixes #686"). Failure to mark dispatched does not block the chat call; the worst case is a false-fail by the no-session sweep, which is exactly the bug this defends against on the parallel codepath.
+
+### Configuration
+- No `docker-compose.yml`, `nginx`, or CORS changes.
+- No `DEBUG=`, wildcard CORS, or security-header changes.
+
+## Recommendation
+
+**CLEAR.** No security blockers for merge.
+
+## Resolutions Applied (2026-05-12)
+
+**LOW (Configuration) — RESOLVED**
+- Added `src/backend/config/agent-templates/quota-*/` to `.gitignore` (mirrors the existing `test-*/` exclusion pattern).
+- Deleted the 4 untracked `quota-deploy-*` / `quota-redeploy-*` residue directories from the working tree.
+- Verified: `git check-ignore` now matches the rule; `git status` is clean of these paths.
+
+**INFO (Injection) — RESOLVED (defense-in-depth)**
+- Added module-level `import uuid` to `src/backend/routers/chat.py`.
+- Wrapped the `real_session_id` assignment in a UUID-format validator: malformed values are logged at WARNING and replaced with `None`, leaving the `'dispatched'` sentinel in place (cleanup sweep stays correct; observability for that row is sacrificed rather than letting an agent-controlled string into the column).
+- Verified: all 10 tests in `tests/unit/test_chat_dispatched_marker.py` pass — including `test_success_update_passes_real_claude_session_id` (the kwarg is still threaded through `update_execution_status`).
+
+**Note on the parallel codepath:** `src/backend/services/task_execution_service.py:515` performs an unvalidated `response_data.get("session_id") or metadata.get("session_id")` in the same trust model. That path predates this diff and is out of scope for this audit, but the same validator would be a one-line addition there too — worth filing as a follow-up.

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -310,6 +310,16 @@ async def chat_with_agent(
         if task_execution_id:
             payload["execution_id"] = task_execution_id
 
+        # Mark execution dispatched BEFORE calling agent so the cleanup-service
+        # no-session sweep doesn't falsely fail long-running executions
+        # (mirrors services/task_execution_service.py:401-410, fixes #686 —
+        # parallel codepath of #279).
+        if task_execution_id:
+            try:
+                db.mark_execution_dispatched(task_execution_id)
+            except Exception as e:
+                logger.warning(f"[Chat] Failed to mark execution dispatched: {e}")
+
         start_time = datetime.utcnow()
 
         # Use retry helper to handle agent server startup delays
@@ -398,6 +408,14 @@ async def chat_with_agent(
         # SECURITY: Use sanitized response and execution logs
         if task_execution_id:
             context_used = session_data.get("context_tokens", 0)
+            # Persist the real Claude session UUID instead of the 'dispatched'
+            # sentinel set by mark_execution_dispatched (#686 UC1 — closes
+            # observability gap; falls back to existing sentinel if absent).
+            real_session_id = (
+                response_data.get("session_id")
+                or session_data.get("session_id")
+                or metadata.get("session_id")
+            )
             db.update_execution_status(
                 execution_id=task_execution_id,
                 status=TaskExecutionStatus.SUCCESS,
@@ -406,7 +424,8 @@ async def chat_with_agent(
                 context_max=session_data.get("context_window") or 200000,
                 cost=metadata.get("cost_usd"),
                 tool_calls=tool_calls_json,  # Simplified format for activity tracking
-                execution_log=execution_log_json  # Raw Claude Code format for UI
+                execution_log=execution_log_json,  # Raw Claude Code format for UI
+                claude_session_id=real_session_id,
             )
 
         execution_success = True

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -9,6 +9,7 @@ import httpx
 import json
 import logging
 import asyncio
+import uuid
 from datetime import datetime
 from typing import Optional
 
@@ -411,11 +412,25 @@ async def chat_with_agent(
             # Persist the real Claude session UUID instead of the 'dispatched'
             # sentinel set by mark_execution_dispatched (#686 UC1 — closes
             # observability gap; falls back to existing sentinel if absent).
+            # Defense-in-depth: agent-server emits session IDs as uuid4 strings
+            # (docker/base-image/agent_server/services/headless_executor.py:167).
+            # Reject malformed values so a buggy/compromised agent can't poison
+            # the claude_session_id column — on rejection leave the 'dispatched'
+            # sentinel (cleanup sweep stays correct, observability lost for row).
             real_session_id = (
                 response_data.get("session_id")
                 or session_data.get("session_id")
                 or metadata.get("session_id")
             )
+            if real_session_id is not None:
+                try:
+                    uuid.UUID(str(real_session_id))
+                except (ValueError, TypeError, AttributeError):
+                    logger.warning(
+                        f"[Chat] Discarding malformed claude_session_id from agent response "
+                        f"(execution_id={task_execution_id})"
+                    )
+                    real_session_id = None
             db.update_execution_status(
                 execution_id=task_execution_id,
                 status=TaskExecutionStatus.SUCCESS,

--- a/tests/unit/test_chat_dispatched_marker.py
+++ b/tests/unit/test_chat_dispatched_marker.py
@@ -36,18 +36,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
-# ---------------------------------------------------------------------------
-# Bootstrap (mirrors tests/unit/test_backlog.py:46-63)
-# ---------------------------------------------------------------------------
-_THIS = Path(__file__).resolve()
-_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
-_BACKEND_STR = str(_BACKEND)
-for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
-    sys.modules.pop(_shadow, None)
-while _BACKEND_STR in sys.path:
-    sys.path.remove(_BACKEND_STR)
-sys.path.insert(0, _BACKEND_STR)
+# tests/unit/conftest.py adds src/backend to sys.path and pre-installs the
+# canonical `utils` package via _preload_backend_utils(), so no per-file
+# sys.path / sys.modules manipulation is needed here. (Issue #762 lint
+# forbids bare `sys.modules` mutations outside conftest.)
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
 
 
 # ===========================================================================
@@ -104,15 +97,14 @@ def tmp_db(tmp_path, monkeypatch):
     conn.commit()
     conn.close()
 
-    def _evict():
-        for mod in ("db.connection", "db.schedules", "database"):
-            sys.modules.pop(mod, None)
+    # Evict any cached backend DB modules so the schedule_ops fixture's
+    # `from db.schedules import ScheduleOperations` re-imports against the
+    # fresh TRINITY_DB_PATH set above. monkeypatch restores the prior
+    # entries at fixture teardown, isolating the next test.
+    for mod in ("db.connection", "db.schedules", "database"):
+        monkeypatch.delitem(sys.modules, mod, raising=False)
 
-    _evict()
-    try:
-        yield db_path
-    finally:
-        _evict()
+    yield db_path
 
 
 @pytest.fixture

--- a/tests/unit/test_chat_dispatched_marker.py
+++ b/tests/unit/test_chat_dispatched_marker.py
@@ -1,0 +1,506 @@
+"""
+Chat dispatched-marker tests (Issue #686)
+
+Issue #686: `/api/chat` had no `mark_execution_dispatched()` defense, so
+long-running executions (cold-start agents, ~5KB MCP prompts) were falsely
+stamped FAILED by `cleanup_service.mark_no_session_executions_failed` after
+60s — even though the agent was still healthy and processing.
+
+The fix mirrors the defense already in `task_execution_service.py:401-410`
+(commit 2798ca95, issue #279). It also closes a latent Chat-UI vulnerability
+because `/api/chat` is the shared codepath for MCP sequential calls AND the
+web Chat-UI.
+
+Hybrid test strategy (per #686 autoplan UC6 + CC unit-test conventions):
+
+- **DB-level tests (real SQLite)**: exercise `mark_no_session_executions_failed`
+  directly with hand-crafted rows. Verifies the cleanup mechanism's
+  exclude-dispatched filter still works AND that the NULL/'' regression path
+  is still caught. These are the load-bearing tests for the fix's mechanism.
+- **AST-level tests (parse `routers/chat.py` source)**: verify the marker call
+  ordering, the try/except wrapper, the `claude_session_id` kwarg threading,
+  and the failure-path `update_execution_status(FAILED)` survive. Mirrors the
+  pattern at `tests/unit/test_backlog.py:828-895` (the `_run_async_task_with_persistence`
+  rename regression guard). AST avoids the full FastAPI dep-injection chain
+  while still catching the recurring bug class.
+"""
+
+from __future__ import annotations
+
+import ast
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap (mirrors tests/unit/test_backlog.py:46-63)
+# ---------------------------------------------------------------------------
+_THIS = Path(__file__).resolve()
+_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+# ===========================================================================
+# DB-level tests: cleanup query behavior
+# ===========================================================================
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Spin up a fresh SQLite database with just `schedule_executions`.
+
+    Pattern lifted from `tests/unit/test_backlog.py:66-156` — minimal schema,
+    env-var redirected, modules evicted on teardown so the next test isn't
+    poisoned.
+    """
+    db_path = tmp_path / "trinity-686.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE schedule_executions (
+            id TEXT PRIMARY KEY,
+            schedule_id TEXT,
+            agent_name TEXT NOT NULL,
+            status TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            completed_at TEXT,
+            duration_ms INTEGER,
+            message TEXT NOT NULL DEFAULT '',
+            response TEXT,
+            error TEXT,
+            triggered_by TEXT NOT NULL DEFAULT 'test',
+            context_used INTEGER,
+            context_max INTEGER,
+            cost REAL,
+            tool_calls TEXT,
+            execution_log TEXT,
+            source_user_id INTEGER,
+            source_user_email TEXT,
+            source_agent_name TEXT,
+            source_mcp_key_id TEXT,
+            source_mcp_key_name TEXT,
+            claude_session_id TEXT,
+            model_used TEXT,
+            fan_out_id TEXT,
+            subscription_id TEXT,
+            queued_at TEXT,
+            backlog_metadata TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    def _evict():
+        for mod in ("db.connection", "db.schedules", "database"):
+            sys.modules.pop(mod, None)
+
+    _evict()
+    try:
+        yield db_path
+    finally:
+        _evict()
+
+
+@pytest.fixture
+def schedule_ops(tmp_db):
+    from db.schedules import ScheduleOperations
+
+    return ScheduleOperations(user_ops=MagicMock(), agent_ops=MagicMock())
+
+
+def _insert_running(tmp_db: Path, *, exec_id: str, claude_session_id, started_at: str):
+    conn = sqlite3.connect(str(tmp_db))
+    conn.execute(
+        """
+        INSERT INTO schedule_executions
+          (id, agent_name, status, started_at, message, triggered_by, claude_session_id)
+        VALUES (?, ?, 'running', ?, ?, 'mcp', ?)
+        """,
+        (exec_id, "test-agent", started_at, "msg", claude_session_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _fetch(tmp_db: Path, exec_id: str):
+    conn = sqlite3.connect(str(tmp_db))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM schedule_executions WHERE id = ?", (exec_id,)
+    ).fetchone()
+    conn.close()
+    return row
+
+
+def _stale_started_at(seconds: int) -> str:
+    """Format an ISO-Z timestamp `seconds` in the past so it sorts past
+    the cleanup threshold computed by `db/schedules.py:1581`.
+    """
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+
+
+class TestNoSessionCleanupFilter:
+    """`mark_no_session_executions_failed` must exclude 'dispatched' rows and
+    still catch genuinely-unmarked silent-launch failures.
+    """
+
+    pytestmark = pytest.mark.unit
+
+    def test_dispatched_row_survives_no_session_cleanup(
+        self, tmp_db, schedule_ops
+    ):
+        """REGRESSION (#686 mechanism): a 'running' row with
+        claude_session_id='dispatched' is NOT matched by the cleanup
+        filter, even after 60s+.
+
+        This is the load-bearing assertion. After Change 1 in
+        `routers/chat.py`, the chat path stamps 'dispatched' before
+        calling the agent — the cleanup sweep's
+        `claude_session_id IS NULL OR claude_session_id = ''` filter
+        no longer matches, so long-running MCP/Chat-UI calls survive.
+        """
+        _insert_running(
+            tmp_db,
+            exec_id="exec-dispatched",
+            claude_session_id="dispatched",
+            started_at=_stale_started_at(seconds=120),
+        )
+
+        count = schedule_ops.mark_no_session_executions_failed(
+            timeout_seconds=60
+        )
+        assert count == 0, (
+            "dispatched rows must not match the no-session cleanup filter"
+        )
+
+        row = _fetch(tmp_db, "exec-dispatched")
+        assert row["status"] == "running"
+        assert row["error"] is None
+        assert row["claude_session_id"] == "dispatched"
+
+    def test_undispatched_row_still_caught_by_no_session_cleanup(
+        self, tmp_db, schedule_ops
+    ):
+        """REGRESSION (cleanup safety net): a 'running' row with NULL
+        claude_session_id is still flagged as a silent launch failure.
+
+        Without this test, a future refactor that weakens the cleanup
+        filter (or accidentally stamps 'dispatched' on every row) would
+        silently break the 60s fast-fail safety net for genuinely-broken
+        launches.
+        """
+        _insert_running(
+            tmp_db,
+            exec_id="exec-undispatched",
+            claude_session_id=None,
+            started_at=_stale_started_at(seconds=120),
+        )
+
+        count = schedule_ops.mark_no_session_executions_failed(
+            timeout_seconds=60
+        )
+        assert count == 1, (
+            "rows with NULL claude_session_id must still be marked FAILED"
+        )
+
+        row = _fetch(tmp_db, "exec-undispatched")
+        assert row["status"] == "failed"
+        assert row["error"] is not None
+        assert "Silent launch failure" in row["error"]
+
+    def test_empty_string_claude_session_id_still_caught(
+        self, tmp_db, schedule_ops
+    ):
+        """Defensive: the cleanup filter is `IS NULL OR = ''`, so empty
+        strings must also be caught. Locks in the existing SQL.
+        """
+        _insert_running(
+            tmp_db,
+            exec_id="exec-empty",
+            claude_session_id="",
+            started_at=_stale_started_at(seconds=120),
+        )
+
+        count = schedule_ops.mark_no_session_executions_failed(
+            timeout_seconds=60
+        )
+        assert count == 1
+        assert _fetch(tmp_db, "exec-empty")["status"] == "failed"
+
+
+class TestMarkExecutionDispatched:
+    """`mark_execution_dispatched` writes 'dispatched' only on a clean
+    (status='running', claude_session_id IS NULL) row — idempotent + safe.
+    """
+
+    pytestmark = pytest.mark.unit
+
+    def test_marks_running_row_with_null_session(self, tmp_db, schedule_ops):
+        _insert_running(
+            tmp_db,
+            exec_id="exec-mark",
+            claude_session_id=None,
+            started_at=_stale_started_at(seconds=5),
+        )
+
+        updated = schedule_ops.mark_execution_dispatched("exec-mark")
+        assert updated is True
+
+        row = _fetch(tmp_db, "exec-mark")
+        assert row["claude_session_id"] == "dispatched"
+        assert row["status"] == "running"
+
+    def test_no_op_when_already_dispatched(self, tmp_db, schedule_ops):
+        """The UPDATE guards on `claude_session_id IS NULL` so calling
+        mark twice doesn't clobber a real UUID written later.
+        """
+        _insert_running(
+            tmp_db,
+            exec_id="exec-twice",
+            claude_session_id=None,
+            started_at=_stale_started_at(seconds=1),
+        )
+
+        first = schedule_ops.mark_execution_dispatched("exec-twice")
+        second = schedule_ops.mark_execution_dispatched("exec-twice")
+
+        assert first is True
+        assert second is False, "second mark must be a no-op"
+
+
+# ===========================================================================
+# AST-level tests: routers/chat.py structural verification
+#
+# Importing routers/chat.py at unit-test time would drag in FastAPI,
+# the database singleton, capacity_manager, audit service, etc. The
+# canonical analog at tests/unit/test_backlog.py:828-895 solves this by
+# parsing the source file with `ast` and asserting the relevant call
+# nodes exist where the fix landed them. The recurring bug class
+# (silent dispatch-marker regression, #279 → #686) demands a guard at
+# this layer — runtime mocks of the full router are too brittle to
+# remain useful across refactors.
+# ===========================================================================
+
+
+class TestChatRouterSource:
+    """Static analysis guards over `src/backend/routers/chat.py`."""
+
+    pytestmark = pytest.mark.unit
+
+    @pytest.fixture(scope="class")
+    def chat_func(self):
+        """Parse routers/chat.py and return the chat_with_agent function node."""
+        chat_src = _BACKEND / "routers" / "chat.py"
+        assert chat_src.exists(), f"routers/chat.py missing at {chat_src}"
+        tree = ast.parse(chat_src.read_text(), filename=str(chat_src))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "chat_with_agent"
+            ):
+                return node
+        pytest.fail("chat_with_agent function not found in routers/chat.py")
+
+    def _walk_calls_with_line(self, node):
+        """Yield (lineno, attr_name, arg_repr) for every call expression
+        inside the function body.
+        """
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            func = child.func
+            # Match `obj.attr(...)` form (db.mark_execution_dispatched, etc.)
+            if isinstance(func, ast.Attribute):
+                yield child.lineno, func.attr, child
+            # Match `name(...)` form (agent_post_with_retry, etc.)
+            elif isinstance(func, ast.Name):
+                yield child.lineno, func.id, child
+
+    def test_marks_execution_dispatched_before_agent_call(self, chat_func):
+        """Core ordering guarantee: `mark_execution_dispatched` appears
+        BEFORE `agent_post_with_retry` in the chat_with_agent body.
+
+        This is the structural check that catches the #686 regression
+        class. Mirrors `task_execution_service.py:401-410`.
+        """
+        calls = list(self._walk_calls_with_line(chat_func))
+        mark_lines = sorted(
+            ln for ln, name, _ in calls if name == "mark_execution_dispatched"
+        )
+        post_lines = sorted(
+            ln for ln, name, _ in calls if name == "agent_post_with_retry"
+        )
+
+        assert mark_lines, (
+            "chat_with_agent must call db.mark_execution_dispatched(...) "
+            "before agent_post_with_retry — see fix for #686. The defense "
+            "is identical to services/task_execution_service.py:401-410."
+        )
+        assert post_lines, "agent_post_with_retry call not found"
+        # First mark must come before first agent POST.
+        assert mark_lines[0] < post_lines[0], (
+            f"mark_execution_dispatched is at line {mark_lines[0]}, "
+            f"agent_post_with_retry at {post_lines[0]} — marker must "
+            f"precede the agent POST so cleanup_service doesn't false-fail "
+            f"in-flight executions."
+        )
+
+    def test_dispatched_marker_wrapped_in_try_except(self, chat_func):
+        """The marker call lives inside a `try / except / warning-log` block
+        so a transient DB error never breaks chat.
+
+        Mirrors `task_execution_service.py:406-410`. Without the wrapper, a
+        flaky `mark_execution_dispatched` would 500 every chat call instead
+        of degrading silently to the prior (vulnerable) behavior.
+        """
+        for try_node in ast.walk(chat_func):
+            if not isinstance(try_node, ast.Try):
+                continue
+            # Does this try-block contain a mark_execution_dispatched call?
+            contains_mark = any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Attribute)
+                and c.func.attr == "mark_execution_dispatched"
+                for c in ast.walk(try_node)
+            )
+            if not contains_mark:
+                continue
+            # And the except clause logs a warning?
+            for handler in try_node.handlers:
+                for h_node in ast.walk(handler):
+                    if (
+                        isinstance(h_node, ast.Call)
+                        and isinstance(h_node.func, ast.Attribute)
+                        and h_node.func.attr == "warning"
+                    ):
+                        return  # pass
+        pytest.fail(
+            "mark_execution_dispatched must be wrapped in try/except with a "
+            "logger.warning(...) on failure — mirrors task_execution_service.py:406-410"
+        )
+
+    def test_success_update_passes_real_claude_session_id(self, chat_func):
+        """UC1: the SUCCESS-path `update_execution_status` call must pass a
+        `claude_session_id=` kwarg so the real Claude UUID overwrites the
+        'dispatched' sentinel.
+
+        Without this, every chat-triggered row permanently shows
+        claude_session_id='dispatched' — destroying observability and
+        creating a future-bug surface for any code reading the column as a
+        real session id.
+        """
+        # Find every update_execution_status call in the body.
+        update_calls = [
+            c
+            for c in ast.walk(chat_func)
+            if isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Attribute)
+            and c.func.attr == "update_execution_status"
+        ]
+        assert update_calls, "no update_execution_status calls found"
+
+        success_calls = []
+        for call in update_calls:
+            for kw in call.keywords:
+                if kw.arg == "status":
+                    # Status is `TaskExecutionStatus.SUCCESS` — captured as
+                    # an ast.Attribute node.
+                    if (
+                        isinstance(kw.value, ast.Attribute)
+                        and kw.value.attr == "SUCCESS"
+                    ):
+                        success_calls.append(call)
+        assert success_calls, (
+            "no update_execution_status(status=TaskExecutionStatus.SUCCESS) "
+            "call found in chat_with_agent"
+        )
+
+        for call in success_calls:
+            kwarg_names = {kw.arg for kw in call.keywords}
+            assert "claude_session_id" in kwarg_names, (
+                f"update_execution_status SUCCESS call at line {call.lineno} "
+                f"must pass claude_session_id=... — without it the row keeps "
+                f"the 'dispatched' sentinel forever (#686 UC1)."
+            )
+
+    def test_failure_path_marks_execution_failed(self, chat_func):
+        """Sanity: the httpx.HTTPError handler still calls
+        `update_execution_status(status=TaskExecutionStatus.FAILED, ...)`.
+
+        Regression guard against accidentally weakening the failure-path
+        cleanup that the cleanup-service can't substitute for (because
+        cleanup only catches NULL/'' rows, not dispatched-then-errored
+        ones).
+        """
+        has_failed_update = False
+        for call in ast.walk(chat_func):
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "update_execution_status"
+            ):
+                continue
+            for kw in call.keywords:
+                if (
+                    kw.arg == "status"
+                    and isinstance(kw.value, ast.Attribute)
+                    and kw.value.attr == "FAILED"
+                ):
+                    has_failed_update = True
+                    break
+        assert has_failed_update, (
+            "chat_with_agent must call update_execution_status("
+            "status=TaskExecutionStatus.FAILED) in its httpx error handler"
+        )
+
+
+# ===========================================================================
+# Mirror-pattern guard: chat.py and task_execution_service.py stay in sync
+# ===========================================================================
+
+
+class TestMirrorPatternStillInSync:
+    """The chat-router fix is a verbatim mirror of the
+    `task_execution_service.py` defense. If one side rolls back the marker
+    call, the other must signal a regression — that's the bug class behind
+    both #279 and #686.
+    """
+
+    pytestmark = pytest.mark.unit
+
+    def test_both_paths_call_mark_execution_dispatched(self):
+        """Both `routers/chat.py` and `services/task_execution_service.py`
+        must call `db.mark_execution_dispatched(...)`.
+
+        UC3 follow-up will pull this into a shared `dispatch_to_agent`
+        primitive — until then, the call must exist in BOTH places.
+        """
+        chat_src = (_BACKEND / "routers" / "chat.py").read_text()
+        task_src = (
+            _BACKEND / "services" / "task_execution_service.py"
+        ).read_text()
+
+        assert "mark_execution_dispatched" in chat_src, (
+            "routers/chat.py is missing the mark_execution_dispatched call — "
+            "#686 regression"
+        )
+        assert "mark_execution_dispatched" in task_src, (
+            "services/task_execution_service.py is missing the "
+            "mark_execution_dispatched call — #279 regression"
+        )

--- a/tests/unit/test_cleanup_unreachable_orphan.py
+++ b/tests/unit/test_cleanup_unreachable_orphan.py
@@ -56,27 +56,32 @@ if str(_BACKEND) not in sys.path:
 
 # The unit test venv does NOT have the `docker` Python package installed,
 # but `services/__init__.py` eagerly imports `services.docker_service` which
-# imports `docker`. Stub both BEFORE we import anything from `services`.
-# Same shape as tests/test_watchdog_unit.py's preload block — mirrored here
-# instead of imported because the unit/ conftest preloads a different module
-# set and importing the top-level test file would re-execute its stubs.
-if "docker" not in sys.modules:
-    sys.modules["docker"] = MagicMock(name="docker_stub")
-if "services.docker_service" not in sys.modules:
-    _ds_stub = types.ModuleType("services.docker_service")
-    _ds_stub.docker_client = MagicMock()
-    _ds_stub.get_agent_container = lambda *a, **kw: None
-    _ds_stub.get_agent_status_from_container = lambda *a, **kw: "stopped"
-    _ds_stub.list_all_agents = lambda *a, **kw: []
-    _ds_stub.get_agent_by_name = lambda *a, **kw: None
-    _ds_stub.get_next_available_port = lambda *a, **kw: 2222
-    async def _exec(*a, **kw):
-        return {"exit_code": 0, "output": ""}
-    _ds_stub.execute_command_in_container = _exec
-    sys.modules["services.docker_service"] = _ds_stub
-# database.db is hit transitively; pre-stub it before cleanup_service loads.
-if "database" not in sys.modules:
-    sys.modules["database"] = MagicMock(name="database_stub")
+# imports `docker`. Stub both BEFORE the test method imports cleanup_service.
+# Issue #762 lint forbids bare `sys.modules` mutations outside conftest, so
+# install via an autouse monkeypatch fixture — the imports inside each test
+# (`from services.cleanup_service import CleanupService`) and `@patch(...)`
+# resolution both happen after fixture setup, so the stubs land in time.
+@pytest.fixture(autouse=True)
+def _stub_docker_and_database(monkeypatch):
+    if "docker" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "docker", MagicMock(name="docker_stub"))
+    if "services.docker_service" not in sys.modules:
+        _ds_stub = types.ModuleType("services.docker_service")
+        _ds_stub.docker_client = MagicMock()
+        _ds_stub.get_agent_container = lambda *a, **kw: None
+        _ds_stub.get_agent_status_from_container = lambda *a, **kw: "stopped"
+        _ds_stub.list_all_agents = lambda *a, **kw: []
+        _ds_stub.get_agent_by_name = lambda *a, **kw: None
+        _ds_stub.get_next_available_port = lambda *a, **kw: 2222
+
+        async def _exec(*a, **kw):
+            return {"exit_code": 0, "output": ""}
+
+        _ds_stub.execute_command_in_container = _exec
+        monkeypatch.setitem(sys.modules, "services.docker_service", _ds_stub)
+    # database.db is hit transitively; pre-stub it before cleanup_service loads.
+    if "database" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "database", MagicMock(name="database_stub"))
 
 
 def _iso_past_minutes(minutes: int) -> str:


### PR DESCRIPTION
## Summary

Fixes #686 — the interactive `/api/chat` handler was missing the `mark_execution_dispatched()` defense that lives in `services/task_execution_service.py`, so cold-start or large-prompt chat executions were being false-stamped FAILED by `cleanup_service.mark_no_session_executions_failed` after 60s while the agent was still healthy and processing. This is the parallel codepath of #279 (which fixed the same bug class for `/task`).

- `routers/chat.py:317-321` — call `db.mark_execution_dispatched()` before `agent_post_with_retry` so the no-session sweep skips the row
- `routers/chat.py:411-428` — on SUCCESS, replace the `'dispatched'` sentinel with the real Claude session UUID derived from `response_data` → `session_data` → `metadata` (UC1, closes the observability gap so `/api/chat` rows show the real UUID instead of permanently reading `'dispatched'`)
- Mirrors `task_execution_service.py:401-410` (commit 2798ca95, issue #279)

## Tests

`tests/unit/test_chat_dispatched_marker.py` (3 layers):

- **DB-level**: real sqlite verifies dispatched rows survive the 60s no-session sweep AND NULL/`''` rows are still caught
- **AST-level**: parses `routers/chat.py` and asserts marker ordering, the try/except wrapper, the `claude_session_id` kwarg on the SUCCESS update, and the FAILED-path `update_execution_status` survive future refactors
- **Mirror invariant**: `routers/chat.py` and `task_execution_service.py` must BOTH contain the `mark_execution_dispatched` call — guards against the recurring bug class behind #279 and #686

## Docs

- `docs/memory/feature-flows/cleanup-service.md` — broadened the no-session sweep + `mark_execution_dispatched` docs to list both producers of the `'dispatched'` sentinel
- `docs/memory/feature-flows/task-execution-service.md` — Coverage-table note on the Interactive chat row + Step 3b "parallel codepath" sub-paragraph; service still does NOT cover `/chat`, only the dispatched-sentinel mechanism is now shared

## Test plan

- [x] `pytest tests/unit/test_chat_dispatched_marker.py` — 3 test layers pass locally
- [ ] CI green on PR
- [ ] Manual: trigger a slow MCP chat (cold-start agent) and verify the execution row reaches SUCCESS with a real Claude UUID rather than being false-failed at 60s