### PR TITLE
fix(telemetry): non-blocking /api/telemetry/containers — back-merge to dev (#1096)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -298,6 +298,27 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 OTEL_METRIC_EXPORT_INTERVAL=60000
 
 # ===========================================
+# CONTAINER TELEMETRY (Optional, #1096)
+# ===========================================
+
+# GET /api/telemetry/containers serves a short-TTL, background-refreshed
+# cache so the request path never blocks on Docker (the endpoint is
+# non-blocking out of the box — these knobs are optional tuning overrides).
+# Like OTEL_SAMPLE_RATE, they are read via os.getenv with safe defaults and
+# are NOT wired into compose by default; to tune on a standalone prod
+# deployment, add them to the backend service's environment.
+
+# Seconds a cached container-stats payload stays "fresh" before a background
+# refresh is scheduled (default: 10; "0" disables the cache → every request
+# schedules a refresh and serves stale, still non-blocking).
+TELEMETRY_CONTAINER_STATS_TTL=10
+
+# Max concurrent Docker stat fetches during a background refresh
+# (default: 16; clamped to 1..64). Sized to the fleet so a cold refresh is
+# ~one Docker-sample window rather than ceil(N/4) windows.
+TELEMETRY_DOCKER_POOL_SIZE=16
+
+# ===========================================
 # DOCKER SOCKET GROUP (Linux only)
 # ===========================================
 

--- a/docs/memory/feature-flows/host-telemetry.md
+++ b/docs/memory/feature-flows/host-telemetry.md
@@ -144,11 +144,19 @@ disk = psutil.disk_usage('/')
 ```
 
 #### GET /api/telemetry/containers
-`src/backend/routers/telemetry.py:112-173`
+`src/backend/routers/telemetry.py` — `get_container_stats`
 
 Returns aggregate statistics across all running agent containers.
 
 **Requires authentication** (Bearer token, SEC-180).
+
+**Non-blocking — stale-while-revalidate cache (#1096):** the request path
+NEVER awaits the Docker daemon. `container.stats(stream=False)` costs ~1-2s
+per container, so the original synchronous endpoint took
+`ceil(N/pool) * ~1.5s` (~6s at 11 agents), pinning a uvicorn worker for its
+whole duration and starving the rest of the UI on low-worker prod (2 workers).
+The handler now reads a short-TTL, background-refreshed cache and returns
+immediately; the expensive Docker work runs out-of-band.
 
 **Response Schema:**
 ```json
@@ -161,25 +169,48 @@ Returns aggregate statistics across all running agent containers.
     {"name": "agent-b", "cpu": 4.5, "memory_mb": 256.1},
     {"name": "agent-c", "cpu": 2.6, "memory_mb": 256.2}
   ],
-  "timestamp": "2026-01-13T12:00:00.000000Z"
+  "timestamp": "2026-01-13T12:00:00.000000Z",
+  "cached": true,
+  "stale": false,
+  "cache_age_seconds": 3.2
 }
 ```
 
+The original 5 fields are unchanged; `cached`, `stale`, and
+`cache_age_seconds` (float | null) are **additive** (the endpoint has no
+`response_model`, so existing consumers ignore the extra keys).
+
+**Caching behaviour:**
+
+| Cache state | Response | Refresh |
+|-------------|----------|---------|
+| Fresh (`age < TTL`) | live cached payload, `stale:false` | none |
+| Stale (`age ≥ TTL`) | last payload, `stale:true` | scheduled in background |
+| Cold (no data yet) | empty payload (`running_count:0`, `[]`), `cached:false, stale:true` | scheduled in background |
+
+Cold state only occurs on a worker's first poll after (re)start and
+self-heals within one TTL once the background refresh completes.
+
 **Performance Optimization:**
 ```python
-# Line 18-20: Thread pool for parallel Docker stats
-_docker_executor = ThreadPoolExecutor(max_workers=4)
+# Pool sized to the fleet (default 16, env TELEMETRY_DOCKER_POOL_SIZE,
+# clamped 1..64) — the refresh now runs off the request path, so a cold
+# refresh is ~one Docker-sample window instead of ceil(N/4) windows.
+_docker_executor = ThreadPoolExecutor(max_workers=_POOL_SIZE, ...)
 
-# Line 126: Use fast agent listing (labels only)
-agents = list_all_agents_fast()
+# TTL of a "fresh" payload (default 10s, env TELEMETRY_CONTAINER_STATS_TTL).
+_CACHE_TTL = ...
 
-# Line 140-147: Parallel execution with asyncio
-tasks = [
-    loop.run_in_executor(_docker_executor, _get_single_container_stats_sync, agent.name)
-    for agent in running_agents
-]
-containers_stats = await asyncio.gather(*tasks, return_exceptions=True)
+# Single-flight: one background refresh per process at a time, holding a
+# strong task ref so it can't be GC'd mid-run (_schedule_refresh).
+# _compute_container_stats() offloads the agent listing AND each container's
+# stats to the executor and aggregates via asyncio.gather(return_exceptions=True).
 ```
+
+Cache state is per-process (each uvicorn worker keeps its own); a failed
+refresh leaves the previous payload intact and never surfaces as a request
+error. Config env vars are defensively parsed — a bad value falls back to the
+default and can never crash the router at import.
 
 **Single Container Stats Helper:**
 ```python
@@ -262,9 +293,10 @@ Dashboard.vue
 
 | Error Case | HTTP Status | Handling |
 |------------|-------------|----------|
-| psutil error | 500 | `Error getting host stats: {message}` |
-| Docker unavailable | 503 | `Docker not available` |
-| Container stats error | - | Returns `{error: message}` per container, continues |
+| psutil error (`/host`) | 500 | `Error getting host stats: {message}` |
+| Docker unavailable (`docker_client` falsy) | 503 | `Docker not available` (`/containers`) |
+| Container stats error (per container) | - | Returns `{error: message}` for that container, continues |
+| Background refresh fails (`/containers`, #1096) | 200 | Logged at WARNING; previous (or empty) cached payload served — no 500 |
 | Fetch timeout | - | Frontend: 3s timeout, silently fails |
 
 **Frontend Error Handling:**
@@ -335,6 +367,8 @@ signal: AbortSignal.timeout(3000)
 |----------|-------------------|
 | No running agents | `running_count: 0`, empty `containers` array |
 | Docker unavailable | 503 error on `/containers`, host stats still work |
+| Cold cache (first poll after restart) | Instant empty payload, `stale:true`; real data on the next poll (#1096) |
+| Background refresh fails | Previous payload served (`stale:true`); warning logged; no 500 (#1096) |
 | High CPU load (>90%) | Red color class applied |
 | Disk nearly full (>90%) | Red progress bar |
 
@@ -343,7 +377,7 @@ No cleanup required - read-only endpoints.
 
 ### Status
 - Host Telemetry Display: Working
-- Container Aggregate Stats: Working (API only, no UI integration)
+- Container Aggregate Stats: Working (API only, no UI integration); non-blocking SWR cache since #1096
 
 ---
 
@@ -351,5 +385,6 @@ No cleanup required - read-only endpoints.
 
 | Date | Change |
 |------|--------|
+| 2026-06-08 | #1096: `/containers` made non-blocking via short-TTL background-refreshed cache (stale-while-revalidate); added `cached`/`stale`/`cache_age_seconds` fields |
 | 2026-03-27 | SEC-180: Authentication added to all telemetry endpoints |
 | 2026-01-13 | Initial documentation |

--- a/src/backend/routers/telemetry.py
+++ b/src/backend/routers/telemetry.py
@@ -4,13 +4,25 @@ Host and Container Telemetry Endpoints
 Provides real-time system metrics for the Dashboard:
 - Host system stats (CPU, memory, disk)
 - Aggregate container stats across all running agents
+
+Container stats are served from a short-TTL, background-refreshed cache so the
+request path NEVER blocks on the Docker daemon (#1096). `container.stats()` is
+a ~1-2s-per-container call, so a fleet of N agents made the endpoint take
+`ceil(N/pool) * ~1.5s` — ~6s at 11 agents — pinning a uvicorn worker for the
+whole duration and starving the rest of the UI. The handler now does
+stale-while-revalidate: it returns whatever is cached immediately and schedules
+an out-of-band refresh; the expensive Docker work is fully decoupled from the
+HTTP request.
 """
 
 import asyncio
-import psutil
+import logging
+import os
+import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 from typing import List, Dict, Any, Optional
+
+import psutil
 from fastapi import APIRouter, Depends, HTTPException
 
 from dependencies import get_current_user
@@ -18,9 +30,62 @@ from models import User
 from services.docker_service import docker_client, list_all_agents_fast
 from utils.helpers import utc_now_iso
 
-# Module-level executor for Docker operations (blocking calls)
-# Limited to 4 workers to avoid overwhelming Docker daemon
-_docker_executor = ThreadPoolExecutor(max_workers=4)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration (env-overridable, defensively parsed so a bad value can never
+# crash the router at import time — it falls back to the default).
+# ---------------------------------------------------------------------------
+_DEFAULT_CACHE_TTL = 10.0   # seconds a cached container-stats payload is "fresh"
+_DEFAULT_POOL_SIZE = 16     # max concurrent Docker stat fetches on the refresh
+_POOL_SIZE_MAX = 64
+
+
+def _parse_float_env(value: Optional[str], default: float, *, minimum: float = 0.0) -> float:
+    """Parse a float env var, falling back to `default` on anything invalid.
+
+    Negative / zero is clamped to `minimum` (0 disables the cache → every
+    request schedules a refresh and serves stale, never blocking)."""
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= minimum else minimum
+
+
+def _parse_pool_size(value: Optional[str], default: int) -> int:
+    """Parse the Docker stat pool size; clamp to [1, _POOL_SIZE_MAX]."""
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(parsed, _POOL_SIZE_MAX))
+
+
+_CACHE_TTL = _parse_float_env(os.getenv("TELEMETRY_CONTAINER_STATS_TTL"), _DEFAULT_CACHE_TTL)
+_POOL_SIZE = _parse_pool_size(os.getenv("TELEMETRY_DOCKER_POOL_SIZE"), _DEFAULT_POOL_SIZE)
+
+# Module-level executor for the blocking Docker stat fetches. Sized larger than
+# the old hard cap of 4 because the work now runs on a background task off the
+# request path, so a cold refresh is ~one Docker-sample window instead of
+# ceil(N/4) windows. Threads idle cheaply when there is no refresh in flight.
+_docker_executor = ThreadPoolExecutor(
+    max_workers=_POOL_SIZE, thread_name_prefix="telemetry-docker"
+)
+
+# Background-refreshed cache. `data` is the last fully-computed payload (or
+# None before the first successful refresh); `timestamp` is the monotonic time
+# of that compute. Single-process state — each uvicorn worker keeps its own.
+_stats_cache: Dict[str, Any] = {"timestamp": 0.0, "data": None}
+
+# Strong reference to the in-flight refresh task so (a) we never launch two at
+# once and (b) the fire-and-forget task can't be garbage-collected mid-run.
+_refresh_task: Optional["asyncio.Task"] = None
 
 router = APIRouter(prefix="/api/telemetry", tags=["telemetry"])
 
@@ -112,65 +177,116 @@ def _get_single_container_stats_sync(agent_name: str) -> Dict[str, Any]:
         }
 
 
+def _empty_payload(running_count: int = 0) -> Dict[str, Any]:
+    """A fully-shaped container-stats payload with no per-container data."""
+    return {
+        "running_count": running_count,
+        "total_cpu_percent": 0,
+        "total_memory_mb": 0,
+        "containers": [],
+        "timestamp": utc_now_iso(),
+    }
+
+
+async def _compute_container_stats() -> Dict[str, Any]:
+    """Do the expensive work: list running agents and fetch each container's
+    Docker stats in parallel. Returns a fully-shaped payload. This is what the
+    background refresh runs — it must never touch the request path directly."""
+    loop = asyncio.get_running_loop()
+
+    # Off-load even the agent listing (a Docker call) to the executor so the
+    # event loop is never blocked during a refresh.
+    agents = await loop.run_in_executor(_docker_executor, list_all_agents_fast)
+    running_agents = [a for a in agents if a.status == "running"]
+
+    if not running_agents:
+        return _empty_payload(0)
+
+    tasks = [
+        loop.run_in_executor(_docker_executor, _get_single_container_stats_sync, agent.name)
+        for agent in running_agents
+    ]
+    containers_stats = await asyncio.gather(*tasks, return_exceptions=True)
+
+    processed_stats: List[Dict[str, Any]] = []
+    total_cpu_percent = 0.0
+    total_memory_mb = 0.0
+
+    for result in containers_stats:
+        if isinstance(result, dict):
+            processed_stats.append(result)
+            if "error" not in result:
+                total_cpu_percent += result.get("cpu", 0)
+                total_memory_mb += result.get("memory_mb", 0)
+
+    return {
+        "running_count": len(running_agents),
+        "total_cpu_percent": round(total_cpu_percent, 1),
+        "total_memory_mb": round(total_memory_mb, 1),
+        "containers": sorted(processed_stats, key=lambda x: x.get('cpu', 0), reverse=True),
+        "timestamp": utc_now_iso(),
+    }
+
+
+async def _refresh_cache() -> None:
+    """Recompute the container-stats cache. On failure the previous cache is
+    left untouched (best-effort metrics — never surface a Docker hiccup as a
+    request error)."""
+    try:
+        payload = await _compute_container_stats()
+        _stats_cache["data"] = payload
+        _stats_cache["timestamp"] = time.monotonic()
+    except Exception as e:
+        logger.warning("telemetry container-stats refresh failed: %s", e)
+
+
+def _schedule_refresh() -> None:
+    """Launch a background refresh unless one is already in flight. Race-free
+    on the asyncio event loop: there is no `await` between the done() check and
+    create_task(), so no other coroutine can interleave."""
+    global _refresh_task
+    if _refresh_task is not None and not _refresh_task.done():
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop (shouldn't happen from inside an async handler).
+        return
+    _refresh_task = loop.create_task(_refresh_cache())
+
+
 @router.get("/containers")
 async def get_container_stats(current_user: User = Depends(get_current_user)):
     """
     Get aggregate statistics across all running agent containers.
 
     Returns total CPU usage, memory consumption, and per-container breakdown.
-    Uses parallel execution for better performance with multiple containers.
-    Requires authentication (SEC-180).
+
+    Non-blocking (#1096): served from a short-TTL cache that is refreshed by a
+    background task. The request never waits on the Docker daemon, so a fleet
+    of agents can no longer pin a uvicorn worker for ~6s and stall the UI.
+    Adds three fields on top of the original contract: `cached` (bool),
+    `stale` (bool), and `cache_age_seconds` (float|None).
     """
     if not docker_client:
         raise HTTPException(status_code=503, detail="Docker not available")
 
-    try:
-        # Get all running agent containers - use fast version (only need names)
-        agents = list_all_agents_fast()
-        running_agents = [a for a in agents if a.status == "running"]
+    now = time.monotonic()
+    cached = _stats_cache["data"]
+    age = now - _stats_cache["timestamp"] if cached is not None else None
 
-        if not running_agents:
-            return {
-                "running_count": 0,
-                "total_cpu_percent": 0,
-                "total_memory_mb": 0,
-                "containers": [],
-                "timestamp": utc_now_iso()
-            }
+    # Fresh cache hit — return instantly, no refresh needed.
+    if cached is not None and age is not None and age < _CACHE_TTL:
+        return {**cached, "cached": True, "stale": False, "cache_age_seconds": round(age, 1)}
 
-        # Fetch all container stats in PARALLEL using thread pool
-        # This reduces time from O(n * 1-2s) to O(1-2s) for n containers
-        loop = asyncio.get_event_loop()
-        tasks = [
-            loop.run_in_executor(_docker_executor, _get_single_container_stats_sync, agent.name)
-            for agent in running_agents
-        ]
+    # Cache is stale or cold: kick off an out-of-band refresh and return now.
+    _schedule_refresh()
 
-        # Wait for all stats to complete concurrently
-        containers_stats = await asyncio.gather(*tasks, return_exceptions=True)
+    if cached is not None:
+        # Serve stale data while the refresh runs (stale-while-revalidate).
+        return {**cached, "cached": True, "stale": True, "cache_age_seconds": round(age, 1)}
 
-        # Process results, handling any exceptions
-        processed_stats: List[Dict[str, Any]] = []
-        total_cpu_percent = 0.0
-        total_memory_mb = 0
-
-        for result in containers_stats:
-            if isinstance(result, Exception):
-                # Unlikely, but handle gracefully
-                continue
-            if isinstance(result, dict):
-                processed_stats.append(result)
-                if "error" not in result:
-                    total_cpu_percent += result.get("cpu", 0)
-                    total_memory_mb += result.get("memory_mb", 0)
-
-        return {
-            "running_count": len(running_agents),
-            "total_cpu_percent": round(total_cpu_percent, 1),
-            "total_memory_mb": round(total_memory_mb, 1),
-            "containers": sorted(processed_stats, key=lambda x: x.get('cpu', 0), reverse=True),
-            "timestamp": utc_now_iso()
-        }
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error getting container stats: {str(e)}")
+    # Cold start (no data computed yet): return an instant, valid, empty
+    # payload. The next poll (a few seconds later) gets real data once the
+    # background refresh completes. No request ever pays the Docker latency.
+    return {**_empty_payload(0), "cached": False, "stale": True, "cache_age_seconds": None}

--- a/tests/unit/test_1096_telemetry_cache.py
+++ b/tests/unit/test_1096_telemetry_cache.py
@@ -1,0 +1,389 @@
+"""Unit tests for #1096 — non-blocking /api/telemetry/containers.
+
+`container.stats(stream=False)` costs ~1-2s per container, so the aggregate
+endpoint blocked for `ceil(N/pool) * ~1.5s` (~6s at 11 agents), pinning a
+uvicorn worker and stalling the whole UI. The fix serves the payload from a
+short-TTL, background-refreshed cache (stale-while-revalidate): the request
+path NEVER awaits the Docker daemon.
+
+These tests prove:
+  - a fresh cache hit returns WITHOUT touching Docker (no blocking call);
+  - a cold cache returns an instant, valid, empty payload (no inline compute)
+    and schedules a background refresh that then populates the cache;
+  - a stale cache serves the old payload immediately and schedules a refresh;
+  - the original response contract is preserved (backward-compat);
+  - the refresh aggregation is correct and is the ONLY place Docker is touched;
+  - env parsing is defensive (a bad value can't crash the router at import).
+
+True unit tests: the Docker seam is monkeypatched, no daemon / backend needed.
+
+Issue: https://github.com/Abilityai/trinity/issues/1096
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+# Point the backend at an ephemeral SQLite file BEFORE any backend module
+# imports (database.py tries to mkdir /data on import otherwise). The unit
+# conftest already does this; belt-and-suspenders for direct invocation.
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+pytestmark = pytest.mark.unit
+
+
+# Modules this file installs into sys.modules at collection time (the loader
+# below registers the importlib-loaded router and briefly swaps stubs). Snapshot
+# + restore them around every test so they can't leak into sibling test files —
+# this is the sanctioned escape hatch recognized by tests/lint_sys_modules.py
+# (precedent: tests/unit/test_telegram_webhook_backfill.py).
+_STUBBED_MODULE_NAMES = [
+    "routers.telemetry",
+    "dependencies",
+    "services.docker_service",
+    "psutil",
+    "fastapi",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot sys.modules before each test and restore after."""
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+# ── Importlib-load routers/telemetry.py without dragging in routers/__init__ ──
+#
+# `from routers import telemetry` would import 50+ unrelated routers via
+# routers/__init__.py. Load the file directly with scoped dependency stubs,
+# mirroring tests/unit/test_monitoring_router_signatures.py.
+
+def _make_psutil_stub():
+    """telemetry.py imports psutil and primes cpu_percent() at module load.
+    The host endpoint isn't under test here, so a minimal stub keeps this a
+    dependency-light unit test (psutil need not be installed)."""
+    stub = types.ModuleType("psutil")
+    stub.cpu_percent = lambda interval=None: 0.0
+    stub.cpu_count = lambda: 1
+    stub.virtual_memory = lambda: types.SimpleNamespace(
+        percent=0.0, used=0, total=1
+    )
+    stub.disk_usage = lambda _p: types.SimpleNamespace(percent=0.0, used=0, total=1)
+    return stub
+
+
+def _load_telemetry_router():
+    _deps = types.ModuleType("dependencies")
+    _deps.get_current_user = lambda: None
+
+    _docker_svc = types.ModuleType("services.docker_service")
+    _docker_svc.docker_client = object()          # truthy → not the 503 branch
+    _docker_svc.list_all_agents_fast = MagicMock(return_value=[])
+
+    # test_inject_assigned_credentials.py can overwrite sys.modules['fastapi']
+    # with a Mock at collection time; evict briefly so @router.get() binds the
+    # real decorator, then restore.
+    _saved_fastapi = sys.modules.pop("fastapi", None)
+    import fastapi as _real_fastapi  # noqa: PLC0415
+    if _saved_fastapi is not None:
+        sys.modules["fastapi"] = _saved_fastapi
+
+    path = _BACKEND / "routers" / "telemetry.py"
+    spec = importlib.util.spec_from_file_location("routers.telemetry", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["routers.telemetry"] = mod
+    with patch.dict(sys.modules, {
+        "dependencies": _deps,
+        "services.docker_service": _docker_svc,
+        "fastapi": _real_fastapi,
+        "psutil": _make_psutil_stub(),
+    }):
+        spec.loader.exec_module(mod)
+    return mod
+
+
+telemetry = _load_telemetry_router()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+class _FakeAgent:
+    """Stand-in for the dataclass returned by list_all_agents_fast()."""
+
+    def __init__(self, name: str, status: str = "running"):
+        self.name = name
+        self.status = status
+
+
+_ORIGINAL_FIELDS = {
+    "running_count",
+    "total_cpu_percent",
+    "total_memory_mb",
+    "containers",
+    "timestamp",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Reset the module-level cache + in-flight task around every test so
+    cases don't leak state into one another."""
+    telemetry._stats_cache.update(timestamp=0.0, data=None)
+    telemetry._refresh_task = None
+    yield
+    telemetry._stats_cache.update(timestamp=0.0, data=None)
+    telemetry._refresh_task = None
+
+
+def _seed_fresh(payload: dict) -> None:
+    telemetry._stats_cache.update(timestamp=time.monotonic(), data=payload)
+
+
+def _seed_stale(payload: dict) -> None:
+    telemetry._stats_cache.update(
+        timestamp=time.monotonic() - (telemetry._CACHE_TTL + 100), data=payload
+    )
+
+
+# ── Fresh cache hit: NO Docker call, NO refresh scheduled ───────────────────
+
+@pytest.mark.asyncio
+async def test_fresh_cache_hit_does_not_touch_docker(monkeypatch):
+    """A fresh cache must be returned verbatim with no blocking Docker work
+    and without scheduling a refresh."""
+    def _boom_single(name):  # pragma: no cover - must never run
+        raise AssertionError("blocking Docker call on the request path!")
+
+    def _boom_list():  # pragma: no cover - must never run
+        raise AssertionError("agent listing on the request path!")
+
+    monkeypatch.setattr(telemetry, "_get_single_container_stats_sync", _boom_single)
+    monkeypatch.setattr(telemetry, "list_all_agents_fast", _boom_list)
+
+    cached = {
+        "running_count": 2,
+        "total_cpu_percent": 15.0,
+        "total_memory_mb": 150.0,
+        "containers": [{"name": "a", "cpu": 10.0, "memory_mb": 100.0}],
+        "timestamp": "2026-06-08T00:00:00Z",
+    }
+    _seed_fresh(cached)
+
+    res = await telemetry.get_container_stats(current_user=None)
+
+    assert res["cached"] is True
+    assert res["stale"] is False
+    assert res["running_count"] == 2
+    assert res["cache_age_seconds"] is not None and res["cache_age_seconds"] < telemetry._CACHE_TTL
+    assert _ORIGINAL_FIELDS <= set(res)          # backward-compatible contract
+    assert telemetry._refresh_task is None       # fresh → no refresh scheduled
+
+
+# ── Cold start: instant empty payload, NO inline compute, refresh fills cache ─
+
+@pytest.mark.asyncio
+async def test_cold_start_returns_instant_empty_then_refreshes(monkeypatch):
+    """First-ever call (no cached data) must return an instant valid empty
+    payload — proof it did NOT run the ~6s compute inline — then a background
+    refresh populates the cache for the next poll."""
+    monkeypatch.setattr(telemetry, "list_all_agents_fast", lambda: [_FakeAgent("a")])
+    monkeypatch.setattr(
+        telemetry, "_get_single_container_stats_sync",
+        lambda name: {"name": name, "cpu": 5.0, "memory_mb": 100.0},
+    )
+
+    res = await telemetry.get_container_stats(current_user=None)
+
+    # Returned the cold payload — could only happen if compute was NOT awaited.
+    assert res["cached"] is False
+    assert res["stale"] is True
+    assert res["running_count"] == 0
+    assert res["containers"] == []
+    assert res["cache_age_seconds"] is None
+    assert _ORIGINAL_FIELDS <= set(res)
+
+    # A background refresh was scheduled; awaiting it fills the cache.
+    assert telemetry._refresh_task is not None
+    await telemetry._refresh_task
+    assert telemetry._stats_cache["data"] is not None
+    assert telemetry._stats_cache["data"]["running_count"] == 1
+    assert telemetry._stats_cache["data"]["total_memory_mb"] == 100.0
+
+
+# ── Stale cache: serve old data now, schedule refresh ───────────────────────
+
+@pytest.mark.asyncio
+async def test_stale_cache_serves_old_data_and_refreshes(monkeypatch):
+    monkeypatch.setattr(telemetry, "list_all_agents_fast", lambda: [_FakeAgent("a")])
+    monkeypatch.setattr(
+        telemetry, "_get_single_container_stats_sync",
+        lambda name: {"name": name, "cpu": 1.0, "memory_mb": 10.0},
+    )
+
+    stale = {
+        "running_count": 2,
+        "total_cpu_percent": 99.0,
+        "total_memory_mb": 999.0,
+        "containers": [{"name": "old", "cpu": 99.0, "memory_mb": 999.0}],
+        "timestamp": "2026-06-08T00:00:00Z",
+    }
+    _seed_stale(stale)
+
+    res = await telemetry.get_container_stats(current_user=None)
+
+    # Served the STALE payload immediately (running_count 2, not the fresh 1).
+    assert res["cached"] is True
+    assert res["stale"] is True
+    assert res["running_count"] == 2
+    assert res["cache_age_seconds"] >= telemetry._CACHE_TTL
+    assert telemetry._refresh_task is not None
+
+    # The scheduled refresh recomputes to the new value.
+    await telemetry._refresh_task
+    assert telemetry._stats_cache["data"]["running_count"] == 1
+
+
+# ── Docker unavailable → 503 ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_docker_unavailable_returns_503(monkeypatch):
+    monkeypatch.setattr(telemetry, "docker_client", None)
+    with pytest.raises(HTTPException) as exc:
+        await telemetry.get_container_stats(current_user=None)
+    assert exc.value.status_code == 503
+
+
+# ── Refresh aggregation correctness (the ONLY place Docker is touched) ──────
+
+@pytest.mark.asyncio
+async def test_compute_aggregates_only_running_and_sorts_by_cpu(monkeypatch):
+    monkeypatch.setattr(
+        telemetry, "list_all_agents_fast",
+        lambda: [_FakeAgent("a"), _FakeAgent("b"), _FakeAgent("c", "exited")],
+    )
+    per = {
+        "a": {"name": "a", "cpu": 5.0, "memory_mb": 50.0},
+        "b": {"name": "b", "cpu": 10.0, "memory_mb": 100.0},
+    }
+    monkeypatch.setattr(telemetry, "_get_single_container_stats_sync", lambda n: per[n])
+
+    payload = await telemetry._compute_container_stats()
+
+    assert payload["running_count"] == 2                       # 'c' excluded (exited)
+    assert payload["total_cpu_percent"] == 15.0
+    assert payload["total_memory_mb"] == 150.0
+    assert [c["name"] for c in payload["containers"]] == ["b", "a"]  # CPU desc
+
+
+@pytest.mark.asyncio
+async def test_compute_excludes_errored_containers_from_totals(monkeypatch):
+    monkeypatch.setattr(
+        telemetry, "list_all_agents_fast",
+        lambda: [_FakeAgent("a"), _FakeAgent("b")],
+    )
+    per = {
+        "a": {"name": "a", "cpu": 7.0, "memory_mb": 70.0},
+        "b": {"name": "b", "cpu": 0, "memory_mb": 0, "error": "boom"},
+    }
+    monkeypatch.setattr(telemetry, "_get_single_container_stats_sync", lambda n: per[n])
+
+    payload = await telemetry._compute_container_stats()
+
+    assert payload["running_count"] == 2          # both running...
+    assert len(payload["containers"]) == 2        # ...both listed...
+    assert payload["total_cpu_percent"] == 7.0    # ...but errored one not summed
+    assert payload["total_memory_mb"] == 70.0
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_leaves_previous_cache_intact(monkeypatch):
+    """A Docker hiccup during refresh must not blow away good cached data nor
+    raise — best-effort metrics."""
+    good = {
+        "running_count": 1,
+        "total_cpu_percent": 1.0,
+        "total_memory_mb": 1.0,
+        "containers": [{"name": "a", "cpu": 1.0, "memory_mb": 1.0}],
+        "timestamp": "2026-06-08T00:00:00Z",
+    }
+    _seed_fresh(good)
+
+    def _boom():
+        raise RuntimeError("docker boom")
+
+    monkeypatch.setattr(telemetry, "list_all_agents_fast", _boom)
+
+    await telemetry._refresh_cache()  # must not raise
+
+    assert telemetry._stats_cache["data"] == good  # untouched
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_schedule_single_refresh(monkeypatch):
+    """Many simultaneous stale/cold requests must coalesce to ONE in-flight
+    refresh task (no thundering herd of Docker sweeps)."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = {"n": 0}
+
+    def _list():
+        calls["n"] += 1
+        return [_FakeAgent("a")]
+
+    monkeypatch.setattr(telemetry, "list_all_agents_fast", _list)
+    monkeypatch.setattr(
+        telemetry, "_get_single_container_stats_sync",
+        lambda n: {"name": n, "cpu": 1.0, "memory_mb": 1.0},
+    )
+
+    # Cold cache for all callers.
+    results = await asyncio.gather(
+        *[telemetry.get_container_stats(current_user=None) for _ in range(8)]
+    )
+
+    assert all(r["stale"] is True for r in results)
+    assert telemetry._refresh_task is not None
+    await telemetry._refresh_task
+    # Exactly one refresh ran despite 8 concurrent cold requests.
+    assert calls["n"] == 1
+
+
+# ── Defensive env parsing (runs at import; must never raise) ────────────────
+
+def test_parse_float_env_is_defensive():
+    assert telemetry._parse_float_env(None, 10.0) == 10.0
+    assert telemetry._parse_float_env("not-a-number", 10.0) == 10.0
+    assert telemetry._parse_float_env("", 10.0) == 10.0
+    assert telemetry._parse_float_env("5.5", 10.0) == 5.5
+    assert telemetry._parse_float_env("-3", 10.0, minimum=0.0) == 0.0   # clamped
+    assert telemetry._parse_float_env("0", 10.0, minimum=0.0) == 0.0    # disables cache
+
+
+def test_parse_pool_size_is_defensive():
+    assert telemetry._parse_pool_size(None, 16) == 16
+    assert telemetry._parse_pool_size("not-an-int", 16) == 16
+    assert telemetry._parse_pool_size("", 16) == 16
+    assert telemetry._parse_pool_size("8", 16) == 8
+    assert telemetry._parse_pool_size("0", 16) == 1                       # floor
+    assert telemetry._parse_pool_size("99999", 16) == telemetry._POOL_SIZE_MAX  # cap

--- a/tests/unit/test_1096_telemetry_cache.py
+++ b/tests/unit/test_1096_telemetry_cache.py
@@ -317,6 +317,34 @@ async def test_compute_excludes_errored_containers_from_totals(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_compute_skips_raw_exceptions_from_gather(monkeypatch):
+    """If a per-container fetch RAISES (rather than returning an error-dict),
+    asyncio.gather(return_exceptions=True) yields an Exception object in the
+    results. It must be skipped from BOTH the totals and the container list —
+    parity with the original's explicit `isinstance(result, Exception)` guard.
+    `_get_single_container_stats_sync` normally swallows everything, so this
+    pins the defensive branch against a future regression."""
+    monkeypatch.setattr(
+        telemetry, "list_all_agents_fast",
+        lambda: [_FakeAgent("ok"), _FakeAgent("boom")],
+    )
+
+    def _maybe_raise(name):
+        if name == "boom":
+            raise RuntimeError("docker exploded mid-fetch")
+        return {"name": name, "cpu": 3.0, "memory_mb": 30.0}
+
+    monkeypatch.setattr(telemetry, "_get_single_container_stats_sync", _maybe_raise)
+
+    payload = await telemetry._compute_container_stats()
+
+    assert payload["running_count"] == 2                          # both agents running
+    assert [c["name"] for c in payload["containers"]] == ["ok"]    # raised one excluded
+    assert payload["total_cpu_percent"] == 3.0                     # excluded from totals
+    assert payload["total_memory_mb"] == 30.0
+
+
+@pytest.mark.asyncio
 async def test_refresh_failure_leaves_previous_cache_intact(monkeypatch):
     """A Docker hiccup during refresh must not blow away good cached data nor
     raise — best-effort metrics."""


### PR DESCRIPTION
## Summary

Back-merge of the #1096 telemetry non-blocking fix into `dev`. The fix was landed on `main` first (PR #1097, hotfix path) at the maintainer's direction; this PR brings the identical change to `dev` so the branches don't diverge.

Cherry-pick of the 3 commits from PR #1097 (telemetry.py was byte-identical on main and dev, so it applied cleanly):
- `fix(telemetry)`: serve `/api/telemetry/containers` from a short-TTL, background-refreshed cache (stale-while-revalidate) — the request path never awaits Docker.
- `test(telemetry)`: 11 unit tests incl. the `gather()` raised-exception parity branch.
- `docs(env)`: document `TELEMETRY_CONTAINER_STATS_TTL` / `TELEMETRY_DOCKER_POOL_SIZE` knobs + refresh `host-telemetry.md` feature flow.

Reviewed via an adversarial multi-agent pass (valid + non-breaking, no must-fix) and `/validate-pr` (APPROVE). Already merged to `main` and verified green on CI there.

## Test Plan
- [x] 11/11 unit tests pass on the dev base
- [x] sys.modules lint gate clean
- [x] Full CI green on the equivalent change in PR #1097

Relates to #1096 (closed by #1097 on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)