### PR TITLE
feat(sharing): notify requester on channel access-request approval (#951)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -594,7 +594,7 @@ picks up on its next poll. (#389 S1a)
 | GET | `/api/agents/{name}/access-policy` | Get cross-channel access policy (#311) |
 | PUT | `/api/agents/{name}/access-policy` | Set `require_email` / `open_access` flags |
 | GET | `/api/agents/{name}/access-requests` | List pending access requests |
-| POST | `/api/agents/{name}/access-requests/{id}/decide` | Approve (auto-shares) or reject |
+| POST | `/api/agents/{name}/access-requests/{id}/decide` | Approve (auto-shares + fires fire-and-forget approval notification back on the requester's originating channel for telegram/slack/whatsapp, #951) or reject |
 
 ### Schedules (12 endpoints)
 | Method | Path | Description |
@@ -1018,6 +1018,7 @@ ALTER TABLE telegram_chat_links ADD COLUMN verified_at TEXT;
 - `ChannelAdapter.resolve_verified_email()` translates native channel identity → verified email.
 - `message_router` runs a single gate: owner/admin/`agent_sharing` → `open_access` → upsert pending `access_requests` row.
 - Approving a request inserts into `agent_sharing` and (if email auth is enabled) whitelists the email.
+- Approval also fires a fire-and-forget proactive notification back to the requester on the originating channel via `proactive_message_service.send_access_grant_notification` — only for `telegram | slack | whatsapp` (web users see the change via the existing `agent_shared` WebSocket event). Notification bypasses the `allow_proactive` opt-in (the user explicitly initiated the request) and the per-recipient rate limit (one-shot, not a campaign). Outcome (`delivered` / `recipient_not_found` / channel error) is audit-logged via `AuditEventType.PROACTIVE_MESSAGE`. Failure to deliver does not roll back the approval. (#951)
 - Group chats bypass the gate; agents with both policy flags off retain legacy permissive behavior (backward compatibility).
 
 **mcp_api_keys:**

--- a/docs/memory/feature-flows/unified-channel-access-control.md
+++ b/docs/memory/feature-flows/unified-channel-access-control.md
@@ -444,6 +444,17 @@ On approval the endpoint:
 2. Calls `db.share_agent(agent_name, current_user.username, email)` — idempotent insert into `agent_sharing`. Future messages from this email are admitted by `email_has_agent_access`.
 3. If `email_auth_enabled` setting is true, auto-adds the email to the platform whitelist with `source="access_request"`.
 4. Broadcasts a `agent_shared` WebSocket event so the Sharing panel refreshes for owners viewing it.
+5. **Notifies the requester on their originating channel** (#951). For `telegram | slack | whatsapp`, fires `proactive_message_service.send_access_grant_notification` as an `asyncio.create_task` so a missing binding or transport hiccup can't block the HTTP response. The notification bypasses the `allow_proactive` opt-in (the user explicitly initiated the request) and the per-recipient rate limit (one-shot). Delivery outcome (`delivered` / `recipient_not_found` / channel error) is captured in the `proactive_message` audit event. Rejection is intentionally silent.
+
+### Manual test path (#951)
+
+The notification fires only after a real approval, so set up one access request per channel and approve from the admin UI.
+
+- **Telegram**: bind a bot to the agent in Settings → Channels → Telegram. From a second Telegram account, `/login <verified-email>` against the bot, then DM the agent — you should get "🔒 Your access request is pending approval." Approve from the owner's web UI; the same Telegram chat should immediately receive "✅ Access to {agent_name} approved by the agent owner. You can now message the agent here."
+- **Slack**: bind a Slack workspace under Settings → Channels → Slack. From a Slack workspace user whose email is verified, DM the agent — same pending reply. Approve from the owner's web UI; the same DM should receive the same approval text.
+- **WhatsApp**: bind a Twilio WhatsApp sender to the agent. From a WhatsApp number whose verified email is linked, DM the agent — same pending reply. Approve; same approval text arrives.
+- **Negative path (web)**: approve a request whose `access_requests.channel = 'web'` and confirm only the existing `agent_shared` WebSocket dashboard event fires — no proactive send.
+- **Negative path (missing binding)**: approve a Telegram-channel request on an agent without a Telegram binding. Approval HTTP response must still be 200; check `GET /api/audit-log?event_type=proactive_message` for an entry with `details.success=false` and `details.error="recipient_not_found: …"`.
 
 ### Pydantic models (`routers/sharing.py:22-42`)
 

--- a/src/backend/routers/sharing.py
+++ b/src/backend/routers/sharing.py
@@ -1,7 +1,9 @@
 """
 Agent sharing routes for the Trinity backend.
 """
+import asyncio
 import json
+import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -12,6 +14,53 @@ from database import db, AgentShare, AgentShareRequest
 from dependencies import get_current_user, OwnedAgentByName, CurrentUser
 from services.docker_service import get_agent_container
 from services.platform_audit_service import platform_audit_service, AuditEventType
+from services.proactive_message_service import proactive_message_service
+
+logger = logging.getLogger(__name__)
+
+# #951: Channels we can proactively notify the requester on when their access
+# request is approved. `web` users see the change via the existing
+# `agent_shared` WebSocket dashboard event and don't need a chat callback.
+_NOTIFIABLE_APPROVAL_CHANNELS = {"telegram", "slack", "whatsapp"}
+
+
+def _build_access_grant_text(agent_name: str) -> str:
+    """User-facing notification body when an access request is approved.
+
+    Mirrors the tone of the pending-approval reply emitted by
+    `adapters/message_router.py` ("I'll let you know once the agent owner
+    responds.") so the user recognises this as the promised follow-up.
+    """
+    return (
+        f"✅ Access to {agent_name} approved by the agent owner. "
+        f"You can now message the agent here."
+    )
+
+
+async def _notify_access_request_approval(
+    agent_name: str,
+    recipient_email: str,
+    channel: str,
+) -> None:
+    """Fire-and-forget post-approval notification (#951).
+
+    Failures are caught + audit-logged inside
+    `proactive_message_service.send_access_grant_notification`; this wrapper
+    only ensures an exception escaping the task doesn't show up as an
+    "Task exception was never retrieved" warning in the backend logs.
+    """
+    try:
+        await proactive_message_service.send_access_grant_notification(
+            agent_name=agent_name,
+            recipient_email=recipient_email,
+            channel=channel,  # type: ignore[arg-type]
+            text=_build_access_grant_text(agent_name),
+        )
+    except Exception as e:
+        logger.warning(
+            f"[#951] Background access-grant notification crashed for "
+            f"{recipient_email} on {channel}: {e}"
+        )
 
 router = APIRouter(prefix="/api/agents", tags=["sharing"])
 
@@ -256,6 +305,20 @@ async def decide_access_request_endpoint(
                 "event": "agent_shared",
                 "data": {"name": agent_name, "shared_with": existing["email"]},
             }))
+
+        # #951: notify the requester on their originating channel. Fire-and-
+        # forget — approval must succeed even if the channel transport is
+        # unavailable or the user has since revoked their chat binding. Audit
+        # of delivered/skipped/failed lives in the service method.
+        channel = (existing.get("channel") or "").lower()
+        if channel in _NOTIFIABLE_APPROVAL_CHANNELS:
+            asyncio.create_task(
+                _notify_access_request_approval(
+                    agent_name=agent_name,
+                    recipient_email=existing["email"],
+                    channel=channel,
+                )
+            )
 
     # SEC-001: audit access request decision
     await platform_audit_service.log(

--- a/src/backend/services/proactive_message_service.py
+++ b/src/backend/services/proactive_message_service.py
@@ -232,6 +232,57 @@ class ProactiveMessageService:
         await self._audit_send(agent_name, recipient_email, channel, False, error_msg)
         raise RecipientNotFoundError(error_msg)
 
+    async def send_access_grant_notification(
+        self,
+        agent_name: str,
+        recipient_email: str,
+        channel: Literal["telegram", "slack", "whatsapp"],
+        text: str,
+    ) -> DeliveryResult:
+        """Notify a user that their channel access request was just approved.
+
+        Bypasses the `allow_proactive` opt-in (this is a response to a request
+        the user explicitly initiated, not unsolicited outreach) and skips the
+        per-recipient rate limit (one-shot, not a campaign). Still emits an
+        audit event with the delivery outcome so #951's "delivered / skipped /
+        failed" requirement is observable.
+
+        Channel resolution is explicit — the caller passes the originating
+        channel from `access_requests.channel`. Web is handled upstream via
+        the existing `agent_shared` WebSocket event and never reaches here.
+        """
+        recipient_email = recipient_email.lower()
+        message_preview = text[:100] if text else ""
+
+        try:
+            result = await self._deliver_via_channel(
+                agent_name, recipient_email, text, channel, reply_to_thread=False
+            )
+        except RecipientNotFoundError as e:
+            await self._audit_send(
+                agent_name, recipient_email, channel, False,
+                error=f"recipient_not_found: {e}",
+                message_preview=message_preview,
+            )
+            return DeliveryResult(success=False, channel=channel, error=str(e))
+        except Exception as e:
+            logger.warning(
+                f"[#951] Access-grant notification to {channel} failed: {e}"
+            )
+            await self._audit_send(
+                agent_name, recipient_email, channel, False,
+                error=str(e), message_preview=message_preview,
+            )
+            return DeliveryResult(success=False, channel=channel, error=str(e))
+
+        await self._audit_send(
+            agent_name, recipient_email, channel,
+            success=result.success,
+            error=result.error,
+            message_preview=message_preview,
+        )
+        return result
+
     async def _deliver_via_channel(
         self,
         agent_name: str,

--- a/tests/test_access_grant_notification_unit.py
+++ b/tests/test_access_grant_notification_unit.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for #951 — post-approval channel notification.
+
+`ProactiveMessageService.send_access_grant_notification` is a one-shot
+notification path that bypasses the `allow_proactive` opt-in and the
+per-recipient rate limit (the user explicitly initiated the request; this
+is the response). The router's decide endpoint fires it as a background
+task so a missing channel binding or transport hiccup never blocks the
+approval response.
+
+These tests mock the per-channel `_deliver_*` helpers and assert the
+audit envelope captures the delivered/skipped/failed outcome.
+"""
+
+import asyncio
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+_backend_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "backend")
+)
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+
+@pytest.fixture
+def proactive_service(monkeypatch):
+    """Load ProactiveMessageService with stubbed database + audit modules."""
+    fake_db_mod = types.ModuleType("database")
+    fake_db_mod.db = MagicMock()
+    monkeypatch.setitem(sys.modules, "database", fake_db_mod)
+
+    fake_audit_mod = types.ModuleType("services.platform_audit_service")
+
+    class _AuditEventType:
+        PROACTIVE_MESSAGE = "proactive_message"
+
+    fake_audit = MagicMock()
+    fake_audit.log = AsyncMock(return_value="evt-1")
+    fake_audit_mod.platform_audit_service = fake_audit
+    fake_audit_mod.AuditEventType = _AuditEventType
+    monkeypatch.setitem(
+        sys.modules, "services.platform_audit_service", fake_audit_mod
+    )
+
+    for mod in (
+        "services.proactive_message_service",
+        "proactive_message_service",
+    ):
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    from services.proactive_message_service import ProactiveMessageService
+
+    return ProactiveMessageService(), fake_audit
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_telegram_delivery_success_audited(proactive_service):
+    service, audit = proactive_service
+    service._deliver_via_channel = AsyncMock(
+        return_value=MagicMock(success=True, channel="telegram", error=None)
+    )
+
+    result = _run(
+        service.send_access_grant_notification(
+            agent_name="research-bot",
+            recipient_email="alice@example.com",
+            channel="telegram",
+            text="Access granted!",
+        )
+    )
+
+    assert result.success is True
+    assert result.channel == "telegram"
+
+    audit.log.assert_awaited_once()
+    kwargs = audit.log.call_args.kwargs
+    assert kwargs["actor_agent_name"] == "research-bot"
+    assert kwargs["target_type"] == "user"
+    assert kwargs["target_id"] == "alice@example.com"
+    assert kwargs["details"]["channel"] == "telegram"
+    assert kwargs["details"]["success"] is True
+    assert kwargs["details"]["error"] is None
+
+
+def test_recipient_not_found_returns_failure_not_raise(proactive_service):
+    """If the requester unbound the channel between request and approval,
+    we must NOT raise — the approval succeeded; the notification is best-
+    effort, and the audit row records the miss."""
+    service, audit = proactive_service
+    from services.proactive_message_service import RecipientNotFoundError
+
+    service._deliver_via_channel = AsyncMock(
+        side_effect=RecipientNotFoundError("no telegram link")
+    )
+
+    result = _run(
+        service.send_access_grant_notification(
+            agent_name="research-bot",
+            recipient_email="alice@example.com",
+            channel="telegram",
+            text="Access granted!",
+        )
+    )
+
+    assert result.success is False
+    assert result.channel == "telegram"
+    assert "no telegram link" in (result.error or "")
+
+    audit.log.assert_awaited_once()
+    kwargs = audit.log.call_args.kwargs
+    assert kwargs["details"]["success"] is False
+    assert "recipient_not_found" in kwargs["details"]["error"]
+
+
+def test_unexpected_exception_audited_and_swallowed(proactive_service):
+    """Transport-layer crash must not surface to the caller — audit only."""
+    service, audit = proactive_service
+
+    service._deliver_via_channel = AsyncMock(
+        side_effect=RuntimeError("twilio went pop")
+    )
+
+    result = _run(
+        service.send_access_grant_notification(
+            agent_name="research-bot",
+            recipient_email="bob@example.com",
+            channel="whatsapp",
+            text="Access granted!",
+        )
+    )
+
+    assert result.success is False
+    assert result.error == "twilio went pop"
+
+    audit.log.assert_awaited_once()
+    kwargs = audit.log.call_args.kwargs
+    assert kwargs["details"]["channel"] == "whatsapp"
+    assert kwargs["details"]["success"] is False
+    assert "twilio went pop" in kwargs["details"]["error"]
+
+
+def test_opt_in_check_is_bypassed(proactive_service):
+    """The opt-in `allow_proactive` check that gates `send_message()` must
+    NOT apply here — the user explicitly initiated the request."""
+    service, audit = proactive_service
+
+    # Wire the db mock so `can_agent_message_email` would say NO if asked.
+    import database
+    database.db.can_agent_message_email = MagicMock(return_value=False)
+
+    service._deliver_via_channel = AsyncMock(
+        return_value=MagicMock(success=True, channel="slack", error=None)
+    )
+
+    result = _run(
+        service.send_access_grant_notification(
+            agent_name="research-bot",
+            recipient_email="alice@example.com",
+            channel="slack",
+            text="Access granted!",
+        )
+    )
+
+    # Delivered, audit recorded — opt-in was never consulted.
+    assert result.success is True
+    database.db.can_agent_message_email.assert_not_called()

--- a/tests/test_access_grant_notification_unit.py
+++ b/tests/test_access_grant_notification_unit.py
@@ -28,6 +28,30 @@ if _backend_path not in sys.path:
     sys.path.insert(0, _backend_path)
 
 
+# Modules stubbed by the fixture below — snapshot/restored around each test so
+# the stubs don't leak into sibling test files. Pattern matches
+# tests/unit/test_telegram_webhook_backfill.py (see tests/lint_sys_modules.py).
+_STUBBED_MODULE_NAMES = [
+    "database",
+    "services.platform_audit_service",
+    "services.proactive_message_service",
+    "proactive_message_service",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 @pytest.fixture
 def proactive_service(monkeypatch):
     """Load ProactiveMessageService with stubbed database + audit modules."""
@@ -48,12 +72,11 @@ def proactive_service(monkeypatch):
         sys.modules, "services.platform_audit_service", fake_audit_mod
     )
 
-    for mod in (
-        "services.proactive_message_service",
-        "proactive_message_service",
-    ):
-        if mod in sys.modules:
-            del sys.modules[mod]
+    # Force a fresh import so the stubs above take effect. The
+    # autouse `_restore_sys_modules` fixture above puts the prior
+    # cached modules back, so this is safe.
+    monkeypatch.delitem(sys.modules, "services.proactive_message_service", raising=False)
+    monkeypatch.delitem(sys.modules, "proactive_message_service", raising=False)
 
     from services.proactive_message_service import ProactiveMessageService
 


### PR DESCRIPTION
## Summary

After #311 introduced unified channel access control, a user who DMs an agent on Telegram/Slack/WhatsApp without prior sharing is told *"I'll let you know once the agent owner responds"* — but the decide endpoint never actually told them. Requesters were left guessing whether they'd been admitted.

This wires up the existing proactive-message primitive (#321) to close the loop.

## Backend

- `ProactiveMessageService.send_access_grant_notification(agent, email, channel, text)` — one-shot path that calls `_deliver_via_channel` directly and audits the outcome. Bypasses the `allow_proactive` opt-in (the user explicitly initiated the request; this is the response) and the per-recipient rate limit (one-shot, not a campaign). Failures and missing bindings are caught, audit-logged, and returned as `DeliveryResult(success=False, ...)` — never raised.
- `routers/sharing.py` decide endpoint: when `decision.approve` AND `existing.channel in {telegram, slack, whatsapp}`, fires the notification as `asyncio.create_task` so a missing binding or transport hiccup can't block the HTTP response. Rejections stay silent (deliberate — owners may not want to confirm the agent exists). Web channel handled by the existing `agent_shared` WebSocket dashboard event.

Notification text mirrors the tone of the original pending-approval reply:

> ✅ Access to {agent_name} approved by the agent owner. You can now message the agent here.

## Docs

- `architecture.md` decide-endpoint row + Access Control Flow note call out the post-approval notification and where the audit lands.
- `feature-flows/unified-channel-access-control.md` documents the approve flow's new step plus a manual test path for each of Telegram, Slack, WhatsApp, web (negative), and missing-binding (negative).

## Tests

4 new unit cases in `tests/test_access_grant_notification_unit.py`:
- delivery success → audit success
- `RecipientNotFoundError` → audited as `recipient_not_found`, returned not raised
- unexpected exception → audited + swallowed (approval must succeed)
- opt-in `allow_proactive` bypass verified

Related to #951

## Test plan

- [x] `.venv/bin/pytest tests/test_access_grant_notification_unit.py tests/test_proactive_audit_unit.py tests/test_sharing_null_email_unit.py` — 13 passed.
- [x] **Live: missing-binding path.** Inserted access_request with `channel='telegram'` for an agent without any Telegram binding, approved via `POST /api/agents/.../access-requests/.../decide`:
  - Approval HTTP response: **200** (not blocked by the missing transport)
  - `GET /api/audit-log?event_type=proactive_message` shows new entry with `details.channel='telegram'`, `details.success=false`, `details.error="recipient_not_found: No Telegram bot configured for agent 'trinity-system'"`, `details.message_preview="✅ Access to trinity-system approved by the agent owner. You can now message the agent here."`
- [ ] Manual Telegram path: bind a bot, request access from a second account, approve, confirm the approval message lands in the DM. (Documented in feature-flow doc; requires a live Telegram bot to run.)
- [ ] Manual Slack path: same flow against a connected workspace.
- [ ] Manual WhatsApp path: same flow against a Twilio sender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)