### PR TITLE
fix(agent-server): bound accumulators + /health diagnostics (#333 hardening)

### DIFF
--- a/docker/base-image/agent_server/routers/info.py
+++ b/docker/base-image/agent_server/routers/info.py
@@ -3,7 +3,9 @@ Agent info, template info, health, and metrics endpoints.
 """
 import os
 import json
+import asyncio
 import logging
+import threading
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -14,6 +16,35 @@ from ..state import agent_state
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _diagnostics() -> Dict[str, Any]:
+    """Lightweight runtime gauges for spotting accumulator leaks. #333."""
+    try:
+        thread_count = threading.active_count()
+    except Exception:
+        thread_count = -1
+
+    try:
+        loop = asyncio.get_running_loop()
+        task_count = len(asyncio.all_tasks(loop))
+    except RuntimeError:
+        task_count = -1
+
+    running_executions = -1
+    try:
+        from ..services.process_registry import get_process_registry
+        running_executions = len(get_process_registry().list_running())
+    except Exception:
+        pass
+
+    return {
+        "thread_count": thread_count,
+        "asyncio_task_count": task_count,
+        "running_executions": running_executions,
+        "conversation_history_size": len(agent_state.conversation_history),
+        "conversation_history_limit": agent_state.history_limit,
+    }
 
 
 @router.get("/")
@@ -66,7 +97,12 @@ async def get_agent_info():
 
 @router.get("/health")
 async def health_check():
-    """Health check endpoint"""
+    """Health check endpoint.
+
+    Includes lightweight runtime gauges (thread count, asyncio task count,
+    running executions, history size) so a curl against /health is enough to
+    spot accumulator leaks without strace or pprof. #333.
+    """
     return {
         "status": "healthy",
         "agent_name": agent_state.agent_name,
@@ -74,7 +110,8 @@ async def health_check():
         "runtime_available": agent_state.runtime_available,
         # Backward compatibility
         "claude_available": agent_state.claude_code_available,
-        "message_count": len(agent_state.conversation_history)
+        "message_count": len(agent_state.conversation_history),
+        "diagnostics": _diagnostics(),
     }
 
 

--- a/docker/base-image/agent_server/services/gemini_runtime.py
+++ b/docker/base-image/agent_server/services/gemini_runtime.py
@@ -9,6 +9,7 @@ import uuid
 import asyncio
 import subprocess
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Optional, Tuple
 from datetime import datetime
 from pathlib import Path
@@ -21,6 +22,13 @@ from .activity_tracking import start_tool_execution, complete_tool_execution
 from .runtime_adapter import AgentRuntime
 
 logger = logging.getLogger(__name__)
+
+# Single shared executor for subprocess reading. Mirrors the pattern in
+# claude_code.py:63 — one long-lived worker thread instead of a fresh
+# ThreadPoolExecutor per call. Per-call executors rely on CPython's weakref
+# callback to clean up the worker thread on GC, which is not deterministic
+# under load. #333 hardening.
+_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gemini-subproc")
 
 # Gemini pricing per 1K tokens (as of Dec 2024, from ai.google.dev/pricing)
 # Free tier has limits, but we calculate what it *would* cost
@@ -211,10 +219,8 @@ class GeminiRuntime(AgentRuntime):
                 return stderr, return_code
 
             # Run the blocking subprocess reading in a thread pool
-            from concurrent.futures import ThreadPoolExecutor
-            executor = ThreadPoolExecutor(max_workers=1)
             loop = asyncio.get_event_loop()
-            stderr_output, return_code = await loop.run_in_executor(executor, read_subprocess_output)
+            stderr_output, return_code = await loop.run_in_executor(_executor, read_subprocess_output)
 
             # Check for errors
             if return_code != 0:
@@ -608,10 +614,8 @@ class GeminiRuntime(AgentRuntime):
                 return stderr, return_code
 
             # Run the blocking subprocess reading in a thread pool
-            from concurrent.futures import ThreadPoolExecutor
-            executor = ThreadPoolExecutor(max_workers=1)
             loop = asyncio.get_event_loop()
-            stderr_output, return_code = await loop.run_in_executor(executor, read_subprocess_output)
+            stderr_output, return_code = await loop.run_in_executor(_executor, read_subprocess_output)
 
             # Check for errors
             if return_code != 0:

--- a/docker/base-image/agent_server/state.py
+++ b/docker/base-image/agent_server/state.py
@@ -11,6 +11,24 @@ from .models import ChatMessage
 
 logger = logging.getLogger(__name__)
 
+# Cap for in-memory conversation_history. Without it the list grows unbounded
+# across days-long agent uptime — persistent chat history lives in the backend
+# DB; this in-memory copy is only used for the agent-server API (history,
+# session info). Override via AGENT_HISTORY_LIMIT env var. #333 hardening.
+_DEFAULT_HISTORY_LIMIT = 1000
+
+
+def _resolve_history_limit() -> int:
+    raw = os.getenv("AGENT_HISTORY_LIMIT")
+    if not raw:
+        return _DEFAULT_HISTORY_LIMIT
+    try:
+        value = int(raw)
+        return value if value > 0 else _DEFAULT_HISTORY_LIMIT
+    except ValueError:
+        logger.warning("AGENT_HISTORY_LIMIT=%r is not an int; using default", raw)
+        return _DEFAULT_HISTORY_LIMIT
+
 
 class AgentState:
     """
@@ -20,6 +38,7 @@ class AgentState:
 
     def __init__(self):
         self.conversation_history: List[ChatMessage] = []
+        self.history_limit: int = _resolve_history_limit()
         self.agent_name = os.getenv("AGENT_NAME", "unknown")
         self.agent_runtime = os.getenv("AGENT_RUNTIME", "claude-code")
         # Check if the configured runtime is available
@@ -102,6 +121,11 @@ class AgentState:
                 timestamp=datetime.now()
             )
         )
+        # FIFO trim once over the cap. Persistent history is in the backend DB;
+        # the in-memory list is only for /api/chat/history + session counts.
+        overflow = len(self.conversation_history) - self.history_limit
+        if overflow > 0:
+            del self.conversation_history[:overflow]
 
     def reset_session(self):
         """Reset conversation state and token tracking"""

--- a/tests/unit/test_agent_server_hardening.py
+++ b/tests/unit/test_agent_server_hardening.py
@@ -1,0 +1,223 @@
+"""
+Agent-server hardening tests (#333).
+
+Covers three pieces of accumulator-leak hardening shipped against the
+"futex spin after days of uptime" report:
+
+  - AgentState.add_message FIFO-trims conversation_history once over the cap.
+  - gemini_runtime._executor is a module-level singleton, not allocated per
+    call (mirrors the claude_code.py:63 pattern).
+  - /health includes a `diagnostics` block with the runtime gauges
+    (thread_count, asyncio_task_count, running_executions, history size)
+    so future repros can be diagnosed with one curl instead of strace.
+
+These do not prove the original symptom is gone — that needs a multi-day
+soak. They lock in the leak-surface reductions and the observability hook.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+_BASE_IMAGE = Path(__file__).resolve().parent.parent.parent / "docker" / "base-image"
+_BASE_IMAGE_STR = str(_BASE_IMAGE)
+if _BASE_IMAGE_STR not in sys.path:
+    sys.path.insert(0, _BASE_IMAGE_STR)
+
+# Evict any previously cached `agent_server` (shadow or real) so the
+# explicit file-based loader below wins regardless of sys.path order.
+for _mod in list(sys.modules):
+    if _mod == "agent_server" or _mod.startswith("agent_server."):
+        sys.modules.pop(_mod, None)
+
+_AS_INIT = _BASE_IMAGE / "agent_server" / "__init__.py"
+_as_spec = importlib.util.spec_from_file_location(
+    "agent_server", str(_AS_INIT),
+    submodule_search_locations=[str(_BASE_IMAGE / "agent_server")],
+)
+_as_mod = importlib.util.module_from_spec(_as_spec)
+sys.modules["agent_server"] = _as_mod
+_as_spec.loader.exec_module(_as_mod)
+
+
+# ---------------------------------------------------------------------------
+# Conversation history bound
+# ---------------------------------------------------------------------------
+
+
+class TestConversationHistoryBound:
+    """state.AgentState.add_message must FIFO-trim once over history_limit."""
+
+    def _fresh_state(self, limit: int):
+        # Re-import the state module against AGENT_HISTORY_LIMIT for this test.
+        from agent_server import state as state_mod  # noqa: WPS433
+
+        s = state_mod.AgentState()
+        s.history_limit = limit
+        s.conversation_history = []
+        return s
+
+    def test_under_limit_keeps_all_messages(self):
+        s = self._fresh_state(limit=10)
+        for i in range(5):
+            s.add_message("user", f"msg-{i}")
+        assert len(s.conversation_history) == 5
+        assert s.conversation_history[0].content == "msg-0"
+        assert s.conversation_history[-1].content == "msg-4"
+
+    def test_over_limit_drops_oldest(self):
+        s = self._fresh_state(limit=3)
+        for i in range(7):
+            s.add_message("user", f"msg-{i}")
+        assert len(s.conversation_history) == 3
+        # Oldest dropped; tail preserved.
+        assert s.conversation_history[0].content == "msg-4"
+        assert s.conversation_history[-1].content == "msg-6"
+
+    def test_resolve_history_limit_default(self, monkeypatch):
+        from agent_server import state as state_mod  # noqa: WPS433
+
+        monkeypatch.delenv("AGENT_HISTORY_LIMIT", raising=False)
+        assert state_mod._resolve_history_limit() == state_mod._DEFAULT_HISTORY_LIMIT
+
+    def test_resolve_history_limit_override(self, monkeypatch):
+        from agent_server import state as state_mod  # noqa: WPS433
+
+        monkeypatch.setenv("AGENT_HISTORY_LIMIT", "42")
+        assert state_mod._resolve_history_limit() == 42
+
+    def test_resolve_history_limit_invalid_falls_back(self, monkeypatch):
+        from agent_server import state as state_mod  # noqa: WPS433
+
+        monkeypatch.setenv("AGENT_HISTORY_LIMIT", "not-an-int")
+        assert state_mod._resolve_history_limit() == state_mod._DEFAULT_HISTORY_LIMIT
+
+    def test_resolve_history_limit_non_positive_falls_back(self, monkeypatch):
+        from agent_server import state as state_mod  # noqa: WPS433
+
+        monkeypatch.setenv("AGENT_HISTORY_LIMIT", "0")
+        assert state_mod._resolve_history_limit() == state_mod._DEFAULT_HISTORY_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# Gemini executor singleton
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiExecutorSingleton:
+    """gemini_runtime._executor must be a module-level singleton.
+
+    The pre-#333 code allocated `ThreadPoolExecutor(max_workers=1)` on every
+    call to execute(). Per-call executors rely on CPython weakref-callback
+    cleanup of worker threads which is not deterministic under load; the
+    long-uptime futex-spin symptom matches the kind of pthread_cond_timedwait
+    activity those would produce.
+    """
+
+    def test_executor_is_module_level_threadpoolexecutor(self):
+        from agent_server.services import gemini_runtime  # noqa: WPS433
+
+        assert hasattr(gemini_runtime, "_executor"), (
+            "gemini_runtime._executor must exist as a module-level singleton"
+        )
+        assert isinstance(gemini_runtime._executor, ThreadPoolExecutor)
+
+    def test_executor_identity_is_stable_across_module_lookups(self):
+        from agent_server.services import gemini_runtime  # noqa: WPS433
+
+        first = gemini_runtime._executor
+        second = gemini_runtime._executor
+        assert first is second, "executor must not be replaced on attribute access"
+
+    def test_no_per_call_threadpoolexecutor_in_execute_methods(self):
+        """Catch a regression where someone re-introduces per-call allocation."""
+        path = (
+            _BASE_IMAGE / "agent_server" / "services" / "gemini_runtime.py"
+        )
+        source = path.read_text()
+        # The legacy pattern was `executor = ThreadPoolExecutor(max_workers=1)`
+        # at function scope, paired with an immediate `run_in_executor(executor,
+        # ...)`. The module-level singleton uses `_executor` (underscore-prefixed)
+        # plus `run_in_executor(_executor, ...)`, so a bare `executor` reference
+        # to run_in_executor would mean someone re-introduced the per-call form.
+        assert "run_in_executor(executor" not in source, (
+            "gemini_runtime should not allocate a fresh ThreadPoolExecutor per call"
+        )
+        # Belt-and-braces: only one ThreadPoolExecutor instantiation in the file.
+        assert source.count("ThreadPoolExecutor(") == 1, (
+            "gemini_runtime should instantiate exactly one ThreadPoolExecutor "
+            "(the module-level singleton)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# /health diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestHealthDiagnostics:
+    """info._diagnostics must expose the leak-spotting gauges."""
+
+    def test_diagnostics_keys_present(self):
+        from agent_server.routers import info as info_mod  # noqa: WPS433
+
+        diag = info_mod._diagnostics()
+        for key in (
+            "thread_count",
+            "asyncio_task_count",
+            "running_executions",
+            "conversation_history_size",
+            "conversation_history_limit",
+        ):
+            assert key in diag, f"diagnostics missing key {key!r}"
+
+    def test_diagnostics_thread_count_positive(self):
+        from agent_server.routers import info as info_mod  # noqa: WPS433
+
+        diag = info_mod._diagnostics()
+        # At least the main thread is alive.
+        assert diag["thread_count"] >= 1
+
+    def test_diagnostics_history_size_reflects_state(self):
+        from agent_server.routers import info as info_mod  # noqa: WPS433
+        from agent_server.state import agent_state  # noqa: WPS433
+
+        before = info_mod._diagnostics()["conversation_history_size"]
+        agent_state.add_message("user", "ping for diagnostic test")
+        try:
+            after = info_mod._diagnostics()["conversation_history_size"]
+            assert after == before + 1
+        finally:
+            # Pop the test message so the global agent_state isn't dirtied
+            # for sibling tests in this process.
+            agent_state.conversation_history.pop()
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint_includes_diagnostics(self):
+        """Hit the /health route directly via FastAPI test client."""
+        try:
+            from fastapi.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi.testclient not available")
+
+        from fastapi import FastAPI
+
+        from agent_server.routers import info as info_mod  # noqa: WPS433
+
+        app = FastAPI()
+        app.include_router(info_mod.router)
+
+        with TestClient(app) as client:
+            resp = client.get("/health")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["status"] == "healthy"
+        assert "diagnostics" in payload, "/health must include diagnostics block"
+        diag = payload["diagnostics"]
+        assert "thread_count" in diag
+        assert "conversation_history_limit" in diag

--- a/tests/unit/test_agent_server_hardening.py
+++ b/tests/unit/test_agent_server_hardening.py
@@ -17,32 +17,17 @@ soak. They lock in the leak-surface reductions and the observability hook.
 
 from __future__ import annotations
 
-import importlib.util
-import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
+# tests/unit/conftest.py:_preload_real_agent_server() already registers
+# docker/base-image/agent_server as a namespace package in sys.modules,
+# so plain `from agent_server.<sub> import <X>` works here without any
+# importlib gymnastics in this file.
+
 _BASE_IMAGE = Path(__file__).resolve().parent.parent.parent / "docker" / "base-image"
-_BASE_IMAGE_STR = str(_BASE_IMAGE)
-if _BASE_IMAGE_STR not in sys.path:
-    sys.path.insert(0, _BASE_IMAGE_STR)
-
-# Evict any previously cached `agent_server` (shadow or real) so the
-# explicit file-based loader below wins regardless of sys.path order.
-for _mod in list(sys.modules):
-    if _mod == "agent_server" or _mod.startswith("agent_server."):
-        sys.modules.pop(_mod, None)
-
-_AS_INIT = _BASE_IMAGE / "agent_server" / "__init__.py"
-_as_spec = importlib.util.spec_from_file_location(
-    "agent_server", str(_AS_INIT),
-    submodule_search_locations=[str(_BASE_IMAGE / "agent_server")],
-)
-_as_mod = importlib.util.module_from_spec(_as_spec)
-sys.modules["agent_server"] = _as_mod
-_as_spec.loader.exec_module(_as_mod)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Speculative-but-defensible hardening for the long-uptime futex-spin
symptom reported in #333. Does **not** claim to fix the symptom (root
cause in #333 is still unproven, and verification needs a multi-day
soak). It locks in the remaining accumulator-leak surface reductions and
adds the observability hook that turns the next reproduction into a
one-curl diagnosis instead of an strace expedition.

## What changed

- **`gemini_runtime.py`**: replace per-call `ThreadPoolExecutor(max_workers=1)`
  at `execute()` and `execute_task()` with a module-level singleton, mirroring
  `claude_code.py:63`. Per-call executors rely on CPython's weakref-callback
  cleanup of worker threads, which is not deterministic under load.
- **`state.AgentState.add_message`**: FIFO-trim `conversation_history` once
  it exceeds `history_limit` (default 1000, overridable via
  `AGENT_HISTORY_LIMIT`). Persistent history is in the backend DB; the
  in-memory list is only used by `/api/chat/history` + session-info counts.
- **`/health`**: add a `diagnostics` block exposing `thread_count`,
  `asyncio_task_count`, `running_executions`, `conversation_history_size`,
  and `conversation_history_limit`. A future repro can now be triaged with
  `curl /health` instead of `strace -c -p`.

## What this does NOT do

- Prove the original symptom is gone. That requires a 2–6 day soak on a
  reproducing host.
- Identify the root cause of #333. Adjacent subprocess teardown fixes
  shipped since the report (#531, #618, #649, #657, #728/#730) may have
  already addressed the most likely culprits — but that remains
  unverified.

#333 stays open until reproduced on current main.

## Test plan

- [x] `tests/unit/test_agent_server_hardening.py` — 13 cases covering
      history bound, gemini executor singleton, `/health` diagnostics.
- [ ] Multi-day soak with the new `/health` diagnostics block scraped at
      regular intervals — looking for `thread_count`, `asyncio_task_count`,
      or `running_executions` trending up over time.

Relates to #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)