### PR TITLE
fix: shared cross-worker first-time setup token (#1165)

### DIFF
--- a/docs/memory/feature-flows/first-time-setup.md
+++ b/docs/memory/feature-flows/first-time-setup.md
@@ -176,29 +176,44 @@ from routers.setup import router as setup_router
 app.include_router(setup_router)
 ```
 
-**Setup Token** (module-level, generated at startup):
+**Setup Token** (shared across workers via Redis, #1165):
 ```python
-# Single-use setup token generated at startup.
-# Must be provided when calling POST /api/setup/admin-password.
-# Prevents installation hijack: only someone with access to server logs can complete setup.
-_setup_token: str = secrets.token_urlsafe(24)
+# Each worker has a candidate; the first to boot wins the SETNX claim and all
+# workers read the single winner. Validation reads it live, so a token issued on
+# one worker validates on any worker (prod runs uvicorn --workers 2).
+_SETUP_TOKEN_KEY = "trinity:setup:token"
+_candidate_token: str = secrets.token_urlsafe(24)
 
-def get_setup_token() -> str:
-    """Return the setup token for printing during startup."""
-    return _setup_token
+def ensure_setup_token():
+    """Idempotently ensure a shared token exists in Redis; return it (or None if
+    Redis is unreachable). The issuing worker prints it to the logs exactly once."""
+    r = _get_redis()
+    if r is None:
+        return None  # setup blocked until Redis recovers — never a per-worker fallback
+    issued = r.set(_SETUP_TOKEN_KEY, _candidate_token, nx=True)  # first-writer-wins
+    token = r.get(_SETUP_TOKEN_KEY)
+    if issued:
+        logger.warning("TRINITY FIRST-TIME SETUP REQUIRED\nSetup token: %s\n...", token)
+    return token
 ```
+
+> **Why Redis, not a module global (#1165):** prod runs `uvicorn --workers 2`.
+> A per-process `secrets.token_urlsafe(24)` differs per worker, so the operator
+> copies one worker's token but `POST /api/setup/admin-password` load-balances
+> and 403s ~50% of the time on the other worker. The shared Redis token (read
+> live at validation time) removes the per-worker drift entirely. When Redis is
+> unreachable, setup is **blocked** (`setup_available: false` + 503), not
+> silently degraded to a per-worker token.
 
 **Startup Token Emission** (in `main.py` lifespan handler, immediately after
 `setup_logging()`):
 ```python
 if _db.get_setting_value('setup_completed', 'false') != 'true':
-    _setup_token = get_setup_setup_token()
-    logger.warning(
-        "TRINITY FIRST-TIME SETUP REQUIRED\n"
-        f"Setup token: {_setup_token}\n"
-        "Visit the Trinity UI and enter this token to set the admin password.\n"
-        "This token is only valid for this session."
-    )
+    # ensure_setup_token() claims the shared token and prints it (once, on the
+    # issuing worker). If Redis is down, the next GET /api/setup/status reissues
+    # once it recovers — no restart needed.
+    if _ensure_setup_token() is None:
+        logger.error("FIRST-TIME SETUP REQUIRED but Redis unreachable — setup blocked.")
 ```
 
 > **Why `logger.warning`, not `print` (#858):** the lifespan runs under uvicorn with
@@ -229,11 +244,15 @@ async def get_setup_status():
 
     Returns:
         - setup_completed: Whether the admin password has been set
-        - dev_mode_hint: Hint for dev mode (if applicable)
+        - setup_available: False while pending if Redis (token store) is down (#1165)
     """
     setup_completed = db.get_setting_value('setup_completed', 'false') == 'true'
+    setup_available = True
+    if not setup_completed:
+        setup_available = ensure_setup_token() is not None  # probes Redis + self-heals
     return {
-        "setup_completed": setup_completed
+        "setup_completed": setup_completed,
+        "setup_available": setup_available,
     }
 ```
 
@@ -249,8 +268,14 @@ async def set_admin_password(data: SetAdminPasswordRequest, request: Request):
     if db.get_setting_value('setup_completed', 'false') == 'true':
         raise HTTPException(status_code=403, detail="Setup already completed...")
 
-    # 2. Validate setup token (constant-time compare to guard against timing attacks)
-    if not secrets.compare_digest(data.setup_token, _setup_token):
+    # 2. Resolve the shared token; 503 if Redis is unreachable (don't fall back
+    #    to a per-worker token — that is the #1165 bug).
+    shared_token = ensure_setup_token()
+    if shared_token is None:
+        raise HTTPException(status_code=503, detail="Setup temporarily unavailable: Redis unreachable.")
+
+    # 3. Validate setup token (constant-time compare to guard against timing attacks)
+    if not secrets.compare_digest(data.setup_token, shared_token):
         raise HTTPException(
             status_code=403,
             detail="Invalid setup token. Check server logs for the setup token printed at startup."
@@ -668,6 +693,7 @@ env_vars = {
 |------------|-------------|---------|----------|
 | Setup already completed | 403 | "Setup already completed" | Frontend redirects to /login after 2s |
 | Invalid setup token | 403 | "Invalid setup token. Check server logs..." | Frontend shows error, stays on form |
+| Redis unreachable (#1165) | 503 | "Setup temporarily unavailable: ... cannot reach Redis" | Frontend shows "waiting for Redis" panel + polls |
 | Missing setup_token field | 422 | Pydantic validation error | Form prevents submission |
 | Password too short | 400 | "Password must be at least 8 characters" | Form validation |
 | Passwords don't match | 400 | "Passwords do not match" | Form validation |
@@ -695,7 +721,7 @@ env_vars = {
 
 3. **Setup Endpoint Protection** (SEC #177):
    - No network auth required (must work on fresh install)
-   - **Single-use setup token**: Generated at startup via `secrets.token_urlsafe(24)`, printed ONLY to server logs. An attacker without local server access cannot complete setup.
+   - **Shared setup token (#1165)**: Generated via `secrets.token_urlsafe(24)`, stored in Redis (first-writer-wins) so all uvicorn workers share one value, printed ONLY to server logs. An attacker without local server access cannot complete setup. When Redis is down, setup is blocked (503) rather than degraded to a per-worker token.
    - Constant-time token comparison (`secrets.compare_digest`) prevents timing attacks
    - Self-disabling after first use via `setup_completed` flag
    - Audit logged even on blocked attempts
@@ -727,10 +753,11 @@ env_vars = {
    ```
    - **Expected**: a structured JSON log line whose `message` contains
      `Setup token: <token>` (emitted at `WARNING` level since #858).
-   - **Prod caveat**: production runs uvicorn with `--workers 2`, and the token is
-     per-process — each worker logs a *different* token. Until the multi-worker token
-     is unified (#1165), copy a token and retry if `POST /api/setup/admin-password`
-     returns 403 (your request may have hit the other worker).
+   - **Prod (#1165)**: production runs uvicorn with `--workers 2`, but the token is
+     shared via Redis (first-writer-wins), so exactly **one** worker logs the token
+     and it validates regardless of which worker handles the request. If Redis is
+     down, no token is logged and the setup UI shows "waiting for Redis"; the token
+     is issued automatically once Redis recovers (no restart needed).
 
 3. **Visit any page** (e.g., `http://localhost/`)
    - **Expected**: Redirect to `/setup`

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -68,7 +68,7 @@ from routers.ops import router as ops_router
 from routers.public_links import router as public_links_router, set_websocket_manager as set_public_links_ws_manager
 from routers.public import router as public_router
 from routers.files import router as files_router  # FILES-001 — outbound file downloads
-from routers.setup import router as setup_router, get_setup_token as get_setup_setup_token
+from routers.setup import router as setup_router, ensure_setup_token as _ensure_setup_token
 from routers.telemetry import router as telemetry_router
 from routers.logs import router as logs_router
 from routers.agent_dashboard import router as agent_dashboard_router
@@ -324,13 +324,16 @@ async def lifespan(app: FastAPI):
     # silently lost from `docker logs` (#858).
     from database import db as _db
     if _db.get_setting_value('setup_completed', 'false') != 'true':
-        _setup_token = get_setup_setup_token()
-        logger.warning(
-            "TRINITY FIRST-TIME SETUP REQUIRED\n"
-            f"Setup token: {_setup_token}\n"
-            "Visit the Trinity UI and enter this token to set the admin password.\n"
-            "This token is only valid for this session."
-        )
+        # ensure_setup_token() claims the shared cross-worker token and prints it
+        # to the logs itself (exactly once, on the issuing worker — #1165). When
+        # Redis is unreachable no token is issued and setup is blocked; the next
+        # GET /api/setup/status reissues+prints once Redis recovers, so no
+        # restart is needed. logger (not print) keeps the #858 flush guarantee.
+        if _ensure_setup_token() is None:
+            logger.error(
+                "TRINITY FIRST-TIME SETUP REQUIRED but Redis is unreachable — no "
+                "setup token issued yet. Setup is blocked until Redis is reachable."
+            )
 
     # Start Redis Streams event bus + dispatcher (RELIABILITY-003 / #306).
     # Must start before the WebSocket endpoints begin accepting clients so the

--- a/src/backend/routers/setup.py
+++ b/src/backend/routers/setup.py
@@ -4,7 +4,9 @@ First-time setup routes for the Trinity backend.
 Provides endpoints for initial admin password setup on first launch.
 These endpoints require NO authentication and only work before setup is completed.
 """
+import logging
 import secrets
+import threading
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
@@ -12,17 +14,163 @@ from database import db
 from dependencies import hash_password
 from utils.password_validation import validate_password_strength, PASSWORD_REQUIREMENTS_MESSAGE
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/setup", tags=["setup"])
 
-# Single-use setup token generated at startup.
-# Must be provided when calling POST /api/setup/admin-password.
-# Prevents installation hijack: only someone with access to server logs can complete setup.
-_setup_token: str = secrets.token_urlsafe(24)
+# --- Shared cross-worker first-time-setup token (#1165) ---------------------
+#
+# Prevents installation hijack: only someone with access to the server logs can
+# read the token and complete setup (SEC #177).
+#
+# Production runs uvicorn with `--workers 2`, so a per-process module global
+# (`secrets.token_urlsafe(24)` at import) would differ per worker — the operator
+# copies one worker's token but POST /api/setup/admin-password load-balances and
+# 403s ~50% of the time on the other worker (#1165). The token therefore lives
+# in Redis (first-writer-wins) so every worker reads the SAME value, and
+# validation reads it live at request time (no per-worker cached copy → no
+# drift). Redis is a mandatory platform dependency; when it is unreachable setup
+# is *blocked* — GET /api/setup/status reports `setup_available: false` and the
+# endpoint returns 503 — rather than silently falling back to a per-worker token.
+_SETUP_TOKEN_KEY = "trinity:setup:token"
+
+# TTL on the shared token so an abandoned install (token issued, setup never
+# completed) doesn't leave a valid secret in Redis + logs forever — the old
+# per-process global died on every restart; the Redis key would otherwise
+# persist across restarts. Safe to expire because validation reads the token
+# live (no cached per-worker copy to drift): once it lapses the next status
+# poll re-issues and re-prints one. 24h easily covers a minutes-long setup.
+_SETUP_TOKEN_TTL_SECONDS = 86400
+
+# This worker's candidate for the SETNX claim. Only the first worker to boot
+# wins; the rest read the winner. Never used directly for validation.
+_candidate_token: str = secrets.token_urlsafe(24)
+
+_redis_client = None
+_redis_client_lock = threading.Lock()
 
 
-def get_setup_token() -> str:
-    """Return the setup token for printing during startup."""
-    return _setup_token
+def reset_redis_client() -> None:
+    """Drop the cached client so the next call rebuilds it.
+
+    Without this, a client cached while Redis was healthy stays cached after a
+    Redis restart/failover — every later op throws and setup stays blocked until
+    the *process* restarts. Mirrors services/rate_limiter.reset_redis_client so
+    ensure_setup_token() can actually "self-heal without a restart".
+    """
+    global _redis_client
+    with _redis_client_lock:
+        _redis_client = None
+
+
+def _get_redis():
+    """Return a cached Redis client, or None if Redis is unreachable.
+
+    Mirrors services/rate_limiter._get_redis (1s timeouts, AUTH-error logging).
+    """
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
+    try:
+        import redis as _redis
+        from config import REDIS_URL
+    except Exception as e:  # import-time failure (config.py raises on bad URL)
+        logger.error("Setup token: cannot import Redis client/config: %s", e)
+        return None
+
+    from redis.exceptions import (
+        AuthenticationError,
+        AuthenticationWrongNumberOfArgsError,
+        ConnectionError as RedisConnectionError,
+        ResponseError,
+        TimeoutError as RedisTimeoutError,
+    )
+
+    with _redis_client_lock:
+        if _redis_client is not None:  # racy double-check
+            return _redis_client
+        try:
+            r = _redis.from_url(
+                REDIS_URL, decode_responses=True,
+                socket_connect_timeout=1, socket_timeout=1,
+            )
+            r.ping()
+            _redis_client = r
+            return _redis_client
+        except (AuthenticationError, AuthenticationWrongNumberOfArgsError):
+            logger.error("Setup token: Redis AUTH failed — check REDIS_URL/ACL")
+            return None
+        except ResponseError as e:
+            logger.error("Setup token: Redis ResponseError: %s", e)
+            return None
+        except (RedisConnectionError, RedisTimeoutError) as e:
+            logger.warning("Setup token: Redis transient error: %s", e)
+            return None
+        except Exception as e:
+            logger.error("Setup token: unexpected Redis error: %s", type(e).__name__)
+            return None
+
+
+def ensure_setup_token():
+    """Idempotently ensure a shared setup token exists in Redis and return it.
+
+    The first worker to call claims its candidate (atomic `SET ... NX`); all
+    callers then read the single winner. The token is printed to the logs
+    exactly once — by the worker that issues it — so the operator can read it
+    from `docker logs`. Safe to call from startup AND from the status endpoint:
+    if Redis was down at boot and later recovers, the next status poll re-issues
+    and prints the token, so setup self-heals without a restart (#1165).
+
+    Returns the shared token, or None if Redis is unreachable (setup is blocked
+    until Redis recovers — never a silent per-worker fallback).
+    """
+    r = _get_redis()
+    if r is None:
+        logger.error(
+            "Setup token: Redis unreachable — first-time setup is blocked until "
+            "Redis is reachable."
+        )
+        return None
+    try:
+        # First-writer-wins. Two round-trips rather than `SET NX GET` (the
+        # NX+GET combo is only valid on Redis 7.0+): the `SET NX` is the atomic
+        # claim, and the follow-up `GET` always converges on the single winner,
+        # so reading it is race-free regardless of which worker wins.
+        issued = r.set(
+            _SETUP_TOKEN_KEY, _candidate_token, nx=True, ex=_SETUP_TOKEN_TTL_SECONDS
+        )
+        token = r.get(_SETUP_TOKEN_KEY)
+    except Exception as e:
+        logger.error(
+            "Setup token: Redis op failed (%s) — setup blocked.", type(e).__name__
+        )
+        reset_redis_client()  # rebuild on the next call so a Redis blip self-heals
+        return None
+    if issued:
+        # Only the issuing worker logs — losers read the winner silently.
+        logger.warning(
+            "TRINITY FIRST-TIME SETUP REQUIRED\n"
+            "Setup token: %s\n"
+            "Visit the Trinity UI and enter this token to set the admin password.\n"
+            "Valid until first-time setup completes.",
+            token,
+        )
+    return token
+
+
+def clear_setup_token() -> None:
+    """Best-effort delete of the shared token once setup completes (#1165).
+
+    After setup_completed=true the endpoint 403s regardless of the token, so
+    this is hygiene — it stops the now-useless secret lingering in Redis.
+    """
+    r = _get_redis()
+    if r is None:
+        return
+    try:
+        r.delete(_SETUP_TOKEN_KEY)
+    except Exception:
+        reset_redis_client()  # stale client → rebuild next time (TTL still bounds the key)
 
 
 class SetAdminPasswordRequest(BaseModel):
@@ -39,10 +187,21 @@ async def get_setup_status():
 
     Returns:
         - setup_completed: Whether the admin password has been set
+        - setup_available: Whether setup can be completed right now. Always true
+          once setup is done; while pending it is false when Redis is unreachable
+          (the shared setup token lives there) so the UI can show a
+          "waiting for Redis" state instead of a form that would 503 (#1165).
     """
     setup_completed = db.get_setting_value('setup_completed', 'false') == 'true'
+    # While setup is pending, probe Redis via ensure_setup_token() — this both
+    # reports availability AND self-heals: if Redis just recovered and no token
+    # exists yet, it re-issues and prints one (#1165).
+    setup_available = True
+    if not setup_completed:
+        setup_available = ensure_setup_token() is not None
     return {
-        "setup_completed": setup_completed
+        "setup_completed": setup_completed,
+        "setup_available": setup_available,
     }
 
 
@@ -69,9 +228,20 @@ async def set_admin_password(data: SetAdminPasswordRequest, request: Request):
             detail="Setup already completed. Password cannot be changed through this endpoint."
         )
 
+    # Resolve the shared cross-worker setup token from Redis (#1165). If Redis
+    # is unreachable, block with 503 rather than silently validating against a
+    # per-worker token — the latter is the exact bug #1165 fixes.
+    shared_token = ensure_setup_token()
+    if shared_token is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Setup temporarily unavailable: the backend cannot reach Redis. "
+                   "Try again once it has recovered.",
+        )
+
     # Validate setup token to prevent installation hijack.
     # Use constant-time comparison to guard against timing attacks.
-    if not secrets.compare_digest(data.setup_token, _setup_token):
+    if not secrets.compare_digest(data.setup_token, shared_token):
         raise HTTPException(
             status_code=403,
             detail="Invalid setup token. Check server logs for the setup token printed at startup."
@@ -101,5 +271,8 @@ async def set_admin_password(data: SetAdminPasswordRequest, request: Request):
 
     # Mark setup as completed
     db.set_setting('setup_completed', 'true')
+
+    # The token is now useless (endpoint 403s henceforth); remove it from Redis (#1165).
+    clear_setup_token()
 
     return {"success": True}

--- a/src/frontend/src/views/SetupPassword.vue
+++ b/src/frontend/src/views/SetupPassword.vue
@@ -14,8 +14,29 @@
         </p>
       </div>
 
+      <!-- Waiting for Redis: setup can't proceed until the backend reaches Redis (#1165) -->
+      <div v-if="!setupAvailable" class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 text-center">
+        <svg class="animate-spin h-8 w-8 mx-auto text-action-primary-600 dark:text-action-primary-400" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <h2 class="mt-4 text-lg font-medium text-gray-900 dark:text-white">Waiting for backend services</h2>
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          The backend can't reach Redis yet, so first-time setup isn't available. This page continues automatically once Redis is back.
+        </p>
+        <!-- Surface the 503 detail here too: flipping to this panel hides the form's error block (#1165) -->
+        <p v-if="error" class="mt-2 text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
+        <button
+          type="button"
+          @click="checkAvailability"
+          class="mt-4 inline-flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500"
+        >
+          Retry now
+        </button>
+      </div>
+
       <!-- Setup Form -->
-      <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+      <div v-else class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
         <form @submit.prevent="handleSubmit" class="space-y-4">
           <!-- Setup Token Field -->
           <div>
@@ -182,7 +203,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { clearSetupCache } from '../router'
@@ -196,6 +217,38 @@ const showPassword = ref(false)
 const showConfirmPassword = ref(false)
 const loading = ref(false)
 const error = ref(null)
+
+// #1165: setup needs Redis (the shared cross-worker token lives there). When
+// Redis is down, show a "waiting for Redis" panel instead of the form and poll
+// until it recovers, rather than presenting a form that would 503.
+const setupAvailable = ref(true)
+let pollTimer = null
+
+async function checkAvailability() {
+  try {
+    const { data } = await axios.get('/api/setup/status')
+    // Backward-compatible: older backends omit setup_available → treat as available.
+    setupAvailable.value = data.setup_available !== false
+    // Clear any stale "Redis unavailable" error once setup is reachable again.
+    if (setupAvailable.value && error.value) error.value = null
+  } catch (e) {
+    // Status probe failed (network/backend) — show the form anyway; the POST
+    // will surface a clear error if setup genuinely can't proceed.
+    setupAvailable.value = true
+  }
+}
+
+onMounted(() => {
+  checkAvailability()
+  // Poll only while unavailable so the form appears automatically once Redis recovers.
+  pollTimer = setInterval(() => {
+    if (!setupAvailable.value) checkAvailability()
+  }, 4000)
+})
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+})
 
 const passwordsMatch = computed(() => {
   return password.value === confirmPassword.value
@@ -276,6 +329,10 @@ async function handleSubmit() {
         error.value = 'Setup has already been completed.'
         setTimeout(() => router.push('/login'), 2000)
       }
+    } else if (e.response?.status === 503) {
+      // Backend can't reach Redis (#1165) — flip to the waiting panel; polling resumes.
+      error.value = e.response?.data?.detail || 'Setup is temporarily unavailable. Retrying…'
+      setupAvailable.value = false
     } else {
       error.value = e.response?.data?.detail || 'Failed to set password. Please try again.'
     }

--- a/tests/unit/test_1165_setup_token_shared.py
+++ b/tests/unit/test_1165_setup_token_shared.py
@@ -1,0 +1,120 @@
+"""#1165 — shared cross-worker first-time setup token.
+
+Prod runs uvicorn with `--workers 2`. A per-process module-global token would
+differ per worker, so POST /api/setup/admin-password 403s ~50% of the time
+depending on which worker handles the request. The token now lives in Redis
+(first-writer-wins) so every worker reads the SAME value; validation reads it
+live. When Redis is unreachable, setup is *blocked* (token == None) rather than
+silently falling back to a per-worker token.
+
+These tests exercise the token machinery in `routers.setup` directly with a
+fakeredis instance shared across simulated "workers" (distinct candidates).
+"""
+import secrets
+
+import pytest
+import fakeredis
+
+pytestmark = pytest.mark.unit
+
+import routers.setup as setup
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Point routers.setup at a fresh in-process fakeredis shared by all callers."""
+    setup._redis_client = None
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(setup, "_get_redis", lambda: fake)
+    # Restore a deterministic candidate after each test mutates it.
+    monkeypatch.setattr(setup, "_candidate_token", secrets.token_urlsafe(24))
+    return fake
+
+
+def test_first_writer_wins_across_workers(fake_redis, monkeypatch):
+    """Worker A claims; worker B (later, different candidate) reads A's winner."""
+    monkeypatch.setattr(setup, "_candidate_token", "worker-A-token")
+    tok_a = setup.ensure_setup_token()
+    assert tok_a == "worker-A-token"
+
+    monkeypatch.setattr(setup, "_candidate_token", "worker-B-token")
+    tok_b = setup.ensure_setup_token()
+
+    assert tok_b == "worker-A-token"  # B did NOT overwrite the winner
+    assert fake_redis.get(setup._SETUP_TOKEN_KEY) == "worker-A-token"
+
+
+def test_validation_succeeds_regardless_of_worker(fake_redis, monkeypatch):
+    """The bug's symptom: a token issued on one worker validates on another."""
+    monkeypatch.setattr(setup, "_candidate_token", "issued-on-A")
+    issued = setup.ensure_setup_token()  # operator copies this from the logs
+
+    # Now a DIFFERENT worker (own candidate) handles the validation request.
+    monkeypatch.setattr(setup, "_candidate_token", "different-on-B")
+    shared = setup.ensure_setup_token()
+
+    assert secrets.compare_digest(issued, shared)          # operator's token matches
+    assert not secrets.compare_digest("wrong-token", shared)
+
+
+def test_idempotent_resolve(fake_redis):
+    assert setup.ensure_setup_token() == setup.ensure_setup_token()
+
+
+def test_clear_deletes_key(fake_redis):
+    setup.ensure_setup_token()
+    assert fake_redis.get(setup._SETUP_TOKEN_KEY) is not None
+    setup.clear_setup_token()
+    assert fake_redis.get(setup._SETUP_TOKEN_KEY) is None
+
+
+def test_redis_unreachable_blocks_setup(monkeypatch):
+    """No client → None (blocked), never a silent per-worker fallback."""
+    setup._redis_client = None
+    monkeypatch.setattr(setup, "_get_redis", lambda: None)
+    assert setup.ensure_setup_token() is None
+
+
+def test_redis_op_error_blocks_setup(monkeypatch):
+    """Client present but ops raise → None (blocked)."""
+    class Boom:
+        def set(self, *a, **k):
+            raise RuntimeError("redis exploded")
+
+        def get(self, *a, **k):
+            raise RuntimeError("redis exploded")
+
+    setup._redis_client = None
+    monkeypatch.setattr(setup, "_get_redis", lambda: Boom())
+    assert setup.ensure_setup_token() is None
+
+
+def test_clear_is_safe_when_redis_down(monkeypatch):
+    """clear_setup_token never raises even if Redis is unreachable."""
+    setup._redis_client = None
+    monkeypatch.setattr(setup, "_get_redis", lambda: None)
+    setup.clear_setup_token()  # no exception
+
+
+def test_token_has_bounded_ttl(fake_redis):
+    """The key carries a TTL so an abandoned install doesn't leave a forever-secret."""
+    setup.ensure_setup_token()
+    ttl = fake_redis.ttl(setup._SETUP_TOKEN_KEY)
+    assert 0 < ttl <= setup._SETUP_TOKEN_TTL_SECONDS
+
+
+def test_op_error_resets_cached_client(monkeypatch):
+    """A Redis op failure drops the cached client so the next call rebuilds it
+    (self-heal after a Redis restart, rather than a permanently-dead client)."""
+    class Boom:
+        def set(self, *a, **k):
+            raise RuntimeError("redis exploded")
+
+        def get(self, *a, **k):
+            raise RuntimeError("redis exploded")
+
+    setup._redis_client = Boom()  # pretend a healthy client was cached, now dead
+    monkeypatch.setattr(setup, "_get_redis", lambda: setup._redis_client)
+
+    assert setup.ensure_setup_token() is None
+    assert setup._redis_client is None  # reset_redis_client() ran on the failure

--- a/tests/unit/test_858_dockerfile_unbuffered.py
+++ b/tests/unit/test_858_dockerfile_unbuffered.py
@@ -37,6 +37,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 BACKEND_DOCKERFILE = REPO_ROOT / "docker" / "backend" / "Dockerfile"
 SCHEDULER_DOCKERFILE = REPO_ROOT / "docker" / "scheduler" / "Dockerfile"
 BACKEND_MAIN = REPO_ROOT / "src" / "backend" / "main.py"
+BACKEND_SETUP = REPO_ROOT / "src" / "backend" / "routers" / "setup.py"
 
 # Matches a real Docker `ENV PYTHONUNBUFFERED=1` instruction (line-leading `ENV`,
 # `KEY=VALUE` form), not a commented-out line or prose mentioning the variable.
@@ -132,25 +133,30 @@ def _is_method_call(call: ast.Call, obj: str, method: str) -> bool:
 @pytest.mark.unit
 def test_lifespan_emits_setup_token_via_logger_before_event_bus() -> None:
     """The token must go through logger.warning, after setup_logging() and
-    before event_bus.start() — a hang in later startup must not suppress it."""
+    before event_bus.start() — a hang in later startup must not suppress it.
+
+    Since #1165 the emission is one frame deeper: lifespan calls
+    ``_ensure_setup_token()`` (which logs the token via ``logger.warning`` inside
+    ``routers/setup.py``) instead of building the warning inline. The #858
+    invariant is unchanged — this checks the *ordering* of the triggering call
+    here, and ``test_ensure_setup_token_logs_token_via_logger_warning`` checks
+    the emission still flows through the flushing logger.
+    """
     body = _lifespan_body()
 
     logging_idx = _first_statement_index(
         body, lambda c: _is_name_call(c, "setup_logging")
     )
     token_idx = _first_statement_index(
-        body,
-        lambda c: _is_method_call(c, "logger", "warning")
-        and "Setup token:" in _string_content(c),
+        body, lambda c: _is_name_call(c, "_ensure_setup_token")
     )
     event_bus_idx = _first_statement_index(
         body, lambda c: _is_method_call(c, "event_bus", "start")
     )
 
     assert token_idx is not None, (
-        "lifespan no longer emits the first-time setup token via "
-        "logger.warning('... Setup token: ...') — fresh installs would have no "
-        "way to read the token from `docker logs` (#858)."
+        "lifespan no longer calls _ensure_setup_token() — fresh installs would "
+        "have no way to read the setup token from `docker logs` (#858, #1165)."
     )
     assert logging_idx is not None and logging_idx < token_idx, (
         "the setup-token emission must come after setup_logging() so the "
@@ -160,6 +166,33 @@ def test_lifespan_emits_setup_token_via_logger_before_event_bus() -> None:
         "the setup-token emission must come before event_bus.start() so a hang "
         "in event-bus/audit startup cannot suppress it (#858)."
     )
+
+
+@pytest.mark.unit
+def test_ensure_setup_token_logs_token_via_logger_warning() -> None:
+    """ensure_setup_token() must emit the token through logger.warning, not
+    print() — the #858 flush guarantee now lives in routers/setup.py (#1165)."""
+    tree = ast.parse(BACKEND_SETUP.read_text(encoding="utf-8"))
+    fn = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "ensure_setup_token"),
+        None,
+    )
+    assert fn is not None, "ensure_setup_token() not found in routers/setup.py"
+
+    logs_token = any(
+        isinstance(node, ast.Call)
+        and _is_method_call(node, "logger", "warning")
+        and "Setup token:" in _string_content(node)
+        for node in ast.walk(fn)
+    )
+    assert logs_token, (
+        "ensure_setup_token() must log '... Setup token: ...' via logger.warning "
+        "(flushing path) so the token reaches `docker logs` (#858, #1165)."
+    )
+    prints = [n for n in ast.walk(fn)
+              if isinstance(n, ast.Call) and _is_name_call(n, "print")]
+    assert not prints, "ensure_setup_token() must not use print() (#858)."
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- The first-time-setup token was a per-process module global, so prod (`uvicorn --workers 2`) generated a **different token per worker** — `POST /api/setup/admin-password` load-balanced and 403'd ~50% of the time on the worker the operator didn't copy from. (Surfaced once #858 made the token reach the logs.)
- Token now lives in **Redis** (first-writer-wins `SET NX`, 24h TTL), shared by all workers; **validation reads it live** at request time, eliminating the per-worker drift class entirely.
- When Redis is unreachable, setup is **blocked, not silently degraded** to a per-worker token — and self-heals when Redis returns (no restart).

## Changes
- `src/backend/routers/setup.py` — `ensure_setup_token()` / `clear_setup_token()` / `_get_redis()` (cached, resets on op failure); `GET /status` adds `setup_available`; `POST /admin-password` returns **503** when Redis down, validates against the shared token, deletes the key on completion.
- `src/backend/main.py` — lifespan calls `ensure_setup_token()` (issuing worker prints once; logs error if Redis down).
- `src/frontend/src/views/SetupPassword.vue` — "waiting for Redis" panel + 4s poll when `setup_available:false`; handles 503; backward-compatible when the field is absent.
- `tests/unit/test_1165_setup_token_shared.py` (new, 9 tests) + `test_858_dockerfile_unbuffered.py` (follows the refactored emission path).
- `docs/memory/feature-flows/first-time-setup.md` — updated token model, status/validate, error table (503), security notes.

## Behavior on Redis down
`GET /status` → `setup_available:false`; `POST /admin-password` → 503; UI shows "waiting for Redis" and polls; token is re-issued + re-printed automatically once Redis recovers — no restart.

## Test Plan
- [x] New unit tests pass: `pytest tests/unit/test_1165_setup_token_shared.py -v` (9 passed)
- [x] `pytest tests/unit/test_858_dockerfile_unbuffered.py` (5 passed)
- [x] Code review (correctness + cleanup) — 4 findings applied
- [x] Security review — no critical/high
- [ ] Manual: fresh install with `--workers 2`, confirm one token in logs validates regardless of worker

## Acceptance criteria (#1165)
- [x] All workers report the same token (first-writer-wins; only issuer logs)
- [x] `POST /admin-password` succeeds regardless of worker (reads shared Redis value live)
- [x] Single-use (delete-on-complete) + constant-time compare retained
- [x] Dev (1 worker) unchanged

## Noted (deliberate non-blocker)
Optional per-IP rate-limit on the unauthenticated `GET /status` (2 Redis ops/poll, narrow pre-setup window) — skipped to keep the change minimal and avoid throttling the legit 4s frontend poll.

Fixes abilityai/trinity#1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)