### PR TITLE
chore(tooling): mark root pyproject as uv-unmanaged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.uv]
+managed = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]


### PR DESCRIPTION
## Summary

- Root `pyproject.toml` is pytest config only (no `[project]`, no dependencies).
- Any `uv` invocation from the repo root (or a worktree) generates a near-empty `uv.lock` (52 bytes — just `version`, `revision`, `requires-python`) that then surfaces as untracked in `git status` and noise in PRs.
- `[tool.uv] managed = false` opts out of uv's automatic locking and syncing for this directory ([uv docs reference](https://docs.astral.sh/uv/concepts/projects/layout/#project-environments)). Sub-projects under `src/cli/` and `src/scheduler/` keep their own `pyproject.toml` and are unaffected.

## Test plan

- [ ] `git status` clean after `uv run pytest` from the repo root (no stray `uv.lock`)
- [ ] `pytest` still discovers and runs the suite (the `[tool.pytest.ini_options]` block is unchanged)
- [ ] Existing CI (`pytest`, `lint`, `regression diff`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)