### PR TITLE
fix(voice/voip): announce before slow tool calls + honor 10-min phone call cap

### DIFF
--- a/docs/memory/feature-flows/voice-chat.md
+++ b/docs/memory/feature-flows/voice-chat.md
@@ -242,12 +242,12 @@ Uvicorn runs `--workers 2` in production. HTTP requests (REST `/voice/start`, `/
 | In-memory `_sessions` dict | Live state | Gemini connection, asyncio tasks, panel_state (unserializable) |
 | Redis key `voice_session:{id}` | Serializable metadata | Cross-worker auth lookup (agent_name, user_id, user_email, …) |
 
-- `create_session()` (now `async`) writes JSON metadata to Redis with TTL = `VOICE_MAX_DURATION + 60` (360s). If Redis write fails, in-memory state is rolled back and `RuntimeError` is raised — the client gets 500 at `/voice/start` rather than a session ID that will intermittently 403.
+- `create_session()` (now `async`) writes JSON metadata to Redis with TTL = `session.max_duration + 60` (browser voice: 360s; phone: `VOIP_MAX_CALL_DURATION + 60` = 660s — the TTL tracks the session's own cap so a 10-min phone session's metadata doesn't expire mid-call). If Redis write fails, in-memory state is rolled back and `RuntimeError` is raised — the client gets 500 at `/voice/start` rather than a session ID that will intermittently 403.
 - `get_session()` (now `async`) checks `_sessions` first; on cache miss, falls back to Redis, reconstructs a `VoiceSession` from the stored metadata, and registers it in the worker's `_sessions` for subsequent calls. Redis errors degrade gracefully to `None`.
 - `remove_session()` (now `async`) deletes the Redis key and pops from `_sessions`.
 - `_redis` client is lazy-initialized as `redis.asyncio` (async, non-blocking) reusing the existing platform Redis URL (`config.REDIS_URL`).
 
-**Key implementation:** `src/backend/services/gemini_voice.py` — `_get_redis()`, `_REDIS_SESSION_TTL`, async `create_session`/`get_session`/`remove_session`.
+**Key implementation:** `src/backend/services/gemini_voice.py` — `_get_redis()`, per-session Redis TTL (`session.max_duration + 60`), async `create_session`/`get_session`/`remove_session`.
 
 ---
 
@@ -258,6 +258,7 @@ Uvicorn runs `--workers 2` in production. HTTP requests (REST `/voice/start`, `/
 | Requirement | Detail |
 |-------------|--------|
 | Function declaration | `_RUN_TASK_TOOL` (`FunctionDeclaration` for `run_task`) registered in `LiveConnectConfig` |
+| Spoken-filler etiquette | `run_task` is a **blocking** Gemini function call — the model emits no audio from the moment it decides to call until `send_tool_response` returns (up to ~30s), which on a phone call reads as dead air. `_TOOL_ETIQUETTE_INSTRUCTION` is appended to every session's `system_instruction` (in `connect_and_stream`, so it covers browser **and** phone) and the `run_task` description is sharpened, instructing the model to say a brief filler ("let me check that for you") before calling. Prompt-side fix; no SDK change. A future upgrade to non-blocking async function calling (`Behavior.NON_BLOCKING` + `FunctionResponseScheduling`) would remove the dead air entirely but requires bumping `google-genai` past the pinned `1.12.1`. |
 | Execution | `_execute_and_respond()` coroutine, `asyncio.create_task` per call, 30s `wait_for` timeout |
 | Agent call | `agent_client.task(prompt)` (lazy import), truncated to `_TOOL_PROMPT_MAX=2000` chars |
 | Error handling | `AgentNotReachableError` → "not currently running"; `AgentRequestError` → "Task error: ..." |
@@ -369,7 +370,7 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 | `VOICE_ENABLED` | Global voice toggle (default `true`; effective only when `GEMINI_API_KEY` is set). Wired into backend compose `environment:` (#979) |
 | `WORKSPACE_ENABLED` | Workspace canvas toggle — opt-in BETA, default `false` (#860). `workspace_available = voice_available && WORKSPACE_ENABLED`. Wired into backend compose `environment:` (#979 — previously never passed through, so the canvas couldn't be enabled via `.env`) |
 | `VOICE_MODEL` | Model ID (default: `gemini-2.5-flash-native-audio-preview-12-2025`) |
-| `VOICE_MAX_DURATION` | Max session duration in seconds (default: 300) |
+| `VOICE_MAX_DURATION` | Max **browser** voice session duration in seconds (default: 300 / 5 min). Phone calls use `VOIP_MAX_CALL_DURATION` instead (default 600 / 10 min) — both flow through the same per-session `_timeout_watchdog`, which now sleeps on `session.max_duration` rather than a global. See [voip-telephony.md](voip-telephony.md). |
 
 ### Per-Agent
 

--- a/docs/memory/feature-flows/voip-telephony.md
+++ b/docs/memory/feature-flows/voip-telephony.md
@@ -49,6 +49,15 @@ what we discussed (updates memory, creates tasks, sends follow-ups)."
   helpers (`ulaw8k_to_pcm16k`, `pcm24k_to_ulaw8k`, `pop_frames`). Carries
   per-direction `audioop.ratecv` state across chunks (the anti-click guarantee).
 
+**Bridge no longer strictly "unmodified"**: codec work still lives entirely in
+the transport (above), but two non-codec session knobs are now threaded through
+`gemini_voice.py` and benefit both transports: a per-session `max_duration`
+(the watchdog honors `VOIP_MAX_CALL_DURATION` for phone calls — see Config) and
+a shared `_TOOL_ETIQUETTE_INSTRUCTION` appended to `system_instruction` so the
+agent says a brief filler ("let me check that") before a slow `run_task` call
+instead of going silent. Both are described in [voice-chat.md](voice-chat.md)
+(VOICE-007, VOICE-009).
+
 ### Outbound call flow
 
 ```
@@ -146,11 +155,18 @@ agent-server mirror — the bridge is backend-only.
 
 ## Config
 
-`VOIP_ENABLED` (default `false`), `VOIP_MAX_CALL_DURATION` (600s),
+`VOIP_ENABLED` (default `false`), `VOIP_MAX_CALL_DURATION` (600s / 10 min),
 `VOIP_DEFAULT_DAILY_CALL_CAP` (50), `VOIP_TICKET_TTL_SECONDS` (180),
 `VOIP_INTENT_TTL_SECONDS` (180), `VOIP_CALL_RATE_LIMIT` / `VOIP_CALL_RATE_WINDOW`.
 All read via `os.getenv` in `src/backend/config.py`. `audioop-lts` pinned for
 `python_version >= "3.13"` (stdlib `audioop` removed in 3.13).
+
+**Call duration**: `VOIP_MAX_CALL_DURATION` (default 600s / 10 min) is the phone
+call's hard cap, enforced by the shared `gemini_voice._timeout_watchdog`. The
+trigger path passes it into `voice_service.create_session(max_duration=…)` so the
+per-session watchdog sleeps on it rather than the 5-min browser `VOICE_MAX_DURATION`.
+(Until this wiring the constant was defined but unused — every session, phone
+included, inherited the 300s voice cap, so calls were silently cut at 5 min.)
 
 ### Deployment / packaging (env vars must reach the container)
 

--- a/src/backend/adapters/transports/twilio_media_stream.py
+++ b/src/backend/adapters/transports/twilio_media_stream.py
@@ -34,7 +34,7 @@ from adapters.transports.voip_audio import (
     pop_frames,
     ulaw8k_to_pcm16k,
 )
-from config import REDIS_URL
+from config import REDIS_URL, VOIP_MAX_CALL_DURATION
 from database import db
 from services.gemini_voice import voice_service
 from services.voip_service import voip_service, intent_key
@@ -272,6 +272,8 @@ async def handle_media_stream(websocket: WebSocket, call_id: str, ticket: Option
             user_email=intent["user_email"],
             system_prompt=intent["system_prompt"],
             voice_name=intent.get("voice_name", "Kore"),
+            # Phone calls use the VoIP cap (default 10min), not the 5-min voice cap.
+            max_duration=VOIP_MAX_CALL_DURATION,
         )
         vs_id = session.session_id
         try:

--- a/src/backend/services/gemini_voice.py
+++ b/src/backend/services/gemini_voice.py
@@ -203,7 +203,10 @@ _RUN_TASK_TOOL = genai_types.Tool(
                 "Execute a task in the agent's workspace — look something up, "
                 "read a file, search for information, or perform an action. "
                 "Use this when you need live data or agent capabilities to answer accurately. "
-                "Returns a text response from the agent."
+                "Returns a text response from the agent. "
+                "This can take several seconds and you cannot speak while it runs — "
+                "ALWAYS say a brief out-loud filler (e.g. 'let me check that') before "
+                "calling it so the user isn't left in silence."
             ),
             parameters=genai_types.Schema(
                 type=genai_types.Type.OBJECT,
@@ -218,6 +221,24 @@ _RUN_TASK_TOOL = genai_types.Tool(
         )
     ]
 )
+
+
+# Spoken-filler etiquette appended to every voice session's system_instruction
+# (browser + VoIP). `run_task` round-trips to the agent container and can take
+# several seconds, during which Gemini — a *blocking* function call — emits no
+# audio. On a phone call that dead air reads as a dropped line. Instruct the
+# model to verbally acknowledge BEFORE it calls run_task so the caller knows it
+# is still working. Cheap, model-side fix; no SDK change required.
+_TOOL_ETIQUETTE_INSTRUCTION = """
+
+## Looking things up out loud
+When you use the `run_task` tool it can take several seconds to return, and you
+cannot speak while it runs. Before EVERY `run_task` call, first say a short,
+natural filler so the user knows you're working and the line never falls
+silent — for example "let me check that for you", "one moment while I look that
+up", or "give me a second to pull that up". Vary the wording so it sounds
+natural. Never call `run_task` silently.
+"""
 
 
 @dataclass
@@ -238,6 +259,9 @@ class VoiceSession:
     system_prompt: str
     voice_name: str = "Kore"
     workspace_mode: bool = False
+    # Max session length (seconds) before the watchdog auto-ends it. Browser voice
+    # sessions use VOICE_MAX_DURATION; phone calls pass VOIP_MAX_CALL_DURATION.
+    max_duration: int = VOICE_MAX_DURATION
     transcript: list = field(default_factory=list)
     panel_state: dict = field(default_factory=lambda: {
         "type": "empty", "content": "", "title": None, "updated_at": None
@@ -256,9 +280,6 @@ class VoiceSession:
     _on_status: Optional[Callable] = field(default=None, repr=False)
     _on_tool_call: Optional[Callable] = field(default=None, repr=False)    # (name, args) → None
     _on_tool_result: Optional[Callable] = field(default=None, repr=False)  # (name, result) → None
-
-
-_REDIS_SESSION_TTL = VOICE_MAX_DURATION + 60  # grace buffer beyond max session length
 
 
 class GeminiVoiceService:
@@ -296,9 +317,16 @@ class GeminiVoiceService:
         system_prompt: str,
         voice_name: str = "Kore",
         workspace_mode: bool = False,
+        max_duration: Optional[int] = None,
     ) -> VoiceSession:
-        """Create a new voice session (does not connect yet)."""
+        """Create a new voice session (does not connect yet).
+
+        `max_duration` overrides the watchdog's auto-end timeout (seconds). The
+        browser voice path leaves it None (→ VOICE_MAX_DURATION); the phone path
+        passes VOIP_MAX_CALL_DURATION so calls aren't cut at the 5-min voice cap.
+        """
         session_id = f"vs_{secrets.token_urlsafe(16)}"
+        effective_max_duration = max_duration if max_duration is not None else VOICE_MAX_DURATION
         session = VoiceSession(
             session_id=session_id,
             agent_name=agent_name,
@@ -308,6 +336,7 @@ class GeminiVoiceService:
             system_prompt=system_prompt,
             voice_name=voice_name,
             workspace_mode=workspace_mode,
+            max_duration=effective_max_duration,
         )
         self._sessions[session_id] = session
 
@@ -322,10 +351,15 @@ class GeminiVoiceService:
             "voice_name": voice_name,
             "workspace_mode": workspace_mode,
             "system_prompt": system_prompt,
+            "max_duration": effective_max_duration,
         }
         try:
             r = await self._get_redis()
-            await r.setex(f"voice_session:{session_id}", _REDIS_SESSION_TTL, json.dumps(metadata))
+            # TTL spans the session's own max duration (+grace), not the shared
+            # voice cap — otherwise a 10-min phone session's metadata expires at
+            # ~6min and cross-worker validation would fail mid-call.
+            redis_ttl = effective_max_duration + 60
+            await r.setex(f"voice_session:{session_id}", redis_ttl, json.dumps(metadata))
         except Exception as e:
             # Fail loudly: better to 500 at /voice/start than issue a session_id
             # that will intermittently 403 when the WebSocket lands on another worker.
@@ -370,7 +404,7 @@ class GeminiVoiceService:
 
         config = genai_types.LiveConnectConfig(
             response_modalities=["AUDIO"],
-            system_instruction=session.system_prompt,
+            system_instruction=session.system_prompt + _TOOL_ETIQUETTE_INSTRUCTION,
             speech_config=genai_types.SpeechConfig(
                 voice_config=genai_types.VoiceConfig(
                     prebuilt_voice_config=genai_types.PrebuiltVoiceConfig(
@@ -646,10 +680,11 @@ class GeminiVoiceService:
             return f"Execution error: {str(e)[:200]}"
 
     async def _timeout_watchdog(self, session: VoiceSession):
-        """Auto-end session after max duration."""
-        await asyncio.sleep(VOICE_MAX_DURATION)
+        """Auto-end session after its max duration (per-session; phone calls
+        use VOIP_MAX_CALL_DURATION, browser voice uses VOICE_MAX_DURATION)."""
+        await asyncio.sleep(session.max_duration)
         if session._active:
-            logger.info(f"Voice session {session.session_id} hit max duration ({VOICE_MAX_DURATION}s)")
+            logger.info(f"Voice session {session.session_id} hit max duration ({session.max_duration}s)")
             await self.end_session(session.session_id)
 
     async def send_audio(self, session_id: str, audio_data: bytes):
@@ -714,6 +749,7 @@ class GeminiVoiceService:
             system_prompt=meta["system_prompt"],
             voice_name=meta.get("voice_name", "Kore"),
             workspace_mode=meta.get("workspace_mode", False),
+            max_duration=meta.get("max_duration", VOICE_MAX_DURATION),
         )
         self._sessions[session_id] = session
         logger.info(f"Voice session {session_id} reconstructed from Redis on worker")


### PR DESCRIPTION
## Summary

Two related voice/phone-call UX fixes in the shared Gemini Live bridge (`services/gemini_voice.py`), both surfaced from live voice-calling use.

### 1. Agent goes silent during tool calls
`run_task` is a **blocking** Gemini Live function call — the model emits no audio from the moment it decides to call it until `send_tool_response` returns (up to ~30s of agent-container round-trip). On a phone call that dead air reads as a dropped line.

**Fix:** a shared `_TOOL_ETIQUETTE_INSTRUCTION` is appended to every session's `system_instruction` (in `connect_and_stream`, so it covers **browser voice and phone**), and the `run_task` tool description is sharpened — instructing the model to say a brief filler ("let me check that for you") before calling. Prompt-side only; no SDK change.

> Caller: "What's my balance on the Acme deal?"
> Agent:  "Sure — let me pull that up for you." *(natural pause while run_task runs)* "Okay, the Acme deal is at \$42k, closing Friday."

A future upgrade to non-blocking async function calling (`Behavior.NON_BLOCKING` + `FunctionResponseScheduling`) would remove the pause entirely, but requires bumping `google-genai` past the pinned `1.12.1` — deferred.

### 2. Phone calls silently cut at 5 minutes (latent bug)
`VOIP_MAX_CALL_DURATION` (600s / 10 min) was defined in config **but never wired in** — `_timeout_watchdog` slept on the shared `VOICE_MAX_DURATION` (300s) for *every* session, phone included, despite the config comment claiming otherwise.

**Fix:** `VoiceSession` now carries a per-session `max_duration`; `create_session(max_duration=…)` plumbs it through; the Twilio Media Streams transport passes `VOIP_MAX_CALL_DURATION`. The Redis session-metadata TTL is now sized per-session (`max_duration + 60`) so a 10-min call's metadata can't expire mid-call. Removed the now-unused `_REDIS_SESSION_TTL`.

- **Phone calls: 10 minutes** (the existing 600s default — now actually honored).
- **Browser voice: unchanged at 5 minutes** (`VOICE_MAX_DURATION`).
- Tunable via the `VOIP_MAX_CALL_DURATION` env var (already forwarded in both compose files).

## Files
- `src/backend/services/gemini_voice.py` — filler etiquette + per-session `max_duration` + per-session Redis TTL.
- `src/backend/adapters/transports/twilio_media_stream.py` — pass `VOIP_MAX_CALL_DURATION`.
- `docs/memory/feature-flows/voice-chat.md`, `voip-telephony.md` — synced.

## Testing
- `python -c "ast.parse(...)"` on both changed modules — OK.
- Manual-verify recommended via the **browser voice tab** (same bridge, no Twilio needed): ask something that forces a `run_task` lookup → hear the filler then the answer. Phone-duration change is observable on a real PSTN call.

## Notes
- Both files hot-reload via the `./src/backend` bind mount + `--reload` — no image rebuild.
- Standalone fix, not tied to an existing issue. Targets `dev` per the repo's `feature/* → dev → main` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)