### PR TITLE
fix(security): sandbox voice panel HTML in iframe (CRITICAL XSS) (#821)

### DIFF
--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -181,11 +181,16 @@
               prose-td:text-gray-300 prose-td:border-gray-700"
           />
 
-          <!-- HTML content -->
-          <div
+          <!-- HTML content — sandboxed iframe so agent-supplied scripts run in
+               an opaque origin and cannot reach parent localStorage / cookies /
+               JWT. Deliberately omits allow-same-origin / allow-forms /
+               allow-popups / allow-top-navigation / allow-modals. -->
+          <iframe
             v-else-if="panelState.type === 'html'"
             ref="htmlPanelEl"
-            class="text-gray-300 text-sm leading-relaxed"
+            sandbox="allow-scripts"
+            class="w-full h-full bg-transparent border-0 block"
+            title="Agent panel"
           />
         </div>
       </div>
@@ -201,9 +206,13 @@ import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useVoiceSession } from '../composables/useVoiceSession'
 import { renderMarkdown } from '../utils/markdown'
-import DOMPurify from 'dompurify'
 import AgentAvatar from '../components/AgentAvatar.vue'
-import Chart from 'chart.js/auto'
+// Chart.js is loaded inside the sandboxed iframe (see renderHtmlPanel). The
+// relative path is intentional: chart.js 4 doesn't expose the UMD bundle via
+// its package `exports` field, so a bare specifier like `chart.js/dist/...`
+// fails to resolve. The relative path bypasses module resolution and Vite's
+// `?url` import emits the file as a hashed same-origin asset.
+import chartJsUrl from '../../node_modules/chart.js/dist/chart.umd.js?url'
 
 const route = useRoute()
 const authStore = useAuthStore()
@@ -243,25 +252,33 @@ const panelUpdatedAgo = computed(() => {
 
 // ── HTML panel rendering ─────────────────────────────────────────────────────
 
-// Re-execute <script> tags after innerHTML assignment — v-html and innerHTML
-// both skip script execution. We clone each script node as a live element so
-// Chart.js initialisation code in update_panel HTML runs correctly.
-// Chart.js 4 is pre-loaded globally (see injectChartJs), so agents must NOT
-// add their own CDN <script src> tags.
-function _execScripts(container) {
-  Array.from(container.querySelectorAll('script')).forEach(old => {
-    const s = document.createElement('script')
-    Array.from(old.attributes).forEach(a => s.setAttribute(a.name, a.value))
-    s.textContent = old.textContent
-    old.replaceWith(s)
-  })
-}
-
+// Render the agent's HTML inside a sandboxed iframe. The iframe gets an opaque
+// origin (sandbox="allow-scripts" without allow-same-origin), so agent-supplied
+// JS cannot read parent localStorage / cookies / JWT, submit forms, navigate
+// the parent, or open popups. Chart.js is loaded inside the iframe via a
+// same-origin asset URL so new Chart(...) calls in agent HTML still work.
+//
+// Tag delimiters are built via string concat (s_open / s_close) so the SFC
+// parser doesn't see them as nested block tags.
+const s_open = '<' + 's' + 'cript'
+const s_close = '<' + '/' + 's' + 'cript' + '>'
 function renderHtmlPanel(html) {
   const el = htmlPanelEl.value
   if (!el) return
-  el.innerHTML = DOMPurify.sanitize(html, { ADD_TAGS: ['script'], ADD_ATTR: ['type'] })
-  _execScripts(el)
+  const chartUrl = new URL(chartJsUrl, window.location.origin).href
+  el.srcdoc = [
+    '<!DOCTYPE html><html><head><meta charset="utf-8"><style>',
+    'body{margin:0;padding:8px;color:#d1d5db;background:transparent;',
+    'font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}',
+    'canvas{max-width:100%}',
+    'table{border-collapse:collapse}th,td{padding:4px 8px}',
+    'a{color:#818cf8}',
+    '</style>',
+    s_open, ' src="', chartUrl, '">', s_close,
+    '</head><body>',
+    html ?? '',
+    '</body></html>',
+  ].join('')
 }
 
 // Re-render HTML panel when panelState content changes
@@ -558,8 +575,6 @@ function resizeCanvas() {
 watch(() => voice.status.value, (s) => { targetHueShift = STATE_HUE[s] ?? 0 })
 
 onMounted(async () => {
-  // Expose Chart globally so agent update_panel HTML snippets can call new Chart(...)
-  if (!window.Chart) window.Chart = Chart
   await fetchAgent()
   currentSprites = buildSprites(0)
   initParticles()


### PR DESCRIPTION
Fixes #821

## Summary

Agent-controlled HTML from `update_panel` was DOMPurify-sanitized with `ADD_TAGS:['script']`, then `_execScripts()` cloned surviving `<script>` tags into live DOM nodes that executed in the parent origin. Since the agent's `html` argument is influenceable by any external input (chat, files, MCP tool results, webhooks, channel messages, agent-website visitors), this was a generic indirect-prompt-injection XSS sink in the admin UI with **JWT-theft / cross-agent-pivot blast radius**.

## What changed

Render the panel inside an `<iframe sandbox="allow-scripts">` instead. Without `allow-same-origin` / `allow-forms` / `allow-popups` / `allow-top-navigation` / `allow-modals`, the iframe has an opaque origin: scripts run (Chart.js still works) but cannot read parent `localStorage` / cookies / JWT, submit forms, navigate the parent, or open popups.

- Drop DOMPurify `ADD_TAGS:['script']` and the `_execScripts()` shim
- Drop the parent-side `window.Chart` global injection
- Load Chart.js inside the iframe via Vite `?url` asset import (relative path; chart.js 4 doesn't expose the UMD bundle via package exports)
- `s_open` / `s_close` concat avoids the Vue SFC parser tripping on the inner `<script>` tag inside the srcdoc template

## Why this shape

The previous DOMPurify-then-execScripts pattern conflates content sanitization with code execution: any element that survives sanitization gets cloned into a live script tag. Even tightening the DOMPurify rules wouldn't eliminate the sink — the agent-controlled `html` is the input boundary, and the parent origin is the wrong place for it to evaluate.

The sandbox iframe inverts this: the agent's script runs (preserving the panel's intended Chart.js functionality) but in an origin that has no access to anything that matters. The fix is structural, not a filter tweak.

## Test plan

- [x] Voice panel still renders Chart.js panels correctly
- [x] Voice panel scripts cannot read `parent.localStorage` (verified via test panel attempting to access)
- [x] Voice panel scripts cannot post to backend endpoints with parent's JWT
- [x] Vue SFC parser doesn't trip on the srcdoc template

## Out of scope

This PR was previously bundled into #798 (circuit-breaker fix) — split out for isolated security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
