### PR TITLE
fix(version): derive /api/version from git, fix 'unknown' on prod/dev (#993)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -117,19 +117,29 @@ jobs:
             fi
 
             echo "=== Build ==="
-            # Build-time provenance (#926 / #958). docker-compose.prod.yml
+            # Build-time provenance (#926 / #958 / #993). docker-compose.prod.yml
             # backend.build.args reads these env vars; absent them, the
             # Dockerfile defaults to "unknown" and Build Info in the UI
             # shows a wall of unknown values. Mirrors scripts/deploy/start.sh.
-            # Inline VAR=val form bypasses sudo's default env_reset — `sudo -E`
-            # would depend on env_keep being permissive in sudoers, which it
-            # is not by default on Ubuntu.
+            #
+            # #993: pass via `sudo env VAR=val …` — NOT `sudo VAR=val …`.
+            # Under default Ubuntu sudoers (env_reset on, setenv off), env
+            # assignments placed before the command are filtered out, so the
+            # prior form silently dropped every var and compose fell back to
+            # ${VAR:-unknown}. `env` is the program sudo execs, so the
+            # assignments are its arguments and reach docker compose intact.
             GIT_COMMIT=$(git rev-parse HEAD)
             GIT_COMMIT_SUBJECT=$(git log -1 --pretty=%s)
             GIT_COMMIT_TIMESTAMP=$(git log -1 --pretty=%cI)
             GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
             BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-            sudo \
+            # #993: dynamic version = VERSION file + git short sha (+ .dirty).
+            BASE_VER=$(cat VERSION 2>/dev/null || echo unknown)
+            SHORT_SHA=$(git rev-parse --short=8 HEAD)
+            git diff --quiet HEAD 2>/dev/null || SHORT_SHA="${SHORT_SHA}.dirty"
+            VERSION="${BASE_VER}+g${SHORT_SHA}"
+            sudo env \
+              VERSION="${VERSION}" \
               GIT_COMMIT="${GIT_COMMIT}" \
               GIT_COMMIT_SUBJECT="${GIT_COMMIT_SUBJECT}" \
               GIT_COMMIT_TIMESTAMP="${GIT_COMMIT_TIMESTAMP}" \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,6 +20,7 @@ services:
       # exports these from the checked-out repo before `docker compose
       # build`; absent that, the Dockerfile defaults to "unknown".
       args:
+        VERSION: ${VERSION:-unknown}
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
         GIT_COMMIT_SUBJECT: ${GIT_COMMIT_SUBJECT:-unknown}
         GIT_COMMIT_TIMESTAMP: ${GIT_COMMIT_TIMESTAMP:-unknown}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       # Unset = Dockerfile defaults to "unknown" so an out-of-band build still
       # produces a well-typed /api/version response.
       args:
+        VERSION: ${VERSION:-unknown}
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
         GIT_COMMIT_SUBJECT: ${GIT_COMMIT_SUBJECT:-unknown}
         GIT_COMMIT_TIMESTAMP: ${GIT_COMMIT_TIMESTAMP:-unknown}

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,12 +11,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl git libmag
 # and `GET /api/version` can return commit/branch/build-date for the
 # image actually in flight. Defaults to "unknown" so local builds and
 # operators who skip start.sh still get a well-typed response.
+ARG VERSION=unknown
 ARG GIT_COMMIT=unknown
 ARG GIT_COMMIT_SUBJECT=unknown
 ARG GIT_COMMIT_TIMESTAMP=unknown
 ARG GIT_BRANCH=unknown
 ARG BUILD_DATE=unknown
-ENV GIT_COMMIT=${GIT_COMMIT} \
+ENV VERSION=${VERSION} \
+    GIT_COMMIT=${GIT_COMMIT} \
     GIT_COMMIT_SUBJECT=${GIT_COMMIT_SUBJECT} \
     GIT_COMMIT_TIMESTAMP=${GIT_COMMIT_TIMESTAMP} \
     GIT_BRANCH=${GIT_BRANCH} \

--- a/scripts/deploy/start.sh
+++ b/scripts/deploy/start.sh
@@ -177,6 +177,13 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     export GIT_COMMIT_SUBJECT=$(git log -1 --pretty=%s)
     export GIT_COMMIT_TIMESTAMP=$(git log -1 --pretty=%cI)
     export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    # #993: dynamic version = curated semver (VERSION file) + git short sha
+    # (+ ".dirty" when the tree has uncommitted changes), e.g.
+    # "0.9.0+g4c640b6e". Env-stamped so dev and prod agree per commit.
+    _base_ver=$(cat VERSION 2>/dev/null || echo unknown)
+    _short_sha=$(git rev-parse --short=8 HEAD)
+    git diff --quiet HEAD 2>/dev/null || _short_sha="${_short_sha}.dirty"
+    export VERSION="${_base_ver}+g${_short_sha}"
 fi
 export BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1066,16 +1066,24 @@ def _build_version_payload(voice_enabled: bool) -> dict:
     import os
     from pathlib import Path
 
-    # Read version from VERSION file (check multiple locations)
-    version = "unknown"
-    version_paths = [
-        Path("/app/VERSION"),  # In container (mounted)
-        Path(__file__).parent.parent.parent / "VERSION",  # Development
-    ]
-    for version_file in version_paths:
-        if version_file.exists():
-            version = version_file.read_text().strip()
-            break
+    # Version resolution order (#993):
+    #   1. VERSION env var — build-stamped from git (e.g. "0.9.0+g4c640b6e"),
+    #      wired through docker-compose backend.build.args + start.sh.
+    #   2. VERSION file — curated semver, mounted in dev / copied in image.
+    #   3. "unknown" — neither present.
+    # Env-first means dev (bind-mount) and prod (build-arg) agree for the
+    # same commit instead of diverging on the file-mount being absent.
+    version = os.getenv("VERSION") or None
+    if not version:
+        version_paths = [
+            Path("/app/VERSION"),  # In container (mounted)
+            Path(__file__).parent.parent.parent / "VERSION",  # Development
+        ]
+        for version_file in version_paths:
+            if version_file.exists():
+                version = version_file.read_text().strip()
+                break
+    version = version or "unknown"
 
     git_commit = os.getenv("GIT_COMMIT", "unknown")
     git_commit_short = git_commit[:8] if git_commit != "unknown" else "unknown"

--- a/tests/unit/test_926_version_endpoint.py
+++ b/tests/unit/test_926_version_endpoint.py
@@ -92,6 +92,34 @@ def test_version_payload_falls_back_to_unknown_when_env_missing(monkeypatch):
     assert payload["build_date"] == "unknown"
 
 
+def test_version_payload_prefers_version_env(monkeypatch):
+    """#993 — the build-stamped VERSION env var (e.g. `0.9.0+g4c640b6e`)
+    takes precedence over the VERSION file so dev (bind-mount) and prod
+    (build-arg) agree for the same commit."""
+    monkeypatch.setenv("VERSION", "0.9.0+gdeadbeef")
+
+    build = _load_builder()
+    payload = build(voice_enabled=False)
+
+    assert payload["version"] == "0.9.0+gdeadbeef"
+    # Version flows into the component descriptors too.
+    assert payload["components"]["backend"] == "0.9.0+gdeadbeef"
+    assert payload["components"]["base_image"] == "trinity-agent-base:0.9.0+gdeadbeef"
+
+
+def test_version_payload_empty_version_env_falls_back_to_file(monkeypatch):
+    """An empty VERSION env var must not shadow the file fallback —
+    `os.getenv("VERSION") or None` treats "" as unset (#993)."""
+    monkeypatch.setenv("VERSION", "")
+
+    build = _load_builder()
+    payload = build(voice_enabled=False)
+
+    # Repo VERSION file is read via the injected __file__ path.
+    assert payload["version"] != ""
+    assert payload["version"] != "unknown"  # file present in repo
+
+
 def test_version_payload_preserves_existing_fields(monkeypatch):
     """Pre-#926 keys (version, platform, components, runtimes, voice_enabled)
     must still be present so existing callers don't break."""


### PR DESCRIPTION
## Summary

`GET /api/version` showed `version: "unknown"` (and `unknown` git fields) on the dev instance / any prod-compose deploy. Two independent build-path bugs, fixed here, plus making the version string self-describing from git.

Closes the gap reported on dev. Related to #993.

## Root causes

1. **`version` field** — the `VERSION` file never reached the prod image. The backend Dockerfile doesn't `COPY` it; only `docker-compose.yml` (dev) bind-mounts `./VERSION:/app/VERSION`, which masked the bug locally. `docker-compose.prod.yml` has no mount, so the `__file__` fallback resolves to `/VERSION` (nonexistent) → `"unknown"`.
2. **Git provenance** (`git_commit`/`git_branch`/`build_date`) — `deploy-dev.yml` passed them as `sudo VAR=val docker compose build`. Default Ubuntu sudoers (`env_reset` on, `setenv` off) strips command-line env assignments, so compose fell back to `${VAR:-unknown}`. (`scripts/deploy/start.sh` worked because it runs compose without sudo.)

## Approach — Option B: curated semver + git suffix

Version string = `VERSION` file + git short-sha (+ `.dirty`), e.g. `0.9.0+g4c640b6e`. Chosen over pure `git describe` because the last platform tag (`v0.5.0`) lags the curated file (`0.9.0`) and `cli-v*` tags pollute `describe` — it would regress the displayed version. `git_commit_short` still carries the bare commit separately.

## Changes

- `docker/backend/Dockerfile` — `VERSION` `ARG`/`ENV` in the provenance block.
- `docker-compose.yml` + `docker-compose.prod.yml` — `VERSION` in `backend.build.args`.
- `src/backend/main.py` `_build_version_payload` — env-first (`os.getenv("VERSION")`), then file, then `"unknown"`. Makes dev and prod agree per commit.
- `scripts/deploy/start.sh` — compute & export `VERSION`.
- `.github/workflows/deploy-dev.yml` — compute `VERSION`; switch build to `sudo env VAR=val … docker compose build` so VERSION **and** the existing git fields reach the build.
- `tests/unit/test_926_version_endpoint.py` — env-first precedence + empty-env file fallback.

## Verification

- `pytest tests/unit/test_926_version_endpoint.py` → **5 passed** (3 existing + 2 new).
- Compose interpolation confirmed (`docker compose config` shows `VERSION`), all YAML parses.
- **End-to-end on a rebuilt backend image**: `/api/version` returns `version: "0.9.0+gverify"`, with `git_branch`/`git_commit_short`/`build_date` populated (no `unknown`).

## Acceptance criteria

- [x] Prod-compose deploy returns a real `version` (`0.9.0+g<sha>`), not `unknown`
- [x] `git_commit` / `git_branch` / `build_date` populated on the dev deploy
- [x] Dev and prod report the same `version` for the same commit
- [x] No reliance on the `/app/VERSION` bind-mount for correctness

## Out of scope

- Build-in-CI + registry (stateless dev VM) — #942
- `git describe` / release-tagging discipline (Option A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
