### PR TITLE
test(slots): fix sys.modules lint regression from #871

### DIFF
--- a/tests/unit/test_slot_per_slot_ttl.py
+++ b/tests/unit/test_slot_per_slot_ttl.py
@@ -47,10 +47,29 @@ if str(_BACKEND) not in sys.path:
     sys.path.insert(0, str(_BACKEND))
 
 
+# Modules this test stubs into sys.modules (directly or via the
+# importlib-loaded slot_service_direct / cleanup_service_direct helpers)
+# — restored after each test so they don't leak into other test files in
+# the same pytest session. Declaring this at module level (paired with
+# the `_restore_sys_modules` fixture below) is the sanctioned
+# snapshot/restore pattern recognised by tests/lint_sys_modules.py
+# (precedent: tests/unit/test_telegram_webhook_backfill.py).
+_STUBBED_MODULE_NAMES = [
+    "config",
+    "redis",
+    "utils.helpers",
+    "utils.credential_sanitizer",
+    "database",
+    "models",
+    "services.capacity_manager",
+    "slot_service_direct",
+    "cleanup_service_direct",
+]
+
+
 @pytest.fixture(autouse=True)
 def _restore_sys_modules():
-    names = ["config", "slot_service_direct", "utils.helpers", "redis"]
-    saved = {n: sys.modules.get(n) for n in names}
+    saved = {n: sys.modules.get(n) for n in _STUBBED_MODULE_NAMES}
     try:
         yield
     finally:


### PR DESCRIPTION
## Problem

`dev` CI is **red** on the `lint (sys.modules pollution check)` gate, starting at commit `98574f37` (the #871 / #871-as-#869-fix merge — green at the commit before it). Every PR branched off `dev` inherits the failure (surfaced on #880).

PR #871 added `tests/unit/test_slot_per_slot_ttl.py` with 6 `sys.modules` mutations:
- a local-variable restore fixture (`sys.modules.pop` / `sys.modules[name] = …` at L59/L61), and
- `importlib`-loaded stub injections (`sys.modules.setdefault` / `sys.modules[…] = stub` at L168/L176/L390/L395).

None were registered with `tests/lint_sys_modules.py`, and the baseline (`tests/lint_sys_modules_baseline.txt`) has no entry for the file → `0 → 6` over baseline → gate fails.

## Fix

Promote the restore fixture's local `names` list to a module-level `_STUBBED_MODULE_NAMES` constant. `tests/lint_sys_modules.py` recognises the `_STUBBED_MODULE_NAMES` + `_restore_sys_modules` pair as the **sanctioned** self-contained snapshot/restore pattern (precedent: `tests/unit/test_telegram_webhook_backfill.py`) and whole-file-exempts it — covering all 6 occurrences, not just the fixture.

Also **completed** the module list (`database`, `models`, `utils.credential_sanitizer`, `services.capacity_manager`, `cleanup_service_direct`) so the restore fixture now actually restores every module the importlib helpers stub — closing the real cross-file `sys.modules` leak the lint exists to prevent, not just silencing it.

No change to the #869 test logic.

## Verification

Clean `git archive` extraction + system `python3 tests/lint_sys_modules.py` (mirrors the CI environment — no local venv):

```
OK: 229 violation(s) in 66 file(s); baseline allows 232 — no new violations.
exit 0
```

Baseline left untouched (this is a real fix, not a baseline bump).

Related to #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)