### PR TITLE
fix(ci): stash local changes before git pull on dev deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -33,7 +33,19 @@ jobs:
             echo "=== Pull ==="
             git fetch origin dev
             git checkout dev
-            git pull origin dev
+            # The dev VM has a persistent checkout that may carry hand-applied
+            # fixes (e.g. docker-compose.prod.yml tweaks). `git pull` aborts on
+            # dirty tree, blocking every deploy. Stash with a deploy-run-keyed
+            # message so the changes are recoverable via `git stash list` (and
+            # survive in the reflog for ~90 days) without polluting history.
+            # If the working tree is clean, stash is a no-op (exit 0).
+            #
+            # Long-term fix is to move the build to CI + push images to a
+            # registry so the dev VM is stateless (see #942). Until then, this
+            # keeps deploys unblocked while preserving the audit trail.
+            STASH_MSG="auto-stash-deploy-${GITHUB_RUN_ID:-manual}"
+            git stash push -u -m "${STASH_MSG}" || echo "No local changes to stash"
+            git pull --ff-only origin dev
             echo "Version: $(git log -1 --oneline)"
 
             echo "=== Build ==="

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,7 +43,12 @@ jobs:
             # Long-term fix is to move the build to CI + push images to a
             # registry so the dev VM is stateless (see #942). Until then, this
             # keeps deploys unblocked while preserving the audit trail.
-            STASH_MSG="auto-stash-deploy-${GITHUB_RUN_ID:-manual}"
+            # Workflow-syntax interpolation: GitHub expands `${{ github.run_id }}`
+            # at YAML render time so the literal run id is baked into the script
+            # before it ships over SSH. Using `$GITHUB_RUN_ID` here would fail
+            # silently — that env var lives on the GH Actions runner, not on
+            # the dev VM where this script actually executes.
+            STASH_MSG="auto-stash-deploy-${{ github.run_id }}"
             git stash push -u -m "${STASH_MSG}" || echo "No local changes to stash"
             git pull --ff-only origin dev
             echo "Version: $(git log -1 --oneline)"


### PR DESCRIPTION
## Summary

Every deploy to dev has been failing since 2026-05-13 (#826). This patch unjams it.

## Failure timeline

| Date | Failure | Resolution |
|---|---|---|
| 2026-05-13 → 2026-05-26 | `error: missing server host` — PR #826 moved `DEV_HOST` / `DEV_USER` to repo secrets but they were never set. | Secrets configured 2026-05-26. |
| 2026-05-26 12:35 UTC | `Your local changes to the following files would be overwritten by merge: docker-compose.prod.yml` — `git pull` aborts because the dev VM's checkout has hand-applied changes. | **This PR.** |

## Root cause

The dev deploy is a **pull-style** model: the dev VM owns a persistent source checkout (`~/trinity`) that the SSH script `git pull`s on every deploy. Build happens on the VM, not on CI. Any local modifications to tracked files (intentional hot-fixes, leftover state from a failed deploy, hand-applied prod tweaks) block the pull and break every subsequent deploy.

## Change

Stash dirty changes under a deploy-run-keyed message before pulling, so the deploy proceeds without losing the hand-applied edits.

```yaml
STASH_MSG="auto-stash-deploy-${GITHUB_RUN_ID:-manual}"
git stash push -u -m "${STASH_MSG}" || echo "No local changes to stash"
git pull --ff-only origin dev
```

- Stash includes untracked files (`-u`).
- Stash entries survive in `git stash list` (and the reflog ~90 days) on the VM — recoverable via `git stash show stash@{0}` + `git stash apply stash@{N}`.
- `--ff-only` makes divergent history fail fast instead of producing a silent merge commit.
- Stash is a no-op (exit 0) when the working tree is clean.

## Why not other options

| Option | Why not (for this PR) |
|---|---|
| `git reset --hard origin/dev` | Destructive — silently discards any in-flight hot-fix. No audit trail. |
| `git stash` without `--ff-only` | Same risk as before; deploys could silently merge a divergent history. |
| Move build to CI + image registry (atomic deploy) | The **correct** long-term fix. Trinity's dev VM should be stateless: pull pre-built images instead of running a build on the box. **Separate scope — file follow-up issue.** |

## Test plan

- [x] YAML syntax valid (`yamllint .github/workflows/deploy-dev.yml`)
- [ ] Merge to dev → push triggers Deploy to Dev → stash + pull + build succeeds
- [ ] After deploy succeeds: SSH to dev VM, run `git stash list` and verify the previously-modified `docker-compose.prod.yml` is recoverable as `auto-stash-deploy-<run_id>`
- [ ] Optional but recommended: inspect the stashed change (`git stash show -p stash@{0}`) and decide whether it should be committed back to the repo or discarded permanently

## Follow-up issue to file

**"Move dev deploy to image-registry pull (stateless dev VM)"** — eliminates this whole class of failure. CI builds + pushes images to GHCR, dev runs only `docker compose pull && up`. No git on dev. ~1–2 day rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
