### PR TITLE
feat(ui): in-app bug reporting from the Help widget (hosted intake → GitHub issues) (#1116)

### DIFF
--- a/docs/integrations/bug-report-intake.md
+++ b/docs/integrations/bug-report-intake.md
@@ -1,0 +1,79 @@
+# In-App Bug Report Intake Contract (#1116)
+
+Trinity's Help widget (`HelpChatWidget.vue`) has a **Report a bug** tab. Because
+Trinity is self-hosted and a deployed instance holds **no** GitHub credentials
+of its own, reports are POSTed to a **hosted Ability.ai intake service** — the
+same hosting pattern as the `ask-trinity` Q&A Cloud Function — which holds a
+**server-side** GitHub token and files the issue into `abilityai/trinity`.
+
+This document is the **client↔intake contract**. The intake service lives
+outside this repo (an Ability.ai-operated Cloud Function, sibling to
+`ask-trinity`); this file is the spec it must satisfy. The client half ships in
+this repo.
+
+## Client config
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `VITE_BUG_REPORT_ENDPOINT` | `https://us-central1-mcp-server-project-455215.cloudfunctions.net/report-bug` | Intake URL the widget POSTs to. |
+| `VITE_BUG_REPORT_ENABLED` | `true` | `false` hides the "Report a bug" tab entirely (Q&A still works). |
+
+## Request
+
+`POST <VITE_BUG_REPORT_ENDPOINT>`  ·  `Content-Type: application/json`
+
+```jsonc
+{
+  "title": "string (8–120 chars, required)",
+  "description": "string (20–4000 chars, required)",
+  "source": "in-app",
+  "screenshot": "data:image/png;base64,... | null",   // optional, user-confirmed
+  "diagnostics": {
+    "app":      { "version", "git_commit", "git_branch", "build_date" },
+    "location": { "route", "route_name", "href" },     // scrubbed client-side
+    "browser":  { "user_agent", "language", "platform",
+                  "viewport": { "width", "height", "dpr" } },
+    "console_logs": [ { "level": "error|warn", "ts": "ISO", "text": "scrubbed" } ],
+    "captured_at": "ISO"
+  }
+}
+```
+
+The client **scrubs** `console_logs` and `location` for tokens
+(`Bearer`, `trinity_mcp_*`, `sk-`, `gh*_`, `github_pat_`, `xox*-`, `AIza`, JWTs),
+emails, private IPs, and `key=value` secrets before sending
+(`src/frontend/src/utils/scrub.js`). User-typed `title`/`description` are sent
+verbatim (the user reviews them; the public-issue notice + explicit confirm are
+the safeguard).
+
+## Response
+
+Success (`200`):
+
+```jsonc
+{ "issue_url": "https://github.com/abilityai/trinity/issues/NNNN" }
+// client also accepts "html_url" or "url"; or "reference"/"id" as a fallback tracking ref
+```
+
+Error (`4xx`/`5xx`): optional `{ "error": "human-readable message" }`. The widget
+shows a retryable error state.
+
+## Intake service responsibilities (server-side, out of this repo)
+
+These are **required** of the hosted service — the client cannot enforce them:
+
+- **Server-side GitHub token** — never exposed to the client.
+- **Secondary scrub** (defense-in-depth) of `title`, `description`,
+  `console_logs`, and a best-effort scan of the screenshot's surrounding
+  metadata. Do **not** trust the client scrub alone — issues are public + indexed.
+- **Labels** on the filed issue: `type-bug` + a `source:in-app` marker.
+- **Structured body**: render the diagnostics into a readable issue body;
+  attach the screenshot (e.g. upload to an image host or a gist and embed).
+- **Rate limiting + abuse/spam protection** on the public surface.
+- **Dedupe/throttle** so a flapping client can't open dozens of identical
+  issues (e.g. hash `title`+`route`+`git_commit` over a short window).
+
+## Out of scope (follow-ups)
+
+Authenticated user attribution, multi-file attachments, and per-operator
+configurable destinations beyond the `VITE_*` knobs above.

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -218,6 +218,8 @@ Channel DB modules: `db/slack_channels.py` (workspace connections, channel-agent
 
 **Key directories:** `src/views/` (page components), `src/stores/` (Pinia state), `src/components/` (reusable UI), `src/utils/` (WebSocket client, helpers, `markdown.js` with DOMPurify).
 
+**In-app bug reporting (#1116):** `components/HelpChatWidget.vue` (the floating Help widget, mounted in `App.vue`) carries two tabs — **Ask** (existing `ask-trinity` Q&A) and **Report a bug**. The bug tab gathers scrubbed diagnostics (`utils/diagnostics.js` — app version from `GET /api/version` via `useBuildInfo`, route, browser env, and recent console errors from a capped ring buffer `utils/consoleBuffer.js` installed early in `main.js`), an optional user-confirmed screenshot (lazy `html-to-image`), shows them before sending behind an explicit "public GitHub issue" confirm, and POSTs to a **hosted Ability.ai intake service** (`VITE_BUG_REPORT_ENDPOINT`, toggled by `VITE_BUG_REPORT_ENABLED`) that holds the server-side GitHub token and files into `abilityai/trinity`. Client-side scrubbing (`utils/scrub.js`: tokens/emails/IPs) is first-line; the intake service does the authoritative secondary scrub + rate-limit + dedupe. Contract: `docs/integrations/bug-report-intake.md`.
+
 **Stores (domain-scoped, Invariant #6):**
 - `stores/agents.js` - Agent CRUD, chat, activity
 - `stores/auth.js` - Email/admin authentication + JWT

--- a/src/frontend/.env.local.example
+++ b/src/frontend/.env.local.example
@@ -8,3 +8,16 @@
 # API URL (optional - defaults to same origin)
 # ===========================================
 # VITE_API_BASE_URL=http://localhost:8000
+
+# ===========================================
+# In-app bug reporting (#1116)
+# ===========================================
+# The Help widget's "Report a bug" tab POSTs to a hosted Ability.ai intake
+# service that files a PUBLIC GitHub issue in abilityai/trinity (the client
+# holds no GitHub credentials). Both vars are optional.
+#
+# Repoint the intake endpoint (e.g. your own intake service):
+# VITE_BUG_REPORT_ENDPOINT=https://your-intake.example.com/report-bug
+#
+# Disable in-app bug reporting entirely (hides the "Report a bug" tab):
+# VITE_BUG_REPORT_ENABLED=false

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "axios": "^1.16.1",
         "chart.js": "^4.4.7",
         "dompurify": "^3.4.7",
+        "html-to-image": "^1.11.13",
         "js-yaml": "^4.2.0",
         "marked": "^17.0.0",
         "mermaid": "^11.15.0",
@@ -2798,6 +2799,12 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,6 +26,7 @@
     "axios": "^1.16.1",
     "chart.js": "^4.4.7",
     "dompurify": "^3.4.7",
+    "html-to-image": "^1.11.13",
     "js-yaml": "^4.2.0",
     "marked": "^17.0.0",
     "mermaid": "^11.15.0",

--- a/src/frontend/src/components/HelpChatWidget.vue
+++ b/src/frontend/src/components/HelpChatWidget.vue
@@ -23,6 +23,7 @@
     <div
       v-if="isOpen"
       ref="panelRef"
+      data-bugreport-exclude
       class="fixed bottom-6 right-6 w-96 max-w-[calc(100vw-3rem)] h-[32rem] max-h-[calc(100vh-6rem)] bg-white dark:bg-gray-800 rounded-xl shadow-2xl flex flex-col z-50 border border-gray-200 dark:border-gray-700"
       role="dialog"
       aria-label="Help chat"
@@ -37,9 +38,9 @@
           <span class="font-semibold text-white">Trinity Help</span>
         </div>
         <div class="flex items-center space-x-1">
-          <!-- New conversation button -->
+          <!-- New conversation button (Ask mode only) -->
           <button
-            v-if="messages.length > 0"
+            v-if="mode === 'ask' && messages.length > 0"
             @click="startNewConversation"
             class="p-1.5 text-white/80 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
             title="Start new conversation"
@@ -62,96 +63,266 @@
         </div>
       </div>
 
-      <!-- Messages area -->
-      <div
-        ref="messagesRef"
-        class="flex-1 overflow-y-auto p-4 space-y-4"
-        aria-live="polite"
-        aria-atomic="false"
-      >
-        <!-- Welcome message when empty -->
-        <div v-if="messages.length === 0 && !loading" class="text-center py-8">
-          <div class="w-12 h-12 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
-            <svg class="w-6 h-6 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          </div>
-          <h3 class="text-sm font-medium text-gray-900 dark:text-white mb-1">How can I help?</h3>
-          <p class="text-xs text-gray-500 dark:text-gray-400 max-w-xs mx-auto">
-            Ask me anything about Trinity - agents, credentials, scheduling, and more.
-          </p>
-        </div>
-
-        <!-- Messages -->
-        <ChatBubble
-          v-for="(msg, idx) in messages"
-          :key="idx"
-          :role="msg.role"
-          :content="msg.content"
-        />
-
-        <!-- Loading indicator -->
-        <div v-if="loading" class="flex items-center space-x-2 text-gray-500 dark:text-gray-400">
-          <div class="flex space-x-1">
-            <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 0ms"></div>
-            <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 150ms"></div>
-            <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 300ms"></div>
-          </div>
-          <span class="text-sm">Thinking...</span>
-        </div>
+      <!-- Mode tabs (only when bug reporting is enabled) -->
+      <div v-if="bugReportEnabled" class="flex border-b border-gray-200 dark:border-gray-700 shrink-0">
+        <button
+          @click="mode = 'ask'"
+          :class="mode === 'ask' ? 'border-action-primary-500 text-action-primary-600 dark:text-action-primary-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
+          class="flex-1 px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+        >
+          Ask
+        </button>
+        <button
+          @click="mode = 'bug'"
+          :class="mode === 'bug' ? 'border-action-primary-500 text-action-primary-600 dark:text-action-primary-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
+          class="flex-1 px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+        >
+          Report a bug
+        </button>
       </div>
 
-      <!-- Error message -->
-      <div v-if="error" class="mx-4 mb-2 p-3 bg-status-danger-50 dark:bg-status-danger-900/20 border border-status-danger-200 dark:border-status-danger-800 rounded-lg">
-        <div class="flex items-center justify-between">
-          <p class="text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
+      <!-- ============================ ASK MODE ============================ -->
+      <template v-if="mode === 'ask'">
+        <div
+          ref="messagesRef"
+          class="flex-1 overflow-y-auto p-4 space-y-4"
+          aria-live="polite"
+          aria-atomic="false"
+        >
+          <div v-if="messages.length === 0 && !loading" class="text-center py-8">
+            <div class="w-12 h-12 bg-action-primary-100 dark:bg-action-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
+              <svg class="w-6 h-6 text-action-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <h3 class="text-sm font-medium text-gray-900 dark:text-white mb-1">How can I help?</h3>
+            <p class="text-xs text-gray-500 dark:text-gray-400 max-w-xs mx-auto">
+              Ask me anything about Trinity - agents, credentials, scheduling, and more.
+            </p>
+          </div>
+
+          <ChatBubble
+            v-for="(msg, idx) in messages"
+            :key="idx"
+            :role="msg.role"
+            :content="msg.content"
+          />
+
+          <div v-if="loading" class="flex items-center space-x-2 text-gray-500 dark:text-gray-400">
+            <div class="flex space-x-1">
+              <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 0ms"></div>
+              <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 150ms"></div>
+              <div class="w-2 h-2 bg-action-primary-500 rounded-full animate-bounce" style="animation-delay: 300ms"></div>
+            </div>
+            <span class="text-sm">Thinking...</span>
+          </div>
+        </div>
+
+        <div v-if="error" class="mx-4 mb-2 p-3 bg-status-danger-50 dark:bg-status-danger-900/20 border border-status-danger-200 dark:border-status-danger-800 rounded-lg">
+          <div class="flex items-center justify-between">
+            <p class="text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
+            <button
+              @click="retryLastMessage"
+              class="ml-2 text-xs text-status-danger-600 dark:text-status-danger-400 hover:text-status-danger-700 dark:hover:text-status-danger-300 underline"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+
+        <div class="p-3 border-t border-gray-200 dark:border-gray-700">
+          <form @submit.prevent="sendMessage" class="flex items-end space-x-2">
+            <textarea
+              ref="inputRef"
+              v-model="inputMessage"
+              rows="1"
+              :maxlength="2000"
+              placeholder="Ask a question..."
+              class="flex-1 resize-none border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-action-primary-500 focus:border-transparent text-sm"
+              :disabled="loading"
+              @keydown.enter.exact.prevent="sendMessage"
+              @input="autoResize"
+            ></textarea>
+            <button
+              type="submit"
+              :disabled="loading || !inputMessage.trim()"
+              class="p-2 bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors shrink-0"
+              aria-label="Send message"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+              </svg>
+            </button>
+          </form>
+        </div>
+      </template>
+
+      <!-- ========================= REPORT A BUG MODE ===================== -->
+      <template v-else>
+        <div class="flex-1 overflow-y-auto p-4 space-y-3">
+          <!-- Success state -->
+          <div v-if="bugSuccess" class="text-center py-6">
+            <div class="w-12 h-12 bg-status-success-100 dark:bg-status-success-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
+              <svg class="w-6 h-6 text-status-success-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h3 class="text-sm font-medium text-gray-900 dark:text-white mb-1">Thanks — report submitted</h3>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">Your bug report was filed as a public GitHub issue.</p>
+            <a
+              v-if="bugSuccess.url"
+              :href="bugSuccess.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-block text-sm text-action-primary-600 dark:text-action-primary-400 underline break-all"
+            >{{ bugSuccess.url }}</a>
+            <p v-else-if="bugSuccess.reference" class="text-xs text-gray-600 dark:text-gray-300">
+              Tracking reference: <code>{{ bugSuccess.reference }}</code>
+            </p>
+            <div class="mt-4">
+              <button @click="resetBugForm" class="text-xs text-gray-500 dark:text-gray-400 underline">Report another</button>
+            </div>
+          </div>
+
+          <!-- Form -->
+          <template v-else>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              Found something broken? Send us a report. We'll attach some diagnostics so we can reproduce it.
+            </p>
+
+            <!-- Title -->
+            <div>
+              <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Title <span class="text-status-danger-500">*</span></label>
+              <input
+                v-model="bugTitle"
+                type="text"
+                :maxlength="TITLE_MAX"
+                placeholder="Short summary of the problem"
+                class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-action-primary-500 focus:border-transparent text-sm"
+              />
+              <div class="flex justify-between mt-0.5">
+                <span v-if="titleError" class="text-xs text-status-danger-500">{{ titleError }}</span><span v-else></span>
+                <span class="text-xs text-gray-400">{{ bugTitle.length }}/{{ TITLE_MAX }}</span>
+              </div>
+            </div>
+
+            <!-- Description -->
+            <div>
+              <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Description <span class="text-status-danger-500">*</span></label>
+              <textarea
+                v-model="bugDescription"
+                rows="4"
+                :maxlength="DESC_MAX"
+                placeholder="What happened? What did you expect? Steps to reproduce?"
+                class="w-full resize-none border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-action-primary-500 focus:border-transparent text-sm"
+              ></textarea>
+              <div class="flex justify-between mt-0.5">
+                <span v-if="descError" class="text-xs text-status-danger-500">{{ descError }}</span><span v-else></span>
+                <span class="text-xs text-gray-400">{{ bugDescription.length }}/{{ DESC_MAX }}</span>
+              </div>
+            </div>
+
+            <!-- Screenshot -->
+            <div>
+              <div class="flex items-center justify-between">
+                <label class="text-xs font-medium text-gray-700 dark:text-gray-300">Screenshot (optional)</label>
+                <button
+                  v-if="!screenshot"
+                  @click="captureScreenshot"
+                  :disabled="capturing"
+                  class="text-xs text-action-primary-600 dark:text-action-primary-400 underline disabled:opacity-50"
+                >{{ capturing ? 'Capturing…' : 'Capture current view' }}</button>
+                <button v-else @click="screenshot = null" class="text-xs text-status-danger-500 underline">Remove</button>
+              </div>
+              <img
+                v-if="screenshot"
+                :src="screenshot"
+                alt="Screenshot preview"
+                class="mt-2 w-full rounded border border-gray-200 dark:border-gray-700"
+              />
+              <p v-if="screenshotError" class="text-xs text-status-danger-500 mt-1">{{ screenshotError }}</p>
+            </div>
+
+            <!-- Diagnostics preview (collapsible) -->
+            <div class="border border-gray-200 dark:border-gray-700 rounded-lg">
+              <button
+                @click="showDiagnostics = !showDiagnostics"
+                class="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-gray-700 dark:text-gray-300"
+              >
+                <span>What will be sent (diagnostics)</span>
+                <svg class="w-4 h-4 transition-transform" :class="showDiagnostics ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              <pre
+                v-if="showDiagnostics"
+                class="px-3 pb-3 text-[11px] leading-snug text-gray-600 dark:text-gray-400 overflow-x-auto whitespace-pre-wrap break-words max-h-48 overflow-y-auto"
+              >{{ diagnosticsPreview }}</pre>
+            </div>
+
+            <!-- Public notice + confirm -->
+            <div class="p-2 bg-status-warning-50 dark:bg-status-warning-900/20 border border-status-warning-200 dark:border-status-warning-800 rounded-lg">
+              <p class="text-xs text-status-warning-700 dark:text-status-warning-300">
+                ⚠️ This creates a <strong>public</strong> GitHub issue in <code>abilityai/trinity</code>, visible to anyone. Don't include passwords or secrets.
+              </p>
+            </div>
+            <label class="flex items-start space-x-2 text-xs text-gray-700 dark:text-gray-300 cursor-pointer">
+              <input v-model="bugConfirm" type="checkbox" class="mt-0.5 rounded border-gray-300 dark:border-gray-600" />
+              <span>I understand this report (including the diagnostics and screenshot above) will be posted publicly.</span>
+            </label>
+
+            <div v-if="bugError" class="p-2 bg-status-danger-50 dark:bg-status-danger-900/20 border border-status-danger-200 dark:border-status-danger-800 rounded-lg flex items-center justify-between">
+              <p class="text-xs text-status-danger-600 dark:text-status-danger-400">{{ bugError }}</p>
+              <button @click="submitBug" class="ml-2 text-xs text-status-danger-600 dark:text-status-danger-400 underline">Retry</button>
+            </div>
+          </template>
+        </div>
+
+        <!-- Submit footer -->
+        <div v-if="!bugSuccess" class="p-3 border-t border-gray-200 dark:border-gray-700">
           <button
-            @click="retryLastMessage"
-            class="ml-2 text-xs text-status-danger-600 dark:text-status-danger-400 hover:text-status-danger-700 dark:hover:text-status-danger-300 underline"
+            @click="submitBug"
+            :disabled="!canSubmitBug || submitting"
+            class="w-full py-2 bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors text-sm font-medium"
           >
-            Retry
+            {{ submitting ? 'Submitting…' : 'Submit bug report' }}
           </button>
         </div>
-      </div>
-
-      <!-- Input area -->
-      <div class="p-3 border-t border-gray-200 dark:border-gray-700">
-        <form @submit.prevent="sendMessage" class="flex items-end space-x-2">
-          <textarea
-            ref="inputRef"
-            v-model="inputMessage"
-            rows="1"
-            :maxlength="2000"
-            placeholder="Ask a question..."
-            class="flex-1 resize-none border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-action-primary-500 focus:border-transparent text-sm"
-            :disabled="loading"
-            @keydown.enter.exact.prevent="sendMessage"
-            @input="autoResize"
-          ></textarea>
-          <button
-            type="submit"
-            :disabled="loading || !inputMessage.trim()"
-            class="p-2 bg-action-primary-600 hover:bg-action-primary-700 disabled:bg-action-primary-400 disabled:cursor-not-allowed text-white rounded-lg transition-colors shrink-0"
-            aria-label="Send message"
-          >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-            </svg>
-          </button>
-        </form>
-      </div>
+      </template>
     </div>
   </Transition>
 </template>
 
 <script setup>
-import { ref, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import ChatBubble from './chat/ChatBubble.vue'
+import { useBuildInfo } from '../composables/useBuildInfo'
+import { gatherDiagnostics } from '../utils/diagnostics'
 
 const ENDPOINT = 'https://us-central1-mcp-server-project-455215.cloudfunctions.net/ask-trinity'
 const SESSION_KEY = 'trinity_help_session_id'
 
+// #1116: hosted intake endpoint (sibling Cloud Function holding the
+// server-side GitHub token). Operators can repoint or disable via build env.
+const BUG_ENDPOINT =
+  import.meta.env.VITE_BUG_REPORT_ENDPOINT ||
+  'https://us-central1-mcp-server-project-455215.cloudfunctions.net/report-bug'
+const bugReportEnabled =
+  import.meta.env.VITE_BUG_REPORT_ENABLED !== 'false' && !!BUG_ENDPOINT
+
+const TITLE_MAX = 120
+const TITLE_MIN = 8
+const DESC_MAX = 4000
+const DESC_MIN = 20
+
+const route = useRoute()
+const buildInfo = useBuildInfo()
+
 const isOpen = ref(false)
+const mode = ref('ask') // 'ask' | 'bug'
+
+// --- Ask mode state ---
 const messages = ref([])
 const inputMessage = ref('')
 const loading = ref(false)
@@ -159,29 +330,54 @@ const error = ref(null)
 const sessionId = ref(null)
 const lastUserMessage = ref('')
 
+// --- Bug mode state ---
+const bugTitle = ref('')
+const bugDescription = ref('')
+const bugConfirm = ref(false)
+const showDiagnostics = ref(false)
+const screenshot = ref(null)
+const capturing = ref(false)
+const screenshotError = ref(null)
+const submitting = ref(false)
+const bugError = ref(null)
+const bugSuccess = ref(null)
+const diagnostics = ref(null)
+
 const panelRef = ref(null)
 const messagesRef = ref(null)
 const inputRef = ref(null)
 
+const titleError = computed(() => {
+  if (!bugTitle.value) return ''
+  if (bugTitle.value.trim().length < TITLE_MIN) return `At least ${TITLE_MIN} characters`
+  return ''
+})
+const descError = computed(() => {
+  if (!bugDescription.value) return ''
+  if (bugDescription.value.trim().length < DESC_MIN) return `At least ${DESC_MIN} characters`
+  return ''
+})
+const canSubmitBug = computed(() =>
+  bugTitle.value.trim().length >= TITLE_MIN &&
+  bugDescription.value.trim().length >= DESC_MIN &&
+  bugConfirm.value
+)
+const diagnosticsPreview = computed(() =>
+  diagnostics.value ? JSON.stringify(diagnostics.value, null, 2) : 'Gathering…'
+)
+
 const openChat = () => {
   isOpen.value = true
-  nextTick(() => {
-    inputRef.value?.focus()
-  })
+  nextTick(() => inputRef.value?.focus())
 }
-
-const closeChat = () => {
-  isOpen.value = false
-}
+const closeChat = () => { isOpen.value = false }
 
 const startNewConversation = () => {
   messages.value = []
   sessionId.value = null
   localStorage.removeItem(SESSION_KEY)
   error.value = null
-  nextTick(() => {
-    inputRef.value?.focus()
-  })
+  nextTick(() => inputRef.value?.focus())
 }
 
 const autoResize = (event) => {
@@ -192,12 +388,11 @@ const autoResize = (event) => {
 
 const scrollToBottom = () => {
   nextTick(() => {
-    if (messagesRef.value) {
-      messagesRef.value.scrollTop = messagesRef.value.scrollHeight
-    }
+    if (messagesRef.value) messagesRef.value.scrollTop = messagesRef.value.scrollHeight
   })
 }
 
+// ---------------------------------------------------------------- Ask mode
 const sendMessage = async () => {
   const question = inputMessage.value.trim()
   if (!question || loading.value) return
@@ -205,60 +400,35 @@ const sendMessage = async () => {
   error.value = null
   lastUserMessage.value = question
   inputMessage.value = ''
+  if (inputRef.value) inputRef.value.style.height = 'auto'
 
-  // Reset textarea height
-  if (inputRef.value) {
-    inputRef.value.style.height = 'auto'
-  }
-
-  // Add user message immediately
-  messages.value.push({
-    role: 'user',
-    content: question
-  })
+  messages.value.push({ role: 'user', content: question })
   scrollToBottom()
-
   loading.value = true
 
   try {
     const payload = { question }
-    if (sessionId.value) {
-      payload.session_id = sessionId.value
-    }
+    if (sessionId.value) payload.session_id = sessionId.value
 
     const response = await fetch(ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
     })
-
-    if (!response.ok) {
-      throw new Error(`Request failed: ${response.status}`)
-    }
+    if (!response.ok) throw new Error(`Request failed: ${response.status}`)
 
     const data = await response.json()
+    if (!data.answer) throw new Error('No answer received')
 
-    if (!data.answer) {
-      throw new Error('No answer received')
-    }
-
-    // Save session ID for multi-turn
     if (data.session_id) {
       sessionId.value = data.session_id
       localStorage.setItem(SESSION_KEY, data.session_id)
     }
-
-    // Add assistant response
-    messages.value.push({
-      role: 'assistant',
-      content: data.answer
-    })
+    messages.value.push({ role: 'assistant', content: data.answer })
     scrollToBottom()
-
   } catch (err) {
     console.error('Help chat error:', err)
     error.value = 'Failed to get response. Please try again.'
-    // Remove the user message on error so retry works cleanly
     messages.value.pop()
   } finally {
     loading.value = false
@@ -273,19 +443,95 @@ const retryLastMessage = () => {
   }
 }
 
-// Handle keyboard navigation (focus trap)
+// ---------------------------------------------------------------- Bug mode
+const refreshDiagnostics = () => {
+  diagnostics.value = gatherDiagnostics({ versionInfo: buildInfo.info.value, route })
+}
+
+const captureScreenshot = async () => {
+  capturing.value = true
+  screenshotError.value = null
+  try {
+    // Dynamic import keeps html-to-image out of the main bundle until used.
+    const { toPng } = await import('html-to-image')
+    screenshot.value = await toPng(document.body, {
+      pixelRatio: 0.7, // downscale — keeps the data URL payload modest
+      cacheBust: true,
+      // Exclude the widget panel itself so the report shows the page, not us.
+      filter: (node) =>
+        !(node?.hasAttribute && node.hasAttribute('data-bugreport-exclude')),
+    })
+  } catch (err) {
+    console.error('Screenshot capture failed:', err)
+    screenshotError.value = 'Could not capture a screenshot of this view.'
+  } finally {
+    capturing.value = false
+  }
+}
+
+const resetBugForm = () => {
+  bugTitle.value = ''
+  bugDescription.value = ''
+  bugConfirm.value = false
+  screenshot.value = null
+  screenshotError.value = null
+  bugError.value = null
+  bugSuccess.value = null
+  showDiagnostics.value = false
+  refreshDiagnostics()
+}
+
+const submitBug = async () => {
+  if (!canSubmitBug.value || submitting.value) return
+  bugError.value = null
+  submitting.value = true
+
+  // Re-gather diagnostics at submit time so console_logs reflect the moment
+  // of report, and send EXACTLY what the preview showed (no silent edits).
+  refreshDiagnostics()
+
+  try {
+    const payload = {
+      title: bugTitle.value.trim(),
+      description: bugDescription.value.trim(),
+      diagnostics: diagnostics.value,
+      screenshot: screenshot.value || null,
+      source: 'in-app',
+    }
+    const response = await fetch(BUG_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (!response.ok) {
+      let detail = ''
+      try { detail = (await response.json())?.error || '' } catch { /* ignore */ }
+      throw new Error(detail || `Request failed: ${response.status}`)
+    }
+    const data = await response.json().catch(() => ({}))
+    bugSuccess.value = {
+      url: data.issue_url || data.html_url || data.url || null,
+      reference: data.reference || data.id || null,
+    }
+  } catch (err) {
+    console.error('Bug report submit error:', err)
+    bugError.value =
+      'Failed to submit the report. Check your connection and try again.'
+  } finally {
+    submitting.value = false
+  }
+}
+
+// Focus trap
 const handleKeydown = (event) => {
   if (!isOpen.value) return
-
   if (event.key === 'Tab') {
     const focusableElements = panelRef.value?.querySelectorAll(
-      'button:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      'button:not([disabled]), textarea:not([disabled]), input:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
     )
     if (!focusableElements || focusableElements.length === 0) return
-
     const first = focusableElements[0]
     const last = focusableElements[focusableElements.length - 1]
-
     if (event.shiftKey && document.activeElement === first) {
       event.preventDefault()
       last.focus()
@@ -296,12 +542,9 @@ const handleKeydown = (event) => {
   }
 }
 
-// Load session from localStorage on mount
 onMounted(() => {
   const savedSession = localStorage.getItem(SESSION_KEY)
-  if (savedSession) {
-    sessionId.value = savedSession
-  }
+  if (savedSession) sessionId.value = savedSession
   document.addEventListener('keydown', handleKeydown)
 })
 
@@ -309,12 +552,19 @@ onUnmounted(() => {
   document.removeEventListener('keydown', handleKeydown)
 })
 
-// Watch for panel open to focus input
 watch(isOpen, (open) => {
-  if (open) {
-    nextTick(() => {
-      inputRef.value?.focus()
-    })
+  if (open && mode.value === 'ask') {
+    nextTick(() => inputRef.value?.focus())
+  }
+})
+
+// Lazily gather diagnostics when the user first switches to bug mode, and
+// kick a build-info fetch so the version block is populated.
+watch(mode, async (m) => {
+  if (m === 'bug') {
+    refreshDiagnostics() // immediate (version may still be 'unknown')
+    try { await buildInfo.load() } catch { /* version stays 'unknown' */ }
+    refreshDiagnostics() // re-gather once build info resolves
   }
 })
 </script>

--- a/src/frontend/src/main.js
+++ b/src/frontend/src/main.js
@@ -5,6 +5,11 @@ import router from './router'
 import App from './App.vue'
 import './style.css'
 import { useAuthStore } from './stores/auth'
+import { installConsoleBuffer } from './utils/consoleBuffer'
+
+// #1116: capture console errors/warnings into a capped ring buffer as early
+// as possible so the in-app bug reporter can attach recent diagnostics.
+installConsoleBuffer()
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/src/frontend/src/utils/consoleBuffer.js
+++ b/src/frontend/src/utils/consoleBuffer.js
@@ -1,0 +1,73 @@
+/**
+ * Lightweight capped ring buffer of recent console errors/warnings and
+ * uncaught errors, for the in-app bug reporter (#1116).
+ *
+ * Installed once, early in app bootstrap, so the Help widget can read the
+ * last N entries at report time. Entries are stored RAW here and scrubbed at
+ * read time (`getRecentLogs`) so the scrub logic lives in one place
+ * (`utils/scrub.js`) and a future viewer can choose its own policy.
+ *
+ * Deliberately minimal: no deps, bounded memory, never throws into the app's
+ * own console path (a logging buffer must not break the thing it observes).
+ */
+import { scrubText } from './scrub'
+
+const MAX_ENTRIES = 50
+const MAX_LEN = 1000 // per-entry char cap — stack traces can be huge
+
+const buffer = []
+let installed = false
+
+function push(level, parts) {
+  try {
+    const text = parts
+      .map((p) => {
+        if (p instanceof Error) return `${p.name}: ${p.message}\n${p.stack || ''}`
+        if (typeof p === 'string') return p
+        try {
+          return JSON.stringify(p)
+        } catch {
+          return String(p)
+        }
+      })
+      .join(' ')
+      .slice(0, MAX_LEN)
+    buffer.push({ level, ts: new Date().toISOString(), text })
+    if (buffer.length > MAX_ENTRIES) buffer.shift()
+  } catch {
+    /* never let capture break the caller */
+  }
+}
+
+/**
+ * Install console + window error hooks. Idempotent. Call once at bootstrap,
+ * before app.mount, so early errors are captured too.
+ */
+export function installConsoleBuffer() {
+  if (installed || typeof window === 'undefined') return
+  installed = true
+
+  for (const level of ['error', 'warn']) {
+    const original = console[level]
+    console[level] = function (...args) {
+      push(level, args)
+      return original.apply(this, args)
+    }
+  }
+
+  window.addEventListener('error', (e) => {
+    push('error', [e.message, e.error || `${e.filename}:${e.lineno}:${e.colno}`])
+  })
+  window.addEventListener('unhandledrejection', (e) => {
+    push('error', ['Unhandled promise rejection:', e.reason])
+  })
+}
+
+/**
+ * Return the most recent captured entries, newest last, each scrubbed.
+ * @param {number} limit
+ * @returns {Array<{level: string, ts: string, text: string}>}
+ */
+export function getRecentLogs(limit = MAX_ENTRIES) {
+  return buffer.slice(-limit).map((e) => ({ ...e, text: scrubText(e.text) }))
+}

--- a/src/frontend/src/utils/diagnostics.js
+++ b/src/frontend/src/utils/diagnostics.js
@@ -1,0 +1,52 @@
+/**
+ * Assemble the diagnostic payload attached to an in-app bug report (#1116).
+ *
+ * Everything here is shown to the user BEFORE sending (the widget renders a
+ * collapsible preview) and is scrubbed: console logs via the ring buffer's
+ * read-time scrub, and the route/URL via `scrubText` (a path or query string
+ * can carry an email or token). The version block comes from `GET /api/version`
+ * (build provenance, #926) which the widget already has via `useBuildInfo`.
+ */
+import { getRecentLogs } from './consoleBuffer'
+import { scrubText } from './scrub'
+
+/**
+ * @param {object} opts
+ * @param {object|null} opts.versionInfo  result of GET /api/version (or null)
+ * @param {object} opts.route             vue-router route (uses fullPath/name)
+ * @param {number} [opts.logLimit=20]
+ * @returns {object} plain JSON-serializable diagnostics
+ */
+export function gatherDiagnostics({ versionInfo, route, logLimit = 20 }) {
+  const v = versionInfo || {}
+  const nav = typeof navigator !== 'undefined' ? navigator : {}
+  const win = typeof window !== 'undefined' ? window : {}
+
+  return {
+    app: {
+      version: v.version || 'unknown',
+      git_commit: v.git_commit_short || v.git_commit || 'unknown',
+      git_branch: v.git_branch || 'unknown',
+      build_date: v.build_date || 'unknown',
+    },
+    location: {
+      // route.fullPath is the in-app route; href is the absolute URL. Both
+      // scrubbed — a query param can carry a token or email.
+      route: scrubText(route?.fullPath || ''),
+      route_name: route?.name ? String(route.name) : '',
+      href: scrubText(win.location?.href || ''),
+    },
+    browser: {
+      user_agent: nav.userAgent || 'unknown',
+      language: nav.language || 'unknown',
+      platform: nav.userAgentData?.platform || nav.platform || 'unknown',
+      viewport: {
+        width: win.innerWidth || 0,
+        height: win.innerHeight || 0,
+        dpr: win.devicePixelRatio || 1,
+      },
+    },
+    console_logs: getRecentLogs(logLimit),
+    captured_at: new Date().toISOString(),
+  }
+}

--- a/src/frontend/src/utils/scrub.js
+++ b/src/frontend/src/utils/scrub.js
@@ -1,0 +1,71 @@
+/**
+ * Client-side secret/PII scrubber for in-app bug reports (#1116).
+ *
+ * Bug reports land as PUBLIC GitHub issues in abilityai/trinity, so console
+ * logs and any free text must be scrubbed of credentials and PII BEFORE they
+ * leave the browser. This is the first line of defense; the hosted intake
+ * service runs a secondary server-side scrub (issues are public + indexed).
+ *
+ * Patterns deliberately err toward over-redaction — a redacted token is a
+ * non-event, a leaked one is permanent and search-indexed.
+ */
+
+// Order matters: longer/more-specific token shapes first so a generic
+// fallback can't partially mask a known prefix.
+const PATTERNS = [
+  // Authorization: Bearer <jwt/opaque> — keep the scheme, drop the value.
+  [/\b(Bearer)\s+[A-Za-z0-9._\-+/=]+/gi, '$1 [REDACTED]'],
+  // Trinity MCP API keys.
+  [/\btrinity_mcp_[A-Za-z0-9._\-]+/g, 'trinity_mcp_[REDACTED]'],
+  // Anthropic / OpenAI-style keys.
+  [/\bsk-[A-Za-z0-9._\-]{8,}/g, 'sk-[REDACTED]'],
+  // GitHub PATs (classic + fine-grained) and other gh* token prefixes.
+  [/\bgh[pousr]_[A-Za-z0-9]{8,}/g, 'gh_[REDACTED]'],
+  [/\bgithub_pat_[A-Za-z0-9_]{8,}/g, 'github_pat_[REDACTED]'],
+  // Slack bot/user/app tokens.
+  [/\bxox[baprs]-[A-Za-z0-9-]{8,}/g, 'xox_[REDACTED]'],
+  // Google API keys.
+  [/\bAIza[A-Za-z0-9._\-]{10,}/g, 'AIza[REDACTED]'],
+  // JWT triplets (header.payload.signature) not already caught by Bearer.
+  [/\beyJ[A-Za-z0-9._\-]+\.[A-Za-z0-9._\-]+\.[A-Za-z0-9._\-]+/g, '[REDACTED_JWT]'],
+  // Email addresses (PII).
+  [/\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b/g, '[REDACTED_EMAIL]'],
+  // Private / internal IPv4 ranges (10/8, 172.16/12, 192.168/16, 127/8).
+  [/\b(?:10|127)(?:\.\d{1,3}){3}\b/g, '[REDACTED_IP]'],
+  [/\b192\.168(?:\.\d{1,3}){2}\b/g, '[REDACTED_IP]'],
+  [/\b172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}\b/g, '[REDACTED_IP]'],
+  // Generic key=value / "key": "value" secrets for common secret-y names.
+  [/\b(api[_-]?key|token|secret|password|passwd|auth)["']?\s*[:=]\s*["']?[^\s"',&]{6,}/gi,
+   '$1=[REDACTED]'],
+]
+
+/**
+ * Scrub a string. Returns '' for nullish input.
+ * @param {string} input
+ * @returns {string}
+ */
+export function scrubText(input) {
+  if (input == null) return ''
+  let out = String(input)
+  for (const [re, repl] of PATTERNS) {
+    out = out.replace(re, repl)
+  }
+  return out
+}
+
+/**
+ * Deep-scrub a JSON-serializable value (strings, arrays, plain objects).
+ * Object KEYS are preserved; only string values are scrubbed.
+ * @param {*} value
+ * @returns {*}
+ */
+export function scrubDeep(value) {
+  if (typeof value === 'string') return scrubText(value)
+  if (Array.isArray(value)) return value.map(scrubDeep)
+  if (value && typeof value === 'object') {
+    const out = {}
+    for (const k of Object.keys(value)) out[k] = scrubDeep(value[k])
+    return out
+  }
+  return value
+}


### PR DESCRIPTION
## Summary

Adds a **Report a bug** tab to the floating `HelpChatWidget` (no second floating button) so any self-hosted, credential-free Trinity instance can file a diagnostic-rich **public** GitHub issue in `abilityai/trinity` via a hosted intake service — the same hosting pattern as the existing `ask-trinity` Q&A function.

## What's in this PR (client — fully implemented)

- **Tabs:** `HelpChatWidget.vue` now has **Ask** (existing Q&A, untouched) and **Report a bug**.
- **Form:** title (8–120) + description (20–4000), both required, inline validation + char counters.
- **Diagnostics auto-capture** (`utils/diagnostics.js`): app version + git commit (`GET /api/version` via `useBuildInfo`), route/URL, browser env, and recent console errors/warnings from a capped ring buffer (`utils/consoleBuffer.js`, installed early in `main.js`).
- **Show-before-send:** collapsible diagnostics preview + optional user-initiated **screenshot** (lazy `html-to-image`, downscaled, widget panel filtered out of the capture), a clear **public-issue** notice, and an explicit **confirm checkbox** gating submit.
- **Scrubbing** (`utils/scrub.js`): tokens (`Bearer`/`trinity_mcp_`/`sk-`/`gh*_`/`github_pat_`/`xox*-`/`AIza`/JWT), emails, private IPs, `key=value` secrets — scrubbed on console logs + route **before leaving the browser**. User-typed title/description sent verbatim (reviewed by the user; public notice + confirm are the safeguard).
- **Success/error:** success returns the created issue URL (or tracking ref); error is retryable.
- **Config:** `VITE_BUG_REPORT_ENDPOINT` (repoint) and `VITE_BUG_REPORT_ENABLED=false` (hide the tab). Documented in `.env.local.example`.

## Hosted intake service — out of this repo

The intake endpoint is an **Ability.ai-operated Cloud Function** (sibling to `ask-trinity`) that holds the **server-side** GitHub token and does the authoritative **secondary scrub + labels (`type-bug`, `source:in-app`) + rate-limit + dedupe**. It does not live in `abilityai/trinity`. Its full request/response contract is specced in [`docs/integrations/bug-report-intake.md`](docs/integrations/bug-report-intake.md) so it can be built to match this client.

⚠️ **End-to-end issue filing depends on that endpoint being deployed.** This PR ships the complete client + the contract; until the function exists, submit shows the retryable error state (graceful).

## Verification

- Production build compiles clean (`html-to-image` lazy-chunked, not in main bundle).
- Scrubber unit-checked via node: redacts all listed secret shapes + emails/IPs, preserves plain text, deep-scrubs nested objects.
- Vite dev server HMR-clean; `scrub.js`/`consoleBuffer.js`/`diagnostics.js` all serve 200; `html-to-image` auto-optimized by Vite.
- (Live click-through of the tab/screenshot/confirm flow not run headlessly — Playwright unavailable in session; build + module-serve + scrubber checks stand in.)

## AC status

- [x] Report-a-bug mode in the existing widget, no second button
- [x] Title+description required, char limits, inline validation
- [x] Show-before-send (diagnostics + screenshot preview) + explicit confirm
- [x] Public-GitHub-issue notice
- [x] Success → issue URL / tracking ref; error retryable
- [x] Diagnostics: version+commit, route, browser env, scrubbed console errors, optional screenshot
- [x] Client-side scrub of tokens/PII/internal URLs
- [x] Config knob to disable / repoint
- [ ] Hosted intake service (server token, labels, rate-limit, dedupe, secondary scrub) — **separate out-of-repo deliverable**, contract documented

Related to #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)