### PR TITLE
ci(unit-test): run lint on push to dev/main to catch baseline rebase race

### DIFF
--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -8,11 +8,19 @@ name: backend-unit-test
 # any new failing test ID that was not failing in `base` under any seed, or
 # if any pytest run produced no JUnit XML (fail-closed on infra failure).
 #
+# Issue #802: also runs on push to dev/main so baseline-style invariant checks
+# (lint-sys-modules) fire post-merge — catches the case where two PRs both
+# pass their pre-merge CI but the merge of one invalidates the baseline the
+# other landed. The per-PR diff jobs (test, diff) only run on pull_request
+# since there's no base/head to compare on a push.
+#
 # Trigger manually via the Actions tab (workflow_dispatch) for backfill.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [dev, main]
+  push:
     branches: [dev, main]
   workflow_dispatch:
 
@@ -45,6 +53,8 @@ jobs:
 
   test:
     name: pytest (${{ matrix.side }}, seed ${{ matrix.seed }})
+    # Per-PR diff job — no base/head exists on a push, so skip there.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -114,7 +124,8 @@ jobs:
   diff:
     name: regression diff
     needs: test
-    if: always()
+    # Mirror the `test` gate — diff is meaningless without base/head artifacts.
+    if: always() && github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Summary

- Adds `push: branches: [dev, main]` trigger to `backend-unit-test.yml` so the `lint-sys-modules` baseline check fires post-merge, catching the rebase race documented in #802.
- Gates the per-PR diff jobs (`test`, `diff`) to `pull_request` only — they have no base/head to compare on a push.

## Why

`lint-sys-modules` (added in #791) is a baseline-style invariant: a passing run only proves the PR is consistent with its base at CI-run time, not with the actual post-merge state. Two PRs touching disjoint paths can each pass their pre-merge CI, then leave dev red after the second merges. #791 + #783 hit this exact case 2026-05-11; #606 inherited the red CI as a side effect.

Adding a `push` trigger is option (B) from the issue — gives a fast post-merge alarm. Option (A) (branch-protection "require up-to-date before merging") is intentionally out of scope here; it's an admin repo setting and a separate decision.

## Test plan

- [ ] Push trigger fires on next merge to dev — verify `lint-sys-modules` job runs and `pytest (base/head, seed *)` + `regression diff` jobs are skipped.
- [ ] PR trigger unchanged — this PR's own CI runs the full matrix.
- [ ] Concurrency key still keys off `github.ref` so PR run and push run on the merge commit don't cancel each other.

Related to #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)