### PR TITLE
feat(ui): Agent Detail Overview as default tab + Info redesign (#1107)

### DIFF
--- a/src/frontend/e2e/overview-tab.spec.js
+++ b/src/frontend/e2e/overview-tab.spec.js
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Agent Detail "Overview" default tab + Info redesign e2e (#1107).
+ *
+ * Verifies:
+ *  1. Overview is the DEFAULT landing tab on /agents/{name} (replaces Tasks).
+ *  2. The `?tab=` deep-link is honored for both the new 'overview' id and the
+ *     existing 'tasks' id — guards the hoisted VALID_TABS list (the
+ *     onMounted/onActivated two-copy drift that this PR collapsed).
+ *  3. The Info tab leads with About and tucks exhaustive template.yaml metadata
+ *     behind a collapsed "Technical details" <details> (data-dependent — only
+ *     asserts the collapse when the test agent actually ships such metadata).
+ *
+ * Auth is supplied by auth.setup.js storageState (see playwright config). The
+ * real backend serves GET /api/agents/{name}, so a TEST_AGENT must exist; the
+ * suite skips cleanly if the detail page can't load.
+ */
+
+const TEST_AGENT = process.env.TEST_AGENT || 'trinity-system'
+
+// TEST_AGENT defaults to 'trinity-system' — the platform system agent, which
+// always exists on any Trinity stack (it cannot be deleted). No skip-probe: a
+// missing agent should fail loudly rather than silently skip.
+test.describe('agent detail overview tab (#1107)', () => {
+  test('@smoke Overview is the default landing tab', async ({ page }) => {
+    await page.goto(`/agents/${TEST_AGENT}`)
+
+    // Overview panel renders without any tab click.
+    await expect(page.getByTestId('overview-panel')).toBeVisible({ timeout: 15000 })
+
+    // The task-entry shim (the action affordance preserved from Tasks) is present.
+    await expect(page.getByPlaceholder(/give .* a task/i)).toBeVisible()
+
+    // The Overview tab button is the active one (action-primary border token).
+    const overviewTab = page.getByRole('button', { name: 'Overview', exact: true })
+    await expect(overviewTab).toBeVisible()
+    await expect(overviewTab).toHaveClass(/border-action-primary-500/)
+  })
+
+  test('?tab= deep-link is honored for tasks and overview (VALID_TABS guard)', async ({ page }) => {
+    // Deep-link straight to Tasks — must NOT land on Overview.
+    await page.goto(`/agents/${TEST_AGENT}?tab=tasks`)
+    await expect(page.getByTestId('overview-panel')).toHaveCount(0, { timeout: 15000 })
+    // TasksPanel leads with its New Task textarea.
+    await expect(page.getByPlaceholder(/enter task message/i)).toBeVisible()
+
+    // Deep-link to Overview explicitly — must render the Overview.
+    await page.goto(`/agents/${TEST_AGENT}?tab=overview`)
+    await expect(page.getByTestId('overview-panel')).toBeVisible({ timeout: 15000 })
+  })
+
+  test('in-app navigation away and back preserves the deep-linked tab (KeepAlive)', async ({ page }) => {
+    // Land on Tasks via deep-link, navigate to the fleet list, then back.
+    await page.goto(`/agents/${TEST_AGENT}?tab=tasks`)
+    await expect(page.getByPlaceholder(/enter task message/i)).toBeVisible({ timeout: 15000 })
+
+    await page.getByRole('link', { name: /agents/i }).first().click()
+    await page.waitForURL(/\/agents\/?$/, { timeout: 15000 }).catch(() => {})
+
+    // Back into the same agent — the onActivated `?tab=` path keeps Tasks.
+    await page.goBack()
+    // Either Tasks stays (KeepAlive cached) or a cold reload re-applies ?tab=tasks.
+    await expect(page.getByTestId('overview-panel')).toHaveCount(0, { timeout: 15000 })
+  })
+
+  test('Info tab leads with About; technical metadata is collapsed behind a toggle', async ({ page }) => {
+    // Mock the template info so the assertion is deterministic regardless of the
+    // test agent's real template (trinity-system ships none). Mirrors the
+    // route-mock approach in circuit-breaker-badge.spec.js.
+    await page.route('**/api/agents/*/info', (route) =>
+      route.fulfill({
+        json: {
+          has_template: true,
+          name: TEST_AGENT,
+          display_name: 'Overview E2E Agent',
+          description: 'About-lead narrative for the Info redesign test.',
+          tools: ['Bash', 'Read'],
+          sub_agents: [{ name: 'helper', description: 'does things' }],
+        },
+      })
+    )
+    await page.goto(`/agents/${TEST_AGENT}?tab=info`)
+
+    // About leads — the description is visible above the fold.
+    await expect(
+      page.getByText('About-lead narrative for the Info redesign test.')
+    ).toBeVisible({ timeout: 15000 })
+
+    // Technical metadata is tucked behind a collapsed <details>; inner sections
+    // (e.g. "Enabled Tools") are hidden until the user expands it.
+    const tech = page.getByTestId('info-technical-details')
+    await expect(tech).toBeVisible()
+    await expect(tech).not.toHaveJSProperty('open', true)
+    await expect(page.getByText('Enabled Tools')).toBeHidden()
+
+    // Expanding reveals the metadata.
+    await tech.locator('summary').click()
+    await expect(tech).toHaveJSProperty('open', true)
+    await expect(page.getByText('Enabled Tools')).toBeVisible()
+  })
+})

--- a/src/frontend/src/components/InfoPanel.vue
+++ b/src/frontend/src/components/InfoPanel.vue
@@ -90,6 +90,23 @@
         </div>
       </div>
 
+      <!-- Technical details — exhaustive template.yaml metadata, tucked behind a
+           collapsible so the About + "What You Can Ask" lead the glance (#1107).
+           Native <details> for free keyboard + screen-reader semantics. -->
+      <details v-if="hasTechnicalDetails" class="group" data-testid="info-technical-details">
+        <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden px-5 py-3 flex items-center justify-between bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+          <span class="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider flex items-center">
+            <svg class="w-4 h-4 mr-2 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+            </svg>
+            Technical details
+          </span>
+          <svg class="w-4 h-4 text-gray-400 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="mt-4 space-y-4">
+
       <!-- Resources Section -->
       <div v-if="templateInfo.resources && Object.keys(templateInfo.resources).length > 0" class="bg-white dark:bg-gray-800 rounded-lg p-5 border border-gray-200 dark:border-gray-700">
         <h3 class="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-3 flex items-center">
@@ -268,12 +285,14 @@
           </span>
         </div>
       </div>
+        </div>
+      </details>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents'
 
 const props = defineProps({
@@ -292,6 +311,23 @@ const emit = defineEmits(['item-click'])
 const agentsStore = useAgentsStore()
 const templateInfo = ref(null)
 const loading = ref(true)
+
+// Whether there's any exhaustive metadata to tuck behind the "Technical details"
+// collapsible — hides the toggle entirely when the template has none (#1107).
+const hasTechnicalDetails = computed(() => {
+  const t = templateInfo.value
+  if (!t) return false
+  return (
+    (t.resources && Object.keys(t.resources).length > 0) ||
+    (t.sub_agents && t.sub_agents.length > 0) ||
+    (t.commands && t.commands.length > 0) ||
+    (t.mcp_servers && t.mcp_servers.length > 0) ||
+    (t.skills && t.skills.length > 0) ||
+    (t.capabilities && t.capabilities.length > 0) ||
+    (t.platforms && t.platforms.length > 0) ||
+    (t.tools && t.tools.length > 0)
+  )
+})
 
 const loadTemplateInfo = async () => {
   loading.value = true

--- a/src/frontend/src/components/OverviewPanel.vue
+++ b/src/frontend/src/components/OverviewPanel.vue
@@ -1,0 +1,589 @@
+<template>
+  <div class="space-y-5" data-testid="overview-panel">
+    <!-- ============================================================ -->
+    <!-- 1. ABOUT (lead) — header has no description at all (#1107)   -->
+    <!-- ============================================================ -->
+    <div class="bg-gradient-to-r from-action-primary-50 to-accent-purple-50 dark:from-action-primary-900/30 dark:to-accent-purple-900/30 rounded-lg p-5 border border-action-primary-100 dark:border-action-primary-800">
+      <div v-if="loading.info" class="animate-pulse space-y-2">
+        <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3"></div>
+        <div class="h-3 bg-gray-200 dark:bg-gray-700 rounded w-2/3"></div>
+      </div>
+      <template v-else>
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <p v-if="info?.tagline" class="text-sm text-action-primary-600 dark:text-action-primary-400 font-medium">
+              {{ info.tagline }}
+            </p>
+            <p
+              v-if="info?.description"
+              class="mt-1 text-sm text-gray-600 dark:text-gray-300 whitespace-pre-line line-clamp-4"
+            >{{ info.description }}</p>
+            <p v-else class="mt-1 text-sm text-gray-400 dark:text-gray-500 italic">
+              No description provided in this agent's template.
+            </p>
+          </div>
+          <button
+            class="flex-shrink-0 text-xs font-medium text-action-primary-600 dark:text-action-primary-400 hover:underline whitespace-nowrap"
+            @click="$emit('navigate', { tab: 'info' })"
+          >Full details →</button>
+        </div>
+
+        <!-- Task-entry shim: preserves the action surface that the default-swap
+             would otherwise demote (#1107 coherence fix). Deep-links into Tasks. -->
+        <form class="mt-4 flex items-center gap-2" @submit.prevent="submitQuickTask">
+          <input
+            v-model="quickTask"
+            type="text"
+            :placeholder="`Give ${agentName} a task…`"
+            class="flex-1 min-w-0 text-sm px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-action-primary-500"
+          />
+          <button
+            type="submit"
+            :disabled="!quickTask.trim()"
+            class="flex-shrink-0 inline-flex items-center gap-1 text-sm font-medium py-2 px-3 rounded-md bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 text-white transition-colors"
+            title="Open the Tasks tab with this message prefilled"
+          >
+            Run →
+          </button>
+        </form>
+      </template>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- 2. NEEDS ATTENTION — only shown when non-empty (#1107)       -->
+    <!-- ============================================================ -->
+    <div
+      v-if="hasAttention"
+      class="bg-status-warning-50 dark:bg-status-warning-900/20 rounded-lg p-4 border border-status-warning-300 dark:border-status-warning-700"
+    >
+      <h3 class="text-xs font-semibold text-status-warning-800 dark:text-status-warning-300 uppercase tracking-wider mb-3 flex items-center">
+        <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        Needs attention
+      </h3>
+      <ul class="space-y-2 text-sm">
+        <!-- Circuit breaker open: point to the header badge, do NOT re-render it (#1107) -->
+        <li v-if="circuitOpen" class="flex items-center gap-2 text-status-danger-700 dark:text-status-danger-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-status-danger-500 flex-shrink-0"></span>
+          <span>Dispatch circuit breaker is <strong>open</strong> — see the <span class="font-medium">⚡ circuit open</span> badge in the header above; new tasks fast-fail until it recovers.</span>
+        </li>
+        <!-- Sync failing -->
+        <li v-if="syncFailing" class="flex items-center gap-2 text-status-warning-800 dark:text-status-warning-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-status-warning-500 flex-shrink-0"></span>
+          <span>Git sync failing — {{ syncState.consecutive_failures }} consecutive failure(s).
+            <button class="underline hover:no-underline" @click="$emit('navigate', { tab: 'git' })">View Git</button>
+          </span>
+        </li>
+        <!-- Operator-queue items -->
+        <li
+          v-for="item in operatorItems.slice(0, 5)"
+          :key="item.id"
+          class="flex items-start gap-2 text-gray-700 dark:text-gray-300"
+        >
+          <span class="w-1.5 h-1.5 mt-1.5 rounded-full bg-action-primary-500 flex-shrink-0"></span>
+          <span>
+            <span class="px-1.5 py-0.5 text-[10px] font-semibold rounded uppercase mr-1"
+              :class="opPriorityClass(item.priority)">{{ item.type }}</span>
+            {{ item.title || item.question }}
+          </span>
+        </li>
+        <!-- Pending notifications -->
+        <li
+          v-for="note in pendingNotifications.slice(0, 5)"
+          :key="note.id"
+          class="flex items-start gap-2 text-gray-700 dark:text-gray-300"
+        >
+          <span class="w-1.5 h-1.5 mt-1.5 rounded-full bg-accent-purple-500 flex-shrink-0"></span>
+          <span>{{ note.title || note.message }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- 3. PERFORMANCE — net-new breakdowns the header lacks (#1107) -->
+    <!-- ============================================================ -->
+    <div>
+      <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">Performance</h3>
+      <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <!-- Tasks (24h / 7d) -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Tasks · 24h</p>
+          <div v-if="loading.stats24" class="animate-pulse h-7 mt-1 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
+          <template v-else>
+            <p class="text-2xl font-bold text-gray-900 dark:text-white mt-0.5">{{ stats24?.total ?? 0 }}</p>
+            <div class="mt-1 flex items-center gap-2 text-[11px]">
+              <span :class="successRateClass(stats24?.success_rate)">{{ fmtPct(stats24?.success_rate) }} ok</span>
+              <span v-if="(stats24?.failed_count ?? 0) > 0" class="text-status-danger-600 dark:text-status-danger-400">{{ stats24.failed_count }} failed</span>
+            </div>
+            <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5">7d: {{ stats7?.total ?? 0 }} · {{ fmtPct(stats7?.success_rate) }} ok</p>
+          </template>
+        </div>
+
+        <!-- Running + queued (live) -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Running · Queued</p>
+          <div v-if="loading.stats24" class="animate-pulse h-7 mt-1 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
+          <template v-else>
+            <p class="text-2xl font-bold mt-0.5" :class="(stats24?.running_count ?? 0) > 0 ? 'text-status-warning-600 dark:text-status-warning-400' : 'text-gray-900 dark:text-white'">
+              {{ stats24?.running_count ?? 0 }}<span class="text-gray-400 dark:text-gray-500 text-lg font-normal"> · {{ stats24?.queued_count ?? 0 }}</span>
+            </p>
+            <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1">live now</p>
+          </template>
+        </div>
+
+        <!-- Context window utilization (container-gated) -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Context window</p>
+          <p v-if="!isRunning" class="text-sm text-gray-400 dark:text-gray-500 mt-2">Offline</p>
+          <div v-else-if="loading.context" class="animate-pulse h-7 mt-1 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
+          <template v-else>
+            <p class="text-2xl font-bold text-gray-900 dark:text-white mt-0.5">{{ Math.round(context?.contextPercent ?? 0) }}%</p>
+            <div class="mt-1.5 h-1.5 w-full bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div class="h-full rounded-full" :class="contextBarClass" :style="{ width: Math.min(100, context?.contextPercent ?? 0) + '%' }"></div>
+            </div>
+            <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1">{{ fmtTokens(context?.contextUsed) }} / {{ fmtTokens(context?.contextMax) }}</p>
+          </template>
+        </div>
+
+        <!-- Schedules + capacity (combined card) -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <button class="text-left w-full" @click="$emit('navigate', { tab: 'schedules' })" title="Open Schedules">
+            <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Schedules</p>
+            <div v-if="loading.schedules" class="animate-pulse h-7 mt-1 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
+            <template v-else>
+              <p class="text-2xl font-bold text-gray-900 dark:text-white mt-0.5">
+                {{ schedulesEnabled }}<span class="text-gray-400 dark:text-gray-500 text-lg font-normal">/{{ schedules.length }}</span>
+              </p>
+              <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1 truncate">
+                <template v-if="nextRunAt">next {{ formatRelativeTime(nextRunAt) }}</template>
+                <template v-else>none enabled</template>
+              </p>
+            </template>
+          </button>
+          <div class="mt-2 pt-2 border-t border-gray-100 dark:border-gray-700 flex items-center justify-between text-[11px]">
+            <span class="text-gray-500 dark:text-gray-400">Slots</span>
+            <span v-if="!isRunning" class="text-gray-400 dark:text-gray-500">offline</span>
+            <span v-else-if="loading.capacity" class="text-gray-400 dark:text-gray-500">…</span>
+            <span v-else class="font-mono text-gray-700 dark:text-gray-300">{{ capacity?.active_slots ?? 0 }} / {{ capacity?.max_parallel_tasks ?? '—' }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- 4. HEALTH & RELIABILITY — aggregate rollup (#1107)           -->
+    <!-- Header shows instantaneous CPU/MEM/uptime-since-start only.  -->
+    <!-- ============================================================ -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+      <div class="flex items-center justify-between mb-3">
+        <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Health &amp; reliability</h3>
+        <span v-if="health?.aggregate_status" class="px-2 py-0.5 text-xs font-medium rounded-full" :class="healthStatusClass(health.aggregate_status)">
+          {{ health.aggregate_status }}
+        </span>
+      </div>
+      <p v-if="!isRunning" class="text-sm text-gray-400 dark:text-gray-500">Agent is stopped — start it to see live health.</p>
+      <div v-else-if="loading.health" class="animate-pulse grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div v-for="n in 4" :key="n" class="h-12 bg-gray-100 dark:bg-gray-700 rounded"></div>
+      </div>
+      <div v-else class="grid grid-cols-2 sm:grid-cols-4 gap-y-3 gap-x-4 text-sm">
+        <!-- Liveness (heartbeat / business status). Distinct from the header's
+             instantaneous status badge — this is the monitored health-probe state. -->
+        <div>
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Liveness</p>
+          <p class="font-medium" :class="health?.business?.status === 'healthy' ? 'text-status-success-600 dark:text-status-success-400' : 'text-gray-700 dark:text-gray-300'">
+            {{ health?.business?.status || 'unknown' }}
+          </p>
+        </div>
+        <!-- 24h uptime — explicitly labeled "24h" so it does NOT collide with the
+             header's "uptime since start" (#1107 coherence fix). -->
+        <div>
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">24h uptime</p>
+          <p class="font-medium text-gray-700 dark:text-gray-300">{{ health?.uptime_percent_24h != null ? health.uptime_percent_24h + '%' : '—' }}</p>
+        </div>
+        <!-- Avg latency 24h -->
+        <div>
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Avg latency</p>
+          <p class="font-medium text-gray-700 dark:text-gray-300">{{ health?.avg_latency_24h_ms != null ? Math.round(health.avg_latency_24h_ms) + 'ms' : '—' }}</p>
+        </div>
+        <!-- Restarts + OOM -->
+        <div>
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Restarts</p>
+          <p class="font-medium" :class="(health?.docker?.restart_count ?? 0) > 0 ? 'text-status-warning-600 dark:text-status-warning-400' : 'text-gray-700 dark:text-gray-300'">
+            {{ health?.docker?.restart_count ?? 0 }}
+            <span v-if="health?.docker?.oom_killed" class="ml-1 px-1 py-0.5 text-[9px] font-semibold rounded bg-status-danger-100 dark:bg-status-danger-900/50 text-status-danger-700 dark:text-status-danger-300">OOM</span>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- 5. RECENT ACTIVITY — net-new (#1107)                         -->
+    <!-- ============================================================ -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+      <div class="flex items-center justify-between mb-3">
+        <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Recent activity</h3>
+        <span class="flex items-center gap-1.5 text-xs">
+          <span class="w-2 h-2 rounded-full" :class="activityDotClass"></span>
+          <span class="text-gray-500 dark:text-gray-400">{{ activityLabel }}</span>
+        </span>
+      </div>
+      <div v-if="loading.recent" class="animate-pulse space-y-2">
+        <div v-for="n in 3" :key="n" class="h-6 bg-gray-100 dark:bg-gray-700 rounded"></div>
+      </div>
+      <p v-else-if="recentExecutions.length === 0" class="text-sm text-gray-400 dark:text-gray-500">No executions yet.</p>
+      <ul v-else class="divide-y divide-gray-100 dark:divide-gray-700">
+        <li
+          v-for="exec in recentExecutions"
+          :key="exec.id"
+          class="flex items-center gap-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 -mx-2 px-2 rounded transition-colors"
+          @click="$emit('navigate', { tab: 'tasks', executionId: exec.id })"
+        >
+          <span class="w-2 h-2 rounded-full flex-shrink-0" :class="execDotClass(exec.status)"></span>
+          <span class="flex-1 min-w-0 text-sm text-gray-700 dark:text-gray-300 truncate">{{ exec.message || exec.triggered_by || exec.status }}</span>
+          <span class="flex-shrink-0 text-[11px] text-gray-400 dark:text-gray-500">{{ formatRelativeTime(exec.started_at) }}</span>
+        </li>
+      </ul>
+      <button
+        v-if="recentExecutions.length > 0"
+        class="mt-2 text-xs font-medium text-action-primary-600 dark:text-action-primary-400 hover:underline"
+        @click="$emit('navigate', { tab: 'tasks' })"
+      >View all tasks →</button>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- 6. FOOTPRINT — compact, net-new (#1107)                      -->
+    <!-- ============================================================ -->
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <!-- Sharing (owner-gated: /shares + /access-policy are owner-scoped) -->
+      <div v-if="agent?.can_share" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <h4 class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Sharing</h4>
+        <div v-if="loading.sharing" class="animate-pulse h-5 bg-gray-100 dark:bg-gray-700 rounded w-20"></div>
+        <template v-else>
+          <p class="text-sm text-gray-700 dark:text-gray-300">
+            {{ shares.length }} {{ shares.length === 1 ? 'person' : 'people' }}
+          </p>
+          <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5 truncate">
+            <span v-if="accessPolicy?.open_access">Open access</span>
+            <span v-else-if="accessPolicy?.require_email">Email required</span>
+            <span v-else>Invite only</span>
+          </p>
+        </template>
+      </div>
+
+      <!-- Sync health (controls live in header; this is the health readout) -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <h4 class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Sync health</h4>
+        <div v-if="loading.sync" class="animate-pulse h-5 bg-gray-100 dark:bg-gray-700 rounded w-20"></div>
+        <template v-else>
+          <p class="text-sm font-medium capitalize" :class="syncStatusClass">{{ syncState?.last_sync_status || 'never' }}</p>
+          <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5">
+            <template v-if="syncState?.last_sync_at">{{ formatRelativeTime(syncState.last_sync_at) }}</template>
+            <template v-else-if="(syncState?.consecutive_failures ?? 0) > 0">{{ syncState.consecutive_failures }} failure(s)</template>
+            <template v-else>not configured</template>
+          </p>
+        </template>
+      </div>
+
+      <!-- Skills & playbooks -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <h4 class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Skills &amp; playbooks</h4>
+        <div v-if="loading.skills" class="animate-pulse h-5 bg-gray-100 dark:bg-gray-700 rounded w-20"></div>
+        <template v-else>
+          <p class="text-sm text-gray-700 dark:text-gray-300">
+            {{ skills.length }} skill{{ skills.length === 1 ? '' : 's' }}<span v-if="isRunning"> · {{ playbooks.length }} playbook{{ playbooks.length === 1 ? '' : 's' }}</span>
+          </p>
+          <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5 truncate">{{ topSkillNames || '—' }}</p>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, reactive, onMounted, watch } from 'vue'
+import axios from 'axios'
+import { useAgentsStore } from '../stores/agents'
+import { useMonitoringStore } from '../stores/monitoring'
+import { useAuthStore } from '../stores/auth'
+import { useFormatters } from '../composables'
+
+const props = defineProps({
+  agentName: { type: String, required: true },
+  // Full agent object passed from parent so we don't re-fetch status/can_share/
+  // circuit_breaker_state (eng review: pass props down to halve mount fan-out).
+  agent: { type: Object, default: null }
+})
+
+const emit = defineEmits(['navigate', 'item-click'])
+
+const agentsStore = useAgentsStore()
+const monitoringStore = useMonitoringStore()
+const authStore = useAuthStore()
+const { formatRelativeTime } = useFormatters()
+
+// --- Per-card state (local refs — NEVER mutate the shared executions/
+// monitoring/notifications/operatorQueue store singletons, which back the
+// NavBar badges; see eng review finding #1). -------------------------------
+const info = ref(null)
+const stats24 = ref(null)
+const stats7 = ref(null)
+const context = ref(null)
+const schedules = ref([])
+const capacity = ref(null)
+const health = ref(null)
+const recentExecutions = ref([])
+const operatorItems = ref([])
+const pendingNotifications = ref([])
+const syncState = ref(null)
+const shares = ref([])
+const accessPolicy = ref(null)
+const skills = ref([])
+const playbooks = ref([])
+
+const quickTask = ref('')
+
+const loading = reactive({
+  info: true, stats24: true, context: true, schedules: true, capacity: true,
+  health: true, recent: true, sync: true, sharing: true, skills: true
+})
+
+const isRunning = computed(() => props.agent?.status === 'running')
+const circuitOpen = computed(() => props.agent?.circuit_breaker_state === 'open')
+const syncFailing = computed(() => (syncState.value?.consecutive_failures ?? 0) >= 3)
+
+const hasAttention = computed(() =>
+  circuitOpen.value ||
+  syncFailing.value ||
+  operatorItems.value.length > 0 ||
+  pendingNotifications.value.length > 0
+)
+
+const schedulesEnabled = computed(() => schedules.value.filter(s => s.enabled).length)
+const nextRunAt = computed(() => {
+  const times = schedules.value
+    .filter(s => s.enabled && s.next_run_at)
+    .map(s => s.next_run_at)
+    .sort()
+  return times[0] || null
+})
+
+const topSkillNames = computed(() =>
+  skills.value.slice(0, 3).map(s => s.name || s.skill_name || s).filter(Boolean).join(', ')
+)
+
+// --- Activity state (from context-stats activityState) ---------------------
+const activityLabel = computed(() => {
+  if (!isRunning.value) return 'offline'
+  return context.value?.activityState || 'idle'
+})
+const activityDotClass = computed(() => {
+  const s = activityLabel.value
+  if (s === 'active') return 'bg-status-success-500 animate-pulse'
+  if (s === 'idle') return 'bg-gray-400'
+  return 'bg-gray-300 dark:bg-gray-600'
+})
+
+// --- Style helpers ---------------------------------------------------------
+const contextBarClass = computed(() => {
+  const p = context.value?.contextPercent ?? 0
+  if (p > 85) return 'bg-status-danger-500'
+  if (p > 60) return 'bg-status-warning-500'
+  return 'bg-status-success-500'
+})
+const syncStatusClass = computed(() => {
+  const s = syncState.value?.last_sync_status
+  if (s === 'success') return 'text-status-success-600 dark:text-status-success-400'
+  if (s === 'failed') return 'text-status-danger-600 dark:text-status-danger-400'
+  return 'text-gray-500 dark:text-gray-400'
+})
+
+function successRateClass(rate) {
+  const r = rate ?? 0
+  if (r >= 90) return 'text-status-success-600 dark:text-status-success-400'
+  if (r >= 70) return 'text-status-warning-600 dark:text-status-warning-400'
+  return 'text-status-danger-600 dark:text-status-danger-400'
+}
+function healthStatusClass(status) {
+  if (status === 'healthy') return 'bg-status-success-100 dark:bg-status-success-900/50 text-status-success-700 dark:text-status-success-300'
+  if (status === 'degraded') return 'bg-status-warning-100 dark:bg-status-warning-900/50 text-status-warning-700 dark:text-status-warning-300'
+  if (status === 'unhealthy') return 'bg-status-danger-100 dark:bg-status-danger-900/50 text-status-danger-700 dark:text-status-danger-300'
+  return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+}
+function execDotClass(status) {
+  if (status === 'success') return 'bg-status-success-500'
+  if (status === 'failed' || status === 'error') return 'bg-status-danger-500'
+  if (status === 'running') return 'bg-status-warning-500 animate-pulse'
+  if (status === 'queued') return 'bg-action-primary-400'
+  return 'bg-gray-300 dark:bg-gray-600'
+}
+function opPriorityClass(priority) {
+  if (priority === 'critical' || priority === 'high') return 'bg-status-danger-100 dark:bg-status-danger-900/50 text-status-danger-700 dark:text-status-danger-300'
+  return 'bg-action-primary-100 dark:bg-action-primary-900/50 text-action-primary-700 dark:text-action-primary-300'
+}
+
+function fmtPct(rate) {
+  return `${Math.round(rate ?? 0)}%`
+}
+function fmtTokens(n) {
+  if (!n) return '0'
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`
+  return String(n)
+}
+
+function submitQuickTask() {
+  const text = quickTask.value.trim()
+  if (!text) return
+  // Reuse InfoPanel's item-click contract → parent prefills Tasks + switches tab.
+  emit('item-click', { type: 'overview-task', text })
+  quickTask.value = ''
+}
+
+// --- Fetchers (local axios; stateless store methods where safe) ------------
+const hdr = () => ({ headers: authStore.authHeader })
+
+async function loadInfo() {
+  loading.info = true
+  try { info.value = await agentsStore.getAgentInfo(props.agentName) }
+  catch { info.value = null }
+  finally { loading.info = false }
+}
+
+async function loadTaskStats() {
+  loading.stats24 = true
+  try {
+    const [r24, r7] = await Promise.allSettled([
+      axios.get(`/api/executions/stats?agent=${encodeURIComponent(props.agentName)}&hours=24`, hdr()),
+      axios.get(`/api/executions/stats?agent=${encodeURIComponent(props.agentName)}&hours=168`, hdr())
+    ])
+    if (r24.status === 'fulfilled') stats24.value = r24.value.data
+    if (r7.status === 'fulfilled') stats7.value = r7.value.data
+  } finally { loading.stats24 = false }
+}
+
+async function loadRecentExecutions() {
+  loading.recent = true
+  try {
+    const res = await axios.get(`/api/executions?agent=${encodeURIComponent(props.agentName)}&limit=5&hours=168`, hdr())
+    recentExecutions.value = Array.isArray(res.data) ? res.data : []
+  } catch { recentExecutions.value = [] }
+  finally { loading.recent = false }
+}
+
+async function loadSchedules() {
+  loading.schedules = true
+  try {
+    const res = await axios.get(`/api/agents/${props.agentName}/schedules`, hdr())
+    schedules.value = Array.isArray(res.data) ? res.data : (res.data?.schedules || [])
+  } catch { schedules.value = [] }
+  finally { loading.schedules = false }
+}
+
+async function loadContext() {
+  if (!isRunning.value) { loading.context = false; return }
+  loading.context = true
+  try {
+    const res = await axios.get('/api/agents/context-stats', hdr())
+    const list = res.data?.agents || []
+    context.value = list.find(a => a.name === props.agentName) || null
+  } catch { context.value = null }
+  finally { loading.context = false }
+}
+
+async function loadCapacity() {
+  if (!isRunning.value) { loading.capacity = false; return }
+  loading.capacity = true
+  try {
+    const res = await axios.get(`/api/agents/${props.agentName}/capacity`, hdr())
+    capacity.value = res.data
+  } catch { capacity.value = null }
+  finally { loading.capacity = false }
+}
+
+async function loadHealth() {
+  if (!isRunning.value) { loading.health = false; return }
+  loading.health = true
+  try {
+    // Stateless cache-only store method — safe to reuse (eng review).
+    health.value = await monitoringStore.fetchAgentHealth(props.agentName)
+  } catch { health.value = null }
+  finally { loading.health = false }
+}
+
+async function loadAttention() {
+  // operator-queue + pending notifications (local axios — do NOT touch the
+  // notifications/operatorQueue store singletons that feed the NavBar badges).
+  try {
+    const res = await axios.get(`/api/operator-queue/agents/${props.agentName}?status=pending`, hdr())
+    operatorItems.value = res.data?.items || []
+  } catch { operatorItems.value = [] }
+  try {
+    const res = await axios.get(`/api/agents/${props.agentName}/notifications?status=pending`, hdr())
+    pendingNotifications.value = res.data?.notifications || []
+  } catch { pendingNotifications.value = [] }
+}
+
+async function loadSync() {
+  loading.sync = true
+  try {
+    const res = await axios.get(`/api/agents/${props.agentName}/git/sync-state`, hdr())
+    syncState.value = res.data
+  } catch { syncState.value = null }
+  finally { loading.sync = false }
+}
+
+async function loadSharing() {
+  if (!props.agent?.can_share) { loading.sharing = false; return }
+  loading.sharing = true
+  try {
+    const [s, p] = await Promise.allSettled([
+      axios.get(`/api/agents/${props.agentName}/shares`, hdr()),
+      axios.get(`/api/agents/${props.agentName}/access-policy`, hdr())
+    ])
+    if (s.status === 'fulfilled') shares.value = s.value.data?.shares || (Array.isArray(s.value.data) ? s.value.data : [])
+    if (p.status === 'fulfilled') accessPolicy.value = p.value.data
+  } finally { loading.sharing = false }
+}
+
+async function loadSkills() {
+  loading.skills = true
+  try {
+    const res = await axios.get(`/api/agents/${props.agentName}/skills`, hdr())
+    skills.value = Array.isArray(res.data) ? res.data : (res.data?.skills || [])
+  } catch { skills.value = [] }
+  finally { loading.skills = false }
+  if (isRunning.value) {
+    try {
+      const res = await axios.get(`/api/agents/${props.agentName}/playbooks`, hdr())
+      playbooks.value = Array.isArray(res.data) ? res.data : (res.data?.skills || res.data?.playbooks || [])
+    } catch { playbooks.value = [] }
+  }
+}
+
+// DB-sourced cards always load; container-gated cards load only when running.
+function loadAll() {
+  loadInfo()
+  loadTaskStats()
+  loadRecentExecutions()
+  loadSchedules()
+  loadAttention()
+  loadSync()
+  loadSharing()
+  loadSkills()
+  loadContext()
+  loadCapacity()
+  loadHealth()
+}
+
+// Re-fetch container-gated cards when the agent transitions to running
+// (mirrors InfoPanel's status watcher).
+watch(() => props.agent?.status, (s, prev) => {
+  if (s === 'running' && prev !== 'running') {
+    loadContext(); loadCapacity(); loadHealth()
+    // playbooks live in the container too
+    loadSkills()
+  }
+})
+
+onMounted(loadAll)
+</script>

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -92,6 +92,11 @@
               </nav>
             </div>
 
+            <!-- Overview Tab Content (#1107 — platform-rendered, deterministic default landing) -->
+            <div v-if="activeTab === 'overview'" class="p-6">
+              <OverviewPanel :agent-name="agent.name" :agent="agent" @navigate="handleOverviewNavigate" @item-click="handleInfoItemClick" />
+            </div>
+
             <!-- Info Tab Content -->
             <div v-if="activeTab === 'info'" class="p-6">
               <InfoPanel :agent-name="agent.name" :agent-status="agent.status" @item-click="handleInfoItemClick" />
@@ -268,6 +273,7 @@ import TasksPanel from '../components/TasksPanel.vue'
 import GitPanel from '../components/GitPanel.vue'
 import InfoPanel from '../components/InfoPanel.vue'
 import DashboardPanel from '../components/DashboardPanel.vue'
+import OverviewPanel from '../components/OverviewPanel.vue'
 import FoldersPanel from '../components/FoldersPanel.vue'
 import GuardrailsPanel from '../components/GuardrailsPanel.vue'
 
@@ -307,7 +313,10 @@ const sessionsStore = useSessionsStore()  // SESSION_TAB_2026-04 Phase 3
 const agent = ref(null)
 const loading = ref(true)
 const error = ref('')
-const activeTab = ref('tasks')
+// Single source of truth for `?tab=` deep-link validation — hoisted to kill the
+// onMounted/onActivated two-copy drift (#1107). Overview is the default landing tab.
+const VALID_TABS = ['overview', 'tasks', 'chat', 'session', 'dashboard', 'logs', 'files', 'schedules', 'credentials', 'skills', 'sharing', 'permissions', 'git', 'folders', 'info']
+const activeTab = ref('overview')
 // Tabs that need a full-viewport flex layout (input pinned to bottom).
 // Chat + Session both render ChatMessages which depends on flex-1 grow.
 const isFullscreenTab = computed(() => activeTab.value === 'chat' || activeTab.value === 'session')
@@ -591,8 +600,9 @@ const {
 const visibleTabs = computed(() => {
   const isSystem = agent.value?.is_system
 
-  // Primary tabs - most frequently used
+  // Primary tabs - most frequently used. Overview is the default landing tab (#1107).
   const tabs = [
+    { id: 'overview', label: 'Overview' },
     { id: 'tasks', label: 'Tasks' },
     { id: 'chat', label: 'Chat' }
   ]
@@ -927,7 +937,7 @@ watch(() => route.params.name, async (newName, oldName) => {
     nextTick(() => {
       const validTabIds = visibleTabs.value.map(t => t.id)
       if (!validTabIds.includes(activeTab.value)) {
-        activeTab.value = 'tasks'
+        activeTab.value = 'overview'
       }
     })
     startAllPolling()
@@ -1013,8 +1023,7 @@ onMounted(async () => {
   // Handle tab query param (from Timeline click navigation)
   if (route.query.tab) {
     const requestedTab = route.query.tab
-    const validTabs = ['tasks', 'chat', 'session', 'dashboard', 'logs', 'files', 'schedules', 'credentials', 'skills', 'sharing', 'permissions', 'git', 'folders', 'info']
-    if (validTabs.includes(requestedTab)) {
+    if (VALID_TABS.includes(requestedTab)) {
       activeTab.value = requestedTab
     }
   }
@@ -1038,8 +1047,7 @@ onActivated(async () => {
   // Must also check here since onMounted doesn't fire for cached components
   if (route.query.tab) {
     const requestedTab = route.query.tab
-    const validTabs = ['tasks', 'chat', 'session', 'dashboard', 'logs', 'files', 'schedules', 'credentials', 'skills', 'sharing', 'permissions', 'git', 'folders', 'info']
-    if (validTabs.includes(requestedTab)) {
+    if (VALID_TABS.includes(requestedTab)) {
       activeTab.value = requestedTab
     }
   }
@@ -1066,6 +1074,19 @@ onUnmounted(() => {
   stopAllPolling()
   stopEmotionCycling()
 })
+
+// Handle navigation requests from the Overview tab — deep-link to another tab,
+// optionally highlighting an execution in the Tasks tab (#1107).
+const handleOverviewNavigate = ({ tab, executionId }) => {
+  if (executionId) {
+    activeTab.value = 'tasks'
+    router.replace({ query: { ...route.query, execution: executionId } })
+    return
+  }
+  if (tab && VALID_TABS.includes(tab)) {
+    activeTab.value = tab
+  }
+}
 
 // Handle item click from Info tab - switch to Tasks tab with prefilled message
 const handleInfoItemClick = ({ type, text }) => {


### PR DESCRIPTION
## Summary
- New **Overview** tab replaces Tasks as the default AgentDetail landing view — platform-rendered, fully deterministic (DB counts, config flags, git/sync state, health rollups; no LLM-generated content).
- **Info tab redesigned**: leads with the About narrative; the exhaustive `template.yaml` metadata is tucked behind a native `<details>` collapsible.
- Honors the issue's hard **non-duplication constraint** against the persistent `AgentHeader` — and resolves two coherence gaps the constraint surfaced.

## Approach (autoplan-reviewed)
Independent strategy + engineering reviews ran before implementation. Key calls baked in:
- **No singleton-store clobber** (eng CRITICAL): `OverviewPanel` uses **local axios fetches**; it never mutates the shared `executions`/`monitoring`/`notifications`/`operatorQueue` Pinia singletons that back the NavBar "running" + notification badges. Only stateless return-only methods (`getAgentInfo`, `monitoring.fetchAgentHealth`) are reused.
- **Default-tab swap drift-proofed** (eng CRITICAL): the two duplicated `?tab=` validation arrays hoisted to one `VALID_TABS` const; all 6 swap sites updated incl. the KeepAlive `onActivated` path.
- **Coherence fixes** (strategy): health metric labeled **"24h uptime"** so it can't be confused with the header's *uptime-since-start*; the attention zone **points to** the header's circuit-open badge rather than re-rendering it; a one-line **task-entry shim** preserves the action affordance the default-swap would otherwise demote.
- **Graceful degradation**: container-gated cards (health/context/capacity/playbooks) show "offline/stopped" placeholders instead of firing guaranteed-failing requests; DB-sourced cards always render.

## Changes
| File | Change |
|------|--------|
| `src/frontend/src/components/OverviewPanel.vue` | **New.** 7 sections: About + task shim, Needs-attention (hidden when empty), Performance (tasks 24h/7d · running+queued · context% · schedules+capacity), Health rollup, Recent activity, Footprint (sharing*/sync/skills). Per-card skeletons; local fetches. |
| `src/frontend/src/views/AgentDetail.vue` | Default tab → `overview`; hoisted `VALID_TABS`; render block; `handleOverviewNavigate` deep-link handler. |
| `src/frontend/src/components/InfoPanel.vue` | About + "What You Can Ask" lead (preserves `item-click` → Tasks prefill); 8 metadata sections behind `<details>`. |
| `src/frontend/e2e/overview-tab.spec.js` | **New.** 4 e2e tests. |

*Sharing card is owner-gated (`v-if="agent.can_share"`).

## Test Plan
Verified against a live local stack:
- [x] `overview-tab.spec.js` — **4/4 pass**: default tab, `?tab=` VALID_TABS guard, KeepAlive away-and-back, Info About-leads + collapse toggle.
- [x] Full **`@smoke` suite green** (10 passed, 0 failed) — no regression from the default-tab swap; `circuit-breaker-badge` (navigates AgentDetail, asserts the header badge) still passes under the new default tab.
- [x] Vite compiles all three components clean (no transform errors).

Run: `cd src/frontend && ADMIN_PASSWORD=… npx playwright test e2e/overview-tab.spec.js`

## Notes
- No backend/API/schema change — all data comes from ~13 existing deterministic endpoints. The aggregation endpoint `GET /api/agents/{name}/overview` remains a deferred fast-follow (YAGNI until mount latency regresses).
- Existing tabs (Chat, Session, Dashboard, Schedules, Playbooks, …) and `AgentHeader` are unchanged.

Fixes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)