### PR TITLE
fix(git): increase push subprocess timeout from 60s to 300s (#989)

### DIFF
--- a/docker/base-image/agent_server/routers/git.py
+++ b/docker/base-image/agent_server/routers/git.py
@@ -178,7 +178,7 @@ def _run_auto_sync_once(home_dir: Path) -> Dict:
 
         push = subprocess.run(
             ["git", "push", "origin", "HEAD"],
-            cwd=str(home_dir), capture_output=True, text=True, timeout=60,
+            cwd=str(home_dir), capture_output=True, text=True, timeout=300,
         )
         if push.returncode != 0:
             err = _summarize_git_error(push.stderr or push.stdout or "push failed")
@@ -765,7 +765,7 @@ async def sync_to_github(request: GitSyncRequest):
                 capture_output=True,
                 text=True,
                 cwd=str(home_dir),
-                timeout=60,
+                timeout=300,
             )
             if push_result.returncode != 0:
                 stderr = push_result.stderr or ""
@@ -796,7 +796,7 @@ async def sync_to_github(request: GitSyncRequest):
                 capture_output=True,
                 text=True,
                 cwd=str(home_dir),
-                timeout=60
+                timeout=300
             )
 
             if push_result.returncode != 0:
@@ -808,7 +808,7 @@ async def sync_to_github(request: GitSyncRequest):
                         capture_output=True,
                         text=True,
                         cwd=str(home_dir),
-                        timeout=60
+                        timeout=300
                     )
                     if upstream_result.returncode != 0:
                         raise HTTPException(

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -505,7 +505,7 @@ async def sync_to_github(
 
     try:
         # Call the agent's internal sync endpoint
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        async with httpx.AsyncClient(timeout=360.0) as client:
             payload = {"strategy": strategy}
             if message:
                 payload["message"] = message


### PR DESCRIPTION
## Summary

- Fixes #989 — Push button shows error but changes are already pushed to GitHub
- Root cause: `git push` subprocess had a 60-second timeout in the agent server; for large repos (100–300 files) or slow networks the push takes longer, Python kills the process via SIGKILL at 60s, but pack objects are already on GitHub — so the frontend shows a false error while the push actually succeeded
- Increases all `git push` subprocess timeouts: **60s → 300s** (agent server)
- Increases backend httpx timeout to agent: **120s → 360s** (must exceed the push timeout so the backend doesn't time out before the agent finishes)

## Affected locations

| File | Change |
|------|--------|
| `docker/base-image/agent_server/routers/git.py` | 4 `git push` subprocess calls: 60s → 300s |
| `src/backend/services/git_service.py` | httpx client timeout: 120s → 360s |

## Test plan

- [ ] Push an agent with 100+ files — no spurious timeout error shown
- [ ] Normal small push still works
- [ ] Force-push strategy works on large repos
- [ ] Auto-sync heartbeat (every 15 min) no longer fails on large repos with slow networks
- [ ] Verify timeout error (504) is still raised correctly if push genuinely takes >5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)