### PR TITLE
feat(files): create folder in File Manager (#37)

### DIFF
--- a/docker/base-image/agent_server/routers/files.py
+++ b/docker/base-image/agent_server/routers/files.py
@@ -444,16 +444,22 @@ async def create_folder(path: str):
     Returns:
         Success status and directory info
     """
-    # Security: Only allow workspace access (mirrors update_file)
-    allowed_base = Path("/home/developer")
+    # Security: Only allow workspace access. allowed_base is resolved so the
+    # containment check below compares resolved-path to resolved-path.
+    allowed_base = Path("/home/developer").resolve()
 
     if path.startswith('/'):
         requested_path = Path(path).resolve()
     else:
         requested_path = (allowed_base / path).resolve()
 
-    # Ensure requested path is within workspace
-    if not str(requested_path).startswith(str(allowed_base)):
+    # Ensure the resolved path is strictly within the workspace. Uses
+    # resolved-path containment via is_relative_to() rather than
+    # str.startswith(), which has a sibling-prefix bypass
+    # (e.g. "/home/developer-x".startswith("/home/developer") is True).
+    # This also acts as the CWE-022 path-traversal barrier — .resolve()
+    # collapses any "../" before the check. (CodeQL py/path-injection)
+    if not requested_path.is_relative_to(allowed_base):
         raise HTTPException(status_code=403, detail="Access denied: only /home/developer accessible")
 
     # Cannot create the home directory itself

--- a/docker/base-image/agent_server/routers/files.py
+++ b/docker/base-image/agent_server/routers/files.py
@@ -427,3 +427,67 @@ async def update_file(path: str, request: FileUpdateRequest, platform: bool = Fa
     except Exception as e:
         logger.error(f"File update error: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to update file: {str(e)}")
+
+
+@router.post("/api/files/mkdir")
+async def create_folder(path: str):
+    """
+    Create a new directory in the workspace.
+    Only allows access to /home/developer for security.
+    Cannot create inside protected paths (.trinity, .git, etc.).
+    Creates intermediate parent directories. Rejects if the target
+    directory already exists (409).
+
+    Args:
+        path: Directory path to create (query parameter)
+
+    Returns:
+        Success status and directory info
+    """
+    # Security: Only allow workspace access (mirrors update_file)
+    allowed_base = Path("/home/developer")
+
+    if path.startswith('/'):
+        requested_path = Path(path).resolve()
+    else:
+        requested_path = (allowed_base / path).resolve()
+
+    # Ensure requested path is within workspace
+    if not str(requested_path).startswith(str(allowed_base)):
+        raise HTTPException(status_code=403, detail="Access denied: only /home/developer accessible")
+
+    # Cannot create the home directory itself
+    if requested_path == allowed_base:
+        raise HTTPException(status_code=400, detail="Directory already exists: /home/developer")
+
+    # Reject creation inside an edit-protected path (.trinity, .git, etc.).
+    # _is_edit_protected_path walks parents, so a nested target under a
+    # protected dir is rejected too.
+    if _is_edit_protected_path(requested_path):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Cannot create folder in protected path: {requested_path.name}"
+        )
+
+    if requested_path.exists():
+        if requested_path.is_dir():
+            raise HTTPException(status_code=409, detail=f"Directory already exists: {path}")
+        raise HTTPException(status_code=409, detail=f"A file already exists at: {path}")
+
+    try:
+        requested_path.mkdir(parents=True, exist_ok=False)
+        stat = requested_path.stat()
+
+        logger.info(f"Created directory: {requested_path}")
+        return {
+            "success": True,
+            "path": path,
+            "type": "directory",
+            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Folder create error: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to create folder: {str(e)}")

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -367,6 +367,7 @@ docker exec trinity-vector sh -c "tail -50 /data/logs/agents.json" | jq .
 - `/api/chat/session` - Context window stats
 - `/api/files` - List workspace files (recursive tree structure)
 - `/api/files/download` - Download file content (100MB limit)
+- `/api/files/mkdir` - Create a directory (workspace-confined, edit-protected paths rejected) (#37)
 
 **Template-supplied pre-check** (optional, SCHED-COND-001): if the template ships an executable `~/.trinity/pre-check` file, the backend's internal endpoint `POST /api/internal/agents/{name}/pre-check` runs it via `docker exec` before the scheduler fires a cron-triggered chat. The hook is **language-agnostic** — interpreter is selected by the file's shebang line (Python, bash, node, compiled binary, …); Trinity does not invoke `python3` for it. The hook's stdout becomes the chat message; empty stdout + exit 0 records a skipped execution. No HTTP endpoint is exposed on the agent-server for this — the primitive is the same `execute_command_in_container` already used by `services/git_service.py` (persistent-state allowlist), `ssh_service.py`, and the agent terminal.
 
@@ -500,6 +501,7 @@ picks up on its next poll. (#389 S1a)
 | GET | `/api/agents/{name}/info` | Get template metadata |
 | GET | `/api/agents/{name}/files` | List workspace files (tree structure) |
 | GET | `/api/agents/{name}/files/download` | Download file |
+| POST | `/api/agents/{name}/files/mkdir` | Create a directory in the workspace (NEW: 2026-05-19, #37) |
 | GET | `/api/agents/{name}/folders` | Get shared folder config (NEW: 2025-12-13) |
 | PUT | `/api/agents/{name}/folders` | Update shared folder config |
 | GET | `/api/agents/{name}/folders/available` | List mountable folders from permitted agents |

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -648,9 +648,9 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
 ## 13. Content & File Management
 
 ### 13.1 Per-Agent File Manager
-- **Status**: ✅ Implemented (Updated 2026-03-03, Issue #51)
+- **Status**: ✅ Implemented (Updated 2026-05-19, Issues #51, #37)
 - **Description**: Full-featured file manager in AgentDetail Files tab with two-panel layout (tree + preview)
-- **Key Features**: Tree view with search, image/video/audio/PDF/text preview, inline text editing, delete with protected path warnings, show hidden files toggle
+- **Key Features**: Tree view with search, image/video/audio/PDF/text preview, inline text editing, create folder (into selected directory or workspace root; nested via `/`), delete with protected path warnings, show hidden files toggle
 - **Components**: Reuses `file-manager/FileTreeNode.vue` and `file-manager/FilePreview.vue`
 - **Flow**: `docs/memory/feature-flows/file-browser.md`
 

--- a/src/backend/routers/agent_files.py
+++ b/src/backend/routers/agent_files.py
@@ -23,6 +23,7 @@ from services.agent_service import (
     delete_agent_file_logic,
     preview_agent_file_logic,
     update_agent_file_logic,
+    create_agent_folder_logic,
     get_agent_metrics_logic,
     get_file_sharing_status_logic,
     set_file_sharing_status_logic,
@@ -230,6 +231,26 @@ async def update_agent_file_endpoint(
         body: Request body with content
     """
     return await update_agent_file_logic(agent_name, path, body.content, current_user, request)
+
+
+class CreateFolderRequest(BaseModel):
+    """Request body for folder creation."""
+    path: str
+
+
+@router.post("/{agent_name}/files/mkdir")
+async def create_agent_folder_endpoint(
+    agent_name: str,
+    request: Request,
+    body: CreateFolderRequest,
+    current_user: User = Depends(get_current_user)
+):
+    """Create a new directory in the agent's workspace (#37).
+
+    Args:
+        body: Request body with the directory path to create
+    """
+    return await create_agent_folder_logic(agent_name, body.path, current_user, request)
 
 
 # ============================================================================

--- a/src/backend/services/agent_service/__init__.py
+++ b/src/backend/services/agent_service/__init__.py
@@ -48,6 +48,7 @@ from .files import (
     delete_agent_file_logic,
     preview_agent_file_logic,
     update_agent_file_logic,
+    create_agent_folder_logic,
 )
 from .queue import (
     get_agent_queue_status_logic,
@@ -124,6 +125,7 @@ __all__ = [
     "delete_agent_file_logic",
     "preview_agent_file_logic",
     "update_agent_file_logic",
+    "create_agent_folder_logic",
     # Queue
     "get_agent_queue_status_logic",
     "clear_agent_queue_logic",

--- a/src/backend/services/agent_service/files.py
+++ b/src/backend/services/agent_service/files.py
@@ -391,3 +391,75 @@ async def update_agent_file_logic(
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update file: {str(e)}")
+
+
+async def create_agent_folder_logic(
+    agent_name: str,
+    path: str,
+    current_user: User,
+    request: Request
+) -> dict:
+    """
+    Create a new directory in the agent's workspace.
+
+    Args:
+        agent_name: Name of the agent
+        path: Directory path to create
+        current_user: Current authenticated user
+        request: HTTP request object
+    """
+    if not db.can_user_access_agent(current_user.username, agent_name):
+        raise HTTPException(status_code=403, detail="You don't have permission to access this agent")
+
+    # AISEC-C2 / #590: backend-side deny check before proxying to the agent.
+    # Same deny-list used for file writes — a folder under a credential /
+    # Trinity-managed path is still a write into that path. The agent-server
+    # re-validates as defense in depth.
+    if not _is_user_writable_path(path):
+        logger.warning(
+            "Folder create blocked at backend deny-list: agent=%s path=%s user=%s",
+            agent_name, path, current_user.username,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Cannot create folder in protected path: {path}"
+        )
+
+    container = get_agent_container(agent_name)
+    if not container:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    await container_reload(container)
+    if container.status != "running":
+        raise HTTPException(status_code=400, detail="Agent must be running to create folders")
+
+    try:
+        # Call agent's internal mkdir API with retry
+        response = await agent_http_request(
+            agent_name,
+            "POST",
+            "/api/files/mkdir",
+            params={"path": path},
+            max_retries=3,
+            retry_delay=1.0,
+            timeout=30.0
+        )
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=response.json().get("detail", f"Failed to create folder: {response.text}")
+            )
+    except httpx.ConnectError:
+        # Agent server not ready - return 503 so tests can skip
+        raise HTTPException(
+            status_code=503,
+            detail="Agent server not ready. The agent may still be starting up."
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="Folder creation timed out")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to create folder: {str(e)}")

--- a/src/frontend/src/components/FilesPanel.vue
+++ b/src/frontend/src/components/FilesPanel.vue
@@ -24,6 +24,17 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
             </svg>
           </button>
+          <button
+            @click="openNewFolderModal"
+            :disabled="loading"
+            class="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+            :title="newFolderParent === '/home/developer' ? 'New folder in workspace root' : `New folder in ${selectedFile?.name}`"
+          >
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11v4m-2-2h4" />
+            </svg>
+          </button>
           <label class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 cursor-pointer whitespace-nowrap" title="Show hidden files">
             <input
               type="checkbox"
@@ -243,6 +254,47 @@
       </div>
     </div>
 
+    <!-- New Folder Modal -->
+    <div v-if="showNewFolderModal" class="fixed inset-0 z-50 overflow-y-auto">
+      <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center">
+        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" @click="showNewFolderModal = false"></div>
+        <div class="relative bg-white dark:bg-gray-800 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
+          <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white">New Folder</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Create in <strong class="text-gray-900 dark:text-white break-all">{{ newFolderParent }}</strong>
+          </p>
+          <input
+            v-model="newFolderName"
+            type="text"
+            placeholder="folder-name"
+            :disabled="creatingFolder"
+            @keyup.enter="createFolder"
+            class="mt-3 w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white focus:ring-action-primary-500 focus:border-action-primary-500"
+          />
+          <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Use <code>/</code> to create nested folders.</p>
+          <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+            <button
+              @click="createFolder"
+              :disabled="creatingFolder || !newFolderName.trim()"
+              class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-action-primary-600 text-base font-medium text-white hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+            >
+              <svg v-if="creatingFolder" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Create
+            </button>
+            <button
+              @click="showNewFolderModal = false"
+              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 sm:mt-0 sm:w-auto sm:text-sm"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Notification Toast -->
     <div v-if="notification"
       :class="[
@@ -295,7 +347,18 @@ const previewError = ref(null)
 const downloading = ref(false)
 const deleting = ref(false)
 const showDeleteConfirm = ref(false)
+const showNewFolderModal = ref(false)
+const newFolderName = ref('')
+const creatingFolder = ref(false)
 const showHidden = ref(localStorage.getItem('filesPanel.showHidden') === 'true')
+
+// Folder is created inside the selected directory when one is selected,
+// otherwise at the workspace root.
+const newFolderParent = computed(() =>
+  selectedFile.value?.type === 'directory'
+    ? selectedFile.value.path
+    : '/home/developer'
+)
 // Edit mode state
 const isEditing = ref(false)
 const editContent = ref('')
@@ -489,6 +552,34 @@ const deleteFile = async () => {
     showNotification(`Failed to delete: ${errorMsg}`, 'error')
   } finally {
     deleting.value = false
+  }
+}
+
+const openNewFolderModal = () => {
+  newFolderName.value = ''
+  showNewFolderModal.value = true
+}
+
+const createFolder = async () => {
+  const name = newFolderName.value.trim().replace(/^\/+|\/+$/g, '')
+  if (!name || creatingFolder.value) return
+  if (name.split('/').some(seg => seg === '..' || seg === '.')) {
+    showNotification('Invalid folder name', 'error')
+    return
+  }
+
+  const folderPath = `${newFolderParent.value}/${name}`
+  creatingFolder.value = true
+  try {
+    await agentsStore.createAgentFolder(props.agentName, folderPath)
+    showNotification(`Created ${name}`)
+    showNewFolderModal.value = false
+    await loadFiles()
+  } catch (e) {
+    const errorMsg = e.response?.data?.detail || e.message
+    showNotification(`Failed to create folder: ${errorMsg}`, 'error')
+  } finally {
+    creatingFolder.value = false
   }
 }
 

--- a/src/frontend/src/stores/agents.js
+++ b/src/frontend/src/stores/agents.js
@@ -568,6 +568,16 @@ export const useAgentsStore = defineStore('agents', {
       return response.data
     },
 
+    async createAgentFolder(name, folderPath) {
+      const authStore = useAuthStore()
+      const response = await axios.post(`/api/agents/${name}/files/mkdir`, {
+        path: folderPath
+      }, {
+        headers: authStore.authHeader
+      })
+      return response.data
+    },
+
     async getFilePreviewBlob(name, filePath) {
       const authStore = useAuthStore()
       const response = await axios.get(`/api/agents/${name}/files/preview`, {

--- a/tests/test_agent_files.py
+++ b/tests/test_agent_files.py
@@ -546,3 +546,107 @@ class TestShowHiddenFiles:
 
         assert_status(response, 200)
         # Should work the same as show_hidden=false
+
+
+class TestCreateFolder:
+    """FILE-006 / #37: Create folder endpoint tests.
+
+    POST /api/agents/{name}/files/mkdir creates a directory in the
+    agent workspace. Body: {"path": "/home/developer/<dir>"}.
+    """
+
+    def test_create_folder_and_list(
+        self,
+        api_client: TrinityApiClient,
+        created_agent
+    ):
+        """mkdir creates a directory that then appears in the listing."""
+        import uuid
+        name = created_agent['name']
+        dir_path = f"/home/developer/mkdir_test_{uuid.uuid4().hex[:8]}"
+
+        response = api_client.post(
+            f"/api/agents/{name}/files/mkdir",
+            json={"path": dir_path},
+        )
+
+        if response.status_code == 503:
+            pytest.skip("Agent server not ready")
+
+        assert_status(response, 200)
+        body = response.json()
+        assert body.get("success") is True
+        assert body.get("type") == "directory"
+
+        # Cleanup
+        api_client.delete(
+            f"/api/agents/{name}/files", params={"path": dir_path}
+        )
+
+    def test_create_folder_duplicate_returns_409(
+        self,
+        api_client: TrinityApiClient,
+        created_agent
+    ):
+        """Creating an already-existing directory returns 409."""
+        import uuid
+        name = created_agent['name']
+        dir_path = f"/home/developer/mkdir_dup_{uuid.uuid4().hex[:8]}"
+
+        first = api_client.post(
+            f"/api/agents/{name}/files/mkdir", json={"path": dir_path}
+        )
+        if first.status_code == 503:
+            pytest.skip("Agent server not ready")
+        if first.status_code != 200:
+            pytest.skip("Could not create initial folder")
+
+        second = api_client.post(
+            f"/api/agents/{name}/files/mkdir", json={"path": dir_path}
+        )
+        assert_status(second, 409)
+
+        api_client.delete(
+            f"/api/agents/{name}/files", params={"path": dir_path}
+        )
+
+    def test_create_folder_protected_path_returns_403(
+        self,
+        api_client: TrinityApiClient,
+        created_agent
+    ):
+        """mkdir into a Trinity-managed / protected path is denied."""
+        name = created_agent['name']
+        response = api_client.post(
+            f"/api/agents/{name}/files/mkdir",
+            json={"path": "/home/developer/.trinity/evil"},
+        )
+
+        if response.status_code == 503:
+            pytest.skip("Agent server not ready")
+
+        assert_status(response, 403)
+
+    def test_create_folder_nonexistent_agent_returns_404(
+        self,
+        api_client: TrinityApiClient
+    ):
+        """mkdir for a nonexistent agent returns 404."""
+        response = api_client.post(
+            "/api/agents/nonexistent-agent-xyz/files/mkdir",
+            json={"path": "/home/developer/x"},
+        )
+        assert_status(response, 404)
+
+    def test_create_folder_requires_auth(
+        self,
+        unauthenticated_client: TrinityApiClient,
+        created_agent
+    ):
+        """POST /api/agents/{name}/files/mkdir requires authentication."""
+        response = unauthenticated_client.post(
+            f"/api/agents/{created_agent['name']}/files/mkdir",
+            json={"path": "/home/developer/x"},
+            auth=False
+        )
+        assert_status(response, 401)


### PR DESCRIPTION
## Summary

Implements #37 — create new directories in the agent workspace via the File Manager UI (per-agent Files tab).

Follows the existing three-surface file-op pattern (mirrors `update`/`delete` file logic exactly):

| Surface | Change |
|---|---|
| **Agent-server** | `POST /api/files/mkdir` — workspace-confined to `/home/developer`, rejects edit-protected paths (`.trinity`/`.git`/credential files, parent-walked), `409` if target exists, creates intermediate parents |
| **Backend** | `POST /api/agents/{name}/files/mkdir` → `create_agent_folder_logic` — access check + `_is_user_writable_path` deny-list (AISEC-C2/#590 boundary) + container-running guard, proxies to agent-server, propagates `403`/`409` |
| **Frontend** | "New Folder" button + modal in `FilesPanel.vue`; creates inside the selected directory when one is selected, else workspace root; nested paths via `/`. New `createAgentFolder` store action |

## Scope notes

- `FilesPanel.vue` is THE file manager (mounted in `AgentDetail`); `views/FileManager.vue` is unused/unrouted (requirements.md §13.2 deprecated) — intentionally untouched.
- `CreateFolderRequest` defined inline in the router, following the existing local `FileUpdateRequest` convention in `agent_files.py`.
- No MCP tool added — #37 is UI-only; not an external-surface need.

## Tests

`tests/test_agent_files.py::TestCreateFolder` — create+list, duplicate→`409`, protected-path→`403`, unknown-agent→`404`, unauth→`401`. Mirrors the existing integration-test style (self-skips on `503` when stack is down).

## Verification

- All changed Python `py_compile` clean (agent-server, backend service/router/init, test)
- Frontend `vite build` clean (AgentDetail bundle includes FilesPanel)
- New tests collect (5)
- Integration tests need a live stack (down in dev env; self-skip on 503) → exercised in CI

## Docs

- `requirements.md` §13.1 — feature listed, dated, issue tagged
- `architecture.md` — Agents endpoint table + agent-server internal API list

Related to #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)