### PR TITLE
fix(base-image): stop appending to .gitignore from startup.sh (#953)

### DIFF
--- a/docker/base-image/startup.sh
+++ b/docker/base-image/startup.sh
@@ -113,11 +113,15 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
             # Restore Python packages (these are from the base image, not the repo)
             cp -r /tmp/.local.bak /home/developer/.local 2>/dev/null || true
 
-            # Add Python packages to .gitignore (don't sync these to GitHub)
-            if [ ! -f /home/developer/.gitignore ]; then
-                echo "# Trinity agent infrastructure files" > /home/developer/.gitignore
-            fi
-            grep -q ".local/" /home/developer/.gitignore || echo ".local/" >> /home/developer/.gitignore
+            # #953: do NOT touch .gitignore from startup.sh. The canonical
+            # pattern list lives in `_GITIGNORE_PATTERNS`
+            # (src/backend/services/git_service.py) and is applied by
+            # `_build_gitignore_merge_command` on first Trinity-orchestrated
+            # init/push. The old shell-level append produced `M .gitignore`
+            # against `origin/main` whenever the cloned template's
+            # `.gitignore` already (correctly) contained the patterns —
+            # because the unanchored/anchored greps gave false negatives on
+            # trailing whitespace, CRLF, or missing newline-terminator.
 
             echo "Git sync initialization complete"
             else
@@ -375,12 +379,12 @@ fi
 echo "Setting up content folder convention..."
 mkdir -p /home/developer/content/{videos,audio,images,exports}
 
-# Ensure content/ is in .gitignore (prevents large files from bloating Git repos)
-if [ ! -f /home/developer/.gitignore ]; then
-    echo "# Trinity agent infrastructure files" > /home/developer/.gitignore
-fi
-grep -q "^content/$" /home/developer/.gitignore || echo "content/" >> /home/developer/.gitignore
-grep -q "^\.local/$" /home/developer/.gitignore || echo ".local/" >> /home/developer/.gitignore
+# #953: do NOT touch .gitignore here. `content/` and `.local/` are in the
+# canonical `_GITIGNORE_PATTERNS` list applied by
+# `_build_gitignore_merge_command` on first Trinity-orchestrated init and
+# again on every push via `_migrate_workspace_gitignore`. The previous
+# shell-level append created `M .gitignore` drift for freshly-deployed
+# agents whose template already shipped the patterns correctly.
 
 echo "Agent ready. Keeping container alive..."
 tail -f /dev/null

--- a/tests/unit/test_953_startup_sh_no_gitignore_writes.py
+++ b/tests/unit/test_953_startup_sh_no_gitignore_writes.py
@@ -1,0 +1,72 @@
+"""
+Regression test for #953 — `M .gitignore` drift on freshly-deployed agents.
+
+`docker/base-image/startup.sh` used to append `.local/` and `content/` to
+`/home/developer/.gitignore` at every boot. Combined with the canonical
+list now applied by `_build_gitignore_merge_command`
+(`src/backend/services/git_service.py`), the shell-level append was
+redundant — and on agents whose template `.gitignore` already shipped the
+patterns correctly, false-negative greps (anchored patterns hitting CRLF
+or trailing whitespace) re-appended duplicates, producing `M .gitignore`
+against `origin/main` with no user action.
+
+Fix: remove both append sites. The canonical merge in `git_service.py`
+handles every git-initialized agent — `initialize_git_in_container` runs
+it on first init and `_migrate_workspace_gitignore` runs it on every
+push.
+
+This test pins the fix: it fails if anyone re-introduces an
+`>> .gitignore` write inside `docker/base-image/startup.sh`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+STARTUP = (
+    Path(__file__).resolve().parents[2]
+    / "docker"
+    / "base-image"
+    / "startup.sh"
+)
+
+
+def test_startup_sh_does_not_write_to_gitignore():
+    """No append-or-overwrite-style write to `.gitignore` from startup.sh.
+
+    Greps for any of the redirect operators (`> /home/developer/.gitignore`
+    or `>> /home/developer/.gitignore`). Comments mentioning `.gitignore`
+    are fine — only redirect syntax is forbidden.
+    """
+    assert STARTUP.exists(), f"startup.sh missing at {STARTUP}"
+    text = STARTUP.read_text()
+
+    forbidden_substrings = (
+        "> /home/developer/.gitignore",
+        ">> /home/developer/.gitignore",
+        '> "/home/developer/.gitignore"',
+        '>> "/home/developer/.gitignore"',
+    )
+    found = [s for s in forbidden_substrings if s in text]
+    assert not found, (
+        "startup.sh writes to /home/developer/.gitignore "
+        f"(found: {found}). The canonical pattern list lives in "
+        "_GITIGNORE_PATTERNS (src/backend/services/git_service.py); "
+        "let _build_gitignore_merge_command apply it on init/push instead."
+    )
+
+
+def test_startup_sh_keeps_pointer_to_canonical_helper():
+    """The replaced block keeps a comment pointing readers at git_service.py
+    so the next person looking for "where do the patterns come from?"
+    doesn't have to git blame their way there.
+    """
+    text = STARTUP.read_text()
+    # Just check that the canonical helper is named somewhere — the exact
+    # comment text is allowed to drift.
+    assert "_build_gitignore_merge_command" in text or "_GITIGNORE_PATTERNS" in text, (
+        "startup.sh should reference the canonical gitignore helper "
+        "(_build_gitignore_merge_command or _GITIGNORE_PATTERNS) so "
+        "future readers can find it."
+    )


### PR DESCRIPTION
## Summary

Freshly-deployed agents reported `M .gitignore` against `origin/main` immediately after deployment, with no user action. The drift came from two `echo "<pattern>" >> /home/developer/.gitignore` sites in \`docker/base-image/startup.sh\` whose `grep -q` guards used inconsistent / fragile patterns:

- Site 1 (inside the GitHub-clone block): `grep -q ".local/"` — unanchored regex, fragile against the comment-only header written by the `[ ! -f ]` create-if-missing block right above it.
- Site 2 (end of startup): `grep -q "^content/$"` / `grep -q "^\.local/$"` — anchored exact match, false-negative on trailing whitespace, comments, CRLF, or files missing terminal newline.

Result: even templates whose committed `.gitignore` already shipped the canonical patterns ended up with `M .gitignore` against `origin/main`.

## Reproduction (verified locally)

```bash
mkdir -p /tmp/t953-fake && cd /tmp/t953-fake
git init -q
printf 'node_modules/\n*.log\n' > .gitignore
git add .gitignore && git commit -qm initial
git update-ref refs/remotes/origin/main HEAD

# Simulate the OLD startup.sh blocks:
grep -q ".local/" .gitignore || echo ".local/" >> .gitignore
grep -q "^content/$" .gitignore || echo "content/" >> .gitignore
grep -q "^\.local/$" .gitignore || echo ".local/" >> .gitignore

git status -s   # → " M .gitignore"
git diff origin/main   # → +.local/ +content/
```

After the fix (no `>> .gitignore` writes from startup.sh), the same script leaves the working tree clean.

## Fix

Removed both append sites entirely. The canonical pattern list lives in `_GITIGNORE_PATTERNS` (`src/backend/services/git_service.py`) and is applied via `_build_gitignore_merge_command`'s idempotent `grep -qxF` checks (fixed-string, exact-line — no anchor false-negatives). Two call sites cover the lifecycle:

- `initialize_git_in_container` runs the merge on first Trinity-orchestrated git init.
- `_migrate_workspace_gitignore` runs it on every push so existing agents adopt new patterns without rebuilding.

## Trade-off

For the GitHub-clone-in-container flow, between container boot and first Trinity push, `git status` may show `.local/`-class files as untracked if the cloned template's `.gitignore` is incomplete. **No remote impact** — the canonical merge runs at the start of Trinity's push handler before any commit hits GitHub. Templates whose `.gitignore` ships the patterns correctly stop drifting (AC #4).

Existing agents are unaffected: their already-baked `startup.sh` keeps writing patterns until they pull a new base image, at which point the canonical merge takes over via the next push.

## Tests

- `tests/unit/test_953_startup_sh_no_gitignore_writes.py` — regression guard: greps `startup.sh` for any `> /home/developer/.gitignore` or `>>` redirect and fails if one is reintroduced. Also asserts the replacement comment keeps a pointer to the canonical helper.

Related to #953

## Test plan

- [x] Reproduce drift with OLD shell logic in scratch git repo (`M .gitignore` + `+.local/ +content/` diff)
- [x] Verify same scenario with NEW (empty) appender → clean `git status`
- [x] `.venv/bin/pytest tests/unit/test_953_startup_sh_no_gitignore_writes.py` — 2 passed
- [ ] Rebuild `trinity-agent-base:latest` and deploy a fresh agent against a minimal template — confirm `git status` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)