### PR TITLE
fix(frontend): scope dark hover bg to class-based dark mode (#960)

### DIFF
--- a/src/frontend/src/views/Agents.vue
+++ b/src/frontend/src/views/Agents.vue
@@ -1237,11 +1237,4 @@ async function removeBulkTag(tag) {
 .border-l-3 {
   border-left-width: 3px;
 }
-
-/* Dark hover shade between gray-700 and gray-800 */
-@media (prefers-color-scheme: dark) {
-  .dark\:hover\:bg-gray-750:hover {
-    background-color: rgb(42, 48, 60);
-  }
-}
 </style>

--- a/src/frontend/tailwind.config.js
+++ b/src/frontend/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
       //   action-*  interactive surface that performs a verb (primary buttons,
       //             links, focus rings).
       colors: {
+        gray: { ...colors.gray, 750: 'rgb(42, 48, 60)' },
         'status-success':    colors.green,
         'status-warning':    colors.yellow,
         'status-danger':     colors.red,


### PR DESCRIPTION
## Summary

Fixes the dark hover band that appeared on Agents list rows when the OS was in dark mode but the app theme was set to light.

- `src/frontend/src/views/Agents.vue` defined `dark:hover:bg-gray-750` inside `@media (prefers-color-scheme: dark)`, but the app's Tailwind config uses `darkMode: 'class'`. OS dark + app light triggered the dark hover anyway, covering the row in an unreadable navy band.
- Promote `gray-750` to a real Tailwind utility via the config palette extension. The generated `dark:hover:bg-gray-750` now resolves through `:is(.dark *)` and respects the app's theme class strategy.
- Drop the custom `@media (prefers-color-scheme: dark)` block — no longer needed.
- Side benefit: `QueueList.vue` referenced the same `dark:hover:bg-gray-750` class but silently rendered nothing (no scoped CSS definition there). It now picks up the real utility.

Related to #960

## Test plan

Verified in browser via Playwright (headless Chromium, `colorScheme` context to emulate OS preference):

- [x] Light OS + Light app → row idle `rgb(255,255,255)`, hover `rgb(249,250,251)` (gray-50). PASS
- [x] **Dark OS + Light app (original bug case)** → `html` carries no `dark` class, row stays `rgb(255,255,255)` at rest, hovers to `rgb(249,250,251)`. No dark artifact. PASS
- [x] Dark OS + Dark app → row idle `rgb(31,41,55)` (gray-800), hover `rgb(42,48,60)` (gray-750). Subtle darker hover preserved. PASS
- [x] CSS bundle confirms generated selector is `.dark\:hover\:bg-gray-750:hover:is(.dark *)` — broken `@media` rule is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)