### PR TITLE
chore(ci): point Dependabot version updates at dev, not main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,15 @@
 version: 2
+# All version-update PRs target `dev` per the SDLC (feature → dev → main).
+# Note: Dependabot reads this file from the DEFAULT branch (main), so changes
+# here only take effect after a release cut. Security updates ignore
+# target-branch and still go to main by GitHub design.
 updates:
   # GitHub Actions: catch new SHAs for already-pinned third-party actions and
   # flag CVEs in first-party actions. Weekly cadence — security PRs from
   # Dependabot are auto-grouped by ecosystem so review burden stays low.
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     labels:
@@ -14,6 +19,7 @@ updates:
   # Frontend (Vite + Vue): catches Vue / Vite / Chart.js / DOMPurify CVEs.
   - package-ecosystem: npm
     directory: /src/frontend
+    target-branch: dev
     schedule:
       interval: weekly
     labels:
@@ -30,6 +36,7 @@ updates:
   # this entry continues that cadence.
   - package-ecosystem: pip
     directory: /src/backend
+    target-branch: dev
     schedule:
       interval: weekly
     labels:
@@ -44,6 +51,7 @@ updates:
   # MCP server (TypeScript).
   - package-ecosystem: npm
     directory: /src/mcp-server
+    target-branch: dev
     schedule:
       interval: weekly
     labels:
@@ -65,6 +73,7 @@ updates:
       - /docker/backend
       - /docker/frontend
       - /docker/scheduler
+    target-branch: dev
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
## Summary

All six currently-open Dependabot PRs target `main` because `.github/dependabot.yml` never set `target-branch` — Dependabot defaults to the repo default branch. That violates the feature → dev → main SDLC and leaves the bumps perpetually conflicting with dev-first changes (e.g. #1014's lockfile conflict).

## Changes

- Add `target-branch: dev` to all five ecosystem blocks (github-actions, frontend npm, backend pip, mcp-server npm, docker).
- Header comment documenting the two GitHub-side caveats:
  - Dependabot reads this file from the **default branch**, so the change activates at the next release cut (dev → main).
  - **Security** updates ignore `target-branch` by design and will still target `main` — acceptable, they're rare and urgent.

## Rollout

1. Merge this to dev.
2. Existing main-targeting Dependabot PRs are closed (closed versions are not re-raised against the same branch).
3. On the next release cut, the config lands on main — GitHub triggers an immediate Dependabot run for edited ecosystems, recreating the still-relevant bumps against dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)