### PR TITLE
fix(db): alias agent_ownership in agent-count subquery to fix auth-report 500 (#1199)

### DIFF
--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -92,14 +92,25 @@ class SubscriptionOperations:
 
     @staticmethod
     def _agent_count_subquery():
-        """Correlated agent-count subquery: live (non-deleted) agents per subscription."""
+        """Correlated agent-count subquery: live (non-deleted) agents per subscription.
+
+        ``agent_ownership`` is aliased (#1199) so the subquery's FROM table is
+        always distinct from any ``agent_ownership`` in the enclosing query.
+        Without the alias, callers that *also* join ``agent_ownership`` in their
+        outer FROM (``get_agent_subscription``) make SQLAlchemy auto-correlate
+        ``agent_ownership`` out of the subquery, leaving it with no FROM clause —
+        a compile-time ``InvalidRequestError``. With the alias, auto-correlation
+        only removes ``subscription_credentials`` (the intended correlation), so
+        the helper is safe in every caller.
+        """
+        ao = agent_ownership.alias("ao_count")
         return (
             select(func.count())
-            .select_from(agent_ownership)
+            .select_from(ao)
             .where(
                 and_(
-                    agent_ownership.c.subscription_id == subscription_credentials.c.id,
-                    agent_ownership.c.deleted_at.is_(None),
+                    ao.c.subscription_id == subscription_credentials.c.id,
+                    ao.c.deleted_at.is_(None),
                 )
             )
             .scalar_subquery()

--- a/tests/unit/test_1199_agent_subscription_correlation.py
+++ b/tests/unit/test_1199_agent_subscription_correlation.py
@@ -1,0 +1,148 @@
+"""Regression test for #1199 — SQLAlchemy auto-correlation in the agent-count
+subquery (introduced by the #1093 SQLAlchemy-Core db rewrite, v0.6.1).
+
+`SubscriptionOperations._agent_count_subquery()` builds a scalar subquery whose
+only FROM is `agent_ownership`, correlated to the outer query on
+`agent_ownership.subscription_id == subscription_credentials.id`. That is safe
+in callers whose outer FROM is just `subscription_credentials JOIN users`
+(`get_subscription`, `list_subscriptions`, `get_least_used_subscription`,
+`select_best_alternative_subscription`). But `get_agent_subscription` *also*
+joins `agent_ownership` in its outer query (to filter by `agent_name`), so
+SQLAlchemy auto-correlates `agent_ownership` *out* of the subquery — leaving it
+with no FROM clause and raising `InvalidRequestError` at statement-compile time.
+Because it fails at compile time, `GET /api/ops/auth-report` 500s for every call
+regardless of data, on **both** SQLite and PostgreSQL.
+
+The fix aliases `agent_ownership` inside the subquery (`ao_count`) so its FROM
+is always distinct from any outer `agent_ownership`; auto-correlation then only
+removes `subscription_credentials`, the intended correlation.
+
+Backend-agnostic via ``db_harness`` (#300): runs on SQLite and, when
+``TEST_POSTGRES_URL`` is set, PostgreSQL too — mirroring the issue's
+"reproduces identically on both backends".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_THIS = Path(__file__).resolve()
+_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend, run as _hrun  # noqa: E402
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def tmp_db(db_backend):
+    """Active backend with a fresh full schema (db_harness, #300). Pops cached
+    db modules so production code re-resolves against the test engine, while
+    keeping the harness-loaded engine/tables/schema modules importable."""
+    for modname in list(sys.modules):
+        if modname == "database" or modname.startswith("db."):
+            if modname in ("db.engine", "db.tables", "db.schema"):
+                continue
+            sys.modules.pop(modname, None)
+    return db_backend
+
+
+_NOW = "2026-01-01T00:00:00Z"
+
+
+def _seed_owner_and_subscription(owner_id: int = 1, sub_id: str = "sub-1") -> None:
+    _hrun(
+        "INSERT INTO users (id, username, role, email, created_at, updated_at) "
+        "VALUES (:id, :u, 'user', :e, :n, :n)",
+        id=owner_id, u=f"owner-{owner_id}", e=f"owner-{owner_id}@example.com", n=_NOW,
+    )
+    _hrun(
+        "INSERT INTO subscription_credentials "
+        "(id, name, encrypted_credentials, subscription_type, rate_limit_tier, "
+        " owner_id, created_at, updated_at) "
+        "VALUES (:id, :name, :enc, 'max', 'default', :o, :n, :n)",
+        id=sub_id, name=f"max-{sub_id}", enc="{}", o=owner_id, n=_NOW,
+    )
+
+
+def _seed_agent(agent_name: str, owner_id: int = 1,
+                sub_id: str | None = None, deleted_at: str | None = None) -> None:
+    _hrun(
+        "INSERT INTO agent_ownership "
+        "(agent_name, owner_id, subscription_id, created_at, deleted_at) "
+        "VALUES (:a, :o, :s, :n, :d)",
+        a=agent_name, o=owner_id, s=sub_id, n=_NOW, d=deleted_at,
+    )
+
+
+def _ops():
+    from db.subscriptions import SubscriptionOperations
+
+    return SubscriptionOperations()
+
+
+def test_get_agent_subscription_compiles_and_returns_row(tmp_db):
+    """The crux of #1199: get_agent_subscription must not raise at compile time
+    and must return the agent's subscription with a correct agent_count."""
+    _seed_owner_and_subscription(sub_id="sub-1")
+    _seed_agent("agent-1", sub_id="sub-1")
+
+    # Pre-fix this raised sqlalchemy.exc.InvalidRequestError
+    # ("returned no FROM clauses due to auto-correlation").
+    sub = _ops().get_agent_subscription("agent-1")
+
+    assert sub is not None
+    assert sub.id == "sub-1"
+    assert sub.owner_email is not None  # users join still resolves
+    assert sub.agent_count == 1
+
+
+def test_agent_count_excludes_soft_deleted_agents(tmp_db):
+    """The aliased subquery must preserve the deleted_at IS NULL filter — a
+    soft-deleted agent on the same subscription must not inflate the count."""
+    _seed_owner_and_subscription(sub_id="sub-1")
+    _seed_agent("agent-live", sub_id="sub-1")
+    _seed_agent("agent-gone", sub_id="sub-1", deleted_at=_NOW)
+
+    sub = _ops().get_agent_subscription("agent-live")
+
+    assert sub is not None
+    # Only the live agent counts (the deleted sibling is filtered out).
+    assert sub.agent_count == 1
+
+
+def test_get_agent_subscription_none_when_unassigned(tmp_db):
+    """An agent with no subscription returns None (the join yields no row),
+    not an error — confirms the fix doesn't change the no-match contract."""
+    _seed_owner_and_subscription(sub_id="sub-1")
+    _seed_agent("agent-unassigned", sub_id=None)
+
+    assert _ops().get_agent_subscription("agent-unassigned") is None
+
+
+def test_sibling_callers_still_compile(tmp_db):
+    """The shared helper is used by callers without an outer agent_ownership
+    join too — make sure the alias didn't regress them. ``list_subscriptions``
+    and ``get_subscription`` embed ``_agent_count_subquery()`` with a
+    non-agent_ownership outer FROM and don't decrypt the token, so they isolate
+    the compile/correlation path cleanly."""
+    _seed_owner_and_subscription(sub_id="sub-1")
+    _seed_agent("agent-1", sub_id="sub-1")
+
+    ops = _ops()
+    subs = ops.list_subscriptions()
+    assert len(subs) == 1
+    assert subs[0].agent_count == 1
+
+    one = ops.get_subscription("sub-1")
+    assert one is not None and one.agent_count == 1


### PR DESCRIPTION
## Summary
- `GET /api/ops/auth-report` (and per-agent subscription-status lookups) 500'd on **every** call on v0.6.1 with `sqlalchemy.exc.InvalidRequestError: ... returned no FROM clauses due to auto-correlation`.
- Root cause: `SubscriptionOperations._agent_count_subquery()` builds a scalar subquery whose only FROM is `agent_ownership`, correlated on `agent_ownership.subscription_id == subscription_credentials.id`. `get_agent_subscription` *also* joins `agent_ownership` in its outer query, so SQLAlchemy auto-correlates `agent_ownership` out of the subquery too — leaving it FROM-less and failing at statement-compile time (so it 500s regardless of data, on both SQLite and PostgreSQL).
- Fix: alias `agent_ownership` as `ao_count` inside the subquery so its FROM is always distinct from any outer `agent_ownership`. Auto-correlation now only removes `subscription_credentials` (the intended correlation). One-point fix in the shared helper → safe in every caller.

## Changes
- `src/backend/db/subscriptions.py` — alias `agent_ownership` (`ao_count`) inside `_agent_count_subquery()` + explanatory docstring.
- `tests/unit/test_1199_agent_subscription_correlation.py` — new backend-agnostic regression tests (`db_harness`, SQLite + Postgres).

## Why the alias (not `.correlate()`)
The alias makes the helper correct in **all** callers, including any future one that joins `agent_ownership` in its outer FROM — the issue's recommended, most-robust option. The four existing callers without an `agent_ownership` outer join (`get_subscription`, `list_subscriptions`, `get_least_used_subscription`, `select_best_alternative_subscription`) are unaffected (covered by the sibling-compile test).

## Test Plan
- [x] Pre-fix: the 3 `get_agent_subscription` cases fail with the exact `InvalidRequestError: returned no FROM clauses due to auto-correlation` (verified by reverting the source fix in isolation).
- [x] Post-fix: all 4 new cases pass — statement compiles, returns the right row + `agent_count`, `deleted_at IS NULL` filter preserved through the alias, no-subscription contract unchanged, sibling callers still compile.
- [x] No regressions: 37 subscription unit tests pass (`test_1199_*`, `test_subscription_auto_switch_*`, `test_inject_assigned_credentials`, `test_subscription_bola`).
- Run: `cd tests && python -m pytest unit/test_1199_agent_subscription_correlation.py -v`

## Docs
None — bug-fix tier (commit message only). No feature flow / architecture change: the endpoint, call, and `agent_count` shape are unchanged; the fix restores the behavior `subscription-management.md` already documents.

Fixes #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)