### PR TITLE
fix(agent-server): drop retired Gemini models from /api/model allowlist (#1137)

### DIFF
--- a/docker/base-image/agent_server/routers/chat.py
+++ b/docker/base-image/agent_server/routers/chat.py
@@ -193,8 +193,8 @@ async def get_model():
         return {
             "model": agent_state.current_model,
             "runtime": runtime,
-            "available_models": ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
-            "note": "Gemini models. 2.5-pro has 1M context window."
+            "available_models": ["gemini-3-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"],
+            "note": "Gemini models. 3-pro is the most capable; 3-flash is the fast default."
         }
     else:
         return {
@@ -214,7 +214,7 @@ async def set_model(request: ModelRequest):
 
     # Validate based on runtime
     if runtime == "gemini-cli" or runtime == "gemini":
-        valid_models = ["gemini-3-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"]
+        valid_models = ["gemini-3-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"]
         if request.model in valid_models or request.model.startswith("gemini-"):
             agent_state.current_model = request.model
             logger.info(f"Model changed to: {request.model}")
@@ -226,7 +226,7 @@ async def set_model(request: ModelRequest):
         else:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid Gemini model: {request.model}. Use: gemini-2.5-pro, gemini-2.5-flash, etc."
+                detail=f"Invalid Gemini model: {request.model}. Use: gemini-3-pro, gemini-3-flash, gemini-2.5-pro, gemini-2.5-flash."
             )
     else:
         # Claude Code validation

--- a/docker/base-image/agent_server/services/gemini_runtime.py
+++ b/docker/base-image/agent_server/services/gemini_runtime.py
@@ -52,6 +52,8 @@ GEMINI_PRICING = {
         "input": 0.0003,    # $0.30 per 1M = $0.0003 per 1K
         "output": 0.0025,   # $2.50 per 1M = $0.0025 per 1K
     },
+    # Historical (retired by Google; kept only so cost calc of older
+    # executions still resolves — not offered in the /api/model lists, #1137)
     "gemini-2.0-flash": {
         "input": 0.0001,    # $0.10 per 1M = $0.0001 per 1K
         "output": 0.0004,   # $0.40 per 1M = $0.0004 per 1K


### PR DESCRIPTION
## Summary

Follow-up from #1130. The agent-server model endpoints in `docker/base-image/agent_server/routers/chat.py` still advertised retired Gemini models — a `gemini-cli` runtime agent could pick one and get a 404 from Google at runtime.

## Changes

- **`GET /api/model`** `available_models`: `gemini-2.0-flash` → live set `[gemini-3-pro, gemini-3-flash, gemini-2.5-pro, gemini-2.5-flash]`; note updated.
- **`PUT /api/model`** `valid_models`: dropped `gemini-2.0-flash`, `gemini-1.5-pro`, `gemini-1.5-flash`; kept only the four live models. 400 hint updated. The `startswith("gemini-")` forward-compat fallback is intentionally retained.
- **`gemini_runtime.py`** pricing table: `2.0-flash` / `2.0-flash-lite` commented as historical — kept so cost calc of *older* executions still resolves, not offered in the lists.

## Decision note

Model set sourced from the runtime's own `GEMINI_PRICING` table (agent default `gemini-3-flash`), **not** the issue's parenthetical guesses (`gemini-3.5-flash`, `gemini-3-flash-preview`) — those don't exist in the runtime.

## Verification

- `py_compile` clean on both files.
- Base image rebuilt: `trinity-agent-base:0.6.0` / `:latest`.
- New lists confirmed inside the built image (`grep` on `/app/agent_server/routers/chat.py`) — no retired models present.

## AC

- [x] `GET /api/model` no longer advertises retired models
- [x] `PUT /api/model` allowlist contains only currently-available models
- [x] Base image rebuilt and verified

Related to #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)