### PR TITLE
fix(#935): unit conftest stub cleanup for cross-file sys.modules pollution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,7 @@ _SYS_MODULES_INVARIANT_KEYS = (
     # settings_service), test_voice_tools.py (agent_client), etc.
     "services",
     "services.agent_client",
+    "services.docker_service",
     "services.platform_audit_service",
     "services.settings_service",
     "services.task_execution_service",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -251,6 +251,9 @@ _POP_PREFIXES: tuple[str, ...] = (
     "services.template_service",
     "services.gemini_voice",
     "services.platform_audit_service",
+    "services.task_execution_service",
+    "services.cleanup_service",
+    "dependencies",
     "passlib",
 )
 


### PR DESCRIPTION
## Summary

Closes #935.

Adds the four module names called out in the issue to the existing
baseline-restore / pop-prefix machinery so stubs installed by one unit
test file stop leaking into the next:

- `tests/conftest.py` `_SYS_MODULES_INVARIANT_KEYS`: + `services.docker_service`
- `tests/unit/conftest.py` `_POP_PREFIXES`: + `services.task_execution_service`, `services.cleanup_service`, `dependencies`

Two-line surface, no production code touched.

## Repro / verification

Deterministic order (per the issue's repro command):

```
pytest tests/unit/test_auto_retry_reader_race.py \
       tests/unit/test_file_upload.py \
       tests/unit/test_session_persistence_flag.py \
       tests/unit/test_fleet_status_resilience.py \
       tests/unit/test_startup_recovery_race.py \
       tests/test_github_pat_propagation_unit.py -p no:randomly
```

**Before:** `22 failed, 58 passed` — a stub for `services.docker_service`
(missing `get_agent_container`) leaked into `adapters.message_router` and
`services.cleanup_service` imports collected by later test files.

**After:** `80 passed`. Also clean with default `pytest-randomly`
ordering.

## Test plan

- [x] Reproduce the failure on `origin/dev`
- [x] Apply the conftest changes
- [x] Confirm the same command now passes deterministically
- [x] Confirm the same command passes under default `pytest-randomly` ordering