### PR TITLE
fix(voice): render workspace canvas in-parent — prod CSP blocked the iframe (#979)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}  # For Gemini-powered agents
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # For platform image generation (IMG-001)
       - VOICE_MODEL=${VOICE_MODEL:-}  # Gemini Live model override (default: gemini-2.5-flash-native-audio-preview-12-2025)
+      - VOICE_ENABLED=${VOICE_ENABLED:-true}  # Voice mode (default on when GEMINI_API_KEY set)
+      - WORKSPACE_ENABLED=${WORKSPACE_ENABLED:-false}  # Voice Workspace canvas — opt-in BETA (#860)
       - GITHUB_PAT=${GITHUB_PAT:-}
       - HOST_TEMPLATES_PATH=${PWD}/config/agent-templates
       # OpenTelemetry Configuration (Optional)

--- a/docs/memory/feature-flows/voice-chat.md
+++ b/docs/memory/feature-flows/voice-chat.md
@@ -1,7 +1,7 @@
 # Voice Chat — Gemini 2.5 Flash Native Audio
 
 **Status**: ✅ Phase 1 + Tool Calling + Workspace Mode (BETA) Complete
-**Date**: 2026-05-07
+**Date**: 2026-05-30 (workspace canvas rendering moved in-parent — #979 prod-CSP fix)
 **Priority**: P1
 
 ---
@@ -54,9 +54,9 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 │  │                         │  │                               │   │
 │  │  <canvas> orb (same     │  │  Panel content rendered via   │   │
 │  │   particle system as    │  │  show_markdown → renderMarkdown│  │
-│  │   VoiceOverlay)         │  │  update_panel → DOMPurify +   │   │
-│  │                         │  │  _execScripts (Chart.js ok)   │   │
-│  │  Status label           │  │  Chart.js 4 pre-loaded        │   │
+│  │   VoiceOverlay)         │  │  html/mermaid → DOMPurify     │   │
+│  │                         │  │  in parent DOM (H-005);       │   │
+│  │  Status label           │  │  scripts stripped — no JS     │   │
 │  │  Tool name badge        │  │                               │   │
 │  │  [Mute] [Start/End]     │  │  Polled 300ms; updated_at     │   │
 │  │  Voice selector         │  │  gate + in-flight guard       │   │
@@ -83,16 +83,20 @@ Anthropic has no speech-to-speech or realtime audio API. Any Claude voice pipeli
 The workspace canvas renders five live panel types plus history:
 
 - **markdown** — `renderMarkdown` (marked + DOMPurify) in the parent DOM.
-- **mermaid** (`show_diagram`) — rendered strictly inside the opaque-origin
-  `sandbox="allow-scripts"` iframe via a self-contained `mermaid.min.js` IIFE
-  bundle (same `?url` mechanism as Chart.js, no runtime chunk fetches). Diagram
-  text is injected as a JS string (`JSON.stringify` + `<`→`<`, so a
-  `</script>` in the text can't break out) and rendered with
-  `securityLevel:'strict'`; invalid syntax shows a contained error + source.
+- **mermaid** (`show_diagram`) — rendered **in-parent** via the bundled `mermaid`
+  ESM lib (no iframe). `mermaid.initialize({securityLevel:'strict', theme:'dark'})`
+  disables interactivity + htmlLabels; `mermaid.render()` runs off-DOM and the
+  output SVG is **DOMPurify-sanitized** before `v-html` (H-005). A monotonic seq
+  token drops stale async renders during live update / history navigation; invalid
+  syntax shows a contained error + source. The prior `srcdoc` iframe was dropped
+  because the production CSP (`script-src 'self'`) blocks its inline render script
+  and CORP blocks the bundle from the iframe's opaque origin (#979).
 - **image** (`show_image`) — web URLs render directly via Vue `:src`;
   workspace file paths are fetched through the authenticated `/files/preview`
   endpoint as a blob (a bare `<img src>` would 401) and bound as an objectURL.
-- **html** (`update_panel`) — sandboxed iframe with Chart.js (unchanged).
+- **html** (`update_panel`) — **DOMPurify-sanitized and rendered in-parent**
+  (same trust model as markdown, H-005). Scripts are stripped, so agent JS
+  (e.g. Chart.js) does **not** execute — static layout only (#979).
 - **empty** — placeholder.
 
 Frontend-only additions (no backend change): a 40-snapshot history ring buffer
@@ -272,14 +276,14 @@ Uvicorn runs `--workers 2` in production. HTTP requests (REST `/voice/start`, `/
 | Route | `/agents/:name/workspace` → `AgentWorkspace.vue` |
 | Layout | Left 40% (orb + controls) + Right 60% (canvas panel) |
 | `workspace_mode` flag | Passed in `POST /voice/start` body; appends `WORKSPACE_PANEL_INSTRUCTIONS` to system prompt |
-| Panel tools | `show_markdown`, `update_panel`, `append_to_panel`, `clear_panel` — handled in-process via `_execute_panel_tool()`, never forwarded to agent container |
-| Panel state | `VoiceSession.panel_state` dict (in-memory); type ∈ {empty, markdown, html}; content capped at `_PANEL_CONTENT_MAX=524288` (512 KB) |
+| Panel tools | `show_markdown`, `show_diagram`, `show_image`, `update_panel`, `append_to_panel`, `clear_panel` — handled in-process via `_execute_panel_tool()`, never forwarded to agent container |
+| Panel state | `VoiceSession.panel_state` dict (in-memory); type ∈ {empty, markdown, mermaid, image, html}; content capped at `_PANEL_CONTENT_MAX=524288` (512 KB) |
 | Panel endpoint | `GET /api/agents/{name}/voice/{session_id}/panel` — returns empty state for missing sessions (no 404 during teardown window); ownership-gated (user_id + agent_name check, admin bypass) |
 | Frontend poll | `setInterval(fetchPanel, 300)` — in-flight guard (`panelFetching` flag) prevents overlapping requests; skips state update when `updated_at` unchanged (prevents 3×/sec Vue re-renders and preserves content after session ends) |
 | Content preservation | Panel content preserved on session end (poll stops, state not reset); reset on new session **start** via `resetPanelState()` |
-| HTML rendering | `update_panel`/`append_to_panel` → `ref="htmlPanelEl"` + `renderHtmlPanel()`: `DOMPurify.sanitize(html, {ADD_TAGS:['script']})` then `_execScripts()` re-clones `<script>` nodes as live DOM elements so Chart.js `new Chart(...)` calls execute |
-| Chart.js | Chart.js 4.4.0 pre-loaded globally via `injectChartJs()` on mount (CDN `<script>` tag injected once into `document.head`, guarded by `#chartjs-cdn` id check) |
-| XSS protection | `show_markdown` → `renderMarkdown()` (DOMPurify-wrapped); `update_panel` HTML — DOMPurify strips event handlers and `javascript:` hrefs; `<script>` tags are re-executed (Chart.js init) — trade-off: accepted per issue #707 security review, same trust level as agent MCP calls |
+| HTML rendering | `update_panel`/`append_to_panel` → `v-html="sanitizedHtml"`, where `sanitizedHtml = DOMPurify.sanitize(content)` (default profile) renders **in-parent**. `<script>` tags are stripped — agent JS does **not** execute. Replaces the prior `srcdoc` iframe, which the production CSP (`script-src 'self'`) + CORP blocked entirely (#979) |
+| Mermaid rendering | `show_diagram` → `mermaid.render()` (`securityLevel:'strict'`, htmlLabels off) off-DOM → `DOMPurify.sanitize(svg)` → `v-html`. Monotonic seq token drops stale async renders during live-update / history nav |
+| XSS protection | All three `v-html` sites (`show_markdown`, `show_diagram` SVG, `update_panel` HTML) are DOMPurify-sanitized in the parent DOM — same trust model as platform markdown (H-005). DOMPurify strips `<script>`, event handlers, and `javascript:` hrefs. The opaque-origin iframe boundary from #981 is dropped (it was non-functional under the prod CSP, so it protected nothing in production); residual risk is a DOMPurify bypass, identical to every other markdown surface on the platform |
 | BETA indicator | Amber "BETA" badge in header button and page header |
 
 ---
@@ -346,7 +350,7 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 **Response:**
 ```json
 {
-  "type": "empty|markdown|html",
+  "type": "empty|markdown|mermaid|image|html",
   "content": "...",
   "title": "optional title or null",
   "updated_at": "ISO-Z timestamp or null"
@@ -362,7 +366,8 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 | Setting | Description |
 |---------|-------------|
 | `GEMINI_API_KEY` | API key for Gemini Live API |
-| `VOICE_ENABLED` | Global toggle |
+| `VOICE_ENABLED` | Global voice toggle (default `true`; effective only when `GEMINI_API_KEY` is set). Wired into backend compose `environment:` (#979) |
+| `WORKSPACE_ENABLED` | Workspace canvas toggle — opt-in BETA, default `false` (#860). `workspace_available = voice_available && WORKSPACE_ENABLED`. Wired into backend compose `environment:` (#979 — previously never passed through, so the canvas couldn't be enabled via `.env`) |
 | `VOICE_MODEL` | Model ID (default: `gemini-2.5-flash-native-audio-preview-12-2025`) |
 | `VOICE_MAX_DURATION` | Max session duration in seconds (default: 300) |
 
@@ -389,7 +394,7 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 | **Frontend** | `src/frontend/src/composables/useVoiceSession.js` | `start(sessionId, voiceName, workspaceMode)` — passes `workspace_mode` to backend |
 | **Frontend** | `src/frontend/src/stores/sessions.js` | `voiceAvailable` state from feature flags |
 | **Frontend** | `src/frontend/src/utils/audio.js` | AudioWorklet-first capture/playback, `getAmplitude()` via `AnalyserNode` |
-| **Tests** | `tests/unit/test_voice_tools.py` | 26 unit tests: tool execution, panel tool handlers, content cap, routing guard, Redis session fallback (#704) |
+| **Tests** | `tests/unit/test_voice_tools.py` | 58 unit tests: tool execution (`run_task` reads `.response_text`, guards the #979 regression), panel tool handlers, `show_diagram`/`show_image` registration, image-src classification, content cap, routing guard, Redis session fallback (#704) |
 | **Tests** | `tests/unit/test_voice_auth.py` | 19 unit tests: WS auth, stop auth, panel ownership, audit attribution kwargs (#705) |
 
 ---
@@ -431,7 +436,7 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 - ✅ 512 KB content cap on accumulated `append_to_panel` content
 - ✅ Panel flicker fixed: `updated_at` change-detection gate + in-flight fetch guard (#707)
 - ✅ Panel content preserved on session end; reset on new session start (#707)
-- ✅ Chart.js 4 pre-loaded; `update_panel` HTML with `<script>` tags executes correctly (#707)
+- ✅ `update_panel` HTML + `show_diagram` Mermaid render **in-parent** via DOMPurify (H-005); scripts stripped, no JS execution (#979 — replaced the #981 `srcdoc` iframe that the production CSP blocked)
 - ⏳ Export panel content as PDF/markdown
 - ⏳ Multi-page / tabbed canvas
 

--- a/src/backend/services/gemini_voice.py
+++ b/src/backend/services/gemini_voice.py
@@ -152,9 +152,10 @@ Mermaid rule (for `show_diagram`):
 - Pass raw Mermaid source only (no ```mermaid fences). Example: `graph TD; Start-->Stop`.
 - Keep diagrams focused; invalid syntax shows a contained error in the panel.
 
-Chart.js rule (for `update_panel` HTML):
-- Chart.js 4 is available as `window.Chart` in the workspace (bundled, no CDN needed). NEVER add a `<script src>` tag for it.
-- Use `new Chart(...)` directly. Always give the canvas a fixed height: `<canvas id="c" style="max-height:380px"></canvas>`.
+HTML rule (for `update_panel`):
+- Panel HTML is sanitized before display: scripts do NOT execute. Use it for static layout only — tables, headings, lists, styled `<div>`s, inline `style=` attributes, images.
+- Do NOT use `<script>`, `<canvas>` + JS charting, or any JS-driven rendering — it will be stripped and show nothing.
+- For data visualisation, prefer `show_diagram` (Mermaid: fl/pie/quadrant/xychart) or `show_image` (a chart image by URL or workspace path). Reserve `update_panel` for rich static layouts that markdown can't express.
 """
 
 def _classify_image_src(src: str) -> Optional[tuple[str, str]]:
@@ -635,7 +636,7 @@ class GeminiVoiceService:
         try:
             client = get_agent_client(agent_name)
             response = await client.task(prompt, timeout=28.0)
-            return response.response or "Task completed with no response."
+            return response.response_text or "Task completed with no response."
         except AgentNotReachableError:
             return f"Agent {agent_name!r} is not currently running."
         except AgentRequestError as e:

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -229,15 +229,18 @@
                   prose-td:text-gray-300 prose-td:border-gray-700"
               />
 
-              <!-- Mermaid diagram — sandboxed iframe (same opaque-origin model as
-                   HTML); agent diagram text never reaches the parent DOM. -->
-              <iframe
-                v-else-if="displayedPanel.type === 'mermaid'"
-                :srcdoc="mermaidSrcdoc"
-                sandbox="allow-scripts"
-                class="w-full h-full bg-transparent border-0 block"
-                title="Agent diagram"
-              />
+              <!-- Mermaid diagram — rendered in-parent via the bundled mermaid lib
+                   (securityLevel:'strict') then DOMPurify-sanitized before v-html
+                   (H-005). No iframe: the production CSP (script-src 'self') blocks
+                   inline scripts in a srcdoc iframe and CORP blocks the bundle from
+                   the iframe's opaque origin (#979 prod-CSP regression). -->
+              <div v-else-if="displayedPanel.type === 'mermaid'" class="flex items-center justify-center h-full">
+                <pre
+                  v-if="mermaidError"
+                  class="text-xs text-status-danger-400 whitespace-pre-wrap font-mono max-w-full overflow-auto"
+                >{{ mermaidError }}</pre>
+                <div v-else v-html="mermaidSvg" class="mermaid-host max-w-full max-h-full" />
+              </div>
 
               <!-- Image — rendered in the parent DOM via a Vue :src binding (safe;
                    no markup injection). Workspace-path images come from an
@@ -258,16 +261,14 @@
                 </p>
               </div>
 
-              <!-- HTML content — sandboxed iframe so agent-supplied scripts run in
-                   an opaque origin and cannot reach parent localStorage / cookies /
-                   JWT. Deliberately omits allow-same-origin / allow-forms /
-                   allow-popups / allow-top-navigation / allow-modals. -->
-              <iframe
+              <!-- HTML content — DOMPurify-sanitized and rendered in-parent (H-005),
+                   same trust model as markdown. Scripts are stripped, so agent JS
+                   (e.g. chart.js) does NOT execute — static layout only. Replaces
+                   the prior srcdoc iframe, which the production CSP blocked (#979). -->
+              <div
                 v-else-if="displayedPanel.type === 'html'"
-                :srcdoc="htmlSrcdoc"
-                sandbox="allow-scripts"
-                class="w-full h-full bg-transparent border-0 block"
-                title="Agent panel"
+                v-html="sanitizedHtml"
+                class="agent-html-panel text-sm text-gray-300 max-w-none"
               />
             </div>
           </Transition>
@@ -287,15 +288,16 @@ import { useAgentsStore } from '../stores/agents'
 import { useVoiceSession } from '../composables/useVoiceSession'
 import { renderMarkdown } from '../utils/markdown'
 import AgentAvatar from '../components/AgentAvatar.vue'
-// Chart.js and Mermaid are loaded inside the sandboxed iframe (see
-// renderHtmlPanel / renderMermaidPanel). The relative path is intentional:
-// chart.js 4 doesn't expose the UMD bundle via its package `exports` field, and
-// mermaid's `exports['.']` only points at the ESM `mermaid.core.mjs`. Both ship
-// a self-contained IIFE bundle (chart.umd.js / mermaid.min.js) that assigns a
-// browser global; the relative path bypasses module resolution and Vite's `?url`
-// import emits each as a hashed same-origin asset.
-import chartJsUrl from '../../node_modules/chart.js/dist/chart.umd.js?url'
-import mermaidJsUrl from '../../node_modules/mermaid/dist/mermaid.min.js?url'
+// Mermaid renders in-parent (not in a sandboxed iframe): the production CSP
+// (script-src 'self') blocks inline scripts in a srcdoc iframe, and CORP blocks
+// the bundle from the iframe's opaque origin (#979). securityLevel:'strict'
+// disables interactivity/htmlLabels; the output SVG is DOMPurify-sanitized before
+// it touches the DOM (H-005). Imported as a normal ESM dep so it lands in this
+// route's chunk.
+import mermaid from 'mermaid'
+import DOMPurify from 'dompurify'
+
+mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: 'dark' })
 
 const route = useRoute()
 const authStore = useAuthStore()
@@ -423,80 +425,42 @@ function pushHistory(snap) {
   }
 }
 
-// ── Iframe panel rendering (HTML + Mermaid) ──────────────────────────────────
+// ── In-parent panel rendering (HTML + Mermaid) ───────────────────────────────
 
-// Agent-supplied markup renders inside a sandboxed iframe with an opaque origin
-// (sandbox="allow-scripts" without allow-same-origin): agent JS cannot read
-// parent localStorage / cookies / JWT, submit forms, navigate the parent, or
-// open popups. The iframe is driven by a reactive `:srcdoc` binding (computed
-// below) so it re-renders declaratively on update/navigation — no element ref or
-// nextTick, which keeps it safe when the content transition recreates the node.
-//
-// Tag delimiters are built via string concat (s_open / s_close) so the SFC
-// parser doesn't see them as nested block tags.
-const s_open = '<' + 's' + 'cript'
-const s_close = '<' + '/' + 's' + 'cript' + '>'
+// HTML panels render via DOMPurify (same trust model as markdown, H-005). Scripts
+// are stripped, so agent JS (chart.js) does not run — static layout only. This
+// replaces the prior srcdoc iframe, which the production CSP (script-src 'self')
+// + CORP blocked entirely (#979).
+const sanitizedHtml = computed(() =>
+  displayedPanel.value.type === 'html'
+    ? DOMPurify.sanitize(displayedPanel.value.content || '')
+    : ''
+)
 
-// Encode an arbitrary string as a JS string literal safe to embed in an inline
-// script. JSON.stringify handles quotes/backslashes/newlines; the extra
-// `<` → < replacement prevents a diagram containing a script close-tag from
-// terminating the script element early (the JS engine restores < to "<").
-// Load-bearing guard for the agent-supplied diagram text (review F4).
-function jsString(s) {
-  return JSON.stringify(s == null ? '' : String(s)).replace(/</g, '\\u003c')
+// Mermaid renders to an SVG string off-DOM (securityLevel:'strict' disables
+// interactivity + htmlLabels), then DOMPurify-sanitizes the SVG before v-html.
+// mermaid.render is async and the displayed snapshot can change while a render is
+// in flight (live update or history navigation), so a monotonic seq token drops
+// stale results. Invalid syntax surfaces a contained error + the source.
+const mermaidSvg = ref('')
+const mermaidError = ref('')
+let mermaidRenderSeq = 0
+
+async function renderMermaid(src) {
+  const seq = ++mermaidRenderSeq
+  mermaidError.value = ''
+  mermaidSvg.value = ''
+  if (!src) return
+  try {
+    const { svg } = await mermaid.render(`voice-mmd-${seq}`, String(src))
+    if (seq !== mermaidRenderSeq) return  // superseded by a newer snapshot
+    mermaidSvg.value = DOMPurify.sanitize(svg)
+  } catch (e) {
+    if (seq !== mermaidRenderSeq) return
+    mermaidSvg.value = ''
+    mermaidError.value = `Diagram error:\n${(e && e.message) ? e.message : String(e)}\n\n${src}`
+  }
 }
-
-// Chart.js is loaded inside the iframe via a same-origin asset URL so
-// new Chart(...) calls in agent HTML still work.
-const htmlSrcdoc = computed(() => {
-  if (displayedPanel.value.type !== 'html') return ''
-  const chartUrl = new URL(chartJsUrl, window.location.origin).href
-  return [
-    '<!DOCTYPE html><html><head><meta charset="utf-8"><style>',
-    'body{margin:0;padding:8px;color:#d1d5db;background:transparent;',
-    'font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}',
-    'canvas{max-width:100%}',
-    'table{border-collapse:collapse}th,td{padding:4px 8px}',
-    'a{color:#818cf8}',
-    '</style>',
-    s_open, ' src="', chartUrl, '">', s_close,
-    '</head><body>',
-    displayedPanel.value.content ?? '',
-    '</body></html>',
-  ].join('')
-})
-
-// Mermaid renders strictly inside the sandboxed iframe — agent diagram text never
-// touches the parent DOM. mermaid.min.js is a self-contained IIFE bundle (no
-// runtime chunk fetches) that exposes window.mermaid. Invalid syntax renders a
-// contained error + the source, not a broken panel.
-const mermaidSrcdoc = computed(() => {
-  if (displayedPanel.value.type !== 'mermaid') return ''
-  const mermaidUrl = new URL(mermaidJsUrl, window.location.origin).href
-  return [
-    '<!DOCTYPE html><html><head><meta charset="utf-8"><style>',
-    'body{margin:0;padding:12px;background:transparent;',
-    'font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}',
-    '#out svg{max-width:100%;height:auto}',
-    '#err{display:none;color:#fca5a5;white-space:pre-wrap;',
-    'font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}',
-    '</style></head><body>',
-    '<div id="out"></div><pre id="err"></pre>',
-    s_open, ' src="', mermaidUrl, '">', s_close,
-    s_open, '>',
-    'var SRC=', jsString(displayedPanel.value.content), ';',
-    'function fail(e){var p=document.getElementById("err");',
-    'p.style.display="block";p.textContent="Diagram error:\\n"+',
-    '((e&&e.message)?e.message:String(e))+"\\n\\n"+SRC;}',
-    'try{if(!window.mermaid){throw new Error("mermaid failed to load");}',
-    'window.mermaid.initialize({startOnLoad:false,securityLevel:"strict",theme:"dark"});',
-    'window.mermaid.render("d",SRC).then(function(r){',
-    'document.getElementById("out").innerHTML=r.svg;}).catch(fail);',
-    '}catch(e){fail(e);}',
-    s_close,
-    '</body></html>',
-  ].join('')
-})
 
 // Fetch a workspace-path image through the authenticated /files/preview endpoint
 // (reuses the store's blob helper) and bind the objectURL. Web-URL images bypass
@@ -523,13 +487,16 @@ async function loadImageBlob(path) {
   }
 }
 
-// Image is the only type needing async work on display: a workspace-path image
-// must be fetched as an authenticated blob. HTML/Mermaid render via :srcdoc.
+// Image and mermaid need work on display: a workspace-path image is fetched as an
+// authenticated blob; a mermaid diagram is rendered to SVG asynchronously. HTML
+// renders synchronously via the sanitizedHtml computed.
 watch(displayedPanel, (panel) => {
   if (panel.type === 'image') {
     imageError.value = false
     if (panel.image_kind === 'path') loadImageBlob(panel.content)
     else imageObjectUrl.value = null  // url-kind renders content directly
+  } else if (panel.type === 'mermaid') {
+    renderMermaid(panel.content)
   }
 }, { deep: true })
 
@@ -924,5 +891,26 @@ const statusLabel = computed(() => {
 }
 .canvas-fade-leave-to {
   opacity: 0;
+}
+
+/* v-html'd panel content (mermaid SVG + sanitized agent HTML) needs :deep() to be
+   reached by scoped styles. */
+.mermaid-host :deep(svg) {
+  max-width: 100%;
+  height: auto;
+}
+.agent-html-panel :deep(table) {
+  border-collapse: collapse;
+}
+.agent-html-panel :deep(th),
+.agent-html-panel :deep(td) {
+  padding: 4px 8px;
+}
+.agent-html-panel :deep(a) {
+  color: #818cf8;
+}
+.agent-html-panel :deep(img),
+.agent-html-panel :deep(canvas) {
+  max-width: 100%;
 }
 </style>

--- a/tests/unit/test_voice_tools.py
+++ b/tests/unit/test_voice_tools.py
@@ -209,7 +209,9 @@ class TestExecuteTool:
     def test_success_real(self, svc):
         """Test _execute_tool with a mocked get_agent_client."""
         mock_response = MagicMock()
-        mock_response.response = "Task result text."
+        # AgentChatResponse exposes `.response_text`, not `.response` — guards the
+        # #979 regression where _execute_tool read the wrong attribute.
+        mock_response.response_text = "Task result text."
         mock_client = MagicMock()
         mock_client.task = AsyncMock(return_value=mock_response)
 
@@ -244,7 +246,7 @@ class TestExecuteTool:
     def test_prompt_truncated_to_max(self, svc):
         """Prompts longer than _TOOL_PROMPT_MAX are truncated before forwarding."""
         mock_response = MagicMock()
-        mock_response.response = "ok"
+        mock_response.response_text = "ok"
         mock_client = MagicMock()
         mock_client.task = AsyncMock(return_value=mock_response)
 


### PR DESCRIPTION
## Problem
The Voice Workspace canvas (#981) was **blank in production** — mermaid diagrams and HTML panels never rendered, despite the agent reporting it drew them.

**Root cause (not the DevOps `.response` finding):** the panels rendered inside a `sandbox="allow-scripts"` `srcdoc` iframe. Under the production CSP (`security-headers.conf`):
- a `srcdoc` iframe **inherits** the parent's `script-src 'self'` → the inline render script is blocked (`about:srcdoc: Executing inline script violates 'script-src 'self''`);
- the iframe's **opaque origin** + `Cross-Origin-Resource-Policy: same-origin` blocks the `mermaid.min.js` fetch (`ERR_BLOCKED_BY_RESPONSE.NotSameOrigin`).

Worked in dev only because the dev CSP (`vite.config.js`) allows `'unsafe-inline'`.

## Fix
- **Mermaid** renders **in-parent** via the bundled `mermaid` lib (`securityLevel:'strict'`) with **DOMPurify** on the output SVG (H-005). No iframe, no CSP/CORP dependency.
- **HTML (`update_panel`)** renders **DOMPurify-sanitized** in-parent (same trust model as markdown). Accepted tradeoff: agent JS (chart.js) no longer executes — static layout only. Voice instructions updated to steer charts to `show_diagram`/`show_image`.
- **Unrelated voice `run_task` bug:** `AgentChatResponse` exposes `.response_text`, not `.response` (`_execute_tool`). The tests encoded the same wrong attribute — moved to `.response_text` so they now guard the regression.
- **Config:** wired `VOICE_ENABLED` / `WORKSPACE_ENABLED` into the backend compose `environment:` — `WORKSPACE_ENABLED` was never passed through, so the canvas couldn't be enabled via `.env`.

## Verification
- `tests/unit/test_voice_tools.py`: **58/58 pass**.
- Deployed locally: `voice_available: true`, `workspace_available: true`; mermaid renders in the canvas end-to-end.

## Notes / follow-ups
- The page-level `blob:` script CSP warning (voice audio worklet) is **separate** and non-fatal (voice works) — worth a follow-up.
- `chart.js` is now an orphaned dep in `src/frontend/package.json` — optional cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)