### PR TITLE
feat(ops): per-tab Clear All on the Operations page (#1017)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -612,11 +612,15 @@ Generalises #868 to agent scope (`db/schedules.py:get_agent_analytics`); read-on
 |--------|------|-------------|
 | GET | `/api/operator-queue` | List queue items (filters: status, type, priority, agent_name, since) |
 | GET | `/api/operator-queue/stats` | Counts by status/type/priority/agent |
+| POST | `/api/operator-queue/bulk-cancel` | Cancel listed pending items (`{ids: [...]}`, 1–500, ids-scoped so a sync race can't cancel unseen items); returns `{cancelled, skipped}`; audit-logged (#1017) |
+| POST | `/api/operator-queue/clear-resolved` | Hide terminal rows (acknowledged/cancelled/expired) by setting `cleared_at` — NOT a DELETE (the 5s sync loop would resurrect items whose agent-file entry still says `pending`); `responded` kept visible until delivered; actual deletion deferred to the retention sweep (#1142); returns `{cleared}`; audit-logged (#1017) |
 | GET | `/api/operator-queue/{id}` | Single item |
-| POST | `/api/operator-queue/{id}/respond` / `/cancel` | Submit operator response / cancel pending item |
+| POST | `/api/operator-queue/{id}/respond` / `/cancel` | Submit operator response / cancel pending item. Respond returns **409** if the item left `pending` under the caller (race vs bulk-cancel, #1017) |
 | GET | `/api/operator-queue/agents/{name}` | Items for one agent |
 
-WebSocket events: `operator_queue_new`, `operator_queue_responded`, `operator_queue_acknowledged`. Backed by the 5s Operator Queue Sync background service.
+Bulk ops scope writes to the caller's accessible agents (tri-state: admin = no filter, empty set = no-op). The sync service write-back also propagates `cancelled`/`expired` status into agent queue files (in-place flips of still-`pending` entries only) so agents stop waiting on cleared items and stale file entries can't resurrect purged rows (#1017). The Operations UI exposes these as a per-tab **Clear All** button (`notifications` tab uses `POST /api/notifications/dismiss-all` — bulk pending+acknowledged → dismissed, same accessible-set scoping).
+
+WebSocket events: `operator_queue_new`, `operator_queue_responded`, `operator_queue_acknowledged`, `operator_queue_cleared` (one per bulk op, #1017; `notifications_cleared` for the notifications variant). Backed by the 5s Operator Queue Sync background service.
 
 ### Platform Audit Log (SEC-001)
 | Method | Path | Auth | Description |
@@ -1279,13 +1283,14 @@ CREATE TABLE operator_queue (
     responded_by_email TEXT,
     responded_at TEXT,
     acknowledged_at TEXT,
+    cleared_at TEXT,                    -- #1017: NULL = visible; set = hidden by Clear All (deletion deferred to retention sweep #1142)
     FOREIGN KEY (responded_by_id) REFERENCES users(id)
 );
-CREATE INDEX idx_opqueue_status ON operator_queue(status);
-CREATE INDEX idx_opqueue_agent ON operator_queue(agent_name);
-CREATE INDEX idx_opqueue_priority ON operator_queue(priority);
-CREATE INDEX idx_opqueue_created ON operator_queue(created_at);
-CREATE INDEX idx_opqueue_agent_status ON operator_queue(agent_name, status);
+CREATE INDEX idx_operator_queue_agent ON operator_queue(agent_name);
+CREATE INDEX idx_operator_queue_status ON operator_queue(status);
+CREATE INDEX idx_operator_queue_priority ON operator_queue(priority);
+CREATE INDEX idx_operator_queue_type ON operator_queue(type);
+CREATE INDEX idx_operator_queue_created ON operator_queue(created_at DESC);
 ```
 
 **agent_sync_state** (#389 — see [Git Sync Health](#git-sync-health-389390)):

--- a/docs/memory/feature-flows/agent-notifications.md
+++ b/docs/memory/feature-flows/agent-notifications.md
@@ -10,9 +10,11 @@ Enables agents to send structured notifications to the Trinity platform. Agents 
 
 ## Entry Points
 - **MCP Tool**: `send_notification` in `src/mcp-server/src/tools/notifications.ts:40-117`
+- **UI**: `src/frontend/src/views/Operations.vue:95-106` - "Clear All" button on the Operations page Notifications tab (#1017)
 - **API Endpoints**:
   - `POST /api/notifications` - Create notification (MCP clients)
   - `GET /api/notifications` - List with filters
+  - `POST /api/notifications/dismiss-all` - Bulk-dismiss all non-dismissed notifications (#1017)
   - `GET /api/notifications/{id}` - Get single notification
   - `POST /api/notifications/{id}/acknowledge` - Acknowledge
   - `POST /api/notifications/{id}/dismiss` - Dismiss
@@ -198,7 +200,7 @@ The correct agent name attribution involves three layers:
    )
    ```
 
-3. **Notification Router** (`src/backend/routers/notifications.py:106-109`):
+3. **Notification Router** (`src/backend/routers/notifications.py:114-117`):
    ```python
    # Get agent name from user context
    # For agent-scoped keys, current_user.agent_name is the agent sending the notification
@@ -224,11 +226,12 @@ class User(BaseModel):
 
 ### Router (`src/backend/routers/notifications.py`)
 
-**Module Setup** (lines 1-40):
-- Imports `get_current_user`, `AuthorizedAgent` dependencies
+**Module Setup** (lines 1-47):
+- Imports `get_current_user`, `AuthorizedAgent` dependencies, `get_accessible_agents` accessor, and `platform_audit_service`/`AuditEventType` (#1017)
+- `DismissAllRequest` body model defined in-router (lines 26-28)
 - Global variables for WebSocket managers (set during app startup)
 
-**WebSocket Manager Injection** (lines 30-39):
+**WebSocket Manager Injection** (lines 38-47):
 ```python
 _websocket_manager = None
 _filtered_websocket_manager = None
@@ -242,7 +245,7 @@ def set_filtered_websocket_manager(manager):
     _filtered_websocket_manager = manager
 ```
 
-**Broadcast Helper** (lines 42-63):
+**Broadcast Helper** (lines 50-70):
 ```python
 async def _broadcast_notification(notification: Notification):
     event = {
@@ -267,15 +270,18 @@ async def _broadcast_notification(notification: Notification):
 
 | Line | Endpoint | Method | Description |
 |------|----------|--------|-------------|
-| 69-118 | `/api/notifications` | POST | Create notification |
-| 121-163 | `/api/notifications` | GET | List with filters |
-| 166-177 | `/api/notifications/{id}` | GET | Get single |
-| 180-202 | `/api/notifications/{id}/acknowledge` | POST | Acknowledge |
-| 205-227 | `/api/notifications/{id}/dismiss` | POST | Dismiss |
-| 234-261 | `/api/agents/{name}/notifications` | GET | Agent-specific list |
-| 264-272 | `/api/agents/{name}/notifications/count` | GET | Pending count |
+| 77-124 | `/api/notifications` | POST | Create notification |
+| 127-181 | `/api/notifications` | GET | List with filters |
+| 184-231 | `/api/notifications/dismiss-all` | POST | Bulk-dismiss all non-dismissed (#1017) |
+| 234-247 | `/api/notifications/{id}` | GET | Get single |
+| 250-279 | `/api/notifications/{id}/acknowledge` | POST | Acknowledge |
+| 282-311 | `/api/notifications/{id}/dismiss` | POST | Dismiss |
+| 318-345 | `/api/agents/{name}/notifications` | GET | Agent-specific list |
+| 348-356 | `/api/agents/{name}/notifications/count` | GET | Pending count |
 
-**Create Notification** (`POST /api/notifications`, lines 69-116):
+**Route registration order**: `/notifications/dismiss-all` is registered BEFORE the `/notifications/{notification_id}` routes so the literal path segment `dismiss-all` is never captured as a notification ID (Architectural Invariant #4).
+
+**Create Notification** (`POST /api/notifications`, lines 77-124):
 ```python
 @router.post("/notifications", response_model=Notification, status_code=201)
 async def create_notification(
@@ -296,29 +302,51 @@ async def create_notification(
     return notification
 ```
 
-**List Notifications** (`GET /api/notifications`, lines 121-163):
+**List Notifications** (`GET /api/notifications`, lines 127-181):
 - Query params: `agent_name`, `status`, `priority` (comma-separated), `limit` (1-500, default 50)
+- Filters results to agents from `get_accessible_agents(current_user)`; explicit `agent_name` outside that set → 403
 - Returns `NotificationList` with count and notifications array
 
-**Agent Notifications** (`GET /api/agents/{name}/notifications`, lines 234-261):
+**Dismiss All** (`POST /api/notifications/dismiss-all`, lines 184-231, #1017):
+- Body: `DismissAllRequest` `{agent_name?: string}` (model defined in the router at lines 26-28)
+- Dismisses ALL non-dismissed (pending + acknowledged) notifications in one SQL UPDATE — sets `status='dismissed'`, `acknowledged_at`, `acknowledged_by`
+- Scoped via the **same** `get_accessible_agents(current_user)` accessor the GET list endpoint uses, so "what I see" == "what I can clear"
+- Explicit `agent_name` outside the accessible set → 403; empty accessible set → no-op `{"dismissed": 0}` (tri-state contract enforced in the DB layer)
+- Ignores priority/type filters by design (a "Clear All" button clears the whole feed, including rows beyond the loaded page)
+- When `dismissed > 0`: audit-logged via `platform_audit_service.log(event_type=AuditEventType.NOTIFICATION, event_action="dismiss_all", ...)` with `{dismissed, agent_name}` details, and broadcasts ONE `notifications_cleared` WebSocket event (main manager only)
+- Response: `{"dismissed": <count>}` (200)
+
+**Agent Notifications** (`GET /api/agents/{name}/notifications`, lines 318-345):
 - Uses `AuthorizedAgent` dependency (owner, shared, or admin required)
 - Query params: `status`, `limit` (1-500, default 50)
 
 ### CRUD Operations (`src/backend/db/notifications.py`)
 
-**Class: NotificationOperations** (lines 17-315)
+**Class: NotificationOperations** (lines 18-366)
 
 | Line | Method | Description |
 |------|--------|-------------|
-| 20-75 | `create_notification()` | Insert new notification, return model |
-| 77-101 | `get_notification()` | Get by ID, parse metadata JSON |
-| 103-152 | `list_notifications()` | Query with filters, ORDER BY created_at DESC |
-| 154-175 | `list_agent_notifications()` | Delegate to list_notifications |
-| 177-214 | `acknowledge_notification()` | Update status to 'acknowledged' |
-| 216-247 | `dismiss_notification()` | Update status to 'dismissed' |
-| 249-266 | `delete_agent_notifications()` | Delete all for agent |
-| 268-291 | `count_pending_notifications()` | Count pending with optional agent filter |
-| 293-315 | `_row_to_notification()` | Convert SQLite row to Pydantic model |
+| 21-76 | `create_notification()` | Insert new notification, return model |
+| 78-102 | `get_notification()` | Get by ID, parse metadata JSON |
+| 104-159 | `list_notifications()` | Query with filters, ORDER BY created_at DESC |
+| 161-182 | `list_agent_notifications()` | Delegate to list_notifications |
+| 184-221 | `acknowledge_notification()` | Update status to 'acknowledged' |
+| 223-254 | `dismiss_notification()` | Update status to 'dismissed' |
+| 256-298 | `dismiss_all()` | Bulk UPDATE of pending+acknowledged rows (#1017) |
+| 300-317 | `delete_agent_notifications()` | Delete all for agent |
+| 319-342 | `count_pending_notifications()` | Count pending with optional agent filter |
+| 344-366 | `_row_to_notification()` | Convert SQLite row to Pydantic model |
+
+**dismiss_all tri-state accessible-set contract** (`db/notifications.py:256-298`, #1017):
+```python
+def dismiss_all(self, dismissed_by, agent_name=None, accessible_agent_names=None) -> int:
+    # accessible_agent_names: None = no filter; empty set = no-op (return 0);
+    # non-empty = "AND agent_name IN (?,...)" SQL filter
+```
+- Targets `status IN ('pending', 'acknowledged')` — the visible feed shows both, so "Clear All" must clear both
+- Optional `agent_name` adds a further `AND agent_name = ?` narrowing
+- Returns `cursor.rowcount` (number of rows dismissed)
+- Facade delegation: `database.py:1435-1439` `dismiss_all_notifications()`
 
 **ID Generation** (line 35):
 ```python
@@ -393,7 +421,7 @@ app.include_router(notifications_router)  # Agent Notifications (NOTIF-001)
 }
 ```
 
-**Filtered Broadcast** (`routers/notifications.py:60-62`):
+**Filtered Broadcast** (`routers/notifications.py:68-70`):
 ```python
 # Broadcast to filtered WebSocket (Trinity Connect clients)
 if _filtered_websocket_manager:
@@ -401,6 +429,34 @@ if _filtered_websocket_manager:
 ```
 
 The `FilteredWebSocketManager` (in `main.py`) extracts `agent_name` from the event and only forwards to clients who have access to that agent.
+
+### Event Type: notifications_cleared (#1017)
+
+Emitted once per successful dismiss-all (only when `dismissed > 0`), main WebSocket only (`routers/notifications.py:221-229`):
+```json
+{
+  "type": "notifications_cleared",
+  "data": {
+    "count": 12,
+    "agent_name": null,
+    "cleared_by": "user@example.com"
+  }
+}
+```
+
+Frontend handler (`src/frontend/src/utils/websocket.js:151-154`): routes `notifications_cleared` → `notificationsStore.fetchPendingCount()` + `fetchNotifications()` so every connected client's badge and loaded list refresh, not just the operator who clicked.
+
+---
+
+## Frontend Layer (#1017 — Clear All)
+
+### State Management
+- `src/frontend/src/stores/notifications.js:187-200` - `dismissAll(agentName = null)` action: `api.post('/api/notifications/dismiss-all', {agent_name: agentName})` via the shared `api.js` client (Invariant #7), then refetches `fetchNotifications()` + `fetchPendingCount()`. Unlike the per-id `bulkDismiss()` helper below it (one request per loaded row), one server-side call clears rows beyond the loaded page.
+
+### Components
+- `src/frontend/src/views/Operations.vue:95-106` - "Clear All" button on the Operations page tab strip (shared across Needs Response / Notifications / Resolved tabs; shown when `isOperatorTab && clearableCount > 0`, `data-testid="ops-clear-all"`)
+- `Operations.vue:180-190` - `ConfirmDialog` (danger variant). The Notifications-tab message warns the action ignores the current type/priority filters and clears beyond the loaded page: "This dismisses every non-dismissed notification from your accessible agents — including any not shown by the current filters — for all operators of these agents." (lines 289-298)
+- `Operations.vue:300-318` - `confirmClearAll()` dispatches per tab; the `notifications` branch calls `notificationsStore.dismissAll()` (line 308)
 
 ---
 
@@ -415,6 +471,8 @@ The `FilteredWebSocketManager` (in `main.py`) extracts `agent_name` from the eve
 | Notification not found | 404 | "Notification not found" |
 | Invalid status filter | 400 | "Invalid status. Must be: pending, acknowledged, or dismissed" |
 | Invalid priority filter | 400 | "Invalid priorities: {invalid_list}" |
+| dismiss-all with `agent_name` outside accessible set | 403 | "Access denied to agent" |
+| dismiss-all with zero accessible agents | 200 | `{"dismissed": 0}` (no-op, not an error) |
 | No MCP API key | Error | "MCP API key authentication required but no API key found in request context" (MCP tool) |
 
 ---
@@ -426,6 +484,7 @@ The `FilteredWebSocketManager` (in `main.py`) extracts `agent_name` from the eve
 3. **Authorization on Agent Endpoints**: `GET /api/agents/{name}/notifications` uses `AuthorizedAgent` dependency (owner, shared, or admin)
 4. **WebSocket Filtering**: Filtered WebSocket only sends notifications for agents the client has access to
 5. **Input Validation**: Title length, enum values, JSON metadata all validated server-side
+6. **Dismiss-All Scoping** (#1017): Uses the same `get_accessible_agents()` accessor as the GET list endpoint, so the clearable set can never exceed the visible set. The DB layer enforces a tri-state contract (`None` = no filter, empty set = no-op, non-empty = SQL IN) so an empty accessible set never falls through to "dismiss everything". Successful bulk dismissals are audit-logged (`AuditEventType.NOTIFICATION` / `dismiss_all`).
 
 ---
 
@@ -515,6 +574,27 @@ curl -X POST -H "Authorization: Bearer $TOKEN" "http://localhost:8000/api/notifi
 - [ ] Acknowledge changes status to "acknowledged"
 - [ ] Dismiss changes status to "dismissed"
 
+### 4b. Test Dismiss All (#1017)
+**Action**:
+```bash
+# Dismiss everything (all accessible agents)
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{}' "http://localhost:8000/api/notifications/dismiss-all"
+
+# Dismiss for one agent only
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"agent_name": "my-agent"}' "http://localhost:8000/api/notifications/dismiss-all"
+```
+
+**Verify**:
+- [ ] Returns `{"dismissed": N}` where N = pending + acknowledged rows for accessible agents
+- [ ] Second identical call returns `{"dismissed": 0}` (idempotent)
+- [ ] `agent_name` for an inaccessible agent returns 403
+- [ ] `notifications_cleared` WebSocket event observed on `/ws` (only when N > 0)
+- [ ] Audit row: `sqlite3 ~/trinity-data/trinity.db "SELECT event_action, details FROM audit_log WHERE event_action='dismiss_all' ORDER BY id DESC LIMIT 1"`
+
+**Automated tests**: `tests/test_ops_clear_all.py` — `TestDismissAllNotifications` (happy path + idempotency exercised at the DB layer because the `get_accessible_agents` accessor is Docker-backed; auth-required, foreign-agent 403, and zero-agent no-op covered at the API level).
+
 ### 5. Test Agent-Specific Endpoints
 **Action**:
 ```bash
@@ -599,5 +679,6 @@ sqlite3 ~/trinity-data/trinity.db "DELETE FROM agent_notifications WHERE title L
 
 | Date | Changes |
 |------|---------|
+| 2026-06-11 | **#1017 Dismiss All**: New `POST /api/notifications/dismiss-all` (registered before `/{notification_id}` routes) bulk-dismisses pending + acknowledged notifications scoped to the caller's accessible agents in one SQL UPDATE. DB layer `db/notifications.py:dismiss_all()` with tri-state accessible-set contract; facade `database.py:dismiss_all_notifications`. Audit event `NOTIFICATION/dismiss_all` + WS event `notifications_cleared`. Frontend: `stores/notifications.js:dismissAll()`, `utils/websocket.js` refresh handler, Clear All button + ConfirmDialog on Operations → Notifications tab. Tests: `tests/test_ops_clear_all.py::TestDismissAllNotifications`. |
 | 2026-02-20 | **NOTIF-003 Bug Fix**: Fixed agent attribution - notifications now correctly show agent name instead of API key owner. Root cause: `agent_name` from agent-scoped MCP keys was not being passed to `User` model in `get_current_user()`. Fix: Added `agent_name` field to User model (models.py:62-63), updated `get_current_user()` to extract from mcp_key_info (dependencies.py:147-154), simplified notification router logic (notifications.py:106-109). |
 | 2026-02-20 | Initial implementation (Phase 1: Backend + MCP Tool) |

--- a/docs/memory/feature-flows/operating-room.md
+++ b/docs/memory/feature-flows/operating-room.md
@@ -1,9 +1,10 @@
 # Operations (OPS-001)
 
 > **Status**: Implemented (Phases 1-4)
-> **Updated 2026-06-09 (#1109)**: Frontend IA refactor -- "Operating Room" renamed to **Operations** and extended from 3 to **5 tabs** (added Health + Executions). View `OperatingRoom.vue` -> `Operations.vue`, route `/operating-room` -> `/operations`. NavBar "Health"/"Ops"/"Executions" links collapsed into one "Operations" link. Legacy routes redirect. **No backend changes** -- all operator-queue protocol/sync/DB documentation below is unchanged.
+> **Updated 2026-06-11 (#1017)**: "Clear All" -- per-tab bulk clear on the operator tabs. Two new endpoints (`POST /api/operator-queue/bulk-cancel`, `POST /api/operator-queue/clear-resolved`), a new `cleared_at` hide column (clear-resolved hides, never deletes), a new WS event (`operator_queue_cleared`), a respond-race 409, and terminal-status (cancelled/expired) write-back to agent queue files.
+> **Updated 2026-06-09 (#1109)**: Frontend IA refactor -- "Operating Room" renamed to **Operations** and extended from 3 to **5 tabs** (added Health + Executions). View `OperatingRoom.vue` -> `Operations.vue`, route `/operating-room` -> `/operations`. NavBar "Health"/"Ops"/"Executions" links collapsed into one "Operations" link. Legacy routes redirect.
 > **Requirements**: [OPERATOR_QUEUE_OPERATING_ROOM.md](../../requirements/OPERATOR_QUEUE_OPERATING_ROOM.md)
-> **Tests**: `tests/test_operator_queue.py`
+> **Tests**: `tests/test_operator_queue.py`, `tests/test_ops_clear_all.py` (#1017)
 
 ---
 
@@ -37,6 +38,7 @@ As an operator, I want a single inbox where I can see and respond to all agent r
 - **API**: `GET /api/operator-queue` -- List queue items
 - **API**: `POST /api/operator-queue/{id}/respond` -- Submit response
 - **API**: `GET /api/operator-queue/stats` -- Queue statistics
+- **API** (#1017): `POST /api/operator-queue/bulk-cancel` / `POST /api/operator-queue/clear-resolved` -- per-tab "Clear All" bulk actions
 - **API**: `GET /api/notifications` -- List agent notifications (used by Notifications tab)
 - **API**: `GET /api/monitoring/status` -- Fleet health (Health tab, admin-only)
 - **API**: `GET /api/executions` / `GET /api/executions/stats` -- Fleet execution list + stats (Executions tab)
@@ -53,11 +55,11 @@ As an operator, I want a single inbox where I can see and respond to all agent r
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `src/frontend/src/views/Operations.vue` | -- | Main page -- 5-tab layout (Needs Response / Notifications / Health / Executions / Resolved), `?tab=` deep linking, combined subtitle, refresh button, polling lifecycle. Container is `max-w-7xl`; narrow operator card-feed tabs re-constrain to `max-w-3xl mx-auto`; Health/Executions panels own their `max-w-7xl` width. Tabs toggle by `v-if` (not v-show) so each panel's store-owned polling tears down on tab-leave. Operator-queue polling (`operatorQueueStore.startPolling(10000)`) and `agentsStore.fetchAgents()` run once at container level (queue polling drives Needs Response/Resolved feeds AND the NavBar badge). `isAdmin = computed(() => authStore.role === 'admin')` gates the Health tab. |
+| `src/frontend/src/views/Operations.vue` | -- | Main page -- 5-tab layout (Needs Response / Notifications / Health / Executions / Resolved), `?tab=` deep linking, combined subtitle, refresh button, polling lifecycle. Container is `max-w-7xl`; narrow operator card-feed tabs re-constrain to `max-w-3xl mx-auto`; Health/Executions panels own their `max-w-7xl` width. Tabs toggle by `v-if` (not v-show) so each panel's store-owned polling tears down on tab-leave. Operator-queue polling (`operatorQueueStore.startPolling(10000)`) and `agentsStore.fetchAgents()` run once at container level (queue polling drives Needs Response/Resolved feeds AND the NavBar badge). `isAdmin = computed(() => authStore.role === 'admin')` gates the Health tab. **Clear All** (#1017): per-tab button (operator tabs only via `isOperatorTab`, hidden when `clearableCount === 0`, `data-testid="ops-clear-all"`, lines 94-106) opens a `ConfirmDialog` (variant danger) with tab-specific blast-radius copy (`clearConfirmTitle`/`clearConfirmMessage`, lines 283-298); `confirmClearAll()` (lines 300-318) routes: needs-response -> `operatorQueueStore.bulkCancel(openItems ids)`, notifications -> `notificationsStore.dismissAll()`, resolved -> `operatorQueueStore.clearResolved()`. |
 | `src/frontend/src/components/MonitoringPanel.vue` | -- | Health tab -- fleet monitoring content extracted from the deleted `views/Monitoring.vue`. Rendered `v-if="activeTab === 'health' && isAdmin"`. |
 | `src/frontend/src/components/ExecutionsPanel.vue` | -- | Executions tab -- fleet execution list extracted from the deleted `views/Executions.vue`. Includes the "N running now" strip (the running-count badge that used to live on the NavBar Executions link). |
 | `src/frontend/src/components/operator/QueueCard.vue` | 1-253 | Expandable card -- `AgentAvatar` component (with real avatar images from agents store), markdown body, inline response controls |
-| `src/frontend/src/components/operator/ResolvedCard.vue` | 1-67 | Compact resolved item -- `AgentAvatar` component (with real avatar images), checkmark, response text, timestamp |
+| `src/frontend/src/components/operator/ResolvedCard.vue` | 1-82 | Compact resolved item -- `AgentAvatar` component (with real avatar images), checkmark + response text for responded/acknowledged items; for response-less terminal items (cancelled/expired, #1017) renders a gray X badge "Cancelled"/"Expired" instead (`isTerminalWithoutResponse`, lines 17-40, 59-61) |
 | `src/frontend/src/components/operator/NotificationsPanel.vue` | 1-541 | Notification list with agent/type/priority/status filters, bulk actions (acknowledge/dismiss), stats row, expandable messages, empty state |
 | `src/frontend/src/components/operator/QueueList.vue` | 1-195 | Filterable list view (type, priority, agent, status) with priority indicators |
 | `src/frontend/src/components/operator/QueueStats.vue` | 1-88 | Stats sidebar -- pending by priority, today's total, avg response time, by agent |
@@ -104,7 +106,7 @@ Tab selection uses `?tab=` query parameter. `Operations.vue` reads `route.query.
 
 ### State Management
 
-**Primary Store**: `src/frontend/src/stores/operatorQueue.js` (194 lines) -- Manages the operator queue (Needs Response + Resolved tabs)
+**Primary Store**: `src/frontend/src/stores/operatorQueue.js` (239 lines) -- Manages the operator queue (Needs Response + Resolved tabs)
 
 **Additional Stores** (used by Notifications tab; see its own flow doc for full details):
 - `src/frontend/src/stores/notifications.js` (315 lines) -- Manages notification list, filters, bulk actions, pending count. Used by `NotificationsPanel.vue`. Key getters: `pendingCount`, `hasUrgentPending`.
@@ -119,20 +121,22 @@ Tab selection uses `?tab=` query parameter. `Operations.vue` reads `route.query.
 
 **Getters (computed):**
 - `openItems` -- Pending items sorted by priority order (critical=0, high=1, medium=2, low=3), then by created_at ascending
-- `resolvedItems` -- Items with status responded/acknowledged, sorted by responded_at descending
+- `resolvedItems` -- Items with status in `RESOLVED_STATUSES = ['responded', 'acknowledged', 'cancelled', 'expired']` (cancelled/expired added by #1017 -- previously cancelled items vanished from the UI entirely), sorted by `responded_at || created_at` descending (lines 53-61)
 - `pendingCount` -- Count of items with status=pending (drives NavBar badge)
 - `criticalCount` -- Count of pending items with priority=critical (drives badge color: red+pulse vs orange)
 - `openItemsByAgent` -- Open items grouped by agent_name
 - `getProfile(agentName)` -- Returns `{initials, color, role}` using deterministic hash of agent name against 8 Tailwind colors (legacy; `QueueCard` and `ResolvedCard` now use `AgentAvatar` component with real avatar images instead)
 
 **Actions:**
-- `fetchItems()` -- `GET /api/operator-queue?limit=200` with auth header (line 82-97)
-- `respondToItem(id, response, responseText)` -- `POST /api/operator-queue/{id}/respond`, optimistic local update, auto-advance to next open item (line 99-126)
-- `acknowledgeItem(id)` -- Shorthand that calls `respondToItem(id, 'acknowledged', '')` (line 128-130)
-- `toggleExpand(id)` -- Toggle expandedItemId (line 132-134)
-- `handleWebSocketEvent(data)` -- Handles real-time updates from WebSocket (line 137-157)
-- `startPolling(interval)` -- Begin polling with initial fetch + setInterval (default 15s, called with 10s from Operations.vue at container level) (line 160-164)
-- `stopPolling()` -- Clear poll timer (line 166-171)
+- `fetchItems()` -- `GET /api/operator-queue?limit=200` with auth header (line 87-102)
+- `respondToItem(id, response, responseText)` -- `POST /api/operator-queue/{id}/respond`, optimistic local update, auto-advance to next open item. On **409** (item left 'pending' under us, e.g. another operator's bulk-cancel landed first, #1017) sets a user-visible `error` ("...your response was not recorded.") and refetches (line 104-138)
+- `bulkCancel(ids)` -- `POST /api/operator-queue/bulk-cancel` via shared `api.js` client; refetches; returns `{cancelled, skipped}` (#1017, line 141-152)
+- `clearResolved(agentName = null)` -- `POST /api/operator-queue/clear-resolved` via `api.js`; refetches; returns `{cleared}` (#1017, line 154-166)
+- `acknowledgeItem(id)` -- Shorthand that calls `respondToItem(id, 'acknowledged', '')` (line 168-170)
+- `toggleExpand(id)` -- Toggle expandedItemId (line 172-174)
+- `handleWebSocketEvent(data)` -- Handles real-time updates from WebSocket; `operator_queue_cleared` triggers a full `fetchItems()` refetch (line 177-200)
+- `startPolling(interval)` -- Begin polling with initial fetch + setInterval (default 15s, called with 10s from Operations.vue at container level) (line 203-207)
+- `stopPolling()` -- Clear poll timer (line 209-214)
 
 ### API Calls
 
@@ -148,26 +152,34 @@ await axios.post(`/api/operator-queue/${id}/respond`, {
   response: response,
   response_text: responseText || null
 }, { headers: authStore.authHeader })
+
+// Clear All on Needs Response tab (bulkCancel, #1017) — via shared api.js client
+await api.post('/api/operator-queue/bulk-cancel', { ids })   // -> {cancelled, skipped}
+
+// Clear All on Resolved tab (clearResolved, #1017)
+await api.post('/api/operator-queue/clear-resolved', { agent_name: agentName })  // -> {cleared}
 ```
 
 ### WebSocket Events
 
-Handled in `src/frontend/src/utils/websocket.js:96-98`:
+Handled in `src/frontend/src/utils/websocket.js:147-149`:
 
 Events are keyed by `type` (not `event`), dispatched from the `default` case in the WebSocket message handler:
 
 ```javascript
 if (data.type === 'operator_queue_new' ||
     data.type === 'operator_queue_responded' ||
-    data.type === 'operator_queue_acknowledged') {
+    data.type === 'operator_queue_acknowledged' ||
+    data.type === 'operator_queue_cleared') {
   operatorQueueStore.handleWebSocketEvent(data)
 }
 ```
 
-Event handling in the store (`handleWebSocketEvent`, line 137-157):
+Event handling in the store (`handleWebSocketEvent`, line 177-200):
 - `operator_queue_new` -- Triggers full `fetchItems()` refetch to get complete item data
 - `operator_queue_responded` -- Updates item status, response, and responded_by locally (avoids refetch)
 - `operator_queue_acknowledged` -- Updates item status to 'acknowledged' locally
+- `operator_queue_cleared` (#1017) -- Bulk clear by an operator (any browser tab/user) -- triggers full `fetchItems()` refetch of authoritative state
 
 ### Response Controls by Type
 
@@ -205,6 +217,7 @@ Event handling in the store (`handleWebSocketEvent`, line 137-157):
 10. **Form reset** -- `watch(isExpanded)` in QueueCard resets selectedOption, responseText, showContext on collapse (line 191-197)
 11. **Manual refresh** -- Refresh button next to tabs (`Operations.vue`). Shows spinning icon (`animate-spin`) while `store.loading` is true. Calls `store.fetchItems()` and `notificationsStore.fetchPendingCount()`. Disabled during loading. Positioned via `ml-auto` to sit at the right edge of the tab bar.
 12. **Notifications tab features** -- Agent/type/priority/status filters, show-dismissed toggle, bulk acknowledge/dismiss, select-all, expandable messages, load-more pagination, stats cards (pending/acknowledged/total/agents)
+13. **Clear All** (#1017) -- Per-tab button on operator tabs only (Needs Response / Notifications / Resolved; hidden on Health/Executions and when the tab has nothing to clear). Always confirms via `ConfirmDialog` with blast-radius copy (e.g. Needs Response: "agents waiting on them will be told their requests were cancelled... affects all operators of these agents"). Needs Response sends only the **rendered** `openItems` ids, so a sync-loop race can never cancel items the operator never saw.
 
 ---
 
@@ -222,37 +235,48 @@ Event handling in the store (`handleWebSocketEvent`, line 137-157):
 
 ### Endpoints
 
-**Router**: `src/backend/routers/operator_queue.py` (164 lines)
+**Router**: `src/backend/routers/operator_queue.py` (311 lines)
 
 Prefix: `/api/operator-queue`, Tags: `["operator-queue"]`
 
-All endpoints require JWT authentication via `get_current_user` dependency.
+All endpoints require JWT authentication via `get_current_user` dependency. Per-caller agent scoping comes from `_accessible_set()` (line 60-70): returns `None` for admins (no filter) or a `Set[str]` of accessible agent names (possibly empty) for regular users — the tri-state contract is threaded down into the DB layer for the bulk endpoints.
 
 | Method | Path | Handler | Line | Description |
 |--------|------|---------|------|-------------|
-| GET | `/api/operator-queue` | `list_queue_items()` | 45-66 | List with filters: status, type, priority, agent_name, since, limit (1-500, default 100), offset |
-| GET | `/api/operator-queue/stats` | `get_queue_stats()` | 69-74 | Counts by status/type/priority/agent, avg response time, responded today |
-| GET | `/api/operator-queue/{item_id}` | `get_queue_item()` | 77-86 | Single item by ID; 404 if not found |
-| POST | `/api/operator-queue/{item_id}/respond` | `respond_to_queue_item()` | 89-127 | Submit operator response. Validates status=pending, broadcasts WebSocket event |
-| POST | `/api/operator-queue/{item_id}/cancel` | `cancel_queue_item()` | 130-147 | Cancel pending item. Validates status=pending |
-| GET | `/api/operator-queue/agents/{agent_name}` | `get_agent_queue_items()` | 150-163 | Items for specific agent with optional status filter, limit (1-500, default 50) |
+| GET | `/api/operator-queue` | `list_queue_items()` | 83-106 | List with filters: status, type, priority, agent_name, since, limit (1-500, default 100), offset. Rows hidden by Clear All are excluded (`cleared_at IS NULL` default in `list_items`, #1017) |
+| GET | `/api/operator-queue/stats` | `get_queue_stats()` | 109-115 | Counts by status/type/priority/agent, avg response time, responded today |
+| POST | `/api/operator-queue/bulk-cancel` | `bulk_cancel_queue_items()` | 118-155 | (#1017) Cancel a list of still-pending items in one call. Body `{ids: [...]}` (1-500); ids are deduped order-preserving (`list(dict.fromkeys(body.ids))`) so the `skipped` count is honest. Only listed ids are touched; non-pending/inaccessible ids are skipped. Returns `{cancelled, skipped}`. Audit-logged (`OPERATOR_QUEUE` / `bulk_cancel`), broadcasts one `operator_queue_cleared` WS event (`scope: "pending"`) when `cancelled > 0` |
+| POST | `/api/operator-queue/clear-resolved` | `clear_resolved_queue_items()` | 158-204 | (#1017) **Hide** terminal items (`acknowledged`/`cancelled`/`expired`) by setting `cleared_at` — NOT a DELETE (a delete would be resurrected by the 5s sync loop; see DB layer). `responded` rows are kept visible so the sync write-back can still deliver the answer. Actual row deletion is deferred to the retention sweep (#1142). Body `{agent_name?}` (403 if inaccessible). Idempotent — empty match returns `{cleared: 0}`. Audit-logged (`clear_resolved`), broadcasts `operator_queue_cleared` (`scope: "resolved"`) when `cleared > 0` |
+| GET | `/api/operator-queue/{item_id}` | `get_queue_item()` | 207-218 | Single item by ID; 404 if not found (does NOT filter on `cleared_at` — hidden items remain fetchable by id) |
+| POST | `/api/operator-queue/{item_id}/respond` | `respond_to_queue_item()` | 221-270 | Submit operator response. Validates status=pending, 409 on respond/cancel race (#1017), broadcasts WebSocket event |
+| POST | `/api/operator-queue/{item_id}/cancel` | `cancel_queue_item()` | 273-293 | Cancel pending item. Validates status=pending |
+| GET | `/api/operator-queue/agents/{agent_name}` | `get_agent_queue_items()` | 296-311 | Items for specific agent with optional status filter, limit (1-500, default 50) |
 
-**Request model** (line 35-38):
+**Route ordering**: the static `/bulk-cancel` and `/clear-resolved` routes are registered BEFORE the `/{item_id}` catch-all (Architectural Invariant #4).
+
+**Request models** (line 36-53):
 ```python
 class OperatorResponse(BaseModel):
     response: str
     response_text: Optional[str] = None
+
+class BulkCancelRequest(BaseModel):          # #1017
+    ids: List[str] = Field(..., min_length=1, max_length=500)
+
+class ClearResolvedRequest(BaseModel):       # #1017
+    agent_name: Optional[str] = None
 ```
 
-**Respond endpoint flow** (line 89-127):
+**Respond endpoint flow** (line 221-270):
 1. Fetch existing item from DB
 2. Validate item exists (404 if not)
 3. Validate item status is "pending" (400 if not)
 4. Call `db.respond_to_operator_queue_item()` with response, user ID, user email
-5. Broadcast `operator_queue_responded` WebSocket event via `_websocket_manager`
-6. Return updated item
+5. **Race check** (#1017, line 252-256): if the DB layer returned the `_status_conflict` marker (item left 'pending' between step 3 and the UPDATE, e.g. a bulk-cancel landed) -> 409 "Item is no longer pending (now '{status}') — response was not recorded" instead of a silent 200
+6. Broadcast `operator_queue_responded` WebSocket event via `_websocket_manager`
+7. Return updated item
 
-**WebSocket broadcast payload** (line 117-125):
+**WebSocket broadcast payload** (line 259-268):
 ```json
 {
   "type": "operator_queue_responded",
@@ -265,11 +289,23 @@ class OperatorResponse(BaseModel):
 }
 ```
 
+**`operator_queue_cleared` broadcast payload** (#1017, line 146-153 / 195-202 — one event per bulk operation, not per item):
+```json
+{
+  "type": "operator_queue_cleared",
+  "data": {
+    "scope": "pending|resolved",
+    "count": 7,
+    "cleared_by": "<user_email>"
+  }
+}
+```
+
 ### Sync Service
 
-**File**: `src/backend/services/operator_queue_service.py` (269 lines)
+**File**: `src/backend/services/operator_queue_service.py` (290 lines)
 
-Background async service that bridges agent containers and the database. Global singleton instance at line 268.
+Background async service that bridges agent containers and the database. Global singleton instance at line 290.
 
 **Constants**:
 - `QUEUE_FILE_PATH = ".trinity/operator-queue.json"` (line 30)
@@ -281,7 +317,7 @@ Background async service that bridges agent containers and the database. Global 
 3. Calls `db.mark_operator_queue_expired()` for items past `expires_at`
 4. Concurrently syncs each agent via `asyncio.gather(*tasks)`
 
-**Agent sync** (`_sync_agent`, line 102-191):
+**Agent sync** (`_sync_agent`, line 102-199):
 1. Creates `AgentClient(agent_name)` and reads `~/.trinity/operator-queue.json` via `client.read_file()` with 5s timeout
 2. **Restart resilience** (line 113-127): If the file does not exist (e.g., container restart wiped filesystem), the service no longer returns early. Instead it creates an empty `queue_data = {"$schema": "operator-queue-v1", "requests": []}` and continues, tracking `file_exists = False`. This allows responded items in the DB to be reconstructed and delivered back to the agent.
 3. Parses JSON (if file existed), iterates `requests` array
@@ -289,22 +325,23 @@ Background async service that bridges agent containers and the database. Global 
 5. For each request with `status=acknowledged`: marks acknowledged in DB via `db.mark_operator_queue_acknowledged()`
 6. Broadcasts `operator_queue_new` WebSocket events for new items (line 156-171)
 7. Broadcasts `operator_queue_acknowledged` WebSocket events for acknowledged items (line 173-184)
-8. Checks for `responded` items via `db.get_operator_queue_responded_for_agent()`, writes responses back to agent. Passes `file_exists` flag to `_write_responses_to_agent()` (line 187-191).
+8. Checks for `responded` items via `db.get_operator_queue_responded_for_agent()` AND — only when `file_exists` (#1017) — recently terminal (`cancelled`/`expired`) items via `db.get_operator_queue_terminal_for_agent()` (created_at-bounded to the last 168h so the per-agent 5s query stays cheap; there is no per-status timestamp column; deliberately NOT filtered on `cleared_at` — hidden items still need their flip delivered). Passes both lists + `file_exists` to `_write_responses_to_agent()` (line 186-199).
 
-**Response write-back** (`_write_responses_to_agent`, line 193-265):
+**Response write-back** (`_write_responses_to_agent`, line 201-286):
 
-Accepts a `file_exists` parameter (default `True`) to handle the case where the agent's queue file is missing after a container restart.
+Accepts `terminal_items` (#1017 — cancelled/expired) and a `file_exists` parameter (default `True`) to handle the case where the agent's queue file is missing after a container restart.
 
-1. Builds lookup map of responded items by ID
+1. Builds lookup maps of responded items and terminal items by ID
 2. Iterates agent's JSON requests, updates matching pending items with response data
-3. **Reconstruction of missing items** (line 223-241): For any responded item in the DB whose ID is not found in the agent's `requests` array (tracked via `seen_ids` set), the service reconstructs a full request entry from DB data and appends it to the `requests` array. Reconstructed fields include: `id`, `type`, `status` (set to `"responded"`), `priority`, `title`, `question`, `options`, `context`, `created_at`, `response`, `response_text`, `responded_by`, `responded_at`.
-4. Writes updated JSON back to agent via `client.write_file(QUEUE_FILE_PATH, content, timeout=10.0, platform=True)`
-5. Sets `status=responded`, `response`, `response_text`, `responded_by`, `responded_at` fields in the agent's JSON
-6. The agent server's `write_file` endpoint (`docker/base-image/agent_server/routers/files.py:360`) automatically creates parent directories (`mkdir(parents=True, exist_ok=True)`), so `.trinity/` is created if it doesn't exist.
+3. **Terminal-status propagation** (#1017, line 235-238): file entries still in `status=pending` whose ID is in the terminal map are flipped in place to the item's DB status (`req["status"] = terminal_map[req_id]["status"]` — `cancelled` or `expired`) so the agent stops waiting on them (and so a stale 'pending' file entry can't resurrect the item if its row is ever purged). Terminal entries are **never appended** if missing from the file (unlike responded items) — there is nothing to deliver.
+4. **Reconstruction of missing items** (line 242-260): For any responded item in the DB whose ID is not found in the agent's `requests` array (tracked via `seen_ids` set), the service reconstructs a full request entry from DB data and appends it to the `requests` array. Reconstructed fields include: `id`, `type`, `status` (set to `"responded"`), `priority`, `title`, `question`, `options`, `context`, `created_at`, `response`, `response_text`, `responded_by`, `responded_at`.
+5. Writes updated JSON back to agent via `client.write_file(QUEUE_FILE_PATH, content, timeout=10.0, platform=True)`; on success logs "Wrote N responses and M terminal-status flips back to {agent}" (line 277-280)
+6. Sets `status=responded`, `response`, `response_text`, `responded_by`, `responded_at` fields in the agent's JSON
+7. The agent server's `write_file` endpoint (`docker/base-image/agent_server/routers/files.py:360`) automatically creates parent directories (`mkdir(parents=True, exist_ok=True)`), so `.trinity/` is created if it doesn't exist.
 
 **WebSocket broadcast payloads**:
 
-`operator_queue_new` (line 158-168):
+`operator_queue_new` (line 159-169):
 ```json
 {
   "type": "operator_queue_new",
@@ -319,7 +356,7 @@ Accepts a `file_exists` parameter (default `True`) to handle the case where the 
 }
 ```
 
-`operator_queue_acknowledged` (line 175-182):
+`operator_queue_acknowledged` (line 176-182):
 ```json
 {
   "type": "operator_queue_acknowledged",
@@ -334,22 +371,25 @@ Accepts a `file_exists` parameter (default `True`) to handle the case where the 
 
 ### Database Delegation
 
-**File**: `src/backend/database.py` (lines 1195-1230)
+**File**: `src/backend/database.py` (lines 1940-1989)
 
-`DatabaseManager` delegates to `self._operator_queue_ops` (initialized at line 254 as `OperatorQueueOperations()`):
+`DatabaseManager` delegates to `self._operator_queue_ops` (`OperatorQueueOperations()`):
 
 | DatabaseManager Method | Delegates To | Line |
 |----------------------|-------------|------|
-| `create_operator_queue_item(agent_name, item)` | `create_item()` | 1199-1200 |
-| `get_operator_queue_item(item_id)` | `get_item()` | 1202-1203 |
-| `list_operator_queue_items(**kwargs)` | `list_items()` | 1205-1206 |
-| `respond_to_operator_queue_item(...)` | `respond_to_item()` | 1208-1212 |
-| `cancel_operator_queue_item(item_id)` | `cancel_item()` | 1214-1215 |
-| `mark_operator_queue_acknowledged(item_id)` | `mark_acknowledged()` | 1217-1218 |
-| `mark_operator_queue_expired()` | `mark_expired()` | 1220-1221 |
-| `get_operator_queue_stats()` | `get_stats()` | 1223-1224 |
-| `get_operator_queue_responded_for_agent(agent_name)` | `get_responded_items_for_agent()` | 1226-1227 |
-| `operator_queue_item_exists(item_id)` | `item_exists()` | 1229-1230 |
+| `create_operator_queue_item(agent_name, item)` | `create_item()` | 1944-1945 |
+| `get_operator_queue_item(item_id)` | `get_item()` | 1947-1948 |
+| `list_operator_queue_items(**kwargs)` | `list_items()` | 1950-1951 |
+| `respond_to_operator_queue_item(...)` | `respond_to_item()` | 1953-1957 |
+| `cancel_operator_queue_item(item_id)` | `cancel_item()` | 1959-1960 |
+| `bulk_cancel_operator_queue_items(ids, accessible_agent_names)` (#1017) | `bulk_cancel_items()` | 1962-1963 |
+| `clear_resolved_operator_queue_items(agent_name, accessible_agent_names)` (#1017) | `clear_resolved_items()` | 1965-1969 |
+| `get_operator_queue_terminal_for_agent(agent_name, since_hours)` (#1017) | `get_terminal_items_for_agent()` | 1971-1974 |
+| `mark_operator_queue_acknowledged(item_id)` | `mark_acknowledged()` | 1976-1977 |
+| `mark_operator_queue_expired()` | `mark_expired()` | 1979-1980 |
+| `get_operator_queue_stats(**kwargs)` | `get_stats()` | 1982-1983 |
+| `get_operator_queue_responded_for_agent(agent_name)` | `get_responded_items_for_agent()` | 1985-1986 |
+| `operator_queue_item_exists(item_id)` | `item_exists()` | 1988-1989 |
 
 ---
 
@@ -357,7 +397,7 @@ Accepts a `file_exists` parameter (default `True`) to handle the case where the 
 
 ### Database Table
 
-**Table**: `operator_queue` (in `src/backend/db/schema.py:531-553`)
+**Table**: `operator_queue` (in `src/backend/db/schema.py:981-1005`)
 
 ```sql
 CREATE TABLE IF NOT EXISTS operator_queue (
@@ -379,11 +419,14 @@ CREATE TABLE IF NOT EXISTS operator_queue (
     responded_by_email TEXT,
     responded_at TEXT,
     acknowledged_at TEXT,
+    cleared_at TEXT,                 -- #1017: NULL = visible; set = hidden by Clear All (Resolved tab)
     FOREIGN KEY (responded_by_id) REFERENCES users(id)
 )
 ```
 
-**Indexes** (`src/backend/db/schema.py:699-704`):
+**Migration** (#1017): `operator_queue_cleared_at` (`src/backend/db/migrations.py:_migrate_operator_queue_cleared_at`, line 2386-2402) — `ALTER TABLE operator_queue ADD COLUMN cleared_at TEXT` via `_safe_add_column`. Rationale (from the migration docstring): clearing the Resolved tab **hides** rows rather than deleting them — a DELETE would let the 5s sync loop resurrect any item whose agent-file entry still says 'pending' (always true for expired items, which are never written back, and for cancelled items whose status flip hasn't been written back yet). Actual deletion is the retention sweep's job (#1142).
+
+**Indexes** (`src/backend/db/schema.py:1313-1317`):
 ```sql
 CREATE INDEX IF NOT EXISTS idx_operator_queue_agent ON operator_queue(agent_name);
 CREATE INDEX IF NOT EXISTS idx_operator_queue_status ON operator_queue(status);
@@ -394,24 +437,27 @@ CREATE INDEX IF NOT EXISTS idx_operator_queue_created ON operator_queue(created_
 
 ### Database Operations
 
-**File**: `src/backend/db/operator_queue.py` (335 lines) -- `OperatorQueueOperations` class
+**File**: `src/backend/db/operator_queue.py` (495 lines) -- `OperatorQueueOperations` class
 
 | Method | Line | Description |
 |--------|------|-------------|
-| `_row_to_item(row)` | 20-41 | Convert DB row (18 columns) to dict, JSON-parses options and context |
-| `create_item(agent_name, item)` | 50-86 | INSERT OR IGNORE from agent JSON data. Extracts execution_id from `context.execution_id` |
-| `get_item(item_id)` | 88-100 | SELECT single item by ID |
-| `list_items(...)` | 102-153 | Filtered list with dynamic WHERE clauses. Sort: pending first, then by priority order, then created_at DESC |
-| `respond_to_item(...)` | 155-192 | UPDATE status=responded WHERE status=pending. Sets response, responded_by_id, responded_by_email, responded_at |
-| `cancel_item(item_id)` | 194-210 | UPDATE status=cancelled WHERE status=pending |
-| `mark_acknowledged(item_id)` | 212-223 | UPDATE status=acknowledged WHERE status=responded. Sets acknowledged_at |
-| `mark_expired()` | 225-241 | UPDATE status=expired WHERE status=pending AND expires_at < now. Returns count |
-| `get_stats()` | 243-306 | Aggregate counts by status, type (pending), priority (pending), agent (pending). Calculates avg_response_seconds and responded_today |
-| `get_pending_item_ids()` | 308-313 | SELECT id WHERE status=pending |
-| `get_responded_items_for_agent(agent_name)` | 315-327 | SELECT WHERE agent_name=? AND status=responded (for sync service write-back) |
-| `item_exists(item_id)` | 329-334 | SELECT 1 existence check |
+| `_row_to_item(row)` | 19-42 | Convert DB row (19 columns) to dict, JSON-parses options and context. `cleared_at` is `row[18]` — it must stay positionally LAST in `_SELECT_COLS` (line 44-50, #1017) |
+| `create_item(agent_name, item)` | 52-88 | INSERT OR IGNORE from agent JSON data. Extracts execution_id from `context.execution_id` |
+| `get_item(item_id)` | 90-102 | SELECT single item by ID (no `cleared_at` filter) |
+| `list_items(..., include_cleared=False)` | 104-177 | Filtered list with dynamic WHERE clauses. `include_cleared: bool = False` (#1017) — cleared rows (`cleared_at IS NOT NULL`) are excluded by default; only listing honors this — `get_item` and the sync-service accessors never filter on `cleared_at`. Sort: pending first, then by priority order, then created_at DESC |
+| `respond_to_item(...)` | 179-221 | UPDATE status=responded WHERE status=pending. Sets response, responded_by_id, responded_by_email, responded_at. **Race marker (#1017)**: `rowcount == 0` with an existing row means the item left 'pending' between the router's check and the UPDATE — returns the current item with `_status_conflict: True` so the router can 409 instead of returning a silent 200 |
+| `cancel_item(item_id)` | 223-239 | UPDATE status=cancelled WHERE status=pending |
+| `bulk_cancel_items(ids, accessible_agent_names)` (#1017) | 241-280 | Single UPDATE status=cancelled WHERE status=pending AND id IN (...). Tri-state scoping: `None` = no filter (admin), empty set = no-op (returns 0), non-empty = SQL-side `agent_name IN (...)`. Returns rowcount |
+| `clear_resolved_items(agent_name, accessible_agent_names)` (#1017) | 282-327 | UPDATE SET cleared_at=now WHERE status IN ('acknowledged','cancelled','expired') AND cleared_at IS NULL. A **hide flag, NOT a DELETE** — the 5s sync loop re-creates any DB-missing item whose agent-file entry still says 'pending' (always true for expired items, and for cancelled items whose flip hasn't been written back yet), so a DELETE would resurrect them; actual deletion is the retention sweep's job (#1142). `responded` rows are intentionally kept (sync service still has to deliver the answer). Same tri-state scoping; optional `agent_name` narrows further. Returns rowcount |
+| `mark_acknowledged(item_id)` | 329-340 | UPDATE status=acknowledged WHERE status=responded. Sets acknowledged_at |
+| `mark_expired()` | 342-358 | UPDATE status=expired WHERE status=pending AND expires_at < now. Returns count |
+| `get_stats()` | 360-445 | Aggregate counts by status, type (pending), priority (pending), agent (pending). Calculates avg_response_seconds and responded_today |
+| `get_pending_item_ids()` | 447-452 | SELECT id WHERE status=pending |
+| `get_responded_items_for_agent(agent_name)` | 454-466 | SELECT WHERE agent_name=? AND status=responded (for sync service write-back) |
+| `get_terminal_items_for_agent(agent_name, since_hours=168)` (#1017) | 468-488 | SELECT WHERE agent_name=? AND status IN ('cancelled','expired') AND created_at >= `iso_cutoff(since_hours)` — created_at-bounded (no per-status timestamp column) so the per-agent 5s sync query stays cheap. Deliberately NOT filtered on `cleared_at` — hidden items still need their flip delivered. Feeds the terminal-status write-back |
+| `item_exists(item_id)` | 490-495 | SELECT 1 existence check |
 
-**List query sort order** (line 133-144):
+**List query sort order** (line 156-169):
 ```sql
 ORDER BY
     CASE status WHEN 'pending' THEN 0 ELSE 1 END,
@@ -457,9 +503,11 @@ Agents write to `~/.trinity/operator-queue.json`:
 
 ```
 Agent creates -> pending -> responded (by operator) -> acknowledged (by agent)
-                         -> cancelled (by operator)
+                         -> cancelled (by operator — single cancel or bulk Clear All)
                          -> expired (by platform, if expires_at passed)
 ```
+
+Cancellations and expirations are propagated back to the agent on the next sync cycle (#1017): still-`pending` entries in the agent's file are flipped in place to their terminal DB status (`cancelled` or `expired`) so the agent stops waiting on them (entries missing from the file are never appended — there is nothing to deliver).
 
 ### Meta-Prompt Integration
 
@@ -481,10 +529,12 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 
 ## Side Effects
 
-- **WebSocket broadcast**: `operator_queue_new` -- When new items are synced from agents (sync service, line 155-170)
-- **WebSocket broadcast**: `operator_queue_responded` -- When operator submits response (router, line 116-125)
-- **WebSocket broadcast**: `operator_queue_acknowledged` -- When agent acknowledges response (sync service, line 172-183)
-- **File write**: Response data written back to agent container JSON via `AgentClient.write_file()` (sync service, line 218-234)
+- **WebSocket broadcast**: `operator_queue_new` -- When new items are synced from agents (sync service, line 155-171)
+- **WebSocket broadcast**: `operator_queue_responded` -- When operator submits response (router, line 255-264)
+- **WebSocket broadcast**: `operator_queue_acknowledged` -- When agent acknowledges response (sync service, line 173-184)
+- **WebSocket broadcast**: `operator_queue_cleared` (#1017) -- One event per bulk-cancel (`scope: "pending"`) or clear-resolved (`scope: "resolved"`) operation; all connected clients refetch
+- **Audit log** (#1017): `AuditEventType.OPERATOR_QUEUE` with `event_action="bulk_cancel"` (details: cancelled/skipped counts + ids) or `event_action="clear_resolved"` (details: cleared count + agent_name) -- only when the operation actually touched rows
+- **File write**: Response data (and #1017 terminal-status flips, cancelled/expired) written back to agent container JSON via `AgentClient.write_file()` (sync service, line 267-286)
 - **NavBar badge**: Updates pending count in real time via WebSocket events and polling
 
 ---
@@ -493,25 +543,32 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 
 | Error Case | HTTP Status | Message | Source |
 |------------|-------------|---------|--------|
-| Item not found | 404 | "Queue item not found" | `operator_queue.py:85,99,137` |
-| Respond to non-pending | 400 | "Cannot respond to item with status '{status}'" | `operator_queue.py:101-105` |
-| Cancel non-pending | 400 | "Cannot cancel item with status '{status}'" | `operator_queue.py:140-144` |
+| Item not found | 404 | "Queue item not found" | `operator_queue.py:215,230,281` |
+| Respond to non-pending | 400 | "Cannot respond to item with status '{status}'" | `operator_queue.py:235-239` |
+| Respond/cancel race (#1017) | 409 | "Item is no longer pending (now '{status}') — response was not recorded" | `operator_queue.py:252-256` (via `_status_conflict` DB marker) |
+| Cancel non-pending | 400 | "Cannot cancel item with status '{status}'" | `operator_queue.py:286-290` |
+| Inaccessible agent | 403 | "Access denied" | `_assert_agent_accessible()` (`operator_queue.py:73-76`) |
+| Bulk-cancel ids out of bounds (#1017) | 422 | Validation error (`ids` 1-500 items) | Pydantic `BulkCancelRequest` |
 | Missing response body | 422 | Validation error (Pydantic) | FastAPI automatic |
 | Unauthenticated | 401 | "Not authenticated" | `get_current_user` dependency |
-| Invalid JSON in agent file | -- | Logged as warning, skipped | `operator_queue_service.py:123` |
+| Invalid JSON in agent file | -- | Logged as warning, skipped | `operator_queue_service.py:124` |
 | Agent unreachable | -- | Silently skipped (no log) | `operator_queue_service.py:109-111` |
-| Write-back failure | -- | Logged as warning/error | `operator_queue_service.py:230-234` |
+| Write-back failure | -- | Logged as warning/error | `operator_queue_service.py:281-286` |
+
+Note: bulk-cancel never errors on individual ids — non-pending or inaccessible ids are silently skipped and reported in the `skipped` count. An empty accessible-agent set (zero-agent user) is a no-op (`cancelled: 0` / `cleared: 0`), not a 403.
 
 ---
 
 ## Testing
 
-### Test File
+### Test Files
 
-`tests/test_operator_queue.py` -- registered in `tests/registry.json`
+- `tests/test_operator_queue.py` -- registered in `tests/registry.json`
+- `tests/test_ops_clear_all.py` (#1017, 20 tests) -- registered in `tests/registry.json`
 
 ### Test Categories
 
+`test_operator_queue.py`:
 - **Authentication** (6 tests): All endpoints require JWT auth
 - **List items** (10 tests): Structure, pagination, filters, validation
 - **Get item** (2 tests): Found and not found cases
@@ -519,6 +576,14 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 - **Respond** (5 tests): Happy path, already responded, not found, validation
 - **Cancel** (3 tests): Happy path, already responded, not found
 - **Agent items** (5 tests): Per-agent queries, filters, empty results
+
+`test_ops_clear_all.py` (#1017):
+- **TestClearAllAuthentication**: bulk-cancel / clear-resolved / notifications dismiss-all require JWT
+- **TestBulkCancel**: only listed pending ids cancelled, skipped counting, ids validation (1-500)
+- **TestRespondConflictMarker**: respond after cancel returns 409, response not recorded
+- **TestClearResolved**: hides acknowledged/cancelled/expired (sets `cleared_at`, rows drop out of listings), keeps responded + pending, optional agent_name filter, idempotency
+- **TestDismissAllNotifications**: Notifications-tab Clear All counterpart (`POST /api/notifications/dismiss-all`)
+- **TestClearAllAccessControl**: tri-state accessible-agent scoping (admin = unfiltered; empty set = no-op)
 
 ### Prerequisites
 
@@ -533,6 +598,8 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 3. **Get stats**: `GET /api/operator-queue/stats` -> `{by_status, by_type, ...}`
 4. **Respond to item**: `POST /api/operator-queue/{id}/respond` -> 200, status=responded
 5. **Cancel item**: `POST /api/operator-queue/{id}/cancel` -> 200, status=cancelled
+6. **Bulk cancel** (#1017): `POST /api/operator-queue/bulk-cancel` with `{"ids": [...]}` -> 200 `{cancelled, skipped}`; listed pending items become cancelled
+7. **Clear resolved** (#1017): `POST /api/operator-queue/clear-resolved` -> 200 `{cleared}`; acknowledged/cancelled/expired rows get `cleared_at` set and drop out of listings (rows are NOT deleted — retention sweep #1142), responded rows remain visible
 
 ---
 
@@ -595,6 +662,31 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 11. Agent reads reconstructed JSON, finds responded items, processes them normally
 ```
 
+### Flow 5: Clear All on Needs Response (#1017)
+
+```
+1. Operator on the Needs Response tab clicks "Clear All" (data-testid ops-clear-all)
+2. ConfirmDialog warns: agents will be told their requests were cancelled;
+   affects all operators of these agents
+3. confirmClearAll() -> operatorQueueStore.bulkCancel(openItems ids)
+   (only the rendered ids — a sync-race item the operator never saw is untouched)
+4. POST /api/operator-queue/bulk-cancel {ids} -> db.bulk_cancel_operator_queue_items()
+   Single UPDATE status=cancelled WHERE status=pending AND id IN (...) [+ agent scoping]
+5. Audit log (bulk_cancel) + one WS broadcast {type: "operator_queue_cleared",
+   data: {scope: "pending", count, cleared_by}}
+6. All connected clients refetch; cancelled items move to the Resolved tab
+   (resolvedItems now includes cancelled/expired), rendered with a gray badge
+7. Concurrent respond on a just-cancelled item: router status check passed but the
+   UPDATE ... WHERE status='pending' hits 0 rows -> DB returns _status_conflict
+   -> router 409 -> store shows "your response was not recorded" and refetches
+8. Next sync cycle: get_operator_queue_terminal_for_agent() (168h window,
+   cancelled+expired, not filtered on cleared_at) -> still-'pending' entries
+   in the agent's operator-queue.json flipped to their terminal status in
+   place -> agent stops waiting
+```
+
+Clear All on **Resolved** instead calls `clearResolved()` -> `POST /api/operator-queue/clear-resolved` -> sets `cleared_at` on acknowledged/cancelled/expired rows so they drop out of listings (`responded` kept visible for write-back delivery; rows are NOT deleted — a DELETE would be resurrected by the sync loop, actual deletion deferred to retention sweep #1142) -> same WS event with `scope: "resolved"`. Clear All on **Notifications** calls `notificationsStore.dismissAll()` -> `POST /api/notifications/dismiss-all` (broadcasts `notifications_cleared`; see [agent-notifications.md](agent-notifications.md)).
+
 ---
 
 ## UI Layout
@@ -654,6 +746,10 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 | Sync direction | Platform polls agents | Agents don't need to know about the platform API |
 | Poll interval | 5 seconds (sync service), 10s (queue frontend), 60s (alerts/notifications) | Fast for queue, lighter for background counts |
 | WebSocket key | `type` field (not `event`) | Distinct from agent lifecycle events which use `event` field |
+| Clear All sends rendered ids (#1017) | Client posts the ids it showed, not "cancel everything pending" | A sync-loop race can never cancel an item the operator never saw |
+| Clear Resolved = `cleared_at` hide, NOT a DELETE (#1017) | UPDATE cleared_at on terminal rows; keep `responded` visible until acknowledged | A DELETE would be resurrected by the 5s sync loop — it re-creates any DB-missing item whose agent-file entry still says 'pending', which is always true for expired items (never written back before #1017) and for cancelled items whose flip hasn't propagated. Sync write-back also still has to deliver the operator's answer for `responded` rows. Actual deletion deferred to the retention sweep (#1142) |
+| Respond race -> 409, not silent 200 (#1017) | DB `_status_conflict` marker surfaces concurrent cancel | The operator must know their answer was NOT recorded |
+| Terminal write-back flips in place (#1017) | Never appends missing entries to the agent file | There is nothing to deliver for a cancelled/expired item; appending would resurrect noise. Flipping also prevents a stale 'pending' file entry from resurrecting the item once its row is eventually purged |
 
 ---
 
@@ -664,11 +760,13 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 | File | Lines | Purpose |
 |------|-------|---------|
 | `src/backend/main.py` | 70, 82, 193-194, 254-258, 290-294, 357 | Router/service imports, WS injection, lifespan start/stop, router registration |
-| `src/backend/routers/operator_queue.py` | 164 | REST API endpoints (6 endpoints) |
-| `src/backend/services/operator_queue_service.py` | 269 | Background sync service (poll, create, write-back, restart resilience) |
-| `src/backend/db/operator_queue.py` | 335 | Database operations class (12 methods) |
-| `src/backend/db/schema.py` | 529-553, 699-704 | Table definition + 5 indexes |
-| `src/backend/database.py` | 127, 254, 1195-1230 | Import, init, delegation methods (10 methods) |
+| `src/backend/routers/operator_queue.py` | 311 | REST API endpoints (8 endpoints incl. #1017 bulk-cancel/clear-resolved) |
+| `src/backend/services/operator_queue_service.py` | 290 | Background sync service (poll, create, write-back incl. #1017 terminal-status flips, restart resilience) |
+| `src/backend/db/operator_queue.py` | 495 | Database operations class (15 methods incl. #1017 bulk_cancel_items/clear_resolved_items/get_terminal_items_for_agent) |
+| `src/backend/db/schema.py` | 981-1005, 1313-1317 | Table definition (incl. #1017 `cleared_at`) + 5 indexes |
+| `src/backend/db/migrations.py` | 2386-2402 | #1017 `operator_queue_cleared_at` migration (`_migrate_operator_queue_cleared_at`) |
+| `src/backend/database.py` | 1940-1989 | Delegation methods (13 methods) |
+| `tests/test_ops_clear_all.py` | -- | #1017 test suite (20 tests, 6 classes) |
 
 ### Agent Base Image Files
 
@@ -684,17 +782,17 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 | `src/frontend/src/views/Operations.vue` | -- | Main page with 5 tabs, `?tab=` deep linking, admin-gated Health tab, combined subtitle, refresh, container-level polling lifecycle (renamed from `OperatingRoom.vue`, #1109) |
 | `src/frontend/src/components/MonitoringPanel.vue` | -- | Health tab content (extracted from deleted `views/Monitoring.vue`, #1109) |
 | `src/frontend/src/components/ExecutionsPanel.vue` | -- | Executions tab content (extracted from deleted `views/Executions.vue`, #1109) |
-| `src/frontend/src/stores/operatorQueue.js` | 194 | Pinia store for operator queue (state, getters, actions, WS handler) |
+| `src/frontend/src/stores/operatorQueue.js` | 239 | Pinia store for operator queue (state, getters, actions incl. #1017 bulkCancel/clearResolved, WS handler, 409 surfacing) |
 | `src/frontend/src/stores/notifications.js` | 315 | Pinia store for notifications (filters, bulk actions, polling) |
 | `src/frontend/src/components/operator/QueueCard.vue` | 257 | Expandable card with response controls |
-| `src/frontend/src/components/operator/ResolvedCard.vue` | 68 | Compact resolved card |
+| `src/frontend/src/components/operator/ResolvedCard.vue` | 82 | Compact resolved card (incl. #1017 Cancelled/Expired badge) |
 | `src/frontend/src/components/operator/NotificationsPanel.vue` | 541 | Notifications tab -- filters, bulk actions, stats, notification list with expand/dismiss/acknowledge |
 | `src/frontend/src/components/operator/QueueList.vue` | 195 | Filterable list view |
 | `src/frontend/src/components/operator/QueueStats.vue` | 88 | Stats sidebar |
 | `src/frontend/src/components/operator/QueueItemDetail.vue` | 286 | Full item detail panel |
 | `src/frontend/src/components/NavBar.vue` | -- | Single "Operations" link + combined badge (2 stores), starts notification polling (#1109: replaced separate Health/Ops/Executions links + Executions running badge) |
 | `src/frontend/src/router/index.js` | -- | `/operations` route registration + legacy redirects (`/operating-room`, `/monitoring`, `/executions`, `/events`) (#1109) |
-| `src/frontend/src/utils/websocket.js` | 4, 12, 96-98 | Import store, init store, dispatch WS events |
+| `src/frontend/src/utils/websocket.js` | 147-149 | Dispatch operator-queue WS events (incl. #1017 `operator_queue_cleared`) to the store |
 
 **Deleted files** (consolidated into Operations, then subsequently removed):
 - `src/frontend/src/views/Events.vue` -- Replaced by `NotificationsPanel.vue` in the Notifications tab
@@ -709,9 +807,9 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 ## Not Yet Implemented
 
 ### Phase 5: MCP Tools & Polish
-- [ ] MCP tools: `list_operator_queue`, `respond_to_operator_request`, `get_operator_queue_stats`
+- [x] MCP read tools: `list_operator_queue`, `get_operator_queue_item` (#1101); write/respond over MCP still deferred
+- [x] Batch cancel/clear ("Clear All", #1017); batch **respond** to multiple items still open
 - [ ] Activity feed integration (log responses as activities)
-- [ ] Batch operations (respond to multiple items)
 - [ ] Sound/desktop notifications for critical items
 - [ ] Keyboard shortcuts (j/k navigation, Enter to respond)
 
@@ -730,6 +828,7 @@ The `/api/trinity/inject` endpoint compares the source `prompt.md` (at `/trinity
 
 | Date | Change |
 |------|--------|
+| 2026-06-11 | #1017 "Clear All": per-tab bulk clear on the operator tabs (Needs Response -> `POST /api/operator-queue/bulk-cancel` `{ids}` (deduped order-preserving for an honest `skipped` count); Resolved -> `POST /api/operator-queue/clear-resolved` `{agent_name?}`; Notifications -> existing `POST /api/notifications/dismiss-all`). Clear-resolved **hides** terminal rows (new `cleared_at` column, migration `operator_queue_cleared_at`) instead of hard-deleting — a DELETE would be resurrected by the 5s sync loop (it re-creates DB-missing items whose file entry still says 'pending'); actual deletion deferred to the retention sweep (#1142). `list_items` gained `include_cleared=False`; `get_item` and the sync accessors never filter on `cleared_at`. Both new endpoints are audit-logged and broadcast one `operator_queue_cleared` WS event (`scope: pending\|resolved`). Tri-state accessible-agent scoping (None=admin, empty set=no-op) pushed into the DB layer. Respond/cancel race fixed: `respond_to_item` returns `_status_conflict` when the item left 'pending', router 409s instead of a silent 200; store surfaces a user-visible error. Sync service now also fetches recently-terminal items (`get_operator_queue_terminal_for_agent` — cancelled+expired, 168h created_at window) and flips still-'pending' agent-file entries to their terminal status in place (never appends). Frontend: Clear All button (`data-testid ops-clear-all`) + ConfirmDialog with blast-radius copy in `Operations.vue`; `resolvedItems` now includes cancelled/expired; `ResolvedCard.vue` Cancelled/Expired badge; `websocket.js` routes `operator_queue_cleared`. Tests: `tests/test_ops_clear_all.py` (20 tests). |
 | 2026-06-09 | #1109 frontend IA refactor: "Operating Room" -> **Operations**. `OperatingRoom.vue` -> `Operations.vue`, route `/operating-room` -> `/operations` (name `Operations`). Tabs 3 -> 5 (added Health + Executions; `VALID_TABS = ['needs-response','notifications','health','executions','resolved']`). Health renders new `MonitoringPanel.vue` (from deleted `views/Monitoring.vue`), admin-tab-gated. Executions renders new `ExecutionsPanel.vue` (from deleted `views/Executions.vue`); `ExecutionDetail.vue` unchanged. Tabs toggle via `v-if` for polling teardown; operator-queue polling + `fetchAgents()` stay container-level. NavBar collapsed Health/Ops/Executions links into one "Operations" link with the existing combined badge; removed the separate Executions running-count badge. Legacy redirects added: `/operating-room` (function form, preserves `?tab=`), `/monitoring`->`?tab=health`, `/executions`->`?tab=executions`, `/events`->`?tab=notifications`. No backend changes. |
 | 2026-03-08 | Consolidated Events page and Cost Alerts page into Operating Room as tabs. Added NotificationsPanel.vue, CostAlertsPanel.vue. Removed NavBar bell icons. Combined Ops badge count. Old routes redirect. |
 | 2026-03-08 | Restart-resilient sync, refresh button, stale prompt detection |

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1432,6 +1432,12 @@ class DatabaseManager:
     def dismiss_notification(self, notification_id: str, dismissed_by: str):
         return self._notification_ops.dismiss_notification(notification_id, dismissed_by)
 
+    def dismiss_all_notifications(self, dismissed_by: str, agent_name=None,
+                                  accessible_agent_names=None):
+        return self._notification_ops.dismiss_all(
+            dismissed_by, agent_name, accessible_agent_names
+        )
+
     def delete_agent_notifications(self, agent_name: str):
         return self._notification_ops.delete_agent_notifications(agent_name)
 
@@ -1952,6 +1958,20 @@ class DatabaseManager:
 
     def cancel_operator_queue_item(self, item_id):
         return self._operator_queue_ops.cancel_item(item_id)
+
+    def bulk_cancel_operator_queue_items(self, ids, accessible_agent_names=None):
+        return self._operator_queue_ops.bulk_cancel_items(ids, accessible_agent_names)
+
+    def clear_resolved_operator_queue_items(self, agent_name=None,
+                                            accessible_agent_names=None):
+        return self._operator_queue_ops.clear_resolved_items(
+            agent_name, accessible_agent_names
+        )
+
+    def get_operator_queue_terminal_for_agent(self, agent_name, since_hours=168):
+        return self._operator_queue_ops.get_terminal_items_for_agent(
+            agent_name, since_hours
+        )
 
     def mark_operator_queue_acknowledged(self, item_id):
         return self._operator_queue_ops.mark_acknowledged(item_id)

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -2383,6 +2383,25 @@ def _migrate_users_suspended_at(cursor, conn):
     conn.commit()
 
 
+def _migrate_operator_queue_cleared_at(cursor, conn):
+    """#1017 — Clear All on the Operations Resolved tab.
+
+    Adds `cleared_at TEXT` (NULL = visible) to `operator_queue`. Clearing
+    the Resolved tab hides rows rather than deleting them: a DELETE would
+    let the 5s sync loop resurrect any item whose agent-file entry still
+    says 'pending' (always true for expired items, and for cancelled items
+    whose status flip hasn't been written back yet). Actual deletion is the
+    retention sweep's job (#1142).
+    """
+    _safe_add_column(
+        cursor,
+        "operator_queue",
+        "cleared_at",
+        "ALTER TABLE operator_queue ADD COLUMN cleared_at TEXT",
+    )
+    conn.commit()
+
+
 MIGRATIONS = [
     ("agent_sharing", _migrate_agent_sharing_table),
     ("schedule_executions_observability", _migrate_schedule_executions_observability),
@@ -2455,4 +2474,5 @@ MIGRATIONS = [
     ("users_suspended_at", _migrate_users_suspended_at),
     ("agent_ownership_circuit_breaker", _migrate_agent_ownership_circuit_breaker),
     ("voip_tables", _migrate_voip_tables),
+    ("operator_queue_cleared_at", _migrate_operator_queue_cleared_at),
 ]

--- a/src/backend/db/notifications.py
+++ b/src/backend/db/notifications.py
@@ -253,6 +253,50 @@ class NotificationOperations:
 
         return self.get_notification(notification_id)
 
+    def dismiss_all(
+        self,
+        dismissed_by: str,
+        agent_name: Optional[str] = None,
+        accessible_agent_names: Optional[set] = None,
+    ) -> int:
+        """Dismiss all non-dismissed notifications in one statement (#1017).
+
+        Targets pending AND acknowledged rows — a button named "Clear All"
+        must clear the visible feed, which shows both.
+
+        accessible_agent_names: None = no filter; empty set = no-op (a
+        zero-agent user must not touch anything); non-empty = SQL IN filter.
+
+        Returns the number of notifications dismissed.
+        """
+        if accessible_agent_names is not None and len(accessible_agent_names) == 0:
+            return 0
+
+        now = utc_now_iso()
+        query = """
+            UPDATE agent_notifications
+            SET status = 'dismissed',
+                acknowledged_at = ?,
+                acknowledged_by = ?
+            WHERE status IN ('pending', 'acknowledged')
+        """
+        params: list = [now, dismissed_by]
+
+        if accessible_agent_names is not None:
+            placeholders = ",".join(["?"] * len(accessible_agent_names))
+            query += f" AND agent_name IN ({placeholders})"
+            params.extend(sorted(accessible_agent_names))
+
+        if agent_name:
+            query += " AND agent_name = ?"
+            params.append(agent_name)
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            conn.commit()
+            return cursor.rowcount
+
     def delete_agent_notifications(self, agent_name: str) -> int:
         """
         Delete all notifications for an agent.

--- a/src/backend/db/operator_queue.py
+++ b/src/backend/db/operator_queue.py
@@ -10,7 +10,7 @@ from typing import Optional, List, Dict, Set
 from datetime import datetime
 
 from .connection import get_db_connection
-from utils.helpers import utc_now_iso
+from utils.helpers import utc_now_iso, iso_cutoff
 
 
 class OperatorQueueOperations:
@@ -38,13 +38,15 @@ class OperatorQueueOperations:
             "responded_by_email": row[15],
             "responded_at": row[16],
             "acknowledged_at": row[17],
+            "cleared_at": row[18],
         }
 
+    # cleared_at must stay LAST — _row_to_item indexes positionally (#1017)
     _SELECT_COLS = """
         id, agent_name, type, status, priority, title, question,
         options, context, execution_id, created_at, expires_at,
         response, response_text, responded_by_id, responded_by_email,
-        responded_at, acknowledged_at
+        responded_at, acknowledged_at, cleared_at
     """
 
     def create_item(self, agent_name: str, item: Dict) -> str:
@@ -109,18 +111,26 @@ class OperatorQueueOperations:
         limit: int = 100,
         offset: int = 0,
         accessible_agent_names: Optional[Set[str]] = None,
+        include_cleared: bool = False,
     ) -> List[Dict]:
         """List queue items with optional filters.
 
         accessible_agent_names: if None, no access filter (admin). If a set,
         only items whose agent_name is in the set are returned. Empty set
         short-circuits to [] (user has no accessible agents).
+
+        include_cleared: rows hidden by Clear All (#1017) are excluded by
+        default. Only listing honors this — get_item and the sync-service
+        accessors never filter on cleared_at.
         """
         if accessible_agent_names is not None and len(accessible_agent_names) == 0:
             return []
 
         query = f"SELECT {self._SELECT_COLS} FROM operator_queue WHERE 1=1"
         params = []
+
+        if not include_cleared:
+            query += " AND cleared_at IS NULL"
 
         if accessible_agent_names is not None:
             placeholders = ",".join(["?"] * len(accessible_agent_names))
@@ -200,8 +210,13 @@ class OperatorQueueOperations:
                 row = cursor.fetchone()
                 if not row:
                     return None
-                # Item exists but not pending — return it anyway
-                return self.get_item(item_id)
+                # Item exists but not pending — lost a race (e.g. bulk-cancel
+                # landed between the router's status check and this UPDATE).
+                # Mark the conflict so the router can 409 instead of returning
+                # a 200 for a response that was never recorded (#1017).
+                item = self.get_item(item_id)
+                item["_status_conflict"] = True
+                return item
 
         return self.get_item(item_id)
 
@@ -222,6 +237,94 @@ class OperatorQueueOperations:
                     return None
 
         return self.get_item(item_id)
+
+    def bulk_cancel_items(
+        self,
+        ids: List[str],
+        accessible_agent_names: Optional[Set[str]] = None,
+    ) -> int:
+        """Cancel the listed items that are still pending (#1017).
+
+        Only items in `ids` are touched — the caller sends the ids it actually
+        showed the operator, so a sync-loop race can never cancel items the
+        operator never saw. Non-pending and inaccessible ids are skipped.
+
+        accessible_agent_names: None = no filter (admin); empty set = no-op
+        (a zero-agent user must not be able to touch anything); non-empty =
+        SQL-side IN filter.
+
+        Returns the number of items actually cancelled.
+        """
+        if not ids:
+            return 0
+        if accessible_agent_names is not None and len(accessible_agent_names) == 0:
+            return 0
+
+        id_placeholders = ",".join(["?"] * len(ids))
+        query = f"""
+            UPDATE operator_queue
+            SET status = 'cancelled'
+            WHERE status = 'pending' AND id IN ({id_placeholders})
+        """
+        params: List = list(ids)
+
+        if accessible_agent_names is not None:
+            agent_placeholders = ",".join(["?"] * len(accessible_agent_names))
+            query += f" AND agent_name IN ({agent_placeholders})"
+            params.extend(sorted(accessible_agent_names))
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            conn.commit()
+            return cursor.rowcount
+
+    def clear_resolved_items(
+        self,
+        agent_name: Optional[str] = None,
+        accessible_agent_names: Optional[Set[str]] = None,
+    ) -> int:
+        """Hide terminal queue items — Clear All on the Resolved tab (#1017).
+
+        Sets cleared_at on acknowledged/cancelled/expired rows; list_items
+        excludes them by default. 'responded' rows are intentionally kept
+        visible: the sync service still has to deliver the operator's answer
+        to the agent file. A hide flag — NOT a DELETE — because the 5s sync
+        loop re-creates any DB-missing item whose agent-file entry still says
+        'pending' (always true for expired items, and for cancelled items
+        whose flip hasn't been written back yet); deleting those rows would
+        resurrect them. Actual row deletion is the retention sweep's job
+        (#1142).
+
+        Same tri-state accessible_agent_names contract as bulk_cancel_items.
+        Returns the number of rows hidden.
+        """
+        if accessible_agent_names is not None and len(accessible_agent_names) == 0:
+            return 0
+
+        now = utc_now_iso()
+        query = """
+            UPDATE operator_queue
+            SET cleared_at = ?
+            WHERE status IN ('acknowledged', 'cancelled', 'expired')
+              AND cleared_at IS NULL
+        """
+        params: List = [now]
+
+        if accessible_agent_names is not None:
+            placeholders = ",".join(["?"] * len(accessible_agent_names))
+            query += f" AND agent_name IN ({placeholders})"
+            params.extend(sorted(accessible_agent_names))
+
+        if agent_name:
+            query += " AND agent_name = ?"
+            params.append(agent_name)
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            conn.commit()
+            return cursor.rowcount
 
     def mark_acknowledged(self, item_id: str) -> bool:
         """Mark an item as acknowledged by the agent."""
@@ -360,6 +463,28 @@ class OperatorQueueOperations:
                 FROM operator_queue
                 WHERE agent_name = ? AND status = 'responded'
             """, (agent_name,))
+            return [self._row_to_item(row) for row in cursor.fetchall()]
+
+    def get_terminal_items_for_agent(self, agent_name: str, since_hours: int = 168) -> List[Dict]:
+        """Get recently cancelled/expired items for a specific agent (#1017).
+
+        Used by the sync service to flip still-'pending' entries in the
+        agent's queue file to their terminal status so the agent stops
+        waiting (and so a stale 'pending' file entry can't resurrect the
+        item if its row is ever purged). Deliberately NOT filtered on
+        cleared_at — hidden items still need their flip delivered. Bounded
+        by created_at (there is no per-status timestamp) so the per-agent
+        5s sync query stays cheap.
+        """
+        cutoff = iso_cutoff(since_hours)
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(f"""
+                SELECT {self._SELECT_COLS}
+                FROM operator_queue
+                WHERE agent_name = ? AND status IN ('cancelled', 'expired')
+                  AND created_at >= ?
+            """, (agent_name, cutoff))
             return [self._row_to_item(row) for row in cursor.fetchall()]
 
     def item_exists(self, item_id: str) -> bool:

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -998,6 +998,7 @@ TABLES = {
             responded_by_email TEXT,
             responded_at TEXT,
             acknowledged_at TEXT,
+            cleared_at TEXT,
             FOREIGN KEY (responded_by_id) REFERENCES users(id)
         )
     """,

--- a/src/backend/routers/notifications.py
+++ b/src/backend/routers/notifications.py
@@ -7,11 +7,13 @@ Notifications are persisted, broadcast via WebSocket, and queryable via API.
 
 import json
 from typing import Optional, List
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 
 from database import db
 from dependencies import get_current_user, AuthorizedAgent
 from services.agent_service import get_accessible_agents
+from services.platform_audit_service import platform_audit_service, AuditEventType
 from db_models import (
     User,
     NotificationCreate,
@@ -19,6 +21,11 @@ from db_models import (
     NotificationList,
     NotificationAcknowledge
 )
+
+
+class DismissAllRequest(BaseModel):
+    """Body for bulk-dismissing notifications (#1017)."""
+    agent_name: Optional[str] = None
 
 
 router = APIRouter(prefix="/api", tags=["notifications"])
@@ -172,6 +179,56 @@ async def list_notifications(
         count=len(notifications),
         notifications=notifications
     )
+
+
+@router.post("/notifications/dismiss-all")
+async def dismiss_all_notifications(
+    body: DismissAllRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Dismiss all non-dismissed (pending + acknowledged) notifications (#1017).
+
+    Scoped to agents the caller can access — the same accessor the list
+    endpoint uses, so "what I see" and "what I can clear" never diverge.
+    Ignores priority/type filters by design; optionally narrowed to one
+    agent via `agent_name`. Idempotent: empty match returns {"dismissed": 0}.
+    """
+    accessible_agent_names = {a['name'] for a in get_accessible_agents(current_user)}
+
+    if body.agent_name and body.agent_name not in accessible_agent_names:
+        raise HTTPException(status_code=403, detail="Access denied to agent")
+
+    dismissed = db.dismiss_all_notifications(
+        dismissed_by=str(current_user.id),
+        agent_name=body.agent_name,
+        accessible_agent_names=accessible_agent_names,
+    )
+
+    if dismissed > 0:
+        await platform_audit_service.log(
+            event_type=AuditEventType.NOTIFICATION,
+            event_action="dismiss_all",
+            source="api",
+            actor_user=current_user,
+            actor_ip=request.client.host if request.client else None,
+            target_type="notification",
+            target_id=body.agent_name,
+            endpoint=str(request.url.path),
+            details={"dismissed": dismissed, "agent_name": body.agent_name},
+        )
+        if _websocket_manager:
+            await _websocket_manager.broadcast(json.dumps({
+                "type": "notifications_cleared",
+                "data": {
+                    "count": dismissed,
+                    "agent_name": body.agent_name,
+                    "cleared_by": current_user.email or current_user.username,
+                }
+            }))
+
+    return {"dismissed": dismissed}
 
 
 @router.get("/notifications/{notification_id}", response_model=Notification)

--- a/src/backend/routers/operator_queue.py
+++ b/src/backend/routers/operator_queue.py
@@ -7,13 +7,14 @@ operator_queue_service background poller.
 """
 
 import json
-from typing import Optional, Set
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from typing import List, Optional, Set
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
 
 from database import db
 from dependencies import get_current_user
 from db_models import User
+from services.platform_audit_service import platform_audit_service, AuditEventType
 
 
 router = APIRouter(prefix="/api/operator-queue", tags=["operator-queue"])
@@ -36,6 +37,20 @@ class OperatorResponse(BaseModel):
     """Body for responding to a queue item."""
     response: str
     response_text: Optional[str] = None
+
+
+class BulkCancelRequest(BaseModel):
+    """Body for bulk-cancelling pending queue items (#1017).
+
+    The client sends the ids it actually rendered, so a sync-loop race can
+    never cancel items the operator never saw.
+    """
+    ids: List[str] = Field(..., min_length=1, max_length=500)
+
+
+class ClearResolvedRequest(BaseModel):
+    """Body for clearing the Resolved tab (#1017)."""
+    agent_name: Optional[str] = None
 
 
 # ============================================================================
@@ -100,6 +115,95 @@ async def get_queue_stats(
     return db.get_operator_queue_stats(accessible_agent_names=accessible)
 
 
+@router.post("/bulk-cancel")
+async def bulk_cancel_queue_items(
+    body: BulkCancelRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Cancel a list of pending queue items in one call (#1017).
+
+    Only the listed ids are touched; non-pending or inaccessible ids are
+    skipped (reported in `skipped`). Affects all operators of the agents.
+    """
+    accessible = _accessible_set(current_user)
+    ids = list(dict.fromkeys(body.ids))  # dedupe, keep order — honest skipped count
+    cancelled = db.bulk_cancel_operator_queue_items(ids, accessible)
+    skipped = len(ids) - cancelled
+
+    if cancelled > 0:
+        await platform_audit_service.log(
+            event_type=AuditEventType.OPERATOR_QUEUE,
+            event_action="bulk_cancel",
+            source="api",
+            actor_user=current_user,
+            actor_ip=request.client.host if request.client else None,
+            target_type="operator_queue",
+            endpoint=str(request.url.path),
+            details={"cancelled": cancelled, "skipped": skipped, "ids": body.ids},
+        )
+        if _websocket_manager:
+            await _websocket_manager.broadcast(json.dumps({
+                "type": "operator_queue_cleared",
+                "data": {
+                    "scope": "pending",
+                    "count": cancelled,
+                    "cleared_by": current_user.email or current_user.username,
+                }
+            }))
+
+    return {"cancelled": cancelled, "skipped": skipped}
+
+
+@router.post("/clear-resolved")
+async def clear_resolved_queue_items(
+    body: ClearResolvedRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Hide terminal (acknowledged/cancelled/expired) queue items (#1017).
+
+    Sets cleared_at so the rows drop out of listings; actual deletion is
+    deferred to the retention sweep (#1142) because a DELETE could be
+    resurrected by the sync loop (see db layer docstring). 'responded'
+    items awaiting agent acknowledgement are kept visible — their response
+    still has to be delivered to the agent. Affects all operators of the
+    agents. Idempotent: an empty match returns {"cleared": 0}.
+    """
+    accessible = _accessible_set(current_user)
+    if body.agent_name:
+        _assert_agent_accessible(body.agent_name, accessible)
+
+    cleared = db.clear_resolved_operator_queue_items(
+        agent_name=body.agent_name,
+        accessible_agent_names=accessible,
+    )
+
+    if cleared > 0:
+        await platform_audit_service.log(
+            event_type=AuditEventType.OPERATOR_QUEUE,
+            event_action="clear_resolved",
+            source="api",
+            actor_user=current_user,
+            actor_ip=request.client.host if request.client else None,
+            target_type="operator_queue",
+            target_id=body.agent_name,
+            endpoint=str(request.url.path),
+            details={"cleared": cleared, "agent_name": body.agent_name},
+        )
+        if _websocket_manager:
+            await _websocket_manager.broadcast(json.dumps({
+                "type": "operator_queue_cleared",
+                "data": {
+                    "scope": "resolved",
+                    "count": cleared,
+                    "cleared_by": current_user.email or current_user.username,
+                }
+            }))
+
+    return {"cleared": cleared}
+
+
 @router.get("/{item_id}")
 async def get_queue_item(
     item_id: str,
@@ -141,6 +245,15 @@ async def respond_to_queue_item(
         responded_by_id=str(current_user.id),
         responded_by_email=current_user.email or current_user.username,
     )
+
+    # Lost the race: the item left 'pending' between the check above and the
+    # UPDATE (e.g. a bulk-cancel landed). The response was NOT recorded —
+    # surface that instead of a silent 200 (#1017).
+    if item and item.pop("_status_conflict", False):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Item is no longer pending (now '{item['status']}') — response was not recorded"
+        )
 
     # Broadcast WebSocket event
     if _websocket_manager and item:

--- a/src/backend/services/operator_queue_service.py
+++ b/src/backend/services/operator_queue_service.py
@@ -183,11 +183,19 @@ class OperatorQueueSyncService:
                 except Exception:
                     pass
 
-        # 4. Write responses back to the agent's file
+        # 4. Write responses back to the agent's file. Cancelled/expired
+        # items are propagated too (#1017) so the agent stops waiting on
+        # them — but only as in-place status flips on entries still in the
+        # file.
         responded_items = db.get_operator_queue_responded_for_agent(agent_name)
-        if responded_items:
+        terminal_items = (
+            db.get_operator_queue_terminal_for_agent(agent_name)
+            if file_exists else []
+        )
+        if responded_items or terminal_items:
             await self._write_responses_to_agent(
-                agent_name, client, queue_data, responded_items, file_exists
+                agent_name, client, queue_data, responded_items,
+                terminal_items, file_exists
             )
 
     async def _write_responses_to_agent(
@@ -196,14 +204,21 @@ class OperatorQueueSyncService:
         client: AgentClient,
         queue_data: dict,
         responded_items: list,
+        terminal_items: Optional[list] = None,
         file_exists: bool = True,
     ):
         """Write operator responses back to the agent's queue file."""
         requests = queue_data.get("requests", [])
         updated = False
+        terminal_flips = 0
 
         # Build a lookup of responded items by ID
         response_map = {item["id"]: item for item in responded_items}
+        # Cancelled/expired items (#1017): flip still-'pending' file entries
+        # to their terminal status so the agent stops waiting (and so a
+        # stale 'pending' file entry can't resurrect a purged row). Never
+        # appended if missing from the file.
+        terminal_map = {item["id"]: item for item in (terminal_items or [])}
 
         # Update items already in the agent's requests array
         seen_ids = set()
@@ -217,6 +232,10 @@ class OperatorQueueSyncService:
                 req["responded_by"] = resp.get("responded_by_email")
                 req["responded_at"] = resp.get("responded_at")
                 updated = True
+            elif req_id in terminal_map and req.get("status") == "pending":
+                req["status"] = terminal_map[req_id]["status"]
+                updated = True
+                terminal_flips += 1
             if req_id:
                 seen_ids.add(req_id)
 
@@ -255,7 +274,10 @@ class OperatorQueueSyncService:
                 platform=True,  # Allow writes to .trinity directory
             )
             if result.get("success"):
-                logger.info(f"Wrote {len(response_map)} responses back to {agent_name}")
+                logger.info(
+                    f"Wrote {len(response_map)} responses and {terminal_flips} "
+                    f"terminal-status flips back to {agent_name}"
+                )
             else:
                 logger.warning(
                     f"Failed to write responses to {agent_name}: {result.get('error')}"

--- a/src/backend/services/platform_audit_service.py
+++ b/src/backend/services/platform_audit_service.py
@@ -41,6 +41,8 @@ class AuditEventType(str, Enum):
     GIT_OPERATION = "git_operation"
     PROACTIVE_MESSAGE = "proactive_message"  # Issue #321
     SITE_ACCESS = "site_access"  # SITE-001: agent website proxy visits
+    OPERATOR_QUEUE = "operator_queue"  # Issue #1017: bulk clear actions
+    NOTIFICATION = "notification"  # Issue #1017: bulk dismiss
     SYSTEM = "system"
 
 

--- a/src/frontend/src/components/operator/ResolvedCard.vue
+++ b/src/frontend/src/components/operator/ResolvedCard.vue
@@ -14,9 +14,18 @@
 
         <p class="text-sm text-gray-600 dark:text-gray-400">{{ item.title }}</p>
 
-        <!-- Response -->
+        <!-- Response (responded/acknowledged) or terminal status (cancelled/expired, #1017) -->
         <div class="mt-2 flex items-center gap-2">
-          <span class="inline-flex items-center gap-1 text-xs text-status-success-600 dark:text-status-success-400">
+          <span
+            v-if="isTerminalWithoutResponse"
+            class="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500"
+          >
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            {{ item.status === 'expired' ? 'Expired' : 'Cancelled' }}
+          </span>
+          <span v-else class="inline-flex items-center gap-1 text-xs text-status-success-600 dark:text-status-success-400">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>
@@ -26,7 +35,7 @@
             &mdash; {{ item.response_text }}
           </span>
           <span class="text-xs text-gray-400 dark:text-gray-500 ml-auto">
-            {{ timeAgo(item.responded_at) }}
+            {{ timeAgo(item.responded_at || item.created_at) }}
           </span>
         </div>
       </div>
@@ -46,6 +55,10 @@ const props = defineProps({
 
 const store = useOperatorQueueStore()
 const agentsStore = useAgentsStore()
+
+const isTerminalWithoutResponse = computed(() =>
+  props.item.status === 'cancelled' || props.item.status === 'expired'
+)
 const agentAvatarUrl = computed(() => {
   const agent = agentsStore.agents.find(a => a.name === props.item.agent_name)
   return agent?.avatar_url || null

--- a/src/frontend/src/stores/notifications.js
+++ b/src/frontend/src/stores/notifications.js
@@ -8,6 +8,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import axios from 'axios'
+import api from '../api'
 
 export const useNotificationsStore = defineStore('notifications', () => {
   // State
@@ -180,6 +181,24 @@ export const useNotificationsStore = defineStore('notifications', () => {
     }
   }
 
+  // Server-side Clear All (#1017): one call dismisses every non-dismissed
+  // notification for accessible agents — including ones beyond the loaded
+  // page — unlike the per-id bulk helpers below.
+  async function dismissAll(agentName = null) {
+    error.value = null
+    try {
+      const response = await api.post('/api/notifications/dismiss-all', {
+        agent_name: agentName,
+      })
+      await fetchNotifications()
+      await fetchPendingCount()
+      return response.data
+    } catch (err) {
+      error.value = err.response?.data?.detail || 'Failed to dismiss notifications'
+      throw err
+    }
+  }
+
   async function bulkAcknowledge(ids) {
     const results = await Promise.allSettled(
       ids.map(id => acknowledgeNotification(id))
@@ -299,6 +318,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     fetchPendingCount,
     acknowledgeNotification,
     dismissNotification,
+    dismissAll,
     bulkAcknowledge,
     bulkDismiss,
     addNotification,

--- a/src/frontend/src/stores/operatorQueue.js
+++ b/src/frontend/src/stores/operatorQueue.js
@@ -8,6 +8,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import axios from 'axios'
+import api from '../api'
 import { useAuthStore } from './auth'
 
 // Agent display helpers
@@ -49,9 +50,13 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
     return result
   })
 
+  // Resolved feed includes cancelled/expired (#1017) — before that, items
+  // cancelled from Needs Response vanished from the UI entirely.
+  const RESOLVED_STATUSES = ['responded', 'acknowledged', 'cancelled', 'expired']
+
   const resolvedItems = computed(() => {
     return items.value
-      .filter(i => i.status === 'responded' || i.status === 'acknowledged')
+      .filter(i => RESOLVED_STATUSES.includes(i.status))
       .sort((a, b) => new Date(b.responded_at || b.created_at) - new Date(a.responded_at || a.created_at))
   })
 
@@ -121,7 +126,42 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
         expandedItemId.value = nextOpen.id
       }
     } catch (err) {
+      if (err.response?.status === 409) {
+        // Item left 'pending' under us (e.g. another operator cleared the
+        // queue) — the response was NOT recorded (#1017).
+        error.value = 'This item was cancelled or answered by another operator — your response was not recorded.'
+        fetchItems()
+      } else {
+        error.value = err.response?.data?.detail || err.message
+      }
+    }
+  }
+
+  // Bulk actions (#1017)
+  async function bulkCancel(ids) {
+    if (!ids || ids.length === 0) return { cancelled: 0, skipped: 0 }
+    error.value = null
+    try {
+      const response = await api.post('/api/operator-queue/bulk-cancel', { ids })
+      await fetchItems()
+      return response.data
+    } catch (err) {
       error.value = err.response?.data?.detail || err.message
+      throw err
+    }
+  }
+
+  async function clearResolved(agentName = null) {
+    error.value = null
+    try {
+      const response = await api.post('/api/operator-queue/clear-resolved', {
+        agent_name: agentName,
+      })
+      await fetchItems()
+      return response.data
+    } catch (err) {
+      error.value = err.response?.data?.detail || err.message
+      throw err
     }
   }
 
@@ -153,6 +193,9 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
       if (item) {
         item.status = 'acknowledged'
       }
+    } else if (data.type === 'operator_queue_cleared') {
+      // Bulk clear by an operator (#1017) — refetch authoritative state
+      fetchItems()
     }
   }
 
@@ -186,6 +229,8 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
     toggleExpand,
     respondToItem,
     acknowledgeItem,
+    bulkCancel,
+    clearResolved,
     handleWebSocketEvent,
     startPolling,
     stopPolling,

--- a/src/frontend/src/utils/websocket.js
+++ b/src/frontend/src/utils/websocket.js
@@ -144,8 +144,13 @@ export function useWebSocket() {
         break
       default:
         // Handle events keyed by 'type' instead of 'event'
-        if (data.type === 'operator_queue_new' || data.type === 'operator_queue_responded' || data.type === 'operator_queue_acknowledged') {
+        if (data.type === 'operator_queue_new' || data.type === 'operator_queue_responded' || data.type === 'operator_queue_acknowledged' || data.type === 'operator_queue_cleared') {
           operatorQueueStore.handleWebSocketEvent(data)
+        }
+        // #1017: bulk dismiss by an operator — refresh badge + loaded list
+        if (data.type === 'notifications_cleared') {
+          notificationsStore.fetchPendingCount()
+          notificationsStore.fetchNotifications()
         }
         if (data.type === 'agent_activity') {
           executionsStore.handleWebSocketEvent(data)

--- a/src/frontend/src/views/Operations.vue
+++ b/src/frontend/src/views/Operations.vue
@@ -88,9 +88,22 @@
           Resolved
         </button>
 
-        <!-- Spacer + Refresh button (operator tabs only — Health/Executions
-             panels carry their own refresh controls) -->
-        <div class="ml-auto flex items-center pb-1">
+        <!-- Spacer + Clear All / Refresh buttons (operator tabs only —
+             Health/Executions panels carry their own refresh controls) -->
+        <div class="ml-auto flex items-center gap-1 pb-1">
+          <!-- Clear All (#1017) — hidden when the active tab has nothing to clear -->
+          <button
+            v-if="isOperatorTab && clearableCount > 0"
+            @click="showClearConfirm = true"
+            :disabled="clearing"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-status-danger-600 dark:text-status-danger-400 hover:text-status-danger-700 dark:hover:text-status-danger-300 rounded-md hover:bg-status-danger-50 dark:hover:bg-status-danger-900/20 transition-colors disabled:opacity-50 whitespace-nowrap"
+            data-testid="ops-clear-all"
+          >
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            Clear All
+          </button>
           <button
             v-if="isOperatorTab"
             @click="refresh"
@@ -163,6 +176,18 @@
         </div>
       </div>
     </main>
+
+    <!-- Clear All confirmation (#1017) -->
+    <ConfirmDialog
+      :visible="showClearConfirm"
+      :title="clearConfirmTitle"
+      :message="clearConfirmMessage"
+      confirm-text="Clear All"
+      variant="danger"
+      @confirm="confirmClearAll"
+      @cancel="showClearConfirm = false"
+      @update:visible="showClearConfirm = $event"
+    />
   </div>
 </template>
 
@@ -170,6 +195,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import NavBar from '../components/NavBar.vue'
+import ConfirmDialog from '../components/ConfirmDialog.vue'
 import QueueCard from '../components/operator/QueueCard.vue'
 import ResolvedCard from '../components/operator/ResolvedCard.vue'
 import NotificationsPanel from '../components/operator/NotificationsPanel.vue'
@@ -234,6 +260,62 @@ function switchTab(tab) {
 function refresh() {
   operatorQueueStore.fetchItems()
   notificationsStore.fetchPendingCount()
+}
+
+// --- Clear All (#1017) ---
+const showClearConfirm = ref(false)
+const clearing = ref(false)
+
+// What the active tab can clear. For notifications this is only a visibility
+// heuristic (pendingCount from the badge poll is effectively 0/1 — #1143 —
+// so we also count loaded non-dismissed rows); the dismiss-all endpoint
+// itself clears pending + acknowledged beyond the loaded page.
+const clearableCount = computed(() => {
+  if (activeTab.value === 'needs-response') return operatorQueueStore.openItems.length
+  if (activeTab.value === 'resolved') return operatorQueueStore.resolvedItems.length
+  if (activeTab.value === 'notifications') {
+    const loadedNonDismissed = notificationsStore.notifications
+      .filter(n => n.status !== 'dismissed').length
+    return Math.max(notificationsStore.pendingCount, loadedNonDismissed)
+  }
+  return 0
+})
+
+const clearConfirmTitle = computed(() => {
+  if (activeTab.value === 'needs-response') return 'Cancel all pending items?'
+  if (activeTab.value === 'notifications') return 'Dismiss all notifications?'
+  return 'Clear resolved items?'
+})
+
+const clearConfirmMessage = computed(() => {
+  const n = clearableCount.value
+  if (activeTab.value === 'needs-response') {
+    return `This cancels ${n} pending ${n === 1 ? 'item' : 'items'} shown here. The agents waiting on them will be told their requests were cancelled and will not receive an answer. This affects all operators of these agents.`
+  }
+  if (activeTab.value === 'notifications') {
+    return 'This dismisses every non-dismissed notification from your accessible agents — including any not shown by the current filters — for all operators of these agents.'
+  }
+  return `This permanently deletes ${n === 1 ? 'this resolved item' : 'the resolved items'} for all operators of these agents. Items still awaiting agent confirmation are kept.`
+})
+
+async function confirmClearAll() {
+  showClearConfirm.value = false
+  clearing.value = true
+  try {
+    if (activeTab.value === 'needs-response') {
+      const ids = operatorQueueStore.openItems.map(i => i.id)
+      await operatorQueueStore.bulkCancel(ids)
+    } else if (activeTab.value === 'notifications') {
+      await notificationsStore.dismissAll()
+    } else if (activeTab.value === 'resolved') {
+      await operatorQueueStore.clearResolved()
+    }
+  } catch (err) {
+    // Store actions set their own error state; nothing else to do here.
+    console.error('Clear All failed:', err)
+  } finally {
+    clearing.value = false
+  }
 }
 
 // If the role resolves asynchronously after mount and confirms non-admin,

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -630,6 +630,18 @@
         "overview"
       ],
       "description": "Agent-scoped execution analytics (#1107): triggered_by bucketing into user-facing buckets + Other fallback, terminal-based success rate, full-set avg vs sampled p95 correctness, NULL-skipping context avg, gap-filled timeline."
+    },
+    {
+      "file": "test_ops_clear_all.py",
+      "feature": "#1017",
+      "added": "2026-06-11",
+      "categories": [
+        "backend",
+        "api",
+        "operator-queue",
+        "notifications"
+      ],
+      "description": "Bulk Clear All endpoints for the Operations page (#1017): bulk-cancel (ids-scoped), clear-resolved (terminal-row delete, responded kept), notifications dismiss-all; respond-race conflict marker; tri-state accessible-set scoping."
     }
   ]
 }

--- a/tests/test_ops_clear_all.py
+++ b/tests/test_ops_clear_all.py
@@ -1,0 +1,558 @@
+"""
+Operations Clear All Tests (test_ops_clear_all.py)
+
+Tests for the bulk clear endpoints behind the Operations page Clear All
+button (#1017):
+  - POST /api/operator-queue/bulk-cancel
+  - POST /api/operator-queue/clear-resolved
+  - POST /api/notifications/dismiss-all
+
+Also pins the respond-vs-bulk-cancel race fix (DB-layer conflict marker)
+and the tri-state accessible-set contract (None=admin, empty set=no-op).
+
+Feature Flow: operating-room.md
+"""
+
+import os
+import subprocess
+import pytest
+import uuid
+from datetime import datetime, timezone
+
+from utils.api_client import TrinityApiClient, ApiConfig
+from utils.assertions import assert_status
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+_BACKEND_CONTAINER = os.getenv("TRINITY_BACKEND_CONTAINER", "trinity-backend")
+_RUN = uuid.uuid4().hex[:6]
+_AGENT = f"test-clr-agent-{_RUN}"
+_ISO_USERNAME = f"testuser-clr-{_RUN}"
+_ISO_PASSWORD = "test-clr-password-1017"
+_ISO_EMAIL = f"{_ISO_USERNAME}@test.example.com"
+
+
+def _exec_backend(python_code: str) -> str:
+    """Run python inside the backend container and return its output.
+
+    Scripts that `import database` trigger an import-time ADMIN_PASSWORD
+    warning on stdout; such scripts must print their value as `RESULT:<v>`
+    and we extract it here. Plain sqlite3 scripts return raw stdout.
+    """
+    result = subprocess.run(
+        ["docker", "exec", _BACKEND_CONTAINER, "python3", "-c", python_code],
+        capture_output=True, text=True, timeout=20,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Backend exec failed: {result.stderr}")
+    out = result.stdout.strip()
+    for line in reversed(out.splitlines()):
+        if line.startswith("RESULT:"):
+            return line[len("RESULT:"):]
+    return out
+
+
+def _seed_queue_item(item_id: str, status: str = "pending", agent: str = _AGENT):
+    """Insert an operator_queue row directly in the DB."""
+    now = datetime.now(timezone.utc).isoformat()
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+conn.execute(
+    "INSERT OR IGNORE INTO operator_queue "
+    "(id, agent_name, type, status, priority, title, question, created_at) "
+    "VALUES (?, ?, 'question', ?, 'medium', 'Clear-all test', 'Proceed?', ?)",
+    ("{item_id}", "{agent}", "{status}", "{now}"),
+)
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+
+def _seed_notification(notif_id: str, status: str = "pending", agent: str = _AGENT):
+    """Insert an agent_notifications row directly in the DB."""
+    now = datetime.now(timezone.utc).isoformat()
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+conn.execute(
+    "INSERT OR IGNORE INTO agent_notifications "
+    "(id, agent_name, notification_type, title, priority, status, created_at) "
+    "VALUES (?, ?, 'info', 'Clear-all test notif', 'normal', ?, ?)",
+    ("{notif_id}", "{agent}", "{status}", "{now}"),
+)
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+
+def _queue_item_status(item_id: str) -> str:
+    """Read an operator_queue row's status straight from the DB ('' if gone)."""
+    return _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+row = conn.execute("SELECT status FROM operator_queue WHERE id = ?", ("{item_id}",)).fetchone()
+conn.close()
+print(row[0] if row else "")
+""")
+
+
+@pytest.fixture(scope="module")
+def clr_setup(api_client: TrinityApiClient):
+    """Sentinel agent owned by admin + a zero-agent non-admin user."""
+    # Non-admin user with no agents (exercises the empty-accessible-set path)
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+from passlib.context import CryptContext
+ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pw = ctx.hash("{_ISO_PASSWORD}")
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+conn.execute(
+    "INSERT OR IGNORE INTO users (username, password_hash, role, email, created_at, updated_at) "
+    "VALUES (?, ?, 'user', ?, datetime('now'), datetime('now'))",
+    ("{_ISO_USERNAME}", pw, "{_ISO_EMAIL}"),
+)
+admin_id = conn.execute("SELECT id FROM users WHERE username='admin'").fetchone()[0]
+conn.execute(
+    "INSERT OR IGNORE INTO agent_ownership (agent_name, owner_id, created_at) "
+    "VALUES (?, ?, datetime('now'))",
+    ("{_AGENT}", admin_id),
+)
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+    cfg = ApiConfig(
+        base_url=os.getenv("TRINITY_API_URL", "http://localhost:8000"),
+        username=_ISO_USERNAME,
+        password=_ISO_PASSWORD,
+    )
+    non_admin = TrinityApiClient(cfg)
+    non_admin.authenticate()
+
+    yield {"admin": api_client, "non_admin": non_admin, "agent": _AGENT}
+
+    non_admin.close()
+
+    _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+conn.execute("DELETE FROM operator_queue WHERE agent_name = ?", ("{_AGENT}",))
+conn.execute("DELETE FROM agent_notifications WHERE agent_name = ?", ("{_AGENT}",))
+conn.execute("DELETE FROM agent_ownership WHERE agent_name = ?", ("{_AGENT}",))
+conn.execute("DELETE FROM users WHERE username = ?", ("{_ISO_USERNAME}",))
+conn.commit()
+conn.close()
+print("OK")
+""")
+
+
+# ============================================================================
+# Authentication
+# ============================================================================
+
+class TestClearAllAuthentication:
+    pytestmark = pytest.mark.smoke
+
+    def test_bulk_cancel_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        response = unauthenticated_client.post(
+            "/api/operator-queue/bulk-cancel", json={"ids": ["x"]}, auth=False
+        )
+        assert_status(response, 401)
+
+    def test_clear_resolved_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        response = unauthenticated_client.post(
+            "/api/operator-queue/clear-resolved", json={}, auth=False
+        )
+        assert_status(response, 401)
+
+    def test_dismiss_all_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        response = unauthenticated_client.post(
+            "/api/notifications/dismiss-all", json={}, auth=False
+        )
+        assert_status(response, 401)
+
+
+# ============================================================================
+# Bulk cancel (Needs Response tab)
+# ============================================================================
+
+class TestBulkCancel:
+    pytestmark = pytest.mark.smoke
+
+    def test_empty_ids_rejected(self, api_client: TrinityApiClient):
+        """ids is required and must be non-empty."""
+        response = api_client.post("/api/operator-queue/bulk-cancel", json={"ids": []})
+        assert_status(response, 422)
+
+    def test_missing_body_rejected(self, api_client: TrinityApiClient):
+        response = api_client.post("/api/operator-queue/bulk-cancel", json={})
+        assert_status(response, 422)
+
+    def test_oversized_ids_rejected(self, api_client: TrinityApiClient):
+        """More than 500 ids is rejected before reaching SQL."""
+        response = api_client.post(
+            "/api/operator-queue/bulk-cancel",
+            json={"ids": [f"x-{i}" for i in range(501)]},
+        )
+        assert_status(response, 422)
+
+    def test_bulk_cancel_pending_items(self, clr_setup):
+        """Listed pending items transition to cancelled."""
+        admin = clr_setup["admin"]
+        ids = [f"clr-bc-{_RUN}-{i}" for i in range(2)]
+        for item_id in ids:
+            _seed_queue_item(item_id, status="pending")
+
+        response = admin.post("/api/operator-queue/bulk-cancel", json={"ids": ids})
+        assert_status(response, 200)
+        data = response.json()
+        assert data["cancelled"] == 2
+        assert data["skipped"] == 0
+
+        for item_id in ids:
+            assert _queue_item_status(item_id) == "cancelled"
+
+    def test_bulk_cancel_skips_non_pending(self, clr_setup):
+        """Already-resolved ids are skipped, pending ones cancelled."""
+        admin = clr_setup["admin"]
+        pending_id = f"clr-bc-mix-p-{_RUN}"
+        responded_id = f"clr-bc-mix-r-{_RUN}"
+        _seed_queue_item(pending_id, status="pending")
+        _seed_queue_item(responded_id, status="responded")
+
+        response = admin.post(
+            "/api/operator-queue/bulk-cancel",
+            json={"ids": [pending_id, responded_id]},
+        )
+        assert_status(response, 200)
+        data = response.json()
+        assert data["cancelled"] == 1
+        assert data["skipped"] == 1
+        assert _queue_item_status(responded_id) == "responded"
+
+    def test_bulk_cancel_idempotent(self, clr_setup):
+        """Re-cancelling already-cancelled ids cancels nothing."""
+        admin = clr_setup["admin"]
+        item_id = f"clr-bc-idem-{_RUN}"
+        _seed_queue_item(item_id, status="pending")
+
+        first = admin.post("/api/operator-queue/bulk-cancel", json={"ids": [item_id]})
+        assert_status(first, 200)
+        assert first.json()["cancelled"] == 1
+
+        second = admin.post("/api/operator-queue/bulk-cancel", json={"ids": [item_id]})
+        assert_status(second, 200)
+        data = second.json()
+        assert data["cancelled"] == 0
+        assert data["skipped"] == 1
+
+
+# ============================================================================
+# Respond-vs-cancel race (DB conflict marker → router 409)
+# ============================================================================
+
+class TestRespondConflictMarker:
+    pytestmark = pytest.mark.smoke
+
+    def test_respond_to_cancelled_item_returns_conflict_marker(self, clr_setup):
+        """The DB layer flags 'exists but not pending' instead of swallowing it.
+
+        The router's pre-check 400s on a known non-pending item, so the 409
+        path only fires in the true race window — pin the DB seam directly.
+        """
+        item_id = f"clr-race-{_RUN}"
+        _seed_queue_item(item_id, status="cancelled")
+
+        marker = _exec_backend(f"""
+from database import db
+item = db.respond_to_operator_queue_item(
+    item_id="{item_id}", response="approve", response_text=None,
+    responded_by_id="1", responded_by_email="admin@test",
+)
+print("RESULT:" + str(item.get("_status_conflict", False)))
+""")
+        assert marker == "True"
+        # And the response must NOT have been recorded
+        assert _queue_item_status(item_id) == "cancelled"
+
+
+# ============================================================================
+# Clear resolved (Resolved tab)
+# ============================================================================
+
+class TestClearResolved:
+    pytestmark = pytest.mark.smoke
+
+    def test_clear_hides_terminal_keeps_responded_and_pending(self, clr_setup):
+        """acknowledged/cancelled/expired get cleared_at; responded/pending
+        stay visible. Rows are hidden, NOT deleted — a DELETE would let the
+        sync loop resurrect items whose agent-file entry still says pending.
+        """
+        admin = clr_setup["admin"]
+        agent = clr_setup["agent"]
+
+        # Flush terminal rows left behind by earlier test classes (the
+        # bulk-cancel tests share this agent) so the count below is exact.
+        admin.post("/api/operator-queue/clear-resolved", json={"agent_name": agent})
+
+        seeded = {
+            "acknowledged": f"clr-cr-ack-{_RUN}",
+            "cancelled": f"clr-cr-can-{_RUN}",
+            "expired": f"clr-cr-exp-{_RUN}",
+            "responded": f"clr-cr-res-{_RUN}",
+            "pending": f"clr-cr-pen-{_RUN}",
+        }
+        for status, item_id in seeded.items():
+            _seed_queue_item(item_id, status=status)
+
+        response = admin.post(
+            "/api/operator-queue/clear-resolved", json={"agent_name": agent}
+        )
+        assert_status(response, 200)
+        assert response.json()["cleared"] == 3
+
+        # Rows still exist with their status intact (hidden, not deleted)
+        for key in ("acknowledged", "cancelled", "expired", "responded", "pending"):
+            assert _queue_item_status(seeded[key]) == {
+                "acknowledged": "acknowledged",
+                "cancelled": "cancelled",
+                "expired": "expired",
+                "responded": "responded",
+                "pending": "pending",
+            }[key]
+
+        # Cleared rows are excluded from the list; responded/pending remain
+        listing = admin.get(f"/api/operator-queue?agent_name={agent}&limit=500")
+        assert_status(listing, 200)
+        listed_ids = {i["id"] for i in listing.json()["items"]}
+        for key in ("acknowledged", "cancelled", "expired"):
+            assert seeded[key] not in listed_ids, f"cleared {key} row still listed"
+        assert seeded["responded"] in listed_ids
+        assert seeded["pending"] in listed_ids
+
+        # But get-by-id still returns a cleared row (audit/debugging path)
+        direct = admin.get(f"/api/operator-queue/{seeded['acknowledged']}")
+        assert_status(direct, 200)
+        assert direct.json()["cleared_at"] is not None
+
+    def test_responded_item_still_deliverable_after_clear(self, clr_setup):
+        """The sync write-back accessor still sees responded rows post-clear."""
+        admin = clr_setup["admin"]
+        agent = clr_setup["agent"]
+        item_id = f"clr-cr-wb-{_RUN}"
+        _seed_queue_item(item_id, status="responded")
+
+        admin.post("/api/operator-queue/clear-resolved", json={"agent_name": agent})
+
+        found = _exec_backend(f"""
+from database import db
+items = db.get_operator_queue_responded_for_agent("{agent}")
+print("RESULT:" + str(any(i["id"] == "{item_id}" for i in items)))
+""")
+        assert found == "True"
+
+    def test_clear_resolved_idempotent(self, clr_setup):
+        """Second clear with nothing left returns cleared=0 (200, not error)."""
+        admin = clr_setup["admin"]
+        agent = clr_setup["agent"]
+        item_id = f"clr-cr-idem-{_RUN}"
+        _seed_queue_item(item_id, status="acknowledged")
+
+        first = admin.post(
+            "/api/operator-queue/clear-resolved", json={"agent_name": agent}
+        )
+        assert_status(first, 200)
+        assert first.json()["cleared"] >= 1
+
+        second = admin.post(
+            "/api/operator-queue/clear-resolved", json={"agent_name": agent}
+        )
+        assert_status(second, 200)
+        assert second.json()["cleared"] == 0
+
+
+# ============================================================================
+# Dismiss all notifications (Notifications tab)
+# ============================================================================
+
+class TestDismissAllNotifications:
+    pytestmark = pytest.mark.smoke
+
+    def test_dismiss_all_clears_pending_and_acknowledged(self, clr_setup):
+        """DB-layer happy path: pending + acknowledged → dismissed with
+        acknowledged_at/by set; already-dismissed rows untouched.
+
+        Exercised at the DB layer because the router's accessible-agents
+        accessor is Docker-backed and the seeded agent has no container;
+        the router's guard paths are covered by the API tests below.
+        """
+        agent = clr_setup["agent"]
+        ids = {
+            "pending1": f"clr-na-{_RUN}",
+            "pending2": f"clr-nb-{_RUN}",
+            "acknowledged": f"clr-nc-{_RUN}",
+            "dismissed": f"clr-nd-{_RUN}",
+        }
+        _seed_notification(ids["pending1"], status="pending")
+        _seed_notification(ids["pending2"], status="pending")
+        _seed_notification(ids["acknowledged"], status="acknowledged")
+        _seed_notification(ids["dismissed"], status="dismissed")
+
+        dismissed = _exec_backend(f"""
+from database import db
+n = db.dismiss_all_notifications(
+    dismissed_by="1", agent_name="{agent}",
+    accessible_agent_names={{"{agent}"}},
+)
+print("RESULT:" + str(n))
+""")
+        # >= because the monitoring loop may have generated its own pending
+        # notifications for this (container-less) agent in the meantime.
+        assert int(dismissed) >= 3
+
+        # The three seeded non-dismissed rows are now dismissed with
+        # acknowledged_at set; the pre-dismissed row was left untouched
+        # (its acknowledged_at stays NULL).
+        check = _exec_backend(f"""
+import sqlite3, os, json
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+rows = {{}}
+for nid in {list(ids.values())!r}:
+    r = conn.execute(
+        "SELECT status, acknowledged_at FROM agent_notifications WHERE id = ?", (nid,)
+    ).fetchone()
+    rows[nid] = list(r) if r else None
+conn.close()
+print("RESULT:" + json.dumps(rows))
+""")
+        import json as _json
+        rows = _json.loads(check)
+        for key in ("pending1", "pending2", "acknowledged"):
+            status, ack_at = rows[ids[key]]
+            assert status == "dismissed", f"{key} not dismissed"
+            assert ack_at, f"{key} missing acknowledged_at"
+        # Pre-dismissed row untouched
+        status, ack_at = rows[ids["dismissed"]]
+        assert status == "dismissed"
+        assert ack_at is None, "already-dismissed row must not be re-stamped"
+
+    def test_dismiss_all_idempotent(self, clr_setup):
+        """A second dismiss-all does not re-stamp already-dismissed rows."""
+        agent = clr_setup["agent"]
+        nid = ids_marker = f"clr-n-idem-{_RUN}"
+        _seed_notification(nid, status="pending")
+
+        first_stamp = _exec_backend(f"""
+from database import db
+db.dismiss_all_notifications(
+    dismissed_by="1", agent_name="{agent}", accessible_agent_names={{"{agent}"}},
+)
+n = db.get_notification("{nid}")
+print("RESULT:" + str(n.acknowledged_at))
+""")
+        assert first_stamp and first_stamp != "None"
+
+        second_stamp = _exec_backend(f"""
+from database import db
+db.dismiss_all_notifications(
+    dismissed_by="1", agent_name="{agent}", accessible_agent_names={{"{agent}"}},
+)
+n = db.get_notification("{nid}")
+print("RESULT:" + str(n.acknowledged_at))
+""")
+        assert second_stamp == first_stamp, "second dismiss-all must not touch dismissed rows"
+
+    def test_non_admin_dismiss_all_foreign_agent_403(self, clr_setup):
+        """Explicit agent_name outside the caller's accessible set → 403."""
+        non_admin = clr_setup["non_admin"]
+        agent = clr_setup["agent"]
+        response = non_admin.post(
+            "/api/notifications/dismiss-all", json={"agent_name": agent}
+        )
+        assert_status(response, 403)
+
+    def test_zero_agent_user_dismiss_all_noop(self, clr_setup):
+        """Empty accessible set short-circuits to dismissed=0 (no SQL error,
+        no fleet-wide UPDATE)."""
+        non_admin = clr_setup["non_admin"]
+        agent = clr_setup["agent"]
+        sentinel = f"clr-n-iso-{_RUN}"
+        _seed_notification(sentinel, status="pending")
+
+        response = non_admin.post("/api/notifications/dismiss-all", json={})
+        assert_status(response, 200)
+        assert response.json()["dismissed"] == 0
+
+        # Admin's notification untouched
+        status = _exec_backend(f"""
+import sqlite3, os
+from pathlib import Path
+db = os.getenv("TRINITY_DB_PATH", str(Path.home() / "trinity-data" / "trinity.db"))
+conn = sqlite3.connect(db)
+row = conn.execute("SELECT status FROM agent_notifications WHERE id = ?", ("{sentinel}",)).fetchone()
+conn.close()
+print(row[0] if row else "")
+""")
+        assert status == "pending"
+
+
+# ============================================================================
+# Cross-user isolation for the queue bulk endpoints
+# ============================================================================
+
+class TestClearAllAccessControl:
+    pytestmark = pytest.mark.smoke
+
+    def test_non_admin_bulk_cancel_foreign_items_skipped(self, clr_setup):
+        """A non-admin cannot cancel items of agents they don't own."""
+        non_admin = clr_setup["non_admin"]
+        item_id = f"clr-iso-bc-{_RUN}"
+        _seed_queue_item(item_id, status="pending")
+
+        response = non_admin.post(
+            "/api/operator-queue/bulk-cancel", json={"ids": [item_id]}
+        )
+        assert_status(response, 200)
+        data = response.json()
+        assert data["cancelled"] == 0
+        assert data["skipped"] == 1
+        assert _queue_item_status(item_id) == "pending"
+
+    def test_non_admin_clear_resolved_noop(self, clr_setup):
+        """Zero-agent user clearing resolved touches nothing fleet-wide (C1)."""
+        non_admin = clr_setup["non_admin"]
+        item_id = f"clr-iso-cr-{_RUN}"
+        _seed_queue_item(item_id, status="acknowledged")
+
+        response = non_admin.post("/api/operator-queue/clear-resolved", json={})
+        assert_status(response, 200)
+        assert response.json()["cleared"] == 0
+        assert _queue_item_status(item_id) == "acknowledged"
+
+    def test_non_admin_clear_resolved_foreign_agent_403(self, clr_setup):
+        """Explicit agent_name outside the accessible set → 403."""
+        non_admin = clr_setup["non_admin"]
+        agent = clr_setup["agent"]
+        response = non_admin.post(
+            "/api/operator-queue/clear-resolved", json={"agent_name": agent}
+        )
+        assert_status(response, 403)


### PR DESCRIPTION
## Summary

- Adds a per-tab **Clear All** button to the Operations page (Needs Response / Notifications / Resolved) with a confirmation dialog stating the fleet-global blast radius; hidden when the active tab is empty; badges and feeds update immediately via one WebSocket event per bulk op.
- Three new bulk endpoints, all scoped to the caller's accessible agents (tri-state contract: admin = no filter, empty set = no-op):
  - `POST /api/operator-queue/bulk-cancel` `{ids}` — cancels only the items the operator actually saw (race-safe vs the 5s sync loop), returns `{cancelled, skipped}`
  - `POST /api/operator-queue/clear-resolved` — hides terminal rows via a new `cleared_at` column (migration `operator_queue_cleared_at`). Deliberately **not** a DELETE: the sync loop re-creates DB-missing items whose agent-file entry still says `pending` (always true for expired items, and for cancelled ones inside the propagation window). Actual deletion deferred to the retention sweep (#1142)
  - `POST /api/notifications/dismiss-all` — pending + acknowledged → dismissed in one statement
- Closes two adjacent reliability gaps the bulk feature would have amplified:
  - sync write-back now propagates `cancelled`/`expired` status into agent queue files, so agents stop waiting on cleared items
  - respond-vs-bulk-cancel race returns **409** instead of a silent 200 that never recorded the response
- Both bulk ops are audit-logged (new `AuditEventType.OPERATOR_QUEUE` / `NOTIFICATION`).
- Resolved feed now also shows `cancelled`/`expired` items (previously they vanished from the UI entirely).

## Changes

Backend: `routers/operator_queue.py`, `routers/notifications.py`, `db/operator_queue.py`, `db/notifications.py`, `db/schema.py` + `db/migrations.py` (cleared_at), `database.py`, `services/operator_queue_service.py`, `services/platform_audit_service.py`
Frontend: `views/Operations.vue`, `stores/operatorQueue.js`, `stores/notifications.js`, `utils/websocket.js`, `components/operator/ResolvedCard.vue`
Docs: `architecture.md`, feature flows `operating-room.md` + `agent-notifications.md`

## Test Plan

- [x] New suite passes: `pytest tests/test_ops_clear_all.py -v` (20 tests — scoping isolation between users, tri-state accessible-set incl. zero-agent no-op, idempotency, 409 conflict marker, hide-not-delete + list exclusion, responded-row delivery survival, oversized-ids 422)
- [x] Existing suites unaffected: `test_operator_queue.py` + `test_notifications.py` (85 passed)
- [x] Migration verified on a populated local DB (`schema_migrations` row + column present)
- [x] Manual UI verification via Playwright: confirm dialogs per tab, clear executes, empty state appears, button hides, NavBar badge drops without refresh, audit rows written

Follow-ups filed: #1142 (operator_queue retention sweep), #1143 (NavBar notification badge capped at 1 — pre-existing).

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)