### PR TITLE
feat(workspace): gate Agent Workspace behind admin feature flag, off by default (#860)

### DIFF
--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -118,14 +118,19 @@ async def get_public_feature_flags(
     - ``session_tab_enabled`` — gates the Session tab in AgentDetail.
       Reads through ``services.settings_service.is_session_tab_enabled()``
       so the resolution order (DB → env → False default) stays in one place.
+    - ``workspace_available`` — gates the Agent Workspace (voice + canvas).
+      Requires both voice infrastructure (VOICE_ENABLED + GEMINI_API_KEY) AND
+      ``WORKSPACE_ENABLED=true`` (or DB override). Defaults to False (#860).
 
     Auth required (any role) — these flags reveal nothing sensitive but we
     still keep them out of the unauthenticated surface.
     """
     from config import GEMINI_API_KEY, VOICE_ENABLED
+    voice_available = VOICE_ENABLED and bool(GEMINI_API_KEY)
     return {
         "session_tab_enabled": settings_service.is_session_tab_enabled(),
-        "voice_available": VOICE_ENABLED and bool(GEMINI_API_KEY),
+        "voice_available": voice_available,
+        "workspace_available": voice_available and settings_service.is_workspace_enabled(),
         "platform_default_model": settings_service.get_platform_default_model(),
     }
 

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -173,6 +173,33 @@ class SettingsService:
         return True
 
     # =========================================================================
+    # Workspace feature flag (#860)
+    # =========================================================================
+
+    def is_workspace_enabled(self) -> bool:
+        """
+        Whether the Agent Workspace (voice + canvas) surface is exposed to users.
+
+        Resolves in this order:
+        1. system_settings row 'workspace_enabled' ("true"/"false")
+        2. WORKSPACE_ENABLED env var (only honored as "true"/"1"/"yes" to opt in)
+        3. Default: False (BETA — opt-in required)
+
+        Admins opt in by setting ``workspace_enabled=true`` in system_settings
+        or by exporting ``WORKSPACE_ENABLED=true``.
+
+        Note: workspace also requires voice to be available (VOICE_ENABLED +
+        GEMINI_API_KEY). The feature-flags endpoint combines both conditions.
+        """
+        stored = self.get_setting('workspace_enabled')
+        if stored is not None:
+            return str(stored).lower() in ("true", "1", "yes")
+        env_val = os.getenv('WORKSPACE_ENABLED', '').strip().lower()
+        if env_val in ("true", "1", "yes"):
+            return True
+        return False
+
+    # =========================================================================
     # GitHub Templates (TMPL-001)
     # =========================================================================
 

--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -149,7 +149,7 @@
         <div class="flex items-center space-x-3">
           <!-- Workspace button (voice + canvas, BETA) -->
           <button
-            v-if="voiceAvailable"
+            v-if="workspaceAvailable"
             @click="goToWorkspace"
             :disabled="agent.status !== 'running'"
             class="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-colors"
@@ -556,6 +556,10 @@ const props = defineProps({
     default: null
   },
   voiceAvailable: {
+    type: Boolean,
+    default: false
+  },
+  workspaceAvailable: {
     type: Boolean,
     default: false
   }

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import { useSessionsStore } from '../stores/sessions'
 
 const routes = [
   {
@@ -48,7 +49,16 @@ const routes = [
     path: '/agents/:name/workspace',
     name: 'AgentWorkspace',
     component: () => import('../views/AgentWorkspace.vue'),
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true },
+    beforeEnter: async (to, from, next) => {
+      const sessionsStore = useSessionsStore()
+      await sessionsStore.loadFeatureFlags()
+      if (!sessionsStore.workspaceAvailable) {
+        next({ name: 'AgentDetail', params: { name: to.params.name } })
+      } else {
+        next()
+      }
+    },
   },
   {
     path: '/agents/:name/executions/:executionId',

--- a/src/frontend/src/stores/sessions.js
+++ b/src/frontend/src/stores/sessions.js
@@ -40,6 +40,7 @@ export const useSessionsStore = defineStore('sessions', {
     featureFlagsLoaded: false,
     sessionTabEnabled: false,
     voiceAvailable: false,
+    workspaceAvailable: false,
   }),
 
   getters: {
@@ -67,9 +68,11 @@ export const useSessionsStore = defineStore('sessions', {
         })
         this.sessionTabEnabled = !!r.data?.session_tab_enabled
         this.voiceAvailable = !!r.data?.voice_available
+        this.workspaceAvailable = !!r.data?.workspace_available
       } catch {
         this.sessionTabEnabled = false
         this.voiceAvailable = false
+        this.workspaceAvailable = false
       } finally {
         this.featureFlagsLoaded = true
       }

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -66,6 +66,7 @@
             :has-avatar-prompt="!!avatarIdentityPrompt"
             :emotion-avatar-url="emotionAvatarUrl"
             :voice-available="sessionsStore.voiceAvailable"
+            :workspace-available="sessionsStore.workspaceAvailable"
           />
 
           <!-- Tabs -->

--- a/tests/test_platform_default_model.py
+++ b/tests/test_platform_default_model.py
@@ -151,6 +151,30 @@ class TestFeatureFlagsEndpoint:
         resp = httpx.get(f"{BASE_URL}/api/settings/feature-flags", timeout=10)
         assert resp.status_code == 401
 
+    def test_feature_flags_includes_workspace_available(self):
+        """feature-flags must expose workspace_available key (#860)."""
+        headers = get_auth_headers()
+        resp = httpx.get(f"{BASE_URL}/api/settings/feature-flags", headers=headers, timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "workspace_available" in data, (
+            "feature-flags response missing 'workspace_available' key"
+        )
+        assert isinstance(data["workspace_available"], bool)
+
+    def test_workspace_available_false_by_default(self):
+        """workspace_available must be False unless WORKSPACE_ENABLED is set (#860)."""
+        headers = get_auth_headers()
+        resp = httpx.get(f"{BASE_URL}/api/settings/feature-flags", headers=headers, timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        # In CI/test environments WORKSPACE_ENABLED is not set, so this must be False.
+        # If GEMINI_API_KEY is also absent, voice_available=False makes workspace_available
+        # False regardless — both conditions confirm the default-off behaviour.
+        assert data["workspace_available"] is False, (
+            "workspace_available should default to False unless explicitly enabled"
+        )
+
 
 class TestPlatformDefaultModelSetting:
     """Admin can read/write platform_default_model via /api/settings/{key}."""


### PR DESCRIPTION
## Summary

- Agent Workspace (voice + canvas, BETA) was shown to all users whenever voice was available; now requires explicit opt-in via `WORKSPACE_ENABLED=true`
- Adds a router `beforeEnter` guard so direct URL navigation to `/agents/:name/workspace` also redirects when the flag is off — button-hide alone was insufficient
- Follows the exact `is_session_tab_enabled()` pattern but with inverted polarity (opt-in, not opt-out)

## Changes

| File | Change |
|------|--------|
| `src/backend/services/settings_service.py` | Add `is_workspace_enabled()` — DB → env → `False` default |
| `src/backend/routers/settings.py` | Add `workspace_available` to `/api/settings/feature-flags` |
| `src/frontend/src/stores/sessions.js` | Add `workspaceAvailable` state, read from feature-flags |
| `src/frontend/src/components/AgentHeader.vue` | New `workspaceAvailable` prop; `v-if` changed from `voiceAvailable` |
| `src/frontend/src/views/AgentDetail.vue` | Thread `:workspace-available` prop to AgentHeader |
| `src/frontend/src/router/index.js` | `beforeEnter` guard on workspace route — redirects to AgentDetail when disabled |
| `tests/test_platform_default_model.py` | Two new tests in `TestFeatureFlagsEndpoint` |

## Test Plan

- [x] `TestFeatureFlagsEndpoint` — all 5 tests pass (2 new: key presence + default-off)
- [x] Default off: backend running without `WORKSPACE_ENABLED` returns `workspace_available: false`
- [ ] Manual: set `WORKSPACE_ENABLED=true`, verify Workspace button appears and route is accessible
- [ ] Manual: without env var, confirm direct URL `/agents/X/workspace` redirects to AgentDetail

**Enable workspace**: set `WORKSPACE_ENABLED=true` in `.env` and restart backend.

Fixes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)