### PR TITLE
feat: platform default model setting + UI clarity for null model (#831)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -87,7 +87,7 @@ class ClaudeCodeRuntime(AgentRuntime):
 
     def get_default_model(self) -> str:
         """Get default Claude model."""
-        return "sonnet"  # Claude Sonnet 4.5
+        return "claude-sonnet-4-6"
 
     def get_context_window(self, model: Optional[str] = None) -> int:
         """Get context window for Claude models."""
@@ -190,14 +190,11 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
         # 2. ANTHROPIC_API_KEY environment variable (API billing)
         # We don't require ANTHROPIC_API_KEY since users may be logged in with their subscription.
 
-        # Issue #138: Default to "sonnet" when no model is specified and none is set on state.
-        # Same fix as Issue #81 for execute_headless_task() — without --model, Claude Code
-        # uses the agent's ~/.claude/settings.json model, which may be incompatible with
-        # the assigned subscription (e.g., haiku on Claude Max), causing misleading
-        # "token expired" errors.
+        # Safety-net fallback: backend always resolves model before calling the agent
+        # (#831), so this branch should only fire for direct agent-server calls.
         if not model and not agent_state.current_model:
-            model = "sonnet"
-            logger.debug("[Chat] No model specified, defaulting to 'sonnet' for subscription compatibility")
+            model = "claude-sonnet-4-6"
+            logger.debug("[Chat] No model specified, defaulting to 'claude-sonnet-4-6'")
 
         # Update model if specified (persists for session)
         if model:

--- a/docker/base-image/agent_server/services/headless_executor.py
+++ b/docker/base-image/agent_server/services/headless_executor.py
@@ -144,10 +144,11 @@ def _setup_headless_command(
     --input-format / --append-system-prompt / --max-turns), and unique
     task-session-id generation. Pure — no subprocess spawn, no DI.
     """
-    # Issue #81: Default to "sonnet" when model is not specified.
+    # Safety-net fallback: backend always resolves model before calling the agent
+    # (#831), so this branch should only fire for direct agent-server calls.
     if model is None:
-        model = "sonnet"
-        logger.debug("[Headless Task] No model specified, defaulting to 'sonnet' for subscription compatibility")
+        model = "claude-sonnet-4-6"
+        logger.debug("[Headless Task] No model specified, defaulting to 'claude-sonnet-4-6'")
 
     # Build command - NO --continue flag (stateless) unless resuming
     cmd = ["claude", "--print", "--output-format", "stream-json", "--verbose", "--dangerously-skip-permissions"]

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -126,6 +126,7 @@ async def get_public_feature_flags(
     return {
         "session_tab_enabled": settings_service.is_session_tab_enabled(),
         "voice_available": VOICE_ENABLED and bool(GEMINI_API_KEY),
+        "platform_default_model": settings_service.get_platform_default_model(),
     }
 
 
@@ -1373,6 +1374,12 @@ async def update_setting(
 
     try:
         setting = db.set_setting(key, body.value)
+
+        # #831: Invalidate platform default model TTL cache on write
+        if key == "platform_default_model":
+            import services.settings_service as _ss
+            _ss._platform_model_cache = None
+            _ss._platform_model_cache_ts = 0.0
 
         # SEC-001: audit generic setting change
         await platform_audit_service.log(

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -12,8 +12,16 @@ routers.settings re-exports these functions for backward compatibility.
 """
 import json
 import os
+import time
 from typing import List, Optional
 from database import db
+
+# Platform default model (#831)
+PLATFORM_DEFAULT_MODEL_KEY = "platform_default_model"
+PLATFORM_DEFAULT_MODEL_VALUE = "claude-sonnet-4-6"
+_platform_model_cache: Optional[str] = None
+_platform_model_cache_ts: float = 0.0
+_PLATFORM_MODEL_CACHE_TTL = 60.0
 
 
 # ============================================================================
@@ -194,6 +202,22 @@ class SettingsService:
     def delete_github_templates(self) -> bool:
         """Delete GitHub templates configuration (revert to defaults)."""
         return db.delete_setting('github_templates')
+
+    def get_platform_default_model(self) -> str:
+        """
+        Return the platform-wide default Claude model (#831).
+
+        Resolution: system_settings.platform_default_model → PLATFORM_DEFAULT_MODEL_VALUE.
+        Result is cached for 60 s to avoid per-turn SQLite reads during burst drain.
+        """
+        global _platform_model_cache, _platform_model_cache_ts
+        now = time.monotonic()
+        if _platform_model_cache is not None and (now - _platform_model_cache_ts) < _PLATFORM_MODEL_CACHE_TTL:
+            return _platform_model_cache
+        value = self.get_setting(PLATFORM_DEFAULT_MODEL_KEY, PLATFORM_DEFAULT_MODEL_VALUE)
+        _platform_model_cache = value or PLATFORM_DEFAULT_MODEL_VALUE
+        _platform_model_cache_ts = now
+        return _platform_model_cache
 
     def get_ops_setting(self, key: str, as_type: type = str):
         """
@@ -385,3 +409,8 @@ def get_agent_default_resources() -> dict:
 def get_github_templates() -> Optional[List[dict]]:
     """Get admin-configured GitHub templates, or None for defaults."""
     return settings_service.get_github_templates()
+
+
+def get_platform_default_model() -> str:
+    """Return the platform-wide default Claude model (#831)."""
+    return settings_service.get_platform_default_model()

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -32,6 +32,7 @@ from services.activity_service import activity_service
 from services.agent_client import CircuitState
 from services.capacity_manager import CapacityFull, get_capacity_manager
 from utils.credential_sanitizer import sanitize_execution_log, sanitize_response
+from services.settings_service import settings_service
 from services.platform_prompt_service import (
     ExecutionContext,
     compose_system_prompt,
@@ -279,6 +280,11 @@ class TaskExecutionService:
         # TIMEOUT-001: Use agent's configured timeout if not explicitly provided
         if timeout_seconds is None:
             timeout_seconds = db.get_execution_timeout(agent_name)
+
+        # #831: Resolve null model → platform default so the agent always receives
+        # a concrete model string. Avoids the stale "sonnet" hardcode in base-image.
+        if model is None:
+            model = settings_service.get_platform_default_model()
 
         # ---- 1. Create execution record (if not provided) ----------------
         if not execution_id:

--- a/src/frontend/src/components/ModelSelector.vue
+++ b/src/frontend/src/components/ModelSelector.vue
@@ -12,7 +12,7 @@
         @keydown.down.prevent="highlightNext"
         @keydown.up.prevent="highlightPrev"
         @keydown.enter.prevent="selectHighlighted"
-        :placeholder="placeholder"
+        :placeholder="resolvedPlaceholder"
         :class="inputClass"
       />
       <button
@@ -71,24 +71,31 @@ const props = defineProps({
   },
   placeholder: {
     type: String,
-    default: 'Select or type a model...'
+    default: null
   },
   compact: {
     type: Boolean,
     default: false
+  },
+  platformDefault: {
+    type: String,
+    default: null
   }
 })
 
 const emit = defineEmits(['update:modelValue'])
 
+// Canonical model list — synced from https://docs.anthropic.com/en/docs/about-claude/models/overview
+// Last updated: 2026-05-13 (#831)
 const PRESET_MODELS = [
-  { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5', note: 'Default — most capable' },
-  { value: 'claude-opus-4-6', label: 'Claude Opus 4.6', note: 'Latest generation' },
-  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', note: 'Fast + smart' },
-  { value: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5', note: 'Previous gen, fast' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', note: 'Fastest, cheapest' },
-  { value: 'claude-opus-4-20250514', label: 'Claude Opus 4', note: 'Legacy' },
-  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4', note: 'Legacy' }
+  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7', note: 'Most capable (latest)' },
+  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', note: 'Fast + smart (latest)' },
+  { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', note: 'Fastest, cheapest (latest)' },
+  { value: 'claude-opus-4-6', label: 'Claude Opus 4.6', note: 'Legacy' },
+  { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5', note: 'Legacy' },
+  { value: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5', note: 'Legacy' },
+  { value: 'claude-opus-4-20250514', label: 'Claude Opus 4', note: 'Deprecated — retiring Jun 15 2026' },
+  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4', note: 'Deprecated — retiring Jun 15 2026' },
 ]
 
 const showDropdown = ref(false)
@@ -96,6 +103,12 @@ const highlightedIndex = ref(-1)
 const containerRef = ref(null)
 const inputRef = ref(null)
 const isTyping = ref(false)
+
+const resolvedPlaceholder = computed(() => {
+  if (props.placeholder !== null) return props.placeholder
+  if (props.platformDefault) return `platform default (${props.platformDefault})`
+  return 'Select or type a model...'
+})
 
 const inputClass = computed(() => {
   const base = 'w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500 pr-8'

--- a/src/frontend/src/components/SchedulesPanel.vue
+++ b/src/frontend/src/components/SchedulesPanel.vue
@@ -80,9 +80,17 @@
               />
             </div>
 
-            <!-- Model Selector (MODEL-001) -->
+            <!-- Model Selector (#831) -->
             <div>
-              <ModelSelector v-model="formData.model" label="Model" />
+              <ModelSelector
+                v-model="formData.model"
+                label="Model"
+                :platformDefault="platformDefaultModel"
+              />
+              <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Leave blank to use the platform default
+                <span v-if="platformDefaultModel" class="font-mono">({{ platformDefaultModel }})</span>.
+              </p>
             </div>
 
             <div class="grid grid-cols-2 gap-4">
@@ -291,11 +299,13 @@
                 </svg>
                 {{ schedule.allowed_tools.length }} tools
               </span>
-              <span v-if="schedule.model" class="flex items-center" :title="`Model: ${schedule.model}`">
+              <span class="flex items-center" :title="`Model: ${schedule.model || 'platform default'}`">
                 <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
-                {{ schedule.model }}
+                <span :class="!schedule.model ? 'text-gray-400 dark:text-gray-500 italic' : ''">
+                  {{ schedule.model || `platform default${platformDefaultModel ? ` (${platformDefaultModel})` : ''}` }}
+                </span>
               </span>
               <!-- RETRY-001: Retry configuration badge -->
               <span v-if="schedule.max_retries > 0" class="flex items-center" :title="`Retry: ${schedule.max_retries}x, ${schedule.retry_delay_seconds}s delay`">
@@ -517,7 +527,9 @@
             </div>
             <div>
               <p class="text-xs text-gray-500 dark:text-gray-400">Model</p>
-              <p class="text-sm font-medium font-mono dark:text-white">{{ selectedExecution.model_used || 'default' }}</p>
+              <p class="text-sm font-medium font-mono dark:text-white">
+                {{ selectedExecution.model_used || `platform default${platformDefaultModel ? ` (${platformDefaultModel})` : ''}` }}
+              </p>
             </div>
             <div>
               <p class="text-xs text-gray-500 dark:text-gray-400">Triggered By</p>
@@ -603,6 +615,9 @@ import ConfirmDialog from './ConfirmDialog.vue'
 import ModelSelector from './ModelSelector.vue'
 import { useAuthStore } from '../stores/auth'
 
+// Platform default model fetched from /api/settings/feature-flags (#831)
+const platformDefaultModel = ref('')
+
 const props = defineProps({
   agentName: {
     type: String,
@@ -663,7 +678,7 @@ const formData = ref({
   enabled: true,
   timeout_seconds: 900,
   allowed_tools: null,  // null = all tools allowed
-  model: 'claude-opus-4-5-20251101',  // MODEL-001
+  model: '',  // '' = use platform default (#831); non-empty = explicit override
   // RETRY-001: Retry configuration. 0 = disabled (default, #476); 1-5 opt-in.
   max_retries: 0,
   retry_delay_seconds: 60  // Seconds between retries (30-600 range)
@@ -754,18 +769,20 @@ async function saveSchedule() {
   formError.value = ''
 
   try {
+    // Normalize '' → null so DB stores NULL, not empty string (#831)
+    const payload = { ...formData.value, model: formData.value.model || null }
     if (editingSchedule.value) {
       // Update
       await axios.put(
         `/api/agents/${props.agentName}/schedules/${editingSchedule.value.id}`,
-        formData.value,
+        payload,
         { headers: authStore.authHeader }
       )
     } else {
       // Create
       await axios.post(
         `/api/agents/${props.agentName}/schedules`,
-        formData.value,
+        payload,
         { headers: authStore.authHeader }
       )
     }
@@ -792,7 +809,7 @@ function closeForm() {
     enabled: true,
     timeout_seconds: 900,
     allowed_tools: null,
-    model: 'claude-opus-4-5-20251101',
+    model: '',  // '' = use platform default (#831)
     // RETRY-001
     max_retries: 0,
     retry_delay_seconds: 60
@@ -811,7 +828,7 @@ function editSchedule(schedule) {
     enabled: schedule.enabled,
     timeout_seconds: schedule.timeout_seconds || 900,
     allowed_tools: schedule.allowed_tools || null,
-    model: schedule.model || 'claude-opus-4-6',
+    model: schedule.model || '',  // '' = use platform default (#831)
     // RETRY-001
     max_retries: schedule.max_retries ?? 0,
     retry_delay_seconds: schedule.retry_delay_seconds ?? 60
@@ -1040,8 +1057,15 @@ watch(() => props.initialMessage, (newMessage) => {
   }
 }, { immediate: true })
 
-onMounted(() => {
+onMounted(async () => {
   loadSchedules()
+  // Fetch platform default model for display and ModelSelector placeholder (#831)
+  try {
+    const r = await axios.get('/api/settings/feature-flags', { headers: authStore.authHeader })
+    platformDefaultModel.value = r.data.platform_default_model || ''
+  } catch {
+    // non-critical; falls back to generic placeholder
+  }
 })
 
 onUnmounted(() => {

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -109,6 +109,44 @@
                     Used for Telegram webhooks, Slack OAuth callbacks, and shareable public links.
                   </p>
                 </div>
+
+                <!-- Platform Default Model (#831) -->
+                <div v-if="isAdmin">
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Default Model
+                  </label>
+                  <div class="mt-1 flex gap-2 items-center">
+                    <select
+                      v-model="platformDefaultModelValue"
+                      :disabled="savingPlatformDefaultModel"
+                      class="block flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
+                    >
+                      <option value="claude-sonnet-4-6">Claude Sonnet 4.6 — Fast + smart (recommended)</option>
+                      <option value="claude-opus-4-7">Claude Opus 4.7 — Most capable</option>
+                    </select>
+                    <button
+                      @click="savePlatformDefaultModel"
+                      :disabled="savingPlatformDefaultModel"
+                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <svg v-if="savingPlatformDefaultModel" class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      Save
+                    </button>
+                  </div>
+                  <div v-if="platformDefaultModelSaveSuccess" class="mt-1 flex items-center text-sm text-status-success-600 dark:text-status-success-400">
+                    <svg class="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                    Saved
+                  </div>
+                  <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                    Model used for schedules and chats where no model is explicitly selected.
+                    Changes take effect on the next execution — no restart required.
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -1788,6 +1826,11 @@ const originalPrompt = ref('')
 // Public URL state
 const publicUrl = ref('')
 const publicUrlCurrent = ref('')
+
+// Platform default model (#831)
+const platformDefaultModelValue = ref('claude-sonnet-4-6')
+const savingPlatformDefaultModel = ref(false)
+const platformDefaultModelSaveSuccess = ref(false)
 const savingPublicUrl = ref(false)
 const publicUrlSaveSuccess = ref(false)
 
@@ -1948,6 +1991,7 @@ async function loadSettings() {
     // Load independent settings in parallel
     await Promise.all([
       loadPublicUrl(),
+      loadPlatformDefaultModel(),
       loadApiKeyStatus(),
       loadSlackSettings(),
       loadSlackTransportStatus(),
@@ -2148,6 +2192,30 @@ function removeGithubPat() {
     }
   }
   confirmDialog.visible = true
+}
+
+// Platform default model methods (#831)
+async function loadPlatformDefaultModel() {
+  try {
+    const value = await settingsStore.getSetting('platform_default_model')
+    if (value) platformDefaultModelValue.value = value
+  } catch {
+    // non-critical; UI shows the code-default
+  }
+}
+
+async function savePlatformDefaultModel() {
+  savingPlatformDefaultModel.value = true
+  platformDefaultModelSaveSuccess.value = false
+  try {
+    await settingsStore.updateSetting('platform_default_model', platformDefaultModelValue.value)
+    platformDefaultModelSaveSuccess.value = true
+    setTimeout(() => { platformDefaultModelSaveSuccess.value = false }, 3000)
+  } catch (e) {
+    error.value = e.response?.data?.detail || 'Failed to save default model'
+  } finally {
+    savingPlatformDefaultModel.value = false
+  }
 }
 
 // Public URL methods

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -497,6 +497,17 @@
         "executions",
         "circuit-breaker"
       ]
+    },
+    {
+      "file": "test_platform_default_model.py",
+      "feature": "MODEL-DEFAULT-001",
+      "added": "2026-05-13",
+      "categories": [
+        "unit",
+        "integration",
+        "backend",
+        "settings"
+      ]
     }
   ]
 }

--- a/tests/test_platform_default_model.py
+++ b/tests/test_platform_default_model.py
@@ -1,0 +1,194 @@
+"""
+Tests for platform default model setting (#831).
+
+Covers:
+- feature-flags endpoint includes platform_default_model
+- settings_service.get_platform_default_model() returns fallback when no row
+- settings_service.get_platform_default_model() returns DB value when set
+- task_execution_service resolves None model → platform default
+
+Run against a live backend: TRINITY_API_URL=http://localhost:8000
+"""
+import os
+import time
+import pytest
+import httpx
+
+BASE_URL = os.getenv("TRINITY_API_URL", "http://localhost:8000")
+USERNAME = os.getenv("TRINITY_TEST_USERNAME", "admin")
+PASSWORD = os.getenv("TRINITY_TEST_PASSWORD", "password")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get_auth_headers():
+    resp = httpx.post(
+        f"{BASE_URL}/api/token",
+        data={"username": USERNAME, "password": PASSWORD},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Unit-style tests (backend service — no live server required)
+# ---------------------------------------------------------------------------
+
+class TestGetPlatformDefaultModelUnit:
+    """Tests for settings_service.get_platform_default_model() in isolation."""
+
+    def test_returns_fallback_when_no_db_row(self, monkeypatch):
+        """When system_settings has no platform_default_model row, return hardcoded default."""
+        import sys
+        import types
+
+        # Provide a minimal stub for the `database` module so we can import
+        # settings_service without a running database.
+        if "database" not in sys.modules:
+            db_stub = types.ModuleType("database")
+            db_stub.db = types.SimpleNamespace(
+                get_setting_value=lambda key, default=None: default
+            )
+            sys.modules["database"] = db_stub
+
+        # Clear the module cache so our monkeypatched db takes effect.
+        sys.modules.pop("services.settings_service", None)
+
+        import importlib
+        import src.backend.services.settings_service as svc_module
+        importlib.reload(svc_module)
+
+        svc = svc_module.SettingsService()
+        result = svc.get_platform_default_model()
+        assert result == "claude-sonnet-4-6"
+
+    def test_returns_db_value_when_set(self, monkeypatch):
+        """When system_settings has a platform_default_model row, return that value."""
+        import sys
+        import types
+
+        db_stub = types.ModuleType("database")
+        db_stub.db = types.SimpleNamespace(
+            get_setting_value=lambda key, default=None: (
+                "claude-opus-4-7" if key == "platform_default_model" else default
+            )
+        )
+        sys.modules["database"] = db_stub
+        sys.modules.pop("services.settings_service", None)
+
+        import importlib
+        import src.backend.services.settings_service as svc_module
+        importlib.reload(svc_module)
+
+        svc = svc_module.SettingsService()
+        result = svc.get_platform_default_model()
+        assert result == "claude-opus-4-7"
+
+    def test_ttl_cache_returns_cached_value(self, monkeypatch):
+        """TTL cache returns the cached value within 60s without a new DB read."""
+        import sys
+        import types
+
+        call_count = [0]
+
+        def counting_get(key, default=None):
+            if key == "platform_default_model":
+                call_count[0] += 1
+            return "claude-sonnet-4-6" if key == "platform_default_model" else default
+
+        db_stub = types.ModuleType("database")
+        db_stub.db = types.SimpleNamespace(get_setting_value=counting_get)
+        sys.modules["database"] = db_stub
+        sys.modules.pop("services.settings_service", None)
+
+        import importlib
+        import src.backend.services.settings_service as svc_module
+        importlib.reload(svc_module)
+
+        svc = svc_module.SettingsService()
+        svc.get_platform_default_model()
+        svc.get_platform_default_model()
+        svc.get_platform_default_model()
+        # Only one DB read due to TTL cache
+        assert call_count[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (live backend required)
+# ---------------------------------------------------------------------------
+
+class TestFeatureFlagsEndpoint:
+    """GET /api/settings/feature-flags must include platform_default_model."""
+
+    def test_feature_flags_includes_platform_default_model(self):
+        headers = get_auth_headers()
+        resp = httpx.get(f"{BASE_URL}/api/settings/feature-flags", headers=headers, timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "platform_default_model" in data, (
+            "feature-flags response missing 'platform_default_model' key"
+        )
+        assert isinstance(data["platform_default_model"], str)
+        assert len(data["platform_default_model"]) > 0
+
+    def test_feature_flags_default_is_claude_sonnet(self):
+        """Out-of-box default must be claude-sonnet-4-6 unless overridden in DB."""
+        headers = get_auth_headers()
+        resp = httpx.get(f"{BASE_URL}/api/settings/feature-flags", headers=headers, timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        # Accept either the code default or a valid admin override
+        assert data["platform_default_model"] in (
+            "claude-sonnet-4-6",
+            "claude-opus-4-7",
+        ), f"Unexpected default: {data['platform_default_model']}"
+
+    def test_feature_flags_unauthenticated_returns_401(self):
+        resp = httpx.get(f"{BASE_URL}/api/settings/feature-flags", timeout=10)
+        assert resp.status_code == 401
+
+
+class TestPlatformDefaultModelSetting:
+    """Admin can read/write platform_default_model via /api/settings/{key}."""
+
+    def test_admin_can_read_platform_default_model(self):
+        headers = get_auth_headers()
+        resp = httpx.get(
+            f"{BASE_URL}/api/settings/platform_default_model",
+            headers=headers,
+            timeout=10,
+        )
+        # Either 200 (row exists) or 404 (no row yet — fallback used)
+        assert resp.status_code in (200, 404)
+
+    def test_admin_can_set_and_retrieve_platform_default_model(self):
+        headers = get_auth_headers()
+        # Set to opus
+        put_resp = httpx.put(
+            f"{BASE_URL}/api/settings/platform_default_model",
+            json={"value": "claude-opus-4-7"},
+            headers=headers,
+            timeout=10,
+        )
+        assert put_resp.status_code in (200, 201)
+
+        # Verify via feature-flags
+        ff_resp = httpx.get(
+            f"{BASE_URL}/api/settings/feature-flags",
+            headers=headers,
+            timeout=10,
+        )
+        assert ff_resp.status_code == 200
+        assert ff_resp.json()["platform_default_model"] == "claude-opus-4-7"
+
+        # Reset to sonnet
+        httpx.put(
+            f"{BASE_URL}/api/settings/platform_default_model",
+            json={"value": "claude-sonnet-4-6"},
+            headers=headers,
+            timeout=10,
+        )


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `task_execution_service.execute_task()` now resolves `model=None` → `platform_default_model` setting (default `claude-sonnet-4-6`) before calling the agent. This fixes the silent Sonnet substitution for all 44+ null-model schedules in a single choke point.
- **Configurable default**: Admin can select between Claude Sonnet 4.6 (recommended) and Claude Opus 4.7 in Settings → General. Stored in `system_settings`, exposed via `GET /api/settings/feature-flags` with 60s TTL cache + write-through invalidation.
- **UI clarity**: `SchedulesPanel` shows `platform default (claude-sonnet-4-6)` for null-model schedules; `ModelSelector` updated to canonical Anthropic model list with deprecated models labelled.

## Changes

**Backend:**
- `src/backend/services/settings_service.py` — `get_platform_default_model()` with 60s TTL cache
- `src/backend/routers/settings.py` — `platform_default_model` in feature-flags + cache invalidation on `PUT /{key}`
- `src/backend/services/task_execution_service.py` — resolve `model=None` → platform default

**Agent base-image:**
- `docker/base-image/agent_server/services/headless_executor.py` — replace hardcoded `"sonnet"` → `"claude-sonnet-4-6"`
- `docker/base-image/agent_server/services/claude_code.py` — same

**Frontend:**
- `src/frontend/src/components/ModelSelector.vue` — canonical model list (Opus 4.7 added, deprecated models labelled, `platformDefault` prop)
- `src/frontend/src/components/SchedulesPanel.vue` — null model display, form inconsistencies fixed (lines 666/795/814), `""` → `null` normalization on save
- `src/frontend/src/views/Settings.vue` — Platform Default Model selector widget (admin-only)

## Test Plan

- [x] `pytest tests/test_platform_default_model.py` — 8 tests, all passing
- [x] `GET /api/settings/feature-flags` returns `platform_default_model`
- [x] `PUT /api/settings/platform_default_model` updates value and invalidates cache
- [ ] Manual: create a null-model schedule → verify execution uses `claude-sonnet-4-6`
- [ ] Manual: Settings → General shows "Default Model" selector for admin
- [ ] Manual: SchedulesPanel shows "platform default (claude-sonnet-4-6)" for null-model schedules

Fixes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)