### PR TITLE
refactor(chat): extract post-task side effects from async task wrapper (#1026)

### DIFF
--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -865,121 +865,21 @@ async def _run_async_task_with_persistence(
 
         execution_time_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
 
-        # ---- Post-task: chat session persistence (THINK-001) ----
-        if request.save_to_session and user_id and user_email:
-            chat_session_id = await _persist_chat_session(
-                agent_name=agent_name,
-                request=request,
-                result=result,
-                user_id=user_id,
-                user_email=user_email,
-                subscription_id=subscription_id,
-                execution_time_ms=execution_time_ms,
-            )
-            if chat_session_id and _websocket_manager:
-                try:
-                    await _websocket_manager.broadcast(json.dumps({
-                        "type": "chat_response_ready",
-                        "execution_id": execution_id,
-                        "agent_name": agent_name,
-                        "chat_session_id": chat_session_id,
-                        "timestamp": utc_now_iso(),
-                    }))
-                except Exception as e:
-                    logger.warning(f"[Task Async] chat_response_ready broadcast failed: {e}")
-
-        # ---- Post-task: complete collaboration activity ----
-        if collaboration_activity_id:
-            try:
-                await activity_service.complete_activity(
-                    activity_id=collaboration_activity_id,
-                    status=(
-                        ActivityState.COMPLETED
-                        if result.status == TaskExecutionStatus.SUCCESS
-                        else ActivityState.FAILED
-                    ),
-                    details={
-                        "response_length": len(result.response or ""),
-                        "execution_time_ms": execution_time_ms,
-                        "execution_id": execution_id,
-                    },
-                    error=(result.error if result.status == TaskExecutionStatus.FAILED else None),
-                )
-            except Exception as e:
-                logger.warning(f"[Task Async] collaboration activity completion failed: {e}")
-
-        # ---- Post-task: complete self-task activity and inject result (SELF-EXEC-001) ----
-        if is_self_task and self_task_activity_id:
-            activity_status = (
-                ActivityState.COMPLETED
-                if result.status == TaskExecutionStatus.SUCCESS
-                else ActivityState.FAILED
-            )
-
-            # Complete the self-task activity
-            try:
-                await activity_service.complete_activity(
-                    activity_id=self_task_activity_id,
-                    status=activity_status,
-                    details={
-                        "response_length": len(result.response or ""),
-                        "execution_time_ms": execution_time_ms,
-                        "execution_id": execution_id,
-                        "inject_result": request.inject_result,
-                    },
-                    error=(result.error if result.status == TaskExecutionStatus.FAILED else None),
-                )
-            except Exception as e:
-                logger.warning(f"[Task Async] self-task activity completion failed: {e}")
-
-            # Inject result into chat session if requested
-            if request.inject_result and request.chat_session_id and result.status == TaskExecutionStatus.SUCCESS:
-                try:
-                    # Validate session exists and belongs to user
-                    session = db.get_chat_session(request.chat_session_id)
-                    if session and session.get("user_id") == user_id:
-                        # Add self-task result as a chat message
-                        db.add_chat_message(
-                            session_id=request.chat_session_id,
-                            agent_name=agent_name,
-                            user_id=user_id,
-                            user_email=user_email or "",
-                            role="assistant",
-                            content=result.response or "",
-                            cost=result.cost,
-                            context_used=result.context_used,
-                            context_max=result.context_max,
-                            execution_time_ms=execution_time_ms,
-                            source="self_task",  # Mark as self-task result
-                        )
-                        logger.info(f"[Self-Task] Injected result into chat session {request.chat_session_id}")
-                    else:
-                        logger.warning(f"[Self-Task] Cannot inject result: session {request.chat_session_id} not found or not owned by user")
-                except Exception as e:
-                    logger.warning(f"[Self-Task] Failed to inject result into chat session: {e}")
-
-            # Broadcast self-task completion event
-            if _websocket_manager:
-                try:
-                    await _websocket_manager.broadcast(json.dumps({
-                        "type": "agent_activity",
-                        "agent_name": agent_name,
-                        "activity_type": "self_task",
-                        "activity_state": "completed" if result.status == TaskExecutionStatus.SUCCESS else "failed",
-                        "action": f"Background task completed",
-                        "timestamp": utc_now_iso(),
-                        "details": {
-                            "execution_id": execution_id,
-                            "chat_session_id": request.chat_session_id,
-                            "cost_usd": result.cost,
-                            "execution_time_ms": execution_time_ms,
-                            "response_preview": (result.response or "")[:200],
-                            "inject_result": request.inject_result,
-                            "result_injected": request.inject_result and request.chat_session_id is not None,
-                        }
-                    }))
-                except Exception as e:
-                    logger.warning(f"[Self-Task] WebSocket broadcast failed: {e}")
+        # Post-task side effects (each guarded + self-isolating; see helpers).
+        chat_session_id = await _persist_and_broadcast_chat_session(
+            agent_name=agent_name, request=request, result=result,
+            execution_id=execution_id, user_id=user_id, user_email=user_email,
+            subscription_id=subscription_id, execution_time_ms=execution_time_ms,
+        )
+        await _complete_collaboration_activity(
+            collaboration_activity_id, result, execution_id, execution_time_ms,
+        )
+        await _finalize_self_task(
+            is_self_task=is_self_task, self_task_activity_id=self_task_activity_id,
+            agent_name=agent_name, request=request, result=result,
+            execution_id=execution_id, user_id=user_id, user_email=user_email,
+            execution_time_ms=execution_time_ms,
+        )
 
         logger.info(
             f"[Task Async] Completed background task for agent '{agent_name}', "
@@ -989,6 +889,151 @@ async def _run_async_task_with_persistence(
         # Issue #498: signal any sync HTTP caller waiting on this execution.
         # No-op when no waiter is registered (the common async path).
         signal_sync_waiter(execution_id, result, chat_session_id)
+
+
+async def _persist_and_broadcast_chat_session(
+    *, agent_name, request, result, execution_id, user_id, user_email,
+    subscription_id, execution_time_ms,
+):
+    """Post-task block 1 (THINK-001): persist the authenticated chat session and
+    broadcast chat_response_ready. Returns the chat_session_id (or None when
+    persistence isn't applicable) — the caller threads it to signal_sync_waiter.
+
+    The persist call is intentionally un-wrapped (a persistence failure
+    propagates, after the caller's finally signals the waiter); only the
+    best-effort broadcast is isolated — preserving the pre-refactor behavior.
+    """
+    if not (request.save_to_session and user_id and user_email):
+        return None
+    chat_session_id = await _persist_chat_session(
+        agent_name=agent_name,
+        request=request,
+        result=result,
+        user_id=user_id,
+        user_email=user_email,
+        subscription_id=subscription_id,
+        execution_time_ms=execution_time_ms,
+    )
+    if chat_session_id and _websocket_manager:
+        try:
+            await _websocket_manager.broadcast(json.dumps({
+                "type": "chat_response_ready",
+                "execution_id": execution_id,
+                "agent_name": agent_name,
+                "chat_session_id": chat_session_id,
+                "timestamp": utc_now_iso(),
+            }))
+        except Exception as e:
+            logger.warning(f"[Task Async] chat_response_ready broadcast failed: {e}")
+    return chat_session_id
+
+
+async def _complete_collaboration_activity(
+    collaboration_activity_id, result, execution_id, execution_time_ms,
+):
+    """Post-task block 2: complete the agent-to-agent collaboration activity.
+    No-op when there is no collaboration activity; self-isolating on error."""
+    if not collaboration_activity_id:
+        return
+    try:
+        await activity_service.complete_activity(
+            activity_id=collaboration_activity_id,
+            status=(
+                ActivityState.COMPLETED
+                if result.status == TaskExecutionStatus.SUCCESS
+                else ActivityState.FAILED
+            ),
+            details={
+                "response_length": len(result.response or ""),
+                "execution_time_ms": execution_time_ms,
+                "execution_id": execution_id,
+            },
+            error=(result.error if result.status == TaskExecutionStatus.FAILED else None),
+        )
+    except Exception as e:
+        logger.warning(f"[Task Async] collaboration activity completion failed: {e}")
+
+
+async def _finalize_self_task(
+    *, is_self_task, self_task_activity_id, agent_name, request, result,
+    execution_id, user_id, user_email, execution_time_ms,
+):
+    """Post-task block 3 (SELF-EXEC-001): complete the self-task activity,
+    inject the result into the originating chat session when requested, and
+    broadcast the completion event. No-op unless this is a self-task."""
+    if not (is_self_task and self_task_activity_id):
+        return
+
+    activity_status = (
+        ActivityState.COMPLETED
+        if result.status == TaskExecutionStatus.SUCCESS
+        else ActivityState.FAILED
+    )
+
+    # Complete the self-task activity
+    try:
+        await activity_service.complete_activity(
+            activity_id=self_task_activity_id,
+            status=activity_status,
+            details={
+                "response_length": len(result.response or ""),
+                "execution_time_ms": execution_time_ms,
+                "execution_id": execution_id,
+                "inject_result": request.inject_result,
+            },
+            error=(result.error if result.status == TaskExecutionStatus.FAILED else None),
+        )
+    except Exception as e:
+        logger.warning(f"[Task Async] self-task activity completion failed: {e}")
+
+    # Inject result into chat session if requested
+    if request.inject_result and request.chat_session_id and result.status == TaskExecutionStatus.SUCCESS:
+        try:
+            # Validate session exists and belongs to user
+            session = db.get_chat_session(request.chat_session_id)
+            if session and session.get("user_id") == user_id:
+                # Add self-task result as a chat message
+                db.add_chat_message(
+                    session_id=request.chat_session_id,
+                    agent_name=agent_name,
+                    user_id=user_id,
+                    user_email=user_email or "",
+                    role="assistant",
+                    content=result.response or "",
+                    cost=result.cost,
+                    context_used=result.context_used,
+                    context_max=result.context_max,
+                    execution_time_ms=execution_time_ms,
+                    source="self_task",  # Mark as self-task result
+                )
+                logger.info(f"[Self-Task] Injected result into chat session {request.chat_session_id}")
+            else:
+                logger.warning(f"[Self-Task] Cannot inject result: session {request.chat_session_id} not found or not owned by user")
+        except Exception as e:
+            logger.warning(f"[Self-Task] Failed to inject result into chat session: {e}")
+
+    # Broadcast self-task completion event
+    if _websocket_manager:
+        try:
+            await _websocket_manager.broadcast(json.dumps({
+                "type": "agent_activity",
+                "agent_name": agent_name,
+                "activity_type": "self_task",
+                "activity_state": "completed" if result.status == TaskExecutionStatus.SUCCESS else "failed",
+                "action": f"Background task completed",
+                "timestamp": utc_now_iso(),
+                "details": {
+                    "execution_id": execution_id,
+                    "chat_session_id": request.chat_session_id,
+                    "cost_usd": result.cost,
+                    "execution_time_ms": execution_time_ms,
+                    "response_preview": (result.response or "")[:200],
+                    "inject_result": request.inject_result,
+                    "result_injected": request.inject_result and request.chat_session_id is not None,
+                }
+            }))
+        except Exception as e:
+            logger.warning(f"[Self-Task] WebSocket broadcast failed: {e}")
 
 
 @router.post("/{name}/task")

--- a/tests/unit/test_async_task_persistence.py
+++ b/tests/unit/test_async_task_persistence.py
@@ -1,0 +1,146 @@
+"""
+Characterization tests for routers.chat._run_async_task_with_persistence (#1026).
+
+This is the async /task background wrapper (#95): it delegates execution to
+TaskExecutionService, then layers chat-endpoint post-task side effects
+(chat-session persistence + broadcast, collaboration-activity completion,
+self-task completion + result injection) and always signals a sync waiter in
+its finally (#498).
+
+These drive the real function with every collaborator patched and pin the
+observable behavior of each guarded post-task block + the finally guarantee.
+Green before and after the strategy extraction.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from routers.chat import _run_async_task_with_persistence
+from models import ParallelTaskRequest, TaskExecutionStatus
+
+_CHAT = sys.modules[_run_async_task_with_persistence.__module__]
+
+
+def _result(status=TaskExecutionStatus.SUCCESS, response="ok"):
+    r = MagicMock()
+    r.status = status
+    r.response = response
+    r.error = None if status == TaskExecutionStatus.SUCCESS else "boom"
+    r.cost = 0.01
+    r.context_used = 100
+    r.context_max = 200000
+    return r
+
+
+@contextmanager
+def _env(result=None):
+    """Patch every collaborator the wrapper touches; yield the mock bundle."""
+    result = result or _result()
+    service = MagicMock()
+    service.execute_task = AsyncMock(return_value=result)
+
+    ws = MagicMock()
+    ws.broadcast = AsyncMock()
+
+    activity = MagicMock()
+    activity.complete_activity = AsyncMock()
+
+    db = MagicMock()
+    db.get_chat_session.return_value = {"user_id": 7}
+
+    persist = AsyncMock(return_value="cs1")
+    signal = MagicMock()
+
+    with patch.object(_CHAT, "get_task_execution_service", return_value=service), \
+         patch.object(_CHAT, "_websocket_manager", ws), \
+         patch.object(_CHAT, "activity_service", activity), \
+         patch.object(_CHAT, "db", db), \
+         patch.object(_CHAT, "_persist_chat_session", persist), \
+         patch.object(_CHAT, "signal_sync_waiter", signal):
+        yield {
+            "service": service, "ws": ws, "activity": activity, "db": db,
+            "persist": persist, "signal": signal, "result": result,
+        }
+
+
+def _call(request=None, **overrides):
+    request = request or ParallelTaskRequest(message="hi")
+    kwargs = dict(
+        agent_name="agent1",
+        request=request,
+        execution_id="e1",
+        collaboration_activity_id=None,
+        x_source_agent=None,
+        user_id=None,
+        user_email=None,
+    )
+    kwargs.update(overrides)
+    asyncio.run(_run_async_task_with_persistence(**kwargs))
+
+
+def test_basic_executes_and_signals_waiter():
+    with _env() as m:
+        _call()
+    m["service"].execute_task.assert_awaited_once()
+    m["signal"].assert_called_once()              # finally always signals (#498)
+    m["persist"].assert_not_awaited()             # no save_to_session
+    m["activity"].complete_activity.assert_not_awaited()
+
+
+def test_save_to_session_persists_and_broadcasts():
+    req = ParallelTaskRequest(message="hi", save_to_session=True)
+    with _env() as m:
+        _call(req, user_id=7, user_email="u@e.com")
+    m["persist"].assert_awaited_once()
+    # chat_response_ready broadcast fired
+    assert m["ws"].broadcast.await_count == 1
+
+
+def test_save_to_session_skipped_without_user():
+    req = ParallelTaskRequest(message="hi", save_to_session=True)
+    with _env() as m:
+        _call(req)  # no user_id/user_email
+    m["persist"].assert_not_awaited()
+
+
+def test_collaboration_activity_completed():
+    with _env() as m:
+        _call(collaboration_activity_id="collab1", x_source_agent="agentB")
+    m["activity"].complete_activity.assert_awaited_once()
+
+
+def test_self_task_injects_result_into_session():
+    req = ParallelTaskRequest(message="hi", inject_result=True, chat_session_id="cs9")
+    with _env() as m:
+        _call(req, user_id=7, user_email="u@e.com",
+              is_self_task=True, self_task_activity_id="st1")
+    # self-task activity completed + result injected + completion broadcast
+    m["activity"].complete_activity.assert_awaited_once()
+    m["db"].add_chat_message.assert_called_once()
+    assert m["ws"].broadcast.await_count == 1
+
+
+def test_self_task_no_inject_when_session_not_owned():
+    req = ParallelTaskRequest(message="hi", inject_result=True, chat_session_id="cs9")
+    with _env() as m:
+        m["db"].get_chat_session.return_value = {"user_id": 999}  # different owner
+        _call(req, user_id=7, user_email="u@e.com",
+              is_self_task=True, self_task_activity_id="st1")
+    m["db"].add_chat_message.assert_not_called()
+
+
+def test_signal_waiter_called_even_if_side_effect_raises():
+    """The #498 finally guarantee: a post-task side-effect failure still signals
+    the sync waiter. Current behavior: the un-wrapped _persist_chat_session call
+    propagates its error *after* the finally signals — pin both facts."""
+    req = ParallelTaskRequest(message="hi", save_to_session=True)
+    with _env() as m:
+        m["persist"].side_effect = RuntimeError("persist boom")
+        with pytest.raises(RuntimeError):
+            _call(req, user_id=7, user_email="u@e.com")
+    m["signal"].assert_called_once()


### PR DESCRIPTION
## Summary

Third #1026 refactor (after #1035 cleanup-sweeps, #1036 message_router). Targets `routers/chat.py::_run_async_task_with_persistence` (190 lines, CC 33 per the refactor-audit) — the #95 async `/task` background wrapper.

It ran the execution, then **three guarded post-task blocks inline**: chat-session persistence + `chat_response_ready` broadcast (THINK-001), collaboration-activity completion, and self-task completion + result injection (SELF-EXEC-001) — all under one `try` with a `signal_sync_waiter` `finally` (#498).

Extracted each block into a focused module-level helper:
- `_persist_and_broadcast_chat_session` → returns `chat_session_id` (threaded to the `finally` signal)
- `_complete_collaboration_activity`
- `_finalize_self_task`

The wrapper is now a thin **execute → 3 side-effect calls → signal** sequence.

## Result
`_run_async_task_with_persistence`: **195 → 95 lines** (under the 100 target), CC ~33 → low single digits.

## Behavior preserved exactly (the subtle bits)
- The **un-wrapped** `_persist_chat_session` error still **propagates after** the `finally` signals the waiter (#498) — pinned by a dedicated test; only the best-effort broadcast stays isolated.
- Each block keeps its own guard + best-effort `try/except`.
- `chat_session_id` stays `None` on the persist-failure path → `signal_sync_waiter` gets `None` as before.

## Tests
New `tests/unit/test_async_task_persistence.py` — **7 characterization tests** driving the real function with every collaborator patched (basic execute+signal, `save_to_session` persist+broadcast, `save_to_session` skipped without user, collaboration completion, self-task inject, not-owned-session skip, signal-on-side-effect-error). **Green before and after** the extraction — net-new coverage on a previously import-only-AST-checked function.

- ✅ 7/7 new characterization tests green pre+post
- ✅ 66 chat-adjacent unit tests pass (backlog, terminate-async, dispatched-marker, auto-retry)
- ✅ 22 `test_self_execute.py` tests pass (directly exercises the extracted self-task block)

## Scope
One function per the issue's incremental guidance. Remaining #1026 in chat.py: `execute_parallel_task` (551/69) and `chat_with_agent` (601/79); `execute_task` (663/116) is gated on #1027.

Related to #1026