### PR TITLE
fix(csp): allow ask-trinity Cloud Function in connect-src (#1224)

### DIFF
--- a/src/frontend/security-headers.conf
+++ b/src/frontend/security-headers.conf
@@ -19,5 +19,5 @@ add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), microphone=(self), geolocation=(), payment=()" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
 add_header Cross-Origin-Resource-Policy "same-origin" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ws: wss: https://us-central1-mcp-server-project-455215.cloudfunctions.net; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
 add_header Strict-Transport-Security $hsts_header always;

--- a/src/frontend/vite.config.js
+++ b/src/frontend/vite.config.js
@@ -30,7 +30,7 @@ const devSecurityHeaders = {
     "style-src 'self' 'unsafe-inline'; " +
     "img-src 'self' data: blob:; " +
     "font-src 'self'; " +
-    "connect-src 'self' ws: wss:; " +
+    "connect-src 'self' ws: wss: https://us-central1-mcp-server-project-455215.cloudfunctions.net; " +
     "frame-ancestors 'self'; " +
     "base-uri 'self'; " +
     "form-action 'self'",


### PR DESCRIPTION
## Summary
Direct-to-`main` hotfix for the P0 Help chat (Ask Trinity) CSP block. Same change as #1225 (merged to `dev`), cherry-picked onto a `main`-based branch so it lands on production without dragging in dev's other unreleased commits.

Adds the specific docs Q&A Cloud Function origin to `connect-src` in the prod (`security-headers.conf`) and dev (`vite.config.js`) CSP — narrow allowlist, no wildcard, no public-surface expansion.

## Test Plan
- [x] `ws:`/`wss:` preserved — WebSocket delivery unaffected
- [x] Allowlisted origin exactly matches the widget's hardcoded `ENDPOINT`
- [x] CORS preflight verified (`OPTIONS` → `204`, `ACAO: *`, `POST, OPTIONS`, `Content-Type`); endpoint answers `HTTP 200` to the widget's `{question}` schema
- [x] Diff vs `main` is the two CSP files only

Fixes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)