### PR TITLE
fix: env-tag sweep catches setsid'd, FD-detached subprocess orphans (#817)

### DIFF
--- a/config/agent-templates/test-leak-hook/.claude/settings.local.json
+++ b/config/agent-templates/test-leak-hook/.claude/settings.local.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "_comment": "Issue #817 repro hook. UserPromptSubmit fires before Claude sees the prompt. The hook spawns 8 parallel CPU-burners via setsid (escaping Claude's pgid + detaching FDs so neither terminate_process_group nor _kill_orphan_pipe_writers can reach them). 8 saturates a typical dev host (4-8 cores) hard enough that uvicorn's event-loop slice shrinks below the health-probe timeout — matching the production observation of 133-156% CPU. The hook then sleeps 120s in the foreground so the schedule's timeout_seconds=30 fires and the execution lands in pending_retry.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/sh -c 'for i in 1 2 3 4 5 6 7 8; do setsid /bin/sh -c \"exec </dev/null >/dev/null 2>&1; while :; do :; done\" </dev/null >/dev/null 2>&1 & done; sleep 120'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/config/agent-templates/test-leak-hook/CLAUDE.md
+++ b/config/agent-templates/test-leak-hook/CLAUDE.md
@@ -1,0 +1,13 @@
+# Test Leak-Hook Agent (Issue #817 regression repro)
+
+You exist only to drive the Issue #817 subprocess-leak regression test.
+
+A `UserPromptSubmit` hook in `.claude/settings.local.json` spawns a detached
+CPU-burner via `setsid` *before* you ever see the prompt. By the time you
+respond, the burner is already in its own process group and outside your
+reach. The hook then sleeps in the foreground so the scheduled task hits
+its `timeout_seconds` and fails as `pending_retry` — the exact production
+failure shape from #817.
+
+Do NOT use any tools. Do NOT reason about the hook. If you ever see this
+prompt, respond with exactly `ok` and nothing else.

--- a/config/agent-templates/test-leak-hook/template.yaml
+++ b/config/agent-templates/test-leak-hook/template.yaml
@@ -1,0 +1,13 @@
+name: Test Subprocess-Leak Hook
+display_name: Test Leak Hook
+description: Engineered subprocess-leak harness for Issue #817 regression repro. Spawns a setsid CPU burner from a UserPromptSubmit hook so the burner escapes Claude's pgid and survives terminate_process_group. Intended ONLY for local automated tests — do NOT deploy in production.
+version: "1.0.0"
+author: Trinity Platform
+
+resources:
+  cpu: "1"
+  memory: "2g"
+
+mcp_servers: []
+
+credentials: {}

--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -13,6 +13,7 @@ Refactored per #122 (split of the original 2137-LOC monolith).
 import asyncio
 import json
 import logging
+import os
 import subprocess
 import threading
 import uuid
@@ -46,6 +47,7 @@ from .subprocess_lifecycle import (
     _safe_close_pipes,
     _terminate_process_group,
 )
+from ..utils.subprocess_pgroup import EXECUTION_TAG_NAME
 
 __all__ = [
     "ClaudeCodeRuntime",
@@ -269,6 +271,10 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
         # it spawns) into their own process group so we can reap the whole
         # tree on exit — hook grandchildren can otherwise outlive claude
         # and wedge readline() forever via inherited pipe FDs.
+        # Issue #817: TRINITY_EXECUTION_ID env var is inherited by every
+        # descendant across fork/exec/setsid/double-fork. Cleanup uses it
+        # to identify and kill orphans that escape both the pgid sweep
+        # and the FD-based pipe-writer sweep.
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -277,6 +283,7 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
             text=True,
             bufsize=1,  # Line buffered
             start_new_session=True,
+            env={**os.environ, EXECUTION_TAG_NAME: execution_id},
         )
         # Issue #407: capture pgid now — after wait() reaps the parent,
         # the pid is gone and we lose the ability to signal the group.
@@ -368,13 +375,15 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
                     f"[Chat] Session {execution_id} timed out after {timeout_seconds}s "
                     f"— killing process group"
                 )
-                _terminate_process_group(process, graceful_timeout=5, pgid=process_pgid)
+                _terminate_process_group(process, graceful_timeout=5, pgid=process_pgid, execution_tag=execution_id)
                 _drain_bounded(process, stdout_thread, stderr_thread,
-                               grace=3, pgid=process_pgid)
+                               grace=3, pgid=process_pgid,
+                               execution_tag=execution_id)
                 raise
 
             _drain_bounded(process, stdout_thread, stderr_thread,
-                           grace=5, pgid=process_pgid)
+                           grace=5, pgid=process_pgid,
+                           execution_tag=execution_id)
 
             stderr = ''.join(stderr_lines)
             stderr = sanitize_text(stderr) if stderr else stderr
@@ -400,7 +409,7 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
                 # off-load to the executor so the event loop stays responsive while we tear down.
                 await loop.run_in_executor(
                     None,
-                    lambda: _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid),
+                    lambda: _terminate_process_group(process, graceful_timeout=2, pgid=process_pgid, execution_tag=execution_id),
                 )
                 await loop.run_in_executor(None, _safe_close_pipes, process)
                 raise HTTPException(

--- a/docker/base-image/agent_server/services/gemini_runtime.py
+++ b/docker/base-image/agent_server/services/gemini_runtime.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException
 
 from ..models import ExecutionLogEntry, ExecutionMetadata
 from ..state import agent_state
+from ..utils.subprocess_pgroup import EXECUTION_TAG_NAME, kill_processes_by_env_tag
 from .activity_tracking import start_tool_execution, complete_tool_execution
 from .runtime_adapter import AgentRuntime
 
@@ -180,6 +181,12 @@ class GeminiRuntime(AgentRuntime):
 
             logger.info(f"Starting Gemini CLI: {' '.join(cmd[:5])}...")
 
+            # Issue #817: ensure execution_id is set so we can tag the
+            # Gemini subprocess and any descendants. Tag is inherited at
+            # every fork/exec/setsid, lets the post-wait sweep identify
+            # and kill orphans the same way the Claude path does.
+            execution_id = execution_id or str(uuid.uuid4())
+
             # Use Popen for real-time streaming
             process = subprocess.Popen(
                 cmd,
@@ -187,7 +194,8 @@ class GeminiRuntime(AgentRuntime):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                bufsize=1  # Line buffered
+                bufsize=1,  # Line buffered
+                env={**os.environ, EXECUTION_TAG_NAME: execution_id},
             )
 
             # Write prompt to stdin and close it
@@ -216,6 +224,23 @@ class GeminiRuntime(AgentRuntime):
                 # Wait for process to complete and get stderr
                 stderr = process.stderr.read()
                 return_code = process.wait()
+
+                # Issue #817: env-tag sweep for Gemini-spawned descendants
+                # that may have escaped via setsid + FD detachment. Best-
+                # effort — never fail the response on this path.
+                try:
+                    killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, execution_id)
+                    if killed:
+                        logger.info(
+                            f"[Gemini] Killed {killed} env-tagged orphan(s) "
+                            f"for execution {execution_id} after Gemini exit"
+                        )
+                except Exception:
+                    logger.exception(
+                        f"[Gemini] kill_processes_by_env_tag({execution_id}) "
+                        "raised — continuing"
+                    )
+
                 return stderr, return_code
 
             # Run the blocking subprocess reading in a thread pool
@@ -578,14 +603,19 @@ class GeminiRuntime(AgentRuntime):
 
             logger.info(f"[Headless Task {session_id}] Starting Gemini CLI...")
 
-            # Use Popen for real-time streaming with timeout
+            # Use Popen for real-time streaming with timeout.
+            # Issue #817: TRINITY_EXECUTION_ID env var is inherited by every
+            # descendant across fork/exec/setsid/double-fork. The post-wait
+            # sweep below uses it to identify orphans the same way the Claude
+            # path does.
             process = subprocess.Popen(
                 cmd,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                bufsize=1
+                bufsize=1,
+                env={**os.environ, EXECUTION_TAG_NAME: session_id},
             )
 
             # Write prompt to stdin and close it
@@ -607,10 +637,35 @@ class GeminiRuntime(AgentRuntime):
                         self._process_stream_line(line, execution_log, metadata, tool_start_times, tool_names, response_parts, model)
                 except Exception as e:
                     logger.error(f"[Headless Task {session_id}] Error: {e}")
+                    # Issue #817: even on error, run the env-tag sweep so
+                    # leaked descendants don't survive the failed task.
+                    try:
+                        kill_processes_by_env_tag(EXECUTION_TAG_NAME, session_id)
+                    except Exception:
+                        logger.exception(
+                            f"[Headless Task {session_id}] env-tag sweep "
+                            "raised on error path — continuing"
+                        )
                     raise
 
                 stderr = process.stderr.read()
                 return_code = process.wait()
+
+                # Issue #817: env-tag sweep for descendants that may have
+                # escaped via setsid + FD detachment. Best-effort.
+                try:
+                    killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, session_id)
+                    if killed:
+                        logger.info(
+                            f"[Headless Task {session_id}] Killed {killed} "
+                            f"env-tagged orphan(s) after Gemini exit"
+                        )
+                except Exception:
+                    logger.exception(
+                        f"[Headless Task {session_id}] env-tag sweep raised "
+                        "— continuing"
+                    )
+
                 return stderr, return_code
 
             # Run the blocking subprocess reading in a thread pool

--- a/docker/base-image/agent_server/services/headless_executor.py
+++ b/docker/base-image/agent_server/services/headless_executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import subprocess
 import threading
 import uuid
@@ -48,6 +49,7 @@ from .subprocess_lifecycle import (
     _safe_close_pipes,
     _terminate_process_group,
 )
+from ..utils.subprocess_pgroup import EXECUTION_TAG_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +117,10 @@ class HeadlessRunContext:
         improvement over the original closure-captured ``process`` variable.
         """
         if self.process is not None:
-            _terminate_process_group(self.process, graceful_timeout=2, pgid=self.process_pgid)
+            _terminate_process_group(
+                self.process, graceful_timeout=2,
+                pgid=self.process_pgid, execution_tag=self.task_session_id,
+            )
             _safe_close_pipes(self.process)
 
 
@@ -251,6 +256,10 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
     # spawns) into their own process group so we can reap the whole tree
     # on exit/timeout. Without this, hook grandchildren can outlive
     # claude, keep pipe FDs open, and wedge readline() forever.
+    # Issue #817: TRINITY_EXECUTION_ID env var is inherited by every
+    # descendant across fork/exec/setsid/double-fork. Cleanup uses it
+    # to identify and kill orphans that escape both the pgid sweep
+    # and the FD-based pipe-writer sweep.
     process = subprocess.Popen(
         ctx.cmd,
         stdin=subprocess.PIPE,
@@ -259,6 +268,7 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
         text=True,
         bufsize=1,  # Line buffered
         start_new_session=True,
+        env={**os.environ, EXECUTION_TAG_NAME: ctx.task_session_id},
     )
     ctx.process = process
     # Issue #407: capture pgid now — after wait() reaps the parent,
@@ -292,7 +302,7 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
                     # Kill the whole process group so stdout's readline()
                     # gets EOF and we unwind cleanly (Issue #407).
                     try:
-                        _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid)
+                        _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid, execution_tag=ctx.task_session_id)
                     except Exception as kill_err:
                         logger.error(
                             f"[Headless Task] Failed to kill process on auth abort: {kill_err}"
@@ -369,7 +379,7 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
                                     f"Killing process tree to prevent silent timeout. "
                                     f"Task: {ctx.task_session_id}"
                                 )
-                                _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid)
+                                _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid, execution_tag=ctx.task_session_id)
                                 raise RuntimeError(
                                     f"Permission bypass failed: permissionMode={perm_mode}. "
                                     f"This may be caused by a stale Claude Code session process "
@@ -405,7 +415,7 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
             ctx.stdout_exc.append(e)
             # Wake the main thread's process.wait() by killing the group
             try:
-                _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid)
+                _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid, execution_tag=ctx.task_session_id)
             except Exception:
                 pass
 
@@ -448,16 +458,18 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
             f"[Headless Task] Task {ctx.task_session_id} timed out after {ctx.effective_timeout}s "
             f"— killing process group"
         )
-        _terminate_process_group(process, graceful_timeout=5, pgid=ctx.process_pgid)
+        _terminate_process_group(process, graceful_timeout=5, pgid=ctx.process_pgid, execution_tag=ctx.task_session_id)
         _drain_bounded(process, stdout_thread, stderr_thread,
-                       grace=3, pgid=ctx.process_pgid)
+                       grace=3, pgid=ctx.process_pgid,
+                       execution_tag=ctx.task_session_id)
         raise
 
     # Subprocess exited. Drain readers — if a hook grandchild still
     # holds a pipe, the helper will close the pipe FDs so the
     # reader threads can exit.
     _drain_bounded(process, stdout_thread, stderr_thread,
-                   grace=5, pgid=ctx.process_pgid)
+                   grace=5, pgid=ctx.process_pgid,
+                   execution_tag=ctx.task_session_id)
 
     # Re-raise permission-mode failure captured by stdout thread
     if ctx.stdout_exc:

--- a/docker/base-image/agent_server/services/process_registry.py
+++ b/docker/base-image/agent_server/services/process_registry.py
@@ -15,7 +15,11 @@ from datetime import datetime
 from typing import Dict, Optional, List, AsyncIterator
 from threading import Lock
 
-from ..utils.subprocess_pgroup import signal_process_tree as _signal_process_tree
+from ..utils.subprocess_pgroup import (
+    EXECUTION_TAG_NAME,
+    kill_processes_by_env_tag,
+    signal_process_tree as _signal_process_tree,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +146,25 @@ class ProcessRegistry:
                     )
 
             returncode = process.returncode
+
+            # Issue #817: env-tag sweep for descendants that escaped the
+            # pgid kill via setsid + FD detachment. Best-effort — never
+            # fail termination on this. Mirrors the post-kill pass added
+            # to terminate_process_group; ProcessRegistry.terminate uses
+            # _signal_process_tree directly (different kill primitive)
+            # so we run the env-tag pass here too.
+            try:
+                killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, execution_id)
+                if killed:
+                    logger.info(
+                        f"[ProcessRegistry] Killed {killed} env-tagged "
+                        f"orphan(s) for execution {execution_id} after pgid sweep"
+                    )
+            except Exception:
+                logger.exception(
+                    f"[ProcessRegistry] kill_processes_by_env_tag({execution_id}) "
+                    "raised — continuing termination"
+                )
 
             with self._lock:
                 if execution_id in self._processes:

--- a/docker/base-image/agent_server/services/subprocess_lifecycle.py
+++ b/docker/base-image/agent_server/services/subprocess_lifecycle.py
@@ -50,6 +50,7 @@ def _drain_bounded(
     *threads: Optional[threading.Thread],
     grace: int = 5,
     pgid: Optional[int] = None,
+    execution_tag: Optional[str] = None,
 ) -> None:
     """Run drain_reader_threads with a hard _DRAIN_BUDGET_SECONDS time cap.
 
@@ -58,12 +59,18 @@ def _drain_bounded(
     Uses the same asyncio.run() pattern required by drain_reader_threads'
     async-to-sync callers (established in #657); adds a daemon-thread wrapper
     so the budget is enforced at the threading level, not the asyncio level.
+
+    Issue #817: ``execution_tag`` is threaded through to the underlying
+    ``drain_reader_threads`` so the env-tag sweep runs after every drain.
     """
     done = threading.Event()
 
     def _target() -> None:
         try:
-            asyncio.run(_drain_reader_threads(process, *threads, grace=grace, pgid=pgid))
+            asyncio.run(_drain_reader_threads(
+                process, *threads, grace=grace, pgid=pgid,
+                execution_tag=execution_tag,
+            ))
         except Exception:
             pass
         finally:

--- a/docker/base-image/agent_server/utils/subprocess_pgroup.py
+++ b/docker/base-image/agent_server/utils/subprocess_pgroup.py
@@ -32,9 +32,25 @@ import stat as _stat
 import subprocess
 import threading
 import time
-from typing import Optional
+from typing import Iterable, Optional
 
 logger = logging.getLogger(__name__)
+
+
+# Issue #817: env tag we inject into every Claude Popen so the cleanup path
+# can identify subprocess descendants that escape both terminate_process_group
+# (different pgid via setsid) AND _kill_orphan_pipe_writers (no shared pipe
+# FDs). Env vars are inherited at every fork/exec/setsid and survive
+# double-fork daemonization, so the tag is the most reliable "we own this"
+# signal we can plant without privileged operations.
+EXECUTION_TAG_NAME = "TRINITY_EXECUTION_ID"
+
+
+# Cap log lines from the env-tag killer for the same reason
+# _ORPHAN_LOG_DETAIL_CAP exists: a runaway MCP fan-out can leave dozens of
+# orphans and we don't want one cleanup to flood the logs. Beyond this many
+# distinct PIDs killed in a single call, we emit one count-only summary line.
+_ENV_TAG_LOG_DETAIL_CAP = 10
 
 
 def capture_pgid(process: subprocess.Popen) -> Optional[int]:
@@ -72,11 +88,99 @@ def _signal_group_or_process(
         pass
 
 
+def kill_processes_by_env_tag(
+    tag_name: str,
+    tag_value: str,
+    *,
+    exclude_pids: Optional[Iterable[int]] = None,
+    sig: int = signal.SIGKILL,
+) -> int:
+    """SIGKILL every process whose ``/proc/<pid>/environ`` contains
+    ``tag_name=tag_value``.
+
+    Issue #817: catches subprocess descendants that escape both existing
+    cleanup passes:
+      - ``terminate_process_group`` (caught by killpg) — escaped by setsid
+      - ``_kill_orphan_pipe_writers`` (caught by FD identity) — escaped by
+        redirecting stdin/stdout/stderr to /dev/null
+
+    Env tags are inherited at every fork/exec/setsid AND survive double-fork
+    daemonization (parent dies, child reparented to PID 1, env intact), so
+    a process that drops the tag has either explicitly ``unsetenv()``'d it
+    or been exec'd through an env-scrubbing wrapper (sudo, ssh, env -i).
+    None of those sit in Claude Code's typical descendant set.
+
+    Permissions: ``/proc/<pid>/environ`` is readable only when the calling
+    UID matches the target's UID. Inside an agent container all processes
+    run as developer:1000, so we can read every other process's environ.
+
+    Always excludes the calling PID. Caller can pass additional PIDs to
+    skip via ``exclude_pids``.
+
+    Returns the number of processes signaled (whether or not they actually
+    died — the kernel will reap them asynchronously).
+    """
+    needle = f"{tag_name}={tag_value}".encode()
+    excluded = set(exclude_pids or ())
+    excluded.add(os.getpid())
+
+    try:
+        proc_entries = os.listdir("/proc")
+    except OSError:
+        return 0
+
+    killed = 0
+    for pid_str in proc_entries:
+        if not pid_str.isdigit():
+            continue
+        pid = int(pid_str)
+        if pid in excluded:
+            continue
+        try:
+            with open(f"/proc/{pid}/environ", "rb") as f:
+                env_blob = f.read()
+        except OSError:
+            # ESRCH (process gone), EACCES (different uid), ENOENT (race)
+            continue
+        # /proc/<pid>/environ is NUL-separated; split for exact-match so
+        # a tag value of "abc" doesn't false-positive on
+        # "TRINITY_EXECUTION_ID_OTHER=abc".
+        if needle not in env_blob.split(b"\x00"):
+            continue
+        if killed < _ENV_TAG_LOG_DETAIL_CAP:
+            cmdline = _read_proc_cmdline(pid)
+            ppid = _read_proc_field(pid, "PPid") or "?"
+            try:
+                pgid_str = str(os.getpgid(pid))
+            except OSError:
+                pgid_str = "?"
+            logger.info(
+                "[Subprocess] Env-tagged orphan SIGKILL: "
+                "pid=%s ppid=%s pgid=%s tag=%s=%s cmd=%s",
+                pid, ppid, pgid_str, tag_name, tag_value, cmdline,
+            )
+        try:
+            os.kill(pid, sig)
+            killed += 1
+        except OSError:
+            pass
+
+    if killed > _ENV_TAG_LOG_DETAIL_CAP:
+        logger.info(
+            "[Subprocess] Env-tagged orphan SIGKILL: %s additional pid(s) "
+            "killed (detail logging capped at %s)",
+            killed - _ENV_TAG_LOG_DETAIL_CAP, _ENV_TAG_LOG_DETAIL_CAP,
+        )
+
+    return killed
+
+
 def terminate_process_group(
     process: subprocess.Popen,
     graceful_timeout: int = 5,
     *,
     pgid: Optional[int] = None,
+    execution_tag: Optional[str] = None,
 ) -> None:
     """Terminate the subprocess AND its entire process group.
 
@@ -89,6 +193,15 @@ def terminate_process_group(
     they captured at spawn time, otherwise the helper falls back to
     signaling the single (already-reaped) pid and grandchildren are
     left running.
+
+    Issue #817: when ``execution_tag`` is provided, runs a final cleanup
+    pass via ``kill_processes_by_env_tag(EXECUTION_TAG_NAME, execution_tag)``
+    after the killpg sequence. This catches descendants that escaped the
+    pgid-based kill via ``setsid()`` AND escaped the FD-based orphan-pipe
+    sweep via FD redirection — the gap that produces the runaway-CPU
+    scenario in the ticket. Callers that spawn Claude with the matching
+    env var (``TRINITY_EXECUTION_ID=<execution_tag>``) should pass it
+    here; callers that don't can omit and get the legacy behavior.
 
     Safe to call on already-exited processes and safe to call multiple
     times.
@@ -116,6 +229,25 @@ def terminate_process_group(
         except subprocess.TimeoutExpired:
             logger.error(
                 "[Subprocess] pid=%s did not exit after SIGKILL", process.pid
+            )
+
+    # Issue #817: env-tag sweep for setsid'd, FD-detached orphans that
+    # escaped both prior passes. Best-effort — never fail termination on
+    # this path's exceptions.
+    if execution_tag:
+        try:
+            killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, execution_tag)
+            if killed:
+                logger.info(
+                    "[Subprocess] Killed %s env-tagged orphan(s) for "
+                    "execution=%s after pgid sweep",
+                    killed, execution_tag,
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "[Subprocess] kill_processes_by_env_tag(%s) raised — "
+                "continuing termination",
+                execution_tag,
             )
 
 
@@ -347,6 +479,7 @@ async def drain_reader_threads(
     grace: int = 5,
     post_kill_grace: int = 30,
     pgid: Optional[int] = None,
+    execution_tag: Optional[str] = None,
 ) -> None:
     """Join subprocess reader threads with a bounded timeout.
 
@@ -367,6 +500,13 @@ async def drain_reader_threads(
     must pass ``pgid`` — after reaping, the pid is gone and we'd
     otherwise lose the ability to signal grandchildren.
 
+    Issue #817: when ``execution_tag`` is provided, runs a final env-tag
+    sweep regardless of whether reader threads were stuck. This catches
+    setsid'd, FD-detached descendants on the *successful*-completion path
+    too — claude can spawn a leaking grandchild and then exit cleanly,
+    leaving the reader threads to EOF naturally; without this pass the
+    orphan would survive until the next task.
+
     This function is ``async`` so every ``t.join()`` runs off the event-loop
     thread via ``asyncio.to_thread``.  ``asyncio.wait_for`` enforces the
     deadline at the event-loop level, preventing the asyncio event loop from
@@ -375,6 +515,43 @@ async def drain_reader_threads(
     thread functions) must wrap this with ``asyncio.run(drain_reader_threads(…))``.
     Issue #657.
     """
+    try:
+        await _drain_reader_threads_inner(
+            process, *threads,
+            grace=grace, post_kill_grace=post_kill_grace, pgid=pgid,
+        )
+    finally:
+        # Issue #817: env-tag sweep ALWAYS runs at end of drain regardless
+        # of which exit path we took (no-stuck, drained-naturally, or
+        # force-closed). Catches descendants spawned via setsid + FD
+        # detachment, on both timeout AND successful-completion paths.
+        if execution_tag:
+            try:
+                killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, execution_tag)
+                if killed:
+                    logger.info(
+                        "[Subprocess] Killed %s env-tagged orphan(s) for "
+                        "execution=%s after drain",
+                        killed, execution_tag,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "[Subprocess] kill_processes_by_env_tag(%s) raised in "
+                    "drain_reader_threads — continuing",
+                    execution_tag,
+                )
+
+
+async def _drain_reader_threads_inner(
+    process: subprocess.Popen,
+    *threads: Optional[threading.Thread],
+    grace: int = 5,
+    post_kill_grace: int = 30,
+    pgid: Optional[int] = None,
+) -> None:
+    """Pre-#817 body of drain_reader_threads. Extracted so the env-tag
+    sweep can wrap it via try/finally without touching every existing
+    early-return path."""
     alive_threads = [t for t in threads if t is not None]
 
     # Initial grace-period joins — each runs in a worker thread so the event

--- a/tests/test_817_subprocess_leak.py
+++ b/tests/test_817_subprocess_leak.py
@@ -1,0 +1,377 @@
+"""
+Issue #817 — Runaway subprocess after task failure regression repro.
+
+Deterministically reproduces the symptom chain reported in the ticket:
+    schedule timeout-kill -> pending_retry -> orphaned CPU-burner -> agent
+    /health unresponsive.
+
+The engineered leak lives in config/agent-templates/test-leak-hook/: a
+UserPromptSubmit hook spawns a `setsid` CPU-burner with stdin/stdout/stderr
+detached to /dev/null. That satisfies all three conditions that let an
+orphan slip past the existing cleanup (#618 / #728 / #808):
+
+    1. Outside Claude's pgid (setsid)               -> escapes terminate_process_group
+    2. Holds no stdout pipe write end (FDs detached) -> escapes _kill_orphan_pipe_writers
+    3. Spins on CPU                                  -> starves agent-server event loop
+
+The schedule's timeout_seconds=30 + max_retries=1 forces the execution to
+fail and the scheduler to mark it pending_retry — matching the production
+shape from #817.
+
+This test does NOT assert the downstream circuit-breaker cascade. That is
+governed by `services/agent_client.py` tunables that need ~32 min of probe
+backoff to reach `dormant` at production constants; the CB module has its
+own unit tests. CPU pin + /health timeout is sufficient evidence of the
+root cause.
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+import uuid
+
+import pytest
+
+from utils.api_client import TrinityApiClient
+from utils.assertions import assert_status, assert_json_response
+from utils.cleanup import cleanup_test_agent
+
+
+# Schedule firing window: timeout_seconds=30 + backend buffer (10s) +
+# scheduler poll cadence + retry scheduling latency. 90s is comfortably
+# above the worst-case while staying tight enough to surface regressions
+# in the path that produces pending_retry.
+PENDING_RETRY_WAIT_SECONDS = 90
+
+# CPU-pin assertion budget. The burner spawns from UserPromptSubmit, so it
+# is already running by the time the chat dispatches; we just need Docker
+# stats to settle. 30s is well past `docker stats` sampling jitter.
+CPU_PIN_WAIT_SECONDS = 30
+
+# Threshold for "burner is loose". Conservative: the production ticket
+# observed 133-156%, single-core; even on a busy CI host a setsid'd while-
+# loop comfortably exceeds 50% of one core.
+CPU_PIN_THRESHOLD_PERCENT = 50.0
+
+
+def _docker_cpu_percent(container_name: str) -> float | None:
+    """Return current CPU% from `docker stats --no-stream`, or None on error.
+
+    Docker reports e.g. "153.40%" — we strip the suffix and parse. None
+    on parse failure / container missing so the polling loop can retry.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker", "stats", "--no-stream",
+                "--format", "{{.CPUPerc}}", container_name,
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip().rstrip("%")
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _health_curl_times_out(container_name: str) -> bool:
+    """Run `docker exec <c> curl -m 5 http://localhost:8000/health` and
+    return True iff it exits non-zero (timeout / connection refused).
+
+    Curl's exit code 28 is the operation-timeout we're hoping for; we
+    accept any non-zero exit since the bug surface includes connection
+    failures during event-loop starvation, not just timeouts.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker", "exec", container_name,
+                "curl", "-m", "5", "-s", "-o", "/dev/null",
+                "-w", "%{http_code}",
+                "http://localhost:8000/health",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        # docker exec itself blocked past 15s — that is exactly the
+        # symptom we are looking for (event-loop fully starved).
+        return True
+    return result.returncode != 0
+
+
+def _count_burner_processes(container_name: str) -> int:
+    """Count surviving subprocess-leak PIDs inside the agent container.
+
+    Matches the burner cmdline pattern `while :; do :; done` (BusyBox `ps`
+    on Alpine truncates argv but keeps the loop body visible). Returns 0
+    on docker exec error so the caller can distinguish "no leak" from
+    "couldn't measure" via separate diagnostics.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker", "exec", container_name,
+                "ps", "-eo", "pid,pgid,cmd",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return 0
+    if result.returncode != 0:
+        return 0
+    return sum(
+        1 for line in result.stdout.splitlines()
+        if "while :" in line or "while:" in line
+    )
+
+
+def _ps_dump_for_diagnostics(container_name: str) -> str:
+    """Return surviving-burner ps lines for the failure message."""
+    try:
+        result = subprocess.run(
+            [
+                "docker", "exec", container_name,
+                "ps", "-eo", "pid,pgid,cmd",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return "(docker exec failed — container may have been cleaned up)"
+    if result.returncode != 0:
+        return f"(ps exited {result.returncode})"
+    return "\n".join(
+        line for line in result.stdout.splitlines()
+        if "while :" in line or "while:" in line
+    )
+
+
+@pytest.mark.slow
+def test_817_repro_subprocess_leak_survives_termination(api_client: TrinityApiClient):
+    """Reproduce Issue #817: subprocess survives task termination.
+
+    The bug is "subprocess survives that should not". CPU pin and /health
+    timeout are downstream symptoms whose reproducibility depends on host
+    CPU contention (a fast Mac with 8 cores does not starve the event
+    loop the same way a 1-2 core production VM does). The test asserts
+    the cause directly: count `while :` burner PIDs inside the container
+    AFTER the scheduler has pending_retry'd the execution and the backend
+    has issued its post-failure /api/cancel + terminate path.
+
+    A green run after a fix lands means the cleanup path now reaches
+    setsid'd processes that escape Claude's pgid AND have detached FDs.
+    """
+    suffix = uuid.uuid4().hex[:6]
+    system_name = f"test-leak817-{suffix}"
+    agent_short = "victim"
+    agent_name = f"{system_name}-{agent_short}"
+    container_name = f"agent-{agent_name}"
+
+    manifest = f"""
+name: {system_name}
+agents:
+  {agent_short}:
+    template: local:test-leak-hook
+"""
+
+    schedule_id: str | None = None
+
+    try:
+        # -------- Stage 1: deploy -------------------------------------------
+        deploy = api_client.post(
+            "/api/systems/deploy",
+            json={"manifest": manifest, "dry_run": False},
+            timeout=120.0,
+        )
+        assert_status(deploy, 200)
+        deploy_data = assert_json_response(deploy)
+        assert agent_name in deploy_data["agents_created"], (
+            f"Agent {agent_name} not in {deploy_data['agents_created']}"
+        )
+
+        # Wait for the agent container to be running.
+        deadline = time.monotonic() + 90
+        while time.monotonic() < deadline:
+            agent_resp = api_client.get(f"/api/agents/{agent_name}")
+            if agent_resp.status_code == 200:
+                status = agent_resp.json().get("status")
+                if status == "running":
+                    break
+            time.sleep(2)
+        else:
+            pytest.fail(f"Agent {agent_name} did not reach running status within 90s")
+
+        # Docker "running" doesn't mean the internal agent-server is accepting
+        # requests yet — startup.sh still has to copy template files, run
+        # write-runtime-config, etc. Poll the agent's /health from inside the
+        # container until it returns 200. If we trigger the schedule before
+        # this, the backend's call to /api/task fast-fails with ConnectError
+        # and the scheduler records `failed` with no useful timing.
+        deadline = time.monotonic() + 60
+        agent_ready = False
+        while time.monotonic() < deadline:
+            try:
+                probe = subprocess.run(
+                    [
+                        "docker", "exec", container_name,
+                        "curl", "-m", "3", "-s", "-o", "/dev/null",
+                        "-w", "%{http_code}",
+                        "http://localhost:8000/health",
+                    ],
+                    capture_output=True, text=True, timeout=8,
+                )
+                if probe.returncode == 0 and probe.stdout.strip() == "200":
+                    agent_ready = True
+                    break
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+            time.sleep(2)
+        if not agent_ready:
+            pytest.fail(
+                f"Agent {agent_name} /health did not return 200 within 60s "
+                f"of reaching Docker status=running"
+            )
+
+        # Pin the container to 1 CPU. The template ships cpu: "1" but
+        # Trinity's create path doesn't propagate it to the Docker create
+        # call — `docker inspect` shows NanoCpus=0 / CpuQuota=0 on agent
+        # containers — so the dev host's full 4-8 cores are available and
+        # 8 burners can't actually starve uvicorn. Forcing the limit here
+        # matches the production scenario (1-2 core cloud VM) so the
+        # /health-timeout stage of the cascade reproduces.
+        cpu_pin = subprocess.run(
+            ["docker", "update", "--cpus=1", container_name],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert cpu_pin.returncode == 0, (
+            f"Failed to pin {container_name} to 1 CPU: "
+            f"stdout={cpu_pin.stdout!r} stderr={cpu_pin.stderr!r}"
+        )
+
+        # -------- Stage 2: schedule with short timeout + retries ------------
+        # cron: 0 0 1 1 * = midnight Jan 1 — never fires naturally during
+        # the test window. We trigger manually below.
+        sched_resp = api_client.post(
+            f"/api/agents/{agent_name}/schedules",
+            json={
+                "name": "leak817-repro",
+                "cron_expression": "0 0 1 1 *",
+                "message": "trigger the hook",
+                "timeout_seconds": 30,
+                "max_retries": 1,
+                "retry_delay_seconds": 60,
+                "enabled": True,
+            },
+        )
+        assert_status(sched_resp, 201)
+        schedule_id = sched_resp.json()["id"]
+
+        # -------- Stage 3: manually trigger --------------------------------
+        trigger = api_client.post(
+            f"/api/agents/{agent_name}/schedules/{schedule_id}/trigger",
+        )
+        assert trigger.status_code in (200, 202), (
+            f"Trigger returned {trigger.status_code}: {trigger.text}"
+        )
+        trigger_time = time.monotonic()
+
+        # -------- Stage 4: poll for pending_retry ---------------------------
+        # The hook sleeps 120s in the foreground. Backend's chat timeout =
+        # schedule timeout_seconds (30) + 10s buffer = 40s. Backend marks
+        # FAILED, scheduler's _maybe_schedule_retry promotes to PENDING_RETRY.
+        deadline = trigger_time + PENDING_RETRY_WAIT_SECONDS
+        reached_pending_retry = False
+        executions_seen: list[dict] = []
+        while time.monotonic() < deadline:
+            exec_resp = api_client.get(
+                f"/api/agents/{agent_name}/schedules/{schedule_id}/executions",
+            )
+            if exec_resp.status_code == 200:
+                executions_seen = exec_resp.json() or []
+                if any(e.get("status") == "pending_retry" for e in executions_seen):
+                    reached_pending_retry = True
+                    break
+            time.sleep(3)
+
+        assert reached_pending_retry, (
+            f"Execution never reached pending_retry within "
+            f"{PENDING_RETRY_WAIT_SECONDS}s. Last seen: "
+            f"{[(e.get('id'), e.get('status')) for e in executions_seen]}"
+        )
+
+        # -------- Stage 5: instrumented burner-survival timeline -----------
+        # Sample immediately, then at 5s/10s/20s, to detect whether a
+        # delayed cleanup path is killing the burners after pending_retry.
+        burner_timeline = []
+        for delay in (0, 5, 10, 20):
+            if delay:
+                time.sleep(delay - (burner_timeline[-1][0] if burner_timeline else 0))
+            burner_timeline.append((delay, _count_burner_processes(container_name)))
+        print(f"\n[#817 repro] burner-count timeline (s, count): {burner_timeline}")
+
+        # -------- Stage 6 (informational): /health must time out -----------
+        # With CPU pinned to 1 core and 8 burners spinning, uvicorn's slice
+        # should shrink below the curl 5s timeout. Logged informationally
+        # for now — host scheduler variance can still leak a slice through.
+        any_timed_out = False
+        for _ in range(3):
+            if _health_curl_times_out(container_name):
+                any_timed_out = True
+                break
+            time.sleep(8)
+        if not any_timed_out:
+            print(
+                f"\n[#817 repro] /health responded under 5s despite cpu=1 + "
+                f"8 burners. Host scheduler may still be giving uvicorn a "
+                f"slice; the leak itself is still proven by the burner-PID "
+                f"assertion below."
+            )
+        else:
+            print("\n[#817 repro] /health timed out — full production cascade reproduced.")
+
+        # -------- Stage 7: regression gate — no burner should survive ------
+        # Asserted as `== 0` so this test FAILS today (proving the bug)
+        # and PASSES after the fix lands. The failure message dumps the
+        # surviving cmdlines so the bug shape is obvious from CI logs
+        # alone — no need to docker exec into the (already-deleted) agent.
+        burner_count = _count_burner_processes(container_name)
+        diag_ps = _ps_dump_for_diagnostics(container_name) if burner_count else ""
+        assert burner_count == 0, (
+            f"Subprocess leak (#817) reproduced: {burner_count} burner "
+            f"PID(s) survived agent-server cleanup after pending_retry. "
+            f"This regression gate is expected to FAIL until #817 is "
+            f"fixed; a green run means the cleanup path now reaches "
+            f"setsid'd processes whose FDs are detached from Claude's "
+            f"pipes.\n\n"
+            f"Surviving processes inside {container_name}:\n{diag_ps}"
+        )
+
+        # -------- Stage 7 (informational): CPU pin -------------------------
+        # On a fast multi-core host this won't reach 100% per-core ceiling,
+        # but the production correlation is real — log it so a regression
+        # against a busier host surfaces. Failure here does NOT fail the
+        # test (host hardware variance is too high to gate on).
+        cpu_observed = _docker_cpu_percent(container_name)
+        if cpu_observed is not None and cpu_observed < CPU_PIN_THRESHOLD_PERCENT:
+            print(
+                f"\n[#817 repro] CPU pin observed at {cpu_observed}% — below "
+                f"the {CPU_PIN_THRESHOLD_PERCENT}% production threshold but "
+                f"{burner_count} burner(s) confirmed alive. Likely host "
+                f"hardware variance, not a regression."
+            )
+
+    finally:
+        if schedule_id:
+            try:
+                api_client.delete(
+                    f"/api/agents/{agent_name}/schedules/{schedule_id}",
+                )
+            except Exception:
+                pass
+        # cleanup_test_agent deletes the container, which reaps the burner
+        # (Docker SIGKILLs every PID in the container's pid namespace).
+        cleanup_test_agent(api_client, agent_name)

--- a/tests/unit/test_subprocess_pgroup.py
+++ b/tests/unit/test_subprocess_pgroup.py
@@ -39,8 +39,10 @@ if _agent_utils_path not in sys.path:
 
 import subprocess_pgroup  # noqa: E402
 from subprocess_pgroup import (  # noqa: E402
+    EXECUTION_TAG_NAME,
     capture_pgid,
     drain_reader_threads,
+    kill_processes_by_env_tag,
     safe_close_pipes,
     signal_process_tree,
     terminate_process_group,
@@ -857,3 +859,208 @@ class TestSetIdlePriority:
         import subprocess_pgroup as spg
         spg._set_idle_priority()
         spg._set_idle_priority()
+
+
+# ---------------------------------------------------------------------------
+# Issue #817 — env-tag sweep: kill_processes_by_env_tag
+# ---------------------------------------------------------------------------
+#
+# Spawns a long-sleep child with TRINITY_EXECUTION_ID set in its env, then
+# verifies the sweep can identify and SIGKILL it (or correctly skip it). All
+# tests are Linux-only because the implementation reads /proc/<pid>/environ
+# which does not exist on macOS.
+
+import uuid as _uuid
+
+
+def _spawn_tagged_sleep(tag_value: str | None = None) -> subprocess.Popen:
+    """Spawn `sleep 60` with TRINITY_EXECUTION_ID=tag_value in its env.
+    If tag_value is None, no tag is injected (control case)."""
+    env = dict(os.environ)
+    if tag_value is not None:
+        env[EXECUTION_TAG_NAME] = tag_value
+    return subprocess.Popen(
+        ["sleep", "60"],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _wait_for_exit(proc: subprocess.Popen, timeout: float = 3.0) -> int | None:
+    """Poll until the process exits or timeout. Returns return code or None."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        rc = proc.poll()
+        if rc is not None:
+            return rc
+        time.sleep(0.05)
+    return None
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="kill_processes_by_env_tag uses /proc/<pid>/environ (Linux only)",
+)
+class TestKillProcessesByEnvTag:
+    """Issue #817: env-tag sweep catches descendants that escape both
+    pgid- and FD-based cleanup."""
+
+    def test_kills_process_with_matching_tag(self):
+        """A process whose env contains the tag is SIGKILLed and the
+        return value reflects the kill."""
+        tag_value = f"test-{_uuid.uuid4().hex[:8]}"
+        proc = _spawn_tagged_sleep(tag_value)
+        try:
+            killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, tag_value)
+            assert killed == 1, f"expected 1 killed, got {killed}"
+            rc = _wait_for_exit(proc)
+            assert rc is not None, "tagged process did not exit after sweep"
+            # SIGKILL exit: -9 from Popen
+            assert rc == -9, f"expected SIGKILL (-9), got {rc}"
+        finally:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+
+    def test_does_not_kill_process_with_different_tag(self):
+        """A process whose env contains a *different* tag is left alive."""
+        our_tag = f"target-{_uuid.uuid4().hex[:8]}"
+        other_tag = f"other-{_uuid.uuid4().hex[:8]}"
+        proc = _spawn_tagged_sleep(other_tag)
+        try:
+            killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, our_tag)
+            assert killed == 0, (
+                f"expected 0 killed (different tag), got {killed}"
+            )
+            assert proc.poll() is None, "non-matching process was killed"
+        finally:
+            proc.kill()
+            proc.wait(timeout=2)
+
+    def test_does_not_kill_process_without_tag(self):
+        """A process with no tag at all is invisible to the sweep."""
+        our_tag = f"target-{_uuid.uuid4().hex[:8]}"
+        proc = _spawn_tagged_sleep(tag_value=None)
+        try:
+            killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, our_tag)
+            assert killed == 0
+            assert proc.poll() is None
+        finally:
+            proc.kill()
+            proc.wait(timeout=2)
+
+    def test_does_not_kill_calling_pid(self):
+        """The caller's own PID is always excluded — even if its env
+        carries the tag (guards against killing agent-server itself)."""
+        tag_value = f"self-{_uuid.uuid4().hex[:8]}"
+        # Inject the tag into our own env so we'd "match" without the guard
+        os.environ[EXECUTION_TAG_NAME] = tag_value
+        try:
+            killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, tag_value)
+            # Our PID must be skipped — we should still be alive after
+            # this line. If the kill went through, the process would be
+            # gone before this assertion ran.
+            assert killed == 0, (
+                f"sweep killed {killed} including possibly self — "
+                f"calling-PID exclusion broken"
+            )
+        finally:
+            os.environ.pop(EXECUTION_TAG_NAME, None)
+
+    def test_exclude_pids_param(self):
+        """Caller can pass additional PIDs to exclude from the sweep."""
+        tag_value = f"excl-{_uuid.uuid4().hex[:8]}"
+        keeper = _spawn_tagged_sleep(tag_value)
+        victim = _spawn_tagged_sleep(tag_value)
+        try:
+            killed = kill_processes_by_env_tag(
+                EXECUTION_TAG_NAME, tag_value, exclude_pids=[keeper.pid],
+            )
+            assert killed == 1, (
+                f"expected 1 killed (victim) with keeper excluded, got {killed}"
+            )
+            rc = _wait_for_exit(victim)
+            assert rc == -9, "victim should be SIGKILLed"
+            assert keeper.poll() is None, "keeper was not in exclude_pids"
+        finally:
+            for p in (keeper, victim):
+                try:
+                    p.kill()
+                except OSError:
+                    pass
+
+    def test_exact_match_not_substring_prefix(self):
+        """Tag value 'abc' must not match 'abcdef' (NUL-separated split).
+        Guards against false positives on similarly-named env vars."""
+        proc = _spawn_tagged_sleep("abcdef")
+        try:
+            killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, "abc")
+            assert killed == 0, (
+                f"sweep matched substring 'abc' against env value 'abcdef' — "
+                f"expected exact match"
+            )
+            assert proc.poll() is None
+        finally:
+            proc.kill()
+            proc.wait(timeout=2)
+
+    def test_exact_match_not_different_var_name(self):
+        """A different env var with the same value must not match.
+        Guards against the tag value appearing in some other variable."""
+        # Spawn a sleep with a different env var carrying our value
+        env = dict(os.environ)
+        env["UNRELATED_VAR"] = "shared-value"
+        # Strip our tag if it happens to be in our env
+        env.pop(EXECUTION_TAG_NAME, None)
+        proc = subprocess.Popen(
+            ["sleep", "60"], env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            killed = kill_processes_by_env_tag(
+                EXECUTION_TAG_NAME, "shared-value",
+            )
+            assert killed == 0, (
+                f"sweep killed process with different env var name — "
+                f"matching is not name-scoped"
+            )
+            assert proc.poll() is None
+        finally:
+            proc.kill()
+            proc.wait(timeout=2)
+
+    def test_returns_count_of_killed(self):
+        """Count returned == number of distinct tagged processes killed."""
+        tag_value = f"multi-{_uuid.uuid4().hex[:8]}"
+        procs = [_spawn_tagged_sleep(tag_value) for _ in range(3)]
+        try:
+            killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, tag_value)
+            assert killed == 3, (
+                f"expected 3 killed for 3 tagged procs, got {killed}"
+            )
+            for p in procs:
+                rc = _wait_for_exit(p)
+                assert rc == -9
+        finally:
+            for p in procs:
+                try:
+                    p.kill()
+                except OSError:
+                    pass
+
+    def test_returns_zero_when_proc_unavailable(self, monkeypatch):
+        """If /proc cannot be listed (e.g., not Linux), return 0 cleanly
+        without raising — allows the helper to be a no-op safety net on
+        environments that don't have /proc."""
+        def _raise(*_a, **_kw):
+            raise OSError("simulated /proc unavailable")
+        monkeypatch.setattr(os, "listdir", _raise)
+        # Must not raise; must return 0
+        killed = kill_processes_by_env_tag(EXECUTION_TAG_NAME, "any-value")
+        assert killed == 0


### PR DESCRIPTION
Closes #817.

## Summary
- Tags every Claude subprocess with `TRINITY_EXECUTION_ID=<uuid>` so we can identify its descendants regardless of how they try to detach (setsid, FD redirect, double-fork).
- New cleanup pass `kill_processes_by_env_tag` scans `/proc/<pid>/environ` and SIGKILLs everything carrying the matching tag. Wired into `terminate_process_group`, `drain_reader_threads`, and `ProcessRegistry.terminate` so it fires on every task end (success, timeout, and `/api/cancel`).
- Sweep is local to the agent container — does not depend on the backend reaching the agent, so it still fires when the dormant CB has the agent isolated.

## Root cause
The existing cleanup has two passes:

1. `terminate_process_group` — kills the Claude pgid via `killpg`.
2. `_kill_orphan_pipe_writers` — `/proc` scan for processes holding our stdout pipe inode.

A subprocess that escapes BOTH — `setsid()` (new pgid) AND `</dev/null >/dev/null 2>&1` (no FDs back to our pipes) — survives. Production observed this as a runaway-CPU agent that started up after a scheduled task ended in `pending_retry`, eventually starving the agent-server event loop, opening the `agent_client` CB, and cascading the scheduler CB into the dormant state.

## Why env tag beats PPid-walk
Considered approach: walk `/proc` ancestry from `claude_pid` before killing claude. Rejected because it misses double-fork daemonized processes (parent dies, child reparented to PID 1, ancestry chain broken). Env vars are inherited at every fork/exec/setsid and survive reparenting, so the tag is a strictly stronger ownership signal — no race window, no BFS, single `/proc` scan.

## How the fix unwinds the cascade
The sweep runs at the end of every Claude task on the agent itself. Even at 160% CPU with a dormant CB, when Claude eventually finishes (naturally or via the internal `process.wait(timeout)` budget), `drain_reader_threads` runs, the sweep fires, the leaked processes die, CPU returns to baseline, the next CB probe succeeds, the cascade unwinds.

## Test plan
- [x] `tests/test_817_subprocess_leak.py` — engineered repro via `config/agent-templates/test-leak-hook/`. A UserPromptSubmit hook spawns 8 setsid'd + FD-detached CPU burners then sleeps 120s. The schedule's `timeout_seconds=30, max_retries=1` produces `pending_retry` deterministically.
- [x] Pre-fix: 10 burner PIDs survive every run; test fails with full `ps` dump in the message.
- [x] Post-fix: 0 surviving PIDs across 3 consecutive runs (108s avg).
- [x] CPU returns to baseline (0.1%) immediately after cleanup.

The test is marked `@pytest.mark.slow` and gated to manual/nightly runs.

## Out of scope
- The dormant-CB-doesn't-self-recover bug (ticket's secondary issue) is a separate scheduler-side fix worth a follow-up. It is no longer a recurring outage with this fix because the underlying leak no longer accumulates CPU pressure between probes.
- The `retry_scheduled_at = NULL` bug (ticket's tertiary issue) is a separate follow-up.

## Production evidence ask
Asked Eugene on the ticket to capture `ps -eo pid,ppid,pgid,sid,cmd` + `ls -l /proc/<pid>/fd/` next time the bug fires, to confirm the production leak shape matches the engineered repro (setsid + detached FDs). The fix should hold either way (env tag is independent of how the orphan escapes), but the evidence will tell us whether to expect any blind-spot follow-ups.