### PR TITLE
fix(voip): pass Media Streams ticket via <Parameter>, not query string (#1073)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -228,7 +228,7 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 - `transports/twilio_webhook.py` - Twilio webhook transport: HMAC-SHA1 signature (via `twilio.request_validator`), MessageSid dedup, form-encoded body
 
 *VoIP Telephony (via Twilio Media Streams) — a voice transport, NOT a text `ChannelAdapter` (VOIP-001, #1056):*
-- `transports/twilio_media_stream.py` - Media Streams WS bridge (`handle_media_stream`): call-bound ticket + scope check, `GETDEL` staged intent (consume-once), creates the Gemini `VoiceSession` on the connecting worker, runs the unmodified `connect_and_stream`. Per-connection `_CallBridge`: inbound μ-law→PCM resample, outbound queue + paced 20ms 160-byte μ-law sender, `clear`-on-barge-in, `streamSid` capture, teardown ties Gemini-end→Twilio-close + SETNX-guarded single transcript save (`source="voice"`) + post-call processing dispatch.
+- `transports/twilio_media_stream.py` - Media Streams WS bridge (`handle_media_stream`): `accept()`-then-authenticate — Twilio does NOT forward the `<Stream url>` query string, so the call-bound ticket arrives as a `<Parameter>` in the first `start` frame (`start.customParameters.ticket`), read only after the handshake completes (#1073); a query-string `?ticket=` is still honored as a fallback for non-Twilio/diagnostic clients. Then scope check, `GETDEL` staged intent (consume-once), creates the Gemini `VoiceSession` on the connecting worker, runs the unmodified `connect_and_stream`. Per-connection `_CallBridge`: inbound μ-law→PCM resample, outbound queue + paced 20ms 160-byte μ-law sender, `clear`-on-barge-in, `streamSid` capture, teardown ties Gemini-end→Twilio-close + SETNX-guarded single transcript save (`source="voice"`) + post-call processing dispatch.
 - `transports/voip_audio.py` - Pure stdlib-`audioop` codec helpers (`ulaw8k_to_pcm16k`, `pcm24k_to_ulaw8k` direct 3:1, `pop_frames`). Carries per-direction `ratecv` state across chunks (anti-click). `audioop-lts` pinned for Python ≥ 3.13.
 
 *Database:*
@@ -555,7 +555,7 @@ picks up on its next poll. (#389 S1a)
 | PUT | `/api/agents/{name}/voip` | Owner | Configure Twilio voice creds (validated via Twilio Account fetch; AuthToken AES-256-GCM encrypted). |
 | DELETE | `/api/agents/{name}/voip` | Owner | Remove the voice binding. |
 | POST | `/api/agents/{name}/voip/call` | JWT/MCP (`AuthorizedAgent`) | Place an outbound call. Rate-limited per `(owner, destination)` + durable per-agent daily cap; optional `Idempotency-Key` (Invariant #18). Returns `{call_id, status:"ringing", twilio_call_sid}`. |
-| WS | `/api/voip/voice/{call_id}` | Call-bound ticket (`?ticket=`) | Twilio Media Streams audio bridge (no JWT — Twilio can't send one). Ticket `scope="voip:{call_id}"`; staged intent consumed once via Redis `GETDEL`. |
+| WS | `/api/voip/voice/{call_id}` | Call-bound ticket (`<Parameter>`; `?ticket=` fallback) | Twilio Media Streams audio bridge (no JWT — Twilio can't send one). Ticket arrives via the `start` frame's `customParameters` (Twilio drops the query string — #1073); `scope="voip:{call_id}"`; staged intent consumed once via Redis `GETDEL`. |
 
 MCP tool: `call_user` (`src/mcp-server/src/tools/voip.ts`). The call transcript
 is persisted to `chat_messages` (`source="voice"`) and, by default, dispatched

--- a/src/backend/adapters/transports/twilio_media_stream.py
+++ b/src/backend/adapters/transports/twilio_media_stream.py
@@ -42,7 +42,9 @@ from services.ws_ticket_service import consume_ticket
 
 logger = logging.getLogger(__name__)
 
-_FRAME_INTERVAL = 0.02      # 20ms pacing
+_FRAME_INTERVAL = 0.02       # 20ms pacing
+_START_FRAME_TIMEOUT = 10.0  # seconds to wait for Twilio's first `start` frame
+_START_FRAME_MAX_READS = 20  # frames to skim for `start` before giving up
 
 # Strong refs for fire-and-forget post-call processing tasks (avoid GC).
 _BG_TASKS: set = set()
@@ -167,19 +169,83 @@ class _CallBridge:
             # connected / mark / dtmf — ignore
 
 
+def _parse_start_frame(data: dict) -> tuple[Optional[str], Optional[str]]:
+    """Extract (ticket, stream_sid) from a Twilio Media Streams `start` event.
+
+    Twilio surfaces `<Parameter>` children under `start.customParameters` and
+    the stream id under `start.streamSid` (top-level `streamSid` as a fallback).
+    Either field may be absent; the caller validates the ticket.
+    """
+    start = data.get("start") or {}
+    ticket = (start.get("customParameters") or {}).get("ticket")
+    stream_sid = start.get("streamSid") or data.get("streamSid")
+    return ticket, stream_sid
+
+
+async def _read_until_start(websocket: WebSocket) -> Optional[dict]:
+    """Read frames until Twilio's `start` event (skipping `connected`).
+
+    Bounded by a timeout and a max-read cap so a client that completes the
+    handshake but never sends a `start` frame can't pin a worker. Returns the
+    parsed `start` frame dict, or None on timeout/disconnect/early-stop.
+    """
+    for _ in range(_START_FRAME_MAX_READS):
+        try:
+            raw = await asyncio.wait_for(
+                websocket.receive_text(), timeout=_START_FRAME_TIMEOUT
+            )
+        except (asyncio.TimeoutError, WebSocketDisconnect):
+            return None
+        except Exception:  # noqa: BLE001 — any transport error ends the wait
+            return None
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        event = data.get("event")
+        if event == "start":
+            return data
+        if event == "stop":
+            return None
+        # connected / mark / other — keep skimming
+    return None
+
+
 async def handle_media_stream(websocket: WebSocket, call_id: str, ticket: Optional[str]):
     """Authenticate, consume the staged intent, and run the live bridge.
 
     Runs on whichever worker Twilio's Media Streams socket connects to — the
     Gemini session is created HERE, not at trigger time (cross-worker safety).
+
+    Twilio Media Streams does **not** forward the `<Stream url>` query string,
+    so the auth ticket arrives as a `<Parameter>` in the first `start` frame —
+    readable only AFTER the handshake completes. We therefore `accept()` first,
+    then authenticate (#1073). A query-string ticket is still honored as a
+    fallback for non-Twilio / diagnostic clients.
     """
-    # 1. Call-bound, single-use ticket (Twilio can't send a JWT).
+    # 1. Accept the transport first — the ticket lives in the `start` frame for
+    #    Twilio, and rejecting before accept() is what surfaced as the 403 that
+    #    dropped every call on answer (#1073).
+    await websocket.accept()
+
+    # 2. Resolve the call-bound, single-use ticket (Twilio can't send a JWT).
+    #    Query string wins when present (non-Twilio/diagnostic clients);
+    #    otherwise read it from the first Twilio `start` frame's customParameters
+    #    and capture the streamSid from that same frame.
+    prelude_stream_sid: Optional[str] = None
+    if not ticket:
+        start_data = await _read_until_start(websocket)
+        if start_data is None:
+            await websocket.close(code=4001, reason="No start frame / ticket")
+            return
+        ticket, prelude_stream_sid = _parse_start_frame(start_data)
+
     info = consume_ticket(ticket) if ticket else None
     if not info or info.get("scope") != f"voip:{call_id}":
         await websocket.close(code=4001, reason="Invalid or missing ticket")
         return
 
-    # 2. Consume the staged intent exactly once (GETDEL) — a double Twilio
+    # 3. Consume the staged intent exactly once (GETDEL) — a double Twilio
     #    connect for the same call finds nothing and is rejected.
     r = await _get_redis()
     try:
@@ -192,10 +258,8 @@ async def handle_media_stream(websocket: WebSocket, call_id: str, ticket: Option
         return
     intent = json.loads(raw)
 
-    # 3. Accept the transport, THEN create the Gemini session on THIS worker —
-    #    so an accept() failure can't orphan a created session.
-    await websocket.accept()
-
+    # 4. Create the Gemini session on THIS worker (only after auth succeeds, so
+    #    a rejected connection never orphans a session).
     session = None
     vs_id = None
     bridge = None
@@ -216,6 +280,10 @@ async def handle_media_stream(websocket: WebSocket, call_id: str, ticket: Option
             pass
 
         bridge = _CallBridge(websocket, vs_id, call_id, intent)
+        # The Twilio `start` frame was already consumed during auth; carry its
+        # streamSid over so the sender can emit media before the next frame.
+        if prelude_stream_sid:
+            bridge._stream_sid = prelude_stream_sid
         gemini_task = asyncio.create_task(
             voice_service.connect_and_stream(
                 vs_id,

--- a/src/backend/services/voip_service.py
+++ b/src/backend/services/voip_service.py
@@ -99,12 +99,25 @@ class VoipService:
         return "wss://" + base
 
     def build_stream_twiml(self, call_id: str, ticket: str, public_url: str) -> str:
-        """`<Connect><Stream>` TwiML pointing Twilio at our Media Streams WS."""
+        """`<Connect><Stream>` TwiML pointing Twilio at our Media Streams WS.
+
+        The auth ticket is passed as a Media Streams `<Parameter>` (Twilio
+        surfaces these under the `start` event's `customParameters`), NOT a URL
+        query string — Twilio does **not** forward query params on the
+        `<Stream url>` WebSocket, so a query-string ticket arrives as `None` and
+        the handshake 403s on answer (#1073). `call_id` stays in the path so the
+        ticket scope (`voip:{call_id}`) can still be verified.
+        """
         from xml.sax.saxutils import quoteattr
-        wss_url = f"{self._wss_base(public_url)}/api/voip/voice/{call_id}?ticket={ticket}"
+        wss_url = f"{self._wss_base(public_url)}/api/voip/voice/{call_id}"
         # quoteattr returns a value WITH surrounding quotes and proper escaping.
+        # <Stream> now has a child so it cannot be self-closing.
         return (
-            f"<Response><Connect><Stream url={quoteattr(wss_url)}/></Connect></Response>"
+            f"<Response><Connect>"
+            f"<Stream url={quoteattr(wss_url)}>"
+            f"<Parameter name=\"ticket\" value={quoteattr(ticket)}/>"
+            f"</Stream>"
+            f"</Connect></Response>"
         )
 
     # =========================================================================

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -22,6 +22,13 @@
       "description": "VoIP service helpers: E.164 validation, ws(s):// base + TwiML build (XML-escaped), and place_outbound_call abuse-control gates (flag/binding/cap/rate, mocked Twilio) (#1056)."
     },
     {
+      "file": "unit/test_1073_voip_media_stream_ticket.py",
+      "feature": "VOIP-001",
+      "added": "2026-06-04",
+      "categories": ["backend", "unit", "voip"],
+      "description": "Regression for #1073: Media Streams WS reads the auth ticket from the start frame's customParameters (<Parameter>), not the query string Twilio drops; accept()-then-authenticate ordering, start-frame parse, scope/intent rejection, and query-string fallback."
+    },
+    {
       "file": "test_agent_rename.py",
       "feature": "RENAME-001",
       "added": "2026-03-01",

--- a/tests/unit/test_1069_voip_call_path_param.py
+++ b/tests/unit/test_1069_voip_call_path_param.py
@@ -78,6 +78,42 @@ if str(_BACKEND) not in sys.path:
     sys.path.insert(0, str(_BACKEND))
 
 
+# Modules this test stubs into sys.modules during the import-time router load
+# below — restored synchronously inside `_load_voip_router()` and, as a
+# belt-and-suspenders guard, snapshot/restored around every test by the autouse
+# fixture. This named-helper pair is the sanctioned exemption from the
+# tests/lint_sys_modules.py ban on bare sys.modules mutation (Issue #762),
+# matching the precedent in tests/unit/test_telegram_webhook_backfill.py.
+_STUBBED_MODULE_NAMES = [
+    "services",
+    "services.voip_service",
+    "services.idempotency_service",
+    "services.settings_service",
+    "services.platform_audit_service",
+    "routers.voip",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot sys.modules before each test and restore after.
+
+    The leaf-service stubs are installed and removed inside
+    `_load_voip_router()` at import time (leaving real `dependencies`/`jose`
+    untouched); this fixture guards against any per-test re-stub leaking into
+    sibling test files in the same session.
+    """
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 # ── Load routers/voip.py with leaf services stubbed but dependencies REAL ─────
 
 def _load_voip_router() -> types.ModuleType:

--- a/tests/unit/test_1073_voip_media_stream_ticket.py
+++ b/tests/unit/test_1073_voip_media_stream_ticket.py
@@ -65,6 +65,45 @@ if str(_BACKEND) not in sys.path:
     sys.path.insert(0, str(_BACKEND))
 
 
+# Modules this test stubs into sys.modules during the import-time module load
+# below — restored synchronously inside `_load_media_stream_module()` and, as a
+# belt-and-suspenders guard, snapshot/restored around every test by the autouse
+# fixture. This named-helper pair is the sanctioned exemption from the
+# tests/lint_sys_modules.py ban on bare sys.modules mutation (Issue #762),
+# matching the precedent in tests/unit/test_telegram_webhook_backfill.py.
+_STUBBED_MODULE_NAMES = [
+    "adapters",
+    "adapters.transports",
+    "adapters.transports.voip_audio",
+    "adapters.transports.twilio_media_stream",
+    "config",
+    "database",
+    "services",
+    "services.gemini_voice",
+    "services.voip_service",
+    "services.ws_ticket_service",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot sys.modules before each test and restore after.
+
+    The heavy-leaf stubs are installed and removed inside
+    `_load_media_stream_module()` at import time; this fixture guards against
+    any per-test re-stub leaking into sibling test files in the same session.
+    """
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 def _load_media_stream_module() -> types.ModuleType:
     """Exec twilio_media_stream.py with its heavy leaf imports stubbed.
 

--- a/tests/unit/test_1073_voip_media_stream_ticket.py
+++ b/tests/unit/test_1073_voip_media_stream_ticket.py
@@ -1,0 +1,375 @@
+"""
+Regression tests for #1073 — VoIP Media Streams WS 403'd on answer.
+
+Bug: the auth ticket was passed in the `<Stream url>` query string. Twilio
+Media Streams does NOT forward query params on that WebSocket, so the handler
+saw `ticket=None`, closed *before* `accept()` (HTTP 403 handshake failure →
+Twilio error 31920), and every outbound call dropped ~1s after answer.
+
+Fix (`adapters/transports/twilio_media_stream.py`):
+  - `accept()` the transport FIRST (the ticket arrives in the first `start`
+    frame, only readable after the handshake completes);
+  - read `start.customParameters.ticket` (a Media Streams `<Parameter>`),
+    capturing the `streamSid` from that same frame;
+  - validate the ticket scope, then consume the staged intent and create the
+    Gemini session — exactly as before, just after accept;
+  - a query-string ticket is still honored as a fallback for non-Twilio /
+    diagnostic clients.
+
+The module pulls heavy leaf imports (gemini_voice, database, config, the audio
+codec). Following the `test_1069` precedent, we exec the module file directly
+with ONLY those leaves stubbed, saving/restoring the exact sys.modules keys we
+touch (NOT patch.dict — that wipes the whole snapshot and splits crypto/jose
+identity for sibling tests). Async handlers are driven with `asyncio.run`, the
+same pattern `test_voip_service.py` uses.
+
+Module under test: src/backend/adapters/transports/twilio_media_stream.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path as _FsPath
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+
+
+def _find_backend_root() -> _FsPath:
+    candidates = [
+        _FsPath(__file__).resolve().parent.parent.parent / "src" / "backend",  # host
+        _FsPath("/app"),  # trinity-backend container
+    ]
+    env_override = os.environ.get("TRINITY_BACKEND_PATH")
+    if env_override:
+        candidates.insert(0, _FsPath(env_override))
+    for c in candidates:
+        if (c / "adapters" / "transports" / "twilio_media_stream.py").exists():
+            return c
+    raise RuntimeError("Cannot locate backend source tree (set TRINITY_BACKEND_PATH)")
+
+
+_BACKEND = _find_backend_root()
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _load_media_stream_module() -> types.ModuleType:
+    """Exec twilio_media_stream.py with its heavy leaf imports stubbed.
+
+    Stubs are installed and removed by saving/restoring only the specific
+    sys.modules keys we touch, so real modules other tests rely on are left
+    untouched after load. The loaded module keeps references to the stub
+    objects via its globals; tests then patch those globals directly.
+    """
+    def _pkg(name: str) -> types.ModuleType:
+        m = types.ModuleType(name)
+        m.__path__ = []  # mark as a package so dotted submodule imports resolve
+        return m
+
+    adapters_pkg = _pkg("adapters")
+    transports_pkg = _pkg("adapters.transports")
+
+    audio_mod = types.ModuleType("adapters.transports.voip_audio")
+    audio_mod.FRAME_BYTES = 160
+    audio_mod.pcm24k_to_ulaw8k = lambda pcm, state: (b"", state)
+    audio_mod.ulaw8k_to_pcm16k = lambda mulaw, state: (b"", state)
+    audio_mod.pop_frames = lambda buf, n: []
+
+    config_mod = types.ModuleType("config")
+    config_mod.REDIS_URL = "redis://test:test@redis:6379"
+
+    database_mod = types.ModuleType("database")
+    database_mod.db = MagicMock()
+
+    services_pkg = _pkg("services")
+
+    gemini_mod = types.ModuleType("services.gemini_voice")
+    gemini_mod.voice_service = MagicMock()
+
+    voip_svc_mod = types.ModuleType("services.voip_service")
+    voip_svc_mod.voip_service = MagicMock()
+    voip_svc_mod.intent_key = lambda call_id: f"voip_intent:{call_id}"
+
+    ws_ticket_mod = types.ModuleType("services.ws_ticket_service")
+    ws_ticket_mod.consume_ticket = lambda t: None
+
+    path = _BACKEND / "adapters" / "transports" / "twilio_media_stream.py"
+    spec = importlib.util.spec_from_file_location(
+        "adapters.transports.twilio_media_stream", str(path)
+    )
+    mod = importlib.util.module_from_spec(spec)
+
+    stubs = {
+        "adapters": adapters_pkg,
+        "adapters.transports": transports_pkg,
+        "adapters.transports.voip_audio": audio_mod,
+        "adapters.transports.twilio_media_stream": mod,
+        "config": config_mod,
+        "database": database_mod,
+        "services": services_pkg,
+        "services.gemini_voice": gemini_mod,
+        "services.voip_service": voip_svc_mod,
+        "services.ws_ticket_service": ws_ticket_mod,
+    }
+    saved = {k: sys.modules.get(k) for k in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        for k, original in saved.items():
+            if original is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = original
+    return mod
+
+
+MS = _load_media_stream_module()
+
+
+# ── Test doubles ──────────────────────────────────────────────────────────────
+
+class _FakeWebSocket:
+    """Minimal Starlette-WebSocket stand-in driven from a frame list."""
+
+    def __init__(self, frames):
+        self._frames = [json.dumps(f) if isinstance(f, dict) else f for f in frames]
+        self.accepted = False
+        self.closed = None        # (code, reason) once closed
+        self.sent = []
+
+    async def accept(self):
+        self.accepted = True
+
+    async def receive_text(self):
+        if self._frames:
+            return self._frames.pop(0)
+        # No more frames — emulate the PSTN leg hanging up.
+        raise MS.WebSocketDisconnect(code=1000)
+
+    async def send_json(self, data):
+        self.sent.append(data)
+
+    async def close(self, code=1000, reason=None):
+        self.closed = (code, reason)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.session_id = "vs_test"
+        self.transcript = []
+
+
+class _FakeVoiceService:
+    def __init__(self):
+        self.create_calls = []
+
+    async def create_session(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return _FakeSession()
+
+    async def connect_and_stream(self, vs_id, **kwargs):
+        return  # complete immediately so the handler tears down cleanly
+
+    async def end_session(self, vs_id):
+        return
+
+    async def remove_session(self, vs_id):
+        return
+
+
+class _FakeRedis:
+    def __init__(self, intent_json):
+        self._intent = intent_json
+        self.getdel_keys = []
+
+    async def getdel(self, key):
+        self.getdel_keys.append(key)
+        return self._intent
+
+    async def set(self, *a, **k):
+        return True
+
+
+_INTENT = {
+    "agent_name": "cornelius-m",
+    "chat_session_id": "cs_1",
+    "user_id": 7,
+    "user_email": "owner@example.com",
+    "system_prompt": "SYS",
+    "to_number": "+14155551234",
+    "process_transcript": True,
+}
+
+
+def _start_frame(ticket=None, stream_sid="MZ_streamsid"):
+    start = {"streamSid": stream_sid}
+    if ticket is not None:
+        start["customParameters"] = {"ticket": ticket}
+    return {"event": "start", "start": start, "streamSid": stream_sid}
+
+
+def _wire(monkeypatch, *, ticket_scope, redis_intent):
+    """Patch the loaded module's globals with cooperative fakes.
+
+    Returns (fake_voice, fake_redis, consume_calls).
+    """
+    consume_calls = []
+
+    def _consume(t):
+        consume_calls.append(t)
+        return {"sub": "voip", "scope": ticket_scope} if ticket_scope else None
+
+    fake_voice = _FakeVoiceService()
+    fake_redis = _FakeRedis(redis_intent)
+
+    async def _get_redis():
+        return fake_redis
+
+    async def _finalize(*a, **k):  # avoid importing routers.voice in teardown
+        return
+
+    monkeypatch.setattr(MS, "consume_ticket", _consume)
+    monkeypatch.setattr(MS, "voice_service", fake_voice)
+    monkeypatch.setattr(MS, "_get_redis", _get_redis)
+    monkeypatch.setattr(MS, "_finalize", _finalize)
+    return fake_voice, fake_redis, consume_calls
+
+
+# ── _parse_start_frame (pure) ─────────────────────────────────────────────────
+
+class TestParseStartFrame:
+    def test_extracts_ticket_and_stream_sid_from_custom_parameters(self):
+        data = _start_frame(ticket="TKT_abc", stream_sid="MZ123")
+        ticket, sid = MS._parse_start_frame(data)
+        assert ticket == "TKT_abc"
+        assert sid == "MZ123"
+
+    def test_missing_custom_parameters_yields_none_ticket(self):
+        ticket, sid = MS._parse_start_frame({"event": "start", "start": {"streamSid": "MZ9"}})
+        assert ticket is None
+        assert sid == "MZ9"
+
+    def test_top_level_stream_sid_fallback(self):
+        ticket, sid = MS._parse_start_frame({"event": "start", "streamSid": "MZ_top"})
+        assert ticket is None
+        assert sid == "MZ_top"
+
+
+# ── handle_media_stream — the #1073 fix ───────────────────────────────────────
+
+class TestHandleMediaStreamTicketFromStartFrame:
+    def test_twilio_start_parameter_authenticates_and_creates_session(self, monkeypatch):
+        """Happy path: ticket arrives as a customParameter in the `start` frame
+        (Twilio's transport), the handshake is accepted, the ticket is consumed
+        with the call-bound scope, and the Gemini session is created."""
+        call_id = "voip_call1"
+        fake_voice, fake_redis, consume_calls = _wire(
+            monkeypatch, ticket_scope=f"voip:{call_id}", redis_intent=json.dumps(_INTENT)
+        )
+        # Record the bridge instance so we can assert the streamSid was seeded.
+        created = {}
+        real_bridge = MS._CallBridge
+
+        class _RecordingBridge(real_bridge):
+            def __init__(self, *a, **k):
+                super().__init__(*a, **k)
+                created["bridge"] = self
+
+        monkeypatch.setattr(MS, "_CallBridge", _RecordingBridge)
+
+        ws = _FakeWebSocket([
+            {"event": "connected", "protocol": "Call"},
+            _start_frame(ticket="TKT_good", stream_sid="MZ_seed"),
+            {"event": "stop"},
+        ])
+
+        # No query-string ticket → Twilio path (read from start frame).
+        asyncio.run(MS.handle_media_stream(ws, call_id, None))
+
+        assert ws.accepted is True
+        assert consume_calls == ["TKT_good"]                  # ticket read from <Parameter>
+        assert len(fake_voice.create_calls) == 1              # session created
+        assert fake_voice.create_calls[0]["agent_name"] == "cornelius-m"
+        assert fake_redis.getdel_keys == [f"voip_intent:{call_id}"]
+        assert created["bridge"]._stream_sid == "MZ_seed"     # streamSid carried over
+        # Auth passed → the connection was NOT rejected with a ticket/intent code.
+        assert ws.closed is None or ws.closed[0] not in (4001, 4004)
+
+    def test_missing_ticket_parameter_rejected_after_accept_without_session(self, monkeypatch):
+        """A `start` frame with no ticket parameter must be rejected (close 4001)
+        AFTER accept — and must never create a session or consume the intent."""
+        call_id = "voip_call2"
+        fake_voice, fake_redis, consume_calls = _wire(
+            monkeypatch, ticket_scope=None, redis_intent=json.dumps(_INTENT)
+        )
+        ws = _FakeWebSocket([
+            {"event": "connected", "protocol": "Call"},
+            _start_frame(ticket=None),   # no customParameters.ticket
+        ])
+
+        asyncio.run(MS.handle_media_stream(ws, call_id, None))
+
+        assert ws.accepted is True                 # accept happens regardless (#1073)
+        assert ws.closed is not None and ws.closed[0] == 4001
+        assert consume_calls == []                 # None ticket short-circuits consume
+        assert fake_voice.create_calls == []       # no session
+        assert fake_redis.getdel_keys == []        # intent never touched
+
+    def test_wrong_scope_ticket_rejected(self, monkeypatch):
+        """A ticket bound to a different call must fail the scope check."""
+        call_id = "voip_call3"
+        fake_voice, fake_redis, consume_calls = _wire(
+            monkeypatch, ticket_scope="voip:SOME_OTHER_CALL", redis_intent=json.dumps(_INTENT)
+        )
+        ws = _FakeWebSocket([_start_frame(ticket="TKT_other")])
+
+        asyncio.run(MS.handle_media_stream(ws, call_id, None))
+
+        assert consume_calls == ["TKT_other"]
+        assert ws.closed is not None and ws.closed[0] == 4001
+        assert fake_voice.create_calls == []
+
+    def test_no_start_frame_times_out_into_rejection(self, monkeypatch):
+        """Handshake completes but the client never sends a `start` frame →
+        bounded read returns None → reject without hanging the worker."""
+        call_id = "voip_call4"
+        fake_voice, _, consume_calls = _wire(
+            monkeypatch, ticket_scope=f"voip:{call_id}", redis_intent=json.dumps(_INTENT)
+        )
+        ws = _FakeWebSocket([])  # receive_text() immediately raises disconnect
+
+        asyncio.run(MS.handle_media_stream(ws, call_id, None))
+
+        assert ws.accepted is True
+        assert ws.closed is not None and ws.closed[0] == 4001
+        assert consume_calls == []
+        assert fake_voice.create_calls == []
+
+    def test_query_string_ticket_fallback_still_works(self, monkeypatch):
+        """Non-Twilio / diagnostic clients can still present the ticket in the
+        query string; the handler uses it directly and skips the start-frame read."""
+        call_id = "voip_call5"
+        fake_voice, fake_redis, consume_calls = _wire(
+            monkeypatch, ticket_scope=f"voip:{call_id}", redis_intent=json.dumps(_INTENT)
+        )
+        ws = _FakeWebSocket([{"event": "stop"}])
+
+        asyncio.run(MS.handle_media_stream(ws, call_id, "QS_TICKET"))
+
+        assert ws.accepted is True
+        assert consume_calls == ["QS_TICKET"]          # query-string ticket honored
+        assert len(fake_voice.create_calls) == 1
+        assert fake_redis.getdel_keys == [f"voip_intent:{call_id}"]

--- a/tests/unit/test_voip_service.py
+++ b/tests/unit/test_voip_service.py
@@ -105,7 +105,7 @@ class TestWssBase:
 # ---------------------------------------------------------------------------
 
 class TestBuildTwiml:
-    def test_well_formed_and_contains_call_id_and_ticket(self):
+    def test_call_id_in_path_ticket_in_parameter(self):
         vs = _import_voip_service()
         svc = vs.VoipService()
         twiml = svc.build_stream_twiml("voip_abc123", "TICKET_xyz", "https://agent.example.com")
@@ -116,20 +116,43 @@ class TestBuildTwiml:
         stream = root.find("./Connect/Stream")
         assert stream is not None
         url = stream.attrib["url"]
-        assert url == "wss://agent.example.com/api/voip/voice/voip_abc123?ticket=TICKET_xyz"
+        # call_id stays in the PATH; no query string (Twilio drops it — #1073).
+        assert url == "wss://agent.example.com/api/voip/voice/voip_abc123"
+        # The ticket travels as a <Parameter> child — Twilio forwards these in
+        # the `start` event's customParameters; it does NOT forward the query
+        # string on the <Stream url> WebSocket.
+        param = stream.find("./Parameter")
+        assert param is not None
+        assert param.attrib["name"] == "ticket"
+        assert param.attrib["value"] == "TICKET_xyz"
 
-    def test_attribute_is_escaped_against_injection(self):
-        """A ticket containing a quote/angle-bracket must not break out of the
-        url attribute (quoteattr escaping). Defense-in-depth even though
+    def test_ticket_never_in_query_string_regression_1073(self):
+        """#1073: a query-string ticket is silently dropped by Twilio Media
+        Streams, so the WS handshake 403s on answer. Guard we never emit one."""
+        vs = _import_voip_service()
+        svc = vs.VoipService()
+        twiml = svc.build_stream_twiml("voip_abc", "TKT", "https://h.example.com")
+        assert "?ticket=" not in twiml
+        assert "/api/voip/voice/voip_abc?" not in twiml
+
+    def test_attributes_are_escaped_against_injection(self):
+        """A ticket containing quotes/angle-brackets must not break out of its
+        attribute (quoteattr escaping). Defense-in-depth even though
         call_id/ticket are server-generated tokens."""
         vs = _import_voip_service()
         svc = vs.VoipService()
-        twiml = svc.build_stream_twiml("voip_x", '"/><Hangup', "https://h.example.com")
-        # Still a single well-formed Stream element — no injected Hangup tag.
+        payload = '"/><Hangup/><Parameter value="'
+        twiml = svc.build_stream_twiml("voip_x", payload, "https://h.example.com")
+        # Still well-formed (escaping worked) — no injected Hangup element.
         import xml.etree.ElementTree as ET
         root = ET.fromstring(twiml)
         assert root.find("./Connect/Hangup") is None
-        assert root.find("./Connect/Stream") is not None
+        stream = root.find("./Connect/Stream")
+        assert stream is not None
+        # The malicious payload survives intact as the literal attribute value.
+        param = stream.find("./Parameter")
+        assert param is not None
+        assert param.attrib["value"] == payload
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- VoIP outbound calls **placed and rang** after #1069, but **dropped ~1s after answer** with Twilio error 31920 (WebSocket handshake error). Root cause: the Media Streams auth ticket was passed in the `<Stream url>` **query string**, which Twilio does **not** forward on the Media Streams WebSocket. The handler saw `ticket=None`, closed *before* `accept()`, and the handshake 403'd.
- Fix: pass the ticket as a Media Streams **`<Parameter>`** (Twilio surfaces these in the `start` event's `customParameters`), and reorder the handler to **`accept()` first, then authenticate** from the start frame. A query-string `?ticket=` is retained as a fallback for non-Twilio/diagnostic clients.

## Changes
- `src/backend/services/voip_service.py` — `build_stream_twiml`: ticket → `<Stream><Parameter name="ticket" value="…"/></Stream>`; `call_id` stays in the path (no query string). Both `url` and `value` remain `quoteattr`-escaped.
- `src/backend/adapters/transports/twilio_media_stream.py` — `handle_media_stream`: `accept()` first; resolve the ticket from the query string (fallback) or `start.customParameters.ticket`; scope-check (`voip:{call_id}`); `GETDEL` the staged intent; create the Gemini session. New `_parse_start_frame` + bounded `_read_until_start` (10s / 20 frames) so a silent client can't pin a worker; the `start`-frame `streamSid` is carried into the bridge.
- `tests/unit/test_voip_service.py` — TwiML assertions rewritten for the `<Parameter>` form + a regression guard that no query-string ticket is ever emitted.
- `tests/unit/test_1073_voip_media_stream_ticket.py` (new) — drives `handle_media_stream` with a Twilio-style `start` event: happy path, missing-ticket, wrong-scope, no-start-frame timeout, query-string fallback, plus the pure `_parse_start_frame` helper.
- `tests/registry.json`, `docs/memory/architecture.md` — synced.

## Test Plan
- [x] New + updated unit tests pass locally: `pytest tests/unit/test_voip_service.py tests/unit/test_1073_voip_media_stream_ticket.py -v` → **26 passed**
- [ ] Full in-container suite (CI) — couldn't run locally (Docker down); the host-only gap is the `passlib`/`jose` chain that affects `test_1069`/`test_voice_auth` collection on the bare host, unrelated to this change
- [ ] Manual: place an outbound VoIP call on a `VOIP_ENABLED` instance behind a tunnel → call connects and stays up past answer (no Twilio 31920)

Fixes #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)