### PR TITLE
fix(ci): drop -u from git stash so Docker-owned untracked files don't break the deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -48,8 +48,17 @@ jobs:
             # before it ships over SSH. Using `$GITHUB_RUN_ID` here would fail
             # silently — that env var lives on the GH Actions runner, not on
             # the dev VM where this script actually executes.
+            #
+            # NO `-u`: the dev VM has Docker-volume directories (trinity-data/,
+            # archives/, avatars/) owned by root inside containers. The trinity
+            # user can't `rm` those, so `git stash -u` aborts mid-cleanup with
+            # "Permission denied", leaves the stash entry created but the
+            # working tree UNREVERTED, returns non-zero, our `|| echo` masks
+            # the failure as "no changes" — and the subsequent pull aborts on
+            # the still-dirty tracked file. Tracked-only stash is what actually
+            # blocks the pull; untracked Docker-owned files don't block git.
             STASH_MSG="auto-stash-deploy-${{ github.run_id }}"
-            git stash push -u -m "${STASH_MSG}" || echo "No local changes to stash"
+            git stash push -m "${STASH_MSG}" || echo "No local changes to stash"
             git pull --ff-only origin dev
             echo "Version: $(git log -1 --oneline)"
 


### PR DESCRIPTION
## Summary

Follow-up to #943. First deploy after #943 merged (run [26454209415](https://github.com/Abilityai/trinity/actions/runs/26454209415)) failed again — same surface error, different root cause.

## The failure

```
Saved working directory and index state On dev: auto-stash-deploy-26454209415
warning: failed to remove trinity-data/archives/: Permission denied
warning: failed to remove trinity-data/avatars/...: Permission denied
warning: failed to remove trinity-data/q.py: Permission denied
No local changes to stash         ← our `|| echo` fallback, MISLEADING
...
error: Your local changes to the following files would be overwritten by merge:
	docker-compose.prod.yml
Aborting
```

## Root cause

`git stash push -u` (include untracked) tries to remove **all** untracked files as part of its working-tree-cleanup phase. The dev VM has Docker-volume directories (`trinity-data/`, `archives/`, `avatars/`) populated by containers running as root. The `trinity` user can't `unlink` those files.

Sequence:
1. ✅ Stash commit created with the tracked changes
2. ❌ Working-tree cleanup phase aborts on the `Permission denied` rm of Docker-owned files
3. ❌ `docker-compose.prod.yml` modification **NOT reverted** in the working tree
4. ❌ `git stash` exits non-zero → `|| echo "No local changes to stash"` fires (misleading)
5. ❌ `git pull --ff-only` aborts on the still-dirty tracked file

The stash entry from the failed run (`auto-stash-deploy-26454209415`) **does exist** on the dev VM and **does contain** the `docker-compose.prod.yml` change — recoverable via `git stash list` + `git stash show -p stash@{N}`.

## Fix

Drop the `-u`. Tracked-only stash captures the blocking file, reverts the working tree, lets pull proceed. Untracked Docker-owned files were never the issue — they don't block `git pull`.

```diff
- git stash push -u -m "${STASH_MSG}" || echo "No local changes to stash"
+ git stash push -m "${STASH_MSG}" || echo "No local changes to stash"
```

Inline comment block expanded to flag the trap so a future contributor doesn't re-add `-u`.

## Test plan

- [ ] Merge to dev → next push triggers Deploy to Dev
- [ ] Stash output should show `Saved working directory and index state` with NO "permission denied" warnings
- [ ] `git pull --ff-only` succeeds (fast-forward)
- [ ] Build + restart proceed
- [ ] On the dev VM: `git stash list` shows two entries:
  - `auto-stash-deploy-26454209415` (from #943's broken first deploy)
  - `auto-stash-deploy-<new-run-id>` (from this deploy)
- [ ] `git stash show -p stash@{N}` reveals the docker-compose.prod.yml diff for manual triage

## Followup (still out of scope here)

Move the build to CI + image registry → stateless dev VM. This whole class of "git state on the production-adjacent box" failures disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
