### PR TITLE
fix(agents): apply CPU cgroup limit on Linux (NanoCpus) + fix resource config UI (#1126)

### DIFF
--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -729,7 +729,10 @@ async def create_agent_internal(
                 tmpfs={'/tmp': 'noexec,nosuid,size=100m'},
                 network='trinity-agent-network',
                 mem_limit=config.resources.get('memory') or _get_default_resource('memory'),
-                cpu_count=int(config.resources.get('cpu') or _get_default_resource('cpu'))
+                # #1126: nano_cpus (Linux CFS quota), NOT cpu_count — the latter
+                # is Windows-only in docker-py and left NanoCpus=0, so newly
+                # created agents never got a CPU limit on Linux.
+                nano_cpus=int(config.resources.get('cpu') or _get_default_resource('cpu')) * 1_000_000_000,
             )
 
             agent_status = get_agent_status_from_container(container)

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -539,7 +539,10 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
         tmpfs={'/tmp': 'noexec,nosuid,size=100m'},
         network='trinity-agent-network',
         mem_limit=memory,
-        cpu_count=int(cpu)
+        # #1126: nano_cpus (Linux CFS quota → HostConfig.NanoCpus), NOT
+        # cpu_count — docker-py's cpu_count maps to the Windows-only CpuCount
+        # and leaves NanoCpus=0 on Linux, so the CPU limit was never enforced.
+        nano_cpus=int(cpu) * 1_000_000_000,
     )
 
     logger.info(f"Recreated container for agent {agent_name} with updated configuration")

--- a/src/backend/services/system_agent_service.py
+++ b/src/backend/services/system_agent_service.py
@@ -241,7 +241,8 @@ class SystemAgentService:
             environment=env_vars,
             labels=labels,
             mem_limit=resources.get("memory", "8g"),
-            cpu_count=int(resources.get("cpu", "4")),
+            # #1126: nano_cpus (Linux CFS quota), NOT cpu_count (Windows-only → NanoCpus=0).
+            nano_cpus=int(resources.get("cpu", "4")) * 1_000_000_000,
             restart_policy={"Name": "unless-stopped"},  # Auto-restart on failure
             # Always apply AppArmor for additional sandboxing
             security_opt=['apparmor:docker-default'],

--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -251,6 +251,8 @@
               class="font-mono w-10 text-right"
               :class="agentStats.cpu_percent > 80 ? 'text-status-danger-500' : agentStats.cpu_percent > 50 ? 'text-status-warning-500' : 'text-status-success-500'"
             >{{ agentStats.cpu_percent }}%</span>
+            <!-- #1126: configured core ceiling, so live % reads against capacity -->
+            <span class="text-gray-400 dark:text-gray-500 font-mono">/ {{ resourceLimits.current_cpu || '2' }} cores</span>
           </div>
           <!-- Memory -->
           <div class="flex items-center space-x-1.5">
@@ -266,6 +268,8 @@
               class="font-mono w-14 text-right"
               :class="agentStats.memory_percent > 80 ? 'text-status-danger-500' : agentStats.memory_percent > 50 ? 'text-status-warning-500' : 'text-status-success-500'"
             >{{ formatBytes(agentStats.memory_used_bytes) }}</span>
+            <!-- #1126: configured max memory, so live usage reads against the ceiling -->
+            <span class="text-gray-400 dark:text-gray-500 font-mono">/ {{ (resourceLimits.current_memory || '4g').toUpperCase() }}</span>
           </div>
           <!-- Uptime -->
           <div class="text-gray-500 dark:text-gray-400 font-mono w-16 text-right">

--- a/src/frontend/src/components/ResourceModal.vue
+++ b/src/frontend/src/components/ResourceModal.vue
@@ -34,17 +34,25 @@
           </div>
         </div>
 
+        <!-- Load-error banner (#1126): the GET failed, so the selects below may
+             show stale defaults rather than the agent's real values. -->
+        <div v-if="resourceLimits.error" class="mt-4 p-3 bg-status-danger-50 dark:bg-status-danger-900/30 border border-status-danger-200 dark:border-status-danger-800 rounded-lg">
+          <p class="text-sm text-status-danger-700 dark:text-status-danger-300">
+            Could not load current resource limits — showing defaults. {{ resourceLimits.error }}
+          </p>
+        </div>
+
         <!-- Resource Configuration Form -->
         <div class="mt-5 space-y-4">
           <div>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Memory</label>
             <select
-              :value="resourceLimits.memory"
+              :value="resourceLimits.memory ?? resourceLimits.current_memory"
               @change="$emit('update:memory', $event.target.value || null)"
               :disabled="loading"
               class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-action-primary-500 focus:border-action-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
             >
-              <option :value="null">Default ({{ resourceLimits.current_memory || '4g' }})</option>
+              <option value="">Inherit default ({{ resourceLimits.current_memory || '4g' }})</option>
               <option value="1g">1 GB</option>
               <option value="2g">2 GB</option>
               <option value="4g">4 GB</option>
@@ -57,12 +65,12 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">CPU Cores</label>
             <select
-              :value="resourceLimits.cpu"
+              :value="resourceLimits.cpu ?? resourceLimits.current_cpu"
               @change="$emit('update:cpu', $event.target.value || null)"
               :disabled="loading"
               class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-action-primary-500 focus:border-action-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
             >
-              <option :value="null">Default ({{ resourceLimits.current_cpu || '2' }})</option>
+              <option value="">Inherit default ({{ resourceLimits.current_cpu || '2' }})</option>
               <option value="1">1 Core</option>
               <option value="2">2 Cores</option>
               <option value="4">4 Cores</option>

--- a/src/frontend/src/composables/useAgentSettings.js
+++ b/src/frontend/src/composables/useAgentSettings.js
@@ -19,7 +19,8 @@ export function useAgentSettings(agentRef, agentsStore, showNotification) {
     cpu: null,
     current_memory: '4g',
     current_cpu: '2',
-    restart_needed: false
+    restart_needed: false,
+    error: null
   })
   const resourceLimitsLoading = ref(false)
 
@@ -84,15 +85,24 @@ export function useAgentSettings(agentRef, agentsStore, showNotification) {
         cpu: result.cpu,
         current_memory: result.current_memory || '4g',
         current_cpu: result.current_cpu || '2',
-        restart_needed: false
+        restart_needed: false,
+        error: null
       }
     } catch (err) {
+      // #1126: surface the failure instead of silently leaving stale defaults.
+      // The ResourceModal renders resourceLimits.error as a banner.
       console.error('Failed to load resource limits:', err)
+      resourceLimits.value = {
+        ...resourceLimits.value,
+        error: err?.response?.data?.detail || err?.message || 'Request failed',
+      }
     }
   }
 
+  // #1126: returns true on success / false on failure so the caller can avoid
+  // restarting the agent after a save that didn't persist.
   const updateResourceLimits = async () => {
-    if (resourceLimitsLoading.value) return
+    if (resourceLimitsLoading.value) return false
     resourceLimitsLoading.value = true
     try {
       const result = await agentsStore.setResourceLimits(
@@ -102,8 +112,10 @@ export function useAgentSettings(agentRef, agentsStore, showNotification) {
       )
       resourceLimits.value.restart_needed = result.restart_needed
       showNotification(result.message, 'success')
+      return true
     } catch (err) {
       showNotification(err.message || 'Failed to update resource limits', 'error')
+      return false
     } finally {
       resourceLimitsLoading.value = false
     }

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -571,24 +571,68 @@ const {
 } = useAgentSettings(agent, agentsStore, showNotification)
 
 // Save resource limits and restart agent if needed
+// #1126: poll the agent's real status until it reaches one of `targets`, or
+// timeout. Returns true if reached. Tolerates transient fetch errors mid-stop.
+async function waitForAgentStatus(targets, timeoutMs = 30000, intervalMs = 1000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const a = await agentsStore.fetchAgent(agent.value.name)
+      if (a) {
+        agent.value = a
+        if (targets.includes(a.status)) return true
+      }
+    } catch (_) {
+      // transient (container mid-teardown) — keep polling
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs))
+  }
+  return false
+}
+
 async function saveResourceLimits() {
-  // Check if values actually changed
+  // Check if values actually changed. Compare against the effective (current_*)
+  // values; an empty override means "inherit", which equals current.
   const newMemory = resourceLimits.value.memory || resourceLimits.value.current_memory
   const newCpu = resourceLimits.value.cpu || resourceLimits.value.current_cpu
   const oldMemory = resourceLimits.value.current_memory
   const oldCpu = resourceLimits.value.current_cpu
   const valuesChanged = newMemory !== oldMemory || newCpu !== oldCpu
 
-  await updateResourceLimits()
+  // #1126: don't restart if the save didn't actually persist.
+  const saved = await updateResourceLimits()
+  if (!saved) return  // composable already surfaced the error
   showResourceModal.value = false
 
-  // If values changed and agent is running, restart it
+  // If values changed and agent is running, restart it to apply the new limits.
   if (valuesChanged && agent.value?.status === 'running') {
     showNotification('Restarting agent to apply new resource limits...', 'info')
-    await stopAgent()
-    // Wait a moment for container to fully stop
-    await new Promise(resolve => setTimeout(resolve, 1000))
-    await startAgent()
+    try {
+      await stopAgent()
+      // #1126: gate the start on the container actually being stopped rather
+      // than a fixed 1s sleep (insufficient under load → "sometimes works").
+      const stopped = await waitForAgentStatus(['stopped', 'exited', 'created'])
+      if (!stopped) {
+        showNotification(
+          'Agent did not stop within 30s — not restarting automatically. Start it manually to apply the new limits.',
+          'error',
+        )
+        return
+      }
+      await startAgent()
+      // Refresh effective values so the header/dialog reflect the applied limits.
+      await loadAgent()
+      await loadResourceLimits()
+      showNotification('Agent restarted with new resource limits.', 'success')
+    } catch (err) {
+      showNotification(
+        `Restart failed: ${err?.message || err}. The agent may be stopped — start it manually.`,
+        'error',
+      )
+    }
+  } else {
+    // No restart needed — still refresh the effective values shown in the UI.
+    await loadResourceLimits()
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the per-agent CPU/memory resource configuration end-to-end. The headline is the **confirmed backend bug** (DevOps inspection in the issue): CPU limits were **never enforced on Linux** for any agent.

## Backend — CPU limit never applied (root cause)

Every container-creation site passed `cpu_count` to docker-py, which maps to the **Windows-only** `HostConfig.CpuCount` and leaves `NanoCpus=0` on Linux — so the cgroup was unconstrained for **every** agent (created, recreated, and system). Memory was fine because `mem_limit` is the correct Linux parameter (consistent with the bug being CPU-only).

Replaced `cpu_count=int(cores)` → `nano_cpus=int(cores) * 1_000_000_000` (Linux CFS quota → `HostConfig.NanoCpus`) at all three sites:
- `services/agent_service/crud.py` (agent creation)
- `services/agent_service/lifecycle.py` (restart/recreate)
- `services/system_agent_service.py` (system agent)

## Frontend

- **`ResourceModal.vue`** — selects now pre-select the **effective** value (`cpu ?? current_cpu`, `memory ?? current_memory`) instead of the DB override (which is `null` until explicitly set, hence the blank/`Default`-only dialog). The null option becomes an explicit **"Inherit default (Xg)"**. Adds a load-error banner.
- **`useAgentSettings.js`** — `loadResourceLimits` records `error` (rendered in the modal) instead of swallowing to `console.error`; `updateResourceLimits` returns a success boolean.
- **`AgentHeader.vue`** — shows the **configured** core count + max memory next to the live CPU/MEM gauges while running (previously only when stopped), so live usage reads against the ceiling.
- **`AgentDetail.saveResourceLimits`** — gates the restart on the container actually reaching a stopped state (poll via `fetchAgent`, 30s cap) instead of a fixed 1s sleep; skips the restart if the save didn't persist; reports restart failures to the user instead of silently leaving the agent stopped.

## Acceptance criteria

- [x] Changing CPU cores → non-zero `HostConfig.NanoCpus` matching the configured count (verified `docker inspect`).
- [x] CPU limits applied at **creation** too (all three sites), not only reconfigure.
- [x] Header shows configured cores + max memory at all times (running and stopped).
- [x] Dialog pre-selects the effective CPU/memory values (no blank/`Default`-only).
- [x] Failed load surfaces a visible error instead of silent defaults.
- [x] Apply restarts reliably — start gated on the container being stopped (poll, not fixed sleep), with failure reported.
- [x] After apply, container labels and DB limits agree (recreate-on-restart already syncs labels; the cgroup was the missing piece).
- [ ] Optional capacity-pressure hint — deferred (issue marks it drop-if-not-easy).

## Verification (live)

| Step | Before | After |
|------|--------|-------|
| running agent | `NanoCpus=0`, `CpuCount=2` (ineffective) | — |
| PUT cpu=1 + restart | — | `NanoCpus=1000000000`, `label.cpu=1`, Mem unchanged |
| restore cpu=2 + restart | — | `NanoCpus=2000000000`, `label.cpu=2` |

Memory limit (`HostConfig.Memory`) correct throughout. UI files compile via `vue/compiler-sfc`. Test agent restored to its original 2 CPU / 4g.

Related to #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)