### PR TITLE
feat(agent-runtime): richer /health signal — active_tasks, last_task_at, consecutive_failures (#1020)

### DIFF
--- a/docker/base-image/agent_server/routers/chat.py
+++ b/docker/base-image/agent_server/routers/chat.py
@@ -42,14 +42,22 @@ async def chat(request: ChatRequest):
         runtime = get_runtime()
         # Use request.model if provided, otherwise use the model set via /api/model endpoint
         effective_model = request.model or agent_state.current_model
-        response_text, execution_log, metadata, raw_messages = await runtime.execute(
-            prompt=request.message,
-            model=effective_model,
-            continue_session=True,
-            stream=request.stream,
-            system_prompt=request.system_prompt,
-            execution_id=request.execution_id
-        )
+        # #1020: feed the richer /health signal — count this execution and
+        # record success/failure (drives consecutive_failures).
+        agent_state.record_task_start()
+        try:
+            response_text, execution_log, metadata, raw_messages = await runtime.execute(
+                prompt=request.message,
+                model=effective_model,
+                continue_session=True,
+                stream=request.stream,
+                system_prompt=request.system_prompt,
+                execution_id=request.execution_id
+            )
+        except BaseException:
+            agent_state.record_task_finish(success=False)
+            raise
+        agent_state.record_task_finish(success=True)
 
         # Add assistant response to history
         agent_state.add_message("assistant", response_text)
@@ -120,18 +128,26 @@ async def execute_task(request: ParallelTaskRequest):
 
     # Execute via runtime adapter in headless mode (no lock, no --continue)
     runtime = get_runtime()
-    response_text, raw_messages, metadata, session_id = await runtime.execute_headless(
-        prompt=request.message,
-        model=request.model,
-        allowed_tools=request.allowed_tools,
-        system_prompt=request.system_prompt,
-        timeout_seconds=request.timeout_seconds or 900,  # Default 15 minutes for research tasks
-        max_turns=request.max_turns,
-        execution_id=request.execution_id,  # Use provided ID for process registry (enables termination)
-        resume_session_id=request.resume_session_id,  # Resume previous session (EXEC-023)
-        persist_session=bool(request.persist_session),  # Session tab: write JSONL for future --resume
-        images=request.images,  # Vision images from channel adapters (#562)
-    )
+    # #1020: feed the richer /health signal — count this execution and record
+    # success/failure (drives consecutive_failures, consumed by #526).
+    agent_state.record_task_start()
+    try:
+        response_text, raw_messages, metadata, session_id = await runtime.execute_headless(
+            prompt=request.message,
+            model=request.model,
+            allowed_tools=request.allowed_tools,
+            system_prompt=request.system_prompt,
+            timeout_seconds=request.timeout_seconds or 900,  # Default 15 minutes for research tasks
+            max_turns=request.max_turns,
+            execution_id=request.execution_id,  # Use provided ID for process registry (enables termination)
+            resume_session_id=request.resume_session_id,  # Resume previous session (EXEC-023)
+            persist_session=bool(request.persist_session),  # Session tab: write JSONL for future --resume
+            images=request.images,  # Vision images from channel adapters (#562)
+        )
+    except BaseException:
+        agent_state.record_task_finish(success=False)
+        raise
+    agent_state.record_task_finish(success=True)
 
     logger.info(f"[Task] Task {session_id} completed successfully")
 

--- a/docker/base-image/agent_server/routers/info.py
+++ b/docker/base-image/agent_server/routers/info.py
@@ -111,6 +111,14 @@ async def health_check():
         # Backward compatibility
         "claude_available": agent_state.claude_code_available,
         "message_count": len(agent_state.conversation_history),
+        # #1020: richer health signal (target-arch §Agent Runtime). Named,
+        # contractual fields the platform consumes for the dispatch circuit
+        # breaker (#526) and fleet-health scoring (#307). `mailbox_depth` is
+        # intentionally absent — there is no agent-side mailbox yet (actor
+        # model, #945); the backend derives queue depth from CapacityManager.
+        "active_tasks": agent_state.active_task_count,
+        "last_task_at": agent_state.last_task_at,
+        "consecutive_failures": agent_state.consecutive_failures,
         "diagnostics": _diagnostics(),
     }
 

--- a/docker/base-image/agent_server/state.py
+++ b/docker/base-image/agent_server/state.py
@@ -4,8 +4,9 @@ Agent state management for the agent server.
 import os
 import subprocess
 import logging
+import threading
 from typing import List, Dict, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .models import ChatMessage
 
@@ -57,6 +58,36 @@ class AgentState:
         self.session_activity = self._create_empty_activity()
         # Store full tool outputs for drill-down (separate from timeline summaries)
         self.tool_outputs: Dict[str, str] = {}
+
+        # Richer /health signal (#1020). Tracked across both execution paths
+        # (/api/chat and /api/task) so the platform gets a real health gauge,
+        # not just {status: ok}. Guarded by a lock because tasks run
+        # concurrently. `mailbox_depth` is intentionally NOT tracked here —
+        # there is no agent-side mailbox until the actor model lands (#945);
+        # the backend derives queue depth from CapacityManager.
+        self._health_lock = threading.Lock()
+        self.active_task_count: int = 0
+        self.last_task_at: Optional[str] = None
+        self.consecutive_failures: int = 0
+
+    def record_task_start(self) -> None:
+        """Mark an execution as started (either chat or headless task)."""
+        with self._health_lock:
+            self.active_task_count += 1
+            self.last_task_at = datetime.now(timezone.utc).isoformat()
+
+    def record_task_finish(self, success: bool) -> None:
+        """Mark an execution as finished. Resets the consecutive-failure
+        counter on success, increments it on failure — this is the signal the
+        dispatch circuit breaker (#526) consumes."""
+        with self._health_lock:
+            if self.active_task_count > 0:
+                self.active_task_count -= 1
+            self.last_task_at = datetime.now(timezone.utc).isoformat()
+            if success:
+                self.consecutive_failures = 0
+            else:
+                self.consecutive_failures += 1
 
     def _get_default_context_window(self) -> int:
         """Get default context window based on runtime"""

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -362,7 +362,7 @@ docker exec trinity-vector sh -c "tail -50 /data/logs/agents.json" | jq .
 **Internal Server:** `agent-server.py`
 - FastAPI app on port 8000
 - `/api/chat` - Claude Code execution (messages persisted to database)
-- `/health` - Health check
+- `/health` - Health check. Beyond `{status}`, returns a richer signal (#1020): `active_tasks` (concurrent executions across `/api/chat` + `/api/task`), `last_task_at` (ISO), `consecutive_failures` (reset on success, incremented on failure — consumed by the dispatch circuit breaker #526 and fleet-health #307), plus the #333 `diagnostics` gauges. `mailbox_depth` is intentionally NOT emitted — there is no agent-side mailbox until the actor model (#945); the backend derives queue depth from `CapacityManager`. Counters live in `agent_server/state.py` (`record_task_start`/`record_task_finish`); the backend reads `consecutive_failures`/`last_task_at` in `monitoring_service.py` (graceful default for pre-#1020 agent images).
 - `/api/credentials/update` - Hot-reload credentials
 - `/api/chat/session` - Context window stats
 - `/api/files` - List workspace files (recursive tree structure)

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -700,6 +700,18 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
 - **Status Levels**: healthy → degraded → unhealthy → critical → unknown
 - **Flow**: `docs/memory/feature-flows/agent-monitoring.md`
 
+### 12.8a Richer Agent `/health` Signal (#1020)
+- **Status**: ✅ Implemented (2026-06-02)
+- **GitHub Issue**: #1020
+- **Description**: Promote the agent container's `/health` from `{status}` + ad-hoc diagnostics to a named, contractual signal the platform acts on — an incremental step toward `TARGET_ARCHITECTURE.md` §Agent Runtime.
+- **Key Features**:
+  - New top-level fields: `active_tasks` (concurrent executions across `/api/chat` + `/api/task`), `last_task_at` (ISO), `consecutive_failures` (reset on success, incremented on failure).
+  - Counters tracked in `agent_server/state.py` (`record_task_start`/`record_task_finish`), wired at both execution chokepoints in `agent_server/routers/chat.py`. Thread-safe (concurrent tasks).
+  - `consecutive_failures` is the signal the dispatch circuit breaker (#526) consumes; `last_task_at` powers liveness; both feed the heartbeat push (#307).
+  - Backend `monitoring_service.py` reads `consecutive_failures`/`last_task_at` into `BusinessHealthCheck` (graceful `None` default for pre-#1020 agent images).
+  - `mailbox_depth` intentionally NOT emitted — no agent-side mailbox until the actor model (#945); backend derives queue depth from `CapacityManager`.
+  - Back-compat: existing `/health` keys unchanged; new keys additive.
+
 ### 12.9 Cleanup Service for Stuck Resources
 - **Status**: ✅ Implemented (Updated 2026-03-25, Issue #129)
 - **Requirement ID**: CLEANUP-001

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -846,6 +846,11 @@ class BusinessHealthCheck(BaseModel):
     stuck_execution_count: int = 0
     recent_error_rate: float = 0.0  # 0.0 - 1.0
     credential_status: Optional[str] = None  # null, "ok", "missing" (SUB-001/MON-001)
+    # #1020: richer /health signal. None when the agent image predates #1020
+    # (older agents omit these keys). `consecutive_failures` is the signal the
+    # dispatch circuit breaker (#526) consumes; `last_task_at` powers liveness.
+    consecutive_failures: Optional[int] = None
+    last_task_at: Optional[str] = None
     checked_at: str
 
 

--- a/src/backend/services/monitoring_service.py
+++ b/src/backend/services/monitoring_service.py
@@ -405,6 +405,8 @@ async def check_business_health(
     active_execution_count = 0
     stuck_execution_count = 0
     recent_error_rate = 0.0
+    consecutive_failures = None  # #1020: None when agent image predates the field
+    last_task_at = None
 
     # Check /health endpoint for runtime status
     try:
@@ -414,6 +416,11 @@ async def check_business_health(
                 health_data = health_response.json()
                 runtime_available = health_data.get("runtime_available", True)
                 claude_available = health_data.get("claude_available", True)
+                # #1020: richer /health signal — graceful when keys are absent
+                # (older agent images). Used for fleet-health + the dispatch
+                # circuit breaker (#526).
+                consecutive_failures = health_data.get("consecutive_failures")
+                last_task_at = health_data.get("last_task_at")
     except Exception:
         pass  # Will be marked as degraded/unhealthy by aggregation
 
@@ -476,6 +483,8 @@ async def check_business_health(
         stuck_execution_count=stuck_execution_count,
         recent_error_rate=recent_error_rate,
         credential_status=None,
+        consecutive_failures=consecutive_failures,  # #1020
+        last_task_at=last_task_at,  # #1020
         checked_at=now
     )
 

--- a/tests/test_agent_health_signal.py
+++ b/tests/test_agent_health_signal.py
@@ -1,0 +1,107 @@
+"""
+Agent /health richer-signal unit tests (#1020).
+
+Covers the AgentState health counters that back the richer `/health` response:
+`active_task_count`, `last_task_at`, `consecutive_failures` — the named fields
+the platform consumes for the dispatch circuit breaker (#526) and fleet-health
+scoring (#307).
+
+Pure-logic test: it imports `agent_server.state` from `docker/base-image`,
+constructs an AgentState via `__new__` (bypassing the runtime-availability
+subprocess probe in `__init__`), and drives the record_* methods directly. No
+backend, no running agent. Skips cleanly if the agent-server package can't be
+imported in this environment, so it can never become a CI collection error.
+"""
+
+import os
+import sys
+import threading
+
+import pytest
+
+# Add the agent-server package root to the path.
+_AGENT_BASE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "docker", "base-image")
+)
+if _AGENT_BASE not in sys.path:
+    sys.path.insert(0, _AGENT_BASE)
+
+try:
+    from agent_server.state import AgentState
+except Exception as e:  # pragma: no cover - environment-dependent
+    pytest.skip(f"agent_server.state not importable here: {e}", allow_module_level=True)
+
+
+# Override the backend-requiring autouse fixtures from the package conftest so
+# this pure-unit test runs without a live backend.
+@pytest.fixture(scope="session")
+def api_client():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+
+
+@pytest.fixture
+def health_state():
+    """An AgentState with only the health counters initialized (no __init__,
+    so the runtime-availability subprocess probe never runs)."""
+    inst = AgentState.__new__(AgentState)
+    inst._health_lock = threading.Lock()
+    inst.active_task_count = 0
+    inst.last_task_at = None
+    inst.consecutive_failures = 0
+    return inst
+
+
+def test_initial_state(health_state):
+    assert health_state.active_task_count == 0
+    assert health_state.last_task_at is None
+    assert health_state.consecutive_failures == 0
+
+
+def test_start_increments_active_and_sets_last_task_at(health_state):
+    health_state.record_task_start()
+    assert health_state.active_task_count == 1
+    assert health_state.last_task_at is not None
+
+
+def test_finish_decrements_active(health_state):
+    health_state.record_task_start()
+    health_state.record_task_finish(success=True)
+    assert health_state.active_task_count == 0
+
+
+def test_concurrent_tasks_tracked(health_state):
+    health_state.record_task_start()
+    health_state.record_task_start()
+    assert health_state.active_task_count == 2
+    health_state.record_task_finish(success=True)
+    assert health_state.active_task_count == 1
+
+
+def test_failure_increments_consecutive(health_state):
+    health_state.record_task_start()
+    health_state.record_task_finish(success=False)
+    health_state.record_task_start()
+    health_state.record_task_finish(success=False)
+    assert health_state.consecutive_failures == 2
+
+
+def test_success_resets_consecutive_failures(health_state):
+    health_state.record_task_start()
+    health_state.record_task_finish(success=False)
+    health_state.record_task_start()
+    health_state.record_task_finish(success=False)
+    assert health_state.consecutive_failures == 2
+    health_state.record_task_start()
+    health_state.record_task_finish(success=True)
+    assert health_state.consecutive_failures == 0
+
+
+def test_finish_never_goes_negative(health_state):
+    # Defensive: a finish without a matching start must not underflow.
+    health_state.record_task_finish(success=True)
+    assert health_state.active_task_count == 0


### PR DESCRIPTION
## Summary

Promote the agent container's `/health` from `{status}` + ad-hoc diagnostics to a **named, contractual signal** the platform acts on — per `TARGET_ARCHITECTURE.md` §"Agent Runtime → What Improves". Small, additive, incremental target-architecture adoption with effectively zero blast radius.

```
/health → { status, active_tasks, last_task_at, consecutive_failures, ...existing }
```

## What changed

**Agent-server**
- `agent_server/state.py` — thread-safe health counters on `AgentState` (`active_task_count`, `last_task_at`, `consecutive_failures`) via `record_task_start()` / `record_task_finish(success)`.
- `agent_server/routers/chat.py` — wired at **both** execution chokepoints (`/api/chat` → `runtime.execute`, `/api/task` → `runtime.execute_headless`), so counters track every execution and `consecutive_failures` reflects real outcomes (raised exception = failure, return = success).
- `agent_server/routers/info.py` — `/health` returns the new named fields alongside existing keys.

**Backend**
- `db_models.py` — `BusinessHealthCheck` gains optional `consecutive_failures` / `last_task_at` (`None` for pre-#1020 agent images).
- `services/monitoring_service.py` — reads the new fields from `/health` with graceful defaults and surfaces them on the health record. Feeds the dispatch circuit breaker (#526) and heartbeat push (#307). MCP `get_agent_health` inherits the fields via the Pydantic response (Invariant #13) — no TS change.

## Honest scope call: `mailbox_depth`

The target-arch field list includes `mailbox_depth`, but it is **intentionally NOT emitted**. There is no agent-side mailbox until the actor model (#945); queue/backlog depth lives backend-side in `CapacityManager`. Faking it on the agent would be a lie. Documented as reserved/backend-derived in the endpoint + `architecture.md`.

## Back-compat
Existing `/health` keys unchanged; new keys are purely additive. Backend reads the new fields defensively (missing → `None`), so old agent images keep working.

## Testing
- `tests/test_agent_health_signal.py` — 7 backend-free unit tests for the counter logic (start/finish, concurrency, failure increment, success reset, no underflow). Skips cleanly if the agent-server package isn't importable, so it can't become a CI collection error. **All green** locally; backend `monitoring_service`/`db_models` import-verified.

## Docs
`docs/memory/architecture.md` (agent-server `/health`) + `docs/memory/requirements.md` (12.8a).

Related to #1020, #526, #307, #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)