### PR TITLE
ci(security): CodeQL + Dependabot Docker ecosystem (#850, Option A)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,23 @@ updates:
         update-types:
           - patch
           - minor
+
+  # Docker base images (#850): flag CVEs in FROM lines — the Python/Node
+  # agent base, backend, frontend (incl. Dockerfile.prod), nginx, scheduler.
+  # Dependabot scans every Dockerfile under each listed directory. Grouped
+  # so a single review covers a base-image bump across services.
+  - package-ecosystem: docker
+    directories:
+      - /docker/base-image
+      - /docker/backend
+      - /docker/frontend
+      - /docker/scheduler
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# CodeQL static analysis (#850, Option A).
+# Free for public repos. Covers Python (backend, scheduler, agent base
+# server) and JS/TS (Vue frontend + TypeScript MCP server). No Go module
+# in the repo, so no go target. Findings land in the repo Security tab
+# (Code scanning alerts) — Dependabot/CodeQL surface there; the daily
+# issue-creating scanner (Option B) is a separate follow-up.
+name: CodeQL
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  schedule:
+    # Weekly, Monday 03:27 UTC. Off-the-hour per GitHub scheduling guidance.
+    - cron: "27 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          language: ${{ matrix.language }}
+          # Interpreted languages — no compilation step needed.
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Option A (GitHub-native, lowest-friction) of #850 — automated security vulnerability monitoring.

- **`.github/workflows/codeql.yml`** (new): CodeQL static analysis, languages `python` + `javascript-typescript`, on push + PR to `dev`/`main` and a weekly Monday cron. No Go module in the repo → no Go target. Free for public repos.
- **`.github/dependabot.yml`**: added the `docker` ecosystem covering every Dockerfile under `docker/{base-image,backend,frontend,scheduler}` (incl. `frontend/Dockerfile.prod`), grouped, weekly. Closes the base-image CVE gap (Python/Node/nginx `FROM` lines) — npm/pip/github-actions were already covered.
- Created repo labels `dependencies` + `docker` so Dependabot PRs are filterable (only `frontend` existed; this also makes the pre-existing entries' labels resolve).

## ⚠️ Manual step required (repo admin)

These are repo **Settings** toggles, not committable files. They return 404 via API with `maintain` permission — a repo **admin** must enable them once in **Settings → Code security and analysis**:

- [ ] **Dependabot alerts** — `PUT /repos/abilityai/trinity/vulnerability-alerts`
- [ ] **Dependabot security updates** (auto security-fix PRs) — `PUT /repos/abilityai/trinity/automated-security-fixes`
- [ ] **Secret scanning** + **Push protection** — Settings → Code security and analysis

`dependabot.yml` controls version-update PR *coverage*; the **alerts** toggle is what turns on CVE-driven security PRs/notifications. Both are needed for full Option A.

## Acceptance criteria status

- [x] Dependabot enabled for all ecosystems (npm ×2, pip, github-actions, **+ docker**) — Go N/A (no `go.mod`)
- [x] CodeQL on push + weekly schedule
- [ ] Daily issue-creating scanner (Option B) — out of scope for Option A; tracked in #850 for a follow-up PR
- [ ] Dependabot alerts / secret scanning — admin manual step above

Option B (Trivy daily scan → deduplicated labeled issues) and Option C (CSO agent) remain for follow-up per the issue's "start with A, graduate" guidance.

Related to #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)