### PR TITLE
refactor(frontend): add action-primary token + sweep indigo (#554)

### DIFF
--- a/src/frontend/scripts/check-design-tokens.mjs
+++ b/src/frontend/scripts/check-design-tokens.mjs
@@ -34,6 +34,7 @@ const EXPECTED_ALIASES = {
   'brand-claude':     'orange',
   'brand-gemini':     'blue',
   'accent-purple':    'purple',
+  'action-primary':   'indigo',
 }
 
 // Known token families. Reference scanner uses this to flag references like
@@ -43,6 +44,7 @@ const KNOWN_FAMILIES = {
   state:  new Set(['autonomous', 'locked']),
   brand:  new Set(['claude', 'gemini']),
   accent: new Set(['purple']),
+  action: new Set(['primary']),
 }
 
 function checkPaletteEquivalence() {

--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -2,7 +2,7 @@
   <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg mb-4 relative">
     <!-- Overlapping Avatar (AVATAR-001) - centered on left edge of card (50% in, 50% out) -->
     <div class="absolute left-0 top-3 z-10 group -translate-x-1/2">
-      <div class="rounded-full border-[3px] border-indigo-400 dark:border-indigo-500 shadow-lg overflow-hidden">
+      <div class="rounded-full border-[3px] border-action-primary-400 dark:border-action-primary-500 shadow-lg overflow-hidden">
         <div class="relative w-28 h-28">
           <Transition name="avatar-crossfade">
             <div :key="emotionAvatarUrl || agent.avatar_url" class="absolute inset-0">
@@ -61,7 +61,7 @@
                 ref="nameInput"
                 v-model="editedName"
                 type="text"
-                class="text-2xl font-bold text-gray-900 dark:text-white bg-transparent border-b-2 border-indigo-500 focus:outline-none focus:border-indigo-600 py-0 px-0"
+                class="text-2xl font-bold text-gray-900 dark:text-white bg-transparent border-b-2 border-action-primary-500 focus:outline-none focus:border-action-primary-600 py-0 px-0"
                 :class="{ 'border-status-danger-500': nameError }"
                 @keydown.enter="saveName"
                 @keydown.escape="cancelEditName"
@@ -75,7 +75,7 @@
               <button
                 v-if="agent.can_share && !agent.is_system"
                 @click="startEditName"
-                class="text-gray-400 dark:text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                class="text-gray-400 dark:text-gray-500 hover:text-action-primary-600 dark:hover:text-action-primary-400 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                 title="Rename agent"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -154,7 +154,7 @@
             :disabled="agent.status !== 'running'"
             class="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-colors"
             :class="agent.status === 'running'
-              ? 'text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-700'
+              ? 'text-action-primary-600 dark:text-action-primary-400 hover:bg-action-primary-50 dark:hover:bg-action-primary-900/30 border border-action-primary-200 dark:border-action-primary-700'
               : 'text-gray-300 dark:text-gray-600 border border-gray-200 dark:border-gray-700 cursor-not-allowed'"
             title="Open Workspace — voice + canvas (Beta)"
           >
@@ -281,7 +281,7 @@
         <button
           v-if="agent.can_share"
           @click="$emit('open-resource-modal')"
-          class="p-1.5 text-gray-400 dark:text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors flex-shrink-0"
+          class="p-1.5 text-gray-400 dark:text-gray-500 hover:text-action-primary-600 dark:hover:text-action-primary-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors flex-shrink-0"
           title="Configure resources (Memory/CPU)"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/frontend/src/components/AgentNode.vue
+++ b/src/frontend/src/components/AgentNode.vue
@@ -23,7 +23,7 @@
     <!-- Avatar on left edge (50% in, 50% out) -->
     <div class="absolute left-0 top-5 z-10 -translate-x-1/2">
       <div class="rounded-full border-2 shadow-md overflow-hidden"
-           :class="isSystemAgent ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-indigo-400 dark:border-indigo-500'"
+           :class="isSystemAgent ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-action-primary-400 dark:border-action-primary-500'"
       >
         <AgentAvatar :name="data.label" :avatar-url="data.avatarUrl" size="xl" />
       </div>

--- a/src/frontend/src/components/AvatarGenerateModal.vue
+++ b/src/frontend/src/components/AvatarGenerateModal.vue
@@ -33,7 +33,7 @@
         rows="3"
         maxlength="500"
         placeholder='e.g. "a wise owl with spectacles" or "a friendly robot with glowing blue eyes"'
-        class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 resize-none"
+        class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:ring-2 focus:ring-action-primary-500 focus:border-action-primary-500 resize-none"
         :disabled="generating"
       ></textarea>
       <div class="text-xs text-gray-400 dark:text-gray-500 mt-1 text-right">{{ identityPrompt.length }}/500</div>
@@ -64,7 +64,7 @@
           <button
             @click="generate"
             :disabled="!identityPrompt.trim() || generating"
-            class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 rounded-lg transition-colors flex items-center gap-2"
+            class="px-4 py-2 text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 rounded-lg transition-colors flex items-center gap-2"
           >
             <svg v-if="generating" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/frontend/src/components/ChatPanel.vue
+++ b/src/frontend/src/components/ChatPanel.vue
@@ -36,7 +36,7 @@
                 :key="session.id"
                 @click="selectSession(session)"
                 class="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                :class="{ 'bg-indigo-50 dark:bg-indigo-900/30': currentSessionId === session.id }"
+                :class="{ 'bg-action-primary-50 dark:bg-action-primary-900/30': currentSessionId === session.id }"
               >
                 <div class="flex items-center justify-between">
                   <span class="text-sm font-medium text-gray-700 dark:text-gray-200">
@@ -65,7 +65,7 @@
         <button
           @click="startNewChat"
           :disabled="loading"
-          class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded-lg transition-colors"
+          class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-700 dark:hover:text-action-primary-300 hover:bg-action-primary-50 dark:hover:bg-action-primary-900/30 rounded-lg transition-colors"
         >
           <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -95,15 +95,15 @@
       <!-- Resume mode banner (EXEC-023) -->
       <div
         v-if="isResumeMode"
-        class="mx-6 mt-3 px-4 py-3 bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 rounded-lg flex items-center justify-between"
+        class="mx-6 mt-3 px-4 py-3 bg-action-primary-50 dark:bg-action-primary-900/30 border border-action-primary-200 dark:border-action-primary-800 rounded-lg flex items-center justify-between"
       >
         <div class="flex items-center space-x-2">
-          <svg class="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-5 h-5 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
-          <span class="text-sm text-indigo-700 dark:text-indigo-300">
+          <span class="text-sm text-action-primary-700 dark:text-action-primary-300">
             Continuing from execution
-            <span class="font-mono text-xs bg-indigo-100 dark:bg-indigo-800 px-1.5 py-0.5 rounded">
+            <span class="font-mono text-xs bg-action-primary-100 dark:bg-action-primary-800 px-1.5 py-0.5 rounded">
               {{ resumeExecutionIdLocal?.substring(0, 8) }}...
             </span>
             - The agent has full context from that execution.
@@ -111,7 +111,7 @@
         </div>
         <button
           @click="dismissResumeMode"
-          class="text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-300"
+          class="text-action-primary-500 hover:text-action-primary-700 dark:hover:text-action-primary-300"
           title="Dismiss"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/frontend/src/components/ConfirmDialog.vue
+++ b/src/frontend/src/components/ConfirmDialog.vue
@@ -67,7 +67,7 @@
             </button>
             <button
               type="button"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-action-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
               @click="onCancel"
               data-testid="confirm-dialog-cancel"
             >

--- a/src/frontend/src/components/CreateAgentModal.vue
+++ b/src/frontend/src/components/CreateAgentModal.vue
@@ -17,7 +17,7 @@
                   v-model="form.name"
                   type="text"
                   required
-                  class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                  class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                   placeholder="my-agent"
                 />
               </div>
@@ -27,7 +27,7 @@
 
                 <!-- Loading state -->
                 <div v-if="templatesLoading" class="mt-2 flex items-center justify-center py-4">
-                  <svg class="animate-spin h-5 w-5 text-indigo-500 mr-2" fill="none" viewBox="0 0 24 24">
+                  <svg class="animate-spin h-5 w-5 text-action-primary-500 mr-2" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
@@ -48,7 +48,7 @@
                     @click="form.template = ''"
                     :class="[
                       'relative flex items-center p-3 border rounded-lg cursor-pointer transition-all',
-                      form.template === '' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 ring-2 ring-indigo-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
+                      form.template === '' ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/30 ring-2 ring-action-primary-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
                     ]"
                   >
                     <div class="flex-shrink-0 w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-600 flex items-center justify-center">
@@ -60,7 +60,7 @@
                       <p class="text-sm font-medium text-gray-900 dark:text-white">Blank Agent (Claude Code)</p>
                       <p class="text-xs text-gray-500 dark:text-gray-400">Start with empty config using Claude Code runtime</p>
                     </div>
-                    <div v-if="form.template === ''" class="flex-shrink-0 text-indigo-500 dark:text-indigo-400">
+                    <div v-if="form.template === ''" class="flex-shrink-0 text-action-primary-500 dark:text-action-primary-400">
                       <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                       </svg>
@@ -72,7 +72,7 @@
                     @click="form.template = 'github-custom'"
                     :class="[
                       'relative flex items-center p-3 border rounded-lg cursor-pointer transition-all',
-                      form.template === 'github-custom' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 ring-2 ring-indigo-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
+                      form.template === 'github-custom' ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/30 ring-2 ring-action-primary-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
                     ]"
                   >
                     <div class="flex-shrink-0 w-8 h-8 rounded-full bg-gray-900 dark:bg-gray-700 flex items-center justify-center">
@@ -84,7 +84,7 @@
                       <p class="text-sm font-medium text-gray-900 dark:text-white">GitHub Repository</p>
                       <p class="text-xs text-gray-500 dark:text-gray-400">Create from any GitHub repository URL</p>
                     </div>
-                    <div v-if="form.template === 'github-custom'" class="flex-shrink-0 text-indigo-500 dark:text-indigo-400">
+                    <div v-if="form.template === 'github-custom'" class="flex-shrink-0 text-action-primary-500 dark:text-action-primary-400">
                       <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                       </svg>
@@ -96,7 +96,7 @@
                       v-model="githubRepoUrl"
                       type="text"
                       ref="githubRepoInput"
-                      class="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                      class="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                       placeholder="owner/repo or https://github.com/owner/repo"
                       @click.stop
                     />
@@ -117,11 +117,11 @@
                       @click="form.template = template.id"
                       :class="[
                         'relative flex items-center p-3 border rounded-lg cursor-pointer transition-all',
-                        form.template === template.id ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 ring-2 ring-indigo-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
+                        form.template === template.id ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/30 ring-2 ring-action-primary-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
                       ]"
                     >
-                      <div class="flex-shrink-0 w-8 h-8 rounded-full bg-indigo-100 dark:bg-indigo-900/50 flex items-center justify-center">
-                        <svg class="w-4 h-4 text-indigo-600 dark:text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <div class="flex-shrink-0 w-8 h-8 rounded-full bg-action-primary-100 dark:bg-action-primary-900/50 flex items-center justify-center">
+                        <svg class="w-4 h-4 text-action-primary-600 dark:text-action-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                         </svg>
                       </div>
@@ -129,7 +129,7 @@
                         <p class="text-sm font-medium text-gray-900 dark:text-white">{{ template.display_name }}</p>
                         <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ truncateDescription(template.description) }}</p>
                       </div>
-                      <div v-if="form.template === template.id" class="flex-shrink-0 text-indigo-500 dark:text-indigo-400">
+                      <div v-if="form.template === template.id" class="flex-shrink-0 text-action-primary-500 dark:text-action-primary-400">
                         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                           <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                         </svg>
@@ -151,7 +151,7 @@
                       @click="form.template = template.id"
                       :class="[
                         'relative flex items-center p-3 border rounded-lg cursor-pointer transition-all',
-                        form.template === template.id ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 ring-2 ring-indigo-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
+                        form.template === template.id ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/30 ring-2 ring-action-primary-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
                       ]"
                     >
                       <div class="flex-shrink-0 w-8 h-8 rounded-full bg-gray-900 dark:bg-gray-700 flex items-center justify-center">
@@ -163,7 +163,7 @@
                         <p class="text-sm font-medium text-gray-900 dark:text-white">{{ template.display_name }}</p>
                         <p class="text-xs text-gray-500 dark:text-gray-400">{{ template.github_repo }}</p>
                       </div>
-                      <div v-if="form.template === template.id" class="flex-shrink-0 text-indigo-500 dark:text-indigo-400">
+                      <div v-if="form.template === template.id" class="flex-shrink-0 text-action-primary-500 dark:text-action-primary-400">
                         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                           <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                         </svg>
@@ -196,7 +196,7 @@
             <button
               type="submit"
               :disabled="loading"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-action-primary-600 text-base font-medium text-white hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-action-primary-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
             >
               <svg v-if="loading" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -207,7 +207,7 @@
             <button
               type="button"
               @click="$emit('close')"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-action-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
             >
               Cancel
             </button>

--- a/src/frontend/src/components/CredentialsPanel.vue
+++ b/src/frontend/src/components/CredentialsPanel.vue
@@ -2,7 +2,7 @@
   <div class="p-6 space-y-6">
     <!-- Loading State -->
     <div v-if="loading" class="text-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
       <p class="text-gray-500 dark:text-gray-400 mt-2">Loading credentials...</p>
     </div>
 
@@ -58,7 +58,7 @@
               <button
                 @click="editFile(file.name)"
                 :disabled="agentStatus !== 'running'"
-                class="text-sm text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                class="text-sm text-action-primary-600 hover:text-action-primary-700 dark:text-action-primary-400 dark:hover:text-action-primary-300 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {{ file.exists ? 'Edit' : 'Add' }}
               </button>

--- a/src/frontend/src/components/DashboardPanel.vue
+++ b/src/frontend/src/components/DashboardPanel.vue
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <!-- Loading State -->
     <div v-if="loading" class="flex items-center justify-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500"></div>
     </div>
 
     <!-- Agent Not Running State -->
@@ -101,7 +101,7 @@
             v-if="hasUpdateDashboardPlaybook"
             @click="triggerUpdateDashboard"
             :disabled="updatingDashboard"
-            class="inline-flex items-center px-2.5 py-1.5 text-xs font-medium rounded bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:bg-indigo-900/50 dark:text-indigo-300 dark:hover:bg-indigo-900/70 disabled:opacity-50"
+            class="inline-flex items-center px-2.5 py-1.5 text-xs font-medium rounded bg-action-primary-50 text-action-primary-700 hover:bg-action-primary-100 dark:bg-action-primary-900/50 dark:text-action-primary-300 dark:hover:bg-action-primary-900/70 disabled:opacity-50"
             title="Run /update-dashboard playbook"
           >
             <svg v-if="updatingDashboard" class="w-3.5 h-3.5 mr-1 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -130,15 +130,15 @@
         v-for="(section, sectionIndex) in dashboardData.config.sections"
         :key="sectionIndex"
         class="space-y-4"
-        :class="section.platform_managed ? 'mt-6 pt-6 border-t border-indigo-200 dark:border-indigo-800' : ''"
+        :class="section.platform_managed ? 'mt-6 pt-6 border-t border-action-primary-200 dark:border-action-primary-800' : ''"
       >
         <!-- Section Header -->
-        <div v-if="section.title" class="border-b border-gray-200 dark:border-gray-700 pb-2" :class="section.platform_managed ? 'border-indigo-200 dark:border-indigo-800' : ''">
+        <div v-if="section.title" class="border-b border-gray-200 dark:border-gray-700 pb-2" :class="section.platform_managed ? 'border-action-primary-200 dark:border-action-primary-800' : ''">
           <div class="flex items-center gap-2">
-            <h3 class="text-sm font-semibold uppercase tracking-wider" :class="section.platform_managed ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-900 dark:text-white'">
+            <h3 class="text-sm font-semibold uppercase tracking-wider" :class="section.platform_managed ? 'text-action-primary-600 dark:text-action-primary-400' : 'text-gray-900 dark:text-white'">
               {{ section.title }}
             </h3>
-            <span v-if="section.platform_managed" class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300">
+            <span v-if="section.platform_managed" class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-action-primary-100 text-action-primary-700 dark:bg-action-primary-900/50 dark:text-action-primary-300">
               Auto
             </span>
           </div>

--- a/src/frontend/src/components/EditorHelpPanel.vue
+++ b/src/frontend/src/components/EditorHelpPanel.vue
@@ -6,7 +6,7 @@
     <!-- Header -->
     <div class="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
       <div class="flex items-center gap-2">
-        <QuestionMarkCircleIcon class="h-4 w-4 text-indigo-500" />
+        <QuestionMarkCircleIcon class="h-4 w-4 text-action-primary-500" />
         <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">Quick Help</h3>
       </div>
       <button
@@ -69,7 +69,7 @@
               <code
                 v-for="opt in helpContent.options"
                 :key="opt"
-                class="text-xs px-1.5 py-0.5 bg-indigo-50 dark:bg-indigo-900/30 rounded text-indigo-700 dark:text-indigo-300"
+                class="text-xs px-1.5 py-0.5 bg-action-primary-50 dark:bg-action-primary-900/30 rounded text-action-primary-700 dark:text-action-primary-300"
               >
                 {{ opt }}
               </code>
@@ -87,7 +87,7 @@
         <router-link
           v-if="helpContent.docs_link"
           :to="helpContent.docs_link"
-          class="inline-flex items-center gap-1 text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+          class="inline-flex items-center gap-1 text-sm text-action-primary-600 dark:text-action-primary-400 hover:underline"
         >
           <BookOpenIcon class="h-4 w-4" />
           Learn more in documentation

--- a/src/frontend/src/components/FileSharingPanel.vue
+++ b/src/frontend/src/components/FileSharingPanel.vue
@@ -19,7 +19,7 @@
           :disabled="toggleLoading || statusLoading"
           @change="onToggle($event.target.checked)"
         />
-        <div class="w-11 h-6 bg-gray-200 dark:bg-gray-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-indigo-600"></div>
+        <div class="w-11 h-6 bg-gray-200 dark:bg-gray-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-action-primary-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-action-primary-600"></div>
       </label>
       <div class="flex-1">
         <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
@@ -77,7 +77,7 @@
             <td class="px-4 py-2 text-right whitespace-nowrap">
               <button
                 @click="copyUrl(file)"
-                class="px-2 py-1 text-xs font-medium rounded-md text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/40 hover:bg-indigo-100 dark:hover:bg-indigo-900/70 mr-2"
+                class="px-2 py-1 text-xs font-medium rounded-md text-action-primary-700 dark:text-action-primary-300 bg-action-primary-50 dark:bg-action-primary-900/40 hover:bg-action-primary-100 dark:hover:bg-action-primary-900/70 mr-2"
                 :title="file.url"
               >
                 {{ copiedId === file.file_id ? 'Copied!' : 'Copy URL' }}

--- a/src/frontend/src/components/FileTreeNode.vue
+++ b/src/frontend/src/components/FileTreeNode.vue
@@ -54,7 +54,7 @@ export default defineComponent({
             ]),
             // Folder icon
             h('svg', {
-              class: `w-5 h-5 mr-2 ${isExpanded() ? 'text-indigo-500 dark:text-indigo-400' : 'text-gray-400 dark:text-gray-500'}`,
+              class: `w-5 h-5 mr-2 ${isExpanded() ? 'text-action-primary-500 dark:text-action-primary-400' : 'text-gray-400 dark:text-gray-500'}`,
               fill: 'currentColor',
               viewBox: '0 0 20 20'
             }, [
@@ -114,7 +114,7 @@ export default defineComponent({
           }, formatFileSize(props.item.size)),
           // Download button
           h('button', {
-            class: 'p-1 text-indigo-600 dark:text-indigo-400 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded',
+            class: 'p-1 text-action-primary-600 dark:text-action-primary-400 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-action-primary-50 dark:hover:bg-action-primary-900/30 rounded',
             title: 'Download file',
             onClick: downloadFile
           }, [

--- a/src/frontend/src/components/FilesPanel.vue
+++ b/src/frontend/src/components/FilesPanel.vue
@@ -29,7 +29,7 @@
               type="checkbox"
               v-model="showHidden"
               @change="loadFiles"
-              class="rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-indigo-600 focus:ring-indigo-500 h-3.5 w-3.5"
+              class="rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-action-primary-600 focus:ring-action-primary-500 h-3.5 w-3.5"
             />
             <span>Hidden</span>
           </label>
@@ -42,7 +42,7 @@
               v-model="searchQuery"
               type="text"
               placeholder="Search files..."
-              class="w-full pl-7 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white focus:ring-indigo-500 focus:border-indigo-500"
+              class="w-full pl-7 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white focus:ring-action-primary-500 focus:border-action-primary-500"
             />
             <svg class="absolute left-2 top-2 h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -53,7 +53,7 @@
         <!-- Tree View -->
         <div class="flex-1 overflow-auto p-2">
           <div v-if="loading" class="flex items-center justify-center h-32">
-            <svg class="animate-spin h-6 w-6 text-indigo-600" fill="none" viewBox="0 0 24 24">
+            <svg class="animate-spin h-6 w-6 text-action-primary-600" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
               <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
             </svg>
@@ -127,7 +127,7 @@
                   <button
                     @click="saveFile"
                     :disabled="saving || !hasUnsavedChanges"
-                    class="inline-flex items-center px-3 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                    class="inline-flex items-center px-3 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50"
                   >
                     <svg v-if="saving" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -141,7 +141,7 @@
                   <button
                     @click="cancelEdit"
                     :disabled="saving"
-                    class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                    class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50"
                   >
                     Cancel
                   </button>
@@ -152,7 +152,7 @@
                   <button
                     v-if="isTextFile && !isEditProtected"
                     @click="startEdit"
-                    class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500"
                   >
                     <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -162,7 +162,7 @@
                   <button
                     @click="downloadFile"
                     :disabled="downloading"
-                    class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                    class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50"
                   >
                     <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
@@ -234,7 +234,7 @@
             </button>
             <button
               @click="showDeleteConfirm = false"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:mt-0 sm:w-auto sm:text-sm"
             >
               Cancel
             </button>

--- a/src/frontend/src/components/FoldersPanel.vue
+++ b/src/frontend/src/components/FoldersPanel.vue
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <!-- Loading State -->
     <div v-if="loading" class="flex items-center justify-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500"></div>
     </div>
 
     <!-- Not Owner State -->
@@ -53,8 +53,8 @@
               @click="toggleExpose"
               :disabled="saving"
               :class="[
-                'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800',
-                foldersData?.expose_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600'
+                'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800',
+                foldersData?.expose_enabled ? 'bg-action-primary-600' : 'bg-gray-200 dark:bg-gray-600'
               ]"
             >
               <span
@@ -79,8 +79,8 @@
               @click="toggleConsume"
               :disabled="saving"
               :class="[
-                'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800',
-                foldersData?.consume_enabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600'
+                'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800',
+                foldersData?.consume_enabled ? 'bg-action-primary-600' : 'bg-gray-200 dark:bg-gray-600'
               ]"
             >
               <span
@@ -195,19 +195,19 @@
         <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">How Shared Folders Work</h4>
         <ul class="text-xs text-gray-600 dark:text-gray-400 space-y-1">
           <li class="flex items-start">
-            <span class="text-indigo-500 mr-2">1.</span>
+            <span class="text-action-primary-500 mr-2">1.</span>
             Enable "Expose" on Agent A to create a shared volume at <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">/home/developer/shared-out</code>
           </li>
           <li class="flex items-start">
-            <span class="text-indigo-500 mr-2">2.</span>
+            <span class="text-action-primary-500 mr-2">2.</span>
             Grant Agent B permission to access Agent A (via Permissions tab)
           </li>
           <li class="flex items-start">
-            <span class="text-indigo-500 mr-2">3.</span>
+            <span class="text-action-primary-500 mr-2">3.</span>
             Enable "Mount" on Agent B to mount Agent A's folder at <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">/home/developer/shared-in/agent-a</code>
           </li>
           <li class="flex items-start">
-            <span class="text-indigo-500 mr-2">4.</span>
+            <span class="text-action-primary-500 mr-2">4.</span>
             Restart both agents to apply the volume mounts
           </li>
         </ul>

--- a/src/frontend/src/components/GitPanel.vue
+++ b/src/frontend/src/components/GitPanel.vue
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <!-- Loading State -->
     <div v-if="loading" class="text-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
       <p class="text-gray-500 dark:text-gray-400 mt-2">Loading git status...</p>
     </div>
 
@@ -17,7 +17,7 @@
       <!-- Initialize Button -->
       <button
         @click="showInitializeModal = true"
-        class="mt-4 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        class="mt-4 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500"
       >
         <svg class="h-5 w-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
           <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
@@ -36,8 +36,8 @@
         <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
           <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
-              <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100 dark:bg-indigo-900/30 sm:mx-0 sm:h-10 sm:w-10">
-                <svg class="h-6 w-6 text-indigo-600 dark:text-indigo-400" fill="currentColor" viewBox="0 0 24 24">
+              <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-action-primary-100 dark:bg-action-primary-900/30 sm:mx-0 sm:h-10 sm:w-10">
+                <svg class="h-6 w-6 text-action-primary-600 dark:text-action-primary-400" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                 </svg>
               </div>
@@ -62,7 +62,7 @@
                       v-model="repoOwner"
                       placeholder="your-username"
                       :disabled="initializing"
-                      class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-white"
+                      class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm dark:bg-gray-700 dark:text-white"
                     />
                     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Your GitHub username or organization name</p>
                   </div>
@@ -78,7 +78,7 @@
                       v-model="repoName"
                       placeholder="my-agent"
                       :disabled="initializing"
-                      class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-white"
+                      class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm dark:bg-gray-700 dark:text-white"
                     />
                     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Name for the new repository</p>
                   </div>
@@ -90,7 +90,7 @@
                       type="checkbox"
                       v-model="createRepo"
                       :disabled="initializing"
-                      class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                      class="h-4 w-4 text-action-primary-600 focus:ring-action-primary-500 border-gray-300 rounded"
                     />
                     <label for="create-repo" class="ml-2 block text-sm text-gray-700 dark:text-gray-300">
                       Create repository if it doesn't exist
@@ -103,7 +103,7 @@
                       type="checkbox"
                       v-model="privateRepo"
                       :disabled="initializing"
-                      class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                      class="h-4 w-4 text-action-primary-600 focus:ring-action-primary-500 border-gray-300 rounded"
                     />
                     <label for="private-repo" class="ml-2 block text-sm text-gray-700 dark:text-gray-300">
                       Make repository private
@@ -144,7 +144,7 @@
               type="button"
               @click="initializeGitHub"
               :disabled="!repoOwner || !repoName || initializing"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-action-primary-600 text-base font-medium text-white hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <svg v-if="initializing" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -156,7 +156,7 @@
               type="button"
               @click="closeInitializeModal"
               :disabled="initializing"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Cancel
             </button>
@@ -191,11 +191,11 @@
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
             </svg>
             <div>
-              <a :href="gitStatus.remote_url" target="_blank" class="text-sm font-medium text-indigo-600 hover:text-indigo-800">
+              <a :href="gitStatus.remote_url" target="_blank" class="text-sm font-medium text-action-primary-600 hover:text-action-primary-800">
                 {{ gitStatus.remote_url }}
               </a>
               <div class="flex items-center space-x-2 mt-1">
-                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-300">
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-action-primary-100 dark:bg-action-primary-900/30 text-action-primary-800 dark:text-action-primary-300">
                   <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>
@@ -322,7 +322,7 @@
             </div>
             <button
               @click="showPatModal = true"
-              class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 shadow-sm text-xs font-medium rounded text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 shadow-sm text-xs font-medium rounded text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500"
             >
               {{ patStatus.configured ? 'Change' : 'Configure' }}
             </button>
@@ -342,7 +342,7 @@
 
         <!-- Loading PAT status -->
         <div v-else class="text-center py-4">
-          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-500 mx-auto"></div>
+          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-action-primary-500 mx-auto"></div>
         </div>
       </div>
 
@@ -353,8 +353,8 @@
           <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
             <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
               <div class="sm:flex sm:items-start">
-                <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100 dark:bg-indigo-900/30 sm:mx-0 sm:h-10 sm:w-10">
-                  <svg class="h-6 w-6 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-action-primary-100 dark:bg-action-primary-900/30 sm:mx-0 sm:h-10 sm:w-10">
+                  <svg class="h-6 w-6 text-action-primary-600 dark:text-action-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
                   </svg>
                 </div>
@@ -384,7 +384,7 @@
                         v-model="newPat"
                         placeholder="ghp_xxxxxxxxxxxx"
                         :disabled="patSaving"
-                        class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-white font-mono"
+                        class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm dark:bg-gray-700 dark:text-white font-mono"
                       />
                       <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         Token must have <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">repo</code> scope
@@ -413,7 +413,7 @@
                 type="button"
                 @click="savePat"
                 :disabled="!newPat || patSaving"
-                class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-action-primary-600 text-base font-medium text-white hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <svg v-if="patSaving" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -425,7 +425,7 @@
                 type="button"
                 @click="closePatModal"
                 :disabled="patSaving"
-                class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel
               </button>

--- a/src/frontend/src/components/HelpChatWidget.vue
+++ b/src/frontend/src/components/HelpChatWidget.vue
@@ -3,7 +3,7 @@
   <button
     v-if="!isOpen"
     @click="openChat"
-    class="fixed bottom-6 right-6 w-14 h-14 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 z-50"
+    class="fixed bottom-6 right-6 w-14 h-14 bg-action-primary-600 hover:bg-action-primary-700 text-white rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 z-50"
     aria-label="Open help chat"
   >
     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -29,7 +29,7 @@
       @keydown.escape="closeChat"
     >
       <!-- Header -->
-      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-indigo-600 rounded-t-xl">
+      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-action-primary-600 rounded-t-xl">
         <div class="flex items-center space-x-2">
           <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -71,8 +71,8 @@
       >
         <!-- Welcome message when empty -->
         <div v-if="messages.length === 0 && !loading" class="text-center py-8">
-          <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
-            <svg class="w-6 h-6 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-12 h-12 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
+            <svg class="w-6 h-6 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
@@ -93,9 +93,9 @@
         <!-- Loading indicator -->
         <div v-if="loading" class="flex items-center space-x-2 text-gray-500 dark:text-gray-400">
           <div class="flex space-x-1">
-            <div class="w-2 h-2 bg-indigo-500 rounded-full animate-bounce" style="animation-delay: 0ms"></div>
-            <div class="w-2 h-2 bg-indigo-500 rounded-full animate-bounce" style="animation-delay: 150ms"></div>
-            <div class="w-2 h-2 bg-indigo-500 rounded-full animate-bounce" style="animation-delay: 300ms"></div>
+            <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 0ms"></div>
+            <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 150ms"></div>
+            <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 300ms"></div>
           </div>
           <span class="text-sm">Thinking...</span>
         </div>
@@ -123,7 +123,7 @@
             rows="1"
             :maxlength="2000"
             placeholder="Ask a question..."
-            class="flex-1 resize-none border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-transparent text-sm"
+            class="flex-1 resize-none border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-action-primary-500 focus:border-transparent text-sm"
             :disabled="loading"
             @keydown.enter.exact.prevent="sendMessage"
             @input="autoResize"
@@ -131,7 +131,7 @@
           <button
             type="submit"
             :disabled="loading || !inputMessage.trim()"
-            class="p-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors shrink-0"
+            class="p-2 bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors shrink-0"
             aria-label="Send message"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/frontend/src/components/InfoPanel.vue
+++ b/src/frontend/src/components/InfoPanel.vue
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <!-- Loading State -->
     <div v-if="loading" class="flex items-center justify-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500"></div>
     </div>
 
     <!-- No Template State -->
@@ -24,14 +24,14 @@
     <!-- Template Info Display -->
     <div v-else>
       <!-- Header Section -->
-      <div class="bg-gradient-to-r from-indigo-50 to-accent-purple-50 dark:from-indigo-900/30 dark:to-accent-purple-900/30 rounded-lg p-6 border border-indigo-100 dark:border-indigo-800">
+      <div class="bg-gradient-to-r from-action-primary-50 to-accent-purple-50 dark:from-action-primary-900/30 dark:to-accent-purple-900/30 rounded-lg p-6 border border-action-primary-100 dark:border-action-primary-800">
         <div class="flex items-start justify-between">
           <div>
             <h2 class="text-2xl font-bold text-gray-900 dark:text-white">
               {{ templateInfo.display_name || templateInfo.name }}
             </h2>
             <!-- Tagline -->
-            <p v-if="templateInfo.tagline" class="mt-1 text-sm text-indigo-600 dark:text-indigo-400 font-medium">
+            <p v-if="templateInfo.tagline" class="mt-1 text-sm text-action-primary-600 dark:text-action-primary-400 font-medium">
               {{ templateInfo.tagline }}
             </p>
             <div class="mt-2 flex items-center space-x-3 text-sm text-gray-500 dark:text-gray-400">
@@ -55,7 +55,7 @@
               </span>
             </div>
           </div>
-          <div v-if="templateInfo.type" class="px-3 py-1 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-300 text-xs font-medium rounded-full">
+          <div v-if="templateInfo.type" class="px-3 py-1 bg-action-primary-100 dark:bg-action-primary-900/50 text-action-primary-800 dark:text-action-primary-300 text-xs font-medium rounded-full">
             {{ templateInfo.type }}
           </div>
         </div>
@@ -78,11 +78,11 @@
           <div
             v-for="(useCase, index) in templateInfo.use_cases"
             :key="index"
-            class="flex items-start space-x-2 px-3 py-2 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-indigo-50 dark:hover:bg-indigo-900/30 hover:border-indigo-200 dark:hover:border-indigo-700 border border-transparent transition-colors cursor-pointer"
+            class="flex items-start space-x-2 px-3 py-2 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-action-primary-50 dark:hover:bg-action-primary-900/30 hover:border-action-primary-200 dark:hover:border-action-primary-700 border border-transparent transition-colors cursor-pointer"
             @click="handleUseCaseClick(useCase)"
             title="Click to run this task"
           >
-            <svg class="w-4 h-4 text-indigo-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-action-primary-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
             </svg>
             <span class="text-sm text-gray-700 dark:text-gray-200">"{{ useCase }}"</span>

--- a/src/frontend/src/components/MetricsPanel.vue
+++ b/src/frontend/src/components/MetricsPanel.vue
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <!-- Loading State -->
     <div v-if="loading" class="flex items-center justify-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500"></div>
     </div>
 
     <!-- Agent Not Running State -->

--- a/src/frontend/src/components/ModelSelector.vue
+++ b/src/frontend/src/components/ModelSelector.vue
@@ -39,13 +39,13 @@
         :class="[
           'w-full text-left px-3 py-2 text-sm transition-colors',
           highlightedIndex === index
-            ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300'
+            ? 'bg-action-primary-50 dark:bg-action-primary-900/30 text-action-primary-700 dark:text-action-primary-300'
             : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
         ]"
       >
         <div class="flex items-center justify-between">
           <span>{{ model.label }}</span>
-          <span v-if="model.value === modelValue" class="text-indigo-500">
+          <span v-if="model.value === modelValue" class="text-action-primary-500">
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
             </svg>
@@ -98,7 +98,7 @@ const inputRef = ref(null)
 const isTyping = ref(false)
 
 const inputClass = computed(() => {
-  const base = 'w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 pr-8'
+  const base = 'w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500 pr-8'
   return props.compact
     ? `${base} px-2 py-1.5 text-xs`
     : `${base} px-3 py-2 text-sm`

--- a/src/frontend/src/components/NeverminedPanel.vue
+++ b/src/frontend/src/components/NeverminedPanel.vue
@@ -2,7 +2,7 @@
   <div class="p-6 space-y-6">
     <!-- Loading State -->
     <div v-if="loading" class="text-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
       <p class="text-gray-500 dark:text-gray-400 mt-2">Loading payment config...</p>
     </div>
 
@@ -74,7 +74,7 @@
                   :type="showApiKey ? 'text' : 'password'"
                   :disabled="!canEdit"
                   placeholder="sandbox:eyJhbGci..."
-                  :class="['w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-indigo-500 focus:border-indigo-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
+                  :class="['w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-action-primary-500 focus:border-action-primary-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
                 />
                 <button
                   type="button"
@@ -99,7 +99,7 @@
               <select
                 v-model="form.nvm_environment"
                 :disabled="!canEdit"
-                :class="['w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-indigo-500 focus:border-indigo-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
+                :class="['w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-action-primary-500 focus:border-action-primary-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
               >
                 <option value="sandbox">Sandbox (testnet)</option>
                 <option value="live">Live (mainnet)</option>
@@ -118,7 +118,7 @@
                   type="text"
                   :disabled="!canEdit"
                   placeholder="304071263598..."
-                  :class="['w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-indigo-500 focus:border-indigo-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
+                  :class="['w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-action-primary-500 focus:border-action-primary-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
                 />
               </div>
               <div>
@@ -128,7 +128,7 @@
                   type="text"
                   :disabled="!canEdit"
                   placeholder="828208014058..."
-                  :class="['w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-indigo-500 focus:border-indigo-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
+                  :class="['w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-action-primary-500 focus:border-action-primary-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
                 />
               </div>
             </div>
@@ -141,7 +141,7 @@
                 type="number"
                 min="1"
                 :disabled="!canEdit"
-                :class="['w-32 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-indigo-500 focus:border-indigo-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
+                :class="['w-32 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-action-primary-500 focus:border-action-primary-500', canEdit ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed']"
               />
             </div>
 
@@ -150,7 +150,7 @@
               <button
                 type="submit"
                 :disabled="saving || !isFormValid"
-                class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                class="px-4 py-2 bg-action-primary-600 text-white text-sm font-medium rounded-md hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {{ saving ? 'Saving...' : (config ? 'Update Configuration' : 'Save Configuration') }}
               </button>
@@ -174,7 +174,7 @@
           <h3 class="text-lg font-medium text-gray-900 dark:text-white">Payment Log</h3>
           <button
             @click="loadPaymentLog"
-            class="text-sm text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+            class="text-sm text-action-primary-600 hover:text-action-primary-700 dark:text-action-primary-400 dark:hover:text-action-primary-300"
           >
             Refresh
           </button>

--- a/src/frontend/src/components/OnboardingChecklist.vue
+++ b/src/frontend/src/components/OnboardingChecklist.vue
@@ -3,7 +3,7 @@
   <Teleport to="body">
     <div
       v-if="showHint"
-      class="fixed bottom-24 right-4 z-[9998] w-80 bg-indigo-600 text-white rounded-lg shadow-2xl p-4 flex items-start gap-3 transition-all duration-300"
+      class="fixed bottom-24 right-4 z-[9998] w-80 bg-action-primary-600 text-white rounded-lg shadow-2xl p-4 flex items-start gap-3 transition-all duration-300"
       style="animation: slideIn 0.3s ease-out;"
     >
       <div class="flex-shrink-0">
@@ -33,7 +33,7 @@
   >
     <!-- Header -->
     <div
-      class="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-indigo-500 to-accent-purple-500 text-white cursor-pointer"
+      class="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-action-primary-500 to-accent-purple-500 text-white cursor-pointer"
       @click="toggleMinimized"
     >
       <div class="flex items-center gap-2">
@@ -66,7 +66,7 @@
       <div class="mb-4">
         <div class="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
           <div
-            class="h-full bg-gradient-to-r from-indigo-500 to-accent-purple-500 transition-all duration-500"
+            class="h-full bg-gradient-to-r from-action-primary-500 to-accent-purple-500 transition-all duration-500"
             :style="{ width: `${progressPercent}%` }"
           />
         </div>
@@ -86,9 +86,9 @@
             item.completed
               ? 'bg-status-success-50 dark:bg-status-success-900/20'
               : isCurrentStep(index)
-                ? 'bg-indigo-50 dark:bg-indigo-900/20 ring-1 ring-indigo-200 dark:ring-indigo-700'
+                ? 'bg-action-primary-50 dark:bg-action-primary-900/20 ring-1 ring-action-primary-200 dark:ring-action-primary-700'
                 : 'opacity-50',
-            !item.completed && item.link && isCurrentStep(index) ? 'cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-900/30' : ''
+            !item.completed && item.link && isCurrentStep(index) ? 'cursor-pointer hover:bg-action-primary-100 dark:hover:bg-action-primary-900/30' : ''
           ]"
           @click="handleItemClick(item, index)"
         >
@@ -97,7 +97,7 @@
             :class="item.completed
               ? 'bg-status-success-500 text-white'
               : isCurrentStep(index)
-                ? 'border-2 border-indigo-500 dark:border-indigo-400'
+                ? 'border-2 border-action-primary-500 dark:border-action-primary-400'
                 : 'border-2 border-gray-300 dark:border-gray-600'"
           >
             <CheckIcon v-if="item.completed" class="h-3 w-3" />
@@ -132,7 +132,7 @@
             class="flex-shrink-0 text-xs font-medium"
             :class="isOnTargetPage(item)
               ? 'text-state-autonomous-600 dark:text-state-autonomous-400'
-              : 'text-indigo-600 dark:text-indigo-400'"
+              : 'text-action-primary-600 dark:text-action-primary-400'"
           >
             {{ isOnTargetPage(item) ? 'See above ↑' : 'Start →' }}
           </span>
@@ -204,7 +204,7 @@
         <button
           @click.stop.prevent="navigateTo('/processes/docs')"
           type="button"
-          class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline cursor-pointer pointer-events-auto"
+          class="text-xs text-action-primary-600 dark:text-action-primary-400 hover:underline cursor-pointer pointer-events-auto"
         >
           View all docs →
         </button>

--- a/src/frontend/src/components/PermissionsPanel.vue
+++ b/src/frontend/src/components/PermissionsPanel.vue
@@ -8,7 +8,7 @@
 
       <!-- Loading State -->
       <div v-if="permissionsLoading" class="text-center py-4">
-        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto"></div>
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
         <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Loading permissions...</p>
       </div>
 
@@ -19,7 +19,7 @@
           <button
             @click="allowAllAgents"
             :disabled="permissionsSaving"
-            class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-medium disabled:opacity-50"
+            class="text-sm text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300 font-medium disabled:opacity-50"
           >
             Allow All
           </button>
@@ -46,7 +46,7 @@
                 v-model="targetAgent.permitted"
                 @change="markDirty"
                 :disabled="permissionsSaving"
-                class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700"
+                class="h-4 w-4 text-action-primary-600 focus:ring-action-primary-500 border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700"
               />
               <div class="flex-1">
                 <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ targetAgent.name }}</span>
@@ -67,7 +67,7 @@
           <button
             @click="savePermissions"
             :disabled="permissionsSaving || !permissionsDirty"
-            class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
+            class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 dark:focus:ring-offset-gray-800 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
           >
             <svg v-if="permissionsSaving" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/frontend/src/components/PlaybooksPanel.vue
+++ b/src/frontend/src/components/PlaybooksPanel.vue
@@ -19,7 +19,7 @@
 
     <!-- Loading State -->
     <div v-else-if="loading" class="flex justify-center py-12">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-600"></div>
     </div>
 
     <!-- Error State -->
@@ -49,7 +49,7 @@
           v-model="searchQuery"
           type="text"
           placeholder="Search playbooks..."
-          class="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+          class="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
         />
         <svg class="absolute left-3 top-2.5 h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -65,7 +65,7 @@
         >
           <!-- Skill Name -->
           <div class="flex items-start justify-between mb-2">
-            <code class="text-sm font-semibold text-indigo-600 dark:text-indigo-400">/{{ skill.name }}</code>
+            <code class="text-sm font-semibold text-action-primary-600 dark:text-action-primary-400">/{{ skill.name }}</code>
             <!-- Automation Badge -->
             <span
               v-if="skill.automation"
@@ -114,7 +114,7 @@
             <!-- Run with Instructions Button -->
             <button
               @click="runWithInstructions(skill)"
-              class="inline-flex items-center justify-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-xs font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+              class="inline-flex items-center justify-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-xs font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 transition-colors"
               title="Add instructions before running"
             >
               <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/frontend/src/components/PublicLinksPanel.vue
+++ b/src/frontend/src/components/PublicLinksPanel.vue
@@ -10,7 +10,7 @@
       </div>
       <button
         @click="showCreateModal = true"
-        class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
+        class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 dark:focus:ring-offset-gray-800"
       >
         <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -21,7 +21,7 @@
 
     <!-- Loading state -->
     <div v-if="loading" class="text-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
       <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Loading links...</p>
     </div>
 
@@ -34,7 +34,7 @@
       <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Create a link to share this agent with others.</p>
       <button
         @click="showCreateModal = true"
-        class="mt-4 inline-flex items-center px-3 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+        class="mt-4 inline-flex items-center px-3 py-2 text-sm font-medium text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-700 dark:hover:text-action-primary-300"
       >
         <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -126,7 +126,7 @@
                   <button
                     @click="connectSlack(link)"
                     :disabled="slackLoading[link.id]"
-                    class="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 disabled:opacity-50"
+                    class="inline-flex items-center px-2 py-1 text-xs font-medium text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-700 dark:hover:text-action-primary-300 disabled:opacity-50"
                   >
                     <span v-if="slackLoading[link.id]">Connecting...</span>
                     <span v-else>Connect Slack</span>
@@ -191,7 +191,7 @@
               class="p-1.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
               title="Edit link"
             >
-              <svg class="w-4 h-4 text-gray-400 hover:text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-4 h-4 text-gray-400 hover:text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
               </svg>
             </button>
@@ -234,7 +234,7 @@
                     v-model="formData.name"
                     type="text"
                     placeholder="e.g., Customer Support Demo"
-                    class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-indigo-500 focus:border-indigo-500"
+                    class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-action-primary-500 focus:border-action-primary-500"
                   />
                 </div>
 
@@ -250,12 +250,12 @@
                       :class="[
                         'flex flex-col items-start p-3 rounded-lg border-2 text-left transition-colors',
                         formData.link_type === 'chat'
-                          ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
+                          ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/20'
                           : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
                       ]"
                     >
                       <div class="flex items-center mb-1">
-                        <svg class="w-4 h-4 mr-1.5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg class="w-4 h-4 mr-1.5 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
                         </svg>
                         <span class="text-sm font-medium text-gray-900 dark:text-white">Chat</span>
@@ -268,12 +268,12 @@
                       :class="[
                         'flex flex-col items-start p-3 rounded-lg border-2 text-left transition-colors',
                         formData.link_type === 'site'
-                          ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
+                          ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/20'
                           : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
                       ]"
                     >
                       <div class="flex items-center mb-1">
-                        <svg class="w-4 h-4 mr-1.5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg class="w-4 h-4 mr-1.5 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
                         </svg>
                         <span class="text-sm font-medium text-gray-900 dark:text-white">Website</span>
@@ -301,7 +301,7 @@
                   <input
                     v-model="formData.expires_at"
                     type="datetime-local"
-                    class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-indigo-500 focus:border-indigo-500"
+                    class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-action-primary-500 focus:border-action-primary-500"
                   />
                 </div>
 
@@ -311,7 +311,7 @@
                     id="enabled"
                     v-model="formData.enabled"
                     type="checkbox"
-                    class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                    class="h-4 w-4 text-action-primary-600 focus:ring-action-primary-500 border-gray-300 dark:border-gray-600 rounded"
                   />
                   <label for="enabled" class="ml-2 block text-sm text-gray-700 dark:text-gray-300">
                     Link enabled
@@ -336,7 +336,7 @@
               <button
                 type="submit"
                 :disabled="formLoading"
-                class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md disabled:bg-indigo-400"
+                class="px-4 py-2 text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 rounded-md disabled:bg-action-primary-400"
               >
                 <span v-if="formLoading" class="flex items-center">
                   <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -138,7 +138,7 @@
             <!-- Avatar (vertically centered, with border ring) -->
             <div class="flex-shrink-0 flex items-center mr-1.5">
               <div class="rounded-full border-2 overflow-hidden shadow-sm"
-                   :class="row.isSystemAgent ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-indigo-400 dark:border-indigo-500'"
+                   :class="row.isSystemAgent ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-action-primary-400 dark:border-action-primary-500'"
               >
                 <AgentAvatar :name="row.name" :avatar-url="row.avatarUrl" size="lg" />
               </div>

--- a/src/frontend/src/components/ResourceModal.vue
+++ b/src/frontend/src/components/ResourceModal.vue
@@ -7,8 +7,8 @@
       <!-- Modal panel -->
       <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
         <div>
-          <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100 dark:bg-indigo-900/50">
-            <svg class="h-6 w-6 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-action-primary-100 dark:bg-action-primary-900/50">
+            <svg class="h-6 w-6 text-action-primary-600 dark:text-action-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
             </svg>
           </div>
@@ -42,7 +42,7 @@
               :value="resourceLimits.memory"
               @change="$emit('update:memory', $event.target.value || null)"
               :disabled="loading"
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-action-primary-500 focus:border-action-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
             >
               <option :value="null">Default ({{ resourceLimits.current_memory || '4g' }})</option>
               <option value="1g">1 GB</option>
@@ -60,7 +60,7 @@
               :value="resourceLimits.cpu"
               @change="$emit('update:cpu', $event.target.value || null)"
               :disabled="loading"
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-action-primary-500 focus:border-action-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
             >
               <option :value="null">Default ({{ resourceLimits.current_cpu || '2' }})</option>
               <option value="1">1 Core</option>
@@ -78,14 +78,14 @@
             type="button"
             @click="$emit('save')"
             :disabled="loading"
-            class="w-full inline-flex justify-center rounded-lg border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:col-start-2 sm:text-sm disabled:opacity-50"
+            class="w-full inline-flex justify-center rounded-lg border border-transparent shadow-sm px-4 py-2 bg-action-primary-600 text-base font-medium text-white hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:col-start-2 sm:text-sm disabled:opacity-50"
           >
             {{ loading ? 'Saving...' : 'Save Changes' }}
           </button>
           <button
             type="button"
             @click="$emit('update:show', false)"
-            class="mt-3 w-full inline-flex justify-center rounded-lg border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:col-start-1 sm:text-sm"
+            class="mt-3 w-full inline-flex justify-center rounded-lg border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:mt-0 sm:col-start-1 sm:text-sm"
           >
             Cancel
           </button>

--- a/src/frontend/src/components/SchedulesPanel.vue
+++ b/src/frontend/src/components/SchedulesPanel.vue
@@ -8,7 +8,7 @@
       </div>
       <button
         @click="showCreateForm = true"
-        class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500"
       >
         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -34,7 +34,7 @@
                 type="text"
                 required
                 placeholder="Daily report"
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
               />
             </div>
 
@@ -45,7 +45,7 @@
                 type="text"
                 required
                 placeholder="0 9 * * *"
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md font-mono focus:outline-none focus:ring-2 focus:ring-action-primary-500"
               />
               <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 Format: minute hour day month day_of_week (e.g., "0 9 * * *" for 9 AM daily)
@@ -65,7 +65,7 @@
                 required
                 rows="3"
                 placeholder="Generate and post the daily analytics report..."
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
               ></textarea>
               <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">This message will be sent to the agent when the schedule triggers</p>
             </div>
@@ -76,7 +76,7 @@
                 v-model="formData.description"
                 type="text"
                 placeholder="Optional description"
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
               />
             </div>
 
@@ -90,7 +90,7 @@
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timezone</label>
                 <select
                   v-model="formData.timezone"
-                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
                 >
                   <option value="UTC">UTC</option>
                   <option value="America/New_York">America/New_York (EST/EDT)</option>
@@ -105,7 +105,7 @@
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timeout</label>
                 <select
                   v-model="formData.timeout_seconds"
-                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
                 >
                   <option :value="300">5 minutes</option>
                   <option :value="900">15 minutes (default)</option>
@@ -122,7 +122,7 @@
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Max Retries</label>
                 <select
                   v-model="formData.max_retries"
-                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
                 >
                   <option :value="0">Disabled (default)</option>
                   <option :value="1">1 retry</option>
@@ -135,7 +135,7 @@
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Retry Delay</label>
                 <select
                   v-model="formData.retry_delay_seconds"
-                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
                 >
                   <option :value="30">30 seconds</option>
                   <option :value="60">1 minute (default)</option>
@@ -157,7 +157,7 @@
                   type="button"
                   @click="toggleAllTools"
                   class="text-xs px-2 py-1 rounded"
-                  :class="formData.allowed_tools === null ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'"
+                  :class="formData.allowed_tools === null ? 'bg-action-primary-100 dark:bg-action-primary-900/30 text-action-primary-700 dark:text-action-primary-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'"
                 >
                   {{ formData.allowed_tools === null ? 'All Tools (Unrestricted)' : 'Enable All' }}
                 </button>
@@ -170,7 +170,7 @@
                       v-for="tool in category.tools"
                       :key="tool.value"
                       class="inline-flex items-center px-2 py-1 rounded text-xs cursor-pointer transition-colors"
-                      :class="isToolSelected(tool.value) ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'"
+                      :class="isToolSelected(tool.value) ? 'bg-action-primary-100 dark:bg-action-primary-900/30 text-action-primary-700 dark:text-action-primary-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'"
                     >
                       <input
                         type="checkbox"
@@ -194,7 +194,7 @@
                 v-model="formData.enabled"
                 type="checkbox"
                 id="enabled"
-                class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                class="h-4 w-4 text-action-primary-600 focus:ring-action-primary-500 border-gray-300 rounded"
               />
               <label for="enabled" class="ml-2 text-sm text-gray-700 dark:text-gray-300">Enable schedule immediately</label>
             </div>
@@ -214,7 +214,7 @@
               <button
                 type="submit"
                 :disabled="formLoading"
-                class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md hover:bg-indigo-700 disabled:bg-gray-400"
+                class="px-4 py-2 text-sm font-medium text-white bg-action-primary-600 border border-transparent rounded-md hover:bg-action-primary-700 disabled:bg-gray-400"
               >
                 <span v-if="formLoading" class="flex items-center">
                   <svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
@@ -233,7 +233,7 @@
 
     <!-- Schedules List -->
     <div v-if="loading" class="text-center py-8">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto"></div>
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
       <p class="text-sm text-gray-500 dark:text-gray-400 mt-2">Loading schedules...</p>
     </div>
 
@@ -304,7 +304,7 @@
                 </svg>
                 {{ schedule.max_retries }}x retry
               </span>
-              <span v-if="schedule.next_run_at" class="flex items-center text-indigo-600 dark:text-indigo-400">
+              <span v-if="schedule.next_run_at" class="flex items-center text-action-primary-600 dark:text-action-primary-400">
                 <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
                 </svg>
@@ -327,7 +327,7 @@
             <button
               @click="triggerSchedule(schedule)"
               :disabled="triggerLoading === schedule.id"
-              class="p-1.5 text-gray-400 hover:text-indigo-600 rounded transition-colors"
+              class="p-1.5 text-gray-400 hover:text-action-primary-600 rounded transition-colors"
               title="Run now"
             >
               <svg v-if="triggerLoading === schedule.id" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
@@ -356,7 +356,7 @@
             </button>
             <button
               @click="editSchedule(schedule)"
-              class="p-1.5 text-gray-400 hover:text-indigo-600 rounded transition-colors"
+              class="p-1.5 text-gray-400 hover:text-action-primary-600 rounded transition-colors"
               title="Edit"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -383,7 +383,7 @@
         <!-- Expand to show executions -->
         <button
           @click="toggleExecutions(schedule.id)"
-          class="mt-3 text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 flex items-center"
+          class="mt-3 text-xs text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300 flex items-center"
         >
           <svg
             class="w-3 h-3 mr-1 transform transition-transform"
@@ -400,7 +400,7 @@
         <!-- Execution History -->
         <div v-if="expandedSchedule === schedule.id" class="mt-3 border-t border-gray-100 dark:border-gray-700 pt-3">
           <div v-if="executionsLoading" class="text-center py-4">
-            <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-500 mx-auto"></div>
+            <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-action-primary-500 mx-auto"></div>
           </div>
           <div v-else-if="!executions[schedule.id] || executions[schedule.id].length === 0" class="text-center py-4 text-xs text-gray-400 dark:text-gray-500">
             No executions yet
@@ -549,7 +549,7 @@
                   class="flex items-center justify-between text-xs bg-gray-100 dark:bg-gray-700 rounded px-2 py-1"
                 >
                   <div class="flex items-center space-x-2">
-                    <span class="font-medium text-indigo-600 dark:text-indigo-400">{{ tool.tool }}</span>
+                    <span class="font-medium text-action-primary-600 dark:text-action-primary-400">{{ tool.tool }}</span>
                     <span v-if="tool.input" class="text-gray-500 dark:text-gray-400 truncate max-w-xs">
                       {{ summarizeToolInput(tool) }}
                     </span>

--- a/src/frontend/src/components/SessionPanel.vue
+++ b/src/frontend/src/components/SessionPanel.vue
@@ -9,7 +9,7 @@
             @click="showSessionDropdown = !showSessionDropdown"
             class="flex items-center space-x-2 px-3 py-1.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
           >
-            <svg class="w-4 h-4 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <span class="max-w-32 truncate">{{ currentSessionLabel }}</span>
@@ -36,7 +36,7 @@
                 :key="session.id"
                 @click="selectSession(session)"
                 class="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                :class="{ 'bg-indigo-50 dark:bg-indigo-900/30': currentSessionId === session.id }"
+                :class="{ 'bg-action-primary-50 dark:bg-action-primary-900/30': currentSessionId === session.id }"
               >
                 <div class="flex items-center justify-between">
                   <span class="text-sm font-medium text-gray-700 dark:text-gray-200">
@@ -92,7 +92,7 @@
         <button
           @click="startNewSession"
           :disabled="loading || creatingSession"
-          class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded-lg transition-colors"
+          class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-700 dark:hover:text-action-primary-300 hover:bg-action-primary-50 dark:hover:bg-action-primary-900/30 rounded-lg transition-colors"
         >
           <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -153,8 +153,8 @@
       >
         <template #empty>
           <div class="text-center py-12">
-            <div class="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg class="w-8 h-8 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="w-16 h-16 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg class="w-8 h-8 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
               </svg>
             </div>

--- a/src/frontend/src/components/SharingPanel.vue
+++ b/src/frontend/src/components/SharingPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-6 space-y-8">
     <!-- Framing: identity vs. authorization (Issue #446) -->
-    <div class="rounded-lg bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-100 dark:border-indigo-900/40 p-4 text-sm text-indigo-900 dark:text-indigo-200">
+    <div class="rounded-lg bg-action-primary-50 dark:bg-action-primary-900/20 border border-action-primary-100 dark:border-action-primary-900/40 p-4 text-sm text-action-primary-900 dark:text-action-primary-200">
       Access to this agent has two layers:
       <ul class="mt-2 list-disc pl-5 space-y-1">
         <li><strong>Identity proof</strong> — "Require verified email" (below) forces every user to prove who they are via email verification before chatting. It is enforced on web, Slack, and Telegram.</li>
@@ -115,12 +115,12 @@
           type="email"
           placeholder="user@example.com"
           :disabled="shareLoading"
-          class="flex-1 max-w-md px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-900"
+          class="flex-1 max-w-md px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-action-primary-500 disabled:bg-gray-100 dark:disabled:bg-gray-900"
         />
         <button
           type="submit"
           :disabled="shareLoading || !shareEmail.trim()"
-          class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
+          class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 dark:focus:ring-offset-gray-800 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
         >
           <svg v-if="shareLoading" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -175,8 +175,8 @@
                   @click="toggleProactive(share)"
                   :disabled="proactiveLoading === share.shared_with_email"
                   :class="[
-                    share.allow_proactive ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600',
-                    'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
+                    share.allow_proactive ? 'bg-action-primary-600' : 'bg-gray-200 dark:bg-gray-600',
+                    'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
                   ]"
                 >
                   <span

--- a/src/frontend/src/components/SkillsPanel.vue
+++ b/src/frontend/src/components/SkillsPanel.vue
@@ -15,7 +15,7 @@
             v-if="agentStatus === 'running'"
             @click="injectSkills"
             :disabled="injecting || assignedSkills.length === 0"
-            class="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <svg v-if="injecting" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -39,7 +39,7 @@
 
       <!-- Loading State -->
       <div v-if="loading" class="flex justify-center py-8">
-        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-600"></div>
       </div>
 
       <!-- Library Not Configured -->
@@ -65,7 +65,7 @@
             v-model="searchQuery"
             type="text"
             placeholder="Search skills..."
-            class="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+            class="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
           />
           <svg class="absolute left-3 top-2.5 h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -80,7 +80,7 @@
             class="relative flex items-start p-3 border rounded-lg cursor-pointer transition-colors"
             :class="[
               selectedSkills.has(skill.name)
-                ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 dark:border-indigo-600'
+                ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/30 dark:border-action-primary-600'
                 : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
             ]"
             @click="toggleSkill(skill.name)"
@@ -89,7 +89,7 @@
               <input
                 type="checkbox"
                 :checked="selectedSkills.has(skill.name)"
-                class="h-4 w-4 text-indigo-600 border-gray-300 dark:border-gray-600 rounded focus:ring-indigo-500"
+                class="h-4 w-4 text-action-primary-600 border-gray-300 dark:border-gray-600 rounded focus:ring-action-primary-500"
                 @change.stop="toggleSkill(skill.name)"
               />
             </div>

--- a/src/frontend/src/components/SlackChannelPanel.vue
+++ b/src/frontend/src/components/SlackChannelPanel.vue
@@ -37,7 +37,7 @@
           <!-- DM default control: badge if already default, button otherwise -->
           <span
             v-if="channel.is_dm_default"
-            class="inline-flex items-center gap-1 text-xs font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 rounded px-2 py-1"
+            class="inline-flex items-center gap-1 text-xs font-medium text-action-primary-700 dark:text-action-primary-300 bg-action-primary-50 dark:bg-action-primary-900/30 border border-action-primary-200 dark:border-action-primary-800 rounded px-2 py-1"
             :title="dmDefaultTooltip"
           >
             <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
@@ -48,7 +48,7 @@
             @click="makeDmDefault"
             :disabled="makingDefault"
             :title="dmDefaultTooltip"
-            class="text-xs px-2 py-1 border border-indigo-300 dark:border-indigo-700 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+            class="text-xs px-2 py-1 border border-action-primary-300 dark:border-action-primary-700 text-action-primary-700 dark:text-action-primary-300 hover:bg-action-primary-50 dark:hover:bg-action-primary-900/30 rounded disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {{ makingDefault ? 'Setting...' : 'Make default' }}
           </button>
@@ -69,7 +69,7 @@
       <button
         @click="createChannel"
         :disabled="creating"
-        class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <svg v-if="creating" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/frontend/src/components/TasksPanel.vue
+++ b/src/frontend/src/components/TasksPanel.vue
@@ -10,7 +10,7 @@
         <!-- Trigger Type Filter -->
         <select
           v-model="triggerFilter"
-          class="text-xs px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          class="text-xs px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1 focus:ring-action-primary-500"
         >
           <option value="all">All triggers</option>
           <option value="chat">Chat</option>
@@ -94,7 +94,7 @@
           <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Timeout</label>
           <select
             v-model="taskTimeout"
-            class="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            class="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1 focus:ring-action-primary-500"
           >
             <option :value="300">5 min</option>
             <option :value="900">15 min</option>
@@ -114,13 +114,13 @@
             @keydown.enter.exact.prevent="runNewTask"
             @keydown.meta.enter="runNewTask"
             @keydown.ctrl.enter="runNewTask"
-            class="w-full h-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-900 disabled:cursor-not-allowed resize-none"
+            class="w-full h-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-action-primary-500 disabled:bg-gray-100 dark:disabled:bg-gray-900 disabled:cursor-not-allowed resize-none"
           ></textarea>
         </div>
         <button
           @click="runNewTask"
           :disabled="taskLoading || !newTaskMessage.trim() || agentStatus !== 'running'"
-          class="inline-flex items-center justify-center px-4 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
+          class="inline-flex items-center justify-center px-4 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
         >
           <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -138,7 +138,7 @@
     <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
       <!-- Loading State -->
       <div v-if="loading && allTasks.length === 0" class="text-center py-8">
-        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto"></div>
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-2">Loading tasks...</p>
       </div>
 
@@ -162,7 +162,7 @@
             'bg-status-warning-50/50 dark:bg-status-warning-900/10': task.status === 'running',
             'bg-status-danger-50/30 dark:bg-status-danger-900/10': task.status === 'failed',
             'bg-status-urgent-50/30 dark:bg-status-urgent-900/10': task.status === 'cancelled',
-            'ring-2 ring-indigo-500 ring-inset bg-indigo-50/50 dark:bg-indigo-900/20': isHighlightedTask(task.id)
+            'ring-2 ring-action-primary-500 ring-inset bg-action-primary-50/50 dark:bg-action-primary-900/20': isHighlightedTask(task.id)
           }"
         >
           <div class="flex items-start justify-between">
@@ -227,7 +227,7 @@
 
               <!-- Message -->
               <p
-                class="text-sm text-gray-700 dark:text-gray-300 cursor-pointer hover:text-indigo-600 dark:hover:text-indigo-400"
+                class="text-sm text-gray-700 dark:text-gray-300 cursor-pointer hover:text-action-primary-600 dark:hover:text-action-primary-400"
                 @click="toggleTaskExpand(task.id)"
               >
                 {{ task.message.substring(0, 120) }}{{ task.message.length > 120 ? '...' : '' }}
@@ -284,7 +284,7 @@
                   'p-1.5 rounded transition-colors flex items-center space-x-1',
                   task.status === 'running'
                     ? 'text-status-success-600 dark:text-status-success-400 hover:text-status-success-700 dark:hover:text-status-success-300 bg-status-success-50 dark:bg-status-success-900/20'
-                    : 'text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400'
+                    : 'text-gray-400 hover:text-action-primary-600 dark:hover:text-action-primary-400'
                 ]"
                 :title="task.status === 'running' ? 'View live execution' : 'Open execution details'"
               >
@@ -311,7 +311,7 @@
               <!-- Copy Input Button -->
               <button
                 @click="copyTaskMessage(task)"
-                class="p-1.5 text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 rounded transition-colors"
+                class="p-1.5 text-gray-400 hover:text-action-primary-600 dark:hover:text-action-primary-400 rounded transition-colors"
                 title="Copy task input"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -361,7 +361,7 @@
               <!-- Expand/Collapse Button -->
               <button
                 @click="toggleTaskExpand(task.id)"
-                class="p-1.5 text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 rounded transition-colors"
+                class="p-1.5 text-gray-400 hover:text-action-primary-600 dark:hover:text-action-primary-400 rounded transition-colors"
                 :title="expandedTaskId === task.id ? 'Collapse' : 'Expand'"
               >
                 <svg
@@ -410,7 +410,7 @@
             <!-- Modal Body -->
             <div class="flex-1 overflow-y-auto overflow-x-hidden p-4">
               <div v-if="logLoading" class="flex items-center justify-center py-12">
-                <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
+                <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500"></div>
               </div>
               <div v-else-if="logError" class="text-center py-8">
                 <p class="text-status-danger-500 dark:text-status-danger-400">{{ logError }}</p>
@@ -437,13 +437,13 @@
 
                   <!-- Assistant Message (thinking text) -->
                   <div v-else-if="entry.type === 'assistant-text'" class="flex space-x-3">
-                    <div class="flex-shrink-0 w-8 h-8 bg-indigo-100 dark:bg-indigo-900/50 rounded-full flex items-center justify-center">
-                      <svg class="w-4 h-4 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="flex-shrink-0 w-8 h-8 bg-action-primary-100 dark:bg-action-primary-900/50 rounded-full flex items-center justify-center">
+                      <svg class="w-4 h-4 text-action-primary-600 dark:text-action-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                       </svg>
                     </div>
-                    <div class="flex-1 min-w-0 bg-indigo-50 dark:bg-indigo-900/20 rounded-lg p-3">
-                      <div class="text-xs font-medium text-indigo-700 dark:text-indigo-300 mb-1">Claude</div>
+                    <div class="flex-1 min-w-0 bg-action-primary-50 dark:bg-action-primary-900/20 rounded-lg p-3">
+                      <div class="text-xs font-medium text-action-primary-700 dark:text-action-primary-300 mb-1">Claude</div>
                       <div class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">{{ entry.text }}</div>
                     </div>
                   </div>
@@ -486,7 +486,7 @@
                       </div>
                       <div class="flex items-center space-x-3 font-mono">
                         <span>{{ entry.duration }}</span>
-                        <span class="text-indigo-600 dark:text-indigo-400">${{ entry.cost }}</span>
+                        <span class="text-action-primary-600 dark:text-action-primary-400">${{ entry.cost }}</span>
                       </div>
                     </div>
                   </div>

--- a/src/frontend/src/components/TelegramChannelPanel.vue
+++ b/src/frontend/src/components/TelegramChannelPanel.vue
@@ -34,7 +34,7 @@
                 :href="binding.bot_link"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+                class="text-xs text-action-primary-600 dark:text-action-primary-400 hover:underline"
               >
                 {{ binding.bot_link }}
               </a>
@@ -44,7 +44,7 @@
             <button
               @click="verifyBot"
               :disabled="verifying"
-              class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 disabled:opacity-50"
+              class="text-sm text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300 disabled:opacity-50"
             >
               {{ verifying ? 'Verifying...' : 'Verify' }}
             </button>
@@ -102,7 +102,7 @@
                   value="mention"
                   :checked="group.trigger_mode === 'mention'"
                   @change="updateGroup(group, { trigger_mode: 'mention' })"
-                  class="text-indigo-600 focus:ring-indigo-500"
+                  class="text-action-primary-600 focus:ring-action-primary-500"
                 />
                 <span class="text-gray-600 dark:text-gray-400">@mention only</span>
               </label>
@@ -113,7 +113,7 @@
                   value="all"
                   :checked="group.trigger_mode === 'all'"
                   @change="updateGroup(group, { trigger_mode: 'all' })"
-                  class="text-indigo-600 focus:ring-indigo-500"
+                  class="text-action-primary-600 focus:ring-action-primary-500"
                 />
                 <span class="text-gray-600 dark:text-gray-400">All messages</span>
               </label>
@@ -124,7 +124,7 @@
                   value="observe"
                   :checked="group.trigger_mode === 'observe'"
                   @change="updateGroup(group, { trigger_mode: 'observe' })"
-                  class="text-indigo-600 focus:ring-indigo-500"
+                  class="text-action-primary-600 focus:ring-action-primary-500"
                 />
                 <span class="text-gray-600 dark:text-gray-400">Observe</span>
               </label>
@@ -137,7 +137,7 @@
                   type="checkbox"
                   :checked="group.welcome_enabled"
                   @change="updateGroup(group, { welcome_enabled: !group.welcome_enabled })"
-                  class="rounded text-indigo-600 focus:ring-indigo-500"
+                  class="rounded text-action-primary-600 focus:ring-action-primary-500"
                 />
                 <span class="text-gray-600 dark:text-gray-400">Welcome new members</span>
               </label>
@@ -147,7 +147,7 @@
                   :value="group.welcome_text || ''"
                   @blur="updateGroup(group, { welcome_text: $event.target.value })"
                   placeholder="Welcome, {name}! I'm here to help."
-                  class="w-full text-xs px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  class="w-full text-xs px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-action-primary-500"
                 />
                 <p class="mt-0.5 text-xs text-gray-400">Use {name} for the user's first name</p>
               </div>
@@ -173,16 +173,16 @@
             type="password"
             placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
             :disabled="connecting"
-            class="w-full max-w-lg px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-900"
+            class="w-full max-w-lg px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-action-primary-500 disabled:bg-gray-100 dark:disabled:bg-gray-900"
           />
           <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-            Get a token from <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" class="text-indigo-600 dark:text-indigo-400 hover:underline">@BotFather</a> on Telegram.
+            Get a token from <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" class="text-action-primary-600 dark:text-action-primary-400 hover:underline">@BotFather</a> on Telegram.
           </p>
         </div>
         <button
           type="submit"
           :disabled="connecting || !botToken.trim()"
-          class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <svg v-if="connecting" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/frontend/src/components/TerminalPanelContent.vue
+++ b/src/frontend/src/components/TerminalPanelContent.vue
@@ -63,7 +63,7 @@
                   :checked="apiKeySetting.use_platform_api_key"
                   @change="$emit('update-api-key-setting', true)"
                   :disabled="apiKeySettingLoading"
-                  class="text-indigo-500 focus:ring-indigo-500"
+                  class="text-action-primary-500 focus:ring-action-primary-500"
                 />
                 <div>
                   <span class="text-sm text-gray-200">Use Platform API Key</span>
@@ -76,7 +76,7 @@
                   :checked="!apiKeySetting.use_platform_api_key"
                   @change="$emit('update-api-key-setting', false)"
                   :disabled="apiKeySettingLoading"
-                  class="text-indigo-500 focus:ring-indigo-500"
+                  class="text-action-primary-500 focus:ring-action-primary-500"
                 />
                 <div>
                   <span class="text-sm text-gray-200">Authenticate in Terminal</span>

--- a/src/frontend/src/components/UnifiedActivityPanel.vue
+++ b/src/frontend/src/components/UnifiedActivityPanel.vue
@@ -127,7 +127,7 @@
 
       <!-- Load more button (for pagination) -->
       <div v-if="activity.timeline?.length >= 20" class="px-4 py-2 text-center">
-        <button class="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300">
+        <button class="text-xs text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300">
           Load more...
         </button>
       </div>

--- a/src/frontend/src/components/WhatsAppChannelPanel.vue
+++ b/src/frontend/src/components/WhatsAppChannelPanel.vue
@@ -44,7 +44,7 @@
             <button
               @click="verifyCredentials"
               :disabled="verifying"
-              class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 disabled:opacity-50"
+              class="text-sm text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300 disabled:opacity-50"
             >
               {{ verifying ? 'Verifying...' : 'Verify' }}
             </button>
@@ -60,22 +60,22 @@
       </div>
 
       <!-- Webhook URL Display -->
-      <div v-if="binding.webhook_url" class="p-3 rounded-lg bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-100 dark:border-indigo-800/40">
-        <p class="text-xs font-medium text-indigo-900 dark:text-indigo-200 mb-1">
+      <div v-if="binding.webhook_url" class="p-3 rounded-lg bg-action-primary-50 dark:bg-action-primary-900/20 border border-action-primary-100 dark:border-action-primary-800/40">
+        <p class="text-xs font-medium text-action-primary-900 dark:text-action-primary-200 mb-1">
           Webhook URL — paste into Twilio Console
         </p>
         <div class="flex items-center gap-2">
-          <code class="flex-1 text-xs text-indigo-900 dark:text-indigo-100 font-mono break-all select-all">
+          <code class="flex-1 text-xs text-action-primary-900 dark:text-action-primary-100 font-mono break-all select-all">
             {{ binding.webhook_url }}
           </code>
           <button
             @click="copyWebhook"
-            class="text-xs text-indigo-700 dark:text-indigo-300 hover:text-indigo-900 dark:hover:text-indigo-100"
+            class="text-xs text-action-primary-700 dark:text-action-primary-300 hover:text-action-primary-900 dark:hover:text-action-primary-100"
           >
             {{ copied ? 'Copied!' : 'Copy' }}
           </button>
         </div>
-        <p class="mt-2 text-xs text-indigo-700 dark:text-indigo-300">
+        <p class="mt-2 text-xs text-action-primary-700 dark:text-action-primary-300">
           In Twilio Console → Messaging → {{ binding.is_sandbox ? 'Sandbox settings' : 'your sender' }} →
           <strong>When a message comes in</strong>, set method to <strong>HTTP POST</strong> and paste this URL.
         </p>
@@ -119,7 +119,7 @@
             type="text"
             placeholder="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
             :disabled="connecting"
-            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-900 font-mono text-xs"
+            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-action-primary-500 disabled:bg-gray-100 dark:disabled:bg-gray-900 font-mono text-xs"
           />
         </div>
         <div>
@@ -132,7 +132,7 @@
             type="password"
             placeholder="Paste your Twilio Auth Token"
             :disabled="connecting"
-            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-900"
+            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-action-primary-500 disabled:bg-gray-100 dark:disabled:bg-gray-900"
           />
           <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
             From Twilio Console — stored encrypted.
@@ -148,7 +148,7 @@
             type="text"
             placeholder="whatsapp:+14155238886"
             :disabled="connecting"
-            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-900 font-mono text-xs"
+            class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-action-primary-500 disabled:bg-gray-100 dark:disabled:bg-gray-900 font-mono text-xs"
           />
           <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
             Must start with <code class="font-mono">whatsapp:+</code>. Use
@@ -158,7 +158,7 @@
         <button
           type="submit"
           :disabled="connecting || !canSubmit"
-          class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <svg v-if="connecting" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/frontend/src/components/chat/ChatBubble.vue
+++ b/src/frontend/src/components/chat/ChatBubble.vue
@@ -4,7 +4,7 @@
     v-if="role === 'user'"
     class="max-w-[85%] min-w-0 ml-auto"
   >
-    <div class="rounded-xl px-4 py-3 bg-indigo-600 text-white overflow-hidden">
+    <div class="rounded-xl px-4 py-3 bg-action-primary-600 text-white overflow-hidden">
       <div v-if="source === 'voice'" class="flex items-center gap-1.5 mb-1 opacity-75">
         <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4M12 15a3 3 0 003-3V5a3 3 0 00-6 0v7a3 3 0 003 3z" /></svg>
         <span class="text-[10px] uppercase tracking-wide">Voice</span>
@@ -55,7 +55,7 @@
       <!-- Expanded content -->
       <div
         v-else
-        class="prose prose-sm dark:prose-invert max-w-none break-words prose-p:my-2 prose-headings:my-3 prose-ul:my-2 prose-ol:my-2 prose-li:my-0 prose-pre:my-2 prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:whitespace-pre prose-code:text-indigo-600 dark:prose-code:text-indigo-400 prose-code:bg-gray-100 dark:prose-code:bg-gray-700 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:break-words prose-code:before:content-none prose-code:after:content-none prose-a:break-words"
+        class="prose prose-sm dark:prose-invert max-w-none break-words prose-p:my-2 prose-headings:my-3 prose-ul:my-2 prose-ol:my-2 prose-li:my-0 prose-pre:my-2 prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:whitespace-pre prose-code:text-action-primary-600 dark:prose-code:text-action-primary-400 prose-code:bg-gray-100 dark:prose-code:bg-gray-700 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:break-words prose-code:before:content-none prose-code:after:content-none prose-a:break-words"
         v-html="renderedContent"
       ></div>
     </div>
@@ -82,7 +82,7 @@
         <span class="text-[10px] uppercase tracking-wide">Voice</span>
       </div>
       <div
-        class="prose prose-sm dark:prose-invert max-w-none break-words prose-p:my-2 prose-headings:my-3 prose-ul:my-2 prose-ol:my-2 prose-li:my-0 prose-pre:my-2 prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:whitespace-pre prose-code:text-indigo-600 dark:prose-code:text-indigo-400 prose-code:bg-gray-100 dark:prose-code:bg-gray-700 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:break-words prose-code:before:content-none prose-code:after:content-none prose-a:break-words"
+        class="prose prose-sm dark:prose-invert max-w-none break-words prose-p:my-2 prose-headings:my-3 prose-ul:my-2 prose-ol:my-2 prose-li:my-0 prose-pre:my-2 prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:whitespace-pre prose-code:text-action-primary-600 dark:prose-code:text-action-primary-400 prose-code:bg-gray-100 dark:prose-code:bg-gray-700 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:break-words prose-code:before:content-none prose-code:after:content-none prose-a:break-words"
         v-html="renderedContent"
       ></div>
     </div>

--- a/src/frontend/src/components/chat/ChatEmptyState.vue
+++ b/src/frontend/src/components/chat/ChatEmptyState.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="text-center py-8 px-4">
-    <div v-if="showIcon" class="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-      <svg class="w-8 h-8 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <div v-if="showIcon" class="w-16 h-16 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+      <svg class="w-8 h-8 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
       </svg>
     </div>
@@ -16,7 +16,7 @@
         :key="idx"
         type="button"
         @click="$emit('select', { text: item.text, sendImmediately: item.sendImmediately })"
-        class="text-left px-4 py-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-indigo-400 dark:hover:border-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-colors group"
+        class="text-left px-4 py-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-action-primary-400 dark:hover:border-action-primary-500 hover:bg-action-primary-50 dark:hover:bg-action-primary-900/20 transition-colors group"
       >
         <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
           {{ item.label }}

--- a/src/frontend/src/components/chat/ChatHistoryDropdown.vue
+++ b/src/frontend/src/components/chat/ChatHistoryDropdown.vue
@@ -4,7 +4,7 @@
     <button
       @click="toggleDropdown"
       class="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
-      :class="{ 'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/20': isOpen }"
+      :class="{ 'text-action-primary-600 dark:text-action-primary-400 bg-action-primary-50 dark:bg-action-primary-900/20': isOpen }"
       title="Chat history"
     >
       <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -37,7 +37,7 @@
 
         <!-- Loading state -->
         <div v-if="loading" class="px-3 py-4 text-center">
-          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-500 mx-auto"></div>
+          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-action-primary-500 mx-auto"></div>
         </div>
 
         <!-- Error state -->

--- a/src/frontend/src/components/chat/ChatInput.vue
+++ b/src/frontend/src/components/chat/ChatInput.vue
@@ -39,13 +39,13 @@
             :class="[
               'flex items-start gap-2 px-3 py-2 cursor-pointer transition-colors',
               idx === ac.selectedIndex.value
-                ? 'bg-indigo-50 dark:bg-indigo-900/40'
+                ? 'bg-action-primary-50 dark:bg-action-primary-900/40'
                 : 'hover:bg-gray-50 dark:hover:bg-gray-700/60'
             ]"
             @click="onClickSuggestion(playbook)"
           >
             <!-- Command name -->
-            <code class="shrink-0 text-sm font-semibold text-indigo-600 dark:text-indigo-400">
+            <code class="shrink-0 text-sm font-semibold text-action-primary-600 dark:text-action-primary-400">
               /{{ playbook.name }}
             </code>
 
@@ -87,7 +87,7 @@
       <div
         v-for="(f, idx) in pendingFiles"
         :key="idx"
-        class="flex items-center gap-1 px-2 py-0.5 bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 text-xs rounded-full"
+        class="flex items-center gap-1 px-2 py-0.5 bg-action-primary-100 dark:bg-action-primary-900/40 text-action-primary-700 dark:text-action-primary-300 text-xs rounded-full"
       >
         <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
@@ -104,9 +104,9 @@
     <!-- ── Drag-over overlay ──────────────────────────────────────────────── -->
     <div
       v-if="dragOver"
-      class="absolute inset-0 rounded-xl bg-indigo-50/90 dark:bg-indigo-900/60 border-2 border-dashed border-indigo-400 flex items-center justify-center z-20 pointer-events-none"
+      class="absolute inset-0 rounded-xl bg-action-primary-50/90 dark:bg-action-primary-900/60 border-2 border-dashed border-action-primary-400 flex items-center justify-center z-20 pointer-events-none"
     >
-      <span class="text-indigo-600 dark:text-indigo-300 text-sm font-medium">Drop files here</span>
+      <span class="text-action-primary-600 dark:text-action-primary-300 text-sm font-medium">Drop files here</span>
     </div>
 
     <!-- ── Input row ─────────────────────────────────────────────────────── -->
@@ -155,7 +155,7 @@
         type="button"
         @click="fileInputRef?.click()"
         :disabled="disabled || pendingFiles.length >= 3"
-        class="p-2 rounded-lg transition-colors shrink-0 bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/30 hover:text-indigo-600 dark:hover:text-indigo-400 disabled:opacity-40"
+        class="p-2 rounded-lg transition-colors shrink-0 bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 hover:bg-action-primary-100 dark:hover:bg-action-primary-900/30 hover:text-action-primary-600 dark:hover:text-action-primary-400 disabled:opacity-40"
         title="Attach files (max 3, 5 MB each)"
       >
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -172,7 +172,7 @@
         class="p-2 rounded-lg transition-colors shrink-0"
         :class="voiceActive
           ? 'bg-status-danger-500 hover:bg-status-danger-600 text-white'
-          : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/30 hover:text-indigo-600 dark:hover:text-indigo-400 disabled:opacity-50'"
+          : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 hover:bg-action-primary-100 dark:hover:bg-action-primary-900/30 hover:text-action-primary-600 dark:hover:text-action-primary-400 disabled:opacity-50'"
         :title="voiceActive ? 'Voice session active' : 'Start voice conversation'"
       >
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -184,7 +184,7 @@
       <button
         type="submit"
         :disabled="disabled || (!localMessage.trim() && pendingFiles.length === 0)"
-        class="p-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors shrink-0"
+        class="p-2 bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 text-white rounded-lg transition-colors shrink-0"
       >
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
@@ -205,7 +205,7 @@
         v-if="ac.activeArgHint.value"
         class="mt-1.5 flex items-center gap-1.5 text-xs font-mono text-gray-400 dark:text-gray-500"
       >
-        <span class="text-indigo-500 dark:text-indigo-400">/{{ ac.activeArgHint.value.name }}</span>
+        <span class="text-action-primary-500 dark:text-action-primary-400">/{{ ac.activeArgHint.value.name }}</span>
         <span>{{ ac.activeArgHint.value.argument_hint }}</span>
         <span
           v-if="ac.activeArgHint.value.description"

--- a/src/frontend/src/components/chat/ChatMessages.vue
+++ b/src/frontend/src/components/chat/ChatMessages.vue
@@ -7,8 +7,8 @@
         <!-- Empty state slot -->
         <slot v-if="messages.length === 0 && !loading" name="empty">
           <div class="text-center py-12">
-            <div class="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg class="w-8 h-8 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="w-16 h-16 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg class="w-8 h-8 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
               </svg>
             </div>

--- a/src/frontend/src/components/file-manager/FilePreview.vue
+++ b/src/frontend/src/components/file-manager/FilePreview.vue
@@ -3,7 +3,7 @@
     <!-- Loading State -->
     <div v-if="previewLoading" class="flex-1 flex items-center justify-center">
       <div class="text-center">
-        <svg class="animate-spin h-8 w-8 text-indigo-600 mx-auto" fill="none" viewBox="0 0 24 24">
+        <svg class="animate-spin h-8 w-8 text-action-primary-600 mx-auto" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
         </svg>
@@ -96,7 +96,7 @@
           v-if="props.isEditing"
           :value="props.editContent"
           @input="emit('update:editContent', $event.target.value)"
-          class="flex-1 p-4 text-sm font-mono bg-gray-900 text-gray-100 m-2 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          class="flex-1 p-4 text-sm font-mono bg-gray-900 text-gray-100 m-2 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-action-primary-500"
           spellcheck="false"
         ></textarea>
         <!-- View Mode: Pre/Code -->

--- a/src/frontend/src/components/file-manager/FileTreeNode.vue
+++ b/src/frontend/src/components/file-manager/FileTreeNode.vue
@@ -5,7 +5,7 @@
       @click="handleClick"
       :class="[
         'flex items-center px-2 py-1 rounded cursor-pointer text-sm',
-        isSelected ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-900 dark:text-indigo-100' : 'hover:bg-gray-100 dark:hover:bg-gray-700',
+        isSelected ? 'bg-action-primary-100 dark:bg-action-primary-900/30 text-action-primary-900 dark:text-action-primary-100' : 'hover:bg-gray-100 dark:hover:bg-gray-700',
         isMatched ? 'bg-status-warning-50 dark:bg-status-warning-900/20' : ''
       ]"
     >

--- a/src/frontend/src/components/process/RoleMatrix.vue
+++ b/src/frontend/src/components/process/RoleMatrix.vue
@@ -15,7 +15,7 @@
           :class="[
             'px-3 py-1.5 text-sm font-medium rounded-lg transition-colors',
             editMode
-              ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400'
+              ? 'bg-action-primary-100 text-action-primary-700 dark:bg-action-primary-900/30 dark:text-action-primary-400'
               : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
           ]"
         >
@@ -26,7 +26,7 @@
           <input
             type="checkbox"
             v-model="showAllAgents"
-            class="rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500"
+            class="rounded border-gray-300 dark:border-gray-600 text-action-primary-600 focus:ring-action-primary-500"
           />
           Show all agents
         </label>
@@ -36,7 +36,7 @@
     <!-- Legend -->
     <div class="flex items-center gap-4 mb-4 text-sm text-gray-600 dark:text-gray-400">
       <div class="flex items-center gap-1.5">
-        <span class="inline-flex items-center justify-center w-6 h-6 rounded bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400 font-semibold text-xs">E</span>
+        <span class="inline-flex items-center justify-center w-6 h-6 rounded bg-action-primary-100 dark:bg-action-primary-900/40 text-action-primary-700 dark:text-action-primary-400 font-semibold text-xs">E</span>
         <span>Executor</span>
       </div>
       <div class="flex items-center gap-1.5">
@@ -80,7 +80,7 @@
             >
               <button
                 @click="showAddAgentModal = true"
-                class="text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 text-xs"
+                class="text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-700 dark:hover:text-action-primary-300 text-xs"
               >
                 + Add Agent
               </button>
@@ -168,7 +168,7 @@
           v-model="newAgentName"
           type="text"
           placeholder="Enter agent name"
-          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-action-primary-500 focus:border-action-primary-500"
           @keyup.enter="addAgent"
         />
         <div class="flex justify-end gap-3 mt-4">
@@ -181,7 +181,7 @@
           <button
             @click="addAgent"
             :disabled="!newAgentName.trim()"
-            class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg"
+            class="px-4 py-2 text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg"
           >
             Add
           </button>
@@ -312,7 +312,7 @@ function getRoleCellClass(stepId, agent) {
   const base = editMode.value ? 'cursor-pointer hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-600' : '';
   switch (role) {
     case 'executor':
-      return `${base} bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400 font-semibold`;
+      return `${base} bg-action-primary-100 dark:bg-action-primary-900/40 text-action-primary-700 dark:text-action-primary-400 font-semibold`;
     case 'monitor':
       return `${base} bg-state-autonomous-100 dark:bg-state-autonomous-900/40 text-state-autonomous-700 dark:text-state-autonomous-400 font-semibold`;
     case 'informed':

--- a/src/frontend/src/components/settings/McpKeysTab.vue
+++ b/src/frontend/src/components/settings/McpKeysTab.vue
@@ -9,7 +9,7 @@
       </div>
       <button
         @click="showCreateModal = true"
-        class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700"
+        class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700"
       >
         <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -49,7 +49,7 @@
     <!-- API Keys List -->
     <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg overflow-hidden">
       <div v-if="loading" class="p-8 text-center">
-        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-action-primary-600 mx-auto"></div>
         <p class="mt-4 text-gray-500 dark:text-gray-400">Loading API keys...</p>
       </div>
 
@@ -144,7 +144,7 @@
                 <input
                   v-model="newKey.name"
                   type="text"
-                  class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                  class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                   placeholder="My Claude Code Key"
                 />
               </div>
@@ -154,7 +154,7 @@
                 <textarea
                   v-model="newKey.description"
                   rows="2"
-                  class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                  class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                   placeholder="Used for..."
                 ></textarea>
               </div>
@@ -165,7 +165,7 @@
             <button
               @click="createKey"
               :disabled="creating || !newKey.name"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-action-primary-600 text-base font-medium text-white hover:bg-action-primary-700 focus:outline-none sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
             >
               {{ creating ? 'Creating...' : 'Create' }}
             </button>
@@ -221,7 +221,7 @@
                     class="inline-flex items-center px-3 py-1 text-xs font-medium rounded-md"
                     :class="copiedConfig
                       ? 'bg-status-success-100 dark:bg-status-success-900/50 text-status-success-700 dark:text-status-success-300'
-                      : 'bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-200 dark:hover:bg-indigo-900'"
+                      : 'bg-action-primary-100 dark:bg-action-primary-900/50 text-action-primary-700 dark:text-action-primary-300 hover:bg-action-primary-200 dark:hover:bg-action-primary-900'"
                   >
                     <svg v-if="!copiedConfig" class="h-3.5 w-3.5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
@@ -277,7 +277,7 @@
           <div class="bg-gray-50 dark:bg-gray-900 px-4 py-3 sm:px-6">
             <button
               @click="closeKeyModal"
-              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none sm:text-sm"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-action-primary-600 text-base font-medium text-white hover:bg-action-primary-700 focus:outline-none sm:text-sm"
             >
               I've copied the configuration
             </button>

--- a/src/frontend/src/stores/operatorQueue.js
+++ b/src/frontend/src/stores/operatorQueue.js
@@ -13,7 +13,7 @@ import { useAuthStore } from './auth'
 // Agent display helpers
 const AGENT_COLORS = [
   'bg-blue-500', 'bg-emerald-500', 'bg-accent-purple-500', 'bg-state-autonomous-500',
-  'bg-state-locked-500', 'bg-cyan-500', 'bg-indigo-500', 'bg-teal-500'
+  'bg-state-locked-500', 'bg-cyan-500', 'bg-action-primary-500', 'bg-teal-500'
 ]
 
 function getAgentProfile(name) {

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -5,7 +5,7 @@
     <main :class="['max-w-[1400px] mx-auto py-2 sm:px-6 lg:px-8', isFullscreenTab ? 'flex-1 flex flex-col overflow-hidden' : 'overflow-visible']">
       <div :class="['px-4 sm:px-0 py-2', isFullscreenTab ? 'flex-1 flex flex-col overflow-hidden' : 'overflow-visible']">
         <div v-if="loading" class="text-center py-8">
-          <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-500 mx-auto"></div>
+          <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-action-primary-500 mx-auto"></div>
         </div>
 
         <!-- Notification Toast -->
@@ -79,7 +79,7 @@
                   :class="[
                     'px-4 py-3 border-b-2 font-medium text-sm transition-colors whitespace-nowrap',
                     activeTab === tab.id
-                      ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+                      ? 'border-action-primary-500 text-action-primary-600 dark:text-action-primary-400'
                       : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600'
                   ]"
                 >

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -86,7 +86,7 @@
             <select
               v-model="selectedVoice"
               :disabled="voice.isActive.value"
-              class="flex-1 text-xs bg-gray-900 border border-gray-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-indigo-500 disabled:opacity-40"
+              class="flex-1 text-xs bg-gray-900 border border-gray-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-action-primary-500 disabled:opacity-40"
             >
               <option v-for="v in VOICES" :key="v.id" :value="v.id">{{ v.label }}</option>
             </select>
@@ -173,8 +173,8 @@
               prose-pre:bg-gray-800 prose-pre:border prose-pre:border-gray-700
               prose-ul:text-gray-300 prose-ol:text-gray-300
               prose-li:marker:text-gray-500
-              prose-blockquote:border-indigo-500 prose-blockquote:text-gray-400
-              prose-a:text-indigo-400 hover:prose-a:text-indigo-300
+              prose-blockquote:border-action-primary-500 prose-blockquote:text-gray-400
+              prose-a:text-action-primary-400 hover:prose-a:text-action-primary-300
               prose-hr:border-gray-700
               prose-table:text-sm
               prose-th:text-gray-200 prose-th:bg-gray-800

--- a/src/frontend/src/views/Agents.vue
+++ b/src/frontend/src/views/Agents.vue
@@ -27,7 +27,7 @@
               v-model="filterName"
               type="text"
               placeholder="Search agents..."
-              class="block w-44 rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2 pl-8 pr-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
+              class="block w-44 rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 text-sm py-2 pl-8 pr-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
             />
           </div>
 
@@ -40,7 +40,7 @@
               :class="[
                 'px-3 py-2 font-medium transition-colors',
                 filterStatus === opt.value
-                  ? 'bg-indigo-600 text-white'
+                  ? 'bg-action-primary-600 text-white'
                   : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'
               ]"
             >
@@ -52,7 +52,7 @@
           <select
             v-if="availableTags.length > 0"
             v-model="selectedFilterTagDropdown"
-            class="block rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2 px-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
+            class="block rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 text-sm py-2 px-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
           >
             <option value="">All Tags</option>
             <option v-for="tagInfo in availableTags" :key="tagInfo.tag" :value="tagInfo.tag">
@@ -64,7 +64,7 @@
           <select
             v-if="availableOwners.length > 1"
             v-model="selectedOwner"
-            class="block rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2 px-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
+            class="block rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 text-sm py-2 px-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
           >
             <option value="">All Owners</option>
             <option v-for="owner in availableOwners" :key="owner.name || '__unassigned__'" :value="owner.name || '__unassigned__'">
@@ -96,7 +96,7 @@
           <div class="flex items-center gap-3 ml-auto">
             <select
               v-model="agentsStore.sortBy"
-              class="block rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2 px-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
+              class="block rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 text-sm py-2 px-3 bg-white dark:bg-gray-700 dark:text-gray-200 border"
             >
               <option value="created_desc">Newest First</option>
               <option value="created_asc">Oldest First</option>
@@ -108,7 +108,7 @@
 
             <button
               @click="showCreateModal = true"
-              class="bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded whitespace-nowrap"
+              class="bg-action-primary-600 hover:bg-action-primary-700 text-white font-bold py-2 px-4 rounded whitespace-nowrap"
             >
               Create Agent
             </button>
@@ -260,7 +260,7 @@
             <!-- Avatar: half out of the box (all breakpoints) -->
             <div class="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10">
               <div class="rounded-full border-2 shadow-md overflow-hidden"
-                   :class="agent.is_system ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-indigo-400 dark:border-indigo-500'">
+                   :class="agent.is_system ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-action-primary-400 dark:border-action-primary-500'">
                 <AgentAvatar :name="agent.name" :avatar-url="agent.avatar_url" size="md" />
               </div>
             </div>
@@ -298,7 +298,7 @@
                 <div class="flex items-center min-w-0 gap-2">
                   <router-link
                     :to="`/agents/${agent.name}`"
-                    class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-indigo-600 dark:hover:text-indigo-400"
+                    class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-action-primary-600 dark:hover:text-action-primary-400"
                     :title="agent.name"
                   >
                     {{ agent.name }}
@@ -410,7 +410,7 @@
                 <!-- Arrow link -->
                 <router-link
                   :to="`/agents/${agent.name}`"
-                  class="text-gray-400 dark:text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+                  class="text-gray-400 dark:text-gray-500 hover:text-action-primary-600 dark:hover:text-action-primary-400 transition-colors"
                 >
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -467,7 +467,7 @@
                 ></div>
                 <router-link
                   :to="`/agents/${agent.name}`"
-                  class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-indigo-600 dark:hover:text-indigo-400"
+                  class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-action-primary-600 dark:hover:text-action-primary-400"
                   :title="agent.name"
                 >
                   {{ agent.name }}
@@ -497,7 +497,7 @@
                   </div>
                   <router-link
                     :to="`/agents/${agent.name}`"
-                    class="text-gray-400 dark:text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+                    class="text-gray-400 dark:text-gray-500 hover:text-action-primary-600 dark:hover:text-action-primary-400 transition-colors"
                   >
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -609,7 +609,7 @@
                 ></div>
                 <router-link
                   :to="`/agents/${agent.name}`"
-                  class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-indigo-600 dark:hover:text-indigo-400 flex-1 min-w-0"
+                  class="text-gray-900 dark:text-white font-semibold text-sm truncate hover:text-action-primary-600 dark:hover:text-action-primary-400 flex-1 min-w-0"
                   :title="agent.name"
                 >
                   {{ agent.name }}
@@ -630,7 +630,7 @@
                   />
                   <router-link
                     :to="`/agents/${agent.name}`"
-                    class="text-gray-400 dark:text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+                    class="text-gray-400 dark:text-gray-500 hover:text-action-primary-600 dark:hover:text-action-primary-400 transition-colors"
                   >
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -683,7 +683,7 @@
             <div class="mt-6">
               <button
                 @click="showCreateModal = true"
-                class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+                class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700"
               >
                 Create Agent
               </button>

--- a/src/frontend/src/views/ExecutionDetail.vue
+++ b/src/frontend/src/views/ExecutionDetail.vue
@@ -30,7 +30,7 @@
               <p class="text-sm text-gray-500 dark:text-gray-400">
                 <router-link
                   :to="{ name: 'AgentDetail', params: { name: agentName } }"
-                  class="hover:text-indigo-600 dark:hover:text-indigo-400"
+                  class="hover:text-action-primary-600 dark:hover:text-action-primary-400"
                 >
                   {{ agentName }}
                 </router-link>
@@ -60,7 +60,7 @@
             <button
               v-if="execution?.claude_session_id && execution?.status !== 'running'"
               @click="continueAsChat"
-              class="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center space-x-1"
+              class="px-3 py-1.5 bg-action-primary-600 hover:bg-action-primary-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center space-x-1"
               title="Continue this execution as an interactive chat"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -84,7 +84,7 @@
 
     <!-- Loading state -->
     <div v-if="loading" class="flex items-center justify-center py-20">
-      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-500"></div>
+      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-action-primary-500"></div>
     </div>
 
     <!-- Error state -->
@@ -187,7 +187,7 @@
             <span class="text-gray-500 dark:text-gray-400">Source Agent:</span>
             <router-link
               :to="{ name: 'AgentDetail', params: { name: execution.source_agent_name } }"
-              class="ml-2 text-indigo-600 dark:text-indigo-400 font-medium hover:underline"
+              class="ml-2 text-action-primary-600 dark:text-action-primary-400 font-medium hover:underline"
             >
               {{ execution.source_agent_name }}
             </router-link>
@@ -293,7 +293,7 @@
             <button
               v-if="isStreaming"
               @click="toggleAutoScroll"
-              :class="autoScroll ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-400 dark:text-gray-500'"
+              :class="autoScroll ? 'text-action-primary-600 dark:text-action-primary-400' : 'text-gray-400 dark:text-gray-500'"
               class="text-xs font-medium hover:underline"
               title="Toggle auto-scroll"
             >
@@ -307,7 +307,7 @@
         <div class="p-4 log-scroll-container" :class="{ 'max-h-[600px] overflow-y-auto': isStreaming }">
           <!-- Streaming - waiting for entries -->
           <div v-if="isStreaming && logEntries.length === 0" class="text-center py-8">
-            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mx-auto mb-4"></div>
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto mb-4"></div>
             <p class="text-gray-500 dark:text-gray-400">Waiting for execution output...</p>
           </div>
 
@@ -338,13 +338,13 @@
 
               <!-- Assistant Message (thinking text) -->
               <div v-else-if="entry.type === 'assistant-text'" class="flex space-x-3">
-                <div class="flex-shrink-0 w-8 h-8 bg-indigo-100 dark:bg-indigo-900/50 rounded-full flex items-center justify-center">
-                  <svg class="w-4 h-4 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="flex-shrink-0 w-8 h-8 bg-action-primary-100 dark:bg-action-primary-900/50 rounded-full flex items-center justify-center">
+                  <svg class="w-4 h-4 text-action-primary-600 dark:text-action-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                   </svg>
                 </div>
-                <div class="flex-1 min-w-0 bg-indigo-50 dark:bg-indigo-900/20 rounded-lg p-3">
-                  <div class="text-xs font-medium text-indigo-700 dark:text-indigo-300 mb-1">Claude</div>
+                <div class="flex-1 min-w-0 bg-action-primary-50 dark:bg-action-primary-900/20 rounded-lg p-3">
+                  <div class="text-xs font-medium text-action-primary-700 dark:text-action-primary-300 mb-1">Claude</div>
                   <div class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">{{ entry.text }}</div>
                 </div>
               </div>
@@ -387,7 +387,7 @@
                   </div>
                   <div class="flex items-center space-x-3 font-mono">
                     <span>{{ entry.duration }}</span>
-                    <span class="text-indigo-600 dark:text-indigo-400">${{ entry.cost }}</span>
+                    <span class="text-action-primary-600 dark:text-action-primary-400">${{ entry.cost }}</span>
                   </div>
                 </div>
               </div>

--- a/src/frontend/src/views/FileManager.vue
+++ b/src/frontend/src/views/FileManager.vue
@@ -24,7 +24,7 @@
           <div class="p-2 border-b border-gray-200 dark:border-gray-700 flex items-center gap-2">
             <select
               v-model="selectedAgentName"
-              class="flex-1 min-w-0 text-sm rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white py-1.5 focus:border-indigo-500 focus:ring-indigo-500"
+              class="flex-1 min-w-0 text-sm rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white py-1.5 focus:border-action-primary-500 focus:ring-action-primary-500"
               @change="onAgentChange"
             >
               <option value="">Select agent...</option>
@@ -51,7 +51,7 @@
                 type="checkbox"
                 v-model="showHidden"
                 @change="loadFiles"
-                class="rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-indigo-600 focus:ring-indigo-500 h-3.5 w-3.5"
+                class="rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-action-primary-600 focus:ring-action-primary-500 h-3.5 w-3.5"
               />
               <span>Hidden</span>
             </label>
@@ -64,7 +64,7 @@
                 v-model="searchQuery"
                 type="text"
                 placeholder="Search files..."
-                class="w-full pl-7 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white focus:ring-indigo-500 focus:border-indigo-500"
+                class="w-full pl-7 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white focus:ring-action-primary-500 focus:border-action-primary-500"
               />
               <svg class="absolute left-2 top-2 h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -85,7 +85,7 @@
               </p>
             </div>
             <div v-else-if="loading" class="flex items-center justify-center h-32">
-              <svg class="animate-spin h-6 w-6 text-indigo-600" fill="none" viewBox="0 0 24 24">
+              <svg class="animate-spin h-6 w-6 text-action-primary-600" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
               </svg>
@@ -160,7 +160,7 @@
                     <button
                       @click="saveFile"
                       :disabled="saving || !hasUnsavedChanges"
-                      class="inline-flex items-center px-3 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                      class="inline-flex items-center px-3 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50"
                     >
                       <svg v-if="saving" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -174,7 +174,7 @@
                     <button
                       @click="cancelEdit"
                       :disabled="saving"
-                      class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                      class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50"
                     >
                       Cancel
                     </button>
@@ -185,7 +185,7 @@
                     <button
                       v-if="isTextFile && !isEditProtected"
                       @click="startEdit"
-                      class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500"
                     >
                       <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -195,7 +195,7 @@
                     <button
                       @click="downloadFile"
                       :disabled="downloading"
-                      class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                      class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50"
                     >
                       <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
@@ -268,7 +268,7 @@
             </button>
             <button
               @click="showDeleteConfirm = false"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:mt-0 sm:w-auto sm:text-sm"
             >
               Cancel
             </button>

--- a/src/frontend/src/views/MobileAdmin.vue
+++ b/src/frontend/src/views/MobileAdmin.vue
@@ -55,7 +55,7 @@
       <main class="tab-content" ref="scrollContainer">
         <!-- Pull to Refresh indicator -->
         <div v-if="pullDistance > 0" class="pull-indicator" :style="{ height: pullDistance + 'px' }">
-          <svg class="w-5 h-5 text-indigo-400" :class="{ 'animate-spin': pullRefreshing }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <svg class="w-5 h-5 text-action-primary-400" :class="{ 'animate-spin': pullRefreshing }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
           </svg>
         </div>
@@ -147,7 +147,7 @@
                 <!-- Logs -->
                 <div class="detail-row">
                   <span class="detail-label">Logs</span>
-                  <button @click="fetchAgentLogs(agent.name)" class="text-xs text-indigo-400 underline">
+                  <button @click="fetchAgentLogs(agent.name)" class="text-xs text-action-primary-400 underline">
                     {{ agentLogs[agent.name] ? 'Refresh' : 'Load' }}
                   </button>
                 </div>

--- a/src/frontend/src/views/PublicChat.vue
+++ b/src/frontend/src/views/PublicChat.vue
@@ -80,7 +80,7 @@
       <!-- Loading state -->
       <div v-if="loading" class="flex-1 flex items-center justify-center">
         <div class="text-center">
-          <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-indigo-500 mx-auto mb-4"></div>
+          <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-action-primary-500 mx-auto mb-4"></div>
           <p class="text-gray-500 dark:text-gray-400">Loading...</p>
         </div>
       </div>
@@ -119,8 +119,8 @@
       <div v-else-if="linkInfo.require_email && !isVerified" class="flex-1 flex items-center justify-center">
         <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8 max-w-md w-full">
           <div class="text-center mb-6">
-            <div class="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg class="w-8 h-8 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="w-16 h-16 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg class="w-8 h-8 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
               </svg>
             </div>
@@ -138,14 +138,14 @@
                 type="email"
                 required
                 placeholder="your@email.com"
-                class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-action-primary-500 focus:border-transparent"
                 :disabled="verifyLoading"
               />
             </div>
             <button
               type="submit"
               :disabled="verifyLoading || !email"
-              class="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-lg transition-colors"
+              class="w-full py-3 px-4 bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 text-white font-medium rounded-lg transition-colors"
             >
               <span v-if="verifyLoading" class="flex items-center justify-center">
                 <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
@@ -167,7 +167,7 @@
                 required
                 maxlength="6"
                 placeholder="123456"
-                class="w-full px-4 py-3 text-center text-2xl tracking-widest border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-indigo-500 focus:border-transparent font-mono"
+                class="w-full px-4 py-3 text-center text-2xl tracking-widest border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-action-primary-500 focus:border-transparent font-mono"
                 :disabled="verifyLoading"
               />
               <p class="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
@@ -177,7 +177,7 @@
             <button
               type="submit"
               :disabled="verifyLoading || code.length !== 6"
-              class="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-lg transition-colors"
+              class="w-full py-3 px-4 bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 text-white font-medium rounded-lg transition-colors"
             >
               <span v-if="verifyLoading" class="flex items-center justify-center">
                 <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
@@ -233,8 +233,8 @@
           <template #empty>
             <!-- Loading intro -->
             <div v-if="introLoading" class="text-center py-12">
-              <div class="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg class="w-8 h-8 text-indigo-500 animate-spin" fill="none" viewBox="0 0 24 24">
+              <div class="w-16 h-16 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg class="w-8 h-8 text-action-primary-500 animate-spin" fill="none" viewBox="0 0 24 24">
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                   <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
@@ -247,8 +247,8 @@
 
             <!-- Fallback welcome message (only if intro failed or not fetched yet) -->
             <div v-else class="text-center py-12">
-              <div class="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg class="w-8 h-8 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div class="w-16 h-16 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg class="w-8 h-8 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
                 </svg>
               </div>

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -22,7 +22,7 @@
               :class="[
                 'whitespace-nowrap py-2 px-1 border-b-2 text-sm font-medium',
                 activeTab === tab.id
-                  ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+                  ? 'border-action-primary-500 text-action-primary-600 dark:text-action-primary-400'
                   : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-200'
               ]"
               type="button"
@@ -33,7 +33,7 @@
 
         <!-- Loading State -->
         <div v-if="loading" class="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-900 p-8 text-center">
-          <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+          <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-action-primary-600 mx-auto"></div>
           <p class="mt-4 text-gray-500 dark:text-gray-400">Loading settings...</p>
         </div>
 
@@ -65,12 +65,12 @@
                       v-model="publicUrl"
                       :placeholder="publicUrlCurrent || 'https://your-domain.com'"
                       :disabled="savingPublicUrl"
-                      class="block flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+                      class="block flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                     />
                     <button
                       @click="savePublicUrl"
                       :disabled="!publicUrl || savingPublicUrl"
-                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <svg v-if="savingPublicUrl" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -137,7 +137,7 @@
                         v-model="anthropicKey"
                         :placeholder="anthropicKeyStatus.configured ? anthropicKeyStatus.masked : 'sk-ant-...'"
                         :disabled="savingApiKey"
-                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                       />
                       <button
                         type="button"
@@ -167,7 +167,7 @@
                     <button
                       @click="saveApiKey"
                       :disabled="!anthropicKey || savingApiKey"
-                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <svg v-if="savingApiKey" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -223,7 +223,7 @@
                   </div>
                   <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
                     Required for agents to use Claude. Get your key at
-                    <a href="https://console.anthropic.com" target="_blank" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                    <a href="https://console.anthropic.com" target="_blank" class="text-action-primary-600 dark:text-action-primary-400 hover:underline">
                       console.anthropic.com
                     </a>
                   </p>
@@ -242,7 +242,7 @@
                         v-model="githubPat"
                         :placeholder="githubPatStatus.configured ? githubPatStatus.masked : 'ghp_... or github_pat_...'"
                         :disabled="savingGithubPat"
-                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                       />
                       <button
                         type="button"
@@ -272,7 +272,7 @@
                     <button
                       @click="saveGithubPat"
                       :disabled="!githubPat || savingGithubPat"
-                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <svg v-if="savingGithubPat" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -352,7 +352,7 @@
                   </div>
                   <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
                     Required for creating and pushing agents to GitHub repositories. Get your token at
-                    <a href="https://github.com/settings/tokens/new" target="_blank" class="text-indigo-600 dark:text-indigo-400 hover:underline">
+                    <a href="https://github.com/settings/tokens/new" target="_blank" class="text-action-primary-600 dark:text-action-primary-400 hover:underline">
                       github.com/settings/tokens
                     </a>
                     with <code class="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs">repo</code> scope.
@@ -401,7 +401,7 @@
                       v-model="slackClientId"
                       :placeholder="slackSettings.client_id?.configured ? slackSettings.client_id.masked : 'Enter Slack Client ID'"
                       :disabled="savingSlackSettings"
-                      class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                      class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                     />
                   </div>
                   <div v-if="slackSettings.client_id?.configured" class="mt-1 text-xs text-status-success-600 dark:text-status-success-400">
@@ -421,7 +421,7 @@
                       v-model="slackClientSecret"
                       :placeholder="slackSettings.client_secret?.configured ? slackSettings.client_secret.masked : 'Enter Slack Client Secret'"
                       :disabled="savingSlackSettings"
-                      class="block w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                      class="block w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                     />
                     <button
                       type="button"
@@ -454,7 +454,7 @@
                       v-model="slackSigningSecret"
                       :placeholder="slackSettings.signing_secret?.configured ? slackSettings.signing_secret.masked : 'Enter Slack Signing Secret'"
                       :disabled="savingSlackSettings"
-                      class="block w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                      class="block w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                     />
                     <button
                       type="button"
@@ -480,7 +480,7 @@
                   <button
                     @click="saveSlackSettings"
                     :disabled="(!slackClientId && !slackClientSecret && !slackSigningSecret) || savingSlackSettings"
-                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <svg v-if="savingSlackSettings" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -528,7 +528,7 @@
                       v-model="slackAppToken"
                       :placeholder="slackTransportStatus.app_token_configured ? slackTransportStatus.app_token_masked : 'xapp-1-...'"
                       :disabled="connectingSlack"
-                      class="block w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                      class="block w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                     />
                     <button
                       type="button"
@@ -605,7 +605,7 @@
                         <span
                           v-for="agent in ws.agents"
                           :key="agent"
-                          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300"
+                          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-action-primary-100 text-action-primary-800 dark:bg-action-primary-900/40 dark:text-action-primary-300"
                         >
                           {{ agent }}
                         </span>
@@ -616,11 +616,11 @@
 
                 <!-- Setup Instructions -->
                 <details class="mt-2">
-                  <summary class="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer hover:text-indigo-600 dark:hover:text-indigo-400">
+                  <summary class="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer hover:text-action-primary-600 dark:hover:text-action-primary-400">
                     Setup Instructions
                   </summary>
                   <div class="mt-3 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg text-sm text-gray-600 dark:text-gray-300 space-y-2">
-                    <p><strong>1.</strong> Create a Slack App at <a href="https://api.slack.com/apps" target="_blank" class="text-indigo-600 dark:text-indigo-400 hover:underline">api.slack.com/apps</a></p>
+                    <p><strong>1.</strong> Create a Slack App at <a href="https://api.slack.com/apps" target="_blank" class="text-action-primary-600 dark:text-action-primary-400 hover:underline">api.slack.com/apps</a></p>
                     <p><strong>2.</strong> Copy <strong>Client ID</strong>, <strong>Client Secret</strong>, and <strong>Signing Secret</strong> from Basic Information and save above</p>
                     <p><strong>3.</strong> Add Bot Token Scopes: <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">im:history</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">im:read</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">im:write</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">chat:write</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">chat:write.customize</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">users:read.email</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">app_mentions:read</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">channels:read</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">channels:manage</code>, <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">reactions:write</code></p>
                     <p><strong>4.</strong> Enable <strong>Socket Mode</strong> and create an App-Level Token with <code class="px-1 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs">connections:write</code> scope. Paste it above as App Token.</p>
@@ -678,7 +678,7 @@
                         id="subscription-name"
                         v-model="newSubscription.name"
                         placeholder="e.g., eugene-max"
-                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                         :disabled="addingSubscription"
                       />
                     </div>
@@ -691,7 +691,7 @@
                       <select
                         id="subscription-type"
                         v-model="newSubscription.type"
-                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+                        class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                         :disabled="addingSubscription"
                       >
                         <option value="max">Claude Max</option>
@@ -711,7 +711,7 @@
                       v-model="newSubscription.token"
                       placeholder="sk-ant-oat01-..."
                       :disabled="addingSubscription"
-                      class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:ring-2 focus:ring-action-primary-500 focus:border-action-primary-500"
                       :class="{ 'border-status-danger-400 dark:border-status-danger-500': newSubscription.token && !newSubscription.token.startsWith('sk-ant-oat01-') }"
                     />
                     <p v-if="newSubscription.token && !newSubscription.token.startsWith('sk-ant-oat01-')" class="mt-1 text-xs text-status-danger-500">
@@ -734,7 +734,7 @@
                     <button
                       @click="addSubscription"
                       :disabled="!newSubscription.name || !newSubscription.token.startsWith('sk-ant-oat01-') || addingSubscription || !encryptionConfigured"
-                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <svg v-if="addingSubscription" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -770,7 +770,7 @@
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                       <tr v-if="loadingSubscriptions">
                         <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
-                          <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-600 mx-auto"></div>
+                          <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-action-primary-600 mx-auto"></div>
                         </td>
                       </tr>
                       <tr v-else-if="subscriptions.length === 0">
@@ -827,7 +827,7 @@
                                 <strong class="text-gray-600 dark:text-gray-400">Assigned Agents:</strong>
                                 <div v-if="sub.agents && sub.agents.length > 0" class="mt-2 flex flex-wrap gap-2">
                                   <span v-for="agent in sub.agents" :key="agent"
-                                        class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200">
+                                        class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-action-primary-100 text-action-primary-800 dark:bg-action-primary-900 dark:text-action-primary-200">
                                     <svg class="mr-1 h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
                                       <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" />
                                       <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd" />
@@ -836,7 +836,7 @@
                                     <button
                                       @click.stop="unassignAgentFromSubscription(agent)"
                                       :disabled="unassigningAgent === agent"
-                                      class="ml-1.5 inline-flex items-center justify-center h-4 w-4 rounded-full hover:bg-indigo-200 dark:hover:bg-indigo-800 text-indigo-600 dark:text-indigo-300 disabled:opacity-50"
+                                      class="ml-1.5 inline-flex items-center justify-center h-4 w-4 rounded-full hover:bg-action-primary-200 dark:hover:bg-action-primary-800 text-action-primary-600 dark:text-action-primary-300 disabled:opacity-50"
                                       title="Remove agent from subscription"
                                     >
                                       <svg v-if="unassigningAgent === agent" class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24">
@@ -857,7 +857,7 @@
                                   <select
                                     v-model="selectedAgentToAssign[sub.id]"
                                     :disabled="assigningAgent || loadingAgents"
-                                    class="flex-1 max-w-xs px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white"
+                                    class="flex-1 max-w-xs px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white"
                                     @click.stop
                                   >
                                     <option value="" disabled selected>{{ loadingAgents ? 'Loading agents...' : 'Select agent...' }}</option>
@@ -872,7 +872,7 @@
                                   <button
                                     @click.stop="assignAgentToSubscription(sub.name, selectedAgentToAssign[sub.id])"
                                     :disabled="!selectedAgentToAssign[sub.id] || assigningAgent"
-                                    class="inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-xs font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                                    class="inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-xs font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                                   >
                                     <svg v-if="assigningAgent" class="animate-spin -ml-0.5 mr-1.5 h-3 w-3" fill="none" viewBox="0 0 24 24">
                                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -909,8 +909,8 @@
                       id="auto-switch-toggle"
                       type="button"
                       :class="[
-                        autoSwitchEnabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600',
-                        'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2'
+                        autoSwitchEnabled ? 'bg-action-primary-600' : 'bg-gray-200 dark:bg-gray-600',
+                        'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2'
                       ]"
                       :disabled="savingAutoSwitch"
                       @click="toggleAutoSwitch"
@@ -949,7 +949,7 @@
                       id="trinity-prompt"
                       v-model="trinityPrompt"
                       rows="15"
-                      class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 dark:border-gray-600 rounded-md font-mono bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                      class="shadow-sm focus:ring-action-primary-500 focus:border-action-primary-500 block w-full sm:text-sm border border-gray-300 dark:border-gray-600 rounded-md font-mono bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                       placeholder="Enter custom instructions for all agents...
 
 Example:
@@ -983,7 +983,7 @@ Example:
                   <button
                     @click="savePrompt"
                     :disabled="saving || !hasChanges"
-                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <svg v-if="saving" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -1014,14 +1014,14 @@ Example:
                     v-model="newEmail"
                     type="email"
                     placeholder="user@example.com"
-                    class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+                    class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                     :disabled="addingEmail"
                     @keyup.enter="addEmailToWhitelist"
                   />
                   <button
                     @click="addEmailToWhitelist"
                     :disabled="!newEmail || addingEmail"
-                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <svg v-if="addingEmail" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -1053,7 +1053,7 @@ Example:
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                       <tr v-if="loadingWhitelist">
                         <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
-                          <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-600 mx-auto"></div>
+                          <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-action-primary-600 mx-auto"></div>
                         </td>
                       </tr>
                       <tr v-else-if="emailWhitelist.length === 0">
@@ -1111,7 +1111,7 @@ Example:
               <div class="flex flex-wrap gap-2 mb-4 text-xs text-gray-500 dark:text-gray-400">
                 <span class="font-medium">Roles:</span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-accent-purple-100 text-accent-purple-800 dark:bg-accent-purple-900 dark:text-accent-purple-200">admin — full control</span>
-                <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200">creator — create &amp; manage agents</span>
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-action-primary-100 text-action-primary-800 dark:bg-action-primary-900 dark:text-action-primary-200">creator — create &amp; manage agents</span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">operator — run existing agents</span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">user — public links only</span>
               </div>
@@ -1130,7 +1130,7 @@ Example:
                   <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                     <tr v-if="loadingUsers">
                       <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
-                        <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-600 mx-auto"></div>
+                        <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-action-primary-600 mx-auto"></div>
                       </td>
                     </tr>
                     <tr v-else-if="usersList.length === 0">
@@ -1148,7 +1148,7 @@ Example:
                           v-if="u.username !== currentUsername"
                           :value="u.role"
                           @change="updateUserRole(u.username, $event.target.value)"
-                          class="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                          class="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500"
                         >
                           <option value="admin">admin</option>
                           <option value="creator">creator</option>
@@ -1202,12 +1202,12 @@ Example:
                   v-model="mcpUrlInput"
                   type="url"
                   :placeholder="mcpUrlConfig.default_url || 'https://your-domain.com/mcp'"
-                  class="flex-1 block rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                  class="flex-1 block rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 sm:text-sm"
                 />
                 <button
                   @click="saveMcpUrl"
                   :disabled="!mcpUrlInput || savingMcpUrl"
-                  class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {{ savingMcpUrl ? 'Saving...' : 'Save' }}
                 </button>
@@ -1239,7 +1239,7 @@ Example:
                 <span v-if="githubTemplatesSource === 'defaults'" class="inline-flex items-center ml-2 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300">
                   Using defaults
                 </span>
-                <span v-else class="inline-flex items-center ml-2 px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300">
+                <span v-else class="inline-flex items-center ml-2 px-2 py-0.5 rounded-full text-xs font-medium bg-action-primary-100 text-action-primary-700 dark:bg-action-primary-900 dark:text-action-primary-300">
                   Custom config
                 </span>
               </p>
@@ -1253,7 +1253,7 @@ Example:
                     v-model="newTemplateRepo"
                     type="text"
                     placeholder="owner/repo"
-                    class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                    class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                     :disabled="savingGithubTemplates"
                     @keyup.enter="addGithubTemplate"
                   />
@@ -1261,14 +1261,14 @@ Example:
                     v-model="newTemplateName"
                     type="text"
                     placeholder="Display name (optional)"
-                    class="w-48 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+                    class="w-48 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                     :disabled="savingGithubTemplates"
                     @keyup.enter="addGithubTemplate"
                   />
                   <button
                     @click="addGithubTemplate"
                     :disabled="!newTemplateRepo || savingGithubTemplates"
-                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Add
                   </button>
@@ -1296,7 +1296,7 @@ Example:
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                       <tr v-if="loadingGithubTemplates">
                         <td colspan="3" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
-                          <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-600 mx-auto"></div>
+                          <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-action-primary-600 mx-auto"></div>
                         </td>
                       </tr>
                       <tr v-else-if="githubTemplates.length === 0">
@@ -1310,7 +1310,7 @@ Example:
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                           {{ tmpl.resolved_name || tmpl.display_name || '-' }}
-                          <span v-if="tmpl.display_name" class="ml-1 text-xs text-indigo-500">(custom)</span>
+                          <span v-if="tmpl.display_name" class="ml-1 text-xs text-action-primary-500">(custom)</span>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                           <button
@@ -1338,7 +1338,7 @@ Example:
                   <button
                     @click="saveGithubTemplates"
                     :disabled="savingGithubTemplates || !githubTemplatesDirty"
-                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <svg v-if="savingGithubTemplates" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -1374,8 +1374,8 @@ Example:
                   id="ssh-access-toggle"
                   type="button"
                   :class="[
-                    sshAccessEnabled ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600',
-                    'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2'
+                    sshAccessEnabled ? 'bg-action-primary-600' : 'bg-gray-200 dark:bg-gray-600',
+                    'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2'
                   ]"
                   :disabled="savingSshAccess"
                   @click="toggleSshAccess"
@@ -1421,7 +1421,7 @@ Example:
                   id="quota-creator"
                   v-model="agentQuotaValues.max_agents_creator"
                   min="0"
-                  class="w-20 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm text-center"
+                  class="w-20 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 sm:text-sm text-center"
                 />
               </div>
 
@@ -1436,7 +1436,7 @@ Example:
                   id="quota-operator"
                   v-model="agentQuotaValues.max_agents_operator"
                   min="0"
-                  class="w-20 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm text-center"
+                  class="w-20 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 sm:text-sm text-center"
                 />
               </div>
 
@@ -1451,7 +1451,7 @@ Example:
                   id="quota-user"
                   v-model="agentQuotaValues.max_agents_user"
                   min="0"
-                  class="w-20 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm text-center"
+                  class="w-20 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-action-primary-500 focus:ring-action-primary-500 sm:text-sm text-center"
                 />
               </div>
 
@@ -1466,7 +1466,7 @@ Example:
               <div class="flex justify-end">
                 <button
                   type="button"
-                  class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                  class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50"
                   :disabled="savingQuotas"
                   @click="saveAgentQuotas"
                 >
@@ -1502,7 +1502,7 @@ Example:
                     id="skills-library-url"
                     v-model="skillsLibraryUrl"
                     placeholder="github.com/owner/skills-library"
-                    class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+                    class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                   />
                 </div>
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
@@ -1521,7 +1521,7 @@ Example:
                     id="skills-library-branch"
                     v-model="skillsLibraryBranch"
                     placeholder="main"
-                    class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
+                    class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                   />
                 </div>
               </div>
@@ -1565,7 +1565,7 @@ Example:
                 <button
                   @click="saveSkillsLibrarySettings"
                   :disabled="savingSkillsLibrary"
-                  class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <svg v-if="savingSkillsLibrary" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -1606,7 +1606,7 @@ Example:
               <button
                 @click="generateDefaultAvatars"
                 :disabled="generatingDefaultAvatars"
-                class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <svg v-if="generatingDefaultAvatars" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/frontend/src/views/SetupPassword.vue
+++ b/src/frontend/src/views/SetupPassword.vue
@@ -3,8 +3,8 @@
     <div class="max-w-md w-full">
       <!-- Logo/Header -->
       <div class="text-center mb-8">
-        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-indigo-100 dark:bg-indigo-900/50 mb-4">
-          <svg class="w-8 h-8 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-action-primary-100 dark:bg-action-primary-900/50 mb-4">
+          <svg class="w-8 h-8 text-action-primary-600 dark:text-action-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
           </svg>
         </div>
@@ -28,7 +28,7 @@
                 id="setupToken"
                 v-model="setupToken"
                 :disabled="loading"
-                class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                 placeholder="Paste token from server logs"
                 required
                 autocomplete="off"
@@ -50,7 +50,7 @@
                 id="password"
                 v-model="password"
                 :disabled="loading"
-                class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white"
+                class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Enter password (12+ characters)"
                 required
                 minlength="12"
@@ -82,7 +82,7 @@
                 id="confirmPassword"
                 v-model="confirmPassword"
                 :disabled="loading"
-                class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white"
+                class="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white"
                 placeholder="Confirm your password"
                 required
                 minlength="12"
@@ -162,7 +162,7 @@
           <button
             type="submit"
             :disabled="!isValid || loading"
-            class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <svg v-if="loading" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/frontend/src/views/Templates.vue
+++ b/src/frontend/src/views/Templates.vue
@@ -43,7 +43,7 @@
             </svg>
           </div>
           <p class="text-gray-600 dark:text-gray-400">{{ error }}</p>
-          <button @click="fetchTemplates" class="mt-4 text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300">
+          <button @click="fetchTemplates" class="mt-4 text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300">
             Try again
           </button>
         </div>
@@ -110,7 +110,7 @@
 
                 <button
                   @click="useTemplate(template)"
-                  class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded transition-colors mt-auto"
+                  class="w-full bg-action-primary-600 hover:bg-action-primary-700 text-white font-bold py-2 px-4 rounded transition-colors mt-auto"
                 >
                   Use Template
                 </button>
@@ -127,7 +127,7 @@
               Custom Agent
             </h2>
             <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg p-6 border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-indigo-300 dark:hover:border-indigo-500 transition-colors">
+              <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg p-6 border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-action-primary-300 dark:hover:border-action-primary-500 transition-colors">
                 <div class="text-center py-4">
                   <div class="mx-auto w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-4">
                     <svg class="w-6 h-6 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/frontend/tailwind.config.js
+++ b/src/frontend/tailwind.config.js
@@ -19,6 +19,8 @@ export default {
       //   accent-*  decorative highlight that isn't status (named after the
       //             literal color so future accents like `accent-green` join
       //             cleanly without renaming).
+      //   action-*  interactive surface that performs a verb (primary buttons,
+      //             links, focus rings).
       colors: {
         'status-success':    colors.green,
         'status-warning':    colors.yellow,
@@ -30,6 +32,7 @@ export default {
         'brand-claude':      colors.orange,
         'brand-gemini':      colors.blue,
         'accent-purple':     colors.purple,
+        'action-primary':    colors.indigo,
       },
     },
   },


### PR DESCRIPTION
## Summary

Final slice of the design-system migration (#554). Introduces the **`action-primary`** token family and sweeps all 376 indigo references across 55 files.

After this lands, the frontend uses tokens for every semantic palette use (status, state, brand, accent, action) — the structural migration is complete.

## Changes

### 1. New token family

`tailwind.config.js`:
```js
'action-primary': colors.indigo,
```

Documented alongside `status/state/brand/accent` — describes "interactive surface that performs a verb (primary buttons, links, focus rings)".

### 2. Validator update

`scripts/check-design-tokens.mjs` — adds `action-primary` to `EXPECTED_ALIASES` and `action: new Set(['primary'])` to `KNOWN_FAMILIES`.

### 3. Bulk sweep

55 files migrated, 376 raw indigo refs → action-primary. Palette-equivalent, zero visual change.

## What's intentionally NOT touched

Blue/sky/teal references survive as raw colors:
- **blue (157 refs)** — heterogeneous: manual-trigger-badge, status-info-ish accents, decorative
- **sky (1 ref)** — chat-trigger-badge in TasksPanel
- **teal (20 refs)** — public-trigger-badge, integration callouts

These are category labels, not semantic selected-state. A `state-selected` token would need per-callsite judgment, not a mechanical sweep. Defer to a future cleanup if/when we have UX direction on what "selected" should look like.

## Lessons from prior slices

Perl prefix list **deliberately excludes `accent`** this time. Slices 8 and 9 had `accent` in the alternation, which caused `accent-purple-X` (already-migrated refs and Tailwind form-control accent uses) to double-substitute to `accent-accent-purple-X`. Verified post-migration: zero `family-family-` patterns anywhere in source.

## Verification

- `grep -rE 'indigo-\d+' src/` → **0**
- `grep -rE '(accent\|action\|state\|status\|brand)-(accent\|action\|state\|status\|brand)-'` → **0**
- `npm run check:tokens` → ✅ 11 tokens equivalent, all references resolve
- `npm run build` → ✅
- e2e smoke: deferred to CI

## Test plan

- [ ] `frontend-build` CI green
- [ ] `frontend-e2e` CI green (label: `ui`)
- [ ] Manual sanity: any view with primary actions (Create Agent button, focus rings, links) renders the same indigo

Closes the migration arc of #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)