### PR TITLE
fix(base-image): drop ppa:deadsnakes by switching to python:3.11-slim-bookworm (#658)

### DIFF
--- a/docker/base-image/Dockerfile
+++ b/docker/base-image/Dockerfile
@@ -1,4 +1,8 @@
-FROM ubuntu:22.04
+# Python 3.11 is provided by the official python image (Debian Bookworm
+# slim). This eliminates the dependency on ppa:deadsnakes/ppa, which has
+# no SLA and historically blocked deployment of critical agent-runtime
+# fixes for days at a time when the PPA was unreachable. See #658.
+FROM python:3.11-slim-bookworm
 
 # Version tracking - set at build time via --build-arg VERSION=x.y.z
 ARG VERSION=latest
@@ -8,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York
 ENV TRINITY_BASE_VERSION="${VERSION}"
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     wget \
     git \
@@ -16,7 +20,6 @@ RUN apt-get update && apt-get install -y \
     nano \
     htop \
     build-essential \
-    software-properties-common \
     apt-transport-https \
     ca-certificates \
     gnupg \
@@ -27,22 +30,20 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install -y python3.11 python3.11-venv python3.11-dev python3-pip && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN wget -q https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go1.23.4.linux-amd64.tar.gz && \
     rm go1.23.4.linux-amd64.tar.gz
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+# Docker apt repo for debian (was linux/ubuntu when the base was ubuntu:22.04).
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update && \
-    apt-get install -y docker-ce-cli
+    apt-get install -y --no-install-recommends docker-ce-cli && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g @anthropic-ai/claude-code@latest
 


### PR DESCRIPTION
## Summary

The agent base Dockerfile depended on `ppa:deadsnakes/ppa` for Python 3.11.
Launchpad PPAs have no SLA — `ppa.launchpadcontent.net` has been unreachable
for multi-day stretches, blocking `docker build` of the agent base image.
The #649 `_kill_orphan_pipe_writers` timeout fix was stranded on platform
containers for 3+ days because the PPA outage prevented the agent image
from being rebuilt.

Switch from `ubuntu:22.04` + deadsnakes to `python:3.11-slim-bookworm`,
which ships Python 3.11 prebuilt and removes the PPA dependency entirely
(Option A in the issue's suggested-fix list).

## Changes

- Base: `ubuntu:22.04` → `python:3.11-slim-bookworm`
- Removed: `software-properties-common`, `add-apt-repository ppa:deadsnakes/ppa`,
  `apt-get install python3.11 python3.11-venv python3.11-dev python3-pip`,
  `update-alternatives` — all subsumed by the base image.
- Docker-ce-cli apt repo: `linux/ubuntu` → `linux/debian`.
- Added `--no-install-recommends` + matching `rm -rf /var/lib/apt/lists/*`
  on the package-installing RUN steps (smaller image, faster builds).

## Verification

`docker build -f docker/base-image/Dockerfile docker/base-image/` succeeds
end-to-end on a clean docker. Smoke-tested the resulting image:

| Check | Result |
|---|---|
| `python3 --version` | `Python 3.11.15` |
| `python3 -m pip --version` | `pip 26.1.1` |
| `import fastapi, uvicorn, httpx, pydantic, yaml, rich, cryptography` | all ok |
| `node --version` | `v20.20.2` |
| `go version` (`/usr/local/go/bin/go`) | `go1.23.4 linux/amd64` |
| `docker --version` | `Docker version 29.4.3` |
| `claude --version` | `2.1.139 (Claude Code)` |
| `gemini --version` | `0.41.2` |
| `jq`, `sudo`, `ssh`, container user `developer` (uid 1000), WORKDIR `/home/developer` | all present |

## Test plan

- [x] Local clean `docker build` from `docker/base-image/Dockerfile` — succeeds.
- [x] Smoke-test all language runtimes + agent CLIs in the built image.
- [ ] Rebuild & redeploy agent fleet on staging, verify agent containers start and chat works.
- [ ] Watch for any agent-template assumption that's debian-vs-ubuntu sensitive (templates that `apt-get install` ubuntu-only packages, for example).

Relates to #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)