### PR TITLE
fix(deploy): auto re-own data volumes to UID 1000 (#958 / #874)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -87,6 +87,35 @@ jobs:
             # outcome as if the overlay weren't applied.
             COMPOSE_FILES="-f docker-compose.prod.yml -f docker-compose.prod.enterprise.yml"
 
+            echo "=== Volume ownership (#874 / #958) ==="
+            # Backend + scheduler run as UID 1000 (issue #874). Existing
+            # deployments rolled before #874 still have data paths owned by
+            # root from the prior root-container era. The first migration to
+            # actually UPDATE existing rows (#922's null_legacy_schedule_
+            # timeouts) hits "attempt to write a readonly database" on
+            # startup, /health returns 503 forever, deploy times out.
+            # Canonical recipe: docs/migrations/NON_ROOT_CONTAINERS_2026-05.md.
+            # Both checks are idempotent — silent no-ops on healthy VMs.
+            TRINITY_DATA_PATH="${TRINITY_DATA_PATH:-./trinity-data}"
+            if [ -d "$TRINITY_DATA_PATH" ]; then
+              DATA_UID=$(stat -c %u "$TRINITY_DATA_PATH")
+              if [ "$DATA_UID" != "1000" ]; then
+                echo "Re-owning $TRINITY_DATA_PATH from UID=$DATA_UID to UID=1000"
+                sudo chown -R 1000:1000 "$TRINITY_DATA_PATH"
+              fi
+            fi
+            # agent-configs is a named volume; check + chown via ephemeral
+            # alpine container running as root.
+            PROJECT=$(basename "$PWD")
+            VOL_NAME="${PROJECT}_agent-configs"
+            if sudo docker volume inspect "$VOL_NAME" >/dev/null 2>&1; then
+              VOL_UID=$(sudo docker run --rm -v "$VOL_NAME:/v" alpine stat -c %u /v 2>/dev/null || echo "0")
+              if [ "$VOL_UID" != "1000" ]; then
+                echo "Re-owning volume $VOL_NAME from UID=$VOL_UID to UID=1000"
+                sudo docker run --rm -v "$VOL_NAME:/v" --user 0 alpine chown -R 1000:1000 /v
+              fi
+            fi
+
             echo "=== Build ==="
             # Build-time provenance (#926 / #958). docker-compose.prod.yml
             # backend.build.args reads these env vars; absent them, the


### PR DESCRIPTION
## Summary

Dev deploys have been failing since 2026-05-27 with `container ***-backend is unhealthy`. Root cause confirmed via `docker logs` on the dev VM:

```
sqlite3.OperationalError: attempt to write a readonly database
  File "/app/db/migrations.py", line 2096, in _migrate_null_legacy_schedule_timeouts
    cursor.execute("UPDATE agent_schedules SET timeout_seconds = NULL ...")
```

After issue #874 the backend and scheduler run as UID 1000 inside the container, but the dev VM's `/data` bind mount + `agent-configs` named volume were still owned by root from the prior root-container era. Earlier deploys survived because no migration actually *wrote* to existing rows — #922's `null_legacy_schedule_timeouts` was the first UPDATE migration after #874, so it's the one that surfaces the permission gap. SQLite then fails the whole startup, `/health` returns 503 forever, and the workflow's `up -d` times out at the unhealthy gate.

`docs/migrations/NON_ROOT_CONTAINERS_2026-05.md` documents the manual re-own recipe for operators. Nobody ran it on the dev VM.

## Fix

Pre-flight in `deploy-dev.yml` that auto-runs the canonical recipe. Idempotent:

- Bind mount: `stat -c %u "${TRINITY_DATA_PATH:-./trinity-data}"` → `chown -R 1000:1000` only if not already 1000.
- Named volume `${PROJECT}_agent-configs`: probe ownership with an ephemeral `alpine` container, chown via a second ephemeral container (`--user 0`) only if not 1000.

Both branches no-op silently on healthy VMs, so it's safe on every deploy.

## Why CI rather than a one-shot manual fix

- This works the first time on the dev VM and any future VM rolled before #874.
- No SSH access required for the routine deploy path.
- Self-heals if some other procedure later re-roots the volumes.

## Test plan

- [ ] Merge → `deploy-dev` workflow runs → pre-flight detects the root-owned data path, re-owns, build proceeds, backend reaches `/health` healthy.
- [ ] Subsequent deploys: pre-flight is silent (no `Re-owning ...` log line), unchanged behavior.
- [ ] If the dev VM's `TRINITY_DATA_PATH` is something other than the compose default, the bind-mount check is a no-op (directory doesn't exist) — script proceeds without error.

## Out of scope (follow-up)

When `up -d` times out for any *other* reason, the workflow currently produces no logs because `set -e` aborts before the "Error check" step. Worth a separate small PR to wrap the up + health checks with a trailing `docker logs` capture so the next incident is one-click triaged. Not bundling here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)