### PR TITLE
feat: Voice Workspace canvas enrichment (Mermaid, images, panel history) + orb polish (#979)

### DIFF
--- a/docs/memory/feature-flows/voice-chat.md
+++ b/docs/memory/feature-flows/voice-chat.md
@@ -69,11 +69,37 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
    Trinity Backend (routers/voice.py)
          │
          ├─ Panel tools handled in-process (_execute_panel_tool)
-         │   show_markdown, update_panel, append_to_panel, clear_panel
+         │   show_markdown, show_diagram, show_image,
+         │   update_panel, append_to_panel, clear_panel
          │   → session.panel_state (in-memory, capped at 512 KB)
+         │   show_image src validated by _classify_image_src
+         │   (web URL | workspace-confined path; rejects traversal)
          │
          └─ run_task → Agent Container (Claude Code)
 ```
+
+### Canvas enrichment (#979 / VOICE-009)
+
+The workspace canvas renders five live panel types plus history:
+
+- **markdown** — `renderMarkdown` (marked + DOMPurify) in the parent DOM.
+- **mermaid** (`show_diagram`) — rendered strictly inside the opaque-origin
+  `sandbox="allow-scripts"` iframe via a self-contained `mermaid.min.js` IIFE
+  bundle (same `?url` mechanism as Chart.js, no runtime chunk fetches). Diagram
+  text is injected as a JS string (`JSON.stringify` + `<`→`<`, so a
+  `</script>` in the text can't break out) and rendered with
+  `securityLevel:'strict'`; invalid syntax shows a contained error + source.
+- **image** (`show_image`) — web URLs render directly via Vue `:src`;
+  workspace file paths are fetched through the authenticated `/files/preview`
+  endpoint as a blob (a bare `<img src>` would 401) and bound as an objectURL.
+- **html** (`update_panel`) — sandboxed iframe with Chart.js (unchanged).
+- **empty** — placeholder.
+
+Frontend-only additions (no backend change): a 40-snapshot history ring buffer
+(prev/next + dropdown; "live" follows the latest, navigating back pins until a
+new update arrives; image blobs revoked on eviction/unmount), orb smoothing
+(asymmetric attack/release energy lerp, idle breathe floor, larger core/glow),
+and a `prefers-reduced-motion`-aware cross-fade on canvas updates.
 
 ---
 

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -2061,7 +2061,18 @@ Standalone mobile-friendly admin page for managing agents on the go. Designed as
 ### 29.8 Voice Workspace (VOICE-008)
 - **Status**: ✅ Implemented (#699)
 - **Description**: Full-page workspace at `/agents/:name/workspace` with split layout — orb + controls left, agent-controlled canvas panel right; gated behind `voice_available` feature flag
-- **Key Features**: 4 in-process panel tools (`show_markdown`, `update_panel`, `append_to_panel`, `clear_panel`); 300ms poll via `GET /voice/{session_id}/panel`; DOMPurify sanitization; 512 KB content cap; `workspace_mode` param on `voice/start`; BETA-badged button in AgentHeader
+- **Key Features**: 6 in-process panel tools (`show_markdown`, `show_diagram`, `show_image`, `update_panel`, `append_to_panel`, `clear_panel`); 300ms poll via `GET /voice/{session_id}/panel`; DOMPurify sanitization; 512 KB content cap; `workspace_mode` param on `voice/start`; BETA-badged button in AgentHeader
+
+### 29.9 Voice Workspace Canvas Enrichment (VOICE-009)
+- **Status**: ✅ Implemented (#979)
+- **Description**: Enriches the VOICE-008 canvas with Mermaid diagrams, image display, client-side panel history, and orb/transition polish — endpoint contract unchanged
+- **Key Features**:
+  - `show_diagram(diagram, title?)` → `mermaid` panel type rendered strictly inside the existing opaque-origin `sandbox="allow-scripts"` iframe via a self-contained `mermaid.min.js` IIFE bundle (no runtime chunk fetches); agent diagram text injected as a JS string (`JSON.stringify` + `<`→`<`, no `</script>` breakout) with `securityLevel:'strict'`; invalid syntax renders a contained error + source, not a broken panel
+  - `show_image(src, title?, caption?)` → `image` panel type; web URLs render directly via Vue `:src`, workspace file paths fetched through the authenticated `/files/preview` endpoint as a blob (a bare `<img src>` would 401). Path confinement enforced in-process by `_classify_image_src` (rejects `..`, absolute escapes, the `/home/developer-evil` sibling, `data:`, and non-http schemes — stricter than the agent-server prefix check)
+  - Client-side panel history: ring buffer of the last 40 snapshots with prev/next + dropdown selector; "live" follows the latest, navigating back pins a snapshot until a new update arrives; frontend-only, no backend change; image blob objectURLs revoked on eviction + unmount
+  - Orb polish: asymmetric attack/release smoothing on energy (0.18/0.10), smoothed core size, idle "breathe" floor, larger core (58) and glow swing (32×)
+  - Graceful canvas-update cross-fade + header "updated" flash, honoring `prefers-reduced-motion`
+- **Security**: agent markup/diagrams render only inside the opaque-origin sandboxed iframe; images render via `:src` (no `v-html`); panel tools are backend+frontend only (not on the MCP surface — Invariant #13 N/A)
 
 ### Phase Roadmap
 1. **Phase 1 (MVP)**: Authenticated chat only, basic overlay, transcript on session end, manual voice prompt ✅

--- a/src/backend/services/gemini_voice.py
+++ b/src/backend/services/gemini_voice.py
@@ -12,6 +12,7 @@ Architecture:
 import asyncio
 import json
 import logging
+import posixpath
 import secrets
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -33,7 +34,13 @@ _TOOL_PROMPT_MAX = 2000
 # Max bytes stored in panel_state["content"] to bound memory per session
 _PANEL_CONTENT_MAX = 524_288  # 512 KB
 
-_PANEL_TOOL_NAMES = {"show_markdown", "update_panel", "append_to_panel", "clear_panel"}
+# Agent workspace root inside the container; show_image file paths must resolve under it.
+_WORKSPACE_ROOT = "/home/developer"
+
+_PANEL_TOOL_NAMES = {
+    "show_markdown", "update_panel", "append_to_panel", "clear_panel",
+    "show_diagram", "show_image",
+}
 
 _PANEL_TOOLS = genai_types.Tool(
     function_declarations=[
@@ -84,6 +91,41 @@ _PANEL_TOOLS = genai_types.Tool(
                 properties={},
             ),
         ),
+        genai_types.FunctionDeclaration(
+            name="show_diagram",
+            description=(
+                "Render a Mermaid diagram in the canvas panel — flowcharts, sequence "
+                "diagrams, mindmaps, timelines, state/class/ER diagrams. Pass the raw "
+                "Mermaid source (e.g. 'graph TD; A-->B'). Use this to visualize "
+                "structure, flow, or relationships you're explaining out loud."
+            ),
+            parameters=genai_types.Schema(
+                type=genai_types.Type.OBJECT,
+                properties={
+                    "diagram": genai_types.Schema(type=genai_types.Type.STRING, description="Mermaid diagram source code"),
+                    "title": genai_types.Schema(type=genai_types.Type.STRING, description="Optional panel title"),
+                },
+                required=["diagram"],
+            ),
+        ),
+        genai_types.FunctionDeclaration(
+            name="show_image",
+            description=(
+                "Display an image in the canvas panel. `src` is either a web URL "
+                "(https://...) or a path to a file in your workspace "
+                "(e.g. 'content/chart.png' or '/home/developer/content/chart.png'). "
+                "Use to show a generated chart, screenshot, or diagram asset."
+            ),
+            parameters=genai_types.Schema(
+                type=genai_types.Type.OBJECT,
+                properties={
+                    "src": genai_types.Schema(type=genai_types.Type.STRING, description="Web URL or workspace file path"),
+                    "title": genai_types.Schema(type=genai_types.Type.STRING, description="Optional panel title"),
+                    "caption": genai_types.Schema(type=genai_types.Type.STRING, description="Optional caption shown under the image"),
+                },
+                required=["src"],
+            ),
+        ),
     ]
 )
 
@@ -94,20 +136,62 @@ You have a visual canvas panel visible to the user on the right side of the scre
 
 Panel tools:
 - `show_markdown(content, title?)` — Render markdown. Use most often for notes, summaries, action items, analysis.
+- `show_diagram(diagram, title?)` — Render a Mermaid diagram. Use for flowcharts, sequence diagrams, mindmaps, timelines, state/class/ER diagrams — anytime structure or flow is easier shown than spoken.
+- `show_image(src, title?, caption?)` — Display an image by web URL or workspace file path.
 - `update_panel(html, title?)` — Replace panel with HTML for richer layouts.
 - `append_to_panel(html)` — Add to existing panel without clearing.
 - `clear_panel()` — Clear when shifting to a new topic.
 
 Guidelines:
-- The panel is a persistent whiteboard — voice is transient, the panel is the artefact.
-- Use `show_markdown` by default. Reach for `update_panel` only when structure genuinely adds value.
+- The panel is a persistent whiteboard — voice is transient, the panel is the artefact. Each update is kept in history, so the user can scroll back through what you drew.
+- Use `show_markdown` by default. Reach for `show_diagram` when a picture of the structure helps, `update_panel` only when custom layout genuinely adds value.
 - Don't mirror every voice response in the panel — use it when structured content helps.
 - Clear when the topic changes significantly.
+
+Mermaid rule (for `show_diagram`):
+- Pass raw Mermaid source only (no ```mermaid fences). Example: `graph TD; Start-->Stop`.
+- Keep diagrams focused; invalid syntax shows a contained error in the panel.
 
 Chart.js rule (for `update_panel` HTML):
 - Chart.js 4 is available as `window.Chart` in the workspace (bundled, no CDN needed). NEVER add a `<script src>` tag for it.
 - Use `new Chart(...)` directly. Always give the canvas a fixed height: `<canvas id="c" style="max-height:380px"></canvas>`.
 """
+
+def _classify_image_src(src: str) -> Optional[tuple[str, str]]:
+    """Classify a show_image src as a web URL or a workspace-confined file path.
+
+    Returns (value, kind) where kind is "url" or "path", or None if the src is
+    neither an allowed web URL nor a path that resolves inside the agent
+    workspace. The frontend renders "url" directly and fetches "path" through the
+    authenticated /files/preview endpoint, so this is the only confinement gate
+    on the panel side — and it is stricter than the agent-server's prefix check,
+    rejecting sibling escapes like /home/developer-evil and any '..' traversal.
+    """
+    if not src:
+        return None
+    low = src.lower()
+    if low.startswith("http://") or low.startswith("https://"):
+        return (src, "url")
+    if low.startswith("data:") or "://" in low:
+        # data: URIs (unbounded inline bytes) and other schemes (file:, ftp:, …)
+        # are not allowed.
+        return None
+
+    # Treat as a workspace file path. Accept absolute (/home/developer/...) or
+    # relative (resolved against the workspace root). '~/' is workspace-relative.
+    path = src[2:] if src.startswith("~/") else src
+    # A ':' in the first path segment is a URI scheme (javascript:, mailto:, …),
+    # not a real path segment — reject before resolving.
+    if ":" in path.split("/", 1)[0]:
+        return None
+    if path.startswith("/"):
+        candidate = posixpath.normpath(path)
+    else:
+        candidate = posixpath.normpath(posixpath.join(_WORKSPACE_ROOT, path))
+    if candidate != _WORKSPACE_ROOT and not candidate.startswith(_WORKSPACE_ROOT + "/"):
+        return None
+    return (candidate, "path")
+
 
 # Single tool declaration for all voice sessions
 _RUN_TASK_TOOL = genai_types.Tool(
@@ -439,6 +523,33 @@ class GeminiVoiceService:
             session.panel_state = {
                 "type": "markdown",
                 "content": args.get("content", ""),
+                "title": args.get("title"),
+                "updated_at": now,
+            }
+        elif tool_name == "show_diagram":
+            session.panel_state = {
+                "type": "mermaid",
+                "content": args.get("diagram", ""),
+                "title": args.get("title"),
+                "updated_at": now,
+            }
+        elif tool_name == "show_image":
+            src = str(args.get("src", "")).strip()
+            if not src:
+                return "No image source provided."
+            kind = _classify_image_src(src)
+            if kind is None:
+                # Not a web URL and not a workspace-confined file path — reject.
+                return (
+                    "Image rejected: src must be an https:// URL or a path inside "
+                    "your workspace (/home/developer). Path traversal is not allowed."
+                )
+            value, image_kind = kind
+            session.panel_state = {
+                "type": "image",
+                "content": value,
+                "image_kind": image_kind,   # "url" | "path"
+                "caption": args.get("caption"),
                 "title": args.get("title"),
                 "updated_at": now,
             }

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -18,11 +18,12 @@
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^5.5.0",
-        "axios": "^1.13.5",
+        "axios": "^1.16.0",
         "chart.js": "^4.4.7",
         "dompurify": "^3.3.3",
         "js-yaml": "^4.1.1",
         "marked": "^17.0.0",
+        "mermaid": "^11.15.0",
         "monaco-editor": "^0.52.0",
         "pinia": "^2.3.0",
         "uplot": "^1.6.32",
@@ -54,6 +55,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -93,6 +107,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -541,6 +567,23 @@
         "vue": ">= 3"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "dev": true,
@@ -574,6 +617,15 @@
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -993,9 +1045,268 @@
         "node": ">=4"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/js-yaml": {
@@ -1013,6 +1324,16 @@
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
       "license": "MIT"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -1452,6 +1773,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "dev": true,
@@ -1467,9 +1797,171 @@
       "version": "3.2.3",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.4",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
+      "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -1492,9 +1984,99 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -1509,9 +2091,150 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -1552,6 +2275,31 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -1643,6 +2391,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1860,6 +2618,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "license": "MIT",
@@ -1891,6 +2655,37 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -1963,6 +2758,42 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "dev": true,
@@ -1977,6 +2808,12 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/magic-string": {
@@ -2009,6 +2846,47 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/micromatch": {
@@ -2106,6 +2984,18 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -2207,6 +3097,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -2434,6 +3340,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -2479,6 +3391,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -2501,12 +3425,30 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -2595,6 +3537,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.3.tgz",
+      "integrity": "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "dev": true,
@@ -2650,6 +3601,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "dev": true,
@@ -2692,6 +3652,19 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -28,6 +28,7 @@
     "dompurify": "^3.3.3",
     "js-yaml": "^4.1.1",
     "marked": "^17.0.0",
+    "mermaid": "^11.15.0",
     "monaco-editor": "^0.52.0",
     "pinia": "^2.3.0",
     "uplot": "^1.6.32",

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -250,7 +250,7 @@
                   class="max-w-full max-h-full object-contain rounded-lg"
                   @error="imageError = true"
                 />
-                <div v-else class="text-sm" :class="imageError ? 'text-status-error-400' : 'text-gray-500'">
+                <div v-else class="text-sm" :class="imageError ? 'text-status-danger-400' : 'text-gray-500'">
                   {{ imageError ? 'Image could not be loaded.' : 'Loading image…' }}
                 </div>
                 <p v-if="displayedPanel.caption" class="text-sm text-gray-400 text-center max-w-prose">

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -138,60 +138,139 @@
       <div class="flex-1 flex flex-col bg-gray-900 border-l border-gray-800 overflow-hidden">
 
         <!-- Canvas header -->
-        <div class="flex-shrink-0 flex items-center justify-between px-5 py-3 border-b border-gray-800">
-          <h2 class="text-sm font-medium text-gray-200">
-            {{ panelState.title || 'Canvas' }}
+        <div class="flex-shrink-0 flex items-center justify-between gap-3 px-5 py-3 border-b border-gray-800">
+          <h2 class="text-sm font-medium text-gray-200 truncate">
+            {{ displayedPanel.title || 'Canvas' }}
           </h2>
-          <span v-if="panelUpdatedAgo" class="text-xs text-gray-600">{{ panelUpdatedAgo }}</span>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <!-- History navigation (shown once ≥2 snapshots exist) -->
+            <div v-if="hasHistory" class="flex items-center gap-1">
+              <button
+                @click="goPrev"
+                :disabled="effectiveIndex <= 0"
+                class="p-1 rounded hover:bg-gray-800 text-gray-400 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                title="Previous snapshot"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+              <select
+                :value="effectiveIndex"
+                @change="selectSnapshot"
+                class="max-w-[12rem] text-xs bg-gray-900 border border-gray-700 rounded px-1.5 py-0.5 text-gray-300 focus:outline-none focus:border-action-primary-500"
+                title="Jump to snapshot"
+              >
+                <option v-for="(snap, i) in history" :key="i" :value="i">{{ snapshotLabel(snap, i) }}</option>
+              </select>
+              <button
+                @click="goNext"
+                :disabled="isLive"
+                class="p-1 rounded hover:bg-gray-800 text-gray-400 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                title="Next snapshot"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+              <span
+                v-if="isLive"
+                class="px-1.5 py-0.5 text-[10px] font-semibold rounded bg-status-success-900/40 text-status-success-400 tracking-wide"
+              >LIVE</span>
+              <span
+                v-else
+                class="px-1.5 py-0.5 text-[10px] font-semibold rounded bg-gray-700 text-gray-300 tracking-wide"
+              >PINNED</span>
+            </div>
+            <span
+              v-if="panelUpdatedAgo"
+              :class="['text-xs transition-colors duration-700', justUpdated ? 'text-state-autonomous-300' : 'text-gray-600']"
+            >{{ panelUpdatedAgo }}</span>
+          </div>
         </div>
 
-        <!-- Canvas content -->
-        <div class="flex-1 overflow-auto p-6">
-          <!-- Empty state -->
-          <div v-if="!panelState.content" class="flex flex-col items-center justify-center h-full gap-4 text-center">
-            <div class="w-16 h-16 rounded-full border-2 border-gray-800 flex items-center justify-center">
-              <svg class="w-7 h-7 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-              </svg>
+        <!-- Canvas content — cross-fades on each update / history navigation;
+             the keyed inner node is the single transition child. -->
+        <div class="flex-1 overflow-auto p-6 relative">
+          <Transition :name="canvasTransition" mode="out-in">
+            <div :key="transitionKey" class="h-full">
+
+              <!-- Empty state -->
+              <div v-if="!displayedPanel.content" class="flex flex-col items-center justify-center h-full gap-4 text-center">
+                <div class="w-16 h-16 rounded-full border-2 border-gray-800 flex items-center justify-center">
+                  <svg class="w-7 h-7 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                  </svg>
+                </div>
+                <p class="text-gray-600 text-sm max-w-xs">
+                  {{ voice.isActive.value
+                    ? 'The agent can display notes, summaries, and structured content here during your conversation.'
+                    : 'Start a conversation — the agent will display structured content here in real time.' }}
+                </p>
+              </div>
+
+              <!-- Markdown content -->
+              <div
+                v-else-if="displayedPanel.type === 'markdown'"
+                v-html="renderedContent"
+                class="prose prose-sm prose-invert max-w-none
+                  prose-headings:text-gray-100 prose-headings:font-semibold
+                  prose-p:text-gray-300 prose-p:leading-relaxed
+                  prose-strong:text-gray-100
+                  prose-code:text-state-autonomous-300 prose-code:bg-gray-800 prose-code:px-1 prose-code:rounded prose-code:text-xs
+                  prose-pre:bg-gray-800 prose-pre:border prose-pre:border-gray-700
+                  prose-ul:text-gray-300 prose-ol:text-gray-300
+                  prose-li:marker:text-gray-500
+                  prose-blockquote:border-action-primary-500 prose-blockquote:text-gray-400
+                  prose-a:text-action-primary-400 hover:prose-a:text-action-primary-300
+                  prose-hr:border-gray-700
+                  prose-table:text-sm
+                  prose-th:text-gray-200 prose-th:bg-gray-800
+                  prose-td:text-gray-300 prose-td:border-gray-700"
+              />
+
+              <!-- Mermaid diagram — sandboxed iframe (same opaque-origin model as
+                   HTML); agent diagram text never reaches the parent DOM. -->
+              <iframe
+                v-else-if="displayedPanel.type === 'mermaid'"
+                :srcdoc="mermaidSrcdoc"
+                sandbox="allow-scripts"
+                class="w-full h-full bg-transparent border-0 block"
+                title="Agent diagram"
+              />
+
+              <!-- Image — rendered in the parent DOM via a Vue :src binding (safe;
+                   no markup injection). Workspace-path images come from an
+                   authenticated blob fetch; web URLs render directly. -->
+              <div v-else-if="displayedPanel.type === 'image'" class="flex flex-col items-center justify-center h-full gap-3">
+                <img
+                  v-if="displayedImageSrc && !imageError"
+                  :src="displayedImageSrc"
+                  :alt="displayedPanel.title || 'Agent image'"
+                  class="max-w-full max-h-full object-contain rounded-lg"
+                  @error="imageError = true"
+                />
+                <div v-else class="text-sm" :class="imageError ? 'text-status-error-400' : 'text-gray-500'">
+                  {{ imageError ? 'Image could not be loaded.' : 'Loading image…' }}
+                </div>
+                <p v-if="displayedPanel.caption" class="text-sm text-gray-400 text-center max-w-prose">
+                  {{ displayedPanel.caption }}
+                </p>
+              </div>
+
+              <!-- HTML content — sandboxed iframe so agent-supplied scripts run in
+                   an opaque origin and cannot reach parent localStorage / cookies /
+                   JWT. Deliberately omits allow-same-origin / allow-forms /
+                   allow-popups / allow-top-navigation / allow-modals. -->
+              <iframe
+                v-else-if="displayedPanel.type === 'html'"
+                :srcdoc="htmlSrcdoc"
+                sandbox="allow-scripts"
+                class="w-full h-full bg-transparent border-0 block"
+                title="Agent panel"
+              />
             </div>
-            <p class="text-gray-600 text-sm max-w-xs">
-              {{ voice.isActive.value
-                ? 'The agent can display notes, summaries, and structured content here during your conversation.'
-                : 'Start a conversation — the agent will display structured content here in real time.' }}
-            </p>
-          </div>
-
-          <!-- Markdown content -->
-          <div
-            v-else-if="panelState.type === 'markdown'"
-            v-html="renderedContent"
-            class="prose prose-sm prose-invert max-w-none
-              prose-headings:text-gray-100 prose-headings:font-semibold
-              prose-p:text-gray-300 prose-p:leading-relaxed
-              prose-strong:text-gray-100
-              prose-code:text-state-autonomous-300 prose-code:bg-gray-800 prose-code:px-1 prose-code:rounded prose-code:text-xs
-              prose-pre:bg-gray-800 prose-pre:border prose-pre:border-gray-700
-              prose-ul:text-gray-300 prose-ol:text-gray-300
-              prose-li:marker:text-gray-500
-              prose-blockquote:border-action-primary-500 prose-blockquote:text-gray-400
-              prose-a:text-action-primary-400 hover:prose-a:text-action-primary-300
-              prose-hr:border-gray-700
-              prose-table:text-sm
-              prose-th:text-gray-200 prose-th:bg-gray-800
-              prose-td:text-gray-300 prose-td:border-gray-700"
-          />
-
-          <!-- HTML content — sandboxed iframe so agent-supplied scripts run in
-               an opaque origin and cannot reach parent localStorage / cookies /
-               JWT. Deliberately omits allow-same-origin / allow-forms /
-               allow-popups / allow-top-navigation / allow-modals. -->
-          <iframe
-            v-else-if="panelState.type === 'html'"
-            ref="htmlPanelEl"
-            sandbox="allow-scripts"
-            class="w-full h-full bg-transparent border-0 block"
-            title="Agent panel"
-          />
+          </Transition>
         </div>
       </div>
 
@@ -200,22 +279,27 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
+import { useAgentsStore } from '../stores/agents'
 import { useVoiceSession } from '../composables/useVoiceSession'
 import { renderMarkdown } from '../utils/markdown'
 import AgentAvatar from '../components/AgentAvatar.vue'
-// Chart.js is loaded inside the sandboxed iframe (see renderHtmlPanel). The
-// relative path is intentional: chart.js 4 doesn't expose the UMD bundle via
-// its package `exports` field, so a bare specifier like `chart.js/dist/...`
-// fails to resolve. The relative path bypasses module resolution and Vite's
-// `?url` import emits the file as a hashed same-origin asset.
+// Chart.js and Mermaid are loaded inside the sandboxed iframe (see
+// renderHtmlPanel / renderMermaidPanel). The relative path is intentional:
+// chart.js 4 doesn't expose the UMD bundle via its package `exports` field, and
+// mermaid's `exports['.']` only points at the ESM `mermaid.core.mjs`. Both ship
+// a self-contained IIFE bundle (chart.umd.js / mermaid.min.js) that assigns a
+// browser global; the relative path bypasses module resolution and Vite's `?url`
+// import emits each as a hashed same-origin asset.
 import chartJsUrl from '../../node_modules/chart.js/dist/chart.umd.js?url'
+import mermaidJsUrl from '../../node_modules/mermaid/dist/mermaid.min.js?url'
 
 const route = useRoute()
 const authStore = useAuthStore()
+const agentsStore = useAgentsStore()
 // route.params.name is a plain string in Vue Router 4 setup()
 const agentName = route.params.name
 const voice = useVoiceSession(agentName)
@@ -223,9 +307,29 @@ const voice = useVoiceSession(agentName)
 const agent = ref(null)
 const selectedVoice = ref('Kore')
 const panelState = ref({ type: 'empty', content: '', title: null, updated_at: null })
-const htmlPanelEl = ref(null)
 let panelPollTimer = null
 let panelFetching = false
+
+// ── Panel history (client-side, ephemeral) ───────────────────────────────────
+// Ring buffer of panel snapshots. "Live" (viewIndex === -1) follows the latest
+// update; navigating back pins a snapshot until the user returns to live or a
+// brand-new update arrives. Frontend-only — no backend/history persistence.
+const HISTORY_MAX = 40
+const history = ref([])      // oldest → newest
+const viewIndex = ref(-1)    // -1 = live; otherwise index into history
+const justUpdated = ref(false)  // drives the header "updated" flash
+
+const prefersReducedMotion =
+  typeof window !== 'undefined' && window.matchMedia
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false
+
+// Image blob cache: workspace-path images are fetched through the authenticated
+// /files/preview endpoint (a bare <img src> would 401), keyed by path so history
+// navigation reuses them. objectURLs are revoked on eviction + unmount (F2).
+const imageBlobCache = new Map()  // path → objectURL
+const imageObjectUrl = ref(null)
+const imageError = ref(false)
 
 const VOICES = [
   { id: 'Kore',    label: 'Kore — Firm' },
@@ -238,35 +342,116 @@ const VOICES = [
 
 // ── Computed ────────────────────────────────────────────────────────────────
 
+// The snapshot currently shown: a pinned history entry, or the live panel.
+const effectiveIndex = computed(() => {
+  if (viewIndex.value >= 0 && viewIndex.value < history.value.length) return viewIndex.value
+  return history.value.length - 1
+})
+const displayedPanel = computed(() => {
+  const i = effectiveIndex.value
+  if (i >= 0 && i < history.value.length) return history.value[i]
+  return panelState.value
+})
+const isLive = computed(() => effectiveIndex.value === history.value.length - 1)
+const hasHistory = computed(() => history.value.length >= 2)
+
+// Re-key the canvas content on every snapshot change so the Transition fires on
+// both live updates and history navigation. updated_at is unique per snapshot;
+// effectiveIndex disambiguates the empty state.
+const transitionKey = computed(() => `${effectiveIndex.value}:${displayedPanel.value.updated_at || 'empty'}`)
+// prefers-reduced-motion → an undefined transition name (no CSS classes) = instant swap.
+const canvasTransition = computed(() => (prefersReducedMotion ? 'canvas-none' : 'canvas-fade'))
+
+const displayedImageSrc = computed(() => {
+  const p = displayedPanel.value
+  if (p.type !== 'image') return null
+  return p.image_kind === 'url' ? p.content : imageObjectUrl.value
+})
+
 const renderedContent = computed(() =>
-  panelState.value.type === 'markdown' ? renderMarkdown(panelState.value.content || '') : ''
+  displayedPanel.value.type === 'markdown' ? renderMarkdown(displayedPanel.value.content || '') : ''
 )
 
 const panelUpdatedAgo = computed(() => {
-  if (!panelState.value.updated_at) return null
-  const secs = Math.round((Date.now() - new Date(panelState.value.updated_at).getTime()) / 1000)
+  if (!displayedPanel.value.updated_at) return null
+  const secs = Math.round((Date.now() - new Date(displayedPanel.value.updated_at).getTime()) / 1000)
   if (secs < 5)  return 'just now'
   if (secs < 60) return `${secs}s ago`
   return `${Math.round(secs / 60)}m ago`
 })
 
-// ── HTML panel rendering ─────────────────────────────────────────────────────
+function snapshotLabel(snap, idx) {
+  const t = snap.updated_at
+    ? new Date(snap.updated_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    : '—'
+  const kind = snap.type === 'mermaid' ? 'diagram' : snap.type
+  return `${idx + 1}. ${snap.title || kind} · ${t}`
+}
 
-// Render the agent's HTML inside a sandboxed iframe. The iframe gets an opaque
-// origin (sandbox="allow-scripts" without allow-same-origin), so agent-supplied
-// JS cannot read parent localStorage / cookies / JWT, submit forms, navigate
-// the parent, or open popups. Chart.js is loaded inside the iframe via a
-// same-origin asset URL so new Chart(...) calls in agent HTML still work.
+// ── History navigation ────────────────────────────────────────────────────────
+
+function goPrev() {
+  const i = effectiveIndex.value
+  if (i > 0) viewIndex.value = i - 1
+}
+function goNext() {
+  const i = effectiveIndex.value
+  if (i < history.value.length - 1) {
+    const next = i + 1
+    viewIndex.value = next >= history.value.length - 1 ? -1 : next  // snap to live at the end
+  }
+}
+function selectSnapshot(e) {
+  const idx = Number(e.target.value)
+  viewIndex.value = idx >= history.value.length - 1 ? -1 : idx
+}
+
+function pushHistory(snap) {
+  history.value.push(snap)
+  while (history.value.length > HISTORY_MAX) {
+    const evicted = history.value.shift()
+    // Revoke a cached image blob only if no remaining snapshot references its path.
+    if (evicted.type === 'image' && evicted.image_kind === 'path') {
+      const stillUsed = history.value.some(
+        (s) => s.type === 'image' && s.image_kind === 'path' && s.content === evicted.content
+      )
+      if (!stillUsed && imageBlobCache.has(evicted.content)) {
+        URL.revokeObjectURL(imageBlobCache.get(evicted.content))
+        imageBlobCache.delete(evicted.content)
+      }
+    }
+  }
+}
+
+// ── Iframe panel rendering (HTML + Mermaid) ──────────────────────────────────
+
+// Agent-supplied markup renders inside a sandboxed iframe with an opaque origin
+// (sandbox="allow-scripts" without allow-same-origin): agent JS cannot read
+// parent localStorage / cookies / JWT, submit forms, navigate the parent, or
+// open popups. The iframe is driven by a reactive `:srcdoc` binding (computed
+// below) so it re-renders declaratively on update/navigation — no element ref or
+// nextTick, which keeps it safe when the content transition recreates the node.
 //
 // Tag delimiters are built via string concat (s_open / s_close) so the SFC
 // parser doesn't see them as nested block tags.
 const s_open = '<' + 's' + 'cript'
 const s_close = '<' + '/' + 's' + 'cript' + '>'
-function renderHtmlPanel(html) {
-  const el = htmlPanelEl.value
-  if (!el) return
+
+// Encode an arbitrary string as a JS string literal safe to embed in an inline
+// script. JSON.stringify handles quotes/backslashes/newlines; the extra
+// `<` → < replacement prevents a diagram containing a script close-tag from
+// terminating the script element early (the JS engine restores < to "<").
+// Load-bearing guard for the agent-supplied diagram text (review F4).
+function jsString(s) {
+  return JSON.stringify(s == null ? '' : String(s)).replace(/</g, '\\u003c')
+}
+
+// Chart.js is loaded inside the iframe via a same-origin asset URL so
+// new Chart(...) calls in agent HTML still work.
+const htmlSrcdoc = computed(() => {
+  if (displayedPanel.value.type !== 'html') return ''
   const chartUrl = new URL(chartJsUrl, window.location.origin).href
-  el.srcdoc = [
+  return [
     '<!DOCTYPE html><html><head><meta charset="utf-8"><style>',
     'body{margin:0;padding:8px;color:#d1d5db;background:transparent;',
     'font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}',
@@ -276,20 +461,92 @@ function renderHtmlPanel(html) {
     '</style>',
     s_open, ' src="', chartUrl, '">', s_close,
     '</head><body>',
-    html ?? '',
+    displayedPanel.value.content ?? '',
     '</body></html>',
   ].join('')
+})
+
+// Mermaid renders strictly inside the sandboxed iframe — agent diagram text never
+// touches the parent DOM. mermaid.min.js is a self-contained IIFE bundle (no
+// runtime chunk fetches) that exposes window.mermaid. Invalid syntax renders a
+// contained error + the source, not a broken panel.
+const mermaidSrcdoc = computed(() => {
+  if (displayedPanel.value.type !== 'mermaid') return ''
+  const mermaidUrl = new URL(mermaidJsUrl, window.location.origin).href
+  return [
+    '<!DOCTYPE html><html><head><meta charset="utf-8"><style>',
+    'body{margin:0;padding:12px;background:transparent;',
+    'font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}',
+    '#out svg{max-width:100%;height:auto}',
+    '#err{display:none;color:#fca5a5;white-space:pre-wrap;',
+    'font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}',
+    '</style></head><body>',
+    '<div id="out"></div><pre id="err"></pre>',
+    s_open, ' src="', mermaidUrl, '">', s_close,
+    s_open, '>',
+    'var SRC=', jsString(displayedPanel.value.content), ';',
+    'function fail(e){var p=document.getElementById("err");',
+    'p.style.display="block";p.textContent="Diagram error:\\n"+',
+    '((e&&e.message)?e.message:String(e))+"\\n\\n"+SRC;}',
+    'try{if(!window.mermaid){throw new Error("mermaid failed to load");}',
+    'window.mermaid.initialize({startOnLoad:false,securityLevel:"strict",theme:"dark"});',
+    'window.mermaid.render("d",SRC).then(function(r){',
+    'document.getElementById("out").innerHTML=r.svg;}).catch(fail);',
+    '}catch(e){fail(e);}',
+    s_close,
+    '</body></html>',
+  ].join('')
+})
+
+// Fetch a workspace-path image through the authenticated /files/preview endpoint
+// (reuses the store's blob helper) and bind the objectURL. Web-URL images bypass
+// this entirely (rendered directly). Cached by path for history navigation.
+async function loadImageBlob(path) {
+  imageError.value = false
+  if (imageBlobCache.has(path)) {
+    imageObjectUrl.value = imageBlobCache.get(path)
+    return
+  }
+  // Still showing the path we set out to fetch? Guards against out-of-order
+  // resolution when the user navigates history faster than blobs load.
+  const stillCurrent = () =>
+    displayedPanel.value.type === 'image' && displayedPanel.value.content === path
+  try {
+    const res = await agentsStore.getFilePreviewBlob(agentName, path)
+    imageBlobCache.set(path, res.url)  // cache regardless, for later navigation
+    if (stillCurrent()) imageObjectUrl.value = res.url
+  } catch (_) {
+    if (stillCurrent()) {
+      imageObjectUrl.value = null
+      imageError.value = true
+    }
+  }
 }
 
-// Re-render HTML panel when panelState content changes
-watch(() => panelState.value, (state) => {
-  if (state.type === 'html') nextTick(() => renderHtmlPanel(state.content || ''))
+// Image is the only type needing async work on display: a workspace-path image
+// must be fetched as an authenticated blob. HTML/Mermaid render via :srcdoc.
+watch(displayedPanel, (panel) => {
+  if (panel.type === 'image') {
+    imageError.value = false
+    if (panel.image_kind === 'path') loadImageBlob(panel.content)
+    else imageObjectUrl.value = null  // url-kind renders content directly
+  }
 }, { deep: true })
 
 // ── Session lifecycle ────────────────────────────────────────────────────────
 
+function revokeAllImageBlobs() {
+  for (const url of imageBlobCache.values()) URL.revokeObjectURL(url)
+  imageBlobCache.clear()
+  imageObjectUrl.value = null
+}
+
 function resetPanelState() {
   panelState.value = { type: 'empty', content: '', title: null, updated_at: null }
+  history.value = []
+  viewIndex.value = -1
+  imageError.value = false
+  revokeAllImageBlobs()
 }
 
 async function toggleSession() {
@@ -305,6 +562,14 @@ async function toggleSession() {
 }
 
 // ── Panel polling ────────────────────────────────────────────────────────────
+
+let flashTimer = null
+function flashUpdated() {
+  if (prefersReducedMotion) return
+  justUpdated.value = true
+  if (flashTimer !== null) clearTimeout(flashTimer)
+  flashTimer = setTimeout(() => { justUpdated.value = false }, 1100)
+}
 
 function startPanelPoll() {
   stopPanelPoll()
@@ -332,6 +597,9 @@ async function fetchPanel() {
     // not found or no tool ever called" — never overwrite real content with it.
     if (r.data.updated_at !== null && r.data.updated_at !== panelState.value.updated_at) {
       panelState.value = r.data
+      pushHistory(r.data)
+      viewIndex.value = -1  // a brand-new update snaps the view back to live
+      flashUpdated()
     }
   } catch (_) {
     // Ignore poll errors (session may have just ended)
@@ -499,6 +767,9 @@ let particles = []
 let currentSprites = null
 let currentHueShift = 0
 let targetHueShift = 0
+// Persistent orb smoothing state (lerped across frames, not recomputed raw).
+let smoothedEnergy = 0
+let coreSize = 58
 
 function rebuildSprites(hueShift) {
   currentSprites = buildSprites(hueShift)
@@ -547,7 +818,14 @@ function renderFrame() {
     if (next !== currentHueShift) rebuildSprites(next)
   }
   const amp = voice.amplitude?.value ?? 0
-  const energy = Math.min(1, amp * 2.5)
+  const targetEnergy = Math.min(1, amp * 2.5)
+  // Asymmetric attack/release: rise quickly toward louder audio (0.18), fall back
+  // gently (0.10) so the orb glides instead of stepping with each amplitude frame.
+  const k = targetEnergy > smoothedEnergy ? 0.18 : 0.10
+  smoothedEnergy = lerp(smoothedEnergy, targetEnergy, k)
+  // Idle "breathe" floor — a slow low-amplitude sine so the orb never goes flat.
+  const breathe = (Math.sin(frameCount * 0.035) * 0.5 + 0.5) * 0.06
+  const energy = Math.max(smoothedEnergy, breathe)
   const bass = energy * 0.8, mid = energy * 0.5, high = energy * 0.3
   ctx.fillStyle = '#000'
   ctx.fillRect(0, 0, W, H)
@@ -555,9 +833,13 @@ function renderFrame() {
   ctx.translate(W/2, H/2)
   for (const p of particles) {
     p.update(energy, bass, mid, high, frameCount)
-    p.draw(ctx, 1.1, 1.1, 1.0)
+    p.draw(ctx, 1.25, 1.25, 1.0)
   }
-  drawCore(ctx, 45 + energy * 20, frameCount)
+  // Smooth the core size toward its target (larger base 58, stronger 32× swing)
+  // so the soft glow grows/shrinks smoothly rather than snapping.
+  const targetCoreSize = 58 + energy * 32
+  coreSize = lerp(coreSize, targetCoreSize, 0.12)
+  drawCore(ctx, coreSize, frameCount)
   ctx.restore()
   rafHandle = requestAnimationFrame(renderFrame)
 }
@@ -585,7 +867,9 @@ onMounted(async () => {
 
 onUnmounted(() => {
   if (rafHandle !== null) cancelAnimationFrame(rafHandle)
+  if (flashTimer !== null) clearTimeout(flashTimer)
   stopPanelPoll()
+  revokeAllImageBlobs()
   window.removeEventListener('resize', resizeCanvas)
   if (voice.isActive.value) voice.stop()
 })
@@ -623,3 +907,22 @@ const statusLabel = computed(() => {
   }
 })
 </script>
+
+<style scoped>
+/* Canvas content cross-fade + subtle slide-in on update / history navigation.
+   The `canvas-none` transition name (used under prefers-reduced-motion) has no
+   matching classes, so Vue swaps content instantly. */
+.canvas-fade-enter-active {
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+.canvas-fade-leave-active {
+  transition: opacity 0.16s ease;
+}
+.canvas-fade-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
+}
+.canvas-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/tests/unit/test_voice_tools.py
+++ b/tests/unit/test_voice_tools.py
@@ -144,6 +144,7 @@ sys.modules.pop("services.gemini_voice", None)
 # Now we can import the service
 from services.gemini_voice import (  # noqa: E402
     GeminiVoiceService, VoiceSession, _TOOL_PROMPT_MAX, _PANEL_CONTENT_MAX,
+    _PANEL_TOOL_NAMES, _classify_image_src, _WORKSPACE_ROOT,
 )
 
 # gemini_voice has captured what it needed from the docker/template stubs.
@@ -468,6 +469,170 @@ class TestExecutePanelTool:
             mock_exec.assert_not_awaited()
 
         assert session.panel_state["type"] == "markdown"
+        gemini_session.send_tool_response.assert_awaited_once()
+
+    # ── #979: show_diagram (Mermaid) ─────────────────────────────────────────
+
+    def test_show_diagram_sets_mermaid_state(self, svc):
+        session = _make_session()
+        result = svc._execute_panel_tool(
+            session, "show_diagram", {"diagram": "graph TD; A-->B", "title": "Flow"}
+        )
+        assert result == "Panel updated."
+        assert session.panel_state["type"] == "mermaid"
+        assert session.panel_state["content"] == "graph TD; A-->B"
+        assert session.panel_state["title"] == "Flow"
+        assert session.panel_state["updated_at"] is not None
+
+    def test_show_diagram_missing_arg_defaults_empty(self, svc):
+        session = _make_session()
+        svc._execute_panel_tool(session, "show_diagram", {})
+        assert session.panel_state["type"] == "mermaid"
+        assert session.panel_state["content"] == ""
+
+    # ── #979: show_image (web URL + workspace path) ──────────────────────────
+
+    def test_show_image_web_url(self, svc):
+        session = _make_session()
+        result = svc._execute_panel_tool(
+            session, "show_image",
+            {"src": "https://example.com/chart.png", "caption": "A chart"},
+        )
+        assert result == "Panel updated."
+        assert session.panel_state["type"] == "image"
+        assert session.panel_state["image_kind"] == "url"
+        assert session.panel_state["content"] == "https://example.com/chart.png"
+        assert session.panel_state["caption"] == "A chart"
+
+    def test_show_image_relative_workspace_path_normalized(self, svc):
+        session = _make_session()
+        svc._execute_panel_tool(session, "show_image", {"src": "content/chart.png"})
+        assert session.panel_state["type"] == "image"
+        assert session.panel_state["image_kind"] == "path"
+        # Relative path resolved under the workspace root.
+        assert session.panel_state["content"] == f"{_WORKSPACE_ROOT}/content/chart.png"
+
+    def test_show_image_absolute_workspace_path(self, svc):
+        session = _make_session()
+        svc._execute_panel_tool(
+            session, "show_image", {"src": "/home/developer/content/a.png"}
+        )
+        assert session.panel_state["image_kind"] == "path"
+        assert session.panel_state["content"] == "/home/developer/content/a.png"
+
+    def test_show_image_tilde_is_workspace_relative(self, svc):
+        session = _make_session()
+        svc._execute_panel_tool(session, "show_image", {"src": "~/content/a.png"})
+        assert session.panel_state["image_kind"] == "path"
+        assert session.panel_state["content"] == f"{_WORKSPACE_ROOT}/content/a.png"
+
+    def test_show_image_empty_src_rejected(self, svc):
+        session = _make_session()
+        before = dict(session.panel_state)
+        result = svc._execute_panel_tool(session, "show_image", {"src": "   "})
+        assert "No image source" in result
+        # Panel unchanged on rejection.
+        assert session.panel_state == before
+
+    @pytest.mark.parametrize("bad_src", [
+        "../../etc/passwd",                       # relative traversal escapes root
+        "/home/developer/../etc/passwd",          # absolute traversal escapes root
+        "/etc/passwd",                            # outside the workspace entirely
+        "/home/developer-evil/secret",            # sibling-prefix escape (the startswith bug)
+        "data:image/png;base64,AAAA",             # inline data URI not allowed
+        "file:///etc/passwd",                     # non-http scheme not allowed
+        "ftp://host/x.png",                        # non-http scheme not allowed
+    ])
+    def test_show_image_rejects_unsafe_src(self, svc, bad_src):
+        session = _make_session()
+        before = dict(session.panel_state)
+        result = svc._execute_panel_tool(session, "show_image", {"src": bad_src})
+        assert "rejected" in result.lower() or "no image source" in result.lower()
+        # Panel state must NOT be updated for a rejected source.
+        assert session.panel_state == before
+
+
+# ── #979: _classify_image_src path-confinement unit tests ────────────────────
+
+class TestClassifyImageSrc:
+    """Direct tests of the show_image src classifier / confinement gate."""
+
+    @pytest.mark.parametrize("url", [
+        "http://example.com/a.png",
+        "https://example.com/a.png",
+        "HTTPS://EXAMPLE.COM/A.PNG",  # scheme match is case-insensitive
+    ])
+    def test_web_urls_classified_as_url(self, url):
+        out = _classify_image_src(url)
+        assert out is not None and out[1] == "url"
+        assert out[0] == url  # value preserved verbatim
+
+    def test_relative_path_resolved_under_root(self):
+        out = _classify_image_src("content/x.png")
+        assert out == (f"{_WORKSPACE_ROOT}/content/x.png", "path")
+
+    def test_root_itself_allowed(self):
+        out = _classify_image_src("/home/developer")
+        assert out == (_WORKSPACE_ROOT, "path")
+
+    @pytest.mark.parametrize("bad", [
+        "",
+        "../escape.png",
+        "/home/developer/../../etc/passwd",
+        "/etc/passwd",
+        "/home/developer-evil/x.png",  # the sibling-prefix bug this gate fixes
+        "data:text/html,<script>alert(1)</script>",
+        "file:///etc/passwd",
+        "javascript:alert(1)",         # has no scheme://, treated as path, escapes → rejected
+    ])
+    def test_unsafe_inputs_rejected(self, bad):
+        assert _classify_image_src(bad) is None
+
+
+# ── #979: new panel tools are registered + declared ──────────────────────────
+
+class TestNewPanelToolRegistration:
+
+    def test_new_tools_in_panel_tool_names(self):
+        assert "show_diagram" in _PANEL_TOOL_NAMES
+        assert "show_image" in _PANEL_TOOL_NAMES
+
+    def test_new_tools_declared(self):
+        from services.gemini_voice import _PANEL_TOOLS
+        names = {fd.name for fd in _PANEL_TOOLS.function_declarations}
+        assert "show_diagram" in names
+        assert "show_image" in names
+
+    def test_show_diagram_requires_diagram_arg(self):
+        from services.gemini_voice import _PANEL_TOOLS
+        fd = next(f for f in _PANEL_TOOLS.function_declarations if f.name == "show_diagram")
+        assert "diagram" in (fd.parameters.required or [])
+
+    def test_show_image_requires_src_arg(self):
+        from services.gemini_voice import _PANEL_TOOLS
+        fd = next(f for f in _PANEL_TOOLS.function_declarations if f.name == "show_image")
+        assert "src" in (fd.parameters.required or [])
+
+    def test_show_diagram_routed_not_forwarded_to_agent(self, svc):
+        """show_diagram executes in-process, never reaching the agent container."""
+        session = _make_session()
+        session._active = True
+        gemini_session = MagicMock()
+        gemini_session.send_tool_response = AsyncMock()
+        session._gemini_session = gemini_session
+        session._on_tool_call = None
+        session._on_tool_result = None
+
+        fc = MagicMock()
+        fc.id = "fc_diag"
+        fc.name = "show_diagram"
+        fc.args = {"diagram": "graph TD; A-->B"}
+
+        with patch.object(svc, "_execute_tool", AsyncMock()) as mock_exec:
+            _run(svc._execute_and_respond(session, "fc_diag", fc))
+            mock_exec.assert_not_awaited()
+
+        assert session.panel_state["type"] == "mermaid"
         gemini_session.send_tool_response.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- Adds two in-process voice **panel tools** — `show_diagram` (Mermaid) and `show_image` — to the Voice Workspace canvas, plus client-side **panel history**, **orb polish**, and a **graceful canvas transition**. Endpoint contract unchanged (still the 300ms poll of `GET /voice/{session_id}/panel`).
- Mermaid renders **strictly inside the existing opaque-origin sandboxed iframe** (per the issue's stated security model) via a self-contained `mermaid.min.js` IIFE bundle that exposes `window.mermaid` with **zero runtime chunk fetches** — so the Chart.js `?url`-into-iframe pattern transfers cleanly.
- Images: web URLs render directly via Vue `:src`; agent-workspace file paths stream through the existing **authenticated** `/files/preview` endpoint as a blob (a bare `<img src>` would 401).

## Changes
- **`src/backend/services/gemini_voice.py`** — `show_diagram` + `show_image` tool declarations, registered in `_PANEL_TOOL_NAMES` and `WORKSPACE_PANEL_INSTRUCTIONS`; `_classify_image_src()` path-confinement helper (rejects `..`, absolute escapes, the `/home/developer-evil` sibling, `data:`, non-http schemes — stricter than the agent-server prefix check).
- **`src/frontend/src/views/AgentWorkspace.vue`** — `mermaid`/`image` render branches; reactive `:srcdoc` iframe bindings (transition-safe); 40-snapshot history ring buffer (prev/next + dropdown, live/pinned); orb asymmetric attack/release smoothing + idle breathe + larger core/glow; `prefers-reduced-motion`-aware cross-fade + header "updated" flash; image objectURL cache with eviction/unmount revocation + out-of-order load guard.
- **`src/frontend/package.json`** — add `mermaid` (v11).
- **`tests/unit/test_voice_tools.py`** — new panel-tool state tests, path-confinement rejection (traversal/sibling/`data:`/scheme), `_classify_image_src` unit tests, tool registration/declaration.
- **`docs/memory/requirements.md`** (VOICE-009) + **`docs/memory/feature-flows/voice-chat.md`**.

## Security
- Agent markup/diagrams render **only** inside the opaque-origin `sandbox="allow-scripts"` iframe; diagram text injected as a JS string (`JSON.stringify` + `<`→`<`, no `</script>` breakout) with mermaid `securityLevel:'strict'`.
- Images render via Vue `:src` (no `v-html`); url-kind restricted to `http(s)://`.
- Path confinement enforced in-process **and** at the existing authenticated endpoint; the confinement gate is unit-tested.
- Panel tools are backend+frontend only — **not** on the MCP surface (Invariant #13 N/A).

## Test Plan
- [x] New + existing unit tests pass: `pytest tests/unit/test_voice_tools.py` (58 passed)
- [x] Full unit suite green: **1811 passed, 6 skipped**
- [x] Frontend builds (`npm run build`); mermaid emitted as a hashed same-origin asset
- [ ] Manual: voice workspace — `show_diagram` renders a flowchart; invalid syntax shows a contained error; `show_image` with a web URL and a workspace path; history prev/next; orb smoothing; reduced-motion

Fixes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)