### PR TITLE
fix(#970): bound headless wait on result message + tool stall

### DIFF
--- a/docker/base-image/agent_server/services/headless_executor.py
+++ b/docker/base-image/agent_server/services/headless_executor.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -64,6 +65,35 @@ logger = logging.getLogger(__name__)
 # the cost/pain inflection: short fan-out is cheap to re-run, long
 # deliverables aren't.
 _JSONL_PERSIST_THRESHOLD_S = 600
+
+# #970: cadence for the bounded subprocess wait, and the no-progress ceiling
+# for a single tool_use that never receives a tool_result. Claude Code has
+# NO per-MCP-tool timeout, so a hung stdio tools/call would otherwise wedge
+# `process.wait` for the full execution budget (the ticket's 2h false-
+# timeout). The stall limit is intentionally generous — "tool running" is
+# not "tool stalled" — so only a genuinely wedged call trips it.
+_WAIT_POLL_S = 2.0
+_STALL_LIMIT_S = 300.0
+
+
+def _open_tool_exceeding(ctx: HeadlessRunContext, limit_s: float) -> Optional[str]:
+    """Name of a tool_use open (no matching tool_result) for > ``limit_s``, else None.
+
+    #970 stall-watchdog signal. Reuses the stream parser's existing
+    bookkeeping — ``tool_start_times`` (set on every tool_use) and the
+    ``execution_log`` tool_result entries that close them. A hung stdio
+    MCP ``tools/call`` never emits a tool_result, so its tool_use stays
+    open: the only externally-visible signal that claude is wedged.
+    """
+    log = list(ctx.execution_log)  # snapshot — reader thread mutates concurrently
+    completed = {e.id for e in log if e.type == "tool_result"}
+    now = datetime.now()
+    for e in log:
+        if e.type == "tool_use" and e.id not in completed:
+            started = ctx.tool_start_times.get(e.id)
+            if started and (now - started).total_seconds() > limit_s:
+                return e.tool
+    return None
 
 
 def _attempt_empty_result_recovery(
@@ -192,6 +222,7 @@ class HeadlessRunContext:
     auth_abort_event: threading.Event = field(default_factory=threading.Event)
     auth_abort_reason: List[str] = field(default_factory=list)
     permission_mode_validated: bool = False
+    result_seen: threading.Event = field(default_factory=threading.Event)  # #970: claude emitted {"type":"result"}
     stdout_exc: List[BaseException] = field(default_factory=list)
 
     # Shared mutable buffers (populated by stream_parser via process_stream_line)
@@ -530,6 +561,13 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
                         ctx.tool_start_times,
                         ctx.response_parts,
                     )
+
+                    # #970 early-completion: the result line is the definitive
+                    # end of a `claude --print` turn. Signal it AFTER parsing so
+                    # metadata/response_parts are populated; the wait loop can
+                    # then finalize even if the process lingers in teardown.
+                    if isinstance(raw_msg, dict) and raw_msg.get("type") == "result":
+                        ctx.result_seen.set()
                 except RuntimeError:
                     raise  # Re-raise permission-mode failures
                 except Exception as line_err:  # noqa: BLE001
@@ -582,14 +620,44 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
     process.stdin.write(stdin_payload)
     process.stdin.close()
 
-    # Bounded wait on the subprocess itself. If claude hangs, we
-    # never wedge the executor thread for more than effective_timeout.
+    # Bounded, polling wait. Three exits beyond the overall budget (#970):
+    #   (a) early-completion — claude emitted its {"type":"result"} (the turn
+    #       is definitively over) but the process lingers in teardown (e.g. a
+    #       stdio MCP child holding the pipe). Finalize with the captured
+    #       result instead of burning the budget. The result IS success, so
+    #       set return_code=0 — genuine errors were already classified into
+    #       metadata.error_type from the stream and are surfaced in finalize.
+    #   (b) stall watchdog — an open tool_use with no tool_result for
+    #       >_STALL_LIMIT_S. Claude Code has no per-MCP-tool timeout, so a
+    #       hung tools/call would otherwise wedge until the full budget.
+    #   (c) effective_timeout budget — unchanged backstop.
+    deadline = time.monotonic() + ctx.effective_timeout
+    stalled_tool: Optional[str] = None
     try:
-        ctx.return_code = process.wait(timeout=ctx.effective_timeout)
+        while True:
+            try:
+                ctx.return_code = process.wait(timeout=_WAIT_POLL_S)
+                break
+            except subprocess.TimeoutExpired:
+                if ctx.result_seen.is_set():
+                    logger.warning(
+                        f"[Headless Task] Task {ctx.task_session_id} produced a result "
+                        f"but did not exit — finalizing early, terminating teardown"
+                    )
+                    _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid, execution_tag=ctx.task_session_id)
+                    ctx.return_code = 0
+                    break
+                stalled_tool = _open_tool_exceeding(ctx, _STALL_LIMIT_S)
+                if stalled_tool or time.monotonic() >= deadline:
+                    raise
     except subprocess.TimeoutExpired:
+        reason = (
+            f"tool '{stalled_tool}' stalled with no result for >{_STALL_LIMIT_S:.0f}s"
+            if stalled_tool
+            else f"timed out after {ctx.effective_timeout}s"
+        )
         logger.error(
-            f"[Headless Task] Task {ctx.task_session_id} timed out after {ctx.effective_timeout}s "
-            f"— killing process group"
+            f"[Headless Task] Task {ctx.task_session_id} {reason} — killing process group"
         )
         _terminate_process_group(process, graceful_timeout=5, pgid=ctx.process_pgid, execution_tag=ctx.task_session_id)
         _drain_bounded(process, stdout_thread, stderr_thread,

--- a/tests/unit/test_headless_executor_970_timeout.py
+++ b/tests/unit/test_headless_executor_970_timeout.py
@@ -1,0 +1,230 @@
+"""Unit tests for #970: headless 2h false-timeout fixes.
+
+Two defects shared one symptom (a scheduled task wedged for the full
+``effective_timeout`` — up to 2h — then marked FAILED, with the slot held
+the whole time):
+
+  1. The executor finalized on process EXIT, not on claude's response. When
+     claude emitted ``{"type":"result"}`` (turn definitively over) but the
+     process lingered in teardown (e.g. a stdio MCP child holding the pipe),
+     ``process.wait`` burned the entire budget on already-complete work.
+     Fix: ``result_seen`` event + early-completion in the wait loop, with
+     ``return_code`` forced to 0 so finalize treats it as the success it is.
+
+  2. A hung stdio MCP ``tools/call`` (Claude Code has NO per-MCP-tool
+     timeout) leaves an open ``tool_use`` with no ``tool_result`` forever.
+     Fix: ``_open_tool_exceeding`` stall watchdog in the same loop.
+
+These tests cover the pure watchdog signal and the four wait-loop branches
+(early-completion, stall, natural-exit regression, budget-timeout
+regression) by driving ``_run_headless_subprocess`` with a fake Popen.
+
+Module under test:
+    docker/base-image/agent_server/services/headless_executor.py
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+# conftest.py preloads the real agent_server namespace package.
+from agent_server.models import ExecutionLogEntry  # noqa: E402
+from agent_server.services import headless_executor as he  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Context + fake-subprocess helpers
+# ---------------------------------------------------------------------------
+
+def _ctx(**over) -> "he.HeadlessRunContext":
+    base = dict(
+        cmd=["claude", "--print"],
+        task_session_id="t-970",
+        task_start_iso="2026-01-01T00:00:00Z",
+        effective_timeout=5,
+        images=None,
+        prompt="hello",
+    )
+    base.update(over)
+    return he.HeadlessRunContext(**base)
+
+
+def _tool_use_entry(tool_id: str, tool: str) -> ExecutionLogEntry:
+    return ExecutionLogEntry(id=tool_id, type="tool_use", tool=tool,
+                             timestamp="2026-01-01T00:00:00Z")
+
+
+def _tool_result_entry(tool_id: str, tool: str) -> ExecutionLogEntry:
+    return ExecutionLogEntry(id=tool_id, type="tool_result", tool=tool,
+                             success=True, timestamp="2026-01-01T00:00:01Z")
+
+
+class _FakePipe:
+    """Minimal stdout/stderr stand-in: readline() yields lines then '' (EOF)."""
+
+    def __init__(self, lines):
+        self._it = iter(lines)
+
+    def readline(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            return ""
+
+
+class _FakePopen:
+    def __init__(self, stdout_lines, *, never_exits, returncode=0, wait_sleep=0.02):
+        self.pid = 4242
+        self.stdout = _FakePipe(stdout_lines)
+        self.stderr = _FakePipe([])
+        self.stdin = MagicMock()
+        self._never_exits = never_exits
+        self._returncode = returncode
+        self._wait_sleep = wait_sleep
+        self.returncode = None
+
+    def wait(self, timeout=None):
+        if self._never_exits:
+            time.sleep(min(self._wait_sleep, timeout or self._wait_sleep))
+            raise subprocess.TimeoutExpired(cmd="claude", timeout=timeout)
+        self.returncode = self._returncode
+        return self._returncode
+
+
+@pytest.fixture
+def patched_loop(monkeypatch):
+    """Neutralise OS-level side effects so we test only the wait-loop logic."""
+    monkeypatch.setattr(he, "_capture_pgid", lambda _p: 4242)
+    monkeypatch.setattr(he, "get_process_registry", lambda: MagicMock())
+    term = MagicMock()
+    monkeypatch.setattr(he, "_terminate_process_group", term)
+    monkeypatch.setattr(he, "_drain_bounded", MagicMock())
+    monkeypatch.setattr(he, "_WAIT_POLL_S", 0.05)
+    return monkeypatch, term
+
+
+def _install_popen(monkeypatch, fake):
+    monkeypatch.setattr(he.subprocess, "Popen", lambda *a, **k: fake)
+
+
+# ---------------------------------------------------------------------------
+# _open_tool_exceeding (pure)
+# ---------------------------------------------------------------------------
+
+class TestOpenToolExceeding:
+    def test_none_when_no_tools(self):
+        assert he._open_tool_exceeding(_ctx(), 300) is None
+
+    def test_returns_name_when_open_tool_older_than_limit(self):
+        ctx = _ctx()
+        ctx.execution_log = [_tool_use_entry("t1", "mcp__x__hang")]
+        ctx.tool_start_times = {"t1": datetime.now() - timedelta(seconds=400)}
+        assert he._open_tool_exceeding(ctx, 300) == "mcp__x__hang"
+
+    def test_none_when_open_tool_younger_than_limit(self):
+        ctx = _ctx()
+        ctx.execution_log = [_tool_use_entry("t1", "mcp__x__hang")]
+        ctx.tool_start_times = {"t1": datetime.now() - timedelta(seconds=10)}
+        assert he._open_tool_exceeding(ctx, 300) is None
+
+    def test_none_when_tool_completed(self):
+        """A tool with a matching tool_result is closed — never a stall, even if old."""
+        ctx = _ctx()
+        ctx.execution_log = [
+            _tool_use_entry("t1", "mcp__x__hang"),
+            _tool_result_entry("t1", "mcp__x__hang"),
+        ]
+        ctx.tool_start_times = {"t1": datetime.now() - timedelta(seconds=400)}
+        assert he._open_tool_exceeding(ctx, 300) is None
+
+    def test_only_the_open_tool_is_flagged(self):
+        ctx = _ctx()
+        ctx.execution_log = [
+            _tool_use_entry("done", "Bash"),
+            _tool_result_entry("done", "Bash"),
+            _tool_use_entry("stuck", "mcp__x__hang"),
+        ]
+        now = datetime.now()
+        ctx.tool_start_times = {
+            "done": now - timedelta(seconds=400),
+            "stuck": now - timedelta(seconds=400),
+        }
+        assert he._open_tool_exceeding(ctx, 300) == "mcp__x__hang"
+
+
+# ---------------------------------------------------------------------------
+# Wait-loop branches via _run_headless_subprocess
+# ---------------------------------------------------------------------------
+
+_RESULT_LINE = (
+    '{"type":"result","subtype":"success","total_cost_usd":0.01,'
+    '"num_turns":1,"result":"done"}\n'
+)
+_TOOL_USE_LINE = (
+    '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+    '"id":"t1","name":"mcp__x__hang","input":{}}]}}\n'
+)
+
+
+class TestWaitLoop:
+    def test_early_completion_forces_success_when_process_wont_exit(
+        self, patched_loop, caplog
+    ):
+        """Result emitted + process lingers → finalize early with return_code=0
+        (not a signal-exit failure), and the teardown is killed."""
+        monkeypatch, term = patched_loop
+        _install_popen(monkeypatch, _FakePopen([_RESULT_LINE], never_exits=True))
+        ctx = _ctx(effective_timeout=10)
+
+        with caplog.at_level(logging.WARNING, logger=he.logger.name):
+            he._run_headless_subprocess(ctx)
+
+        assert ctx.return_code == 0
+        assert ctx.result_seen.is_set()
+        assert term.called  # teardown terminated
+        assert any("finalizing early" in r.getMessage() for r in caplog.records)
+
+    def test_stall_watchdog_raises_for_open_tool(self, patched_loop, caplog):
+        """An open tool_use with no result for >_STALL_LIMIT_S raises
+        TimeoutExpired well before the budget."""
+        monkeypatch, _term = patched_loop
+        monkeypatch.setattr(he, "_STALL_LIMIT_S", 0.0)
+        _install_popen(monkeypatch, _FakePopen([_TOOL_USE_LINE], never_exits=True))
+        ctx = _ctx(effective_timeout=30)  # large — must NOT be what fires
+
+        start = time.monotonic()
+        with caplog.at_level(logging.ERROR, logger=he.logger.name):
+            with pytest.raises(subprocess.TimeoutExpired):
+                he._run_headless_subprocess(ctx)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 5.0, "stall should fire fast, not at the 30s budget"
+        assert any("stalled with no result" in r.getMessage() for r in caplog.records)
+
+    def test_natural_exit_still_returns_real_code(self, patched_loop):
+        """Regression: a process that exits on its own is unchanged."""
+        monkeypatch, _term = patched_loop
+        _install_popen(
+            monkeypatch, _FakePopen([_RESULT_LINE], never_exits=False, returncode=0)
+        )
+        ctx = _ctx()
+        he._run_headless_subprocess(ctx)
+        assert ctx.return_code == 0
+
+    def test_budget_timeout_still_fires_with_no_progress(self, patched_loop, caplog):
+        """Regression: no result and no open tool → the overall budget still
+        bounds the wait and raises TimeoutExpired."""
+        monkeypatch, _term = patched_loop
+        monkeypatch.setattr(he, "_WAIT_POLL_S", 0.1)
+        _install_popen(monkeypatch, _FakePopen([], never_exits=True))
+        ctx = _ctx(effective_timeout=0.3)
+
+        with caplog.at_level(logging.ERROR, logger=he.logger.name):
+            with pytest.raises(subprocess.TimeoutExpired):
+                he._run_headless_subprocess(ctx)
+        assert any("timed out after" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary

Fixes the #970 "2h false-timeout" class of failure: a scheduled task wedged for the full `execution_timeout_seconds` (up to 2h), got marked `failed`, and held its capacity slot the entire time — so later schedules failed with `Agent at capacity (N/N parallel tasks running)` even with no real work in flight.

The fix is ~30 functional LOC in `_run_headless_subprocess`, reusing existing infrastructure. **No new thread, service, or file.**

### Root cause (two distinct defects, one symptom)

1. **The executor finalized on process EXIT, not on claude's response.** `read_stdout` had no break on `{"type":"result"}` — it looped to pipe-EOF (process exit) while the main thread parked on `process.wait(timeout=effective_timeout)`. When claude emitted its result (turn definitively over) but the process lingered in teardown (e.g. a stdio MCP child holding the pipe), the budget burned on **already-complete work**.

2. **Claude Code has no per-MCP-tool timeout.** A hung stdio MCP `tools/call` blocks `claude` forever (only `BASH_*`/`API_TIMEOUT_MS` exist; `MCP_TOOL_TIMEOUT` is **not** a real env var). The open `tool_use` never gets a `tool_result`.

### The fix

Replace the single blocking `process.wait` with a polling loop:

- **Early-completion** — on `result_seen`, finalize with the captured result and force `return_code=0`. Genuine errors (`max_turns`, `rate_limit`, auth) are already classified into `metadata.error_type` from the stream and still surface in `_finalize_headless_result` (which runs its `error_type` checks *before* the `return_code` check). Converts a 2h false-**FAILURE** into an immediate **SUCCESS**. Non-heuristic — the `result` message *is* the end of a `claude --print` turn.
- **Stall watchdog** — `_open_tool_exceeding()` raises `TimeoutExpired` when an open `tool_use` has had no `tool_result` for >300s, reusing the stream parser's existing `tool_start_times` bookkeeping. Heuristic, generous limit (covers the MCP-hang case where no result is ever emitted).
- **Overall `effective_timeout`** unchanged as the backstop.

Both reuse the existing `_terminate_process_group` kill and follow the file's existing *detect-from-stream → kill-early* pattern (auth-abort #285, permission-mode validation).

---

## Why the issue's suggested fixes are wrong

The issue is titled a "reader thread leak" and proposes (1) decoupling the orchestrator from the leaked reader, and (2) wider pipe-holder discovery via `lsof`/`/proc`. Both are wrong, and the issue's own evidence proves it.

**The 2h is spent in `process.wait`, not the reader drain.**
- Reader threads live in the **agent-server** process and read claude's stdout pipe. They **cannot keep the claude child alive**, so they are mechanically incapable of extending `process.wait(claude_pid)`. The only place a stuck reader costs wall-clock is the *drain* phase, which is hard-capped at **90s** by `_drain_bounded` (#728). A leaked reader therefore bounds to ≤90s — never 2h.
- The issue's own number proves it: `duration_ms ≈ 7,215,000 = 7,200,000 (budget) + ~15,000 (post-kill drain)`. That decomposition only fits "time spent in `process.wait`, then a short cleanup." If the drain were the hang, you would never see the full 7200s.

**Suggested fix #1 (decouple from the leaked reader) is already implemented and cannot reduce a 2h hang.** `_drain_bounded` (Issue #728) already runs the drain in a daemon thread and returns within `_DRAIN_BUDGET_SECONDS = 90` regardless of whether a reader leaked. The orchestrator does not block on the leaked thread. Since the 2h is in `process.wait` (which runs *before* the drain), bounding the drain tighter saves nothing.

**Suggested fix #2 (`lsof`/`/proc` pipe-holder hunt) is dead weight and a regression risk.** Issue #817 already replaced per-FD pipe-writer scanning with `kill_cgroup_orphans()` — killing on cgroup membership, "the inescapable boundary" that catches escapees regardless of `setsid`/FD-detachment/env-stripping. Re-introducing an `lsof`/`/proc/*/fd` scan brings back exactly the `os.stat` D-state deadlock that #817 removed, for a case that's already covered.

**Net:** the "reader leaked" / `outcome=leaked` log lines the issue points at are emitted by the **post-timeout cleanup** (after the budget was already burned in `process.wait`), not the cause of the hang. The leak is a symptom; the wait-on-exit + missing tool timeout is the cause.

---

## Reproduction evidence

- **Slot squat** (issue symptom #6) reproduced against a live agent with `max_parallel_tasks=1`: a wedged execution held the slot, and a second schedule failed at admission with the verbatim `Agent at capacity (1/1 parallel tasks running)` (`duration_ms=74`, never ran claude) via the scheduler's `overflow_policy="reject"` path (`task_execution_service.py`).
- Live trace of the wedge showed the budget burned in `process.wait` on a hung stdio MCP `tools/call`, with the slot held the whole time.

## Test plan

- [x] New unit tests: `tests/unit/test_headless_executor_970_timeout.py` (9 tests) — `_open_tool_exceeding` (5 pure cases) + the 4 wait-loop branches (early-completion forces `return_code=0`, stall raises, natural-exit regression, budget-timeout regression) driven by a fake Popen.
- [x] Adjacent subprocess/headless tests green (drain_bounded, subprocess_pgroup, pipe_drop, error_classification, jsonl_recovery, orphan_sweep, wallclock_timeout).
- [x] Full unit suite: **1790 passed, 4 skipped, 0 failed**.