### PR TITLE
fix: replace retired gemini-2.0-flash with env-configurable model (#1130)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,15 @@ GEMINI_API_KEY=
 # May be the same value as GEMINI_API_KEY.
 GOOGLE_API_KEY=
 
+# Gemini model overrides (#1130) — set these if Google retires the built-in
+# default (both default to gemini-3.5-flash, set in src/backend/config.py).
+# Two vars because the modalities differ: TEXT is text-only (image-gen prompt
+# refinement), TRANSCRIPTION needs inline-audio support (Telegram voice).
+# Leave commented unless overriding — an uncommented empty value exports ""
+# which shadows the default (#1076).
+# GEMINI_TEXT_MODEL=gemini-3.5-flash
+# GEMINI_TRANSCRIPTION_MODEL=gemini-3.5-flash
+
 # ===========================================
 # VOICE & VoIP TELEPHONY (Optional - VOICE-001 / VOIP-001)
 # ===========================================

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,11 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}  # For Gemini-powered agents
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # For platform image generation (IMG-001)
+      # Gemini model overrides (#1130) — mirrors docker-compose.yml; without these
+      # lines the env knobs are inert in prod (#1039 packaging-gap class). Non-empty
+      # defaults so an unset var doesn't inject "" (#1076).
+      - GEMINI_TEXT_MODEL=${GEMINI_TEXT_MODEL:-gemini-3.5-flash}              # image-gen prompt refinement
+      - GEMINI_TRANSCRIPTION_MODEL=${GEMINI_TRANSCRIPTION_MODEL:-gemini-3.5-flash}  # Telegram voice transcription
       # Voice chat (VOICE-001) — mirrors docker-compose.yml so operators can
       # tune/disable voice in prod (code default is ON; without these lines the
       # knobs are inert — the #1039 packaging-gap class).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}  # For Gemini-powered agents
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # For platform image generation (IMG-001)
+      # Gemini model overrides (#1130) — non-empty defaults so an unset var doesn't inject "" (#1076)
+      - GEMINI_TEXT_MODEL=${GEMINI_TEXT_MODEL:-gemini-3.5-flash}              # image-gen prompt refinement
+      - GEMINI_TRANSCRIPTION_MODEL=${GEMINI_TRANSCRIPTION_MODEL:-gemini-3.5-flash}  # Telegram voice transcription
       - VOICE_MODEL=${VOICE_MODEL:-models/gemini-3.1-flash-live-preview}  # Gemini Live model override (#1076: non-empty default so an unset var doesn't inject "")
       - VOICE_ENABLED=${VOICE_ENABLED:-true}  # Voice mode (default on when GEMINI_API_KEY set)
       - WORKSPACE_ENABLED=${WORKSPACE_ENABLED:-false}  # Voice Workspace canvas — opt-in BETA (#860)

--- a/docs/memory/feature-flows/agent-avatars.md
+++ b/docs/memory/feature-flows/agent-avatars.md
@@ -244,7 +244,7 @@ The avatar generation uses the shared image generation service (IMG-001).
 **File**: `src/backend/services/image_generation_service.py`
 
 **Models** (lines 29-30):
-- Text model (prompt refinement): `gemini-2.0-flash` (fast text generation)
+- Text model (prompt refinement): `GEMINI_TEXT_MODEL` (default `gemini-3.5-flash`, env-overridable — #1130)
 - Image model (image generation): `gemini-3.1-flash-image-preview` (latest image model)
 
 **Generate flow** (`generate_image()`, line 71):

--- a/docs/memory/feature-flows/image-generation.md
+++ b/docs/memory/feature-flows/image-generation.md
@@ -63,7 +63,7 @@ router = APIRouter(prefix="/api/images", tags=["images"])
   {
       "available": true,
       "models": {
-          "text_refinement": "gemini-2.0-flash",
+          "text_refinement": "gemini-3.5-flash",
           "image_generation": "gemini-3.1-flash-image-preview"
       },
       "default_model": "gemini-3.1-flash-image-preview",
@@ -88,7 +88,7 @@ Singleton service accessed via `get_image_generation_service()` (line 395).
 **Constants** (lines 29-35):
 | Constant | Value |
 |----------|-------|
-| `GEMINI_TEXT_MODEL` | `gemini-2.0-flash` |
+| `GEMINI_TEXT_MODEL` | `gemini-3.5-flash` (env-overridable, defined in `config.py` — #1130) |
 | `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` |
 | `GEMINI_API_BASE` | `https://generativelanguage.googleapis.com/v1beta/models` |
 | `PROMPT_REFINEMENT_TIMEOUT` | 30 seconds |
@@ -114,7 +114,7 @@ Main entry point. Parameters: `prompt`, `use_case`, `aspect_ratio`, `refine_prom
    - Returns `ImageGenerationResult` dataclass with image bytes, mime type, and metadata
 
 #### _call_gemini_text() (line 183)
-- **URL**: `{GEMINI_API_BASE}/gemini-2.0-flash:generateContent`
+- **URL**: `{GEMINI_API_BASE}/{GEMINI_TEXT_MODEL}:generateContent`
 - **Auth**: `x-goog-api-key` header with `GEMINI_API_KEY`
 - **Config**: temperature 0.7, maxOutputTokens 512
 - **Response parsing**: `data["candidates"][0]["content"]["parts"][0]["text"]`
@@ -244,10 +244,12 @@ Used by `avatar.py:_generate_emotions_background()` to build emotion-specific pr
 
 ### Configuration
 **File**: `src/backend/config.py`
-- **Line 103**: `GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")`
+- `GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")`
+- `GEMINI_TEXT_MODEL = os.getenv("GEMINI_TEXT_MODEL") or "gemini-3.5-flash"` -- prompt-refinement model, env-overridable (#1130; `or`-coalesce per #1076 so an empty var can't shadow the default)
 
-**File**: `docker-compose.yml`
-- **Line 20**: `GEMINI_API_KEY=${GEMINI_API_KEY:-}` -- Passed through from host `.env` to backend container
+**Files**: `docker-compose.yml` + `docker-compose.prod.yml`
+- `GEMINI_API_KEY=${GEMINI_API_KEY:-}` -- Passed through from host `.env` to backend container
+- `GEMINI_TEXT_MODEL=${GEMINI_TEXT_MODEL:-gemini-3.5-flash}` -- non-empty default (#1130)
 
 ---
 

--- a/docs/memory/feature-flows/telegram-integration.md
+++ b/docs/memory/feature-flows/telegram-integration.md
@@ -142,7 +142,7 @@ Two routers are registered in `main.py:523-524`:
 - `process_photo(bot_token, photo_sizes)` (line 93) — Downloads largest photo, saves to temp file, returns size description. Temp file always cleaned up.
 - `process_document(bot_token, document)` (line 127) — Downloads and extracts text from plain text files (.txt, .md, .csv, .json, .py, etc.). Truncates at 10,000 chars. Non-text files get metadata-only description.
 - `process_voice(bot_token, voice)` (line 170) — **NEW (Issue #318)**: Downloads OGG voice message and transcribes via Gemini API. **Limits**: 5 minutes max duration, 10MB max size. Returns `🎙️ "transcribed text"` or error placeholder. Falls back to placeholder if GEMINI_API_KEY not configured.
-- `_transcribe_audio_gemini(audio_data, mime_type)` (line 209) — Internal: Calls Gemini 2.0 Flash with inline audio for transcription.
+- `_transcribe_audio_gemini(audio_data, mime_type)` (line 220) — Internal: Calls the configured Gemini model (`GEMINI_TRANSCRIPTION_MODEL`, default `gemini-3.5-flash`, env-overridable — #1130) with inline audio for transcription.
 
 ### Message Router: `src/backend/adapters/message_router.py`
 
@@ -921,3 +921,4 @@ The `GeminiRuntime` and `AgentRuntime` ABC gained an `images` parameter (ignored
 | 2026-04-18 | #318: Voice transcription via Gemini. `process_voice()` in telegram_media.py, voice processing hook in message_router.py. Limits: 5 min duration, 10MB size. 22 unit tests. |
 | 2026-04-25 | #487 Phase 2: workspace delivery hardened. New `_sanitize_filename` helper (NFKC + basename + safe-chars + 200-char truncation + collision dedup). Chat injection format `[File uploaded by {uploader}]: {name} ({size}) saved to {path}`. All-writes-failed now replies via channel and aborts execution. Audit entries include `uploader`. 16 new tests (27 total in `test_file_upload.py`). |
 | 2026-04-28 | #562: Vision delivery fixed. Replaced broken base64 data URI text embedding with proper `--input-format stream-json` vision content blocks delivered via Claude CLI stdin. `_handle_file_uploads` returns 4-tuple with `image_data`. `GeminiRuntime` and `AgentRuntime` ABC updated to accept `images` param. 17 new tests in `test_channel_image_vision.py`. |
+| 2026-06-10 | #1130: Transcription model no longer hardcoded. Google retired `gemini-2.0-flash` (404 on every voice message); `_transcribe_audio_gemini` now uses `GEMINI_TRANSCRIPTION_MODEL` from config.py (default `gemini-3.5-flash`, env-overridable, #1076 empty-string-safe wiring in both compose files). Explicit retired-model log hint on 404. |

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -125,6 +125,16 @@ VOICE_ENABLED = os.getenv("VOICE_ENABLED", "true").lower() == "true"
 VOICE_MODEL = os.getenv("VOICE_MODEL") or "models/gemini-3.1-flash-live-preview"
 VOICE_MAX_DURATION = int(os.getenv("VOICE_MAX_DURATION", "300"))  # seconds
 
+# Gemini text/audio models (#1130). Hardcoded `gemini-2.0-flash` was retired by
+# Google (404 NOT_FOUND) with no config escape hatch — these env overrides make
+# the next model retirement a config change instead of a code change. Same `or`
+# coalesce as VOICE_MODEL above (#1076): empty string must not shadow the default.
+# Two separate vars because the modalities can diverge: TEXT is text-only
+# (image-gen prompt refinement), TRANSCRIPTION needs inline-audio support
+# (Telegram voice messages). Both default to the same model today.
+GEMINI_TEXT_MODEL = os.getenv("GEMINI_TEXT_MODEL") or "gemini-3.5-flash"
+GEMINI_TRANSCRIPTION_MODEL = os.getenv("GEMINI_TRANSCRIPTION_MODEL") or "gemini-3.5-flash"
+
 # VoIP Telephony Configuration (VOIP-001, #1056 — Phase 1, outbound)
 # Default OFF — mirrors the workspace_available opt-in (#860). The feature
 # also requires a per-agent voip_bindings row to function. `voip_available`

--- a/src/backend/routers/image_generation.py
+++ b/src/backend/routers/image_generation.py
@@ -14,10 +14,10 @@ from pydantic import BaseModel
 
 from dependencies import get_current_user
 from models import User
+from config import GEMINI_TEXT_MODEL
 from services.image_generation_service import (
     get_image_generation_service,
     GEMINI_IMAGE_MODEL,
-    GEMINI_TEXT_MODEL,
 )
 from services.image_generation_prompts import VALID_ASPECT_RATIOS, VALID_USE_CASES
 

--- a/src/backend/services/image_generation_service.py
+++ b/src/backend/services/image_generation_service.py
@@ -2,7 +2,8 @@
 Platform-level image generation service (IMG-001).
 
 Two-step pipeline:
-1. Prompt refinement — Gemini 2.0 Flash (text) rewrites the raw prompt using best practices
+1. Prompt refinement — the configured Gemini text model (GEMINI_TEXT_MODEL) rewrites
+   the raw prompt using best practices
 2. Image generation — Gemini 3.1 Flash Image Preview produces the actual image
 
 Other code (routers, services, MCP tools, agents) calls:
@@ -16,7 +17,7 @@ from typing import Optional
 
 import httpx
 
-from config import GEMINI_API_KEY
+from config import GEMINI_API_KEY, GEMINI_TEXT_MODEL
 from services.image_generation_prompts import (
     USE_CASE_PROMPTS,
     VALID_ASPECT_RATIOS,
@@ -25,8 +26,7 @@ from services.image_generation_prompts import (
 
 logger = logging.getLogger(__name__)
 
-# Gemini API configuration
-GEMINI_TEXT_MODEL = "gemini-2.0-flash"
+# Gemini API configuration (text model lives in config.py — env-overridable, #1130)
 GEMINI_IMAGE_MODEL = "gemini-3.1-flash-image-preview"
 GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
@@ -156,7 +156,19 @@ class ImageGenerationService:
                 refined = await self.refine_prompt(prompt, use_case, aspect_ratio)
                 logger.info(f"{log_prefix} Refined prompt: {refined[:100]}...")
             except Exception as e:
-                logger.warning(f"{log_prefix} Prompt refinement failed, using raw prompt: {e}")
+                # 404 here usually means Google retired the model (#1130) —
+                # recoverable by config, no code change needed. Anchored on
+                # _call_gemini_text's own raise format to avoid misfiring on
+                # transport errors that happen to contain "404".
+                if "API error 404" in str(e):
+                    logger.error(
+                        f"{log_prefix} Prompt refinement failed, using raw prompt: "
+                        f"model '{GEMINI_TEXT_MODEL}' not found — it may have been "
+                        f"retired by Google. Set the GEMINI_TEXT_MODEL env var to a "
+                        f"current model. {e}"
+                    )
+                else:
+                    logger.warning(f"{log_prefix} Prompt refinement failed, using raw prompt: {e}")
                 refined = prompt
 
         # Step 2: Image generation

--- a/src/backend/services/telegram_media.py
+++ b/src/backend/services/telegram_media.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from config import GEMINI_API_KEY
+from config import GEMINI_API_KEY, GEMINI_TRANSCRIPTION_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +229,7 @@ async def _transcribe_audio_gemini(audio_data: bytes, mime_type: str = "audio/og
         client = genai.Client(api_key=GEMINI_API_KEY)
 
         response = await client.aio.models.generate_content(
-            model="gemini-2.0-flash",
+            model=GEMINI_TRANSCRIPTION_MODEL,
             contents=[
                 {
                     "parts": [
@@ -256,5 +256,14 @@ async def _transcribe_audio_gemini(audio_data: bytes, mime_type: str = "audio/og
         return None
 
     except Exception as e:
-        logger.error(f"Gemini transcription error: {e}", exc_info=True)
+        # 404 NOT_FOUND here usually means Google retired the model (#1130) —
+        # recoverable by config, no code change needed.
+        if "404" in str(e) or "NOT_FOUND" in str(e):
+            logger.error(
+                f"Gemini transcription error: model '{GEMINI_TRANSCRIPTION_MODEL}' "
+                f"not found — it may have been retired by Google. Set the "
+                f"GEMINI_TRANSCRIPTION_MODEL env var to a current model. {e}"
+            )
+        else:
+            logger.error(f"Gemini transcription error: {e}", exc_info=True)
         return None

--- a/tests/test_image_generation.py
+++ b/tests/test_image_generation.py
@@ -72,6 +72,16 @@ class TestImageModelsEndpoint:
         assert data["default_model"] == data["models"]["image_generation"]
 
     @pytest.mark.smoke
+    def test_text_refinement_model_not_retired(self, api_client: TrinityApiClient):
+        """Regression guard (#1130): the text-refinement model must not be a
+        Gemini generation Google has retired (gemini-2.0-* / gemini-1.x 404)."""
+        response = api_client.get("/api/images/models")
+        assert_status(response, 200)
+        model = response.json()["models"]["text_refinement"]
+        assert not model.startswith("gemini-2.0"), f"retired model configured: {model}"
+        assert not model.startswith("gemini-1."), f"retired model configured: {model}"
+
+    @pytest.mark.smoke
     def test_get_models_availability_is_boolean(self, api_client: TrinityApiClient):
         """GET /api/images/models 'available' field is a boolean."""
         response = api_client.get("/api/images/models")


### PR DESCRIPTION
## Summary
- Google retired `gemini-2.0-flash` (404 NOT_FOUND) — every Telegram voice message failed transcription and image-gen prompt refinement silently degraded to the raw prompt. Both model ids were hardcoded with no operator workaround.
- New `GEMINI_TEXT_MODEL` / `GEMINI_TRANSCRIPTION_MODEL` constants in `config.py`, defaulting to `gemini-3.5-flash` (live-verified for both text and inline-audio; `gemini-2.5-flash` was rejected because it carries an announced Oct 2026 shutdown — defaulting to it would schedule a rerun of this incident).
- Env wiring follows the #1076 `VOICE_MODEL` empty-string-safe pattern exactly: `os.getenv(...) or "default"` in code, `${VAR:-default}` in **both** compose files, commented-out `.env.example` entries.
- Explicit retired-model log hints on 404 in both call paths, so the next retirement is a same-day config fix instead of a user-reported bug.

## Changes
- `src/backend/config.py` — the two new env-overridable constants
- `src/backend/services/telegram_media.py` — configurable transcription model + 404 hint
- `src/backend/services/image_generation_service.py` — constant moved to config, 404 hint, docstring fix
- `src/backend/routers/image_generation.py` — import updated (was importing the constant from the service)
- `docker-compose.yml` + `docker-compose.prod.yml` — env passthrough with non-empty defaults
- `.env.example` — both vars documented (commented out)
- `tests/test_image_generation.py` — retired-model regression guard
- `docs/memory/feature-flows/` — image-generation, telegram-integration, agent-avatars synced

## Test Plan
- [x] `gemini-3.5-flash` live-verified pre-merge on both modalities (text generateContent + inline-audio transcription with the exact prompt contract)
- [x] Backend container recreated; env vars confirmed inside container; `GET /api/images/models` returns `gemini-3.5-flash`
- [x] Real `_transcribe_audio_gemini` code path exercised in-container against live Gemini — no 404
- [x] `pytest tests/test_image_generation.py -m smoke` — 22/22 pass (incl. new regression guard)
- [x] Both compose files validate (`docker compose config --quiet`)
- [x] Pre-landing review + CSO --diff: no critical findings; both should-fixes applied (prod compose wiring, tightened 404 anchor)

## Follow-up
- #1137 — agent-server model allowlist still offers retired models (different deploy surface, needs base-image rebuild)

Fixes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)