### PR TITLE
refactor(scheduler): split _execute_schedule_with_lock into gate + dispatch (#1026)

### DIFF
--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -756,49 +756,11 @@ class SchedulerService:
             logger.info(f"Schedule {schedule_id} skipped: agent {schedule.agent_name} autonomy is disabled")
             return
 
-        # Agent-owned pre-check hook (#454). Only for cron-triggered invocations:
-        # manual triggers from the UI represent an explicit operator decision and
-        # must always fire. Fail-open: any None return means the agent has no
-        # pre-check or the call errored — fall through to normal firing.
-        effective_message = schedule.message
-        if triggered_by == "schedule":
-            decision = await self._run_pre_check(schedule.agent_name)
-            if decision is not None:
-                if not decision.get("fire", True):
-                    reason = decision.get("reason") or "pre-check returned fire=false"
-                    skipped = self.db.create_skipped_execution(
-                        schedule_id=schedule.id,
-                        agent_name=schedule.agent_name,
-                        message=schedule.message,
-                        triggered_by=triggered_by,
-                        skip_reason=f"pre-check: {reason}",
-                    )
-                    logger.info(
-                        f"Schedule {schedule.name} skipped by pre-check: {reason}"
-                    )
-                    now = datetime.utcnow()
-                    next_run = self._get_next_run_time(
-                        schedule.cron_expression, schedule.timezone
-                    )
-                    self.db.update_schedule_run_times(
-                        schedule.id, last_run_at=now, next_run_at=next_run
-                    )
-                    await self._publish_event({
-                        "type": "schedule_execution_skipped",
-                        "agent": schedule.agent_name,
-                        "schedule_id": schedule.id,
-                        "execution_id": skipped.id if skipped else None,
-                        "schedule_name": schedule.name,
-                        "reason": reason,
-                    })
-                    return
-                override = decision.get("message")
-                if override and isinstance(override, str):
-                    effective_message = override
-                    logger.info(
-                        f"Schedule {schedule.name} pre-check overrode message "
-                        f"({len(override)} chars)"
-                    )
+        # Agent-owned pre-check gate (#454): may skip the firing entirely or
+        # override the message. Manual triggers always fire.
+        should_fire, effective_message = await self._apply_pre_check_gate(schedule, triggered_by)
+        if not should_fire:
+            return
 
         logger.info(f"Executing schedule: {schedule.name} for agent {schedule.agent_name} (triggered_by={triggered_by})")
 
@@ -825,10 +787,76 @@ class SchedulerService:
             "triggered_by": triggered_by
         })
 
-        # Delegate to backend's TaskExecutionService via internal API.
-        # This ensures scheduled tasks go through the same code path as manual
-        # and public tasks: slot acquisition, activity tracking, credential
-        # sanitization, and dashboard capacity meter visibility.
+        await self._dispatch_and_record_outcome(schedule, execution, effective_message, triggered_by)
+
+    async def _apply_pre_check_gate(self, schedule, triggered_by: str) -> tuple[bool, str]:
+        """Agent-owned pre-check hook (#454). Cron-triggered only — manual
+        triggers from the UI are an explicit operator decision and always fire.
+
+        Returns ``(should_fire, effective_message)``. On a ``fire=false``
+        decision this records a skipped execution, advances the schedule run
+        times, and publishes the skipped event, then returns
+        ``(False, ...)`` — the caller aborts. A string ``message`` override is
+        threaded back as ``effective_message``. Fail-open: a ``None`` decision
+        (no hook, or the call errored) falls through to normal firing.
+        """
+        effective_message = schedule.message
+        if triggered_by != "schedule":
+            return True, effective_message
+
+        decision = await self._run_pre_check(schedule.agent_name)
+        if decision is None:
+            return True, effective_message
+
+        if not decision.get("fire", True):
+            reason = decision.get("reason") or "pre-check returned fire=false"
+            skipped = self.db.create_skipped_execution(
+                schedule_id=schedule.id,
+                agent_name=schedule.agent_name,
+                message=schedule.message,
+                triggered_by=triggered_by,
+                skip_reason=f"pre-check: {reason}",
+            )
+            logger.info(
+                f"Schedule {schedule.name} skipped by pre-check: {reason}"
+            )
+            now = datetime.utcnow()
+            next_run = self._get_next_run_time(
+                schedule.cron_expression, schedule.timezone
+            )
+            self.db.update_schedule_run_times(
+                schedule.id, last_run_at=now, next_run_at=next_run
+            )
+            await self._publish_event({
+                "type": "schedule_execution_skipped",
+                "agent": schedule.agent_name,
+                "schedule_id": schedule.id,
+                "execution_id": skipped.id if skipped else None,
+                "schedule_name": schedule.name,
+                "reason": reason,
+            })
+            return False, effective_message
+
+        override = decision.get("message")
+        if override and isinstance(override, str):
+            effective_message = override
+            logger.info(
+                f"Schedule {schedule.name} pre-check overrode message "
+                f"({len(override)} chars)"
+            )
+        return True, effective_message
+
+    async def _dispatch_and_record_outcome(self, schedule, execution, effective_message: str, triggered_by: str):
+        """Dispatch the schedule to the backend's TaskExecutionService (same path
+        as manual/public tasks: slots, activity tracking, sanitization, capacity
+        meter) and record the outcome.
+
+        Handles the three result modes — fire-and-forget ``dispatched`` (#132,
+        advance run times + return, the background poll emits completion),
+        ``success``, and failure — plus the exception path's SCHED-ASYNC-001
+        anti-overwrite guard (don't clobber an execution the backend already
+        finalized).
+        """
         try:
             result = await self._call_backend_execute_task(
                 agent_name=schedule.agent_name,

--- a/tests/scheduler_tests/test_service.py
+++ b/tests/scheduler_tests/test_service.py
@@ -19,7 +19,7 @@ import pytest
 from scheduler.service import SchedulerService
 from scheduler.database import SchedulerDatabase
 from scheduler.locking import LockManager
-from scheduler.models import Schedule
+from scheduler.models import Schedule, ExecutionStatus
 
 
 class TestSchedulerService:
@@ -398,3 +398,60 @@ class TestBackendDelegation:
             mock_backend.assert_called_once()
             call_kwargs = mock_backend.call_args[1]
             assert call_kwargs["triggered_by"] == "manual"
+
+    # ----- dispatch-path characterization (#1026) -----
+
+    @pytest.mark.asyncio
+    async def test_execute_schedule_dispatched_updates_runtimes(self, db_with_data, mock_lock_manager):
+        """Fire-and-forget (#132): a 'dispatched' result updates run times
+        immediately and returns before any 'completed' event."""
+        service = SchedulerService(database=db_with_data, lock_manager=mock_lock_manager)
+        with patch.object(service, '_call_backend_execute_task', new_callable=AsyncMock) as backend, \
+             patch.object(service, '_publish_event', new_callable=AsyncMock) as pub, \
+             patch.object(service.db, 'update_schedule_run_times') as rt:
+            backend.return_value = {"status": "dispatched", "execution_id": "x"}
+            await service._execute_schedule_with_lock("schedule-1", triggered_by="schedule")
+        rt.assert_called_once()
+        assert pub.await_count == 1  # 'started' only — no 'completed' on dispatch
+
+    @pytest.mark.asyncio
+    async def test_execute_schedule_failed_publishes_failed(self, db_with_data, mock_lock_manager):
+        service = SchedulerService(database=db_with_data, lock_manager=mock_lock_manager)
+        with patch.object(service, '_call_backend_execute_task', new_callable=AsyncMock) as backend, \
+             patch.object(service, '_publish_event', new_callable=AsyncMock) as pub:
+            backend.return_value = {"status": "failed", "error": "boom"}
+            await service._execute_schedule_with_lock("schedule-1", triggered_by="schedule")
+        assert pub.await_count == 2  # started + completed(failed)
+        last = pub.await_args_list[-1].args[0]
+        assert last["status"] == "failed"
+        assert last["error"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_execute_schedule_exception_does_not_overwrite_finalized(self, db_with_data, mock_lock_manager):
+        """SCHED-ASYNC-001: a scheduler-side exception must not overwrite an
+        execution the backend already finalized (e.g. as 'success')."""
+        service = SchedulerService(database=db_with_data, lock_manager=mock_lock_manager)
+        finalized = MagicMock()
+        finalized.status = ExecutionStatus.SUCCESS
+        with patch.object(service, '_call_backend_execute_task', new_callable=AsyncMock) as backend, \
+             patch.object(service, '_publish_event', new_callable=AsyncMock) as pub, \
+             patch.object(service.db, 'get_execution', return_value=finalized), \
+             patch.object(service.db, 'update_execution_status') as upd:
+            backend.side_effect = RuntimeError("conn dropped")
+            await service._execute_schedule_with_lock("schedule-1", triggered_by="schedule")
+        upd.assert_not_called()  # anti-overwrite
+        assert pub.await_args_list[-1].args[0]["status"] == ExecutionStatus.SUCCESS
+
+    @pytest.mark.asyncio
+    async def test_execute_schedule_precheck_skip(self, db_with_data, mock_lock_manager):
+        """Pre-check fire=false (#454): record a skipped execution, never dispatch."""
+        service = SchedulerService(database=db_with_data, lock_manager=mock_lock_manager)
+        with patch.object(service, '_run_pre_check', new_callable=AsyncMock) as pc, \
+             patch.object(service, '_call_backend_execute_task', new_callable=AsyncMock) as backend, \
+             patch.object(service, '_publish_event', new_callable=AsyncMock), \
+             patch.object(service.db, 'create_skipped_execution') as skip, \
+             patch.object(service.db, 'update_schedule_run_times'):
+            pc.return_value = {"fire": False, "reason": "nope"}
+            await service._execute_schedule_with_lock("schedule-1", triggered_by="schedule")
+        skip.assert_called_once()
+        backend.assert_not_called()


### PR DESCRIPTION
## Summary

Fourth #1026 refactor (after #1035 cleanup, #1036 message_router, #1038 async-task-wrapper). Targets `scheduler/service.py::_execute_schedule_with_lock` (~195 lines) — the AC-listed scheduler hotspot.

It ran gating guards, the #454 pre-check (skip / message-override), execution-record creation, and a large dispatch `try/except` (dispatched / success / failed / exception-with-SCHED-ASYNC-001-anti-overwrite) all inline. Extract the two heavy phases:

- **`_apply_pre_check_gate(schedule, triggered_by) -> (should_fire, effective_message)`** — cron-only pre-check; owns the skip side-effects (skipped execution + run-time advance + skipped event) and the message override; fail-open on `None`.
- **`_dispatch_and_record_outcome(schedule, execution, effective_message, triggered_by)`** — the backend call + all three result modes + the exception path's anti-overwrite guard.

`_execute_schedule_with_lock` is now a **54-line** orchestrator: guards → gate → create execution → started event → dispatch.

## Result
~195 → **54 lines**. No behavior change — every branch (disabled/autonomy guards, pre-check skip/override/fail-open, dispatched fire-and-forget, success, failed, exception anti-overwrite) preserved verbatim.

## Tests
Extends `scheduler_tests/test_service.py` with **4 characterization tests** for previously-uncovered paths:
- dispatched → run-times advanced, no `completed` event (fire-and-forget)
- failed → `completed`/`failed` event with error
- exception → SCHED-ASYNC-001 anti-overwrite (finalized execution not clobbered; `update_execution_status` not called)
- pre-check skip → skipped execution recorded, backend never called

**Green before and after** the extraction. Existing success (cron + manual) tests still pass.

- ✅ 22/22 in `test_service.py` (18 existing + 4 new) pre+post
- ✅ 173 passed across the full `scheduler_tests/` suite — zero regressions

## Note on verification
This is the scheduler **process** (not the source-mounted backend), so I leaned on the test suite rather than a live in-process exercise. The behaviour is fully pinned by the 22 `test_service.py` cases (real `SchedulerDatabase`, mocked lock/backend/events).

## Scope
One function per the issue's incremental guidance. Remaining #1026: `execute_parallel_task` (551/69) and `chat_with_agent` (601/79) in chat.py; `execute_task` (663/116) gated on #1027.

Related to #1026