### PR TITLE
refactor(#921): close watchdog race agent-side; -336 LOC

### DIFF
--- a/docker/base-image/agent_server/routers/chat.py
+++ b/docker/base-image/agent_server/routers/chat.py
@@ -278,12 +278,25 @@ async def terminate_execution(execution_id: str):
 @router.get("/api/executions/running")
 async def list_running_executions():
     """
-    List all currently running executions.
+    List all currently running executions, plus IDs that finished within
+    the recently-completed window (#921).
 
-    Returns execution_id, start time, and metadata for each running process.
+    The backend watchdog (cleanup_service) reads this endpoint to decide
+    "is this execution still being tracked by the agent?" It treats either
+    a currently-running entry OR a recently-completed ID as proof-of-life,
+    so the race between the agent's `finally: unregister()` and the
+    backend's `update_execution_status(SUCCESS)` write never produces a
+    false orphan recovery.
     """
     registry = get_process_registry()
-    return {"executions": registry.list_running()}
+    return {
+        "executions": registry.list_running(),
+        # #921: backend unions this with the `executions` list when computing
+        # the set of agent-known execution_ids. Older backend versions that
+        # don't read this field still work — they just lose the race window
+        # protection (pre-#921 behaviour).
+        "recently_completed_ids": registry.list_recently_completed_ids(),
+    }
 
 
 @router.get("/api/executions/{execution_id}/status")

--- a/docker/base-image/agent_server/services/process_registry.py
+++ b/docker/base-image/agent_server/services/process_registry.py
@@ -11,6 +11,7 @@ import signal
 import subprocess
 import asyncio
 import logging
+import time
 from datetime import datetime
 from typing import Dict, Optional, List, AsyncIterator
 from threading import Lock
@@ -21,6 +22,14 @@ from ..utils.subprocess_pgroup import (
 from ..utils.orphan_sweep import kill_cgroup_orphans
 
 logger = logging.getLogger(__name__)
+
+# Issue #921: window during which a just-finished execution is still surfaced
+# by `/api/executions/running` to the backend watchdog. Covers the race
+# between this process's `finally: unregister()` and the backend's
+# `task_execution_service.update_execution_status(SUCCESS)` write. Sized
+# above the worst observed in-flight delay in the original incident (~55s)
+# with comfortable headroom for backend slowness.
+RECENTLY_COMPLETED_TTL_SECONDS = 300  # 5 minutes
 
 
 class ProcessRegistry:
@@ -45,6 +54,11 @@ class ProcessRegistry:
         self._log_buffers: Dict[str, List[dict]] = {}
         # Maximum buffer size per execution (prevents memory bloat)
         self._max_buffer_size = 1000
+        # Issue #921: execution_id -> unix timestamp when unregister() ran.
+        # Entries past RECENTLY_COMPLETED_TTL_SECONDS are evicted lazily on
+        # read. Capped indirectly by traffic — at agent's ~10 concurrent
+        # max with 5 min retention this is a few dozen entries at peak.
+        self._recently_completed: Dict[str, float] = {}
 
     def register(self, execution_id: str, process: subprocess.Popen, metadata: dict = None):
         """
@@ -85,6 +99,12 @@ class ProcessRegistry:
             # Clean up buffer (keep for a bit for late requests, but this is fine)
             if execution_id in self._log_buffers:
                 del self._log_buffers[execution_id]
+
+            # Issue #921: mark for the recently-completed window so the
+            # backend watchdog doesn't see this as missing during the race
+            # between this `finally: unregister()` and the backend writing
+            # `success` to the schedule_executions row.
+            self._recently_completed[execution_id] = time.time()
 
     def terminate(self, execution_id: str, graceful_timeout: int = 5) -> dict:
         """
@@ -262,6 +282,23 @@ class ProcessRegistry:
                 if isinstance(pgid, int) and pgid > 0:
                     result.append(pgid)
         return result
+
+    def list_recently_completed_ids(self) -> List[str]:
+        """Issue #921: IDs of executions that finished within the last
+        RECENTLY_COMPLETED_TTL_SECONDS.
+
+        Surfaced via /api/executions/running so the backend watchdog can
+        treat "agent finished it moments ago" the same as "agent still
+        has it" — no orphan recovery, no false-positive. Expired entries
+        are dropped lazily here; no separate sweeper needed.
+        """
+        cutoff = time.time() - RECENTLY_COMPLETED_TTL_SECONDS
+        with self._lock:
+            # Drop expired entries while we're holding the lock.
+            expired = [eid for eid, ts in self._recently_completed.items() if ts < cutoff]
+            for eid in expired:
+                del self._recently_completed[eid]
+            return list(self._recently_completed.keys())
 
     def cleanup_finished(self) -> int:
         """

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -73,6 +73,25 @@ def set_cleanup_ws_manager(manager):
     _ws_manager = manager
 
 
+def _extract_agent_known_ids(payload: Dict) -> set:
+    """Set of execution IDs the agent considers 'known': currently-running
+    plus the recently-completed window (#921).
+
+    Single source of truth for parsing the `/api/executions/running`
+    response so the periodic watchdog (`_reconcile_orphaned_executions`)
+    and the startup recovery (`recover_orphaned_executions`) can't drift
+    out of sync. Defensive against malformed entries and missing fields:
+    older agent images that haven't shipped the buffer return only the
+    `executions` field — the union degrades silently to pre-#921 behaviour.
+    """
+    ids = {
+        eid for ex in (payload.get("executions") or [])
+        if (eid := ex.get("execution_id"))
+    }
+    ids.update(payload.get("recently_completed_ids") or [])
+    return ids
+
+
 def _read_retention_settings() -> tuple[int, int, int]:
     """Read retention windows from ops settings (#772).
 
@@ -819,15 +838,9 @@ class CleanupService:
                 f"http://agent-{agent_name}:8000/api/executions/running"
             )
             if response.status_code == 200:
-                data = response.json()
-                executions = data.get("executions", [])
-                ids = {eid for ex in executions if (eid := ex.get("execution_id"))}
-                # #921: union with the recently-completed window so the race
-                # between the agent's `finally: unregister()` and the backend's
-                # success-write doesn't produce a false orphan. Missing field
-                # (older agent images) degrades silently to pre-#921 behaviour.
-                ids.update(data.get("recently_completed_ids") or [])
-                return ids
+                # #921: union of currently-running + recently-completed via
+                # the shared helper — same parsing as `recover_orphaned_executions`.
+                return _extract_agent_known_ids(response.json())
             else:
                 logger.warning(
                     f"[Watchdog] Agent '{agent_name}' returned {response.status_code} "
@@ -1144,14 +1157,15 @@ async def recover_orphaned_executions() -> Dict:
             continue
 
         # Container is up — check agent's process registry
-        registry_ids: set[str] = set()
+        registry_ids: set = set()
         try:
             client = get_agent_client(agent_name)
             resp = await client.get("/api/executions/running", timeout=5.0)
             if resp.status_code == 200:
-                registry_ids = {
-                    e["execution_id"] for e in resp.json().get("executions", [])
-                }
+                # #921: same union as the periodic watchdog — includes
+                # recently-completed IDs so a backend restart that races
+                # an in-flight completion doesn't false-orphan it.
+                registry_ids = _extract_agent_known_ids(resp.json())
         except AgentClientError as e:
             logger.warning(f"[Recovery] Could not reach agent {agent_name} registry: {e}")
 

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -20,11 +20,6 @@ from typing import Optional, Dict, List
 
 import httpx
 
-try:
-    import redis.asyncio as aioredis
-except Exception:  # pragma: no cover — redis is a hard runtime dep
-    aioredis = None
-
 from database import db
 from models import TaskExecutionStatus
 from services.capacity_manager import get_capacity_manager
@@ -40,14 +35,6 @@ ACTIVITY_STALE_TIMEOUT_MINUTES = 120  # SCHED-ASYNC-001: increased from 30 to su
 NO_SESSION_TIMEOUT_SECONDS = 60  # Issue #106: fast-fail executions that never got a Claude session
 WATCHDOG_HTTP_TIMEOUT = 15.0  # Timeout for agent HTTP calls during reconciliation (#869: increased from 5s to handle agents under load)
 WATCHDOG_MIN_AGE_SECONDS = 60  # Don't orphan-recover executions younger than this (dispatch window)
-# Issue #921: two-cycle confirmation for orphan recovery. First time we see
-# (DB-running + agent-missing), we record a sentinel and defer; only on the
-# next cycle that also sees it missing do we actually recover. Closes the
-# false-positive window between the agent's in-finally `registry.unregister`
-# and the backend's success-write in `task_execution_service`. TTL spans
-# enough cycles that a one-shot Redis blip doesn't lose the deferred state.
-ORPHAN_SENTINEL_PREFIX = "watchdog:suspected_orphan:"
-ORPHAN_SENTINEL_TTL_SECONDS = 2 * CLEANUP_INTERVAL_SECONDS + 60  # 660s @ 5min cycle
 STARTUP_RECOVERY_GRACE_SECONDS = 15  # #748: skip startup orphan-recovery for rows
                                      # whose started_at is within this window — they
                                      # may be from an in-flight /internal/execute-task
@@ -142,10 +129,6 @@ class CleanupReport:
     """Results from a single cleanup cycle."""
     orphaned_executions: int = 0
     auto_terminated: int = 0
-    # Issue #921: count of executions deferred for two-cycle confirmation this
-    # cycle. Informational only — does not contribute to `total` because no
-    # state change occurred yet (the sentinel itself is not a "cleanup").
-    orphans_suspected: int = 0
     stale_executions: int = 0
     no_session_executions: int = 0
     orphaned_skipped: int = 0
@@ -176,7 +159,6 @@ class CleanupReport:
         return {
             "orphaned_executions": self.orphaned_executions,
             "auto_terminated": self.auto_terminated,
-            "orphans_suspected": self.orphans_suspected,
             "stale_executions": self.stale_executions,
             "no_session_executions": self.no_session_executions,
             "orphaned_skipped": self.orphaned_skipped,
@@ -211,84 +193,6 @@ class CleanupService:
         # inside the 5-min cleanup loop. First cycle runs maintenance
         # immediately; then every 12th cycle (60 min at 5-min interval).
         self._cycle_count: int = 0
-        # Issue #921: lazy Redis client for the orphan-confirmation sentinel.
-        # Lazy because cleanup_service is imported before Redis is reachable
-        # during the cold-start window.
-        self._redis: Optional["aioredis.Redis"] = None
-
-    async def _get_redis(self) -> Optional["aioredis.Redis"]:
-        """Return an async Redis client for the orphan-sentinel, or None if
-        Redis is unreachable.
-
-        Issue #921: the two-cycle orphan-confirmation needs cross-process
-        state. We fail OPEN — if Redis is gone we revert to the legacy
-        single-cycle behaviour so the watchdog still recovers true orphans
-        (the price is reintroducing the race during the outage; acceptable
-        since the rest of the platform is also degraded then).
-        """
-        if self._redis is not None:
-            return self._redis
-        if aioredis is None:
-            return None
-        try:
-            from config import REDIS_URL
-            client = aioredis.from_url(
-                REDIS_URL,
-                decode_responses=True,
-                socket_connect_timeout=1,
-                socket_timeout=1,
-            )
-            await client.ping()
-            self._redis = client
-            return self._redis
-        except Exception as e:
-            logger.warning("[Watchdog] Redis unavailable for orphan sentinel (%s) — failing open", e)
-            return None
-
-    async def _mark_suspected_orphan(self, execution_id: str) -> bool:
-        """Record the first observation of (DB-running + agent-missing).
-
-        Returns True if the sentinel was written, False on Redis failure.
-        """
-        client = await self._get_redis()
-        if client is None:
-            return False
-        try:
-            await client.setex(
-                f"{ORPHAN_SENTINEL_PREFIX}{execution_id}",
-                ORPHAN_SENTINEL_TTL_SECONDS,
-                utc_now_iso(),
-            )
-            return True
-        except Exception as e:
-            logger.warning("[Watchdog] SETEX sentinel for %s failed (%s)", execution_id, e)
-            return False
-
-    async def _is_suspected_orphan(self, execution_id: str) -> bool:
-        """Has this execution been flagged in a previous cycle?
-
-        Fail-open: on Redis failure return True so we recover (legacy
-        behaviour). This is intentional — see `_get_redis` docstring.
-        """
-        client = await self._get_redis()
-        if client is None:
-            return True
-        try:
-            return await client.exists(f"{ORPHAN_SENTINEL_PREFIX}{execution_id}") > 0
-        except Exception as e:
-            logger.warning("[Watchdog] EXISTS sentinel for %s failed (%s)", execution_id, e)
-            return True
-
-    async def _clear_suspected_orphan(self, execution_id: str) -> None:
-        """Drop the sentinel — either because the agent brought the execution
-        back or because we just confirmed-and-recovered it."""
-        client = await self._get_redis()
-        if client is None:
-            return
-        try:
-            await client.delete(f"{ORPHAN_SENTINEL_PREFIX}{execution_id}")
-        except Exception as e:
-            logger.warning("[Watchdog] DEL sentinel for %s failed (%s)", execution_id, e)
 
     def start(self):
         """Start the background cleanup loop."""
@@ -325,22 +229,17 @@ class CleanupService:
         # from falsely failing executions the watchdog verified as alive.
         confirmed_running_ids: set = set()
         try:
-            orphaned, terminated, confirmed_running_ids, suspected = (
+            orphaned, terminated, confirmed_running_ids = (
                 await self._reconcile_orphaned_executions()
             )
             report.orphaned_executions = orphaned
             report.auto_terminated = terminated
-            report.orphans_suspected = suspected
             self.cumulative_orphaned += orphaned
             self.cumulative_auto_terminated += terminated
             if orphaned > 0:
                 logger.info(f"[Watchdog] Recovered {orphaned} orphaned executions")
             if terminated > 0:
                 logger.info(f"[Watchdog] Auto-terminated {terminated} timed-out executions")
-            if suspected > 0:
-                logger.info(
-                    f"[Watchdog] Deferred {suspected} suspected orphans for two-cycle confirmation"
-                )
         except Exception as e:
             logger.error(f"[Watchdog] Reconciliation error: {e}")
 
@@ -764,26 +663,30 @@ class CleanupService:
                             f"[Cleanup] Error failing {execution_id} after slot reclaim: {e}"
                         )
 
-    async def _reconcile_orphaned_executions(self) -> tuple[int, int, set, int]:
+    async def _reconcile_orphaned_executions(self) -> tuple[int, int, set]:
         """Reconcile DB execution state against agent process registries.
 
         For each execution marked 'running' in the DB:
-        1. Check if the agent's process registry still has it
-        2. If not found AND previously flagged (Issue #921): mark failed, release resources
-        3. If not found but seen for the first time: write Redis sentinel, defer
-        4. If found but exceeded timeout: terminate, mark failed, release resources
+        1. Check if the agent's process registry still has it (including
+           the #921 recently-completed window — see `_get_agent_running_ids`)
+        2. If not found: mark failed, release resources
+        3. If found but exceeded timeout: terminate, mark failed, release resources
+
+        Issue #921: the race between the agent's `finally: unregister()`
+        and the backend's `update_execution_status(SUCCESS)` is closed at
+        the source — agents include recently-completed IDs in their
+        `/api/executions/running` response. The watchdog therefore needs
+        no two-cycle confirmation: a single observation of "missing from
+        agent + DB still running" is a true orphan.
 
         Returns:
-            Tuple of (orphaned_count, auto_terminated_count, confirmed_running_ids,
-            suspected_count) where:
-              - confirmed_running_ids: execution IDs verified as still running on
-                their agents (used by slot cleanup, #226)
-              - suspected_count: executions seen as missing for the first time this
-                cycle and deferred for two-cycle confirmation (#921)
+            Tuple of (orphaned_count, auto_terminated_count, confirmed_running_ids)
+            where confirmed_running_ids is the set of execution IDs verified as still
+            running on their agents (used by slot cleanup to avoid false failures, #226).
         """
         running_executions = db.get_running_executions_with_agent_info()
         if not running_executions:
-            return (0, 0, set(), 0)
+            return (0, 0, set())
 
         # Group by agent for batch HTTP calls (one call per agent)
         agents: Dict[str, List[Dict]] = defaultdict(list)
@@ -807,7 +710,6 @@ class CleanupService:
 
             orphaned_count = 0
             terminated_count = 0
-            suspected_count = 0  # #921: first-cycle deferrals
             recovery_attempts = 0
             recovery_failures = 0
             confirmed_running: set = set()  # #226: track IDs verified as still running
@@ -836,25 +738,11 @@ class CleanupService:
                                 )
                                 continue
 
-                            # Issue #921: two-cycle confirmation. The agent's
-                            # `registry.unregister` in `claude_code.py`'s
-                            # `finally` block fires BEFORE the backend writes
-                            # `success` in `task_execution_service`. A single
-                            # snapshot can't tell that race apart from a true
-                            # orphan. Defer the decision by one cycle: the
-                            # natural-completion case will have the DB row in
-                            # a terminal status by then and won't appear in
-                            # the next cycle's running query.
-                            if not await self._is_suspected_orphan(execution_id):
-                                await self._mark_suspected_orphan(execution_id)
-                                suspected_count += 1
-                                logger.info(
-                                    f"[Watchdog] Suspected orphan {execution_id} on "
-                                    f"'{agent_name}' — deferring recovery to next cycle"
-                                )
-                                continue
-
-                            # Second consecutive sighting — confirmed orphan
+                            # Orphan: missing from agent's running + recently-
+                            # completed sets. The agent-side window in
+                            # `process_registry.list_recently_completed_ids`
+                            # already absorbed the success-write race (#921),
+                            # so this is a true orphan.
                             recovery_attempts += 1
                             error_msg = (
                                 "Execution completed on agent but status not reported "
@@ -865,16 +753,8 @@ class CleanupService:
                             )
                             if recovered:
                                 orphaned_count += 1
-                            # Clear the sentinel regardless: either we recovered
-                            # (so the row will no longer appear running), or the
-                            # recovery raced and lost — in both cases a fresh
-                            # observation starts the cycle over.
-                            await self._clear_suspected_orphan(execution_id)
                         else:
                             # Execution is on agent — check timeout.
-                            # #921: agent vouches for it, clear any stale sentinel
-                            # from a previous flap.
-                            await self._clear_suspected_orphan(execution_id)
                             timeout_seconds = ex.get("timeout_seconds") or 900
 
                             if age_seconds <= timeout_seconds:
@@ -920,7 +800,7 @@ class CleanupService:
                 f"recovery attempts failed in this cycle"
             )
 
-        return (orphaned_count, terminated_count, confirmed_running, suspected_count)
+        return (orphaned_count, terminated_count, confirmed_running)
 
     async def _get_agent_running_ids(
         self, client: httpx.AsyncClient, agent_name: str
@@ -941,7 +821,13 @@ class CleanupService:
             if response.status_code == 200:
                 data = response.json()
                 executions = data.get("executions", [])
-                return {eid for ex in executions if (eid := ex.get("execution_id"))}
+                ids = {eid for ex in executions if (eid := ex.get("execution_id"))}
+                # #921: union with the recently-completed window so the race
+                # between the agent's `finally: unregister()` and the backend's
+                # success-write doesn't produce a false orphan. Missing field
+                # (older agent images) degrades silently to pre-#921 behaviour.
+                ids.update(data.get("recently_completed_ids") or [])
+                return ids
             else:
                 logger.warning(
                     f"[Watchdog] Agent '{agent_name}' returned {response.status_code} "

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -5,8 +5,11 @@ Tests for Issue #129: Active watchdog remediation of stuck executions.
 Integration tests against the running backend — verify cleanup report
 includes watchdog fields.
 
-Issue #921: two-cycle confirmation regression — guards against the false-
-positive recovery race between agent unregister and backend success-write.
+Issue #921 (revised): the race between agent unregister and backend
+success-write is closed agent-side via `process_registry`'s recently-
+completed window. The watchdog therefore recovers a true orphan on a
+single cycle and never sees the race-window false-positive in the first
+place. These tests cover the surviving end-to-end behaviours.
 
 Feature Flow: docs/memory/feature-flows/cleanup-service.md
 """
@@ -79,47 +82,12 @@ c.close()
     return _json.loads(out)
 
 
-def _sentinel_exists(execution_id: str) -> bool:
-    out = _exec_backend(f"""
-import redis, os
-from config import REDIS_URL
-client = redis.from_url(REDIS_URL, decode_responses=True, socket_connect_timeout=2)
-print('1' if client.exists('watchdog:suspected_orphan:{execution_id}') > 0 else '0')
-""")
-    return out == "1"
-
-
-def _force_success(execution_id: str) -> None:
-    """Simulate task_execution_service writing the success status that the
-    watchdog races against — see services/task_execution_service.py:728."""
-    _exec_backend(f"""
-import sqlite3
-c = sqlite3.connect('/data/trinity.db')
-c.execute(
-    'UPDATE schedule_executions SET status=?, completed_at=?, response=? WHERE id=?',
-    ('success', '2099-01-01T00:00:00Z', 'task completed normally', '{execution_id}'),
-)
-c.commit(); c.close()
-print('OK')
-""")
-
-
 def _delete_row(execution_id: str) -> None:
     _exec_backend(f"""
 import sqlite3
 c = sqlite3.connect('/data/trinity.db')
 c.execute('DELETE FROM schedule_executions WHERE id=?', ('{execution_id}',))
 c.commit(); c.close()
-print('OK')
-""")
-
-
-def _clear_sentinel(execution_id: str) -> None:
-    _exec_backend(f"""
-import redis
-from config import REDIS_URL
-client = redis.from_url(REDIS_URL, decode_responses=True, socket_connect_timeout=2)
-client.delete('watchdog:suspected_orphan:{execution_id}')
 print('OK')
 """)
 
@@ -180,128 +148,54 @@ class TestWatchdogCleanupReportFields:
 
 
 # ============================================================================
-# Two-Cycle Orphan Confirmation (Issue #921)
+# Single-Cycle Orphan Recovery (Issue #921 — agent-side completion buffer)
 # ============================================================================
 
 
-class TestTwoCycleOrphanConfirmation:
+class TestSingleCycleOrphanRecovery:
     """Live-stack regression for #921.
 
-    The agent's `claude_code.py` unregisters its process registry in a
-    `finally` block BEFORE `task_execution_service` writes `success` to
-    the DB. A single watchdog snapshot can't distinguish that race window
-    from a true orphan, so recovery now requires two consecutive sightings
-    of (DB-running + agent-missing).
+    The natural-completion race (agent's `finally: unregister()` running
+    before the backend writes `success`) is closed agent-side: the
+    `process_registry` keeps recently-completed IDs for ~5 min and
+    surfaces them via `/api/executions/running`. The watchdog unions
+    those IDs into its agent-known set, so a "missing from agent" sighting
+    is a true orphan and we recover on a single cycle — no two-cycle
+    deferral, no Redis sentinel, no `orphans_suspected` accounting.
 
-    These tests drive `POST /api/monitoring/cleanup-trigger` directly to
-    invoke the watchdog synchronously, then inspect the DB row and the
-    Redis sentinel to verify the two-cycle protocol behaves correctly.
+    This test exercises the surviving behaviour: trigger cleanup against
+    a fabricated running row whose execution_id the agent has never
+    heard of (not running, not recently completed) — expect a clean
+    single-cycle recovery.
     """
 
     @pytest.fixture
     def execution_id(self):
-        """Generate a unique execution_id and guarantee cleanup of both the
-        DB row and the Redis sentinel — even if the test fails mid-way."""
+        """Unique execution_id; teardown deletes the row even on failure."""
         eid = f"test-921-int-{uuid.uuid4().hex[:12]}"
         yield eid
-        # Teardown: always tidy up, ignore individual failures
         try:
             _delete_row(eid)
         except Exception:
             pass
-        try:
-            _clear_sentinel(eid)
-        except Exception:
-            pass
 
-    def test_first_cycle_defers_without_recovery(
+    def test_true_orphan_recovered_on_single_cycle(
         self, api_client: TrinityApiClient, execution_id: str
     ):
-        """The race window itself: agent says missing, DB still running.
+        """DB has 'running' row, agent doesn't have it in either running
+        OR recently_completed_ids => one cycle marks it failed.
 
-        Expected: watchdog records the sentinel and reports
-        `orphans_suspected=1`, but does NOT mark the row failed. This is
-        the heart of the #921 fix — under the old code the same scenario
-        produced `orphaned_executions=1` and a watchdog-failed row.
-        """
+        Under the original #921 fix this required two cycles. Closing the
+        race agent-side restored single-cycle recovery — what the watchdog
+        was always meant to do."""
         _insert_running_row(execution_id)
-
-        before = _row_state(execution_id)
-        assert before["status"] == "running"
-        assert not _sentinel_exists(execution_id)
+        assert _row_state(execution_id)["status"] == "running"
 
         response = api_client.post("/api/monitoring/cleanup-trigger")
         assert_status(response, 200)
         report = response.json()["report"]
-
-        assert "orphans_suspected" in report, "Missing orphans_suspected field"
-        assert report["orphans_suspected"] >= 1
-        # Row must still be running — recovery was deferred.
-        after = _row_state(execution_id)
-        assert after["status"] == "running"
-        assert after["error"] is None
-        # Sentinel must be in Redis to gate the next cycle.
-        assert _sentinel_exists(execution_id)
-
-    def test_second_cycle_confirms_and_recovers(
-        self, api_client: TrinityApiClient, execution_id: str
-    ):
-        """True orphan: two consecutive cycles see (DB-running + agent-missing).
-
-        Expected: first cycle defers, second cycle recovers and clears the
-        sentinel. Confirms the fix doesn't break legitimate orphan recovery —
-        it only delays it by one cycle.
-        """
-        _insert_running_row(execution_id)
-
-        # Cycle 1 — defer
-        report_1 = api_client.post("/api/monitoring/cleanup-trigger").json()["report"]
-        assert report_1["orphans_suspected"] >= 1
-        assert _row_state(execution_id)["status"] == "running"
-
-        # Cycle 2 — recover
-        report_2 = api_client.post("/api/monitoring/cleanup-trigger").json()["report"]
-        assert report_2["orphaned_executions"] >= 1
+        assert report["orphaned_executions"] >= 1
 
         after = _row_state(execution_id)
         assert after["status"] == "failed"
         assert "recovered by watchdog" in (after["error"] or "")
-        # Sentinel cleared so a future row with the same id doesn't skip
-        # straight to recovery.
-        assert not _sentinel_exists(execution_id)
-
-    def test_natural_completion_race_no_false_positive(
-        self, api_client: TrinityApiClient, execution_id: str
-    ):
-        """The #921 smoking-gun scenario reproduced end-to-end.
-
-        Cycle 1: row is `running`, agent has unregistered (race window).
-        Between cycles: backend lands the `success` write (we simulate
-          task_execution_service's update directly).
-        Cycle 2: the row is no longer in the running query, so the watchdog
-          never even looks at it. The row's natural `success` state survives
-          intact — no false orphan recovery overwrites it.
-
-        Under the old code, cycle 1 alone would mark the row failed with a
-        watchdog error message, destroying the real completion data.
-        """
-        _insert_running_row(execution_id)
-
-        # Cycle 1: race window — watchdog defers.
-        report_1 = api_client.post("/api/monitoring/cleanup-trigger").json()["report"]
-        assert report_1["orphans_suspected"] >= 1
-        assert _row_state(execution_id)["status"] == "running"
-
-        # Between cycles: the backend's task_execution_service lands its
-        # success-write that was in flight all along.
-        _force_success(execution_id)
-
-        # Cycle 2: the row is in a terminal status and is no longer returned
-        # by get_running_executions_with_agent_info — watchdog ignores it.
-        api_client.post("/api/monitoring/cleanup-trigger")
-
-        final = _row_state(execution_id)
-        # The crucial assertion: the natural success was NOT overwritten.
-        assert final["status"] == "success"
-        assert final["error"] is None
-        assert final["response"] == "task completed normally"

--- a/tests/test_watchdog_unit.py
+++ b/tests/test_watchdog_unit.py
@@ -617,6 +617,52 @@ class TestReconcileOrphanedExecutions:
 # ---------------------------------------------------------------------------
 
 
+class TestExtractAgentKnownIds:
+    """Direct tests for `_extract_agent_known_ids` — the shared seam between
+    the periodic watchdog and the startup-recovery pass. Locks in the
+    parsing contract so the two callers can't drift out of sync."""
+
+    pytestmark = pytest.mark.unit
+
+    @staticmethod
+    def _fn():
+        from services.cleanup_service import _extract_agent_known_ids
+        return _extract_agent_known_ids
+
+    def test_unions_running_and_recently_completed(self):
+        ids = self._fn()({
+            "executions": [{"execution_id": "live-1"}, {"execution_id": "live-2"}],
+            "recently_completed_ids": ["done-1", "done-2"],
+        })
+        assert ids == {"live-1", "live-2", "done-1", "done-2"}
+
+    def test_missing_recently_completed_degrades_to_pre_921(self):
+        ids = self._fn()({"executions": [{"execution_id": "live-1"}]})
+        assert ids == {"live-1"}
+
+    def test_empty_response_returns_empty_set(self):
+        assert self._fn()({}) == set()
+
+    def test_null_fields_treated_as_empty(self):
+        """Defensive against agents that explicitly send null for either
+        field — `None` instead of `[]`."""
+        ids = self._fn()({"executions": None, "recently_completed_ids": None})
+        assert ids == set()
+
+    def test_skips_entries_missing_execution_id(self):
+        """Malformed execution entries (no `execution_id` key) are dropped
+        rather than raising. Defensive — protects against partial server
+        responses or schema drift."""
+        ids = self._fn()({
+            "executions": [
+                {"execution_id": "live-1"},
+                {"started_at": "2026-05-25T00:00:00Z"},  # no execution_id
+            ],
+            "recently_completed_ids": ["done-1"],
+        })
+        assert ids == {"live-1", "done-1"}
+
+
 class TestGetAgentRunningIdsUnionsRecentlyCompleted:
     """`_get_agent_running_ids` is the seam #921 hangs on: it unions the
     `executions` field with `recently_completed_ids` from the agent's

--- a/tests/test_watchdog_unit.py
+++ b/tests/test_watchdog_unit.py
@@ -408,26 +408,26 @@ class TestReconcileOrphanedExecutions:
         # Mock _get_agent_running_ids to return None (unreachable)
         service._get_agent_running_ids = AsyncMock(return_value=None)
 
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 0
         assert confirmed_running == set()
-        assert suspected == 0
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
 
     @patch("services.cleanup_service.httpx.AsyncClient")
     @patch("services.cleanup_service.db")
     @patch("services.cleanup_service.get_capacity_manager")
     def test_orphan_not_found_on_agent(self, mock_capacity_fn, mock_db, mock_httpx):
-        """Execution not found on agent -> orphan recovery (second cycle).
+        """Execution not found in agent's running + recently-completed sets
+        => orphan recovery on a single cycle.
 
-        Issue #921: orphan recovery now requires two consecutive sightings.
-        This test simulates the second sighting by pre-asserting the sentinel
-        already exists; see TestTwoCycleOrphanConfirmation for the first-
-        sighting deferral behaviour.
+        Issue #921: the natural-completion race is closed agent-side by
+        `process_registry.list_recently_completed_ids`, so a single
+        observation of "missing from agent" is a true orphan and we
+        recover immediately. No two-cycle confirmation needed.
         """
         mock_cm, _ = self._mock_httpx_client()
         mock_httpx.return_value = mock_cm
@@ -443,25 +443,18 @@ class TestReconcileOrphanedExecutions:
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
-        # #921: pretend this is the second cycle — the sentinel already exists.
-        service._is_suspected_orphan = AsyncMock(return_value=True)
-        service._mark_suspected_orphan = AsyncMock(return_value=True)
-        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 1
         assert terminated == 0
         assert confirmed_running == set()
-        assert suspected == 0
         mock_db.mark_execution_failed_by_watchdog.assert_called_once()
         # CAPACITY-CONSOLIDATE (#428): one TOCTOU-safe release call covers
         # both the slot count and the in-memory queue bookkeeping.
         mock_capacity.release_if_matches.assert_called_once_with("agent-a", "exec-1")
-        # Sentinel cleared after recovery so a fresh observation starts over.
-        service._clear_suspected_orphan.assert_called_with("exec-1")
 
     @patch("services.cleanup_service.httpx.AsyncClient")
     @patch("services.cleanup_service.db")
@@ -477,15 +470,13 @@ class TestReconcileOrphanedExecutions:
 
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
-        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 0
-        assert suspected == 0
         # #226: Execution confirmed as still running within timeout
         assert confirmed_running == {"exec-1"}
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
@@ -510,15 +501,13 @@ class TestReconcileOrphanedExecutions:
         service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
         service._terminate_on_agent = AsyncMock(return_value=True)
         service._broadcast_watchdog_event = AsyncMock()
-        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
         assert terminated == 1
-        assert suspected == 0
         assert confirmed_running == set()  # Over timeout, so not confirmed
         service._terminate_on_agent.assert_called_once_with(ANY, "agent-a", "exec-1")
         mock_db.mark_execution_failed_by_watchdog.assert_called_once()
@@ -542,15 +531,13 @@ class TestReconcileOrphanedExecutions:
         service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
         service._terminate_on_agent = AsyncMock(return_value=False)
         service._broadcast_watchdog_event = AsyncMock()
-        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         # Terminate failed — should NOT mark as failed or release resources
         assert terminated == 0
-        assert suspected == 0
         assert confirmed_running == set()
         mock_db.mark_execution_failed_by_watchdog.assert_not_called()
         mock_capacity.release_if_matches.assert_not_called()
@@ -559,13 +546,14 @@ class TestReconcileOrphanedExecutions:
     @patch("services.cleanup_service.db")
     @patch("services.cleanup_service.get_capacity_manager")
     def test_race_condition_db_update_noop(self, mock_capacity_fn, mock_db, mock_httpx):
-        """When DB update returns False (race), skip slot/queue release.
+        """When the conditional UPDATE in mark_execution_failed_by_watchdog
+        returns False (the DB row transitioned to a terminal state between
+        the agent query and the recovery write), skip slot/queue release.
 
-        #921: the inner TOCTOU race (DB-update-while-watchdog-decides) is
-        still possible on the second cycle even after the two-cycle defer.
-        This test simulates that: sentinel exists (second cycle), but the
-        conditional UPDATE returns False because task_execution_service
-        landed its success-write just before we tried to mark failed.
+        With #921's agent-side completion buffer this narrow TOCTOU is
+        extremely unlikely (the agent's `recently_completed_ids` already
+        absorbs the race), but the conditional UPDATE remains as defence
+        in depth — this test locks in that the no-op path is honoured.
         """
         mock_cm, _ = self._mock_httpx_client()
         mock_httpx.return_value = mock_cm
@@ -581,16 +569,12 @@ class TestReconcileOrphanedExecutions:
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
-        service._is_suspected_orphan = AsyncMock(return_value=True)
-        service._mark_suspected_orphan = AsyncMock(return_value=True)
-        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 0
-        assert suspected == 0
         assert confirmed_running == set()
         mock_capacity.release_if_matches.assert_not_called()
 
@@ -618,225 +602,75 @@ class TestReconcileOrphanedExecutions:
         service = self._make_service()
         service._get_agent_running_ids = AsyncMock(return_value=set())
         service._broadcast_watchdog_event = AsyncMock()
-        # #921: second-cycle scenario — sentinel pre-exists for both rows.
-        service._is_suspected_orphan = AsyncMock(return_value=True)
-        service._mark_suspected_orphan = AsyncMock(return_value=True)
-        service._clear_suspected_orphan = AsyncMock()
 
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
+        orphaned, terminated, confirmed_running = asyncio.run(
             service._reconcile_orphaned_executions()
         )
 
         assert orphaned == 1
-        assert suspected == 0
         assert confirmed_running == set()
         assert mock_db.mark_execution_failed_by_watchdog.call_count == 2
 
 
 # ---------------------------------------------------------------------------
-# Two-cycle orphan confirmation (Issue #921)
+# Agent /api/executions/running response shape (Issue #921)
 # ---------------------------------------------------------------------------
 
 
-class TestTwoCycleOrphanConfirmation:
-    """Regression tests for #921: the false-positive orphan-recovery race.
-
-    The agent's `claude_code.py` unregisters its process registry in a
-    `finally` block BEFORE the backend writes the success status to the DB.
-    A single watchdog snapshot taken in that window cannot distinguish a
-    completing execution from a true orphan. Recovery now requires two
-    consecutive sightings of (DB-running + agent-missing); the natural
-    completion case never reaches the second sighting because the DB row
-    has transitioned to a terminal status by then.
-    """
+class TestGetAgentRunningIdsUnionsRecentlyCompleted:
+    """`_get_agent_running_ids` is the seam #921 hangs on: it unions the
+    `executions` field with `recently_completed_ids` from the agent's
+    response, so the watchdog treats "just finished on the agent" the
+    same as "still running" — no race-window false orphan."""
 
     pytestmark = pytest.mark.unit
 
-    def _make_service(self):
+    @staticmethod
+    def _service():
         from services.cleanup_service import CleanupService
         return CleanupService()
 
-    def _mock_httpx_client(self):
-        mock_client = AsyncMock()
-        mock_cm = AsyncMock()
-        mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cm.__aexit__ = AsyncMock(return_value=False)
-        return mock_cm, mock_client
+    @staticmethod
+    def _mock_response(payload: dict, status_code: int = 200):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json = MagicMock(return_value=payload)
+        return resp
 
-    @patch("services.cleanup_service.httpx.AsyncClient")
-    @patch("services.cleanup_service.db")
-    @patch("services.cleanup_service.get_capacity_manager")
-    def test_first_cycle_missing_defers_no_recovery(self, mock_capacity_fn, mock_db, mock_httpx):
-        """First sighting of agent-missing => write sentinel, no DB write,
-        no slot release. This is the heart of the #921 fix."""
-        mock_cm, _ = self._mock_httpx_client()
-        mock_httpx.return_value = mock_cm
+    def test_unions_running_and_recently_completed(self):
+        import asyncio
+        service = self._service()
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=self._mock_response({
+            "executions": [{"execution_id": "live-1"}, {"execution_id": "live-2"}],
+            "recently_completed_ids": ["done-1", "done-2"],
+        }))
+        ids = asyncio.run(service._get_agent_running_ids(client, "agent-x"))
+        assert ids == {"live-1", "live-2", "done-1", "done-2"}
 
-        mock_db.get_running_executions_with_agent_info.return_value = [
-            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(10), "timeout_seconds": 900, "schedule_id": "s1"},
-        ]
+    def test_missing_recently_completed_field_is_tolerated(self):
+        """Older agent images that haven't shipped the recently-completed
+        buffer return only `executions`. The watchdog must degrade
+        gracefully to the pre-#921 behaviour for those images."""
+        import asyncio
+        service = self._service()
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=self._mock_response({
+            "executions": [{"execution_id": "live-1"}],
+        }))
+        ids = asyncio.run(service._get_agent_running_ids(client, "agent-x"))
+        assert ids == {"live-1"}
 
-        mock_capacity = AsyncMock()
-        mock_capacity_fn.return_value = mock_capacity
-
-        service = self._make_service()
-        service._get_agent_running_ids = AsyncMock(return_value=set())
-        service._broadcast_watchdog_event = AsyncMock()
-        # First cycle — no sentinel exists yet.
-        service._is_suspected_orphan = AsyncMock(return_value=False)
-        service._mark_suspected_orphan = AsyncMock(return_value=True)
-        service._clear_suspected_orphan = AsyncMock()
-
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
-            service._reconcile_orphaned_executions()
-        )
-
-        # The crucial assertions: row NOT recovered, sentinel written instead.
-        assert orphaned == 0
-        assert suspected == 1
-        assert confirmed_running == set()
-        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
-        mock_capacity.release_if_matches.assert_not_called()
-        service._mark_suspected_orphan.assert_called_once_with("exec-1")
-
-    @patch("services.cleanup_service.httpx.AsyncClient")
-    @patch("services.cleanup_service.db")
-    @patch("services.cleanup_service.get_capacity_manager")
-    def test_second_cycle_still_missing_recovers(self, mock_capacity_fn, mock_db, mock_httpx):
-        """Sentinel pre-exists + still missing on agent => recover and clear sentinel."""
-        mock_cm, _ = self._mock_httpx_client()
-        mock_httpx.return_value = mock_cm
-
-        mock_db.get_running_executions_with_agent_info.return_value = [
-            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(10), "timeout_seconds": 900, "schedule_id": "s1"},
-        ]
-        mock_db.mark_execution_failed_by_watchdog.return_value = True
-
-        mock_capacity = AsyncMock()
-        mock_capacity_fn.return_value = mock_capacity
-
-        service = self._make_service()
-        service._get_agent_running_ids = AsyncMock(return_value=set())
-        service._broadcast_watchdog_event = AsyncMock()
-        service._is_suspected_orphan = AsyncMock(return_value=True)
-        service._mark_suspected_orphan = AsyncMock(return_value=True)
-        service._clear_suspected_orphan = AsyncMock()
-
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
-            service._reconcile_orphaned_executions()
-        )
-
-        assert orphaned == 1
-        assert suspected == 0
-        mock_db.mark_execution_failed_by_watchdog.assert_called_once()
-        mock_capacity.release_if_matches.assert_called_once_with("agent-a", "exec-1")
-        service._clear_suspected_orphan.assert_called_with("exec-1")
-        # No new sentinel written on the recovery cycle.
-        service._mark_suspected_orphan.assert_not_called()
-
-    @patch("services.cleanup_service.httpx.AsyncClient")
-    @patch("services.cleanup_service.db")
-    @patch("services.cleanup_service.get_capacity_manager")
-    def test_natural_completion_race_resolves_without_recovery(self, mock_capacity_fn, mock_db, mock_httpx):
-        """The #921 smoking-gun scenario.
-
-        Cycle N: backend has dispatched a long task. Agent finished it, ran
-        `registry.unregister` in `finally`, but the backend hasn't yet
-        written `success` to the DB. Watchdog sees agent-missing + DB-
-        running. With the fix it defers.
-
-        Cycle N+1: between cycles, task_execution_service finished its
-        success-write. The DB row is now in a terminal status, so
-        `get_running_executions_with_agent_info` no longer returns it.
-        Nothing to act on — the false positive is avoided entirely.
-        """
-        mock_cm, _ = self._mock_httpx_client()
-        mock_httpx.return_value = mock_cm
-
-        mock_capacity = AsyncMock()
-        mock_capacity_fn.return_value = mock_capacity
-
-        # Persistent in-memory "Redis" so cycle N+1 sees cycle N's sentinel.
-        sentinel_store: set = set()
-
-        async def _mark(eid):
-            sentinel_store.add(eid)
-            return True
-
-        async def _check(eid):
-            return eid in sentinel_store
-
-        async def _clear(eid):
-            sentinel_store.discard(eid)
-
-        service = self._make_service()
-        service._get_agent_running_ids = AsyncMock(return_value=set())
-        service._broadcast_watchdog_event = AsyncMock()
-        service._is_suspected_orphan = _check
-        service._mark_suspected_orphan = _mark
-        service._clear_suspected_orphan = _clear
-
-        # ---- Cycle N: race window. DB still says running, agent unregistered.
-        mock_db.get_running_executions_with_agent_info.return_value = [
-            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(10), "timeout_seconds": 900, "schedule_id": "s1"},
-        ]
-        orphaned_n, _, _, suspected_n = asyncio.run(
-            service._reconcile_orphaned_executions()
-        )
-        assert orphaned_n == 0
-        assert suspected_n == 1
-        assert "exec-1" in sentinel_store  # sentinel survives between cycles
-        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
-
-        # ---- Cycle N+1: backend wrote `success` between cycles. The row no
-        #      longer appears in the running query — watchdog never even looks
-        #      at exec-1 again. False positive avoided.
-        mock_db.get_running_executions_with_agent_info.return_value = []
-        orphaned_n1, _, _, suspected_n1 = asyncio.run(
-            service._reconcile_orphaned_executions()
-        )
-        assert orphaned_n1 == 0
-        assert suspected_n1 == 0
-        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
-        mock_capacity.release_if_matches.assert_not_called()
-        # The sentinel will expire on its own via TTL; explicit cleanup is
-        # not required for correctness, only for tidiness.
-
-    @patch("services.cleanup_service.httpx.AsyncClient")
-    @patch("services.cleanup_service.db")
-    @patch("services.cleanup_service.get_capacity_manager")
-    def test_agent_flap_clears_sentinel(self, mock_capacity_fn, mock_db, mock_httpx):
-        """If the agent's registry shows the execution again on the next cycle
-        (transient flap), the sentinel is cleared so a single bad sample
-        doesn't accumulate toward a false-positive recovery."""
-        mock_cm, _ = self._mock_httpx_client()
-        mock_httpx.return_value = mock_cm
-
-        mock_db.get_running_executions_with_agent_info.return_value = [
-            {"id": "exec-1", "agent_name": "agent-a", "started_at": _past_iso(5), "timeout_seconds": 900, "schedule_id": "s1"},
-        ]
-
-        mock_capacity = AsyncMock()
-        mock_capacity_fn.return_value = mock_capacity
-
-        service = self._make_service()
-        # Agent confirms execution is running this cycle.
-        service._get_agent_running_ids = AsyncMock(return_value={"exec-1"})
-        service._broadcast_watchdog_event = AsyncMock()
-        service._is_suspected_orphan = AsyncMock(return_value=True)
-        service._mark_suspected_orphan = AsyncMock(return_value=True)
-        service._clear_suspected_orphan = AsyncMock()
-
-        orphaned, terminated, confirmed_running, suspected = asyncio.run(
-            service._reconcile_orphaned_executions()
-        )
-
-        assert orphaned == 0
-        assert suspected == 0
-        assert confirmed_running == {"exec-1"}
-        # Most important: the stale sentinel is cleared.
-        service._clear_suspected_orphan.assert_called_with("exec-1")
-        mock_db.mark_execution_failed_by_watchdog.assert_not_called()
+    def test_empty_recently_completed_returns_running_only(self):
+        import asyncio
+        service = self._service()
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=self._mock_response({
+            "executions": [{"execution_id": "live-1"}],
+            "recently_completed_ids": [],
+        }))
+        ids = asyncio.run(service._get_agent_running_ids(client, "agent-x"))
+        assert ids == {"live-1"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_recently_completed_buffer.py
+++ b/tests/unit/test_recently_completed_buffer.py
@@ -1,0 +1,109 @@
+"""Unit test for #921 simplification: agent-side recently-completed
+buffer in `process_registry`.
+
+The buffer is what closes the natural-completion race the backend used
+to two-cycle-confirm around. This test exercises the primitive directly:
+- `unregister()` writes an entry with the current timestamp
+- `list_recently_completed_ids()` returns IDs within the TTL window
+- Entries past the TTL are evicted lazily on read
+- `register()` does NOT touch the buffer
+
+Module under test: docker/base-image/agent_server/services/process_registry.py
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Same import shim as test_terminate_async_executor.py — avoid booting the
+# full agent_server package (its routers/__init__.py imports optional deps).
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_AGENT_SERVER_DIR = _PROJECT_ROOT / "docker" / "base-image" / "agent_server"
+
+if "agent_server" not in sys.modules:
+    _stub = types.ModuleType("agent_server")
+    _stub.__path__ = [str(_AGENT_SERVER_DIR)]
+    sys.modules["agent_server"] = _stub
+if "agent_server.services" not in sys.modules:
+    _services_stub = types.ModuleType("agent_server.services")
+    _services_stub.__path__ = [str(_AGENT_SERVER_DIR / "services")]
+    sys.modules["agent_server.services"] = _services_stub
+if "agent_server.utils" not in sys.modules:
+    _utils_stub = types.ModuleType("agent_server.utils")
+    _utils_stub.__path__ = [str(_AGENT_SERVER_DIR / "utils")]
+    sys.modules["agent_server.utils"] = _utils_stub
+
+from agent_server.services.process_registry import (  # noqa: E402
+    ProcessRegistry,
+    RECENTLY_COMPLETED_TTL_SECONDS,
+)
+
+
+def _fake_process(pid: int = 1234) -> MagicMock:
+    """A subprocess.Popen stand-in just realistic enough for register()."""
+    p = MagicMock(spec=subprocess.Popen)
+    p.pid = pid
+    p.poll.return_value = None
+    return p
+
+
+@pytest.mark.unit
+class TestRecentlyCompletedBuffer:
+    def test_unregister_records_id_in_buffer(self):
+        reg = ProcessRegistry()
+        reg.register("exec-1", _fake_process())
+        assert reg.list_recently_completed_ids() == []  # not finished yet
+
+        reg.unregister("exec-1")
+        assert "exec-1" in reg.list_recently_completed_ids()
+
+    def test_register_does_not_touch_buffer(self):
+        reg = ProcessRegistry()
+        reg.register("exec-1", _fake_process())
+        assert reg.list_recently_completed_ids() == []
+
+    def test_buffer_evicts_entries_past_ttl(self, monkeypatch):
+        """Lazy expiry — past-TTL entries are dropped on the next read."""
+        # Tighten the TTL so the test doesn't need to wait minutes.
+        import agent_server.services.process_registry as pr_mod
+        monkeypatch.setattr(pr_mod, "RECENTLY_COMPLETED_TTL_SECONDS", 0.05)
+
+        reg = ProcessRegistry()
+        reg.register("exec-1", _fake_process())
+        reg.unregister("exec-1")
+        assert "exec-1" in reg.list_recently_completed_ids()
+
+        time.sleep(0.1)
+        assert reg.list_recently_completed_ids() == []
+        # And the underlying dict is cleared, not just filtered on read.
+        assert "exec-1" not in reg._recently_completed
+
+    def test_multiple_unregisters_accumulate(self):
+        reg = ProcessRegistry()
+        for eid in ("a", "b", "c"):
+            reg.register(eid, _fake_process())
+            reg.unregister(eid)
+        assert set(reg.list_recently_completed_ids()) == {"a", "b", "c"}
+
+    def test_unregister_unknown_id_still_buffers(self):
+        """The buffer tracks the lifecycle event, not just known processes.
+        Even if `register` was never called (e.g. a defensive unregister
+        from an error path), the ID gets buffered so any racing watchdog
+        view sees it as 'just completed'."""
+        reg = ProcessRegistry()
+        reg.unregister("ghost-id")
+        assert "ghost-id" in reg.list_recently_completed_ids()
+
+    def test_ttl_sized_above_observed_race_window(self):
+        """#921's incident showed a 55s gap between agent unregister and
+        backend success-write. The default TTL must comfortably exceed
+        that with headroom for backend slowness — this guards a future
+        refactor from accidentally shrinking it."""
+        assert RECENTLY_COMPLETED_TTL_SECONDS >= 120

--- a/tests/unit/test_recently_completed_buffer.py
+++ b/tests/unit/test_recently_completed_buffer.py
@@ -22,28 +22,60 @@ from unittest.mock import MagicMock
 import pytest
 
 
-# Same import shim as test_terminate_async_executor.py — avoid booting the
-# full agent_server package (its routers/__init__.py imports optional deps).
+# Import shim to load agent_server.services.process_registry without booting
+# the full agent_server package (routers/__init__.py pulls in optional deps).
+# The bare sys.modules writes below are guarded by the _restore_sys_modules
+# autouse fixture so they can't leak into other test files in the same
+# pytest session — same pattern as tests/unit/test_telegram_webhook_backfill.py.
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _AGENT_SERVER_DIR = _PROJECT_ROOT / "docker" / "base-image" / "agent_server"
 
-if "agent_server" not in sys.modules:
-    _stub = types.ModuleType("agent_server")
-    _stub.__path__ = [str(_AGENT_SERVER_DIR)]
-    sys.modules["agent_server"] = _stub
-if "agent_server.services" not in sys.modules:
-    _services_stub = types.ModuleType("agent_server.services")
-    _services_stub.__path__ = [str(_AGENT_SERVER_DIR / "services")]
-    sys.modules["agent_server.services"] = _services_stub
-if "agent_server.utils" not in sys.modules:
-    _utils_stub = types.ModuleType("agent_server.utils")
-    _utils_stub.__path__ = [str(_AGENT_SERVER_DIR / "utils")]
-    sys.modules["agent_server.utils"] = _utils_stub
+_STUBBED_MODULE_NAMES = [
+    "agent_server",
+    "agent_server.services",
+    "agent_server.utils",
+    "agent_server.services.process_registry",
+]
 
-from agent_server.services.process_registry import (  # noqa: E402
-    ProcessRegistry,
-    RECENTLY_COMPLETED_TTL_SECONDS,
-)
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot sys.modules before each test and restore after, so the
+    namespace stubs we inject for the import shim don't leak into other
+    tests that exercise the real agent_server package or share name
+    prefixes."""
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+def _import_process_registry():
+    """Lazy-import inside the fixture's scope. Stubs the parent packages
+    just enough that `agent_server.services.process_registry` resolves
+    without triggering routers/__init__.py's optional-deps import chain."""
+    if "agent_server" not in sys.modules:
+        stub = types.ModuleType("agent_server")
+        stub.__path__ = [str(_AGENT_SERVER_DIR)]
+        sys.modules["agent_server"] = stub
+    if "agent_server.services" not in sys.modules:
+        stub = types.ModuleType("agent_server.services")
+        stub.__path__ = [str(_AGENT_SERVER_DIR / "services")]
+        sys.modules["agent_server.services"] = stub
+    if "agent_server.utils" not in sys.modules:
+        stub = types.ModuleType("agent_server.utils")
+        stub.__path__ = [str(_AGENT_SERVER_DIR / "utils")]
+        sys.modules["agent_server.utils"] = stub
+    from agent_server.services.process_registry import (  # noqa: WPS433
+        ProcessRegistry,
+        RECENTLY_COMPLETED_TTL_SECONDS,
+    )
+    return ProcessRegistry, RECENTLY_COMPLETED_TTL_SECONDS
 
 
 def _fake_process(pid: int = 1234) -> MagicMock:
@@ -57,6 +89,7 @@ def _fake_process(pid: int = 1234) -> MagicMock:
 @pytest.mark.unit
 class TestRecentlyCompletedBuffer:
     def test_unregister_records_id_in_buffer(self):
+        ProcessRegistry, _ = _import_process_registry()
         reg = ProcessRegistry()
         reg.register("exec-1", _fake_process())
         assert reg.list_recently_completed_ids() == []  # not finished yet
@@ -65,12 +98,14 @@ class TestRecentlyCompletedBuffer:
         assert "exec-1" in reg.list_recently_completed_ids()
 
     def test_register_does_not_touch_buffer(self):
+        ProcessRegistry, _ = _import_process_registry()
         reg = ProcessRegistry()
         reg.register("exec-1", _fake_process())
         assert reg.list_recently_completed_ids() == []
 
     def test_buffer_evicts_entries_past_ttl(self, monkeypatch):
         """Lazy expiry — past-TTL entries are dropped on the next read."""
+        ProcessRegistry, _ = _import_process_registry()
         # Tighten the TTL so the test doesn't need to wait minutes.
         import agent_server.services.process_registry as pr_mod
         monkeypatch.setattr(pr_mod, "RECENTLY_COMPLETED_TTL_SECONDS", 0.05)
@@ -86,6 +121,7 @@ class TestRecentlyCompletedBuffer:
         assert "exec-1" not in reg._recently_completed
 
     def test_multiple_unregisters_accumulate(self):
+        ProcessRegistry, _ = _import_process_registry()
         reg = ProcessRegistry()
         for eid in ("a", "b", "c"):
             reg.register(eid, _fake_process())
@@ -97,6 +133,7 @@ class TestRecentlyCompletedBuffer:
         Even if `register` was never called (e.g. a defensive unregister
         from an error path), the ID gets buffered so any racing watchdog
         view sees it as 'just completed'."""
+        ProcessRegistry, _ = _import_process_registry()
         reg = ProcessRegistry()
         reg.unregister("ghost-id")
         assert "ghost-id" in reg.list_recently_completed_ids()
@@ -106,4 +143,5 @@ class TestRecentlyCompletedBuffer:
         backend success-write. The default TTL must comfortably exceed
         that with headroom for backend slowness — this guards a future
         refactor from accidentally shrinking it."""
-        assert RECENTLY_COMPLETED_TTL_SECONDS >= 120
+        _, ttl = _import_process_registry()
+        assert ttl >= 120


### PR DESCRIPTION
## Summary

The original #921 fix worked around a watchdog race using a backend-side Redis sentinel and two-cycle confirmation. The race actually lives on the **agent side** — `claude_code.py`'s `finally: registry.unregister()` runs before the backend writes `success`. Closing it there lets the backend revert to a simple, single-cycle reconciler.

**Net: 182 added, 518 deleted (-336 lines).**

## Agent side (~37 lines added)

- `process_registry` now keeps a `_recently_completed: dict[id, float]` buffer populated by `unregister()`, with a 5-min TTL (well above the worst observed in-flight delay in the #921 incident, ~55s).
- New `list_recently_completed_ids()` returns IDs within the window, lazily evicting expired entries.
- `GET /api/executions/running` adds a `recently_completed_ids` field alongside `executions`.

## Backend side (~150 lines removed)

- New module-level helper `_extract_agent_known_ids(payload)` is the single source of truth for parsing `/api/executions/running`. It returns the union of currently-running execution_ids + `recently_completed_ids`. Used by **both** the periodic watchdog (`_get_agent_running_ids`) and the startup recovery (`recover_orphaned_executions`) so they can't drift out of sync.
- Deleted: `redis.asyncio` import, `ORPHAN_SENTINEL_PREFIX` / `ORPHAN_SENTINEL_TTL_SECONDS` constants, `self._redis` field, `_get_redis` / `_mark_suspected_orphan` / `_is_suspected_orphan` / `_clear_suspected_orphan` helpers, `orphans_suspected` report field, two-cycle branch in `_reconcile_orphaned_executions`. Return signature reverts from 4-tuple to 3-tuple.

## Backwards compatibility

Older agent images that haven't shipped the buffer return only `executions` — `_extract_agent_known_ids` tolerates the missing field and degrades to pre-#921 behaviour. **No coupled deploy required**; the backend simplification works as soon as it ships. Agents pick up the buffer on the next base-image rebuild + container recreate.

## Behaviour delta

- **Natural-completion race**: same outcome — no false orphan recovery — but now prevented at the source instead of deferred by a cycle.
- **True orphans**: recover in 1 cycle (~5min) instead of 2 (~10min). That latency was an artifact of the deleted two-cycle defer, not a goal.

## Test plan

- [x] `tests/test_watchdog_unit.py` — `TestTwoCycleOrphanConfirmation` deleted; existing tests reverted to 3-tuple unpacking; new `TestExtractAgentKnownIds` (5 tests) covers the union, missing field, empty response, null fields, and malformed entries without `execution_id`; `TestGetAgentRunningIdsUnionsRecentlyCompleted` (3 tests) exercises the watchdog method end-to-end.
- [x] `tests/test_watchdog.py` — `TestTwoCycleOrphanConfirmation` replaced with a single `test_true_orphan_recovered_on_single_cycle` against the live backend.
- [x] `tests/unit/test_recently_completed_buffer.py` (new) — 6 tests for the agent-side primitive: register/unregister lifecycle, lazy TTL eviction, TTL sized above the observed #921 incident gap, unknown-id and multi-id handling. Uses the `_STUBBED_MODULE_NAMES` + `_restore_sys_modules` autouse pattern so the agent-server namespace stubs can't leak.
- [x] `tests/integration/test_circuit_breaker.py` — 34 tests unchanged, all pass. CB work from #924 untouched.
- [x] `tests/test_circuit_breaker_reset.py` — 4 tests unchanged, all pass.
- [x] Existing startup-recovery tests (`test_orphaned_execution_recovery.py`, `test_redis_slot_recovery.py`, `test_startup_recovery_race.py`) — 28/28 still pass; the shared helper is behaviour-preserving for the pre-#921 response shape.
- [x] Live verification: inserted a fake `running` row for `trinity-system`, triggered cleanup, observed `orphaned_executions=1` in one cycle with row marked `failed`. No `orphans_suspected` field in the report.

## Out of scope (deferred from earlier triage)

- **#3**: move `_emit_dormant_alert` out of `agent_client` into `monitoring_service` (decouple low-level CB code from the operator queue DB write).
- **#4**: collapse open + dormant into one CB state with adaptive cooldown.
- **#921 [I2]**: env-tunable `RECENTLY_COMPLETED_TTL_SECONDS` — current 5min default is well above the observed incident gap.
- **#921 [I3]**: live-stack integration test exercising a real chat-and-then-cleanup against an agent. Unit + manual live verification cover the same behaviour.

Each stands on its own and doesn't depend on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)