### PR TITLE
fix(chat-path): classify signal exits before auth fallback (#906)

### DIFF
--- a/docker/base-image/agent_server/services/claude_code.py
+++ b/docker/base-image/agent_server/services/claude_code.py
@@ -33,6 +33,7 @@ from ._runtime_config import (
     _load_guardrails,
 )
 from .error_classifier import (
+    _classify_signal_exit,
     _diagnose_exit_failure,
     _format_rate_limit_error,
     _is_rate_limit_message,
@@ -448,6 +449,18 @@ async def execute_claude_code(prompt: str, stream: bool = False, model: Optional
 
             # Check for errors
             if return_code != 0:
+                # Issue #906: Signal terminations (SIGKILL/SIGTERM/SIGINT — OOM,
+                # timeout, operator cancel) must be classified before the
+                # auth-fallback heuristic in `_diagnose_exit_failure`, which
+                # would otherwise misread "zero tokens processed" as an
+                # expired subscription token. Mirrors the symmetric check
+                # in headless_executor (Issue #516).
+                signal_exit = _classify_signal_exit(return_code, metadata)
+                if signal_exit is not None:
+                    status_code, detail = signal_exit
+                    logger.warning(f"[Chat] {detail}")
+                    raise HTTPException(status_code=status_code, detail=detail)
+
                 error_detail = stderr_output[:500] if stderr_output else ""
                 if not error_detail:
                     error_detail = _diagnose_exit_failure(return_code, metadata)

--- a/tests/unit/test_signal_exit_classification.py
+++ b/tests/unit/test_signal_exit_classification.py
@@ -153,3 +153,54 @@ def test_other_high_exit_codes_are_not_classified_as_signals(return_code):
     Other ≥128 exit codes pass through to normal error handling — apps
     sometimes use ≥128 as application-defined error codes."""
     assert _classify_signal_exit(return_code, ExecutionMetadata()) is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #906: the chat path in claude_code.py was missing the
+# _classify_signal_exit call that was added to headless_executor.py for
+# Issue #516. Both call sites must consult the signal classifier BEFORE
+# falling through to _diagnose_exit_failure — otherwise a SIGKILL at
+# 0 turns is misclassified as "Subscription token may be expired".
+#
+# This is a structural / source-level invariant test. If the call ordering
+# is restructured in either file, this test fires and forces a deliberate
+# re-evaluation of the auth-fallback ordering guarantee.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "claude_code.py",       # chat path /api/chat — added by Issue #906
+        "headless_executor.py", # headless path /api/task — added by Issue #516
+    ],
+)
+def test_signal_exit_classified_before_diagnose_failure(filename):
+    """In both error-path call sites, _classify_signal_exit(...) must appear
+    before _diagnose_exit_failure(...) so signal kills aren't mis-routed
+    through the auth-fallback heuristic. (Issues #516 and #906.)
+
+    The check is purely structural — it looks for the function-call
+    patterns (``name(``) which only match call sites, not imports
+    (imports use trailing commas in the parenthesised block).
+    """
+    path = _AGENT_SERVER_DIR / "services" / filename
+    src = path.read_text()
+
+    signal_call = src.find("_classify_signal_exit(")
+    diagnose_call = src.find("_diagnose_exit_failure(")
+
+    assert signal_call != -1, (
+        f"{filename}: _classify_signal_exit is not called — "
+        f"signal-exit classification is missing (Issue #516 / #906)."
+    )
+    assert diagnose_call != -1, (
+        f"{filename}: _diagnose_exit_failure is not called — "
+        f"unexpected; the error path should still fall through to it "
+        f"for non-signal exits."
+    )
+    assert signal_call < diagnose_call, (
+        f"{filename}: _classify_signal_exit must be called before "
+        f"_diagnose_exit_failure. Reversed ordering would let the "
+        f"auth-fallback heuristic misclassify SIGKILL/SIGTERM/SIGINT "
+        f"as expired-token errors (Issue #906)."
+    )


### PR DESCRIPTION
## Summary

- Add the missing `_classify_signal_exit` call to the chat path (`claude_code.py:450`), mirroring the existing pattern in `headless_executor.py:683` that was added for Issue #516
- A SIGKILL at 0 turns (OOM, watchdog, operator cancel) no longer gets misclassified as "Subscription token may be expired"
- Regression test pins the call-ordering invariant in both files

## Background

Issue #516 introduced `_classify_signal_exit` to fix the SIGKILL → "token expired" misclassification in the **headless** path (`/api/task`, scheduled tasks). The fix never landed on the parallel **chat** path (`/api/chat`, interactive chats), so the same misclassification persists there.

Two-codepath analysis from the issue's diagnosis:

| Codepath | File | Called `_classify_signal_exit` first? |
|----------|------|---------------------------------------|
| Scheduled tasks (`/api/task`) | `headless_executor.py:683` | ✅ Yes (Issue #516) |
| Interactive chat (`/api/chat`) | `claude_code.py:453` | ❌ **No — bug** |

The misclassification has two compounding effects beyond bad operator-facing text:

1. **Operator misdirection** — operators chase token regeneration when the actual cause is OOM / timeout / external kill (the issue cites a 72-hour wrong-fix cycle)
2. **SUB-003 auto-switch state corruption** — the auto-switch trigger pattern matcher reads the error string and rotates subscriptions on phantom auth failures, burning the 2-hour skip-list slot

## Changes

**`docker/base-image/agent_server/services/claude_code.py`** (+12)
- Add `_classify_signal_exit` to the imports from `error_classifier`
- Insert the signal-exit check before `_diagnose_exit_failure` in the chat handler's `if return_code != 0` block. Pattern matches `headless_executor.py:683-687` exactly.

**`tests/unit/test_signal_exit_classification.py`** (+52)
- Add a structural regression test parametrized over both files (`claude_code.py`, `headless_executor.py`)
- Test asserts `_classify_signal_exit(` appears before `_diagnose_exit_failure(` in each file's source. Order reversal in either file would re-introduce the misclassification — verified by manually flipping the order and confirming the test fails.

## Out of scope (deferred to follow-ups)

- **Fix 2 (gate auto-switch on observed wire signal)** — adding a structured `error_class` field to executions and refactoring the SUB-003 matcher to read it instead of the freeform error text. Larger refactor; filed for follow-up.
- **Fix 3 (cgroup OOM event reading)** — upgrading SIGKILL classification to "container OOM observed" when `memory.events.oom_kill` incremented. Optional per the issue body.

## Deployment

This change touches `docker/base-image/agent_server/`. Per `CLAUDE.md` note #7, **base image rebuild + agent restart** is required for the fix to take effect on running agents:

```bash
./scripts/deploy/build-base-image.sh
# Then restart agents (e.g. via /agent stop+start in UI, or fleet-wide restart)
```

Until the rebuild + restart, agents already running will continue to emit the old misclassified error.

## Test plan

- [x] Unit tests: `python3.11 -m pytest tests/unit/test_signal_exit_classification.py --confcutdir=tests/unit -q` — 23 passed (21 existing + 2 new parametrized cases)
- [x] Regression test verified by temporarily reversing the call ordering in `claude_code.py` — test fails as expected, then restores
- [ ] Manual verification post-deploy: trigger a SIGKILL on an agent's chat session (e.g. via cgroup OOM with small memory limit + memory-allocating skill) and observe the recorded error is "Execution terminated by SIGKILL after 0 tool calls / 0 turns…" instead of "Subscription token may be expired…"
- [ ] Verify SUB-003 auto-switch no longer fires on the SIGKILL repro (subscription should remain healthy / unrotated)

Fixes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)