### PR TITLE
fix(e2e): repair smoke drift from #1109 + neutralize ensure-default modal race (#1134)

### DIFF
--- a/src/frontend/e2e/api-keys-copy.spec.js
+++ b/src/frontend/e2e/api-keys-copy.spec.js
@@ -18,9 +18,28 @@ import { test, expect } from '@playwright/test'
 const MCP_KEYS_ROUTE = '/settings?tab=mcp-keys'
 
 test.describe('@smoke api-keys copy buttons (#677, #859)', () => {
-  test.beforeEach(async ({ context }) => {
+  test.beforeEach(async ({ context, page }) => {
     // Headless browsers gate clipboard read by default — opt in for the test.
     await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    // #1134: McpKeysTab's onMounted fires POST /api/mcp/keys/ensure-default;
+    // when no user-scoped key exists it auto-creates "Default MCP Key" and
+    // opens the "Your MCP API Key is Ready!" modal at an arbitrary point
+    // mid-test — both modals are `fixed z-10 inset-0`, so the auto-modal
+    // lands on top and intercepts the Create click. Neutralize the race:
+    // call ensure-default ourselves, then reload — the remounted page's own
+    // ensure-default is a guaranteed no-op, so the auto-modal can never
+    // appear during the test body.
+    await page.goto(MCP_KEYS_ROUTE)
+    const token = await page.evaluate(() => localStorage.getItem('token'))
+    if (token) {
+      await page.request
+        .post('/api/mcp/keys/ensure-default', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        .catch(() => {})
+    }
+    await page.reload()
   })
 
   test('Copy Config button writes MCP JSON to clipboard', async ({ page }) => {

--- a/src/frontend/e2e/smoke.spec.js
+++ b/src/frontend/e2e/smoke.spec.js
@@ -25,11 +25,13 @@ test.describe('smoke', () => {
   })
 
   test('@smoke operating room page loads', async ({ page }) => {
+    // #1109/#1134: /operating-room is a legacy redirect to /operations.
+    // Navigating the old path also covers the redirect itself.
     await page.goto('/operating-room')
-    // Either a queue list, filters, an empty state, or the title.
-    await expect(
-      page.getByText(/operating|queue|priority|all types|no items/i).first()
-    ).toBeVisible({ timeout: 10000 })
+    await expect(page).toHaveURL(/\/operations/, { timeout: 10000 })
+    await expect(page.getByRole('heading', { name: 'Operations' })).toBeVisible({ timeout: 10000 })
+    // Tab strip confirms the view mounted (not just the route resolved).
+    await expect(page.getByRole('button', { name: 'Needs Response' })).toBeVisible()
   })
 
   test('@smoke templates page loads', async ({ page }) => {


### PR DESCRIPTION
## Summary

`frontend-e2e` has been silently red on dev since 2026-06-10 — first failure on the #1114 run, before #1133 existed — because the workflow only runs on `ui`-labelled PRs and recent UI PRs merged without the label. Two pre-existing test issues, both test-only fixes:

## 1. `smoke.spec.js` — operating room (assertion drift from #1109)

`/operating-room` redirects to `/operations` since #1109; the page's visible text (heading **Operations**, tabs, "All clear…") matches none of the old `/operating|queue|priority|all types|no items/` patterns. The redirect itself works fine — verified via run artifacts. New assertions: redirect URL + Operations heading + `Needs Response` tab, so the test now also covers the legacy redirect.

## 2. `api-keys-copy.spec.js` — ensure-default modal race

`McpKeysTab.vue` `onMounted` fires `POST /api/mcp/keys/ensure-default`; with no user-scoped key present it auto-creates **Default MCP Key** and opens the "Your MCP API Key is Ready!" modal at an arbitrary point mid-test. Both that modal and the test's Create modal are `fixed z-10 inset-0`, so the later DOM node (auto-modal) intercepts the Create click for the full 30s budget — run-artifact screenshot shows the auto-modal covering the form. `beforeEach` now calls `ensure-default` via `page.request` and reloads, making the remounted page's own call a guaranteed no-op. Bonus: test 1's clipboard assertions previously could pass against the *auto* modal (same buttons, format-only checks); they now always exercise the test's own key modal.

## Verification

- Root cause evidence: identical failures on the #1114 run (vanilla vue-router 4 / vite 6) and the #1133 run — artifacts (a11y snapshot + screenshot) show the auto-modal overlay and the Operations page text.
- This PR carries the `ui` label, so `frontend-e2e` runs here and must be green to merge.

Unblocks #1133 (which re-runs e2e on top of this fix).

Fixes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)