### PR TITLE
Harden Trinity ops alert recovery

### DIFF
--- a/docker/base-image/agent_server/routers/git.py
+++ b/docker/base-image/agent_server/routers/git.py
@@ -98,6 +98,14 @@ _SYNC_STATE_DEFAULT: Dict = {
 }
 
 
+def _git_index_lock_stale_seconds() -> int:
+    """Age threshold before auto-sync may clear an unowned git index lock."""
+    try:
+        return max(60, int(os.getenv("GIT_INDEX_LOCK_STALE_SECONDS", "900")))
+    except ValueError:
+        return 900
+
+
 def _sync_state_path(home_dir: Path) -> Path:
     return home_dir / ".trinity" / "sync-state.json"
 
@@ -149,6 +157,104 @@ def _write_sync_state_file(
     return prior
 
 
+def _is_same_or_child_path(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_git_process_name(comm: str, args: list) -> bool:
+    name = Path((args or [comm])[0]).name.lower()
+    comm = Path(comm).name.lower()
+    return (
+        name == "git"
+        or name.startswith("git-")
+        or comm == "git"
+        or comm.startswith("git-")
+    )
+
+
+def _git_index_lock_has_live_owner(home_dir: Path) -> bool:
+    """Best-effort check for a live git process associated with this repo."""
+    proc_root = Path("/proc")
+    if not proc_root.is_dir():
+        return False
+
+    try:
+        home = home_dir.resolve()
+    except OSError:
+        home = home_dir
+    home_text = str(home)
+    git_dir_text = str(home / ".git")
+
+    for proc in proc_root.iterdir():
+        if not proc.name.isdigit() or int(proc.name) == os.getpid():
+            continue
+        try:
+            comm = (proc / "comm").read_text(errors="ignore").strip()
+            raw = (proc / "cmdline").read_bytes()
+            args = [arg.decode(errors="ignore") for arg in raw.split(b"\x00") if arg]
+            cwd = (proc / "cwd").resolve()
+        except (FileNotFoundError, PermissionError, OSError):
+            continue
+        if not _is_git_process_name(comm, args):
+            continue
+        if _is_same_or_child_path(cwd, home):
+            return True
+        joined_args = " ".join(args)
+        if home_text in joined_args or git_dir_text in joined_args:
+            return True
+    return False
+
+
+def _prepare_git_index_lock_for_auto_sync(home_dir: Path, now: datetime) -> Optional[str]:
+    """Clear stale, unowned `.git/index.lock` before auto-sync mutates git."""
+    lock_path = home_dir / ".git" / "index.lock"
+    try:
+        stat = lock_path.stat()
+    except FileNotFoundError:
+        return None
+
+    age_seconds = max(0, int(now.timestamp() - stat.st_mtime))
+    stale_after = _git_index_lock_stale_seconds()
+
+    if _git_index_lock_has_live_owner(home_dir):
+        err = f"git index lock active; age_seconds={age_seconds}; action=backoff"
+        logger.warning("auto-sync: %s", err)
+        return err
+
+    if age_seconds < stale_after:
+        err = (
+            "git index lock present below stale threshold; "
+            f"age_seconds={age_seconds}; "
+            f"stale_threshold_seconds={stale_after}; action=backoff"
+        )
+        logger.warning("auto-sync: %s", err)
+        return err
+
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        err = (
+            "git index lock stale but removal failed; "
+            f"age_seconds={age_seconds}; action=backoff; reason={exc.__class__.__name__}"
+        )
+        logger.warning("auto-sync: %s", err)
+        return err
+
+    logger.warning(
+        "auto-sync: git index lock stale; age_seconds=%s; "
+        "stale_threshold_seconds=%s; action=removed",
+        age_seconds,
+        stale_after,
+    )
+    return None
+
+
 def _run_auto_sync_once(home_dir: Path) -> Dict:
     """One auto-sync cycle: stage, commit if dirty, push. Records outcome.
 
@@ -156,8 +262,16 @@ def _run_auto_sync_once(home_dir: Path) -> Dict:
     initiated `sync_to_github` endpoint. Auto-sync is a heartbeat, not a
     rescue.
     """
-    now = datetime.now(timezone.utc).isoformat()
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.isoformat()
     try:
+        lock_error = _prepare_git_index_lock_for_auto_sync(home_dir, now_dt)
+        if lock_error:
+            _write_sync_state_file(
+                home_dir, "failed", last_sync_at=now, last_error_summary=lock_error
+            )
+            return {"status": "failed", "error": lock_error}
+
         # Stage everything.
         subprocess.run(
             ["git", "add", "-A"],

--- a/docs/memory/feature-flows/agent-monitoring.md
+++ b/docs/memory/feature-flows/agent-monitoring.md
@@ -533,6 +533,16 @@ async def _send_degradation_alert(self, ...):
     await self._broadcast_alert(notification)
 ```
 
+Degradation notifications include `metadata.resolution_state='active_failure'`.
+When the aggregate health check later recovers to `healthy`, pending health
+alert notifications for that agent are dismissed by `system:recovered` and a
+new pending info notification is created with
+`metadata.resolution_state='recovered_unacknowledged'` plus
+`recovery_evidence` (`verified_status`, `verified_at`,
+`recovered_from_status`, and the recovered alert IDs). This keeps active
+failures distinct from recovered-but-unacknowledged alerts without deleting
+history.
+
 **Specific Alert Types** (lines 272-410):
 - `alert_container_stopped()` - OOM kill, crash, unexpected stop
 - `alert_high_restart_count()` - Container restarting frequently

--- a/docs/memory/feature-flows/git-sync-health.md
+++ b/docs/memory/feature-flows/git-sync-health.md
@@ -146,6 +146,15 @@ transition from `N-1 < 3` to `N >= 3`. A fresh failure series after a
 `success` reset produces a distinct entry (the ID embeds the emission
 timestamp).
 
+Recovery is also stateful. When a later poll verifies
+`last_sync_status='success'` after an alerting failure series, pending
+`sync_failing` queue entries for that agent are marked `recovered` and
+downgraded to low priority. The row is not deleted: its `context` gains
+`resolution_state='recovered_unacknowledged'`, `recovered_at`, and
+`recovery_evidence` with the verified status, check timestamp, previous
+failure count, last error summary, and current ahead/behind values. Other
+pending operator-queue item types are left untouched.
+
 ### 3. Dual ahead/behind (P6 fix)
 
 `docker/base-image/agent_server/routers/git.py::_dual_ahead_behind_payload`

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -530,6 +530,7 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
   - 15-min `GIT_SYNC_AUTO` heartbeat loop in the agent container (default-on for non-source-mode GitHub-template agents)
   - Dual `ahead_main`/`ahead_working` tuples in `GET /api/git/status` (P6 fix)
   - `SyncHealthService` emits `sync_failing` operator-queue entries at `consecutive_failures ≥ 3`
+  - Recovered sync failures are marked `recovered` with structured recovery evidence instead of being deleted or left as active failures
   - `GET /api/agents/sync-health` (batch) + dashboard dot
   - `GET /api/fleet/sync-audit` with `duplicate_binding` flag (§P5 query)
 - **Flow**: `docs/memory/feature-flows/git-sync-health.md`

--- a/docs/user-docs/README.md
+++ b/docs/user-docs/README.md
@@ -53,6 +53,7 @@
 - [Dashboard](operations/dashboard.md) — Network graph, timeline view, tag clouds
 - [Operating Room](operations/operating-room.md) — Operator queue, notifications, cost alerts
 - [Monitoring](operations/monitoring.md) — Health checks, cleanup service, fleet dashboard
+- [Sync and Network Alert Runbook](operations/sync-and-network-alert-runbook.md) — Triage for sync_failing and network-unreachable alerts
 - [Executions](operations/executions.md) — Execution list, detail, live streaming, termination
 - [Audit Trail](operations/audit-trail.md) — Append-only administrative action log
 - [Agent Quotas](operations/agent-quotas.md) — Per-role agent creation limits

--- a/docs/user-docs/operations/monitoring.md
+++ b/docs/user-docs/operations/monitoring.md
@@ -95,5 +95,6 @@ Agents can query monitoring data through these MCP tools:
 
 ## See Also
 
+- [Sync and Network Alert Runbook](sync-and-network-alert-runbook.md) -- Triage for sync_failing and network-unreachable alerts
 - [Dashboard](dashboard.md) -- Admin dashboard overview
 - [Operating Room](operating-room.md) -- Real-time operations view

--- a/docs/user-docs/operations/sync-and-network-alert-runbook.md
+++ b/docs/user-docs/operations/sync-and-network-alert-runbook.md
@@ -1,0 +1,132 @@
+# Sync and Network Alert Runbook
+
+Use this runbook for `sync_failing` operator-queue items and monitoring alerts that report an agent as network-unreachable.
+
+## Evidence Collection
+
+Public repository safety comes first. Do not paste secrets, access tokens, API keys, real user data, private prompts, private file contents, or sensitive logs into issues, pull requests, docs, screenshots, or chat transcripts. When sharing evidence, redact values and use placeholders such as `AGENT_NAME`, `your-token`, `user@example.com`, and `your-domain.com`.
+
+Record the alert source before changing anything:
+
+- Agent name and alert type: `sync_failing`, network-unreachable, high CPU, or backup-health.
+- Timestamp, current status, and whether the alert is new or stale.
+- Whether the agent is actively executing work in the UI on `/executions` or through `GET /api/agents/AGENT_NAME/executions`.
+- Latest health data from `GET /api/monitoring/agents/AGENT_NAME`.
+- Fleet or container CPU from `GET /api/telemetry/containers` or `docker stats --no-stream agent-AGENT_NAME`.
+- Recent schedule executions for the agent, especially entries with `triggered_by: "schedule"` or repeated failures.
+
+For `sync_failing`, collect git-specific evidence:
+
+```bash
+docker exec agent-AGENT_NAME git -C /home/developer status --short
+docker exec agent-AGENT_NAME git -C /home/developer status --branch --porcelain=v2
+docker exec agent-AGENT_NAME test -e /home/developer/.git/index.lock
+docker exec agent-AGENT_NAME stat -c '%y %n' /home/developer/.git/index.lock
+docker exec agent-AGENT_NAME sh -lc "ps -eo pid,etime,comm | grep '[g]it'"
+```
+
+If the agent is an older workspace, repeat git checks against `/home/developer/workspace` only after `/home/developer` is not the git worktree.
+
+For network-unreachable alerts, collect reachability evidence:
+
+```bash
+docker ps --filter name=agent-AGENT_NAME
+docker inspect --format '{{.State.Status}} restart_count={{.RestartCount}} oom={{.State.OOMKilled}} networks={{range $name, $_ := .NetworkSettings.Networks}}{{$name}} {{end}}' agent-AGENT_NAME
+docker exec agent-AGENT_NAME curl -fsS http://127.0.0.1:8000/health
+curl -fsS -H "Authorization: Bearer ${TRINITY_TOKEN}" http://localhost:8000/api/monitoring/agents/AGENT_NAME
+```
+
+If CPU is high, identify whether the load is tied to active or repeated schedule executions before restarting anything:
+
+```bash
+curl -fsS -H "Authorization: Bearer ${TRINITY_TOKEN}" http://localhost:8000/api/telemetry/containers
+curl -fsS -H "Authorization: Bearer ${TRINITY_TOKEN}" http://localhost:8000/api/agents/AGENT_NAME/executions
+```
+
+## Safe Remediation
+
+Remediate the smallest confirmed cause. Do not acknowledge or dismiss the alert until verification shows the cause is gone.
+
+### Stale Git Lock
+
+Only treat `.git/index.lock` as stale when all of these are true:
+
+- The lock file exists.
+- No live git process is operating in the same worktree.
+- The lock file age is longer than the configured stale threshold or clearly predates the current incident.
+- There is no active execution that could be running git.
+
+Safe path:
+
+1. Confirm no live git process with `ps -eo pid,etime,comm | grep '[g]it'` inside the agent container.
+2. Confirm the worktree path with `git -C /home/developer rev-parse --show-toplevel`.
+3. Preserve evidence of the lock age without copying sensitive file contents.
+4. Remove only the lock file, not the repository or working tree.
+5. Trigger or wait for the next sync attempt.
+
+Do not remove a lock while a git process is alive. Back off and let the process finish, or stop the owning execution if it is hung and safe to terminate.
+
+### Network-Unreachable Agent
+
+Use this order:
+
+1. Confirm the container exists and is expected to be running.
+2. Check local health inside the container at `http://127.0.0.1:8000/health`.
+3. Compare backend monitoring data with direct container evidence.
+4. Check Docker network membership and recent restart count.
+5. Check CPU and memory. High CPU can make a healthy agent look unreachable.
+6. Check recent schedule executions for repeated or long-running jobs.
+
+Safe path:
+
+- If the container is stopped and the agent should be online, start the agent through the UI or the normal lifecycle command.
+- If local health works inside the container but backend monitoring cannot reach it, investigate Docker networking before restarting the agent.
+- If high CPU correlates with a non-critical schedule, pause or disable that schedule first, then let the agent recover.
+- If the agent process is wedged, no important execution is running, and local health fails, restart only `agent-AGENT_NAME`.
+
+Restart criteria:
+
+- Restart a single agent only after evidence shows the container process is unhealthy, unreachable, or pinned, and no active execution should be preserved.
+- Restart the backend only when multiple agents show the same monitoring failure and direct container health suggests the agents themselves are reachable.
+- Do not restart the full fleet for a single-agent `sync_failing` or network-unreachable alert.
+
+### Schedule Execution Load
+
+When schedule executions are part of the incident:
+
+1. Identify the schedule or task that produced the recent execution series.
+2. Check whether failures repeat across retries or across every schedule tick.
+3. Pause the schedule if it is saturating CPU, creating stuck executions, or repeatedly triggering network-unreachable alerts.
+4. Keep manual and unrelated schedules running when possible.
+5. Re-enable the schedule only after a clean manual execution or a corrected task definition.
+
+## Verification
+
+Verify with fresh evidence after remediation:
+
+- `GET /api/monitoring/agents/AGENT_NAME` shows network reachable, expected Docker status, acceptable CPU, and no current network-unreachable issue.
+- `GET /api/agents/sync-health` shows `last_sync_status: "success"` or `consecutive_failures: 0` for the affected agent.
+- `GET /api/agents/AGENT_NAME/executions` shows no unexpected long-running or repeatedly failing schedule executions.
+- `GET /api/monitoring/cleanup-status` shows cleanup service running and no new incident-related orphan or stale execution spike.
+- The Operating Room item is acknowledged only after the live state is clean, not just after a restart.
+
+If verification fails, return to evidence collection. Do not add code changes until repo source has been tied to the observed runtime failure.
+
+## Backblaze and Backup-Health Alerts
+
+Backblaze-related alerts are separate from the resolved git-lock or network-unreachable path above. If an old alert mentions `/host-backblaze` or `backup-health`, first verify whether the runtime actually mounts and uses that path.
+
+Repo triage steps:
+
+1. Search repo-managed docs and config for `Backblaze`, `backblaze`, `/host-backblaze`, `host-backblaze`, and `backup-health`.
+2. If no repo source defines the mount or alert, do not invent a code fix in Trinity.
+3. Inspect the live runtime configuration, container mounts, and host mount state before acknowledging the alert.
+4. Treat unresolved mount configuration as an environment issue until the runtime source of truth is identified.
+
+Do not mark old backup-health alerts as resolved just because git sync and network alerts were fixed. The backup-health path must be verified independently.
+
+## See Also
+
+- [Monitoring](monitoring.md)
+- [Operating Room](operating-room.md)
+- [Executions](executions.md)

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1804,6 +1804,11 @@ class DatabaseManager:
     def cancel_operator_queue_item(self, item_id):
         return self._operator_queue_ops.cancel_item(item_id)
 
+    def mark_operator_queue_items_recovered(self, agent_name, item_type, recovery_evidence):
+        return self._operator_queue_ops.mark_pending_items_recovered(
+            agent_name, item_type, recovery_evidence
+        )
+
     def mark_operator_queue_acknowledged(self, item_id):
         return self._operator_queue_ops.mark_acknowledged(item_id)
 

--- a/src/backend/db/operator_queue.py
+++ b/src/backend/db/operator_queue.py
@@ -6,7 +6,7 @@ Supports listing, filtering, responding, and statistics.
 """
 
 import json
-from typing import Optional, List, Dict, Set
+from typing import Any, Optional, List, Dict, Set
 from datetime import datetime
 
 from .connection import get_db_connection
@@ -223,6 +223,58 @@ class OperatorQueueOperations:
 
         return self.get_item(item_id)
 
+    def mark_pending_items_recovered(
+        self,
+        agent_name: str,
+        item_type: str,
+        recovery_evidence: Dict[str, Any],
+    ) -> List[Dict]:
+        """Mark pending items recovered without deleting operator history.
+
+        This is intentionally narrow: callers must provide both an agent and a
+        queue type so human-action-required items are not swept up by a broad
+        recovery pass.
+        """
+        now = utc_now_iso()
+        recovered_ids: List[str] = []
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT id, context, priority
+                FROM operator_queue
+                WHERE agent_name = ?
+                  AND type = ?
+                  AND status = 'pending'
+            """, (agent_name, item_type))
+            rows = cursor.fetchall()
+
+            for row in rows:
+                context = self._parse_context(row[1])
+                context["resolution_state"] = "recovered_unacknowledged"
+                context["recovered_at"] = now
+                context["recovered_by"] = "system"
+                context["previous_priority"] = row[2]
+                context["recovery_evidence"] = recovery_evidence
+
+                cursor.execute("""
+                    UPDATE operator_queue
+                    SET status = 'recovered',
+                        priority = 'low',
+                        context = ?
+                    WHERE id = ?
+                      AND status = 'pending'
+                """, (json.dumps(context), row[0]))
+                if cursor.rowcount:
+                    recovered_ids.append(row[0])
+
+            conn.commit()
+
+        return [
+            item for item_id in recovered_ids
+            if (item := self.get_item(item_id)) is not None
+        ]
+
     def mark_acknowledged(self, item_id: str) -> bool:
         """Mark an item as acknowledged by the agent."""
         now = utc_now_iso()
@@ -368,3 +420,16 @@ class OperatorQueueOperations:
             cursor = conn.cursor()
             cursor.execute("SELECT 1 FROM operator_queue WHERE id = ?", (item_id,))
             return cursor.fetchone() is not None
+
+    @staticmethod
+    def _parse_context(raw_context) -> Dict:
+        """Parse queue context defensively for recovery annotation."""
+        if not raw_context:
+            return {}
+        try:
+            parsed = json.loads(raw_context)
+        except (TypeError, json.JSONDecodeError):
+            return {"previous_context": raw_context}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"previous_context": parsed}

--- a/src/backend/services/monitoring_alerts.py
+++ b/src/backend/services/monitoring_alerts.py
@@ -176,6 +176,7 @@ class MonitoringAlertService:
             "current_status": curr.value,
             "issues": issues,
             "check_timestamp": utc_now_iso(),
+            "resolution_state": "active_failure",
         }
         if details:
             metadata.update(details)
@@ -212,6 +213,9 @@ class MonitoringAlertService:
         # Clear any active cooldowns for this agent
         db.cleanup_alert_cooldowns(agent_name)
 
+        recovery_timestamp = utc_now_iso()
+        recovered_alert_ids = self._dismiss_recovered_health_alerts(agent_name)
+
         # Build recovery notification
         title = f"Agent {agent_name} recovered"
         message = f"Status changed from {prev.value} to {curr.value}"
@@ -220,7 +224,15 @@ class MonitoringAlertService:
             "agent_name": agent_name,
             "previous_status": prev.value,
             "current_status": curr.value,
-            "recovery_timestamp": utc_now_iso(),
+            "recovery_timestamp": recovery_timestamp,
+            "resolution_state": "recovered_unacknowledged",
+            "recovery_evidence": {
+                "source": "monitoring_alert_service",
+                "verified_status": curr.value,
+                "verified_at": recovery_timestamp,
+                "recovered_from_status": prev.value,
+                "recovered_alert_ids": recovered_alert_ids,
+            },
         }
         if details:
             metadata.update(details)
@@ -242,6 +254,38 @@ class MonitoringAlertService:
         await self._broadcast_alert(notification)
 
         return notification.id
+
+    def _dismiss_recovered_health_alerts(self, agent_name: str) -> List[str]:
+        """Dismiss prior pending health alerts once health is verified clean.
+
+        A new recovery notification remains pending, so the UI can show
+        recovered-but-unacknowledged state without keeping stale active-failure
+        rows in the default alert list.
+        """
+        try:
+            pending = db.list_notifications(
+                agent_name=agent_name,
+                status="pending",
+                category="health",
+                limit=100,
+            )
+        except Exception:
+            return []
+
+        recovered_ids: List[str] = []
+        for notification in pending:
+            if notification.notification_type != "alert":
+                continue
+            try:
+                dismissed = db.dismiss_notification(
+                    notification.id,
+                    dismissed_by="system:recovered",
+                )
+            except Exception:
+                continue
+            if dismissed:
+                recovered_ids.append(notification.id)
+        return recovered_ids
 
     async def _broadcast_alert(self, notification: 'Notification'):
         """Broadcast an alert via WebSocket."""

--- a/src/backend/services/sync_health_service.py
+++ b/src/backend/services/sync_health_service.py
@@ -18,6 +18,7 @@ tighter loop would multiply SQLite writes for no benefit (PERF-269).
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import Dict, Optional
 
@@ -142,6 +143,15 @@ class SyncHealthService:
         new_failures = updated["consecutive_failures"]
         if prior_failures < ALERT_THRESHOLD <= new_failures:
             self._emit_sync_failing_alert(agent_name, updated)
+        elif (
+            prior_failures >= ALERT_THRESHOLD
+            and new_failures == 0
+            and last_sync_status == "success"
+        ):
+            recovered = self._mark_sync_failing_alerts_recovered(
+                agent_name, prior, updated
+            )
+            await self._broadcast_recovered_alerts(recovered)
 
     async def _fetch_git_status(self, agent_name: str) -> Optional[Dict]:
         """Fetch /api/git/status from the agent. None on unreachable."""
@@ -194,6 +204,66 @@ class SyncHealthService:
             )
         except Exception:
             logger.exception("failed to emit sync_failing alert")
+
+    def _mark_sync_failing_alerts_recovered(
+        self,
+        agent_name: str,
+        prior_state: Optional[Dict],
+        state: Dict,
+    ) -> list[Dict]:
+        """Mark pending sync_failing rows recovered after verified success."""
+        evidence = {
+            "source": "sync_health_service",
+            "agent_name": agent_name,
+            "verified_status": state.get("last_sync_status"),
+            "verified_at": state.get("last_check_at"),
+            "last_sync_at": state.get("last_sync_at"),
+            "previous_consecutive_failures": (
+                prior_state.get("consecutive_failures") if prior_state else None
+            ),
+            "current_consecutive_failures": state.get("consecutive_failures"),
+            "last_error_summary": (
+                prior_state.get("last_error_summary") if prior_state else None
+            ),
+            "ahead_main": state.get("ahead_main", 0),
+            "behind_main": state.get("behind_main", 0),
+            "ahead_working": state.get("ahead_working", 0),
+            "behind_working": state.get("behind_working", 0),
+        }
+        try:
+            recovered = db.mark_operator_queue_items_recovered(
+                agent_name, "sync_failing", evidence
+            )
+            if recovered:
+                logger.info(
+                    "sync_failing recovered for %s (items=%s)",
+                    agent_name, len(recovered),
+                )
+            return recovered
+        except Exception:
+            logger.exception("failed to mark sync_failing alert recovered")
+            return []
+
+    async def _broadcast_recovered_alerts(self, items: list[Dict]) -> None:
+        """Broadcast recovered operator-queue items when websocket is present."""
+        if not _websocket_manager or not items:
+            return
+        for item in items:
+            try:
+                await _websocket_manager.broadcast(json.dumps({
+                    "type": "operator_queue_recovered",
+                    "data": {
+                        "id": item["id"],
+                        "agent_name": item["agent_name"],
+                        "item_type": item["type"],
+                        "status": item["status"],
+                        "recovered_at": (
+                            item.get("context") or {}
+                        ).get("recovered_at"),
+                    },
+                }))
+            except Exception:
+                logger.exception("failed to broadcast recovered queue item")
 
 
 # Module-level singleton mirrors operator_queue_service.

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -76,6 +76,38 @@ class TaskExecutionResult:
     error_code: Optional[TaskExecutionErrorCode] = None
 
 
+def _classify_timeout(exc: BaseException) -> str:
+    """Return a stable timeout kind for diagnostics and failure state."""
+    if isinstance(exc, httpx.ConnectTimeout):
+        return "connect_timeout"
+    if isinstance(exc, httpx.ReadTimeout):
+        return "read_timeout"
+    if isinstance(exc, httpx.WriteTimeout):
+        return "write_timeout"
+    if isinstance(exc, httpx.PoolTimeout):
+        return "pool_timeout"
+    if isinstance(exc, asyncio.TimeoutError):
+        return "asyncio_timeout"
+    return "timeout"
+
+
+def _format_timeout_error(
+    *,
+    timeout_seconds: Optional[int],
+    timeout_kind: str,
+    elapsed_seconds: int,
+    termination_attempted: bool,
+    termination_succeeded: bool,
+) -> str:
+    """Build a persisted timeout error that is distinguishable from HTTP failures."""
+    return (
+        f"Execution timeout ({timeout_kind}): agent task did not complete within "
+        f"{timeout_seconds} seconds; backend waited {elapsed_seconds}s; "
+        f"termination_attempted={str(termination_attempted).lower()}; "
+        f"termination_succeeded={str(termination_succeeded).lower()}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Agent HTTP helper (moved from routers/chat.py)
 # ---------------------------------------------------------------------------
@@ -535,14 +567,25 @@ class TaskExecutionService:
                 raw_response=response_data,
             )
 
-        except httpx.TimeoutException:
+        except (httpx.TimeoutException, asyncio.TimeoutError) as e:
             elapsed = int((datetime.utcnow() - start_time).total_seconds())
-            error_msg = f"Task execution timed out after {timeout_seconds} seconds"
-            logger.error(f"[TaskExecService] TIMEOUT on {agent_name} after {elapsed}s (limit={timeout_seconds}s)")
+            timeout_kind = _classify_timeout(e)
+            logger.error(
+                f"[TaskExecService] TIMEOUT on {agent_name} after {elapsed}s "
+                f"(limit={timeout_seconds}s, kind={timeout_kind})"
+            )
 
             # Issue #61: Terminate the execution on the agent to prevent orphaned
             # Claude processes from accumulating. Best-effort — watchdog is safety net.
-            await terminate_execution_on_agent(agent_name, execution_id)
+            termination_attempted = bool(execution_id)
+            termination_succeeded = await terminate_execution_on_agent(agent_name, execution_id)
+            error_msg = _format_timeout_error(
+                timeout_seconds=timeout_seconds,
+                timeout_kind=timeout_kind,
+                elapsed_seconds=elapsed,
+                termination_attempted=termination_attempted,
+                termination_succeeded=termination_succeeded,
+            )
 
             # Don't overwrite cancelled executions
             if execution_id:
@@ -565,6 +608,12 @@ class TaskExecutionService:
                 response="",
                 error=error_msg,
                 error_code=TaskExecutionErrorCode.TIMEOUT,
+                raw_response={
+                    "failure_kind": "timeout",
+                    "timeout_kind": timeout_kind,
+                    "termination_attempted": termination_attempted,
+                    "termination_succeeded": termination_succeeded,
+                },
             )
 
         except httpx.HTTPError as e:
@@ -610,6 +659,8 @@ class TaskExecutionService:
             if agent_status_code == 503:
                 logger.warning(f"[TaskExecService] Auth failure detected on {agent_name}: {error_msg[:200]}")
                 error_code = TaskExecutionErrorCode.AUTH
+            elif isinstance(e, httpx.TransportError) and agent_status_code is None:
+                error_code = TaskExecutionErrorCode.NETWORK
 
             if execution_id:
                 existing = db.get_execution(execution_id)

--- a/src/frontend/src/components/operator/QueueList.vue
+++ b/src/frontend/src/components/operator/QueueList.vue
@@ -42,6 +42,7 @@
           <option value="">All Status</option>
           <option value="pending">Pending</option>
           <option value="responded">Responded</option>
+          <option value="recovered">Recovered</option>
           <option value="acknowledged">Acknowledged</option>
         </select>
       </div>
@@ -172,6 +173,7 @@ function typeIconColor(type) {
 function statusBadge(status) {
   const badges = {
     responded: 'bg-status-success-100 text-status-success-700 dark:bg-status-success-900/30 dark:text-status-success-400',
+    recovered: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
     acknowledged: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
     expired: 'bg-status-danger-100 text-status-danger-600 dark:bg-status-danger-900/30 dark:text-status-danger-400'
   }

--- a/src/frontend/src/components/operator/ResolvedCard.vue
+++ b/src/frontend/src/components/operator/ResolvedCard.vue
@@ -14,19 +14,22 @@
 
         <p class="text-sm text-gray-600 dark:text-gray-400">{{ item.title }}</p>
 
-        <!-- Response -->
+        <!-- Resolution -->
         <div class="mt-2 flex items-center gap-2">
-          <span class="inline-flex items-center gap-1 text-xs text-status-success-600 dark:text-status-success-400">
+          <span
+            class="inline-flex items-center gap-1 text-xs"
+            :class="resolutionColor"
+          >
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>
-            {{ item.response }}
+            {{ resolutionLabel }}
           </span>
-          <span v-if="item.response_text" class="text-xs text-gray-400 dark:text-gray-500">
+          <span v-if="item.response_text && item.status !== 'recovered'" class="text-xs text-gray-400 dark:text-gray-500">
             &mdash; {{ item.response_text }}
           </span>
           <span class="text-xs text-gray-400 dark:text-gray-500 ml-auto">
-            {{ timeAgo(item.responded_at) }}
+            {{ timeAgo(resolutionTime) }}
           </span>
         </div>
       </div>
@@ -50,6 +53,17 @@ const agentAvatarUrl = computed(() => {
   const agent = agentsStore.agents.find(a => a.name === props.item.agent_name)
   return agent?.avatar_url || null
 })
+const resolutionTime = computed(() =>
+  props.item.context?.recovered_at || props.item.responded_at || props.item.created_at
+)
+const resolutionLabel = computed(() =>
+  props.item.status === 'recovered' ? 'Recovered' : props.item.response
+)
+const resolutionColor = computed(() =>
+  props.item.status === 'recovered'
+    ? 'text-blue-600 dark:text-blue-400'
+    : 'text-status-success-600 dark:text-status-success-400'
+)
 
 function timeAgo(isoString) {
   if (!isoString) return ''

--- a/src/frontend/src/stores/operatorQueue.js
+++ b/src/frontend/src/stores/operatorQueue.js
@@ -51,8 +51,12 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
 
   const resolvedItems = computed(() => {
     return items.value
-      .filter(i => i.status === 'responded' || i.status === 'acknowledged')
-      .sort((a, b) => new Date(b.responded_at || b.created_at) - new Date(a.responded_at || a.created_at))
+      .filter(i => i.status === 'responded' || i.status === 'acknowledged' || i.status === 'recovered')
+      .sort((a, b) => {
+        const aTime = a.context?.recovered_at || a.responded_at || a.created_at
+        const bTime = b.context?.recovered_at || b.responded_at || b.created_at
+        return new Date(bTime) - new Date(aTime)
+      })
   })
 
   const pendingCount = computed(() =>
@@ -152,6 +156,20 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
       const item = items.value.find(i => i.id === data.data?.id)
       if (item) {
         item.status = 'acknowledged'
+      }
+    } else if (data.type === 'operator_queue_recovered') {
+      // Backend verified the underlying failure has recovered.
+      const item = items.value.find(i => i.id === data.data?.id)
+      if (item) {
+        item.status = 'recovered'
+        item.priority = item.priority === 'critical' || item.priority === 'high' ? 'low' : item.priority
+        item.context = {
+          ...(item.context || {}),
+          resolution_state: 'recovered_unacknowledged',
+          recovered_at: data.data?.recovered_at || new Date().toISOString()
+        }
+      } else {
+        fetchItems()
       }
     }
   }

--- a/src/frontend/src/utils/websocket.js
+++ b/src/frontend/src/utils/websocket.js
@@ -140,7 +140,12 @@ export function useWebSocket() {
         break
       default:
         // Handle events keyed by 'type' instead of 'event'
-        if (data.type === 'operator_queue_new' || data.type === 'operator_queue_responded' || data.type === 'operator_queue_acknowledged') {
+        if (
+          data.type === 'operator_queue_new' ||
+          data.type === 'operator_queue_responded' ||
+          data.type === 'operator_queue_acknowledged' ||
+          data.type === 'operator_queue_recovered'
+        ) {
           operatorQueueStore.handleWebSocketEvent(data)
         }
         break

--- a/tests/unit/test_agent_server_auto_sync.py
+++ b/tests/unit/test_agent_server_auto_sync.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -150,6 +151,54 @@ class TestRunAutoSyncOnce:
         assert state["last_sync_status"] == "failed"
         assert state["consecutive_failures"] == 1
         assert state["last_error_summary"]
+
+    def test_live_index_lock_backs_off_without_removing_lock(self, repo):
+        lock_path = repo / ".git" / "index.lock"
+        lock_path.write_text("")
+
+        with (
+            patch(
+                "agent_server.routers.git._git_index_lock_has_live_owner",
+                return_value=True,
+            ),
+            patch("agent_server.routers.git.subprocess.run") as git_run,
+        ):
+            result = _run_auto_sync_once(repo)
+
+        assert result["status"] == "failed"
+        assert "git index lock active" in result["error"]
+        assert "action=backoff" in result["error"]
+        assert str(repo) not in result["error"]
+        assert lock_path.exists()
+        git_run.assert_not_called()
+
+        state = _read_sync_state_file(repo)
+        assert state["last_sync_status"] == "failed"
+        assert state["last_error_summary"] == result["error"]
+
+    def test_stale_index_lock_is_removed_and_sync_continues(self, repo):
+        lock_path = repo / ".git" / "index.lock"
+        lock_path.write_text("")
+        old_mtime = time.time() - 120
+        os.utime(lock_path, (old_mtime, old_mtime))
+
+        with (
+            patch(
+                "agent_server.routers.git._git_index_lock_has_live_owner",
+                return_value=False,
+            ),
+            patch(
+                "agent_server.routers.git._git_index_lock_stale_seconds",
+                return_value=60,
+            ),
+        ):
+            result = _run_auto_sync_once(repo)
+
+        assert result["status"] == "success"
+        assert not lock_path.exists()
+        state = _read_sync_state_file(repo)
+        assert state["last_sync_status"] == "success"
+        assert state["consecutive_failures"] == 0
 
 
 class TestAutoSyncStartupGate:

--- a/tests/unit/test_monitoring_alerts_recovery.py
+++ b/tests/unit/test_monitoring_alerts_recovery.py
@@ -1,0 +1,160 @@
+"""
+MonitoringAlertService recovery tests.
+
+These unit tests keep recovery handling away from the live notification DB:
+the service-level database dependency is replaced with a small in-memory fake.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+_THIS = Path(__file__).resolve()
+_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+_croniter_stub = ModuleType("croniter")
+_croniter_stub.croniter = object
+sys.modules.setdefault("croniter", _croniter_stub)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+def _install_services_namespace():
+    services_pkg = ModuleType("services")
+    services_pkg.__path__ = [str(_BACKEND / "services")]
+    sys.modules["services"] = services_pkg
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeDB:
+    def __init__(self, pending=None):
+        self.pending = pending or []
+        self.dismissed = []
+        self.created = []
+        self.cooldowns_cleaned = []
+        self.cooldowns_set = []
+
+    def cleanup_alert_cooldowns(self, agent_name=None):
+        self.cooldowns_cleaned.append(agent_name)
+
+    def list_notifications(self, **kwargs):
+        self.list_kwargs = kwargs
+        return self.pending
+
+    def dismiss_notification(self, notification_id, dismissed_by):
+        self.dismissed.append((notification_id, dismissed_by))
+        return SimpleNamespace(id=notification_id)
+
+    def is_in_alert_cooldown(self, agent_name, condition, cooldown_seconds):
+        return False
+
+    def set_alert_cooldown(self, agent_name, condition):
+        self.cooldowns_set.append((agent_name, condition))
+
+    def create_notification(self, agent_name, data):
+        self.created.append((agent_name, data))
+        return SimpleNamespace(
+            id=f"notif-{len(self.created)}",
+            agent_name=agent_name,
+            notification_type=data.notification_type,
+            priority=data.priority,
+            title=data.title,
+            created_at="2026-04-18T10:00:00.000000Z",
+        )
+
+
+@pytest.fixture
+def alerts_module(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://user:pass@localhost:6379")
+    for modname in list(sys.modules):
+        if modname == "services" or modname == "services.monitoring_alerts":
+            sys.modules.pop(modname, None)
+    _install_services_namespace()
+    import services.monitoring_alerts as monitoring_alerts  # noqa: WPS433
+
+    return monitoring_alerts
+
+
+@pytest.mark.asyncio
+async def test_recovery_dismisses_prior_health_alerts_and_keeps_evidence(
+    alerts_module,
+    monkeypatch,
+):
+    pending_alert = SimpleNamespace(
+        id="old-health-alert",
+        notification_type="alert",
+    )
+    pending_info = SimpleNamespace(
+        id="old-health-info",
+        notification_type="info",
+    )
+    fake_db = _FakeDB(pending=[pending_alert, pending_info])
+    monkeypatch.setattr(alerts_module, "db", fake_db)
+
+    service = alerts_module.MonitoringAlertService()
+    service._broadcast_alert = AsyncMock()
+
+    notification_id = await service._send_recovery_alert(
+        agent_name="alpha",
+        prev=alerts_module.AgentHealthStatus.UNHEALTHY,
+        curr=alerts_module.AgentHealthStatus.HEALTHY,
+        details={"latency_ms": 12.5},
+    )
+
+    assert notification_id == "notif-1"
+    assert fake_db.cooldowns_cleaned == ["alpha"]
+    assert fake_db.list_kwargs == {
+        "agent_name": "alpha",
+        "status": "pending",
+        "category": "health",
+        "limit": 100,
+    }
+    assert fake_db.dismissed == [("old-health-alert", "system:recovered")]
+    _, data = fake_db.created[0]
+    assert data.notification_type == "info"
+    assert data.category == "health"
+    assert data.metadata["resolution_state"] == "recovered_unacknowledged"
+    assert data.metadata["latency_ms"] == 12.5
+    evidence = data.metadata["recovery_evidence"]
+    assert evidence["source"] == "monitoring_alert_service"
+    assert evidence["verified_status"] == "healthy"
+    assert evidence["recovered_from_status"] == "unhealthy"
+    assert evidence["recovered_alert_ids"] == ["old-health-alert"]
+    service._broadcast_alert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_degradation_alert_marks_active_failure(
+    alerts_module,
+    monkeypatch,
+):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(alerts_module, "db", fake_db)
+
+    service = alerts_module.MonitoringAlertService()
+    service._broadcast_alert = AsyncMock()
+
+    notification_id = await service._send_degradation_alert(
+        agent_name="alpha",
+        prev=alerts_module.AgentHealthStatus.HEALTHY,
+        curr=alerts_module.AgentHealthStatus.UNHEALTHY,
+        issues=["network unreachable"],
+    )
+
+    assert notification_id == "notif-1"
+    assert fake_db.cooldowns_set == [("alpha", "status:unhealthy")]
+    _, data = fake_db.created[0]
+    assert data.notification_type == "alert"
+    assert data.category == "health"
+    assert data.metadata["resolution_state"] == "active_failure"
+    assert data.metadata["issues"] == ["network unreachable"]
+    service._broadcast_alert.assert_awaited_once()

--- a/tests/unit/test_sync_health_service.py
+++ b/tests/unit/test_sync_health_service.py
@@ -16,6 +16,7 @@ import asyncio
 import importlib.util
 import sqlite3
 import sys
+from types import ModuleType
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,11 +26,20 @@ import pytest
 _THIS = Path(__file__).resolve()
 _BACKEND = _THIS.parent.parent.parent / "src" / "backend"
 _BACKEND_STR = str(_BACKEND)
+_croniter_stub = ModuleType("croniter")
+_croniter_stub.croniter = object
+sys.modules.setdefault("croniter", _croniter_stub)
 for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
     sys.modules.pop(_shadow, None)
 while _BACKEND_STR in sys.path:
     sys.path.remove(_BACKEND_STR)
 sys.path.insert(0, _BACKEND_STR)
+
+
+def _install_services_namespace():
+    services_pkg = ModuleType("services")
+    services_pkg.__path__ = [str(_BACKEND / "services")]
+    sys.modules["services"] = services_pkg
 
 
 def _load(rel: str, name: str):
@@ -50,6 +60,7 @@ pytestmark = pytest.mark.unit
 def tmp_db(tmp_path, monkeypatch):
     db_path = tmp_path / "trinity.db"
     monkeypatch.setenv("TRINITY_DB_PATH", str(db_path))
+    monkeypatch.setenv("REDIS_URL", "redis://user:pass@localhost:6379")
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
@@ -61,7 +72,7 @@ def tmp_db(tmp_path, monkeypatch):
     # DatabaseManager singleton especially) sees the new DB path.
     for modname in list(sys.modules):
         if modname == "database" or modname.startswith("db.") \
-                or modname == "services.sync_health_service":
+                or modname == "services" or modname.startswith("services."):
             sys.modules.pop(modname, None)
     yield db_path
 
@@ -115,6 +126,7 @@ def _status_payload(status="success", ahead_working=0, behind_working=0, error=N
 @pytest.fixture
 def service(tmp_db):
     """SyncHealthService instance with a stub AgentClient."""
+    _install_services_namespace()
     from services.sync_health_service import SyncHealthService  # noqa: WPS433
     svc = SyncHealthService(poll_interval=0)
     return svc
@@ -190,6 +202,76 @@ class TestOperatorQueueEmission:
         assert len(sync_failing) == 1
         assert "boom" in (sync_failing[0].get("context") or {}).get(
             "last_error_summary", "")
+        assert sync_failing[0]["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_success_marks_sync_alert_recovered_with_evidence(
+        self, service, seed_agent
+    ):
+        seed_agent("alpha")
+        fail = _status_payload(status="failed", error="push failed")
+        ok = _status_payload(status="success")
+
+        with patch.object(service, "_fetch_git_status",
+                           AsyncMock(return_value=fail)):
+            await service._poll_cycle()
+            await service._poll_cycle()
+            await service._poll_cycle()
+        with patch.object(service, "_fetch_git_status",
+                           AsyncMock(return_value=ok)):
+            await service._poll_cycle()
+
+        from database import db
+        items = db.list_operator_queue_items(agent_name="alpha")
+        sync_failing = [i for i in items if i["type"] == "sync_failing"]
+        assert len(sync_failing) == 1
+        item = sync_failing[0]
+        assert item["status"] == "recovered"
+        assert item["priority"] == "low"
+        context = item["context"] or {}
+        assert context["resolution_state"] == "recovered_unacknowledged"
+        assert context["recovered_by"] == "system"
+        evidence = context["recovery_evidence"]
+        assert evidence["source"] == "sync_health_service"
+        assert evidence["verified_status"] == "success"
+        assert evidence["previous_consecutive_failures"] == 3
+        assert evidence["current_consecutive_failures"] == 0
+        assert evidence["last_error_summary"] == "push failed"
+
+    @pytest.mark.asyncio
+    async def test_recovery_does_not_change_human_action_items(
+        self, service, seed_agent
+    ):
+        seed_agent("alpha")
+        fail = _status_payload(status="failed", error="push failed")
+        ok = _status_payload(status="success")
+
+        from database import db
+        db.create_operator_queue_item("alpha", {
+            "id": "approval-alpha-1",
+            "agent_name": "alpha",
+            "type": "approval",
+            "status": "pending",
+            "priority": "high",
+            "title": "Approval needed",
+            "question": "Proceed?",
+            "context": {"human_response_required": True},
+            "created_at": "2026-04-18T10:00:00.000000Z",
+        })
+
+        with patch.object(service, "_fetch_git_status",
+                           AsyncMock(return_value=fail)):
+            await service._poll_cycle()
+            await service._poll_cycle()
+            await service._poll_cycle()
+        with patch.object(service, "_fetch_git_status",
+                           AsyncMock(return_value=ok)):
+            await service._poll_cycle()
+
+        approval = db.get_operator_queue_item("approval-alpha-1")
+        assert approval["status"] == "pending"
+        assert approval["priority"] == "high"
+        assert approval["context"] == {"human_response_required": True}
 
     @pytest.mark.asyncio
     async def test_success_resets_counter_and_allows_future_emissions(
@@ -218,6 +300,9 @@ class TestOperatorQueueEmission:
         sync_failing = [i for i in items if i["type"] == "sync_failing"]
         # Two distinct failure series → two entries (distinct IDs by timestamp).
         assert len(sync_failing) == 2
+        assert sorted(i["status"] for i in sync_failing) == [
+            "pending", "recovered"
+        ]
 
 
 class TestBehindWorkingRedFlag:

--- a/tests/unit/test_task_execution_timeout_hardening.py
+++ b/tests/unit/test_task_execution_timeout_hardening.py
@@ -1,0 +1,197 @@
+"""Timeout hardening tests for TaskExecutionService.
+
+Pins ERI-286 behavior: when the backend times out waiting for an
+agent task response, the persisted failure state identifies the timeout kind
+and records whether the best-effort terminate call reached the agent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+
+class _TaskExecutionStatus:
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class _ActivityState:
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class _ActivityType:
+    CHAT_START = "chat_start"
+
+
+class _FakeDb:
+    def __init__(self):
+        self.status_updates = []
+        self.dispatched = []
+
+    def get_max_parallel_tasks(self, agent_name):
+        return 1
+
+    def mark_execution_dispatched(self, execution_id):
+        self.dispatched.append(execution_id)
+        return True
+
+    def get_execution(self, execution_id):
+        return types.SimpleNamespace(id=execution_id, status=_TaskExecutionStatus.RUNNING)
+
+    def update_execution_status(self, **kwargs):
+        self.status_updates.append(kwargs)
+        return True
+
+
+class _FakeActivityService:
+    def __init__(self):
+        self.started = []
+        self.completed = []
+
+    async def track_activity(self, **kwargs):
+        self.started.append(kwargs)
+        return "activity-286"
+
+    async def complete_activity(self, **kwargs):
+        self.completed.append(kwargs)
+
+
+class _FakeCapacity:
+    def __init__(self):
+        self.acquired = []
+        self.released = []
+
+    async def acquire(self, **kwargs):
+        self.acquired.append(kwargs)
+        return types.SimpleNamespace(state="admitted")
+
+    async def release(self, agent_name, execution_id):
+        self.released.append((agent_name, execution_id))
+
+
+def _load_task_execution_service(monkeypatch):
+    """Load the service module with narrow stubs for its backend dependencies."""
+    module_name = "task_execution_service_timeout_under_test"
+    sys.modules.pop(module_name, None)
+
+    fake_db = _FakeDb()
+    fake_activity = _FakeActivityService()
+    fake_capacity = _FakeCapacity()
+
+    database_mod = types.ModuleType("database")
+    database_mod.db = fake_db
+    monkeypatch.setitem(sys.modules, "database", database_mod)
+
+    models_mod = types.ModuleType("models")
+    models_mod.ActivityState = _ActivityState
+    models_mod.ActivityType = _ActivityType
+    models_mod.TaskExecutionStatus = _TaskExecutionStatus
+    monkeypatch.setitem(sys.modules, "models", models_mod)
+
+    services_pkg = types.ModuleType("services")
+    services_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "services", services_pkg)
+
+    activity_mod = types.ModuleType("services.activity_service")
+    activity_mod.activity_service = fake_activity
+    monkeypatch.setitem(sys.modules, "services.activity_service", activity_mod)
+
+    capacity_mod = types.ModuleType("services.capacity_manager")
+    capacity_mod.CapacityFull = type("CapacityFull", (Exception,), {})
+    capacity_mod.get_capacity_manager = lambda: fake_capacity
+    monkeypatch.setitem(sys.modules, "services.capacity_manager", capacity_mod)
+
+    platform_mod = types.ModuleType("services.platform_prompt_service")
+
+    class ExecutionContext:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        @staticmethod
+        def derive_mode(triggered_by):
+            return triggered_by
+
+    platform_mod.ExecutionContext = ExecutionContext
+    platform_mod.compose_system_prompt = lambda **kwargs: "system prompt"
+    platform_mod.get_platform_system_prompt = lambda: "platform prompt"
+    platform_mod.is_execution_context_enabled = lambda: False
+    monkeypatch.setitem(sys.modules, "services.platform_prompt_service", platform_mod)
+
+    utils_pkg = types.ModuleType("utils")
+    utils_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "utils", utils_pkg)
+
+    sanitizer_mod = types.ModuleType("utils.credential_sanitizer")
+    sanitizer_mod.sanitize_execution_log = lambda value: value
+    sanitizer_mod.sanitize_response = lambda value: value
+    monkeypatch.setitem(sys.modules, "utils.credential_sanitizer", sanitizer_mod)
+
+    service_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "backend"
+        / "services"
+        / "task_execution_service.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, service_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module, fake_db, fake_activity, fake_capacity
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_read_timeout_records_timeout_kind_and_termination_result(monkeypatch):
+    module, fake_db, fake_activity, fake_capacity = _load_task_execution_service(
+        monkeypatch
+    )
+
+    async def raise_read_timeout(*args, **kwargs):
+        raise httpx.ReadTimeout("agent stopped responding")
+
+    terminate = AsyncMock(return_value=False)
+    monkeypatch.setattr(module, "agent_post_with_retry", raise_read_timeout)
+    monkeypatch.setattr(module, "terminate_execution_on_agent", terminate)
+
+    result = await module.TaskExecutionService().execute_task(
+        agent_name="inbox",
+        message="run scheduled work",
+        triggered_by="schedule",
+        timeout_seconds=1,
+        execution_id="exec-eri-286",
+    )
+
+    assert result.status == _TaskExecutionStatus.FAILED
+    assert result.error_code == module.TaskExecutionErrorCode.TIMEOUT
+    assert result.raw_response == {
+        "failure_kind": "timeout",
+        "timeout_kind": "read_timeout",
+        "termination_attempted": True,
+        "termination_succeeded": False,
+    }
+
+    terminate.assert_awaited_once_with("inbox", "exec-eri-286")
+    assert fake_capacity.released == [("inbox", "exec-eri-286")]
+
+    assert fake_db.dispatched == ["exec-eri-286"]
+    assert len(fake_db.status_updates) == 1
+    update = fake_db.status_updates[0]
+    assert update["execution_id"] == "exec-eri-286"
+    assert update["status"] == _TaskExecutionStatus.FAILED
+    assert "Execution timeout (read_timeout)" in update["error"]
+    assert "termination_attempted=true" in update["error"]
+    assert "termination_succeeded=false" in update["error"]
+
+    assert fake_activity.completed[-1]["status"] == _ActivityState.FAILED
+    assert fake_activity.completed[-1]["error"] == update["error"]


### PR DESCRIPTION
## Summary

- add stale .git/index.lock detection/recovery to agent auto-sync
- classify task execution timeouts and persist termination attempt/success metadata
- mark verified recovered sync_failing and health alerts as recovered with structured evidence
- teach the dashboard store/WebSocket/resolved card path to handle recovered operator-queue items
- add an operator runbook for sync/network incidents and Backblaze backup-health triage

## Linear

- ERI-285
- ERI-286
- ERI-288
- ERI-289
- ERI-284 and ERI-287 received runtime triage updates but remain open for monitored re-enable/mount verification

## Verification

- PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/unit/test_sync_health_service.py tests/unit/test_monitoring_alerts_recovery.py -q -> 11 passed
- PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/unit/test_agent_server_auto_sync.py tests/unit/test_task_execution_timeout_hardening.py -q -> 17 passed
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile ... for touched backend/test files
- git diff --check
- touched-file secret-pattern scan found only placeholders/code/test syntax

## Note

npm run build in src/frontend could not run because vite is not installed in this checkout (sh: vite: command not found). I did not install dependencies because of the active disk-pressure context.