### PR TITLE
feat(ui): Guardrails tab on Agent Detail (#967)

### DIFF
--- a/src/frontend/src/components/GuardrailsPanel.vue
+++ b/src/frontend/src/components/GuardrailsPanel.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="p-6">
+    <div class="mb-6">
+      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Guardrails</h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Per-agent execution caps. Leave a field blank to inherit the platform default.
+        Changes require an agent restart to take effect.
+      </p>
+
+      <!-- Loading State -->
+      <div v-if="loading" class="text-center py-4">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Loading guardrails...</p>
+      </div>
+
+      <form v-else @submit.prevent="save" class="space-y-5 max-w-md">
+        <div>
+          <label for="gr-max-turns-chat" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Max turns (chat)
+          </label>
+          <input
+            id="gr-max-turns-chat"
+            v-model.number="maxTurnsChat"
+            type="number"
+            :min="MIN_TURNS"
+            :max="MAX_TURNS"
+            :placeholder="`${DEFAULT_TURNS} (default)`"
+            :disabled="saving"
+            class="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-action-primary-500 focus:border-action-primary-500 disabled:opacity-50"
+          />
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Maximum Claude turns per interactive chat message ({{ MIN_TURNS }}–{{ MAX_TURNS }}).
+          </p>
+        </div>
+
+        <div>
+          <label for="gr-max-turns-task" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Max turns (task)
+          </label>
+          <input
+            id="gr-max-turns-task"
+            v-model.number="maxTurnsTask"
+            type="number"
+            :min="MIN_TURNS"
+            :max="MAX_TURNS"
+            :placeholder="`${DEFAULT_TURNS} (default)`"
+            :disabled="saving"
+            class="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-action-primary-500 focus:border-action-primary-500 disabled:opacity-50"
+          />
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Maximum Claude turns per scheduled/cron task ({{ MIN_TURNS }}–{{ MAX_TURNS }}). Raise this for long-running jobs.
+          </p>
+        </div>
+
+        <p v-if="errorMessage" class="text-sm text-status-danger-600 dark:text-status-danger-400">
+          {{ errorMessage }}
+        </p>
+
+        <div class="flex items-center space-x-3">
+          <button
+            type="submit"
+            :disabled="saving"
+            class="px-4 py-2 text-sm font-medium rounded-lg bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-50"
+          >
+            {{ saving ? 'Saving...' : 'Save' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import { useAgentsStore } from '../stores/agents'
+
+const props = defineProps({
+  agentName: {
+    type: String,
+    required: true
+  },
+  // Toast callback from the parent view (matches Read-Only / Resource limit pattern)
+  notify: {
+    type: Function,
+    default: null
+  }
+})
+
+const MIN_TURNS = 1
+const MAX_TURNS = 500
+const DEFAULT_TURNS = 50
+
+const agentsStore = useAgentsStore()
+
+const loading = ref(false)
+const saving = ref(false)
+const errorMessage = ref('')
+const maxTurnsChat = ref(null)
+const maxTurnsTask = ref(null)
+// Preserve out-of-scope overrides (execution_timeout_sec, *_deny lists) set via API
+const otherKeys = ref({})
+
+function showToast(message, type = 'success') {
+  if (props.notify) props.notify(message, type)
+}
+
+async function load() {
+  if (!props.agentName) return
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const result = await agentsStore.getGuardrails(props.agentName)
+    const g = result?.guardrails || {}
+    maxTurnsChat.value = g.max_turns_chat ?? null
+    maxTurnsTask.value = g.max_turns_task ?? null
+    const { max_turns_chat, max_turns_task, ...rest } = g
+    otherKeys.value = rest
+  } catch (err) {
+    console.error('Failed to load guardrails:', err)
+    errorMessage.value = err.response?.data?.detail || 'Failed to load guardrails'
+  } finally {
+    loading.value = false
+  }
+}
+
+function validateField(value, label) {
+  if (value === null || value === '' || value === undefined) return null
+  if (!Number.isInteger(value) || value < MIN_TURNS || value > MAX_TURNS) {
+    throw new Error(`${label} must be a whole number between ${MIN_TURNS} and ${MAX_TURNS}`)
+  }
+  return value
+}
+
+async function save() {
+  if (saving.value) return
+  errorMessage.value = ''
+
+  let chat, task
+  try {
+    chat = validateField(maxTurnsChat.value, 'Max turns (chat)')
+    task = validateField(maxTurnsTask.value, 'Max turns (task)')
+  } catch (err) {
+    errorMessage.value = err.message
+    return
+  }
+
+  // Merge managed keys over preserved out-of-scope overrides. A blank field
+  // clears that key (inherit platform default).
+  const payload = { ...otherKeys.value }
+  if (chat !== null) payload.max_turns_chat = chat
+  else delete payload.max_turns_chat
+  if (task !== null) payload.max_turns_task = task
+  else delete payload.max_turns_task
+
+  saving.value = true
+  try {
+    await agentsStore.setGuardrails(props.agentName, payload)
+    showToast('Guardrails saved — restart agent to apply', 'success')
+    await load()
+  } catch (err) {
+    const detail = err.response?.data?.detail || 'Failed to save guardrails'
+    errorMessage.value = detail
+    showToast(detail, 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+watch(() => props.agentName, load)
+</script>

--- a/src/frontend/src/stores/agents.js
+++ b/src/frontend/src/stores/agents.js
@@ -764,6 +764,23 @@ export const useAgentsStore = defineStore('agents', {
         headers: authStore.authHeader
       })
       return response.data
+    },
+
+    // Guardrails (GUARD-001 — per-agent max_turns overrides)
+    async getGuardrails(name) {
+      const authStore = useAuthStore()
+      const response = await axios.get(`/api/agents/${name}/guardrails`, {
+        headers: authStore.authHeader
+      })
+      return response.data
+    },
+
+    async setGuardrails(name, guardrails) {
+      const authStore = useAuthStore()
+      const response = await axios.put(`/api/agents/${name}/guardrails`, guardrails, {
+        headers: authStore.authHeader
+      })
+      return response.data
     }
   }
 })

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -190,6 +190,11 @@
               <FoldersPanel :agent-name="agent.name" :agent-status="agent.status" :can-share="agent.can_share" />
             </div>
 
+            <!-- Guardrails Tab Content (GUARD-001 UI, #967) -->
+            <div v-if="activeTab === 'guardrails' && agent.can_share">
+              <GuardrailsPanel :agent-name="agent.name" :notify="showNotification" />
+            </div>
+
           </div>
         </div>
       </div>
@@ -264,6 +269,7 @@ import GitPanel from '../components/GitPanel.vue'
 import InfoPanel from '../components/InfoPanel.vue'
 import DashboardPanel from '../components/DashboardPanel.vue'
 import FoldersPanel from '../components/FoldersPanel.vue'
+import GuardrailsPanel from '../components/GuardrailsPanel.vue'
 
 // Panel Components (newly extracted)
 import AgentHeader from '../components/AgentHeader.vue'
@@ -626,6 +632,11 @@ const visibleTabs = computed(() => {
   // Folders - hide for system agent
   if (agent.value?.can_share && !isSystem) {
     tabs.push({ id: 'folders', label: 'Folders' })
+  }
+
+  // Guardrails - owner-only (GUARD-001 UI, #967)
+  if (agent.value?.can_share && !isSystem) {
+    tabs.push({ id: 'guardrails', label: 'Guardrails' })
   }
 
   // Info at the end (reference/metadata)


### PR DESCRIPTION
## Summary

Adds the missing UI for GUARD-001 per-agent guardrails (#967). The backend endpoint (`GET`/`PUT /api/agents/{name}/guardrails`) shipped without a frontend, so owners could only set `max_turns_chat` / `max_turns_task` via curl, `/docs`, or MCP. This adds an owner-only **Guardrails** tab to `AgentDetail.vue`.

## Changes

- **`stores/agents.js`** — `getGuardrails(name)` / `setGuardrails(name, guardrails)` actions (mirror the resource-limits pattern).
- **`components/GuardrailsPanel.vue`** (new) — owner-only form:
  - `max_turns_chat`, `max_turns_task` number inputs, range 1–500
  - blank field = inherit platform default (placeholder `50 (default)`)
  - Save → toast `"Guardrails saved — restart agent to apply"`, matching the Read-Only / Resource-limit restart pattern
  - light + dark themes; `p-6` root wrapper (participates in the #954 panel-width stability set)
  - preserves out-of-scope override keys (`execution_timeout_sec`, `*_deny` lists) so the whole-config PUT doesn't wipe values set via API
- **`views/AgentDetail.vue`** — import, owner-gated tab (`can_share && !is_system`) + content block.

## Acceptance criteria

- [x] New Guardrails tab, owner-only (hidden for non-owners)
- [x] Form bound to `GET`/`PUT /api/agents/{name}/guardrails`
- [x] `max_turns_chat` / `max_turns_task` (1–500), defaults shown as placeholder when unset
- [x] Save triggers "container restart required" toast (matches Read-Only / Resource pattern)
- [x] Light + dark themes
- [x] No regression to the #954 panel-width-stability fix (reuses `p-6` wrapper)

## Out of scope (per issue)

- New guardrail keys (only the existing two wired)
- Platform-default-guardrails admin screen

## Verification

- Both SFCs parse clean; `vite build` transforms all modules without error.
- Stack started locally; tab renders and saves against the live endpoint.

Related to #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)
