### PR TITLE
feat(#926): version chip + git build provenance in NavBar/Settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,16 @@ services:
     build:
       context: .
       dockerfile: docker/backend/Dockerfile
+      # Build-time provenance (#926). scripts/deploy/start.sh exports these
+      # from the local repo (`git rev-parse HEAD` etc.) before compose builds.
+      # Unset = Dockerfile defaults to "unknown" so an out-of-band build still
+      # produces a well-typed /api/version response.
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+        GIT_COMMIT_SUBJECT: ${GIT_COMMIT_SUBJECT:-unknown}
+        GIT_COMMIT_TIMESTAMP: ${GIT_COMMIT_TIMESTAMP:-unknown}
+        GIT_BRANCH: ${GIT_BRANCH:-unknown}
+        BUILD_DATE: ${BUILD_DATE:-unknown}
     container_name: trinity-backend
     ports:
       - "8000:8000"

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -5,6 +5,23 @@ WORKDIR /app
 # Install curl for healthcheck, git for GitHub cloning, libmagic for file type detection
 RUN apt-get update && apt-get install -y --no-install-recommends curl git libmagic1 && rm -rf /var/lib/apt/lists/*
 
+# Build-time provenance (#926). Each arg is forwarded by docker-compose
+# `backend.build.args` from shell vars set by `scripts/deploy/start.sh`.
+# Re-exported as ENV so the running container reads them via os.getenv()
+# and `GET /api/version` can return commit/branch/build-date for the
+# image actually in flight. Defaults to "unknown" so local builds and
+# operators who skip start.sh still get a well-typed response.
+ARG GIT_COMMIT=unknown
+ARG GIT_COMMIT_SUBJECT=unknown
+ARG GIT_COMMIT_TIMESTAMP=unknown
+ARG GIT_BRANCH=unknown
+ARG BUILD_DATE=unknown
+ENV GIT_COMMIT=${GIT_COMMIT} \
+    GIT_COMMIT_SUBJECT=${GIT_COMMIT_SUBJECT} \
+    GIT_COMMIT_TIMESTAMP=${GIT_COMMIT_TIMESTAMP} \
+    GIT_BRANCH=${GIT_BRANCH} \
+    BUILD_DATE=${BUILD_DATE}
+
 RUN pip install --no-cache-dir \
     fastapi==0.115.6 \
     uvicorn[standard]==0.37.0 \

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -639,6 +639,7 @@ picks up on its next poll. (#389 S1a)
 | GET | `/oauth/{provider}/authorize` | Start OAuth |
 | GET | `/oauth/{provider}/callback` | OAuth callback |
 | GET | `/health` | Health check (unauthenticated, top-level — no `/api/` prefix) |
+| GET | `/api/version` | Platform version + build-time git provenance: `git_commit`, `git_commit_short`, `git_commit_subject`, `git_commit_timestamp`, `git_branch`, `build_date`. Sourced from Dockerfile `ARG`/`ENV` wired through `docker-compose.yml` `backend.build.args` + `scripts/deploy/start.sh`. All git fields default to `"unknown"` when build args are absent (#926). |
 
 ### Soft-Delete Admin Recovery (#834 Phase 1c)
 

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -2426,6 +2426,64 @@ Standalone mobile-friendly admin page for managing agents on the go. Designed as
 
 ---
 
+## 36. Build Info Surface (#926)
+
+### 36.1 Version Chip + Git Commit Detail (#926)
+- **Status**: 🚧 In Progress
+- **Implements**: Issue #926
+- **Description**: Operators need an in-app way to confirm which commit
+  is actually deployed. Pre-#926, only the `VERSION` file (semver
+  string) plus an optional `BUILD_DATE` env var were exposed via
+  `GET /api/version`. Operators had to SSH or `docker inspect` to
+  resolve "is my fix deployed?" — a recurring friction point during
+  hotfixes and incident response. This surfaces git commit + branch
+  metadata baked in at backend image build time.
+- **Backend (`GET /api/version`)** — extended payload:
+  ```json
+  {
+    "version": "0.9.0",
+    "platform": "trinity",
+    "components": { … },
+    "runtimes": ["claude-code", "gemini-cli"],
+    "build_date": "2026-05-25T14:00:00Z",
+    "git_commit": "f1ba610fab…full sha…",
+    "git_commit_short": "f1ba610f",
+    "git_commit_subject": "review(#929): drop dead accessor…",
+    "git_commit_timestamp": "2026-05-25T11:45:00+00:00",
+    "git_branch": "dev",
+    "voice_enabled": false
+  }
+  ```
+  All new fields default to `"unknown"` when the build args are
+  absent (local dev / volume-mount workflows). Endpoint stays
+  JWT-authenticated (SEC-180).
+- **Build wiring**:
+  - `docker/backend/Dockerfile` accepts `GIT_COMMIT`,
+    `GIT_COMMIT_SUBJECT`, `GIT_COMMIT_TIMESTAMP`, `GIT_BRANCH`,
+    `BUILD_DATE` as `ARG`s and re-exports each as `ENV` so the
+    runtime reads them via `os.getenv()`.
+  - `docker-compose.yml` `backend.build.args` block forwards the
+    `${GIT_COMMIT}` etc. shell vars from the environment so
+    `docker compose build` picks them up automatically.
+  - `scripts/deploy/start.sh` exports the args from the local repo
+    before the build: `git rev-parse HEAD`, `git rev-parse --abbrev-ref HEAD`,
+    `git log -1 --pretty=%s`, `git log -1 --pretty=%cI`, and
+    `date -u +%Y-%m-%dT%H:%M:%SZ`.
+- **Frontend**:
+  - `NavBar.vue` renders a small muted version chip (e.g. `v0.9.0`).
+    Click opens a modal with the full build-info block.
+  - `Settings.vue` adds a "Build Info" subsection showing version,
+    commit short SHA + full SHA, commit subject + ISO timestamp,
+    branch, build date.
+  - One-shot fetch on app mount via a `useBuildInfo()` composable
+    that caches the response — build metadata never changes at runtime.
+- **Out of scope**: per-component version drift (frontend vs
+  backend), MCP server version surface (the MCP TypeScript
+  package has its own `package.json` version), agent base-image
+  commit metadata. Follow-ups if useful.
+
+---
+
 ## Out of Scope
 
 - Multi-tenant deployment (single org only)

--- a/scripts/deploy/start.sh
+++ b/scripts/deploy/start.sh
@@ -167,6 +167,19 @@ if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "trinity-agent-
     echo ""
 fi
 
+# Build-time provenance (#926). Export git commit/branch/build-date so
+# docker-compose's `backend.build.args` block forwards them as Dockerfile
+# ARGs → ENV vars → `GET /api/version` payload. Best-effort: if the host
+# isn't a git checkout (CI tarball install) fall back to "unknown" so the
+# downstream Dockerfile defaults still produce a well-typed response.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    export GIT_COMMIT=$(git rev-parse HEAD)
+    export GIT_COMMIT_SUBJECT=$(git log -1 --pretty=%s)
+    export GIT_COMMIT_TIMESTAMP=$(git log -1 --pretty=%cI)
+    export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+fi
+export BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
 echo "Starting services..."
 docker compose up -d
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1022,10 +1022,13 @@ async def health_check():
     return {"status": "healthy", "timestamp": datetime.now()}
 
 
-# Version endpoint
-@app.get("/api/version")
-async def get_version(current_user: User = Depends(get_current_user)):
-    """Get Trinity platform version information. Requires authentication (SEC-180)."""
+def _build_version_payload(voice_enabled: bool) -> dict:
+    """Pure dict-builder for the `/api/version` payload (#926-testable).
+
+    Extracted from the FastAPI handler so the env-var → response mapping
+    can be tested without pulling main.py's full router graph through
+    importlib (opentelemetry, slack_sdk, twilio, …).
+    """
     import os
     from pathlib import Path
 
@@ -1040,6 +1043,9 @@ async def get_version(current_user: User = Depends(get_current_user)):
             version = version_file.read_text().strip()
             break
 
+    git_commit = os.getenv("GIT_COMMIT", "unknown")
+    git_commit_short = git_commit[:8] if git_commit != "unknown" else "unknown"
+
     return {
         "version": version,
         "platform": "trinity",
@@ -1050,8 +1056,27 @@ async def get_version(current_user: User = Depends(get_current_user)):
         },
         "runtimes": ["claude-code", "gemini-cli"],
         "build_date": os.getenv("BUILD_DATE", "unknown"),
-        "voice_enabled": VOICE_ENABLED and bool(GEMINI_API_KEY),
+        "git_commit": git_commit,
+        "git_commit_short": git_commit_short,
+        "git_commit_subject": os.getenv("GIT_COMMIT_SUBJECT", "unknown"),
+        "git_commit_timestamp": os.getenv("GIT_COMMIT_TIMESTAMP", "unknown"),
+        "git_branch": os.getenv("GIT_BRANCH", "unknown"),
+        "voice_enabled": voice_enabled,
     }
+
+
+# Version endpoint
+@app.get("/api/version")
+async def get_version(current_user: User = Depends(get_current_user)):
+    """Get Trinity platform version information. Requires authentication (SEC-180).
+
+    Build-time provenance fields (#926) — `git_commit`, `git_commit_short`,
+    `git_commit_subject`, `git_commit_timestamp`, `git_branch`, `build_date` —
+    come from Dockerfile ARG/ENV wired through docker-compose
+    `backend.build.args` and `scripts/deploy/start.sh`. Default to "unknown"
+    when the build args are absent (local dev / volume-mount workflows).
+    """
+    return _build_version_payload(VOICE_ENABLED and bool(GEMINI_API_KEY))
 
 
 # User info endpoint

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -75,6 +75,19 @@
             {{ isConnected ? 'Connected' : 'Disconnected' }}
           </span>
 
+          <!-- Build Info Chip (#926) — small muted version label; click opens detail modal -->
+          <button
+            v-if="buildInfo.info.value"
+            @click="showBuildInfoModal = true"
+            class="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 font-mono"
+            :title="`Click for build info — commit ${buildInfo.info.value.git_commit_short}`"
+          >
+            v{{ buildInfo.info.value.version }}<span
+              v-if="buildInfo.info.value.git_commit_short && buildInfo.info.value.git_commit_short !== 'unknown'"
+              class="ml-1 opacity-70"
+            >· {{ buildInfo.info.value.git_commit_short }}</span>
+          </button>
+
           <!-- Theme Toggle Button -->
           <button
             @click="cycleTheme"
@@ -180,6 +193,57 @@
         </div>
       </div>
     </div>
+
+    <!-- Build Info Modal (#926) — click-out to dismiss -->
+    <div
+      v-if="showBuildInfoModal && buildInfo.info.value"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      @click.self="showBuildInfoModal = false"
+    >
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full mx-4 p-6">
+        <div class="flex justify-between items-start mb-4">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Build Info</h2>
+          <button
+            @click="showBuildInfoModal = false"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+            aria-label="Close"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <dl class="space-y-2 text-sm">
+          <div class="flex justify-between">
+            <dt class="text-gray-500 dark:text-gray-400">Version</dt>
+            <dd class="font-mono text-gray-900 dark:text-white">{{ buildInfo.info.value.version }}</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="text-gray-500 dark:text-gray-400">Branch</dt>
+            <dd class="font-mono text-gray-900 dark:text-white">{{ buildInfo.info.value.git_branch }}</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="text-gray-500 dark:text-gray-400">Commit</dt>
+            <dd class="font-mono text-gray-900 dark:text-white text-right break-all">
+              <span>{{ buildInfo.info.value.git_commit_short }}</span>
+              <div class="text-xs opacity-60">{{ buildInfo.info.value.git_commit }}</div>
+            </dd>
+          </div>
+          <div class="border-t border-gray-200 dark:border-gray-700 pt-2">
+            <dt class="text-gray-500 dark:text-gray-400 mb-1">Commit subject</dt>
+            <dd class="text-gray-900 dark:text-white break-words">{{ buildInfo.info.value.git_commit_subject }}</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="text-gray-500 dark:text-gray-400">Commit timestamp</dt>
+            <dd class="font-mono text-gray-900 dark:text-white text-xs">{{ buildInfo.info.value.git_commit_timestamp }}</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="text-gray-500 dark:text-gray-400">Build date</dt>
+            <dd class="font-mono text-gray-900 dark:text-white text-xs">{{ buildInfo.info.value.build_date }}</dd>
+          </div>
+        </dl>
+      </div>
+    </div>
   </nav>
 </template>
 
@@ -191,6 +255,7 @@ import { useThemeStore } from '../stores/theme'
 import { useNotificationsStore } from '../stores/notifications'
 import { useOperatorQueueStore } from '../stores/operatorQueue'
 import { useWebSocket } from '../utils/websocket'
+import { useBuildInfo } from '../composables/useBuildInfo'
 import axios from 'axios'
 
 const router = useRouter()
@@ -199,6 +264,10 @@ const themeStore = useThemeStore()
 const notificationsStore = useNotificationsStore()
 const operatorQueueStore = useOperatorQueueStore()
 const { isConnected } = useWebSocket()
+
+// #926: cached fetch of /api/version (singleton across NavBar + Settings)
+const buildInfo = useBuildInfo()
+const showBuildInfoModal = ref(false)
 
 // Check if user is admin (fetch from backend)
 const userRole = ref(null)
@@ -249,6 +318,10 @@ onMounted(async () => {
 
   // Start polling for notifications
   notificationsStore.startPolling(60000)
+
+  // #926: kick off the cached build-info fetch — failures are non-fatal
+  // (chip is hidden if fetch fails; e.g., unauthenticated brief window).
+  buildInfo.load().catch(() => {})
 
   // Fetch user role from backend
   try {

--- a/src/frontend/src/composables/useBuildInfo.js
+++ b/src/frontend/src/composables/useBuildInfo.js
@@ -1,0 +1,44 @@
+import { ref } from 'vue'
+import api from '@/api'
+
+/**
+ * #926 build-info composable.
+ *
+ * One-shot fetch of `GET /api/version` cached in module scope: build
+ * metadata can't change at runtime, so every consumer (NavBar chip,
+ * Settings panel, future "About" dialog) reads the same singleton.
+ *
+ * Returned refs are the cache itself — mutating them would corrupt
+ * the singleton. Treat as read-only. `load()` is idempotent; calling
+ * it more than once returns the same in-flight Promise.
+ */
+
+const info = ref(null)
+const loading = ref(false)
+const error = ref(null)
+let inFlight = null
+
+async function load() {
+  if (info.value) return info.value
+  if (inFlight) return inFlight
+  loading.value = true
+  error.value = null
+  inFlight = (async () => {
+    try {
+      const { data } = await api.get('/api/version')
+      info.value = data
+      return data
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+      inFlight = null
+    }
+  })()
+  return inFlight
+}
+
+export function useBuildInfo() {
+  return { info, loading, error, load }
+}

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -1034,6 +1034,54 @@ Example:
             </div>
           </div>
 
+          <!-- Build Info Section (#926) -->
+          <div v-if="activeTab === 'general'" class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg">
+            <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+              <h2 class="text-lg font-medium text-gray-900 dark:text-white">Build Info</h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Provenance of the currently-running backend image. Populated at <code>docker compose build</code> time
+                via <code>scripts/deploy/start.sh</code> (#926).
+              </p>
+            </div>
+            <div class="px-6 py-4">
+              <div v-if="buildInfo.loading.value" class="text-sm text-gray-500 dark:text-gray-400">
+                Loading…
+              </div>
+              <div v-else-if="buildInfo.error.value" class="text-sm text-status-danger-600 dark:text-status-danger-400">
+                Failed to load build info.
+              </div>
+              <dl v-else-if="buildInfo.info.value" class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+                <div>
+                  <dt class="text-gray-500 dark:text-gray-400">Version</dt>
+                  <dd class="font-mono text-gray-900 dark:text-white">{{ buildInfo.info.value.version }}</dd>
+                </div>
+                <div>
+                  <dt class="text-gray-500 dark:text-gray-400">Branch</dt>
+                  <dd class="font-mono text-gray-900 dark:text-white">{{ buildInfo.info.value.git_branch }}</dd>
+                </div>
+                <div class="sm:col-span-2">
+                  <dt class="text-gray-500 dark:text-gray-400">Commit</dt>
+                  <dd class="font-mono text-gray-900 dark:text-white">
+                    <span>{{ buildInfo.info.value.git_commit_short }}</span>
+                    <span class="ml-2 text-xs opacity-60 break-all">{{ buildInfo.info.value.git_commit }}</span>
+                  </dd>
+                </div>
+                <div class="sm:col-span-2">
+                  <dt class="text-gray-500 dark:text-gray-400">Commit subject</dt>
+                  <dd class="text-gray-900 dark:text-white break-words">{{ buildInfo.info.value.git_commit_subject }}</dd>
+                </div>
+                <div>
+                  <dt class="text-gray-500 dark:text-gray-400">Commit timestamp</dt>
+                  <dd class="font-mono text-gray-900 dark:text-white text-xs">{{ buildInfo.info.value.git_commit_timestamp }}</dd>
+                </div>
+                <div>
+                  <dt class="text-gray-500 dark:text-gray-400">Build date</dt>
+                  <dd class="font-mono text-gray-900 dark:text-white text-xs">{{ buildInfo.info.value.build_date }}</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
           <!-- Email Whitelist Section (Phase 12.4) -->
           <div v-if="activeTab === 'access'" class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg">
             <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
@@ -1724,6 +1772,7 @@ Example:
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useRole } from '../composables/useRole'
+import { useBuildInfo } from '../composables/useBuildInfo'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useSettingsStore } from '../stores/settings'
@@ -1735,6 +1784,9 @@ const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
 const settingsStore = useSettingsStore()
+
+// #926: cached fetch of /api/version (singleton shared with NavBar).
+const buildInfo = useBuildInfo()
 
 const loading = ref(true)
 const saving = ref(false)
@@ -3047,6 +3099,10 @@ watch(isAdmin, (admin) => {
 onMounted(() => {
   // The non-admin-safe init runs unconditionally.
   loading.value = false  // McpKeysTab handles its own loading state
+
+  // #926: build info — non-fatal load; the General-tab panel handles
+  // loading/error states. Singleton, so a no-op when NavBar already loaded.
+  buildInfo.load().catch(() => {})
 
   // Handle Slack OAuth callback
   if (route.query.slack === 'installed') {

--- a/tests/unit/test_926_version_endpoint.py
+++ b/tests/unit/test_926_version_endpoint.py
@@ -1,0 +1,108 @@
+"""
+Tests for #926 — `GET /api/version` exposes build-time git provenance.
+
+Exercises `main._build_version_payload`, the pure dict-builder extracted
+from the FastAPI handler so this test doesn't need to pull main.py's
+full router graph (opentelemetry, slack_sdk, twilio, …) into the venv.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+def _load_builder():
+    """Pull `_build_version_payload` out of main.py without executing the
+    rest of the module. Reads the source, slices out the function block,
+    and execs it into an isolated namespace — the function only depends
+    on stdlib `os` and `pathlib`, so the exec is self-sufficient.
+    """
+    src_path = _BACKEND / "main.py"
+    if not src_path.exists():
+        pytest.skip("backend source not present")
+    text = src_path.read_text()
+    marker = "def _build_version_payload"
+    start = text.find(marker)
+    if start == -1:
+        pytest.fail(f"_build_version_payload not found in {src_path}")
+    # Slice from def → next top-level def
+    rest = text[start:]
+    end = rest.find("\n\n\n")  # function ends before the two blank lines
+    snippet = rest[: end if end != -1 else len(rest)]
+    # The function references `__file__` for the VERSION fallback path.
+    # Inject the real main.py path so `Path(__file__).parent.parent.parent`
+    # resolves to repo root, where the VERSION file actually lives.
+    ns: dict = {"__file__": str(src_path)}
+    exec(snippet, ns)
+    return ns["_build_version_payload"]
+
+
+def test_version_payload_includes_git_provenance_fields(monkeypatch):
+    """All five #926 fields appear in the response when env vars are set."""
+    monkeypatch.setenv("GIT_COMMIT", "abc123de" + "0" * 32)
+    monkeypatch.setenv("GIT_COMMIT_SUBJECT", "feat(#926): build info surface")
+    monkeypatch.setenv("GIT_COMMIT_TIMESTAMP", "2026-05-25T15:00:00+00:00")
+    monkeypatch.setenv("GIT_BRANCH", "feature/926-version-build-info")
+    monkeypatch.setenv("BUILD_DATE", "2026-05-25T15:05:00Z")
+
+    build = _load_builder()
+    payload = build(voice_enabled=False)
+
+    assert payload["git_commit"].startswith("abc123de")
+    # Short SHA is the first 8 chars.
+    assert payload["git_commit_short"] == "abc123de"
+    assert payload["git_commit_subject"] == "feat(#926): build info surface"
+    assert payload["git_commit_timestamp"] == "2026-05-25T15:00:00+00:00"
+    assert payload["git_branch"] == "feature/926-version-build-info"
+    assert payload["build_date"] == "2026-05-25T15:05:00Z"
+
+
+def test_version_payload_falls_back_to_unknown_when_env_missing(monkeypatch):
+    """Local-dev / volume-mount workflows leave the env vars unset.
+    Response stays well-typed with `"unknown"` placeholders instead of
+    `None` or KeyError. Caller (frontend chip) can suppress display."""
+    for var in (
+        "GIT_COMMIT",
+        "GIT_COMMIT_SUBJECT",
+        "GIT_COMMIT_TIMESTAMP",
+        "GIT_BRANCH",
+        "BUILD_DATE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    build = _load_builder()
+    payload = build(voice_enabled=False)
+
+    assert payload["git_commit"] == "unknown"
+    assert payload["git_commit_short"] == "unknown"
+    assert payload["git_commit_subject"] == "unknown"
+    assert payload["git_commit_timestamp"] == "unknown"
+    assert payload["git_branch"] == "unknown"
+    assert payload["build_date"] == "unknown"
+
+
+def test_version_payload_preserves_existing_fields(monkeypatch):
+    """Pre-#926 keys (version, platform, components, runtimes, voice_enabled)
+    must still be present so existing callers don't break."""
+    build = _load_builder()
+    payload = build(voice_enabled=True)
+
+    for key in ("version", "platform", "components", "runtimes", "voice_enabled"):
+        assert key in payload, f"pre-#926 field missing: {key!r}"
+    assert payload["platform"] == "trinity"
+    assert payload["voice_enabled"] is True
+    assert "backend" in payload["components"]
+    assert "agent_server" in payload["components"]
+    assert "base_image" in payload["components"]
+


### PR DESCRIPTION
## Summary

Operators couldn't tell which commit was running without SSH'ing to the host or `docker inspect`. `GET /api/version` only returned the semver string plus an optional `BUILD_DATE` env var — no commit/branch surface, no in-app build info. This bakes the local git state into the backend image at build time and renders it in NavBar + Settings.

## Changes

### Backend
- Extracted `_build_version_payload()` from the `/api/version` handler as a pure helper so unit tests can drive it without main.py's full router graph (opentelemetry, slack_sdk, twilio, …).
- `/api/version` now returns `git_commit`, `git_commit_short` (first 8), `git_commit_subject`, `git_commit_timestamp`, `git_branch`, `build_date`. Everything defaults to `"unknown"` when build args are absent (local volume-mount workflows).
- Endpoint stays JWT-authenticated (SEC-180).

### Build wiring
- `docker/backend/Dockerfile` accepts `GIT_COMMIT`, `GIT_COMMIT_SUBJECT`, `GIT_COMMIT_TIMESTAMP`, `GIT_BRANCH`, `BUILD_DATE` as `ARG`s and re-exports each as `ENV`.
- `docker-compose.yml` `backend.build.args` block forwards the shell vars from the environment so `docker compose build` picks them up without explicit `--build-arg` flags.
- `scripts/deploy/start.sh` exports the args from the local repo via `git rev-parse HEAD` / `git log -1 --pretty=%cI` / etc., gated on `git rev-parse --is-inside-work-tree` so CI tarball installs still build cleanly.

### Frontend
- `composables/useBuildInfo.js` — singleton fetch of `/api/version` cached in module scope; build metadata never changes at runtime.
- `NavBar.vue` renders a small muted version chip (`v0.9.0 · abcd1234`). Click opens a modal with full commit/branch/build-date details.
- `Settings.vue` General tab gets a "Build Info" section with the same payload rendered as a `dl` grid.

## Tests

`tests/unit/test_926_version_endpoint.py` — 3 pass. Exercises `_build_version_payload` directly with patched env vars to verify:
- All five new fields present when ENV set
- `"unknown"` fallback when ENV missing
- Pre-#926 fields preserved (no breaking change for existing callers)

Test extracts the helper by slicing the source (no full main.py import) so it stays venv-light. Sys.modules lint baseline unchanged.

## Live verification

```bash
$ docker compose build backend && docker compose up -d --force-recreate backend
$ curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/version | jq
{
  "version": "0.9.0",
  "platform": "trinity",
  "build_date": "2026-05-25T10:20:57Z",
  "git_commit": "33da38cef66e97a5a9959267bdb42ea599a43951",
  "git_commit_short": "33da38ce",
  "git_commit_subject": "chore(.claude): bump submodule…",
  "git_commit_timestamp": "2026-05-24T18:41:45+01:00",
  "git_branch": "feature/926-version-build-info",
  ...
}
```

NavBar chip + Settings panel render correctly via Vite hot-reload.

## Test plan
- [x] Unit tests pass locally
- [x] Live verify against rebuilt backend
- [x] CI green
- [ ] Manual: confirm chip in production build shows the right commit
- [ ] Manual: confirm modal renders + Settings General tab Build Info section

## Files
- `src/backend/main.py` — extracted `_build_version_payload`, extended `/api/version` (+35/-5)
- `docker/backend/Dockerfile` — ARG/ENV block (+17)
- `docker-compose.yml` — `backend.build.args` (+10)
- `scripts/deploy/start.sh` — export git vars (+13)
- `src/frontend/src/composables/useBuildInfo.js` — singleton cache (new, +45)
- `src/frontend/src/components/NavBar.vue` — version chip + modal (+73)
- `src/frontend/src/views/Settings.vue` — Build Info section (+56)
- `docs/memory/architecture.md` — `/api/version` row updated
- `docs/memory/requirements.md` — §35 Build Info Surface (+58)
- `tests/unit/test_926_version_endpoint.py` — 3 tests (new)

## Out of scope (per issue body)

- Per-component version drift (frontend vs backend)
- MCP server version surface (TypeScript package has its own version)
- Agent base-image commit metadata

Closes will be set on merge.

Related to #926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)