### PR TITLE
fix(startup): sweep Redis for orphan slots whose SQL row is terminal or missing (#749)

### DIFF
--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -35,6 +35,20 @@ ACTIVITY_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to su
 NO_SESSION_TIMEOUT_SECONDS = 60  # Issue #106: fast-fail executions that never got a Claude session
 WATCHDOG_HTTP_TIMEOUT = 5.0  # Timeout for agent HTTP calls during reconciliation
 WATCHDOG_MIN_AGE_SECONDS = 60  # Don't orphan-recover executions younger than this (dispatch window)
+# #749: grace window for the Redis-side orphan-slot sweep. A slot whose
+# ZSET score (unix seconds, recorded at ZADD time) is within this many
+# seconds of "now" may belong to a concurrent /internal/execute-task
+# handler that has done its ZADD but not yet inserted the SQL row.
+# Symmetric with the SQL-side window in `recover_orphaned_executions`.
+SLOT_RECOVERY_GRACE_SECONDS = 15
+# Terminal SQL statuses that mean "the row is done; any matching Redis
+# slot is a leak." Mirrors the values in models.TaskExecutionStatus.
+_TERMINAL_EXECUTION_STATUSES = {"success", "failed", "cancelled", "skipped"}
+# #749: members starting with this prefix are drain sentinels used by
+# the capacity manager — not real executions — and must be skipped by
+# the orphan-slot sweep. Matches the canary S-01 filter
+# (`canary/invariants/s01_slot_row_bijection.py:DRAIN_PREFIX`).
+_DRAIN_SENTINEL_PREFIX = "drain-"
 ERROR_FETCH_TIMEOUT = 2.0  # Issue #286: short timeout for fetching error context from agent
 MAX_ERROR_MESSAGE_LENGTH = 2000  # Issue #286: truncate combined error messages
 # Issue #772: per-cycle row budget for retention sweeps. Caps the work each
@@ -906,19 +920,36 @@ cleanup_service = CleanupService()
 async def recover_orphaned_executions() -> Dict:
     """Recover orphaned task executions on backend startup.
 
-    Checks each 'running' schedule execution against the agent's container
-    and process registry. Executions not found on the agent are marked failed
-    and their capacity slots released.
+    Two passes:
+
+      1. SQL→Redis (legacy): for each 'running' schedule execution row,
+         check the agent's container and process registry — if missing,
+         mark the row failed and release any capacity slot.
+      2. Redis→SQL (#749): scan ``agent:slots:*`` for members whose SQL
+         row is terminal or missing and ZREM them. Necessary because a
+         backend kill between slot ZADD and the finally-block ZREM leaves
+         the slot leaked, and the SQL→Redis pass cannot see Redis-only
+         orphans.
 
     Returns:
-        Dict with recovered, still_running, and errors counts.
+        Dict with recovered, still_running, errors, and redis_slots_reclaimed
+        counts.
     """
     from services.agent_client import AgentClientError, get_agent_client
     from services.docker_service import get_agent_container
 
     running = db.get_running_executions()
     if not running:
-        return {"recovered": 0, "still_running": 0, "errors": 0}
+        # #749: still run the Redis-side sweep — orphan slots can exist
+        # even when SQL has zero running rows (that is in fact the
+        # textbook symptom of the kill-between-ZADD-and-ZREM bug).
+        redis_reclaimed = await _reconcile_orphaned_slots()
+        return {
+            "recovered": 0,
+            "still_running": 0,
+            "errors": 0,
+            "redis_slots_reclaimed": sum(redis_reclaimed.values()),
+        }
 
     capacity = get_capacity_manager()
 
@@ -968,7 +999,21 @@ async def recover_orphaned_executions() -> Dict:
         f"[Recovery] Task execution recovery complete: "
         f"recovered={recovered}, still_running={still_running}, errors={errors}"
     )
-    return {"recovered": recovered, "still_running": still_running, "errors": errors}
+
+    # #749: complete the asymmetric pair. The SQL→Redis pass above flips
+    # SQL rows to FAILED when Redis lost their slot; the Redis→SQL pass
+    # below ZREMs slots whose SQL row is terminal or missing (e.g. backend
+    # killed between ZADD and ZREM). Without this pass the leaked slot
+    # persists until 1200s TTL or the next acquire on this agent.
+    redis_reclaimed = await _reconcile_orphaned_slots()
+    redis_reclaimed_total = sum(redis_reclaimed.values())
+
+    return {
+        "recovered": recovered,
+        "still_running": still_running,
+        "errors": errors,
+        "redis_slots_reclaimed": redis_reclaimed_total,
+    }
 
 
 async def _recover_execution(execution: Dict, agent_name: str, capacity) -> bool:
@@ -985,3 +1030,117 @@ async def _recover_execution(execution: Dict, agent_name: str, capacity) -> bool
     except Exception as e:
         logger.error(f"[Recovery] Error recovering execution {execution['id']}: {e}")
         return False
+
+
+async def _reconcile_orphaned_slots() -> Dict[str, int]:
+    """Sweep Redis for slot members that have no live SQL execution (#749).
+
+    SQL→Redis recovery (the existing path in `recover_orphaned_executions`)
+    flips SQL rows to FAILED when Redis lost their slot. It is asymmetric —
+    it doesn't catch the inverse leak, where Redis still holds a slot for an
+    execution whose SQL row is either terminal (someone wrote SUCCESS /
+    FAILED already) or missing entirely. That happens whenever the backend
+    is killed between `capacity.acquire()` (ZADD) and the `finally`-block
+    `capacity.release()` (ZREM): the in-flight handler dies, the slot
+    stays. The canary S-01 invariant (Issue #411) detects exactly this
+    shape; rows #26/#27/#28 in `canary_violations` reproduced it three
+    cycles in a row during the same incident as #748.
+
+    For each Redis slot member we:
+
+      - skip drain sentinels (members starting with ``drain-``) — they
+        are not executions;
+      - skip members whose ZSET score is within
+        ``SLOT_RECOVERY_GRACE_SECONDS`` of "now" — they may belong to a
+        concurrent /internal/execute-task handler that has done its ZADD
+        but not yet committed the SQL row (mirrors the SQL-side grace
+        window in #748);
+      - look up the execution by id in SQL: if the row is missing or its
+        status is terminal (success/failed/cancelled/skipped), the slot
+        is orphaned → ZREM the member and DELETE its metadata key.
+
+    Returns a dict ``{agent_name: int}`` counting reclaimed slots per
+    agent. Never raises — Redis-unreachable errors are logged and the
+    call returns whatever was reclaimed before the failure.
+    """
+    import time
+
+    from services.slot_service import get_slot_service
+
+    try:
+        slot_service = get_slot_service()
+    except Exception as e:
+        logger.error(f"[Recovery] Slot service unavailable; skipping Redis sweep: {e}")
+        return {}
+
+    redis_client = slot_service.redis
+    prefix = slot_service.slots_prefix
+    grace_cutoff = time.time() - SLOT_RECOVERY_GRACE_SECONDS
+
+    reclaimed: Dict[str, int] = {}
+
+    # SCAN the agent:slots:* keyspace (matches canary/snapshot.py:325 and
+    # slot_service.cleanup_stale_slots — same SCAN pattern, count=200 to
+    # keep network round-trips low under fleet scale).
+    cursor = 0
+    try:
+        while True:
+            cursor, keys = redis_client.scan(cursor=cursor, match=f"{prefix}*", count=200)
+            for key in keys:
+                # decode_responses=True → key is str.
+                agent_name = key[len(prefix):]
+                try:
+                    members_with_scores = redis_client.zrange(
+                        key, 0, -1, withscores=True
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        f"[Recovery] ZRANGE failed for {key}: {exc}"
+                    )
+                    continue
+
+                for execution_id, score in members_with_scores:
+                    if execution_id.startswith(_DRAIN_SENTINEL_PREFIX):
+                        continue
+                    if float(score) >= grace_cutoff:
+                        # In the grace window — may be an in-flight ZADD
+                        # whose SQL row hasn't been written yet.
+                        continue
+
+                    row = db.get_execution(execution_id)
+                    if row is not None and row.status not in _TERMINAL_EXECUTION_STATUSES:
+                        # Still active — leave the slot alone.
+                        continue
+
+                    # Orphan: SQL row missing OR terminal. Reclaim the slot.
+                    try:
+                        removed = redis_client.zrem(key, execution_id)
+                        if removed:
+                            metadata_key = slot_service._metadata_key(
+                                agent_name, execution_id
+                            )
+                            redis_client.delete(metadata_key)
+                            reclaimed[agent_name] = reclaimed.get(agent_name, 0) + 1
+                            logger.info(
+                                f"[Recovery] Reclaimed orphan slot: agent='{agent_name}' "
+                                f"execution_id='{execution_id}' "
+                                f"sql_status={'<missing>' if row is None else row.status}"
+                            )
+                    except Exception as exc:
+                        logger.warning(
+                            f"[Recovery] ZREM failed for {key}/{execution_id}: {exc}"
+                        )
+
+            if cursor == 0:
+                break
+    except Exception as e:
+        # SCAN itself blew up — return partial results.
+        logger.error(f"[Recovery] Redis SCAN failed during orphan-slot sweep: {e}")
+
+    total = sum(reclaimed.values())
+    if total:
+        logger.info(
+            f"[Recovery] Orphan-slot sweep reclaimed {total} slot(s) across "
+            f"{len(reclaimed)} agent(s)"
+        )
+    return reclaimed

--- a/tests/unit/test_orphaned_execution_recovery.py
+++ b/tests/unit/test_orphaned_execution_recovery.py
@@ -103,7 +103,12 @@ class TestRecoverOrphanedExecutions:
         with patch.dict('sys.modules', _SYS_MOCKS):
             result = _run(_recover_fn())
 
-        assert result == {"recovered": 0, "still_running": 0, "errors": 0}
+        # Key-by-key — additional diagnostic keys (e.g. skipped_grace from
+        # #748, redis_slots_reclaimed from #749) may be added to the result
+        # dict over time; the contract here is the per-counter shape.
+        assert result["recovered"] == 0
+        assert result["still_running"] == 0
+        assert result["errors"] == 0
 
     def test_container_down_marks_orphaned(self):
         _mock_db.get_running_executions.return_value = [

--- a/tests/unit/test_redis_slot_recovery.py
+++ b/tests/unit/test_redis_slot_recovery.py
@@ -1,0 +1,372 @@
+"""
+Tests for the Redis-side orphan-slot sweep on backend startup (#749).
+
+Companion to #748: the SQL-side recovery walks `running` rows in SQL and
+flips them to FAILED when Redis lost their slot. #749 closes the inverse
+asymmetry — when the backend is killed between `capacity.acquire()` (ZADD
+on `agent:slots:{name}`) and the `finally`-block `capacity.release()`
+(ZREM), the slot is leaked because no SQL row marks "this execution is
+still active." Startup recovery must SCAN Redis and ZREM members whose
+SQL row is terminal or missing.
+
+Covered:
+
+  - SCAN walks every agent:slots:* key.
+  - Drain sentinel members (prefix `drain-`) are skipped.
+  - Members whose ZSET score is within the grace window are skipped
+    (mirrors the SQL-side `STARTUP_RECOVERY_GRACE_SECONDS` pattern).
+  - Members with terminal SQL status → ZREM + delete metadata.
+  - Members with missing SQL row → ZREM + delete metadata.
+  - Members with `running` SQL row → left alone.
+  - The two-pass `recover_orphaned_executions` correctly composes both
+    sides and reports `redis_slots_reclaimed`.
+
+Mocks Redis end-to-end via a `FakeRedis` so tests don't depend on a live
+broker and can deterministically pin the SCAN/ZRANGE/ZREM contract.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+import types
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Backend on sys.path; stub docker (services/__init__.py imports it eagerly)
+# ---------------------------------------------------------------------------
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+@pytest.fixture(autouse=True)
+def _stub_docker_and_database(monkeypatch):
+    """The unit test venv does not have the `docker` package; stub it +
+    services.docker_service before cleanup_service is loaded. Mirrors
+    tests/unit/test_startup_recovery_race.py."""
+    if "docker" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "docker", MagicMock(name="docker_stub"))
+    if "services.docker_service" not in sys.modules:
+        _ds_stub = types.ModuleType("services.docker_service")
+        _ds_stub.docker_client = MagicMock()
+        _ds_stub.get_agent_container = lambda *a, **kw: None
+        _ds_stub.get_agent_status_from_container = lambda *a, **kw: "stopped"
+        _ds_stub.list_all_agents = lambda *a, **kw: []
+        _ds_stub.get_agent_by_name = lambda *a, **kw: None
+        _ds_stub.get_next_available_port = lambda *a, **kw: 2222
+
+        async def _exec(*a, **kw):
+            return {"exit_code": 0, "output": ""}
+
+        _ds_stub.execute_command_in_container = _exec
+        monkeypatch.setitem(sys.modules, "services.docker_service", _ds_stub)
+    if "database" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "database", MagicMock(name="database_stub"))
+
+
+# ---------------------------------------------------------------------------
+# FakeRedis: only the surface area the sweep + slot_service use
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedis:
+    """Minimal sync Redis double for SCAN/ZRANGE/ZREM/DELETE used by the sweep."""
+
+    def __init__(self):
+        # {key: {member: score}}
+        self.zsets: dict[str, dict[str, float]] = {}
+        # Plain key/value (metadata keys)
+        self.kv: dict[str, bytes] = {}
+
+    # ZADD-equivalent test helper (the sweep itself never writes ZADDs).
+    def _zadd(self, key: str, member: str, score: float) -> None:
+        self.zsets.setdefault(key, {})[member] = score
+
+    def zrange(self, key: str, start: int, end: int, withscores: bool = False):
+        members = sorted(self.zsets.get(key, {}).items(), key=lambda kv: kv[1])
+        if end == -1:
+            sliced = members[start:]
+        else:
+            sliced = members[start:end + 1]
+        if withscores:
+            return [(m, s) for m, s in sliced]
+        return [m for m, _ in sliced]
+
+    def scan(self, cursor: int, match: str = "*", count: int = 200):
+        # Single-shot; ignore cursor pagination — fine for fixture-scale tests.
+        prefix = match.rstrip("*")
+        keys = [k for k in self.zsets.keys() if k.startswith(prefix)]
+        return 0, keys
+
+    def zrem(self, key: str, member: str) -> int:
+        if key in self.zsets and member in self.zsets[key]:
+            del self.zsets[key][member]
+            return 1
+        return 0
+
+    def zcard(self, key: str) -> int:
+        return len(self.zsets.get(key, {}))
+
+    def delete(self, key: str) -> int:
+        gone = 0
+        if key in self.zsets:
+            del self.zsets[key]
+            gone += 1
+        if key in self.kv:
+            del self.kv[key]
+            gone += 1
+        return gone
+
+
+def _make_status_row(status: str):
+    """Build a minimal stand-in for ScheduleExecution with a `.status` attr."""
+    row = MagicMock()
+    row.status = status
+    return row
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Direct sweep behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileOrphanedSlots:
+    """`_reconcile_orphaned_slots` — Redis→SQL direction."""
+
+    def _patched_sweep(self, fake_redis, sql_lookup):
+        """Returns the patched sweep function with a stub slot_service that
+        points at `fake_redis`. `sql_lookup` is a callable
+        (execution_id) -> status_row | None."""
+        from services import cleanup_service as cs
+
+        fake_slot_service = MagicMock()
+        fake_slot_service.redis = fake_redis
+        fake_slot_service.slots_prefix = "agent:slots:"
+        fake_slot_service._metadata_key = (
+            lambda agent, eid: f"agent:slot-meta:{agent}:{eid}"
+        )
+
+        ctx = patch.object(cs, "db")
+        mock_db = ctx.start()
+        mock_db.get_execution.side_effect = sql_lookup
+
+        ctx2 = patch.dict(
+            sys.modules,
+            {"services.slot_service": types.SimpleNamespace(
+                get_slot_service=lambda: fake_slot_service
+            )},
+        )
+        ctx2.start()
+        return cs._reconcile_orphaned_slots, (ctx, ctx2)
+
+    def _teardown(self, ctxs):
+        for c in ctxs:
+            c.stop()
+
+    def test_orphan_with_missing_sql_row_is_zrem(self):
+        fake = _FakeRedis()
+        # Slot present, score well below grace cutoff (old).
+        fake._zadd("agent:slots:agent-a", "exec-orphan", time.time() - 600)
+
+        sweep, ctxs = self._patched_sweep(fake, sql_lookup=lambda _: None)
+        try:
+            result = _run(sweep())
+        finally:
+            self._teardown(ctxs)
+
+        assert result == {"agent-a": 1}
+        assert "exec-orphan" not in fake.zsets["agent:slots:agent-a"]
+
+    def test_orphan_with_terminal_sql_row_is_zrem(self):
+        fake = _FakeRedis()
+        fake._zadd("agent:slots:agent-a", "exec-done", time.time() - 600)
+
+        rows = {"exec-done": _make_status_row("success")}
+        sweep, ctxs = self._patched_sweep(fake, sql_lookup=lambda eid: rows.get(eid))
+        try:
+            result = _run(sweep())
+        finally:
+            self._teardown(ctxs)
+
+        assert result == {"agent-a": 1}
+        assert "exec-done" not in fake.zsets["agent:slots:agent-a"]
+
+    def test_running_sql_row_is_left_alone(self):
+        fake = _FakeRedis()
+        fake._zadd("agent:slots:agent-a", "exec-live", time.time() - 600)
+
+        rows = {"exec-live": _make_status_row("running")}
+        sweep, ctxs = self._patched_sweep(fake, sql_lookup=lambda eid: rows.get(eid))
+        try:
+            result = _run(sweep())
+        finally:
+            self._teardown(ctxs)
+
+        assert result == {}
+        assert "exec-live" in fake.zsets["agent:slots:agent-a"]
+
+    def test_within_grace_window_is_skipped_even_if_orphan(self):
+        """A brand-new ZADD whose SQL row hasn't been written yet must NOT
+        be swept — that's the symmetric companion to the #748 SQL grace
+        window. The race is the inverse: handler did ZADD, didn't yet
+        insert SQL row; sweep would falsely reclaim a live slot.
+        """
+        from services.cleanup_service import SLOT_RECOVERY_GRACE_SECONDS
+
+        fake = _FakeRedis()
+        # Just-ZADDed (now), within grace.
+        fake._zadd("agent:slots:agent-a", "exec-justborn", time.time() - 1)
+        # Also seed an old orphan so we know the sweep ran and only skipped
+        # the fresh one.
+        fake._zadd("agent:slots:agent-a", "exec-orphan", time.time() - 600)
+
+        sweep, ctxs = self._patched_sweep(fake, sql_lookup=lambda _: None)
+        try:
+            result = _run(sweep())
+        finally:
+            self._teardown(ctxs)
+
+        assert result == {"agent-a": 1}
+        assert "exec-justborn" in fake.zsets["agent:slots:agent-a"]
+        assert "exec-orphan" not in fake.zsets["agent:slots:agent-a"]
+
+        # Sanity: grace window matches the documented constant.
+        assert SLOT_RECOVERY_GRACE_SECONDS == 15
+
+    def test_drain_sentinel_is_skipped(self):
+        """Members starting with 'drain-' are capacity-manager sentinels,
+        not real executions. Mirrors the canary S-01 filter."""
+        fake = _FakeRedis()
+        fake._zadd("agent:slots:agent-a", "drain-agent-a-001", time.time() - 600)
+
+        sweep, ctxs = self._patched_sweep(fake, sql_lookup=lambda _: None)
+        try:
+            result = _run(sweep())
+        finally:
+            self._teardown(ctxs)
+
+        assert result == {}
+        # Sentinel still in place — sweep did not touch it.
+        assert "drain-agent-a-001" in fake.zsets["agent:slots:agent-a"]
+
+    def test_metadata_key_is_deleted_with_member(self):
+        """ZREM is paired with DELETE of the per-execution metadata key
+        (matches slot_service._cleanup_stale_slots_for_agent)."""
+        fake = _FakeRedis()
+        fake._zadd("agent:slots:agent-a", "exec-orphan", time.time() - 600)
+        meta_key = "agent:slot-meta:agent-a:exec-orphan"
+        fake.kv[meta_key] = b'{"some": "meta"}'
+
+        sweep, ctxs = self._patched_sweep(fake, sql_lookup=lambda _: None)
+        try:
+            _run(sweep())
+        finally:
+            self._teardown(ctxs)
+
+        assert meta_key not in fake.kv
+
+    def test_multiple_agents_aggregated(self):
+        fake = _FakeRedis()
+        fake._zadd("agent:slots:agent-a", "exec-a1", time.time() - 600)
+        fake._zadd("agent:slots:agent-a", "exec-a2", time.time() - 700)
+        fake._zadd("agent:slots:agent-b", "exec-b1", time.time() - 500)
+
+        sweep, ctxs = self._patched_sweep(fake, sql_lookup=lambda _: None)
+        try:
+            result = _run(sweep())
+        finally:
+            self._teardown(ctxs)
+
+        assert result == {"agent-a": 2, "agent-b": 1}
+        # Every member gone.
+        assert fake.zsets["agent:slots:agent-a"] == {}
+        assert fake.zsets["agent:slots:agent-b"] == {}
+
+    def test_redis_failure_returns_empty_does_not_raise(self):
+        """If get_slot_service() raises (Redis unreachable at startup),
+        the sweep must not crash recovery — it returns {} so the outer
+        function still completes successfully."""
+        from services import cleanup_service as cs
+
+        with patch.dict(
+            sys.modules,
+            {"services.slot_service": types.SimpleNamespace(
+                get_slot_service=MagicMock(side_effect=ConnectionError("redis down")),
+            )},
+        ):
+            result = _run(cs._reconcile_orphaned_slots())
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: recover_orphaned_executions composes both passes
+# ---------------------------------------------------------------------------
+
+
+class TestRecoverOrphanedExecutionsIncludesRedisSweep:
+    """The startup hook must call both passes and report both counts."""
+
+    def test_empty_sql_still_sweeps_redis(self):
+        """The textbook bug shape: zero SQL running rows + a Redis slot
+        that nobody owns. Without the new Redis pass we'd silently return
+        {recovered: 0} and the leak persists until TTL."""
+        from services import cleanup_service as cs
+
+        fake_redis = _FakeRedis()
+        fake_redis._zadd("agent:slots:agent-a", "exec-orphan", time.time() - 600)
+
+        fake_slot_service = MagicMock()
+        fake_slot_service.redis = fake_redis
+        fake_slot_service.slots_prefix = "agent:slots:"
+        fake_slot_service._metadata_key = (
+            lambda agent, eid: f"agent:slot-meta:{agent}:{eid}"
+        )
+
+        with patch.object(cs, "db") as mock_db, patch.dict(
+            sys.modules,
+            {"services.slot_service": types.SimpleNamespace(
+                get_slot_service=lambda: fake_slot_service
+            )},
+        ):
+            mock_db.get_running_executions.return_value = []
+            mock_db.get_execution.return_value = None
+
+            result = _run(cs.recover_orphaned_executions())
+
+        assert result["recovered"] == 0
+        assert result["redis_slots_reclaimed"] == 1
+        assert "exec-orphan" not in fake_redis.zsets["agent:slots:agent-a"]
+
+
+# ---------------------------------------------------------------------------
+# Source-level pin: constants documented + wired together
+# ---------------------------------------------------------------------------
+
+
+def test_constants_are_documented():
+    """If someone deletes the constants, this catches it."""
+    from services import cleanup_service as cs
+
+    assert hasattr(cs, "SLOT_RECOVERY_GRACE_SECONDS")
+    assert cs.SLOT_RECOVERY_GRACE_SECONDS > 0
+    assert "success" in cs._TERMINAL_EXECUTION_STATUSES
+    assert "failed" in cs._TERMINAL_EXECUTION_STATUSES
+    assert "cancelled" in cs._TERMINAL_EXECUTION_STATUSES
+    assert "skipped" in cs._TERMINAL_EXECUTION_STATUSES
+    assert "running" not in cs._TERMINAL_EXECUTION_STATUSES
+    # Drain prefix matches the canary filter constant.
+    assert cs._DRAIN_SENTINEL_PREFIX == "drain-"


### PR DESCRIPTION
## Summary

Closes #749. Mirror of #748 (PR #812) on the inverse direction:

| Direction | Symptom | Fix |
|---|---|---|
| SQL ahead of Redis | row FAILED before slot was ZADDed | #748 grace-window skip |
| **Redis ahead of SQL** | **slot ZADDed but ZREM never ran** | **this PR** |

The second bug is the textbook \"backend killed mid-execute\" leak: uvicorn auto-reload (dev) or signal (prod) kills the in-flight handler between \`capacity.acquire()\` (ZADD on \`agent:slots:{name}\`) and the \`finally\`-block \`capacity.release()\` (ZREM). The slot persists until 1200s TTL or the next acquire on the agent. Canary S-01 (#411) detected this shape three cycles in a row during the same incident that filed #748 + #749.

## Changes

- New \`_reconcile_orphaned_slots()\` in \`cleanup_service.py\`.
  - SCANs \`agent:slots:*\` (mirrors \`canary/snapshot.py:_collect_redis_slot_state\`).
  - Skips drain sentinels (prefix \`drain-\`).
  - Skips members within \`SLOT_RECOVERY_GRACE_SECONDS\` (15s) — symmetric with #748's SQL grace window.
  - For each remaining member: \`db.get_execution(execution_id)\`. If row missing or terminal (\`success\`/\`failed\`/\`cancelled\`/\`skipped\`) → ZREM + DELETE metadata.
- Wired into \`recover_orphaned_executions()\` after the SQL→Redis pass. Result dict adds \`redis_slots_reclaimed\`.
- The sweep runs even when SQL has zero running rows (the bug's textbook shape — SQL is clean, Redis isn't).

## Test plan

- [x] \`tests/unit/test_redis_slot_recovery.py\` — 10 cases:
  - Orphan with missing SQL row → ZREM.
  - Orphan with terminal SQL row → ZREM.
  - Running SQL row → left alone.
  - Within grace window → skipped even if orphan (avoids racing live ZADDs).
  - Drain sentinel → skipped.
  - Metadata key deleted with member.
  - Multiple agents aggregated.
  - Redis unreachable → returns {} without raising.
  - Empty SQL still sweeps Redis (the textbook shape).
  - Source-level constant pin.
- [x] \`test_orphaned_execution_recovery.py::test_no_running_executions\` updated from full-dict equality to key-by-key checks (forward-compatible with #748's \`skipped_grace\` too).
- [ ] Acceptance criterion #4 from the issue: canary S-01 stays clean for ≥1 cycle after a forced restart on a stack with active scheduled load. Needs staging.

Relates to #749. Companion to #748 (PR #812).

🤖 Generated with [Claude Code](https://claude.com/claude-code)