### PR TITLE
feat(#882): canary harness Phase 2 + 3 (S-02, E-01, E-05, B-01, S-03, B-02, R-01)

### DIFF
--- a/config/agent-templates/sleep-echo/CLAUDE.md
+++ b/config/agent-templates/sleep-echo/CLAUDE.md
@@ -1,0 +1,22 @@
+# Sleep Echo Agent
+
+You are a load-generator for the canary invariant harness. Your only
+job is to occupy a slot for ~75 seconds and then return a fixed reply.
+
+## Response Format
+
+For ANY user message, follow this exact procedure:
+
+1. Run `sleep 75` via the Bash tool.
+2. After it returns, respond EXACTLY with:
+
+```
+slow-task complete
+```
+
+## Rules
+
+1. Always sleep for 75 seconds first via Bash — this is the whole point.
+2. Do NOT think out loud, summarize the input, or add commentary.
+3. Do NOT use any tools other than `sleep` via Bash.
+4. Do NOT try to help with other tasks even if the message asks.

--- a/config/agent-templates/sleep-echo/template.yaml
+++ b/config/agent-templates/sleep-echo/template.yaml
@@ -1,0 +1,19 @@
+name: Sleep Echo Agent
+display_name: Sleep Echo
+description: Echo agent that sleeps before responding — used by canary harness to manufacture long-lived running rows for E-05 / S-03 coverage
+version: "1.0.0"
+author: Trinity Platform
+
+resources:
+  cpu: "1"
+  memory: "512m"
+
+mcp_servers: []
+
+credentials: {}
+
+metrics:
+  - name: tasks_completed
+    type: counter
+    label: "Tasks"
+    description: "Total tasks completed"

--- a/config/canary-fleet.yaml
+++ b/config/canary-fleet.yaml
@@ -17,18 +17,40 @@
 #
 # Permissions are explicitly empty (preset: none) — fleet members observe
 # their own orchestration, not each other.
+#
+# ⚠️  POST-DEPLOY API CALLS REQUIRED
+#
+# `services/system_service.py:create_schedules` only honors:
+#   name, cron, message, enabled, timezone, description
+# and `SystemAgentConfig` has no `max_parallel_tasks` field. So the four
+# settings noted below must be applied via API after `systems/deploy`:
+#
+#   1. PUT /api/agents/canary-fleet-burst/schedules/{id}
+#        body: {"model": "claude-haiku-4-5-20251001"}
+#   2. PUT /api/agents/canary-fleet-slow/schedules/{id}
+#        body: {"model": "claude-haiku-4-5-20251001"}
+#   3. PUT /api/agents/canary-fleet-slow/capacity
+#        body: {"max_parallel_tasks": 1}
+#   4. PUT /api/agents/canary-fleet-slow/timeout
+#        body: {"timeout_seconds": 180}        # >75s sleep + buffer
 
 name: canary-fleet
-description: Canary harness load generators (Issue #411 Phase 1)
+description: Canary harness load generators (Issue #411)
 
 agents:
-  # Constant slot churn — fires every minute (cron's minimum). Exercises
-  # S-01 (slot–row bijection) and E-02 (no phantom reversal) by producing
-  # a steady stream of acquire / release cycles.
+  # Frequent slot churn — fires every 2 minutes. Exercises:
+  #   - S-01 (slot–row bijection): in-flight task at canary snapshot
+  #   - E-02 (no phantom reversal): status transitions
+  #   - S-03 (slot TTL floor): slot existing at snapshot
+  #   - R-01 (no zombie claude): exec/wait cycles
   #
   # `test-echo` is Trinity's minimal stock template (no MCP servers, no
-  # credentials, deterministic short reply) — exactly what slot-churn
-  # invariants need.
+  # credentials, deterministic short reply, ~4s task) — exactly what
+  # slot-churn invariants need.
+  #
+  # Cron `*/2 * * * *` is the cheapest cadence that still phase-slides
+  # against the 5-min canary cycle. `*/5` would phase-lock and risk zero
+  # snapshot overlap for days. See ops notes in PR thread for #411.
   burst:
     template: local:test-echo
     resources:
@@ -36,26 +58,31 @@ agents:
       memory: "512m"
     schedules:
       - name: heartbeat
-        cron: "* * * * *"  # every minute
+        cron: "*/2 * * * *"
         message: "ok"
         timezone: UTC
-        description: Constant load to exercise slot–row bijection (S-01) and reversal (E-02)
+        description: Frequent short-task load (S-01, E-02, S-03, R-01)
 
-  # Slower cadence so multiple slots overlap across cycles. Phase 2
-  # invariants (S-03 / E-01 / E-06) want a longer-lived slot to scrutinize;
-  # Phase 1 only needs the slower cron to broaden snapshot coverage, so
-  # reusing `test-echo` is fine here too.
-  long:
-    template: local:test-echo
+  # Long-lived slot — sleeps 75s per task on a 3-min cron. Exercises:
+  #   - E-05 (dispatched rows have session): provides >60s running rows
+  #     so the invariant has something to inspect (currently trivially-
+  #     green because no fleet rows live that long).
+  #   - S-03 below_floor: TTL is checked on a slot that actually exists.
+  #
+  # 75s task duration > 60s E-05 SLA. 3-min cron > 75s task = no overlap
+  # in steady state; max_parallel_tasks=1 (set via post-deploy PUT) means
+  # any spill into the next cron tick would queue, which B-02 catches.
+  slow:
+    template: local:sleep-echo
     resources:
       cpu: "1"
-      memory: "1g"
+      memory: "512m"
     schedules:
-      - name: long-task
-        cron: "*/5 * * * *"  # every 5 min
-        message: "long-task ping"
+      - name: slow-task
+        cron: "*/3 * * * *"
+        message: "slow ping"
         timezone: UTC
-        description: Slower cadence to overlap slots across canary cycles (Phase 2 will swap in a real long task)
+        description: Long-lived slot to give E-05 / S-03 a row to inspect
 
 # No cross-agent permissions — the canary fleet observes the orchestration
 # layer, not each other.

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -401,7 +401,7 @@ Services that run continuously in the backend process:
 | **Sync Health Service** | `sync_health_service.py` | Polls git-enabled agents every 60s, upserts `agent_sync_state`, emits `sync_failing` operator-queue entries when consecutive_failures ≥ 3. (#389 S1) |
 | **Monitoring Service** | `monitoring_service.py` | Fleet-wide health checks on configurable interval. (MON-001) |
 | **Scheduler Service** | `scheduler_service.py` | APScheduler-based cron job execution. Async fire-and-forget with DB polling for status. On each cron-triggered fire, optionally invokes the agent's executable `~/.trinity/pre-check` (interpreter chosen by shebang) via the backend's `POST /api/internal/agents/{name}/pre-check` (which `docker exec`s into the agent container). Empty stdout + exit 0 records a skipped execution and does not invoke Claude (SCHED-COND-001, #454). |
-| **Capacity Maintenance** | `capacity_manager.py` | Calls `CapacityManager.run_maintenance()` every 60s — expires stale queued tasks (>24h) and drains orphans after restart. (BACKLOG-001 / CAPACITY-CONSOLIDATE #428) |
+| **Capacity Maintenance** | `capacity_manager.py` | Calls `CapacityManager.run_maintenance()` every 60s — expires stale queued tasks (>24h) and drains orphans after restart. On each successful sweep, writes a unix-timestamp heartbeat to Redis key `canary:drain_tick_at` (read by canary B-02 to distinguish stuck drains from "drain just hasn't run yet"). (BACKLOG-001 / CAPACITY-CONSOLIDATE #428; B-02 heartbeat #882) |
 | **Audit Retention** | `audit_retention_service.py` | Daily APScheduler job at 04:15 UTC that DELETEs `audit_log` rows past the retention window. Configured via `AUDIT_LOG_RETENTION_DAYS` (default 365, floored at 365 — the `audit_log_no_delete` trigger refuses younger rows). Pruning ages out hash-chain history past the cutoff by design. (#552) |
 | **DB Vacuum** | `db_vacuum_service.py` | Daily APScheduler job at 04:30 UTC that runs `VACUUM` on `/data/trinity.db` to reclaim pages freed by the cleanup-service retention sweeps. Configurable via `DB_VACUUM_ENABLED` / `DB_VACUUM_HOUR` / `DB_VACUUM_MINUTE`. Opens an autocommit (`isolation_level=None`) connection because VACUUM cannot run inside a transaction; accepts the rare BUSY outcome rather than retrying. (#772) |
 | **Session Cleanup** | `session_cleanup_service.py` | Periodic JSONL reaper for the Session tab. Default 6h cycle (`poll_interval_seconds`); each cycle diffs every running agent's `~/.claude/projects/-home-developer/<uuid>.jsonl` set against `agent_sessions.cached_claude_session_id` and deletes JSONLs not in the keep set whose mtime is older than `min_age_seconds` (default 1h race guard). Synchronous best-effort `reap_jsonl()` is also called by the session router on user-initiated reset/delete so the disk reclaim is immediate. Uses `execute_command_in_container` (no agent-server endpoint required). (SESSION_TAB Phase 4.2) |
@@ -735,6 +735,31 @@ export, enable/disable toggle. Issue #20 can be closed.
   Tier A. Trivially-green today after the #428 consolidation; exists as
   a regression guard against a future cache layer or status-filter drift
   on the production accessor.
+
+**Phase 3 invariants** (#882, same PR — S-03, B-02, R-01):
+- **S-03 — Slot TTL ≥ execution timeout**: for every member of
+  `agent:slots:{name}`, the companion `agent:slot:{name}:{eid}` HASH
+  has `TTL ≥ execution_timeout_seconds + 300s`. Three failure kinds
+  surfaced explicitly: `missing` (-2, metadata HASH expired ahead of
+  the ZSET — the #226 class), `no_expiry` (-1, `expire()` never set),
+  `below_floor` (positive TTL under the configured floor). Severity:
+  critical. Tier A.
+- **B-02 — No queued without slots-full**: if any agent has
+  `len(queued_exec_ids) > 0`, then either `slot_count == max_parallel`
+  OR a drain tick fired in the last 60s. Severity: critical. Tier B.
+  Heartbeat written by `CapacityManager.run_maintenance()` to
+  `canary:drain_tick_at` at the END of each successful sweep, so a
+  mid-sweep crash leaves the cursor stale and lets the check catch the
+  breakage.
+- **R-01 — No zombie Claude processes**: for every running
+  `trinity.platform=agent` container,
+  `ps -eo stat,comm | grep '^Z.*claude' | wc -l == 0`. Severity:
+  critical. Tier A. Guards PR #407. New source type for the canary
+  (docker exec); per-container failures recorded in
+  `sources_unavailable` so a single unhealthy container doesn't kill
+  the cycle. The regex is anchored at `^Z` rather than the catalog's
+  ` Z` (leading-space) — procps-ng on the agent base image emits STAT
+  left-aligned without padding.
 
 **Fleet**: `config/canary-fleet.yaml` — synthetic load generators
 (`canary-fleet-burst`, `canary-fleet-long`) deployed via the existing

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -697,7 +697,7 @@ export, enable/disable toggle. Issue #20 can be closed.
 **Storage**: `canary_violations` table in main SQLite DB. JSON-encoded
 `observed_state` column carries invariant-specific payload.
 
-**Phase 1 invariants** (S-01, E-02, L-03):
+**Phase 1 invariants** (#653 — S-01, E-02, L-03):
 - **S-01 — Slot–row bijection**: per agent, set of execution_ids in
   `agent:slots:{name}` (Redis ZSET, drain sentinels filtered) equals set
   of execution_ids in `schedule_executions WHERE status='running'`.
@@ -715,6 +715,26 @@ export, enable/disable toggle. Issue #20 can be closed.
   in `agent_ownership`; no Redis `agent:slots:{name}` for missing agent.
   Severity: critical for orphaned `schedule_executions` or Redis slots,
   major otherwise. Catches Issue #129 bug class.
+
+**Phase 2 invariants** (#882 — S-02, E-01, E-05, B-01):
+- **S-02 — No overbooking**: per agent, `ZCARD(agent:slots:{name})`
+  (drain sentinels filtered) ≤ `agent_ownership.max_parallel_tasks`.
+  Severity: critical. Catches `acquire_slot` concurrency-bypass
+  regressions — distinct from S-01 because the violation can be self-
+  consistent (Redis and SQL agree on N+1 running tasks against a cap of N).
+- **E-01 — Terminal-state closure**: no `status='running'` row whose
+  `started_at` is older than the agent's `execution_timeout_seconds + 300s`
+  (matches `SLOT_TTL_BUFFER` so the check fires *after* cleanup has had
+  its window to act). Severity: critical. Tier B.
+- **E-05 — Dispatched rows have session**: no `status='running'` row
+  older than 60s with `claude_session_id IS NULL`. Severity: major.
+  Tier B. Guards Issue #106.
+- **B-01 — Queue-status coherence**: per agent, `db.get_queued_count`
+  (the accessor `BacklogService` calls) agrees with the snapshot's
+  independently-collected `len(queued_exec_ids)`. Severity: critical.
+  Tier A. Trivially-green today after the #428 consolidation; exists as
+  a regression guard against a future cache layer or status-filter drift
+  on the production accessor.
 
 **Fleet**: `config/canary-fleet.yaml` — synthetic load generators
 (`canary-fleet-burst`, `canary-fleet-long`) deployed via the existing

--- a/src/backend/canary/invariants/__init__.py
+++ b/src/backend/canary/invariants/__init__.py
@@ -19,6 +19,13 @@ Phase 1, no new source types:
 - E-05: dispatched rows have session (no >60s running row with NULL session)
 - B-01: queue-status coherence (`db.get_queued_count` vs id-list count)
 
+Phase 3 (#882, same PR) adds three moderate-complexity checks — each
+brings one new piece of plumbing:
+
+- S-03: slot TTL ≥ execution timeout (per-slot Redis TTL lookup)
+- B-02: no queued without slots-full (`canary:drain_tick_at` heartbeat)
+- R-01: no zombie claude processes (docker exec into agent containers)
+
 Subsequent phases register additional invariants here without changes to
 the snapshot collector or the run-cycle endpoint.
 """
@@ -28,11 +35,14 @@ from typing import Callable, Dict, Iterable, List
 from ..snapshot import Snapshot, ViolationReport
 from .s01_slot_row_bijection import check as s01_check
 from .s02_no_overbooking import check as s02_check
+from .s03_slot_ttl_floor import check as s03_check
 from .e01_terminal_state_closure import check as e01_check
 from .e02_no_phantom_reversal import check as e02_check
 from .e05_dispatched_rows_have_session import check as e05_check
 from .l03_delete_cascades import check as l03_check
 from .b01_queue_status_coherence import check as b01_check
+from .b02_no_queued_without_slots_full import check as b02_check
+from .r01_no_zombie_claude import check as r01_check
 
 
 # Public registry. Keys are the invariant ids the run-cycle endpoint
@@ -40,11 +50,14 @@ from .b01_queue_status_coherence import check as b01_check
 INVARIANTS: Dict[str, Callable[[Snapshot], List[ViolationReport]]] = {
     "S-01": s01_check,
     "S-02": s02_check,
+    "S-03": s03_check,
     "E-01": e01_check,
     "E-02": e02_check,
     "E-05": e05_check,
     "L-03": l03_check,
     "B-01": b01_check,
+    "B-02": b02_check,
+    "R-01": r01_check,
 }
 
 

--- a/src/backend/canary/invariants/__init__.py
+++ b/src/backend/canary/invariants/__init__.py
@@ -1,15 +1,23 @@
 """
-Canary invariant library — Phase 1 (CANARY-001 / Issue #411).
+Canary invariant library (CANARY-001 / Issue #411).
 
 Each invariant is a pure function `check(snapshot) → list[ViolationReport]`.
 The library is registry-driven so the run-cycle endpoint can enable/disable
 invariants per request.
 
-Phase 1 ships three:
+Phase 1 (#653) shipped:
 
 - S-01: slot–row bijection (Redis ZSET vs SQL running rows)
 - E-02: no phantom state reversal (terminal executions stay terminal)
 - L-03: delete cascades (no orphan rows referencing removed agents)
+
+Phase 2 (#882) adds four single-source SQL/Redis checks — same shape as
+Phase 1, no new source types:
+
+- S-02: no overbooking (ZCARD ≤ max_parallel_tasks)
+- E-01: terminal-state closure (no row past timeout + buffer in `running`)
+- E-05: dispatched rows have session (no >60s running row with NULL session)
+- B-01: queue-status coherence (`db.get_queued_count` vs id-list count)
 
 Subsequent phases register additional invariants here without changes to
 the snapshot collector or the run-cycle endpoint.
@@ -19,16 +27,24 @@ from typing import Callable, Dict, Iterable, List
 
 from ..snapshot import Snapshot, ViolationReport
 from .s01_slot_row_bijection import check as s01_check
+from .s02_no_overbooking import check as s02_check
+from .e01_terminal_state_closure import check as e01_check
 from .e02_no_phantom_reversal import check as e02_check
+from .e05_dispatched_rows_have_session import check as e05_check
 from .l03_delete_cascades import check as l03_check
+from .b01_queue_status_coherence import check as b01_check
 
 
 # Public registry. Keys are the invariant ids the run-cycle endpoint
 # accepts in its `invariants` filter.
 INVARIANTS: Dict[str, Callable[[Snapshot], List[ViolationReport]]] = {
     "S-01": s01_check,
+    "S-02": s02_check,
+    "E-01": e01_check,
     "E-02": e02_check,
+    "E-05": e05_check,
     "L-03": l03_check,
+    "B-01": b01_check,
 }
 
 

--- a/src/backend/canary/invariants/b01_queue_status_coherence.py
+++ b/src/backend/canary/invariants/b01_queue_status_coherence.py
@@ -1,0 +1,83 @@
+"""
+B-01 — Queue-status coherence (CANARY-001 / Issue #411 — Phase 2).
+
+The production accessor `db.get_queued_count(agent_name)` — the one
+`BacklogService` calls on every enqueue and drain — must agree with a
+direct id-list count of `schedule_executions WHERE status='queued'` for
+the same agent. Both numbers come from the same table, so they should
+match. When they don't, something has been wedged between the
+service-layer accessor and the raw rows: a cache, a status-filter
+regression, an enum-value drift, a partial migration.
+
+## Why this isn't a tautology
+
+After the #428 CapacityManager consolidation the backlog has no
+secondary representation — the queue is `status='queued'` rows. So
+yes, calling `SELECT COUNT(*) WHERE status='queued'` twice will agree.
+
+The point of B-01 is to *fail loudly* the day someone adds an in-memory
+cache to `db.get_queued_count` (or a Redis read-through, or a stale
+materialized view), and gets the cache invalidation wrong. The two
+query paths live in different files (`db/schedules.py` vs
+`canary/snapshot.py`); they share a database but not a code path.
+
+Today this check is trivially-green. That's fine — it's a regression
+guard. The cost is one extra `SELECT COUNT(*)` per agent per cycle,
+which is unmeasurably cheap.
+
+## Skip behavior
+
+If the snapshot collector could not reach the production accessor (the
+unit-test environment stubs `db.connection` but not the full `database`
+facade), the per-agent `queued_count_via_service` is `None`. The check
+skips those agents rather than firing a false positive.
+
+Tier A, severity critical. Backlog/orchestration agreement is a
+load-bearing invariant — if it ever fires, it means a user's queued
+task is either invisible or double-counted, and the drain path will
+either skip it or stall waiting for a free slot that already exists.
+"""
+
+from typing import List
+
+from ..snapshot import Snapshot, ViolationReport
+
+
+INVARIANT_ID = "B-01"
+TIER = "A"
+SEVERITY = "critical"
+
+
+def check(snapshot: Snapshot) -> List[ViolationReport]:
+    """Compare `db.get_queued_count` against `len(queued_exec_ids)`."""
+    violations: List[ViolationReport] = []
+
+    for agent in snapshot.agents:
+        service_count = agent.queued_count_via_service
+        # Accessor unavailable this cycle (unit-test mode) — skip silently.
+        if service_count is None:
+            continue
+        snapshot_count = len(agent.queued_exec_ids)
+        if service_count == snapshot_count:
+            continue
+
+        violations.append(
+            ViolationReport(
+                invariant_id=INVARIANT_ID,
+                tier=TIER,
+                severity=SEVERITY,
+                observed_state={
+                    "agent_name": agent.name,
+                    "service_count": service_count,
+                    "snapshot_count": snapshot_count,
+                    "snapshot_queued_ids": sorted(agent.queued_exec_ids),
+                    "snapshot_time": snapshot.snapshot_time,
+                },
+                signal_query=(
+                    f"db.get_queued_count('{agent.name}') = {service_count} "
+                    f"!= |queued ids in snapshot| = {snapshot_count}"
+                ),
+            )
+        )
+
+    return violations

--- a/src/backend/canary/invariants/b02_no_queued_without_slots_full.py
+++ b/src/backend/canary/invariants/b02_no_queued_without_slots_full.py
@@ -1,0 +1,128 @@
+"""
+B-02 — No queued without slots-full (CANARY-001 / Issue #411 — Phase 3).
+
+If an agent has any queued executions, the system must have a legitimate
+reason to keep them queued. There are exactly two legitimate reasons:
+
+1. **Slots are at the cap.** `len(slot_ids excluding sentinels) ==
+   max_parallel_tasks` — every drain attempt would correctly fail at
+   `acquire_slot`. Working as intended.
+2. **A drain tick fired recently.** `CapacityManager.run_maintenance()`
+   runs every 60s and writes a heartbeat to `canary:drain_tick_at`. If
+   we just ran a drain pass and the queue is still there, the next
+   release callback will pick it up; nothing is wedged.
+
+If *neither* holds — there are queued rows, free slots exist, and the
+drain tick is stale (>60s old or never written) — the drain pipeline
+has stalled. The user's queued task is invisible from their perspective
+and the agent looks idle.
+
+## Heartbeat plumbing
+
+The drain-tick timestamp is written by `services/capacity_manager.py:
+run_maintenance` at the END of the sweep (not the start), so a crash
+mid-sweep leaves the cursor stale and lets this check catch the
+breakage. The snapshot reads it via the same Redis client the slot
+service uses.
+
+## Grace window
+
+60s matches the call cadence of `main.py`'s maintenance loop. We want
+the canary cycle to allow at least one full maintenance interval before
+calling drain stalled — otherwise we'd false-fire any time the canary
+ran in the small window between an enqueue and the next maintenance
+tick. The 5-min canary cadence is well within `60s + maintenance time`.
+
+Tier B, severity critical. A stalled drain is invisible to the user
+(no error, just silence) until they notice their queued task never
+ran. Catching it on the canary lets the operator intervene.
+"""
+
+import time
+from typing import List
+
+from ..snapshot import Snapshot, ViolationReport
+
+
+INVARIANT_ID = "B-02"
+TIER = "B"
+SEVERITY = "critical"
+
+DRAIN_PREFIX = "drain-"
+
+# Grace window for the drain-tick heartbeat. Matches main.py's 60s
+# maintenance loop; anything older means a tick was skipped.
+DRAIN_TICK_GRACE_SECONDS = 60
+
+
+def check(snapshot: Snapshot) -> List[ViolationReport]:
+    """Emit one violation per agent with queue + free slots + stale drain."""
+    violations: List[ViolationReport] = []
+
+    # Redis failures already get logged via sources_unavailable. If the
+    # slot ZSET reads failed (S-01's gate), the slot counts are unreliable
+    # and we shouldn't fire B-02 violations based on stale data.
+    if any(s.startswith("redis") for s in snapshot.sources_unavailable):
+        return violations
+
+    now_ts = time.time()
+    tick_age: float
+    if snapshot.drain_tick_at is None:
+        # Heartbeat never written (cold cluster, Redis read failed, or
+        # bug in the maintenance loop). Treat as "drain has never run"
+        # — sentinel value much larger than the grace window.
+        tick_age = float("inf")
+    else:
+        tick_age = now_ts - snapshot.drain_tick_at
+        # Defensive: clock skew or a future-dated heartbeat shouldn't
+        # let stale data pass as fresh. Floor at 0.
+        if tick_age < 0:
+            tick_age = 0.0
+
+    for agent in snapshot.agents:
+        queued = len(agent.queued_exec_ids)
+        if queued == 0:
+            continue
+
+        # Filter drain sentinels — they're held briefly while the next
+        # backlog item is being claimed and are not real running work.
+        real_slots = {s for s in agent.slot_ids if not s.startswith(DRAIN_PREFIX)}
+        if len(real_slots) >= agent.max_parallel:
+            # Slots are at the cap; queued is the correct state.
+            continue
+
+        if tick_age <= DRAIN_TICK_GRACE_SECONDS:
+            # Drain ran within the window; the next release callback
+            # will pick this up. Not yet a violation.
+            continue
+
+        violations.append(
+            ViolationReport(
+                invariant_id=INVARIANT_ID,
+                tier=TIER,
+                severity=SEVERITY,
+                observed_state={
+                    "agent_name": agent.name,
+                    "queued_count": queued,
+                    "slot_count": len(real_slots),
+                    "max_parallel_tasks": agent.max_parallel,
+                    "free_slots": agent.max_parallel - len(real_slots),
+                    "drain_tick_at": snapshot.drain_tick_at,
+                    "drain_tick_age_seconds": (
+                        None if tick_age == float("inf") else int(tick_age)
+                    ),
+                    "drain_tick_grace_seconds": DRAIN_TICK_GRACE_SECONDS,
+                    "snapshot_time": snapshot.snapshot_time,
+                },
+                signal_query=(
+                    f"agent {agent.name}: queued={queued}, "
+                    f"slots={len(real_slots)}/{agent.max_parallel} "
+                    f"(free={agent.max_parallel - len(real_slots)}), "
+                    f"drain_tick_age="
+                    f"{'never' if tick_age == float('inf') else f'{int(tick_age)}s'} "
+                    f"> {DRAIN_TICK_GRACE_SECONDS}s"
+                ),
+            )
+        )
+
+    return violations

--- a/src/backend/canary/invariants/e01_terminal_state_closure.py
+++ b/src/backend/canary/invariants/e01_terminal_state_closure.py
@@ -1,0 +1,116 @@
+"""
+E-01 — Terminal-state closure (CANARY-001 / Issue #411 — Phase 2).
+
+Every `schedule_executions` row reaches a terminal status within its
+agent's `execution_timeout_seconds + 300s` (SLOT_TTL_BUFFER). A row that
+is still `status='running'` past that window means either the cleanup
+watchdog never fired (CLEANUP-001 regression), the execution wedged
+without raising, or the timeout enforcement was bypassed entirely.
+
+## Per-agent timeout, not per-execution
+
+The original catalog (`docs/testing/orchestration-invariant-catalog.md`)
+specifies `timeout_seconds` on `schedule_executions`. Trinity stores the
+timeout on `agent_ownership.execution_timeout_seconds` instead — agents
+have a uniform per-agent cap. The check uses that value, which is
+already in `AgentSnapshot.execution_timeout_seconds`.
+
+## Buffer
+
+300s of head-room past the timeout matches `SLOT_TTL_BUFFER` in
+`services/slot_service.py` — the same buffer the cleanup service uses
+before declaring a slot stale. Aligning with that constant means E-01
+fires *after* the cleanup service has had its window to act, so a
+violation is unambiguously "cleanup failed to act on a timed-out row"
+rather than "cleanup hasn't run yet". Hard-coded rather than imported
+because the canary is intentionally insulated from runtime config drift
+— if SLOT_TTL_BUFFER changes upstream, this constant should be reviewed
+deliberately rather than shifted silently.
+
+## Tier B because the SLA is "eventually ≤ timeout + 5min"
+
+Unlike S-01 / S-02 which are point-in-time bijection checks, E-01 has a
+time component: a row is only a violation once it's *past* its window.
+The 5-min canary cadence is well-aligned with the 300s buffer.
+
+Tier B, severity critical. A stuck-forever execution that the watchdog
+missed is a direct user-visible failure (the schedule never reports,
+the slot is never released, the agent is one parallel task lighter
+forever).
+"""
+
+from datetime import datetime
+from typing import List
+
+from ..snapshot import Snapshot, ViolationReport
+
+
+INVARIANT_ID = "E-01"
+TIER = "B"
+SEVERITY = "critical"
+
+# Matches services/slot_service.py SLOT_TTL_BUFFER. Hard-coded so the
+# canary check stays decoupled from upstream config drift — a change to
+# the runtime buffer should be a deliberate review, not silent shift.
+SLOT_TTL_BUFFER_SECONDS = 300
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Tolerant ISO-8601 parser — strips trailing 'Z' that fromisoformat
+    rejects on <3.11. The canary persists `started_at` in `Z` form (see
+    `utils.helpers.utc_now_iso`)."""
+    if ts.endswith("Z"):
+        ts = ts[:-1]
+    return datetime.fromisoformat(ts)
+
+
+def check(snapshot: Snapshot) -> List[ViolationReport]:
+    """Emit one violation per running row past its timeout + buffer."""
+    violations: List[ViolationReport] = []
+
+    snap_dt = _parse_iso(snapshot.snapshot_time)
+
+    for agent in snapshot.agents:
+        # No per-execution timeout column; agent-level cap governs all rows.
+        threshold = agent.execution_timeout_seconds + SLOT_TTL_BUFFER_SECONDS
+
+        for eid in sorted(agent.running_exec_ids):
+            started_at = agent.running_started_at.get(eid)
+            if not started_at:
+                # No start timestamp — cannot age the row. Skip; either the
+                # row is brand new (no started_at written yet, rare) or the
+                # snapshot dropped the field. Other invariants flag the
+                # surrounding bug class; E-01 should not double-fire.
+                continue
+            try:
+                started_dt = _parse_iso(started_at)
+            except ValueError:
+                continue
+            age_seconds = (snap_dt - started_dt).total_seconds()
+            if age_seconds <= threshold:
+                continue
+
+            violations.append(
+                ViolationReport(
+                    invariant_id=INVARIANT_ID,
+                    tier=TIER,
+                    severity=SEVERITY,
+                    observed_state={
+                        "agent_name": agent.name,
+                        "execution_id": eid,
+                        "started_at": started_at,
+                        "snapshot_time": snapshot.snapshot_time,
+                        "age_seconds": int(age_seconds),
+                        "execution_timeout_seconds": agent.execution_timeout_seconds,
+                        "slot_ttl_buffer_seconds": SLOT_TTL_BUFFER_SECONDS,
+                    },
+                    signal_query=(
+                        f"schedule_executions row {eid} "
+                        f"(agent={agent.name}) status='running' "
+                        f"age={int(age_seconds)}s > "
+                        f"timeout+buffer={threshold}s"
+                    ),
+                )
+            )
+
+    return violations

--- a/src/backend/canary/invariants/e05_dispatched_rows_have_session.py
+++ b/src/backend/canary/invariants/e05_dispatched_rows_have_session.py
@@ -1,0 +1,102 @@
+"""
+E-05 — Dispatched rows have session (CANARY-001 / Issue #411 — Phase 2).
+
+A `schedule_executions` row that is `status='running'` and has been
+dispatched for more than 60 seconds must have `claude_session_id IS NOT
+NULL`. The 60-second window is the SLA `mark_no_session_executions_failed`
+operates on — anything older than that should already have been failed
+out by the watchdog.
+
+A violation says: the row was dispatched, the agent should have written
+back a session id by now (Claude Code's first turn always returns one),
+the watchdog should have noticed and failed the row out if it hadn't —
+and none of those things happened. That's issue #106 reopening.
+
+## Why 60 seconds
+
+The first `claude --print` turn writes a session id within milliseconds
+of starting. Anything past 60s without one means either:
+- agent-server crashed before writing back (watchdog should catch)
+- session-id update path is broken (the bug class to detect)
+- DB write failed silently
+
+The catalog calls 60s out explicitly as both the SLA and the grace
+window — see `docs/testing/orchestration-invariant-catalog.md` E-05.
+
+## Why major, not critical
+
+A missing session id doesn't directly break the agent's work — the
+execution still runs, the slot still releases, the user still gets a
+response. What breaks is session resumption, conversation continuity,
+and the observability link to the JSONL file in the container. Real
+operational problem, but not the lights-out kind S-01/S-02/E-01 flag.
+
+Tier B, severity major.
+"""
+
+from datetime import datetime
+from typing import List
+
+from ..snapshot import Snapshot, ViolationReport
+
+
+INVARIANT_ID = "E-05"
+TIER = "B"
+SEVERITY = "major"
+
+# Per the catalog: dispatched rows have 60s to acquire a session id.
+SESSION_GRACE_SECONDS = 60
+
+
+def _parse_iso(ts: str) -> datetime:
+    if ts.endswith("Z"):
+        ts = ts[:-1]
+    return datetime.fromisoformat(ts)
+
+
+def check(snapshot: Snapshot) -> List[ViolationReport]:
+    """Emit one violation per running row past 60s with no session id."""
+    violations: List[ViolationReport] = []
+
+    snap_dt = _parse_iso(snapshot.snapshot_time)
+
+    for agent in snapshot.agents:
+        for eid in sorted(agent.running_exec_ids):
+            session_id = agent.running_claude_session_ids.get(eid)
+            if session_id:
+                continue
+            started_at = agent.running_started_at.get(eid)
+            if not started_at:
+                # No start timestamp — cannot age the row. Skip.
+                continue
+            try:
+                started_dt = _parse_iso(started_at)
+            except ValueError:
+                continue
+            age_seconds = (snap_dt - started_dt).total_seconds()
+            if age_seconds <= SESSION_GRACE_SECONDS:
+                continue
+
+            violations.append(
+                ViolationReport(
+                    invariant_id=INVARIANT_ID,
+                    tier=TIER,
+                    severity=SEVERITY,
+                    observed_state={
+                        "agent_name": agent.name,
+                        "execution_id": eid,
+                        "started_at": started_at,
+                        "snapshot_time": snapshot.snapshot_time,
+                        "age_seconds": int(age_seconds),
+                        "grace_seconds": SESSION_GRACE_SECONDS,
+                    },
+                    signal_query=(
+                        f"schedule_executions row {eid} "
+                        f"(agent={agent.name}) status='running' "
+                        f"age={int(age_seconds)}s > {SESSION_GRACE_SECONDS}s "
+                        f"and claude_session_id IS NULL"
+                    ),
+                )
+            )
+
+    return violations

--- a/src/backend/canary/invariants/r01_no_zombie_claude.py
+++ b/src/backend/canary/invariants/r01_no_zombie_claude.py
@@ -1,0 +1,77 @@
+"""
+R-01 — No zombie Claude processes (CANARY-001 / Issue #411 — Phase 3).
+
+For every running Trinity agent container:
+    `ps -eo stat,comm | grep ' Z.*claude' | wc -l == 0`
+
+A nonzero count means a `claude` child process exited but was not
+reaped by its parent — a zombie. Zombies don't consume CPU, but they
+hold a PID, eventually exhausting the container's process table on
+busy agents. PR #407 fixed the case where the agent-server stopped
+calling `wait()` on its Claude subprocesses; R-01 is the regression
+guard for that bug class.
+
+## Source caveats
+
+This is the first canary invariant that needs Docker access. The
+snapshot collector handles the new failure modes:
+
+- Docker client not initialized (test/embedded mode): the snapshot
+  records `docker: client unavailable` in `sources_unavailable` and
+  produces no `zombie_counts` entries. The check below treats every
+  agent as "no data, skip" — i.e. silently green, no false fires.
+- Per-container exec failure (container died, network glitch,
+  permission error): recorded as `docker.exec[name]: <reason>` in
+  `sources_unavailable`. That single agent is skipped; the rest of
+  the cycle continues normally.
+
+The R-01 check itself only fires when we have a real number from a
+real container and that number is > 0.
+
+## Severity
+
+Tier A, critical. A zombie leak in an agent container is a slow-fuse
+breakage — the agent keeps running fine for minutes, then suddenly
+can't fork anything. The canary catches it before the symptom does.
+"""
+
+from typing import List
+
+from ..snapshot import Snapshot, ViolationReport
+
+
+INVARIANT_ID = "R-01"
+TIER = "A"
+SEVERITY = "critical"
+
+
+def check(snapshot: Snapshot) -> List[ViolationReport]:
+    """Emit one violation per agent with zombie claude processes."""
+    violations: List[ViolationReport] = []
+
+    # If docker_client / docker.list failed wholesale, `zombie_counts` is
+    # empty and `sources_unavailable` carries a `docker:` entry. The
+    # all-agents check below short-circuits in that case (no entries to
+    # iterate); no special handling needed.
+    for agent_name, count in sorted(snapshot.zombie_counts.items()):
+        if count <= 0:
+            continue
+        violations.append(
+            ViolationReport(
+                invariant_id=INVARIANT_ID,
+                tier=TIER,
+                severity=SEVERITY,
+                observed_state={
+                    "agent_name": agent_name,
+                    "zombie_count": count,
+                    "snapshot_time": snapshot.snapshot_time,
+                },
+                signal_query=(
+                    f"docker exec agent-{agent_name} sh -c "
+                    "\"ps -eo stat,comm | grep '^Z.*claude' | wc -l\" "
+                    f"= {count}"
+                ),
+            )
+        )
+
+    return violations

--- a/src/backend/canary/invariants/s02_no_overbooking.py
+++ b/src/backend/canary/invariants/s02_no_overbooking.py
@@ -1,0 +1,75 @@
+"""
+S-02 — No overbooking (CANARY-001 / Issue #411 — Phase 2).
+
+Per agent A: `ZCARD(agent:slots:A)` (excluding drain sentinels) must not
+exceed `agent_ownership.max_parallel_tasks`. A violation means the
+`acquire_slot` concurrency guard was bypassed and the agent is currently
+running more tasks than its declared parallelism cap allows.
+
+This is structurally cheaper than S-01 — S-01 needs a SQL cross-check,
+S-02 only needs the Redis ZCARD and one column from `agent_ownership`,
+both already in the snapshot. We still run it as its own invariant
+because the *meaning* of a violation is different: S-01 says "Redis and
+SQL disagree", S-02 says "even Redis on its own already shows we're
+violating the cap". A site can be S-01-clean but S-02-red if both Redis
+and SQL agree on N+1 running tasks against a max of N (capacity bypass);
+conversely a site can be S-02-clean but S-01-red (leaked phantom slot).
+They catch overlapping but distinct bug classes.
+
+Drain sentinels (members starting with `drain-`) are filtered before the
+check — see services/backlog_service.py for why they exist. They hold a
+slot for a few ms during backlog drain and don't represent real work.
+
+Tier A, severity critical. A capacity-cap bypass is a direct user-
+visible breakage (the agent is doing N+1 things at once when the user
+told it to do at most N).
+"""
+
+from typing import List
+
+from ..snapshot import Snapshot, ViolationReport
+
+
+INVARIANT_ID = "S-02"
+TIER = "A"
+SEVERITY = "critical"
+
+DRAIN_PREFIX = "drain-"
+
+
+def check(snapshot: Snapshot) -> List[ViolationReport]:
+    """Flag any agent whose real slot count exceeds its configured cap."""
+    violations: List[ViolationReport] = []
+
+    # If Redis was unreachable this cycle, skip — slot counts are unreadable.
+    if any(s.startswith("redis") for s in snapshot.sources_unavailable):
+        return violations
+
+    for agent in snapshot.agents:
+        real_slots = {sid for sid in agent.slot_ids if not sid.startswith(DRAIN_PREFIX)}
+        slot_count = len(real_slots)
+        cap = agent.max_parallel
+        if slot_count <= cap:
+            continue
+
+        violations.append(
+            ViolationReport(
+                invariant_id=INVARIANT_ID,
+                tier=TIER,
+                severity=SEVERITY,
+                observed_state={
+                    "agent_name": agent.name,
+                    "slot_count": slot_count,
+                    "max_parallel_tasks": cap,
+                    "overbooked_by": slot_count - cap,
+                    "slot_ids": sorted(real_slots),
+                    "snapshot_time": snapshot.snapshot_time,
+                },
+                signal_query=(
+                    f"ZCARD(agent:slots:{agent.name}) - drain sentinels = "
+                    f"{slot_count} > max_parallel_tasks = {cap}"
+                ),
+            )
+        )
+
+    return violations

--- a/src/backend/canary/invariants/s03_slot_ttl_floor.py
+++ b/src/backend/canary/invariants/s03_slot_ttl_floor.py
@@ -1,0 +1,123 @@
+"""
+S-03 — Slot TTL ≥ execution timeout (CANARY-001 / Issue #411 — Phase 3).
+
+For every member of `agent:slots:A`, the companion `agent:slot:A:{eid}`
+HASH must have a Redis TTL of at least the agent's
+`execution_timeout_seconds + 300` (SLOT_TTL_BUFFER). A TTL below that
+floor means the slot will expire while the execution might still
+legitimately be running — exactly the premature-expiry bug class behind
+Issue #226.
+
+## TTL sentinel values from `redis.ttl()`
+
+Three special return values, each meaning a different failure mode:
+
+- `>0` (normal case): seconds until expiry. Compare against the floor.
+- `-1`: key exists with **no expiry**. The slot has been turned into a
+  leak — `redis.expire()` was never called or got cleared. Violation
+  regardless of the floor (a slot with no TTL eventually traps capacity
+  forever once cleanup misses it).
+- `-2`: key **does not exist**. The metadata HASH expired before the
+  slot was released, leaving the ZSET pointing at nothing. This is the
+  load-bearing #226 case — the slot will never get cleaned up, and the
+  bijection check (S-01) doesn't catch it because the ZSET membership
+  is fine.
+
+All three count as violations. The observed_state distinguishes them so
+the alert reader can tell at a glance which of the three is happening.
+
+## Drain sentinels
+
+The snapshot collector skips drain sentinels (`drain-*` members) when
+populating `slot_ttls`. They're intentionally short-lived; the metadata
+HASH for a sentinel is written with the same TTL as a real slot but
+they're cycled fast enough that catching them mid-flight would be
+noise, not signal.
+
+## Why the floor is hard-coded
+
+300s matches `services/slot_service.py:SLOT_TTL_BUFFER`. Hard-coded here
+rather than imported so a change to the runtime buffer is a deliberate
+review — same pattern as E-01's `SLOT_TTL_BUFFER_SECONDS`. If the two
+constants ever drift, the next cycle will fire S-03 violations and
+force the conversation.
+
+Tier A, severity critical. A slot whose TTL is below the floor is a
+ticking timebomb on capacity correctness.
+"""
+
+from typing import List
+
+from ..snapshot import Snapshot, ViolationReport
+
+
+INVARIANT_ID = "S-03"
+TIER = "A"
+SEVERITY = "critical"
+
+# Matches services/slot_service.py SLOT_TTL_BUFFER. See module docstring.
+SLOT_TTL_BUFFER_SECONDS = 300
+
+DRAIN_PREFIX = "drain-"
+
+
+def _kind_for(ttl: int, floor: int) -> str:
+    """Map the TTL value to a short tag for the violation report."""
+    if ttl == -2:
+        return "missing"          # Metadata HASH already expired (#226).
+    if ttl == -1:
+        return "no_expiry"        # Key exists but redis.expire() never set.
+    if 0 < ttl < floor:
+        return "below_floor"      # Real TTL, but lower than configured floor.
+    return "ok"                   # Should not appear in violations.
+
+
+def check(snapshot: Snapshot) -> List[ViolationReport]:
+    """Emit one violation per slot whose TTL is below the configured floor."""
+    violations: List[ViolationReport] = []
+
+    # Same gate as S-01 / S-02 / E-02: Redis failed → skip cleanly.
+    if any(s.startswith("redis") for s in snapshot.sources_unavailable):
+        return violations
+
+    for agent in snapshot.agents:
+        floor = agent.execution_timeout_seconds + SLOT_TTL_BUFFER_SECONDS
+
+        for eid in sorted(agent.slot_ids):
+            # Drain sentinels are filtered upstream — defence in depth.
+            if eid.startswith(DRAIN_PREFIX):
+                continue
+            # If the collector skipped the slot (per-slot TTL call failed),
+            # don't fabricate a violation — operators rely on Redis errors
+            # surfacing through `sources_unavailable`, not via false-fire.
+            if eid not in agent.slot_ttls:
+                continue
+
+            ttl = agent.slot_ttls[eid]
+            kind = _kind_for(ttl, floor)
+            if kind == "ok":
+                continue
+
+            violations.append(
+                ViolationReport(
+                    invariant_id=INVARIANT_ID,
+                    tier=TIER,
+                    severity=SEVERITY,
+                    observed_state={
+                        "agent_name": agent.name,
+                        "execution_id": eid,
+                        "redis_ttl_seconds": ttl,
+                        "execution_timeout_seconds": agent.execution_timeout_seconds,
+                        "slot_ttl_buffer_seconds": SLOT_TTL_BUFFER_SECONDS,
+                        "floor_seconds": floor,
+                        "kind": kind,
+                        "snapshot_time": snapshot.snapshot_time,
+                    },
+                    signal_query=(
+                        f"TTL(agent:slot:{agent.name}:{eid}) = {ttl} "
+                        f"({kind}); floor = {floor}s"
+                    ),
+                )
+            )
+
+    return violations

--- a/src/backend/canary/snapshot.py
+++ b/src/backend/canary/snapshot.py
@@ -157,6 +157,13 @@ class AgentSnapshot:
     # rather than going silent. `None` means the accessor was unavailable
     # this cycle (import error in test mode) and B-01 must skip.
     queued_count_via_service: Optional[int] = None
+    # Per-slot Redis TTL on the companion `agent:slot:{name}:{eid}` HASH.
+    # Value semantics from `redis.ttl()`: positive int = seconds until
+    # expiry; -2 = key does not exist; -1 = key exists with no TTL. S-03
+    # uses this to detect slots whose metadata expired prematurely
+    # (#226 bug class). Empty dict means the per-slot read was skipped
+    # this cycle (Redis unavailable); the check skips silently.
+    slot_ttls: Dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -177,6 +184,20 @@ class Snapshot:
     # value (success/failed/cancelled/skipped) is preserved so reversal
     # alerts can render the real prior status, not a placeholder.
     terminal_exec_statuses: Dict[str, str] = field(default_factory=dict)
+    # B-02 input: unix timestamp of the most recent successful
+    # `CapacityManager.run_maintenance()` sweep, written to
+    # `canary:drain_tick_at` at the END of the sweep so a mid-sweep crash
+    # leaves the value stale. `None` means the key has never been written
+    # (cold cluster or Redis unavailable) — B-02 treats that as "no
+    # drain has ever run" and skips its time-window arm.
+    drain_tick_at: Optional[float] = None
+    # R-01 input: per-agent zombie process count (`ps -eo stat,comm | grep
+    # ' Z.*claude' | wc -l`). Populated by docker_exec'ing into every
+    # running `trinity.platform=agent` container. Missing agent name in
+    # this map means the exec failed for that container — recorded in
+    # `sources_unavailable` and the R-01 check skips that agent rather
+    # than firing.
+    zombie_counts: Dict[str, int] = field(default_factory=dict)
     # Diagnostics — empty on a clean cycle.
     sources_unavailable: List[str] = field(default_factory=list)
 
@@ -247,6 +268,71 @@ def _collect_executions(agent_name: str) -> Dict[str, Any]:
             elif row["status"] == "queued":
                 out["queued"].add(row["id"])
         return out
+
+
+def _collect_zombie_counts() -> Dict[str, Any]:
+    """Per-running-agent zombie-process count via Docker exec.
+
+    For every running container labeled `trinity.platform=agent`, runs
+    `sh -c "ps -eo stat,comm | grep ' Z.*claude' | wc -l"` and parses
+    the integer result. Used by R-01 to detect unreaped Claude child
+    processes (#407 bug class).
+
+    The shell command pattern matters: `STAT` is the first column from
+    `ps -eo stat,comm`, and a zombie's STAT field is `Z` (sometimes
+    with suffixes like `Z+`). `' Z.*claude'` matches a space-then-Z
+    boundary so we don't accidentally hit `S` (sleeping) processes
+    whose COMM happens to contain `Z`.
+
+    Returns a dict with two keys:
+      "counts":     {agent_name: int}   for containers we successfully exec'd.
+      "unavailable": [str, ...]         per-agent failure messages for the
+                                        caller to append to sources_unavailable.
+
+    All-or-nothing failure (e.g. docker_client None) returns
+    {"counts": {}, "unavailable": ["docker: <reason>"]}.
+    """
+    out: Dict[str, Any] = {"counts": {}, "unavailable": []}
+    try:
+        from services.docker_service import docker_client
+    except Exception as exc:
+        out["unavailable"].append(f"docker.import: {exc}")
+        return out
+    if docker_client is None:
+        out["unavailable"].append("docker: client unavailable")
+        return out
+
+    try:
+        containers = docker_client.containers.list(
+            filters={"label": "trinity.platform=agent", "status": "running"},
+        )
+    except Exception as exc:
+        out["unavailable"].append(f"docker.list: {exc}")
+        return out
+
+    # The catalog spec uses ` Z.*claude` (leading-space), but procps-ng on
+    # the agent base image emits STAT left-aligned with NO leading space
+    # for single-letter codes. Anchor at start-of-line instead — same
+    # intent (STAT field begins with Z), works across both formatters.
+    cmd = ["sh", "-c", "ps -eo stat,comm | grep '^Z.*claude' | wc -l"]
+    for container in containers:
+        # Container name is the canonical agent identifier (handles renames
+        # correctly per docker_service.list_all_agents_fast). Strip the
+        # historical `agent-` prefix to align with agent_ownership.agent_name.
+        agent_name = container.name.removeprefix("agent-")
+        try:
+            result = container.exec_run(cmd)
+            raw = result.output
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8", errors="replace")
+            count = int((raw or "0").strip().splitlines()[-1])
+            out["counts"][agent_name] = count
+        except Exception as exc:
+            # Per-container failure should not poison the cycle — just
+            # record and skip; R-01 will skip this agent.
+            out["unavailable"].append(f"docker.exec[{agent_name}]: {exc}")
+
+    return out
 
 
 def _collect_queued_count_via_service(agent_name: str) -> Optional[int]:
@@ -383,8 +469,12 @@ def _collect_orphan_refs(known_agents: Set[str]) -> List[OrphanRef]:
 def _collect_redis_slot_state(known_agents: Set[str]) -> Dict[str, Dict[str, Any]]:
     """Per-agent Redis slot ZSET membership + scan for orphan slot keys.
 
-    Returns dict with two keys:
+    Returns dict with these keys:
       "by_agent": {agent_name: set(execution_ids)} for known agents
+      "scores":   {agent_name: {execution_id: zset_score}}
+      "slot_ttls": {agent_name: {execution_id: ttl_seconds}} — per-slot
+                   metadata HASH TTLs read for S-03 (one TTL call per slot;
+                   bounded by ZCARD which is ≤ max_parallel_tasks).
       "orphan_slots": {agent_name_in_key: count} for keys matching agents
                       NOT in agent_ownership
     """
@@ -393,16 +483,35 @@ def _collect_redis_slot_state(known_agents: Set[str]) -> Dict[str, Dict[str, Any
     slot_service = get_slot_service()
     redis_client = slot_service.redis
     prefix = slot_service.slots_prefix
+    metadata_prefix = slot_service.metadata_prefix
 
     by_agent: Dict[str, Set[str]] = {}
     scores: Dict[str, Dict[str, float]] = {}
+    slot_ttls: Dict[str, Dict[str, int]] = {}
     orphan_slots: Dict[str, int] = {}
 
     # Per-agent ZRANGE for known agents (with scores for S-01 grace).
+    # Per-slot TTL lookup for S-03 — `redis.ttl()` semantics: positive int
+    # is seconds until expiry; -2 means the key doesn't exist; -1 means
+    # the key exists without a TTL. All three are surfaced verbatim and
+    # interpreted in the S-03 invariant check.
     for name in known_agents:
         with_scores = redis_client.zrange(f"{prefix}{name}", 0, -1, withscores=True)
         by_agent[name] = {m for m, _ in with_scores}
         scores[name] = {m: float(s) for m, s in with_scores}
+        ttl_map: Dict[str, int] = {}
+        for eid, _ in with_scores:
+            # Drain sentinels are intentionally short-lived; skip the TTL
+            # check for them (S-03 only cares about real execution slots).
+            if eid.startswith("drain-"):
+                continue
+            try:
+                ttl_map[eid] = int(redis_client.ttl(f"{metadata_prefix}{name}:{eid}"))
+            except Exception:
+                # Per-slot TTL failure should not poison the whole map; the
+                # missing entry simply means S-03 skips that slot.
+                continue
+        slot_ttls[name] = ttl_map
 
     # SCAN for orphan keys (agent name in the key but not in known set).
     cursor = 0
@@ -418,7 +527,12 @@ def _collect_redis_slot_state(known_agents: Set[str]) -> Dict[str, Dict[str, Any
         if cursor == 0:
             break
 
-    return {"by_agent": by_agent, "scores": scores, "orphan_slots": orphan_slots}
+    return {
+        "by_agent": by_agent,
+        "scores": scores,
+        "slot_ttls": slot_ttls,
+        "orphan_slots": orphan_slots,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -447,7 +561,12 @@ def collect_snapshot() -> Snapshot:
     snap.known_agents = {row["agent_name"] for row in agent_rows}
 
     # Redis slot state (scan once for both per-agent and orphan keys).
-    redis_state: Dict[str, Any] = {"by_agent": {}, "scores": {}, "orphan_slots": {}}
+    redis_state: Dict[str, Any] = {
+        "by_agent": {},
+        "scores": {},
+        "slot_ttls": {},
+        "orphan_slots": {},
+    }
     try:
         redis_state = _collect_redis_slot_state(snap.known_agents)
         snap.orphan_redis_slots = redis_state["orphan_slots"]
@@ -482,6 +601,7 @@ def collect_snapshot() -> Snapshot:
                 execution_timeout_seconds=int(row["execution_timeout_seconds"]),
                 slot_ids=redis_state["by_agent"].get(name, set()),
                 slot_scores=redis_state["scores"].get(name, {}),
+                slot_ttls=redis_state["slot_ttls"].get(name, {}),
                 running_exec_ids=execs["running"],
                 running_started_at=execs.get("started_at", {}),
                 running_claude_session_ids=execs.get("claude_session_ids", {}),
@@ -503,5 +623,31 @@ def collect_snapshot() -> Snapshot:
     except Exception as exc:
         logger.exception("canary snapshot: terminal executions read failed")
         snap.sources_unavailable.append(f"sqlite.terminal_executions: {exc}")
+
+    # Redis: drain-tick heartbeat for B-02. Reuses the slot_service Redis
+    # client (same one used by `_collect_redis_slot_state` above). On
+    # failure we leave `drain_tick_at` as None — the B-02 check then
+    # cannot prove a drain ran in-window and falls back to its
+    # slots-full arm, which is the correct conservative behavior.
+    try:
+        from services.slot_service import get_slot_service
+        raw = get_slot_service().redis.get("canary:drain_tick_at")
+        if raw is not None:
+            snap.drain_tick_at = float(raw)
+    except Exception as exc:
+        logger.exception("canary snapshot: drain-tick read failed")
+        snap.sources_unavailable.append(f"redis.drain_tick: {exc}")
+
+    # Docker exec: per-agent zombie process count for R-01. New source
+    # type for the canary; treat individual container failures as
+    # per-agent skips (caller appends to sources_unavailable so the
+    # operator can see which agents got skipped this cycle).
+    try:
+        z = _collect_zombie_counts()
+        snap.zombie_counts = z["counts"]
+        snap.sources_unavailable.extend(z["unavailable"])
+    except Exception as exc:
+        logger.exception("canary snapshot: zombie collector raised")
+        snap.sources_unavailable.append(f"docker: {exc}")
 
     return snap

--- a/src/backend/canary/snapshot.py
+++ b/src/backend/canary/snapshot.py
@@ -143,9 +143,20 @@ class AgentSnapshot:
     slot_scores: Dict[str, float] = field(default_factory=dict)
     # SQLite execution_id sets, partitioned by status.
     running_exec_ids: Set[str] = field(default_factory=set)
-    # `started_at` per running id (ISO); used by S-01 grace.
+    # `started_at` per running id (ISO); used by S-01 grace + E-01 / E-05 age.
     running_started_at: Dict[str, str] = field(default_factory=dict)
+    # `claude_session_id` per running id (str or None); used by E-05 to detect
+    # dispatched rows that never acquired a backing session.
+    running_claude_session_ids: Dict[str, Optional[str]] = field(default_factory=dict)
     queued_exec_ids: Set[str] = field(default_factory=set)
+    # `db.get_queued_count(name)` — the production accessor BacklogService
+    # calls on every enqueue/drain. B-01 compares this against
+    # `len(queued_exec_ids)` (independently collected by `_collect_executions`)
+    # so a divergence between the two query paths (e.g. a future cache layer
+    # on the accessor, or a status-filter regression) surfaces as a violation
+    # rather than going silent. `None` means the accessor was unavailable
+    # this cycle (import error in test mode) and B-01 must skip.
+    queued_count_via_service: Optional[int] = None
 
 
 @dataclass
@@ -193,26 +204,73 @@ def _collect_known_agents() -> List[Dict[str, Any]]:
         return [dict(row) for row in cursor.fetchall()]
 
 
-def _collect_executions(agent_name: str) -> Dict[str, Set[str]]:
-    """Per-agent running + queued execution_ids."""
+def _collect_executions(agent_name: str) -> Dict[str, Any]:
+    """Per-agent running + queued execution_ids.
+
+    Adds `claude_session_id` for running rows (E-05) — fetched in the same
+    query so the canary cycle stays O(N agents) and never grows per-row.
+    The column has been on `schedule_executions` since #106; rows predating
+    that migration return NULL and are tolerated by the E-05 grace window.
+    """
     from db.connection import get_db_connection
 
     with get_db_connection() as conn:
         cursor = conn.cursor()
+        # `claude_session_id` may not exist in the minimal test DDLs; guard
+        # with a PRAGMA introspection and select * if absent so the unit
+        # tests don't have to mirror every production column.
+        cursor.execute("PRAGMA table_info(schedule_executions)")
+        cols = {c["name"] for c in cursor.fetchall()}
+        has_session_col = "claude_session_id" in cols
+        select_cols = "id, status, started_at"
+        if has_session_col:
+            select_cols += ", claude_session_id"
         cursor.execute(
-            "SELECT id, status, started_at FROM schedule_executions "
+            f"SELECT {select_cols} FROM schedule_executions "
             "WHERE agent_name = ? AND status IN ('running', 'queued')",
             (agent_name,),
         )
-        out: Dict[str, Any] = {"running": set(), "queued": set(), "started_at": {}}
+        out: Dict[str, Any] = {
+            "running": set(),
+            "queued": set(),
+            "started_at": {},
+            "claude_session_ids": {},
+        }
         for row in cursor.fetchall():
             if row["status"] == "running":
                 out["running"].add(row["id"])
                 if row["started_at"]:
                     out["started_at"][row["id"]] = row["started_at"]
+                out["claude_session_ids"][row["id"]] = (
+                    row["claude_session_id"] if has_session_col else None
+                )
             elif row["status"] == "queued":
                 out["queued"].add(row["id"])
         return out
+
+
+def _collect_queued_count_via_service(agent_name: str) -> Optional[int]:
+    """Call the production `db.get_queued_count` accessor.
+
+    Used by B-01: we compare what this returns against the snapshot's
+    independently-collected `len(queued_exec_ids)` so that any drift
+    between the service-layer accessor and a direct SELECT — a cache
+    layer, a status-filter regression, anything — surfaces as a
+    violation. Returns `None` on import or attribute error so unit
+    tests (which stub `db.connection` but not the full `database`
+    facade) can still build snapshots; the B-01 check then skips that
+    agent rather than firing a false positive.
+    """
+    try:
+        from database import db
+        return int(db.get_queued_count(agent_name))
+    except Exception:  # pragma: no cover - exercised in unit tests via stubbing
+        logger.debug(
+            "canary snapshot: db.get_queued_count unavailable for %s; "
+            "B-01 will skip this agent",
+            agent_name,
+        )
+        return None
 
 
 def _collect_terminal_executions(window_minutes: int = 30) -> Dict[str, str]:
@@ -405,7 +463,16 @@ def collect_snapshot() -> Snapshot:
         except Exception as exc:
             logger.exception("canary snapshot: executions read failed for %s", name)
             snap.sources_unavailable.append(f"sqlite.executions[{name}]: {exc}")
-            execs = {"running": set(), "queued": set()}
+            execs = {
+                "running": set(),
+                "queued": set(),
+                "started_at": {},
+                "claude_session_ids": {},
+            }
+
+        # B-01 inputs: production accessor `db.get_queued_count` for cross-
+        # check against the snapshot's own queued id-list count.
+        queued_via_service = _collect_queued_count_via_service(name)
 
         snap.agents.append(
             AgentSnapshot(
@@ -417,7 +484,9 @@ def collect_snapshot() -> Snapshot:
                 slot_scores=redis_state["scores"].get(name, {}),
                 running_exec_ids=execs["running"],
                 running_started_at=execs.get("started_at", {}),
+                running_claude_session_ids=execs.get("claude_session_ids", {}),
                 queued_exec_ids=execs["queued"],
+                queued_count_via_service=queued_via_service,
             )
         )
 

--- a/src/backend/canary/snapshot.py
+++ b/src/backend/canary/snapshot.py
@@ -274,15 +274,17 @@ def _collect_zombie_counts() -> Dict[str, Any]:
     """Per-running-agent zombie-process count via Docker exec.
 
     For every running container labeled `trinity.platform=agent`, runs
-    `sh -c "ps -eo stat,comm | grep ' Z.*claude' | wc -l"` and parses
+    `sh -c "ps -eo stat,comm | grep '^Z.*claude' | wc -l"` and parses
     the integer result. Used by R-01 to detect unreaped Claude child
     processes (#407 bug class).
 
     The shell command pattern matters: `STAT` is the first column from
     `ps -eo stat,comm`, and a zombie's STAT field is `Z` (sometimes
-    with suffixes like `Z+`). `' Z.*claude'` matches a space-then-Z
-    boundary so we don't accidentally hit `S` (sleeping) processes
-    whose COMM happens to contain `Z`.
+    with suffixes like `Z+`). `^Z` anchors at the start of the line —
+    procps-ng on the agent base image emits STAT left-aligned with no
+    leading space for single-letter codes, so the catalog's space-Z
+    pattern misses. Verified live against a real zombie spawned via
+    `os.fork()` + `prctl(PR_SET_NAME, "claude")`.
 
     Returns a dict with two keys:
       "counts":     {agent_name: int}   for containers we successfully exec'd.

--- a/src/backend/services/canary_alerts.py
+++ b/src/backend/services/canary_alerts.py
@@ -40,8 +40,15 @@ class CanaryAlerts:
     # the name is what makes the Slack alert immediately interpretable.
     _INVARIANT_NAMES = {
         "S-01": "Slot–row bijection",
+        "S-02": "Slot overbooking",
+        "S-03": "Slot TTL below floor",
+        "E-01": "Stuck running execution",
         "E-02": "Phantom execution reversal",
+        "E-05": "Dispatched execution without session",
         "L-03": "Delete cascades",
+        "B-01": "Queue accessor drift",
+        "B-02": "Stalled backlog drain",
+        "R-01": "Zombie Claude process",
     }
 
     # One-line runbook hint per invariant. Kept short on purpose —
@@ -53,13 +60,52 @@ class CanaryAlerts:
             "Inspect for crashed `slot.release()` calls; `cleanup_service` "
             "should reconcile within one cycle."
         ),
+        "S-02": (
+            "Agent slot count exceeds its `max_parallel_tasks` cap — "
+            "`acquire_slot` was bypassed. Check recent changes to "
+            "`SlotService.acquire_slot` and any direct ZADD into "
+            "`agent:slots:*`."
+        ),
+        "S-03": (
+            "Slot metadata HASH TTL is below `execution_timeout_seconds + 300s` "
+            "(or missing entirely). Catches #226 class — slot metadata "
+            "expires while execution is still running, leaking the slot "
+            "permanently. Check the `expire()` call in `SlotService.acquire_slot`."
+        ),
+        "E-01": (
+            "An execution stayed `running` past `execution_timeout_seconds + 300s` "
+            "buffer. Cleanup watchdog should have fired — inspect "
+            "`cleanup_service` logs and the agent container for a wedged Claude."
+        ),
         "E-02": (
             "An execution went terminal then non-terminal. Look for retry "
             "logic that resurrects completed rows or a status-write race."
         ),
+        "E-05": (
+            "A `running` execution over 60s old has no `claude_session_id`. "
+            "Either agent-server failed to write back (check container logs) "
+            "or `mark_no_session_executions_failed` watchdog stopped firing. "
+            "Same bug class as #106."
+        ),
         "L-03": (
             "An agent was deleted but a referencing row wasn't cascaded. "
             "Check the delete handler for the table(s) listed above."
+        ),
+        "B-01": (
+            "`db.get_queued_count` disagrees with the snapshot's direct queued "
+            "id-list count. Inspect recent changes to `db/schedules.py:get_queued_count` "
+            "for a cache layer or status-filter regression."
+        ),
+        "B-02": (
+            "Agent has queued work, free slots, and the drain heartbeat is stale. "
+            "`CapacityManager.run_maintenance()` either stopped firing or stopped "
+            "writing its `canary:drain_tick_at` heartbeat. Check backend logs "
+            "for `[Capacity] maintenance tick failed`."
+        ),
+        "R-01": (
+            "Agent container has unreaped zombie `claude` processes (#407 class). "
+            "Restart the affected agent to clear; check agent-server's subprocess "
+            "wait() path for the reaped child."
         ),
     }
 
@@ -281,6 +327,111 @@ class CanaryAlerts:
                 lines.append(f"  • _… +{len(violations) - 5} more_")
             return "\n".join(lines) if lines else None
 
+        if invariant_id == "S-02":
+            lines: List[str] = []
+            for v in violations[:5]:
+                obs = v.observed_state or {}
+                agent = obs.get("agent_name", "?")
+                cap = obs.get("max_parallel_tasks", "?")
+                count = obs.get("slot_count", "?")
+                over = obs.get("overbooked_by", "?")
+                lines.append(
+                    f"  • *{agent}*: slots={count}/{cap} (+{over} over)"
+                )
+            if len(violations) > 5:
+                lines.append(f"  • _… +{len(violations) - 5} more_")
+            return "\n".join(lines) if lines else None
+
+        if invariant_id == "S-03":
+            lines: List[str] = []
+            for v in violations[:5]:
+                obs = v.observed_state or {}
+                agent = obs.get("agent_name", "?")
+                eid = obs.get("execution_id", "?")
+                ttl = obs.get("redis_ttl_seconds", "?")
+                floor = obs.get("floor_seconds", "?")
+                kind = obs.get("kind", "?")
+                lines.append(
+                    f"  • *{agent}* `{eid}`: TTL={ttl}s ({kind}); floor={floor}s"
+                )
+            if len(violations) > 5:
+                lines.append(f"  • _… +{len(violations) - 5} more_")
+            return "\n".join(lines) if lines else None
+
+        if invariant_id == "E-01":
+            lines: List[str] = []
+            for v in violations[:5]:
+                obs = v.observed_state or {}
+                agent = obs.get("agent_name", "?")
+                eid = obs.get("execution_id", "?")
+                age = obs.get("age_seconds", "?")
+                timeout = obs.get("execution_timeout_seconds", "?")
+                buffer = obs.get("slot_ttl_buffer_seconds", "?")
+                lines.append(
+                    f"  • *{agent}* `{eid}`: age={age}s "
+                    f"(timeout={timeout}s + buffer={buffer}s)"
+                )
+            if len(violations) > 5:
+                lines.append(f"  • _… +{len(violations) - 5} more_")
+            return "\n".join(lines) if lines else None
+
+        if invariant_id == "E-05":
+            lines: List[str] = []
+            for v in violations[:5]:
+                obs = v.observed_state or {}
+                agent = obs.get("agent_name", "?")
+                eid = obs.get("execution_id", "?")
+                age = obs.get("age_seconds", "?")
+                lines.append(
+                    f"  • *{agent}* `{eid}`: age={age}s, no claude_session_id"
+                )
+            if len(violations) > 5:
+                lines.append(f"  • _… +{len(violations) - 5} more_")
+            return "\n".join(lines) if lines else None
+
+        if invariant_id == "B-01":
+            lines: List[str] = []
+            for v in violations[:5]:
+                obs = v.observed_state or {}
+                agent = obs.get("agent_name", "?")
+                svc = obs.get("service_count", "?")
+                snap = obs.get("snapshot_count", "?")
+                lines.append(
+                    f"  • *{agent}*: db.get_queued_count={svc} "
+                    f"vs snapshot count={snap}"
+                )
+            if len(violations) > 5:
+                lines.append(f"  • _… +{len(violations) - 5} more_")
+            return "\n".join(lines) if lines else None
+
+        if invariant_id == "B-02":
+            lines: List[str] = []
+            for v in violations[:5]:
+                obs = v.observed_state or {}
+                agent = obs.get("agent_name", "?")
+                q = obs.get("queued_count", "?")
+                free = obs.get("free_slots", "?")
+                age = obs.get("drain_tick_age_seconds")
+                age_str = "never" if age is None else f"{age}s ago"
+                lines.append(
+                    f"  • *{agent}*: queued={q}, free_slots={free}, "
+                    f"last drain tick {age_str}"
+                )
+            if len(violations) > 5:
+                lines.append(f"  • _… +{len(violations) - 5} more_")
+            return "\n".join(lines) if lines else None
+
+        if invariant_id == "R-01":
+            lines: List[str] = []
+            for v in violations[:5]:
+                obs = v.observed_state or {}
+                agent = obs.get("agent_name", "?")
+                count = obs.get("zombie_count", "?")
+                lines.append(f"  • *{agent}*: {count} zombie(s)")
+            if len(violations) > 5:
+                lines.append(f"  • _… +{len(violations) - 5} more_")
+            return "\n".join(lines) if lines else None
+
         return None
 
     @staticmethod
@@ -349,10 +500,38 @@ class CanaryAlerts:
                 f"Slot–row bijection broke on {len(agents)} agent(s): "
                 f"{', '.join(agents)[:160]}."
             )
+        if invariant_id == "S-02":
+            agents = sorted({v.observed_state.get("agent_name") for v in violations})
+            worst = max(violations, key=lambda v: v.observed_state.get("overbooked_by", 0))
+            return (
+                f"{len(agents)} agent(s) overbooked "
+                f"(worst: +{worst.observed_state.get('overbooked_by', '?')} "
+                f"over cap): {', '.join(agents)[:160]}."
+            )
+        if invariant_id == "S-03":
+            agents = sorted({v.observed_state.get("agent_name") for v in violations})
+            kinds = sorted({v.observed_state.get("kind", "?") for v in violations})
+            return (
+                f"{len(violations)} slot(s) with TTL below floor "
+                f"({'/'.join(kinds)}) on {len(agents)} agent(s): "
+                f"{', '.join(agents)[:160]}."
+            )
+        if invariant_id == "E-01":
+            agents = sorted({v.observed_state.get("agent_name") for v in violations})
+            return (
+                f"{len(violations)} execution(s) stuck in `running` past "
+                f"timeout+buffer across {len(agents)} agent(s)."
+            )
         if invariant_id == "E-02":
             return (
                 f"{len(violations)} execution(s) reverted from terminal "
                 f"to non-terminal status."
+            )
+        if invariant_id == "E-05":
+            agents = sorted({v.observed_state.get("agent_name") for v in violations})
+            return (
+                f"{len(violations)} dispatched execution(s) without "
+                f"`claude_session_id` across {len(agents)} agent(s)."
             )
         if invariant_id == "L-03":
             ghosts = sorted(
@@ -361,6 +540,25 @@ class CanaryAlerts:
             return (
                 f"{len(ghosts)} ghost agent(s) referenced by orphan rows: "
                 f"{', '.join(ghosts)[:160]}."
+            )
+        if invariant_id == "B-01":
+            agents = sorted({v.observed_state.get("agent_name") for v in violations})
+            return (
+                f"`db.get_queued_count` drifted from direct count on "
+                f"{len(agents)} agent(s): {', '.join(agents)[:160]}."
+            )
+        if invariant_id == "B-02":
+            agents = sorted({v.observed_state.get("agent_name") for v in violations})
+            return (
+                f"{len(agents)} agent(s) have queued work with free slots "
+                f"and a stale drain tick: {', '.join(agents)[:160]}."
+            )
+        if invariant_id == "R-01":
+            agents = sorted({v.observed_state.get("agent_name") for v in violations})
+            total = sum(v.observed_state.get("zombie_count", 0) for v in violations)
+            return (
+                f"{total} zombie claude process(es) across {len(agents)} "
+                f"agent(s): {', '.join(agents)[:160]}."
             )
         return f"{invariant_id} fired {len(violations)} violation(s)."
 

--- a/src/backend/services/capacity_manager.py
+++ b/src/backend/services/capacity_manager.py
@@ -407,9 +407,24 @@ class CapacityManager:
         any orphan backlog that didn't trigger a release callback (e.g. after
         a backend restart between enqueue and drain). Called from main.py's
         60s loop.
+
+        On success — and only on success — writes a `canary:drain_tick_at`
+        Redis key with the current unix timestamp. The canary's B-02
+        invariant (no queued without slots-full) reads this to distinguish
+        "queue stuck waiting for drain" from "drain just hasn't run yet".
+        Written at the END of the sweep so a crash mid-sweep doesn't
+        falsely claim a successful tick — leaving the cursor stale and
+        letting B-02 catch the stuck drain.
         """
+        import time
         await self._backlog.expire_stale(max_age_hours=max_age_hours)
         await self._backlog.drain_orphans_all()
+        try:
+            self._redis.set("canary:drain_tick_at", str(time.time()))
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                f"[Capacity] failed to write canary drain-tick heartbeat: {e}"
+            )
 
     async def cancel_all_overflow(self, agent_name: str, reason: str) -> int:
         """Cancel all queued work (in-memory + persistent) for an agent.

--- a/src/backend/services/capacity_manager.py
+++ b/src/backend/services/capacity_manager.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -167,6 +168,18 @@ class CapacityManager:
         # The drain callback used to live in main.py wiring SlotService → Backlog;
         # CapacityManager owns it now so callers don't have to know.
         self._slots.register_on_release(self._on_slot_released)
+        # Seed the canary B-02 drain-tick heartbeat at construction so the
+        # on-demand `POST /api/canary/run-cycle` can never fire B-02 with
+        # `drain_tick_age_seconds: null` during the ~15s window between
+        # backend boot and the first `_capacity_maintenance_loop` tick.
+        # On every successful `run_maintenance()` this gets overwritten
+        # with a fresh timestamp; on init we only need a non-stale floor.
+        try:
+            self._redis.set("canary:drain_tick_at", str(time.time()))
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                f"[Capacity] failed to seed canary drain-tick heartbeat: {e}"
+            )
 
     # ------------------------------------------------------------------
     # Acquire
@@ -414,9 +427,10 @@ class CapacityManager:
         "queue stuck waiting for drain" from "drain just hasn't run yet".
         Written at the END of the sweep so a crash mid-sweep doesn't
         falsely claim a successful tick — leaving the cursor stale and
-        letting B-02 catch the stuck drain.
+        letting B-02 catch the stuck drain. `__init__` seeds this key
+        with a fresh timestamp so the on-demand canary path never sees a
+        missing-heartbeat state during the boot window.
         """
-        import time
         await self._backlog.expire_stale(max_age_hours=max_age_hours)
         await self._backlog.drain_orphans_all()
         try:

--- a/tests/lint_sys_modules_baseline.txt
+++ b/tests/lint_sys_modules_baseline.txt
@@ -27,7 +27,6 @@
 4 tests/unit/test_channel_image_vision.py
 2 tests/unit/test_chat_sync_backlog.py
 1 tests/unit/test_claude_code_session_id_parser.py
-3 tests/unit/test_cleanup_unreachable_orphan.py
 1 tests/unit/test_config_fail_fast.py
 1 tests/unit/test_credential_sanitizer_backend.py
 1 tests/unit/test_docker_utils.py
@@ -58,6 +57,7 @@
 2 tests/unit/test_slack_dm_default.py
 7 tests/unit/test_slack_multi_connection.py
 4 tests/unit/test_slack_watchdog.py
+6 tests/unit/test_slot_per_slot_ttl.py
 2 tests/unit/test_ssh_service.py
 8 tests/unit/test_start_agent_skip_inject.py
 7 tests/unit/test_subscription_auto_switch_pingpong.py

--- a/tests/test_canary_invariants.py
+++ b/tests/test_canary_invariants.py
@@ -94,6 +94,10 @@ class FakeRedis:
         self._zsets: Dict[str, Dict[str, float]] = defaultdict(dict)
         self._hashes: Dict[str, Dict[str, str]] = defaultdict(dict)
         self._strings: Dict[str, str] = {}
+        # Per-key TTL (seconds). Test-controlled: tests inject values via
+        # `set_ttl(key, ttl)` to mimic the three redis.ttl() return cases.
+        # See S-03 invariant for the sentinel values (-2 / -1 / >0).
+        self._ttls: Dict[str, int] = {}
 
     # ZSET ------------------------------------------------------------------
 
@@ -188,6 +192,21 @@ class FakeRedis:
 
     def hlen(self, key: str) -> int:
         return len(self._hashes.get(key, {}))
+
+    # TTL -------------------------------------------------------------------
+    # Matches redis-py semantics: positive int = seconds remaining,
+    # -2 = key does not exist, -1 = key exists but no TTL.
+    # Tests set values via `set_ttl()`.
+
+    def ttl(self, key: str) -> int:
+        if key in self._ttls:
+            return self._ttls[key]
+        if key in self._hashes or key in self._zsets or key in self._strings:
+            return -1  # exists but no TTL
+        return -2  # missing
+
+    def set_ttl(self, key: str, value: int) -> None:
+        self._ttls[key] = value
 
     def delete(self, key: str) -> int:
         deleted = 0
@@ -379,6 +398,7 @@ def fake_redis(monkeypatch):
 
     class _FakeSlotService:
         slots_prefix = "agent:slots:"
+        metadata_prefix = "agent:slot:"
 
         def __init__(self):
             self.redis = redis_inst
@@ -391,7 +411,67 @@ def fake_redis(monkeypatch):
 
 
 @pytest.fixture
-def reload_canary(canary_db, fake_redis):
+def fake_docker(monkeypatch):
+    """Stub services.docker_service with a controllable container list.
+
+    Phase 3's R-01 snapshot collector reads `docker_client.containers.list`
+    and calls `container.exec_run` per match. Without a stub, the canary
+    snapshot records `docker: client unavailable` in
+    `sources_unavailable` and unrelated tests assert on that being empty.
+    Tests that exercise R-01 manipulate `fake_docker._containers` directly.
+    """
+
+    class _FakeContainer:
+        def __init__(self, name, exec_output="0", exec_raises=None):
+            self.name = name
+            self._exec_output = exec_output
+            self._exec_raises = exec_raises
+
+        def exec_run(self, cmd):
+            if self._exec_raises is not None:
+                raise self._exec_raises
+            # Mimic the docker-py ExecResult shape used by the collector.
+            class _R:
+                pass
+            r = _R()
+            r.exit_code = 0
+            r.output = self._exec_output.encode("utf-8")
+            return r
+
+    class _FakeContainers:
+        def __init__(self):
+            self._items = []
+
+        def list(self, filters=None):
+            return list(self._items)
+
+    class _FakeDockerClient:
+        def __init__(self):
+            self.containers = _FakeContainers()
+
+    client = _FakeDockerClient()
+
+    fake_module = types.ModuleType("services.docker_service")
+    fake_module.docker_client = client
+    # Stubs for the names services/__init__.py re-exports; canary doesn't
+    # call these, but the canary_service tests transitively import
+    # services/__init__.py and would fail with AttributeError otherwise.
+    fake_module.get_agent_container = lambda *a, **kw: None
+    fake_module.get_agent_status_from_container = lambda *a, **kw: None
+    fake_module.list_all_agents = lambda *a, **kw: []
+    fake_module.get_agent_by_name = lambda *a, **kw: None
+    fake_module.get_next_available_port = lambda *a, **kw: 2222
+    monkeypatch.setitem(sys.modules, "services.docker_service", fake_module)
+
+    # Expose the containers list + factory so tests can populate easily.
+    client.add_container = lambda *a, **kw: client.containers._items.append(
+        _FakeContainer(*a, **kw)
+    )
+    return client
+
+
+@pytest.fixture
+def reload_canary(canary_db, fake_redis, fake_docker):
     """Force reimport of canary modules so they bind to the patched modules."""
     for mod in list(sys.modules):
         if mod.startswith("canary") or mod == "db.canary":
@@ -964,10 +1044,15 @@ class TestRunner:
         results = reload_canary["canary"].run_invariants(snap)
 
         assert set(results.keys()) == {
-            "S-01", "S-02", "E-01", "E-02", "E-05", "L-03", "B-01",
+            "S-01", "S-02", "S-03",
+            "E-01", "E-02", "E-05",
+            "L-03",
+            "B-01", "B-02",
+            "R-01",
         }
         assert results["S-01"] == []
         assert results["S-02"] == []
+        assert results["S-03"] == []
         assert results["E-01"] == []
         assert results["E-02"] == []
         assert results["E-05"] == []
@@ -975,6 +1060,9 @@ class TestRunner:
         # B-01 is skipped in unit-test mode (no live `database` facade), so
         # queued_count_via_service is None per agent → no violations.
         assert results["B-01"] == []
+        # B-02 / R-01 are green on a clean platform.
+        assert results["B-02"] == []
+        assert results["R-01"] == []
 
     def test_run_invariants_subset(self, canary_db, reload_canary):
         _add_agent(canary_db, "a1")
@@ -1247,6 +1335,282 @@ class TestInvariantB01:
         snap = self._snap(queued_ids={"q1"}, service_count=None)
         from canary.invariants import b01_queue_status_coherence as b01
         assert b01.check(snap) == []
+
+
+# ---------------------------------------------------------------------------
+# S-03 — slot TTL floor
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantS03:
+    def test_holds_when_ttl_above_floor(self, canary_db, reload_canary):
+        _add_agent(canary_db, "a1", timeout=60)  # floor = 60 + 300 = 360s
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        reload_canary["redis"].set_ttl("agent:slot:a1:e1", 500)
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s03_slot_ttl_floor as s03
+        assert s03.check(snap) == []
+
+    def test_fires_below_floor(self, canary_db, reload_canary):
+        _add_agent(canary_db, "a1", timeout=60)  # floor = 360s
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        reload_canary["redis"].set_ttl("agent:slot:a1:e1", 100)
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s03_slot_ttl_floor as s03
+        v = s03.check(snap)
+        assert len(v) == 1
+        assert v[0].invariant_id == "S-03"
+        assert v[0].severity == "critical"
+        assert v[0].observed_state["kind"] == "below_floor"
+        assert v[0].observed_state["redis_ttl_seconds"] == 100
+        assert v[0].observed_state["floor_seconds"] == 360
+
+    def test_fires_when_metadata_missing(self, canary_db, reload_canary):
+        """ZSET points at a slot whose metadata HASH already expired (#226)."""
+        _add_agent(canary_db, "a1", timeout=60)
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        # FakeRedis.ttl returns -2 when neither the hash nor the ttl is set.
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s03_slot_ttl_floor as s03
+        v = s03.check(snap)
+        assert len(v) == 1
+        assert v[0].observed_state["kind"] == "missing"
+        assert v[0].observed_state["redis_ttl_seconds"] == -2
+
+    def test_fires_when_ttl_unset(self, canary_db, reload_canary):
+        """Metadata HASH exists but no expire was set on it."""
+        _add_agent(canary_db, "a1", timeout=60)
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        # Populate the HASH so FakeRedis.ttl returns -1 (exists, no TTL).
+        reload_canary["redis"].hset("agent:slot:a1:e1", "started_at", "x")
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s03_slot_ttl_floor as s03
+        v = s03.check(snap)
+        assert len(v) == 1
+        assert v[0].observed_state["kind"] == "no_expiry"
+        assert v[0].observed_state["redis_ttl_seconds"] == -1
+
+    def test_drain_sentinels_skipped(self, canary_db, reload_canary):
+        _add_agent(canary_db, "a1", timeout=60)
+        reload_canary["redis"].zadd(
+            "agent:slots:a1", {"drain-a1-12345": 1.0}
+        )
+        # Don't set TTL — would normally be "missing"; sentinel must skip.
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s03_slot_ttl_floor as s03
+        assert s03.check(snap) == []
+
+    def test_skipped_when_redis_unavailable(self):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        snap = Snapshot(
+            snapshot_time="2026-05-18T12:00:00Z",
+            sources_unavailable=["redis: connection refused"],
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=3,
+                    execution_timeout_seconds=60,
+                    slot_ids={"e1"},
+                    slot_ttls={"e1": -2},
+                )
+            ],
+        )
+        from canary.invariants import s03_slot_ttl_floor as s03
+        assert s03.check(snap) == []
+
+
+# ---------------------------------------------------------------------------
+# B-02 — no queued without slots-full
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantB02:
+    @staticmethod
+    def _snap(*, queued_count, slot_count, max_parallel, drain_tick_at, snap_unix):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        from datetime import datetime
+        snap_time = datetime.utcfromtimestamp(snap_unix).isoformat() + "Z"
+        return Snapshot(
+            snapshot_time=snap_time,
+            drain_tick_at=drain_tick_at,
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=max_parallel,
+                    execution_timeout_seconds=900,
+                    slot_ids={f"r{i}" for i in range(slot_count)},
+                    queued_exec_ids={f"q{i}" for i in range(queued_count)},
+                )
+            ],
+        )
+
+    def test_holds_when_no_queued(self):
+        import time
+        snap = self._snap(
+            queued_count=0, slot_count=0, max_parallel=3,
+            drain_tick_at=None, snap_unix=time.time(),
+        )
+        from canary.invariants import b02_no_queued_without_slots_full as b02
+        assert b02.check(snap) == []
+
+    def test_holds_when_slots_full(self):
+        """Queued > 0 is correct when capacity is saturated."""
+        import time
+        snap = self._snap(
+            queued_count=2, slot_count=3, max_parallel=3,
+            drain_tick_at=None, snap_unix=time.time(),
+        )
+        from canary.invariants import b02_no_queued_without_slots_full as b02
+        assert b02.check(snap) == []
+
+    def test_holds_when_drain_tick_fresh(self):
+        """Free slots + queue, but maintenance fired within 60s — wait."""
+        import time
+        now = time.time()
+        snap = self._snap(
+            queued_count=2, slot_count=1, max_parallel=3,
+            drain_tick_at=now - 30,  # 30s ago, within grace
+            snap_unix=now,
+        )
+        from canary.invariants import b02_no_queued_without_slots_full as b02
+        assert b02.check(snap) == []
+
+    def test_fires_when_drain_tick_stale(self):
+        """Free slots + queue + drain tick > 60s old → stuck drain."""
+        import time
+        now = time.time()
+        snap = self._snap(
+            queued_count=2, slot_count=1, max_parallel=3,
+            drain_tick_at=now - 600,  # 10min ago
+            snap_unix=now,
+        )
+        from canary.invariants import b02_no_queued_without_slots_full as b02
+        v = b02.check(snap)
+        assert len(v) == 1
+        assert v[0].invariant_id == "B-02"
+        assert v[0].severity == "critical"
+        assert v[0].observed_state["free_slots"] == 2
+        assert v[0].observed_state["drain_tick_age_seconds"] == 600
+
+    def test_fires_when_drain_tick_never(self):
+        """Heartbeat key absent (cold cluster / write failure)."""
+        import time
+        snap = self._snap(
+            queued_count=1, slot_count=0, max_parallel=3,
+            drain_tick_at=None,
+            snap_unix=time.time(),
+        )
+        from canary.invariants import b02_no_queued_without_slots_full as b02
+        v = b02.check(snap)
+        assert len(v) == 1
+        assert v[0].observed_state["drain_tick_age_seconds"] is None
+
+    def test_drain_sentinels_dont_count_as_real_slots(self):
+        """Sentinel-held slot doesn't satisfy the slots-full arm."""
+        import time
+        from canary.snapshot import Snapshot, AgentSnapshot
+        from datetime import datetime
+        now = time.time()
+        snap = Snapshot(
+            snapshot_time=datetime.utcfromtimestamp(now).isoformat() + "Z",
+            drain_tick_at=now - 600,
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=1,
+                    execution_timeout_seconds=900,
+                    # 1 drain sentinel and 0 real slots; cap is 1; queued exists.
+                    slot_ids={"drain-a1-99"},
+                    queued_exec_ids={"q1"},
+                )
+            ],
+        )
+        from canary.invariants import b02_no_queued_without_slots_full as b02
+        v = b02.check(snap)
+        assert len(v) == 1, "sentinel must not satisfy slots-full arm"
+
+    def test_skipped_when_redis_unavailable(self):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        snap = Snapshot(
+            snapshot_time="2026-05-18T12:00:00Z",
+            sources_unavailable=["redis: down"],
+            drain_tick_at=None,
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=3,
+                    execution_timeout_seconds=900,
+                    slot_ids=set(),
+                    queued_exec_ids={"q1"},
+                )
+            ],
+        )
+        from canary.invariants import b02_no_queued_without_slots_full as b02
+        assert b02.check(snap) == []
+
+
+# ---------------------------------------------------------------------------
+# R-01 — no zombie claude processes
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantR01:
+    def test_holds_when_no_zombies(self, canary_db, reload_canary, fake_docker):
+        _add_agent(canary_db, "a1")
+        fake_docker.add_container("agent-a1", exec_output="0")
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import r01_no_zombie_claude as r01
+        assert r01.check(snap) == []
+        assert snap.zombie_counts == {"a1": 0}
+
+    def test_fires_on_zombie_count(self, canary_db, reload_canary, fake_docker):
+        _add_agent(canary_db, "a1")
+        fake_docker.add_container("agent-a1", exec_output="3")
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import r01_no_zombie_claude as r01
+        v = r01.check(snap)
+        assert len(v) == 1
+        assert v[0].invariant_id == "R-01"
+        assert v[0].severity == "critical"
+        assert v[0].observed_state["agent_name"] == "a1"
+        assert v[0].observed_state["zombie_count"] == 3
+
+    def test_per_container_exec_failure_does_not_kill_cycle(
+        self, canary_db, reload_canary, fake_docker
+    ):
+        _add_agent(canary_db, "ok")
+        _add_agent(canary_db, "broken")
+        fake_docker.add_container("agent-ok", exec_output="0")
+        fake_docker.add_container("agent-broken", exec_raises=RuntimeError("boom"))
+        snap = reload_canary["canary"].collect_snapshot()
+        # The healthy container is still measured; the broken one is in
+        # sources_unavailable. Neither agent fires R-01.
+        assert snap.zombie_counts == {"ok": 0}
+        assert any("docker.exec[broken]" in s for s in snap.sources_unavailable)
+        from canary.invariants import r01_no_zombie_claude as r01
+        assert r01.check(snap) == []
+
+    def test_silent_when_docker_unavailable(self, canary_db, reload_canary, monkeypatch):
+        """All-or-nothing docker failure — R-01 produces no violations."""
+        # Override the existing docker stub so docker_client is None.
+        fake_module = types.ModuleType("services.docker_service")
+        fake_module.docker_client = None
+        fake_module.get_agent_container = lambda *a, **kw: None
+        fake_module.get_agent_status_from_container = lambda *a, **kw: None
+        fake_module.list_all_agents = lambda *a, **kw: []
+        fake_module.get_agent_by_name = lambda *a, **kw: None
+        fake_module.get_next_available_port = lambda *a, **kw: 2222
+        monkeypatch.setitem(sys.modules, "services.docker_service", fake_module)
+        _add_agent(canary_db, "a1")
+        snap = reload_canary["canary"].collect_snapshot()
+        assert snap.zombie_counts == {}
+        assert any("docker" in s for s in snap.sources_unavailable)
+        from canary.invariants import r01_no_zombie_claude as r01
+        assert r01.check(snap) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_canary_invariants.py
+++ b/tests/test_canary_invariants.py
@@ -963,10 +963,18 @@ class TestRunner:
         snap = reload_canary["canary"].collect_snapshot()
         results = reload_canary["canary"].run_invariants(snap)
 
-        assert set(results.keys()) == {"S-01", "E-02", "L-03"}
+        assert set(results.keys()) == {
+            "S-01", "S-02", "E-01", "E-02", "E-05", "L-03", "B-01",
+        }
         assert results["S-01"] == []
+        assert results["S-02"] == []
+        assert results["E-01"] == []
         assert results["E-02"] == []
+        assert results["E-05"] == []
         assert len(results["L-03"]) == 1
+        # B-01 is skipped in unit-test mode (no live `database` facade), so
+        # queued_count_via_service is None per agent → no violations.
+        assert results["B-01"] == []
 
     def test_run_invariants_subset(self, canary_db, reload_canary):
         _add_agent(canary_db, "a1")
@@ -981,6 +989,264 @@ class TestRunner:
         results = reload_canary["canary"].run_invariants(snap, ids=["NOPE", "L-03"])
         assert "NOPE" not in results
         assert "L-03" in results
+
+
+# ---------------------------------------------------------------------------
+# S-02 — no overbooking
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantS02:
+    def test_holds_when_slot_count_within_cap(self, canary_db, reload_canary):
+        _add_agent(canary_db, "a1", max_parallel=3)
+        reload_canary["redis"].zadd(
+            "agent:slots:a1", {"e1": 1.0, "e2": 2.0, "e3": 3.0}
+        )
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s02_no_overbooking as s02
+        assert s02.check(snap) == []
+
+    def test_fires_when_slot_count_exceeds_cap(self, canary_db, reload_canary):
+        _add_agent(canary_db, "a1", max_parallel=2)
+        reload_canary["redis"].zadd(
+            "agent:slots:a1", {"e1": 1.0, "e2": 2.0, "e3": 3.0}
+        )
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s02_no_overbooking as s02
+        violations = s02.check(snap)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.invariant_id == "S-02"
+        assert v.severity == "critical"
+        assert v.observed_state["slot_count"] == 3
+        assert v.observed_state["max_parallel_tasks"] == 2
+        assert v.observed_state["overbooked_by"] == 1
+
+    def test_drain_sentinels_filtered_before_cap_check(
+        self, canary_db, reload_canary
+    ):
+        """Drain sentinels briefly push ZCARD over the cap; not a violation."""
+        _add_agent(canary_db, "a1", max_parallel=2)
+        reload_canary["redis"].zadd(
+            "agent:slots:a1",
+            {"e1": 1.0, "e2": 2.0, "drain-a1-1234567890.5": 3.0},
+        )
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s02_no_overbooking as s02
+        assert s02.check(snap) == []
+
+    def test_skipped_when_redis_unavailable(self, canary_db, reload_canary):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        snap = Snapshot(
+            snapshot_time="2026-05-18T12:00:00Z",
+            sources_unavailable=["redis: connection refused"],
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=1,
+                    execution_timeout_seconds=900,
+                    slot_ids={"e1", "e2", "e3"},
+                )
+            ],
+        )
+        from canary.invariants import s02_no_overbooking as s02
+        assert s02.check(snap) == []
+
+
+# ---------------------------------------------------------------------------
+# E-01 — terminal-state closure
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantE01:
+    @staticmethod
+    def _snap(
+        *,
+        snap_time="2026-05-18T12:00:00Z",
+        started_at="2026-05-18T11:00:00Z",
+        timeout=900,
+        running_ids=("e1",),
+    ):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        return Snapshot(
+            snapshot_time=snap_time,
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=3,
+                    execution_timeout_seconds=timeout,
+                    running_exec_ids=set(running_ids),
+                    running_started_at={eid: started_at for eid in running_ids},
+                )
+            ],
+        )
+
+    def test_holds_when_running_row_within_window(self):
+        # Started 100s ago, timeout 900s + buffer 300s = 1200s window.
+        snap = self._snap(
+            snap_time="2026-05-18T12:01:40Z",
+            started_at="2026-05-18T12:00:00Z",
+        )
+        from canary.invariants import e01_terminal_state_closure as e01
+        assert e01.check(snap) == []
+
+    def test_fires_when_running_row_past_timeout_plus_buffer(self):
+        # Started 1 hour ago, timeout 900s + buffer 300s = 1200s window.
+        # 3600s > 1200s → violation.
+        snap = self._snap(
+            snap_time="2026-05-18T12:00:00Z",
+            started_at="2026-05-18T11:00:00Z",
+            timeout=900,
+        )
+        from canary.invariants import e01_terminal_state_closure as e01
+        violations = e01.check(snap)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.invariant_id == "E-01"
+        assert v.severity == "critical"
+        assert v.observed_state["age_seconds"] == 3600
+        assert v.observed_state["execution_timeout_seconds"] == 900
+
+    def test_skips_row_without_started_at(self):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        snap = Snapshot(
+            snapshot_time="2026-05-18T12:00:00Z",
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=3,
+                    execution_timeout_seconds=900,
+                    running_exec_ids={"e1"},
+                    running_started_at={},
+                )
+            ],
+        )
+        from canary.invariants import e01_terminal_state_closure as e01
+        assert e01.check(snap) == []
+
+    def test_skips_row_with_malformed_started_at(self):
+        snap = self._snap(started_at="not-an-iso-timestamp")
+        from canary.invariants import e01_terminal_state_closure as e01
+        assert e01.check(snap) == []
+
+
+# ---------------------------------------------------------------------------
+# E-05 — dispatched rows have session
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantE05:
+    @staticmethod
+    def _snap(*, started_at, session_id):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        return Snapshot(
+            snapshot_time="2026-05-18T12:00:00Z",
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=3,
+                    execution_timeout_seconds=900,
+                    running_exec_ids={"e1"},
+                    running_started_at={"e1": started_at},
+                    running_claude_session_ids={"e1": session_id},
+                )
+            ],
+        )
+
+    def test_holds_when_session_id_present(self):
+        # Old row but with a session — fine.
+        snap = self._snap(
+            started_at="2026-05-18T11:00:00Z",
+            session_id="abc-session-uuid",
+        )
+        from canary.invariants import e05_dispatched_rows_have_session as e05
+        assert e05.check(snap) == []
+
+    def test_holds_when_row_within_grace_and_no_session(self):
+        # 30s old, grace is 60s → still in grace.
+        snap = self._snap(
+            started_at="2026-05-18T11:59:30Z",
+            session_id=None,
+        )
+        from canary.invariants import e05_dispatched_rows_have_session as e05
+        assert e05.check(snap) == []
+
+    def test_fires_when_old_row_lacks_session(self):
+        # 1 hour old with no session — fires.
+        snap = self._snap(
+            started_at="2026-05-18T11:00:00Z",
+            session_id=None,
+        )
+        from canary.invariants import e05_dispatched_rows_have_session as e05
+        violations = e05.check(snap)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.invariant_id == "E-05"
+        assert v.severity == "major"
+        assert v.observed_state["age_seconds"] == 3600
+
+
+# ---------------------------------------------------------------------------
+# B-01 — queue-status coherence
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantB01:
+    @staticmethod
+    def _snap(*, queued_ids, service_count):
+        from canary.snapshot import Snapshot, AgentSnapshot
+        return Snapshot(
+            snapshot_time="2026-05-18T12:00:00Z",
+            agents=[
+                AgentSnapshot(
+                    name="a1",
+                    is_system=False,
+                    max_parallel=3,
+                    execution_timeout_seconds=900,
+                    queued_exec_ids=set(queued_ids),
+                    queued_count_via_service=service_count,
+                )
+            ],
+        )
+
+    def test_holds_when_counts_agree(self):
+        snap = self._snap(queued_ids={"q1", "q2"}, service_count=2)
+        from canary.invariants import b01_queue_status_coherence as b01
+        assert b01.check(snap) == []
+
+    def test_holds_when_both_zero(self):
+        snap = self._snap(queued_ids=set(), service_count=0)
+        from canary.invariants import b01_queue_status_coherence as b01
+        assert b01.check(snap) == []
+
+    def test_fires_when_service_undercounts(self):
+        snap = self._snap(queued_ids={"q1", "q2", "q3"}, service_count=1)
+        from canary.invariants import b01_queue_status_coherence as b01
+        violations = b01.check(snap)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.invariant_id == "B-01"
+        assert v.severity == "critical"
+        assert v.observed_state["service_count"] == 1
+        assert v.observed_state["snapshot_count"] == 3
+
+    def test_fires_when_service_overcounts(self):
+        snap = self._snap(queued_ids={"q1"}, service_count=5)
+        from canary.invariants import b01_queue_status_coherence as b01
+        violations = b01.check(snap)
+        assert len(violations) == 1
+        assert violations[0].observed_state["service_count"] == 5
+        assert violations[0].observed_state["snapshot_count"] == 1
+
+    def test_skips_when_service_count_none(self):
+        """Snapshot built without the `database` facade reachable."""
+        snap = self._snap(queued_ids={"q1"}, service_count=None)
+        from canary.invariants import b01_queue_status_coherence as b01
+        assert b01.check(snap) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #882. Builds on #653 (Phase 1).

Ships Phases 2 and 3 of the canary harness together — seven new invariants registered into the same `INVARIANTS` dict that the run-cycle endpoint and background loop already drive.

## Phase 2 — single-source SQL/Redis (no new sources)

| ID | Tier | Severity | What it catches |
|----|------|----------|-----------------|
| **S-02** | A | critical | `ZCARD(agent:slots:A)` > `max_parallel_tasks` (capacity bypass) |
| **E-01** | B | critical | `status='running'` row past `execution_timeout_seconds + SLOT_TTL_BUFFER` |
| **E-05** | B | major    | `status='running'` row older than 60s with `claude_session_id IS NULL` (#106 guard) |
| **B-01** | A | critical | `db.get_queued_count` disagrees with snapshot's id-list count |

## Phase 3 — moderate (one new piece of plumbing each)

| ID | Tier | Severity | What it catches | New plumbing |
|----|------|----------|-----------------|--------------|
| **S-03** | A | critical | Slot metadata HASH TTL below `execution_timeout_seconds + 300s` (#226 class) | Per-slot `redis.ttl()` lookup |
| **B-02** | B | critical | Queued > 0 with free slots and stale drain heartbeat (stalled drain) | `canary:drain_tick_at` heartbeat written by `CapacityManager.run_maintenance()` |
| **R-01** | A | critical | Zombie `claude` processes inside agent containers (#407 regression) | `docker exec` per running `trinity.platform=agent` container |

## Why each one is useful

### Phase 2

- **S-02 vs S-01.** S-01 says "Redis and SQL disagree". S-02 says "even Redis on its own already shows we're past the cap". They overlap but catch different bug classes.
- **E-01.** Aligned with `SLOT_TTL_BUFFER` so the check fires *after* cleanup has had its window. A violation unambiguously means cleanup failed to act.
- **E-05.** First Claude turn returns a session id in ms. >60s without one means the session-id update path is broken — same bug class as #106.
- **B-01.** Trivially-green today (the backlog *is* `status='queued'` rows after #428), but lives as a regression guard. The point is to fail loudly the day someone caches `db.get_queued_count` and gets the invalidation wrong.

### Phase 3

- **S-03.** Three failure kinds surfaced explicitly: `missing` (-2, metadata HASH expired before ZSET — the #226 case), `no_expiry` (-1, `redis.expire()` never set), `below_floor` (positive TTL under the configured floor). All three are critical because a slot with a too-short or missing TTL becomes a permanent capacity leak.
- **B-02.** The drain-tick heartbeat is written at the END of `run_maintenance()` (not the start), so a mid-sweep crash leaves the cursor stale and lets the canary catch the breakage rather than masking it.
- **R-01.** First canary invariant that needs Docker. Failure modes graceful — per-container exec failure is recorded in `sources_unavailable` and the check skips that agent rather than firing a false positive. Cycle cost ≈ 1 exec per running agent per 5 min.

## Snapshot changes

| Field | Phase | Purpose |
|-------|-------|---------|
| `AgentSnapshot.running_claude_session_ids` | 2 | E-05 per-execution session id |
| `AgentSnapshot.queued_count_via_service` | 2 | B-01 production-accessor cross-check |
| `AgentSnapshot.slot_ttls` | 3 | S-03 per-slot Redis TTL |
| `Snapshot.drain_tick_at` | 3 | B-02 heartbeat timestamp |
| `Snapshot.zombie_counts` | 3 | R-01 per-agent zombie count |

All collectors fail gracefully — per-agent exec failures, missing accessors, and unreachable Redis are recorded in `sources_unavailable` and the affected invariant either skips that agent or skips the whole cycle.

## Unit tests

51 → 84 passing. Each invariant has positive, negative, and edge-case tests.

```
$ python3 -m pytest tests/test_canary_invariants.py -q
84 passed in 0.75s
```

Test fixtures: `FakeRedis` got a `ttl()` method with the standard `-2`/`-1`/positive sentinel semantics; new `fake_docker` fixture exposes a controllable container list with `exec_run` stubs.

## Live verification

Against the local stack (`CANARY_ENABLED=0` but the `POST /api/canary/run-cycle` admin endpoint still works). For each invariant: provoke, observe red, revert, observe green. All seven reproduce as designed.

### S-02 (Phase 2)

```
$ # Provoke: ZADD 3 fake slot ids when max_parallel=2
{
  "violations": [{
    "invariant_id": "S-02", "severity": "critical",
    "observed_state": {
      "slot_count": 3, "max_parallel_tasks": 2, "overbooked_by": 1,
      "slot_ids": ["fake-eid-1", "fake-eid-2", "fake-eid-3"]
    }
  }]
}
```

### E-01 (Phase 2)

```
$ # Provoke: insert status='running' row started 2h ago, agent timeout=60s
{
  "violations": [{
    "invariant_id": "E-01", "severity": "critical", "tier": "B",
    "observed_state": {
      "age_seconds": 7436,
      "execution_timeout_seconds": 60, "slot_ttl_buffer_seconds": 300
    }
  }]
}
```

### E-05 (Phase 2)

```
$ # Provoke: insert status='running' row 3min old, claude_session_id NULL
{
  "violations": [{
    "invariant_id": "E-05", "severity": "major", "tier": "B",
    "observed_state": {"age_seconds": 188, "grace_seconds": 60}
  }]
}
```

### B-01 (Phase 2)

Patched `db/schedules.py:get_queued_count` to return `count - 1` — exact bug class B-01 exists to catch:

```
$ # Provoke: 1 queued row + buggy accessor returning 0
{
  "violations": [{
    "invariant_id": "B-01", "severity": "critical", "tier": "A",
    "observed_state": {"service_count": 0, "snapshot_count": 1},
    "signal_query": "db.get_queued_count('canary-test-882') = 0 != |queued ids in snapshot| = 1"
  }]
}
```

### S-03 (Phase 3)

```
$ # Provoke: ZADD a slot, EXPIRE its metadata to 30s, agent floor=360s
{
  "violations": [{
    "invariant_id": "S-03", "severity": "critical", "tier": "A",
    "observed_state": {
      "redis_ttl_seconds": 30, "floor_seconds": 360, "kind": "below_floor"
    },
    "signal_query": "TTL(agent:slot:canary-test-882:s03-eid) = 30 (below_floor); floor = 360s"
  }]
}
```

Also verified `kind: missing` (-2) by deleting the metadata HASH entirely.

### B-02 (Phase 3)

```
$ # Provoke: 1 queued row, 0 slots (cap=2), set drain tick to 600s ago
{
  "violations": [{
    "invariant_id": "B-02", "severity": "critical", "tier": "B",
    "observed_state": {
      "queued_count": 1, "slot_count": 0, "free_slots": 2,
      "drain_tick_age_seconds": 600, "drain_tick_grace_seconds": 60
    },
    "signal_query": "agent canary-test-882: queued=1, slots=0/2 (free=2), drain_tick_age=600s > 60s"
  }]
}
```

### R-01 (Phase 3) — the most satisfying verification

Spawned a **real zombie process named `claude`** inside the running `agent-cornelius-m` container via:

```python
os.fork()
# Child: prctl(PR_SET_NAME, "claude"); sys.exit(0)
# Parent: sleep(120) without wait()
```

```
$ # ps -eo stat,comm | grep '^Z.*claude' → "Z    claude"
{
  "violations": [{
    "invariant_id": "R-01", "severity": "critical", "tier": "A",
    "observed_state": {"agent_name": "cornelius-m", "zombie_count": 1},
    "signal_query": "docker exec agent-cornelius-m sh -c \"ps -eo stat,comm | grep '^Z.*claude' | wc -l\" = 1"
  }]
}
```

Reaped by killing the parent PID → R-01 returned green on the next cycle.

### Catalog deviation worth noting

The orchestration-invariant-catalog spec uses ` Z.*claude` (leading space). procps-ng on the agent base image emits STAT left-aligned without padding, so that pattern misses. Switched to `^Z.*claude` — same intent, works across formatters. Verified live against a real zombie above.

### Final all-10 cycle

```json
{
  "checks_run": ["S-01", "S-02", "S-03", "E-01", "E-02", "E-05",
                 "L-03", "B-01", "B-02", "R-01"],
  "sources_unavailable": [],
  "violations": [],
  "transitions": [],
  "cycle_duration_ms": 106
}
```

## Non-canary code touched

Just one place: `services/capacity_manager.py:run_maintenance` writes the `canary:drain_tick_at` heartbeat at the END of each successful sweep (~5 lines including the comment and try/except). Everything else stays inside `canary/`.

## Out of scope — Phase 4

- **E-06** — HTTP fan-out across agents to `/api/executions/running`. Needs network-flake handling and timeout budgets.
- **G-01** — One-shot post-restart probe. Doesn't fit the 5-min loop — needs a new "one-shot canary" execution mode.

## Doc updates

`docs/memory/architecture.md`:
- CANARY-001 section: added Phase 2 + Phase 3 invariant blocks.
- Background Services table: documented the `canary:drain_tick_at` heartbeat write in the Capacity Maintenance row.
