### PR TITLE
fix(compose): forward INTERNAL_API_SECRET to prod mcp-server + CORS/SSH/LOG levers to prod backend (#722)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -144,6 +144,10 @@ services:
       - ./config/process-docs:/app/config/process-docs:ro
       - agent-configs:/agent-configs
       - ${TRINITY_DATA_PATH:-./trinity-data}:/data
+      # Read-only access to Vector's logs so log_archive_service.py (reads
+      # /data/logs) can run in prod. Mirrors docker-compose.yml; without it the
+      # forwarded LOG_* knobs are inert (LOG_DIR not found) — the #1039 class.
+      - trinity-logs:/data/logs:ro
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -97,6 +97,10 @@ services:
       - PUBLIC_CHAT_URL=${PUBLIC_CHAT_URL:-}
       # Frontend URL for post-OAuth redirects
       - FRONTEND_URL=${FRONTEND_URL:-}
+      # CORS — comma-separated extra allowed origins (read by config.py via
+      # EXTRA_CORS_ORIGINS). Mirrors docker-compose.yml; without this line the
+      # .env value is inert in prod (the #1039 packaging-gap class).
+      - EXTRA_CORS_ORIGINS=${EXTRA_CORS_ORIGINS:-}
       # Backend's own public origin — used to build OAuth redirect URIs
       # ({BACKEND_URL}/api/oauth/{provider}/callback, read by config.py). Mirrors
       # docker-compose.yml; without this line the .env value is inert in prod (the
@@ -121,6 +125,18 @@ services:
       # packaging-gap class).
       - TELEMETRY_CONTAINER_STATS_TTL=${TELEMETRY_CONTAINER_STATS_TTL:-10}
       - TELEMETRY_DOCKER_POOL_SIZE=${TELEMETRY_DOCKER_POOL_SIZE:-16}
+      # SSH access host override (read by services/ssh_service.py). Mirrors
+      # docker-compose.yml; without this line the .env value is inert in prod (the
+      # #1039 packaging-gap class) and SSH host detection falls back to localhost.
+      - SSH_HOST=${SSH_HOST:-}
+      # Log retention & archival (services/log_archive_service.py). Mirrors
+      # docker-compose.yml; without these lines the .env knobs are inert in prod
+      # (the #1039 packaging-gap class). LOG_ARCHIVE_PATH is intentionally omitted:
+      # the code default (/data/archives) already lands in the TRINITY_DATA_PATH
+      # bind mount (/data), so no new volume is needed.
+      - LOG_ARCHIVE_ENABLED=${LOG_ARCHIVE_ENABLED:-true}
+      - LOG_RETENTION_DAYS=${LOG_RETENTION_DAYS:-90}
+      - LOG_CLEANUP_HOUR=${LOG_CLEANUP_HOUR:-3}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/agent-templates:/agent-configs/templates:ro
@@ -364,6 +380,12 @@ services:
       # Fail-loud at compose render rather than silently use a well-known fallback (issue #692).
       - "TRINITY_PASSWORD=${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set in .env}"
       - MCP_REQUIRE_API_KEY=${MCP_REQUIRE_API_KEY:-true}
+      # INTERNAL_API_SECRET (SEC-001) — shared secret for POST /api/internal/audit
+      # so MCP tool-call audit reaches the backend. Mirrors docker-compose.yml;
+      # without it audit.ts (postAudit) early-returns and ALL MCP tool-call audit
+      # is silently dropped in prod (the #1039 packaging-gap class). No default —
+      # matches the backend/scheduler prod style.
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       # No REDIS_URL: src/mcp-server/ (TypeScript) has zero Redis imports.
       # Don't hand a credential to a process that has no use for it.
     depends_on:

--- a/src/frontend/src/components/HostTelemetry.vue
+++ b/src/frontend/src/components/HostTelemetry.vue
@@ -2,7 +2,11 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import SparklineChart from './SparklineChart.vue'
 
-const API_BASE = import.meta.env.VITE_API_BASE || ''
+// Relative, same-origin API base (nginx/Vite proxy) — matches api.js baseURL: ''.
+// Intentionally not an env var: VITE_API_BASE was never set anywhere, so this was
+// always '' (see #722 — do not point it at VITE_API_URL, that build-defaults to
+// http://localhost:8000 and would break same-origin calls).
+const API_BASE = ''
 
 // History configuration: 60 samples at 5s intervals = 5 minutes
 const MAX_POINTS = 60


### PR DESCRIPTION
## Summary

Closes the two remaining **prod packaging-gap** findings from #722's `/validate-config` report. There is **no `env_file:`** in either compose, so a var forwarded in `docker-compose.yml` but absent from `docker-compose.prod.yml` is a **dead lever in prod** — the missing `environment:` entry never reaches the container.

3 of the 5 original findings were already fixed (`GOOGLE_API_KEY`, `FRONTEND_URL` dup, `TRINITY_DATA_PATH`); this PR addresses the 2 that remained, plus a zero-behavior-change frontend cleanup surfaced during review.

## What changed

| File / block | Change |
|---|---|
| `docker-compose.prod.yml` — **mcp-server** | `+ INTERNAL_API_SECRET=${INTERNAL_API_SECRET}` (no default, matches backend/scheduler prod style) |
| `docker-compose.prod.yml` — **backend** | `+ EXTRA_CORS_ORIGINS`, `+ SSH_HOST`, `+ LOG_ARCHIVE_ENABLED / LOG_RETENTION_DAYS / LOG_CLEANUP_HOUR` (mirror dev) |
| `src/frontend/src/components/HostTelemetry.vue` | Drop dead `import.meta.env.VITE_API_BASE` ref → `API_BASE = ''` |

## Corrected failure mode (Finding 1)

The original "every audit 401s" framing was wrong. The prod mcp-server lacked `INTERNAL_API_SECRET`, so `src/mcp-server/src/audit.ts` `postAudit` hits `if (!INTERNAL_SECRET) return;` and **never POSTs** → **all MCP tool-call audit (SEC-001) is silently dropped in prod** (no request, so no 401). Backend + scheduler already receive the secret in prod, so forwarding it to mcp-server makes both ends share the same value (`routers/internal.py` returns **403** only on a *mismatch*).

## Design notes

- `LOG_ARCHIVE_PATH` is **intentionally omitted** — the code default `/data/archives` (`routers/logs.py`, `archive_storage.py`) already lands in the `TRINITY_DATA_PATH` bind mount (`/data`), so no new volume is needed.
- HostTelemetry: `VITE_API_BASE` was never set anywhere, so `API_BASE` was always `''`; the single Axios client (`api.js`) uses `baseURL: ''` (relative, same-origin). The naive "point it at `VITE_API_URL`" fix would be a **regression** (`VITE_API_URL` build-defaults to `http://localhost:8000`). Not routed through `api.js` to preserve the 3s timeout / no 401-redirect / raw-`fetch` response shape (deferred as an Invariant-#7 follow-up).

## Verification

- ✅ `docker compose -f docker-compose.prod.yml config` **and** the `+enterprise` overlay render clean
- ✅ JSON-resolution proof: all 6 vars resolve into the **correct** service blocks (no cross-block leak; `LOG_ARCHIVE_PATH` absent; backend/scheduler `INTERNAL_API_SECRET` untouched)
- ✅ `vite build` passes
- ⏳ Live sibling-stack functional audit-row proof (baseline no-row → post-fix `source='mcp'` row + `200`) not run in this PR — the mechanism is proven at the compose layer (`audit.ts`/`internal.py` unchanged)

## Deferred follow-ups (flagged, not dropped)

- Bucket-C documentation pass (`SLACK_APP_TOKEN`, `TRUSTED_PROXIES`, `REDIS_STREAM_MAXLEN`, etc.) — inert without compose-forwarding too; do compose + docs together in a dedicated issue
- `ADMIN_USERNAME` → prod (needs mcp-server `TRINITY_USERNAME` default alignment)
- Fail-loud `INTERNAL_API_SECRET` (`${VAR:?}`, #692 pattern)
- HostTelemetry → `api.js` refactor (Invariant #7)
- Dead-var cleanup (`VITE_API_URL` build arg)

Fixes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)