### PR TITLE
feat(soft-delete): admin recovery endpoints (#834 Phase 1c)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -640,6 +640,20 @@ picks up on its next poll. (#389 S1a)
 | GET | `/oauth/{provider}/callback` | OAuth callback |
 | GET | `/health` | Health check (unauthenticated, top-level — no `/api/` prefix) |
 
+### Soft-Delete Admin Recovery (#834 Phase 1c)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/admin/soft-deleted/agents` | Admin | List soft-deleted agents (newest first); each row has computed `purge_eta` (null if `agent_soft_delete_retention_days=0`). `limit` capped at 500. |
+| POST | `/api/admin/soft-deleted/agents/{name}/recover` | Admin | Clear `agent_ownership.deleted_at`. 404 if not soft-deleted. Metadata-only — container NOT recreated (`needs_container_recreate=true`); operator runs `POST /api/agents/{name}/start`. Audit `agent_lifecycle:recover`. |
+| GET | `/api/admin/soft-deleted/schedules` | Admin | List soft-deleted schedules (optional `?agent_name=`); `purge_eta` from `schedule_soft_delete_retention_days`. `limit` capped at 500. |
+| POST | `/api/admin/soft-deleted/schedules/{id}/recover` | Admin | Clear `agent_schedules.deleted_at`. 404 if not soft-deleted. Rejoins the scheduler firing list next poll if enabled. Audit `agent_lifecycle:schedule_recover`. |
+
+Recovery is metadata-only (`deleted_at → NULL`); preserved child rows
+make the entity immediately usable via the regular
+`deleted_at`-filtered read paths. Response models `SoftDeletedAgent` /
+`SoftDeletedSchedule` are in `models.py` (Invariant #14).
+
 ### Fleet Sync Audit (#390 / S6)
 
 | Method | Path | Description |

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -2277,8 +2277,36 @@ Standalone mobile-friendly admin page for managing agents on the go. Designed as
   deleted_at IS NOT NULL`. Migration in `db/migrations.py`.
 
 ### 33.3 Admin Recovery Endpoints (#834 — Phase 1c)
-- **Status**: 🚧 In progress (PR #840). Admin surface to list and
-  recover soft-deleted agents/schedules before the retention purge.
+- **Implements**: Issue #834 Phase 1c (PR #840)
+- **Description**: Admin-only surface to list and recover soft-deleted
+  agents/schedules before the retention purge hard-deletes them.
+  Replaces the prior shell-only workaround (manual `UPDATE ... SET
+  deleted_at = NULL`), which required DB access and was unauditable.
+- **Endpoints** (all `require_admin`, all audit-logged):
+  - `GET /api/admin/soft-deleted/agents` — list soft-deleted agents,
+    newest first. Each row carries a computed `purge_eta` (when the
+    retention sweep would hard-purge it; `null` when
+    `agent_soft_delete_retention_days = 0`). `limit` capped at 500.
+  - `POST /api/admin/soft-deleted/agents/{name}/recover` — clear
+    `deleted_at`. 404 if not in the soft-deleted set. **Metadata-only**:
+    the Docker container is *not* recreated (removed at soft-delete);
+    the agent shows `status=stopped` / `needs_container_recreate=true`.
+    Operator brings it back via `POST /api/agents/{name}/start` from the
+    preserved workspace volume. Container recreate-on-recover is #834
+    Phase 2.
+  - `GET /api/admin/soft-deleted/schedules` — list soft-deleted
+    schedules (optionally `?agent_name=`-scoped), with `purge_eta` from
+    `schedule_soft_delete_retention_days`. `limit` capped at 500.
+  - `POST /api/admin/soft-deleted/schedules/{id}/recover` — clear
+    `deleted_at`. 404 if not soft-deleted. The schedule rejoins the
+    scheduler firing list on the next poll if it was enabled.
+- **Recovery semantics**: flips `deleted_at` back to NULL; child rows
+  already survived the soft-delete so the entity is immediately usable
+  via the regular (deleted_at-filtered) read paths.
+- **Audit**: every recovery emits an `agent_lifecycle:recover` /
+  `agent_lifecycle:schedule_recover` platform-audit event.
+- **Models**: `SoftDeletedAgent` / `SoftDeletedSchedule` response
+  models live in `models.py` (Architectural Invariant #14).
 
 ---
 

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -355,6 +355,12 @@ class DatabaseManager:
     def is_agent_name_reserved(self, agent_name: str):
         return self._agent_ops.is_agent_name_reserved(agent_name)
 
+    def recover_agent_ownership(self, agent_name: str):
+        return self._agent_ops.recover_agent_ownership(agent_name)
+
+    def list_soft_deleted_agents(self, limit: int = 200):
+        return self._agent_ops.list_soft_deleted_agents(limit)
+
     def rename_agent(self, old_name: str, new_name: str):
         return self._agent_ops.rename_agent(old_name, new_name)
 
@@ -715,6 +721,12 @@ class DatabaseManager:
 
     def find_soft_deleted_schedules_past_retention(self, retention_days: int, limit: int = 5000):
         return self._schedule_ops.find_soft_deleted_schedules_past_retention(retention_days, limit)
+
+    def recover_schedule(self, schedule_id: str):
+        return self._schedule_ops.recover_schedule(schedule_id)
+
+    def list_soft_deleted_schedules(self, agent_name=None, limit: int = 200):
+        return self._schedule_ops.list_soft_deleted_schedules(agent_name, limit)
 
     # Webhook token management (WEBHOOK-001, #291)
     def generate_webhook_token(self, schedule_id: str):

--- a/src/backend/db/agents.py
+++ b/src/backend/db/agents.py
@@ -211,6 +211,52 @@ class AgentOperations(
             )
             return [row["agent_name"] for row in cursor.fetchall()]
 
+    def recover_agent_ownership(self, agent_name: str) -> bool:
+        """Recover a soft-deleted agent by clearing `deleted_at` (#834).
+
+        Reverses a `delete_agent_ownership()` call within the retention
+        window. Refuses to operate on:
+          - a row that doesn't exist (returns False)
+          - a live row (already `deleted_at IS NULL`; returns False)
+
+        Returns True on successful recovery. Child rows survived the
+        soft-delete intact, so the agent is immediately accessible
+        again via the user-facing read paths. The Docker container is
+        NOT recreated — that's a separate operation (operator must
+        re-start the agent if they want a running container).
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE agent_ownership SET deleted_at = NULL "
+                "WHERE agent_name = ? AND deleted_at IS NOT NULL",
+                (agent_name,),
+            )
+            if cursor.rowcount > 0:
+                conn.commit()
+                return True
+            return False
+
+    def list_soft_deleted_agents(self, limit: int = 200) -> List[Dict]:
+        """List currently-soft-deleted agents with their `deleted_at`.
+
+        Used by the admin recovery endpoint. Returns agent_name,
+        owner_id (so admins can filter by owner), and the timestamp
+        the agent was soft-deleted. The purge ETA is computed at the
+        router layer using `agent_soft_delete_retention_days`.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT agent_name, owner_id, deleted_at, created_at "
+                "FROM agent_ownership "
+                "WHERE deleted_at IS NOT NULL "
+                "ORDER BY deleted_at DESC "
+                "LIMIT ?",
+                (limit,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
     def purge_agent_ownership(self, agent_name: str) -> bool:
         """Hard-delete a soft-deleted agent (#834): runs #816 cascade_delete
         on child tables then removes the agent_ownership row itself.

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -530,6 +530,61 @@ class ScheduleOperations:
             conn.commit()
             return cursor.rowcount > 0
 
+    def recover_schedule(self, schedule_id: str) -> bool:
+        """Recover a soft-deleted schedule by clearing `deleted_at` (#834).
+
+        Refuses to operate on a row that doesn't exist or is already
+        live (`deleted_at IS NULL`). Returns True on successful
+        recovery. The schedule reappears on the scheduler's
+        firing list on the next poll cycle if it was enabled at the
+        time of soft-delete.
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE agent_schedules SET deleted_at = NULL "
+                "WHERE id = ? AND deleted_at IS NOT NULL",
+                (schedule_id,),
+            )
+            if cursor.rowcount > 0:
+                conn.commit()
+                return True
+            return False
+
+    def list_soft_deleted_schedules(
+        self, agent_name: Optional[str] = None, limit: int = 200
+    ) -> list:
+        """List currently-soft-deleted schedules with their `deleted_at`.
+
+        If `agent_name` is given, scopes to that agent's schedules
+        (admin endpoint pattern: GET /api/admin/agents/{name}/schedules/
+        soft-deleted). With `agent_name=None`, returns soft-deleted
+        schedules across the fleet (admin-only).
+        """
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            if agent_name is None:
+                cursor.execute(
+                    "SELECT id, agent_name, name, cron_expression, message, "
+                    "       owner_id, enabled, deleted_at "
+                    "FROM agent_schedules "
+                    "WHERE deleted_at IS NOT NULL "
+                    "ORDER BY deleted_at DESC "
+                    "LIMIT ?",
+                    (limit,),
+                )
+            else:
+                cursor.execute(
+                    "SELECT id, agent_name, name, cron_expression, message, "
+                    "       owner_id, enabled, deleted_at "
+                    "FROM agent_schedules "
+                    "WHERE deleted_at IS NOT NULL AND agent_name = ? "
+                    "ORDER BY deleted_at DESC "
+                    "LIMIT ?",
+                    (agent_name, limit),
+                )
+            return [dict(row) for row in cursor.fetchall()]
+
     def find_soft_deleted_schedules_past_retention(
         self, retention_days: int, limit: int = 5000
     ) -> list:

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -92,6 +92,7 @@ from routers.event_subscriptions import router as event_subscriptions_router, se
 from routers.users import router as users_router
 from routers.debug import router as debug_router  # #306 soak instrumentation
 from routers.a2a import router as a2a_router  # #737 A2A Agent Cards
+from routers.admin_recovery import router as admin_recovery_router  # #834 Phase 1c
 from routers.messages import router as messages_router  # Proactive Messaging (#321)
 from routers.public_memory import router as public_memory_router  # MEM-001 write path (#888)
 from routers.webhooks import router as webhooks_router  # Webhook triggers (WEBHOOK-001, #291)
@@ -847,6 +848,7 @@ app.include_router(event_subscriptions_router)  # Agent Event Subscriptions (EVT
 app.include_router(users_router)  # User Management (ROLE-001)
 app.include_router(debug_router)  # #306 soak dashboard
 app.include_router(a2a_router)  # A2A Agent Cards (#737)
+app.include_router(admin_recovery_router)  # Soft-delete admin recovery (#834 Phase 1c)
 app.include_router(webhooks_router)  # Webhook Triggers (WEBHOOK-001, #291)
 app.include_router(ws_tickets_router)  # WebSocket auth tickets (#550)
 

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -482,3 +482,31 @@ class AgentDefaultResourcesUpdate(BaseModel):
     """Body for PUT /api/settings/agent-defaults/resources (RES-001)."""
     cpu: Optional[str] = None
     memory: Optional[str] = None
+
+
+# =============================================================================
+# Soft-Delete Admin Recovery (#834 Phase 1c)
+# =============================================================================
+
+class SoftDeletedAgent(BaseModel):
+    """Response item for GET /api/admin/soft-deleted/agents."""
+    agent_name: str
+    owner_id: int
+    created_at: str
+    deleted_at: str
+    # When the retention sweep would hard-purge this row (None when
+    # the retention setting is 0 = disabled).
+    purge_eta: Optional[str]
+
+
+class SoftDeletedSchedule(BaseModel):
+    """Response item for GET /api/admin/soft-deleted/schedules."""
+    id: str
+    agent_name: str
+    name: str
+    cron_expression: str
+    message: str
+    owner_id: int
+    enabled: bool
+    deleted_at: str
+    purge_eta: Optional[str]

--- a/src/backend/routers/admin_recovery.py
+++ b/src/backend/routers/admin_recovery.py
@@ -165,10 +165,17 @@ async def recover_agent(
 
     return {
         "message": (
-            f"Agent {agent_name} recovered. Container not started — "
-            f"POST /api/agents/{agent_name}/start to bring it back online."
+            f"Agent {agent_name} recovered: all relational state "
+            f"(chat history, schedules, sharing, permissions, "
+            f"credentials config) is restored and the agent is visible "
+            f"again. The Docker container was removed at soft-delete and "
+            f"is NOT recreated by recovery — bringing the agent back "
+            f"online (container recreate from the preserved workspace "
+            f"volume) is tracked as #834 Phase 2. Until then the agent "
+            f"shows status=stopped with needs_start=true."
         ),
         "agent_name": agent_name,
+        "needs_container_recreate": True,
     }
 
 

--- a/src/backend/routers/admin_recovery.py
+++ b/src/backend/routers/admin_recovery.py
@@ -1,0 +1,243 @@
+"""
+Admin recovery endpoints for soft-deleted entities (Issue #834 Phase 1c).
+
+Until this router shipped, the only way to recover a soft-deleted
+agent or schedule was a direct `UPDATE ... SET deleted_at = NULL`
+against the SQLite DB. That worked but required shell access, was
+unauditable, and didn't surface the soft-deleted set anywhere.
+
+This router fills both gaps:
+
+- `GET  /api/admin/soft-deleted/agents`               list soft-deleted agents
+- `POST /api/admin/soft-deleted/agents/{name}/recover` clear `deleted_at`
+- `GET  /api/admin/soft-deleted/schedules`            list soft-deleted schedules
+- `POST /api/admin/soft-deleted/schedules/{id}/recover` clear `deleted_at`
+
+All endpoints are admin-only and audit-logged (every recovery emits
+an `agent_lifecycle:recover` or `schedule:recover` event).
+
+Recovery semantics: Trinity flips `deleted_at` back to NULL. Child
+rows already survived the soft-delete, so the entity is immediately
+usable via the regular read paths. For agents the Docker container
+is NOT recreated automatically — recovery is metadata-only; the
+operator must `POST /api/agents/{name}/start` to bring the container
+back. The preserved workspace volume keeps the agent's files
+intact across the gap.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from database import db
+from dependencies import require_admin
+from models import User
+from services.platform_audit_service import (
+    platform_audit_service,
+    AuditEventType,
+)
+from services.settings_service import OPS_SETTINGS_DEFAULTS
+
+router = APIRouter(prefix="/api/admin/soft-deleted", tags=["admin-recovery"])
+
+
+# -----------------------------------------------------------------------------
+# Response models
+# -----------------------------------------------------------------------------
+
+
+class SoftDeletedAgent(BaseModel):
+    agent_name: str
+    owner_id: int
+    created_at: str
+    deleted_at: str
+    # When the retention sweep would hard-purge this row (None when
+    # the retention setting is 0 = disabled).
+    purge_eta: Optional[str]
+
+
+class SoftDeletedSchedule(BaseModel):
+    id: str
+    agent_name: str
+    name: str
+    cron_expression: str
+    message: str
+    owner_id: int
+    enabled: bool
+    deleted_at: str
+    purge_eta: Optional[str]
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _retention_days(setting_key: str) -> int:
+    raw = db.get_setting_value(setting_key, OPS_SETTINGS_DEFAULTS.get(setting_key, "0"))
+    try:
+        return max(int(raw), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _purge_eta(deleted_at_iso: str, retention_days: int) -> Optional[str]:
+    """ISO-Z timestamp for when the sweep would hard-purge this row, or
+    None if retention is disabled."""
+    if retention_days <= 0:
+        return None
+    try:
+        # ISO with trailing 'Z' isn't directly parseable by fromisoformat
+        # until 3.11; strip 'Z' and treat as UTC.
+        dt = datetime.fromisoformat(deleted_at_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (dt + timedelta(days=retention_days)).astimezone(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Agents
+# -----------------------------------------------------------------------------
+
+
+@router.get("/agents", response_model=List[SoftDeletedAgent])
+async def list_soft_deleted_agents(
+    limit: int = 200,
+    _: User = Depends(require_admin),
+):
+    """List currently-soft-deleted agents, newest first.
+
+    `purge_eta` is computed from `agent_soft_delete_retention_days`;
+    if that's 0 (sweep disabled), the field is null.
+    """
+    retention = _retention_days("agent_soft_delete_retention_days")
+    rows = db.list_soft_deleted_agents(limit=limit)
+    return [
+        SoftDeletedAgent(
+            agent_name=r["agent_name"],
+            owner_id=r["owner_id"],
+            created_at=r["created_at"],
+            deleted_at=r["deleted_at"],
+            purge_eta=_purge_eta(r["deleted_at"], retention),
+        )
+        for r in rows
+    ]
+
+
+@router.post("/agents/{agent_name}/recover")
+async def recover_agent(
+    agent_name: str,
+    request: Request,
+    current_user: User = Depends(require_admin),
+):
+    """Clear `deleted_at` on the agent_ownership row. Audit-logged.
+
+    404 if the agent doesn't exist or isn't currently soft-deleted
+    (live agents aren't a recovery target). The container is NOT
+    started automatically — operator does that explicitly.
+    """
+    if not db.recover_agent_ownership(agent_name):
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Agent '{agent_name}' is not in the soft-deleted set "
+                f"(either doesn't exist, was already recovered, or has "
+                f"been hard-purged)"
+            ),
+        )
+
+    await platform_audit_service.log(
+        event_type=AuditEventType.AGENT_LIFECYCLE,
+        event_action="recover",
+        source="api",
+        actor_user=current_user,
+        actor_ip=request.client.host if request.client else None,
+        target_type="agent",
+        target_id=agent_name,
+        endpoint=str(request.url.path),
+    )
+
+    return {
+        "message": (
+            f"Agent {agent_name} recovered. Container not started — "
+            f"POST /api/agents/{agent_name}/start to bring it back online."
+        ),
+        "agent_name": agent_name,
+    }
+
+
+# -----------------------------------------------------------------------------
+# Schedules
+# -----------------------------------------------------------------------------
+
+
+@router.get("/schedules", response_model=List[SoftDeletedSchedule])
+async def list_soft_deleted_schedules(
+    agent_name: Optional[str] = None,
+    limit: int = 200,
+    _: User = Depends(require_admin),
+):
+    """List soft-deleted schedules across the fleet (or scoped to one
+    agent via `?agent_name=`). `purge_eta` reflects
+    `schedule_soft_delete_retention_days`."""
+    retention = _retention_days("schedule_soft_delete_retention_days")
+    rows = db.list_soft_deleted_schedules(agent_name=agent_name, limit=limit)
+    return [
+        SoftDeletedSchedule(
+            id=r["id"],
+            agent_name=r["agent_name"],
+            name=r["name"],
+            cron_expression=r["cron_expression"],
+            message=r["message"],
+            owner_id=r["owner_id"],
+            enabled=bool(r["enabled"]),
+            deleted_at=r["deleted_at"],
+            purge_eta=_purge_eta(r["deleted_at"], retention),
+        )
+        for r in rows
+    ]
+
+
+@router.post("/schedules/{schedule_id}/recover")
+async def recover_schedule(
+    schedule_id: str,
+    request: Request,
+    current_user: User = Depends(require_admin),
+):
+    """Clear `deleted_at` on the schedule row. Audit-logged.
+
+    404 if the schedule doesn't exist or isn't currently soft-deleted.
+    The schedule reappears on the scheduler firing list on its next
+    poll cycle if it was enabled at the time of soft-delete.
+    """
+    if not db.recover_schedule(schedule_id):
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Schedule '{schedule_id}' is not in the soft-deleted set "
+                f"(either doesn't exist, was already recovered, or has "
+                f"been hard-purged)"
+            ),
+        )
+
+    await platform_audit_service.log(
+        event_type=AuditEventType.AGENT_LIFECYCLE,
+        event_action="schedule_recover",
+        source="api",
+        actor_user=current_user,
+        actor_ip=request.client.host if request.client else None,
+        target_type="schedule",
+        target_id=schedule_id,
+        endpoint=str(request.url.path),
+    )
+
+    return {
+        "message": f"Schedule {schedule_id} recovered.",
+        "schedule_id": schedule_id,
+    }

--- a/src/backend/routers/admin_recovery.py
+++ b/src/backend/routers/admin_recovery.py
@@ -30,12 +30,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from database import db
 from dependencies import require_admin
-from models import User
+from models import User, SoftDeletedAgent, SoftDeletedSchedule
 from services.platform_audit_service import (
     platform_audit_service,
     AuditEventType,
@@ -44,32 +43,9 @@ from services.settings_service import OPS_SETTINGS_DEFAULTS
 
 router = APIRouter(prefix="/api/admin/soft-deleted", tags=["admin-recovery"])
 
-
-# -----------------------------------------------------------------------------
-# Response models
-# -----------------------------------------------------------------------------
-
-
-class SoftDeletedAgent(BaseModel):
-    agent_name: str
-    owner_id: int
-    created_at: str
-    deleted_at: str
-    # When the retention sweep would hard-purge this row (None when
-    # the retention setting is 0 = disabled).
-    purge_eta: Optional[str]
-
-
-class SoftDeletedSchedule(BaseModel):
-    id: str
-    agent_name: str
-    name: str
-    cron_expression: str
-    message: str
-    owner_id: int
-    enabled: bool
-    deleted_at: str
-    purge_eta: Optional[str]
+# Response models SoftDeletedAgent / SoftDeletedSchedule live in
+# models.py (Architectural Invariant #14 — Pydantic response models are
+# centralized in models.py, not declared in router files).
 
 
 # -----------------------------------------------------------------------------
@@ -108,7 +84,7 @@ def _purge_eta(deleted_at_iso: str, retention_days: int) -> Optional[str]:
 
 @router.get("/agents", response_model=List[SoftDeletedAgent])
 async def list_soft_deleted_agents(
-    limit: int = 200,
+    limit: int = Query(200, le=500),
     _: User = Depends(require_admin),
 ):
     """List currently-soft-deleted agents, newest first.
@@ -187,7 +163,7 @@ async def recover_agent(
 @router.get("/schedules", response_model=List[SoftDeletedSchedule])
 async def list_soft_deleted_schedules(
     agent_name: Optional[str] = None,
-    limit: int = 200,
+    limit: int = Query(200, le=500),
     _: User = Depends(require_admin),
 ):
     """List soft-deleted schedules across the fleet (or scoped to one

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -330,9 +330,37 @@ async def get_agent_endpoint(agent_name: AuthorizedAgentByName, request: Request
     """Get details of a specific agent."""
     agent = get_agent_by_name(agent_name)
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-
-    agent_dict = agent.dict() if hasattr(agent, 'dict') else dict(agent)
+        # #834 Phase 1c: a just-recovered agent has a live
+        # agent_ownership row (deleted_at cleared, so the auth
+        # dependency above passed) but NO container — soft-delete
+        # removed it and recovery is metadata-only. Without this
+        # fallback the operator can't even see the recovered agent
+        # to start it: recovery would be a dead-end. Synthesize a
+        # DB-backed "stopped, no container" representation so the UI
+        # can list it and offer a Start button. (Container recreate
+        # on recover is deferred Phase 2.)
+        owner_row = db.get_agent_owner(agent_name)
+        if not owner_row:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        agent_dict = {
+            "name": agent_name,
+            "type": "",
+            "status": "stopped",
+            "port": 0,
+            "created": owner_row.get("created_at"),
+            "resources": db.get_resource_limits(agent_name) or {},
+            "container_id": None,
+            "template": None,
+            "runtime": "claude-code",
+            "base_image_version": None,
+            # Signal to the UI that this agent has no container yet —
+            # recovered (or otherwise container-less). Drives a
+            # "Start to bring online" affordance instead of the normal
+            # stopped-container controls.
+            "needs_start": True,
+        }
+    else:
+        agent_dict = agent.dict() if hasattr(agent, 'dict') else dict(agent)
     user_data = db.get_user_by_username(current_user.username)
     is_admin = user_data and user_data["role"] == "admin"
 

--- a/tests/unit/test_admin_recovery.py
+++ b/tests/unit/test_admin_recovery.py
@@ -1,0 +1,229 @@
+"""
+Tests for the recover/list helpers backing the admin recovery
+endpoint (#834 Phase 1c). Stays at the DB-layer — router behavior is
+exercised by the live smoke test in the PR.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+def _make_db(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            username TEXT UNIQUE NOT NULL,
+            email TEXT,
+            role TEXT DEFAULT 'user'
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE agent_ownership (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name TEXT UNIQUE NOT NULL,
+            owner_id INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            deleted_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE agent_schedules (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            name TEXT NOT NULL,
+            cron_expression TEXT NOT NULL,
+            message TEXT NOT NULL,
+            enabled INTEGER DEFAULT 1,
+            owner_id INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        "INSERT INTO users(id, username, role) VALUES (1, 'owner', 'user'), (2, 'admin', 'admin')"
+    )
+    conn.commit()
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    try:
+        import db.connection as connection_mod
+    except ImportError:
+        pytest.skip("backend venv required")
+
+    db_path = tmp_path / "trinity.db"
+    conn = sqlite3.connect(str(db_path))
+    _make_db(conn)
+    conn.close()
+
+    monkeypatch.setattr(connection_mod, "DB_PATH", str(db_path))
+    return str(db_path)
+
+
+@pytest.fixture
+def agent_ops(tmp_db):
+    try:
+        from db.agents import AgentOperations
+        from db.users import UserOperations
+    except ImportError:
+        pytest.skip("backend venv required")
+    return AgentOperations(UserOperations())
+
+
+@pytest.fixture
+def schedule_ops(tmp_db):
+    try:
+        from db.schedules import ScheduleOperations
+        from db.users import UserOperations
+        from db.agents import AgentOperations
+    except ImportError:
+        pytest.skip("backend venv required")
+    user_ops = UserOperations()
+    return ScheduleOperations(user_ops, AgentOperations(user_ops))
+
+
+def _seed_agent(db_path: str, name: str, deleted_at: str | None = None):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO agent_ownership(agent_name, owner_id, created_at, deleted_at) "
+        "VALUES (?, 1, '2026-01-01T00:00:00Z', ?)",
+        (name, deleted_at),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_schedule(db_path: str, sid: str, deleted_at: str | None = None):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO agent_schedules
+            (id, agent_name, name, cron_expression, message, enabled,
+             owner_id, created_at, updated_at, deleted_at)
+        VALUES (?, 'agent-1', 'sched', '0 0 * * *', 'hi', 1, 1,
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', ?)
+        """,
+        (sid, deleted_at),
+    )
+    conn.commit()
+    conn.close()
+
+
+# -----------------------------------------------------------------------------
+# Agents
+# -----------------------------------------------------------------------------
+
+def test_recover_agent_clears_deleted_at(tmp_db, agent_ops):
+    _seed_agent(tmp_db, "ghost", deleted_at="2026-01-01T00:00:00Z")
+    assert agent_ops.recover_agent_ownership("ghost") is True
+
+    conn = sqlite3.connect(tmp_db)
+    row = conn.execute("SELECT deleted_at FROM agent_ownership WHERE agent_name = ?", ("ghost",)).fetchone()
+    assert row[0] is None
+
+
+def test_recover_agent_refuses_live_row(tmp_db, agent_ops):
+    """A row that isn't soft-deleted isn't a recovery target."""
+    _seed_agent(tmp_db, "alive")  # deleted_at NULL
+    assert agent_ops.recover_agent_ownership("alive") is False
+
+
+def test_recover_agent_returns_false_for_nonexistent(tmp_db, agent_ops):
+    assert agent_ops.recover_agent_ownership("never_existed") is False
+
+
+def test_list_soft_deleted_agents(tmp_db, agent_ops):
+    _seed_agent(tmp_db, "alive")  # excluded
+    _seed_agent(tmp_db, "ghost-1", deleted_at="2026-01-01T00:00:00Z")
+    _seed_agent(tmp_db, "ghost-2", deleted_at="2026-01-02T00:00:00Z")
+
+    rows = agent_ops.list_soft_deleted_agents(limit=10)
+    names = {r["agent_name"] for r in rows}
+    assert names == {"ghost-1", "ghost-2"}
+    # Newest-first order
+    assert rows[0]["agent_name"] == "ghost-2"
+
+
+def test_list_soft_deleted_agents_respects_limit(tmp_db, agent_ops):
+    for i in range(5):
+        _seed_agent(tmp_db, f"g-{i}", deleted_at=f"2026-01-0{i+1}T00:00:00Z")
+
+    rows = agent_ops.list_soft_deleted_agents(limit=3)
+    assert len(rows) == 3
+
+
+# -----------------------------------------------------------------------------
+# Schedules
+# -----------------------------------------------------------------------------
+
+def test_recover_schedule_clears_deleted_at(tmp_db, schedule_ops):
+    _seed_schedule(tmp_db, "s-1", deleted_at="2026-01-01T00:00:00Z")
+    assert schedule_ops.recover_schedule("s-1") is True
+
+    conn = sqlite3.connect(tmp_db)
+    row = conn.execute("SELECT deleted_at FROM agent_schedules WHERE id = ?", ("s-1",)).fetchone()
+    assert row[0] is None
+
+
+def test_recover_schedule_refuses_live(tmp_db, schedule_ops):
+    _seed_schedule(tmp_db, "s-live")  # deleted_at NULL
+    assert schedule_ops.recover_schedule("s-live") is False
+
+
+def test_recover_schedule_returns_false_for_nonexistent(tmp_db, schedule_ops):
+    assert schedule_ops.recover_schedule("never") is False
+
+
+def test_list_soft_deleted_schedules_unscoped(tmp_db, schedule_ops):
+    _seed_schedule(tmp_db, "live")
+    _seed_schedule(tmp_db, "ghost-1", deleted_at="2026-01-01T00:00:00Z")
+    _seed_schedule(tmp_db, "ghost-2", deleted_at="2026-01-02T00:00:00Z")
+
+    rows = schedule_ops.list_soft_deleted_schedules()
+    ids = {r["id"] for r in rows}
+    assert ids == {"ghost-1", "ghost-2"}
+
+
+def test_list_soft_deleted_schedules_scoped_to_agent(tmp_db, schedule_ops):
+    """`agent_name=` filter limits results to one agent's soft-deleted
+    schedules — the URL-pattern the admin endpoint exposes."""
+    # Insert one for default 'agent-1' and one for a different agent
+    _seed_schedule(tmp_db, "a1-ghost", deleted_at="2026-01-01T00:00:00Z")
+    conn = sqlite3.connect(tmp_db)
+    conn.execute(
+        """
+        INSERT INTO agent_schedules
+            (id, agent_name, name, cron_expression, message, enabled,
+             owner_id, created_at, updated_at, deleted_at)
+        VALUES ('a2-ghost', 'agent-2', 'sched', '0 0 * * *', 'hi', 1, 1,
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                '2026-01-01T00:00:00Z')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    rows = schedule_ops.list_soft_deleted_schedules(agent_name="agent-1")
+    ids = {r["id"] for r in rows}
+    assert ids == {"a1-ghost"}, f"got {ids}"


### PR DESCRIPTION
## Summary

Closes the user-facing side of #834. Pre-PR recovery was a direct-DB `UPDATE deleted_at = NULL` — unauditable, required shell access. This PR exposes the soft-deleted set + reversal via admin-only HTTP.

**Stacked on #839** (which is stacked on #838). Merge order: #838 → #839 → this.

## Endpoints

| Method | Path | What |
|---|---|---|
| GET | `/api/admin/soft-deleted/agents` | List soft-deleted agents with `deleted_at` + `purge_eta` |
| POST | `/api/admin/soft-deleted/agents/{name}/recover` | Clear `deleted_at`; 404 if not in soft-deleted set |
| GET | `/api/admin/soft-deleted/schedules[?agent_name=...]` | Same for schedules; per-agent scope optional |
| POST | `/api/admin/soft-deleted/schedules/{id}/recover` | Clear schedule `deleted_at` |

`purge_eta` = `deleted_at + retention_days` (uses `agent_soft_delete_retention_days` for agents = 180 default, `schedule_soft_delete_retention_days` for schedules = 30). Null when the corresponding retention is 0 (sweep disabled).

All four endpoints are `Depends(require_admin)`. Every successful recovery emits a platform audit event (`agent_lifecycle:recover` or `agent_lifecycle:schedule_recover`).

## Semantics

Recovery is metadata-only. For agents the container is NOT recreated automatically — operator does `POST /api/agents/{name}/start` if they want it running. The preserved workspace volume keeps files intact.

## Live verification

```
1. CREATE agent + schedule, soft-delete both
2. GET soft-deleted/agents     → match, purge_eta=2026-11-10 (180d) ✓
3. GET soft-deleted/schedules  → 1 row, purge_eta=2026-06-13 (30d) ✓
4. POST recover agent          → 200, deleted_at cleared ✓
5. POST recover schedule       → 200, deleted_at cleared ✓
6. POST recover on now-live    → 404 ✓
```

## Test plan

- [x] 10 unit tests in `tests/unit/test_admin_recovery.py`: recover/list/scope, refuse-live, refuse-nonexistent, ordering, limit, agent_name filter
- [x] Live smoke against running backend
- [ ] CI: lint + 6-seed pytest matrix + regression diff

## Notes

- Draft until #838 + #839 land (review depends on their shape settling)
- Once #838 merges to dev, this PR's base auto-updates through the chain on rebase

Related to #834. Phase 1c (recovery surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)