### PR TITLE
refactor(chat): decompose chat_with_agent into admit/prepare/execute slices (#1026)

### DIFF
--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -283,64 +283,43 @@ async def _admit_chat_request(
     )
 
 
-@router.post("/{name}/chat")
-async def chat_with_agent(
+class ChatExecutionContext(NamedTuple):
+    """Execution-setup handoff for chat_with_agent (#1026 slice 2). Carries the
+    records/ids the downstream execute+finalize body consumes. As with
+    ChatAdmission (slice 1), every field here is referenced downstream — leaving
+    one out strands a local and NameErrors the admitted path."""
+    execution: object
+    task_execution_id: object
+    triggered_by: str
+    subscription_id: object
+    collaboration_activity_id: object
+    chat_activity_id: object
+    session: object
+    is_queued: bool
+
+
+async def _prepare_chat_execution(
+    *,
+    name: str,
     request: ChatMessageRequest,
-    name: str = Depends(get_authorized_agent),
-    current_user: User = Depends(get_current_user),
-    x_source_agent: Optional[str] = Header(None),
-    x_via_mcp: Optional[str] = Header(None),
-    x_mcp_key_id: Optional[str] = Header(None),
-    x_mcp_key_name: Optional[str] = Header(None),
-    idempotency_key: Optional[str] = Header(None),
-):
+    current_user: User,
+    x_source_agent: Optional[str],
+    x_via_mcp: Optional[str],
+    x_mcp_key_id: Optional[str],
+    x_mcp_key_name: Optional[str],
+    idem: object,
+    chat_execution_id: str,
+    capacity_result: object,
+    queue_result: str,
+) -> ChatExecutionContext:
+    """Execution setup for chat_with_agent (#1026 slice 2).
+
+    Creates the task-execution record (#96), looks up the agent subscription
+    (SUB-004), broadcasts the agent-to-agent collaboration event + activity,
+    gets/creates the chat session, tracks the chat-start activity, and logs the
+    inbound user message. Returns a ChatExecutionContext carrying the ids/records
+    the downstream execute+finalize body consumes.
     """
-    Proxy chat messages to agent's internal web server and persist to database.
-
-    This endpoint enforces single-execution-at-a-time via the execution queue.
-    If the agent is busy, the request is queued (up to 3 waiting).
-    If the queue is full, returns 429 Too Many Requests.
-
-    Issue #98: Chat executions now also acquire a capacity slot so that
-    SlotService is the single source of truth for agent load. The queue
-    still enforces serial chat; the slot tracks resource usage visible
-    in the capacity meter.
-
-    Headers:
-    - X-Source-Agent: Set when one agent calls another (agent-to-agent)
-    - X-Via-MCP: Set for all MCP calls (both user and agent-scoped)
-    """
-    container = get_agent_container(name)
-    if not container:
-        raise HTTPException(status_code=404, detail="Agent not found")
-
-    if container.status != "running":
-        raise HTTPException(status_code=503, detail="Agent is not running")
-
-    # Admission gate (#1026 slice 1): idempotency (#525) + dispatch breaker
-    # (#526) + capacity acquire (#428). Returns a JSONResponse on idempotent
-    # replay, or a ChatAdmission to proceed; raises 409/503/429 on deny.
-    admission = await _admit_chat_request(
-        name=name,
-        request=request,
-        current_user=current_user,
-        x_source_agent=x_source_agent,
-        x_via_mcp=x_via_mcp,
-        x_mcp_key_id=x_mcp_key_id,
-        x_mcp_key_name=x_mcp_key_name,
-        idempotency_key=idempotency_key,
-    )
-    if isinstance(admission, JSONResponse):
-        return admission
-    idem = admission.idem
-    idem_done = False
-    chat_execution_id = admission.execution_id
-    capacity_result = admission.capacity_result
-    capacity = admission.capacity
-    queue_result = admission.queue_result
-    chat_timeout = admission.chat_timeout
-
-    # Track queue position for observability
     is_queued = capacity_result.state == "queued_in_memory"
     # Backwards-compat names: existing code below references `execution.id`.
     # Map the new chat_execution_id onto the old shape so the rest of the
@@ -437,7 +416,7 @@ async def chat_with_agent(
     )
 
     # Log user message to database
-    user_message = db.add_chat_message(
+    db.add_chat_message(
         session_id=session.id,
         agent_name=name,
         user_id=current_user.id,
@@ -445,6 +424,103 @@ async def chat_with_agent(
         role="user",
         content=request.message
     )
+
+    return ChatExecutionContext(
+        execution=execution,
+        task_execution_id=task_execution_id,
+        triggered_by=triggered_by,
+        subscription_id=_chat_subscription_id,
+        collaboration_activity_id=collaboration_activity_id,
+        chat_activity_id=chat_activity_id,
+        session=session,
+        is_queued=is_queued,
+    )
+
+
+@router.post("/{name}/chat")
+async def chat_with_agent(
+    request: ChatMessageRequest,
+    name: str = Depends(get_authorized_agent),
+    current_user: User = Depends(get_current_user),
+    x_source_agent: Optional[str] = Header(None),
+    x_via_mcp: Optional[str] = Header(None),
+    x_mcp_key_id: Optional[str] = Header(None),
+    x_mcp_key_name: Optional[str] = Header(None),
+    idempotency_key: Optional[str] = Header(None),
+):
+    """
+    Proxy chat messages to agent's internal web server and persist to database.
+
+    This endpoint enforces single-execution-at-a-time via the execution queue.
+    If the agent is busy, the request is queued (up to 3 waiting).
+    If the queue is full, returns 429 Too Many Requests.
+
+    Issue #98: Chat executions now also acquire a capacity slot so that
+    SlotService is the single source of truth for agent load. The queue
+    still enforces serial chat; the slot tracks resource usage visible
+    in the capacity meter.
+
+    Headers:
+    - X-Source-Agent: Set when one agent calls another (agent-to-agent)
+    - X-Via-MCP: Set for all MCP calls (both user and agent-scoped)
+    """
+    container = get_agent_container(name)
+    if not container:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    if container.status != "running":
+        raise HTTPException(status_code=503, detail="Agent is not running")
+
+    # Admission gate (#1026 slice 1): idempotency (#525) + dispatch breaker
+    # (#526) + capacity acquire (#428). Returns a JSONResponse on idempotent
+    # replay, or a ChatAdmission to proceed; raises 409/503/429 on deny.
+    admission = await _admit_chat_request(
+        name=name,
+        request=request,
+        current_user=current_user,
+        x_source_agent=x_source_agent,
+        x_via_mcp=x_via_mcp,
+        x_mcp_key_id=x_mcp_key_id,
+        x_mcp_key_name=x_mcp_key_name,
+        idempotency_key=idempotency_key,
+    )
+    if isinstance(admission, JSONResponse):
+        return admission
+    idem = admission.idem
+    idem_done = False
+    chat_execution_id = admission.execution_id
+    capacity_result = admission.capacity_result
+    capacity = admission.capacity
+    queue_result = admission.queue_result
+    chat_timeout = admission.chat_timeout
+
+    # Track queue position for observability
+    # Execution setup (#1026 slice 2): exec record (#96) + subscription (SUB-004)
+    # + collaboration broadcast/activity + session + chat-start activity + inbound
+    # user-message log. Returns the ids/records the execute+finalize body below
+    # consumes; every field is unpacked (slice-1 lesson: a stranded local
+    # NameErrors the admitted path).
+    ctx = await _prepare_chat_execution(
+        name=name,
+        request=request,
+        current_user=current_user,
+        x_source_agent=x_source_agent,
+        x_via_mcp=x_via_mcp,
+        x_mcp_key_id=x_mcp_key_id,
+        x_mcp_key_name=x_mcp_key_name,
+        idem=idem,
+        chat_execution_id=chat_execution_id,
+        capacity_result=capacity_result,
+        queue_result=queue_result,
+    )
+    execution = ctx.execution
+    task_execution_id = ctx.task_execution_id
+    triggered_by = ctx.triggered_by
+    _chat_subscription_id = ctx.subscription_id
+    collaboration_activity_id = ctx.collaboration_activity_id
+    chat_activity_id = ctx.chat_activity_id
+    session = ctx.session
+    is_queued = ctx.is_queued
 
     execution_success = False
     try:

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -113,6 +113,8 @@ class ChatAdmission(NamedTuple):
     execution_id: str
     capacity_result: object
     capacity: object
+    queue_result: str
+    chat_timeout: int
 
 
 async def _admit_chat_request(
@@ -208,6 +210,10 @@ async def _admit_chat_request(
         _disp = DispatchBreaker(name).to_dict()
         if _disp.get("state") == "open":
             logger.warning(f"[Chat] Agent '{name}' dispatch circuit open, rejecting request")
+            # Nothing dispatched — release the idempotency claim so the caller
+            # can retry with the same key once the breaker recovers (#525),
+            # mirroring the CapacityFull branch below.
+            idempotency_service.fail(idem)
             _raise_circuit_open_503(
                 name, None, CircuitOpen(name, int(_disp.get("retry_after_seconds") or 0))
             )
@@ -272,6 +278,8 @@ async def _admit_chat_request(
         execution_id=chat_execution_id,
         capacity_result=capacity_result,
         capacity=capacity,
+        queue_result=queue_result,
+        chat_timeout=chat_timeout,
     )
 
 
@@ -329,6 +337,8 @@ async def chat_with_agent(
     chat_execution_id = admission.execution_id
     capacity_result = admission.capacity_result
     capacity = admission.capacity
+    queue_result = admission.queue_result
+    chat_timeout = admission.chat_timeout
 
     # Track queue position for observability
     is_queued = capacity_result.state == "queued_in_memory"

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -487,7 +487,6 @@ async def chat_with_agent(
     if isinstance(admission, JSONResponse):
         return admission
     idem = admission.idem
-    idem_done = False
     chat_execution_id = admission.execution_id
     capacity_result = admission.capacity_result
     capacity = admission.capacity
@@ -522,6 +521,62 @@ async def chat_with_agent(
     session = ctx.session
     is_queued = ctx.is_queued
 
+    # Execute + finalize (#1026 slice 3): dispatch to the agent, persist the
+    # assistant message + observability, complete activities, write the terminal
+    # execution row, store the idempotency snapshot, and (on error) run SUB-003
+    # auto-switch + map the HTTPException. Always releases the slot + idem claim.
+    return await _run_chat_and_finalize(
+        name=name,
+        request=request,
+        current_user=current_user,
+        x_source_agent=x_source_agent,
+        x_mcp_key_name=x_mcp_key_name,
+        triggered_by=triggered_by,
+        task_execution_id=task_execution_id,
+        _chat_subscription_id=_chat_subscription_id,
+        chat_activity_id=chat_activity_id,
+        collaboration_activity_id=collaboration_activity_id,
+        session=session,
+        execution=execution,
+        queue_result=queue_result,
+        is_queued=is_queued,
+        chat_timeout=chat_timeout,
+        idem=idem,
+        capacity=capacity,
+    )
+
+
+async def _run_chat_and_finalize(
+    *,
+    name: str,
+    request: ChatMessageRequest,
+    current_user: User,
+    x_source_agent: Optional[str],
+    x_mcp_key_name: Optional[str],
+    triggered_by: str,
+    task_execution_id: object,
+    _chat_subscription_id: object,
+    chat_activity_id: object,
+    collaboration_activity_id: object,
+    session: object,
+    execution: object,
+    queue_result: str,
+    is_queued: bool,
+    chat_timeout: int,
+    idem: object,
+    capacity: object,
+):
+    """Execute the chat against the agent and finalize (#1026 slice 3).
+
+    Dispatches the request to the agent server, persists the assistant message +
+    observability, completes the chat/collaboration activities, writes the
+    terminal execution-status row, and stores the idempotency snapshot. On the
+    agent-call error paths it records the failure, runs SUB-003 auto-switch
+    (429/auth), and raises the mapped HTTPException. The ``finally`` always
+    releases the capacity slot and any still-in-flight idempotency claim.
+    Returns the agent response dict (the endpoint's response body).
+    """
+    idem_done = False
     execution_success = False
     try:
         # chat_timeout already fetched above for slot acquisition (Issue #98)

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -493,7 +493,6 @@ async def chat_with_agent(
     queue_result = admission.queue_result
     chat_timeout = admission.chat_timeout
 
-    # Track queue position for observability
     # Execution setup (#1026 slice 2): exec record (#96) + subscription (SUB-004)
     # + collaboration broadcast/activity + session + chat-start activity + inbound
     # user-message log. Returns the ids/records the execute+finalize body below

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -11,7 +11,7 @@ import logging
 import asyncio
 import uuid
 from datetime import datetime
-from typing import NoReturn, Optional
+from typing import NamedTuple, NoReturn, Optional
 
 from models import User, ChatMessageRequest, ModelChangeRequest, ParallelTaskRequest, ActivityType, ActivityState, TaskExecutionStatus, ExecutionSource
 from dependencies import get_current_user, get_authorized_agent, get_owned_agent
@@ -106,47 +106,46 @@ async def broadcast_collaboration_event(source_agent: str, target_agent: str, ac
         print(f"[Warning] WebSocket manager not set, skipping collaboration broadcast")
 
 
-@router.post("/{name}/chat")
-async def chat_with_agent(
+class ChatAdmission(NamedTuple):
+    """Result of the chat admission gate (#1026 slice 1) when a request is
+    cleared to proceed. Carries the values the rest of the endpoint needs."""
+    idem: object
+    execution_id: str
+    capacity_result: object
+    capacity: object
+
+
+async def _admit_chat_request(
+    *,
+    name: str,
     request: ChatMessageRequest,
-    name: str = Depends(get_authorized_agent),
-    current_user: User = Depends(get_current_user),
-    x_source_agent: Optional[str] = Header(None),
-    x_via_mcp: Optional[str] = Header(None),
-    x_mcp_key_id: Optional[str] = Header(None),
-    x_mcp_key_name: Optional[str] = Header(None),
-    idempotency_key: Optional[str] = Header(None),
+    current_user: User,
+    x_source_agent: Optional[str],
+    x_via_mcp: Optional[str],
+    x_mcp_key_id: Optional[str],
+    x_mcp_key_name: Optional[str],
+    idempotency_key: Optional[str],
 ):
+    """Admission gate for chat_with_agent (#1026 slice 1).
+
+    Runs the idempotency gate (#525), the dispatch-breaker fast-fail (#526), and
+    the CapacityManager.acquire (#428). Returns either:
+      - a ``JSONResponse`` — the caller must return it directly (idempotent
+        replay snapshot); or
+      - a ``ChatAdmission`` — the request is cleared and carries the
+        ``idem`` / ``execution_id`` / ``capacity_result`` / ``capacity`` the
+        rest of the endpoint consumes.
+
+    Raises ``HTTPException`` directly on the deny paths (409 in-flight replay,
+    503 breaker-open, 429 capacity-full — which also releases the idempotency
+    claim so the caller can retry).
     """
-    Proxy chat messages to agent's internal web server and persist to database.
-
-    This endpoint enforces single-execution-at-a-time via the execution queue.
-    If the agent is busy, the request is queued (up to 3 waiting).
-    If the queue is full, returns 429 Too Many Requests.
-
-    Issue #98: Chat executions now also acquire a capacity slot so that
-    SlotService is the single source of truth for agent load. The queue
-    still enforces serial chat; the slot tracks resource usage visible
-    in the capacity meter.
-
-    Headers:
-    - X-Source-Agent: Set when one agent calls another (agent-to-agent)
-    - X-Via-MCP: Set for all MCP calls (both user and agent-scoped)
-    """
-    container = get_agent_container(name)
-    if not container:
-        raise HTTPException(status_code=404, detail="Agent not found")
-
-    if container.status != "running":
-        raise HTTPException(status_code=503, detail="Agent is not running")
-
     # RELIABILITY-006 (#525): idempotency gate. Short-circuit duplicate
     # requests before consuming a capacity slot. The header is optional — when
     # absent, dedup is off and the request proceeds normally (back-compat).
     idem = idempotency_service.begin(
         idempotency_service.make_agent_scope(name), idempotency_key
     )
-    idem_done = False
     if idem.replay:
         await platform_audit_service.log(
             event_type=AuditEventType.EXECUTION,
@@ -267,6 +266,69 @@ async def chat_with_agent(
                 "message": f"Agent '{name}' is busy. Please try again later."
             }
         )
+
+    return ChatAdmission(
+        idem=idem,
+        execution_id=chat_execution_id,
+        capacity_result=capacity_result,
+        capacity=capacity,
+    )
+
+
+@router.post("/{name}/chat")
+async def chat_with_agent(
+    request: ChatMessageRequest,
+    name: str = Depends(get_authorized_agent),
+    current_user: User = Depends(get_current_user),
+    x_source_agent: Optional[str] = Header(None),
+    x_via_mcp: Optional[str] = Header(None),
+    x_mcp_key_id: Optional[str] = Header(None),
+    x_mcp_key_name: Optional[str] = Header(None),
+    idempotency_key: Optional[str] = Header(None),
+):
+    """
+    Proxy chat messages to agent's internal web server and persist to database.
+
+    This endpoint enforces single-execution-at-a-time via the execution queue.
+    If the agent is busy, the request is queued (up to 3 waiting).
+    If the queue is full, returns 429 Too Many Requests.
+
+    Issue #98: Chat executions now also acquire a capacity slot so that
+    SlotService is the single source of truth for agent load. The queue
+    still enforces serial chat; the slot tracks resource usage visible
+    in the capacity meter.
+
+    Headers:
+    - X-Source-Agent: Set when one agent calls another (agent-to-agent)
+    - X-Via-MCP: Set for all MCP calls (both user and agent-scoped)
+    """
+    container = get_agent_container(name)
+    if not container:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    if container.status != "running":
+        raise HTTPException(status_code=503, detail="Agent is not running")
+
+    # Admission gate (#1026 slice 1): idempotency (#525) + dispatch breaker
+    # (#526) + capacity acquire (#428). Returns a JSONResponse on idempotent
+    # replay, or a ChatAdmission to proceed; raises 409/503/429 on deny.
+    admission = await _admit_chat_request(
+        name=name,
+        request=request,
+        current_user=current_user,
+        x_source_agent=x_source_agent,
+        x_via_mcp=x_via_mcp,
+        x_mcp_key_id=x_mcp_key_id,
+        x_mcp_key_name=x_mcp_key_name,
+        idempotency_key=idempotency_key,
+    )
+    if isinstance(admission, JSONResponse):
+        return admission
+    idem = admission.idem
+    idem_done = False
+    chat_execution_id = admission.execution_id
+    capacity_result = admission.capacity_result
+    capacity = admission.capacity
 
     # Track queue position for observability
     is_queued = capacity_result.state == "queued_in_memory"

--- a/tests/unit/test_chat_admission.py
+++ b/tests/unit/test_chat_admission.py
@@ -1,0 +1,138 @@
+"""
+Characterization tests for the admission gate of routers.chat.chat_with_agent
+(#1026, slice 1).
+
+The front of chat_with_agent gates a request before any work: idempotency
+replay/in-flight (#525), dispatch-breaker fast-fail (#526), and the
+CapacityManager.acquire (#428) with its CapacityFull→429 + idempotency-release.
+These pin the four exit modes so the extraction of `_admit_chat_request` is
+provably behavior-preserving. The admitted (happy) path is covered separately
+against the extracted helper.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+from routers.chat import chat_with_agent
+from models import ChatMessageRequest
+from services.capacity_manager import CapacityFull
+
+_CHAT = sys.modules[chat_with_agent.__module__]
+
+
+def _user():
+    u = MagicMock()
+    u.id = 1
+    u.email = "u@e.com"
+    u.username = "u"
+    return u
+
+
+def _idem(replay=False, in_flight=False, execution_id="e0"):
+    m = MagicMock()
+    m.replay = replay
+    m.in_flight = in_flight
+    m.execution_id = execution_id
+    m.snapshot = {"execution": {"task_execution_id": execution_id}}
+    return m
+
+
+@contextmanager
+def _env(idem, breaker_state=None, acquire_exc=None):
+    container = MagicMock()
+    container.status = "running"
+
+    isvc = MagicMock()
+    isvc.begin.return_value = idem
+
+    cap = MagicMock()
+    if acquire_exc is not None:
+        cap.acquire = AsyncMock(side_effect=acquire_exc)
+    else:
+        cap.acquire = AsyncMock(return_value=MagicMock(state="admitted", queue_position=0))
+
+    db = MagicMock()
+    db.get_execution_timeout.return_value = 3600
+    db.get_max_parallel_tasks.return_value = 3
+
+    breaker = MagicMock()
+    breaker.to_dict.return_value = {"state": breaker_state or "closed", "retry_after_seconds": 5}
+
+    with patch.object(_CHAT, "get_agent_container", return_value=container), \
+         patch.object(_CHAT, "idempotency_service", isvc), \
+         patch.object(_CHAT, "dispatch_breaker_active", return_value=bool(breaker_state)), \
+         patch.object(_CHAT, "get_capacity_manager", return_value=cap), \
+         patch.object(_CHAT, "platform_audit_service", MagicMock(log=AsyncMock())), \
+         patch.object(_CHAT, "db", db), \
+         patch("services.dispatch_breaker.DispatchBreaker", return_value=breaker):
+        yield {"isvc": isvc, "cap": cap, "db": db}
+
+
+def _call(idempotency_key="k1"):
+    return asyncio.run(chat_with_agent(
+        request=ChatMessageRequest(message="hi"),
+        name="agent1",
+        current_user=_user(),
+        x_source_agent=None,
+        x_via_mcp=None,
+        x_mcp_key_id=None,
+        x_mcp_key_name=None,
+        idempotency_key=idempotency_key,
+    ))
+
+
+def test_replay_returns_snapshot_response():
+    with _env(_idem(replay=True, in_flight=False)) as m:
+        resp = _call()
+    assert isinstance(resp, JSONResponse)
+    assert resp.headers.get("X-Idempotent-Replay") == "true"
+    m["cap"].acquire.assert_not_awaited()  # short-circuits before capacity
+
+
+def test_in_flight_replay_raises_409():
+    with _env(_idem(replay=True, in_flight=True)):
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == 409
+
+
+def test_breaker_open_raises_503():
+    with _env(_idem(replay=False), breaker_state="open") as m:
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == 503
+    m["cap"].acquire.assert_not_awaited()  # fast-fail before acquire
+
+
+def test_capacity_full_raises_429_and_releases_idem():
+    full = CapacityFull(agent_name="agent1", max_concurrent=3, reason="in_memory_full", depth=3)
+    with _env(_idem(replay=False), acquire_exc=full) as m:
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == 429
+    m["isvc"].fail.assert_called_once()  # idempotency claim released for retry
+
+
+def test_admitted_returns_chat_admission():
+    """Happy path: the extracted helper returns a ChatAdmission carrying the
+    handoff values the endpoint consumes downstream."""
+    from routers.chat import _admit_chat_request, ChatAdmission
+    cap_result = MagicMock(state="admitted", queue_position=0)
+    with _env(_idem(replay=False)) as m:
+        m["cap"].acquire = AsyncMock(return_value=cap_result)
+        admission = asyncio.run(_admit_chat_request(
+            name="agent1", request=ChatMessageRequest(message="hi"),
+            current_user=_user(), x_source_agent=None, x_via_mcp=None,
+            x_mcp_key_id=None, x_mcp_key_name=None, idempotency_key="k1",
+        ))
+    assert isinstance(admission, ChatAdmission)
+    assert admission.capacity_result is cap_result
+    assert isinstance(admission.execution_id, str) and admission.execution_id
+    assert admission.idem is m["isvc"].begin.return_value

--- a/tests/unit/test_chat_admission.py
+++ b/tests/unit/test_chat_admission.py
@@ -1,13 +1,19 @@
 """
-Characterization tests for the admission gate of routers.chat.chat_with_agent
-(#1026, slice 1).
+Characterization tests for the decomposition of routers.chat.chat_with_agent
+(#1026, slices 1-3).
 
-The front of chat_with_agent gates a request before any work: idempotency
-replay/in-flight (#525), dispatch-breaker fast-fail (#526), and the
-CapacityManager.acquire (#428) with its CapacityFull→429 + idempotency-release.
-These pin the four exit modes so the extraction of `_admit_chat_request` is
-provably behavior-preserving. The admitted (happy) path is covered separately
-against the extracted helper.
+- Slice 1 (`_admit_chat_request`): idempotency replay/in-flight (#525),
+  dispatch-breaker fast-fail (#526), CapacityManager.acquire (#428) with its
+  CapacityFull→429 + idempotency-release. The four deny/replay exits are pinned.
+- Slice 2 (`_prepare_chat_execution`): execution record, subscription lookup,
+  collaboration broadcast/activity, session, chat-start activity, user-msg log.
+- Slice 3 (`_run_chat_and_finalize`): agent dispatch, response persistence,
+  activity completion, terminal execution write, idempotency snapshot, the
+  httpx/SUB-003 error paths, and the slot + idempotency release in `finally`.
+
+The full admitted path is covered end-to-end via the real `chat_with_agent`
+(`test_admitted_full_endpoint_path_succeeds`) so no extracted local can be
+stranded without a test failing.
 """
 from __future__ import annotations
 
@@ -220,3 +226,37 @@ def test_prepare_agent_to_agent_broadcasts_collaboration():
     assert ctx.triggered_by == "agent"
     assert ctx.collaboration_activity_id == "act1"   # collaboration activity tracked
     bcast.assert_awaited_once()                       # agent-to-agent broadcast fired
+
+
+# --- #1026 slice 3: _run_chat_and_finalize --------------------------------
+
+def test_run_finalize_http_error_releases_slot_and_idem_then_503():
+    """A non-auth agent transport error maps to 503 and the `finally` releases
+    BOTH the capacity slot and the in-flight idempotency claim (idem_done stays
+    False). SUB-003 is not triggered for a transport error with no status code."""
+    import httpx
+    from routers.chat import _run_chat_and_finalize
+    with _env(_idem(replay=False)) as m, \
+         patch.object(_CHAT, "activity_service", MagicMock(complete_activity=AsyncMock())), \
+         patch.object(_CHAT, "agent_post_with_retry",
+                      AsyncMock(side_effect=httpx.ConnectError("boom"))), \
+         patch.object(_CHAT, "compose_system_prompt", return_value="sys"), \
+         patch.object(_CHAT, "is_execution_context_enabled", return_value=False), \
+         patch("services.subscription_auto_switch.is_auth_failure", return_value=False), \
+         patch("services.subscription_auto_switch.handle_subscription_failure",
+               AsyncMock(return_value=None)):
+        idem = m["isvc"].begin.return_value
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(_run_chat_and_finalize(
+                name="agent1", request=ChatMessageRequest(message="hi"),
+                current_user=_user(), x_source_agent=None, x_mcp_key_name=None,
+                triggered_by="chat", task_execution_id="te1", _chat_subscription_id=None,
+                chat_activity_id="ca1", collaboration_activity_id=None,
+                session=MagicMock(id="s1"), execution=MagicMock(id="cex1"),
+                queue_result="running", is_queued=False, chat_timeout=3600,
+                idem=idem, capacity=m["cap"],
+            ))
+    assert exc.value.status_code == 503
+    assert "Failed to communicate with agent" in str(exc.value.detail)
+    m["cap"].release.assert_awaited_once()   # slot released in finally
+    m["isvc"].fail.assert_called_once()      # idem claim released (idem_done False)

--- a/tests/unit/test_chat_admission.py
+++ b/tests/unit/test_chat_admission.py
@@ -53,6 +53,7 @@ def _env(idem, breaker_state=None, acquire_exc=None):
     isvc.begin.return_value = idem
 
     cap = MagicMock()
+    cap.release = AsyncMock()
     if acquire_exc is not None:
         cap.acquire = AsyncMock(side_effect=acquire_exc)
     else:
@@ -136,3 +137,38 @@ def test_admitted_returns_chat_admission():
     assert admission.capacity_result is cap_result
     assert isinstance(admission.execution_id, str) and admission.execution_id
     assert admission.idem is m["isvc"].begin.return_value
+    # The handoff must carry queue_result + chat_timeout, otherwise the
+    # downstream endpoint body NameErrors on them (regression guard for the
+    # #1051 review finding).
+    assert admission.queue_result == "running"  # state == "admitted"
+    assert admission.chat_timeout == 3600        # db.get_execution_timeout
+
+
+def test_admitted_full_endpoint_path_succeeds():
+    """End-to-end admitted path through the *whole* chat_with_agent body.
+
+    Pins the two values threaded via ChatAdmission that the downstream body
+    consumes: `chat_timeout` (agent_post_with_retry timeout) and `queue_result`
+    (response `execution.queue_status`). Before the #1051 fix these were stranded
+    in the helper's scope and the admitted path raised NameError before the agent
+    was ever called — uncaught because no test drove the full endpoint.
+    """
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"response": "hi back", "metadata": {}, "session": {}}
+
+    with _env(_idem(replay=False)) as m, \
+         patch.object(_CHAT, "activity_service",
+                      MagicMock(track_activity=AsyncMock(return_value="act1"),
+                                complete_activity=AsyncMock())), \
+         patch.object(_CHAT, "agent_post_with_retry", AsyncMock(return_value=resp)) as post, \
+         patch.object(_CHAT, "compose_system_prompt", return_value="sys"), \
+         patch.object(_CHAT, "is_execution_context_enabled", return_value=False):
+        result = _call()
+
+    # No NameError; the endpoint returned the agent response augmented with the
+    # execution block built from queue_result + is_queued.
+    assert result["execution"]["queue_status"] == "running"
+    assert result["execution"]["was_queued"] is False
+    # chat_timeout (3600) + 10s HTTP buffer was forwarded to the agent call.
+    assert post.await_args.kwargs["timeout"] == 3610

--- a/tests/unit/test_chat_admission.py
+++ b/tests/unit/test_chat_admission.py
@@ -172,3 +172,51 @@ def test_admitted_full_endpoint_path_succeeds():
     assert result["execution"]["was_queued"] is False
     # chat_timeout (3600) + 10s HTTP buffer was forwarded to the agent call.
     assert post.await_args.kwargs["timeout"] == 3610
+
+
+# --- #1026 slice 2: _prepare_chat_execution -------------------------------
+
+def _prep(x_source_agent=None):
+    """Run the extracted execution-setup helper under the same patched env."""
+    from routers.chat import _prepare_chat_execution
+    cap_result = MagicMock(state="admitted", queue_position=0)
+    with _env(_idem(replay=False)) as m, \
+         patch.object(_CHAT, "activity_service",
+                      MagicMock(track_activity=AsyncMock(return_value="act1"),
+                                complete_activity=AsyncMock())), \
+         patch.object(_CHAT, "broadcast_collaboration_event", AsyncMock()) as bcast:
+        ctx = asyncio.run(_prepare_chat_execution(
+            name="agent1", request=ChatMessageRequest(message="hi"),
+            current_user=_user(), x_source_agent=x_source_agent, x_via_mcp=None,
+            x_mcp_key_id=None, x_mcp_key_name=None,
+            idem=m["isvc"].begin.return_value,
+            chat_execution_id="cex1", capacity_result=cap_result, queue_result="running",
+        ))
+    return ctx, m, bcast
+
+
+def test_prepare_returns_full_context():
+    """Every field the downstream body consumes is populated; the user message
+    is logged and the execution row is linked to the idempotency claim."""
+    from routers.chat import ChatExecutionContext
+    ctx, m, bcast = _prep(x_source_agent=None)
+    assert isinstance(ctx, ChatExecutionContext)
+    assert ctx.execution.id == "cex1"
+    assert ctx.task_execution_id is not None
+    assert ctx.triggered_by == "chat"
+    assert ctx.session is not None
+    assert ctx.chat_activity_id == "act1"
+    assert ctx.collaboration_activity_id is None   # not agent-to-agent
+    assert ctx.is_queued is False
+    m["isvc"].attach_execution.assert_called_once()  # exec linked to idem claim
+    m["db"].add_chat_message.assert_called_once()    # inbound user message logged
+    bcast.assert_not_awaited()                       # no collaboration for human caller
+
+
+def test_prepare_agent_to_agent_broadcasts_collaboration():
+    """Agent-to-agent path: triggered_by flips to 'agent', the collaboration
+    event is broadcast, and a collaboration activity is tracked."""
+    ctx, m, bcast = _prep(x_source_agent="caller-agent")
+    assert ctx.triggered_by == "agent"
+    assert ctx.collaboration_activity_id == "act1"   # collaboration activity tracked
+    bcast.assert_awaited_once()                       # agent-to-agent broadcast fired

--- a/tests/unit/test_chat_admission.py
+++ b/tests/unit/test_chat_admission.py
@@ -116,6 +116,10 @@ def test_breaker_open_raises_503():
             _call()
     assert exc.value.status_code == 503
     m["cap"].acquire.assert_not_awaited()  # fast-fail before acquire
+    # Nothing dispatched: the idempotency claim is released so the caller can
+    # retry with the same key once the breaker recovers (#525), mirroring the
+    # CapacityFull branch. Pins the behavior change called out in #1051 review.
+    m["isvc"].fail.assert_called_once()
 
 
 def test_capacity_full_raises_429_and_releases_idem():

--- a/tests/unit/test_chat_dispatched_marker.py
+++ b/tests/unit/test_chat_dispatched_marker.py
@@ -297,17 +297,20 @@ class TestChatRouterSource:
 
     @pytest.fixture(scope="class")
     def chat_func(self):
-        """Parse routers/chat.py and return the chat_with_agent function node."""
+        """Parse routers/chat.py and return the function carrying the
+        dispatch/execute/finalize logic. After #1026 slice 3 this body lives in
+        `_run_chat_and_finalize` (extracted from `chat_with_agent`); the #686 /
+        #96 invariants are asserted against it."""
         chat_src = _BACKEND / "routers" / "chat.py"
         assert chat_src.exists(), f"routers/chat.py missing at {chat_src}"
         tree = ast.parse(chat_src.read_text(), filename=str(chat_src))
         for node in ast.walk(tree):
             if (
                 isinstance(node, ast.AsyncFunctionDef)
-                and node.name == "chat_with_agent"
+                and node.name == "_run_chat_and_finalize"
             ):
                 return node
-        pytest.fail("chat_with_agent function not found in routers/chat.py")
+        pytest.fail("_run_chat_and_finalize function not found in routers/chat.py")
 
     def _walk_calls_with_line(self, node):
         """Yield (lineno, attr_name, arg_repr) for every call expression


### PR DESCRIPTION
## Summary

Decomposes `routers/chat.chat_with_agent` (601 lines, CC 79 — the largest
chat.py hotspot) into three keyword-only helper slices, per the incremental
plan on #1026. **All three slices land together in this PR** (atomic, so the
hotspot isn't left half-extracted across separate merges).

**Slice 1 — `_admit_chat_request` (admission gate).** Front-of-function gating:
- idempotency gate (#525) — replay → snapshot `JSONResponse`; in-flight → 409
- dispatch-breaker fast-fail (#526) → 503
- `CapacityManager.acquire` (#428) + audit; `CapacityFull` → 429 **and** releases the idempotency claim

Returns a `ChatAdmission` NamedTuple (`idem` / `execution_id` /
`capacity_result` / `capacity` / `queue_result` / `chat_timeout`) on success, or
a `JSONResponse` the caller returns directly on replay. Deny paths raise
`HTTPException`.

**Slice 2 — `_prepare_chat_execution` (execution setup).** Exec record (#96) +
subscription lookup (SUB-004) + agent-to-agent collaboration broadcast/activity
+ session get/create + chat-start activity + inbound user-message log. Returns a
`ChatExecutionContext` carrying the ids/records the finalize body consumes.

**Slice 3 — `_run_chat_and_finalize` (execute + finalize).** Dispatches to the
agent, persists the assistant message + observability, completes the
chat/collaboration activities, writes the terminal execution row, stores the
idempotency snapshot, and on the agent-error paths records the failure + runs
SUB-003 auto-switch. The `finally` always releases the capacity slot + any
still-in-flight idempotency claim. `chat_with_agent` is now a thin orchestrator
that admits → prepares → finalizes.

## Behavior change (one — intentional)
One deliberate fix rides along: the **dispatch-breaker-open (503) path now
releases the idempotency claim** (`idempotency_service.fail(idem)`), mirroring
the existing `CapacityFull` branch, so a breaker-open response can be retried
with the same key once the breaker recovers (previously the claim was stranded
in-flight for 24h). Pinned by `test_breaker_open_raises_503`. Every other exit
is preserved verbatim — replay snapshot, 409 in-flight, 429 capacity-full +
idempotency release, and the admitted path.

The HTTP signature, headers (`X-Via-MCP`, `X-MCP-Key-*`, `Idempotency-Key`), and
response shape (`execution.queue_status` / `was_queued`) are unchanged — the MCP
proxy surface (Invariant #13) needs no edit.

## Tests
`tests/unit/test_chat_admission.py` — **9 cases** covering all three slices:
- Slice 1: replay snapshot, 409 in-flight, 503 breaker-open (+ idem release),
  429 capacity-full (+ idem release), the `ChatAdmission` handoff, and the full
  admitted path end-to-end through the real `chat_with_agent`.
- Slice 2: full-context return + the agent-to-agent collaboration branch.
- Slice 3: the httpx-error path releasing slot + idem and mapping to 503.

`test_admitted_full_endpoint_path_succeeds` drives the *whole* endpoint so no
extracted local can be stranded without a test failing (regression guard for the
`queue_result` / `chat_timeout` threading bug caught in review).
`test_chat_dispatched_marker.py` updated to assert the #686/#96 invariants
against `_run_chat_and_finalize` (where that body now lives).
- ✅ 9/9 new cases · CI pytest green on head across 3 seeds + regression-diff

Related to #1026
