### PR TITLE
fix(agent-server): distinct error for stall-watchdog kill vs max-duration timeout (#1094)

### DIFF
--- a/docker/base-image/agent_server/services/headless_executor.py
+++ b/docker/base-image/agent_server/services/headless_executor.py
@@ -1030,9 +1030,15 @@ async def execute_headless_task(
                 # ctx.terminate() does up to 4s of process.wait() (SIGTERM grace + SIGKILL grace);
                 # off-load to the executor so the event loop stays responsive while we tear down.
                 await loop.run_in_executor(None, ctx.terminate)
+                # #1094: same semantic cause as the inner max-duration branch —
+                # keep the structured detail symmetric so consumers filtering on
+                # termination_reason see budget timeouts from either path.
                 raise HTTPException(
                     status_code=504,
-                    detail=f"Task execution timed out after {ctx.effective_timeout} seconds"
+                    detail={
+                        "message": f"Task execution timed out after {ctx.effective_timeout} seconds",
+                        "termination_reason": "max_duration",
+                    },
                 )
             except subprocess.TimeoutExpired:
                 # Inner process.wait() bounded out; tree has already been killed.

--- a/docker/base-image/agent_server/services/headless_executor.py
+++ b/docker/base-image/agent_server/services/headless_executor.py
@@ -224,6 +224,12 @@ class HeadlessRunContext:
     permission_mode_validated: bool = False
     result_seen: threading.Event = field(default_factory=threading.Event)  # #970: claude emitted {"type":"result"}
     stdout_exc: List[BaseException] = field(default_factory=list)
+    # #1094: which termination path fired, so the terminal 504 carries a
+    # distinct reason instead of always claiming the max-duration timeout.
+    #   "stall_no_output" — a tool produced no result for >_STALL_LIMIT_S
+    #   "max_duration"    — the effective_timeout budget was genuinely exhausted
+    termination_reason: Optional[str] = None
+    stalled_tool: Optional[str] = None
 
     # Shared mutable buffers (populated by stream_parser via process_stream_line)
     response_parts: List[str] = field(default_factory=list)
@@ -651,6 +657,14 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
                 if stalled_tool or time.monotonic() >= deadline:
                     raise
     except subprocess.TimeoutExpired:
+        # #1094: record which path fired so the terminal 504 (built in the
+        # orchestrator) can carry a distinct reason instead of the generic
+        # max-duration label.
+        if stalled_tool:
+            ctx.termination_reason = "stall_no_output"
+            ctx.stalled_tool = stalled_tool
+        else:
+            ctx.termination_reason = "max_duration"
         reason = (
             f"tool '{stalled_tool}' stalled with no result for >{_STALL_LIMIT_S:.0f}s"
             if stalled_tool
@@ -1021,11 +1035,35 @@ async def execute_headless_task(
                     detail=f"Task execution timed out after {ctx.effective_timeout} seconds"
                 )
             except subprocess.TimeoutExpired:
-                # Inner process.wait() timed out; tree has already been killed.
+                # Inner process.wait() bounded out; tree has already been killed.
+                # #1094: two distinct causes reach here — the per-tool no-output
+                # stall watchdog and genuine max-duration budget exhaustion.
+                # Stamp a reason-specific 504 instead of always claiming the
+                # max-duration timeout (which misled operators into bumping the
+                # execution timeout — the wrong knob for a 300s stall-kill).
+                if ctx.termination_reason == "stall_no_output":
+                    logger.error(
+                        f"[Headless Task] Task {ctx.task_session_id} killed by stall "
+                        f"watchdog (tool '{ctx.stalled_tool}' silent >{_STALL_LIMIT_S:.0f}s)"
+                    )
+                    raise HTTPException(
+                        status_code=504,
+                        detail={
+                            "message": (
+                                f"Killed: tool '{ctx.stalled_tool}' produced no output "
+                                f"for {_STALL_LIMIT_S:.0f}s (stall watchdog)"
+                            ),
+                            "termination_reason": "stall_no_output",
+                            "stalled_tool": ctx.stalled_tool,
+                        },
+                    )
                 logger.error(f"[Headless Task] Task {ctx.task_session_id} timed out after {ctx.effective_timeout}s")
                 raise HTTPException(
                     status_code=504,
-                    detail=f"Task execution timed out after {ctx.effective_timeout} seconds"
+                    detail={
+                        "message": f"Task execution timed out after {ctx.effective_timeout} seconds",
+                        "termination_reason": "max_duration",
+                    },
                 )
             except RuntimeError as e:
                 # Permission mode validation failure — fast-fail with actionable error

--- a/tests/unit/test_1094_stall_termination_reason.py
+++ b/tests/unit/test_1094_stall_termination_reason.py
@@ -14,6 +14,10 @@ Fix: the watchdog records ``ctx.termination_reason`` ("stall_no_output" vs
 orchestrator builds a reason-specific 504 from those fields.
 
 These tests assert the context-level signal (the load-bearing propagation).
+The harness is intentionally self-contained (mirrors the #970 wait-loop
+tests) rather than importing from the sibling test module — a bare
+``from test_headless_executor_970_timeout import ...`` fails collection when
+pytest imports this file alone (``tests/unit`` not yet on sys.path).
 
 Module under test:
     docker/base-image/agent_server/services/headless_executor.py
@@ -22,24 +26,84 @@ from __future__ import annotations
 
 import subprocess
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
-# Reuse the fake-Popen / context harness from the #970 wait-loop tests.
-from test_headless_executor_970_timeout import (  # noqa: E402
-    _ctx,
-    _FakePopen,
-    _install_popen,
-    patched_loop,  # noqa: F401  (pytest fixture)
-    _TOOL_USE_LINE,
-)
+# conftest.py preloads the real agent_server namespace package.
 from agent_server.services import headless_executor as he  # noqa: E402
 
 
-def test_stall_sets_stall_no_output_reason(patched_loop):  # noqa: F811
+_TOOL_USE_LINE = (
+    '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+    '"id":"t1","name":"mcp__x__hang","input":{}}]}}\n'
+)
+
+
+def _ctx(**over) -> "he.HeadlessRunContext":
+    base = dict(
+        cmd=["claude", "--print"],
+        task_session_id="t-1094",
+        task_start_iso="2026-01-01T00:00:00Z",
+        effective_timeout=5,
+        images=None,
+        prompt="hello",
+    )
+    base.update(over)
+    return he.HeadlessRunContext(**base)
+
+
+class _FakePipe:
+    """Minimal stdout/stderr stand-in: readline() yields lines then '' (EOF)."""
+
+    def __init__(self, lines):
+        self._it = iter(lines)
+
+    def readline(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            return ""
+
+
+class _FakePopen:
+    def __init__(self, stdout_lines, *, never_exits, returncode=0, wait_sleep=0.02):
+        self.pid = 4242
+        self.stdout = _FakePipe(stdout_lines)
+        self.stderr = _FakePipe([])
+        self.stdin = MagicMock()
+        self._never_exits = never_exits
+        self._returncode = returncode
+        self._wait_sleep = wait_sleep
+        self.returncode = None
+
+    def wait(self, timeout=None):
+        if self._never_exits:
+            time.sleep(min(self._wait_sleep, timeout or self._wait_sleep))
+            raise subprocess.TimeoutExpired(cmd="claude", timeout=timeout)
+        self.returncode = self._returncode
+        return self._returncode
+
+
+@pytest.fixture
+def patched_loop(monkeypatch):
+    """Neutralise OS-level side effects so we test only the wait-loop logic."""
+    monkeypatch.setattr(he, "_capture_pgid", lambda _p: 4242)
+    monkeypatch.setattr(he, "get_process_registry", lambda: MagicMock())
+    monkeypatch.setattr(he, "_terminate_process_group", MagicMock())
+    monkeypatch.setattr(he, "_drain_bounded", MagicMock())
+    monkeypatch.setattr(he, "_WAIT_POLL_S", 0.05)
+    return monkeypatch
+
+
+def _install_popen(monkeypatch, fake):
+    monkeypatch.setattr(he.subprocess, "Popen", lambda *a, **k: fake)
+
+
+def test_stall_sets_stall_no_output_reason(patched_loop):
     """An open tool_use silent past the stall limit records
     termination_reason='stall_no_output' and the offending tool name."""
-    monkeypatch, _term = patched_loop
+    monkeypatch = patched_loop
     monkeypatch.setattr(he, "_STALL_LIMIT_S", 0.0)
     _install_popen(monkeypatch, _FakePopen([_TOOL_USE_LINE], never_exits=True))
     ctx = _ctx(effective_timeout=30)  # large — budget must NOT be what fires
@@ -54,10 +118,10 @@ def test_stall_sets_stall_no_output_reason(patched_loop):  # noqa: F811
     assert ctx.stalled_tool == "mcp__x__hang"
 
 
-def test_budget_exhaustion_sets_max_duration_reason(patched_loop):  # noqa: F811
+def test_budget_exhaustion_sets_max_duration_reason(patched_loop):
     """No result and no open tool → the budget bounds the wait and records
     termination_reason='max_duration' with no stalled tool."""
-    monkeypatch, _term = patched_loop
+    monkeypatch = patched_loop
     monkeypatch.setattr(he, "_WAIT_POLL_S", 0.1)
     _install_popen(monkeypatch, _FakePopen([], never_exits=True))
     ctx = _ctx(effective_timeout=0.3)

--- a/tests/unit/test_1094_stall_termination_reason.py
+++ b/tests/unit/test_1094_stall_termination_reason.py
@@ -1,0 +1,69 @@
+"""Unit tests for #1094: stall-watchdog kill must not be mislabeled as a
+max-duration timeout.
+
+The per-tool no-output stall watchdog and the max-duration budget are two
+distinct termination paths that both raise ``subprocess.TimeoutExpired`` out
+of ``_run_headless_subprocess``. Before #1094 the terminal 504 always claimed
+"Task execution timed out after {effective_timeout} seconds" regardless of
+which fired — so a 300s stall-kill at ~531s wall-clock was recorded as
+"timed out after 2400 seconds", misleading operators into bumping the
+execution timeout (the wrong knob).
+
+Fix: the watchdog records ``ctx.termination_reason`` ("stall_no_output" vs
+"max_duration") and ``ctx.stalled_tool`` before re-raising, and the
+orchestrator builds a reason-specific 504 from those fields.
+
+These tests assert the context-level signal (the load-bearing propagation).
+
+Module under test:
+    docker/base-image/agent_server/services/headless_executor.py
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+
+import pytest
+
+# Reuse the fake-Popen / context harness from the #970 wait-loop tests.
+from test_headless_executor_970_timeout import (  # noqa: E402
+    _ctx,
+    _FakePopen,
+    _install_popen,
+    patched_loop,  # noqa: F401  (pytest fixture)
+    _TOOL_USE_LINE,
+)
+from agent_server.services import headless_executor as he  # noqa: E402
+
+
+def test_stall_sets_stall_no_output_reason(patched_loop):  # noqa: F811
+    """An open tool_use silent past the stall limit records
+    termination_reason='stall_no_output' and the offending tool name."""
+    monkeypatch, _term = patched_loop
+    monkeypatch.setattr(he, "_STALL_LIMIT_S", 0.0)
+    _install_popen(monkeypatch, _FakePopen([_TOOL_USE_LINE], never_exits=True))
+    ctx = _ctx(effective_timeout=30)  # large — budget must NOT be what fires
+
+    start = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        he._run_headless_subprocess(ctx)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5.0, "stall should fire fast, not at the 30s budget"
+    assert ctx.termination_reason == "stall_no_output"
+    assert ctx.stalled_tool == "mcp__x__hang"
+
+
+def test_budget_exhaustion_sets_max_duration_reason(patched_loop):  # noqa: F811
+    """No result and no open tool → the budget bounds the wait and records
+    termination_reason='max_duration' with no stalled tool."""
+    monkeypatch, _term = patched_loop
+    monkeypatch.setattr(he, "_WAIT_POLL_S", 0.1)
+    _install_popen(monkeypatch, _FakePopen([], never_exits=True))
+    ctx = _ctx(effective_timeout=0.3)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        he._run_headless_subprocess(ctx)
+
+    assert ctx.termination_reason == "max_duration"
+    assert ctx.stalled_tool is None


### PR DESCRIPTION
## Summary

The headless executor's per-tool **no-output stall watchdog** (300s) and the **max-duration budget** are two distinct termination paths, but both raised a bare `subprocess.TimeoutExpired` and the terminal 504 always claimed `Task execution timed out after {effective_timeout} seconds`. So a 300s stall-kill at ~531s wall-clock was persisted as `timed out after 2400 seconds` — operators misdiagnosed it and bumped the execution timeout (the wrong knob; the 300s no-output threshold is what fired).

## Root cause (confirmed)

`docker/base-image/agent_server/services/headless_executor.py`:
- Watchdog `except` (`:653`) computed a distinct `reason` but only **logged** it, then re-raised bare.
- Orchestrator `except subprocess.TimeoutExpired` (`:1023`) stamped the generic string unconditionally.
- Persist chain: agent 504 detail → backend `raise_for_status` → `httpx.HTTPError` handler (`task_execution_service.py:1019-1025`) writes `detail` to `schedule_executions.error`. So the agent's label **is** the persisted error → fix is agent-side only.

## Changes

- `HeadlessRunContext` gains `termination_reason` (`"stall_no_output"` | `"max_duration"`) + `stalled_tool`, set in the watchdog before re-raise.
- Orchestrator builds a **reason-specific** 504 with a **structured dict detail**:
  - stall → `{message: "Killed: tool '<name>' produced no output for 300s (stall watchdog)", termination_reason: "stall_no_output", stalled_tool}`
  - max-duration → `{message: "Task execution timed out after Ns", termination_reason: "max_duration"}`
- Backend already parses dict detail (`detail["message"]`) → persisted error now reflects the real cause; structured reason rides along for UI/API. **No DB migration.**
- The outer `asyncio.TimeoutError` safety net (genuine budget exhaustion, elapsed ≈ N) keeps the plain "timed out after Ns" string.

## Cross-references

- #516, #520 (closed) — sibling misclassification bugs, same family.
- #1083 (open) — fire-and-forget dispatch rework; touches the backend dispatch path, **not** this agent-side label. No conflict.
- Companion (per-issue, **out of scope**): per-task override of the too-tight 300s stall threshold; a dedicated `termination_reason` DB column.

## Verification

- `tests/unit/test_1094_stall_termination_reason.py` — asserts both ctx outcomes via the #970 fake-Popen harness.
- Full #970 wait-loop regression suite still green: **11 passed**.
- `py_compile` clean. Base image rebuilt `trinity-agent-base:0.6.0`/`latest`; fix grep-verified inside the image.

(Live repro needs a >300s silent tool call — covered by unit tests instead of a 5-min live wait.)

## AC

- [x] Stall-kill no longer reuses the max-duration string
- [x] Distinct reason surfaced (`stall_no_output` vs `max_duration`)
- [x] "timed out after Ns" reserved for genuine budget exhaustion
- [x] Base image rebuilt and verified

Related to #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)