### PR TITLE
fix(voip): correct /voip/call path param so outbound calls don't 422 (#1069)

### DIFF
--- a/docs/memory/feature-flows/voip-telephony.md
+++ b/docs/memory/feature-flows/voip-telephony.md
@@ -22,7 +22,7 @@ what we discussed (updates memory, creates tasks, sends follow-ups)."
 
 ## Entry Points
 
-- **REST**: `POST /api/agents/{name}/voip/call` (JWT/MCP; `AuthorizedAgent`)
+- **REST**: `POST /api/agents/{name}/voip/call` (JWT/MCP; `AuthorizedAgentByName`)
 - **MCP**: `call_user` tool (`src/mcp-server/src/tools/voip.ts`)
 - **Binding config (owner-only)**: `GET/PUT/DELETE /api/agents/{name}/voip`
 - **Media Streams WS (Twilio, ticket-authed)**: `WS /api/voip/voice/{call_id}`
@@ -128,7 +128,7 @@ DDL in `db/schema.py`; migration `_migrate_voip_tables` in `db/migrations.py`
 |---------|---------|
 | Feature exposure | `voip_available` flag OFF by default (`VOIP_ENABLED`) + per-agent `voip_bindings` row required |
 | Binding CRUD | Owner-only (`OwnedAgentByName`); AuthToken AES-256-GCM at rest |
-| Outbound trigger | `AuthorizedAgent` (JWT/MCP); rate-limited per `(owner, destination)`; durable per-agent daily call cap; optional `Idempotency-Key` (Invariant #18) |
+| Outbound trigger | `AuthorizedAgentByName` (JWT/MCP); rate-limited per `(owner, destination)`; durable per-agent daily call cap; optional `Idempotency-Key` (Invariant #18) |
 | PSTN spend | On the **agent owner's** Twilio account (each owner brings their own creds) |
 | Media Streams WS | Twilio can't send a JWT → single-use, **call-bound** ticket (`scope="voip:{call_id}"`, 180s TTL); staged intent consumed once via Redis `GETDEL` |
 | TwiML | URL attribute `quoteattr`-escaped (no injection) |

--- a/src/backend/routers/voip.py
+++ b/src/backend/routers/voip.py
@@ -2,8 +2,8 @@
 VoIP telephony router (VOIP-001, #1056 — Phase 1, outbound).
 
 Surfaces:
-- Binding CRUD (owner-only): GET/PUT/DELETE /api/agents/{name}/voip
-- Outbound trigger (any agent-accessor): POST /api/agents/{name}/voip/call
+- Binding CRUD (owner-only): GET/PUT/DELETE /api/agents/{agent_name}/voip
+- Outbound trigger (any agent-accessor): POST /api/agents/{agent_name}/voip/call
 - Media Streams WebSocket (Twilio, ticket-authed): WS /api/voip/voice/{call_id}
 
 The feature is gated by `voip_service.is_available()` (VOIP_ENABLED + GEMINI_API_KEY,
@@ -27,7 +27,7 @@ from fastapi import (
 from pydantic import BaseModel
 
 from database import db
-from dependencies import AuthorizedAgent, OwnedAgentByName, get_current_user
+from dependencies import AuthorizedAgentByName, OwnedAgentByName, get_current_user
 from models import User
 from services import idempotency_service
 from services.settings_service import settings_service
@@ -163,7 +163,7 @@ async def delete_voip_binding(agent_name: OwnedAgentByName):
 @auth_router.post("/{agent_name}/voip/call")
 async def place_voip_call(
     request: VoipCallRequest,
-    agent_name: AuthorizedAgent,
+    agent_name: AuthorizedAgentByName,
     current_user: User = Depends(get_current_user),
     idempotency_key: Optional[str] = Header(None),
 ):

--- a/tests/unit/test_1069_voip_call_path_param.py
+++ b/tests/unit/test_1069_voip_call_path_param.py
@@ -1,0 +1,215 @@
+"""
+Regression test for #1069 — VoIP outbound call always returned HTTP 422.
+
+Bug: ``POST /api/agents/{agent_name}/voip/call`` declared its agent path
+parameter via the ``AuthorizedAgent`` dependency, whose ``Path()`` parameter
+is named ``name``. The route template, however, exposes the segment as
+``{agent_name}`` (matching the sibling GET/PUT/DELETE ``/voip`` handlers,
+which use the ``*_by_name`` dependency family). FastAPI therefore derived a
+required path parameter ``name`` that no URL could ever populate, so every
+call — REST and the ``call_user`` MCP tool that proxies to it — failed with::
+
+    {"detail":[{"type":"missing","loc":["path","name"],"msg":"Field required"}]}
+
+Fix: the handler uses ``AuthorizedAgentByName`` (``Path()`` param
+``agent_name``) so the dependency's path parameter matches the template.
+
+The first test loads the *real* ``routers/voip.py`` with the *real*
+``dependencies`` module (only leaf services are stubbed) and asserts FastAPI's
+flattened dependant for the POST route carries a path parameter ``agent_name``
+and NOT ``name``. Stubbing the dependency aliases — as other router-signature
+tests do — would mask the bug, because the defect lives in the ``Path()``
+parameter name those aliases carry. A revert to ``AuthorizedAgent``
+reintroduces the ``name`` path parameter and fails this test.
+
+The second test pins the dependency-layer contract that makes the fix work
+(``*_by_name`` → ``agent_name`` Path param; the bare aliases → ``name``).
+
+Module under test: src/backend/routers/voip.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path as _FsPath
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ── Environment / backend resolution ─────────────────────────────────────────
+# database.py instantiates `db = DatabaseManager()` on import and tries to
+# mkdir(/data); config.py raises if REDIS_URL lacks credentials. The unit
+# conftest sets these too, but pin them here so this module is import-order
+# self-sufficient (it sorts very early in the collection order).
+os.environ.setdefault(
+    "TRINITY_DB_PATH",
+    str(_FsPath(tempfile.gettempdir()) / "trinity_test_voip_router_1069.db"),
+)
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+
+
+def _find_backend_root() -> _FsPath:
+    """Locate the backend source tree across host and in-container layouts."""
+    candidates = [
+        _FsPath(__file__).resolve().parent.parent.parent / "src" / "backend",  # host
+        _FsPath("/app"),  # trinity-backend container
+    ]
+    env_override = os.environ.get("TRINITY_BACKEND_PATH")
+    if env_override:
+        candidates.insert(0, _FsPath(env_override))
+    for c in candidates:
+        if (c / "routers" / "voip.py").exists():
+            return c
+    raise RuntimeError("Cannot locate backend source tree (set TRINITY_BACKEND_PATH)")
+
+
+_BACKEND = _find_backend_root()
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── Load routers/voip.py with leaf services stubbed but dependencies REAL ─────
+
+def _load_voip_router() -> types.ModuleType:
+    """Exec routers/voip.py directly, stubbing only its heavy leaf services.
+
+    `dependencies` is deliberately left REAL: the bug is in the Path()
+    parameter name carried by `AuthorizedAgent` vs `AuthorizedAgentByName`.
+    `services/__init__.py` eagerly imports docker_service/template_service
+    (Docker SDK), so the `services` package itself is replaced with a light
+    stub package and the four submodules voip.py imports are attached to it.
+
+    Stubs are installed/removed by manually saving and restoring ONLY the
+    specific sys.modules keys we touch — NOT via `patch.dict`. `patch.dict`
+    clears the *entire* sys.modules on exit and restores the snapshot taken at
+    entry; real `dependencies` (→ `jose` → `cryptography`) is imported for the
+    first time *inside* exec_module, so it would be wiped and later re-imported
+    fresh, splitting cryptography's type identity and breaking jose's HMAC
+    backend in later JWT tests (surfaced as JWSError "Expected instance of
+    hashes.HashAlgorithm" in test_voice_auth / test_websocket_auth). Leaving
+    the real modules imported during exec in place is both correct and the
+    normal post-conftest state.
+    """
+    services_pkg = types.ModuleType("services")
+    services_pkg.__path__ = []  # mark as a package so submodule imports resolve
+
+    voip_svc = types.ModuleType("services.voip_service")
+    voip_svc.voip_service = MagicMock()
+    voip_svc.normalize_e164 = lambda x: x
+
+    idem_svc = types.ModuleType("services.idempotency_service")
+    idem_svc.make_agent_scope = MagicMock()
+    idem_svc.begin = MagicMock()
+    idem_svc.complete = MagicMock()
+    idem_svc.fail = MagicMock()
+
+    settings_mod = types.ModuleType("services.settings_service")
+    settings_mod.settings_service = MagicMock()
+
+    audit_mod = types.ModuleType("services.platform_audit_service")
+    audit_mod.platform_audit_service = MagicMock()
+    audit_mod.AuditEventType = MagicMock()
+
+    path = _BACKEND / "routers" / "voip.py"
+    spec = importlib.util.spec_from_file_location("routers.voip", str(path))
+    mod = importlib.util.module_from_spec(spec)
+
+    stubs = {
+        "services": services_pkg,
+        "services.voip_service": voip_svc,
+        "services.idempotency_service": idem_svc,
+        "services.settings_service": settings_mod,
+        "services.platform_audit_service": audit_mod,
+        "routers.voip": mod,
+    }
+    # Save only the keys we touch; restore them in finally. Real modules that
+    # voip.py imports during exec (dependencies, database, models, jose, …)
+    # are intentionally left loaded.
+    saved = {k: sys.modules.get(k) for k in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        for k, original in saved.items():
+            if original is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = original
+    return mod
+
+
+voip_router_mod = _load_voip_router()
+
+
+def _find_call_route():
+    """Return the APIRoute for POST .../voip/call on the voip auth_router."""
+    for route in voip_router_mod.auth_router.routes:
+        methods = getattr(route, "methods", set()) or set()
+        if route.path.endswith("/voip/call") and "POST" in methods:
+            return route
+    raise AssertionError("POST .../voip/call route not found on voip auth_router")
+
+
+# ── The regression: the shipped route resolves the agent from {agent_name} ───
+
+class TestVoipCallPathParam:
+    def test_route_template_uses_agent_name(self):
+        route = _find_call_route()
+        assert route.path.endswith("/{agent_name}/voip/call"), (
+            f"route template changed unexpectedly: {route.path!r}"
+        )
+
+    def test_flat_path_params_are_agent_name_not_name(self):
+        """FastAPI's flattened dependant must require `agent_name`, not `name`.
+
+        This is the exact #1069 condition: a `name` path param under an
+        `{agent_name}` template is unfillable → HTTP 422 on every call.
+        """
+        from fastapi.dependencies.utils import get_flat_dependant
+
+        route = _find_call_route()
+        flat = get_flat_dependant(route.dependant)
+        path_param_names = {p.name for p in flat.path_params}
+
+        assert "agent_name" in path_param_names, (
+            f"POST /voip/call must resolve the agent from the {{agent_name}} "
+            f"path segment; flattened path params were {path_param_names}"
+        )
+        assert "name" not in path_param_names, (
+            "POST /voip/call still declares a `name` path param — this is the "
+            "#1069 regression (AuthorizedAgent under an {agent_name} template). "
+            f"Flattened path params: {path_param_names}"
+        )
+
+
+# ── Dependency-layer contract that makes the fix correct ─────────────────────
+
+class TestAuthorizedAgentAliasContract:
+    """Pin why the fix works: the alias families carry different Path names."""
+
+    def test_by_name_dependency_uses_agent_name_path_param(self):
+        import dependencies
+
+        sig = inspect.signature(dependencies.get_authorized_agent_by_name)
+        assert "agent_name" in sig.parameters
+        assert "name" not in sig.parameters
+
+    def test_bare_dependency_uses_name_path_param(self):
+        import dependencies
+
+        # The bare alias is correct for {name} routes (schedules, chat, …);
+        # it is the WRONG choice under an {agent_name} template — that pairing
+        # is precisely what caused #1069.
+        sig = inspect.signature(dependencies.get_authorized_agent)
+        assert "name" in sig.parameters
+        assert "agent_name" not in sig.parameters


### PR DESCRIPTION
## Summary
- `POST /api/agents/{agent_name}/voip/call` returned **HTTP 422 on every call** (REST and the `call_user` MCP tool). The handler declared its agent path param via the `AuthorizedAgent` dependency, whose `Path()` param is named `name` — but the route template exposes the segment as `{agent_name}`, so FastAPI required a `name` path param that no URL could fill (`loc: ["path","name"]`).
- Fix: swap the handler to `AuthorizedAgentByName` (Path param `agent_name`), matching the route template and the sibling GET/PUT/DELETE `/voip` handlers. The two dependencies perform an **identical** access check (`db.can_user_access_agent`) — only the path-param name differs, so there is **no auth boundary change**.
- The MCP client (`client.ts`) already targets the correct URL, so no MCP-side change is needed (Invariant #13 satisfied).

## Changes
- `src/backend/routers/voip.py` — `AuthorizedAgent` → `AuthorizedAgentByName` (import + POST handler); fixed stale `{name}` → `{agent_name}` in the module docstring.
- `tests/unit/test_1069_voip_call_path_param.py` (new) — loads the **real** voip router with the **real** `dependencies` module (leaf services stubbed) and asserts FastAPI's flattened dependant for the POST route carries `agent_name`, not `name`. Plus a dependency-contract test pinning why the fix works.

## Root cause
| Method | Route template | Declared path param (pre-fix) |
|--------|----------------|-------------------------------|
| `GET/PUT/DELETE /api/agents/{agent_name}/voip` | `{agent_name}` | `agent_name` ✅ (`OwnedAgentByName`) |
| `POST /api/agents/{agent_name}/voip/call` | `{agent_name}` | **`name`** ❌ (`AuthorizedAgent`) |

## Test Plan
- [x] New regression tests pass (4/4) — **mutation-verified**: reverting to `AuthorizedAgent` makes the route-level test fail (`assert 'agent_name' in {'name'}`).
- [x] Full unit suite: **1953 passed, 0 failed** (only the pre-existing `fakeredis`-missing collection error in `test_dispatch_breaker.py`, unrelated to this change).
- [x] The test loader manually saves/restores only the `sys.modules` keys it touches — does not poison sibling JWT tests (`test_voice_auth`, `test_websocket_auth`).

Fixes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)