### PR TITLE
fix(cleanup): per-slot TTL prevents false-kill of long-running executions (#869)

### DIFF
--- a/docs/memory/feature-flows/cleanup-service.md
+++ b/docs/memory/feature-flows/cleanup-service.md
@@ -1,5 +1,7 @@
 # Feature: Cleanup Service (CLEANUP-001)
 
+> **Updated 2026-05-17 (#869):** `WATCHDOG_HTTP_TIMEOUT` increased from 5.0 → 15.0 seconds to handle agents under load. `SlotService._cleanup_stale_slots_for_agent` now reads each slot's `timeout_seconds` from its per-slot metadata HASH (stored at acquire time) instead of using the agent-level default for all slots. Per-slot TTL = `stored_timeout + SLOT_TTL_BUFFER`; falls back to the per-agent default when metadata is absent.
+
 > **Updated 2026-05-11 (#686):** The interactive `chat_with_agent()` handler in `routers/chat.py` is now a second producer of the `claude_session_id='dispatched'` sentinel (parallel of #279). The no-session sweep's correctness assumption now extends to interactive `/chat` executions too. See the updated [`mark_execution_dispatched`](#mark_execution_dispatched-scheduleoperations) and [Fast-fail no-session executions](#cleanup-cycle-run_cleanup) sections.
 
 > **Updated 2026-04-26 (#428):** Stale-slot reclaim and watchdog release now go through [`CapacityManager`](capacity-management.md) — `capacity.reclaim_stale(agent_timeouts)` replaces `slot_service.cleanup_stale_slots(...)` and `capacity.release_if_matches(agent, exec_id)` replaces the prior pair of `slot_service.release_slot` + `execution_queue.force_release_if_matches`. Recovery (`_recover_execution`) calls `capacity.release(...)`. `ExecutionQueue` is gone; the TOCTOU-safe match check lives on the new facade.
@@ -29,7 +31,7 @@ CLEANUP_INTERVAL_SECONDS = 300        # 5 minutes
 EXECUTION_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to support long-running tasks
 ACTIVITY_STALE_TIMEOUT_MINUTES = 120   # SCHED-ASYNC-001: increased from 30 to support long-running tasks
 NO_SESSION_TIMEOUT_SECONDS = 60       # Issue #106: fast-fail executions without Claude session
-WATCHDOG_HTTP_TIMEOUT = 5.0           # Issue #129: timeout for agent HTTP calls during reconciliation
+WATCHDOG_HTTP_TIMEOUT = 15.0          # Timeout for agent HTTP calls during reconciliation (#869: increased from 5s to handle agents under load)
 ERROR_FETCH_TIMEOUT = 2.0             # Issue #286: timeout for fetching error context from agent
 MAX_ERROR_MESSAGE_LENGTH = 2000       # Issue #286: truncate combined error messages
 ```
@@ -113,7 +115,7 @@ Nine sequential operations plus an hourly maintenance gate, each wrapped in indi
        reclaimed, confirmed_running_ids, report
    )
    ```
-   Calls `SlotService.cleanup_stale_slots()` with per-agent timeouts (#226). The service scans all `agent:slots:*` keys, computes each agent's TTL as `timeout_seconds + 5 min buffer` (or default 20 min if no timeout configured), removes entries older than that TTL, and returns a dict mapping agent names to reclaimed execution IDs. Phase 3 is then implemented by `_process_stale_slot_reclaims()` — see [Phase 3 Slot Reclaim Re-verification](#phase-3-slot-reclaim-re-verification-issue-378) below.
+   Calls `SlotService.cleanup_stale_slots()` with per-agent timeouts (#226). The service scans all `agent:slots:*` keys and checks each slot individually (#869): it reads the slot's `timeout_seconds` from its metadata HASH (key `agent:slot:{name}:{execution_id}`, stored at acquire time), computes `effective_ttl = stored_timeout + SLOT_TTL_BUFFER (5 min)`, and removes the slot if its score (timestamp) is older than that TTL. Falls back to the per-agent default TTL (`execution_timeout_seconds + SLOT_TTL_BUFFER`, or `DEFAULT_SLOT_TTL_SECONDS = 1200` if no agent timeout is configured) when metadata is absent. This fixes premature reclamation of slots acquired with a schedule-level `timeout_seconds` that exceeds the agent-level default (e.g., a 7200s schedule on an agent with the 3600s default was previously reclaimed at ~3900s). Returns a dict mapping agent names to reclaimed execution IDs. Phase 3 is then implemented by `_process_stale_slot_reclaims()` — see [Phase 3 Slot Reclaim Re-verification](#phase-3-slot-reclaim-re-verification-issue-378) below.
 
 6. **Hourly maintenance: prune rate-limit events** (Issue #476)
    ```python
@@ -433,15 +435,13 @@ WHERE id = ?
 
 **Logic**:
 1. Scans all keys matching `agent:slots:*` pattern via `SCAN`
-2. For each agent, calls `_cleanup_stale_slots_for_agent()` which returns the reclaimed execution IDs
-3. Removes ZSET entries with score (timestamp) older than TTL:
-   ```
-   ZREMRANGEBYSCORE agent:slots:{name} -inf {cutoff_timestamp}
-   ```
-4. Deletes corresponding metadata keys: `agent:slot:{name}:{execution_id}`
-5. Returns the execution IDs so the caller (cleanup service) can fail corresponding DB records
+2. For each agent, calls `_cleanup_stale_slots_for_agent()` which iterates all slots via `ZRANGE withscores=True` and returns the reclaimed execution IDs
+3. For each slot, reads `timeout_seconds` from its metadata HASH at `agent:slot:{name}:{execution_id}` (stored at acquire time), computes `effective_ttl = stored_timeout + SLOT_TTL_BUFFER`. Falls back to `default_slot_ttl` (per-agent: `execution_timeout_seconds + SLOT_TTL_BUFFER`, or `DEFAULT_SLOT_TTL_SECONDS = 1200` if unconfigured) when metadata is absent (#869)
+4. Removes stale entries individually (slot is expired if `score < now - effective_ttl`) via `ZREM`
+5. Deletes corresponding metadata keys: `agent:slot:{name}:{execution_id}`
+6. Returns the execution IDs so the caller (cleanup service) can fail corresponding DB records
 
-**TTL** (#226): Per-agent, computed as `execution_timeout_seconds + SLOT_TTL_BUFFER (5 min)`. Falls back to `DEFAULT_SLOT_TTL_SECONDS = 1200` (20 minutes) if no agent timeout is configured. This prevents premature slot reclamation for agents with long-running tasks (e.g., 60-120 min timeouts).
+**TTL** (#226, #869): Per-slot, computed from the `timeout_seconds` stored in the slot's metadata HASH at acquire time — this captures the schedule-level timeout actually used (e.g., 7200s), not just the agent-level default (e.g., 3600s). Falls back to the per-agent default (`execution_timeout_seconds + SLOT_TTL_BUFFER`, or `DEFAULT_SLOT_TTL_SECONDS = 1200` if no agent timeout configured) when metadata is absent. Fixes premature reclamation of slots with schedule-level timeouts exceeding the agent-level default.
 
 ## Side Effects
 - **Logging**: Each cleanup cycle logs results at INFO level when resources are cleaned

--- a/docs/memory/feature-flows/parallel-capacity.md
+++ b/docs/memory/feature-flows/parallel-capacity.md
@@ -12,6 +12,7 @@
 
 | Date | Changes |
 |------|---------|
+| 2026-05-17 | #869: `_cleanup_stale_slots_for_agent` now uses per-slot metadata TTL instead of per-agent cutoff; prevents false reclaim when schedule timeout > agent default |
 | 2026-04-13 | BACKLOG-001 (#260): Async `/task` no longer returns 429 when slots are full — requests spill into a persistent SQLite backlog and drain via a new `SlotService.register_on_release` callback. True 429 only when the per-agent `max_backlog_depth` is also exceeded. See [persistent-task-backlog.md](persistent-task-backlog.md). |
 | 2026-03-21 | Issue #98: Chat executions (`/api/chat`) now acquire capacity slots, making SlotService the single source of truth for agent load across all execution types |
 | 2026-03-12 | TIMEOUT-001: Slot TTL now dynamic (agent timeout + 5 min buffer), not fixed 30 min. Aligns with per-agent configurable execution timeout. |
@@ -586,20 +587,21 @@ async def release_slot(self, agent_name, execution_id):
 
 ### 3. Stale Slot Cleanup
 
+**As of #869 (2026-05-17):** Staleness is checked per-slot from stored metadata, not via a single per-agent `ZREMRANGEBYSCORE` cutoff. Each slot's metadata HASH includes the `timeout_seconds` stored at acquire time; the effective TTL for that slot is `stored_timeout + SLOT_TTL_BUFFER`. The per-agent default from `agent_timeouts` is only a fallback when metadata is absent. This prevents false reclaims when a schedule's execution timeout exceeds the agent-level default.
+
 ```python
 # src/backend/services/slot_service.py:223-245
 async def _cleanup_stale_slots_for_agent(self, agent_name):
-    cutoff = time.time() - slot_ttl  # agent timeout + 5 min buffer
-
-    # Get stale entries
-    stale = self.redis.zrangebyscore(slots_key, "-inf", cutoff)
-
-    # Remove from ZSET
-    self.redis.zremrangebyscore(slots_key, "-inf", cutoff)
-
-    # Clean up metadata
-    for execution_id in stale:
-        self.redis.delete(metadata_key)
+    # Iterate all slots in the ZSET; compute each slot's effective TTL
+    # from its stored metadata (timeout_seconds + SLOT_TTL_BUFFER).
+    # Falls back to per-agent default when metadata is missing.
+    for execution_id in self.redis.zrange(slots_key, 0, -1):
+        slot_meta = self.redis.hgetall(metadata_key)
+        stored_timeout = int(slot_meta.get("timeout_seconds", agent_default_timeout))
+        effective_ttl = stored_timeout + SLOT_TTL_BUFFER
+        if started_at + effective_ttl < time.time():
+            self.redis.zrem(slots_key, execution_id)
+            self.redis.delete(metadata_key)
 ```
 
 ## Error Handling

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -33,7 +33,7 @@ CLEANUP_INTERVAL_SECONDS = 300  # 5 minutes
 EXECUTION_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to support long-running tasks
 ACTIVITY_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to support long-running tasks
 NO_SESSION_TIMEOUT_SECONDS = 60  # Issue #106: fast-fail executions that never got a Claude session
-WATCHDOG_HTTP_TIMEOUT = 5.0  # Timeout for agent HTTP calls during reconciliation
+WATCHDOG_HTTP_TIMEOUT = 15.0  # Timeout for agent HTTP calls during reconciliation (#869: increased from 5s to handle agents under load)
 WATCHDOG_MIN_AGE_SECONDS = 60  # Don't orphan-recover executions younger than this (dispatch window)
 STARTUP_RECOVERY_GRACE_SECONDS = 15  # #748: skip startup orphan-recovery for rows
                                      # whose started_at is within this window — they

--- a/src/backend/services/slot_service.py
+++ b/src/backend/services/slot_service.py
@@ -124,8 +124,9 @@ class SlotService:
         # TIMEOUT-001: Dynamic slot TTL based on agent timeout + buffer
         slot_ttl = timeout_seconds + SLOT_TTL_BUFFER
 
-        # Clean up expired slots first (uses dynamic TTL for this agent)
-        await self._cleanup_stale_slots_for_agent(agent_name, slot_ttl)
+        # Clean up expired slots first — use this execution's timeout as the
+        # default fallback; per-slot metadata TTL takes precedence for each slot.
+        await self._cleanup_stale_slots_for_agent(agent_name, default_slot_ttl=slot_ttl)
 
         # Check current count
         current_count = self.redis.zcard(slots_key)
@@ -278,39 +279,65 @@ class SlotService:
         return result
 
     async def _cleanup_stale_slots_for_agent(
-        self, agent_name: str, slot_ttl: int = None
+        self, agent_name: str, default_slot_ttl: int = None
     ) -> List[str]:
-        """Remove slots older than TTL for a single agent.
+        """Remove slots whose per-slot TTL has elapsed for a single agent.
+
+        Each slot's effective TTL is read from its stored metadata
+        (``timeout_seconds + SLOT_TTL_BUFFER``). Falls back to
+        ``default_slot_ttl`` when metadata is absent (e.g. the HASH key
+        expired after the ZSET entry was written but before cleanup ran).
+
+        This replaces the former ZREMRANGEBYSCORE approach that used a
+        single per-agent cutoff computed from ``agent_ownership.
+        execution_timeout_seconds``. That approach incorrectly reclaimed
+        slots acquired with a per-schedule ``timeout_seconds`` longer than
+        the agent default — killing live executions at ~65 min when the
+        configured limit was 120 min (#869).
 
         Args:
-            agent_name: Name of the agent
-            slot_ttl: Slot TTL in seconds. If None, uses DEFAULT_SLOT_TTL_SECONDS.
+            agent_name: Name of the agent.
+            default_slot_ttl: Fallback TTL (seconds) when slot metadata is
+                absent. Defaults to DEFAULT_SLOT_TTL_SECONDS.
 
         Returns:
             List of execution IDs whose slots were reclaimed.
         """
         slots_key = self._slots_key(agent_name)
-        ttl = slot_ttl if slot_ttl is not None else DEFAULT_SLOT_TTL_SECONDS
-        cutoff = time.time() - ttl
+        fallback_ttl = default_slot_ttl if default_slot_ttl is not None else DEFAULT_SLOT_TTL_SECONDS
+        now = time.time()
 
-        # Get stale entries before removing
-        stale = self.redis.zrangebyscore(slots_key, "-inf", cutoff)
+        slot_entries = self.redis.zrange(slots_key, 0, -1, withscores=True)
+        if not slot_entries:
+            return []
+
+        stale = []
+        for execution_id, score in slot_entries:
+            age = now - float(score)
+            # Read the timeout stored at acquire time so each slot uses its
+            # own deadline, not the agent's current default.
+            metadata_key = self._metadata_key(agent_name, execution_id)
+            stored_timeout = self.redis.hget(metadata_key, "timeout_seconds")
+            if stored_timeout:
+                try:
+                    effective_ttl = int(stored_timeout) + SLOT_TTL_BUFFER
+                except (ValueError, TypeError):
+                    effective_ttl = fallback_ttl
+            else:
+                effective_ttl = fallback_ttl
+
+            if age > effective_ttl:
+                stale.append(execution_id)
 
         if stale:
-            # Remove stale slots
-            self.redis.zremrangebyscore(slots_key, "-inf", cutoff)
-
-            # Clean up metadata
+            self.redis.zrem(slots_key, *stale)
             for execution_id in stale:
-                metadata_key = self._metadata_key(agent_name, execution_id)
-                self.redis.delete(metadata_key)
-
+                self.redis.delete(self._metadata_key(agent_name, execution_id))
             logger.warning(
                 f"[Slots] Cleaned up {len(stale)} stale slots for agent '{agent_name}'"
             )
-            return list(stale)
 
-        return []
+        return stale
 
     async def cleanup_stale_slots(
         self, agent_timeouts: Dict[str, int] = None
@@ -337,13 +364,14 @@ class SlotService:
             cursor, keys = self.redis.scan(cursor, match=pattern, count=100)
             for key in keys:
                 agent_name = key.replace(self.slots_prefix, "")
-                # Use per-agent timeout if available, otherwise fall back to default
+                # Per-slot TTL from metadata takes precedence; this is only the
+                # fallback for slots whose metadata HASH has already expired.
                 if agent_timeouts and agent_name in agent_timeouts:
-                    slot_ttl = agent_timeouts[agent_name] + SLOT_TTL_BUFFER
+                    default_ttl = agent_timeouts[agent_name] + SLOT_TTL_BUFFER
                 else:
-                    slot_ttl = DEFAULT_SLOT_TTL_SECONDS
+                    default_ttl = DEFAULT_SLOT_TTL_SECONDS
                 stale_ids = await self._cleanup_stale_slots_for_agent(
-                    agent_name, slot_ttl
+                    agent_name, default_slot_ttl=default_ttl
                 )
                 if stale_ids:
                     reclaimed[agent_name] = stale_ids

--- a/tests/unit/test_slot_per_slot_ttl.py
+++ b/tests/unit/test_slot_per_slot_ttl.py
@@ -1,0 +1,413 @@
+"""
+Issue #869 — cleanup watchdog falsely kills long-running executions whose
+per-schedule ``timeout_seconds`` exceeds ``agent_ownership.execution_timeout_seconds``.
+
+Root cause: ``_cleanup_stale_slots_for_agent`` used a single per-agent
+cutoff (``agent_ownership.execution_timeout_seconds + SLOT_TTL_BUFFER``)
+applied via ZREMRANGEBYSCORE. A slot acquired with a schedule-level
+``timeout_seconds=7200`` would be reclaimed at ~65 min (3900s) because the
+agent's ownership default was 3600s — even though the slot's own effective
+TTL was 7500s (7200 + 300 buffer).
+
+Fix: each slot's effective TTL is now read from its stored metadata HASH
+(``timeout_seconds`` field, written at ``acquire_slot`` time). The per-agent
+default only applies when metadata is absent.
+
+Covered scenarios:
+
+1. Slot with long schedule timeout (7200s) is NOT reclaimed at 65 min when
+   metadata is present — the former false-positive kill case.
+2. Same slot IS reclaimed after its actual deadline (7500s) passes.
+3. Slot with no metadata falls back to the per-agent default TTL.
+4. Slot with short agent-default timeout (3600s) is still reclaimed after
+   3900s (backwards-compatible behaviour).
+5. Mixed agents: one long-timeout slot (not stale), one short (stale) — only
+   the short one is reclaimed.
+6. WATCHDOG_HTTP_TIMEOUT is 15 s (increased from 5 s — #869 secondary fix).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Backend on sys.path; docker is imported eagerly by services/__init__.py
+# ---------------------------------------------------------------------------
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    names = ["config", "slot_service_direct", "utils.helpers", "redis"]
+    saved = {n: sys.modules.get(n) for n in names}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+# ---------------------------------------------------------------------------
+# FakeRedis — minimal surface area for SlotService._cleanup_stale_slots_for_agent
+# ---------------------------------------------------------------------------
+
+class _FakeRedis:
+    """Sync Redis double covering ZSET and HASH operations used by SlotService."""
+
+    def __init__(self):
+        # key → {member: score}
+        self.zsets: dict[str, dict[str, float]] = {}
+        # key → {field: value}
+        self.hashes: dict[str, dict[str, str]] = {}
+
+    # ── ZSET helpers ──────────────────────────────────────────────────────
+
+    def _zadd_raw(self, key: str, member: str, score: float) -> None:
+        """Test setup helper."""
+        self.zsets.setdefault(key, {})[member] = score
+
+    def zrange(self, key: str, start: int, stop: int, withscores: bool = False):
+        members = sorted(self.zsets.get(key, {}).items(), key=lambda kv: kv[1])
+        sliced = members[start:] if stop == -1 else members[start:stop + 1]
+        if withscores:
+            return [(m, s) for m, s in sliced]
+        return [m for m, _ in sliced]
+
+    def zrem(self, key: str, *members: str) -> int:
+        removed = 0
+        for m in members:
+            if key in self.zsets and m in self.zsets[key]:
+                del self.zsets[key][m]
+                removed += 1
+        return removed
+
+    def zcard(self, key: str) -> int:
+        return len(self.zsets.get(key, {}))
+
+    # ── HASH helpers ──────────────────────────────────────────────────────
+
+    def _hset_raw(self, key: str, **fields) -> None:
+        """Test setup helper."""
+        self.hashes.setdefault(key, {}).update(fields)
+
+    def hget(self, key: str, field: str):
+        return self.hashes.get(key, {}).get(field)
+
+    def hset(self, key: str, mapping: dict | None = None, **kwargs) -> int:
+        data = self.hashes.setdefault(key, {})
+        if mapping:
+            data.update(mapping)
+        data.update(kwargs)
+        return len(mapping or {}) + len(kwargs)
+
+    def expire(self, key: str, ttl: int) -> int:
+        return 1
+
+    def delete(self, key: str) -> int:
+        removed = 0
+        if key in self.zsets:
+            del self.zsets[key]
+            removed += 1
+        if key in self.hashes:
+            del self.hashes[key]
+            removed += 1
+        return removed
+
+    def scan(self, cursor: int, match: str = "*", count: int = 100):
+        prefix = match.rstrip("*")
+        keys = [k for k in self.zsets if k.startswith(prefix)]
+        return 0, keys
+
+    def zadd(self, key: str, mapping: dict) -> int:
+        self.zsets.setdefault(key, {}).update(mapping)
+        return len(mapping)
+
+    def zrangebyscore(self, key: str, min_score, max_score, withscores: bool = False):
+        min_s = float("-inf") if min_score == "-inf" else float(min_score)
+        max_s = float("+inf") if max_score == "+inf" else float(max_score)
+        members = [
+            (m, s) for m, s in self.zsets.get(key, {}).items()
+            if min_s <= s <= max_s
+        ]
+        members.sort(key=lambda kv: kv[1])
+        if withscores:
+            return members
+        return [m for m, _ in members]
+
+
+# ---------------------------------------------------------------------------
+# Fixture: SlotService backed by FakeRedis (no live broker needed)
+# ---------------------------------------------------------------------------
+
+def _load_slot_service_module():
+    """Load slot_service.py directly, bypassing services/__init__.py.
+
+    The services package __init__ imports docker_service eagerly, which
+    requires the Docker SDK. Loading the file directly avoids that chain
+    and lets us test SlotService in isolation.
+    """
+    import importlib.util
+
+    slot_path = _BACKEND / "services" / "slot_service.py"
+
+    # Provide the module-level dependencies slot_service.py needs.
+    sys.modules.setdefault(
+        "config",
+        types.SimpleNamespace(REDIS_URL="redis://localhost:6379/0"),
+    )
+    # utils.helpers: only utc_now_iso is needed at module level
+    if "utils.helpers" not in sys.modules:
+        helpers_stub = types.ModuleType("utils.helpers")
+        helpers_stub.utc_now_iso = lambda: "2026-01-01T00:00:00Z"
+        sys.modules["utils.helpers"] = helpers_stub
+
+    spec = importlib.util.spec_from_file_location("slot_service_direct", slot_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def fake_redis():
+    return _FakeRedis()
+
+
+@pytest.fixture()
+def slot_service(fake_redis):
+    """SlotService instance backed by FakeRedis, loaded without docker deps."""
+    mod = _load_slot_service_module()
+    svc = mod.SlotService.__new__(mod.SlotService)
+    svc.redis = fake_redis
+    svc.slots_prefix = "agent:slots:"
+    svc.metadata_prefix = "agent:slot:"
+    svc._on_release_callbacks = []
+    return svc
+
+
+def _get_constants():
+    mod = _load_slot_service_module()
+    return mod.SLOT_TTL_BUFFER, mod.DEFAULT_SLOT_TTL_SECONDS
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _slot_age(seconds: float) -> float:
+    """Return the ZSET score (epoch) for a slot that is `seconds` old."""
+    return time.time() - seconds
+
+
+def _add_slot(fake_redis: _FakeRedis, agent: str, exec_id: str,
+              age_seconds: float, slot_timeout: int | None = None) -> None:
+    """Insert a slot into FakeRedis, optionally with stored timeout metadata."""
+    slots_key = f"agent:slots:{agent}"
+    meta_key = f"agent:slot:{agent}:{exec_id}"
+    score = _slot_age(age_seconds)
+    fake_redis._zadd_raw(slots_key, exec_id, score)
+    if slot_timeout is not None:
+        fake_redis._hset_raw(meta_key, timeout_seconds=str(slot_timeout))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPerSlotTTL:
+    """``_cleanup_stale_slots_for_agent`` uses per-slot metadata TTL (#869)."""
+
+    def test_long_schedule_timeout_not_reclaimed_at_65_min(self, slot_service, fake_redis):
+        """
+        Scenario: agent default = 3600s, schedule timeout = 7200s.
+        Slot age = 3950s (just past agent-default+buffer = 3900s).
+        OLD code: would reclaim → false kill.
+        NEW code: reads stored timeout=7200, effective TTL=7500s → NOT stale.
+        """
+        _add_slot(fake_redis, "agent-a", "exec-1",
+                  age_seconds=3950, slot_timeout=7200)
+
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-a", default_slot_ttl=3900  # agent default (3600+300)
+        ))
+
+        assert stale == [], (
+            "Slot should not be reclaimed at 65 min when schedule timeout is 7200s"
+        )
+        # Slot still in Redis
+        assert "exec-1" in fake_redis.zsets.get("agent:slots:agent-a", {})
+
+    def test_long_schedule_timeout_reclaimed_after_deadline(self, slot_service, fake_redis):
+        """
+        Same agent, same schedule (7200s), but slot is 7600s old — past its
+        effective TTL of 7500s (7200 + 300 buffer). Must be reclaimed.
+        """
+        _add_slot(fake_redis, "agent-a", "exec-1",
+                  age_seconds=7600, slot_timeout=7200)
+
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-a", default_slot_ttl=7500
+        ))
+
+        assert stale == ["exec-1"]
+        assert "exec-1" not in fake_redis.zsets.get("agent:slots:agent-a", {})
+
+    def test_no_metadata_falls_back_to_default_ttl(self, slot_service, fake_redis):
+        """
+        Slot with no stored metadata falls back to default_slot_ttl.
+        If age > default_slot_ttl → reclaim; otherwise → leave.
+        """
+        # Slot age 1500s, no metadata, default=1200s → stale
+        _add_slot(fake_redis, "agent-b", "exec-old", age_seconds=1500, slot_timeout=None)
+        # Slot age 500s, no metadata, default=1200s → not stale
+        _add_slot(fake_redis, "agent-b", "exec-new", age_seconds=500, slot_timeout=None)
+
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-b", default_slot_ttl=1200
+        ))
+
+        assert stale == ["exec-old"]
+        assert "exec-new" in fake_redis.zsets.get("agent:slots:agent-b", {})
+
+    def test_agent_default_timeout_still_reclaimed_after_deadline(self, slot_service, fake_redis):
+        """
+        Standard case: slot acquired with agent-default timeout (3600s),
+        slot age > 3900s → reclaim. Backwards-compatible behaviour.
+        """
+        _add_slot(fake_redis, "agent-c", "exec-1",
+                  age_seconds=4000, slot_timeout=3600)
+
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-c", default_slot_ttl=3900
+        ))
+
+        assert stale == ["exec-1"]
+
+    def test_agent_default_timeout_not_reclaimed_within_deadline(self, slot_service, fake_redis):
+        """
+        Slot with default timeout 3600s at age 3800s — within 3900s TTL. Not stale.
+        """
+        _add_slot(fake_redis, "agent-d", "exec-1",
+                  age_seconds=3800, slot_timeout=3600)
+
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-d", default_slot_ttl=3900
+        ))
+
+        assert stale == []
+
+    def test_mixed_slots_only_stale_one_reclaimed(self, slot_service, fake_redis):
+        """
+        Two slots on same agent:
+        - exec-long: schedule timeout 7200s, age 3950s → NOT stale
+        - exec-short: schedule timeout 3600s, age 3950s → stale (>3900s effective TTL)
+        Only exec-short must be reclaimed.
+        """
+        _add_slot(fake_redis, "agent-e", "exec-long",
+                  age_seconds=3950, slot_timeout=7200)
+        _add_slot(fake_redis, "agent-e", "exec-short",
+                  age_seconds=3950, slot_timeout=3600)
+
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-e", default_slot_ttl=3900
+        ))
+
+        assert stale == ["exec-short"]
+        assert "exec-long" in fake_redis.zsets.get("agent:slots:agent-e", {})
+        assert "exec-short" not in fake_redis.zsets.get("agent:slots:agent-e", {})
+
+    def test_empty_agent_returns_empty_list(self, slot_service, fake_redis):
+        """No slots → no reclaims, no crash."""
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-ghost", default_slot_ttl=1200
+        ))
+        assert stale == []
+
+    def test_corrupt_metadata_timeout_falls_back_to_default(self, slot_service, fake_redis):
+        """Garbage timeout_seconds in metadata → falls back to default_slot_ttl."""
+        _add_slot(fake_redis, "agent-f", "exec-1",
+                  age_seconds=1500, slot_timeout=None)
+        # Corrupt the stored value
+        fake_redis._hset_raw("agent:slot:agent-f:exec-1", timeout_seconds="not-a-number")
+
+        # default_slot_ttl=1200, age=1500 → should reclaim
+        stale = _run(slot_service._cleanup_stale_slots_for_agent(
+            "agent-f", default_slot_ttl=1200
+        ))
+        assert stale == ["exec-1"]
+
+    def test_cleanup_stale_slots_uses_per_slot_ttl_via_metadata(self, slot_service, fake_redis):
+        """
+        End-to-end: ``cleanup_stale_slots`` with agent_timeouts={"agent-g": 3600}
+        must NOT reclaim a slot whose stored metadata says timeout=7200s even
+        though the slot age (4000s) exceeds the agent-default TTL (3900s).
+        """
+        _add_slot(fake_redis, "agent-g", "exec-long",
+                  age_seconds=4000, slot_timeout=7200)
+
+        result = _run(slot_service.cleanup_stale_slots(
+            agent_timeouts={"agent-g": 3600}
+        ))
+
+        # The long-timeout slot must NOT appear in the reclaimed dict.
+        assert "agent-g" not in result, (
+            "cleanup_stale_slots should not reclaim a slot whose per-slot "
+            "timeout (7200s) has not yet elapsed"
+        )
+
+
+# ---------------------------------------------------------------------------
+# WATCHDOG_HTTP_TIMEOUT secondary fix
+# ---------------------------------------------------------------------------
+
+def test_watchdog_http_timeout_increased():
+    """
+    #869 secondary fix: WATCHDOG_HTTP_TIMEOUT must be ≥ 15 s so agents
+    under load are not declared unreachable by a 5 s HTTP timeout.
+    """
+    import importlib.util
+
+    cleanup_path = _BACKEND / "services" / "cleanup_service.py"
+
+    # Stub all transitive imports cleanup_service needs at module level.
+    sys.modules.setdefault("config", types.SimpleNamespace(REDIS_URL="redis://localhost"))
+    for mod_name in ["database", "models", "utils.helpers", "utils.credential_sanitizer",
+                     "services.capacity_manager"]:
+        if mod_name not in sys.modules:
+            stub = MagicMock(name=mod_name)
+            sys.modules[mod_name] = stub
+
+    spec = importlib.util.spec_from_file_location("cleanup_service_direct", cleanup_path)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+        timeout = mod.WATCHDOG_HTTP_TIMEOUT
+    except Exception:
+        # If direct load fails due to deep deps, grep the source directly
+        import re
+        src = cleanup_path.read_text()
+        match = re.search(r"WATCHDOG_HTTP_TIMEOUT\s*=\s*([\d.]+)", src)
+        assert match, "WATCHDOG_HTTP_TIMEOUT constant not found in cleanup_service.py"
+        timeout = float(match.group(1))
+
+    assert timeout >= 15.0, (
+        f"WATCHDOG_HTTP_TIMEOUT should be ≥ 15 s to handle agents under load "
+        f"(#869), got {timeout}"
+    )


### PR DESCRIPTION
## Summary

- **Root cause**: `_cleanup_stale_slots_for_agent` used a single per-agent cutoff (`agent_ownership.execution_timeout_seconds + 300s buffer`) via `ZREMRANGEBYSCORE`. A slot acquired with a per-schedule `timeout_seconds=7200` would be reclaimed at ~65 min (3900s) — well before its 125 min effective deadline — because the agent's ownership default was 3600s.
- **Primary fix**: Replace the single per-agent `ZREMRANGEBYSCORE` with per-slot checking. Each slot's effective TTL is now read from its metadata HASH (`timeout_seconds` stored at `acquire_slot` time). The per-agent default (`agent_timeouts` dict) is retained as a fallback for slots with missing metadata.
- **Secondary fix**: Raise `WATCHDOG_HTTP_TIMEOUT` from 5s → 15s so agents under heavy load (full slot capacity) don't time out the re-verify ping and get force-failed during Phase 3 slot reclaims.

## Changes

- `src/backend/services/slot_service.py` — `_cleanup_stale_slots_for_agent` rewritten to use per-slot metadata TTL; `cleanup_stale_slots` and `acquire_slot` call sites updated to pass `default_slot_ttl`
- `src/backend/services/cleanup_service.py` — `WATCHDOG_HTTP_TIMEOUT` 5.0 → 15.0
- `tests/unit/test_slot_per_slot_ttl.py` — 10 new unit tests covering the per-slot TTL logic, mixed timeouts, missing/corrupt metadata fallback, and the timeout constant

## Test Plan

- [x] 10 new unit tests pass: `pytest tests/unit/test_slot_per_slot_ttl.py -v`
- [x] Existing tests unaffected: `pytest tests/unit/test_cleanup_unreachable_orphan.py tests/unit/test_redis_slot_recovery.py tests/unit/test_capacity_manager.py -v` (37/37)
- [ ] Manual: start agent with `timeout_seconds=7200`, confirm no false-kill at 65 min

## Related

- Closes #869
- Prior fixes in this area: #226 (per-agent TTL), #378 (JIT re-verify), #497 (force-fail unreachable), #749 (startup orphan sweep)
- The architecture-level fix (#429 CLEANUP-COLLAPSE) will eventually retire TTL-based slot tracking entirely; this patch closes the false-positive window in the interim

Generated with [Claude Code](https://claude.com/claude-code)