### PR TITLE
fix(agent-server): spare operator docker-exec sessions from the orphan sweeper (#1153)

### DIFF
--- a/docker/base-image/agent_server/utils/orphan_allowlist.py
+++ b/docker/base-image/agent_server/utils/orphan_allowlist.py
@@ -27,6 +27,9 @@ The allowlist composes three sources:
        agent-server master process)
      - Every PID whose comm name is ``sshd`` (operator SSH sessions
        must survive a cleanup sweep)
+     - Every live ``docker exec`` session (PPID 0) + its descendants —
+       operator/platform exec sessions, the same actor class as SSH
+       (#1153). PID 1 (also PPID 0) is excluded as it's already covered.
 
 2. **In-flight execution descendants** — for each active claude PID
    passed in ``extra_pids``, the full descendant tree by ppid walk.
@@ -237,6 +240,46 @@ def _ssh_session_pids() -> Set[int]:
     return result
 
 
+def _docker_exec_session_pids() -> Set[int]:
+    """Return PIDs of live ``docker exec`` sessions plus their descendants (#1153).
+
+    Inside the container's PID namespace, a ``docker exec`` entry process
+    has **PPID 0** — its real parent (the containerd exec shim) lives
+    outside the namespace, so the kernel reports the parent as 0. Genuinely
+    leaked orphans, by contrast, are reparented to **PID 1**, never to PID
+    0. PPID 0 is therefore an unspoofable signal that the process is an
+    operator/platform exec session — the same class of actor that
+    :func:`_ssh_session_pids` already protects (an operator debugging or
+    maintaining the agent). It also covers the platform's own exec paths
+    (pre-check hooks, git recovery, session-JSONL reaping, the agent
+    terminal) that run via ``docker exec`` / ``execute_command_in_container``.
+
+    PID 1 also has PPID 0 but is already hard-protected; it is excluded
+    here so this does NOT degrade into "protect every child of PID 1"
+    (which would shield real orphans reparented to 1 — the thing the sweep
+    exists to kill).
+
+    Each exec entry's descendant tree is included so the operator's actual
+    command and its children survive. When the session exits, any leftover
+    children reparent to PID 1 (PPID 1, not 0) and fall out of this set —
+    so they are reaped on the next sweep, preserving the #817 guarantee.
+    """
+    result: Set[int] = set()
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return result
+    for name in entries:
+        if not name.isdigit():
+            continue
+        pid = int(name)
+        if pid == 1:
+            continue  # container init also has PPID 0; already hard-protected
+        if _read_ppid(pid) == 0:
+            result.update(descendants_of(pid))
+    return result
+
+
 # Cmdline patterns that are ALWAYS protected, regardless of user
 # allowlist config. These are processes the base image starts that
 # the container's continued operation depends on. They live as direct
@@ -311,6 +354,7 @@ def resolve_allowlist(
     allowlist: Set[int] = set()
     allowlist.update(_hard_protected_pids(sweep_pid))
     allowlist.update(_ssh_session_pids())
+    allowlist.update(_docker_exec_session_pids())  # #1153
     allowlist.update(_platform_essential_pids())
 
     for pid in extra_pids:

--- a/docker/base-image/agent_server/utils/orphan_sweep.py
+++ b/docker/base-image/agent_server/utils/orphan_sweep.py
@@ -70,6 +70,11 @@ _CGROUP_PROCS_PATH = Path("/sys/fs/cgroup/cgroup.procs")
 # pipe-writer sweep so operators see consistent log shape.
 _LOG_DETAIL_CAP = 10
 
+# #1153: cap the cmdline length in each per-kill log line. Long enough to
+# identify the victim (the misdiagnosis this fixes was "which process died?"),
+# short enough not to flood the log with a giant argv.
+_CMDLINE_LOG_CAP = 200
+
 
 def read_cgroup_procs(path: Path = _CGROUP_PROCS_PATH) -> Optional[list[int]]:
     """Read every PID in the container's cgroup.
@@ -147,21 +152,27 @@ def kill_cgroup_orphans(
     # Log identity before killing — once SIGKILL lands, /proc/<pid> is
     # gone and we lose the ability to attribute the leak. Cap to
     # _LOG_DETAIL_CAP entries; tail with count-only summary.
+    #
+    # #1153: a real kill is logged at WARNING with the victim's pid +
+    # (length-capped) cmdline. A single such line would have turned a
+    # weeks-long "which process keeps dying?" misdiagnosis into a 5-minute
+    # fix. dry_run (canary/tests) stays at INFO — nothing actually dies.
     label = "would kill" if dry_run else "SIGKILL"
+    log_kill = logger.info if dry_run else logger.warning
     for i, pid in enumerate(orphan_pids):
         if i >= _LOG_DETAIL_CAP:
             break
-        cmd = _read_cmdline(pid) or "?"
+        cmd = (_read_cmdline(pid) or "?")[:_CMDLINE_LOG_CAP]
         try:
             pgid_str = str(os.getpgid(pid))
         except OSError:
             pgid_str = "?"
-        logger.info(
+        log_kill(
             "[OrphanSweep] %s cgroup orphan: pid=%s pgid=%s cmd=%s",
             label, pid, pgid_str, cmd,
         )
     if len(orphan_pids) > _LOG_DETAIL_CAP:
-        logger.info(
+        log_kill(
             "[OrphanSweep] %s %d additional orphan PID(s) (detail capped at %d)",
             label, len(orphan_pids) - _LOG_DETAIL_CAP, _LOG_DETAIL_CAP,
         )

--- a/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
+++ b/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
@@ -481,6 +481,52 @@ See [Gemini Support Guide](GEMINI_SUPPORT.md) for detailed setup instructions an
 
 ---
 
+## Long-Running & Background Processes (the orphan sweeper)
+
+Each agent container runs a periodic **orphan sweeper** (`agent_server`,
+issue #817). On a fixed interval it reads the container cgroup and
+**SIGKILLs every process not on an allowlist** — this is how Trinity
+recovers CPU/event-loop starvation from processes a finished execution
+leaked behind. A process is **spared** when it is any of:
+
+- the agent-server and its parent chain, and PID 1 (container init);
+- an **in-flight platform execution** (chat / task / schedule / loop) and
+  every subprocess it spawned — these carry a registered PID;
+- an **operator session** — an SSH session **or** a live `docker exec`
+  session (PPID 0) and its children (#1153);
+- a base-image essential (the keep-alive, sshd wrapper, guardrail writer);
+- a process whose argv matches a pattern in
+  **`~/.trinity/persistent-processes.allow`**.
+
+**What this means for templates:**
+
+- **Run maintenance work as a platform execution, not a detached background
+  job.** A FAISS index build, a data refresh, a migration — launch it as a
+  scheduled task, a `run_agent_loop`, or an MCP `chat`/`task`. It then has a
+  registered PID (and, under the pull model, a lease) and is never swept.
+  A bare `nohup … &` or a process double-forked away from the execution has
+  no registered PID and **will be reaped** mid-run.
+- **Long-lived daemons started from a `SessionStart` hook** (e.g. a local
+  MCP HTTP server) must be declared in
+  `~/.trinity/persistent-processes.allow` — one `fnmatch` glob per line,
+  `#` for comments:
+
+  ```
+  # local MCP server started by SessionStart hook
+  *my-mcp-server*
+  ```
+
+- **Operator debugging is safe.** A long `docker exec agent-<name> …` or
+  `trinity ssh` session survives sweeps (#1153). When the session exits,
+  any children it left behind reparent to PID 1 and are reaped on the next
+  sweep — as intended.
+
+Each kill is logged at **WARNING** with the victim's `pid` and a
+length-capped `cmd=` — `docker logs agent-<name> 2>&1 | grep OrphanSweep`
+shows exactly what was reaped if a job disappears unexpectedly.
+
+---
+
 ## Credential Management
 
 > **Updated 2026-02-05 (CRED-002)**: Simplified credential system using direct file injection with encrypted git storage.

--- a/tests/unit/test_1153_docker_exec_allowlist.py
+++ b/tests/unit/test_1153_docker_exec_allowlist.py
@@ -1,0 +1,94 @@
+"""Tests for #1153 — the orphan sweeper must spare live `docker exec`
+sessions (PPID 0), consistent with the SSH-session protection, while still
+reaping genuinely-leaked orphans reparented to PID 1.
+
+`_docker_exec_session_pids()` allowlists every PPID-0 process (except PID 1)
+plus its descendant tree. PID 1 also has PPID 0 but is hard-protected
+separately and must NOT pull "all children of PID 1" into the allowlist.
+
+The module reads real `/proc`; here we monkeypatch its `os.listdir` and the
+`_read_ppid` / `_read_comm` / `_read_cmdline` helpers to drive a synthetic
+process tree.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_BASE_IMAGE = _REPO / "docker" / "base-image"
+if str(_BASE_IMAGE) not in sys.path:
+    sys.path.insert(0, str(_BASE_IMAGE))
+
+from agent_server.utils import orphan_allowlist as oa  # noqa: E402
+
+
+# Synthetic container PID namespace:
+#   1   ppid 0   init (startup.sh)          — PPID 0 but excluded (hard-protected)
+#   39  ppid 1   sudo                       — child of init (NOT auto-protected)
+#   100 ppid 0   sh   (docker exec entry)   — PROTECT + descendants
+#   101 ppid 100 indexer (exec child)       — protected (descendant)
+#   102 ppid 101 python (grandchild)        — protected (descendant)
+#   200 ppid 1   leaked orphan              — NOT protected (reparented to 1)
+#   300 ppid 0   sh   (second exec session) — PROTECT
+_TREE_PPID = {1: 0, 39: 1, 100: 0, 101: 100, 102: 101, 200: 1, 300: 0}
+_TREE_COMM = {1: "startup.sh", 39: "sudo", 100: "sh", 101: "indexer",
+              102: "python3", 200: "sh", 300: "sh"}
+_TREE_CMD = {
+    1: "/app/startup.sh", 39: "sudo tail", 100: "sh",
+    101: "python3 build_index.py", 102: "python3 -c faiss",
+    200: "sh -c leaked", 300: "sh",
+}
+
+
+@pytest.fixture
+def fake_proc(monkeypatch):
+    monkeypatch.setattr(oa.os, "listdir",
+                        lambda p: [str(pid) for pid in _TREE_PPID])
+    monkeypatch.setattr(oa, "_read_ppid", lambda pid: _TREE_PPID.get(pid))
+    monkeypatch.setattr(oa, "_read_comm", lambda pid: _TREE_COMM.get(pid))
+    monkeypatch.setattr(oa, "_read_cmdline", lambda pid: _TREE_CMD.get(pid))
+    return monkeypatch
+
+
+def test_docker_exec_entry_and_descendants_protected(fake_proc):
+    got = oa._docker_exec_session_pids()
+    # Both PPID-0 exec entries (100, 300) + the 100-rooted subtree (101, 102).
+    assert got == {100, 101, 102, 300}
+
+
+def test_pid1_excluded_from_exec_protection(fake_proc):
+    # PID 1 has PPID 0 but must not be returned here (and its child 39 must
+    # not be dragged in as a "descendant of an exec session").
+    got = oa._docker_exec_session_pids()
+    assert 1 not in got
+    assert 39 not in got
+
+
+def test_reparented_orphan_not_protected(fake_proc):
+    # The leaked orphan (200, ppid 1) is exactly what the sweep must still
+    # kill — it is not a PPID-0 session.
+    assert 200 not in oa._docker_exec_session_pids()
+
+
+def test_resolve_allowlist_includes_exec_session_excludes_orphan(fake_proc):
+    # sweep_pid = the indexer's... no — sweep runs from agent-server. Use a
+    # pid not in the exec tree so the only thing keeping 100/101/102 alive is
+    # the new PPID-0 rule. 39 (sudo, child of init) stands in for agent-server.
+    allow = oa.resolve_allowlist(39)
+    assert {100, 101, 102, 300}.issubset(allow)  # exec sessions spared
+    assert 1 in allow                              # init hard-protected
+    assert 200 not in allow                        # leaked orphan still killable
+
+
+def test_exec_child_reparented_after_session_exit_is_reaped(monkeypatch):
+    # Session exited: pid 100 gone, its child 101 reparented to PID 1. With
+    # no PPID-0 ancestor, 101 falls out of the exec allowlist → reaped.
+    tree = {1: 0, 101: 1}
+    monkeypatch.setattr(oa.os, "listdir", lambda p: [str(p) for p in tree])
+    monkeypatch.setattr(oa, "_read_ppid", lambda pid: tree.get(pid))
+    monkeypatch.setattr(oa, "_read_comm", lambda pid: None)
+    monkeypatch.setattr(oa, "_read_cmdline", lambda pid: None)
+    assert oa._docker_exec_session_pids() == set()


### PR DESCRIPTION
## Summary

The periodic cgroup orphan sweeper (#817) SIGKILLed operator `docker exec` sessions within 0–30s — the **same class of actor** the allowlist already protects for SSH. `docker exec agent-X sh -c '...sleep 60'` died with exit 137; weeks of FAISS index-build failures were misdiagnosed as OOM/capacity (a host was upsized for nothing). It also exposed the platform's own exec paths (pre-check hooks, git recovery, session-JSONL reaping, agent terminal — all `docker exec`).

## Root cause

A `docker exec` entry process matches none of the allowlist sources (no execution id, no `TRINITY_EXECUTION_ID`, no shared pgid, not sshd) → reaped as an orphan. But it's exactly the operator-debugging case `_ssh_session_pids()` exists to protect.

## Fix

- **`orphan_allowlist._docker_exec_session_pids()`** — inside the container PID namespace a `docker exec` entry has **PPID 0** (real parent is the containerd shim, outside the namespace); genuinely-leaked orphans reparent to **PID 1**, never 0. PPID 0 is an unspoofable "operator exec session" signal. Allowlist every PPID-0 process (excluding PID 1, already hard-protected) **+ its descendant tree**. Wired into `resolve_allowlist`. When the session exits, leftover children reparent to PID 1 → fall out of the set → reaped next sweep (the #817 guarantee is preserved).
- **`orphan_sweep`** — each real kill logs at **WARNING** with `pid` + a length-capped (`200`) `cmd=` (was INFO, count-only summary in the loop). dry_run stays INFO. One such line turns a weeks-long "which process keeps dying?" into a 5-minute fix.
- **Docs** — `TRINITY_COMPATIBLE_AGENT_GUIDE.md` gains a **"Long-Running & Background Processes (the orphan sweeper)"** section: the `~/.trinity/persistent-processes.allow` escape hatch and "run maintenance as a platform execution" guidance.

## Verification

**Unit** — `tests/unit/test_1153_docker_exec_allowlist.py` (5): PPID-0 entry + descendants protected; PID 1 (and its children) excluded; reparented orphan not protected; `resolve_allowlist` end-to-end; post-exit child reaped. #912 suite still green (**13 passed** together).

**Live** (fresh `trinity-agent-base:0.6.0` agent, real cgroup sweep mid-flight, `sweep_pid` = agent-server's pid as in production):

| Process | Result |
|---|---|
| 30s `docker exec` loop (PPID 0) | spared → **exit 0**, all 6 outputs |
| planted `sh -c sleep 300` (PPID 1, reparented) | **reaped** ✅ |
| `sudo .../sshd` | spared (SSH unchanged) |
| `python3 /app/agent-server.py` | spared |

## AC

- [x] Long `docker exec` survives sweep cycles, exits 0
- [x] Children left behind after session exit ARE reaped (reparented to PID 1)
- [x] SSH-session protection unchanged
- [x] Each kill logs one WARNING with pid + length-capped cmdline
- [x] Unit tests cover the PPID-0 branch (entry + descendants, PID 1 exclusion)
- [x] Agent-container docs describe the sweeper, the escape hatch, and the "maintenance as platform executions" guidance

Note: agent-runtime change → base image rebuilt (`trinity-agent-base:0.6.0`/`latest`); takes effect on newly created/restarted agent containers.

Related to #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)