### PR TITLE
fix(build-info): ship VERSION in backend image, add dialog blurb + fallback (#958)

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -77,6 +77,11 @@ COPY ../../src/backend/canary /app/canary/
 COPY ../../config/process-docs /app/config/process-docs/
 COPY ../../config/process-templates /app/config/process-templates/
 
+# Platform version file — read by /api/version (#958). The dev compose also
+# bind-mounts ./VERSION:/app/VERSION:ro for hot edits, but prod compose
+# doesn't, so without this COPY the version field falls back to "unknown".
+COPY ../../VERSION /app/VERSION
+
 # Ensure all files are readable
 RUN chmod -R 644 /app/*.py && \
     chmod -R 755 /app/routers /app/services /app/adapters /app/utils /app/db /app/canary && \

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -219,7 +219,7 @@
       @click.self="showBuildInfoModal = false"
     >
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full mx-4 p-6">
-        <div class="flex justify-between items-start mb-4">
+        <div class="flex justify-between items-start mb-2">
           <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Build Info</h2>
           <button
             @click="showBuildInfoModal = false"
@@ -230,6 +230,16 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+          Commit, branch, and build date the running platform was built from.
+        </p>
+        <div
+          v-if="buildInfo.isMissing.value"
+          class="mb-4 p-3 rounded bg-gray-50 dark:bg-gray-900 text-xs text-gray-600 dark:text-gray-400"
+        >
+          Build metadata not available — rebuild with
+          <code class="font-mono">scripts/deploy/start.sh</code> to populate.
         </div>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between">

--- a/src/frontend/src/composables/useBuildInfo.js
+++ b/src/frontend/src/composables/useBuildInfo.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import api from '@/api'
 
 /**
@@ -39,6 +39,22 @@ async function load() {
   return inFlight
 }
 
+// True iff every build-provenance field is the literal "unknown" sentinel
+// (no VERSION file COPY'd, no start.sh-exported git args). Drives the
+// "Build metadata not available" guidance in the dialog (#958).
+const isMissing = computed(() => {
+  if (!info.value) return false
+  const fields = [
+    info.value.version,
+    info.value.git_commit,
+    info.value.git_branch,
+    info.value.git_commit_subject,
+    info.value.git_commit_timestamp,
+    info.value.build_date,
+  ]
+  return fields.every((f) => !f || f === 'unknown')
+})
+
 export function useBuildInfo() {
-  return { info, loading, error, load }
+  return { info, loading, error, isMissing, load }
 }

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -1050,6 +1050,13 @@ Example:
               <div v-else-if="buildInfo.error.value" class="text-sm text-status-danger-600 dark:text-status-danger-400">
                 Failed to load build info.
               </div>
+              <div
+                v-else-if="buildInfo.isMissing.value"
+                class="text-sm text-gray-600 dark:text-gray-400"
+              >
+                Build metadata not available — rebuild with
+                <code class="font-mono">scripts/deploy/start.sh</code> to populate.
+              </div>
               <dl v-else-if="buildInfo.info.value" class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
                 <div>
                   <dt class="text-gray-500 dark:text-gray-400">Version</dt>


### PR DESCRIPTION
## Summary

Two problems behind the "every field shows unknown" Build Info dialog:

1. **`version` always unknown on dev/prod.** Backend reads version from `/app/VERSION`, but the file was only present via a `docker-compose.yml` bind mount (`./VERSION:/app/VERSION:ro`). Prod compose has no such mount and the Dockerfile never COPYed the file, so `version` defaulted to "unknown" everywhere except local-dev-with-bind-mount.
2. **No operator guidance when fields are missing.** Even after #926 added the build-args pipeline, an out-of-band Docker build or a missed `start.sh` run produced a wall of "unknown" rows with no explanation of what Build Info is or how to populate it.

## Changes

- `docker/backend/Dockerfile` — `COPY ../../VERSION /app/VERSION` so the file ships in the image. Dev's bind mount still overrides for hot edits.
- `src/frontend/src/composables/useBuildInfo.js` — expose `isMissing` computed (true when every metadata field equals "unknown").
- `src/frontend/src/components/NavBar.vue` (Build Info modal) — short blurb under the title; gray-bg fallback note ("Build metadata not available — rebuild with `scripts/deploy/start.sh` to populate.") shown only when `isMissing`.
- `src/frontend/src/views/Settings.vue` (Build Info section) — same fallback note in the loading/error/data state chain. Existing blurb retained.

Related to #958

## Test plan

Verified via Playwright (headless Chromium, route mock for missing state):

- [x] Backend rebuilt without bind mount → `/app/VERSION` present in image (`docker run --rm --entrypoint cat trinity-backend /app/VERSION` → `0.9.0`).
- [x] `GET /api/version` returns `"version": "0.9.0"` instead of "unknown".
- [x] NavBar modal renders blurb and populated fields. Screenshot.
- [x] Settings → General → Build Info renders populated fields. Screenshot.
- [x] Route-mocked `GET /api/version` with all fields = "unknown" → modal shows fallback note + blurb; Settings panel shows fallback note. Screenshots.
- [x] `isMissing` correctly false when `version` populated but git fields unknown (intentional — partial provenance is still useful, not a "missing metadata" state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)