### PR TITLE
fix(templates): surface local templates in /api/templates + reject unprefixed (#843)

### DIFF
--- a/src/backend/routers/templates.py
+++ b/src/backend/routers/templates.py
@@ -8,6 +8,7 @@ from dependencies import get_current_user
 from services.template_service import (
     get_all_templates,
     get_github_template,
+    get_local_template,
 )
 
 router = APIRouter(prefix="/api/templates", tags=["templates"])
@@ -15,7 +16,13 @@ router = APIRouter(prefix="/api/templates", tags=["templates"])
 
 @router.get("")
 async def list_templates(current_user: User = Depends(get_current_user)):
-    """List available agent templates (GitHub-based, metadata from repo)."""
+    """List available agent templates.
+
+    Includes both local templates (bundled under `config/agent-templates/`,
+    `id` prefix `local:`) and GitHub-configured templates (`id` prefix
+    `github:`). Local templates always available without network; GitHub
+    metadata is cached 10 min per repo. (#843)
+    """
     templates = get_all_templates()
     templates.sort(key=lambda t: (t.get("priority", 100), t.get("display_name", "")))
     return templates
@@ -23,14 +30,19 @@ async def list_templates(current_user: User = Depends(get_current_user)):
 
 @router.get("/{template_id:path}")
 async def get_template(template_id: str, current_user: User = Depends(get_current_user)):
-    """Get template details.
+    """Get template details by id.
 
-    Note: Uses {template_id:path} to capture full path including slashes,
-    which is needed for GitHub template IDs like 'github:org/repo'.
+    Resolves both `github:owner/repo` and `local:<name>` ids. Uses
+    `{template_id:path}` to capture slashes in GitHub ids.
     """
     if template_id.startswith("github:"):
         gh_template = get_github_template(template_id)
         if gh_template:
             return gh_template
+
+    if template_id.startswith("local:"):
+        local = get_local_template(template_id)
+        if local:
+            return local
 
     raise HTTPException(status_code=404, detail="Template not found")

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -127,6 +127,26 @@ async def create_agent_internal(
 
     # Load template configuration
     if config.template:
+        # #843: reject template strings that don't start with a known
+        # scheme. Pre-fix, an unprefixed name (e.g. "dd-compliance"
+        # instead of "local:dd-compliance") fell through every
+        # branch of the dispatch and silently produced a blank agent
+        # — same return code as success, no log warning, the operator
+        # only noticed when the agent had no template.yaml. Reject
+        # explicitly so the failure is loud.
+        if not (
+            config.template.startswith("github:")
+            or config.template.startswith("local:")
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Template '{config.template}' must start with "
+                    f"'local:' (for templates under config/agent-templates/) "
+                    f"or 'github:' (for GitHub-hosted templates). "
+                    f"Example: 'local:{config.template}' or 'github:owner/repo'."
+                ),
+            )
         if config.template.startswith("github:"):
             # GIT-002: First, check if template URL contains @branch syntax
             # This applies to both pre-defined and dynamic templates

--- a/src/backend/services/template_service.py
+++ b/src/backend/services/template_service.py
@@ -158,12 +158,107 @@ def _build_template(repo: str, metadata: dict, admin_override: dict = None) -> d
 # Public API
 # ============================================================================
 
-def get_all_templates() -> List[dict]:
-    """Return the full resolved template list (DB-configured or defaults).
+def _local_templates_dir() -> Path:
+    """Return the canonical local-templates directory.
 
-    Fetches metadata from GitHub for each repo (cached).
+    Production path is the read-only bind mount at
+    `/agent-configs/templates` (set up by docker-compose). When running
+    outside the container, fall back to the in-repo path so the function
+    still works in tests and dev shells. (#843)
+    """
+    inside_container = Path("/agent-configs/templates")
+    if inside_container.exists():
+        return inside_container
+    return Path(__file__).resolve().parent.parent.parent.parent / "config" / "agent-templates"
+
+
+def _build_local_template(template_dir: Path) -> Optional[dict]:
+    """Build a template-list entry from a local-template directory.
+
+    Returns None if the directory doesn't contain a readable
+    `template.yaml`. Shape mirrors `_build_template` so the frontend's
+    rendering code (CreateAgentModal.vue:117) works without a
+    per-source branch.
+    """
+    template_yaml = template_dir / "template.yaml"
+    if not template_yaml.exists():
+        return None
+
+    try:
+        with open(template_yaml) as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning("Failed to parse local template %s: %s", template_dir.name, e)
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    name = template_dir.name
+    return {
+        "id": f"local:{name}",
+        "display_name": data.get("display_name") or data.get("name") or name,
+        "description": data.get("description") or data.get("tagline") or "",
+        "source": "local",
+        "resources": data.get("resources", {"cpu": "2", "memory": "4g"}),
+        "skills": data.get("skills", []),
+        "mcp_servers": list(data.get("credentials", {}).get("mcp_servers", {}).keys())
+            or data.get("mcp_servers", []),
+        "required_credentials": data.get("required_credentials", []),
+        # Local templates surface their full capabilities/use-cases so the
+        # frontend can preview them without a second round-trip.
+        "capabilities": data.get("capabilities", []),
+        "use_cases": data.get("use_cases", []),
+    }
+
+
+def get_local_templates() -> List[dict]:
+    """Scan the local-templates directory and return entries for every
+    directory containing a parseable `template.yaml`.
+
+    Each entry has `id` prefixed `local:<dirname>` and shape matching
+    `_build_template` (the GitHub-template builder) so the frontend
+    handles both sources identically. (#843)
+    """
+    templates_dir = _local_templates_dir()
+    if not templates_dir.exists():
+        return []
+
+    out: List[dict] = []
+    for child in sorted(templates_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        entry = _build_local_template(child)
+        if entry is not None:
+            out.append(entry)
+    return out
+
+
+def get_local_template(template_id: str) -> Optional[dict]:
+    """Get a single local template by `local:<name>` id."""
+    if not template_id.startswith("local:"):
+        return None
+    name = template_id[len("local:"):]
+    template_dir = _local_templates_dir() / name
+    if not template_dir.is_dir():
+        return None
+    return _build_local_template(template_dir)
+
+
+def get_all_templates() -> List[dict]:
+    """Return the full resolved template list — local + GitHub-configured.
+
+    Local templates (under `config/agent-templates/`) come first; they
+    don't require network access and are always available. GitHub
+    metadata is fetched per repo (cached, 10-min TTL).
+
+    Issue #843: local templates were silently omitted before this PR,
+    so the frontend's "Local templates" section in CreateAgentModal
+    rendered empty even when local templates existed on disk.
     """
     from services.settings_service import get_github_templates
+
+    local = get_local_templates()
 
     db_entries = get_github_templates()
 
@@ -171,17 +266,19 @@ def get_all_templates() -> List[dict]:
         # Admin-configured list
         repos = [e["github_repo"] for e in db_entries]
         all_metadata = _fetch_all_metadata(repos)
-        return [
+        github = [
             _build_template(e["github_repo"], all_metadata.get(e["github_repo"], {}), e)
             for e in db_entries
         ]
     else:
         # Defaults
         all_metadata = _fetch_all_metadata(DEFAULT_GITHUB_TEMPLATE_REPOS)
-        return [
+        github = [
             _build_template(repo, all_metadata.get(repo, {}))
             for repo in DEFAULT_GITHUB_TEMPLATE_REPOS
         ]
+
+    return local + github
 
 
 def get_github_template(template_id: str) -> Optional[dict]:

--- a/tests/unit/test_local_templates_listing.py
+++ b/tests/unit/test_local_templates_listing.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for the local-templates listing (#843).
+
+The list endpoint at `routers/templates.py` defers to
+`services/template_service.py::get_local_templates()` and
+`get_local_template()`. Tests load template_service standalone (no
+backend deps) and exercise the local-template scan against a
+temporary directory shaped like `config/agent-templates/`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+
+
+def _load_template_service(monkeypatch, fake_templates_dir: Path):
+    """Load template_service.py and redirect `_local_templates_dir`
+    to point at our fixture instead of `/agent-configs/templates`."""
+    # Backend pulls `config` at import-time. Stub via monkeypatch.setitem
+    # (not bare `sys.modules[...]=` — would trip tests/lint_sys_modules.py
+    # baseline check). monkeypatch undoes the insertion on test teardown.
+    if "config" not in sys.modules:
+        import types
+        config_mod = types.ModuleType("config")
+        config_mod.DEFAULT_GITHUB_TEMPLATE_REPOS = []
+        config_mod.GITHUB_PAT_CREDENTIAL_ID = "test-pat"
+        monkeypatch.setitem(sys.modules, "config", config_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        "ts_under_test", _BACKEND / "services" / "template_service.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "_local_templates_dir", lambda: fake_templates_dir)
+    return module
+
+
+def _seed_template(parent: Path, name: str, body: str | None = None) -> Path:
+    """Create a fake local-template directory with template.yaml."""
+    tdir = parent / name
+    tdir.mkdir(parents=True)
+    if body is not None:
+        (tdir / "template.yaml").write_text(body)
+    return tdir
+
+
+# -----------------------------------------------------------------------------
+# get_local_templates
+# -----------------------------------------------------------------------------
+
+def test_lists_templates_with_template_yaml(tmp_path, monkeypatch):
+    """A directory with a parseable template.yaml is listed."""
+    _seed_template(tmp_path, "dd-compliance", body="""
+name: dd-compliance
+display_name: DD Compliance Agent
+description: Regulatory and compliance analysis
+capabilities:
+  - regulatory-research
+  - compliance-assessment
+use_cases:
+  - Assess regulation
+""")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    templates = ts.get_local_templates()
+    assert len(templates) == 1
+    t = templates[0]
+    assert t["id"] == "local:dd-compliance"
+    assert t["display_name"] == "DD Compliance Agent"
+    assert t["description"] == "Regulatory and compliance analysis"
+    assert t["source"] == "local"
+    assert t["capabilities"] == ["regulatory-research", "compliance-assessment"]
+    assert t["use_cases"] == ["Assess regulation"]
+
+
+def test_skips_directories_without_template_yaml(tmp_path, monkeypatch):
+    """Directories under templates/ that lack template.yaml are silently
+    skipped — they're not Trinity templates."""
+    _seed_template(tmp_path, "no-yaml")  # no template.yaml
+    _seed_template(tmp_path, "real-one", body="name: real-one\ndisplay_name: Real")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    templates = ts.get_local_templates()
+    ids = {t["id"] for t in templates}
+    assert ids == {"local:real-one"}
+
+
+def test_skips_unparseable_yaml(tmp_path, monkeypatch):
+    """Templates with broken YAML are logged and skipped, not surfaced as
+    half-formed entries — better to omit than confuse the UI."""
+    _seed_template(tmp_path, "broken", body="name: [unclosed bracket")
+    _seed_template(tmp_path, "ok", body="name: ok\ndisplay_name: OK")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    templates = ts.get_local_templates()
+    ids = {t["id"] for t in templates}
+    assert ids == {"local:ok"}
+
+
+def test_returns_empty_when_dir_missing(tmp_path, monkeypatch):
+    """Pointing at a nonexistent directory returns [] rather than
+    raising — Trinity ships without the dir on some installs."""
+    ts = _load_template_service(monkeypatch, tmp_path / "does-not-exist")
+    assert ts.get_local_templates() == []
+
+
+def test_skips_files_only_dirs(tmp_path, monkeypatch):
+    """A plain file at the root (not a directory) shouldn't be treated
+    as a template."""
+    (tmp_path / "readme.md").write_text("not a template")
+    _seed_template(tmp_path, "real", body="name: real")
+    ts = _load_template_service(monkeypatch, tmp_path)
+    ids = {t["id"] for t in ts.get_local_templates()}
+    assert ids == {"local:real"}
+
+
+def test_results_sorted_by_directory_name(tmp_path, monkeypatch):
+    """Stable order is alphabetical by directory name — the list endpoint
+    re-sorts by display_name, but the underlying scan should be
+    deterministic."""
+    _seed_template(tmp_path, "zebra", body="name: zebra")
+    _seed_template(tmp_path, "alpha", body="name: alpha")
+    _seed_template(tmp_path, "middle", body="name: middle")
+    ts = _load_template_service(monkeypatch, tmp_path)
+    ids = [t["id"] for t in ts.get_local_templates()]
+    assert ids == ["local:alpha", "local:middle", "local:zebra"]
+
+
+# -----------------------------------------------------------------------------
+# get_local_template (single by id)
+# -----------------------------------------------------------------------------
+
+def test_get_single_local_template(tmp_path, monkeypatch):
+    _seed_template(tmp_path, "x", body="name: x\ndisplay_name: X Agent")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    t = ts.get_local_template("local:x")
+    assert t is not None
+    assert t["id"] == "local:x"
+    assert t["display_name"] == "X Agent"
+
+
+def test_get_local_template_returns_none_for_unknown(tmp_path, monkeypatch):
+    ts = _load_template_service(monkeypatch, tmp_path)
+    assert ts.get_local_template("local:nonexistent") is None
+
+
+def test_get_local_template_rejects_wrong_prefix(tmp_path, monkeypatch):
+    """A `github:` id passed to the local helper must return None
+    rather than scanning the local dir for a same-named directory."""
+    _seed_template(tmp_path, "x", body="name: x")
+    ts = _load_template_service(monkeypatch, tmp_path)
+    assert ts.get_local_template("github:org/x") is None
+    assert ts.get_local_template("x") is None  # unprefixed
+
+
+# -----------------------------------------------------------------------------
+# Display fallbacks
+# -----------------------------------------------------------------------------
+
+def test_display_name_falls_back_to_name_then_dirname(tmp_path, monkeypatch):
+    # No display_name, but has `name`
+    _seed_template(tmp_path, "fallback-a", body="name: yaml-name-only")
+    # Neither — pure dir name
+    _seed_template(tmp_path, "fallback-b", body="description: just a desc")
+    ts = _load_template_service(monkeypatch, tmp_path)
+    by_id = {t["id"]: t for t in ts.get_local_templates()}
+    assert by_id["local:fallback-a"]["display_name"] == "yaml-name-only"
+    assert by_id["local:fallback-b"]["display_name"] == "fallback-b"
+
+
+def test_description_falls_back_to_tagline(tmp_path, monkeypatch):
+    _seed_template(tmp_path, "x", body="name: x\ntagline: punchy line")
+    ts = _load_template_service(monkeypatch, tmp_path)
+    t = ts.get_local_templates()[0]
+    assert t["description"] == "punchy line"


### PR DESCRIPTION
## Summary

Two related defects: the UI never saw local templates, and the API silently accepted broken template names.

Before:
- `GET /api/templates` returned **only GitHub-configured** templates. The 10+ bundled local templates under `config/agent-templates/` were invisible to the frontend — the "Local templates" section in `CreateAgentModal.vue` rendered empty even on installs where local templates were obviously present on disk.
- `POST /api/agents` with `template: "dd-compliance"` (missing `local:` prefix) silently fell through the elif chain in `crud.py:129` and created a blank agent — 200 OK, no warning, no metadata applied.

After:
- `GET /api/templates` returns local + GitHub (27 entries on this dev box; 21 local + 6 GitHub).
- `GET /api/templates/local:<name>` resolves a single local template.
- `POST /api/agents` with an unprefixed template returns 400 with a clear actionable message ("Template '<x>' must start with 'local:' … Example: 'local:<x>'"). Empty template still creates a blank agent (unchanged).

## Files

- `services/template_service.py` — new `get_local_templates()` + `get_local_template(id)`. Entries shape-match `_build_template` (GitHub entries) so the frontend handles both sources identically. `get_all_templates()` merges local first.
- `routers/templates.py` — single-template GET now resolves `local:` ids in addition to `github:`.
- `services/agent_service/crud.py:129` — explicit prefix validation before the elif chain. 400 on unrecognised prefix; empty template still allowed.

## Live verification

```
GET /api/templates                         → 27 entries (21 local + 6 github), was 6
GET /api/templates/local:dd-compliance    → full metadata incl. capabilities, use_cases
POST /api/agents  template="dd-compliance" → 400 with actionable message
POST /api/agents  template=""              → 200 (blank agent, unchanged)
POST /api/agents  template="local:dd-..."  → 200 (no regression)
```

## Tests

`tests/unit/test_local_templates_listing.py` — 11 unit tests:
- scan happy-path
- skip directories without `template.yaml`
- skip directories with malformed YAML
- empty / missing directory
- non-directory entries ignored
- deterministic alphabetical ordering
- single-id GET (`get_local_template`)
- wrong-prefix rejection (`github:` and unprefixed)
- display_name fallback chain (yaml display_name → yaml name → dirname)
- description fallback (description → tagline)

All 11 pass locally. Stdlib-only via the importlib loader pattern other tests use.

## Test plan

- [x] Live smoke covers list, single-GET, all three create variants (unprefixed/empty/prefixed)
- [x] 11 unit tests pass
- [x] Lint clean (`tests/lint_sys_modules.py` — uses monkeypatch.setitem)
- [ ] CI: full 6-seed pytest matrix + regression diff

Related to #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)