### PR TITLE
fix(#921): watchdog orphan race + CB dormant self-heal + admin reset

### DIFF
--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -668,6 +668,33 @@ async def force_release_agent(
     return await force_release_agent_logic(agent_name, current_user)
 
 
+@router.post("/{agent_name}/circuit-breaker/reset")
+async def reset_circuit_breaker_endpoint(
+    agent_name: AuthorizedAgentByName,
+    current_user: User = Depends(require_role("admin")),
+):
+    """Force the agent's circuit breaker to closed (#921).
+
+    Admin only. Operator escape hatch for the dormant-CB cascade described
+    in #921 — equivalent to the manual `redis-cli DEL agent:circuit:{name}`
+    workaround. With the 1h auto-probe shipped in #921 this is rarely
+    needed (the breaker self-heals), but it stays as the first-response
+    tool when an operator already knows the agent is healthy and doesn't
+    want to wait a full cooldown.
+    """
+    from services.agent_client import CircuitState, reset_circuit
+    # Capture state-before for the response so postmortems can see what we
+    # reset out of. Racey against the DEL but fine — best-effort observability.
+    prior_state = CircuitState(agent_name).state
+    reset_circuit(agent_name)
+    return {
+        "agent_name": agent_name,
+        "prior_state": prior_state,
+        "new_state": "closed",
+        "reset_at": utc_now_iso(),
+    }
+
+
 # ============================================================================
 # Activity Stream Endpoints
 # ============================================================================

--- a/src/backend/services/agent_client.py
+++ b/src/backend/services/agent_client.py
@@ -267,6 +267,57 @@ def is_circuit_failure(exc: BaseException) -> bool:
     return isinstance(exc, CIRCUIT_FAILURE_EXCEPTIONS)
 
 
+# ----- Dormant-transition notification (#921) -------------------------------
+#
+# When the breaker enters dormant, surface it in the Operating Room queue so
+# operators see "agent silently failing scheduled tasks" without having to
+# grep logs. Fire-and-forget: if the DB insert blows up, we still log the
+# transition and the breaker is unaffected. Best-effort by design.
+
+def _emit_dormant_alert(agent_name: str) -> None:
+    """Insert a circuit_breaker_dormant operator-queue entry.
+
+    Called from CircuitState.record_failure on the closed/open → dormant
+    transition. The Lua atomicity of _RECORD_FAILURE_LUA guarantees exactly
+    one worker observes the transition, so this fires at most once per
+    distinct dormant entry — no de-dupe layer required.
+    """
+    try:
+        from database import db
+        from utils.helpers import utc_now_iso
+        now = utc_now_iso()
+        item = {
+            "id": f"cb-dormant-{agent_name}-{now}",
+            "agent_name": agent_name,
+            "type": "circuit_breaker_dormant",
+            "status": "pending",
+            "priority": "high",
+            "title": "Agent circuit breaker DORMANT",
+            "question": (
+                f"{agent_name}'s circuit breaker entered DORMANT after "
+                f"{CIRCUIT_DORMANT_AFTER_OPEN_PROBES} consecutive failed probes. "
+                f"Scheduled tasks fast-fail until the agent recovers via the "
+                f"~{int(CIRCUIT_DORMANT_COOLDOWN_SECONDS / 60)} min cooldown "
+                f"probe or an admin reset."
+            ),
+            "context": {
+                "agent_name": agent_name,
+                "transition": "dormant",
+                "dormant_after_open_probes": CIRCUIT_DORMANT_AFTER_OPEN_PROBES,
+                "dormant_cooldown_seconds": CIRCUIT_DORMANT_COOLDOWN_SECONDS,
+            },
+            "created_at": now,
+        }
+        db.create_operator_queue_item(agent_name, item)
+        logger.warning(
+            "[CB] circuit_breaker_dormant operator-queue entry emitted for %s",
+            agent_name,
+        )
+    except Exception:
+        # Don't let alert-delivery failure mask the breaker transition.
+        logger.exception("[CB] failed to emit dormant alert for %s", agent_name)
+
+
 # ----- Public state object --------------------------------------------------
 
 class CircuitState:
@@ -344,6 +395,11 @@ class CircuitState:
                         CIRCUIT_DORMANT_AFTER_OPEN_PROBES,
                         CIRCUIT_DORMANT_COOLDOWN_SECONDS,
                     )
+                    # #921: surface the transition in the Operating Room so
+                    # operators see it without having to grep logs. The Lua
+                    # atomicity guarantees exactly one worker observes the
+                    # transition, so this fires once per dormant entry.
+                    _emit_dormant_alert(self.agent_name)
             return new_state
         except Exception as e:
             logger.warning("Circuit record_failure swallowed (%s)", e)

--- a/src/backend/services/agent_client.py
+++ b/src/backend/services/agent_client.py
@@ -286,10 +286,15 @@ def _emit_dormant_alert(agent_name: str) -> None:
         from database import db
         from utils.helpers import utc_now_iso
         now = utc_now_iso()
+        # Use the generic 'alert' type so the existing Operating Room UI
+        # (QueueCard.vue / QueueItemDetail.vue branch on 'approval|question|alert')
+        # renders an Acknowledge control. The narrower discriminator goes in
+        # context.alert_type for callers that want to filter — same pattern
+        # the existing `sync_failing` work should adopt when its UI is touched.
         item = {
             "id": f"cb-dormant-{agent_name}-{now}",
             "agent_name": agent_name,
-            "type": "circuit_breaker_dormant",
+            "type": "alert",
             "status": "pending",
             "priority": "high",
             "title": "Agent circuit breaker DORMANT",
@@ -302,6 +307,7 @@ def _emit_dormant_alert(agent_name: str) -> None:
             ),
             "context": {
                 "agent_name": agent_name,
+                "alert_type": "circuit_breaker_dormant",
                 "transition": "dormant",
                 "dormant_after_open_probes": CIRCUIT_DORMANT_AFTER_OPEN_PROBES,
                 "dormant_cooldown_seconds": CIRCUIT_DORMANT_COOLDOWN_SECONDS,

--- a/src/backend/services/agent_client.py
+++ b/src/backend/services/agent_client.py
@@ -60,10 +60,16 @@ CIRCUIT_BASE_COOLDOWN_SECONDS = 30.0
 CIRCUIT_MAX_COOLDOWN_SECONDS = 300.0
 CIRCUIT_PROBE_LOCK_TTL_SECONDS = 10
 # After this many consecutive open-state probes without recovery, give up
-# active probing and wait for an external signal (container restart, manual
-# health-check trigger). 10 × exponentially-growing backoff ≈ 40min of
-# attempts before falling silent.
+# fast probing and switch to long-cooldown probing. 10 × exponentially-
+# growing backoff ≈ 40min before we slow down.
 CIRCUIT_DORMANT_AFTER_OPEN_PROBES = 10
+# Issue #921: dormant state no longer requires manual recovery — we still
+# probe occasionally on a long cooldown so the breaker self-heals when the
+# underlying problem clears. Bounds the worst-case false-fail outage to
+# ~DORMANT_COOLDOWN instead of "until a human notices". Set above the
+# open-state max cooldown so we don't churn probes pointlessly when the
+# agent really is down.
+CIRCUIT_DORMANT_COOLDOWN_SECONDS = 3600.0  # 1 hour
 
 
 # ----- Redis client (lazy, cached, fail-open on unreachability) -------------
@@ -114,17 +120,18 @@ def _reset_circuit_redis_client() -> None:
 # ----- Lua scripts (atomic state machine transitions) -----------------------
 
 # allow_request: returns "allow" | "probe" | "deny".
-#   closed   → "allow"
-#   dormant  → "deny"
-#   open     → if past next_probe_at AND we win SET-NX-EX on probe-lock → "probe"
-#              otherwise → "deny"
+#   closed         → "allow"
+#   open / dormant → if past next_probe_at AND we win SET-NX-EX on probe-lock
+#                    → "probe", otherwise → "deny"
+# Issue #921: dormant uses the same probe-on-cooldown logic as open, just
+# with a much longer next_probe_at interval set in _RECORD_FAILURE_LUA.
+# This restores baseline recovery behaviour: even if the breaker has been
+# dormant for hours, exactly one request per cooldown window goes through
+# to test whether the agent is back.
 _ALLOW_REQUEST_LUA = """
 local state = redis.call('HGET', KEYS[1], 'state')
 if not state or state == 'closed' then
     return 'allow'
-end
-if state == 'dormant' then
-    return 'deny'
 end
 local now = tonumber(ARGV[1])
 local next_probe_at = tonumber(redis.call('HGET', KEYS[1], 'next_probe_at') or '0')
@@ -151,6 +158,7 @@ local threshold = tonumber(ARGV[2])
 local base = tonumber(ARGV[3])
 local max_cd = tonumber(ARGV[4])
 local dormant_threshold = tonumber(ARGV[5])
+local dormant_cooldown = tonumber(ARGV[6])
 
 local failures = redis.call('HINCRBY', KEYS[1], 'failures', 1)
 redis.call('HSET', KEYS[1], 'last_failure_ts', ARGV[1])
@@ -167,11 +175,19 @@ if probe_count >= dormant_threshold then
     new_state = 'dormant'
 end
 
--- Cooldown = min(base * 2^(probe_count-1), max_cd). Cap exponent for safety.
-local exp = probe_count - 1
-if exp > 20 then exp = 20 end
-local cooldown = base * math.pow(2, exp)
-if cooldown > max_cd then cooldown = max_cd end
+-- Cooldown selection (#921):
+--   open:     exponential backoff capped at max_cd (~5min default)
+--   dormant:  long cooldown (~1h default) so we self-heal slowly instead
+--             of falling silent forever.
+local cooldown
+if new_state == 'dormant' then
+    cooldown = dormant_cooldown
+else
+    local exp = probe_count - 1
+    if exp > 20 then exp = 20 end
+    cooldown = base * math.pow(2, exp)
+    if cooldown > max_cd then cooldown = max_cd end
+end
 local next_probe_at = now + cooldown
 
 redis.call('HSET', KEYS[1], 'state', new_state, 'next_probe_at', next_probe_at)
@@ -308,6 +324,7 @@ class CircuitState:
                     CIRCUIT_BASE_COOLDOWN_SECONDS,
                     CIRCUIT_MAX_COOLDOWN_SECONDS,
                     CIRCUIT_DORMANT_AFTER_OPEN_PROBES,
+                    CIRCUIT_DORMANT_COOLDOWN_SECONDS,
                 ],
                 client=client,
             )
@@ -321,9 +338,11 @@ class CircuitState:
                     )
                 elif new_state == "dormant":
                     logger.warning(
-                        "Circuit DORMANT for agent %s — stopped probing after %d "
-                        "consecutive open-probe failures (manual recovery required)",
-                        self.agent_name, CIRCUIT_DORMANT_AFTER_OPEN_PROBES,
+                        "Circuit DORMANT for agent %s after %d consecutive open-probe "
+                        "failures — switching to %.0fs cooldown probing (#921)",
+                        self.agent_name,
+                        CIRCUIT_DORMANT_AFTER_OPEN_PROBES,
+                        CIRCUIT_DORMANT_COOLDOWN_SECONDS,
                     )
             return new_state
         except Exception as e:

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -20,6 +20,11 @@ from typing import Optional, Dict, List
 
 import httpx
 
+try:
+    import redis.asyncio as aioredis
+except Exception:  # pragma: no cover — redis is a hard runtime dep
+    aioredis = None
+
 from database import db
 from models import TaskExecutionStatus
 from services.capacity_manager import get_capacity_manager
@@ -35,6 +40,14 @@ ACTIVITY_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to su
 NO_SESSION_TIMEOUT_SECONDS = 60  # Issue #106: fast-fail executions that never got a Claude session
 WATCHDOG_HTTP_TIMEOUT = 15.0  # Timeout for agent HTTP calls during reconciliation (#869: increased from 5s to handle agents under load)
 WATCHDOG_MIN_AGE_SECONDS = 60  # Don't orphan-recover executions younger than this (dispatch window)
+# Issue #921: two-cycle confirmation for orphan recovery. First time we see
+# (DB-running + agent-missing), we record a sentinel and defer; only on the
+# next cycle that also sees it missing do we actually recover. Closes the
+# false-positive window between the agent's in-finally `registry.unregister`
+# and the backend's success-write in `task_execution_service`. TTL spans
+# enough cycles that a one-shot Redis blip doesn't lose the deferred state.
+ORPHAN_SENTINEL_PREFIX = "watchdog:suspected_orphan:"
+ORPHAN_SENTINEL_TTL_SECONDS = 2 * CLEANUP_INTERVAL_SECONDS + 60  # 660s @ 5min cycle
 STARTUP_RECOVERY_GRACE_SECONDS = 15  # #748: skip startup orphan-recovery for rows
                                      # whose started_at is within this window — they
                                      # may be from an in-flight /internal/execute-task
@@ -129,6 +142,10 @@ class CleanupReport:
     """Results from a single cleanup cycle."""
     orphaned_executions: int = 0
     auto_terminated: int = 0
+    # Issue #921: count of executions deferred for two-cycle confirmation this
+    # cycle. Informational only — does not contribute to `total` because no
+    # state change occurred yet (the sentinel itself is not a "cleanup").
+    orphans_suspected: int = 0
     stale_executions: int = 0
     no_session_executions: int = 0
     orphaned_skipped: int = 0
@@ -159,6 +176,7 @@ class CleanupReport:
         return {
             "orphaned_executions": self.orphaned_executions,
             "auto_terminated": self.auto_terminated,
+            "orphans_suspected": self.orphans_suspected,
             "stale_executions": self.stale_executions,
             "no_session_executions": self.no_session_executions,
             "orphaned_skipped": self.orphaned_skipped,
@@ -193,6 +211,84 @@ class CleanupService:
         # inside the 5-min cleanup loop. First cycle runs maintenance
         # immediately; then every 12th cycle (60 min at 5-min interval).
         self._cycle_count: int = 0
+        # Issue #921: lazy Redis client for the orphan-confirmation sentinel.
+        # Lazy because cleanup_service is imported before Redis is reachable
+        # during the cold-start window.
+        self._redis: Optional["aioredis.Redis"] = None
+
+    async def _get_redis(self) -> Optional["aioredis.Redis"]:
+        """Return an async Redis client for the orphan-sentinel, or None if
+        Redis is unreachable.
+
+        Issue #921: the two-cycle orphan-confirmation needs cross-process
+        state. We fail OPEN — if Redis is gone we revert to the legacy
+        single-cycle behaviour so the watchdog still recovers true orphans
+        (the price is reintroducing the race during the outage; acceptable
+        since the rest of the platform is also degraded then).
+        """
+        if self._redis is not None:
+            return self._redis
+        if aioredis is None:
+            return None
+        try:
+            from config import REDIS_URL
+            client = aioredis.from_url(
+                REDIS_URL,
+                decode_responses=True,
+                socket_connect_timeout=1,
+                socket_timeout=1,
+            )
+            await client.ping()
+            self._redis = client
+            return self._redis
+        except Exception as e:
+            logger.warning("[Watchdog] Redis unavailable for orphan sentinel (%s) — failing open", e)
+            return None
+
+    async def _mark_suspected_orphan(self, execution_id: str) -> bool:
+        """Record the first observation of (DB-running + agent-missing).
+
+        Returns True if the sentinel was written, False on Redis failure.
+        """
+        client = await self._get_redis()
+        if client is None:
+            return False
+        try:
+            await client.setex(
+                f"{ORPHAN_SENTINEL_PREFIX}{execution_id}",
+                ORPHAN_SENTINEL_TTL_SECONDS,
+                utc_now_iso(),
+            )
+            return True
+        except Exception as e:
+            logger.warning("[Watchdog] SETEX sentinel for %s failed (%s)", execution_id, e)
+            return False
+
+    async def _is_suspected_orphan(self, execution_id: str) -> bool:
+        """Has this execution been flagged in a previous cycle?
+
+        Fail-open: on Redis failure return True so we recover (legacy
+        behaviour). This is intentional — see `_get_redis` docstring.
+        """
+        client = await self._get_redis()
+        if client is None:
+            return True
+        try:
+            return await client.exists(f"{ORPHAN_SENTINEL_PREFIX}{execution_id}") > 0
+        except Exception as e:
+            logger.warning("[Watchdog] EXISTS sentinel for %s failed (%s)", execution_id, e)
+            return True
+
+    async def _clear_suspected_orphan(self, execution_id: str) -> None:
+        """Drop the sentinel — either because the agent brought the execution
+        back or because we just confirmed-and-recovered it."""
+        client = await self._get_redis()
+        if client is None:
+            return
+        try:
+            await client.delete(f"{ORPHAN_SENTINEL_PREFIX}{execution_id}")
+        except Exception as e:
+            logger.warning("[Watchdog] DEL sentinel for %s failed (%s)", execution_id, e)
 
     def start(self):
         """Start the background cleanup loop."""
@@ -229,17 +325,22 @@ class CleanupService:
         # from falsely failing executions the watchdog verified as alive.
         confirmed_running_ids: set = set()
         try:
-            orphaned, terminated, confirmed_running_ids = (
+            orphaned, terminated, confirmed_running_ids, suspected = (
                 await self._reconcile_orphaned_executions()
             )
             report.orphaned_executions = orphaned
             report.auto_terminated = terminated
+            report.orphans_suspected = suspected
             self.cumulative_orphaned += orphaned
             self.cumulative_auto_terminated += terminated
             if orphaned > 0:
                 logger.info(f"[Watchdog] Recovered {orphaned} orphaned executions")
             if terminated > 0:
                 logger.info(f"[Watchdog] Auto-terminated {terminated} timed-out executions")
+            if suspected > 0:
+                logger.info(
+                    f"[Watchdog] Deferred {suspected} suspected orphans for two-cycle confirmation"
+                )
         except Exception as e:
             logger.error(f"[Watchdog] Reconciliation error: {e}")
 
@@ -663,22 +764,26 @@ class CleanupService:
                             f"[Cleanup] Error failing {execution_id} after slot reclaim: {e}"
                         )
 
-    async def _reconcile_orphaned_executions(self) -> tuple[int, int, set]:
+    async def _reconcile_orphaned_executions(self) -> tuple[int, int, set, int]:
         """Reconcile DB execution state against agent process registries.
 
         For each execution marked 'running' in the DB:
         1. Check if the agent's process registry still has it
-        2. If not found (orphaned): mark failed, release resources
-        3. If found but exceeded timeout: terminate, mark failed, release resources
+        2. If not found AND previously flagged (Issue #921): mark failed, release resources
+        3. If not found but seen for the first time: write Redis sentinel, defer
+        4. If found but exceeded timeout: terminate, mark failed, release resources
 
         Returns:
-            Tuple of (orphaned_count, auto_terminated_count, confirmed_running_ids)
-            where confirmed_running_ids is the set of execution IDs verified as still
-            running on their agents (used by slot cleanup to avoid false failures, #226).
+            Tuple of (orphaned_count, auto_terminated_count, confirmed_running_ids,
+            suspected_count) where:
+              - confirmed_running_ids: execution IDs verified as still running on
+                their agents (used by slot cleanup, #226)
+              - suspected_count: executions seen as missing for the first time this
+                cycle and deferred for two-cycle confirmation (#921)
         """
         running_executions = db.get_running_executions_with_agent_info()
         if not running_executions:
-            return (0, 0, set())
+            return (0, 0, set(), 0)
 
         # Group by agent for batch HTTP calls (one call per agent)
         agents: Dict[str, List[Dict]] = defaultdict(list)
@@ -702,6 +807,7 @@ class CleanupService:
 
             orphaned_count = 0
             terminated_count = 0
+            suspected_count = 0  # #921: first-cycle deferrals
             recovery_attempts = 0
             recovery_failures = 0
             confirmed_running: set = set()  # #226: track IDs verified as still running
@@ -730,7 +836,25 @@ class CleanupService:
                                 )
                                 continue
 
-                            # Orphan: execution not found on agent
+                            # Issue #921: two-cycle confirmation. The agent's
+                            # `registry.unregister` in `claude_code.py`'s
+                            # `finally` block fires BEFORE the backend writes
+                            # `success` in `task_execution_service`. A single
+                            # snapshot can't tell that race apart from a true
+                            # orphan. Defer the decision by one cycle: the
+                            # natural-completion case will have the DB row in
+                            # a terminal status by then and won't appear in
+                            # the next cycle's running query.
+                            if not await self._is_suspected_orphan(execution_id):
+                                await self._mark_suspected_orphan(execution_id)
+                                suspected_count += 1
+                                logger.info(
+                                    f"[Watchdog] Suspected orphan {execution_id} on "
+                                    f"'{agent_name}' — deferring recovery to next cycle"
+                                )
+                                continue
+
+                            # Second consecutive sighting — confirmed orphan
                             recovery_attempts += 1
                             error_msg = (
                                 "Execution completed on agent but status not reported "
@@ -741,8 +865,16 @@ class CleanupService:
                             )
                             if recovered:
                                 orphaned_count += 1
+                            # Clear the sentinel regardless: either we recovered
+                            # (so the row will no longer appear running), or the
+                            # recovery raced and lost — in both cases a fresh
+                            # observation starts the cycle over.
+                            await self._clear_suspected_orphan(execution_id)
                         else:
-                            # Execution is on agent — check timeout
+                            # Execution is on agent — check timeout.
+                            # #921: agent vouches for it, clear any stale sentinel
+                            # from a previous flap.
+                            await self._clear_suspected_orphan(execution_id)
                             timeout_seconds = ex.get("timeout_seconds") or 900
 
                             if age_seconds <= timeout_seconds:
@@ -788,7 +920,7 @@ class CleanupService:
                 f"recovery attempts failed in this cycle"
             )
 
-        return (orphaned_count, terminated_count, confirmed_running)
+        return (orphaned_count, terminated_count, confirmed_running, suspected_count)
 
     async def _get_agent_running_ids(
         self, client: httpx.AsyncClient, agent_name: str

--- a/tests/integration/test_circuit_breaker.py
+++ b/tests/integration/test_circuit_breaker.py
@@ -304,7 +304,11 @@ class TestDormantState:
         assert fake_db.create_operator_queue_item.call_count == 1
         called_agent, item = fake_db.create_operator_queue_item.call_args.args
         assert called_agent == agent_name
-        assert item["type"] == "circuit_breaker_dormant"
+        # Type is the generic 'alert' so the existing Operating Room UI
+        # renders an Acknowledge control. The narrower CB-specific marker
+        # is in context.alert_type for callers that need to filter.
+        assert item["type"] == "alert"
+        assert item["context"]["alert_type"] == "circuit_breaker_dormant"
         assert item["priority"] == "high"
         assert item["status"] == "pending"
         assert item["agent_name"] == agent_name
@@ -352,6 +356,53 @@ class TestDormantState:
         assert cs.allow_request() is True
         # The probe-lock is held, so a second request right after is denied.
         assert cs.allow_request() is False
+
+    def test_dormant_probe_failure_rearms_full_dormant_cooldown(
+        self, agent_name, redis_client, monkeypatch
+    ):
+        """#921: when a dormant probe fails, next_probe_at must be rearmed to
+        the full DORMANT_COOLDOWN — NOT the open-state exponential backoff.
+
+        Locks in the cadence the fix promises: one probe per ~1h while
+        dormant, regardless of how many times the agent stays unreachable.
+        Without this guarantee a dormant CB could churn through fast
+        retries via the open-state backoff curve, defeating the purpose."""
+        # Wide gap between the two cooldown families so the assertion can
+        # distinguish them: dormant=0.5s, open exp cap=0.001s.
+        monkeypatch.setattr(agent_client, "CIRCUIT_DORMANT_COOLDOWN_SECONDS", 0.5)
+        monkeypatch.setattr(agent_client, "CIRCUIT_DORMANT_AFTER_OPEN_PROBES", 4)
+        monkeypatch.setattr(agent_client, "CIRCUIT_BASE_COOLDOWN_SECONDS", 0.001)
+        monkeypatch.setattr(agent_client, "CIRCUIT_MAX_COOLDOWN_SECONDS", 0.001)
+
+        cs = agent_client.CircuitState(agent_name)
+        # Drive into dormant.
+        for _ in range(
+            agent_client.CIRCUIT_FAILURE_THRESHOLD
+            + agent_client.CIRCUIT_DORMANT_AFTER_OPEN_PROBES
+            + 2
+        ):
+            if cs.record_failure() == "dormant":
+                break
+        assert cs.state == "dormant"
+
+        # Wait past the cooldown, take the probe, then simulate it failing.
+        time.sleep(0.6)
+        assert cs.allow_request() is True  # probe admitted
+        cs.record_failure()                # probe failed → record_failure on dormant
+
+        # next_probe_at should be ~0.5s in the future (DORMANT_COOLDOWN),
+        # not ~0.001s (open-state max). Use the redis_client fixture to
+        # read the raw value; the hash field is a unix timestamp.
+        key = f"agent:circuit:{agent_name}"
+        next_probe_at = float(redis_client.hget(key, "next_probe_at"))
+        gap = next_probe_at - time.time()
+        assert agent_client.CIRCUIT_DORMANT_COOLDOWN_SECONDS - 0.1 <= gap <= agent_client.CIRCUIT_DORMANT_COOLDOWN_SECONDS + 0.1, (
+            f"expected gap ~{agent_client.CIRCUIT_DORMANT_COOLDOWN_SECONDS}s "
+            f"(dormant cooldown), got {gap:.3f}s — open-state backoff would "
+            f"have yielded ~{agent_client.CIRCUIT_MAX_COOLDOWN_SECONDS}s"
+        )
+        # Still dormant, no state slide back to open.
+        assert cs.state == "dormant"
 
 
 # ── Probe-lock cross-worker semantics ────────────────────────────────────────

--- a/tests/integration/test_circuit_breaker.py
+++ b/tests/integration/test_circuit_breaker.py
@@ -259,6 +259,68 @@ class TestDormantState:
         for _ in range(5):
             assert cs.allow_request() is False
 
+    def test_dormant_transition_emits_operator_queue_alert(self, agent_name, monkeypatch):
+        """#921: closed/open → dormant transition fires a
+        circuit_breaker_dormant entry in the Operating Room queue so
+        operators see the silently-failing agent without grepping logs.
+
+        Stubs the lazy `database` import inside `_emit_dormant_alert` with
+        an in-memory fake so we can drive the transition against the real
+        Redis CB without needing the live backend SQLite.
+        """
+        import sys
+        import types
+        from unittest.mock import MagicMock
+
+        # Faster transition into dormant.
+        monkeypatch.setattr(agent_client, "CIRCUIT_DORMANT_AFTER_OPEN_PROBES", 4)
+        monkeypatch.setattr(agent_client, "CIRCUIT_BASE_COOLDOWN_SECONDS", 0.01)
+        monkeypatch.setattr(agent_client, "CIRCUIT_MAX_COOLDOWN_SECONDS", 0.01)
+
+        fake_db = MagicMock()
+        fake_module = types.ModuleType("database")
+        fake_module.db = fake_db
+        monkeypatch.setitem(sys.modules, "database", fake_module)
+        # utils.helpers is normally available; we don't need to stub it,
+        # but if running on a stripped sys.path we provide a shim.
+        if "utils.helpers" not in sys.modules:
+            shim = types.ModuleType("utils.helpers")
+            shim.utc_now_iso = lambda: "2026-05-23T00:00:00Z"
+            monkeypatch.setitem(sys.modules, "utils.helpers", shim)
+
+        cs = agent_client.CircuitState(agent_name)
+        last = None
+        for _ in range(
+            agent_client.CIRCUIT_FAILURE_THRESHOLD
+            + agent_client.CIRCUIT_DORMANT_AFTER_OPEN_PROBES
+            + 2
+        ):
+            last = cs.record_failure()
+            if last == "dormant":
+                break
+        assert last == "dormant"
+
+        # Alert fired exactly once on the transition.
+        assert fake_db.create_operator_queue_item.call_count == 1
+        called_agent, item = fake_db.create_operator_queue_item.call_args.args
+        assert called_agent == agent_name
+        assert item["type"] == "circuit_breaker_dormant"
+        assert item["priority"] == "high"
+        assert item["status"] == "pending"
+        assert item["agent_name"] == agent_name
+        assert "DORMANT" in item["title"]
+        assert item["context"]["transition"] == "dormant"
+        assert (
+            item["context"]["dormant_cooldown_seconds"]
+            == agent_client.CIRCUIT_DORMANT_COOLDOWN_SECONDS
+        )
+
+        # Subsequent failures stay dormant (prior==new) — no transition,
+        # no second alert. Verifies the once-per-entry guarantee.
+        for _ in range(3):
+            cs.record_failure()
+        assert fake_db.create_operator_queue_item.call_count == 1
+
     def test_dormant_probes_after_cooldown(self, agent_name, monkeypatch):
         """#921: once the dormant cooldown elapses, exactly one probe is
         admitted per worker race. Restores baseline recovery behaviour

--- a/tests/integration/test_circuit_breaker.py
+++ b/tests/integration/test_circuit_breaker.py
@@ -246,14 +246,50 @@ class TestDormantState:
         assert last == "dormant", f"never transitioned to dormant; last={last}"
         assert cs.state == "dormant"
 
-    def test_dormant_denies_all_requests(self, agent_name):
+    def test_dormant_denies_within_cooldown(self, agent_name):
+        """While inside the dormant cooldown window, all requests are denied.
+
+        #921: dormant no longer means "never probe again" — it means probe
+        on a long cooldown. But within that window, no requests slip through.
+        """
         agent_client.force_circuit_dormant(agent_name, reason="test")
         cs = agent_client.CircuitState(agent_name)
         assert cs.state == "dormant"
         assert cs.allow_request() is False
-        # Repeated calls stay dormant — no half-open attempts.
         for _ in range(5):
             assert cs.allow_request() is False
+
+    def test_dormant_probes_after_cooldown(self, agent_name, monkeypatch):
+        """#921: once the dormant cooldown elapses, exactly one probe is
+        admitted per worker race. Restores baseline recovery behaviour
+        without requiring manual intervention."""
+        # Tiny cooldown so the test elapses it without sleeping for an hour.
+        monkeypatch.setattr(agent_client, "CIRCUIT_DORMANT_COOLDOWN_SECONDS", 0.05)
+        # Drive the breaker into dormant via failures (not the force-helper)
+        # so next_probe_at is set by the failure Lua path with the new
+        # CIRCUIT_DORMANT_COOLDOWN_SECONDS.
+        monkeypatch.setattr(agent_client, "CIRCUIT_DORMANT_AFTER_OPEN_PROBES", 4)
+        monkeypatch.setattr(agent_client, "CIRCUIT_BASE_COOLDOWN_SECONDS", 0.01)
+        monkeypatch.setattr(agent_client, "CIRCUIT_MAX_COOLDOWN_SECONDS", 0.01)
+
+        cs = agent_client.CircuitState(agent_name)
+        last = None
+        for _ in range(
+            agent_client.CIRCUIT_FAILURE_THRESHOLD
+            + agent_client.CIRCUIT_DORMANT_AFTER_OPEN_PROBES
+            + 2
+        ):
+            last = cs.record_failure()
+            if last == "dormant":
+                break
+        assert last == "dormant"
+        # Immediately after entering dormant, the cooldown has not elapsed.
+        assert cs.allow_request() is False
+        time.sleep(0.1)
+        # Cooldown elapsed — exactly one probe goes through.
+        assert cs.allow_request() is True
+        # The probe-lock is held, so a second request right after is denied.
+        assert cs.allow_request() is False
 
 
 # ── Probe-lock cross-worker semantics ────────────────────────────────────────

--- a/tests/test_circuit_breaker_reset.py
+++ b/tests/test_circuit_breaker_reset.py
@@ -1,0 +1,143 @@
+"""
+Circuit Breaker Reset Endpoint Tests (Issue #921)
+
+Integration tests for POST /api/agents/{name}/circuit-breaker/reset —
+the admin escape hatch added in #921 for the dormant-CB cascade. Drives
+the live backend + Redis stack rather than mocking, because the value
+of this test is that the route, the auth dependency, and the underlying
+Redis-DEL all line up end-to-end.
+"""
+
+import os
+import subprocess
+import uuid
+
+import pytest
+from utils.api_client import TrinityApiClient
+from utils.assertions import assert_status
+
+
+_BACKEND_CONTAINER = os.getenv("TRINITY_BACKEND_CONTAINER", "trinity-backend")
+_REDIS_CONTAINER = os.getenv("TRINITY_REDIS_CONTAINER", "trinity-redis")
+# trinity-system is always present on every Trinity instance and stable to
+# poke. We never actually issue HTTP to the agent — only Redis state for the
+# CB key is touched.
+_AGENT = "trinity-system"
+
+
+def _exec_backend(python_code: str) -> str:
+    result = subprocess.run(
+        ["docker", "exec", _BACKEND_CONTAINER, "python3", "-c", python_code],
+        capture_output=True, text=True, timeout=15,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Backend exec failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def _redis_password() -> str:
+    """Pull the operator REDIS_PASSWORD from .env for direct redis-cli access."""
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env = os.path.join(here, ".env")
+    if not os.path.exists(env):
+        pytest.skip(".env missing — cannot derive Redis password")
+    for line in open(env):
+        if line.startswith("REDIS_PASSWORD="):
+            return line.split("=", 1)[1].strip()
+    pytest.skip("REDIS_PASSWORD not found in .env")
+
+
+def _force_dormant(agent_name: str) -> None:
+    """Park the CB in dormant via the existing force helper."""
+    _exec_backend(
+        "from services.agent_client import force_circuit_dormant\n"
+        f"force_circuit_dormant('{agent_name}', reason='test-921-reset')\n"
+    )
+
+
+def _cb_key_exists(agent_name: str, password: str) -> bool:
+    result = subprocess.run(
+        ["docker", "exec", _REDIS_CONTAINER, "redis-cli",
+         "-a", password, "--no-auth-warning",
+         "EXISTS", f"agent:circuit:{agent_name}"],
+        capture_output=True, text=True, timeout=10,
+    )
+    return result.stdout.strip() == "1"
+
+
+def _delete_cb_key(agent_name: str, password: str) -> None:
+    subprocess.run(
+        ["docker", "exec", _REDIS_CONTAINER, "redis-cli",
+         "-a", password, "--no-auth-warning",
+         "DEL", f"agent:circuit:{agent_name}",
+         f"agent:circuit:{agent_name}:probe-lock"],
+        capture_output=True, text=True, timeout=10,
+    )
+
+
+class TestCircuitBreakerResetEndpoint:
+    """POST /api/agents/{name}/circuit-breaker/reset — #921 escape hatch."""
+
+    @pytest.fixture
+    def redis_password(self):
+        return _redis_password()
+
+    @pytest.fixture
+    def parked_dormant(self, redis_password):
+        """Park trinity-system's CB in dormant; tear down by clearing the
+        Redis state so the agent is reachable for subsequent tests."""
+        _force_dormant(_AGENT)
+        yield
+        _delete_cb_key(_AGENT, redis_password)
+
+    def test_reset_returns_prior_state_and_clears_redis(
+        self, api_client: TrinityApiClient, parked_dormant, redis_password
+    ):
+        """Happy path: dormant agent → POST reset → 200 with prior=dormant,
+        new=closed, and the Redis hash deleted."""
+        assert _cb_key_exists(_AGENT, redis_password), "fixture didn't park dormant"
+
+        response = api_client.post(f"/api/agents/{_AGENT}/circuit-breaker/reset")
+        assert_status(response, 200)
+        body = response.json()
+
+        assert body["agent_name"] == _AGENT
+        assert body["prior_state"] == "dormant"
+        assert body["new_state"] == "closed"
+        assert "reset_at" in body
+
+        # The Redis hash is gone — the next CB check will fail-open to 'closed'.
+        assert not _cb_key_exists(_AGENT, redis_password)
+
+    def test_reset_idempotent_on_closed_cb(
+        self, api_client: TrinityApiClient, redis_password
+    ):
+        """Idempotent: calling reset when the CB is already closed (no
+        Redis key present) succeeds and reports prior=closed."""
+        _delete_cb_key(_AGENT, redis_password)
+        assert not _cb_key_exists(_AGENT, redis_password)
+
+        response = api_client.post(f"/api/agents/{_AGENT}/circuit-breaker/reset")
+        assert_status(response, 200)
+        body = response.json()
+        assert body["prior_state"] == "closed"
+        assert body["new_state"] == "closed"
+
+    def test_reset_requires_admin(
+        self, unauthenticated_client: TrinityApiClient, redis_password
+    ):
+        """Unauthenticated requests are rejected — verifies the
+        require_role('admin') dependency wires correctly. Non-admin
+        coverage lives in role-hierarchy tests; here we only need to
+        prove the endpoint isn't anonymous."""
+        response = unauthenticated_client.post(
+            f"/api/agents/{_AGENT}/circuit-breaker/reset"
+        )
+        assert response.status_code in (401, 403)
+
+    def test_reset_404_for_unknown_agent(self, api_client: TrinityApiClient):
+        """Endpoint is per-agent — reset on an unknown agent name returns 404
+        via the AuthorizedAgentByName dependency, not 200 + no-op."""
+        bogus = f"does-not-exist-{uuid.uuid4().hex[:8]}"
+        response = api_client.post(f"/api/agents/{bogus}/circuit-breaker/reset")
+        assert response.status_code == 404

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -5,8 +5,16 @@ Tests for Issue #129: Active watchdog remediation of stuck executions.
 Integration tests against the running backend — verify cleanup report
 includes watchdog fields.
 
+Issue #921: two-cycle confirmation regression — guards against the false-
+positive recovery race between agent unregister and backend success-write.
+
 Feature Flow: docs/memory/feature-flows/cleanup-service.md
 """
+
+import os
+import subprocess
+import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from utils.api_client import TrinityApiClient
@@ -14,6 +22,106 @@ from utils.assertions import (
     assert_status,
     assert_json_response,
 )
+
+_BACKEND_CONTAINER = os.getenv("TRINITY_BACKEND_CONTAINER", "trinity-backend")
+# trinity-system is a stable, always-running agent on every Trinity instance.
+# Its /api/executions/running endpoint returns an empty list when nothing's
+# in flight, which is the exact state the watchdog sees during the race.
+_SENTINEL_AGENT = "trinity-system"
+
+
+def _exec_backend(python_code: str) -> str:
+    """Run Python inside the trinity-backend container — used for DB/Redis
+    fixture setup. Mirrors the pattern in test_operator_queue.py."""
+    result = subprocess.run(
+        ["docker", "exec", _BACKEND_CONTAINER, "python3", "-c", python_code],
+        capture_output=True, text=True, timeout=15,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Backend exec failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def _insert_running_row(execution_id: str, age_seconds: int = 120) -> None:
+    """Insert a schedule_executions row that looks like an in-flight task.
+
+    `claude_session_id` is set so the #106 no-session fast-fail path doesn't
+    fire before the orphan-recovery path can run.
+    """
+    started_at = (
+        datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _exec_backend(f"""
+import sqlite3
+c = sqlite3.connect('/data/trinity.db')
+c.execute(
+    'INSERT INTO schedule_executions (id, schedule_id, agent_name, status, '
+    'started_at, message, triggered_by, claude_session_id) '
+    'VALUES (?,?,?,?,?,?,?,?)',
+    ('{execution_id}', 'sched-921-int', '{_SENTINEL_AGENT}', 'running',
+     '{started_at}', 'integration #921', 'manual', 'sess-921-int'),
+)
+c.commit(); c.close()
+print('OK')
+""")
+
+
+def _row_state(execution_id: str) -> dict:
+    """Return {status, error, response} for a row, or {} if missing."""
+    out = _exec_backend(f"""
+import json, sqlite3
+c = sqlite3.connect('/data/trinity.db'); c.row_factory = sqlite3.Row
+r = c.execute('SELECT status, error, response FROM schedule_executions WHERE id=?', ('{execution_id}',)).fetchone()
+print(json.dumps(dict(r) if r else {{}}))
+c.close()
+""")
+    import json as _json
+    return _json.loads(out)
+
+
+def _sentinel_exists(execution_id: str) -> bool:
+    out = _exec_backend(f"""
+import redis, os
+from config import REDIS_URL
+client = redis.from_url(REDIS_URL, decode_responses=True, socket_connect_timeout=2)
+print('1' if client.exists('watchdog:suspected_orphan:{execution_id}') > 0 else '0')
+""")
+    return out == "1"
+
+
+def _force_success(execution_id: str) -> None:
+    """Simulate task_execution_service writing the success status that the
+    watchdog races against — see services/task_execution_service.py:728."""
+    _exec_backend(f"""
+import sqlite3
+c = sqlite3.connect('/data/trinity.db')
+c.execute(
+    'UPDATE schedule_executions SET status=?, completed_at=?, response=? WHERE id=?',
+    ('success', '2099-01-01T00:00:00Z', 'task completed normally', '{execution_id}'),
+)
+c.commit(); c.close()
+print('OK')
+""")
+
+
+def _delete_row(execution_id: str) -> None:
+    _exec_backend(f"""
+import sqlite3
+c = sqlite3.connect('/data/trinity.db')
+c.execute('DELETE FROM schedule_executions WHERE id=?', ('{execution_id}',))
+c.commit(); c.close()
+print('OK')
+""")
+
+
+def _clear_sentinel(execution_id: str) -> None:
+    _exec_backend(f"""
+import redis
+from config import REDIS_URL
+client = redis.from_url(REDIS_URL, decode_responses=True, socket_connect_timeout=2)
+client.delete('watchdog:suspected_orphan:{execution_id}')
+print('OK')
+""")
 
 
 class TestWatchdogCleanupReportFields:
@@ -69,3 +177,131 @@ class TestWatchdogCleanupReportFields:
         """Watchdog cleanup trigger requires authentication."""
         response = unauthenticated_client.post("/api/monitoring/cleanup-trigger")
         assert response.status_code in [401, 403]
+
+
+# ============================================================================
+# Two-Cycle Orphan Confirmation (Issue #921)
+# ============================================================================
+
+
+class TestTwoCycleOrphanConfirmation:
+    """Live-stack regression for #921.
+
+    The agent's `claude_code.py` unregisters its process registry in a
+    `finally` block BEFORE `task_execution_service` writes `success` to
+    the DB. A single watchdog snapshot can't distinguish that race window
+    from a true orphan, so recovery now requires two consecutive sightings
+    of (DB-running + agent-missing).
+
+    These tests drive `POST /api/monitoring/cleanup-trigger` directly to
+    invoke the watchdog synchronously, then inspect the DB row and the
+    Redis sentinel to verify the two-cycle protocol behaves correctly.
+    """
+
+    @pytest.fixture
+    def execution_id(self):
+        """Generate a unique execution_id and guarantee cleanup of both the
+        DB row and the Redis sentinel — even if the test fails mid-way."""
+        eid = f"test-921-int-{uuid.uuid4().hex[:12]}"
+        yield eid
+        # Teardown: always tidy up, ignore individual failures
+        try:
+            _delete_row(eid)
+        except Exception:
+            pass
+        try:
+            _clear_sentinel(eid)
+        except Exception:
+            pass
+
+    def test_first_cycle_defers_without_recovery(
+        self, api_client: TrinityApiClient, execution_id: str
+    ):
+        """The race window itself: agent says missing, DB still running.
+
+        Expected: watchdog records the sentinel and reports
+        `orphans_suspected=1`, but does NOT mark the row failed. This is
+        the heart of the #921 fix — under the old code the same scenario
+        produced `orphaned_executions=1` and a watchdog-failed row.
+        """
+        _insert_running_row(execution_id)
+
+        before = _row_state(execution_id)
+        assert before["status"] == "running"
+        assert not _sentinel_exists(execution_id)
+
+        response = api_client.post("/api/monitoring/cleanup-trigger")
+        assert_status(response, 200)
+        report = response.json()["report"]
+
+        assert "orphans_suspected" in report, "Missing orphans_suspected field"
+        assert report["orphans_suspected"] >= 1
+        # Row must still be running — recovery was deferred.
+        after = _row_state(execution_id)
+        assert after["status"] == "running"
+        assert after["error"] is None
+        # Sentinel must be in Redis to gate the next cycle.
+        assert _sentinel_exists(execution_id)
+
+    def test_second_cycle_confirms_and_recovers(
+        self, api_client: TrinityApiClient, execution_id: str
+    ):
+        """True orphan: two consecutive cycles see (DB-running + agent-missing).
+
+        Expected: first cycle defers, second cycle recovers and clears the
+        sentinel. Confirms the fix doesn't break legitimate orphan recovery —
+        it only delays it by one cycle.
+        """
+        _insert_running_row(execution_id)
+
+        # Cycle 1 — defer
+        report_1 = api_client.post("/api/monitoring/cleanup-trigger").json()["report"]
+        assert report_1["orphans_suspected"] >= 1
+        assert _row_state(execution_id)["status"] == "running"
+
+        # Cycle 2 — recover
+        report_2 = api_client.post("/api/monitoring/cleanup-trigger").json()["report"]
+        assert report_2["orphaned_executions"] >= 1
+
+        after = _row_state(execution_id)
+        assert after["status"] == "failed"
+        assert "recovered by watchdog" in (after["error"] or "")
+        # Sentinel cleared so a future row with the same id doesn't skip
+        # straight to recovery.
+        assert not _sentinel_exists(execution_id)
+
+    def test_natural_completion_race_no_false_positive(
+        self, api_client: TrinityApiClient, execution_id: str
+    ):
+        """The #921 smoking-gun scenario reproduced end-to-end.
+
+        Cycle 1: row is `running`, agent has unregistered (race window).
+        Between cycles: backend lands the `success` write (we simulate
+          task_execution_service's update directly).
+        Cycle 2: the row is no longer in the running query, so the watchdog
+          never even looks at it. The row's natural `success` state survives
+          intact — no false orphan recovery overwrites it.
+
+        Under the old code, cycle 1 alone would mark the row failed with a
+        watchdog error message, destroying the real completion data.
+        """
+        _insert_running_row(execution_id)
+
+        # Cycle 1: race window — watchdog defers.
+        report_1 = api_client.post("/api/monitoring/cleanup-trigger").json()["report"]
+        assert report_1["orphans_suspected"] >= 1
+        assert _row_state(execution_id)["status"] == "running"
+
+        # Between cycles: the backend's task_execution_service lands its
+        # success-write that was in flight all along.
+        _force_success(execution_id)
+
+        # Cycle 2: the row is in a terminal status and is no longer returned
+        # by get_running_executions_with_agent_info — watchdog ignores it.
+        api_client.post("/api/monitoring/cleanup-trigger")
+
+        final = _row_state(execution_id)
+        # The crucial assertion: the natural success was NOT overwritten.
+        assert final["status"] == "success"
+        assert final["error"] is None
+        assert final["response"] == "task completed normally"

--- a/tests/test_watchdog_unit.py
+++ b/tests/test_watchdog_unit.py
@@ -408,20 +408,27 @@ class TestReconcileOrphanedExecutions:
         # Mock _get_agent_running_ids to return None (unreachable)
         service._get_agent_running_ids = AsyncMock(return_value=None)
 
-        orphaned, terminated, confirmed_running = asyncio.run(
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 0
         assert confirmed_running == set()
+        assert suspected == 0
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
 
     @patch("services.cleanup_service.httpx.AsyncClient")
     @patch("services.cleanup_service.db")
     @patch("services.cleanup_service.get_capacity_manager")
     def test_orphan_not_found_on_agent(self, mock_capacity_fn, mock_db, mock_httpx):
-        """Execution not found on agent -> orphan recovery."""
+        """Execution not found on agent -> orphan recovery (second cycle).
+
+        Issue #921: orphan recovery now requires two consecutive sightings.
+        This test simulates the second sighting by pre-asserting the sentinel
+        already exists; see TestTwoCycleOrphanConfirmation for the first-
+        sighting deferral behaviour.
+        """
         mock_cm, _ = self._mock_httpx_client()
         mock_httpx.return_value = mock_cm
 
@@ -436,18 +443,25 @@ class TestReconcileOrphanedExecutions:
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
+        # #921: pretend this is the second cycle — the sentinel already exists.
+        service._is_suspected_orphan = AsyncMock(return_value=True)
+        service._mark_suspected_orphan = AsyncMock(return_value=True)
+        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running = asyncio.run(
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 1
         assert terminated == 0
         assert confirmed_running == set()
+        assert suspected == 0
         mock_db.mark_execution_failed_by_watchdog.assert_called_once()
         # CAPACITY-CONSOLIDATE (#428): one TOCTOU-safe release call covers
         # both the slot count and the in-memory queue bookkeeping.
         mock_capacity.release_if_matches.assert_called_once_with("agent-a", "exec-1")
+        # Sentinel cleared after recovery so a fresh observation starts over.
+        service._clear_suspected_orphan.assert_called_with("exec-1")
 
     @patch("services.cleanup_service.httpx.AsyncClient")
     @patch("services.cleanup_service.db")
@@ -463,13 +477,15 @@ class TestReconcileOrphanedExecutions:
 
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
+        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running = asyncio.run(
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 0
+        assert suspected == 0
         # #226: Execution confirmed as still running within timeout
         assert confirmed_running == {"exec-1"}
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
@@ -494,13 +510,15 @@ class TestReconcileOrphanedExecutions:
         service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
         service._terminate_on_agent = AsyncMock(return_value=True)
         service._broadcast_watchdog_event = AsyncMock()
+        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running = asyncio.run(
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 1
+        assert suspected == 0
         assert confirmed_running == set()  # Over timeout, so not confirmed
         service._terminate_on_agent.assert_called_once_with(ANY, "agent-a", "exec-1")
         mock_db.mark_execution_failed_by_watchdog.assert_called_once()
@@ -524,13 +542,15 @@ class TestReconcileOrphanedExecutions:
         service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
         service._terminate_on_agent = AsyncMock(return_value=False)
         service._broadcast_watchdog_event = AsyncMock()
+        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running = asyncio.run(
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         # Terminate failed — should NOT mark as failed or release resources
         assert terminated == 0
+        assert suspected == 0
         assert confirmed_running == set()
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
         mock_capacity.release_if_matches.assert_not_called()
@@ -539,7 +559,14 @@ class TestReconcileOrphanedExecutions:
     @patch("services.cleanup_service.db")
     @patch("services.cleanup_service.get_capacity_manager")
     def test_race_condition_db_update_noop(self, mock_capacity_fn, mock_db, mock_httpx):
-        """When DB update returns False (race), skip slot/queue release."""
+        """When DB update returns False (race), skip slot/queue release.
+
+        #921: the inner TOCTOU race (DB-update-while-watchdog-decides) is
+        still possible on the second cycle even after the two-cycle defer.
+        This test simulates that: sentinel exists (second cycle), but the
+        conditional UPDATE returns False because task_execution_service
+        landed its success-write just before we tried to mark failed.
+        """
         mock_cm, _ = self._mock_httpx_client()
         mock_httpx.return_value = mock_cm
 
@@ -554,12 +581,16 @@ class TestReconcileOrphanedExecutions:
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
+        service._is_suspected_orphan = AsyncMock(return_value=True)
+        service._mark_suspected_orphan = AsyncMock(return_value=True)
+        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running = asyncio.run(
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
+        assert suspected == 0
         assert confirmed_running == set()
         mock_capacity.release_if_matches.assert_not_called()
 
@@ -587,14 +618,225 @@ class TestReconcileOrphanedExecutions:
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
+        # #921: second-cycle scenario — sentinel pre-exists for both rows.
+        service._is_suspected_orphan = AsyncMock(return_value=True)
+        service._mark_suspected_orphan = AsyncMock(return_value=True)
+        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running = asyncio.run(
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 1
+        assert suspected == 0
         assert confirmed_running == set()
         assert mock_db.mark_execution_failed_by_watchdog.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Two-cycle orphan confirmation (Issue #921)
+# ---------------------------------------------------------------------------
+
+
+class TestTwoCycleOrphanConfirmation:
+    """Regression tests for #921: the false-positive orphan-recovery race.
+
+    The agent's `claude_code.py` unregisters its process registry in a
+    `finally` block BEFORE the backend writes the success status to the DB.
+    A single watchdog snapshot taken in that window cannot distinguish a
+    completing execution from a true orphan. Recovery now requires two
+    consecutive sightings of (DB-running + agent-missing); the natural
+    completion case never reaches the second sighting because the DB row
+    has transitioned to a terminal status by then.
+    """
+
+    pytestmark = pytest.mark.unit
+
+    def _make_service(self):
+        from services.cleanup_service import CleanupService
+        return CleanupService()
+
+    def _mock_httpx_client(self):
+        mock_client = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        return mock_cm, mock_client
+
+    @patch("services.cleanup_service.httpx.AsyncClient")
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_capacity_manager")
+    def test_first_cycle_missing_defers_no_recovery(self, mock_capacity_fn, mock_db, mock_httpx):
+        """First sighting of agent-missing => write sentinel, no DB write,
+        no slot release. This is the heart of the #921 fix."""
+        mock_cm, _ = self._mock_httpx_client()
+        mock_httpx.return_value = mock_cm
+
+        mock_db.get_running_executions_with_agent_info.return_value = [
+            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(10), "timeout_seconds": 900, "schedule_id": "s1"},
+        ]
+
+        mock_capacity = AsyncMock()
+        mock_capacity_fn.return_value = mock_capacity
+
+        service = self._make_service()
+        service._get_agent_running_ids = AsyncMock(return_value=set())
+        service._broadcast_watchdog_event = AsyncMock()
+        # First cycle — no sentinel exists yet.
+        service._is_suspected_orphan = AsyncMock(return_value=False)
+        service._mark_suspected_orphan = AsyncMock(return_value=True)
+        service._clear_suspected_orphan = AsyncMock()
+
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+            service._reconcile_orphaned_executions()
+        )
+
+        # The crucial assertions: row NOT recovered, sentinel written instead.
+        assert orphaned == 0
+        assert suspected == 1
+        assert confirmed_running == set()
+        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
+        mock_capacity.release_if_matches.assert_not_called()
+        service._mark_suspected_orphan.assert_called_once_with("exec-1")
+
+    @patch("services.cleanup_service.httpx.AsyncClient")
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_capacity_manager")
+    def test_second_cycle_still_missing_recovers(self, mock_capacity_fn, mock_db, mock_httpx):
+        """Sentinel pre-exists + still missing on agent => recover and clear sentinel."""
+        mock_cm, _ = self._mock_httpx_client()
+        mock_httpx.return_value = mock_cm
+
+        mock_db.get_running_executions_with_agent_info.return_value = [
+            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(10), "timeout_seconds": 900, "schedule_id": "s1"},
+        ]
+        mock_db.mark_execution_failed_by_watchdog.return_value = True
+
+        mock_capacity = AsyncMock()
+        mock_capacity_fn.return_value = mock_capacity
+
+        service = self._make_service()
+        service._get_agent_running_ids = AsyncMock(return_value=set())
+        service._broadcast_watchdog_event = AsyncMock()
+        service._is_suspected_orphan = AsyncMock(return_value=True)
+        service._mark_suspected_orphan = AsyncMock(return_value=True)
+        service._clear_suspected_orphan = AsyncMock()
+
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+            service._reconcile_orphaned_executions()
+        )
+
+        assert orphaned == 1
+        assert suspected == 0
+        mock_db.mark_execution_failed_by_watchdog.assert_called_once()
+        mock_capacity.release_if_matches.assert_called_once_with("agent-a", "exec-1")
+        service._clear_suspected_orphan.assert_called_with("exec-1")
+        # No new sentinel written on the recovery cycle.
+        service._mark_suspected_orphan.assert_not_called()
+
+    @patch("services.cleanup_service.httpx.AsyncClient")
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_capacity_manager")
+    def test_natural_completion_race_resolves_without_recovery(self, mock_capacity_fn, mock_db, mock_httpx):
+        """The #921 smoking-gun scenario.
+
+        Cycle N: backend has dispatched a long task. Agent finished it, ran
+        `registry.unregister` in `finally`, but the backend hasn't yet
+        written `success` to the DB. Watchdog sees agent-missing + DB-
+        running. With the fix it defers.
+
+        Cycle N+1: between cycles, task_execution_service finished its
+        success-write. The DB row is now in a terminal status, so
+        `get_running_executions_with_agent_info` no longer returns it.
+        Nothing to act on — the false positive is avoided entirely.
+        """
+        mock_cm, _ = self._mock_httpx_client()
+        mock_httpx.return_value = mock_cm
+
+        mock_capacity = AsyncMock()
+        mock_capacity_fn.return_value = mock_capacity
+
+        # Persistent in-memory "Redis" so cycle N+1 sees cycle N's sentinel.
+        sentinel_store: set = set()
+
+        async def _mark(eid):
+            sentinel_store.add(eid)
+            return True
+
+        async def _check(eid):
+            return eid in sentinel_store
+
+        async def _clear(eid):
+            sentinel_store.discard(eid)
+
+        service = self._make_service()
+        service._get_agent_running_ids = AsyncMock(return_value=set())
+        service._broadcast_watchdog_event = AsyncMock()
+        service._is_suspected_orphan = _check
+        service._mark_suspected_orphan = _mark
+        service._clear_suspected_orphan = _clear
+
+        # ---- Cycle N: race window. DB still says running, agent unregistered.
+        mock_db.get_running_executions_with_agent_info.return_value = [
+            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(10), "timeout_seconds": 900, "schedule_id": "s1"},
+        ]
+        orphaned_n, _, _, suspected_n = asyncio.run(
+            service._reconcile_orphaned_executions()
+        )
+        assert orphaned_n == 0
+        assert suspected_n == 1
+        assert "exec-1" in sentinel_store  # sentinel survives between cycles
+        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
+
+        # ---- Cycle N+1: backend wrote `success` between cycles. The row no
+        #      longer appears in the running query — watchdog never even looks
+        #      at exec-1 again. False positive avoided.
+        mock_db.get_running_executions_with_agent_info.return_value = []
+        orphaned_n1, _, _, suspected_n1 = asyncio.run(
+            service._reconcile_orphaned_executions()
+        )
+        assert orphaned_n1 == 0
+        assert suspected_n1 == 0
+        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
+        mock_capacity.release_if_matches.assert_not_called()
+        # The sentinel will expire on its own via TTL; explicit cleanup is
+        # not required for correctness, only for tidiness.
+
+    @patch("services.cleanup_service.httpx.AsyncClient")
+    @patch("services.cleanup_service.db")
+    @patch("services.cleanup_service.get_capacity_manager")
+    def test_agent_flap_clears_sentinel(self, mock_capacity_fn, mock_db, mock_httpx):
+        """If the agent's registry shows the execution again on the next cycle
+        (transient flap), the sentinel is cleared so a single bad sample
+        doesn't accumulate toward a false-positive recovery."""
+        mock_cm, _ = self._mock_httpx_client()
+        mock_httpx.return_value = mock_cm
+
+        mock_db.get_running_executions_with_agent_info.return_value = [
+            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(5), "timeout_seconds": 900, "schedule_id": "s1"},
+        ]
+
+        mock_capacity = AsyncMock()
+        mock_capacity_fn.return_value = mock_capacity
+
+        service = self._make_service()
+        # Agent confirms execution is running this cycle.
+        service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
+        service._broadcast_watchdog_event = AsyncMock()
+        service._is_suspected_orphan = AsyncMock(return_value=True)
+        service._mark_suspected_orphan = AsyncMock(return_value=True)
+        service._clear_suspected_orphan = AsyncMock()
+
+        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+            service._reconcile_orphaned_executions()
+        )
+
+        assert orphaned == 0
+        assert suspected == 0
+        assert confirmed_running == {"exec-1"}
+        # Most important: the stale sentinel is cleared.
+        service._clear_suspected_orphan.assert_called_with("exec-1")
+        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the #921 false-fail cascade end-to-end. Four commits, each focused:

1. **`780c7270`** — Two-cycle confirmation for watchdog orphan recovery. Closes the race window between the agent's in-finally `registry.unregister` and the backend's success-write that was producing false-positive orphan recoveries (the cascade's root cause).
2. **`dab63744`** — Dormant CB self-heals via 1h cooldown probe. The breaker no longer requires manual intervention — restores baseline recovery behaviour and bounds the worst-case outage from "14.5h until someone notices" to ~1h.
3. **`5b658a98`** — Operator-queue alert on CB dormant transition. The incident behind #921 went unnoticed for hours because the only signal was a single WARN log. Now the transition surfaces in the Operating Room.
4. **`1205dacc`** — `POST /api/agents/{name}/circuit-breaker/reset` admin endpoint. Replaces the `redis-cli DEL agent:circuit:{name}` operator workaround.

Together: the watchdog stops producing the false-positive that opens the CB; if the CB *does* genuinely open and go dormant, it self-heals; if an operator wants to short-circuit the self-heal they have an admin endpoint; and the dormant state is visible in the UI either way.

## Reproduction (pre-fix)

Inserted a `schedule_executions` row in `status='running'` for `trinity-system` with `started_at=120s` ago. `POST /api/monitoring/cleanup-trigger` marked the row `failed` with the watchdog error message — exactly the cascade described in #921, because the watchdog can't tell the natural-completion race window apart from a true orphan from a single snapshot.

## Test plan

- [x] `tests/test_watchdog_unit.py` — 4 new unit tests in `TestTwoCycleOrphanConfirmation`, existing 7 updated for the widened 4-tuple return
- [x] `tests/test_watchdog.py` — 3 new live-stack integration tests in `TestTwoCycleOrphanConfirmation` driving the real `POST /api/monitoring/cleanup-trigger`
- [x] `tests/integration/test_circuit_breaker.py` — 1 new test for the dormant→probe transition, 1 new test for the operator-queue alert shape, 1 updated test for the cooldown-deny semantics
- [x] `tests/test_circuit_breaker_reset.py` — new file, 4 integration tests for the admin reset endpoint (happy path, idempotent, auth, 404)
- [x] Live verification of all four paths against the running stack (commit messages have details)

80 passed, 3 skipped across the four #921-touching test files (`test_watchdog_unit.py`, `test_watchdog.py`, `tests/integration/test_circuit_breaker.py`, `test_circuit_breaker_reset.py`).

## Out of scope

- The "retry collision" symptom in the secondary bullet of the original ticket. The two-cycle fix eliminates the upstream false-positive that triggers it, so the symptom disappears with it. Belt-and-braces on the retry path itself would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)