### PR TITLE
fix(mem-001): split storage + channel injection for per-user memory (#895)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -207,7 +207,7 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 
 *Core:*
 - `base.py` - `ChannelAdapter` ABC, `NormalizedMessage`, `ChannelResponse` models
-- `message_router.py` - `ChannelMessageRouter`: rate limiting, agent resolution, execution pipeline
+- `message_router.py` - `ChannelMessageRouter`: rate limiting, agent resolution, execution pipeline; injects MEM-001 per-user memory into `execute_task(system_prompt=…)` gated on `verified_email and not is_group` (#895)
 
 *Slack:*
 - `slack_adapter.py` - Slack adapter: DMs, @mentions, thread replies, agent identity via `chat:write.customize`

--- a/docs/memory/feature-flows/public-agent-links.md
+++ b/docs/memory/feature-flows/public-agent-links.md
@@ -463,10 +463,10 @@ PUBLIC_CHAT_URL=
 
 | File | Description |
 |------|-------------|
-| `src/backend/db/public_links.py` | Database operations class (includes MEM-001 memory methods at lines 439-522) |
-| `src/backend/db/schema.py` | Table definitions including `public_user_memory` (lines 360-371) and index (line 694) |
+| `src/backend/db/public_links.py` | Database operations class (includes MEM-001 memory methods + #895 split-storage helpers `_parse_memory_blob`/`_encode_memory_blob` and `update_user_memory_agent_notes`/`update_user_memory_conversation_summary`) |
+| `src/backend/db/schema.py` | Table definitions including `public_user_memory` and lookup index — DDL unchanged by #895; `memory_text` now holds JSON |
 | `src/backend/db/migrations.py` | Migration #28 `_migrate_public_user_memory_table`; `_migrate_public_link_require_email_unified` (2026-04-13) — ORs legacy per-link `require_email=1` into `agent_ownership.require_email=1` |
-| `src/backend/services/platform_prompt_service.py` | `format_user_memory_block()` helper (line 97) |
+| `src/backend/services/platform_prompt_service.py` | `format_user_memory_block(dict)` helper + `summarize_user_memory_background()` (extracted from `routers/public.py` in #895; called by both web and channel paths) |
 | `src/backend/routers/public_links.py` | Owner CRUD endpoints; `_build_public_url()` / `_build_external_url()` now accept `link_type` and emit `/site/{token}/` for site links |
 | `src/backend/routers/public_links.py:30-39` | URL builders: `_build_public_url(token, link_type)`, `_build_external_url(token, link_type)` |
 | `src/backend/routers/public_links.py:42-61` | `_link_to_response()` - converts DB dict to API model |
@@ -1684,119 +1684,176 @@ let streamReader = null                    // SSE reader reference
 
 ## Per-User Persistent Memory (MEM-001)
 
-**Status**: Implemented (2026-03-19)
-**Issue**: #147
+**Status**: Implemented 2026-03-19 (#147). Split storage + channel injection: 2026-05-18 (#895).
+**Issues**: #147 (initial), #888 (`write_user_memory` MCP tool), #895 (split storage + channel injection)
 
 When a public link requires email verification, the agent accumulates a persistent memory of facts about each verified user. This memory is injected into the system prompt on every request so the agent can personalize responses across sessions.
 
 Anonymous (unverified) sessions are unaffected — no memory is read or written.
 
-### New Database Table: `public_user_memory`
+**#895 — Split storage**: The `memory_text` column now holds a JSON object with two named sections so the agent-deliberate writer (`write_user_memory` MCP tool, #888) and the every-5-message background summarizer can update independent sections without clobbering each other.
 
-`src/backend/db/schema.py` (lines 360-371) — Added table and unique index.
+**#895 — Channel injection**: Slack / Telegram / WhatsApp DMs now inject memory the same way the web path does, gated on `verified_email and not is_group`. Group chats are excluded because `verified_email` there is the *unlocker's* email (set once per group), so injecting their memory into replies addressed to other group members would leak PII across users.
+
+### Storage Shape (#895)
+
+The `public_user_memory.memory_text` TEXT column holds a JSON object:
+
+```json
+{
+  "agent_notes": "<written only by the write_user_memory MCP tool>",
+  "conversation_summary": "<written only by the background summarizer>"
+}
+```
+
+- The schema is unchanged — no migration. The column still has type `TEXT NOT NULL DEFAULT ''`.
+- **Legacy plaintext rows** (written before #895) are transparently surfaced as `conversation_summary` on read via `db/public_links._parse_memory_blob`. The next section-targeted write upgrades the row to JSON shape in place.
+- Malformed JSON (anything that isn't a JSON object) is also treated as plaintext → `conversation_summary`.
+
+### Database Table: `public_user_memory`
+
+`src/backend/db/schema.py` — table and unique index (DDL unchanged by #895).
 
 | Column | Type | Description |
 |--------|------|-------------|
 | id | TEXT PK | Unique record ID |
 | agent_name | TEXT | Target agent |
 | user_email | TEXT | Verified user email (stored lowercase) |
-| memory_text | TEXT | Plain-text bullet summary of user facts (default `''`) |
+| memory_text | TEXT | JSON `{agent_notes, conversation_summary}` since #895 (default `''`) |
 | message_count | INTEGER | Cumulative messages sent by this user |
 | created_at | TEXT | ISO timestamp of first message |
 | updated_at | TEXT | ISO timestamp of last write |
 
-UNIQUE constraint on `(agent_name, user_email)` — one memory blob per user per agent, shared across all sessions and public link tokens.
+UNIQUE constraint on `(agent_name, user_email)` — one memory blob per user per agent, shared across web and channel sessions.
 
-Index: `idx_public_user_memory_lookup ON public_user_memory(agent_name, user_email)` (`src/backend/db/schema.py` line 694).
+Index: `idx_public_user_memory_lookup ON public_user_memory(agent_name, user_email)`.
 
-Migration: `src/backend/db/migrations.py` — migration #28 `_migrate_public_user_memory_table`.
+Migration: `src/backend/db/migrations.py` — migration #28 `_migrate_public_user_memory_table` (#147; no new migration for #895).
 
-### Database Operations
+### Database Operations (#895)
 
-New methods on `PublicLinkOperations` (`src/backend/db/public_links.py` lines 439-522):
+Methods on `PublicLinkOperations` (`src/backend/db/public_links.py`):
 
-| Method | Line | Description |
-|--------|------|-------------|
-| `get_or_create_user_memory(agent_name, user_email)` | 439 | Fetch existing record or `INSERT` a blank row; returns the row dict |
-| `increment_message_count(agent_name, user_email)` | 479 | Atomic `UPDATE message_count + 1`; returns the new count |
-| `update_user_memory(agent_name, user_email, memory_text)` | 504 | Overwrites `memory_text` and sets `updated_at`; returns `True` if row found |
+| Method | Description |
+|--------|-------------|
+| `get_or_create_user_memory(agent_name, user_email)` | Fetch existing record or `INSERT` a blank row; returns the parsed dict with `agent_notes` and `conversation_summary` keys (plus id/agent_name/user_email/message_count/created_at/updated_at). |
+| `increment_message_count(agent_name, user_email)` | Atomic `UPDATE message_count + 1`; returns the new count. |
+| `update_user_memory_agent_notes(agent_name, user_email, agent_notes)` | Section write: read-modify-write that replaces only the `agent_notes` key. Used by the `write_user_memory` MCP tool (#888). |
+| `update_user_memory_conversation_summary(agent_name, user_email, summary)` | Section write: replaces only `conversation_summary`. Used by `summarize_user_memory_background`. |
+
+Module-level helpers in the same file:
+- `_parse_memory_blob(text)` — handles JSON, legacy plaintext, malformed input. Returns `{agent_notes, conversation_summary}` dict.
+- `_encode_memory_blob(agent_notes, conversation_summary)` — JSON-encodes for storage with `ensure_ascii=False`.
 
 Delegation methods on `db` in `src/backend/database.py`:
 - `get_or_create_public_user_memory(agent_name, user_email)` → `PublicLinkOperations.get_or_create_user_memory()`
 - `increment_public_user_memory_count(agent_name, user_email)` → `PublicLinkOperations.increment_message_count()`
-- `update_public_user_memory(agent_name, user_email, memory_text)` → `PublicLinkOperations.update_user_memory()`
+- `update_public_user_memory_agent_notes(agent_name, user_email, agent_notes)` → `PublicLinkOperations.update_user_memory_agent_notes()` (#895)
+- `update_public_user_memory_conversation_summary(agent_name, user_email, summary)` → `PublicLinkOperations.update_user_memory_conversation_summary()` (#895)
 
-### Request Flow (Memory Injection)
+### Read Flow (Memory Injection)
 
-Occurs inside `POST /api/public/chat/{token}` (`src/backend/routers/public.py` lines 316-321) after the email session is validated and the context prompt is built, before `execute_task()` is called:
+Both the **web** path and the **channel-adapter** path follow the same pattern:
 
 ```
-1. db.get_or_create_public_user_memory(agent_name, verified_email)
-2. If memory_text is non-empty:
-     memory_system_prompt = format_user_memory_block(memory_text)
-   Else:
-     memory_system_prompt = None
-3. execute_task(..., system_prompt=memory_system_prompt)   # both sync and async paths
+1. record = db.get_or_create_public_user_memory(agent_name, verified_email)
+2. memory_system_prompt = format_user_memory_block(record)
+3. execute_task(..., system_prompt=memory_system_prompt)
 ```
 
-`memory_system_prompt` is passed as the `system_prompt` kwarg to both the sync `execute_task()` call (line 368) and the async background task via `_execute_public_chat_background()` (line 350).
-
-Memory block format produced by `format_user_memory_block()` (`src/backend/services/platform_prompt_service.py` line 97-104):
+`format_user_memory_block(memory_record)` (`src/backend/services/platform_prompt_service.py`) accepts the parsed dict and emits a multi-section markdown block — or returns `None` when both sections are empty so callers can skip the `--append-system-prompt` injection entirely.
 
 ```
 ## What you know about this user
 
-{memory_text}
+### Agent notes
+
+{agent_notes}
+
+### Conversation summary
+
+{conversation_summary}
 
 ---
 ```
 
-### Memory Update Flow (Background Summarization)
+Either section is omitted when empty. Agent notes render first (higher signal than the auto-summary).
 
-After execution completes, both the **sync path** (`public.py` lines 401-408) and the **async background task** (`_execute_public_chat_background`, lines 696-704) run the same counter/summarization logic — but only when `identifier_type == "email"`:
+**Web path** — `routers/public.py` (sync + async background paths):
+
+| Path | Gate |
+|------|------|
+| `public_chat()` (sync) | `identifier_type == "email" and verified_email` |
+| `_execute_public_chat_background()` (async) | same |
+
+**Channel-adapter path** — `adapters/message_router.py:_handle_message_inner` (#895):
+
+| Path | Gate |
+|------|------|
+| All channels (Slack DM, Telegram DM, WhatsApp DM) | `verified_email and not is_group` |
+| Group chats (any channel) | excluded — see PII rationale above |
+
+The channel-side fetch is wrapped in try/except with a warning log; a memory-fetch failure never breaks the channel response.
+
+### Write Flow (Background Summarization)
+
+After execution completes, the count is incremented and the summarizer fires every 5 messages — same logic on web and channel paths:
 
 ```
 1. new_count = db.increment_public_user_memory_count(agent_name, verified_email)
 2. If new_count % 5 == 0:
-     asyncio.create_task(_summarize_user_memory(
+     asyncio.create_task(summarize_user_memory_background(
          agent_name=agent_name,
          user_email=verified_email,
-         session_id=chat_session.id,
+         session_id=session_id,
      ))
 ```
 
-`_summarize_user_memory(agent_name, user_email, session_id)` is fire-and-forget (`src/backend/routers/public.py` lines 727-784):
+`summarize_user_memory_background(agent_name, user_email, session_id)` lives in `services/platform_prompt_service.py` (extracted from `routers/public.py` in #895). It is fire-and-forget:
 
 1. Reads `ANTHROPIC_API_KEY` via `get_anthropic_api_key()`; skips silently if absent.
-2. Calls `db.get_or_create_public_user_memory()` to retrieve the current `memory_text`.
+2. Calls `db.get_or_create_public_user_memory()` and reads the current `conversation_summary` (not `agent_notes` — the summarizer must not see deliberate writes).
 3. Calls `db.get_recent_public_chat_messages(session_id, limit=20)` for the last 20 messages.
 4. Formats `_SUMMARIZATION_PROMPT` with `existing_memory` and `conversation` fields.
 5. POSTs to `https://api.anthropic.com/v1/messages` using model `claude-haiku-4-5-20251001`, `max_tokens=512`, 30-second timeout.
-6. On success, writes the returned text to `db.update_public_user_memory()`.
-7. All failures are logged (`[MemSummarize]` prefix) and never surfaced to the user or caller.
+6. On success, writes the returned text to `db.update_public_user_memory_conversation_summary()` — touches only the summary section.
+7. All failures are logged (`[MemSummarize]` prefix) and never surfaced to the user.
 
-Summarization is triggered every 5th message per `(agent_name, user_email)` pair — not per session or per link token.
+Summarization is triggered every 5th message per `(agent_name, user_email)` pair — not per session, per link token, or per channel.
+
+### Channel-Side Hook (#895)
+
+Wired into the same step in `_handle_message_inner` (`src/backend/adapters/message_router.py`):
+- Memory fetch: between source-email resolution and `execute_task` call, gated on `verified_email and not is_group`.
+- Increment + summarizer trigger: after `db.add_public_chat_message(session_id, "assistant", ...)`, same gate, also wrapped in try/except.
 
 ### Scope
 
 | Session type | Memory read | Memory written |
 |---|---|---|
-| Email-verified | Yes (if non-empty) | Yes (every 5th message) |
-| Anonymous (no email) | No | No |
+| Email-verified web | Yes (if non-empty) | Yes (every 5th message) |
+| Email-verified Slack/Telegram/WhatsApp DM | Yes — added in #895 | Yes — added in #895 |
+| Group chat (any channel) | No — PII guard | No |
+| Anonymous (no verified email, any channel) | No | No |
+
+### Known Limitations
+
+- **Race window in section writes (#895)**: `update_user_memory_*` does a read-modify-write inside a single connection. Two writers (e.g., write_user_memory + summarizer firing within ~10ms) can interleave and one write may be lost. The window is much smaller than the pre-#895 deterministic clobber but not zero. A follow-up using atomic SQLite JSON1 `json_set` would close it.
+- **Summarizer cost ceiling**: no per-(agent, user) cooldown — applies to every 5th message. Pre-existing concern.
+- **Memory-text safety filter**: the system-prompt block is rendered raw, leaving a prompt-injection surface from agent-curated content. Pre-existing concern.
 
 ### Files
 
 | File | Description |
 |------|-------------|
-| `src/backend/db/schema.py:360-371` | `public_user_memory` table definition |
-| `src/backend/db/schema.py:693-694` | `idx_public_user_memory_lookup` index |
-| `src/backend/db/migrations.py` | Migration #28 `_migrate_public_user_memory_table` |
-| `src/backend/db/public_links.py:439-522` | `PublicLinkOperations` memory methods |
-| `src/backend/routers/public.py:316-321` | Memory injection in `public_chat()` |
-| `src/backend/routers/public.py:401-408` | Counter + summarization trigger (sync path) |
-| `src/backend/routers/public.py:696-704` | Counter + summarization trigger (async path) |
-| `src/backend/routers/public.py:711-784` | `_summarize_user_memory()` background function |
-| `src/backend/services/platform_prompt_service.py:97-104` | `format_user_memory_block()` helper |
+| `src/backend/db/schema.py` | `public_user_memory` table + lookup index (unchanged by #895) |
+| `src/backend/db/migrations.py` | Migration #28 `_migrate_public_user_memory_table` (#147) |
+| `src/backend/db/public_links.py` | `_parse_memory_blob`, `_encode_memory_blob`, `PublicLinkOperations` memory methods (#895 split storage) |
+| `src/backend/database.py` | `db` facade — `get_or_create_public_user_memory`, `increment_public_user_memory_count`, `update_public_user_memory_agent_notes`, `update_public_user_memory_conversation_summary` |
+| `src/backend/services/platform_prompt_service.py` | `format_user_memory_block(dict)`, `summarize_user_memory_background()` (extracted in #895) |
+| `src/backend/routers/public.py` | Memory injection + counter + summarizer trigger on the web path (sync + async background) |
+| `src/backend/routers/public_memory.py` | `POST /api/agents/{name}/user-memory` (calls `update_public_user_memory_agent_notes` since #895) |
+| `src/backend/adapters/message_router.py` | Memory injection + counter + summarizer trigger on the channel-adapter path (#895) |
 
 ---
 
@@ -1978,6 +2035,7 @@ const viewingHistorySession = ref(null)   // non-null = read-only history mode
 
 | Date | Changes |
 |------|---------|
+| 2026-05-18 | **#895 MEM-001 split storage + channel injection**: `public_user_memory.memory_text` now holds JSON `{agent_notes, conversation_summary}`; the agent-deliberate `write_user_memory` tool (#888) and the every-5-message background summarizer each update their own section so they cannot clobber each other. Legacy plaintext rows surface as `conversation_summary` transparently. Channel adapters (Slack/Telegram/WhatsApp) now mirror the web injection — memory is read, formatted, and passed as `system_prompt=` to `execute_task`, gated on `verified_email and not is_group` (group mode excluded to prevent PII leak from the unlocker's memory). Counter + summarizer trigger added to the channel path on the same gate. Summarizer extracted to `services/platform_prompt_service.summarize_user_memory_background` so web and channel share it. `format_user_memory_block(dict)` rewritten to render both sections; returns `None` when both are empty so callers skip injection. No schema migration. |
 | 2026-05-18 | **#890**: `request_verification_code()` now passes `agent_name` to `email_service.send_verification_code()` so the verification email subject and body name the agent. |
 | 2026-04-29 | **#587 Chat History for Logged-In Users**: Two new JWT-authenticated endpoints (`GET /api/public/sessions/{token}`, `GET /api/public/sessions/{token}/{session_id}`) in `public.py`. New `ChatHistoryDropdown.vue` component. `PublicChat.vue` gains `viewingHistorySession` ref, `handleHistorySessionSelected()`, `exitHistoryView()`, amber read-only banner, and hidden `ChatInput` while in history mode. No new DB tables — reuses `chat_sessions`/`chat_messages`. |
 | 2026-04-27 | **fix #539 Context duplication**: `build_public_chat_context()` was called AFTER `add_public_chat_message(role="user")`, causing the current user message to appear twice in every agent prompt (once in "Previous conversation:", once in "Current message:"). Fixed by swapping the call order — context built first from prior history, user message stored after. Added 6 unit tests in `tests/unit/test_public_chat_context.py`. Updated PUB-005 data flow and backend implementation step ordering to reflect correct call order. |

--- a/docs/memory/feature-flows/write-user-memory.md
+++ b/docs/memory/feature-flows/write-user-memory.md
@@ -1,7 +1,9 @@
-# Feature: write_user_memory MCP Tool (MEM-001, #888)
+# Feature: write_user_memory MCP Tool (MEM-001, #888, #895)
 
 ## Overview
 Agents can persist per-user memory blobs scoped to a single (agent, user_email) pair. This replaces the unsafe pattern of writing to `~/.claude/projects/memory/`, which is shared across all users of an agent and leaks PII between sessions.
+
+**#895 update**: storage was split into two named sections so the agent-deliberate writes from this tool don't clobber the every-5-message conversation summarizer (and vice versa). The MCP wire format is unchanged — the tool still accepts a single `memory_text` field — but the backend now routes that value to the `agent_notes` section of the JSON blob stored on disk. Channel sessions (Slack/Telegram/WhatsApp) now also inject this memory into the agent's system prompt, gated on `verified_email and not is_group`.
 
 ## User Story
 As an agent serving multiple users via public link / Slack / Telegram / WhatsApp, I want to remember facts about each individual user (name, preferences, timezone) so that future sessions are personalized — without contaminating any other user's context.
@@ -52,13 +54,19 @@ The fix is a server-side gated write: the agent never supplies a user email. The
 3. **Execution ownership check** — `execution.agent_name != agent_name`: the execution must belong to the agent named in the path. Returns 403 if mismatch.
 4. **Channel gate** — `triggered_by` must be one of `{"public", "slack", "telegram", "whatsapp"}`. Scheduled tasks and agent-to-agent executions are rejected with 422.
 5. **Email extraction** — `execution.source_user_email` is read directly from the execution record. Agent never supplies this value. Returns 422 if missing or malformed.
-6. **Upsert** — `db.get_or_create_public_user_memory(agent_name, user_email)` then `db.update_public_user_memory(agent_name, user_email, memory_text)`.
+6. **Section write (#895)** — `db.update_public_user_memory_agent_notes(agent_name, user_email, memory_text)`. The helper reads the existing JSON blob, replaces only the `agent_notes` key, and writes back — `conversation_summary` (written by the background summarizer) is left untouched. The row is created on demand inside the helper.
 
 ### Database Operations
-- **Table**: `public_user_memory` (schema at `src/backend/db/schema.py:515`)
+- **Table**: `public_user_memory` (schema at `src/backend/db/schema.py:515`) — unchanged by #895
 - **Unique constraint**: `(agent_name, user_email)` — one blob per user per agent
-- **Read** (`db.get_or_create_public_user_memory`): `SELECT` by `(agent_name, user_email)`; `INSERT` if not found — `src/backend/db/public_links.py:509`
-- **Write** (`db.update_public_user_memory`): `UPDATE memory_text, updated_at` by `(agent_name, user_email)` — `src/backend/db/public_links.py:574`
+- **Storage shape (#895)**: `memory_text TEXT` now holds a JSON object with two named keys (no schema migration required):
+  ```json
+  { "agent_notes": "...", "conversation_summary": "..." }
+  ```
+  `agent_notes` is written by this tool. `conversation_summary` is written by the background summarizer (`services/platform_prompt_service.summarize_user_memory_background`). Legacy plaintext rows (written before #895) are transparently surfaced as `conversation_summary` on read — see `db/public_links._parse_memory_blob`.
+- **Read** (`db.get_or_create_public_user_memory`): `SELECT` by `(agent_name, user_email)`; `INSERT` if not found. Returns the parsed dict `{id, agent_name, user_email, agent_notes, conversation_summary, message_count, created_at, updated_at}` — `src/backend/db/public_links.py:get_or_create_user_memory`
+- **Write — agent_notes only** (`db.update_public_user_memory_agent_notes`): read-modify-write that replaces only the `agent_notes` key — `src/backend/db/public_links.py:update_user_memory_agent_notes`
+- **Write — conversation_summary only** (`db.update_public_user_memory_conversation_summary`): used by the background summarizer; never invoked from this tool — `src/backend/db/public_links.py:update_user_memory_conversation_summary`
 - **Index**: `idx_public_user_memory_lookup ON public_user_memory(agent_name, user_email)` — `src/backend/db/schema.py:1166`
 
 ### Table Schema
@@ -67,7 +75,7 @@ CREATE TABLE IF NOT EXISTS public_user_memory (
     id TEXT PRIMARY KEY,
     agent_name TEXT NOT NULL,
     user_email TEXT NOT NULL,
-    memory_text TEXT NOT NULL DEFAULT '',
+    memory_text TEXT NOT NULL DEFAULT '',  -- JSON blob since #895
     message_count INTEGER DEFAULT 0,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
@@ -116,5 +124,6 @@ The agent never provides the user's email — it supplies only `execution_id`. T
 | `src/backend/main.py:95,830` | Router import and mount |
 
 ## Related Flows
-- [public-agent-links.md](feature-flows/public-agent-links.md) — public chat sessions that produce the `source_user_email` on executions
-- [execution-context-injection.md](feature-flows/execution-context-injection.md) — how `execution_id` is surfaced in the agent system prompt
+- [public-agent-links.md](public-agent-links.md) — web public chat sessions (read path that injects this memory into the system prompt; same split-storage rules)
+- [unified-channel-access-control.md](unified-channel-access-control.md) — Slack/Telegram/WhatsApp channel sessions that also inject memory (#895), gated on `verified_email and not is_group`
+- [execution-context-injection.md](execution-context-injection.md) — how `execution_id` is surfaced in the agent system prompt

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -12,6 +12,7 @@ Uses the same execution path as web public chat (EXEC-024) for:
 - Credential sanitization
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -22,6 +23,10 @@ from collections import defaultdict
 
 from database import db
 from services.docker_service import get_agent_container
+from services.platform_prompt_service import (
+    format_user_memory_block,
+    summarize_user_memory_background,
+)
 from services.settings_service import settings_service
 from services.task_execution_service import get_task_execution_service
 from services.docker_utils import container_exec_run
@@ -488,6 +493,23 @@ class ChannelMessageRouter:
         # off the same identity. Fall back to the channel-native source id.
         source_email = verified_email or adapter.get_source_identifier(message)
 
+        # MEM-001 (#895): inject per-user memory for verified channel users.
+        # Excluded in group mode because `verified_email` there is the
+        # *unlocker's* email (set once per group, not per-speaker), so
+        # injecting their memory into replies addressed to other group
+        # members would leak PII across users.
+        memory_system_prompt: Optional[str] = None
+        if verified_email and not is_group:
+            try:
+                user_memory = db.get_or_create_public_user_memory(
+                    agent_name, verified_email
+                )
+                memory_system_prompt = format_user_memory_block(user_memory)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"[ROUTER:{channel}] memory fetch failed for {verified_email}: {e}"
+                )
+
         # Security: restrict tools for public channel users
         # No file access (Read exposes .env/credentials), no Bash, no Write/Edit
         # Configurable via settings_service (default: WebSearch, WebFetch)
@@ -513,6 +535,7 @@ class ChannelMessageRouter:
                 source_user_email=source_email,
                 timeout_seconds=None,  # Uses agent's configured timeout (TIMEOUT-001)
                 allowed_tools=public_allowed_tools,
+                system_prompt=memory_system_prompt,
                 images=image_data or None,
             )
 
@@ -559,6 +582,26 @@ class ChannelMessageRouter:
         logger.debug(f"[ROUTER:{channel}] Step 11 - persisting messages")
         db.add_public_chat_message(session_id, "user", message.text)
         db.add_public_chat_message(session_id, "assistant", response_text, cost=result.cost)
+
+        # 11a. MEM-001 (#895): mirror the web path — increment per-user count
+        # and fire-and-forget the conversation summarizer every 5 messages.
+        # Same gating as the injection above (verified + not group).
+        if verified_email and not is_group:
+            try:
+                new_count = db.increment_public_user_memory_count(
+                    agent_name, verified_email
+                )
+                if new_count and new_count % 5 == 0:
+                    asyncio.create_task(summarize_user_memory_background(
+                        agent_name=agent_name,
+                        user_email=verified_email,
+                        session_id=session_id,
+                    ))
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"[ROUTER:{channel}] memory count/summarize trigger failed "
+                    f"for {verified_email}: {e}"
+                )
 
         # 11b. Extract code blocks as outbound files (after persisting, before sending)
         outbound_files = []

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1274,15 +1274,26 @@ class DatabaseManager:
     def delete_public_link_sessions(self, link_id: str):
         return self._public_chat_ops.delete_link_sessions(link_id)
 
-    # Public User Memory (MEM-001)
+    # Public User Memory (MEM-001 + #895 split storage)
     def get_or_create_public_user_memory(self, agent_name: str, user_email: str) -> dict:
         return self._public_link_ops.get_or_create_user_memory(agent_name, user_email)
 
     def increment_public_user_memory_count(self, agent_name: str, user_email: str) -> int:
         return self._public_link_ops.increment_message_count(agent_name, user_email)
 
-    def update_public_user_memory(self, agent_name: str, user_email: str, memory_text: str) -> bool:
-        return self._public_link_ops.update_user_memory(agent_name, user_email, memory_text)
+    def update_public_user_memory_agent_notes(
+        self, agent_name: str, user_email: str, agent_notes: str
+    ) -> bool:
+        return self._public_link_ops.update_user_memory_agent_notes(
+            agent_name, user_email, agent_notes
+        )
+
+    def update_public_user_memory_conversation_summary(
+        self, agent_name: str, user_email: str, conversation_summary: str
+    ) -> bool:
+        return self._public_link_ops.update_user_memory_conversation_summary(
+            agent_name, user_email, conversation_summary
+        )
 
     # =========================================================================
     # Agent Tags (delegated to db/tags.py) - ORG-001

--- a/src/backend/db/public_links.py
+++ b/src/backend/db/public_links.py
@@ -7,6 +7,7 @@ Handles:
 - Usage tracking
 """
 
+import json
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional, List
@@ -18,6 +19,43 @@ from utils.helpers import utc_now_iso
 def _utcnow() -> datetime:
     """Return timezone-aware UTC now."""
     return datetime.now(timezone.utc)
+
+
+def _parse_memory_blob(memory_text: Optional[str]) -> dict:
+    """Parse the JSON blob stored in public_user_memory.memory_text (#895).
+
+    Storage shape is a JSON object with two named keys so that the
+    agent-deliberate writer (write_user_memory MCP tool) and the
+    5-message conversation summarizer can update independent sections
+    without clobbering each other.
+
+    Legacy plaintext rows (written before the split) are treated as
+    `conversation_summary` — that is what the original summarizer wrote.
+    Malformed JSON is also treated as plaintext.
+    """
+    if not memory_text:
+        return {"agent_notes": "", "conversation_summary": ""}
+    try:
+        data = json.loads(memory_text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {"agent_notes": "", "conversation_summary": memory_text}
+    if not isinstance(data, dict):
+        return {"agent_notes": "", "conversation_summary": memory_text}
+    return {
+        "agent_notes": str(data.get("agent_notes") or ""),
+        "conversation_summary": str(data.get("conversation_summary") or ""),
+    }
+
+
+def _encode_memory_blob(agent_notes: str, conversation_summary: str) -> str:
+    """Encode the two-section memory representation as JSON for storage."""
+    return json.dumps(
+        {
+            "agent_notes": agent_notes or "",
+            "conversation_summary": conversation_summary or "",
+        },
+        ensure_ascii=False,
+    )
 
 
 def _parse_aware(dt_str: str) -> datetime:
@@ -500,8 +538,12 @@ class PublicLinkOperations:
     def get_or_create_user_memory(self, agent_name: str, user_email: str) -> dict:
         """Get or create a memory record for (agent_name, user_email).
 
-        Returns the memory dict with keys: id, agent_name, user_email,
-        memory_text, message_count, created_at, updated_at.
+        Returns a dict with keys: id, agent_name, user_email, agent_notes,
+        conversation_summary, message_count, created_at, updated_at.
+
+        The two memory sections are parsed from the JSON blob stored in
+        ``memory_text`` (#895). Legacy plaintext rows surface as
+        ``conversation_summary`` (see :func:`_parse_memory_blob`).
         """
         email = user_email.lower()
         now = utc_now_iso()
@@ -516,10 +558,13 @@ class PublicLinkOperations:
             row = cursor.fetchone()
 
             if row:
+                parsed = _parse_memory_blob(row[3])
                 return {
                     "id": row[0], "agent_name": row[1], "user_email": row[2],
-                    "memory_text": row[3], "message_count": row[4],
-                    "created_at": row[5], "updated_at": row[6]
+                    "agent_notes": parsed["agent_notes"],
+                    "conversation_summary": parsed["conversation_summary"],
+                    "message_count": row[4],
+                    "created_at": row[5], "updated_at": row[6],
                 }
 
             # Create new record
@@ -533,8 +578,9 @@ class PublicLinkOperations:
 
         return {
             "id": memory_id, "agent_name": agent_name, "user_email": email,
-            "memory_text": "", "message_count": 0,
-            "created_at": now, "updated_at": now
+            "agent_notes": "", "conversation_summary": "",
+            "message_count": 0,
+            "created_at": now, "updated_at": now,
         }
 
     def increment_message_count(self, agent_name: str, user_email: str) -> int:
@@ -562,25 +608,78 @@ class PublicLinkOperations:
 
         return row[0] if row else 0
 
-    def update_user_memory(self, agent_name: str, user_email: str, memory_text: str) -> bool:
-        """Update memory_text for (agent_name, user_email).
+    def _update_user_memory_section(
+        self,
+        agent_name: str,
+        user_email: str,
+        *,
+        agent_notes: Optional[str] = None,
+        conversation_summary: Optional[str] = None,
+    ) -> bool:
+        """Update one named section of the memory blob without touching the other (#895).
 
-        Returns True if the record was found and updated.
+        The row is created on demand so callers don't need to seed it. Read +
+        write happen on the same connection to keep the parse-merge-write
+        sequence inside SQLite's connection-level serialization.
         """
+        if agent_notes is None and conversation_summary is None:
+            return False
+
         email = user_email.lower()
         now = utc_now_iso()
 
         with get_db_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
+                SELECT memory_text FROM public_user_memory
+                WHERE agent_name = ? AND user_email = ?
+            """, (agent_name, email))
+            row = cursor.fetchone()
+
+            if row is None:
+                memory_id = secrets.token_urlsafe(16)
+                cursor.execute("""
+                    INSERT INTO public_user_memory
+                    (id, agent_name, user_email, memory_text, message_count, created_at, updated_at)
+                    VALUES (?, ?, ?, '', 0, ?, ?)
+                """, (memory_id, agent_name, email, now, now))
+                current = {"agent_notes": "", "conversation_summary": ""}
+            else:
+                current = _parse_memory_blob(row[0])
+
+            if agent_notes is not None:
+                current["agent_notes"] = agent_notes
+            if conversation_summary is not None:
+                current["conversation_summary"] = conversation_summary
+
+            new_blob = _encode_memory_blob(
+                current["agent_notes"], current["conversation_summary"]
+            )
+
+            cursor.execute("""
                 UPDATE public_user_memory
                 SET memory_text = ?, updated_at = ?
                 WHERE agent_name = ? AND user_email = ?
-            """, (memory_text, now, agent_name, email))
-            updated = cursor.rowcount > 0
+            """, (new_blob, now, agent_name, email))
             conn.commit()
 
-        return updated
+        return True
+
+    def update_user_memory_agent_notes(
+        self, agent_name: str, user_email: str, agent_notes: str
+    ) -> bool:
+        """Update only the agent_notes section (written by the write_user_memory MCP tool)."""
+        return self._update_user_memory_section(
+            agent_name, user_email, agent_notes=agent_notes or ""
+        )
+
+    def update_user_memory_conversation_summary(
+        self, agent_name: str, user_email: str, conversation_summary: str
+    ) -> bool:
+        """Update only the conversation_summary section (written by the background summarizer)."""
+        return self._update_user_memory_section(
+            agent_name, user_email, conversation_summary=conversation_summary or ""
+        )
 
     # =========================================================================
     # Helpers

--- a/src/backend/routers/public.py
+++ b/src/backend/routers/public.py
@@ -32,8 +32,10 @@ from routers.auth import check_login_rate_limit, record_login_attempt, get_redis
 from services.docker_service import get_agent_container
 from services.email_service import email_service
 from services.task_execution_service import get_task_execution_service
-from services.platform_prompt_service import format_user_memory_block
-from services.settings_service import get_anthropic_api_key
+from services.platform_prompt_service import (
+    format_user_memory_block,
+    summarize_user_memory_background,
+)
 from services.upload_service import process_file_uploads, decode_web_file, WEB_MAX_FILES, WEB_MAX_FILE_SIZE, WEB_MAX_IMAGE_SIZE, WEB_MAX_TOTAL_IMAGE_SIZE
 
 
@@ -560,12 +562,14 @@ async def public_chat(
         ip_address=client_ip
     )
 
-    # MEM-001: Fetch per-user memory for email-verified sessions and inject into system prompt
+    # MEM-001 (#895): Fetch per-user memory for email-verified sessions and inject
+    # into the system prompt. The record carries two independently-written sections
+    # (agent_notes + conversation_summary); format_user_memory_block renders both
+    # when present and returns None when both are empty.
     memory_system_prompt = None
     if identifier_type == "email" and verified_email:
         user_memory = db.get_or_create_public_user_memory(agent_name, verified_email)
-        if user_memory.get("memory_text"):
-            memory_system_prompt = format_user_memory_block(user_memory["memory_text"])
+        memory_system_prompt = format_user_memory_block(user_memory)
 
     # EXEC-024: Execute via TaskExecutionService (unified execution path)
     # Public executions now get full tracking: execution records, activity stream,
@@ -650,7 +654,7 @@ async def public_chat(
     if identifier_type == "email" and verified_email:
         new_count = db.increment_public_user_memory_count(agent_name, verified_email)
         if new_count % 5 == 0:
-            asyncio.create_task(_summarize_user_memory(
+            asyncio.create_task(summarize_user_memory_background(
                 agent_name=agent_name,
                 user_email=verified_email,
                 session_id=chat_session.id,
@@ -947,7 +951,7 @@ async def _execute_public_chat_background(
             if identifier_type == "email" and verified_email:
                 new_count = db.increment_public_user_memory_count(agent_name, verified_email)
                 if new_count % 5 == 0:
-                    asyncio.create_task(_summarize_user_memory(
+                    asyncio.create_task(summarize_user_memory_background(
                         agent_name=agent_name,
                         user_email=verified_email,
                         session_id=chat_session_id,
@@ -956,82 +960,6 @@ async def _execute_public_chat_background(
             logger.error(f"[PublicChatAsync] Task failed for {agent_name}: {result.error}")
     except Exception as e:
         logger.error(f"[PublicChatAsync] Background execution error for {agent_name}: {e}")
-
-
-_SUMMARIZATION_MODEL = "claude-haiku-4-5-20251001"
-
-_SUMMARIZATION_PROMPT = """\
-You are a memory system. Given this conversation, extract a concise bullet list of facts \
-about the user that would be useful to remember for future conversations.
-Be specific: name, preferences, goals, context. Max 300 words.
-
-Existing memory:
-{existing_memory}
-
-New conversation:
-{conversation}
-
-Output the updated memory text only (bullet points, no headers)."""
-
-
-async def _summarize_user_memory(agent_name: str, user_email: str, session_id: str) -> None:
-    """
-    Background task: summarize recent conversation and update user memory.
-
-    Fire-and-forget — failures are logged but never surfaced to the user.
-    """
-    try:
-        api_key = get_anthropic_api_key()
-        if not api_key:
-            logger.warning("[MemSummarize] No ANTHROPIC_API_KEY configured, skipping summarization")
-            return
-
-        # Get current memory and last 20 messages
-        memory_record = db.get_or_create_public_user_memory(agent_name, user_email)
-        existing_memory = memory_record.get("memory_text", "")
-
-        messages = db.get_recent_public_chat_messages(session_id, limit=20)
-        if not messages:
-            return
-
-        conversation_lines = []
-        for msg in messages:
-            role_label = "User" if msg.role == "user" else "Assistant"
-            conversation_lines.append(f"{role_label}: {msg.content}")
-        conversation_text = "\n".join(conversation_lines)
-
-        prompt = _SUMMARIZATION_PROMPT.format(
-            existing_memory=existing_memory or "(none yet)",
-            conversation=conversation_text,
-        )
-
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(
-                "https://api.anthropic.com/v1/messages",
-                headers={
-                    "x-api-key": api_key,
-                    "anthropic-version": "2023-06-01",
-                    "content-type": "application/json",
-                },
-                json={
-                    "model": _SUMMARIZATION_MODEL,
-                    "max_tokens": 512,
-                    "messages": [{"role": "user", "content": prompt}],
-                },
-            )
-
-        if response.status_code != 200:
-            logger.error(f"[MemSummarize] Anthropic API error {response.status_code}: {response.text[:200]}")
-            return
-
-        data = response.json()
-        new_memory = data.get("content", [{}])[0].get("text", "").strip()
-        if new_memory:
-            db.update_public_user_memory(agent_name, user_email, new_memory)
-            logger.info(f"[MemSummarize] Updated memory for {user_email} on {agent_name} ({len(new_memory)} chars)")
-
-    except Exception as e:
-        logger.error(f"[MemSummarize] Failed to summarize memory for {user_email} on {agent_name}: {e}")
 
 
 @router.get("/executions/{token}/{execution_id}/stream")

--- a/src/backend/routers/public_memory.py
+++ b/src/backend/routers/public_memory.py
@@ -82,12 +82,15 @@ async def write_user_memory(
             detail="No verified user email associated with this execution.",
         )
 
-    # Upsert: create the row if it doesn't exist, then update the blob.
-    db.get_or_create_public_user_memory(agent_name, user_email)
-    db.update_public_user_memory(agent_name, user_email, body.memory_text)
+    # #895: write only the agent_notes section so the background
+    # conversation summarizer can't clobber deliberate agent writes (and
+    # vice versa). The row is created on demand inside the helper.
+    db.update_public_user_memory_agent_notes(
+        agent_name, user_email, body.memory_text
+    )
 
     logger.info(
-        f"[UserMemory] Updated memory for {user_email} on {agent_name} "
+        f"[UserMemory] Updated agent_notes for {user_email} on {agent_name} "
         f"({len(body.memory_text)} chars, execution={body.execution_id})"
     )
     return {"success": True, "agent_name": agent_name, "user_email": user_email}

--- a/src/backend/services/platform_prompt_service.py
+++ b/src/backend/services/platform_prompt_service.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import List, Optional
 
+import httpx
+
 from database import db
 
 logger = logging.getLogger(__name__)
@@ -139,14 +141,137 @@ The `execution_id` is in the **Execution Context** block below. The platform sto
 - Only available during user-facing sessions (public link, Slack, Telegram, WhatsApp). The tool returns an error if called from a scheduled task or agent-to-agent call."""
 
 
-def format_user_memory_block(memory_text: str) -> str:
-    """
-    Format a user memory blob into a system prompt block for injection.
+def format_user_memory_block(memory_record: dict) -> Optional[str]:
+    """Format a user-memory record into a system-prompt block for injection.
 
-    This block is passed as system_prompt to execute_task() and gets layered
-    on top of the platform instructions via --append-system-prompt.
+    ``memory_record`` is the dict returned by
+    :py:meth:`Database.get_or_create_public_user_memory` — it carries two
+    independently-written sections (``agent_notes`` from the
+    write_user_memory MCP tool, and ``conversation_summary`` from the
+    background summarizer; see #895).
+
+    Both sections are rendered when present; empty sections are omitted.
+    Returns ``None`` when both sections are empty so callers can skip the
+    ``--append-system-prompt`` injection entirely.
     """
-    return f"## What you know about this user\n\n{memory_text.strip()}\n\n---"
+    if not isinstance(memory_record, dict):
+        return None
+    agent_notes = (memory_record.get("agent_notes") or "").strip()
+    summary = (memory_record.get("conversation_summary") or "").strip()
+    if not agent_notes and not summary:
+        return None
+
+    lines = ["## What you know about this user", ""]
+    if agent_notes:
+        lines.extend(["### Agent notes", "", agent_notes, ""])
+    if summary:
+        lines.extend(["### Conversation summary", "", summary, ""])
+    lines.append("---")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Background user-memory summarization (#895)
+# ---------------------------------------------------------------------------
+
+_SUMMARIZATION_MODEL = "claude-haiku-4-5-20251001"
+
+_SUMMARIZATION_PROMPT = """\
+You are a memory system. Given this conversation, extract a concise bullet list of facts \
+about the user that would be useful to remember for future conversations.
+Be specific: name, preferences, goals, context. Max 300 words.
+
+Existing memory:
+{existing_memory}
+
+New conversation:
+{conversation}
+
+Output the updated memory text only (bullet points, no headers)."""
+
+
+async def summarize_user_memory_background(
+    agent_name: str, user_email: str, session_id: str
+) -> None:
+    """Summarize recent conversation and update the ``conversation_summary`` section.
+
+    Fire-and-forget — failures are logged but never surfaced to the user.
+    Touches only ``conversation_summary`` so the deliberate agent_notes
+    section (written by ``write_user_memory``) is never re-summarized away
+    (#895).
+
+    Shared by the web public-chat path and the channel-adapter path so both
+    surfaces have the same persistent-memory behavior.
+    """
+    # Local imports to avoid an import cycle at module load:
+    # platform_prompt_service is imported by routers that the settings
+    # service may transitively pull in.
+    from services.settings_service import get_anthropic_api_key
+
+    try:
+        api_key = get_anthropic_api_key()
+        if not api_key:
+            logger.warning(
+                "[MemSummarize] No ANTHROPIC_API_KEY configured, skipping summarization"
+            )
+            return
+
+        memory_record = db.get_or_create_public_user_memory(agent_name, user_email)
+        existing_summary = memory_record.get("conversation_summary", "") or ""
+
+        messages = db.get_recent_public_chat_messages(session_id, limit=20)
+        if not messages:
+            return
+
+        conversation_lines = []
+        for msg in messages:
+            role_label = "User" if msg.role == "user" else "Assistant"
+            conversation_lines.append(f"{role_label}: {msg.content}")
+        conversation_text = "\n".join(conversation_lines)
+
+        prompt = _SUMMARIZATION_PROMPT.format(
+            existing_memory=existing_summary or "(none yet)",
+            conversation=conversation_text,
+        )
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": _SUMMARIZATION_MODEL,
+                    "max_tokens": 512,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+            )
+
+        if response.status_code != 200:
+            logger.error(
+                f"[MemSummarize] Anthropic API error {response.status_code}: "
+                f"{response.text[:200]}"
+            )
+            return
+
+        data = response.json()
+        new_summary = (data.get("content", [{}])[0].get("text", "") or "").strip()
+        if new_summary:
+            db.update_public_user_memory_conversation_summary(
+                agent_name, user_email, new_summary
+            )
+            logger.info(
+                f"[MemSummarize] Updated conversation_summary for {user_email} "
+                f"on {agent_name} ({len(new_summary)} chars)"
+            )
+
+    except Exception as e:  # noqa: BLE001 — fire-and-forget background task
+        logger.error(
+            f"[MemSummarize] Failed to summarize memory for {user_email} "
+            f"on {agent_name}: {e}"
+        )
 
 
 def get_platform_system_prompt() -> str:

--- a/tests/test_public_user_memory.py
+++ b/tests/test_public_user_memory.py
@@ -5,10 +5,23 @@ Memory is scoped to (agent_name, user_email), persists cross-session,
 and is injected into the system prompt for email-verified sessions.
 Background summarization via claude-haiku fires every 5 messages.
 
+#895 split storage: memory_text is a JSON blob with two named sections —
+``agent_notes`` (written by the write_user_memory MCP tool) and
+``conversation_summary`` (written by the background summarizer). Each
+writer touches only its own section. The block injected into the system
+prompt renders both sections when present.
+
+#895 channel injection: the channel adapter path (Slack/Telegram/WhatsApp)
+mirrors the web path — memory is fetched, formatted, and passed as
+``system_prompt`` to ``execute_task``, gated on ``verified_email and not
+is_group``. Group mode is excluded to prevent PII leak (the unlocker's
+memory would be injected into replies addressed to other group members).
+
 Run with: pytest tests/test_public_user_memory.py -v
-Feature: Issue #147
+Feature: Issue #147, #895
 """
 
+import json
 import os
 import pytest
 import sqlite3
@@ -370,43 +383,281 @@ class TestMemoryDatabaseOperations:
 
 
 # ============================================================================
-# Platform Prompt Service — format_user_memory_block
+# #895 split storage — parser/encoder behavior
 # ============================================================================
 
-def _format_user_memory_block(memory_text: str) -> str:
-    """Local copy of format_user_memory_block for test verification.
+def _parse_memory_blob(memory_text):
+    """Inline mirror of db.public_links._parse_memory_blob (#895).
 
-    Mirrors src/backend/services/platform_prompt_service.py exactly.
-    Kept inline to avoid the full backend import chain in the test env.
+    Mirrors the production implementation to keep these tests independent
+    of the backend import chain in the test environment.
     """
-    return f"## What you know about this user\n\n{memory_text.strip()}\n\n---"
+    if not memory_text:
+        return {"agent_notes": "", "conversation_summary": ""}
+    try:
+        data = json.loads(memory_text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {"agent_notes": "", "conversation_summary": memory_text}
+    if not isinstance(data, dict):
+        return {"agent_notes": "", "conversation_summary": memory_text}
+    return {
+        "agent_notes": str(data.get("agent_notes") or ""),
+        "conversation_summary": str(data.get("conversation_summary") or ""),
+    }
+
+
+def _encode_memory_blob(agent_notes, conversation_summary):
+    return json.dumps(
+        {
+            "agent_notes": agent_notes or "",
+            "conversation_summary": conversation_summary or "",
+        },
+        ensure_ascii=False,
+    )
+
+
+class TestParseMemoryBlob:
+    """The parser must round-trip JSON, gracefully handle legacy plaintext,
+    and never crash on malformed input."""
+
+    @pytest.mark.smoke
+    def test_none_returns_empty_sections(self):
+        assert _parse_memory_blob(None) == {
+            "agent_notes": "", "conversation_summary": ""
+        }
+
+    @pytest.mark.smoke
+    def test_empty_string_returns_empty_sections(self):
+        assert _parse_memory_blob("") == {
+            "agent_notes": "", "conversation_summary": ""
+        }
+
+    @pytest.mark.smoke
+    def test_legacy_plaintext_becomes_conversation_summary(self):
+        # Rows written before #895 are raw text from the old summarizer.
+        # Surface them as conversation_summary so existing memory keeps
+        # working transparently after deploy.
+        blob = "- User likes pizza\n- Lives in PST"
+        parsed = _parse_memory_blob(blob)
+        assert parsed == {
+            "agent_notes": "",
+            "conversation_summary": blob,
+        }
+
+    @pytest.mark.smoke
+    def test_json_with_both_keys_round_trips(self):
+        encoded = _encode_memory_blob("Name: Alice", "Prefers Python")
+        parsed = _parse_memory_blob(encoded)
+        assert parsed == {
+            "agent_notes": "Name: Alice",
+            "conversation_summary": "Prefers Python",
+        }
+
+    @pytest.mark.smoke
+    def test_json_missing_key_defaults_empty(self):
+        parsed = _parse_memory_blob(json.dumps({"agent_notes": "X"}))
+        assert parsed == {"agent_notes": "X", "conversation_summary": ""}
+
+    @pytest.mark.smoke
+    def test_json_null_values_become_empty_strings(self):
+        parsed = _parse_memory_blob(
+            json.dumps({"agent_notes": None, "conversation_summary": "Y"})
+        )
+        assert parsed == {"agent_notes": "", "conversation_summary": "Y"}
+
+    @pytest.mark.smoke
+    def test_non_dict_json_treated_as_plaintext(self):
+        # JSON array / scalar — fall through to plaintext path to avoid
+        # accidentally interpreting structured data as memory.
+        parsed = _parse_memory_blob("[1, 2, 3]")
+        assert parsed == {
+            "agent_notes": "",
+            "conversation_summary": "[1, 2, 3]",
+        }
+
+
+# ============================================================================
+# #895 split storage — DB write helpers touch only their own section
+# ============================================================================
+
+class TestSplitStorageWrites:
+    """The agent_notes writer must never modify conversation_summary
+    (and vice versa). Verified at the JSON-storage layer so it does not
+    depend on a running backend."""
+
+    @pytest.mark.smoke
+    def test_agent_notes_writer_preserves_summary(self):
+        # Existing row already has a summary (written by the background
+        # summarizer). The agent-deliberate writer arrives next.
+        existing = _encode_memory_blob("", "Summary from haiku")
+        current = _parse_memory_blob(existing)
+        current["agent_notes"] = "Name: Alice"
+        new_blob = _encode_memory_blob(**current)
+
+        re_parsed = _parse_memory_blob(new_blob)
+        assert re_parsed == {
+            "agent_notes": "Name: Alice",
+            "conversation_summary": "Summary from haiku",
+        }
+
+    @pytest.mark.smoke
+    def test_summary_writer_preserves_agent_notes(self):
+        # Agent has already written deliberate notes. Summarizer runs
+        # next; it must not clobber the agent's content.
+        existing = _encode_memory_blob("Name: Alice", "")
+        current = _parse_memory_blob(existing)
+        current["conversation_summary"] = "Refined by summarizer"
+        new_blob = _encode_memory_blob(**current)
+
+        re_parsed = _parse_memory_blob(new_blob)
+        assert re_parsed == {
+            "agent_notes": "Name: Alice",
+            "conversation_summary": "Refined by summarizer",
+        }
+
+    @pytest.mark.smoke
+    def test_legacy_plaintext_upgrades_to_summary_then_split_writes_work(self):
+        # First read of a legacy row surfaces as conversation_summary.
+        # When the write_user_memory tool fires after deploy, agent_notes
+        # gets populated alongside the legacy text without losing it.
+        legacy = "- User likes pizza"
+        current = _parse_memory_blob(legacy)
+        assert current["conversation_summary"] == legacy
+
+        current["agent_notes"] = "Name: Alice"
+        upgraded = _encode_memory_blob(**current)
+
+        re_parsed = _parse_memory_blob(upgraded)
+        assert re_parsed["agent_notes"] == "Name: Alice"
+        assert re_parsed["conversation_summary"] == legacy
+
+
+# ============================================================================
+# Platform Prompt Service — format_user_memory_block (#895 multi-section)
+# ============================================================================
+
+def _format_user_memory_block(memory_record):
+    """Inline mirror of services.platform_prompt_service.format_user_memory_block.
+
+    Kept in sync with the production implementation; isolated here so the
+    tests don't pull the full backend import chain.
+    """
+    if not isinstance(memory_record, dict):
+        return None
+    agent_notes = (memory_record.get("agent_notes") or "").strip()
+    summary = (memory_record.get("conversation_summary") or "").strip()
+    if not agent_notes and not summary:
+        return None
+    lines = ["## What you know about this user", ""]
+    if agent_notes:
+        lines.extend(["### Agent notes", "", agent_notes, ""])
+    if summary:
+        lines.extend(["### Conversation summary", "", summary, ""])
+    lines.append("---")
+    return "\n".join(lines)
 
 
 class TestFormatUserMemoryBlock:
-    """Tests for the format_user_memory_block output contract.
+    """Output contract of the formatter — see #895 'Read path' section."""
 
-    Uses the inline mirror above to verify the contract independently
-    of backend import chain issues in the test environment.
-    """
+    @pytest.mark.smoke
+    def test_returns_none_for_empty_record(self):
+        assert _format_user_memory_block(None) is None
+        assert _format_user_memory_block({}) is None
+        assert _format_user_memory_block(
+            {"agent_notes": "", "conversation_summary": ""}
+        ) is None
+        # Whitespace-only sections also yield None so callers can skip
+        # the system-prompt injection entirely.
+        assert _format_user_memory_block(
+            {"agent_notes": "  ", "conversation_summary": "\n\n"}
+        ) is None
 
     @pytest.mark.smoke
     def test_block_contains_header(self):
-        block = _format_user_memory_block("- Name: Alice")
+        block = _format_user_memory_block(
+            {"agent_notes": "- Name: Alice", "conversation_summary": ""}
+        )
         assert "## What you know about this user" in block
 
     @pytest.mark.smoke
-    def test_block_contains_memory_text(self):
-        block = _format_user_memory_block("- Name: Alice\n- Prefers Python")
+    def test_agent_notes_only_omits_summary_section(self):
+        block = _format_user_memory_block(
+            {"agent_notes": "- Name: Alice", "conversation_summary": ""}
+        )
+        assert "### Agent notes" in block
         assert "- Name: Alice" in block
-        assert "- Prefers Python" in block
+        assert "### Conversation summary" not in block
 
     @pytest.mark.smoke
-    def test_block_trims_surrounding_whitespace(self):
-        block = _format_user_memory_block("   - Likes coffee   ")
-        content = block.split("## What you know about this user")[1].split("---")[0]
-        assert content.strip() == "- Likes coffee"
+    def test_summary_only_omits_agent_notes_section(self):
+        block = _format_user_memory_block(
+            {"agent_notes": "", "conversation_summary": "Likes coffee"}
+        )
+        assert "### Conversation summary" in block
+        assert "Likes coffee" in block
+        assert "### Agent notes" not in block
+
+    @pytest.mark.smoke
+    def test_both_sections_render_with_agent_notes_first(self):
+        # Agent-deliberate notes are higher signal than the auto-summary,
+        # so they appear first in the system prompt.
+        block = _format_user_memory_block(
+            {
+                "agent_notes": "Name: Alice",
+                "conversation_summary": "Prefers Python",
+            }
+        )
+        assert "### Agent notes" in block
+        assert "### Conversation summary" in block
+        assert block.index("### Agent notes") < block.index("### Conversation summary")
 
     @pytest.mark.smoke
     def test_block_ends_with_separator(self):
-        block = _format_user_memory_block("- Fact")
+        block = _format_user_memory_block(
+            {"agent_notes": "X", "conversation_summary": ""}
+        )
         assert block.strip().endswith("---")
+
+
+# ============================================================================
+# #895 Channel injection — gating logic
+# ============================================================================
+
+def _should_inject_memory(verified_email, is_group):
+    """Inline mirror of the gating check used in
+    ``adapters.message_router._handle_message_inner``.
+
+    Memory is injected only when there is a verified email AND the
+    session is not a group chat. Group mode is excluded because
+    ``verified_email`` there is the unlocker's email, set once per
+    group — injecting their memory into replies addressed to other
+    group members would leak PII across users.
+    """
+    return bool(verified_email) and not is_group
+
+
+class TestChannelInjectionGating:
+    """The new channel-injection guard must allow exactly the DM-with-
+    verified-email path. Everything else (anonymous, group, observe
+    mode) must skip injection."""
+
+    @pytest.mark.smoke
+    def test_dm_with_verified_email_injects(self):
+        assert _should_inject_memory("alice@example.com", is_group=False) is True
+
+    @pytest.mark.smoke
+    def test_group_with_verified_unlocker_skips(self):
+        # The verified email here belongs to the user who unlocked the
+        # group, not the current speaker — must not inject.
+        assert _should_inject_memory("alice@example.com", is_group=True) is False
+
+    @pytest.mark.smoke
+    def test_anonymous_dm_skips(self):
+        assert _should_inject_memory(None, is_group=False) is False
+        assert _should_inject_memory("", is_group=False) is False
+
+    @pytest.mark.smoke
+    def test_anonymous_group_skips(self):
+        assert _should_inject_memory(None, is_group=True) is False
+        assert _should_inject_memory("", is_group=True) is False


### PR DESCRIPTION
## Summary

Two MEM-001 bugs introduced by stacking #888 (`write_user_memory` MCP tool) on top of the original auto-summarization design:

1. **Storage conflict** — `write_user_memory` and the every-5-message `_summarize_user_memory` both `UPDATE public_user_memory SET memory_text = ?`, so deliberate agent writes got re-summarized away or dropped on the next 5-message cycle.
2. **Channel injection gap** — Slack/Telegram/WhatsApp sessions never called `format_user_memory_block` or passed `system_prompt=` to `execute_task`, so the memory block was absent on three channels (a stated goal of MEM-001 + #311).

## Fix

- **Split storage**: `public_user_memory.memory_text` is now a JSON blob `{agent_notes, conversation_summary}` inside the existing TEXT column. No schema migration. `write_user_memory` updates only `agent_notes`; the summarizer updates only `conversation_summary`. Legacy plaintext rows surface as `conversation_summary` transparently.
- **Channel injection**: `adapters/message_router._handle_message_inner` now mirrors the web path — fetches memory, formats the block, passes as `system_prompt=`, increments count, fires the summarizer every 5 messages. Gated on `verified_email and not is_group`. Group mode is excluded because `verified_email` there is the *unlocker's* email, not the speaker's — injecting their memory into group replies addressed to other members would leak PII across users.
- **Summarizer extraction**: `summarize_user_memory_background` moved from `routers/public.py` to `services/platform_prompt_service.py` so web and channel paths share it. Reads only `conversation_summary` so the summarizer can never see (or re-summarize) deliberate agent_notes.
- **Formatter rewrite**: `format_user_memory_block(dict)` accepts the parsed dict and emits both sections (agent notes first; summary second). Returns `None` when both are empty so callers skip the `--append-system-prompt` injection.

## Changes

- `src/backend/db/public_links.py` — `_parse_memory_blob`, `_encode_memory_blob`, `_update_user_memory_section` (private), `update_user_memory_agent_notes`, `update_user_memory_conversation_summary`. `get_or_create_user_memory` now returns the parsed dict.
- `src/backend/database.py` — facade methods for the new section writers.
- `src/backend/services/platform_prompt_service.py` — `format_user_memory_block(dict)` multi-section, `summarize_user_memory_background` extracted.
- `src/backend/routers/public.py` — updated to pass dict to formatter, removed inlined `_summarize_user_memory`.
- `src/backend/routers/public_memory.py` — calls `update_public_user_memory_agent_notes`.
- `src/backend/adapters/message_router.py` — memory injection + counter + summarizer trigger on the channel path.
- `tests/test_public_user_memory.py` — 21 new tests for parser, split storage, formatter, channel gating.
- Docs synced (`architecture.md`, `feature-flows/public-agent-links.md`, `feature-flows/write-user-memory.md`).

## Test Plan

- [x] Unit tests pass: `pytest tests/test_public_user_memory.py -v` → 21 passed, 9 skipped (integration smoke tests that need backend bind-mount path)
- [x] All modified backend files syntax-check (`python3 -m py_compile`)
- [x] Backend `--reload` picks up changes; `curl http://localhost:8000/health` returns 200
- [ ] Manual verification on a verified Slack/Telegram/WhatsApp DM (recommend a follow-up smoke after deploy)
- [ ] Verify no group-mode injection: send a message in a group-verified channel and confirm the memory block is absent

## Known Limitations (deferred per issue)

- Section writes use Python-side read-modify-write inside a single connection. Two concurrent writers within ~10ms can still race. Pre-fix code had a *deterministic* clobber every 5 messages; this fix narrows it to a small probabilistic window. Atomic SQLite JSON1 UPSERT is a follow-up.
- Summarizer cost ceiling / per-(agent, user) cooldown — pre-existing.
- Memory-text safety filter for the rendered system-prompt block — pre-existing prompt-injection surface.

Fixes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)