### PR TITLE
chore(tests): baseline pre-existing sys.modules pollution in test_cleanup_unreachable_orphan.py

### DIFF
--- a/tests/lint_sys_modules_baseline.txt
+++ b/tests/lint_sys_modules_baseline.txt
@@ -26,6 +26,7 @@
 4 tests/unit/test_channel_image_vision.py
 2 tests/unit/test_chat_sync_backlog.py
 1 tests/unit/test_claude_code_session_id_parser.py
+3 tests/unit/test_cleanup_unreachable_orphan.py
 1 tests/unit/test_config_fail_fast.py
 1 tests/unit/test_credential_sanitizer_backend.py
 1 tests/unit/test_docker_utils.py


### PR DESCRIPTION
## Summary

Unblock the `lint (sys.modules pollution check)` CI job for every PR opened against `dev`.

**Root cause** — merge order on `dev`:
- #783 (`79a64814`) added `tests/unit/test_cleanup_unreachable_orphan.py` with 3 top-level `sys.modules[...] = stub` assignments (lines 64, 76, 79: `docker`, `services.docker_service`, `database`)
- #791 (`3043631e`) added `tests/lint_sys_modules.py` and generated `tests/lint_sys_modules_baseline.txt` — but the baseline was generated against a tree that did **not** include the orphan-test file's violations

Result: the lint job now fails on every PR built against current `dev`, even when the PR's own changes are clean. PR #795 hit this immediately (its own violations were fixed in `ece8a7db`, but the orphan-test file remained as a residual failure).

## Fix

Add a single line to the baseline:
```
3 tests/unit/test_cleanup_unreachable_orphan.py
```

Same shape as the already-baselined `test_watchdog_unit.py` (3 violations) — the file the orphan-test's own preload comment cites as its precedent. The 3 stubs are installed at module level **before** importing `services.cleanup_service`, so `monkeypatch` (fixture-scoped) cannot replace them. The lint script's baseline is the intended mechanism for grandfathering exactly this pattern.

Per the baseline file's stated goal ("reduce these counts over time; never grow them"), follow-up cleanup of these 3 stubs into a snapshot/restore helper or moving the test into the no-monkeypatch group is left as a separate hygiene PR.

## Test plan

- [x] `python3 tests/lint_sys_modules.py` → zero violations in the real test tree (only `.venv` site-packages flagged, which CI runners don't have)
- [ ] CI green on this PR
- [ ] After merge: re-trigger PR #795 lint job, confirm it goes green

## References

- Refs #762 (the lint), #783 (the orphan test), #791 (the baseline that missed the orphan test)