### PR TITLE
fix(monitoring): health-check the whole fleet, not just running agents (#675)

### DIFF
--- a/src/backend/services/monitoring_service.py
+++ b/src/backend/services/monitoring_service.py
@@ -775,21 +775,62 @@ class MonitoringService:
             await asyncio.sleep(self.config.docker_check_interval)
 
     async def _run_check_cycle(self):
-        """Run one cycle of health checks for all agents."""
+        """Run one cycle of health checks for every Trinity agent.
+
+        #675: this previously filtered to ``status == "running"`` only.
+        A stopped / exited / crashed agent was excluded from every
+        cycle, so its ``agent_health_checks`` row never refreshed —
+        production showed agents stale for *months* (last refresh
+        2026-02-23..04-28) while the one running agent stayed fresh.
+        That is precisely backwards: a down agent is the case
+        monitoring most needs to surface. `perform_health_check`
+        already produces a correct "docker exited / unreachable →
+        unhealthy" record for a stopped agent (and the #631 dormant
+        short-circuit bounds cost for hard-down agents), so we now
+        check the whole fleet.
+
+        Note: `perform_fleet_health_check` is already per-agent
+        isolated via `asyncio.gather(..., return_exceptions=True)` +
+        per-result handling — issue hypothesis #1 (one agent's failure
+        short-circuits the fleet) did not hold; the bug was this
+        filter, not missing isolation.
+        """
         from services.docker_service import list_all_agents_fast
 
-        # Get list of running agents
+        # `list_all_agents_fast()` already passes `all=True`, so this
+        # includes stopped/exited/dead/created containers (normalised
+        # to status="stopped"). Check all of them.
         agents = list_all_agents_fast()
-        running_agents = [a.name for a in agents if a.status == "running"]
+        all_agent_names = [a.name for a in agents]
 
-        if not running_agents:
+        if not all_agent_names:
             return
 
+        running_count = sum(1 for a in agents if a.status == "running")
+        stopped_count = len(all_agent_names) - running_count
+        cycle_start = time.monotonic()
+
         # Perform health checks
-        await perform_fleet_health_check(
-            running_agents,
+        fleet = await perform_fleet_health_check(
+            all_agent_names,
             self.config,
             store_results=True
+        )
+
+        # #675 ask: one structured line per pass so a stalled / partial
+        # fleet check is observable next time instead of being inferred
+        # months later from stale rollups. Includes the agent count,
+        # running/stopped split, the aggregate-status breakdown, and
+        # wall-clock duration.
+        s = fleet.summary
+        logger.info(
+            "fleet_health_check pass complete: "
+            "agents=%d (running=%d stopped=%d) "
+            "healthy=%d degraded=%d unhealthy=%d critical=%d unknown=%d "
+            "duration_ms=%d",
+            len(all_agent_names), running_count, stopped_count,
+            s.healthy, s.degraded, s.unhealthy, s.critical, s.unknown,
+            int((time.monotonic() - cycle_start) * 1000),
         )
 
         # Cleanup old records periodically (every hour)

--- a/tests/unit/test_fleet_check_covers_all_agents.py
+++ b/tests/unit/test_fleet_check_covers_all_agents.py
@@ -1,0 +1,217 @@
+"""#675 — the periodic fleet health check must cover EVERY agent, not
+just `status == "running"` ones.
+
+Regression guard for the root cause: `_run_check_cycle` filtered to
+running agents, so stopped/exited/crashed agents were never
+re-checked and their `agent_health_checks` rows went stale for
+months in production. A down agent is exactly the case monitoring
+exists to surface.
+
+Also asserts the #675 structured per-pass log line is emitted so a
+stalled / partial fleet check is observable next time.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _stub_module(name: str, **attrs) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+class _FakeAgent:
+    """Stand-in for the AgentStatus dataclass list_all_agents_fast() returns."""
+
+    def __init__(self, name: str, status: str):
+        self.name = name
+        self.status = status
+
+
+@pytest.fixture
+def mon(monkeypatch):
+    """Load monitoring_service.py with its heavy imports stubbed."""
+    fake_docker = _stub_module("docker")
+    fake_docker.from_env = MagicMock(side_effect=Exception("stubbed"))
+    monkeypatch.setitem(sys.modules, "docker", fake_docker)
+
+    fake_db_module = _stub_module("database")
+    fake_db_module.db = MagicMock()
+    monkeypatch.setitem(sys.modules, "database", fake_db_module)
+
+    fake_docker_service = _stub_module("services.docker_service")
+    fake_docker_service.docker_client = None
+    fake_docker_service.get_agent_container = MagicMock(return_value=None)
+    # Default: a realistic mixed fleet — 1 running, 2 stopped. The #675
+    # bug dropped the two stopped ones every cycle.
+    fake_docker_service.list_all_agents_fast = MagicMock(return_value=[
+        _FakeAgent("competitor-analyzer", "running"),
+        _FakeAgent("dd-legal", "stopped"),
+        _FakeAgent("dd-market", "stopped"),
+    ])
+    monkeypatch.setitem(sys.modules, "services.docker_service", fake_docker_service)
+
+    fake_docker_utils = _stub_module("services.docker_utils")
+    fake_docker_utils.container_exec_run = AsyncMock()
+    monkeypatch.setitem(sys.modules, "services.docker_utils", fake_docker_utils)
+
+    fake_agent_client = _stub_module("services.agent_client")
+
+    class _StubCircuitState:
+        _state_overrides: dict = {}
+
+        def __init__(self, agent_name):
+            self.agent_name = agent_name
+            self.state = self._state_overrides.get(agent_name, "closed")
+
+    fake_agent_client.CircuitState = _StubCircuitState
+    monkeypatch.setitem(sys.modules, "services.agent_client", fake_agent_client)
+
+    spec = importlib.util.spec_from_file_location(
+        "monitoring_service_675",
+        str(_BACKEND / "services" / "monitoring_service.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "monitoring_service_675", module)
+    spec.loader.exec_module(module)
+    return module, fake_docker_service
+
+
+# ---------------------------------------------------------------------------
+# Root-cause regression: every agent checked, not just running
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cycle_checks_running_and_stopped_agents(mon):
+    module, _ = mon
+
+    captured = {}
+
+    async def _fake_fleet_check(names, config, store_results=True):
+        captured["names"] = list(names)
+        captured["store_results"] = store_results
+        # Return a minimal FleetHealthStatus-shaped object.
+        summary = module.FleetHealthSummary(total_agents=len(names))
+        summary.healthy = 1
+        summary.unhealthy = 2
+        return module.FleetHealthStatus(
+            enabled=True, last_check_at="now", summary=summary, agents=[]
+        )
+
+    module.perform_fleet_health_check = _fake_fleet_check
+
+    svc = module.MonitoringService()
+    await svc._run_check_cycle()
+
+    # The whole fleet — including the two stopped agents that the #675
+    # bug silently dropped every cycle.
+    assert set(captured["names"]) == {
+        "competitor-analyzer", "dd-legal", "dd-market"
+    }, (
+        "fleet check must include stopped agents (#675); "
+        f"got {captured['names']}"
+    )
+    assert captured["store_results"] is True
+
+
+@pytest.mark.asyncio
+async def test_cycle_no_op_when_zero_agents(mon):
+    module, fake_docker_service = mon
+    fake_docker_service.list_all_agents_fast = MagicMock(return_value=[])
+
+    called = {"n": 0}
+
+    async def _fake_fleet_check(*a, **k):
+        called["n"] += 1
+
+    module.perform_fleet_health_check = _fake_fleet_check
+    svc = module.MonitoringService()
+    await svc._run_check_cycle()
+
+    assert called["n"] == 0, "no agents → no fleet check call"
+
+
+@pytest.mark.asyncio
+async def test_cycle_all_stopped_fleet_still_checked(mon):
+    """The exact #675 production shape: nothing running. Pre-fix this
+    returned early (running_agents empty) and refreshed nothing."""
+    module, fake_docker_service = mon
+    fake_docker_service.list_all_agents_fast = MagicMock(return_value=[
+        _FakeAgent("dd-legal", "stopped"),
+        _FakeAgent("dd-market", "stopped"),
+    ])
+
+    captured = {}
+
+    async def _fake_fleet_check(names, config, store_results=True):
+        captured["names"] = list(names)
+        summary = module.FleetHealthSummary(total_agents=len(names))
+        return module.FleetHealthStatus(
+            enabled=True, last_check_at="now", summary=summary, agents=[]
+        )
+
+    module.perform_fleet_health_check = _fake_fleet_check
+    svc = module.MonitoringService()
+    await svc._run_check_cycle()
+
+    assert set(captured["names"]) == {"dd-legal", "dd-market"}, (
+        "an all-stopped fleet must still be health-checked (#675); "
+        "this is the exact months-stale production scenario"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #675 ask: structured per-pass log line
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pass_summary_log_emitted(mon, caplog):
+    module, _ = mon
+
+    async def _fake_fleet_check(names, config, store_results=True):
+        summary = module.FleetHealthSummary(total_agents=len(names))
+        summary.healthy = 1
+        summary.unhealthy = 2
+        return module.FleetHealthStatus(
+            enabled=True, last_check_at="now", summary=summary, agents=[]
+        )
+
+    module.perform_fleet_health_check = _fake_fleet_check
+    svc = module.MonitoringService()
+
+    with caplog.at_level(logging.INFO, logger=module.logger.name):
+        await svc._run_check_cycle()
+
+    line = next(
+        (r.getMessage() for r in caplog.records
+         if "fleet_health_check pass complete" in r.getMessage()),
+        None,
+    )
+    assert line is not None, (
+        f"expected a structured pass-summary log; "
+        f"got {[r.getMessage() for r in caplog.records]}"
+    )
+    # 1 running + 2 stopped, with the stubbed status breakdown.
+    assert "agents=3 (running=1 stopped=2)" in line
+    assert "healthy=1" in line and "unhealthy=2" in line
+    assert "duration_ms=" in line


### PR DESCRIPTION
## Root cause

#669 patched the user-visible 500 (NULL `status` coercion). This is the actual cause of the *stale 24h rollups*: `_run_check_cycle` filtered the fleet to running agents before the health check —

```python
running_agents = [a.name for a in agents if a.status == "running"]
if not running_agents:
    return
```

A stopped / exited / crashed agent was dropped from **every** cycle, so its `agent_health_checks` row never refreshed. Production: 8 of 9 agents last refreshed 2026-02-23..04-28; only the one running agent stayed current. The filter had the logic backwards — a down agent is exactly what monitoring should surface.

## Fix

Check every agent. `list_all_agents_fast()` already passes `all=True` (stopped containers included, normalised to `status="stopped"`), and `perform_health_check` already produces a correct "docker exited / unreachable → unhealthy" record for a stopped agent.

The #631 dormant short-circuit still bounds cost for hard-down agents (synthetic detail, no DB writes) — **explicitly not modified**: re-enabling writes for dormant agents would reopen the SQLite contention #631 fixed. Net behaviour: a long-down agent settles to *"unhealthy, circuit dormant, last-checked ≤ dormant-window ago"* instead of literal months-stale data — correct and actionable.

## Issue asks

| Ask | Outcome |
|---|---|
| Confirm per-agent isolation, add if missing | **Already present** — `perform_fleet_health_check` uses `asyncio.gather(..., return_exceptions=True)` + per-result handling. Hypothesis #1 (one failure short-circuits fleet) did **not** hold; the bug was the filter. Documented in docstring. |
| Structured per-pass log | **Added** — one INFO line/cycle: `fleet_health_check pass complete: agents=N (running=R stopped=S) healthy=.. degraded=.. unhealthy=.. critical=.. unknown=.. duration_ms=..` |
| Audit registration path | No separate registry — cycle re-derives the fleet from `list_all_agents_fast()` each pass. "Not registered" reduces to this filter. |
| Pull prod logs around stale timestamps | **Not done** — no production access from this environment. |

## Tests

`tests/unit/test_fleet_check_covers_all_agents.py` (4):
- running + stopped both checked (root-cause regression guard)
- all-stopped fleet still checked (the exact months-stale prod shape — pre-fix returned early)
- zero-agent no-op
- pass-summary log emitted with correct running/stopped/status counts

Existing monitoring suite — `test_monitoring_dormant_skip` / `test_monitoring_router_signatures` / `test_fleet_status_resilience` (15) — still green; **#631 dormant-skip behaviour unchanged**.

## Test plan

- [x] 4 new tests pass
- [x] 15 existing monitoring tests pass (no regression, #631 intact)
- [x] lint clean
- [ ] CI: full 6-seed matrix + regression diff

Related to #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)