### PR TITLE
fix(security): drop SYS_PTRACE/MKNOD/NET_RAW/FSETID from FULL_CAPABILITIES (#602)

### DIFF
--- a/src/backend/services/agent_service/capabilities.py
+++ b/src/backend/services/agent_service/capabilities.py
@@ -1,0 +1,66 @@
+"""
+Linux capability sets for agent containers (Issue #602 — Phase 3c).
+
+This module is intentionally stdlib-only and import-light so it can be
+exercised by `tests/unit/test_capability_set.py` without dragging the
+docker / fastapi / database transitive imports of `lifecycle.py` into
+the test runner. `lifecycle.py` re-exports these names for callers.
+
+Trinity always launches agent containers with `cap_drop=ALL` and then
+re-adds one of these sets. The pattern (defense in depth):
+
+    cap_drop = ['ALL']
+    cap_add  = FULL_CAPABILITIES if full_capabilities else RESTRICTED_CAPABILITIES
+"""
+
+from __future__ import annotations
+
+
+# Restricted mode capabilities - minimum for agent operation (default)
+RESTRICTED_CAPABILITIES: list[str] = [
+    'NET_BIND_SERVICE',  # Bind to ports < 1024
+    'SETGID', 'SETUID',  # Change user/group (for su/sudo)
+    'CHOWN',             # Change file ownership
+    'SYS_CHROOT',        # Use chroot
+    'AUDIT_WRITE',       # Write to audit log
+]
+
+# Full capabilities mode - adds package installation support.
+# Used when agents need apt-get, pip install, etc.
+#
+# Issue #602 / Phase 3c (cap tightening): four caps removed from this
+# set after AISEC-C2 review. The remaining set is the minimum that keeps
+# `sudo apt install` working inside an agent container.
+#
+# Dropped (no defensible agent use case — documented here so a future
+# PR doesn't silently re-add them):
+#   SYS_PTRACE  Lets a process read another process's memory. A malicious
+#               MCP server could read Claude Code's heap and exfil the
+#               OAuth token even if the token isn't in env. This is the
+#               direct AISEC-C2 escalation path; removing it closes it
+#               without waiting for Layer 3b (bubblewrap sandbox).
+#   MKNOD       Creates device nodes under /dev. Agents have no use case
+#               for /dev/* manipulation; primarily a container-escape
+#               primitive (e.g. creating a writable raw disk device).
+#   NET_RAW     Raw / ICMP sockets. Trinity's "ping another agent" UX is
+#               HTTP-level, not ICMP. Removing this prevents raw-packet
+#               crafting (TCP RST injection, ARP spoofing on the docker
+#               bridge, etc.).
+#   FSETID      Lets a process keep setuid/setgid bits on chmod after a
+#               non-owner write — used to plant a setuid binary the next
+#               privileged path can run. No agent workflow needs it.
+FULL_CAPABILITIES: list[str] = RESTRICTED_CAPABILITIES + [
+    'DAC_OVERRIDE',      # Bypass file permission checks (needed for sudo apt)
+    'FOWNER',            # Bypass permission checks on file owner
+    'KILL',              # Send signals to processes
+]
+
+# These capabilities are NEVER granted - they pose significant security risks.
+# Listed for documentation; we achieve this by always using cap_drop=['ALL'].
+PROHIBITED_CAPABILITIES: list[str] = [
+    'SYS_ADMIN',         # Mount filesystems, configure namespace - too powerful
+    'NET_ADMIN',         # Network administration - could escape container
+    'SYS_RAWIO',         # Raw I/O access - direct hardware access
+    'SYS_MODULE',        # Load kernel modules - kernel compromise
+    'SYS_BOOT',          # Reboot system
+]

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -85,58 +85,16 @@ async def wait_for_agent_ready(
 
 
 # =============================================================================
-# Container Security Capability Sets
+# Container Security Capability Sets — see capabilities.py for definitions
 # =============================================================================
-# These define the Linux capabilities granted to agent containers.
-# Security principle: Always drop ALL caps, then add back only what's needed.
-
-# Restricted mode capabilities - minimum for agent operation (default)
-RESTRICTED_CAPABILITIES = [
-    'NET_BIND_SERVICE',  # Bind to ports < 1024
-    'SETGID', 'SETUID',  # Change user/group (for su/sudo)
-    'CHOWN',             # Change file ownership
-    'SYS_CHROOT',        # Use chroot
-    'AUDIT_WRITE',       # Write to audit log
-]
-
-# Full capabilities mode - adds package installation support
-# Used when agents need apt-get, pip install, etc.
-#
-# Issue #602 / Phase 3c (cap tightening): four caps removed from this
-# set after AISEC-C2 review. The remaining set is the minimum that keeps
-# `sudo apt install` working inside an agent container.
-#
-# Dropped (no defensible agent use case — kept here for documentation):
-#   SYS_PTRACE  Lets a process read another process's memory. A malicious
-#               MCP server could read Claude Code's heap and exfil the
-#               OAuth token even if the token isn't in env. This is the
-#               direct AISEC-C2 escalation path; removing it closes it
-#               without waiting for Layer 3b (bubblewrap sandbox).
-#   MKNOD       Creates device nodes under /dev. Agents have no use case
-#               for /dev/* manipulation; primarily a container-escape
-#               primitive (e.g. creating a writable raw disk device).
-#   NET_RAW     Raw / ICMP sockets. Trinity's "ping another agent" UX is
-#               HTTP-level, not ICMP. Removing this prevents raw-packet
-#               crafting (TCP RST injection, ARP spoofing on the docker
-#               bridge, etc.).
-#   FSETID     Lets a process keep setuid/setgid bits on chmod after a
-#               non-owner write — used to plant a setuid binary the next
-#               privileged path can run. No agent workflow needs it.
-FULL_CAPABILITIES = RESTRICTED_CAPABILITIES + [
-    'DAC_OVERRIDE',      # Bypass file permission checks (needed for sudo apt)
-    'FOWNER',            # Bypass permission checks on file owner
-    'KILL',              # Send signals to processes
-]
-
-# These capabilities are NEVER granted - they pose significant security risks
-# Listed for documentation; we achieve this by always using cap_drop=['ALL']
-PROHIBITED_CAPABILITIES = [
-    'SYS_ADMIN',         # Mount filesystems, configure namespace - too powerful
-    'NET_ADMIN',         # Network administration - could escape container
-    'SYS_RAWIO',         # Raw I/O access - direct hardware access
-    'SYS_MODULE',        # Load kernel modules - kernel compromise
-    'SYS_BOOT',          # Reboot system
-]
+# Re-exported from .capabilities so that test code (and other callers
+# that only need the constants) can import them without dragging the
+# docker / fastapi / database transitive imports of this module.
+from .capabilities import (  # noqa: F401
+    RESTRICTED_CAPABILITIES,
+    FULL_CAPABILITIES,
+    PROHIBITED_CAPABILITIES,
+)
 
 
 async def inject_assigned_credentials(agent_name: str, max_retries: int = 3, retry_delay: float = 2.0) -> dict:

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -101,14 +101,31 @@ RESTRICTED_CAPABILITIES = [
 
 # Full capabilities mode - adds package installation support
 # Used when agents need apt-get, pip install, etc.
+#
+# Issue #602 / Phase 3c (cap tightening): four caps removed from this
+# set after AISEC-C2 review. The remaining set is the minimum that keeps
+# `sudo apt install` working inside an agent container.
+#
+# Dropped (no defensible agent use case — kept here for documentation):
+#   SYS_PTRACE  Lets a process read another process's memory. A malicious
+#               MCP server could read Claude Code's heap and exfil the
+#               OAuth token even if the token isn't in env. This is the
+#               direct AISEC-C2 escalation path; removing it closes it
+#               without waiting for Layer 3b (bubblewrap sandbox).
+#   MKNOD       Creates device nodes under /dev. Agents have no use case
+#               for /dev/* manipulation; primarily a container-escape
+#               primitive (e.g. creating a writable raw disk device).
+#   NET_RAW     Raw / ICMP sockets. Trinity's "ping another agent" UX is
+#               HTTP-level, not ICMP. Removing this prevents raw-packet
+#               crafting (TCP RST injection, ARP spoofing on the docker
+#               bridge, etc.).
+#   FSETID     Lets a process keep setuid/setgid bits on chmod after a
+#               non-owner write — used to plant a setuid binary the next
+#               privileged path can run. No agent workflow needs it.
 FULL_CAPABILITIES = RESTRICTED_CAPABILITIES + [
-    'DAC_OVERRIDE',      # Bypass file permission checks (needed for apt)
+    'DAC_OVERRIDE',      # Bypass file permission checks (needed for sudo apt)
     'FOWNER',            # Bypass permission checks on file owner
-    'FSETID',            # Don't clear setuid/setgid bits
     'KILL',              # Send signals to processes
-    'MKNOD',             # Create special files
-    'NET_RAW',           # Use raw sockets (ping, etc.)
-    'SYS_PTRACE',        # Trace processes (debugging)
 ]
 
 # These capabilities are NEVER granted - they pose significant security risks

--- a/tests/unit/test_capability_set.py
+++ b/tests/unit/test_capability_set.py
@@ -16,16 +16,30 @@ lifecycle.py.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 import pytest
 
-_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
-_BACKEND_STR = str(_BACKEND)
-while _BACKEND_STR in sys.path:
-    sys.path.remove(_BACKEND_STR)
-sys.path.insert(0, _BACKEND_STR)
+
+# `services.agent_service.capabilities` is pure data, but going through
+# the `services.agent_service` package init triggers eager imports
+# (lifecycle → docker_utils → tenacity / docker) that would force this
+# test to depend on the full backend runtime. Load by file path so the
+# test stays stdlib-only.
+_CAPS_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src" / "backend" / "services" / "agent_service" / "capabilities.py"
+)
+
+
+def _load_caps():
+    spec = importlib.util.spec_from_file_location("caps_under_test", _CAPS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 REMOVED_BY_ISSUE_602 = {
@@ -39,25 +53,25 @@ REMOVED_BY_ISSUE_602 = {
 def test_restricted_set_minimal():
     """Restricted (default) set must stay tight — no debugger/raw-socket
     caps even at the baseline."""
-    from services.agent_service.lifecycle import RESTRICTED_CAPABILITIES
+    caps = _load_caps()
 
-    leaked = REMOVED_BY_ISSUE_602 & set(RESTRICTED_CAPABILITIES)
+    leaked = REMOVED_BY_ISSUE_602 & set(caps.RESTRICTED_CAPABILITIES)
     assert not leaked, (
         f"RESTRICTED_CAPABILITIES regained Issue #602 forbidden caps: {leaked}. "
-        "These are security primitives — see lifecycle.py comments before re-adding."
+        "These are security primitives — see capabilities.py comments before re-adding."
     )
 
 
 def test_full_set_excludes_issue_602_removals():
     """FULL_CAPABILITIES (apt-install mode) must not regain the caps
     Issue #602 / Phase 3c removed."""
-    from services.agent_service.lifecycle import FULL_CAPABILITIES
+    caps = _load_caps()
 
-    leaked = REMOVED_BY_ISSUE_602 & set(FULL_CAPABILITIES)
+    leaked = REMOVED_BY_ISSUE_602 & set(caps.FULL_CAPABILITIES)
     assert not leaked, (
         f"FULL_CAPABILITIES regained Issue #602 forbidden caps: {leaked}. "
         "Each entry in REMOVED_BY_ISSUE_602 is a documented security "
-        "primitive — see lifecycle.py FULL_CAPABILITIES comment block "
+        "primitive — see capabilities.py FULL_CAPABILITIES comment block "
         "before re-adding."
     )
 
@@ -65,12 +79,9 @@ def test_full_set_excludes_issue_602_removals():
 def test_full_set_remains_a_superset_of_restricted():
     """FULL must always include everything in RESTRICTED — tightening
     the FULL set should not accidentally drop a baseline cap."""
-    from services.agent_service.lifecycle import (
-        FULL_CAPABILITIES,
-        RESTRICTED_CAPABILITIES,
-    )
+    caps = _load_caps()
 
-    missing = set(RESTRICTED_CAPABILITIES) - set(FULL_CAPABILITIES)
+    missing = set(caps.RESTRICTED_CAPABILITIES) - set(caps.FULL_CAPABILITIES)
     assert not missing, (
         f"FULL_CAPABILITIES dropped baseline caps: {missing}. "
         "FULL must remain a superset of RESTRICTED."
@@ -80,13 +91,9 @@ def test_full_set_remains_a_superset_of_restricted():
 def test_prohibited_caps_never_appear_in_either_set():
     """SYS_ADMIN-class caps must never leak into RESTRICTED or FULL.
     PROHIBITED_CAPABILITIES is the documented blocklist."""
-    from services.agent_service.lifecycle import (
-        FULL_CAPABILITIES,
-        PROHIBITED_CAPABILITIES,
-        RESTRICTED_CAPABILITIES,
-    )
+    caps = _load_caps()
 
-    leaks_full = set(PROHIBITED_CAPABILITIES) & set(FULL_CAPABILITIES)
-    leaks_restricted = set(PROHIBITED_CAPABILITIES) & set(RESTRICTED_CAPABILITIES)
+    leaks_full = set(caps.PROHIBITED_CAPABILITIES) & set(caps.FULL_CAPABILITIES)
+    leaks_restricted = set(caps.PROHIBITED_CAPABILITIES) & set(caps.RESTRICTED_CAPABILITIES)
     assert not leaks_full, f"PROHIBITED caps in FULL set: {leaks_full}"
     assert not leaks_restricted, f"PROHIBITED caps in RESTRICTED set: {leaks_restricted}"

--- a/tests/unit/test_capability_set.py
+++ b/tests/unit/test_capability_set.py
@@ -35,9 +35,11 @@ _CAPS_PATH = (
 
 
 def _load_caps():
+    # capabilities.py is pure list literals with no decorators that
+    # introspect via sys.modules — no need to register the loaded module
+    # there (which would trip tests/lint_sys_modules.py, #762).
     spec = importlib.util.spec_from_file_location("caps_under_test", _CAPS_PATH)
     module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/tests/unit/test_capability_set.py
+++ b/tests/unit/test_capability_set.py
@@ -1,0 +1,92 @@
+"""
+Pin the FULL_CAPABILITIES set so future PRs can't silently re-add the
+caps that Issue #602 / Phase 3c removed.
+
+Each removed cap is a known security primitive:
+- SYS_PTRACE  — read other process memory (AISEC-C2 token exfil path)
+- MKNOD       — create /dev nodes (container-escape primitive)
+- NET_RAW     — raw / ICMP sockets (packet crafting, ARP spoof)
+- FSETID      — preserve setuid bits on chmod (priv-escalation primitive)
+
+If a future caller has a genuine need for one of these, the right path
+is: document the use case here, then remove the entry from the
+forbidden list with a justification — not silently revert
+lifecycle.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+REMOVED_BY_ISSUE_602 = {
+    "SYS_PTRACE",
+    "MKNOD",
+    "NET_RAW",
+    "FSETID",
+}
+
+
+def test_restricted_set_minimal():
+    """Restricted (default) set must stay tight — no debugger/raw-socket
+    caps even at the baseline."""
+    from services.agent_service.lifecycle import RESTRICTED_CAPABILITIES
+
+    leaked = REMOVED_BY_ISSUE_602 & set(RESTRICTED_CAPABILITIES)
+    assert not leaked, (
+        f"RESTRICTED_CAPABILITIES regained Issue #602 forbidden caps: {leaked}. "
+        "These are security primitives — see lifecycle.py comments before re-adding."
+    )
+
+
+def test_full_set_excludes_issue_602_removals():
+    """FULL_CAPABILITIES (apt-install mode) must not regain the caps
+    Issue #602 / Phase 3c removed."""
+    from services.agent_service.lifecycle import FULL_CAPABILITIES
+
+    leaked = REMOVED_BY_ISSUE_602 & set(FULL_CAPABILITIES)
+    assert not leaked, (
+        f"FULL_CAPABILITIES regained Issue #602 forbidden caps: {leaked}. "
+        "Each entry in REMOVED_BY_ISSUE_602 is a documented security "
+        "primitive — see lifecycle.py FULL_CAPABILITIES comment block "
+        "before re-adding."
+    )
+
+
+def test_full_set_remains_a_superset_of_restricted():
+    """FULL must always include everything in RESTRICTED — tightening
+    the FULL set should not accidentally drop a baseline cap."""
+    from services.agent_service.lifecycle import (
+        FULL_CAPABILITIES,
+        RESTRICTED_CAPABILITIES,
+    )
+
+    missing = set(RESTRICTED_CAPABILITIES) - set(FULL_CAPABILITIES)
+    assert not missing, (
+        f"FULL_CAPABILITIES dropped baseline caps: {missing}. "
+        "FULL must remain a superset of RESTRICTED."
+    )
+
+
+def test_prohibited_caps_never_appear_in_either_set():
+    """SYS_ADMIN-class caps must never leak into RESTRICTED or FULL.
+    PROHIBITED_CAPABILITIES is the documented blocklist."""
+    from services.agent_service.lifecycle import (
+        FULL_CAPABILITIES,
+        PROHIBITED_CAPABILITIES,
+        RESTRICTED_CAPABILITIES,
+    )
+
+    leaks_full = set(PROHIBITED_CAPABILITIES) & set(FULL_CAPABILITIES)
+    leaks_restricted = set(PROHIBITED_CAPABILITIES) & set(RESTRICTED_CAPABILITIES)
+    assert not leaks_full, f"PROHIBITED caps in FULL set: {leaks_full}"
+    assert not leaks_restricted, f"PROHIBITED caps in RESTRICTED set: {leaks_restricted}"


### PR DESCRIPTION
## Summary

Phase 3c of [#602](https://github.com/Abilityai/trinity/issues/602). Tightens the agent-container Linux capability set by removing four caps with no defensible agent use case, each a documented escalation primitive.

Trinity already runs every agent container with `cap_drop=ALL` then re-adds a curated set. `FULL_CAPABILITIES` (the system-wide default; enables `sudo apt install`) had 7 entries on top of `RESTRICTED_CAPABILITIES`. This PR drops 4 of those 7.

## Removed

| Cap | Why it was dangerous | Why we don't need it |
|---|---|---|
| `SYS_PTRACE` | A malicious MCP package can attach to PID 1 (Claude Code) and read the OAuth token from heap memory — even when the token isn't in env. **The AISEC-C2 escalation path.** | No agent runs gdb/strace in production. |
| `MKNOD` | Creates device nodes; well-known container-escape primitive (writable raw disk device, etc.). | No agent workflow touches `/dev/*`. |
| `NET_RAW` | Raw / ICMP sockets — enables packet crafting, ARP spoof on the docker bridge, TCP RST injection. | Trinity's "ping another agent" UX is HTTP-level, not ICMP. |
| `FSETID` | Preserves setuid/setgid bits on chmod after a non-owner write — plant a setuid binary the next privileged path can run. | No agent workflow needs to keep setuid bits across chmod. |

## Kept

- `DAC_OVERRIDE` — required by `sudo apt-get install` (verified live).
- `FOWNER` — kept; broader file-ownership operations.
- `KILL` — kept; agent process management.

## Why this is the right fit now

The larger Layer-3 plan (#602) ships **3a OAuth-token isolation** and **3b bubblewrap-per-MCP sandbox** as separate sprints. Both are weeks of work. **3c is the single sub-fix that closes the AISEC-C2 token-exfil path TODAY** without waiting for either. `SYS_PTRACE` is *the* primitive a malicious MCP needs to read Claude Code's heap; removing it makes the "owner installs evil npm package" path materially less dangerous.

## Live verification (running stack)

```
# Fresh agent, /proc/1/status CapBnd decoded:
✓ CHOWN, DAC_OVERRIDE, FOWNER, KILL, SETGID, SETUID,
  NET_BIND_SERVICE, SYS_CHROOT, AUDIT_WRITE       (9 caps, was 13)
✗ SYS_PTRACE, MKNOD, NET_RAW, FSETID              (absent in kernel bounding set)

# Functional checks:
sudo apt-get update                  → exit 0  (DAC_OVERRIDE preserved)
python AF_INET/SOCK_RAW              → EPERM   (NET_RAW removed)
ptrace(PTRACE_ATTACH, 1, …)          → EPERM   (SYS_PTRACE removed)
```

## Rollout

Capability changes apply per container at create-time. Existing agents keep their old caps until restart; new and recreated agents get the trimmed set immediately. No rolling-restart needed.

`check_full_capabilities_match()` compares the *flag*, not the cap list — so already-running containers won't be auto-recreated. Operators who want the tightening to apply to live agents today can `docker restart agent-<name>` (or use the existing recreate flow on any config change).

## Regression guard

`tests/unit/test_capability_set.py` (4 tests, 92 lines) pins the FULL set:
- The 4 removed caps must not reappear in `FULL_CAPABILITIES` or `RESTRICTED_CAPABILITIES`
- FULL must remain a superset of RESTRICTED (tightening shouldn't drop a baseline cap)
- `PROHIBITED_CAPABILITIES` (`SYS_ADMIN`, `NET_ADMIN`, `SYS_RAWIO`, etc.) never leak into either set

Future PR that silently re-adds `SYS_PTRACE` fails the test with a pointer to this commit + AISEC-C2 context.

## Test plan

- [x] FULL set in code matches what backend hot-reloads (9 entries)
- [x] Container created with PR code has CapBnd missing the 4 caps (kernel-level)
- [x] `sudo apt-get update` still works
- [x] Raw socket + ptrace blocked with EPERM
- [x] Unit tests pass (`pytest tests/unit/test_capability_set.py`) — runs in CI
- [ ] CI: full backend-unit-test diff base vs head clean
- [ ] No existing agent template documents using ping/strace/mknod (grepped — none)

## Out of scope

- **3a** (OAuth token / TRINITY_MCP_API_KEY isolation via `/run/secrets/`) — separate PR
- **3b** (bubblewrap-per-MCP sandbox) — sprint-scale; #602 trigger conditions haven't fired yet
- Re-evaluating `DAC_OVERRIDE` — needs apt-install-without-DAC verification; left as follow-up

Related to #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)