### PR TITLE
fix(ui): reserve scrollbar gutter on html (#954)

### DIFF
--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Reserve scrollbar gutter so pages that toggle between scrolling and
+   non-scrolling layouts (e.g. AgentDetail Chat/Session vs other tabs)
+   don't shift horizontally. Issue #954. */
+html {
+  scrollbar-gutter: stable;
+}
+
 /* Theme transition for smooth dark mode switching */
 * {
   transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;


### PR DESCRIPTION
## Summary

- One-line CSS fix: `html { scrollbar-gutter: stable; }` in `src/frontend/src/style.css`.
- Stops the horizontal panel jerk on the Agent Detail page when switching between Chat / Session tabs and the rest (Info, Tasks, Dashboard, …).
- Root cause is exactly as the issue diagnosed: Chat/Session use `h-screen overflow-hidden` on the root (no body scrollbar), other tabs use `min-h-screen` (scrollbar appears). Reserving the gutter at the document level keeps the centered `max-w-[1400px]` panel pinned.

Did not touch the Chat/Session padding — issue notes "the inner panels manage their own padding and double padding will compress the message area." The remaining padding gap is intentional UX (edge-to-edge message thread vs `p-6` body content); the no-jerk criterion is satisfied without harmonizing it.

Related to #954

## Test plan

- [ ] Agent Detail: Info → Chat → Info → Session → Info — panel left edge does not move
- [ ] Same sequence in dark mode
- [ ] Same sequence at narrow (<1400px) and wide (>1400px) viewports
- [ ] Spot-check other pages (Dashboard, Agents list, Settings) — no visible regression; right-edge gutter is reserved but content not visibly cramped

🤖 Generated with [Claude Code](https://claude.com/claude-code)