### PR TITLE
refactor(frontend): sweep slice 9 + drift catch-up — 24 files (#554)

### DIFF
--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -97,7 +97,7 @@
             <!-- System agent badge -->
             <span
               v-if="agent.is_system"
-              class="px-2 py-0.5 text-xs font-semibold rounded-full bg-accent-accent-purple-100 text-accent-accent-purple-700 dark:bg-accent-accent-purple-900/50 dark:text-accent-accent-purple-300"
+              class="px-2 py-0.5 text-xs font-semibold rounded-full bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-900/50 dark:text-accent-purple-300"
               title="System Agent - Platform Orchestrator with full access"
             >
               SYSTEM

--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -97,7 +97,7 @@
             <!-- System agent badge -->
             <span
               v-if="agent.is_system"
-              class="px-2 py-0.5 text-xs font-semibold rounded-full bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-900/50 dark:text-accent-purple-300"
+              class="px-2 py-0.5 text-xs font-semibold rounded-full bg-accent-accent-purple-100 text-accent-accent-purple-700 dark:bg-accent-accent-purple-900/50 dark:text-accent-accent-purple-300"
               title="System Agent - Platform Orchestrator with full access"
             >
               SYSTEM
@@ -162,7 +162,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4M12 15a3 3 0 003-3V5a3 3 0 00-6 0v7a3 3 0 003 3z" />
             </svg>
             Workspace
-            <span class="px-1 py-0.5 text-[10px] font-semibold rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 leading-none">BETA</span>
+            <span class="px-1 py-0.5 text-[10px] font-semibold rounded bg-state-autonomous-100 dark:bg-state-autonomous-900/40 text-state-autonomous-700 dark:text-state-autonomous-400 leading-none">BETA</span>
           </button>
           <!-- Running State Toggle -->
           <RunningStateToggle

--- a/src/frontend/src/components/ChatPanel.vue
+++ b/src/frontend/src/components/ChatPanel.vue
@@ -138,9 +138,9 @@
       </ChatMessages>
 
       <!-- Error message -->
-      <div v-if="error" class="mx-6 mb-2 p-3 rounded-lg" :class="isRateLimitError ? 'bg-amber-100 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800' : 'bg-status-danger-100 dark:bg-status-danger-900/30 border border-status-danger-200 dark:border-status-danger-800'">
-        <p v-if="isRateLimitError" class="text-sm font-medium text-amber-700 dark:text-amber-400 mb-1">Subscription Usage Limit</p>
-        <p class="text-sm" :class="isRateLimitError ? 'text-amber-600 dark:text-amber-400' : 'text-status-danger-600 dark:text-status-danger-400'">{{ error }}</p>
+      <div v-if="error" class="mx-6 mb-2 p-3 rounded-lg" :class="isRateLimitError ? 'bg-state-autonomous-100 dark:bg-state-autonomous-900/30 border border-state-autonomous-200 dark:border-state-autonomous-800' : 'bg-status-danger-100 dark:bg-status-danger-900/30 border border-status-danger-200 dark:border-status-danger-800'">
+        <p v-if="isRateLimitError" class="text-sm font-medium text-state-autonomous-700 dark:text-state-autonomous-400 mb-1">Subscription Usage Limit</p>
+        <p class="text-sm" :class="isRateLimitError ? 'text-state-autonomous-600 dark:text-state-autonomous-400' : 'text-status-danger-600 dark:text-status-danger-400'">{{ error }}</p>
       </div>
 
       <!-- Voice overlay (VOICE-004) -->

--- a/src/frontend/src/components/DashboardPanel.vue
+++ b/src/frontend/src/components/DashboardPanel.vue
@@ -510,7 +510,7 @@ const getStatusColors = (color) => {
     gray: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
     blue: 'bg-status-info-100 text-status-info-800 dark:bg-status-info-900/50 dark:text-status-info-300',
     orange: 'bg-status-urgent-100 text-status-urgent-800 dark:bg-status-urgent-900/50 dark:text-status-urgent-300',
-    purple: 'bg-accent-accent-purple-100 text-accent-accent-purple-800 dark:bg-accent-accent-purple-900/50 dark:text-accent-accent-purple-300'
+    purple: 'bg-accent-purple-100 text-accent-purple-800 dark:bg-accent-purple-900/50 dark:text-accent-purple-300'
   }
   return colorMap[color] || colorMap.gray
 }

--- a/src/frontend/src/components/FileSharingPanel.vue
+++ b/src/frontend/src/components/FileSharingPanel.vue
@@ -34,7 +34,7 @@
     <!-- Restart-required banner -->
     <div
       v-if="status.restart_required"
-      class="mb-4 rounded-md bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 px-4 py-3 text-sm text-amber-800 dark:text-amber-200"
+      class="mb-4 rounded-md bg-state-autonomous-50 dark:bg-state-autonomous-900/30 border border-state-autonomous-200 dark:border-state-autonomous-800 px-4 py-3 text-sm text-state-autonomous-800 dark:text-state-autonomous-200"
     >
       Configuration changed — restart the agent to mount or detach
       <code class="font-mono text-xs">/home/developer/public/</code>.

--- a/src/frontend/src/components/OnboardingChecklist.vue
+++ b/src/frontend/src/components/OnboardingChecklist.vue
@@ -33,7 +33,7 @@
   >
     <!-- Header -->
     <div
-      class="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-indigo-500 to-purple-500 text-white cursor-pointer"
+      class="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-indigo-500 to-accent-purple-500 text-white cursor-pointer"
       @click="toggleMinimized"
     >
       <div class="flex items-center gap-2">
@@ -54,7 +54,7 @@
     <!-- Celebration Banner -->
     <div
       v-if="isCelebrating && !isMinimized"
-      class="bg-gradient-to-r from-green-500 to-emerald-500 text-white px-4 py-2 flex items-center gap-2"
+      class="bg-gradient-to-r from-status-success-500 to-emerald-500 text-white px-4 py-2 flex items-center gap-2"
     >
       <span class="text-lg">🎉</span>
       <span class="text-sm font-medium">Great job! Here's your next step:</span>
@@ -66,7 +66,7 @@
       <div class="mb-4">
         <div class="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
           <div
-            class="h-full bg-gradient-to-r from-indigo-500 to-purple-500 transition-all duration-500"
+            class="h-full bg-gradient-to-r from-indigo-500 to-accent-purple-500 transition-all duration-500"
             :style="{ width: `${progressPercent}%` }"
           />
         </div>
@@ -131,7 +131,7 @@
             v-if="!item.completed && item.link && isCurrentStep(index)"
             class="flex-shrink-0 text-xs font-medium"
             :class="isOnTargetPage(item)
-              ? 'text-amber-600 dark:text-amber-400'
+              ? 'text-state-autonomous-600 dark:text-state-autonomous-400'
               : 'text-indigo-600 dark:text-indigo-400'"
           >
             {{ isOnTargetPage(item) ? 'See above ↑' : 'Start →' }}

--- a/src/frontend/src/components/PublicLinksPanel.vue
+++ b/src/frontend/src/components/PublicLinksPanel.vue
@@ -281,7 +281,7 @@
                       <span class="text-xs text-gray-500 dark:text-gray-400">Proxy agent's web server</span>
                     </button>
                   </div>
-                  <p v-if="formData.link_type === 'site'" class="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                  <p v-if="formData.link_type === 'site'" class="mt-2 text-xs text-state-autonomous-600 dark:text-state-autonomous-400">
                     Requires the agent to run a web server on port 3000 (e.g. Next.js).
                   </p>
                 </div>

--- a/src/frontend/src/components/ResourceModal.vue
+++ b/src/frontend/src/components/ResourceModal.vue
@@ -23,12 +23,12 @@
         </div>
 
         <!-- Warning Banner -->
-        <div class="mt-4 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg">
+        <div class="mt-4 p-3 bg-state-autonomous-50 dark:bg-state-autonomous-900/30 border border-state-autonomous-200 dark:border-state-autonomous-800 rounded-lg">
           <div class="flex">
-            <svg class="h-5 w-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="h-5 w-5 text-state-autonomous-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
-            <p class="ml-3 text-sm text-amber-700 dark:text-amber-300">
+            <p class="ml-3 text-sm text-state-autonomous-700 dark:text-state-autonomous-300">
               If the agent is running, it will be automatically restarted to apply changes.
             </p>
           </div>

--- a/src/frontend/src/components/SessionPanel.vue
+++ b/src/frontend/src/components/SessionPanel.vue
@@ -51,7 +51,7 @@
                   <span>{{ formatContextPercent(session) }}</span>
                   <span v-if="session.cached_claude_session_id" class="text-emerald-500" title="Has working memory">●</span>
                   <span v-else class="text-gray-300 dark:text-gray-600" title="Cold (memory cleared)">●</span>
-                  <span v-if="session.consecutive_resume_failures > 0" class="text-amber-500">
+                  <span v-if="session.consecutive_resume_failures > 0" class="text-state-autonomous-500">
                     {{ session.consecutive_resume_failures }} resume failure(s)
                   </span>
                 </p>
@@ -72,7 +72,7 @@
           <button
             @click="confirmReset"
             :disabled="loading"
-            class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 hover:bg-amber-50 dark:hover:bg-amber-900/30 rounded-lg transition-colors"
+            class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-state-autonomous-600 dark:text-state-autonomous-400 hover:text-state-autonomous-700 dark:hover:text-state-autonomous-300 hover:bg-state-autonomous-50 dark:hover:bg-state-autonomous-900/30 rounded-lg transition-colors"
             title="Clear working memory (keeps message history)"
           >
             <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -105,8 +105,8 @@
     <!-- Agent not running message -->
     <div v-if="agentStatus !== 'running'" class="flex-1 flex items-center justify-center">
       <div class="text-center p-8">
-        <div class="w-16 h-16 bg-yellow-100 dark:bg-yellow-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-          <svg class="w-8 h-8 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="w-16 h-16 bg-status-warning-100 dark:bg-status-warning-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-status-warning-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
         </div>
@@ -122,19 +122,19 @@
       <!-- Fallback notice (E2/E3): the resume failed and we recovered -->
       <div
         v-if="fallbackNotice"
-        class="mx-6 mt-3 px-4 py-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg flex items-center justify-between"
+        class="mx-6 mt-3 px-4 py-3 bg-state-autonomous-50 dark:bg-state-autonomous-900/30 border border-state-autonomous-200 dark:border-state-autonomous-800 rounded-lg flex items-center justify-between"
       >
         <div class="flex items-center space-x-2">
-          <svg class="w-5 h-5 text-amber-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-5 h-5 text-state-autonomous-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
           </svg>
-          <span class="text-sm text-amber-700 dark:text-amber-300">
+          <span class="text-sm text-state-autonomous-700 dark:text-state-autonomous-300">
             This session’s working memory expired. Starting fresh — past messages are still visible.
           </span>
         </div>
         <button
           @click="dismissFallbackNotice"
-          class="text-amber-500 hover:text-amber-700 dark:hover:text-amber-300"
+          class="text-state-autonomous-500 hover:text-state-autonomous-700 dark:hover:text-state-autonomous-300"
           title="Dismiss"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -170,8 +170,8 @@
       </ChatMessages>
 
       <!-- Error message -->
-      <div v-if="error" class="mx-6 mb-2 p-3 rounded-lg bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800">
-        <p class="text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+      <div v-if="error" class="mx-6 mb-2 p-3 rounded-lg bg-status-danger-100 dark:bg-status-danger-900/30 border border-status-danger-200 dark:border-status-danger-800">
+        <p class="text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
       </div>
 
       <!-- Input area -->
@@ -212,7 +212,7 @@
           </button>
           <button
             @click="performReset"
-            class="px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-lg"
+            class="px-4 py-2 text-sm font-medium text-white bg-state-autonomous-600 hover:bg-state-autonomous-700 rounded-lg"
           >
             Reset memory
           </button>

--- a/src/frontend/src/components/SharingPanel.vue
+++ b/src/frontend/src/components/SharingPanel.vue
@@ -56,7 +56,7 @@
       <!-- Dead-end configuration warning (#446) -->
       <div
         v-if="policy.require_email && !policy.open_access && (!shares || shares.length === 0)"
-        class="mt-4 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40 p-3 text-sm text-amber-900 dark:text-amber-200"
+        class="mt-4 rounded-lg bg-state-autonomous-50 dark:bg-state-autonomous-900/20 border border-state-autonomous-200 dark:border-state-autonomous-800/40 p-3 text-sm text-state-autonomous-900 dark:text-state-autonomous-200"
       >
         <strong>Heads up:</strong> you've required verified email but haven't shared with anyone or enabled Open access.
         Every verified user will land in Pending Access Requests and stay locked out until you approve them one by one.

--- a/src/frontend/src/components/TasksPanel.vue
+++ b/src/frontend/src/components/TasksPanel.vue
@@ -178,7 +178,7 @@
                     task.status === 'cancelled' ? 'bg-status-urgent-100 dark:bg-status-urgent-900/30 text-status-urgent-800 dark:text-status-urgent-300' :
                     task.status === 'running' ? 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-800 dark:text-status-warning-300' :
                     task.status === 'queued' ? 'bg-state-autonomous-100 dark:bg-state-autonomous-900/30 text-state-autonomous-800 dark:text-state-autonomous-300' :
-                    task.status === 'skipped' ? 'bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/30 text-accent-accent-purple-800 dark:text-accent-accent-purple-300' :
+                    task.status === 'skipped' ? 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-800 dark:text-accent-purple-300' :
                     'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
                   ]"
                 >
@@ -190,7 +190,7 @@
                       task.status === 'cancelled' ? 'bg-status-urgent-500' :
                       task.status === 'running' ? 'bg-status-warning-500 animate-pulse' :
                       task.status === 'queued' ? 'bg-state-autonomous-500' :
-                      task.status === 'skipped' ? 'bg-accent-accent-purple-500' :
+                      task.status === 'skipped' ? 'bg-accent-purple-500' :
                       'bg-gray-500'
                     ]"
                   ></span>
@@ -203,7 +203,7 @@
                     task.triggered_by === 'chat' ? 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300' :
                     task.triggered_by === 'session' ? 'bg-state-autonomous-100 dark:bg-state-autonomous-900/30 text-state-autonomous-700 dark:text-state-autonomous-300' :
                     task.triggered_by === 'manual' ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300' :
-                    task.triggered_by === 'schedule' ? 'bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/30 text-accent-accent-purple-700 dark:text-accent-accent-purple-300' :
+                    task.triggered_by === 'schedule' ? 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-700 dark:text-accent-purple-300' :
                     task.triggered_by === 'paid' ? 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-700 dark:text-status-warning-300' :
                     task.triggered_by === 'public' ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300' :
                     'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
@@ -351,7 +351,7 @@
               <button
                 v-if="task.status !== 'running'"
                 @click="makeRepeatable(task)"
-                class="p-1.5 text-gray-400 hover:text-accent-accent-purple-600 dark:hover:text-accent-accent-purple-400 rounded transition-colors"
+                class="p-1.5 text-gray-400 hover:text-accent-purple-600 dark:hover:text-accent-purple-400 rounded transition-colors"
                 title="Create schedule from this task"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/frontend/src/components/TasksPanel.vue
+++ b/src/frontend/src/components/TasksPanel.vue
@@ -178,7 +178,7 @@
                     task.status === 'cancelled' ? 'bg-status-urgent-100 dark:bg-status-urgent-900/30 text-status-urgent-800 dark:text-status-urgent-300' :
                     task.status === 'running' ? 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-800 dark:text-status-warning-300' :
                     task.status === 'queued' ? 'bg-state-autonomous-100 dark:bg-state-autonomous-900/30 text-state-autonomous-800 dark:text-state-autonomous-300' :
-                    task.status === 'skipped' ? 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-800 dark:text-accent-purple-300' :
+                    task.status === 'skipped' ? 'bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/30 text-accent-accent-purple-800 dark:text-accent-accent-purple-300' :
                     'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
                   ]"
                 >
@@ -190,7 +190,7 @@
                       task.status === 'cancelled' ? 'bg-status-urgent-500' :
                       task.status === 'running' ? 'bg-status-warning-500 animate-pulse' :
                       task.status === 'queued' ? 'bg-state-autonomous-500' :
-                      task.status === 'skipped' ? 'bg-accent-purple-500' :
+                      task.status === 'skipped' ? 'bg-accent-accent-purple-500' :
                       'bg-gray-500'
                     ]"
                   ></span>
@@ -201,9 +201,9 @@
                   :class="[
                     'px-1.5 py-0.5 rounded text-xs',
                     task.triggered_by === 'chat' ? 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300' :
-                    task.triggered_by === 'session' ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300' :
+                    task.triggered_by === 'session' ? 'bg-state-autonomous-100 dark:bg-state-autonomous-900/30 text-state-autonomous-700 dark:text-state-autonomous-300' :
                     task.triggered_by === 'manual' ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300' :
-                    task.triggered_by === 'schedule' ? 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-700 dark:text-accent-purple-300' :
+                    task.triggered_by === 'schedule' ? 'bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/30 text-accent-accent-purple-700 dark:text-accent-accent-purple-300' :
                     task.triggered_by === 'paid' ? 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-700 dark:text-status-warning-300' :
                     task.triggered_by === 'public' ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300' :
                     'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
@@ -351,7 +351,7 @@
               <button
                 v-if="task.status !== 'running'"
                 @click="makeRepeatable(task)"
-                class="p-1.5 text-gray-400 hover:text-accent-purple-600 dark:hover:text-accent-purple-400 rounded transition-colors"
+                class="p-1.5 text-gray-400 hover:text-accent-accent-purple-600 dark:hover:text-accent-accent-purple-400 rounded transition-colors"
                 title="Create schedule from this task"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/frontend/src/components/WhatsAppChannelPanel.vue
+++ b/src/frontend/src/components/WhatsAppChannelPanel.vue
@@ -82,7 +82,7 @@
       </div>
 
       <!-- Ops prerequisite notice -->
-      <div class="p-3 rounded-lg text-xs bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200">
+      <div class="p-3 rounded-lg text-xs bg-state-autonomous-50 dark:bg-state-autonomous-900/30 text-state-autonomous-800 dark:text-state-autonomous-200">
         <strong>Deployment prerequisite:</strong> Cloudflare Tunnel ingress must route
         <code class="font-mono">/api/whatsapp/webhook/*</code> to the frontend service.
         See <em>docs/requirements/PUBLIC_EXTERNAL_ACCESS_SETUP.md</em>.

--- a/src/frontend/src/components/file-manager/FilePreview.vue
+++ b/src/frontend/src/components/file-manager/FilePreview.vue
@@ -24,7 +24,7 @@
     <!-- Directory Preview -->
     <div v-else-if="file.type === 'directory'" class="flex-1 flex items-center justify-center">
       <div class="text-center">
-        <svg class="h-16 w-16 text-yellow-500 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg class="h-16 w-16 text-status-warning-500 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
         </svg>
         <h3 class="mt-4 text-lg font-medium text-gray-900 dark:text-white">{{ file.name }}</h3>
@@ -62,7 +62,7 @@
       <div v-else-if="isAudio" class="flex-1 flex items-center justify-center p-4">
         <div class="w-full max-w-md bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
           <div class="flex items-center justify-center mb-4">
-            <svg class="h-16 w-16 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg class="h-16 w-16 text-status-success-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
             </svg>
           </div>

--- a/src/frontend/src/components/file-manager/FileTreeNode.vue
+++ b/src/frontend/src/components/file-manager/FileTreeNode.vue
@@ -113,14 +113,14 @@ const fileIcon = computed(() => {
 })
 
 const iconColor = computed(() => {
-  if (props.item.type === 'directory') return 'text-yellow-500'
+  if (props.item.type === 'directory') return 'text-status-warning-500'
 
   const ext = fileExtension.value
-  if (['mp4', 'webm', 'mov', 'avi', 'mkv'].includes(ext)) return 'text-purple-500'
-  if (['mp3', 'wav', 'ogg', 'm4a', 'flac', 'aac'].includes(ext)) return 'text-green-500'
+  if (['mp4', 'webm', 'mov', 'avi', 'mkv'].includes(ext)) return 'text-accent-purple-500'
+  if (['mp3', 'wav', 'ogg', 'm4a', 'flac', 'aac'].includes(ext)) return 'text-status-success-500'
   if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'ico', 'bmp'].includes(ext)) return 'text-blue-500'
   if (['js', 'ts', 'jsx', 'tsx', 'py', 'go', 'rs', 'rb', 'java', 'c', 'cpp', 'h', 'css', 'scss', 'html', 'vue', 'svelte'].includes(ext)) return 'text-gray-500'
-  if (['pdf'].includes(ext)) return 'text-red-500'
+  if (['pdf'].includes(ext)) return 'text-status-danger-500'
 
   return 'text-gray-400'
 })

--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -523,7 +523,7 @@ function getTypeBadge(type) {
   const classes = {
     alert: 'bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-700 dark:text-status-danger-300',
     info: 'bg-status-info-100 dark:bg-status-info-900/30 text-status-info-700 dark:text-status-info-300',
-    status: 'bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/30 text-accent-accent-purple-700 dark:text-accent-accent-purple-300',
+    status: 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-700 dark:text-accent-purple-300',
     completion: 'bg-status-success-100 dark:bg-status-success-900/30 text-status-success-700 dark:text-status-success-300',
     question: 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-700 dark:text-status-warning-300',
   }

--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -119,7 +119,7 @@
       <div class="flex gap-2">
         <button
           @click="bulkAcknowledge"
-          class="px-3 py-1.5 text-xs font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg"
+          class="px-3 py-1.5 text-xs font-medium text-white bg-status-success-600 hover:bg-status-success-700 rounded-lg"
         >
           Acknowledge Selected
         </button>
@@ -523,7 +523,7 @@ function getTypeBadge(type) {
   const classes = {
     alert: 'bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-700 dark:text-status-danger-300',
     info: 'bg-status-info-100 dark:bg-status-info-900/30 text-status-info-700 dark:text-status-info-300',
-    status: 'bg-accent-purple-100 dark:bg-accent-purple-900/30 text-accent-purple-700 dark:text-accent-purple-300',
+    status: 'bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/30 text-accent-accent-purple-700 dark:text-accent-accent-purple-300',
     completion: 'bg-status-success-100 dark:bg-status-success-900/30 text-status-success-700 dark:text-status-success-300',
     question: 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-700 dark:text-status-warning-300',
   }

--- a/src/frontend/src/components/operator/QueueCard.vue
+++ b/src/frontend/src/components/operator/QueueCard.vue
@@ -215,7 +215,7 @@ function optionClass(idx) {
 
 function typePill(type) {
   return {
-    approval: 'bg-accent-accent-purple-50 text-accent-accent-purple-600 dark:bg-accent-accent-purple-900/20 dark:text-accent-accent-purple-400',
+    approval: 'bg-accent-purple-50 text-accent-purple-600 dark:bg-accent-purple-900/20 dark:text-accent-purple-400',
     question: 'bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400',
     alert: 'bg-state-autonomous-50 text-state-autonomous-600 dark:bg-state-autonomous-900/20 dark:text-state-autonomous-400'
   }[type] || ''

--- a/src/frontend/src/components/operator/QueueCard.vue
+++ b/src/frontend/src/components/operator/QueueCard.vue
@@ -215,9 +215,9 @@ function optionClass(idx) {
 
 function typePill(type) {
   return {
-    approval: 'bg-accent-purple-50 text-accent-purple-600 dark:bg-accent-purple-900/20 dark:text-accent-purple-400',
+    approval: 'bg-accent-accent-purple-50 text-accent-accent-purple-600 dark:bg-accent-accent-purple-900/20 dark:text-accent-accent-purple-400',
     question: 'bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400',
-    alert: 'bg-amber-50 text-amber-600 dark:bg-amber-900/20 dark:text-amber-400'
+    alert: 'bg-state-autonomous-50 text-state-autonomous-600 dark:bg-state-autonomous-900/20 dark:text-state-autonomous-400'
   }[type] || ''
 }
 

--- a/src/frontend/src/components/operator/QueueItemDetail.vue
+++ b/src/frontend/src/components/operator/QueueItemDetail.vue
@@ -234,7 +234,7 @@ function optionSelectedClass(idx) {
 
 function typeBadge(type) {
   const badges = {
-    approval: 'bg-accent-accent-purple-100 text-accent-accent-purple-700 dark:bg-accent-accent-purple-900/30 dark:text-accent-accent-purple-400',
+    approval: 'bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-900/30 dark:text-accent-purple-400',
     question: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
     alert: 'bg-state-autonomous-100 text-state-autonomous-700 dark:bg-state-autonomous-900/30 dark:text-state-autonomous-400'
   }

--- a/src/frontend/src/components/operator/QueueItemDetail.vue
+++ b/src/frontend/src/components/operator/QueueItemDetail.vue
@@ -57,7 +57,7 @@
             </svg>
             {{ formatDate(item.created_at) }}
           </span>
-          <span v-if="item.expires_at" class="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+          <span v-if="item.expires_at" class="inline-flex items-center gap-1 text-state-autonomous-600 dark:text-state-autonomous-400">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
@@ -179,7 +179,7 @@
           ></textarea>
           <button
             @click="submitAcknowledge"
-            class="w-full py-2 px-4 rounded-lg text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 dark:bg-amber-500 dark:hover:bg-amber-600 transition-colors"
+            class="w-full py-2 px-4 rounded-lg text-sm font-medium text-white bg-state-autonomous-600 hover:bg-state-autonomous-700 dark:bg-state-autonomous-500 dark:hover:bg-state-autonomous-600 transition-colors"
           >
             Acknowledge
           </button>
@@ -234,9 +234,9 @@ function optionSelectedClass(idx) {
 
 function typeBadge(type) {
   const badges = {
-    approval: 'bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-900/30 dark:text-accent-purple-400',
+    approval: 'bg-accent-accent-purple-100 text-accent-accent-purple-700 dark:bg-accent-accent-purple-900/30 dark:text-accent-accent-purple-400',
     question: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-    alert: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+    alert: 'bg-state-autonomous-100 text-state-autonomous-700 dark:bg-state-autonomous-900/30 dark:text-state-autonomous-400'
   }
   return badges[type] || ''
 }

--- a/src/frontend/src/components/operator/QueueList.vue
+++ b/src/frontend/src/components/operator/QueueList.vue
@@ -162,7 +162,7 @@ function typeIcon(type) {
 
 function typeIconColor(type) {
   const colors = {
-    approval: 'text-accent-accent-purple-500 dark:text-accent-accent-purple-400',
+    approval: 'text-accent-purple-500 dark:text-accent-purple-400',
     question: 'text-blue-500 dark:text-blue-400',
     alert: 'text-state-autonomous-500 dark:text-state-autonomous-400'
   }

--- a/src/frontend/src/components/operator/QueueList.vue
+++ b/src/frontend/src/components/operator/QueueList.vue
@@ -162,9 +162,9 @@ function typeIcon(type) {
 
 function typeIconColor(type) {
   const colors = {
-    approval: 'text-accent-purple-500 dark:text-accent-purple-400',
+    approval: 'text-accent-accent-purple-500 dark:text-accent-accent-purple-400',
     question: 'text-blue-500 dark:text-blue-400',
-    alert: 'text-amber-500 dark:text-amber-400'
+    alert: 'text-state-autonomous-500 dark:text-state-autonomous-400'
   }
   return colors[type] || 'text-gray-500'
 }

--- a/src/frontend/src/components/process/RoleMatrix.vue
+++ b/src/frontend/src/components/process/RoleMatrix.vue
@@ -40,7 +40,7 @@
         <span>Executor</span>
       </div>
       <div class="flex items-center gap-1.5">
-        <span class="inline-flex items-center justify-center w-6 h-6 rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 font-semibold text-xs">M</span>
+        <span class="inline-flex items-center justify-center w-6 h-6 rounded bg-state-autonomous-100 dark:bg-state-autonomous-900/40 text-state-autonomous-700 dark:text-state-autonomous-400 font-semibold text-xs">M</span>
         <span>Monitor</span>
       </div>
       <div class="flex items-center gap-1.5">
@@ -149,7 +149,7 @@
       <div
         v-for="(warning, index) in validationWarnings"
         :key="index"
-        class="flex items-center gap-2 px-3 py-2 text-sm bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 rounded-lg"
+        class="flex items-center gap-2 px-3 py-2 text-sm bg-state-autonomous-50 dark:bg-state-autonomous-900/20 text-state-autonomous-700 dark:text-state-autonomous-400 rounded-lg"
       >
         <ExclamationTriangleIcon class="w-4 h-4 flex-shrink-0" />
         <span>{{ warning }}</span>
@@ -314,7 +314,7 @@ function getRoleCellClass(stepId, agent) {
     case 'executor':
       return `${base} bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400 font-semibold`;
     case 'monitor':
-      return `${base} bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 font-semibold`;
+      return `${base} bg-state-autonomous-100 dark:bg-state-autonomous-900/40 text-state-autonomous-700 dark:text-state-autonomous-400 font-semibold`;
     case 'informed':
       return `${base} bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-400 font-semibold`;
     default:

--- a/src/frontend/src/components/settings/McpKeysTab.vue
+++ b/src/frontend/src/components/settings/McpKeysTab.vue
@@ -80,7 +80,7 @@
                         :class="key.is_active ? 'bg-status-success-100 dark:bg-status-success-900/50 text-status-success-800 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 text-status-danger-800 dark:text-status-danger-300'">
                     {{ key.is_active ? 'Active' : 'Revoked' }}
                   </span>
-                  <span v-if="key.scope === 'agent'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/50 text-accent-accent-purple-800 dark:text-accent-accent-purple-300">
+                  <span v-if="key.scope === 'agent'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-purple-100 dark:bg-accent-purple-900/50 text-accent-purple-800 dark:text-accent-purple-300">
                     Agent
                   </span>
                   <span v-else-if="key.scope === 'system'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-status-urgent-100 dark:bg-status-urgent-900/50 text-status-urgent-800 dark:text-status-urgent-300">

--- a/src/frontend/src/components/settings/McpKeysTab.vue
+++ b/src/frontend/src/components/settings/McpKeysTab.vue
@@ -80,10 +80,10 @@
                         :class="key.is_active ? 'bg-status-success-100 dark:bg-status-success-900/50 text-status-success-800 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 text-status-danger-800 dark:text-status-danger-300'">
                     {{ key.is_active ? 'Active' : 'Revoked' }}
                   </span>
-                  <span v-if="key.scope === 'agent'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-purple-100 dark:bg-accent-purple-900/50 text-accent-purple-800 dark:text-accent-purple-300">
+                  <span v-if="key.scope === 'agent'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-accent-purple-100 dark:bg-accent-accent-purple-900/50 text-accent-accent-purple-800 dark:text-accent-accent-purple-300">
                     Agent
                   </span>
-                  <span v-else-if="key.scope === 'system'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-900/50 text-orange-800 dark:text-orange-300">
+                  <span v-else-if="key.scope === 'system'" class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-status-urgent-100 dark:bg-status-urgent-900/50 text-status-urgent-800 dark:text-status-urgent-300">
                     System
                   </span>
                 </div>
@@ -232,7 +232,7 @@
                     {{ copiedConfig ? 'Copied!' : 'Copy Config' }}
                   </button>
                 </div>
-                <pre class="bg-gray-900 dark:bg-gray-950 rounded-lg p-4 text-xs overflow-x-auto text-green-400 font-mono border border-gray-700">{{ getMcpConfig(createdApiKey) }}</pre>
+                <pre class="bg-gray-900 dark:bg-gray-950 rounded-lg p-4 text-xs overflow-x-auto text-status-success-400 font-mono border border-gray-700">{{ getMcpConfig(createdApiKey) }}</pre>
               </div>
 
               <div>

--- a/src/frontend/src/stores/operatorQueue.js
+++ b/src/frontend/src/stores/operatorQueue.js
@@ -12,8 +12,8 @@ import { useAuthStore } from './auth'
 
 // Agent display helpers
 const AGENT_COLORS = [
-  'bg-blue-500', 'bg-emerald-500', 'bg-purple-500', 'bg-amber-500',
-  'bg-rose-500', 'bg-cyan-500', 'bg-indigo-500', 'bg-teal-500'
+  'bg-blue-500', 'bg-emerald-500', 'bg-accent-purple-500', 'bg-state-autonomous-500',
+  'bg-state-locked-500', 'bg-cyan-500', 'bg-indigo-500', 'bg-teal-500'
 ]
 
 function getAgentProfile(name) {

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -22,14 +22,14 @@
         :class="[
           'px-2 py-0.5 text-[11px] font-medium rounded-full flex-shrink-0',
           agent.status === 'running'
-            ? 'bg-green-900/50 text-green-400'
+            ? 'bg-status-success-900/50 text-status-success-400'
             : 'bg-gray-700 text-gray-400'
         ]"
       >{{ agent.status }}</span>
 
       <span class="flex-1" />
 
-      <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-amber-900/40 text-amber-400 border border-amber-700/50 tracking-wide flex-shrink-0">
+      <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-state-autonomous-900/40 text-state-autonomous-400 border border-state-autonomous-700/50 tracking-wide flex-shrink-0">
         BETA
       </span>
     </header>
@@ -169,7 +169,7 @@
               prose-headings:text-gray-100 prose-headings:font-semibold
               prose-p:text-gray-300 prose-p:leading-relaxed
               prose-strong:text-gray-100
-              prose-code:text-amber-300 prose-code:bg-gray-800 prose-code:px-1 prose-code:rounded prose-code:text-xs
+              prose-code:text-state-autonomous-300 prose-code:bg-gray-800 prose-code:px-1 prose-code:rounded prose-code:text-xs
               prose-pre:bg-gray-800 prose-pre:border prose-pre:border-gray-700
               prose-ul:text-gray-300 prose-ol:text-gray-300
               prose-li:marker:text-gray-500

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -86,7 +86,7 @@
                 :class="[
                   'flex items-center space-x-1 px-2 py-0.5 rounded text-xs font-medium transition-all',
                   showTagClouds
-                    ? 'bg-purple-600 text-white'
+                    ? 'bg-accent-purple-600 text-white'
                     : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
                 ]"
                 title="Toggle tag grouping clouds"

--- a/src/frontend/src/views/ExecutionDetail.vue
+++ b/src/frontend/src/views/ExecutionDetail.vue
@@ -47,7 +47,7 @@
               v-if="execution?.status === 'running'"
               @click="stopExecution"
               :disabled="isStopping"
-              class="px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 flex items-center space-x-1"
+              class="px-3 py-1.5 bg-status-danger-600 hover:bg-status-danger-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 flex items-center space-x-1"
               title="Stop execution"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -89,15 +89,15 @@
 
     <!-- Error state -->
     <div v-else-if="error" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6 text-center">
-        <svg class="w-12 h-12 text-red-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div class="bg-status-danger-50 dark:bg-status-danger-900/20 border border-status-danger-200 dark:border-status-danger-800 rounded-lg p-6 text-center">
+        <svg class="w-12 h-12 text-status-danger-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
         </svg>
-        <h3 class="text-lg font-medium text-red-800 dark:text-red-300 mb-2">Failed to load execution</h3>
-        <p class="text-red-600 dark:text-red-400">{{ error }}</p>
+        <h3 class="text-lg font-medium text-status-danger-800 dark:text-status-danger-300 mb-2">Failed to load execution</h3>
+        <p class="text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
         <button
           @click="loadExecution"
-          class="mt-4 px-4 py-2 bg-red-100 dark:bg-red-800 text-red-700 dark:text-red-200 rounded-lg hover:bg-red-200 dark:hover:bg-red-700 transition-colors"
+          class="mt-4 px-4 py-2 bg-status-danger-100 dark:bg-status-danger-800 text-status-danger-700 dark:text-status-danger-200 rounded-lg hover:bg-status-danger-200 dark:hover:bg-status-danger-700 transition-colors"
         >
           Try Again
         </button>
@@ -126,8 +126,8 @@
         <!-- Cost Card -->
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
           <div class="flex items-center space-x-3">
-            <div class="flex-shrink-0 w-10 h-10 bg-green-100 dark:bg-green-900/50 rounded-lg flex items-center justify-center">
-              <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="flex-shrink-0 w-10 h-10 bg-status-success-100 dark:bg-status-success-900/50 rounded-lg flex items-center justify-center">
+              <svg class="w-5 h-5 text-status-success-600 dark:text-status-success-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
@@ -141,8 +141,8 @@
         <!-- Context Card -->
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
           <div class="flex items-center space-x-3">
-            <div class="flex-shrink-0 w-10 h-10 bg-purple-100 dark:bg-purple-900/50 rounded-lg flex items-center justify-center">
-              <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="flex-shrink-0 w-10 h-10 bg-accent-purple-100 dark:bg-accent-purple-900/50 rounded-lg flex items-center justify-center">
+              <svg class="w-5 h-5 text-accent-purple-600 dark:text-accent-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
               </svg>
             </div>
@@ -234,9 +234,9 @@
       </div>
 
       <!-- Error Panel (if failed) -->
-      <div v-if="execution.error" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg shadow">
-        <div class="px-4 py-3 border-b border-red-200 dark:border-red-800">
-          <h2 class="text-sm font-semibold text-red-800 dark:text-red-300 flex items-center">
+      <div v-if="execution.error" class="bg-status-danger-50 dark:bg-status-danger-900/20 border border-status-danger-200 dark:border-status-danger-800 rounded-lg shadow">
+        <div class="px-4 py-3 border-b border-status-danger-200 dark:border-status-danger-800">
+          <h2 class="text-sm font-semibold text-status-danger-800 dark:text-status-danger-300 flex items-center">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
@@ -244,7 +244,7 @@
           </h2>
         </div>
         <div class="p-4">
-          <pre class="text-sm text-red-700 dark:text-red-300 whitespace-pre-wrap font-mono">{{ execution.error }}</pre>
+          <pre class="text-sm text-status-danger-700 dark:text-status-danger-300 whitespace-pre-wrap font-mono">{{ execution.error }}</pre>
         </div>
       </div>
 
@@ -259,16 +259,16 @@
       </div>
 
       <!-- Stream Error Banner -->
-      <div v-if="streamError" class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 flex items-start space-x-3">
-        <svg class="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div v-if="streamError" class="bg-state-autonomous-50 dark:bg-state-autonomous-900/20 border border-state-autonomous-200 dark:border-state-autonomous-800 rounded-lg p-4 flex items-start space-x-3">
+        <svg class="w-5 h-5 text-state-autonomous-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
         </svg>
         <div class="flex-1 min-w-0">
-          <p class="text-sm text-amber-800 dark:text-amber-300">{{ streamError }}</p>
+          <p class="text-sm text-state-autonomous-800 dark:text-state-autonomous-300">{{ streamError }}</p>
         </div>
         <button
           @click="retryStream"
-          class="flex-shrink-0 px-3 py-1 text-xs font-medium text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-800/50 rounded hover:bg-amber-200 dark:hover:bg-amber-700 transition-colors"
+          class="flex-shrink-0 px-3 py-1 text-xs font-medium text-state-autonomous-700 dark:text-state-autonomous-300 bg-state-autonomous-100 dark:bg-state-autonomous-800/50 rounded hover:bg-state-autonomous-200 dark:hover:bg-state-autonomous-700 transition-colors"
         >
           Retry
         </button>
@@ -282,10 +282,10 @@
             <!-- Streaming indicator -->
             <div v-if="isStreaming" class="flex items-center space-x-2">
               <span class="relative flex h-2 w-2">
-                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-                <span class="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-status-success-400 opacity-75"></span>
+                <span class="relative inline-flex rounded-full h-2 w-2 bg-status-success-500"></span>
               </span>
-              <span class="text-xs text-green-600 dark:text-green-400 font-medium">Live</span>
+              <span class="text-xs text-status-success-600 dark:text-status-success-400 font-medium">Live</span>
             </div>
           </div>
           <div class="flex items-center space-x-3">
@@ -351,15 +351,15 @@
 
               <!-- Tool Call -->
               <div v-else-if="entry.type === 'tool-call'" class="flex space-x-3">
-                <div class="flex-shrink-0 w-8 h-8 bg-amber-100 dark:bg-amber-900/50 rounded-full flex items-center justify-center">
-                  <svg class="w-4 h-4 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="flex-shrink-0 w-8 h-8 bg-state-autonomous-100 dark:bg-state-autonomous-900/50 rounded-full flex items-center justify-center">
+                  <svg class="w-4 h-4 text-state-autonomous-600 dark:text-state-autonomous-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                   </svg>
                 </div>
-                <div class="flex-1 min-w-0 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-3">
+                <div class="flex-1 min-w-0 bg-state-autonomous-50 dark:bg-state-autonomous-900/20 rounded-lg p-3">
                   <div class="flex items-center space-x-2 mb-1">
-                    <span class="text-xs font-medium text-amber-700 dark:text-amber-300">{{ entry.tool }}</span>
+                    <span class="text-xs font-medium text-state-autonomous-700 dark:text-state-autonomous-300">{{ entry.tool }}</span>
                   </div>
                   <pre class="text-xs text-gray-600 dark:text-gray-400 bg-white/50 dark:bg-black/20 rounded p-2 whitespace-pre-wrap break-words max-h-96 overflow-y-auto">{{ entry.input }}</pre>
                 </div>
@@ -367,13 +367,13 @@
 
               <!-- Tool Result -->
               <div v-else-if="entry.type === 'tool-result'" class="flex space-x-3">
-                <div class="flex-shrink-0 w-8 h-8 bg-green-100 dark:bg-green-900/50 rounded-full flex items-center justify-center">
-                  <svg class="w-4 h-4 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="flex-shrink-0 w-8 h-8 bg-status-success-100 dark:bg-status-success-900/50 rounded-full flex items-center justify-center">
+                  <svg class="w-4 h-4 text-status-success-600 dark:text-status-success-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </div>
-                <div class="flex-1 min-w-0 bg-green-50 dark:bg-green-900/20 rounded-lg p-3">
-                  <div class="text-xs font-medium text-green-700 dark:text-green-300 mb-1">Result</div>
+                <div class="flex-1 min-w-0 bg-status-success-50 dark:bg-status-success-900/20 rounded-lg p-3">
+                  <div class="text-xs font-medium text-status-success-700 dark:text-status-success-300 mb-1">Result</div>
                   <pre class="text-xs text-gray-600 dark:text-gray-400 bg-white/50 dark:bg-black/20 rounded p-2 whitespace-pre-wrap break-words max-h-96 overflow-y-auto">{{ entry.content }}</pre>
                 </div>
               </div>
@@ -382,7 +382,7 @@
               <div v-else-if="entry.type === 'result'" class="bg-gray-100 dark:bg-gray-900 rounded-lg p-3 text-xs border-t-2 border-gray-300 dark:border-gray-600">
                 <div class="flex items-center justify-between text-gray-500 dark:text-gray-400">
                   <div class="flex items-center space-x-3">
-                    <span class="font-semibold text-green-600 dark:text-green-400">Completed</span>
+                    <span class="font-semibold text-status-success-600 dark:text-status-success-400">Completed</span>
                     <span>{{ entry.numTurns }} turns</span>
                   </div>
                   <div class="flex items-center space-x-3 font-mono">
@@ -434,20 +434,20 @@ const MAX_STREAM_RETRIES = 12  // Max retries (12 * 5s = 60s)
 const statusClass = computed(() => {
   if (!execution.value) return ''
   const status = execution.value.status
-  if (status === 'success') return 'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300'
-  if (status === 'failed') return 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300'
+  if (status === 'success') return 'bg-status-success-100 text-status-success-800 dark:bg-status-success-900/50 dark:text-status-success-300'
+  if (status === 'failed') return 'bg-status-danger-100 text-status-danger-800 dark:bg-status-danger-900/50 dark:text-status-danger-300'
   if (status === 'running') return 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300'
-  if (status === 'queued') return 'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-300'
-  if (status === 'skipped') return 'bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-300'
+  if (status === 'queued') return 'bg-state-autonomous-100 text-state-autonomous-800 dark:bg-state-autonomous-900/50 dark:text-state-autonomous-300'
+  if (status === 'skipped') return 'bg-accent-purple-100 text-accent-purple-800 dark:bg-accent-purple-900/50 dark:text-accent-purple-300'
   return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
 })
 
 const triggerIconClass = computed(() => {
   if (!execution.value) return 'bg-gray-100 dark:bg-gray-700'
   const trigger = execution.value.triggered_by
-  if (trigger === 'schedule') return 'bg-purple-100 dark:bg-purple-900/50'
-  if (trigger === 'manual') return 'bg-amber-100 dark:bg-amber-900/50'
-  if (trigger === 'paid') return 'bg-yellow-100 dark:bg-yellow-900/50'
+  if (trigger === 'schedule') return 'bg-accent-purple-100 dark:bg-accent-purple-900/50'
+  if (trigger === 'manual') return 'bg-state-autonomous-100 dark:bg-state-autonomous-900/50'
+  if (trigger === 'paid') return 'bg-status-warning-100 dark:bg-status-warning-900/50'
   if (trigger === 'public') return 'bg-teal-100 dark:bg-teal-900/50'
   return 'bg-cyan-100 dark:bg-cyan-900/50'
 })
@@ -455,9 +455,9 @@ const triggerIconClass = computed(() => {
 const triggerIconColor = computed(() => {
   if (!execution.value) return 'text-gray-600 dark:text-gray-400'
   const trigger = execution.value.triggered_by
-  if (trigger === 'schedule') return 'text-purple-600 dark:text-purple-400'
-  if (trigger === 'manual') return 'text-amber-600 dark:text-amber-400'
-  if (trigger === 'paid') return 'text-yellow-600 dark:text-yellow-400'
+  if (trigger === 'schedule') return 'text-accent-purple-600 dark:text-accent-purple-400'
+  if (trigger === 'manual') return 'text-state-autonomous-600 dark:text-state-autonomous-400'
+  if (trigger === 'paid') return 'text-status-warning-600 dark:text-status-warning-400'
   if (trigger === 'public') return 'text-teal-600 dark:text-teal-400'
   return 'text-cyan-600 dark:text-cyan-400'
 })

--- a/src/frontend/src/views/PublicChat.vue
+++ b/src/frontend/src/views/PublicChat.vue
@@ -46,13 +46,13 @@
             <div class="flex items-center space-x-2">
               <span
                 v-if="linkInfo.is_autonomous"
-                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-state-autonomous-100 text-state-autonomous-800 dark:bg-state-autonomous-900/30 dark:text-state-autonomous-400"
               >
                 AUTO
               </span>
               <span
                 v-if="linkInfo.is_read_only"
-                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-400"
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-state-locked-100 text-state-locked-800 dark:bg-state-locked-900/30 dark:text-state-locked-400"
               >
                 <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -209,14 +209,14 @@
         <!-- Read-only history banner -->
         <div
           v-if="viewingHistorySession"
-          class="mb-3 px-3 py-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg flex items-center justify-between text-xs"
+          class="mb-3 px-3 py-2 bg-state-autonomous-50 dark:bg-state-autonomous-900/20 border border-state-autonomous-200 dark:border-state-autonomous-800 rounded-lg flex items-center justify-between text-xs"
         >
-          <span class="text-amber-700 dark:text-amber-400">
+          <span class="text-state-autonomous-700 dark:text-state-autonomous-400">
             Viewing past session — read only
           </span>
           <button
             @click="exitHistoryView"
-            class="ml-2 text-amber-700 dark:text-amber-400 underline hover:no-underline"
+            class="ml-2 text-state-autonomous-700 dark:text-state-autonomous-400 underline hover:no-underline"
           >
             Return to current chat
           </button>

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -82,24 +82,24 @@
                   <!-- Status -->
                   <div class="mt-2 flex items-center text-sm">
                     <template v-if="publicUrlSaveSuccess">
-                      <svg class="h-4 w-4 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg class="h-4 w-4 text-status-success-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                       </svg>
-                      <span class="text-green-600 dark:text-green-400">Saved</span>
+                      <span class="text-status-success-600 dark:text-status-success-400">Saved</span>
                     </template>
                     <template v-else-if="publicUrlCurrent">
-                      <svg class="h-4 w-4 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg class="h-4 w-4 text-status-success-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                       </svg>
-                      <span class="text-green-600 dark:text-green-400">
+                      <span class="text-status-success-600 dark:text-status-success-400">
                         {{ publicUrlCurrent }}
                       </span>
                     </template>
                     <template v-else>
-                      <svg class="h-4 w-4 text-amber-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg class="h-4 w-4 text-state-autonomous-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                       </svg>
-                      <span class="text-amber-600 dark:text-amber-400">
+                      <span class="text-state-autonomous-600 dark:text-state-autonomous-400">
                         Not configured — required for Telegram bots and public links
                       </span>
                     </template>
@@ -179,7 +179,7 @@
                       v-if="anthropicKeyStatus.configured && anthropicKeyStatus.source === 'settings'"
                       @click="removeAnthropicKey"
                       :disabled="removingApiKey"
-                      class="inline-flex items-center px-4 py-2 border border-red-300 dark:border-red-700 rounded-md shadow-sm text-sm font-medium text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="inline-flex items-center px-4 py-2 border border-status-danger-300 dark:border-status-danger-700 rounded-md shadow-sm text-sm font-medium text-status-danger-700 dark:text-status-danger-300 bg-white dark:bg-gray-700 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <svg v-if="removingApiKey" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -191,21 +191,21 @@
                   <!-- Status/Result -->
                   <div class="mt-2 flex items-center text-sm">
                     <template v-if="apiKeyTestResult !== null">
-                      <svg v-if="apiKeyTestResult" class="h-4 w-4 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg v-if="apiKeyTestResult" class="h-4 w-4 text-status-success-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                       </svg>
-                      <svg v-else class="h-4 w-4 text-red-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg v-else class="h-4 w-4 text-status-danger-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                       </svg>
-                      <span :class="apiKeyTestResult ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
+                      <span :class="apiKeyTestResult ? 'text-status-success-600 dark:text-status-success-400' : 'text-status-danger-600 dark:text-status-danger-400'">
                         {{ apiKeyTestMessage }}
                       </span>
                     </template>
                     <template v-else-if="anthropicKeyStatus.configured">
-                      <svg class="h-4 w-4 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg class="h-4 w-4 text-status-success-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                       </svg>
-                      <span class="text-green-600 dark:text-green-400">
+                      <span class="text-status-success-600 dark:text-status-success-400">
                         Configured
                         <span class="text-gray-500 dark:text-gray-400">
                           ({{ anthropicKeyStatus.source === 'settings' ? 'from settings' : 'from environment' }})
@@ -213,10 +213,10 @@
                       </span>
                     </template>
                     <template v-else>
-                      <svg class="h-4 w-4 text-amber-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg class="h-4 w-4 text-state-autonomous-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                       </svg>
-                      <span class="text-amber-600 dark:text-amber-400">
+                      <span class="text-state-autonomous-600 dark:text-state-autonomous-400">
                         Not configured - required for agents
                       </span>
                     </template>
@@ -284,7 +284,7 @@
                       v-if="githubPatStatus.configured && githubPatStatus.source === 'settings'"
                       @click="removeGithubPat"
                       :disabled="removingGithubPat"
-                      class="inline-flex items-center px-4 py-2 border border-red-300 dark:border-red-700 rounded-md shadow-sm text-sm font-medium text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="inline-flex items-center px-4 py-2 border border-status-danger-300 dark:border-status-danger-700 rounded-md shadow-sm text-sm font-medium text-status-danger-700 dark:text-status-danger-300 bg-white dark:bg-gray-700 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <svg v-if="removingGithubPat" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -296,21 +296,21 @@
                   <!-- Status/Result -->
                   <div class="mt-2 flex items-center text-sm">
                     <template v-if="githubPatTestResult !== null">
-                      <svg v-if="githubPatTestResult" class="h-4 w-4 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg v-if="githubPatTestResult" class="h-4 w-4 text-status-success-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                       </svg>
-                      <svg v-else class="h-4 w-4 text-red-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg v-else class="h-4 w-4 text-status-danger-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                       </svg>
-                      <span :class="githubPatTestResult ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
+                      <span :class="githubPatTestResult ? 'text-status-success-600 dark:text-status-success-400' : 'text-status-danger-600 dark:text-status-danger-400'">
                         {{ githubPatTestMessage }}
                       </span>
                     </template>
                     <template v-else-if="githubPatStatus.configured">
-                      <svg class="h-4 w-4 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg class="h-4 w-4 text-status-success-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                       </svg>
-                      <span class="text-green-600 dark:text-green-400">
+                      <span class="text-status-success-600 dark:text-status-success-400">
                         Configured
                         <span class="text-gray-500 dark:text-gray-400">
                           ({{ githubPatStatus.source === 'settings' ? 'from settings' : 'from environment' }})
@@ -329,7 +329,7 @@
                   <!-- Propagation result (#211) -->
                   <div v-if="githubPatPropagation" class="mt-2 text-sm">
                     <template v-if="githubPatPropagation.error">
-                      <div class="text-red-600 dark:text-red-400">
+                      <div class="text-status-danger-600 dark:text-status-danger-400">
                         PAT saved, but propagation failed: {{ githubPatPropagation.error }}
                       </div>
                     </template>
@@ -339,10 +339,10 @@
                       </div>
                     </template>
                     <template v-else>
-                      <div :class="githubPatPropagation.failed.length ? 'text-yellow-700 dark:text-yellow-400' : 'text-green-600 dark:text-green-400'">
+                      <div :class="githubPatPropagation.failed.length ? 'text-status-warning-700 dark:text-status-warning-400' : 'text-status-success-600 dark:text-status-success-400'">
                         PAT updated and applied to {{ githubPatPropagation.updated.length }} of {{ githubPatPropagation.total_running }} running agent{{ githubPatPropagation.total_running === 1 ? '' : 's' }}.
                       </div>
-                      <div v-if="githubPatPropagation.failed.length" class="mt-1 text-red-600 dark:text-red-400">
+                      <div v-if="githubPatPropagation.failed.length" class="mt-1 text-status-danger-600 dark:text-status-danger-400">
                         Failed: {{ githubPatPropagation.failed.map(a => a.agent_name).join(', ') }}
                       </div>
                       <div v-if="githubPatPropagation.skipped.length" class="mt-1 text-gray-500 dark:text-gray-400">
@@ -375,9 +375,9 @@
                 <span class="flex items-center gap-2">
                   <span
                     class="inline-block w-2.5 h-2.5 rounded-full"
-                    :class="slackTransportStatus.connected ? 'bg-green-500' : 'bg-red-500'"
+                    :class="slackTransportStatus.connected ? 'bg-status-success-500' : 'bg-status-danger-500'"
                   ></span>
-                  <span class="text-sm" :class="slackTransportStatus.connected ? 'text-green-700 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'">
+                  <span class="text-sm" :class="slackTransportStatus.connected ? 'text-status-success-700 dark:text-status-success-400' : 'text-gray-500 dark:text-gray-400'">
                     {{ slackTransportStatus.connected ? (slackTransportStatus.transport_mode === 'socket' ? 'Socket Mode' : 'Webhook') : 'Disconnected' }}
                   </span>
                 </span>
@@ -404,7 +404,7 @@
                       class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                     />
                   </div>
-                  <div v-if="slackSettings.client_id?.configured" class="mt-1 text-xs text-green-600 dark:text-green-400">
+                  <div v-if="slackSettings.client_id?.configured" class="mt-1 text-xs text-status-success-600 dark:text-status-success-400">
                     ✓ Configured ({{ slackSettings.client_id.source === 'settings' ? 'from settings' : 'from environment' }})
                   </div>
                 </div>
@@ -437,7 +437,7 @@
                       </svg>
                     </button>
                   </div>
-                  <div v-if="slackSettings.client_secret?.configured" class="mt-1 text-xs text-green-600 dark:text-green-400">
+                  <div v-if="slackSettings.client_secret?.configured" class="mt-1 text-xs text-status-success-600 dark:text-status-success-400">
                     ✓ Configured ({{ slackSettings.client_secret.source === 'settings' ? 'from settings' : 'from environment' }})
                   </div>
                 </div>
@@ -470,7 +470,7 @@
                       </svg>
                     </button>
                   </div>
-                  <div v-if="slackSettings.signing_secret?.configured" class="mt-1 text-xs text-green-600 dark:text-green-400">
+                  <div v-if="slackSettings.signing_secret?.configured" class="mt-1 text-xs text-status-success-600 dark:text-status-success-400">
                     ✓ Configured ({{ slackSettings.signing_secret.source === 'settings' ? 'from settings' : 'from environment' }})
                   </div>
                 </div>
@@ -492,7 +492,7 @@
                     v-if="slackHasStoredCredentials"
                     @click="removeSlackSettings"
                     :disabled="removingSlackSettings"
-                    class="inline-flex items-center px-4 py-2 border border-red-300 dark:border-red-700 rounded-md shadow-sm text-sm font-medium text-red-700 dark:text-red-300 bg-white dark:bg-gray-700 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center px-4 py-2 border border-status-danger-300 dark:border-status-danger-700 rounded-md shadow-sm text-sm font-medium text-status-danger-700 dark:text-status-danger-300 bg-white dark:bg-gray-700 hover:bg-status-danger-50 dark:hover:bg-status-danger-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <svg v-if="removingSlackSettings" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -500,7 +500,7 @@
                     </svg>
                     Remove Credentials
                   </button>
-                  <span v-if="slackSaveSuccess" class="text-sm text-green-600 dark:text-green-400">
+                  <span v-if="slackSaveSuccess" class="text-sm text-status-success-600 dark:text-status-success-400">
                     ✓ Saved
                   </span>
                 </div>
@@ -544,7 +544,7 @@
                       </svg>
                     </button>
                   </div>
-                  <div v-if="slackTransportStatus.app_token_configured" class="mt-1 text-xs text-green-600 dark:text-green-400">
+                  <div v-if="slackTransportStatus.app_token_configured" class="mt-1 text-xs text-status-success-600 dark:text-status-success-400">
                     ✓ App token configured
                   </div>
                   <p class="mt-1 text-xs text-gray-400">
@@ -559,7 +559,7 @@
                     v-if="!slackTransportStatus.connected"
                     @click="connectSlackTransport"
                     :disabled="connectingSlack || (!slackTransportStatus.app_token_configured && !slackAppToken)"
-                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-status-success-600 hover:bg-status-success-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <svg v-if="connectingSlack" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -567,7 +567,7 @@
                     </svg>
                     {{ connectingSlack ? 'Connecting...' : 'Connect' }}
                   </button>
-                  <span v-if="slackTransportStatus.connected" class="text-sm text-green-600 dark:text-green-400">
+                  <span v-if="slackTransportStatus.connected" class="text-sm text-status-success-600 dark:text-status-success-400">
                     ✓ Socket Mode active
                   </span>
 
@@ -583,7 +583,7 @@
                     </svg>
                     {{ slackTransportStatus.workspaces.length > 0 ? 'Reinstall to Workspace' : 'Install to Workspace' }}
                   </button>
-                  <span v-if="slackInstallSuccess" class="text-sm text-green-600 dark:text-green-400">
+                  <span v-if="slackInstallSuccess" class="text-sm text-status-success-600 dark:text-status-success-400">
                     ✓ Workspace installed
                   </span>
                 </div>
@@ -646,18 +646,18 @@
             <div class="px-6 py-4">
               <div class="space-y-4">
                 <!-- Encryption Not Configured Warning -->
-                <div v-if="!encryptionConfigured" class="bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+                <div v-if="!encryptionConfigured" class="bg-status-warning-50 dark:bg-status-warning-900/30 border border-status-warning-200 dark:border-status-warning-800 rounded-lg p-4">
                   <div class="flex">
                     <div class="flex-shrink-0">
-                      <svg class="h-5 w-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                      <svg class="h-5 w-5 text-status-warning-400" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
                       </svg>
                     </div>
                     <div class="ml-3">
-                      <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-300">Encryption not configured</h3>
-                      <p class="mt-1 text-sm text-yellow-700 dark:text-yellow-400">
-                        Subscription storage requires <code class="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900 rounded text-xs">CREDENTIAL_ENCRYPTION_KEY</code> in your <code class="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900 rounded text-xs">.env</code> file.
-                        Generate with: <code class="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900 rounded text-xs">openssl rand -hex 32</code> and restart the backend.
+                      <h3 class="text-sm font-medium text-status-warning-800 dark:text-status-warning-300">Encryption not configured</h3>
+                      <p class="mt-1 text-sm text-status-warning-700 dark:text-status-warning-400">
+                        Subscription storage requires <code class="px-1 py-0.5 bg-status-warning-100 dark:bg-status-warning-900 rounded text-xs">CREDENTIAL_ENCRYPTION_KEY</code> in your <code class="px-1 py-0.5 bg-status-warning-100 dark:bg-status-warning-900 rounded text-xs">.env</code> file.
+                        Generate with: <code class="px-1 py-0.5 bg-status-warning-100 dark:bg-status-warning-900 rounded text-xs">openssl rand -hex 32</code> and restart the backend.
                       </p>
                     </div>
                   </div>
@@ -712,9 +712,9 @@
                       placeholder="sk-ant-oat01-..."
                       :disabled="addingSubscription"
                       class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                      :class="{ 'border-red-400 dark:border-red-500': newSubscription.token && !newSubscription.token.startsWith('sk-ant-oat01-') }"
+                      :class="{ 'border-status-danger-400 dark:border-status-danger-500': newSubscription.token && !newSubscription.token.startsWith('sk-ant-oat01-') }"
                     />
-                    <p v-if="newSubscription.token && !newSubscription.token.startsWith('sk-ant-oat01-')" class="mt-1 text-xs text-red-500">
+                    <p v-if="newSubscription.token && !newSubscription.token.startsWith('sk-ant-oat01-')" class="mt-1 text-xs text-status-danger-500">
                       Token must start with sk-ant-oat01-
                     </p>
                     <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
@@ -790,7 +790,7 @@
                           </td>
                           <td class="px-6 py-4 whitespace-nowrap">
                             <span v-if="sub.subscription_type" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
-                                  :class="sub.subscription_type === 'max' ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'">
+                                  :class="sub.subscription_type === 'max' ? 'bg-accent-purple-100 text-accent-purple-800 dark:bg-accent-purple-900 dark:text-accent-purple-200' : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'">
                               {{ sub.subscription_type === 'max' ? 'Max' : sub.subscription_type === 'pro' ? 'Pro' : sub.subscription_type }}
                             </span>
                             <span v-else class="text-sm text-gray-500 dark:text-gray-400">—</span>
@@ -807,7 +807,7 @@
                             <button
                               @click.stop="deleteSubscription(sub)"
                               :disabled="deletingSubscription === sub.id"
-                              class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50"
+                              class="text-status-danger-600 hover:text-status-danger-900 dark:text-status-danger-400 dark:hover:text-status-danger-300 disabled:opacity-50"
                             >
                               {{ deletingSubscription === sub.id ? 'Deleting...' : 'Delete' }}
                             </button>
@@ -968,7 +968,7 @@ Example:
                 <!-- Character Count -->
                 <div class="flex justify-between text-sm text-gray-500 dark:text-gray-400">
                   <span>{{ trinityPrompt.length }} characters</span>
-                  <span v-if="hasChanges" class="text-amber-600 dark:text-amber-400">Unsaved changes</span>
+                  <span v-if="hasChanges" class="text-state-autonomous-600 dark:text-state-autonomous-400">Unsaved changes</span>
                 </div>
 
                 <!-- Action Buttons -->
@@ -1080,7 +1080,7 @@ Example:
                           <button
                             @click="removeEmailFromWhitelist(entry.email)"
                             :disabled="removingEmail === entry.email"
-                            class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50"
+                            class="text-status-danger-600 hover:text-status-danger-900 dark:text-status-danger-400 dark:hover:text-status-danger-300 disabled:opacity-50"
                           >
                             {{ removingEmail === entry.email ? 'Removing...' : 'Remove' }}
                           </button>
@@ -1110,7 +1110,7 @@ Example:
               <!-- Role legend -->
               <div class="flex flex-wrap gap-2 mb-4 text-xs text-gray-500 dark:text-gray-400">
                 <span class="font-medium">Roles:</span>
-                <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">admin — full control</span>
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-accent-purple-100 text-accent-purple-800 dark:bg-accent-purple-900 dark:text-accent-purple-200">admin — full control</span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200">creator — create &amp; manage agents</span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">operator — run existing agents</span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">user — public links only</span>
@@ -1155,7 +1155,7 @@ Example:
                           <option value="operator">operator</option>
                           <option value="user">user</option>
                         </select>
-                        <span v-else class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+                        <span v-else class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-accent-purple-100 text-accent-purple-800 dark:bg-accent-purple-900 dark:text-accent-purple-200">
                           {{ u.role }} (you)
                         </span>
                       </td>
@@ -1221,10 +1221,10 @@ Example:
                 </button>
               </div>
 
-              <p v-if="mcpUrlError" class="mt-2 text-sm text-red-600 dark:text-red-400">
+              <p v-if="mcpUrlError" class="mt-2 text-sm text-status-danger-600 dark:text-status-danger-400">
                 {{ mcpUrlError }}
               </p>
-              <p v-if="mcpUrlSuccess" class="mt-2 text-sm text-green-600 dark:text-green-400">
+              <p v-if="mcpUrlSuccess" class="mt-2 text-sm text-status-success-600 dark:text-status-success-400">
                 {{ mcpUrlSuccess }}
               </p>
             </div>
@@ -1273,7 +1273,7 @@ Example:
                     Add
                   </button>
                 </div>
-                <p v-if="templateValidationError" class="text-sm text-red-600 dark:text-red-400">
+                <p v-if="templateValidationError" class="text-sm text-status-danger-600 dark:text-status-danger-400">
                   {{ templateValidationError }}
                 </p>
 
@@ -1316,7 +1316,7 @@ Example:
                           <button
                             @click="removeGithubTemplate(index)"
                             :disabled="savingGithubTemplates"
-                            class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50"
+                            class="text-status-danger-600 hover:text-status-danger-900 dark:text-status-danger-400 dark:hover:text-status-danger-300 disabled:opacity-50"
                           >
                             Remove
                           </button>
@@ -1407,7 +1407,7 @@ Example:
                   <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Admin</label>
                   <p class="text-sm text-gray-500 dark:text-gray-400">Admins can always create unlimited agents</p>
                 </div>
-                <span class="text-sm font-medium text-green-600 dark:text-green-400">Unlimited</span>
+                <span class="text-sm font-medium text-status-success-600 dark:text-status-success-400">Unlimited</span>
               </div>
 
               <!-- Creator role -->
@@ -1456,9 +1456,9 @@ Example:
               </div>
 
               <!-- Legacy setting warning -->
-              <div v-if="agentQuotaLegacy" class="rounded-md bg-yellow-50 dark:bg-yellow-900/20 p-3">
-                <p class="text-sm text-yellow-700 dark:text-yellow-400">
-                  Legacy setting <code class="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900/40 rounded text-xs">max_agents_per_user={{ agentQuotaLegacy }}</code> is active and used as fallback. Save per-role quotas to override it.
+              <div v-if="agentQuotaLegacy" class="rounded-md bg-status-warning-50 dark:bg-status-warning-900/20 p-3">
+                <p class="text-sm text-status-warning-700 dark:text-status-warning-400">
+                  Legacy setting <code class="px-1 py-0.5 bg-status-warning-100 dark:bg-status-warning-900/40 rounded text-xs">max_agents_per_user={{ agentQuotaLegacy }}</code> is active and used as fallback. Save per-role quotas to override it.
                 </p>
               </div>
 
@@ -1531,7 +1531,7 @@ Example:
                 <div class="flex items-center justify-between text-sm">
                   <div class="flex items-center gap-4 text-gray-600 dark:text-gray-300">
                     <span>
-                      <svg class="h-4 w-4 text-green-500 inline mr-1" fill="currentColor" viewBox="0 0 20 20">
+                      <svg class="h-4 w-4 text-status-success-500 inline mr-1" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                       </svg>
                       {{ skillsLibraryStatus.skill_count }} skills available
@@ -1589,8 +1589,8 @@ Example:
             <div class="px-6 py-4 space-y-4">
               <!-- Result message -->
               <div v-if="defaultAvatarResult" class="rounded-md p-3" :class="{
-                'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300': defaultAvatarResult.generated > 0 && defaultAvatarResult.failed === 0,
-                'bg-yellow-50 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300': defaultAvatarResult.failed > 0,
+                'bg-status-success-50 dark:bg-status-success-900/30 text-status-success-700 dark:text-status-success-300': defaultAvatarResult.generated > 0 && defaultAvatarResult.failed === 0,
+                'bg-status-warning-50 dark:bg-status-warning-900/30 text-status-warning-700 dark:text-status-warning-300': defaultAvatarResult.failed > 0,
                 'bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300': defaultAvatarResult.generated === 0 && defaultAvatarResult.failed === 0
               }">
                 <p class="text-sm font-medium">{{ defaultAvatarResult.message }}</p>
@@ -1598,7 +1598,7 @@ Example:
                   <li v-for="name in defaultAvatarResult.agents" :key="name">Generated: {{ name }}</li>
                 </ul>
                 <ul v-if="defaultAvatarResult.errors.length" class="mt-1 text-xs space-y-0.5">
-                  <li v-for="err in defaultAvatarResult.errors" :key="err.agent" class="text-red-600 dark:text-red-400">Failed: {{ err.agent }} - {{ err.error }}</li>
+                  <li v-for="err in defaultAvatarResult.errors" :key="err.agent" class="text-status-danger-600 dark:text-status-danger-400">Failed: {{ err.agent }} - {{ err.error }}</li>
                 </ul>
               </div>
 
@@ -1641,30 +1641,30 @@ Example:
         </div>
 
         <!-- Error Display -->
-        <div v-if="error" class="mt-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-4">
+        <div v-if="error" class="mt-4 bg-status-danger-50 dark:bg-status-danger-900/30 border border-status-danger-200 dark:border-status-danger-800 rounded-lg p-4">
           <div class="flex">
             <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="h-5 w-5 text-status-danger-400" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
               </svg>
             </div>
             <div class="ml-3">
-              <h3 class="text-sm font-medium text-red-800 dark:text-red-300">Error</h3>
-              <p class="mt-1 text-sm text-red-700 dark:text-red-400">{{ error }}</p>
+              <h3 class="text-sm font-medium text-status-danger-800 dark:text-status-danger-300">Error</h3>
+              <p class="mt-1 text-sm text-status-danger-700 dark:text-status-danger-400">{{ error }}</p>
             </div>
           </div>
         </div>
 
         <!-- Success Message -->
-        <div v-if="showSuccess" class="mt-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4">
+        <div v-if="showSuccess" class="mt-4 bg-status-success-50 dark:bg-status-success-900/30 border border-status-success-200 dark:border-status-success-800 rounded-lg p-4">
           <div class="flex">
             <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="h-5 w-5 text-status-success-400" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
               </svg>
             </div>
             <div class="ml-3">
-              <p class="text-sm font-medium text-green-800 dark:text-green-300">Settings saved successfully!</p>
+              <p class="text-sm font-medium text-status-success-800 dark:text-status-success-300">Settings saved successfully!</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Final design-system token sweep (#554). Migrates the last 24 files containing raw semantic palette references — **zero remaining anywhere in `src/`** after this lands.

## Composition

**Slice 9 targets** (grew significantly since slice 8):
- `views/Settings.vue` — 161 refs (Settings was split into tabs + audit log work)
- `views/ExecutionDetail.vue` — 98 refs

**Drift catch-up** — slice 8 regressions (2 refs):
- `components/TasksPanel.vue` (new `session` trigger badge)
- `components/AgentHeader.vue` (BETA pill)

**Drift catch-up** — new files since slice 8 (39 refs):
- `components/SessionPanel.vue` (28)
- `views/AgentWorkspace.vue` (6)
- `components/settings/McpKeysTab.vue` (5)

**Drift catch-up** — previously un-migrated files (~80 refs):
- `views/PublicChat.vue` (16), `components/process/RoleMatrix.vue` (12), `components/operator/QueueItemDetail.vue` (10), `components/ChatPanel.vue` (8), `components/ResourceModal.vue` (7), `components/SharingPanel.vue` (6), `components/FileSharingPanel.vue` (6), `components/OnboardingChecklist.vue` (5), `components/operator/QueueCard.vue` (4), `components/file-manager/FileTreeNode.vue` (4), `components/WhatsAppChannelPanel.vue` (4), `stores/operatorQueue.js` (3), `components/operator/QueueList.vue` (2), `components/operator/NotificationsPanel.vue` (2), `components/file-manager/FilePreview.vue` (2), `components/PublicLinksPanel.vue` (2), `views/Dashboard.vue` (1)

## Mappings (palette-equivalent — zero visual change)

- `yellow` → `status-warning`
- `green`  → `status-success`
- `red`    → `status-danger`
- `orange` → `status-urgent`
- `amber`  → `state-autonomous`
- `rose`   → `state-locked`
- `purple` → `accent-purple`

## After this lands

Slice 10 (final) can focus on:
1. Defining new token families (`action-primary` for indigo, `state-selected` for selected-state blue)
2. Migrating the deferred indigo/blue/sky/teal residuals

## Verification

- `grep -rE '(text\|bg\|border\|ring\|...)-(red\|green\|yellow\|orange\|amber\|rose\|purple)-\d+' src/` → **0 results**
- `npm run check:tokens` → ✅ 10 tokens equivalent, all references resolve
- `npm run build` → ✅ clean
- e2e smoke: deferred to CI (local stack was down)

## Test plan

- [ ] `frontend-build` CI green
- [ ] `frontend-e2e` CI green (label: `ui`)
- [ ] Manual sanity: Settings tabs, ExecutionDetail, PublicChat, OperatingRoom render correctly

Part of #554 — final mechanical sweep before slice 10's structural work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)