### PR TITLE
refactor: deprecate GitHub Project #6 board — issues-only SDLC (#1042)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Current Product Focus
 
-**Primary theme**: Reliability · **Secondary theme**: UI/UX
+**Primary theme**: Reliability (`theme-reliability`) · **Secondary theme**: UI/UX (`theme-ui-ux`)
 
-When picking tickets, prefer items whose Theme matches the current focus. Within the same Tier and Rank, Reliability beats UI/UX beats everything else. Items in other themes are not deprioritized — they're picked only after focus items at that tier are exhausted.
+When picking tickets, prefer items carrying the focus `theme-*` label. Theme focus is a **tiebreaker filter**, not a sort key — among equivalent-priority work, `theme-reliability` is picked first, then `theme-ui-ux`, then everything else. Items in other themes are not deprioritized — they're picked once focus-theme work at that priority is exhausted.
 
 ---
 
@@ -79,16 +79,16 @@ Without `submodule.recurse true`, switching branches will leave `.claude` stale 
 
 ## SDLC
 
-All work follows a 4-stage lifecycle tracked via the **Trinity Roadmap** GitHub Project board:
+All work follows a 4-stage lifecycle tracked via **GitHub Issues** (labels + open/closed state — no project board):
 
 ```
- Todo → In Progress → Review → Done
+ Todo → In Progress → In Dev → Done
 ```
 
-- **Todo**: Issue created, triaged with priority (P0-P3) and type labels, acceptance criteria defined
+- **Todo**: Issue created, triaged with priority (P0-P3), type, and theme labels, acceptance criteria defined
 - **In Progress**: Developer assigned, feature branch created (`feature/<issue>-<slug>`), `status-in-progress` label
-- **Review**: PR opened, `/validate-pr` passes, code review approved
-- **Done**: PR squash-merged, issue closed
+- **In Dev**: PR squash-merged to `dev` — `status-in-dev` label, awaiting the next release cut (dev → main)
+- **Done**: Release PR merged to `main`, issue auto-closed via `Closes #N`
 
 **Full details**: `.claude/DEVELOPMENT_WORKFLOW.md`
 
@@ -108,9 +108,9 @@ All work follows a 4-stage lifecycle tracked via the **Trinity Roadmap** GitHub 
 - No creating documentation files unless explicitly requested
 
 ### 3. Follow the Roadmap
-- Check GitHub Issues and the **Trinity Roadmap** project board for current priorities (`/roadmap` or `gh issue list`)
-- Work P0 issues first, then P1 by Tier (P1a → P1b → P1c), then by issue number (oldest first)
-- Assign yourself, update labels and board status as you progress (see SDLC above)
+- Check **GitHub Issues** for current priorities (`/roadmap` or `gh issue list`) — labels are the single source of truth
+- Work P0 issues first, then P1 (`type-bug` before `type-feature`, then newest issue number first), then P2/P3
+- Assign yourself and update `status-*` labels as you progress (see SDLC above)
 - Close issues when complete
 
 ### 4. Tiered Documentation Updates
@@ -155,7 +155,7 @@ Long-running multi-stage work inside agents (perception → synthesis → publis
 | `docs/planning/TARGET_ARCHITECTURE.md` | **Target system design** — describes the optimal destination; use when evaluating tradeoffs and prioritizing work |
 | `docs/memory/feature-flows.md` | Index of vertical slice docs |
 | `docs/planning/ORCHESTRATION_RELIABILITY_2026-04.md` | Active multi-sprint plan for execution/orchestration reliability. **Current focus: Tier 2.5 Simplification — #306 (push event bus) → #428/#429/#430.** Consult before touching `task_execution_service`, `slot_service`, `backlog_service`, `execution_queue`, or `cleanup_service`. |
-| GitHub Issues + Project Board | Prioritized task queue — **Trinity Roadmap** board (Todo/In Progress/Done), priority labels (P0-P3), Tier sub-priority (P1a/P1b/P1c) |
+| GitHub Issues | Prioritized task queue — labels are authoritative: priority (P0-P3), type, `theme-*`, `complexity-*`; status via `status-*` labels + open/closed; epics are `type-epic` issues with native sub-issues. No project board. |
 
 ---
 

--- a/docs/GITHUB_ISSUES_MIGRATION.md
+++ b/docs/GITHUB_ISSUES_MIGRATION.md
@@ -161,3 +161,38 @@ gh issue create --repo abilityai/trinity --title "Audit Trail System (SEC-001)" 
 | Edit roadmap.md to add item | Run `/roadmap create <title>` |
 | Mark item complete in file | Close issue on GitHub |
 | Check priorities | Run `/roadmap` (shows P0/P1) |
+
+---
+
+## 2026-06-03 — Project board (#6) archived; issues-only SDLC (#1042)
+
+The interim step above ("Create GitHub Project — for visual Kanban/roadmap
+view") was tried and then **retired**. GitHub Project #6 ("Trinity
+Roadmap") was **archived** on 2026-06-03. Prioritization metadata is now
+carried entirely on **labels + native sub-issues** — there is no project
+board. Full rationale and migration plan:
+`docs/planning/PROJECT_BOARD_DEPRECATION_2026-05.md`.
+
+**What changed:**
+
+| Board field (retired) | Replacement |
+|-----------------------|-------------|
+| Theme (single-select) | `theme-*` labels (`theme-reliability`, `theme-ui-ux`, `theme-security`, `theme-channels`, `theme-devex`, `theme-monetization`, `theme-infrastructure`) |
+| Epic (single-select) | Issues labeled `type-epic` + native GitHub **sub-issue** links (automatic rollup) |
+| Complexity (number) | `complexity-low` / `complexity-medium` / `complexity-high` labels |
+| Tier (P1a/P1b/P1c) | **Dropped** — fake precision, ~0% adoption |
+| Rank (number) | **Dropped** — replaced by a written ordering rule |
+
+**Ordering rule** (replaces numeric Rank): P0 first; then P1 with
+`type-bug` before `type-feature` and, within a type, **newest issue number
+first**; then P2/P3. Theme focus (`CLAUDE.md` → "Current Product Focus") is
+a tiebreaker filter, not a sort key.
+
+**Legacy labels removed:** `P1b` (stray Tier label), `status-review` (the
+SDLC dropped the "Review" stage in favor of "In Dev").
+
+Historical Rank/Tier/Epic/Theme values remain readable in the **archived**
+Project #6 (archive preserves data; it was not deleted). Six skills
+(`roadmap`, `groom`, `create-issue`, `metrics`, `read-docs`, `sprint`) and
+`.claude/DEVELOPMENT_WORKFLOW.md` were rewritten to operate on labels +
+sub-issues only.

--- a/docs/planning/PROJECT_BOARD_DEPRECATION_2026-05.md
+++ b/docs/planning/PROJECT_BOARD_DEPRECATION_2026-05.md
@@ -70,6 +70,15 @@ Replaces WORKFLOW.md §Prioritization (lines 53–66, 88):
 
 No Tier ladder. No numeric Rank. The ordering you can defend is the ordering you write down.
 
+> **Execution addendum (2026-06-03, #1042).** During the migration the
+> operator finalized two choices that override the plan defaults above:
+> (1) **Ordering is newest-first** — within a priority/type, **highest issue
+> number first**, not the lowest-number-first FIFO drafted here. (2)
+> **Complexity is kept**, as `complexity-low` / `complexity-medium` /
+> `complexity-high` labels (open question #2 resolved "keep", not "drop") —
+> the board's numeric Complexity field was bucketed `low={1,2,3}`,
+> `medium={5,8}`, `high={13}`. All other plan decisions shipped as written.
+
 ---
 
 ## Skill rewrites


### PR DESCRIPTION
## Summary

Deprecate **GitHub Project #6 ("Trinity Roadmap")** and move the SDLC to **labels + native GitHub sub-issues** only. Prioritization metadata no longer lives on a board.

This is the **superproject half** of a coordinated two-repo change. The 6 skill rewrites + `DEVELOPMENT_WORKFLOW.md` live in the `.claude` submodule (**trinity-dev#2**); this PR bumps the submodule pointer and updates the repo-level docs.

## Changes (this repo)
- **`.claude`** submodule pointer → `df66060` (trinity-dev#2: 6 skills + workflow doc de-boarded).
- **`CLAUDE.md`** — Current Product Focus recast around `theme-*` labels; Rules of Engagement + SDLC de-boarded; lifecycle aligned to **Todo → In Progress → In Dev → Done**; ordering rule = priority, `type-bug` before `type-feature`, **newest issue number first**.
- **`docs/GITHUB_ISSUES_MIGRATION.md`** — appended 2026-06-03 archive note (board fields → label/sub-issue replacements).
- **`docs/planning/PROJECT_BOARD_DEPRECATION_2026-05.md`** — execution addendum (operator overrides: newest-first ordering; complexity kept as labels).

## GitHub-state migration (out-of-band — not in this diff)
- `theme-*` (7) + `complexity-*` (3) + `type-epic` labels created; `theme-*`/`complexity-*` backfilled across ~490 board items (open + closed).
- Epics converted: 8 issue-numbered parents labeled `type-epic`; 6 name-only epics created as new `type-epic` issues; children linked as native sub-issues.
- Legacy `P1b` and `status-review` labels deleted.
- Project #6 **archived** (not deleted — preserves historical Rank/Tier).

## Test plan
- [ ] No surviving "Trinity Roadmap project board" / "Project #6" board-dependency in `CLAUDE.md` / `DEVELOPMENT_WORKFLOW.md`
- [ ] `/roadmap`, `/groom` run with zero `gh project item-list` / GraphQL field-mutation calls
- [ ] All 7 `theme-*` labels carry ≥1 issue; ≥1 `type-epic` issue shows a sub-issue rollup

Depends on trinity-dev#2 (submodule).

Fixes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)