### PR TITLE
fix(voice): coalesce empty VOICE_MODEL to default — voice DOA on compose deploys (#1076)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,8 +136,12 @@ GOOGLE_API_KEY=
 
 # Voice chat (VOICE-001). Default ON in code; set to false to disable platform-wide.
 VOICE_ENABLED=true
-# Gemini Live model override (blank = built-in default).
-VOICE_MODEL=
+# Gemini Live model override. Leave commented to use the built-in default
+# (models/gemini-3.1-flash-live-preview, set in src/backend/config.py). #1076:
+# an uncommented `VOICE_MODEL=` exports an empty string that shadows the default
+# and breaks all voice paths ("model is required") — keep it commented unless
+# you are overriding with a real model id.
+# VOICE_MODEL=models/gemini-3.1-flash-live-preview
 # Voice Workspace canvas — opt-in BETA (#860).
 WORKSPACE_ENABLED=false
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -61,7 +61,7 @@ services:
       # Voice chat (VOICE-001) — mirrors docker-compose.yml so operators can
       # tune/disable voice in prod (code default is ON; without these lines the
       # knobs are inert — the #1039 packaging-gap class).
-      - VOICE_MODEL=${VOICE_MODEL:-}  # Gemini Live model override
+      - VOICE_MODEL=${VOICE_MODEL:-models/gemini-3.1-flash-live-preview}  # Gemini Live model override (#1076: non-empty default so an unset var doesn't inject "")
       - VOICE_ENABLED=${VOICE_ENABLED:-true}  # Voice mode (default on when GEMINI_API_KEY set)
       - WORKSPACE_ENABLED=${WORKSPACE_ENABLED:-false}  # Voice Workspace canvas — opt-in BETA (#860)
       # VoIP telephony (VOIP-001, #1056) — opt-in, default OFF. Default-OFF means

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}  # For Gemini-powered agents
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # For platform image generation (IMG-001)
-      - VOICE_MODEL=${VOICE_MODEL:-}  # Gemini Live model override (default: gemini-2.5-flash-native-audio-preview-12-2025)
+      - VOICE_MODEL=${VOICE_MODEL:-models/gemini-3.1-flash-live-preview}  # Gemini Live model override (#1076: non-empty default so an unset var doesn't inject "")
       - VOICE_ENABLED=${VOICE_ENABLED:-true}  # Voice mode (default on when GEMINI_API_KEY set)
       - WORKSPACE_ENABLED=${WORKSPACE_ENABLED:-false}  # Voice Workspace canvas — opt-in BETA (#860)
       # VoIP telephony (VOIP-001, #1056) — opt-in, default OFF. Master switch must

--- a/docs/memory/feature-flows/voice-chat.md
+++ b/docs/memory/feature-flows/voice-chat.md
@@ -369,7 +369,7 @@ Returns current canvas panel state. Returns empty state (not 404) for non-existe
 | `GEMINI_API_KEY` | API key for Gemini Live API |
 | `VOICE_ENABLED` | Global voice toggle (default `true`; effective only when `GEMINI_API_KEY` is set). Wired into backend compose `environment:` (#979) |
 | `WORKSPACE_ENABLED` | Workspace canvas toggle — opt-in BETA, default `false` (#860). `workspace_available = voice_available && WORKSPACE_ENABLED`. Wired into backend compose `environment:` (#979 — previously never passed through, so the canvas couldn't be enabled via `.env`) |
-| `VOICE_MODEL` | Model ID (default: `gemini-2.5-flash-native-audio-preview-12-2025`) |
+| `VOICE_MODEL` | Model ID (default: `models/gemini-3.1-flash-live-preview`, set in `src/backend/config.py`). #1076: leave unset/commented — a set-but-empty value is coalesced to the default by `os.getenv("VOICE_MODEL") or …`. |
 | `VOICE_MAX_DURATION` | Max **browser** voice session duration in seconds (default: 300 / 5 min). Phone calls use `VOIP_MAX_CALL_DURATION` instead (default 600 / 10 min) — both flow through the same per-session `_timeout_watchdog`, which now sleeps on `session.max_duration` rather than a global. See [voip-telephony.md](voip-telephony.md). |
 
 ### Per-Agent

--- a/docs/user-docs/advanced/voice-chat.md
+++ b/docs/user-docs/advanced/voice-chat.md
@@ -50,7 +50,7 @@ Click **Mute** to silence your microphone mid-session. Gemini continues speaking
 | `GEMINI_API_KEY` | API key for Gemini Live API | — (required) |
 | `VOICE_ENABLED` | Global toggle | `true` |
 | `WORKSPACE_ENABLED` | Enable the Workspace Mode canvas (BETA, admin opt-in) | `false` |
-| `VOICE_MODEL` | Gemini model ID | `gemini-2.5-flash-native-audio-preview-12-2025` |
+| `VOICE_MODEL` | Gemini model ID (leave unset to use the built-in default) | `models/gemini-3.1-flash-live-preview` |
 | `VOICE_MAX_DURATION` | Max session duration in seconds | `300` |
 
 ### Per-Agent Voice Prompt

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -114,7 +114,15 @@ DISPATCH_BREAKER_ENABLED = os.getenv("DISPATCH_BREAKER_ENABLED", "false").lower(
 
 # Voice Chat Configuration (VOICE-001)
 VOICE_ENABLED = os.getenv("VOICE_ENABLED", "true").lower() == "true"
-VOICE_MODEL = os.getenv("VOICE_MODEL", "models/gemini-3.1-flash-live-preview")
+# Coalesce empty → default (#1076): os.getenv(name, default) returns the
+# default only when the var is UNSET, not when it is set-but-empty. A blank
+# VOICE_MODEL (a stray `.env` line, a manual export, or an older compose that
+# injected `${VOICE_MODEL:-}`) would otherwise shadow the default and send
+# model="" to Gemini Live ("model is required" → every voice path DOA). `or`
+# defends against an empty value from any source. This line is the authoritative
+# source of the default model id — keep compose/.env.example in agreement.
+# (mirrors the GEMINI_API_KEY `or` coalesce above.)
+VOICE_MODEL = os.getenv("VOICE_MODEL") or "models/gemini-3.1-flash-live-preview"
 VOICE_MAX_DURATION = int(os.getenv("VOICE_MAX_DURATION", "300"))  # seconds
 
 # VoIP Telephony Configuration (VOIP-001, #1056 — Phase 1, outbound)

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -520,7 +520,12 @@ export class TrinityClient {
     // is what drives naive callers into duplicate-queue retries. Aborting
     // before the gateway gives us a chance to look up the queued
     // execution_id and return a structured receipt instead.
-    const timeoutMs = Number(process.env.MCP_CHAT_TIMEOUT_MS ?? 25000);
+    // `||` (not `??`) so a set-but-empty value coalesces to the default —
+    // the TS twin of the #1076 os.getenv shadow bug. `'' ?? 25000` is `''`
+    // and `Number('')` is 0, which would abort every sync chat instantly.
+    // Compose injects `${MCP_CHAT_TIMEOUT_MS:-25000}` (non-empty) today, so
+    // this is defense-in-depth against a future empty injection / `-e VAR=`.
+    const timeoutMs = Number(process.env.MCP_CHAT_TIMEOUT_MS || 25000);
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     const startTime = Date.now();

--- a/tests/unit/test_1076_voice_model_config.py
+++ b/tests/unit/test_1076_voice_model_config.py
@@ -1,0 +1,107 @@
+"""Unit regression test for #1076 — VOICE_MODEL empty-coalesce.
+
+Bug: `os.getenv("VOICE_MODEL", default)` returns the default ONLY when the
+var is *unset*. Compose injected `VOICE_MODEL=${VOICE_MODEL:-}` and
+`.env.example` shipped `VOICE_MODEL=`, both of which arrive as a *set-but-empty*
+string that shadowed the default and sent `model=""` to Gemini Live
+("model is required" → every voice path DOA on a stock deploy).
+
+Fix (src/backend/config.py):
+    VOICE_MODEL = os.getenv("VOICE_MODEL") or "models/gemini-3.1-flash-live-preview"
+
+These tests load the REAL config.py module fresh under a controlled
+environment and assert the resolved `VOICE_MODEL` for the three input
+states: unset, set-but-empty, and a genuine override. No network, no Redis
+(the tests/unit/ conftest overrides the parent's backend-dependent autouse
+fixtures) — a valid dummy REDIS_URL is supplied solely to satisfy config.py's
+import-time credential guard (Issue #589).
+
+Lives under tests/unit/ so the CI unit job (`cd tests && pytest unit/`)
+actually collects it — the #1076 regression guard must run where the bug
+would regress.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# tests/unit/<this file> → parent=tests/unit, .parent=tests, .parent=repo root
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CONFIG_PATH = _REPO_ROOT / "src" / "backend" / "config.py"
+_EXPECTED_DEFAULT = "models/gemini-3.1-flash-live-preview"
+
+
+def _load_config_with_env(monkeypatch, env: dict[str, str | None]):
+    """Exec src/backend/config.py fresh under `env` and return the module.
+
+    Each call gets a uniquely-named throwaway module so we never touch the
+    process-wide `sys.modules["config"]` other tests may rely on, and so the
+    import-time `os.getenv` reads see exactly the env we set here.
+    """
+    # config.py's only hard import-time requirement is a credentialed REDIS_URL.
+    monkeypatch.setenv("REDIS_URL", "redis://backend:devpassword@localhost:6379/0")
+    for key, value in env.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+
+    spec = importlib.util.spec_from_file_location(
+        f"_config_under_test_{abs(hash(frozenset(env.items())))}", str(_CONFIG_PATH)
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def test_voice_model_unset_uses_default(monkeypatch):
+    """Var entirely unset → built-in default (the os.getenv-default path)."""
+    cfg = _load_config_with_env(monkeypatch, {"VOICE_MODEL": None})
+    assert cfg.VOICE_MODEL == _EXPECTED_DEFAULT
+
+
+def test_voice_model_empty_string_coalesces_to_default(monkeypatch):
+    """THE #1076 bug: set-but-empty must NOT shadow the default."""
+    cfg = _load_config_with_env(monkeypatch, {"VOICE_MODEL": ""})
+    assert cfg.VOICE_MODEL == _EXPECTED_DEFAULT, (
+        "Empty VOICE_MODEL shadowed the default — regression of #1076; "
+        "this sends model=\"\" to Gemini Live and kills every voice path."
+    )
+
+
+def test_voice_model_override_is_respected(monkeypatch):
+    """A genuine operator override must still flow through untouched."""
+    cfg = _load_config_with_env(
+        monkeypatch, {"VOICE_MODEL": "models/some-other-live-model"}
+    )
+    assert cfg.VOICE_MODEL == "models/some-other-live-model"
+
+
+@pytest.mark.parametrize(
+    "compose_file",
+    ["docker-compose.yml", "docker-compose.prod.yml"],
+)
+def test_compose_default_is_non_empty(compose_file):
+    """Defense-in-depth: compose must not inject an empty VOICE_MODEL.
+
+    Guards against a future revert of the compose change re-introducing the
+    `${VOICE_MODEL:-}` set-but-empty injection the code coalesce defends against.
+    """
+    text = (_REPO_ROOT / compose_file).read_text()
+    voice_lines = [
+        ln
+        for ln in text.splitlines()
+        if "VOICE_MODEL=${VOICE_MODEL:-" in ln and not ln.strip().startswith("#")
+    ]
+    assert voice_lines, f"{compose_file}: VOICE_MODEL injection line not found"
+    for ln in voice_lines:
+        assert "${VOICE_MODEL:-}" not in ln, (
+            f"{compose_file}: VOICE_MODEL injects an empty default — "
+            f"regression of #1076. Use ${{VOICE_MODEL:-{_EXPECTED_DEFAULT}}}."
+        )
+        assert _EXPECTED_DEFAULT in ln, (
+            f"{compose_file}: compose default drifted from config.py "
+            f"({_EXPECTED_DEFAULT})."
+        )


### PR DESCRIPTION
## Summary
- **Voice was dead on arrival on every stock compose deploy.** `os.getenv("VOICE_MODEL", default)` only uses its default when the var is *unset* — but compose injected `VOICE_MODEL=${VOICE_MODEL:-}` and `.env.example` shipped a bare `VOICE_MODEL=`, both arriving as `""`, which shadowed the code default and sent `model=""` to Gemini Live (`"model is required"`). This killed voice chat, the voice workspace, **and** VoIP (PSTN call dropped ~1s after answer). Third and final blocker in the #1069 → #1073 → #1076 VoIP chain.
- **Load-bearing fix:** `config.py` now uses `os.getenv("VOICE_MODEL") or "models/gemini-3.1-flash-live-preview"`, coalescing empty from *any* source (`.env`, shell, compose). Mirrors the existing `GEMINI_API_KEY` `or` pattern in the same file.
- **Defense-in-depth:** compose defaults made non-empty so the layers agree; `.env.example` commented out so a fresh copy can't inject empty.

## Changes
| File | Change |
|------|--------|
| `src/backend/config.py` | `os.getenv("VOICE_MODEL") or "models/…"` — the primary fix |
| `docker-compose.yml`, `docker-compose.prod.yml` | non-empty `${VOICE_MODEL:-models/gemini-3.1-flash-live-preview}` + de-drifted comments |
| `.env.example` | `VOICE_MODEL` commented out (with warning) |
| `src/mcp-server/src/client.ts` | sibling-sweep hardening: `MCP_CHAT_TIMEOUT_MS ?? 25000` → `\|\| 25000` |
| `docs/memory/feature-flows/voice-chat.md`, `docs/user-docs/advanced/voice-chat.md` | corrected stale default-model id |
| `tests/unit/test_1076_voice_model_config.py` | **new** regression guard (5 tests) |

## Sibling-var sweep (the issue's "apply the pattern to any siblings" ask)
Three independent scans (backend / scheduler / agent+MCP surfaces) confirm **`VOICE_MODEL` was the *only* instance** of the `${VAR:-}`-empty × non-empty-code-default collision. All 21 other empty-injected vars have matching empty code defaults (intentional "not configured" sentinels); no `int()/float()`-wrapped var is compose-injected empty (no startup-crash variant). The single structural twin found — the TS `MCP_CHAT_TIMEOUT_MS ?? 25000` (`??` isn't empty-safe; `Number('')===0` would instant-abort sync chats) — is hardened here as defense-in-depth (not presently triggerable, since its compose default is non-empty).

## Test Plan
- [x] New unit tests pass under the CI invocation (`cd tests && pytest unit/test_1076_voice_model_config.py`) — **no backend required** (tests/unit conftest overrides the backend-dependent autouse fixture): `5 passed`
- [x] Adversarially verified the empty-string test **fails against the old `os.getenv(name, default)` code** (yields `''`) — genuine regression guard, not a tautology
- [x] `tsc --noEmit` clean on the mcp-server change
- [x] Model id `models/gemini-3.1-flash-live-preview` is byte-identical across config.py, both compose files, and the docs; secrets/PII scan of the diff clean (PUBLIC repo)
- [ ] Manual: on a stock compose deploy with `VOICE_MODEL` unset, a voice/VoIP session connects and holds (the issue's reproduced 105s call)

Fixes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)