### PR TITLE
feat(ui): rename Guardrails tab to Settings — sectioned config home (#1108)

### DIFF
--- a/src/frontend/src/components/settings/SettingsPanel.vue
+++ b/src/frontend/src/components/settings/SettingsPanel.vue
@@ -2,8 +2,10 @@
   <!--
     Per-agent Settings tab (#1108). Sectioned home for agent configuration.
     Each setting is its own <section> card. Adding a new section is purely
-    additive — drop another <section> below; no restructuring required.
-    Section #1 is Guardrails (GUARD-001), rendered unchanged.
+    additive — drop another <section> into the stack; no restructuring needed.
+    Section #1 is Guardrails (GUARD-001), rendered unchanged — its own p-6
+    is the card's content padding, so we don't double-pad here (avoids the
+    extra height that forced a scroller, #1108 follow-up).
 
     Growth path (each a follow-up PR, endpoints already exist):
       Behavior/Execution (/autonomy, /read-only, /timeout, model, /capacity),
@@ -11,7 +13,7 @@
       Compute/Auth (api-key, /github-pat), Git sync (/git/auto-sync,
       /git/freeze-schedules-if-failing).
   -->
-  <div class="p-6 space-y-6">
+  <div class="space-y-4">
     <!-- Section 1: Guardrails -->
     <section class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
       <GuardrailsPanel :agent-name="agentName" :notify="notify" />

--- a/src/frontend/src/components/settings/SettingsPanel.vue
+++ b/src/frontend/src/components/settings/SettingsPanel.vue
@@ -1,0 +1,35 @@
+<template>
+  <!--
+    Per-agent Settings tab (#1108). Sectioned home for agent configuration.
+    Each setting is its own <section> card. Adding a new section is purely
+    additive — drop another <section> below; no restructuring required.
+    Section #1 is Guardrails (GUARD-001), rendered unchanged.
+
+    Growth path (each a follow-up PR, endpoints already exist):
+      Behavior/Execution (/autonomy, /read-only, /timeout, model, /capacity),
+      Resources (/resources), Reliability (/circuit-breaker),
+      Compute/Auth (api-key, /github-pat), Git sync (/git/auto-sync,
+      /git/freeze-schedules-if-failing).
+  -->
+  <div class="p-6 space-y-6">
+    <!-- Section 1: Guardrails -->
+    <section class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <GuardrailsPanel :agent-name="agentName" :notify="notify" />
+    </section>
+  </div>
+</template>
+
+<script setup>
+import GuardrailsPanel from '../GuardrailsPanel.vue'
+
+defineProps({
+  agentName: {
+    type: String,
+    required: true
+  },
+  notify: {
+    type: Function,
+    default: null
+  }
+})
+</script>

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -200,9 +200,10 @@
               <FoldersPanel :agent-name="agent.name" :agent-status="agent.status" :can-share="agent.can_share" />
             </div>
 
-            <!-- Guardrails Tab Content (GUARD-001 UI, #967) -->
-            <div v-if="activeTab === 'guardrails' && agent.can_share">
-              <GuardrailsPanel :agent-name="agent.name" :notify="showNotification" />
+            <!-- Settings Tab Content (#1108) — sectioned home for per-agent
+                 config; Guardrails (GUARD-001 UI, #967) is section #1 -->
+            <div v-if="activeTab === 'settings' && agent.can_share">
+              <SettingsPanel :agent-name="agent.name" :notify="showNotification" />
             </div>
 
           </div>
@@ -281,7 +282,7 @@ import GitPanel from '../components/GitPanel.vue'
 import InfoPanel from '../components/InfoPanel.vue'
 import DashboardPanel from '../components/DashboardPanel.vue'
 import FoldersPanel from '../components/FoldersPanel.vue'
-import GuardrailsPanel from '../components/GuardrailsPanel.vue'
+import SettingsPanel from '../components/settings/SettingsPanel.vue'
 
 // Panel Components (newly extracted)
 import AgentHeader from '../components/AgentHeader.vue'
@@ -322,7 +323,14 @@ const error = ref('')
 const activeTab = ref('overview')  // #1107: Overview is the default landing tab
 // Tabs reachable via ?tab= deep-link (Timeline / EXEC-023 navigation).
 // Single source — referenced in onMounted + onActivated (#1107: dedupe + overview).
-const DEEP_LINK_TABS = ['overview', 'tasks', 'chat', 'session', 'dashboard', 'logs', 'files', 'schedules', 'credentials', 'skills', 'sharing', 'permissions', 'git', 'folders', 'info']
+const DEEP_LINK_TABS = ['overview', 'tasks', 'chat', 'session', 'dashboard', 'logs', 'files', 'schedules', 'credentials', 'skills', 'sharing', 'permissions', 'git', 'folders', 'settings', 'info']
+// Legacy ?tab= ids that moved/renamed — keep old deep-links working (#1108).
+const TAB_ALIASES = { guardrails: 'settings' }
+// Resolve a ?tab= value to a live tab id (applying aliases), or null if unknown.
+function resolveDeepLinkTab(requested) {
+  const resolved = TAB_ALIASES[requested] || requested
+  return DEEP_LINK_TABS.includes(resolved) ? resolved : null
+}
 // Tabs that need a full-viewport flex layout (input pinned to bottom).
 // Chat + Session both render ChatMessages which depends on flex-1 grow.
 const isFullscreenTab = computed(() => activeTab.value === 'chat' || activeTab.value === 'session')
@@ -651,9 +659,9 @@ const visibleTabs = computed(() => {
     tabs.push({ id: 'folders', label: 'Folders' })
   }
 
-  // Guardrails - owner-only (GUARD-001 UI, #967)
+  // Settings - owner-only (#1108); sectioned config home, Guardrails is section #1
   if (agent.value?.can_share && !isSystem) {
-    tabs.push({ id: 'guardrails', label: 'Guardrails' })
+    tabs.push({ id: 'settings', label: 'Settings' })
   }
 
   // Info at the end (reference/metadata)
@@ -1029,9 +1037,9 @@ onMounted(async () => {
 
   // Handle tab query param (from Timeline click navigation)
   if (route.query.tab) {
-    const requestedTab = route.query.tab
-    if (DEEP_LINK_TABS.includes(requestedTab)) {
-      activeTab.value = requestedTab
+    const resolvedTab = resolveDeepLinkTab(route.query.tab)
+    if (resolvedTab) {
+      activeTab.value = resolvedTab
     }
   }
 })
@@ -1053,9 +1061,9 @@ onActivated(async () => {
   // Handle tab query param (EXEC-023: Continue as Chat navigation)
   // Must also check here since onMounted doesn't fire for cached components
   if (route.query.tab) {
-    const requestedTab = route.query.tab
-    if (DEEP_LINK_TABS.includes(requestedTab)) {
-      activeTab.value = requestedTab
+    const resolvedTab = resolveDeepLinkTab(route.query.tab)
+    if (resolvedTab) {
+      activeTab.value = resolvedTab
     }
   }
 


### PR DESCRIPTION
## Summary

Renames the owner-only **Guardrails** tab to **Settings** and reframes its content as a **sectioned container**, with **Guardrails as section #1**. The tab becomes the canonical home for per-agent configuration — future settings land as additive sections rather than new top-level tabs.

Minimal structural change: tab gating and guardrails behavior are unchanged; only the label and the panel's internal layout change.

## Changes

- `views/AgentDetail.vue`
  - `visibleTabs`: `{ id: 'guardrails', label: 'Guardrails' }` → `{ id: 'settings', label: 'Settings' }`, same `agent.can_share && !isSystem` gate.
  - Tab content renders new `SettingsPanel` instead of `GuardrailsPanel` directly.
  - Deep-links: added `settings` to `DEEP_LINK_TABS`; new `TAB_ALIASES` map (`guardrails → settings`) applied via `resolveDeepLinkTab()` so existing `?tab=guardrails` links resolve to Settings. Both deep-link callsites (onMounted + onActivated) deduplicated through the resolver.
- `components/settings/SettingsPanel.vue` (new) — sectioned wrapper; renders `GuardrailsPanel` **unchanged** inside its first `<section>`. Adding a future section is purely additive (drop another `<section>`).

## Acceptance criteria

- [x] Guardrails tab renamed to **Settings** (id `settings`); same gating.
- [x] `?tab=guardrails` deep-links resolve to the Settings tab (no broken links).
- [x] Settings tab renders sectioned layout with Guardrails as section #1; `GET`/`PUT /api/agents/{name}/guardrails` behavior identical.
- [x] Adding a new section is purely additive (no restructuring).
- [x] No regression to header/other tabs; system/owner-less agents still don't see the tab.

## Verification

- Both SFCs (`AgentDetail.vue`, `SettingsPanel.vue`) parse + `compileScript` clean via `vue/compiler-sfc`.
- Full `vite build` is blocked by a **pre-existing** unrelated failure (missing `mermaid` dep in `AgentWorkspace.vue`, stale local `node_modules`) — untouched by this PR.

Pure frontend; no backend changes (all settings endpoints already exist).

Related to #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)