### PR TITLE
refactor(db): SessionMessageInsert request object for add_session_message (#1027)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from db_models import (
     UserCreate,
     User,
+    SessionMessageInsert,
     AgentShare,
     AgentShareRequest,
     McpApiKeyCreate,
@@ -995,20 +996,8 @@ class DatabaseManager:
     def delete_session(self, session_id: str):
         return self._session_ops.delete_session(session_id)
 
-    def add_session_message(self, session_id: str, agent_name: str, user_id: int,
-                            user_email: str, role: str, content: str,
-                            cost: float = None, context_used: int = None,
-                            context_max: int = None, cache_read_tokens: int = None,
-                            tool_calls: str = None, execution_time_ms: int = None,
-                            claude_session_id: str = None,
-                            compact_metadata: str = None, compact_event_count: int = 0):
-        return self._session_ops.add_session_message(
-            session_id, agent_name, user_id, user_email, role, content,
-            cost=cost, context_used=context_used, context_max=context_max,
-            cache_read_tokens=cache_read_tokens, tool_calls=tool_calls,
-            execution_time_ms=execution_time_ms, claude_session_id=claude_session_id,
-            compact_metadata=compact_metadata, compact_event_count=compact_event_count,
-        )
+    def add_session_message(self, msg: SessionMessageInsert):
+        return self._session_ops.add_session_message(msg)
 
     def get_session_messages(self, session_id: str, limit: int = 100):
         return self._session_ops.get_session_messages(session_id, limit=limit)

--- a/src/backend/db/sessions.py
+++ b/src/backend/db/sessions.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Optional, List
 
 from .connection import get_db_connection
-from db_models import AgentSession, AgentSessionMessage
+from db_models import AgentSession, AgentSessionMessage, SessionMessageInsert
 from utils.helpers import utc_now_iso
 
 
@@ -135,24 +135,7 @@ class SessionOperations:
 
     # ---- messages ----------------------------------------------------------
 
-    def add_session_message(
-        self,
-        session_id: str,
-        agent_name: str,
-        user_id: int,
-        user_email: str,
-        role: str,
-        content: str,
-        cost: Optional[float] = None,
-        context_used: Optional[int] = None,
-        context_max: Optional[int] = None,
-        cache_read_tokens: Optional[int] = None,
-        tool_calls: Optional[str] = None,
-        execution_time_ms: Optional[int] = None,
-        claude_session_id: Optional[str] = None,
-        compact_metadata: Optional[str] = None,
-        compact_event_count: int = 0,
-    ) -> AgentSessionMessage:
+    def add_session_message(self, msg: SessionMessageInsert) -> AgentSessionMessage:
         """Insert a session message and update session aggregate stats.
 
         ``compact_metadata`` is a JSON-encoded list of CompactEvent dicts (the
@@ -177,11 +160,11 @@ class SessionOperations:
                 )
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
-                message_id, session_id, agent_name, user_id, user_email,
-                role, content, now,
-                cost, context_used, context_max, cache_read_tokens,
-                tool_calls, execution_time_ms, claude_session_id,
-                compact_metadata,
+                message_id, msg.session_id, msg.agent_name, msg.user_id, msg.user_email,
+                msg.role, msg.content, now,
+                msg.cost, msg.context_used, msg.context_max, msg.cache_read_tokens,
+                msg.tool_calls, msg.execution_time_ms, msg.claude_session_id,
+                msg.compact_metadata,
             ))
 
             # total_context_used reflects the most recent assistant turn's
@@ -204,7 +187,7 @@ class SessionOperations:
                     total_context_max = COALESCE(?, total_context_max),
                     compact_count = compact_count + ?
                 WHERE id = ?
-            """, (now, cost or 0, context_used, context_max, compact_event_count, session_id))
+            """, (now, msg.cost or 0, msg.context_used, msg.context_max, msg.compact_event_count, msg.session_id))
 
             cursor.execute("SELECT * FROM agent_session_messages WHERE id = ?", (message_id,))
             return self._row_to_message(cursor.fetchone())

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -338,6 +338,31 @@ class AgentSessionMessage(BaseModel):
     compact_metadata: Optional[str] = None   # JSON list of compact events fired during this turn
 
 
+class SessionMessageInsert(BaseModel):
+    """Request object for inserting an agent-session message (#1027).
+
+    Replaces the 16-positional-arg signature of
+    ``SessionOperations.add_session_message`` so call sites name every field and
+    can't transpose positional args. The 6 identity/content fields are required;
+    the rest are per-turn observability/compaction metadata with safe defaults.
+    """
+    session_id: str
+    agent_name: str
+    user_id: int
+    user_email: str
+    role: str  # "user" or "assistant"
+    content: str
+    cost: Optional[float] = None
+    context_used: Optional[int] = None
+    context_max: Optional[int] = None
+    cache_read_tokens: Optional[int] = None
+    tool_calls: Optional[str] = None  # JSON array
+    execution_time_ms: Optional[int] = None
+    claude_session_id: Optional[str] = None
+    compact_metadata: Optional[str] = None  # JSON list of compact events
+    compact_event_count: int = 0
+
+
 # =========================================================================
 # Agent Permission Models (Phase 9.10: Agent-to-Agent Permissions)
 # =========================================================================

--- a/src/backend/routers/sessions.py
+++ b/src/backend/routers/sessions.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from database import db
-from db_models import WebFileUpload
+from db_models import WebFileUpload, SessionMessageInsert
 from dependencies import AuthorizedAgent, get_current_user
 from models import User
 from services.docker_service import get_agent_container
@@ -594,14 +594,14 @@ async def send_session_message(
     # Persist the ORIGINAL user message (without the file_descs append) so
     # the visible chat log reads naturally. The agent sees effective_message
     # which has the file references inline.
-    db.add_session_message(
+    db.add_session_message(SessionMessageInsert(
         session_id=session.id,
         agent_name=name,
         user_id=current_user.id,
         user_email=user_email,
         role="user",
         content=body.message,
-    )
+    ))
 
     # In-flight sentinel brackets the turn so GET sessions/{id} can report
     # `turn_in_progress=true` to the UI's onActivated re-sync (Issue #759).
@@ -707,7 +707,7 @@ async def send_session_message(
         compact_events = metadata.get("compact_events") or []
         compact_metadata_json = json.dumps(compact_events) if compact_events else None
 
-        assistant_msg = db.add_session_message(
+        assistant_msg = db.add_session_message(SessionMessageInsert(
             session_id=session.id,
             agent_name=name,
             user_id=current_user.id,
@@ -723,7 +723,7 @@ async def send_session_message(
             claude_session_id=real_uuid,
             compact_metadata=compact_metadata_json,
             compact_event_count=len(compact_events),
-        )
+        ))
 
         # Refresh the session row so the response reflects the post-turn stats.
         refreshed = db.get_session(session.id)

--- a/tests/unit/test_session_operations.py
+++ b/tests/unit/test_session_operations.py
@@ -32,6 +32,18 @@ def _load(name: str, path: Path):
     return module
 
 
+def _add(session_ops, session_id=None, agent_name=None, user_id=None,
+         user_email=None, role=None, content=None, **kw):
+    """#1027: add_session_message now takes a SessionMessageInsert request
+    object. This adapter lets the existing test call sites keep passing the
+    six identity/content fields positionally (Pydantic has no positional init)."""
+    from db_models import SessionMessageInsert
+    return session_ops.add_session_message(SessionMessageInsert(
+        session_id=session_id, agent_name=agent_name, user_id=user_id,
+        user_email=user_email, role=role, content=content, **kw,
+    ))
+
+
 _USERS_DDL = """
 CREATE TABLE users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -158,7 +170,7 @@ def test_list_sessions_filters_and_orders(session_ops):
     other = session_ops.create_session("agentB", 1, "alice@example.com")
 
     # Touch a so its last_message_at moves to "now-after-b".
-    session_ops.add_session_message(
+    _add(session_ops, 
         a.id, "agentA", 1, "alice@example.com", "user", "hi"
     )
 
@@ -180,14 +192,14 @@ def test_list_sessions_filters_and_orders(session_ops):
 def test_add_session_message_updates_aggregate(session_ops):
     s = session_ops.create_session("agentX", 1, "alice@example.com")
 
-    user_msg = session_ops.add_session_message(
+    user_msg = _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com", "user", "hello"
     )
     assert user_msg.role == "user"
     assert user_msg.cost is None
     assert user_msg.cache_read_tokens is None
 
-    asst_msg = session_ops.add_session_message(
+    asst_msg = _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "hi back",
         cost=0.0012, context_used=12000, context_max=200000,
@@ -224,7 +236,7 @@ def test_total_context_used_reflects_last_reading_not_watermark(session_ops):
     s = session_ops.create_session("agentX", 1, "alice@example.com")
 
     # Heavy assistant turn — pre-compact peak.
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "heavy",
         context_used=130_000, context_max=200_000,
@@ -232,7 +244,7 @@ def test_total_context_used_reflects_last_reading_not_watermark(session_ops):
     assert session_ops.get_session(s.id).total_context_used == 130_000
 
     # Auto-compact fires; next turn's reading drops sharply.
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "post-compact",
         context_used=15_000, context_max=200_000,
@@ -243,7 +255,7 @@ def test_total_context_used_reflects_last_reading_not_watermark(session_ops):
     )
 
     # Cap at total_context_max still applies — defends against accounting bugs.
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "impossible",
         context_used=10_000_000, context_max=200_000,
@@ -263,7 +275,7 @@ def test_compact_metadata_persists_and_count_accumulates(session_ops):
         {"trigger": "auto", "pre_tokens": 170_325, "post_tokens": 12_691,
          "duration_ms": 110_361, "timestamp": "t1"},
     ]
-    msg1 = session_ops.add_session_message(
+    msg1 = _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "first heavy turn",
         compact_metadata=_json.dumps(events_turn1),
@@ -279,7 +291,7 @@ def test_compact_metadata_persists_and_count_accumulates(session_ops):
         {"trigger": "auto", "pre_tokens": 167_261, "post_tokens": 14_298,
          "duration_ms": 113_181, "timestamp": "t3"},
     ]
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "second heavy turn",
         compact_metadata=_json.dumps(events_turn2),
@@ -288,7 +300,7 @@ def test_compact_metadata_persists_and_count_accumulates(session_ops):
     assert session_ops.get_session(s.id).compact_count == 3
 
     # Turn 3: no compact — message stores NULL, session counter stays.
-    msg3 = session_ops.add_session_message(
+    msg3 = _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "light turn",
     )
@@ -304,7 +316,7 @@ def test_total_context_used_unchanged_when_value_omitted(session_ops):
     """
     s = session_ops.create_session("agentX", 1, "alice@example.com")
 
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "first",
         context_used=42_000, context_max=200_000,
@@ -312,7 +324,7 @@ def test_total_context_used_unchanged_when_value_omitted(session_ops):
     assert session_ops.get_session(s.id).total_context_used == 42_000
 
     # Turn lands without context_used (None) — the existing value should hold.
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com",
         "assistant", "second",
         context_used=None, context_max=None,
@@ -323,7 +335,7 @@ def test_total_context_used_unchanged_when_value_omitted(session_ops):
 def test_get_session_messages_returns_oldest_first(session_ops):
     s = session_ops.create_session("agentX", 1, "alice@example.com")
     for i in range(3):
-        session_ops.add_session_message(
+        _add(session_ops, 
             s.id, "agentX", 1, "alice@example.com",
             "user" if i % 2 == 0 else "assistant",
             f"msg{i}",
@@ -371,10 +383,10 @@ def test_resume_failure_and_success_counters(session_ops):
 
 def test_delete_session_removes_messages(session_ops):
     s = session_ops.create_session("agentX", 1, "alice@example.com")
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com", "user", "hi"
     )
-    session_ops.add_session_message(
+    _add(session_ops, 
         s.id, "agentX", 1, "alice@example.com", "assistant", "back"
     )
     assert len(session_ops.get_session_messages(s.id)) == 2


### PR DESCRIPTION
## Summary

First slice of #1027 — kill the positional-arg fragility on the param-heavy DB inserts, starting with the smaller blast radius: `SessionOperations.add_session_message` (16 params).

Replaces the 16-param signature with a single **`SessionMessageInsert`** Pydantic request object (in `db_models.py`, alongside `AgentSessionMessage`). Every call site now names its fields — a transposed positional arg becomes impossible.

## Changes
- **`db_models.py`** — new `SessionMessageInsert` (6 required identity/content fields + per-turn observability/compaction metadata with defaults).
- **`db/sessions.py`** — `add_session_message(self, msg: SessionMessageInsert)`; body reads `msg.*`. SQL and the session-aggregate UPDATE unchanged.
- **`database.py`** facade — delegates the object straight through (`return self._session_ops.add_session_message(msg)`).
- **`routers/sessions.py`** — both call sites (user-turn + assistant-turn) build `SessionMessageInsert(...)`.
- **`test_session_operations.py`** — a small `_add()` adapter maps the existing positional test calls onto the object (Pydantic has no positional init), so the assertions stay identical.

## No schema / behavior change
Pure call-shape refactor. The insert + aggregate-stats UPDATE are byte-identical.

## Tests
- ✅ 12/12 `test_session_operations.py` green before and after (behavior pinned: aggregate updates, cache_read_tokens, claude_session_id, compact tally).
- ✅ 34 session-related unit tests pass.
- ✅ 1841 unit tests pass. The only failures are the pre-existing, environment-only `test_git_pull_branch.py` cases (need a real `origin/main`); `test_dispatch_breaker.py` / slack collectors error only on missing local `fakeredis`/deps (CI has them) — all unrelated to this diff.

## Scope / remaining #1027
- [x] `add_session_message` → request object (this PR)
- [ ] `add_chat_message` (db/chat.py, 15 params, 7 callers) → request object
- [ ] split `db/schedules.py` (1,987 lines) into composed modules

Pairs with the orchestration keystone: the same request-object pattern is what unblocks `execute_task`'s 25-param signature (#1026).

Related to #1027