### PR TITLE
fix(#936): refresh stale test expectations for #665, #898, #474

### DIFF
--- a/tests/integration/test_monitoring_service.py
+++ b/tests/integration/test_monitoring_service.py
@@ -293,8 +293,15 @@ class TestCheckNetworkHealthClassification:
         assert result.status_code is None
         assert self._read_failures(agent_name) == 1
 
-    def test_read_timeout_does_not_record(self, agent_name, monkeypatch):
-        """Case 5: ReadTimeout → reachable=False, 0 circuit delta."""
+    def test_read_timeout_records_failure(self, agent_name, monkeypatch):
+        """Case 5: ReadTimeout on /health → reachable=False, +1 circuit failure.
+
+        /health is supposed to be a small, fast endpoint. A read timeout
+        here is a liveness signal (event-loop wedged / GIL stuck), so the
+        /health-specific TimeoutException handler in monitoring_service
+        DOES record_failure() even though the same exception is circuit-
+        neutral in AgentClient._request().
+        """
 
         def handler(_req):
             raise httpx.ReadTimeout("slow")
@@ -302,11 +309,16 @@ class TestCheckNetworkHealthClassification:
         _patch_httpx(monkeypatch, handler)
         result = asyncio.run(monitoring_service.check_network_health(agent_name))
         assert result.reachable is False
-        assert self._read_failures(agent_name) == 0
-        assert self._read_state(agent_name) == "closed"
+        assert self._read_failures(agent_name) == 1
 
-    def test_read_error_does_not_record(self, agent_name, monkeypatch):
-        """Case 6: ReadError → reachable=False, 0 circuit delta."""
+    def test_read_error_records_failure(self, agent_name, monkeypatch):
+        """Case 6: ReadError on /health → reachable=False, +1 circuit failure.
+
+        Partial-write/mid-read drop on /health is a liveness signal
+        (agent crashed mid-write — OOM, segfault, event-loop wedge), so
+        the /health-specific handler in monitoring_service does
+        record_failure().
+        """
 
         def handler(_req):
             raise httpx.ReadError("mid-read socket loss")
@@ -314,12 +326,14 @@ class TestCheckNetworkHealthClassification:
         _patch_httpx(monkeypatch, handler)
         result = asyncio.run(monitoring_service.check_network_health(agent_name))
         assert result.reachable is False
-        assert self._read_failures(agent_name) == 0
+        assert self._read_failures(agent_name) == 1
 
-    def test_pool_timeout_does_not_record(self, agent_name, monkeypatch):
-        """Case 7: PoolTimeout → reachable=False, 0 circuit delta.
+    def test_pool_timeout_records_failure(self, agent_name, monkeypatch):
+        """Case 7: PoolTimeout on /health → reachable=False, +1 circuit failure.
 
-        Pool exhaustion is a client-side resource issue.
+        PoolTimeout subclasses httpx.TimeoutException, so it falls into the
+        /health-specific timeout handler that treats any timeout as a
+        liveness signal and records_failure().
         """
 
         def handler(_req):
@@ -328,7 +342,7 @@ class TestCheckNetworkHealthClassification:
         _patch_httpx(monkeypatch, handler)
         result = asyncio.run(monitoring_service.check_network_health(agent_name))
         assert result.reachable is False
-        assert self._read_failures(agent_name) == 0
+        assert self._read_failures(agent_name) == 1
 
     def test_unrelated_exception_does_not_record(self, agent_name, monkeypatch):
         """Case 8: unrelated RuntimeError → log+swallow, 0 circuit delta.

--- a/tests/test_agent_files.py
+++ b/tests/test_agent_files.py
@@ -5,6 +5,8 @@ Tests for agent workspace file browser.
 Covers REQ-FILES-001 through REQ-FILES-002.
 """
 
+import time
+
 import pytest
 from utils.api_client import TrinityApiClient
 from utils.assertions import (
@@ -14,6 +16,33 @@ from utils.assertions import (
     assert_has_fields,
     assert_tree_structure,
 )
+
+
+def _wait_for_container_ready(
+    api_client: TrinityApiClient, agent_name: str, timeout_s: float = 30.0
+) -> None:
+    """Poll an endpoint that requires the agent container to exist until it
+    responds (i.e., no longer 404 from `get_agent_container() is None`).
+
+    `created_agent` waits for the backend to report `status == "running"`,
+    but the Docker container can momentarily disappear from the backend's
+    SDK view during early startup. The mkdir endpoint surfaces that as
+    404, with no 503 fallback, so the test needs an explicit barrier
+    before exercising the endpoint.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        # /api/agents/{name}/files goes through the same get_agent_container
+        # lookup as mkdir; a 200 (or 503 "agent server not ready") means
+        # the container is visible to the backend.
+        probe = api_client.get(f"/api/agents/{agent_name}/files")
+        if probe.status_code != 404:
+            return
+        time.sleep(0.5)
+    pytest.skip(
+        f"Agent container for {agent_name} did not become visible to the "
+        f"backend within {timeout_s}s"
+    )
 
 
 class TestListFiles:
@@ -563,6 +592,7 @@ class TestCreateFolder:
         """mkdir creates a directory that then appears in the listing."""
         import uuid
         name = created_agent['name']
+        _wait_for_container_ready(api_client, name)
         dir_path = f"/home/developer/mkdir_test_{uuid.uuid4().hex[:8]}"
 
         response = api_client.post(
@@ -591,6 +621,7 @@ class TestCreateFolder:
         """Creating an already-existing directory returns 409."""
         import uuid
         name = created_agent['name']
+        _wait_for_container_ready(api_client, name)
         dir_path = f"/home/developer/mkdir_dup_{uuid.uuid4().hex[:8]}"
 
         first = api_client.post(

--- a/tests/test_agent_timeout.py
+++ b/tests/test_agent_timeout.py
@@ -71,15 +71,15 @@ class TestTimeoutGet:
         assert isinstance(data["execution_timeout_seconds"], int)
         assert isinstance(data["execution_timeout_minutes"], int)
 
-    def test_get_timeout_default_is_900(self, api_client: TrinityApiClient, created_agent):
-        """Agents should default to execution_timeout_seconds=900 (15 minutes)."""
+    def test_get_timeout_default_is_3600(self, api_client: TrinityApiClient, created_agent):
+        """Agents should default to execution_timeout_seconds=3600 (60 minutes)."""
         response = api_client.get(f"/api/agents/{created_agent['name']}/timeout")
         skip_if_agent_not_ready(response)
 
         assert_status(response, 200)
         data = response.json()
-        # Default should be 900 seconds (15 minutes) per TIMEOUT-001 requirements
-        assert data["execution_timeout_seconds"] == 900
+        # Default raised from 900s to 3600s in #665 (TIMEOUT-001 update).
+        assert data["execution_timeout_seconds"] == 3600
 
     def test_get_timeout_minutes_calculation(self, api_client: TrinityApiClient, created_agent):
         """execution_timeout_minutes should equal execution_timeout_seconds // 60."""


### PR DESCRIPTION
Closes #936.

## Summary
- `test_get_timeout_default_is_900` → `test_get_timeout_default_is_3600` (default raised in #665).
- `TestCheckNetworkHealthClassification`: rename `test_{read_timeout,read_error,pool_timeout}_does_not_record` → `..._records_failure` and flip the assertion to `== 1`. `/health` probes treat these exceptions as agent-liveness signals and DO record on the circuit (override of `TRANSIENT_TRANSPORT_EXCEPTIONS`).
- `TestCreateFolder`: add a small `_wait_for_container_ready` helper that polls until the agent container is visible to the backend's Docker SDK, and call it from the two tests that actually hit `POST /files/mkdir` (#898). The other three tests in the class fail-fast before the container lookup and don't need the wait.

No production code changes — tests only.

## Test plan
- [x] `tests/test_watchdog.py::TestTwoCycleOrphanConfirmation` — 3/3 pass (already correct after #924; left untouched).
- [x] `tests/integration/test_monitoring_service.py::TestCheckNetworkHealthClassification::test_{read_timeout,read_error,pool_timeout}_records_failure` — 3/3 pass.
- [x] `tests/test_agent_timeout.py::TestTimeoutGet::test_get_timeout_default_is_3600` — pass.
- [x] `tests/test_agent_files.py::TestCreateFolder::test_create_folder_and_list` — pass (after rebuilding `trinity-agent-base` to include #898's mkdir endpoint).
- [x] `tests/test_subscription_auto_switch.py::TestAutoSwitchSetting::test_get_auto_switch_default_on` — passes against current dev (no change needed; the runtime default still resolves to True per #441).

Note: `tests/integration/test_monitoring_service.py` requires `REDIS_URL` to be exported before `pytest` starts (the module sets `localhost:6379` at import time, but `tests/conftest.py` pre-loads `services.agent_client` first, which captures `config.REDIS_URL`). Pre-existing setup quirk, not introduced here.