### PR TITLE
feat(mcp): operator-queue read tools — list + get (#1101)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -317,7 +317,7 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 - Tools access auth context via `context.session` parameter
 - Agent-to-agent collaboration uses agent-scoped keys for access control
 
-**Tools** across 17 tool modules (`src/tools/`):
+**Tools** across 20 tool modules (`src/tools/`):
 
 | Module | Tools | Description |
 |--------|-------|-------------|
@@ -339,6 +339,8 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 | `files.ts` (1) | `share_file` | Outbound file sharing — publish file from `/home/developer/public/` and return download URL (FILES-001) |
 | `loops.ts` (3) | `run_agent_loop`, `get_loop_status`, `stop_loop` | Sequential bounded task execution (#740) |
 | `memory.ts` (1) | `write_user_memory` | Write per-user memory blob in isolated store; resolves user email server-side from execution_id (MEM-001, #888) |
+| `voip.ts` (1) | `call_user` | Place an outbound phone call to a user via Twilio Media Streams; server-gated + rate-limited (VOIP-001, #1056) |
+| `operator_queue.ts` (2) | `list_operator_queue`, `get_operator_queue_item` | Read the Operating Room queue — broad or scoped by `agent_name` filter; read-only (write/respond deferred). Agent-scoped keys gated to `{self} ∪ permitted` in the MCP layer (OPS-001, #1101) |
 
 ### Vector Log Aggregator (`config/vector.yaml`)
 

--- a/docs/memory/feature-flows/operating-room.md
+++ b/docs/memory/feature-flows/operating-room.md
@@ -33,6 +33,7 @@ As an operator, I want a single inbox where I can see and respond to all agent r
 - **API**: `POST /api/operator-queue/{id}/respond` -- Submit response
 - **API**: `GET /api/operator-queue/stats` -- Queue statistics
 - **API**: `GET /api/notifications` -- List agent notifications (used by Notifications tab)
+- **MCP** (#1101): `list_operator_queue` (broad or scoped by `agent_name`) and `get_operator_queue_item` -- read-only triage surface over the queue for agents and external Claude Code clients (`src/mcp-server/src/tools/operator_queue.ts`). Agent-scoped keys are gated in the MCP layer to `{self} ∪ permitted` (the backend resolves an agent key to its owner, so agent-to-agent gating cannot live in the REST layer). Write/respond over MCP is deferred.
 - **NavBar**: Combined badge on "Ops" link showing `operatorQueueStore.pendingCount + notificationsStore.pendingCount` (`src/frontend/src/components/NavBar.vue:218-220`)
 - **Legacy redirects**: `/events` redirects to `/operating-room?tab=notifications`, `/alerts` still redirects to `/operating-room?tab=cost-alerts` (stale redirect -- tab no longer exists; lands on default tab)
 - **Agent**: Writes `~/.trinity/operator-queue.json` inside container

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -21,6 +21,8 @@ import type {
   ScheduleToggleResult,
   ScheduleTriggerResult,
   ActivityTimelineResponse,
+  OperatorQueueItem,
+  OperatorQueueListResponse,
 } from "./types.js";
 
 /**
@@ -1152,6 +1154,49 @@ export class TrinityClient {
       "POST",
       "/api/notifications",
       data
+    );
+  }
+
+  // ============================================================================
+  // Operator Queue (OPS-001, #1101) — read surface
+  // ============================================================================
+
+  /**
+   * List operator-queue (Operating Room) items with optional filters. The
+   * backend applies owner-level accessible-agent filtering; the MCP tool layer
+   * additionally gates agent-scoped keys down to agent_permissions.
+   */
+  async listOperatorQueue(params: {
+    status?: string;
+    type?: string;
+    priority?: string;
+    agent_name?: string;
+    since?: string;
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<OperatorQueueListResponse> {
+    const sp = new URLSearchParams();
+    if (params.status) sp.set("status", params.status);
+    if (params.type) sp.set("type", params.type);
+    if (params.priority) sp.set("priority", params.priority);
+    if (params.agent_name) sp.set("agent_name", params.agent_name);
+    if (params.since) sp.set("since", params.since);
+    if (params.limit !== undefined) sp.set("limit", String(params.limit));
+    if (params.offset !== undefined) sp.set("offset", String(params.offset));
+    const qs = sp.toString();
+    return this.request<OperatorQueueListResponse>(
+      "GET",
+      `/api/operator-queue${qs ? `?${qs}` : ""}`,
+    );
+  }
+
+  /**
+   * Get a single operator-queue item by id.
+   */
+  async getOperatorQueueItem(itemId: string): Promise<OperatorQueueItem> {
+    return this.request<OperatorQueueItem>(
+      "GET",
+      `/api/operator-queue/${encodeURIComponent(itemId)}`,
     );
   }
 

--- a/src/mcp-server/src/operator_queue.test.ts
+++ b/src/mcp-server/src/operator_queue.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for #1101 — operator-queue agent-scope post-filter.
+ *
+ * Pins `filterQueueItemsForAgentScope` so a future edit can't silently widen
+ * what an agent-scoped key sees in a broad `list_operator_queue` call (the
+ * load-bearing gate: the backend filters to the KEY OWNER's accessible agents,
+ * so the MCP layer is the only place agent_permissions are enforced).
+ *
+ * Runner: built-in `node:test`. No new devDependency. Run via:
+ *   node --import tsx --test src/*.test.ts
+ */
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { filterQueueItemsForAgentScope } from "./tools/operator_queue.js";
+
+type Item = { id: string; agent_name: string };
+
+const items: Item[] = [
+  { id: "a", agent_name: "self" },
+  { id: "b", agent_name: "friend" },
+  { id: "c", agent_name: "stranger" },
+  { id: "d", agent_name: "self" },
+];
+
+describe("#1101 filterQueueItemsForAgentScope", () => {
+  it("keeps only items whose agent is in the allowed set (self + permitted)", () => {
+    const out = filterQueueItemsForAgentScope(items, new Set(["self", "friend"]));
+    assert.deepEqual(out.map((i) => i.id), ["a", "b", "d"]);
+  });
+
+  it("a self-only allowed set keeps just the caller's own items", () => {
+    const out = filterQueueItemsForAgentScope(items, new Set(["self"]));
+    assert.deepEqual(out.map((i) => i.id), ["a", "d"]);
+  });
+
+  it("drops every item whose agent is not permitted", () => {
+    const out = filterQueueItemsForAgentScope(items, new Set(["nobody"]));
+    assert.deepEqual(out, []);
+  });
+
+  it("an empty allowed set drops everything", () => {
+    assert.deepEqual(filterQueueItemsForAgentScope(items, new Set<string>()), []);
+  });
+
+  it("an empty item list returns empty", () => {
+    assert.deepEqual(filterQueueItemsForAgentScope([], new Set(["self"])), []);
+  });
+
+  it("is a pure filter — does not mutate the input array", () => {
+    const snapshot = items.map((i) => ({ ...i }));
+    filterQueueItemsForAgentScope(items, new Set(["self"]));
+    assert.deepEqual(items, snapshot);
+  });
+
+  it("is order-preserving", () => {
+    const out = filterQueueItemsForAgentScope(items, new Set(["self", "stranger"]));
+    assert.deepEqual(out.map((i) => i.id), ["a", "c", "d"]);
+  });
+});

--- a/src/mcp-server/src/server.ts
+++ b/src/mcp-server/src/server.ts
@@ -26,6 +26,7 @@ import { createVoipTools } from "./tools/voip.js";
 import { createFileTools } from "./tools/files.js";
 import { createMemoryTools } from "./tools/memory.js";
 import { createLoopTools } from "./tools/loops.js";
+import { createOperatorQueueTools } from "./tools/operator_queue.js";
 import { withAudit } from "./audit.js";
 import type { McpAuthContext } from "./types.js";
 
@@ -219,6 +220,7 @@ export async function createServer(config: ServerConfig = {}) {
     createMemoryTools(client, requireApiKey),     // MEM-001 write path (#888)
     createLoopTools(client, requireApiKey),       // Sequential agent loops (#740)
     createVoipTools(client, requireApiKey),       // VoIP telephony — call_user (VOIP-001, #1056)
+    createOperatorQueueTools(client, requireApiKey), // Operator queue read surface (OPS-001, #1101)
   ];
   for (const group of toolGroups) {
     addAllTools(group);

--- a/src/mcp-server/src/tools/index.ts
+++ b/src/mcp-server/src/tools/index.ts
@@ -14,3 +14,4 @@ export { createNeverminedTools } from "./nevermined.js";
 export { createEventTools } from "./events.js";
 export { createMemoryTools } from "./memory.js";
 export { createLoopTools } from "./loops.js";
+export { createOperatorQueueTools } from "./operator_queue.js";

--- a/src/mcp-server/src/tools/operator_queue.ts
+++ b/src/mcp-server/src/tools/operator_queue.ts
@@ -1,0 +1,244 @@
+/**
+ * Operator Queue read tools (OPS-001, #1101)
+ *
+ * Two MCP tools exposing the Operating Room queue over MCP (read-only v1):
+ *   - list_operator_queue      — broad listing, or scoped via the agent_name filter
+ *   - get_operator_queue_item  — a single item by id
+ *
+ * Access control crux: the backend resolves an agent-scoped MCP key to its
+ * OWNER and filters by the owner's accessible agents — it does NOT apply
+ * agent_permissions (architecture §5). So agent-to-agent gating lives HERE,
+ * mirroring executions.ts (`checkAgentAccess`) and agents.ts (`list_agents`
+ * post-filter). Write actions (respond / cancel) are intentionally deferred to
+ * a follow-up — this surface is read-only.
+ */
+
+import { z } from "zod";
+import { TrinityClient } from "../client.js";
+import type { McpAuthContext } from "../types.js";
+
+/**
+ * Pure helper: keep only items whose agent is in the allowed set. Used to gate
+ * a broad (agent_name-omitted) listing for an agent-scoped key down to
+ * {self} ∪ permitted. Exported so a unit test can pin the filter rule without
+ * standing up a backend. Generic over `{ agent_name }` so it stays independent
+ * of the full item shape (same spirit as agents.ts filtering on `{ name }`).
+ */
+export function filterQueueItemsForAgentScope<T extends { agent_name: string }>(
+  items: T[],
+  allowedNames: Set<string>,
+): T[] {
+  return items.filter((item) => allowedNames.has(item.agent_name));
+}
+
+export function createOperatorQueueTools(
+  client: TrinityClient,
+  requireApiKey: boolean,
+) {
+  const getClient = (authContext?: McpAuthContext): TrinityClient => {
+    if (requireApiKey) {
+      if (!authContext?.mcpApiKey) {
+        throw new Error(
+          "MCP API key authentication required but no API key found in request context",
+        );
+      }
+      const userClient = new TrinityClient(client.getBaseUrl());
+      userClient.setToken(authContext.mcpApiKey);
+      return userClient;
+    }
+    return client;
+  };
+
+  /**
+   * Agent-to-agent read gate (mirrors executions.ts). system → allow; user →
+   * allow (the backend already scoped to the user's accessible agents); agent →
+   * self, or a target the calling agent has been explicitly permitted.
+   */
+  const checkAgentAccess = async (
+    apiClient: TrinityClient,
+    authContext: McpAuthContext | undefined,
+    targetAgent: string,
+  ): Promise<{ allowed: boolean; reason?: string }> => {
+    if (authContext?.scope === "system") {
+      return { allowed: true };
+    }
+    if (authContext?.scope !== "agent" || !authContext?.agentName) {
+      return { allowed: true };
+    }
+    const caller = authContext.agentName;
+    if (targetAgent === caller) {
+      return { allowed: true };
+    }
+    const permitted = await apiClient.getPermittedAgents(caller);
+    if (!permitted.includes(targetAgent)) {
+      return {
+        allowed: false,
+        reason: `Agent '${caller}' does not have permission to access '${targetAgent}'`,
+      };
+    }
+    return { allowed: true };
+  };
+
+  return {
+    // ========================================================================
+    // list_operator_queue
+    // ========================================================================
+    listOperatorQueue: {
+      name: "list_operator_queue",
+      description:
+        "List Operating Room (operator queue) items — alerts, questions, and " +
+        "approval requests raised by agents for an operator to triage. Omit " +
+        "agent_name for a broad listing across every agent you can access; pass " +
+        "agent_name to scope to one agent (your own, or another you have " +
+        "permission for). Filters: status " +
+        "(pending/responded/acknowledged/expired/cancelled), type " +
+        "(alert/question/approval), priority (critical/high/medium/low), since " +
+        "(ISO 8601 timestamp). Read-only. Access control: agent-scoped keys see " +
+        "only their own items plus agents they have explicit permission for.",
+      parameters: z.object({
+        agent_name: z
+          .string()
+          .optional()
+          .describe(
+            "Scope to a single agent (own or permitted). Omit for a broad listing across all accessible agents.",
+          ),
+        status: z
+          .string()
+          .optional()
+          .describe("Filter by status: pending, responded, acknowledged, expired, cancelled."),
+        type: z
+          .string()
+          .optional()
+          .describe("Filter by type: alert, question, approval."),
+        priority: z
+          .string()
+          .optional()
+          .describe("Filter by priority: critical, high, medium, low."),
+        since: z
+          .string()
+          .optional()
+          .describe("Only items created after this ISO 8601 timestamp."),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .default(100)
+          .describe("Maximum number of items to return (1–500, default 100)."),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .default(0)
+          .describe("Pagination offset (default 0)."),
+      }),
+      execute: async (
+        params: {
+          agent_name?: string;
+          status?: string;
+          type?: string;
+          priority?: string;
+          since?: string;
+          limit?: number;
+          offset?: number;
+        },
+        context?: { session?: McpAuthContext },
+      ) => {
+        const authContext = context?.session;
+        const apiClient = getClient(authContext);
+
+        // Scoped request: gate the named agent up-front for agent-scoped keys.
+        if (params.agent_name) {
+          const access = await checkAgentAccess(apiClient, authContext, params.agent_name);
+          if (!access.allowed) {
+            console.log(`[list_operator_queue] Access denied: ${access.reason}`);
+            return JSON.stringify({ error: "Access denied", reason: access.reason }, null, 2);
+          }
+        }
+
+        try {
+          const result = await apiClient.listOperatorQueue({
+            status: params.status,
+            type: params.type,
+            priority: params.priority,
+            agent_name: params.agent_name,
+            since: params.since,
+            limit: params.limit,
+            offset: params.offset,
+          });
+
+          let items = result.items || [];
+
+          // Broad listing under an agent-scoped key: the backend filtered to the
+          // KEY OWNER's accessible agents — broader than this agent's permits.
+          // Post-filter to {self} ∪ permitted. system/user scopes pass through.
+          if (
+            !params.agent_name &&
+            authContext?.scope === "agent" &&
+            authContext?.agentName
+          ) {
+            const caller = authContext.agentName;
+            const permitted = await apiClient.getPermittedAgents(caller);
+            const allowed = new Set([caller, ...permitted]);
+            const before = items.length;
+            items = filterQueueItemsForAgentScope(items, allowed);
+            console.log(
+              `[list_operator_queue] Agent '${caller}' filtered: ${items.length}/${before} items visible`,
+            );
+          }
+
+          return JSON.stringify({ count: items.length, items }, null, 2);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          console.error(`[list_operator_queue] error: ${msg}`);
+          return JSON.stringify({ error: msg }, null, 2);
+        }
+      },
+    },
+
+    // ========================================================================
+    // get_operator_queue_item
+    // ========================================================================
+    getOperatorQueueItem: {
+      name: "get_operator_queue_item",
+      description:
+        "Get a single Operating Room (operator queue) item by id — full detail " +
+        "including title, question, options, context, status, priority, and any " +
+        "operator response. Read-only. Access control: agent-scoped keys may " +
+        "only read items belonging to themselves or agents they have explicit " +
+        "permission for.",
+      parameters: z.object({
+        item_id: z.string().min(1).describe("Operator queue item id."),
+      }),
+      execute: async (
+        params: { item_id: string },
+        context?: { session?: McpAuthContext },
+      ) => {
+        const authContext = context?.session;
+        const apiClient = getClient(authContext);
+
+        let item: { agent_name: string };
+        try {
+          item = await apiClient.getOperatorQueueItem(params.item_id);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          console.error(`[get_operator_queue_item] error: ${msg}`);
+          return JSON.stringify({ error: msg }, null, 2);
+        }
+
+        // MCP-layer agent_permissions gate: the backend returned this item under
+        // the KEY OWNER's access — re-check it against the calling agent's
+        // permits before handing it over.
+        const access = await checkAgentAccess(apiClient, authContext, item.agent_name);
+        if (!access.allowed) {
+          console.log(`[get_operator_queue_item] Access denied: ${access.reason}`);
+          return JSON.stringify({ error: "Access denied", reason: access.reason }, null, 2);
+        }
+
+        return JSON.stringify(item, null, 2);
+      },
+    },
+  };
+}

--- a/src/mcp-server/src/types.ts
+++ b/src/mcp-server/src/types.ts
@@ -281,3 +281,31 @@ export interface AgentAuthStatus {
   subscription_id?: string;
   has_api_key: boolean;
 }
+
+// Operator Queue Types (OPS-001, #1101)
+
+export interface OperatorQueueItem {
+  id: string;
+  agent_name: string;
+  type: string;                       // alert | question | approval
+  status: string;                     // pending | responded | acknowledged | expired | cancelled
+  priority: string;                   // critical | high | medium | low
+  title: string;
+  question: string;
+  options?: string | null;            // JSON array string (approval choices)
+  context?: string | null;            // JSON metadata string
+  execution_id?: string | null;
+  created_at: string;
+  expires_at?: string | null;
+  response?: string | null;
+  response_text?: string | null;
+  responded_by_id?: string | null;
+  responded_by_email?: string | null;
+  responded_at?: string | null;
+  acknowledged_at?: string | null;
+}
+
+export interface OperatorQueueListResponse {
+  items: OperatorQueueItem[];
+  count: number;
+}


### PR DESCRIPTION
## Summary
- Adds the MCP **read** surface over the Operator Queue (OPS-001), closing Invariant #13 ("MCP = third surface in sync") for the operator-queue feature.
- **Read-only v1** — `respond`/`cancel` deferred (the queue is the human-in-the-loop Operating Room; the agent-autonomous-write blast radius was deferred to a follow-up).
- Pure TypeScript proxy over the existing REST router — **no backend, endpoint, or dependency changes**.

## Tools
| Tool | Proxies | Notes |
|------|---------|-------|
| `list_operator_queue` | `GET /api/operator-queue` | Broad listing, or scoped via the `agent_name` filter. Filters: `status`, `type`, `priority`, `since`, `limit`, `offset`. |
| `get_operator_queue_item` | `GET /api/operator-queue/{id}` | Single item by id. |

## Access control (the load-bearing part)
The backend resolves an agent-scoped MCP key to its **owner** and filters by the owner's accessible agents — it does **not** apply `agent_permissions` (architecture §5). So agent-to-agent gating lives in the MCP layer, mirroring `executions.ts` (`checkAgentAccess`) and `agents.ts` (`list_agents` post-filter):
- `list` broad path → post-filter items to `{self} ∪ permitted` for agent-scoped keys; `system`/`user` pass through.
- `list` scoped path (`agent_name` given) → `checkAgentAccess` up-front, deny-as-JSON.
- `get` → `checkAgentAccess(item.agent_name)` **after** fetch, **before** return.

A pure, unit-tested `filterQueueItemsForAgentScope` helper pins the broad-path filter rule.

## Changes
- `src/mcp-server/src/tools/operator_queue.ts` *(new)* — `createOperatorQueueTools` + the pure helper
- `src/mcp-server/src/operator_queue.test.ts` *(new)* — 7 `node:test` cases for the filter
- `src/mcp-server/src/client.ts` — `listOperatorQueue` / `getOperatorQueueItem`
- `src/mcp-server/src/types.ts` — `OperatorQueueItem` / `OperatorQueueListResponse`
- `src/mcp-server/src/server.ts`, `tools/index.ts` — registration + barrel export (auto-counted, auto-audited via `withAudit`)
- `docs/memory/architecture.md` — MCP tools table: `+operator_queue.ts`, `+voip.ts` (was missing), count 17→20
- `docs/memory/feature-flows/operating-room.md` — MCP read-surface note

## Test Plan
- [x] `docker compose build mcp-server` — strict `tsc` compiles clean
- [x] `node --test dist/*.test.js` — **16/16 pass** (7 new + 9 existing)
- [x] No dependency changes; no secrets in diff
- [ ] (post-merge) MCP container rebuild to expose the tools live

Fixes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)