### PR TITLE
feat(loops): web UI for sequential agent loops (#1106)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -281,6 +281,7 @@ Each agent runs as an isolated Docker container with standardized interfaces for
 - `stores/agents.js` - Agent CRUD, chat, activity
 - `stores/auth.js` - Email/admin authentication + JWT
 - `stores/collaborations.js` - Collaboration graph state, WebSocket integration
+- `stores/loops.js` - Sequential agent loops UI state, agent-scoped, WebSocket-driven live progress (#1106)
 
 **Real-time:**
 - WebSocket client at `utils/websocket.js`
@@ -903,6 +904,8 @@ Storage: `/data/agent-files/{file_id}` under the existing `trinity-data` volume 
 | POST | `/api/loops/{loop_id}/stop` | JWT/MCP | Graceful stop. Returns `{status: "stopping" \| "already_done"}`. |
 
 MCP tools: `run_agent_loop`, `get_loop_status`, `stop_loop` (`src/mcp-server/src/tools/loops.ts`). Loop runner lives in `services/loop_service.py`; each iteration dispatches through `task_execution_service.execute_task()` with `triggered_by="loop"` and the parent `loop_id` carried on the resulting `schedule_executions` row.
+
+**Web UI (#1106, Phase 2):** a **Loops** tab on the Agent Detail page (between Schedules and Playbooks) provides Start/List/Detail/Stop over the endpoints above. Domain store `stores/loops.js` (uses the shared `api.js` client per Invariant #7) + `components/LoopsPanel.vue`. The store is agent-scoped: `LoopsPanel` calls `setAgent(name)` on mount / `clear()` on unmount, and the global WS handler (`utils/websocket.js`) routes the fleet-wide `loop_run_completed`/`loop_completed` events (keyed by `data.type`) to `loopsStore.handleWebSocketEvent`, which filters by the mounted agent and targeted-refreshes only the affected loop. A 12s backstop poll runs while any loop is `queued`/`running` to recover a missed terminal event. Last full response rendered via `utils/markdown.js` (DOMPurify).
 
 ### Platform Settings (5 endpoints)
 

--- a/docs/memory/feature-flows/run-agent-loop.md
+++ b/docs/memory/feature-flows/run-agent-loop.md
@@ -11,8 +11,16 @@ As an agent orchestrator, I want to run a task N times in order, optionally chai
 ## Entry Points
 - **API**: `POST /api/agents/{name}/loops`, `GET /api/agents/{name}/loops`, `GET /api/loops/{id}`, `POST /api/loops/{id}/stop`
 - **MCP tools**: `run_agent_loop`, `get_loop_status`, `stop_loop`
+- **Web UI (Phase 2, #1106)**: the **Loops** tab on the Agent Detail page (`AgentDetail.vue`, between Schedules and Playbooks).
 
-No frontend UI entry point in Phase 1. Iterations appear in the standard execution timeline tagged with `loop_id`.
+Phase 1 shipped headless (API/MCP only); iterations also appear in the standard execution timeline tagged with `loop_id`.
+
+## Frontend Layer (Phase 2, #1106)
+- **Tab**: `src/frontend/src/views/AgentDetail.vue` adds `{ id: 'loops', label: 'Loops' }` and mounts `<LoopsPanel :agent-name :agent-status />`.
+- **Component**: `src/frontend/src/components/LoopsPanel.vue` — collapsible Run-loop form (message template w/ `{{run}}`/`{{previous_response}}` helper text, `max_runs`, `stop_signal`, `delay_seconds`, `timeout_per_run`, `model` via `ModelSelector`, `allowed_tools` picker), loop list with status badge + `runs_completed/max_runs` + `stop_reason`, expandable per-run table (#/status/cost/duration/response), last full response via `renderMarkdown`, and a Stop control reflecting `stopping`→`stopped`. The Run-loop button is gated on `agentStatus === 'running'`.
+- **Store**: `src/frontend/src/stores/loops.js` — agent-scoped Pinia store on the shared `api.js` client (Invariant #7). `setAgent(name)`/`clear()` bind the store to the mounted agent; `handleWebSocketEvent` filters fleet-wide `loop_run_completed`/`loop_completed` events by that agent and targeted-refreshes only the affected loop; a 12s backstop poll runs while any loop is `queued`/`running` to recover a missed terminal event. `expandedLoopId` lives in the store so it survives the `v-if` tab remount.
+- **WS wiring**: `src/frontend/src/utils/websocket.js` routes the `data.type`-keyed loop events to `loopsStore.handleWebSocketEvent` in the `default:` branch.
+- **e2e**: `src/frontend/e2e/loops-panel.spec.js` (@interactive — needs a live stack + running agent).
 
 ## MCP Layer
 
@@ -114,7 +122,7 @@ No frontend UI entry point in Phase 1. Iterations appear in the standard executi
 
 **Unit tests**: `tests/unit/test_loop_service.py` covers fixed/until modes, template substitution, graceful stop, failure paths, restart recovery, and `get_status`.
 
-**Status**: 🚧 In progress (Phase 1).
+**Status**: ✅ Phase 1 (backend/MCP) + Phase 2 (web UI, #1106) shipped.
 
 ## Related Flows
 - **Upstream**: `task-execution-service.md` — each iteration dispatches through `TaskExecutionService`.

--- a/src/frontend/e2e/loops-panel.spec.js
+++ b/src/frontend/e2e/loops-panel.spec.js
@@ -1,0 +1,96 @@
+import { test, expect, request } from '@playwright/test'
+
+/**
+ * Loops tab e2e (#1106 / #740 Phase 2).
+ *
+ * Drives the new Loops tab on the Agent Detail page against a live stack:
+ *   - tab is present (no feature flag — always visible)
+ *   - "Run Loop" opens the form with the documented inputs
+ *   - starting a 1-run loop lands a row that reaches a terminal status,
+ *     and the expanded detail shows the per-run table
+ *
+ * The start path dispatches a real Claude execution, so the start/run
+ * test is marked @interactive (10–60s) — opt-in via
+ * `npm run test:e2e -- loops-panel.spec`. The form-render test is also
+ * @interactive only because it needs the agent running to enable the
+ * "Run Loop" button.
+ *
+ * Required env: ADMIN_PASSWORD (enforced by auth.setup.js) and
+ * LOOPS_TEST_AGENT (defaults to "testfix"). The agent must already exist;
+ * beforeAll starts it if it isn't running.
+ */
+
+const TEST_AGENT = process.env.LOOPS_TEST_AGENT || 'testfix'
+
+let api
+let token
+
+test.beforeAll(async ({ baseURL }) => {
+  api = await request.newContext({ baseURL })
+  const loginResp = await api.post('/api/token', {
+    form: { username: 'admin', password: process.env.ADMIN_PASSWORD || '' },
+  })
+  if (!loginResp.ok()) {
+    throw new Error(`Admin login failed: ${loginResp.status()}`)
+  }
+  token = (await loginResp.json()).access_token
+
+  // Ensure the agent is running so the "Run Loop" button is enabled.
+  // Best-effort: a 409/already-running response is fine.
+  await api.post(`/api/agents/${TEST_AGENT}/start`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+})
+
+test.afterAll(async () => {
+  if (api) await api.dispose()
+})
+
+test.describe('loops tab', () => {
+  test('@interactive tab is visible and Run Loop opens the form', async ({ page }) => {
+    await page.goto(`/agents/${TEST_AGENT}`)
+
+    const loopsTab = page.getByRole('button', { name: 'Loops', exact: true })
+    await expect(loopsTab).toBeVisible({ timeout: 15000 })
+    await loopsTab.click()
+
+    // Empty/intro copy from LoopsPanel header.
+    await expect(page.getByRole('heading', { name: 'Loops' })).toBeVisible()
+
+    const runBtn = page.getByRole('button', { name: 'Run Loop' })
+    await expect(runBtn).toBeVisible()
+    await runBtn.click()
+
+    // Form fields from the documented inputs.
+    await expect(page.getByText('Message template')).toBeVisible()
+    await expect(page.getByText('Max runs', { exact: false })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Start Loop' })).toBeVisible()
+  })
+
+  test('@interactive starting a 1-run loop lands a terminal row with per-run detail', async ({ page }) => {
+    await page.goto(`/agents/${TEST_AGENT}`)
+    await page.getByRole('button', { name: 'Loops', exact: true }).click()
+    await page.getByRole('button', { name: 'Run Loop' }).click()
+
+    // Fill the form: 1 run, trivial message.
+    await page.getByPlaceholder(/Process item/).fill('Reply with just the word OK.')
+    // Max runs input — set to 1 for a fast single iteration.
+    const maxRuns = page.locator('input[type="number"]').first()
+    await maxRuns.fill('1')
+
+    await page.getByRole('button', { name: 'Start Loop' }).click()
+
+    // A loop row appears (status badge + "Run x / 1").
+    await expect(page.getByText(/Run \d+ \/ 1/)).toBeVisible({ timeout: 15000 })
+
+    // It reaches a terminal status (completed/failed/stopped). Real Claude
+    // call — generous timeout. The badge text is one of the terminal states.
+    await expect(
+      page.getByText(/^(completed|failed|stopped)$/).first()
+    ).toBeVisible({ timeout: 90000 })
+
+    // Expand the loop and assert the per-run table renders.
+    await page.getByText(/Run \d+ \/ 1/).click()
+    await expect(page.getByText('Runs', { exact: true })).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/src/frontend/src/components/LoopsPanel.vue
+++ b/src/frontend/src/components/LoopsPanel.vue
@@ -1,0 +1,435 @@
+<template>
+  <div class="p-6">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <h3 class="text-lg font-medium text-gray-900 dark:text-white">Loops</h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Run a task repeatedly — fixed count or until a stop signal. Each iteration runs sequentially.
+        </p>
+      </div>
+      <button
+        type="button"
+        @click="showForm = !showForm"
+        :disabled="agentStatus !== 'running'"
+        :title="agentStatus !== 'running' ? 'Agent must be running to start a loop' : ''"
+        class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 disabled:bg-gray-400 disabled:cursor-not-allowed"
+      >
+        {{ showForm ? 'Cancel' : 'Run Loop' }}
+      </button>
+    </div>
+
+    <!-- Start form -->
+    <div v-if="showForm" class="mb-6 p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+      <form @submit.prevent="submit" class="space-y-4">
+        <!-- Message template -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Message template <span class="text-status-danger-500">*</span></label>
+          <textarea
+            v-model="form.message"
+            rows="4"
+            required
+            :placeholder="messagePlaceholder"
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
+          ></textarea>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Use <code class="px-1 bg-gray-200 dark:bg-gray-700 rounded">{{ RUN_VAR }}</code> for the 1-indexed run number and
+            <code class="px-1 bg-gray-200 dark:bg-gray-700 rounded">{{ PREV_VAR }}</code> for the previous iteration's output.
+          </p>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <!-- Max runs -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Max runs <span class="text-status-danger-500">*</span></label>
+            <input
+              v-model.number="form.max_runs"
+              type="number"
+              min="1"
+              max="100"
+              required
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
+            />
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">1–100</p>
+          </div>
+
+          <!-- Stop signal -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Stop signal</label>
+            <input
+              v-model="form.stop_signal"
+              type="text"
+              placeholder="optional — substring that ends the loop"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
+            />
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">If a response contains this text, the loop stops early.</p>
+          </div>
+
+          <!-- Delay -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Delay between runs (seconds)</label>
+            <input
+              v-model.number="form.delay_seconds"
+              type="number"
+              min="0"
+              max="3600"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
+            />
+          </div>
+
+          <!-- Timeout per run -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timeout per run (seconds)</label>
+            <input
+              v-model.number="form.timeout_per_run"
+              type="number"
+              min="10"
+              max="7200"
+              placeholder="agent default"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-action-primary-500"
+            />
+          </div>
+        </div>
+
+        <!-- Model -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Model</label>
+          <ModelSelector v-model="form.model" placeholder="Agent default" />
+        </div>
+
+        <!-- Allowed tools -->
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Allowed tools</label>
+            <button
+              type="button"
+              @click="toggleAllTools"
+              class="text-xs px-2 py-1 rounded"
+              :class="form.allowed_tools === null ? 'bg-action-primary-100 dark:bg-action-primary-900/30 text-action-primary-700 dark:text-action-primary-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'"
+            >
+              {{ form.allowed_tools === null ? 'All Tools (Unrestricted)' : 'Enable All' }}
+            </button>
+          </div>
+          <div v-if="form.allowed_tools !== null" class="space-y-3">
+            <div v-for="category in toolCategories" :key="category.name">
+              <p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{{ category.name }}</p>
+              <div class="flex flex-wrap gap-2">
+                <label
+                  v-for="tool in category.tools"
+                  :key="tool.value"
+                  class="inline-flex items-center px-2 py-1 rounded text-xs cursor-pointer transition-colors"
+                  :class="isToolSelected(tool.value) ? 'bg-action-primary-100 dark:bg-action-primary-900/30 text-action-primary-700 dark:text-action-primary-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'"
+                >
+                  <input
+                    type="checkbox"
+                    :value="tool.value"
+                    :checked="isToolSelected(tool.value)"
+                    @change="toggleTool(tool.value)"
+                    class="sr-only"
+                  />
+                  {{ tool.label }}
+                </label>
+              </div>
+            </div>
+          </div>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            {{ form.allowed_tools === null ? 'Agent can use any tool' : `${form.allowed_tools.length} tool(s) selected` }}
+          </p>
+        </div>
+
+        <div v-if="store.error" class="p-3 bg-status-danger-50 dark:bg-status-danger-900/30 text-status-danger-700 dark:text-status-danger-300 text-sm rounded-md">
+          {{ store.error }}
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            @click="resetForm"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600"
+          >
+            Reset
+          </button>
+          <button
+            type="submit"
+            :disabled="store.starting || !form.message"
+            class="px-4 py-2 text-sm font-medium text-white bg-action-primary-600 border border-transparent rounded-md hover:bg-action-primary-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {{ store.starting ? 'Starting…' : 'Start Loop' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="store.loading && !store.loops.length" class="text-center py-8 text-gray-500 dark:text-gray-400">
+      Loading loops…
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="!store.loops.length" class="text-center py-8 text-gray-500 dark:text-gray-400">
+      No loops yet. Start one with “Run Loop”.
+    </div>
+
+    <!-- Loop list -->
+    <div v-else class="space-y-3">
+      <div
+        v-for="loop in store.loops"
+        :key="loop.loop_id"
+        class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden"
+      >
+        <!-- Row header -->
+        <div
+          class="flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50"
+          @click="store.toggleExpanded(loop.loop_id)"
+        >
+          <div class="flex items-center gap-3 min-w-0">
+            <span
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+              :class="statusBadgeClass(loop.status)"
+            >
+              <span v-if="loop.status === 'running'" class="w-1.5 h-1.5 rounded-full bg-current mr-1 animate-pulse"></span>
+              {{ loop.status }}
+            </span>
+            <span class="text-sm font-medium text-gray-900 dark:text-white">
+              Run {{ loop.runs_completed }} / {{ loop.max_runs }}
+            </span>
+            <span v-if="loop.stop_reason" class="text-xs text-gray-500 dark:text-gray-400 truncate">
+              · {{ formatStopReason(loop.stop_reason) }}
+            </span>
+          </div>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <span class="text-xs text-gray-400 dark:text-gray-500 hidden sm:inline">{{ formatDate(loop.created_at) }}</span>
+            <button
+              v-if="isActive(loop)"
+              type="button"
+              @click.stop="store.stopLoop(loop.loop_id)"
+              :disabled="store.stoppingIds.includes(loop.loop_id)"
+              class="px-2.5 py-1 text-xs font-medium rounded-md text-status-danger-700 dark:text-status-danger-300 bg-status-danger-50 dark:bg-status-danger-900/30 hover:bg-status-danger-100 dark:hover:bg-status-danger-900/50 disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {{ store.stoppingIds.includes(loop.loop_id) ? 'Stopping…' : 'Stop' }}
+            </button>
+            <svg
+              class="w-4 h-4 text-gray-400 transition-transform"
+              :class="store.expandedLoopId === loop.loop_id ? 'rotate-180' : ''"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
+        </div>
+
+        <!-- Expanded detail -->
+        <div v-if="store.expandedLoopId === loop.loop_id" class="border-t border-gray-200 dark:border-gray-700 p-4 space-y-4 bg-gray-50 dark:bg-gray-800/30">
+          <div v-if="loop.error" class="p-3 bg-status-danger-50 dark:bg-status-danger-900/30 text-status-danger-700 dark:text-status-danger-300 text-sm rounded-md">
+            {{ loop.error }}
+          </div>
+
+          <!-- Per-run table -->
+          <div>
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">Runs</p>
+            <div v-if="!loop.runs || !loop.runs.length" class="text-sm text-gray-500 dark:text-gray-400">
+              No runs yet.
+            </div>
+            <div v-else class="overflow-x-auto">
+              <table class="min-w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                    <th class="py-1 pr-4 font-medium">#</th>
+                    <th class="py-1 pr-4 font-medium">Status</th>
+                    <th class="py-1 pr-4 font-medium">Cost</th>
+                    <th class="py-1 pr-4 font-medium">Duration</th>
+                    <th class="py-1 font-medium">Response</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="run in loop.runs" :key="run.run_number" class="border-b border-gray-100 dark:border-gray-800 align-top">
+                    <td class="py-1.5 pr-4 text-gray-700 dark:text-gray-300">{{ run.run_number }}</td>
+                    <td class="py-1.5 pr-4">
+                      <span :class="runStatusClass(run.status)">{{ run.status }}</span>
+                    </td>
+                    <td class="py-1.5 pr-4 text-gray-600 dark:text-gray-400">{{ formatCost(run.cost) }}</td>
+                    <td class="py-1.5 pr-4 text-gray-600 dark:text-gray-400">{{ formatDuration(run.duration_ms) }}</td>
+                    <td class="py-1.5 text-gray-600 dark:text-gray-400">
+                      <span v-if="run.error" class="text-status-danger-600 dark:text-status-danger-400">{{ run.error }}</span>
+                      <span v-else class="line-clamp-2">{{ run.response_preview || '—' }}</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Last full response -->
+          <div v-if="loop.last_response">
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Last response</p>
+            <div
+              class="prose prose-sm dark:prose-invert max-w-none max-h-80 overflow-y-auto p-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md"
+              v-html="renderMarkdown(loop.last_response)"
+            ></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted, onUnmounted, watch } from 'vue'
+import { useLoopsStore } from '../stores/loops'
+import { renderMarkdown } from '../utils/markdown'
+import ModelSelector from './ModelSelector.vue'
+
+const props = defineProps({
+  agentName: { type: String, required: true },
+  agentStatus: { type: String, default: '' },
+})
+
+const store = useLoopsStore()
+const showForm = ref(false)
+
+// Literal template placeholders — held as constants because Vue's template
+// parser can't tokenize `{{run}}` written inline in markup.
+const RUN_VAR = '{{run}}'
+const PREV_VAR = '{{previous_response}}'
+const messagePlaceholder = `e.g. Process item ${RUN_VAR}. Previous result: ${PREV_VAR}`
+
+const ACTIVE_STATUSES = ['queued', 'running']
+
+const defaultForm = () => ({
+  message: '',
+  max_runs: 5,
+  stop_signal: '',
+  delay_seconds: 0,
+  timeout_per_run: null,
+  model: '',
+  allowed_tools: null,
+})
+const form = reactive(defaultForm())
+
+const toolCategories = [
+  { name: 'File', tools: [
+    { value: 'Read', label: 'Read' },
+    { value: 'Write', label: 'Write' },
+    { value: 'Edit', label: 'Edit' },
+  ] },
+  { name: 'Search', tools: [
+    { value: 'Glob', label: 'Glob' },
+    { value: 'Grep', label: 'Grep' },
+  ] },
+  { name: 'Execution', tools: [
+    { value: 'Bash', label: 'Bash' },
+  ] },
+  { name: 'Web', tools: [
+    { value: 'WebFetch', label: 'WebFetch' },
+    { value: 'WebSearch', label: 'WebSearch' },
+  ] },
+]
+
+function isToolSelected(tool) {
+  return form.allowed_tools !== null && form.allowed_tools.includes(tool)
+}
+function toggleTool(tool) {
+  if (form.allowed_tools === null) {
+    form.allowed_tools = [tool]
+  } else if (form.allowed_tools.includes(tool)) {
+    form.allowed_tools = form.allowed_tools.filter((t) => t !== tool)
+  } else {
+    form.allowed_tools = [...form.allowed_tools, tool]
+  }
+}
+function toggleAllTools() {
+  form.allowed_tools = form.allowed_tools === null ? [] : null
+}
+
+function resetForm() {
+  Object.assign(form, defaultForm())
+  store.error = null
+}
+
+async function submit() {
+  const payload = {
+    message: form.message,
+    max_runs: form.max_runs,
+  }
+  if (form.stop_signal && form.stop_signal.trim()) payload.stop_signal = form.stop_signal.trim()
+  if (form.delay_seconds) payload.delay_seconds = form.delay_seconds
+  if (form.timeout_per_run) payload.timeout_per_run = form.timeout_per_run
+  if (form.model) payload.model = form.model
+  if (form.allowed_tools !== null) payload.allowed_tools = form.allowed_tools
+
+  const ok = await store.startLoop(payload)
+  if (ok) {
+    resetForm()
+    showForm.value = false
+  }
+}
+
+// --- formatting / styling helpers ---
+function isActive(loop) {
+  return ACTIVE_STATUSES.includes(loop.status)
+}
+
+function statusBadgeClass(status) {
+  switch (status) {
+    case 'running':
+    case 'queued':
+      return 'bg-status-warning-100 dark:bg-status-warning-900/30 text-status-warning-800 dark:text-status-warning-300'
+    case 'completed':
+      return 'bg-status-success-100 dark:bg-status-success-900/30 text-status-success-800 dark:text-status-success-300'
+    case 'failed':
+      return 'bg-status-danger-100 dark:bg-status-danger-900/30 text-status-danger-800 dark:text-status-danger-300'
+    case 'stopped':
+    case 'interrupted':
+      return 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+    default:
+      return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+  }
+}
+
+function runStatusClass(status) {
+  if (status === 'completed') return 'text-status-success-600 dark:text-status-success-400'
+  if (status === 'failed') return 'text-status-danger-600 dark:text-status-danger-400'
+  return 'text-status-warning-600 dark:text-status-warning-400'
+}
+
+function formatStopReason(reason) {
+  const map = {
+    max_runs_reached: 'reached max runs',
+    stop_signal_matched: 'stop signal matched',
+    user_stopped: 'stopped by user',
+    error: 'error',
+    interrupted: 'interrupted',
+  }
+  return map[reason] || reason
+}
+
+function formatCost(cost) {
+  if (cost === null || cost === undefined) return '—'
+  return `$${cost.toFixed(4)}`
+}
+
+function formatDuration(ms) {
+  if (ms === null || ms === undefined) return '—'
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+// --- lifecycle: bind the store to this agent and fetch ---
+function bind(name) {
+  store.setAgent(name)
+  store.fetchLoops()
+}
+
+onMounted(() => bind(props.agentName))
+watch(() => props.agentName, (name) => { if (name) bind(name) })
+onUnmounted(() => store.clear())
+</script>

--- a/src/frontend/src/stores/loops.js
+++ b/src/frontend/src/stores/loops.js
@@ -1,0 +1,181 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import api from '../api'
+
+// Sequential agent loops UI store (#1106 / #740 Phase 2).
+//
+// Domain-scoped, agent-at-a-time: LoopsPanel mounts per agent and calls
+// setAgent(name) — the store tracks that name so the GLOBAL WebSocket handler
+// (loop events are broadcast fleet-wide, unfiltered) only reacts to events for
+// the agent currently on screen. All HTTP goes through the shared api.js client
+// (Invariant #7) so auth + 401→/login handling is inherited.
+const ACTIVE_STATUSES = ['queued', 'running']
+const POLL_INTERVAL_MS = 12000
+
+export const useLoopsStore = defineStore('loops', () => {
+  // --- state ---
+  const loops = ref([])            // LoopStatusResponse[] for the mounted agent
+  const agentName = ref(null)      // the agent LoopsPanel is currently showing
+  const loading = ref(false)
+  const starting = ref(false)
+  const error = ref(null)
+  const expandedLoopId = ref(null) // kept in the store so it survives tab remount
+  const stoppingIds = ref([])      // loop_ids with an in-flight stop request
+
+  let _pollTimer = null
+  const _loadInFlight = new Set()  // per-loop loadLoop() guard
+
+  // --- getters ---
+  const hasActiveLoops = computed(() =>
+    loops.value.some((l) => ACTIVE_STATUSES.includes(l.status))
+  )
+
+  // --- helpers ---
+  function _upsertLoop(loop) {
+    const idx = loops.value.findIndex((l) => l.loop_id === loop.loop_id)
+    if (idx === -1) {
+      loops.value = [loop, ...loops.value]
+    } else {
+      loops.value.splice(idx, 1, loop)
+    }
+  }
+
+  function _ensurePolling() {
+    // Backstop for a missed loop_completed event: while any loop is active,
+    // poll the list so a dropped WS event can't leave the UI spinning forever.
+    if (hasActiveLoops.value) {
+      if (!_pollTimer) _pollTimer = setInterval(fetchLoops, POLL_INTERVAL_MS)
+    } else {
+      stopPolling()
+    }
+  }
+
+  // --- actions ---
+  function setAgent(name) {
+    if (agentName.value !== name) {
+      agentName.value = name
+      loops.value = []
+      error.value = null
+    }
+  }
+
+  async function fetchLoops() {
+    if (!agentName.value || loading.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const res = await api.get(`/api/agents/${agentName.value}/loops`, {
+        params: { limit: 50 },
+      })
+      loops.value = res.data
+    } catch (err) {
+      error.value = err.response?.data?.detail || err.message
+    } finally {
+      loading.value = false
+      _ensurePolling()
+    }
+  }
+
+  async function startLoop(payload) {
+    if (!agentName.value) return
+    starting.value = true
+    error.value = null
+    try {
+      await api.post(`/api/agents/${agentName.value}/loops`, payload)
+      await fetchLoops()
+      return true
+    } catch (err) {
+      error.value = err.response?.data?.detail || err.message
+      return false
+    } finally {
+      starting.value = false
+    }
+  }
+
+  // Targeted single-loop refresh — cheaper than refetching the whole list and
+  // avoids list reorder flicker. Used by the WS handler and after stop.
+  async function loadLoop(loopId) {
+    if (_loadInFlight.has(loopId)) return
+    _loadInFlight.add(loopId)
+    try {
+      const res = await api.get(`/api/loops/${loopId}`)
+      _upsertLoop(res.data)
+    } catch {
+      // A 403/404 here (e.g. loop gone) shouldn't wedge the panel — the next
+      // list poll reconciles. Swallow.
+    } finally {
+      _loadInFlight.delete(loopId)
+      _ensurePolling()
+    }
+  }
+
+  async function stopLoop(loopId) {
+    if (stoppingIds.value.includes(loopId)) return
+    stoppingIds.value = [...stoppingIds.value, loopId]
+    error.value = null
+    try {
+      await api.post(`/api/loops/${loopId}/stop`)
+      // Cooperative stop: the loop finishes its current iteration, then emits
+      // loop_completed. Reconcile now and let WS/poll catch the terminal state.
+      await loadLoop(loopId)
+    } catch (err) {
+      error.value = err.response?.data?.detail || err.message
+    } finally {
+      stoppingIds.value = stoppingIds.value.filter((id) => id !== loopId)
+    }
+  }
+
+  function toggleExpanded(loopId) {
+    expandedLoopId.value = expandedLoopId.value === loopId ? null : loopId
+  }
+
+  // Loop events are broadcast fleet-wide and keyed by `type`; only react to
+  // those for the agent currently on screen.
+  function handleWebSocketEvent(data) {
+    if (!agentName.value) return
+    if (data.type !== 'loop_run_completed' && data.type !== 'loop_completed') return
+    if (data.agent_name !== agentName.value) return
+    if (!data.loop_id) return
+    // Targeted reconcile of just the affected loop.
+    loadLoop(data.loop_id)
+  }
+
+  function stopPolling() {
+    if (_pollTimer) {
+      clearInterval(_pollTimer)
+      _pollTimer = null
+    }
+  }
+
+  // Called on panel unmount: stop the timer and drop the agent filter so the
+  // global WS handler becomes a no-op while no panel is showing.
+  // expandedLoopId is intentionally preserved (it's keyed by a globally-unique
+  // loop_id) so an expanded loop survives a v-if tab remount; a stale id from a
+  // different agent simply matches no row and expands nothing.
+  function clear() {
+    stopPolling()
+    agentName.value = null
+    loops.value = []
+    error.value = null
+  }
+
+  return {
+    loops,
+    agentName,
+    loading,
+    starting,
+    error,
+    expandedLoopId,
+    stoppingIds,
+    hasActiveLoops,
+    setAgent,
+    fetchLoops,
+    startLoop,
+    loadLoop,
+    stopLoop,
+    toggleExpanded,
+    handleWebSocketEvent,
+    stopPolling,
+    clear,
+  }
+})

--- a/src/frontend/src/utils/websocket.js
+++ b/src/frontend/src/utils/websocket.js
@@ -4,6 +4,7 @@ import { useAgentsStore } from '../stores/agents'
 import { useNotificationsStore } from '../stores/notifications'
 import { useOperatorQueueStore } from '../stores/operatorQueue'
 import { useExecutionsStore } from '../stores/executions'
+import { useLoopsStore } from '../stores/loops'
 
 const ws = ref(null)
 const isConnected = ref(false)
@@ -23,6 +24,7 @@ export function useWebSocket() {
   const notificationsStore = useNotificationsStore()
   const operatorQueueStore = useOperatorQueueStore()
   const executionsStore = useExecutionsStore()
+  const loopsStore = useLoopsStore()
 
   const connect = async () => {
     if (ws.value) return
@@ -147,6 +149,11 @@ export function useWebSocket() {
         }
         if (data.type === 'agent_activity') {
           executionsStore.handleWebSocketEvent(data)
+        }
+        // #1106: loop progress events (broadcast fleet-wide, keyed by type).
+        // The store filters by the agent currently shown in LoopsPanel.
+        if (data.type === 'loop_run_completed' || data.type === 'loop_completed') {
+          loopsStore.handleWebSocketEvent(data)
         }
         break
     }

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -161,6 +161,11 @@
               <SchedulesPanel :agent-name="agent.name" :initial-message="schedulePrefillMessage" />
             </div>
 
+            <!-- Loops Tab Content (#1106 / #740 Phase 2) -->
+            <div v-if="activeTab === 'loops'">
+              <LoopsPanel :agent-name="agent.name" :agent-status="agent.status" />
+            </div>
+
             <!-- Playbooks Tab Content -->
             <div v-if="activeTab === 'playbooks'" class="p-6">
               <PlaybooksPanel
@@ -264,6 +269,7 @@ import GitConflictModal from '../components/GitConflictModal.vue'
 
 // Panel Components (existing)
 import SchedulesPanel from '../components/SchedulesPanel.vue'
+import LoopsPanel from '../components/LoopsPanel.vue'
 import TasksPanel from '../components/TasksPanel.vue'
 import GitPanel from '../components/GitPanel.vue'
 import InfoPanel from '../components/InfoPanel.vue'
@@ -610,6 +616,7 @@ const visibleTabs = computed(() => {
 
   tabs.push(
     { id: 'schedules', label: 'Schedules' },
+    { id: 'loops', label: 'Loops' },
     { id: 'playbooks', label: 'Playbooks' },
     { id: 'credentials', label: 'Credentials' },
     { id: 'nevermined', label: 'Payments' }


### PR DESCRIPTION
## Summary
- Adds a **Loops** tab on the Agent Detail page — Phase 2 of #740, completing the web UI for sequential agent loops.
- **Frontend-only** slice over the existing `dev` backend (`routers/loops.py`, `services/loop_service.py`, MCP `loops.ts`). No backend changes.
- Covers all four acceptance criteria: **Start** (form), **List** (status / `runs_completed/max_runs` / `stop_reason`), **Detail + live progress** (per-run table, last response, WS-driven), **Stop** (cooperative `stopping`→`stopped`).

## Changes
- `src/frontend/src/stores/loops.js` — agent-scoped Pinia store on the shared `api.js` client (Invariant #7). Filters fleet-wide `loop_run_completed`/`loop_completed` WS events by the mounted agent, targeted-refreshes only the affected loop, and runs a 12s backstop poll while any loop is `queued`/`running` to recover a missed terminal event.
- `src/frontend/src/components/LoopsPanel.vue` — Run-loop form (message template w/ `{{run}}`+`{{previous_response}}` helper, `max_runs`, `stop_signal`, `delay_seconds`, `timeout_per_run`, `ModelSelector`, `allowed_tools` picker), loop list, expandable per-run table, last response via DOMPurify `renderMarkdown`, Stop control.
- `src/frontend/src/views/AgentDetail.vue` — Loops tab between Schedules and Playbooks.
- `src/frontend/src/utils/websocket.js` — route loop events to the store in the `data.type`-keyed branch.
- `src/frontend/e2e/loops-panel.spec.js` + `architecture.md` / `run-agent-loop.md` docs.

## Test Plan
- [x] Production `vite build` passes (no errors)
- [x] **Live verification** on local stack: Loops tab renders, Run-loop form submits, loop row appears and reaches a terminal status via the live-update path, expanded detail renders the per-run table + loop error. (The test loop showed `failed` only because the local Anthropic account had no credit balance — the loop machinery & UI handled it correctly.)
- [x] e2e spec added (`@interactive` — needs a live stack + running agent)
- [ ] CI: frontend e2e (gated by `ui` label)

## Design decisions (from `/autoplan`)
- Uses the `api.js` client (Invariant #7 + the issue AC) rather than the raw-axios pattern some sibling stores drifted to — gains the 401→/login interceptor for free.
- WS events are broadcast fleet-wide; the store filters by the mounted agent and a 12s poll backstops a dropped terminal event.

Closes #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)