### PR TITLE
refactor(cleanup): per-sweep strategies for _run_cleanup_inner (#1026)

### DIFF
--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -241,15 +241,52 @@ class CleanupService:
             return await self._run_cleanup_inner()
 
     async def _run_cleanup_inner(self) -> CleanupReport:
-        """Inner cleanup logic, called under lock."""
+        """Inner cleanup logic, called under lock.
+
+        Each sweep is an independent strategy method that owns its own
+        try/except, so one sweep failing never aborts the cycle (#1026). The
+        watchdog runs FIRST (releases resources before stale cleanup marks
+        executions failed) and hands `confirmed_running_ids` (#226) to the slot
+        sweep so it won't falsely fail executions verified alive.
+        """
         report = CleanupReport()
 
-        # 0. Watchdog: reconcile DB vs agent process registries (Issue #129)
-        # Runs FIRST so it can release resources before stale cleanup marks
-        # executions failed without resource cleanup.
-        # Also returns confirmed_running_ids (#226) to prevent slot cleanup
-        # from falsely failing executions the watchdog verified as alive.
-        confirmed_running_ids: set = set()
+        confirmed_running_ids = await self._sweep_watchdog(report)
+        self._sweep_stale_executions(report)
+        self._sweep_no_session_executions(report)
+        self._sweep_orphaned_skipped(report)
+        self._sweep_stale_activities(report)
+        await self._sweep_stale_slots(report, confirmed_running_ids)
+        self._sweep_rate_limit_events()
+        self._sweep_shared_files(report)
+        self._sweep_retention_772(report)
+        self._sweep_soft_deleted_agents(report)
+        self._sweep_soft_deleted_schedules(report)
+        self._sweep_idempotency_keys(report)
+        self._maybe_wal_checkpoint(report)
+
+        self._cycle_count += 1
+
+        self.last_run_at = utc_now_iso()
+        self.last_report = report
+
+        if report.total > 0:
+            logger.info(f"[Cleanup] Cycle complete: {report.to_dict()}")
+
+        return report
+
+    # ------------------------------------------------------------------
+    # Sweep strategies (#1026). Each is self-contained: owns its try/except,
+    # writes its own CleanupReport field(s), and never raises to the caller.
+    # ------------------------------------------------------------------
+
+    async def _sweep_watchdog(self, report: CleanupReport) -> set:
+        """0. Reconcile DB vs agent process registries (Issue #129).
+
+        Returns confirmed_running_ids (#226) so the slot sweep won't fail
+        executions the watchdog verified as alive. Returns an empty set on
+        error so the rest of the cycle proceeds.
+        """
         try:
             orphaned, terminated, confirmed_running_ids = (
                 await self._reconcile_orphaned_executions()
@@ -262,10 +299,13 @@ class CleanupService:
                 logger.info(f"[Watchdog] Recovered {orphaned} orphaned executions")
             if terminated > 0:
                 logger.info(f"[Watchdog] Auto-terminated {terminated} timed-out executions")
+            return confirmed_running_ids
         except Exception as e:
             logger.error(f"[Watchdog] Reconciliation error: {e}")
+            return set()
 
-        # 1. Mark stale executions as failed (safety net for agent-unreachable cases)
+    def _sweep_stale_executions(self, report: CleanupReport) -> None:
+        """1. Mark stale executions failed (agent-unreachable safety net)."""
         try:
             count = db.mark_stale_executions_failed(EXECUTION_STALE_TIMEOUT_MINUTES)
             report.stale_executions = count
@@ -274,7 +314,8 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error marking stale executions: {e}")
 
-        # 1b. Fast-fail running executions with no Claude session (Issue #106)
+    def _sweep_no_session_executions(self, report: CleanupReport) -> None:
+        """1b. Fast-fail running executions with no Claude session (Issue #106)."""
         try:
             count = db.mark_no_session_executions_failed(NO_SESSION_TIMEOUT_SECONDS)
             report.no_session_executions = count
@@ -283,7 +324,8 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error marking no-session executions: {e}")
 
-        # 1c. Finalize orphaned skipped executions (Issue #106)
+    def _sweep_orphaned_skipped(self, report: CleanupReport) -> None:
+        """1c. Finalize orphaned skipped executions (Issue #106)."""
         try:
             count = db.finalize_orphaned_skipped_executions()
             report.orphaned_skipped = count
@@ -292,7 +334,8 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error finalizing orphaned skipped executions: {e}")
 
-        # 2. Mark stale activities as failed
+    def _sweep_stale_activities(self, report: CleanupReport) -> None:
+        """2. Mark stale activities failed."""
         try:
             count = db.mark_stale_activities_failed(ACTIVITY_STALE_TIMEOUT_MINUTES)
             report.stale_activities = count
@@ -301,8 +344,13 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error marking stale activities: {e}")
 
-        # 3. Cleanup stale Redis slots and fail corresponding execution records
-        #    (#219, #226, #378 — see _process_stale_slot_reclaims docstring).
+    async def _sweep_stale_slots(
+        self, report: CleanupReport, confirmed_running_ids: set
+    ) -> None:
+        """3. Reclaim stale Redis slots + fail their execution records.
+
+        (#219, #226, #378 — see _process_stale_slot_reclaims docstring.)
+        """
         try:
             capacity = get_capacity_manager()
 
@@ -321,21 +369,29 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error cleaning stale slots: {e}")
 
-        # 4. Hourly maintenance: prune rate-limit events older than 24h (#476).
-        # Runs every 12th cycle (60 min at 5-min interval) plus the first
-        # cycle after startup so we don't wait an hour on boot.
-        if self._cycle_count % 12 == 0:
-            try:
-                pruned = db.cleanup_old_rate_limit_events()
-                if pruned > 0:
-                    logger.info(f"[Cleanup] Pruned {pruned} rate-limit events (>24h old)")
-            except Exception as e:
-                logger.error(f"[Cleanup] Error pruning rate-limit events: {e}")
+    def _sweep_rate_limit_events(self) -> None:
+        """4. Hourly maintenance: prune rate-limit events older than 24h (#476).
 
-        # 4b. Purge expired / old-revoked shared files (C4 / FILES-001).
-        # Every cycle — the set is usually small and both DB row + disk
-        # unlink are cheap. Grace period for revoked rows keeps them
-        # queryable for a day post-revoke (incident diagnosis).
+        Runs every 12th cycle (60 min at 5-min interval) plus the first cycle
+        after startup so we don't wait an hour on boot. The gate reads
+        `_cycle_count` before the orchestrator increments it.
+        """
+        if self._cycle_count % 12 != 0:
+            return
+        try:
+            pruned = db.cleanup_old_rate_limit_events()
+            if pruned > 0:
+                logger.info(f"[Cleanup] Pruned {pruned} rate-limit events (>24h old)")
+        except Exception as e:
+            logger.error(f"[Cleanup] Error pruning rate-limit events: {e}")
+
+    def _sweep_shared_files(self, report: CleanupReport) -> None:
+        """4b. Purge expired / old-revoked shared files (C4 / FILES-001).
+
+        Every cycle — the set is usually small and both DB row + disk unlink
+        are cheap. Grace period for revoked rows keeps them queryable for a day
+        post-revoke (incident diagnosis).
+        """
         try:
             from pathlib import Path
             stored_filenames = db.delete_expired_and_revoked_shared_files(
@@ -360,11 +416,13 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error purging shared files: {e}")
 
-        # 4c. Issue #772: retention pruning for execution_log, execution rows,
-        # and agent_health_checks. All three obey the configurable retention
-        # window from ops settings; "0" disables the corresponding sweep.
-        # Per-cycle budget caps each sweep so the first post-deploy backfill
-        # spans multiple cycles instead of holding the write lock end-to-end.
+    def _sweep_retention_772(self, report: CleanupReport) -> None:
+        """4c. Issue #772: retention pruning for execution_log, execution rows,
+        and agent_health_checks. All three obey the configurable retention
+        window from ops settings; "0" disables the corresponding sweep.
+        Per-cycle budget caps each sweep so the first post-deploy backfill
+        spans multiple cycles instead of holding the write lock end-to-end.
+        """
         try:
             log_days, row_days, hc_days = _read_retention_settings()
         except Exception as e:
@@ -416,12 +474,14 @@ class CleanupService:
             except Exception as e:
                 logger.error(f"[Cleanup] Error pruning health checks: {e}")
 
-        # 4c-bis. Issue #834 Phase 1a: hard-purge soft-deleted agents past
-        # their retention window. `purge_agent_ownership` runs the #816
-        # cascade_delete primitive so every per-agent child row goes with
-        # the parent in a single transaction. Bounded by the same
-        # 5000-row/cycle cap as the other sweeps so a backlog after a
-        # long-disabled retention setting drains gradually.
+    def _sweep_soft_deleted_agents(self, report: CleanupReport) -> None:
+        """4c-bis. Issue #834 Phase 1a: hard-purge soft-deleted agents past
+        their retention window. `purge_agent_ownership` runs the #816
+        cascade_delete primitive so every per-agent child row goes with the
+        parent in a single transaction. Bounded by the same 5000-row/cycle cap
+        as the other sweeps so a backlog after a long-disabled retention
+        setting drains gradually.
+        """
         try:
             from services.settings_service import OPS_SETTINGS_DEFAULTS
 
@@ -461,12 +521,14 @@ class CleanupService:
             except Exception as e:
                 logger.error(f"[Cleanup] Error pruning soft-deleted agents: {e}")
 
-        # 4c-ter. Issue #834 Phase 1b: hard-purge soft-deleted schedules
-        # past their retention window. Unlike the agent purge, this does
-        # not chain into cascade_delete — schedules don't have child
-        # rows registered with #816 (schedule_executions are KEEP-policy
-        # via subscription_id rollups, and the per-schedule cleanup of
-        # executions belongs to #772's separate sweep).
+    def _sweep_soft_deleted_schedules(self, report: CleanupReport) -> None:
+        """4c-ter. Issue #834 Phase 1b: hard-purge soft-deleted schedules past
+        their retention window. Unlike the agent purge, this does not chain
+        into cascade_delete — schedules don't have child rows registered with
+        #816 (schedule_executions are KEEP-policy via subscription_id rollups,
+        and the per-schedule cleanup of executions belongs to #772's separate
+        sweep).
+        """
         try:
             from services.settings_service import OPS_SETTINGS_DEFAULTS
 
@@ -506,9 +568,11 @@ class CleanupService:
             except Exception as e:
                 logger.error(f"[Cleanup] Error pruning soft-deleted schedules: {e}")
 
-        # 4c-quater. RELIABILITY-006 (#525): purge idempotency keys past their
-        # 24h TTL. Fixed window (not an ops setting) — the contract guarantees
-        # dedup for 24h, no longer. Cheap point-delete on the created_at index.
+    def _sweep_idempotency_keys(self, report: CleanupReport) -> None:
+        """4c-quater. RELIABILITY-006 (#525): purge idempotency keys past their
+        24h TTL. Fixed window (not an ops setting) — the contract guarantees
+        dedup for 24h, no longer. Cheap point-delete on the created_at index.
+        """
         try:
             purged = db.idempotency_purge_expired(ttl_hours=24)
             report.idempotency_keys_purged = purged
@@ -519,10 +583,12 @@ class CleanupService:
         except Exception as e:
             logger.error(f"[Cleanup] Error purging idempotency keys: {e}")
 
-        # 4d. Issue #772: after a retention sweep reclaims meaningful space,
-        # truncate the WAL so the OS sees the free pages. Checkpoint is cheap
-        # and safe to run per-cycle when there's work to do; full VACUUM is
-        # gated to a daily off-peak job (see start()).
+    def _maybe_wal_checkpoint(self, report: CleanupReport) -> None:
+        """4d. Issue #772: after a retention sweep reclaims meaningful space,
+        truncate the WAL so the OS sees the free pages. Checkpoint is cheap and
+        safe to run per-cycle when there's work to do; full VACUUM is gated to a
+        daily off-peak job (see start()).
+        """
         retention_total = (report.execution_logs_pruned
                            + report.execution_rows_pruned
                            + report.health_checks_pruned
@@ -534,16 +600,6 @@ class CleanupService:
                 _wal_checkpoint_truncate()
             except Exception as e:
                 logger.warning(f"[Cleanup] WAL checkpoint failed: {e}")
-
-        self._cycle_count += 1
-
-        self.last_run_at = utc_now_iso()
-        self.last_report = report
-
-        if report.total > 0:
-            logger.info(f"[Cleanup] Cycle complete: {report.to_dict()}")
-
-        return report
 
     async def _process_stale_slot_reclaims(
         self,

--- a/tests/unit/test_cleanup_inner_sweeps.py
+++ b/tests/unit/test_cleanup_inner_sweeps.py
@@ -1,0 +1,180 @@
+"""
+Characterization tests for CleanupService._run_cleanup_inner (#1026).
+
+These pin the *current* behavior of the cleanup cycle so the strategy-per-sweep
+refactor can be proven behavior-preserving. They run without a backend — `db`,
+the capacity manager, the HTTP-bearing watchdog/slot methods, and the WAL
+checkpoint are all mocked.
+
+Invariants pinned:
+- every sweep runs and writes its CleanupReport field (happy path)
+- a sweep raising does NOT abort the cycle (per-sweep error isolation)
+- rate-limit-event prune is cycle-gated (only every 12th cycle)
+- WAL checkpoint fires only when a retention sweep reclaimed rows
+- retention sweeps are skipped when their retention window is 0 (disabled)
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.cleanup_service import CleanupService, CleanupReport
+
+# The unit-test harness can register the backend package under more than one
+# module name; resolve the exact module object the class methods bind their
+# globals to so patch.object targets the same `db` / `get_capacity_manager`
+# the running code looks up.
+_CS = sys.modules[CleanupService.__module__]
+
+
+def _make_service():
+    """A CleanupService with the HTTP-bearing methods stubbed out."""
+    svc = CleanupService(poll_interval=300)
+    # Watchdog (#129) and slot reclaim do real HTTP / Redis — stub them.
+    svc._reconcile_orphaned_executions = AsyncMock(return_value=(8, 9, set()))
+    svc._process_stale_slot_reclaims = AsyncMock(return_value=None)
+    return svc
+
+
+def _setting_side_effect(key, default=None):
+    if key == "agent_soft_delete_retention_days":
+        return "180"
+    if key == "schedule_soft_delete_retention_days":
+        return "30"
+    return default
+
+
+def _configure_db(db):
+    db.mark_stale_executions_failed.return_value = 1
+    db.mark_no_session_executions_failed.return_value = 2
+    db.finalize_orphaned_skipped_executions.return_value = 3
+    db.mark_stale_activities_failed.return_value = 4
+    db.get_all_execution_timeouts.return_value = {}
+    db.cleanup_old_rate_limit_events.return_value = 0
+    db.delete_expired_and_revoked_shared_files.return_value = ["a", "b"]
+    db.prune_execution_logs.return_value = 5
+    db.prune_execution_rows.return_value = 6
+    db.cleanup_old_health_records.return_value = 7
+    db.get_setting_value.side_effect = _setting_side_effect
+    db.find_soft_deleted_agents_past_retention.return_value = ["ag1"]
+    db.purge_agent_ownership.return_value = True
+    db.find_soft_deleted_schedules_past_retention.return_value = ["s1", "s2"]
+    db.purge_schedule.return_value = True
+    db.idempotency_purge_expired.return_value = 11  # RELIABILITY-006 / #525
+
+
+def _run(svc):
+    return asyncio.run(svc._run_cleanup_inner())
+
+
+def test_happy_path_runs_all_sweeps_and_populates_report():
+    svc = _make_service()
+    capacity = MagicMock()
+    capacity.reclaim_stale = AsyncMock(return_value={})
+    with patch.object(_CS, "db") as db, \
+         patch.object(_CS, "get_capacity_manager", return_value=capacity), \
+         patch.object(_CS, "_read_retention_settings", return_value=(30, 90, 7)), \
+         patch.object(_CS, "_wal_checkpoint_truncate") as wal:
+        _configure_db(db)
+        report = _run(svc)
+
+    assert report.orphaned_executions == 8
+    assert report.auto_terminated == 9
+    assert report.stale_executions == 1
+    assert report.no_session_executions == 2
+    assert report.orphaned_skipped == 3
+    assert report.stale_activities == 4
+    assert report.shared_files_purged == 2
+    assert report.execution_logs_pruned == 5
+    assert report.execution_rows_pruned == 6
+    assert report.health_checks_pruned == 7
+    assert report.soft_deleted_agents_purged == 1
+    assert report.soft_deleted_schedules_purged == 2
+    assert report.idempotency_keys_purged == 11
+    assert report.total == 8 + 9 + 1 + 2 + 3 + 4 + 2 + 5 + 6 + 7 + 1 + 2 + 11
+    # retention reclaimed rows ⇒ WAL checkpoint fires
+    wal.assert_called_once()
+    # cycle counter advanced
+    assert svc._cycle_count == 1
+
+
+def test_sweep_error_does_not_abort_cycle():
+    """One sweep raising must not stop subsequent sweeps (per-sweep try/except)."""
+    svc = _make_service()
+    capacity = MagicMock()
+    capacity.reclaim_stale = AsyncMock(return_value={})
+    with patch.object(_CS, "db") as db, \
+         patch.object(_CS, "get_capacity_manager", return_value=capacity), \
+         patch.object(_CS, "_read_retention_settings", return_value=(30, 90, 7)), \
+         patch.object(_CS, "_wal_checkpoint_truncate"):
+        _configure_db(db)
+        db.mark_stale_executions_failed.side_effect = RuntimeError("boom")
+        report = _run(svc)
+
+    # the failing sweep contributes 0, everything after it still ran
+    assert report.stale_executions == 0
+    assert report.no_session_executions == 2
+    assert report.execution_rows_pruned == 6
+    assert report.soft_deleted_schedules_purged == 2
+
+
+def test_rate_limit_prune_is_cycle_gated():
+    capacity = MagicMock()
+    capacity.reclaim_stale = AsyncMock(return_value={})
+
+    def run_at_cycle(cycle):
+        svc = _make_service()
+        svc._cycle_count = cycle
+        with patch.object(_CS, "db") as db, \
+             patch.object(_CS, "get_capacity_manager", return_value=capacity), \
+             patch.object(_CS, "_read_retention_settings", return_value=(0, 0, 0)), \
+             patch.object(_CS, "_wal_checkpoint_truncate"):
+            _configure_db(db)
+            _run(svc)
+            return db.cleanup_old_rate_limit_events.called
+
+    assert run_at_cycle(0) is True       # 0 % 12 == 0 → runs
+    assert run_at_cycle(1) is False      # 1 % 12 != 0 → skipped
+    assert run_at_cycle(12) is True      # wraps
+
+
+def test_wal_checkpoint_skipped_when_no_retention_work():
+    svc = _make_service()
+    capacity = MagicMock()
+    capacity.reclaim_stale = AsyncMock(return_value={})
+    with patch.object(_CS, "db") as db, \
+         patch.object(_CS, "get_capacity_manager", return_value=capacity), \
+         patch.object(_CS, "_read_retention_settings", return_value=(30, 90, 7)), \
+         patch.object(_CS, "_wal_checkpoint_truncate") as wal:
+        _configure_db(db)
+        # nothing reclaimed by any retention sweep
+        db.prune_execution_logs.return_value = 0
+        db.prune_execution_rows.return_value = 0
+        db.cleanup_old_health_records.return_value = 0
+        db.find_soft_deleted_agents_past_retention.return_value = []
+        db.find_soft_deleted_schedules_past_retention.return_value = []
+        db.idempotency_purge_expired.return_value = 0
+        _run(svc)
+    wal.assert_not_called()
+
+
+def test_retention_sweeps_skipped_when_disabled():
+    """retention_days == 0 disables the #772 + #834 sweeps."""
+    svc = _make_service()
+    capacity = MagicMock()
+    capacity.reclaim_stale = AsyncMock(return_value={})
+    with patch.object(_CS, "db") as db, \
+         patch.object(_CS, "get_capacity_manager", return_value=capacity), \
+         patch.object(_CS, "_read_retention_settings", return_value=(0, 0, 0)), \
+         patch.object(_CS, "_wal_checkpoint_truncate"):
+        _configure_db(db)
+        db.get_setting_value.side_effect = lambda key, default=None: "0"
+        _run(svc)
+        db.prune_execution_logs.assert_not_called()
+        db.prune_execution_rows.assert_not_called()
+        db.cleanup_old_health_records.assert_not_called()
+        db.find_soft_deleted_agents_past_retention.assert_not_called()
+        db.find_soft_deleted_schedules_past_retention.assert_not_called()


### PR DESCRIPTION
## Summary

First (lowest-difficulty) refactor from #1026 — decompose the cleanup-service hotspot.

`CleanupService._run_cleanup_inner` was a single **290-line** method running ~11 sequential sweeps, each wrapped in its own try/except. This extracts each sweep into a focused `_sweep_*` method; the orchestrator is now a **33-line** sequence that reads top-to-bottom.

**No behavior change.** Preserved exactly:
- per-sweep error isolation (one sweep raising never aborts the cycle)
- the rate-limit prune cycle gate (`_cycle_count % 12`, read before the orchestrator's end-of-cycle increment)
- the watchdog → slot-sweep `confirmed_running_ids` handoff (#226)
- the WAL-checkpoint retention gate (fires only when a retention sweep reclaimed rows)

## Sweeps extracted
`_sweep_watchdog` (#129) · `_sweep_stale_executions` · `_sweep_no_session_executions` (#106) · `_sweep_orphaned_skipped` (#106) · `_sweep_stale_activities` · `_sweep_stale_slots` (#219/#226/#378) · `_sweep_rate_limit_events` (#476) · `_sweep_shared_files` (FILES-001) · `_sweep_retention_772` (#772) · `_sweep_soft_deleted_agents` (#834 1a) · `_sweep_soft_deleted_schedules` (#834 1b) · `_maybe_wal_checkpoint`

## Tests
Adds `tests/unit/test_cleanup_inner_sweeps.py` — characterization tests pinning the cycle's contract (sweep set, report-field population, error isolation, cycle-gating, WAL gate). **Green before and after** the extraction — the proof of behavior preservation.

- ✅ 5/5 new characterization tests green pre- and post-refactor
- ✅ 1730 passed in the unit suite (`-m "not slow"`); the only failures are 5 pre-existing/environmental `test_git_pull_branch.py` cases (need a real `origin/main` repo) — unrelated to this diff
- Acceptance: orchestrator now 33 lines / cyclomatic ~2 (target <100 / <20)

## Scope
Single function per the issue's "small incremental PRs" guidance. Next in #1026: `adapters/message_router._handle_message_inner`. `execute_task` (25 params) saved for last, after the #1027 request-object pattern.

Related to #1026