### PR TITLE
docs(canary-fleet): correct timeout PUT field name in manifest header

### DIFF
--- a/config/canary-fleet.yaml
+++ b/config/canary-fleet.yaml
@@ -32,7 +32,7 @@
 #   3. PUT /api/agents/canary-fleet-slow/capacity
 #        body: {"max_parallel_tasks": 1}
 #   4. PUT /api/agents/canary-fleet-slow/timeout
-#        body: {"timeout_seconds": 180}        # >75s sleep + buffer
+#        body: {"execution_timeout_seconds": 180}   # >75s sleep + buffer
 
 name: canary-fleet
 description: Canary harness load generators (Issue #411)


### PR DESCRIPTION
## Summary
- Manifest header in `config/canary-fleet.yaml` documented the post-deploy timeout PUT body as `{"timeout_seconds": 180}`, but the API endpoint `PUT /api/agents/{name}/timeout` requires `execution_timeout_seconds` and rejects the request with `execution_timeout_seconds is required` otherwise.
- One-character (well, one-field) doc-comment fix so the next operator who copies the recipe verbatim gets a working call.

## Caught during
Deploying the slow agent (`canary-fleet-slow`) on the dev instance via the documented recipe.

## Test plan
- [x] Re-ran the corrected `PUT` body against dev — `execution_timeout_seconds: 180` returns `{"message":"Timeout updated","execution_timeout_minutes":3}`