### PR TITLE
fix(#913): scheduler honors per-agent execution_timeout_seconds

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -759,11 +759,21 @@ export, enable/disable toggle. Issue #20 can be closed.
 **Phase 3 invariants** (#882, same PR — S-03, B-02, R-01):
 - **S-03 — Slot TTL ≥ execution timeout**: for every member of
   `agent:slots:{name}`, the companion `agent:slot:{name}:{eid}` HASH
-  has `TTL ≥ execution_timeout_seconds + 300s`. Three failure kinds
+  must have been created with at least
+  `execution_timeout_seconds + 300s` of TTL. Three failure kinds
   surfaced explicitly: `missing` (-2, metadata HASH expired ahead of
   the ZSET — the #226 class), `no_expiry` (-1, `expire()` never set),
-  `below_floor` (positive TTL under the configured floor). Severity:
-  critical. Tier A.
+  `below_floor` (initial TTL under the configured floor). Severity:
+  critical. Tier A. **Decay-invariance (#913):** the raw `TTL` of a
+  long-lived slot decays linearly from `EXPIRE`, so once #913 makes the
+  initial TTL equal the floor exactly, a raw `ttl < floor` check would
+  fire by ~1s within the cycle. The Phase 3.1 implementation
+  reconstructs the *initial* TTL as `ttl + age` where
+  `age = snapshot_time - slot_score` (the ZSET member's score is the
+  unix epoch recorded by `SlotService` at ZADD time) and compares
+  against `floor - 1` (1s tolerance for Redis float→int wire rounding).
+  A real #226-class bug (initial TTL set below the floor) still
+  surfaces; natural decay does not.
 - **B-02 — No queued without slots-full**: if any agent has
   `len(queued_exec_ids) > 0`, then either `slot_count == max_parallel`
   OR a drain tick fired in the last 60s. Severity: critical. Tier B.
@@ -1041,6 +1051,7 @@ CREATE TABLE agent_schedules (
     last_run_at TEXT,
     next_run_at TEXT,
     model TEXT,                                  -- MODEL-001: Model override (NULL = agent default)
+    timeout_seconds INTEGER,                     -- #913: NULL = inherit agent_ownership.execution_timeout_seconds
     webhook_token TEXT,                          -- WEBHOOK-001: opaque 43-char urlsafe token, nullable
     webhook_enabled INTEGER DEFAULT 0,           -- WEBHOOK-001: 0 = disabled, 1 = active
     deleted_at TEXT,                             -- #834 Phase 1b: NULL = live; set = soft-deleted

--- a/src/backend/canary/invariants/s03_slot_ttl_floor.py
+++ b/src/backend/canary/invariants/s03_slot_ttl_floor.py
@@ -2,17 +2,36 @@
 S-03 — Slot TTL ≥ execution timeout (CANARY-001 / Issue #411 — Phase 3).
 
 For every member of `agent:slots:A`, the companion `agent:slot:A:{eid}`
-HASH must have a Redis TTL of at least the agent's
-`execution_timeout_seconds + 300` (SLOT_TTL_BUFFER). A TTL below that
-floor means the slot will expire while the execution might still
-legitimately be running — exactly the premature-expiry bug class behind
-Issue #226.
+HASH must have been created with a TTL of at least the agent's
+`execution_timeout_seconds + 300` (SLOT_TTL_BUFFER). An initial TTL
+below that floor means the slot will expire while the execution might
+still legitimately be running — exactly the premature-expiry bug class
+behind Issue #226.
+
+## Why the check is decay-invariant
+
+Redis `TTL` returns the *current* remaining seconds, which decays
+linearly from the moment `EXPIRE` was set. After #913, the slot's
+initial TTL exactly equals `execution_timeout + SLOT_TTL_BUFFER` (the
+floor), so the raw `ttl < floor` check would fire on every cycle the
+moment any wall-clock time has passed — a 1-second false positive on
+fresh slots.
+
+The fix is to compare the *initial* TTL against the floor, reconstructed
+as `ttl + age`, where `age = snapshot_time - slot_score` and
+`slot_score` is the unix epoch at acquire (recorded by SlotService in
+the ZSET). A slot created with `EXPIRE(floor)` then ages `t` seconds
+has current TTL `floor - t`, so `ttl + age = floor` — exactly at the
+floor regardless of when the snapshot is taken. A #913-class bug where
+the initial TTL was set to `900 + 300 = 1200s` but the floor is
+`3600 + 300 = 3900s` shows up as `ttl + age = 1200` < `3900` — caught.
 
 ## TTL sentinel values from `redis.ttl()`
 
 Three special return values, each meaning a different failure mode:
 
-- `>0` (normal case): seconds until expiry. Compare against the floor.
+- `>0` (normal case): current seconds until expiry. Reconstruct the
+  initial TTL via `ttl + age` and compare against the floor.
 - `-1`: key exists with **no expiry**. The slot has been turned into a
   leak — `redis.expire()` was never called or got cleared. Violation
   regardless of the floor (a slot with no TTL eventually traps capacity
@@ -46,7 +65,8 @@ Tier A, severity critical. A slot whose TTL is below the floor is a
 ticking timebomb on capacity correctness.
 """
 
-from typing import List
+from datetime import datetime, timezone
+from typing import List, Optional
 
 from ..snapshot import Snapshot, ViolationReport
 
@@ -61,24 +81,35 @@ SLOT_TTL_BUFFER_SECONDS = 300
 DRAIN_PREFIX = "drain-"
 
 
-def _kind_for(ttl: int, floor: int) -> str:
-    """Map the TTL value to a short tag for the violation report."""
-    if ttl == -2:
-        return "missing"          # Metadata HASH already expired (#226).
-    if ttl == -1:
-        return "no_expiry"        # Key exists but redis.expire() never set.
-    if 0 < ttl < floor:
-        return "below_floor"      # Real TTL, but lower than configured floor.
-    return "ok"                   # Should not appear in violations.
+def _parse_iso_to_unix(ts: str) -> Optional[float]:
+    """Convert an ISO-Z timestamp into unix epoch seconds.
+
+    Mirrors `_parse_iso` in e01_terminal_state_closure.py — strips the
+    trailing 'Z' that `fromisoformat` rejects on Python <3.11, and
+    forces UTC tz on naive results so the subtract is sane.
+    """
+    if not ts:
+        return None
+    if ts.endswith("Z"):
+        ts = ts[:-1]
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
 
 
 def check(snapshot: Snapshot) -> List[ViolationReport]:
-    """Emit one violation per slot whose TTL is below the configured floor."""
+    """Emit one violation per slot whose initial TTL was below the floor."""
     violations: List[ViolationReport] = []
 
     # Same gate as S-01 / S-02 / E-02: Redis failed → skip cleanly.
     if any(s.startswith("redis") for s in snapshot.sources_unavailable):
         return violations
+
+    snapshot_unix = _parse_iso_to_unix(snapshot.snapshot_time)
 
     for agent in snapshot.agents:
         floor = agent.execution_timeout_seconds + SLOT_TTL_BUFFER_SECONDS
@@ -94,25 +125,58 @@ def check(snapshot: Snapshot) -> List[ViolationReport]:
                 continue
 
             ttl = agent.slot_ttls[eid]
-            kind = _kind_for(ttl, floor)
-            if kind == "ok":
-                continue
+
+            # Two-state sentinels first — independent of age.
+            if ttl == -2:
+                kind = "missing"          # Metadata HASH already expired (#226).
+            elif ttl == -1:
+                kind = "no_expiry"        # `redis.expire()` never set.
+            elif ttl > 0:
+                # Reconstruct the slot's initial TTL by adding back the age
+                # since acquisition. `slot_scores[eid]` is the unix epoch
+                # recorded by SlotService at ZADD time; absent score means
+                # the snapshot dropped it (rare race) — skip rather than
+                # fabricate a violation. Same defensive stance the rest of
+                # the canary takes when an input is incomplete.
+                score = agent.slot_scores.get(eid)
+                if score is None or snapshot_unix is None:
+                    continue
+                age = max(0.0, snapshot_unix - float(score))
+                initial_ttl = ttl + age
+                # 1-second tolerance absorbs the float→int rounding that
+                # Redis `TTL` does on the wire. Without it, a slot created
+                # with `EXPIRE(3900)` and observed instantly can read
+                # `ttl=3899, age=0` → `initial_ttl=3899 < 3900` — exactly
+                # the false-positive #913 surfaced.
+                if initial_ttl >= floor - 1:
+                    continue
+                kind = "below_floor"
+            else:
+                continue  # ttl == 0 means just expired; let the next cycle pick it up.
+
+            observed_state = {
+                "agent_name": agent.name,
+                "execution_id": eid,
+                "redis_ttl_seconds": ttl,
+                "execution_timeout_seconds": agent.execution_timeout_seconds,
+                "slot_ttl_buffer_seconds": SLOT_TTL_BUFFER_SECONDS,
+                "floor_seconds": floor,
+                "kind": kind,
+                "snapshot_time": snapshot.snapshot_time,
+            }
+            if kind == "below_floor":
+                # Surface the reconstructed initial TTL so the alert reader
+                # can see the actual bug magnitude, not the decayed
+                # remainder.
+                observed_state["initial_ttl_seconds"] = int(initial_ttl)
+                observed_state["age_seconds"] = int(age)
 
             violations.append(
                 ViolationReport(
                     invariant_id=INVARIANT_ID,
                     tier=TIER,
                     severity=SEVERITY,
-                    observed_state={
-                        "agent_name": agent.name,
-                        "execution_id": eid,
-                        "redis_ttl_seconds": ttl,
-                        "execution_timeout_seconds": agent.execution_timeout_seconds,
-                        "slot_ttl_buffer_seconds": SLOT_TTL_BUFFER_SECONDS,
-                        "floor_seconds": floor,
-                        "kind": kind,
-                        "snapshot_time": snapshot.snapshot_time,
-                    },
+                    observed_state=observed_state,
                     signal_query=(
                         f"TTL(agent:slot:{agent.name}:{eid}) = {ttl} "
                         f"({kind}); floor = {floor}s"

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -2066,6 +2066,40 @@ def _migrate_fix_retention_index_status_values(cursor, conn):
     conn.commit()
 
 
+def _migrate_null_legacy_schedule_timeouts(cursor, conn):
+    """Issue #913: NULL out legacy default schedule timeouts so the
+    per-agent value actually takes effect.
+
+    Before #913, `agent_schedules.timeout_seconds` was always populated
+    (DEFAULT 900, later rewritten to 3600 by
+    `_migrate_default_execution_timeout_to_3600`). The scheduler passed
+    that value directly to `/api/internal/execute-task`, which meant the
+    backend's per-agent fallback at `task_execution_service.py:281` was
+    dead code on the scheduler path — and `PUT /api/agents/{name}/timeout`
+    was silently ineffective for scheduled runs.
+
+    The fix at the code layer is to round-trip None through the scheduler
+    so the backend's per-agent fallback fires. But existing rows still
+    carry a concrete 900/3600 value that came from the platform default,
+    not from an operator choice — so the canary harness keeps firing S-03
+    (slot TTL below per-agent floor) and E-01 (terminal-state closure)
+    until those rows are cleared.
+
+    We null out only rows whose value matches one of the historical
+    defaults (900, 3600). Operators who explicitly set a different value
+    are untouched. Same fidelity tradeoff as
+    `_migrate_default_execution_timeout_to_3600` — accepted there for
+    #665, accepted here for #913.
+
+    Idempotent: subsequent runs find no matching rows and no-op.
+    """
+    cursor.execute(
+        "UPDATE agent_schedules SET timeout_seconds = NULL "
+        "WHERE timeout_seconds IN (900, 3600)"
+    )
+    conn.commit()
+
+
 def _migrate_default_execution_timeout_to_3600(cursor, conn):
     """Issue #665: bump default chat execution timeout from 15min → 60min.
 
@@ -2213,4 +2247,7 @@ MIGRATIONS = [
     ("agent_ownership_soft_delete", _migrate_agent_ownership_soft_delete),
     ("execution_retry_count", _migrate_execution_retry_count),
     ("agent_schedules_soft_delete", _migrate_agent_schedules_soft_delete),
+    # #913 — must come AFTER default_execution_timeout_to_3600 so we null out
+    # both 900 (legacy) and 3600 (post-#665 rewrite) in one pass.
+    ("null_legacy_schedule_timeouts", _migrate_null_legacy_schedule_timeouts),
 ]

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -92,7 +92,9 @@ class ScheduleOperations:
             updated_at=parse_iso_timestamp(row["updated_at"]),
             last_run_at=parse_iso_timestamp(row["last_run_at"]) if row["last_run_at"] else None,
             next_run_at=parse_iso_timestamp(row["next_run_at"]) if row["next_run_at"] else None,
-            timeout_seconds=row["timeout_seconds"] if "timeout_seconds" in row_keys and row["timeout_seconds"] else 3600,
+            # #913: NULL ⇒ inherit from agent_ownership.execution_timeout_seconds.
+            # Do NOT fall through to a constant here — that was the bug.
+            timeout_seconds=row["timeout_seconds"] if "timeout_seconds" in row_keys else None,
             allowed_tools=allowed_tools,
             model=row["model"] if "model" in row_keys else None,
             # Retry configuration (RETRY-001)

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -173,7 +173,9 @@ TABLES = {
             updated_at TEXT NOT NULL,
             last_run_at TEXT,
             next_run_at TEXT,
-            timeout_seconds INTEGER DEFAULT 3600,
+            -- #913: NULL ⇒ inherit from agent_ownership.execution_timeout_seconds.
+            -- Dropped the DEFAULT 3600 that masked per-agent timeout for cron.
+            timeout_seconds INTEGER,
             allowed_tools TEXT,
             model TEXT,
             max_retries INTEGER DEFAULT 0,

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -113,7 +113,10 @@ class ScheduleCreate(BaseModel):
     enabled: bool = True
     timezone: str = "UTC"
     description: Optional[str] = None
-    timeout_seconds: int = 900  # Default 15 minutes
+    # #913: None means "use the agent's `execution_timeout_seconds`". Storing
+    # NULL is what makes per-agent timeout actually effective for scheduled
+    # runs — the old default of 900 silently masked PUT /api/agents/{name}/timeout.
+    timeout_seconds: Optional[int] = None
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
     # Retry configuration (RETRY-001)
@@ -143,7 +146,8 @@ class Schedule(BaseModel):
     updated_at: datetime
     last_run_at: Optional[datetime] = None
     next_run_at: Optional[datetime] = None
-    timeout_seconds: int = 900  # Default 15 minutes
+    # #913: NULL = inherit from agent_ownership.execution_timeout_seconds.
+    timeout_seconds: Optional[int] = None
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
     # Retry configuration (RETRY-001). 0 = disabled (default, #476), 1-5 opt-in.

--- a/src/backend/routers/schedules.py
+++ b/src/backend/routers/schedules.py
@@ -223,6 +223,10 @@ def _enforce_timeout_below_agent_cap(agent_name: str, requested_seconds: int) ->
     `agent_ownership.execution_timeout_seconds` is the hard ceiling.
     Raises HTTPException(400) with a structured `detail` dict so clients
     can branch on `detail["error"] == "schedule_timeout_exceeds_agent_cap"`.
+
+    Callers must guard with `is not None` — after #913 both
+    `ScheduleCreate.timeout_seconds` and `ScheduleUpdateRequest.timeout_seconds`
+    are `Optional[int]`, and `None > int` raises TypeError in Python 3.
     """
     cap = db.get_execution_timeout(agent_name)
     if requested_seconds > cap:
@@ -267,7 +271,9 @@ async def create_schedule(
 
     # #929: schedule timeout cannot exceed the agent cap. Validated here so
     # the operator gets the 400 at config time instead of a SIGKILL at run time.
-    _enforce_timeout_below_agent_cap(name, schedule_data.timeout_seconds)
+    # After #913 the field is Optional — only enforce when the caller set it.
+    if schedule_data.timeout_seconds is not None:
+        _enforce_timeout_below_agent_cap(name, schedule_data.timeout_seconds)
 
     schedule = db.create_schedule(name, current_user.username, schedule_data)
     if not schedule:

--- a/src/backend/routers/schedules.py
+++ b/src/backend/routers/schedules.py
@@ -108,7 +108,8 @@ class ScheduleResponse(BaseModel):
     updated_at: datetime
     last_run_at: Optional[datetime]
     next_run_at: Optional[datetime]
-    timeout_seconds: int = 900
+    # #913: null means "inherit from agent_ownership.execution_timeout_seconds".
+    timeout_seconds: Optional[int] = None
     allowed_tools: Optional[List[str]] = None
     model: Optional[str] = None  # Model override (MODEL-001)
     # Validation configuration (VALIDATE-001)

--- a/src/scheduler/database.py
+++ b/src/scheduler/database.py
@@ -73,7 +73,11 @@ class SchedulerDatabase:
             updated_at=datetime.fromisoformat(row["updated_at"]),
             last_run_at=datetime.fromisoformat(row["last_run_at"]) if row["last_run_at"] else None,
             next_run_at=datetime.fromisoformat(row["next_run_at"]) if row["next_run_at"] else None,
-            timeout_seconds=row["timeout_seconds"] if "timeout_seconds" in row_keys and row["timeout_seconds"] else 900,
+            # #913: NULL ⇒ inherit from agent's execution_timeout_seconds. The
+            # backend's TaskExecutionService applies that fallback when it
+            # sees None. Substituting 900 here was what made
+            # PUT /api/agents/{name}/timeout silently ineffective for cron.
+            timeout_seconds=row["timeout_seconds"] if "timeout_seconds" in row_keys else None,
             allowed_tools=allowed_tools,
             model=row["model"] if "model" in row_keys else None,
             # Retry configuration (RETRY-001)

--- a/src/scheduler/models.py
+++ b/src/scheduler/models.py
@@ -45,7 +45,11 @@ class Schedule:
     updated_at: datetime
     last_run_at: Optional[datetime] = None
     next_run_at: Optional[datetime] = None
-    timeout_seconds: int = 900  # Default 15 minutes
+    # #913: None = inherit from agent_ownership.execution_timeout_seconds.
+    # Scheduler must round-trip None through to /api/internal/execute-task so
+    # the backend's TaskExecutionService falls back to the per-agent value.
+    # Treating NULL as 900 was the bug.
+    timeout_seconds: Optional[int] = None
     allowed_tools: Optional[List[str]] = None  # None = all tools allowed
     model: Optional[str] = None  # Model override (MODEL-001). None = agent default
     # Retry configuration (RETRY-001). 0 = disabled (default, #476), 1-5 opt-in.

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -81,6 +81,15 @@ def _is_auth_failure(error_msg: str) -> bool:
     return any(ind in error_lower for ind in _AUTH_INDICATORS)
 
 
+# #913: Polling-deadline fallback when the schedule's timeout_seconds is
+# NULL (= "inherit per-agent value"). The scheduler does not have the
+# per-agent value in this process; the backend enforces the real timeout.
+# 7200s matches the upper clamp of PUT /api/agents/{name}/timeout — any
+# per-agent value is bounded by this, so the scheduler's poll deadline
+# never gives up before the backend itself does.
+_POLL_DEADLINE_WHEN_NULL = 7200
+
+
 class SchedulerService:
     """
     Manages scheduled task execution for agents.
@@ -1002,7 +1011,7 @@ class SchedulerService:
         message: str,
         triggered_by: str,
         model: Optional[str] = None,
-        timeout_seconds: int = 900,
+        timeout_seconds: Optional[int] = None,
         allowed_tools: Optional[list] = None,
         execution_id: Optional[str] = None,
     ) -> dict:
@@ -1089,7 +1098,7 @@ class SchedulerService:
     async def _poll_execution_completion(
         self,
         execution_id: str,
-        timeout_seconds: int,
+        timeout_seconds: Optional[int],
     ) -> dict:
         """
         Poll the DB for execution completion (SCHED-ASYNC-001).
@@ -1103,8 +1112,14 @@ class SchedulerService:
         Raises:
             Exception if polling deadline exceeded.
         """
+        # #913: schedule.timeout_seconds may be None (= inherit per-agent
+        # value). The backend enforces the real timeout; the scheduler just
+        # needs a poll budget that's at least as long as any per-agent
+        # timeout can be. _POLL_DEADLINE_WHEN_NULL is the agent-config upper
+        # clamp, so we never give up before the backend itself does.
+        effective_timeout = float(timeout_seconds if timeout_seconds is not None else _POLL_DEADLINE_WHEN_NULL)
         # Deadline = task timeout + grace buffer for slot acquisition and cleanup
-        deadline = time.monotonic() + float(timeout_seconds) + config.poll_deadline_buffer
+        deadline = time.monotonic() + effective_timeout + config.poll_deadline_buffer
         poll_count = 0
 
         while time.monotonic() < deadline:
@@ -1132,7 +1147,7 @@ class SchedulerService:
                 }
 
             if poll_count % 6 == 0:  # Log every ~60s at default 10s interval
-                elapsed = int(time.monotonic() - (deadline - float(timeout_seconds) - 60))
+                elapsed = int(time.monotonic() - (deadline - effective_timeout - 60))
                 logger.info(f"Execution {execution_id} still running ({elapsed}s elapsed, poll #{poll_count})")
 
         raise Exception(
@@ -1143,7 +1158,7 @@ class SchedulerService:
     async def _poll_and_finalize(
         self,
         execution_id: str,
-        timeout_seconds: int,
+        timeout_seconds: Optional[int],
         agent_name: str,
     ):
         """
@@ -1155,7 +1170,9 @@ class SchedulerService:
 
         Args:
             execution_id: The execution ID to poll
-            timeout_seconds: Task timeout for polling deadline
+            timeout_seconds: Task timeout for polling deadline. None ⇒ use
+                _POLL_DEADLINE_WHEN_NULL (#913 — schedule inherits per-agent
+                value, which the scheduler does not have locally).
             agent_name: Agent name for logging and events
         """
         try:
@@ -1350,7 +1367,7 @@ class SchedulerService:
         schedule_id: str,
         agent_name: str,
         message: str,
-        timeout_seconds: int,
+        timeout_seconds: Optional[int],
         model: str,
         allowed_tools: list,
         next_attempt_number: int

--- a/tests/scheduler_tests/test_per_agent_timeout.py
+++ b/tests/scheduler_tests/test_per_agent_timeout.py
@@ -1,0 +1,305 @@
+"""
+Tests for #913: scheduler honors per-agent execution_timeout_seconds.
+
+Before #913, the scheduler always passed a concrete integer (the
+schedule row's `timeout_seconds`, default 900 / later 3600) to
+`/api/internal/execute-task`. That made the backend's per-agent
+fallback at `task_execution_service.py:281` dead code on the scheduler
+path — `PUT /api/agents/{name}/timeout` was silently ineffective for
+cron-triggered runs.
+
+The fix round-trips `None` through the scheduler boundary so the
+backend's fallback fires. These tests pin the round-trip:
+
+- DB read: NULL → `Schedule.timeout_seconds is None` (no fallback to 900)
+- Dispatch payload: `Schedule.timeout_seconds=None` → JSON `"timeout_seconds": null`
+- Polling deadline: None → uses `_POLL_DEADLINE_WHEN_NULL` (7200s)
+- Pass-through: explicit int still propagates as that int (no regression)
+"""
+
+# Path setup must happen before scheduler imports
+import sys
+from pathlib import Path
+_this_file = Path(__file__).resolve()
+_src_path = str(_this_file.parent.parent.parent / 'src')
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+import sqlite3
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+
+from scheduler.database import SchedulerDatabase
+from scheduler.locking import LockManager
+from scheduler.models import ExecutionStatus
+from scheduler.service import SchedulerService, _POLL_DEADLINE_WHEN_NULL
+
+
+# ---------------------------------------------------------------------------
+# DB read: NULL → None
+# ---------------------------------------------------------------------------
+
+
+class TestRowToScheduleNullTimeout:
+    """The scheduler's DB layer must return None for a NULL timeout column.
+
+    Before #913 this site fell back to `900`, which is what made the
+    backend's per-agent fallback dead code.
+    """
+
+    def test_null_column_returns_none(self, initialized_db: str):
+        """Insert a schedule with `timeout_seconds=NULL`; read must yield None."""
+        # The conftest schema doesn't carry `timeout_seconds`; add it so
+        # this test exercises the realistic production read path.
+        conn = sqlite3.connect(initialized_db)
+        cursor = conn.cursor()
+        cursor.execute("ALTER TABLE agent_schedules ADD COLUMN timeout_seconds INTEGER")
+        cursor.execute(
+            """
+            INSERT INTO agent_schedules (
+                id, agent_name, name, cron_expression, message, enabled,
+                timezone, owner_id, created_at, updated_at, timeout_seconds
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+            """,
+            (
+                "sched-null",
+                "agent-a",
+                "Inherit timeout",
+                "*/5 * * * *",
+                "hi",
+                1,
+                "UTC",
+                1,
+                "2026-05-23T00:00:00",
+                "2026-05-23T00:00:00",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        db = SchedulerDatabase(database_path=initialized_db)
+        schedule = db.get_schedule("sched-null")
+
+        assert schedule is not None
+        assert schedule.timeout_seconds is None, (
+            "NULL in DB must surface as None so the backend's "
+            "per-agent fallback fires (#913)."
+        )
+
+    def test_explicit_value_round_trips(self, initialized_db: str):
+        """Explicit per-schedule overrides survive the read path unchanged."""
+        conn = sqlite3.connect(initialized_db)
+        cursor = conn.cursor()
+        cursor.execute("ALTER TABLE agent_schedules ADD COLUMN timeout_seconds INTEGER")
+        cursor.execute(
+            """
+            INSERT INTO agent_schedules (
+                id, agent_name, name, cron_expression, message, enabled,
+                timezone, owner_id, created_at, updated_at, timeout_seconds
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "sched-explicit",
+                "agent-a",
+                "Override timeout",
+                "*/5 * * * *",
+                "hi",
+                1,
+                "UTC",
+                1,
+                "2026-05-23T00:00:00",
+                "2026-05-23T00:00:00",
+                1234,
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        db = SchedulerDatabase(database_path=initialized_db)
+        schedule = db.get_schedule("sched-explicit")
+
+        assert schedule is not None
+        assert schedule.timeout_seconds == 1234
+
+
+# ---------------------------------------------------------------------------
+# Dispatch payload: round-trip None to backend
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchPayloadCarriesNone:
+    """`_call_backend_execute_task` must forward `None` as JSON `null` so
+    `task_execution_service.py:281` per-agent fallback fires.
+    """
+
+    @staticmethod
+    def _stub_async_accepted_response() -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "status": "accepted",
+            "execution_id": "exec-1",
+            "async_mode": True,
+        }
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_none_propagates_to_payload(
+        self,
+        db_with_data: SchedulerDatabase,
+        mock_lock_manager: LockManager,
+    ):
+        service = SchedulerService(
+            database=db_with_data,
+            lock_manager=mock_lock_manager,
+        )
+
+        execution = db_with_data.create_execution(
+            schedule_id="schedule-1",
+            agent_name="test-agent",
+            message="Inherit",
+        )
+        # Resolve immediately so the background poll task exits fast.
+        db_with_data.update_execution_status(
+            execution_id=execution.id,
+            status=ExecutionStatus.SUCCESS,
+            response="ok",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_cls, \
+             patch("scheduler.service.config") as mock_config:
+            mock_config.poll_interval = 0.01  # keep the spawned poll task short
+            mock_config.poll_deadline_buffer = 1.0
+            mock_config.internal_api_secret = None
+            mock_config.backend_url = "http://backend"
+
+            mock_client = AsyncMock()
+            mock_client.post.return_value = self._stub_async_accepted_response()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await service._call_backend_execute_task(
+                agent_name="test-agent",
+                message="Inherit",
+                triggered_by="schedule",
+                timeout_seconds=None,
+                execution_id=execution.id,
+            )
+
+            payload = mock_client.post.call_args.kwargs["json"]
+            # Field present and explicitly None — pins the wire contract so
+            # a regression to a default integer surfaces immediately.
+            assert "timeout_seconds" in payload
+            assert payload["timeout_seconds"] is None
+
+        # Drain the spawned background poll task so pytest doesn't warn.
+        for t in list(service._active_poll_tasks):
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_explicit_int_still_propagates(
+        self,
+        db_with_data: SchedulerDatabase,
+        mock_lock_manager: LockManager,
+    ):
+        """Per-schedule overrides must continue to work unchanged."""
+        service = SchedulerService(
+            database=db_with_data,
+            lock_manager=mock_lock_manager,
+        )
+
+        execution = db_with_data.create_execution(
+            schedule_id="schedule-1",
+            agent_name="test-agent",
+            message="Explicit",
+        )
+        db_with_data.update_execution_status(
+            execution_id=execution.id,
+            status=ExecutionStatus.SUCCESS,
+            response="ok",
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_cls, \
+             patch("scheduler.service.config") as mock_config:
+            mock_config.poll_interval = 0.01
+            mock_config.poll_deadline_buffer = 1.0
+            mock_config.internal_api_secret = None
+            mock_config.backend_url = "http://backend"
+
+            mock_client = AsyncMock()
+            mock_client.post.return_value = self._stub_async_accepted_response()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await service._call_backend_execute_task(
+                agent_name="test-agent",
+                message="Explicit",
+                triggered_by="schedule",
+                timeout_seconds=1234,
+                execution_id=execution.id,
+            )
+
+            payload = mock_client.post.call_args.kwargs["json"]
+            assert payload["timeout_seconds"] == 1234
+
+        for t in list(service._active_poll_tasks):
+            t.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Polling deadline fallback
+# ---------------------------------------------------------------------------
+
+
+class TestPollingDeadlineFallback:
+    """The poll deadline math must use `_POLL_DEADLINE_WHEN_NULL` when the
+    schedule's timeout is None — without it the deadline calc would
+    `float(None) + buffer` and raise TypeError.
+    """
+
+    def test_constant_matches_api_clamp(self):
+        """`PUT /api/agents/{name}/timeout` clamps at 7200s; the scheduler's
+        None-fallback must be at least that high so it never gives up
+        before the backend's enforcement does."""
+        assert _POLL_DEADLINE_WHEN_NULL == 7200
+
+    @pytest.mark.asyncio
+    async def test_poll_completion_with_none_timeout_does_not_raise(
+        self,
+        db_with_data: SchedulerDatabase,
+        mock_lock_manager: LockManager,
+    ):
+        """Poll must not TypeError when `timeout_seconds=None` and the row
+        resolves cleanly. Before #913 the deadline math would have hit
+        `float(None) + buffer` and raised."""
+        service = SchedulerService(
+            database=db_with_data,
+            lock_manager=mock_lock_manager,
+        )
+
+        execution = db_with_data.create_execution(
+            schedule_id="schedule-1",
+            agent_name="test-agent",
+            message="Inherit",
+        )
+        # Pre-resolve so the first poll iteration returns the terminal row.
+        db_with_data.update_execution_status(
+            execution_id=execution.id,
+            status=ExecutionStatus.SUCCESS,
+            response="done",
+        )
+
+        # Patch the config so we don't sleep 10s for the first poll tick.
+        with patch("scheduler.service.config") as mock_config:
+            mock_config.poll_interval = 0.01
+            mock_config.poll_deadline_buffer = 1.0
+
+            result = await service._poll_execution_completion(
+                execution_id=execution.id,
+                timeout_seconds=None,  # the #913 path
+            )
+
+        assert result["status"] == ExecutionStatus.SUCCESS

--- a/tests/test_canary_invariants.py
+++ b/tests/test_canary_invariants.py
@@ -1344,9 +1344,18 @@ class TestInvariantB01:
 
 
 class TestInvariantS03:
+    # ZSET score must look like a real acquire-time unix epoch, not 1.0
+    # (year 1970), because S-03 reconstructs the slot's initial TTL via
+    # `ttl + (snapshot_time - score)` after #913 made the natural
+    # 1-second TTL decay against the floor a false positive.
+    @staticmethod
+    def _now_score() -> float:
+        import time
+        return time.time()
+
     def test_holds_when_ttl_above_floor(self, canary_db, reload_canary):
         _add_agent(canary_db, "a1", timeout=60)  # floor = 60 + 300 = 360s
-        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": self._now_score()})
         reload_canary["redis"].set_ttl("agent:slot:a1:e1", 500)
         snap = reload_canary["canary"].collect_snapshot()
         from canary.invariants import s03_slot_ttl_floor as s03
@@ -1354,7 +1363,9 @@ class TestInvariantS03:
 
     def test_fires_below_floor(self, canary_db, reload_canary):
         _add_agent(canary_db, "a1", timeout=60)  # floor = 360s
-        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        # Slot acquired ~now with EXPIRE=100. Initial TTL = 100 + ~0 age
+        # = 100 < 360 floor — fires.
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": self._now_score()})
         reload_canary["redis"].set_ttl("agent:slot:a1:e1", 100)
         snap = reload_canary["canary"].collect_snapshot()
         from canary.invariants import s03_slot_ttl_floor as s03
@@ -1366,10 +1377,24 @@ class TestInvariantS03:
         assert v[0].observed_state["redis_ttl_seconds"] == 100
         assert v[0].observed_state["floor_seconds"] == 360
 
+    def test_natural_decay_not_below_floor(self, canary_db, reload_canary):
+        """#913 regression — a slot created with EXPIRE=floor and observed
+        seconds later must not fire just because of natural TTL decay."""
+        import time
+        _add_agent(canary_db, "a1", timeout=60)  # floor = 360s
+        # Slot was created 5s ago with the canonical EXPIRE=floor. Real
+        # TTL now reads `360 - 5 = 355` — below the raw floor — but the
+        # reconstructed initial TTL is 360, exactly at the floor.
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": time.time() - 5})
+        reload_canary["redis"].set_ttl("agent:slot:a1:e1", 355)
+        snap = reload_canary["canary"].collect_snapshot()
+        from canary.invariants import s03_slot_ttl_floor as s03
+        assert s03.check(snap) == []
+
     def test_fires_when_metadata_missing(self, canary_db, reload_canary):
         """ZSET points at a slot whose metadata HASH already expired (#226)."""
         _add_agent(canary_db, "a1", timeout=60)
-        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": self._now_score()})
         # FakeRedis.ttl returns -2 when neither the hash nor the ttl is set.
         snap = reload_canary["canary"].collect_snapshot()
         from canary.invariants import s03_slot_ttl_floor as s03
@@ -1381,7 +1406,7 @@ class TestInvariantS03:
     def test_fires_when_ttl_unset(self, canary_db, reload_canary):
         """Metadata HASH exists but no expire was set on it."""
         _add_agent(canary_db, "a1", timeout=60)
-        reload_canary["redis"].zadd("agent:slots:a1", {"e1": 1.0})
+        reload_canary["redis"].zadd("agent:slots:a1", {"e1": self._now_score()})
         # Populate the HASH so FakeRedis.ttl returns -1 (exists, no TTL).
         reload_canary["redis"].hset("agent:slot:a1:e1", "started_at", "x")
         snap = reload_canary["canary"].collect_snapshot()
@@ -1394,7 +1419,7 @@ class TestInvariantS03:
     def test_drain_sentinels_skipped(self, canary_db, reload_canary):
         _add_agent(canary_db, "a1", timeout=60)
         reload_canary["redis"].zadd(
-            "agent:slots:a1", {"drain-a1-12345": 1.0}
+            "agent:slots:a1", {"drain-a1-12345": self._now_score()}
         )
         # Don't set TTL — would normally be "missing"; sentinel must skip.
         snap = reload_canary["canary"].collect_snapshot()

--- a/tests/unit/test_929_timeout_validation.py
+++ b/tests/unit/test_929_timeout_validation.py
@@ -353,7 +353,7 @@ def test_create_schedule_path_skips_enforcement_when_timeout_none(monkeypatch):
     fake_user = types.SimpleNamespace(username="owner", role="user")
 
     # Invoke the async route handler directly.
-    asyncio.get_event_loop().run_until_complete(
+    asyncio.run(
         sched_router.create_schedule(
             name="alice",
             schedule_data=schedule_data,
@@ -424,7 +424,7 @@ def test_create_schedule_path_runs_enforcement_when_timeout_set(monkeypatch):
 
     fake_user = types.SimpleNamespace(username="owner", role="user")
 
-    asyncio.get_event_loop().run_until_complete(
+    asyncio.run(
         sched_router.create_schedule(
             name="alice",
             schedule_data=schedule_data,

--- a/tests/unit/test_929_timeout_validation.py
+++ b/tests/unit/test_929_timeout_validation.py
@@ -262,6 +262,179 @@ def test_enforce_helper_rejects_above_cap_with_structured_detail(monkeypatch):
     assert "Raise the agent cap" in detail["message"]
 
 
+def test_enforce_helper_raises_typeerror_on_none(monkeypatch):
+    """Regression pin for the #913 × #929 interaction.
+
+    After #913 made `ScheduleCreate.timeout_seconds` Optional, the helper
+    is no longer safe to call unconditionally — `None > int` raises
+    TypeError in Python 3. This pins the helper's actual behavior so the
+    write-side `is not None` guards in `create_schedule`/`update_schedule`
+    can't silently regress without breaking this test (which would expose
+    the guard as the contract).
+    """
+    sched_router = _load_sched_router(monkeypatch)
+    monkeypatch.setattr(
+        sched_router.db, "get_execution_timeout", lambda _name: 3600, raising=False
+    )
+    with pytest.raises(TypeError):
+        sched_router._enforce_timeout_below_agent_cap("alice", None)
+
+
+def test_create_schedule_path_skips_enforcement_when_timeout_none(monkeypatch):
+    """`create_schedule` must not call the enforcer when caller omits timeout.
+
+    Eugene's PR #922 review caught the missing `is not None` guard on the
+    POST path: it would 500 with TypeError for every consumer that didn't
+    explicitly set `timeout_seconds`. Pin the guard by asserting the route
+    function does not call `_enforce_timeout_below_agent_cap` on None.
+
+    We invoke the route function directly with stubbed dependencies — going
+    through FastAPI TestClient would drag the whole router init chain.
+    """
+    import asyncio
+
+    sched_router = _load_sched_router(monkeypatch)
+
+    # Track whether the enforcer ran.
+    enforcer_calls = []
+
+    def fake_enforce(agent_name, requested_seconds):
+        enforcer_calls.append((agent_name, requested_seconds))
+
+    monkeypatch.setattr(
+        sched_router, "_enforce_timeout_below_agent_cap", fake_enforce
+    )
+
+    # Stub `db.create_schedule` to return a minimal Schedule-like object so
+    # the route's `ScheduleResponse(**schedule.model_dump())` succeeds.
+    class _FakeSchedule:
+        def model_dump(self):
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc)
+            return {
+                "id": "sched-1",
+                "agent_name": "alice",
+                "name": "test",
+                "cron_expression": "*/5 * * * *",
+                "message": "hi",
+                "enabled": True,
+                "timezone": "UTC",
+                "description": None,
+                "created_at": now,
+                "updated_at": now,
+                "last_run_at": None,
+                "next_run_at": None,
+                "timeout_seconds": None,
+                "allowed_tools": None,
+                "model": None,
+                "validation_enabled": False,
+                "validation_prompt": None,
+                "validation_timeout_seconds": 120,
+            }
+
+    monkeypatch.setattr(
+        sched_router.db,
+        "create_schedule",
+        lambda *_a, **_k: _FakeSchedule(),
+        raising=False,
+    )
+
+    # ScheduleCreate with timeout_seconds left at its default (None).
+    schedule_data = sched_router.ScheduleCreate(
+        name="test",
+        cron_expression="*/5 * * * *",
+        message="hi",
+    )
+    assert schedule_data.timeout_seconds is None, (
+        "Test premise: ScheduleCreate.timeout_seconds defaults to None after #913"
+    )
+
+    fake_user = types.SimpleNamespace(username="owner", role="user")
+
+    # Invoke the async route handler directly.
+    asyncio.get_event_loop().run_until_complete(
+        sched_router.create_schedule(
+            name="alice",
+            schedule_data=schedule_data,
+            current_user=fake_user,
+        )
+    )
+
+    assert enforcer_calls == [], (
+        f"Enforcer must not run when timeout_seconds is None; "
+        f"got calls: {enforcer_calls!r}. Eugene's guard regressed."
+    )
+
+
+def test_create_schedule_path_runs_enforcement_when_timeout_set(monkeypatch):
+    """Counterpart: when caller DOES set `timeout_seconds`, the enforcer fires."""
+    import asyncio
+
+    sched_router = _load_sched_router(monkeypatch)
+
+    enforcer_calls = []
+
+    def fake_enforce(agent_name, requested_seconds):
+        enforcer_calls.append((agent_name, requested_seconds))
+
+    monkeypatch.setattr(
+        sched_router, "_enforce_timeout_below_agent_cap", fake_enforce
+    )
+
+    class _FakeSchedule:
+        def model_dump(self):
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc)
+            return {
+                "id": "sched-1",
+                "agent_name": "alice",
+                "name": "test",
+                "cron_expression": "*/5 * * * *",
+                "message": "hi",
+                "enabled": True,
+                "timezone": "UTC",
+                "description": None,
+                "created_at": now,
+                "updated_at": now,
+                "last_run_at": None,
+                "next_run_at": None,
+                "timeout_seconds": 600,
+                "allowed_tools": None,
+                "model": None,
+                "validation_enabled": False,
+                "validation_prompt": None,
+                "validation_timeout_seconds": 120,
+            }
+
+    monkeypatch.setattr(
+        sched_router.db,
+        "create_schedule",
+        lambda *_a, **_k: _FakeSchedule(),
+        raising=False,
+    )
+
+    schedule_data = sched_router.ScheduleCreate(
+        name="test",
+        cron_expression="*/5 * * * *",
+        message="hi",
+        timeout_seconds=600,
+    )
+
+    fake_user = types.SimpleNamespace(username="owner", role="user")
+
+    asyncio.get_event_loop().run_until_complete(
+        sched_router.create_schedule(
+            name="alice",
+            schedule_data=schedule_data,
+            current_user=fake_user,
+        )
+    )
+
+    assert enforcer_calls == [("alice", 600)]
+
+
 # ---------------------------------------------------------------------------
 # Orthogonal SIGKILL error_classifier message (agent-server)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `agent_schedules.timeout_seconds` becomes `Optional[int]` and round-trips `None` through the scheduler to `/api/internal/execute-task`, so the backend's per-agent fallback at `task_execution_service.py:281` finally fires for cron-triggered runs.
- Migration `null_legacy_schedule_timeouts` nulls existing rows at the historical defaults (900, 3600) so `PUT /api/agents/{name}/timeout` takes effect on already-deployed schedules.
- Drive-by: S-03 canary invariant is made decay-invariant (it would fire by 1s on every fresh slot once #913 makes slot TTL match the floor exactly).

## Root cause (#913)

Before this PR, every schedule row carried a concrete `timeout_seconds` (DEFAULT 900, later rewritten to 3600 by `_migrate_default_execution_timeout_to_3600`). The scheduler passed that to the backend, so the backend's `if timeout_seconds is None: timeout_seconds = db.get_execution_timeout(agent_name)` fallback was dead code on the scheduler path. `PUT /api/agents/{name}/timeout` was silently ineffective for cron — the per-agent value never reached slot acquisition, slot HASH metadata, or cleanup-watchdog termination.

The canary harness fired S-03 / E-01 every cycle on any agent whose per-agent timeout differed from the schedule default.

## Fix — Option A (round-trip None through scheduler)

- ` ScheduleCreate` / `Schedule` / `ScheduleResponse` / scheduler `Schedule`: `timeout_seconds: Optional[int] = None`
- `_row_to_schedule` (backend + scheduler): NULL → None (not 900/3600)
- `scheduler/service.py`: `_call_backend_execute_task`, `_poll_execution_completion`, `_execute_retry` accept `Optional[int]`; polling deadline falls back to `_POLL_DEADLINE_WHEN_NULL = 7200` (the upper clamp of `PUT /api/agents/{name}/timeout`) so the scheduler never gives up before the backend's own enforcement
- `schema.py`: drops `DEFAULT 3600` on `agent_schedules.timeout_seconds`
- Migration: `null_legacy_schedule_timeouts` nulls rows at 900/3600 (same fidelity tradeoff as the prior `_migrate_default_execution_timeout_to_3600`)

The cleanup-side COALESCE in `get_running_executions_with_agent_info` already preferred the per-agent value when the schedule's column was NULL; this PR is what finally makes the column actually carry NULL.

## S-03 decay-invariance follow-up

After #913 the slot TTL exactly equals the floor at creation, so the raw `ttl < floor` check fires by ~1s on natural decay — Redis `TTL` decays linearly from `EXPIRE`. The fix reconstructs the initial TTL via `ttl + age`, where `age = snapshot_time - slot_score` (slot_score is the unix epoch recorded by SlotService at ZADD time). A real #226-class bug (initial TTL set to 1200s while floor is 3900s) still surfaces; natural decay does not.

1s tolerance (`floor - 1`) absorbs Redis's float→int rounding on the wire.

## Test plan

- [x] `tests/scheduler_tests/test_per_agent_timeout.py` — 6 new tests pin the round-trip:
  - DB NULL → `Schedule.timeout_seconds is None`
  - DB explicit int → unchanged on read
  - Dispatch payload carries `"timeout_seconds": null` (not a default integer)
  - Explicit per-schedule overrides still propagate unchanged
  - `_POLL_DEADLINE_WHEN_NULL == 7200`
  - `_poll_execution_completion` does not TypeError on None
- [x] `tests/test_canary_invariants.py` — added `test_natural_decay_not_below_floor` as S-03 regression; existing S-03 fixtures updated to use realistic acquire scores
- [x] All 85 canary unit tests + 6 scheduler tests pass locally
- [x] Slot HASH on canary-fleet-slow: `timeout_seconds=180` (per-agent), TTL=480 — was 3600/3900 before
- [x] Slot HASH on canary-fleet-burst: `timeout_seconds=3600` (per-agent), TTL=3900 — was 900/1200 before
- [x] 3-min live run spanning burst (*/2) and slow (*/3) cron cadences: 0 canary violations
- [ ] Review

## Note on supersedence

PR #920 was opened earlier on `feature/882-canary-phase2`, which carried duplicate Phase 2/3 canary commits already merged to `dev` via #884. Closed in favor of this clean two-commit PR off `dev`.

Fixes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)