### PR TITLE
fix(tests): override "test" sentinel in security conftest (closes #804)

### DIFF
--- a/tests/security/conftest.py
+++ b/tests/security/conftest.py
@@ -17,12 +17,21 @@ except ImportError:  # pragma: no cover
 
 @pytest.fixture(scope="session", autouse=True)
 def _load_redis_env():
+    # tests/conftest.py setdefaults REDIS_PASSWORD/REDIS_BACKEND_PASSWORD to the
+    # literal "test" at global pytest import so backend modules can be imported
+    # without real Redis creds. That sentinel must be cleared here before we
+    # overlay real values from .env, otherwise setdefault is a no-op and the
+    # skip-guard below sees "test" and lets the suite run with wrong creds (#804).
+    for key in ("REDIS_PASSWORD", "REDIS_BACKEND_PASSWORD"):
+        if os.environ.get(key) == "test":
+            del os.environ[key]
+
     if dotenv_values is not None:
         env_path = Path(__file__).resolve().parents[2] / ".env"
         if env_path.exists():
             for key, value in dotenv_values(env_path).items():
                 if key in {"REDIS_PASSWORD", "REDIS_BACKEND_PASSWORD"} and value:
-                    os.environ.setdefault(key, value)
+                    os.environ[key] = value
 
     for required in ("REDIS_PASSWORD", "REDIS_BACKEND_PASSWORD"):
         if required not in os.environ or not os.environ[required]:

--- a/tests/security/test_redis_conftest_regression.py
+++ b/tests/security/test_redis_conftest_regression.py
@@ -1,0 +1,75 @@
+"""Regression test for #804 — security conftest's `.env` overlay must
+defeat the parent conftest's `"test"` sentinel.
+
+`tests/conftest.py` setdefaults `REDIS_PASSWORD` / `REDIS_BACKEND_PASSWORD`
+to the literal string `"test"` at global pytest import so backend module
+imports don't blow up. Before #804 was fixed, `tests/security/conftest.py`
+used `os.environ.setdefault(...)` to overlay real values from `.env` —
+which is a no-op once the sentinel is set. Result: `redis-cli` ran with
+`-a test` against a healthy stack and the ACL tests failed for the wrong
+reason. The fix in `tests/security/conftest.py:_load_redis_env` pops the
+sentinel before overlaying, and uses direct assignment.
+
+This test relies on the session-autouse `_load_redis_env` having already
+fired — which either skipped the whole suite (when no creds are available
+anywhere) or populated `os.environ` with real values. If we got here, the
+fixture decided creds are present; they must not be the sentinel.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+try:
+    from dotenv import dotenv_values  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover
+    dotenv_values = None  # type: ignore[assignment]
+
+
+@pytest.mark.integration
+def test_security_conftest_overlays_test_sentinel() -> None:
+    for key in ("REDIS_PASSWORD", "REDIS_BACKEND_PASSWORD"):
+        actual = os.environ.get(key)
+        assert actual is not None and actual != "", (
+            f"{key} missing — the autouse `_load_redis_env` should have "
+            f"skipped the session before this test ran"
+        )
+        assert actual != "test", (
+            f'{key} is still the parent conftest\'s "test" sentinel — '
+            f"tests/security/conftest.py:_load_redis_env failed to override "
+            f"it (regression of #804: setdefault is a no-op once the parent "
+            f"conftest has set the key)"
+        )
+
+
+@pytest.mark.integration
+def test_dotenv_value_won_when_env_present() -> None:
+    """Stronger check: when `.env` defines either key, the live value
+    must equal the `.env` value (not the `"test"` sentinel, not a stale
+    earlier value). Skips per-key when `.env` is absent or doesn't define it.
+    """
+    if dotenv_values is None:
+        pytest.skip("python-dotenv not installed")
+
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if not env_path.exists():
+        pytest.skip("project .env not present — precondition unmet")
+
+    env_values = dotenv_values(env_path)
+    checked = 0
+    for key in ("REDIS_PASSWORD", "REDIS_BACKEND_PASSWORD"):
+        expected = env_values.get(key)
+        if not expected:
+            continue
+        checked += 1
+        actual = os.environ.get(key)
+        assert actual == expected, (
+            f"{key} in os.environ does not match .env: "
+            f"expected={expected!r}, got={actual!r} — "
+            f"tests/security/conftest.py:_load_redis_env failed to overlay "
+            f"the .env value over the prior os.environ value (regression of #804)"
+        )
+
+    if checked == 0:
+        pytest.skip(".env defines neither REDIS_PASSWORD nor REDIS_BACKEND_PASSWORD")


### PR DESCRIPTION
## Summary

Fixes the fixture-precedence bug from #804 — `tests/security/test_redis_network_isolation.py` ACL tests have failed against any live stack since #589 (2026-05-04) because the global `tests/conftest.py:30` `setdefault`s `REDIS_BACKEND_PASSWORD="test"` and the security conftest then tries to override from `.env` using `setdefault` (no-op when the key already exists). The bogus `"test"` value reached `redis-cli`, Redis correctly rejected it, and the tests failed with `NOAUTH`.

Two-line fix in `tests/security/conftest.py`:
1. `del os.environ[key]` for `REDIS_PASSWORD` / `REDIS_BACKEND_PASSWORD` when they equal the literal `"test"` sentinel, before loading `.env`.
2. Direct assignment (`os.environ[key] = value`) instead of `setdefault` when applying values from `.env`.

Plus a new file `tests/security/test_redis_conftest_regression.py` with 2 unit tests that lock in the precedence behavior — they'd fail under the old code and pass under the new code.

## Verification

Full integration suite against a fresh stack:

```
========= 27 passed, 3 skipped, 3584 deselected, 8 warnings in 38.42s ==========
```

The three previously-failing tests now pass:
- `test_platform_container_can_authenticate` ✅
- `test_backend_acl_blocks_flushall` ✅
- `test_backend_acl_blocks_config_get` ✅

Plus the 2 new regression tests:
- `test_security_conftest_overlays_test_sentinel` ✅
- `test_dotenv_value_won_when_env_present` ✅

## Stacking

Based on top of #796 (`AndriiPasternak31/lint-baseline-orphan-test`) — that PR baselines the pre-existing 3 `sys.modules` violations in `test_cleanup_unreachable_orphan.py` so the lint check passes. Without it, this PR's lint job fails on an unrelated pre-existing violation. **#796 should land first**; this PR auto-retargets to `dev` once #796 merges.

## Test plan

- [ ] CI: lint passes (relies on #796's baseline bump being in base)
- [ ] CI: pytest passes
- [ ] CI: regression diff clean
- [ ] On a live stack: `pytest tests/security/ -m integration -v` → 5 passed (the 3 ACL tests + 2 regression tests + the 2 already-passing existence tests)

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)