### PR TITLE
fix(deploy): populate build provenance on dev (#958)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -88,7 +88,25 @@ jobs:
             COMPOSE_FILES="-f docker-compose.prod.yml -f docker-compose.prod.enterprise.yml"
 
             echo "=== Build ==="
-            sudo docker compose ${COMPOSE_FILES} build --no-cache backend frontend mcp-server scheduler
+            # Build-time provenance (#926 / #958). docker-compose.prod.yml
+            # backend.build.args reads these env vars; absent them, the
+            # Dockerfile defaults to "unknown" and Build Info in the UI
+            # shows a wall of unknown values. Mirrors scripts/deploy/start.sh.
+            # Inline VAR=val form bypasses sudo's default env_reset — `sudo -E`
+            # would depend on env_keep being permissive in sudoers, which it
+            # is not by default on Ubuntu.
+            GIT_COMMIT=$(git rev-parse HEAD)
+            GIT_COMMIT_SUBJECT=$(git log -1 --pretty=%s)
+            GIT_COMMIT_TIMESTAMP=$(git log -1 --pretty=%cI)
+            GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            sudo \
+              GIT_COMMIT="${GIT_COMMIT}" \
+              GIT_COMMIT_SUBJECT="${GIT_COMMIT_SUBJECT}" \
+              GIT_COMMIT_TIMESTAMP="${GIT_COMMIT_TIMESTAMP}" \
+              GIT_BRANCH="${GIT_BRANCH}" \
+              BUILD_DATE="${BUILD_DATE}" \
+              docker compose ${COMPOSE_FILES} build --no-cache backend frontend mcp-server scheduler
 
             echo "=== Restart ==="
             sudo docker compose ${COMPOSE_FILES} up -d backend frontend mcp-server scheduler

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,16 @@ services:
     build:
       context: .
       dockerfile: docker/backend/Dockerfile
+      # Build-time provenance (#926 / #958). Forwarded to Dockerfile ARGs
+      # → ENV vars → `GET /api/version` payload. The deploy-dev workflow
+      # exports these from the checked-out repo before `docker compose
+      # build`; absent that, the Dockerfile defaults to "unknown".
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+        GIT_COMMIT_SUBJECT: ${GIT_COMMIT_SUBJECT:-unknown}
+        GIT_COMMIT_TIMESTAMP: ${GIT_COMMIT_TIMESTAMP:-unknown}
+        GIT_BRANCH: ${GIT_BRANCH:-unknown}
+        BUILD_DATE: ${BUILD_DATE:-unknown}
     container_name: trinity-backend
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

Fixes two independent bugs that left `GET /api/version` (and the NavBar Build Info dialog) showing `unknown` for every git/build field on the dev deployment.

1. **`docker-compose.prod.yml` backend service was missing its `build.args` block.** Base `docker-compose.yml:11-15` declares `GIT_COMMIT` / `GIT_BRANCH` / `GIT_COMMIT_SUBJECT` / `GIT_COMMIT_TIMESTAMP` / `BUILD_DATE` build args, but the dev workflow builds with `-f docker-compose.prod.yml` only — not chained with base — so the Dockerfile ARGs never received any values. Added the equivalent block to prod compose.

2. **`.github/workflows/deploy-dev.yml` didn't compute the git provenance env vars** before `docker compose build`. `scripts/deploy/start.sh:175-181` does this for local runs; the workflow was missing the equivalent. Added a block that reads the values off the dev VM's checked-out tree and passes them inline on the `sudo docker compose build` invocation.

The `sudo VAR=val …` inline form is intentional rather than `sudo -E` because Ubuntu's default sudoers `env_reset` does not preserve `GIT_*` through `-E`.

Local runs were always fine — `start.sh` did both halves of the work (export + base compose carries the args). Only the CI deploy path was broken.

Related to #958

## Test plan

- [ ] Merge → dev deploy runs → SSH check the `trinity-backend` container env after the build:
  ```
  docker exec trinity-backend env | grep -E 'GIT_|BUILD_DATE'
  ```
  …shows the dev commit/branch/timestamp, not `unknown`.
- [ ] Hit `/api/version` on dev (authenticated) — all fields populated.
- [ ] Open NavBar → Build Info — no `unknown` rows.

## Out of scope (follow-up in #958)

The issue also asks for a dialog UX fallback when all fields are still `unknown` (true e.g. for ad-hoc `docker build` without args) and an explanatory blurb under the dialog title. Frontend-only — not blocked on this deploy fix and would expand the PR's blast radius. Happy to send a second PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)