### PR TITLE
docs: convert license to Apache 2.0 and update all related documentation (#1139)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Trinity is an autonomous agent orchestration platform: every agent runs in its o
 | Agent SSH ports | 2222+ (incrementing per agent) |
 | Required agent files | `CLAUDE.md` (agent instructions), `template.yaml` (metadata); optional `.env.example`, `.mcp.json.template` |
 | Persistence | SQLite at `~/trinity-data/trinity.db` (host bind mount); Redis for transient state |
-| License | Polyform Noncommercial — free for non-commercial use; commercial use requires a license |
+| License | Apache 2.0 — free for any use, commercial included |
 
 ## Stand up a Trinity instance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Trinity! This document provides g
 
 ## License
 
-By contributing to Trinity, you agree that your contributions will be licensed under the [Polyform Noncommercial License 1.0.0](LICENSE).
+Trinity is licensed under the [Apache License 2.0](LICENSE). Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in Trinity by you shall be licensed under the Apache License 2.0, without any additional terms or conditions (per Section 5 of the license).
 
 ## Code of Conduct
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,143 +1,202 @@
-# Polyform Noncommercial License 1.0.0
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-## Acceptance
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+   1. Definitions.
 
-## Copyright License
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-## Distribution License
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-## Notices
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-> Required Notice: Copyright Ability AI (https://ability.ai)
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-## Changes and New Works License
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-## Patent License
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-## Noncommercial Purposes
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-Any noncommercial purpose is a permitted purpose.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-## Personal Uses
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-## Noncommercial Organizations
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-## Fair Use
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-## No Other Rights
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-## Patent Defense
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-## Violations
+   END OF TERMS AND CONDITIONS
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+   APPENDIX: How to apply the Apache License to your work.
 
-## No Liability
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+   Copyright 2025-2026 Ability AI
 
-## Definitions
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-The **licensor** is the entity offering these terms, and the
-**software** is the software the licensor makes available under
-these terms.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-**You** refers to the individual or entity agreeing to these
-terms.
-
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
-
-**Use** means anything you do with the software requiring one
-of your licenses.
-
----
-
-Required Notice: Copyright 2024-2025 Ability AI (https://ability.ai)
-
----
-
-## Commercial Licensing
-
-For commercial use of Trinity, please contact Ability AI:
-- Email: hello@ability.ai
-- Website: https://ability.ai
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Trinity
+Copyright 2025-2026 Ability AI
+
+This product includes software developed at
+Ability AI (https://www.ability.ai/).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <a href="https://github.com/abilityai/trinity/stargazers"><img src="https://img.shields.io/github/stars/abilityai/trinity?style=flat" alt="Stars"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Polyform%20NC-blue.svg" alt="License: Polyform NC"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License: Apache 2.0"></a>
   <a href="https://pypi.org/project/trinity-cli/"><img src="https://img.shields.io/pypi/v/trinity-cli?label=CLI&color=blue" alt="CLI"></a>
   <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/vue-3.x-green.svg" alt="Vue">
@@ -33,7 +33,7 @@ Trinity is the production runtime for your AI agents — governed, auditable, on
 
 Each agent runs in its own isolated Docker container with real-time observability, fleet-wide scheduling, agent-to-agent delegation, and a tamper-evident audit trail. Self-host it, or run it on any cloud you control.
 
-> Source-available · **Polyform Noncommercial** — free for non-commercial use; commercial use needs a commercial license and deploys anywhere you run it · Independently pentested — **UnderDefense Grade A** · We run Trinity in production ourselves — and so do our customers.
+> Open source · **Apache 2.0** — free for any use, commercial included, and deploys anywhere you run it · Independently pentested — **UnderDefense Grade A** · We run Trinity in production ourselves — and so do our customers.
 
 > 🤖 **AI agent reading this repo?** Start at [AGENTS.md](AGENTS.md) — a task router with exact commands, key facts, and verification steps. Detailed docs index: [docs/user-docs/README.md](docs/user-docs/README.md).
 
@@ -690,17 +690,9 @@ git push origin cli-v1.0.0
 
 ## License
 
-This project is licensed under the [Polyform Noncommercial License 1.0.0](LICENSE).
+This project is licensed under the [Apache License 2.0](LICENSE) — free for any use, commercial included, with an explicit patent grant. Run it on your own infrastructure, any cloud, or a managed instance.
 
-**Free for**:
-- Personal use
-- Research and education
-- Non-profit organizations
-- Hobby projects
-
-**Commercial use** requires a separate license — which you can run on your own infrastructure, any cloud, or a managed instance. Contact [hello@ability.ai](mailto:hello@ability.ai) for commercial licensing.
-
-> Trinity is **source-available** under Polyform Noncommercial — not an OSI open-source license. The source is public and free for the non-commercial uses above; commercial use needs a license.
+Optional **enterprise modules** (SSO, user management, SIEM export, and more) are available under a separate commercial license. Contact [hello@ability.ai](mailto:hello@ability.ai) for enterprise licensing.
 
 ## Contributing
 

--- a/docs/onboarding/00-welcome.md
+++ b/docs/onboarding/00-welcome.md
@@ -202,12 +202,12 @@ For advanced topics, explore the main documentation:
 - **API Reference**: Interactive API docs at `http://localhost:8000/docs`
 
 ### 🤝 Contribute
-Trinity is open source under the Polyform Noncommercial License. We welcome contributions!
+Trinity is open source under the Apache License 2.0. We welcome contributions!
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
 
-### 🏢 Commercial Use
-For commercial licensing, contact hello@ability.ai
+### 🏢 Enterprise
+For enterprise modules and support, contact hello@ability.ai
 
 ---
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -89,4 +89,4 @@ trinity agents list --format json
 
 ## License
 
-MIT
+Apache-2.0

--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -7,7 +7,7 @@ name = "trinity-cli"
 version = "0.0.0"  # Replaced at build time by CI (auto-publishes on push to main)
 description = "CLI for the Trinity Autonomous Agent Orchestration Platform"
 readme = "README.md"
-license = "MIT"
+license = "Apache-2.0"
 requires-python = ">=3.10"
 authors = [
     {name = "Ability AI", email = "hello@ability.ai"},

--- a/src/mcp-server/package.json
+++ b/src/mcp-server/package.json
@@ -18,7 +18,7 @@
     "orchestration"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "fastmcp": "^3.32.0",
     "zod": "^3.24.1"


### PR DESCRIPTION
## Summary

- Replaces the Polyform Noncommercial License 1.0.0 with the **verbatim Apache License 2.0** (downloaded from apache.org; only the appendix copyright boilerplate filled in: `Copyright 2025-2026 Ability AI`), making Trinity OSI-approved open source
- Adds a `NOTICE` file per Apache 2.0 convention
- Updates every license reference found by audit, including two not listed in the issue: `AGENTS.md` (key-facts table) and `src/cli/` (pyproject + README declared `MIT` — same inconsistency class as the MCP server's `package.json`)

## Changes

| File | Change |
|------|--------|
| `LICENSE` | Verbatim Apache 2.0 text with Ability AI copyright line |
| `NOTICE` | New — Apache 2.0 attribution convention |
| `README.md` | Badge → Apache 2.0; tagline reframed "Source-available · Polyform NC" → "Open source · Apache 2.0"; License section rewritten — commercial-licensing paragraph reframed around enterprise modules (#847 seam) |
| `CONTRIBUTING.md` | Inbound contributions now under Apache 2.0 §5 (inbound = outbound) |
| `AGENTS.md` | License row in key-facts table updated |
| `docs/onboarding/00-welcome.md` | License mention updated; "Commercial Use" section reframed as "Enterprise" |
| `src/mcp-server/package.json` | `MIT` → `Apache-2.0` |
| `src/cli/pyproject.toml`, `src/cli/README.md` | `MIT` → `Apache-2.0` (PyPI `trinity-cli` metadata) |

Not changed (intentional): `docs/planning/` strategy docs discuss enterprise *license mechanisms* (Ed25519 tokens), not the repo license — no Polyform references there. `src/backend/enterprise/` (private submodule) stays proprietary per the issue.

## Verification

- `grep -ri "polyform\|noncommercial" --include="*.md"` → no matches (repo-wide, all file types also clean)
- `package.json` / `pyproject.toml` re-parsed as valid JSON/TOML after edit
- LICENSE is byte-identical to the canonical apache.org text except the filled-in appendix copyright line, so GitHub's licensee will detect `Apache-2.0` after merge (verify on the repo page post-merge)
- No CI workflow or test asserts on license strings (checked)

## ⚠️ Pre-merge legal check (from issue Technical Notes)

Relicensing requires authority over all contributions. `git shortlog -sne` shows external-looking contributors beyond the Ability AI team (Alex Korin, dolho, Andrii Pasternak, Pavlo Shulin, obasilakis, webmixgamer, Oleksii Dolhov, plus dependabot). **Please confirm all are covered (employees / contractors / CLA / DCO) before merging.**

## Test Plan

- [x] Stale-reference grep clean
- [x] JSON/TOML validity verified
- [ ] GitHub repo license detection shows Apache 2.0 (post-merge check)

Fixes #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)