### PR TITLE
fix(csp): allow ask-trinity Cloud Function in connect-src (#1224)

### DIFF
--- a/src/frontend/security-headers.conf
+++ b/src/frontend/security-headers.conf
@@ -19,5 +19,5 @@ add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), microphone=(self), geolocation=(), payment=()" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
 add_header Cross-Origin-Resource-Policy "same-origin" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ws: wss: https://us-central1-mcp-server-project-455215.cloudfunctions.net; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
 add_header Strict-Transport-Security $hsts_header always;

--- a/src/frontend/vite.config.js
+++ b/src/frontend/vite.config.js
@@ -30,7 +30,7 @@ const devSecurityHeaders = {
     "style-src 'self' 'unsafe-inline'; " +
     "img-src 'self' data: blob:; " +
     "font-src 'self'; " +
-    "connect-src 'self' ws: wss:; " +
+    "connect-src 'self' ws: wss: https://us-central1-mcp-server-project-455215.cloudfunctions.net; " +
     "frame-ancestors 'self'; " +
     "base-uri 'self'; " +
     "form-action 'self'",


### PR DESCRIPTION
## Summary
- The in-app **Help chat (Ask Trinity)** widget was fully non-functional under the production CSP: `connect-src 'self' ws: wss:` omitted the docs Q&A Cloud Function origin, so the browser blocked every `fetch()` with `Refused to connect ... violates CSP` → `TypeError: Failed to fetch`.
- Adds the **specific** Cloud Function origin (`https://us-central1-mcp-server-project-455215.cloudfunctions.net`) to `connect-src` in both CSP sources — narrow allowlist, no wildcard, no public-surface expansion (already a documented public endpoint).

## Changes
- `src/frontend/security-headers.conf` — prod nginx CSP `connect-src`
- `src/frontend/vite.config.js` — dev-server CSP `connect-src` (mirrors prod)

## Test Plan
- [x] `ws:`/`wss:` still present in both files — WebSocket real-time delivery unaffected
- [x] Allowlisted origin exactly matches the widget's hardcoded `ENDPOINT` (no drift)
- [x] CORS preflight verified: `OPTIONS` → `204` with `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: POST, OPTIONS`, `Access-Control-Allow-Headers: Content-Type` — no follow-on CORS blocker
- [x] Endpoint answers `HTTP 200` to the widget's real `{question}` request schema
- [ ] Manual: in a prod-style build, send a Help chat message → response renders, zero CSP violations in console

Fixes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)