### PR TITLE
fix(voip): wire VOIP_* env vars through prod compose so the feature can be enabled (#1056)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,32 @@ GEMINI_API_KEY=
 GOOGLE_API_KEY=
 
 # ===========================================
+# VOICE & VoIP TELEPHONY (Optional - VOICE-001 / VOIP-001)
+# ===========================================
+# Both ride on Gemini Live, so GEMINI_API_KEY (above) must be set for either.
+
+# Voice chat (VOICE-001). Default ON in code; set to false to disable platform-wide.
+VOICE_ENABLED=true
+# Gemini Live model override (blank = built-in default).
+VOICE_MODEL=
+# Voice Workspace canvas — opt-in BETA (#860).
+WORKSPACE_ENABLED=false
+
+# VoIP telephony (VOIP-001, #1056) — agents place outbound phone calls over
+# Gemini Live via Twilio Media Streams. Opt-in, default OFF. Set to true to
+# expose `voip_available` in the feature flags; the feature ALSO requires a
+# per-agent voip_bindings row (Twilio account_sid / auth_token / from_number,
+# configured via PUT /api/agents/{name}/voip) to actually place calls.
+VOIP_ENABLED=false
+# PSTN abuse / spend controls (sane defaults — tune for your Twilio plan).
+VOIP_MAX_CALL_DURATION=600        # hard per-call cap (seconds)
+VOIP_DEFAULT_DAILY_CALL_CAP=50    # per-agent calls/day (overridable per binding)
+VOIP_CALL_RATE_LIMIT=5            # outbound calls per owner+destination window
+VOIP_CALL_RATE_WINDOW=60          # rate-limit window (seconds)
+VOIP_TICKET_TTL_SECONDS=180       # Media Streams WSS ticket TTL (covers dial+ring)
+VOIP_INTENT_TTL_SECONDS=180       # staged Gemini-session intent TTL
+
+# ===========================================
 # SERVICE URLS (Usually no need to change)
 # ===========================================
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,22 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}  # For Gemini-powered agents
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # For platform image generation (IMG-001)
+      # Voice chat (VOICE-001) — mirrors docker-compose.yml so operators can
+      # tune/disable voice in prod (code default is ON; without these lines the
+      # knobs are inert — the #1039 packaging-gap class).
+      - VOICE_MODEL=${VOICE_MODEL:-}  # Gemini Live model override
+      - VOICE_ENABLED=${VOICE_ENABLED:-true}  # Voice mode (default on when GEMINI_API_KEY set)
+      - WORKSPACE_ENABLED=${WORKSPACE_ENABLED:-false}  # Voice Workspace canvas — opt-in BETA (#860)
+      # VoIP telephony (VOIP-001, #1056) — opt-in, default OFF. Default-OFF means
+      # the master switch MUST reach the container or voip_available stays false;
+      # omitting it here was the prod packaging gap (same class as #1039 LOG_*).
+      - VOIP_ENABLED=${VOIP_ENABLED:-false}
+      - VOIP_MAX_CALL_DURATION=${VOIP_MAX_CALL_DURATION:-600}      # per-call cap (s)
+      - VOIP_DEFAULT_DAILY_CALL_CAP=${VOIP_DEFAULT_DAILY_CALL_CAP:-50}  # per-agent/day spend bound
+      - VOIP_CALL_RATE_LIMIT=${VOIP_CALL_RATE_LIMIT:-5}           # calls per owner+destination window
+      - VOIP_CALL_RATE_WINDOW=${VOIP_CALL_RATE_WINDOW:-60}        # rate-limit window (s)
+      - VOIP_TICKET_TTL_SECONDS=${VOIP_TICKET_TTL_SECONDS:-180}   # Media Streams WSS ticket TTL
+      - VOIP_INTENT_TTL_SECONDS=${VOIP_INTENT_TTL_SECONDS:-180}   # staged Gemini-intent TTL
       - GITHUB_PAT=${GITHUB_PAT}
       # Host paths for volumes (used when creating agent containers)
       - HOST_TEMPLATES_PATH=${HOST_TEMPLATES_PATH:-${PWD}/config/agent-templates}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,15 @@ services:
       - VOICE_MODEL=${VOICE_MODEL:-}  # Gemini Live model override (default: gemini-2.5-flash-native-audio-preview-12-2025)
       - VOICE_ENABLED=${VOICE_ENABLED:-true}  # Voice mode (default on when GEMINI_API_KEY set)
       - WORKSPACE_ENABLED=${WORKSPACE_ENABLED:-false}  # Voice Workspace canvas — opt-in BETA (#860)
+      # VoIP telephony (VOIP-001, #1056) — opt-in, default OFF. Master switch must
+      # reach the container or voip_available stays false (read by config.py).
+      - VOIP_ENABLED=${VOIP_ENABLED:-false}
+      - VOIP_MAX_CALL_DURATION=${VOIP_MAX_CALL_DURATION:-600}      # per-call cap (s)
+      - VOIP_DEFAULT_DAILY_CALL_CAP=${VOIP_DEFAULT_DAILY_CALL_CAP:-50}  # per-agent/day spend bound
+      - VOIP_CALL_RATE_LIMIT=${VOIP_CALL_RATE_LIMIT:-5}           # calls per owner+destination window
+      - VOIP_CALL_RATE_WINDOW=${VOIP_CALL_RATE_WINDOW:-60}        # rate-limit window (s)
+      - VOIP_TICKET_TTL_SECONDS=${VOIP_TICKET_TTL_SECONDS:-180}   # Media Streams WSS ticket TTL
+      - VOIP_INTENT_TTL_SECONDS=${VOIP_INTENT_TTL_SECONDS:-180}   # staged Gemini-intent TTL
       - GITHUB_PAT=${GITHUB_PAT:-}
       - HOST_TEMPLATES_PATH=${PWD}/config/agent-templates
       # OpenTelemetry Configuration (Optional)

--- a/docs/memory/feature-flows/voip-telephony.md
+++ b/docs/memory/feature-flows/voip-telephony.md
@@ -149,7 +149,39 @@ agent-server mirror — the bridge is backend-only.
 `VOIP_ENABLED` (default `false`), `VOIP_MAX_CALL_DURATION` (600s),
 `VOIP_DEFAULT_DAILY_CALL_CAP` (50), `VOIP_TICKET_TTL_SECONDS` (180),
 `VOIP_INTENT_TTL_SECONDS` (180), `VOIP_CALL_RATE_LIMIT` / `VOIP_CALL_RATE_WINDOW`.
-`audioop-lts` pinned for `python_version >= "3.13"` (stdlib `audioop` removed in 3.13).
+All read via `os.getenv` in `src/backend/config.py`. `audioop-lts` pinned for
+`python_version >= "3.13"` (stdlib `audioop` removed in 3.13).
+
+### Deployment / packaging (env vars must reach the container)
+
+Because `VOIP_ENABLED` defaults **OFF**, the master switch only takes effect if
+it is actually present in the backend container's environment — a code default of
+`false` means setting `VOIP_ENABLED=true` in `.env` is a no-op unless compose
+forwards it. The full `VOIP_*` set is wired into the `backend.environment:` block
+of **both** `docker-compose.yml` (dev) and `docker-compose.prod.yml` (prod, which
+launches standalone with no base-compose merge), plus the `VOICE_*` flags for
+parity, and is documented in `.env.example`. Omitting these from the prod compose
+was the original packaging gap (same class as #1039's `LOG_*` no-op) — the
+supported `.env` lever did nothing because it never reached the container. The
+enterprise prod overlay (`docker-compose.prod.enterprise.yml`) inherits this env
+block, so no separate wiring is needed there.
+
+### Operator enablement checklist (prod)
+
+1. **Code/packaging** (in-repo, ships via `/update`): `VOIP_*` lines present in the
+   prod compose `backend.environment:` — ✅ done.
+2. **`.env`**: set `VOIP_ENABLED=true` (and `GEMINI_API_KEY`); recreate the backend
+   container so the value is read.
+3. **Cloudflare Tunnel ingress**: the Media Streams socket is
+   `WS /api/voip/voice/{call_id}`. The frontend nginx `location /api/` block
+   already proxies with `Upgrade`/`Connection` headers, so a catch-all
+   `* → frontend:80` tunnel hostname needs nothing extra; a tunnel that routes
+   specific paths straight to `backend:8000` must add an `api/voip/.*` route. This
+   is Cloudflare-dashboard config (`cloudflared` runs `tunnel run` with a
+   `TUNNEL_TOKEN`), not repo state.
+4. **Per-agent binding**: configure Twilio voice creds via
+   `PUT /api/agents/{name}/voip` (owner-only). Without a `voip_bindings` row the
+   feature flag is on but calls 400.
 
 ## Testing
 


### PR DESCRIPTION
## Problem

VoIP-001 (#1056) shipped its code, `GEMINI_API_KEY` is present, but **VoIP cannot be enabled in production**. `src/backend/config.py` reads `VOIP_ENABLED = os.getenv("VOIP_ENABLED", "false")` — and the var was never added to `docker-compose.prod.yml`'s `backend.environment:` block. Prod launches standalone (no base-compose merge, no `env_file:`), so setting `VOIP_ENABLED=true` in `.env` was **inert** — it never reached the container, and `voip_available` stayed `false`.

This is the same packaging-gap class as Abilityai/trinity-enterprise#31's `LOG_*` no-op: feature code shipped, but prod compose never exposed its env surface, so the supported `.env` lever does nothing.

Found it was slightly worse than first reported:
- `VOIP_ENABLED` was missing from **both** dev and prod compose.
- Prod compose was also missing the `VOICE_*` / `WORKSPACE_ENABLED` flags (voice only "worked" in prod because its code default is ON — operators couldn't tune/disable it).

## Fix (in-repo — ships via `/update`)

| File | Change |
|------|--------|
| `docker-compose.prod.yml` | Add the full `VOIP_*` set + the 3 `VOICE_*` flags (parity with dev) to `backend.environment:`. All `${VAR:-default}` → behavior unchanged until an operator opts in. |
| `docker-compose.yml` (dev) | Add the `VOIP_*` block (was missing here too). |
| `.env.example` | New **VOICE & VoIP TELEPHONY** section documenting every knob. |
| `docs/memory/feature-flows/voip-telephony.md` | Document the packaging path + operator enablement checklist. |

Verified: both compose files parse as valid YAML, and all 7 `VOIP_*` names match `config.py` exactly. The enterprise prod overlay (`docker-compose.prod.enterprise.yml`) inherits the base backend env block, so no separate wiring is needed there. Sibling/gitea composes are test-only and untouched.

## Out of scope (instance-side — cannot be fixed in the repo)

1. Set `VOIP_ENABLED=true` in the instance `.env` and recreate the backend container.
2. **Cloudflare Tunnel ingress** for the Media Streams WS (`WS /api/voip/voice/{call_id}`). `cloudflared` runs `tunnel run` with a `TUNNEL_TOKEN` → dashboard-managed. nginx already proxies `/api/` with `Upgrade`/`Connection` headers, so a catch-all `* → frontend:80` hostname needs nothing extra; a tunnel routing specific paths straight to `backend:8000` must add an `api/voip/.*` route.
3. Per-agent Twilio binding via `PUT /api/agents/{name}/voip`.

## Test plan

- [x] `python -c "yaml.safe_load(...)"` parses both compose files
- [x] All 7 `VOIP_*` var names match `config.py`
- [ ] On a prod-like stack: `VOIP_ENABLED=true` in `.env` → `docker exec trinity-backend printenv VOIP_ENABLED` → `true`; `GET /api/settings/feature-flags` → `voip_available: true`

Refs Abilityai/trinity#1056. Precedent: Abilityai/trinity-enterprise#31 (`LOG_*` packaging gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)