### PR TITLE
fix(perf): kill Dashboard/timeline N+1 fan-out at fleet scale (#1265)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -904,6 +904,9 @@ class DatabaseManager:
     def get_schedule_executions(self, schedule_id: str, limit: int = 50):
         return self._schedule_ops.get_schedule_executions(schedule_id, limit)
 
+    def get_latest_execution_per_schedule(self, schedule_ids: list):
+        return self._schedule_ops.get_latest_execution_per_schedule(schedule_ids)
+
     def get_agent_executions(self, agent_name: str, limit: int = 50):
         return self._schedule_ops.get_agent_executions(agent_name, limit)
 
@@ -1103,8 +1106,11 @@ class DatabaseManager:
     def get_agent_activities(self, agent_name: str, activity_type: str = None, activity_state: str = None, limit: int = 100):
         return self._activity_ops.get_agent_activities(agent_name, activity_type, activity_state, limit)
 
-    def get_activities_in_range(self, start_time: str = None, end_time: str = None, activity_types: list = None, limit: int = 100):
-        return self._activity_ops.get_activities_in_range(start_time, end_time, activity_types, limit)
+    def get_activities_in_range(self, start_time: str = None, end_time: str = None, activity_types: list = None, limit: int = 100, agent_names: list = None):
+        return self._activity_ops.get_activities_in_range(start_time, end_time, activity_types, limit, agent_names)
+
+    def get_latest_activity_for_agents(self, agent_names: list):
+        return self._activity_ops.get_latest_activity_for_agents(agent_names)
 
     def get_current_activities(self, agent_name: str):
         return self._activity_ops.get_current_activities(agent_name)

--- a/src/backend/db/activities.py
+++ b/src/backend/db/activities.py
@@ -13,9 +13,10 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Dict
 
-from sqlalchemy import select, insert, update, and_, func
+from sqlalchemy import select, insert, update, and_
 
 from .engine import get_engine
+from .query_helpers import latest_per_group
 from .tables import agent_activities
 from models import ActivityState
 from utils.helpers import utc_now_iso, to_utc_iso, parse_iso_timestamp
@@ -63,6 +64,33 @@ class ActivityOperations:
             "details": json.loads(row[12]) if row[12] else None,
             "error": row[13],
             "created_at": row[14]
+        }
+
+    @staticmethod
+    def _mapping_to_activity(row) -> Dict:
+        """Convert a name-accessible mapping row to an activity dict.
+
+        Used by ``get_latest_activity_for_agents`` (which projects the curated
+        ``_ACTIVITY_COLUMNS`` via the shared window helper). Name-based access —
+        unlike the positional ``_row_to_activity`` — so reordering a column in
+        ``_ACTIVITY_COLUMNS`` can never silently misalign the fields.
+        """
+        return {
+            "id": row["id"],
+            "agent_name": row["agent_name"],
+            "activity_type": row["activity_type"],
+            "activity_state": row["activity_state"],
+            "parent_activity_id": row["parent_activity_id"],
+            "started_at": row["started_at"],
+            "completed_at": row["completed_at"],
+            "duration_ms": row["duration_ms"],
+            "user_id": row["user_id"],
+            "triggered_by": row["triggered_by"],
+            "related_chat_message_id": row["related_chat_message_id"],
+            "related_execution_id": row["related_execution_id"],
+            "details": json.loads(row["details"]) if row["details"] else None,
+            "error": row["error"],
+            "created_at": row["created_at"],
         }
 
     def create_activity(self, activity: 'ActivityCreate') -> str:
@@ -169,34 +197,20 @@ class ActivityOperations:
 
         #1265: replaces a per-agent ``get_agent_activities(name, limit=1)``
         fan-out (one query per running agent) on the Dashboard context-stats
-        path. Uses a ``ROW_NUMBER() OVER (PARTITION BY agent_name ORDER BY
-        created_at DESC)`` window served by ``idx_activities_agent``.
+        path. Uses the shared ``latest_per_group`` window helper (partition by
+        agent_name, order by created_at DESC) — served by ``idx_activities_agent``.
 
         Returns ``{agent_name: activity_dict}``; agents with no activity are
         simply absent from the map.
         """
-        if not agent_names:
-            return {}
-
-        rn = func.row_number().over(
-            partition_by=agent_activities.c.agent_name,
-            order_by=agent_activities.c.created_at.desc(),
-        ).label("rn")
-        subq = (
-            select(*_ACTIVITY_COLUMNS, rn)
-            .where(agent_activities.c.agent_name.in_(list(agent_names)))
-            .subquery()
+        rows = latest_per_group(
+            _ACTIVITY_COLUMNS,
+            agent_activities.c.agent_name,   # partition
+            agent_activities.c.created_at,   # order (DESC)
+            agent_activities.c.agent_name,   # filter IN
+            agent_names,
         )
-        # Select only the activity columns (drop the rn helper) so positional
-        # row access in _row_to_activity stays aligned [0]..[14].
-        stmt = select(*subq.c[: len(_ACTIVITY_COLUMNS)]).where(subq.c.rn == 1)
-
-        result: Dict[str, Dict] = {}
-        with get_engine().connect() as conn:
-            for row in conn.execute(stmt).all():
-                activity = self._row_to_activity(row)
-                result[activity["agent_name"]] = activity
-        return result
+        return {row["agent_name"]: self._mapping_to_activity(row) for row in rows}
 
     def get_activities_in_range(self, start_time: Optional[str] = None,
                                 end_time: Optional[str] = None,

--- a/src/backend/db/activities.py
+++ b/src/backend/db/activities.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Dict
 
-from sqlalchemy import select, insert, update, and_
+from sqlalchemy import select, insert, update, and_, func
 
 from .engine import get_engine
 from .tables import agent_activities
@@ -164,13 +164,52 @@ class ActivityOperations:
         with get_engine().connect() as conn:
             return [self._row_to_activity(row) for row in conn.execute(stmt).all()]
 
+    def get_latest_activity_for_agents(self, agent_names: List[str]) -> Dict[str, Dict]:
+        """Return the single most-recent activity per agent, in one query.
+
+        #1265: replaces a per-agent ``get_agent_activities(name, limit=1)``
+        fan-out (one query per running agent) on the Dashboard context-stats
+        path. Uses a ``ROW_NUMBER() OVER (PARTITION BY agent_name ORDER BY
+        created_at DESC)`` window served by ``idx_activities_agent``.
+
+        Returns ``{agent_name: activity_dict}``; agents with no activity are
+        simply absent from the map.
+        """
+        if not agent_names:
+            return {}
+
+        rn = func.row_number().over(
+            partition_by=agent_activities.c.agent_name,
+            order_by=agent_activities.c.created_at.desc(),
+        ).label("rn")
+        subq = (
+            select(*_ACTIVITY_COLUMNS, rn)
+            .where(agent_activities.c.agent_name.in_(list(agent_names)))
+            .subquery()
+        )
+        # Select only the activity columns (drop the rn helper) so positional
+        # row access in _row_to_activity stays aligned [0]..[14].
+        stmt = select(*subq.c[: len(_ACTIVITY_COLUMNS)]).where(subq.c.rn == 1)
+
+        result: Dict[str, Dict] = {}
+        with get_engine().connect() as conn:
+            for row in conn.execute(stmt).all():
+                activity = self._row_to_activity(row)
+                result[activity["agent_name"]] = activity
+        return result
+
     def get_activities_in_range(self, start_time: Optional[str] = None,
                                 end_time: Optional[str] = None,
                                 activity_types: Optional[List[str]] = None,
-                                limit: int = 100) -> List[Dict]:
+                                limit: int = 100,
+                                agent_names: Optional[List[str]] = None) -> List[Dict]:
         """
         Get activities across all agents in a time range.
-        Optionally filter by activity types.
+        Optionally filter by activity types and by an access-control allow-list.
+
+        #1265: ``agent_names`` pushes the per-user access filter into SQL so the
+        timeline no longer over-fetches ``limit*2`` rows and filters in Python.
+        ``None`` means no agent filter (admin); an empty list returns nothing.
         """
         conditions = []
 
@@ -182,6 +221,11 @@ class ActivityOperations:
 
         if activity_types:
             conditions.append(agent_activities.c.activity_type.in_(activity_types))
+
+        if agent_names is not None:
+            if not agent_names:
+                return []
+            conditions.append(agent_activities.c.agent_name.in_(agent_names))
 
         stmt = select(*_ACTIVITY_COLUMNS)
         if conditions:

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -2425,6 +2425,21 @@ def _migrate_users_suspended_at(cursor, conn):
     conn.commit()
 
 
+def _migrate_activities_created_index(cursor, conn):
+    """Issue #1265: standalone index on agent_activities(created_at DESC).
+
+    The cross-agent timeline (/api/activities/timeline) sorts by created_at DESC
+    with no agent_name predicate, which the composite idx_activities_agent
+    (agent_name, created_at DESC) cannot serve as a sort — it degraded to a
+    full scan + sort as activity volume grew with fleet size. Idempotent.
+    """
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activities_created "
+        "ON agent_activities(created_at DESC)"
+    )
+    conn.commit()
+
+
 def _migrate_operator_queue_cleared_at(cursor, conn):
     """#1017 — Clear All on the Operations Resolved tab.
 
@@ -2517,4 +2532,5 @@ MIGRATIONS = [
     ("agent_ownership_circuit_breaker", _migrate_agent_ownership_circuit_breaker),
     ("voip_tables", _migrate_voip_tables),
     ("operator_queue_cleared_at", _migrate_operator_queue_cleared_at),
+    ("activities_created_index", _migrate_activities_created_index),
 ]

--- a/src/backend/db/monitoring.py
+++ b/src/backend/db/monitoring.py
@@ -124,7 +124,9 @@ class MonitoringOperations:
         limit: int = 100
     ) -> List[Dict]:
         """Get health check history for an agent."""
-        since = (datetime.utcnow() - timedelta(hours=hours)).isoformat() + "Z"
+        # #1265 / Invariant #16: compare ISO-Z columns against an iso_cutoff()
+        # value, not datetime.utcnow() (whose format breaks lexicographic order).
+        since = iso_cutoff(hours)
 
         stmt = (
             select(agent_health_checks)

--- a/src/backend/db/query_helpers.py
+++ b/src/backend/db/query_helpers.py
@@ -1,0 +1,49 @@
+"""Shared query helpers (#1265).
+
+Small, backend-agnostic SQLAlchemy Core building blocks reused by more than one
+``XOperations`` class so the window/aggregation SQL lives in one place instead
+of being copy-pasted per domain.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sqlalchemy import select, func
+from sqlalchemy import Column
+
+from .engine import get_engine
+
+
+def latest_per_group(
+    columns,
+    partition_col: "Column",
+    order_col: "Column",
+    filter_col: "Column",
+    values: Iterable,
+) -> List:
+    """Return the newest row per group in a single query.
+
+    Runs ``ROW_NUMBER() OVER (PARTITION BY partition_col ORDER BY order_col
+    DESC)`` over the rows where ``filter_col IN values`` and keeps ``rn == 1``
+    per group. Returns name-accessible mapping rows (the ``rn`` helper column is
+    dropped), so callers map by column name — never by position.
+
+    Keep ``columns`` narrow: project only what the caller needs, not the whole
+    table (avoids streaming large TEXT blobs the caller never reads). Empty
+    ``values`` short-circuits to ``[]``.
+    """
+    values = list(values)
+    if not values:
+        return []
+
+    rn = func.row_number().over(
+        partition_by=partition_col,
+        order_by=order_col.desc(),
+    ).label("rn")
+    subq = select(*columns, rn).where(filter_col.in_(values)).subquery()
+    # Drop the trailing rn helper column; keep the projected columns by name.
+    projected = list(subq.c)[:-1]
+    stmt = select(*projected).where(subq.c.rn == 1)
+
+    with get_engine().connect() as conn:
+        return conn.execute(stmt).mappings().all()

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -18,6 +18,7 @@ from sqlalchemy import select, insert, update, delete, and_, or_, func, text, ca
 from sqlalchemy.exc import IntegrityError
 
 from .engine import get_engine
+from .query_helpers import latest_per_group
 from .tables import (
     agent_schedules,
     schedule_executions,
@@ -1390,36 +1391,55 @@ class ScheduleOperations:
                 for row in conn.execute(stmt).mappings()
             ]
 
-    def get_latest_execution_per_schedule(self, schedule_ids: List[str]) -> Dict[str, ScheduleExecution]:
+    def get_latest_execution_per_schedule(self, schedule_ids: List[str]) -> Dict[str, Dict]:
         """Return the most-recent execution per schedule, in one query.
 
         #1265: replaces the per-schedule ``get_schedule_executions(id, limit=5)``
         fan-out on the /api/ops/schedules dashboard endpoint (one query per
-        schedule -> N+1 that grows with total schedule count). Uses a
-        ``ROW_NUMBER() OVER (PARTITION BY schedule_id ORDER BY started_at DESC)``
-        window. Returns ``{schedule_id: ScheduleExecution}``; schedules with no
-        executions are absent from the map.
+        schedule -> N+1 that grows with total schedule count). Uses the shared
+        ``latest_per_group`` window helper (partition by schedule_id, order by
+        started_at DESC).
+
+        Projects ONLY the columns the dashboard's ``last_execution`` block needs
+        — never the large TEXT blobs (``response``, ``execution_log``,
+        ``tool_calls``, ``message``) — so the single bulk query stays light even
+        with hundreds of schedules. Returns ``{schedule_id: {id, status,
+        started_at, completed_at, duration_ms, error}}``; ``started_at`` /
+        ``completed_at`` are normalised to ISO strings (matching the prior
+        ``.isoformat()`` API output). Schedules with no executions are absent.
         """
-        if not schedule_ids:
-            return {}
-
-        rn = func.row_number().over(
-            partition_by=schedule_executions.c.schedule_id,
-            order_by=schedule_executions.c.started_at.desc(),
-        ).label("rn")
-        subq = (
-            select(schedule_executions, rn)
-            .where(schedule_executions.c.schedule_id.in_(list(schedule_ids)))
-            .subquery()
+        cols = (
+            schedule_executions.c.schedule_id,
+            schedule_executions.c.id,
+            schedule_executions.c.status,
+            schedule_executions.c.started_at,
+            schedule_executions.c.completed_at,
+            schedule_executions.c.duration_ms,
+            schedule_executions.c.error,
         )
-        stmt = select(subq).where(subq.c.rn == 1)
+        rows = latest_per_group(
+            cols,
+            schedule_executions.c.schedule_id,   # partition
+            schedule_executions.c.started_at,    # order (DESC)
+            schedule_executions.c.schedule_id,   # filter IN
+            schedule_ids,
+        )
 
-        result: Dict[str, ScheduleExecution] = {}
-        with get_engine().connect() as conn:
-            for row in conn.execute(stmt).mappings():
-                ex = self._row_to_schedule_execution(row)
-                result[ex.schedule_id] = ex
-        return result
+        def _iso(v):
+            ts = parse_iso_timestamp(v) if v else None
+            return ts.isoformat() if ts else None
+
+        return {
+            row["schedule_id"]: {
+                "id": row["id"],
+                "status": row["status"],
+                "started_at": _iso(row["started_at"]),
+                "completed_at": _iso(row["completed_at"]),
+                "duration_ms": row["duration_ms"],
+                "error": row["error"],
+            }
+            for row in rows
+        }
 
     def get_agent_executions(self, agent_name: str, limit: int = 50) -> List[ScheduleExecution]:
         """Get all executions for an agent across all schedules."""

--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -1390,6 +1390,37 @@ class ScheduleOperations:
                 for row in conn.execute(stmt).mappings()
             ]
 
+    def get_latest_execution_per_schedule(self, schedule_ids: List[str]) -> Dict[str, ScheduleExecution]:
+        """Return the most-recent execution per schedule, in one query.
+
+        #1265: replaces the per-schedule ``get_schedule_executions(id, limit=5)``
+        fan-out on the /api/ops/schedules dashboard endpoint (one query per
+        schedule -> N+1 that grows with total schedule count). Uses a
+        ``ROW_NUMBER() OVER (PARTITION BY schedule_id ORDER BY started_at DESC)``
+        window. Returns ``{schedule_id: ScheduleExecution}``; schedules with no
+        executions are absent from the map.
+        """
+        if not schedule_ids:
+            return {}
+
+        rn = func.row_number().over(
+            partition_by=schedule_executions.c.schedule_id,
+            order_by=schedule_executions.c.started_at.desc(),
+        ).label("rn")
+        subq = (
+            select(schedule_executions, rn)
+            .where(schedule_executions.c.schedule_id.in_(list(schedule_ids)))
+            .subquery()
+        )
+        stmt = select(subq).where(subq.c.rn == 1)
+
+        result: Dict[str, ScheduleExecution] = {}
+        with get_engine().connect() as conn:
+            for row in conn.execute(stmt).mappings():
+                ex = self._row_to_schedule_execution(row)
+                result[ex.schedule_id] = ex
+        return result
+
     def get_agent_executions(self, agent_name: str, limit: int = 50) -> List[ScheduleExecution]:
         """Get all executions for an agent across all schedules."""
         stmt = (

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -1238,6 +1238,9 @@ INDEXES = [
 
     # Activity indexes
     "CREATE INDEX IF NOT EXISTS idx_activities_agent ON agent_activities(agent_name, created_at DESC)",
+    # #1265: fleet-wide timeline sorts by created_at DESC with no agent_name predicate;
+    # the composite idx_activities_agent can't serve that sort, so it degraded to scan+sort.
+    "CREATE INDEX IF NOT EXISTS idx_activities_created ON agent_activities(created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_activities_type ON agent_activities(activity_type)",
     "CREATE INDEX IF NOT EXISTS idx_activities_state ON agent_activities(activity_state)",
     "CREATE INDEX IF NOT EXISTS idx_activities_user ON agent_activities(user_id)",

--- a/src/backend/migrations/versions/0002_activities_created_index.py
+++ b/src/backend/migrations/versions/0002_activities_created_index.py
@@ -1,0 +1,35 @@
+"""activities created_at index (#1265)
+
+Adds ``idx_activities_created`` on ``agent_activities(created_at DESC)`` for the
+cross-agent timeline, which sorts by ``created_at DESC`` with no ``agent_name``
+predicate — a sort the composite ``idx_activities_agent`` cannot serve, so it
+degraded to a scan+sort as activity volume grew with fleet size.
+
+Fresh PG builds already get this index because ``0001_baseline`` iterates
+``db/schema.py:INDEXES`` (which now includes it). This revision exists so an
+*existing* PG deployment — stamped at ``0001_baseline`` and never re-running
+baseline — also picks the index up on ``alembic upgrade head``. Mirrors the
+SQLite ``activities_created_index`` migration in ``db/migrations.py`` (#1265).
+
+Revision ID: 0002_activities_created_index
+Revises: 0001_baseline
+Create Date: 2026-06-19
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0002_activities_created_index"
+down_revision = "0001_baseline"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activities_created "
+        "ON agent_activities(created_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_activities_created")

--- a/src/backend/routers/activities.py
+++ b/src/backend/routers/activities.py
@@ -30,26 +30,21 @@ async def get_activity_timeline(
     if activity_types:
         types_list = [t.strip() for t in activity_types.split(',')]
 
-    # Get all activities
-    all_activities = db.get_activities_in_range(
+    # #1265: push the per-user access filter into SQL (None = admin, no filter)
+    # so we fetch exactly `limit` rows instead of over-fetching limit*2 and
+    # filtering in Python.
+    from services.agent_service.helpers import accessible_agent_names
+    allowed = accessible_agent_names(current_user)
+
+    activities = db.get_activities_in_range(
         start_time=start_time,
         end_time=end_time,
         activity_types=types_list,
-        limit=limit * 2  # Get more than needed for filtering
+        limit=limit,
+        agent_names=allowed,
     )
 
-    # Get accessible agents for this user
-    from routers.agents import get_accessible_agents
-    accessible_agents = get_accessible_agents(current_user)
-    accessible_agent_names = {agent['name'] for agent in accessible_agents}
-
-    # Filter activities to only include accessible agents
-    filtered_activities = [
-        activity for activity in all_activities
-        if activity['agent_name'] in accessible_agent_names
-    ][:limit]
-
     return {
-        "count": len(filtered_activities),
-        "activities": filtered_activities
+        "count": len(activities),
+        "activities": activities
     }

--- a/src/backend/routers/activities.py
+++ b/src/backend/routers/activities.py
@@ -33,6 +33,13 @@ async def get_activity_timeline(
     # #1265: push the per-user access filter into SQL (None = admin, no filter)
     # so we fetch exactly `limit` rows instead of over-fetching limit*2 and
     # filtering in Python.
+    #
+    # Admin scope note: `accessible_agent_names` returns None for admins, so the
+    # admin timeline is unfiltered and surfaces the full audit history — including
+    # activity rows of agents whose containers were since deleted. This is
+    # intentional (admins should see complete history). The prior code filtered
+    # admins to Docker-present agents only via get_accessible_agents(); that
+    # incidental narrowing is dropped on purpose, not by accident.
     from services.agent_service.helpers import accessible_agent_names
     allowed = accessible_agent_names(current_user)
 

--- a/src/backend/routers/ops.py
+++ b/src/backend/routers/ops.py
@@ -472,14 +472,9 @@ async def list_all_schedules(
             "created_at": schedule.created_at.isoformat() if schedule.created_at else None,
             "last_run_at": schedule.last_run_at.isoformat() if schedule.last_run_at else None,
             "next_run_at": schedule.next_run_at.isoformat() if schedule.next_run_at else None,
-            "last_execution": {
-                "id": last_execution.id,
-                "status": last_execution.status,
-                "started_at": last_execution.started_at.isoformat(),
-                "completed_at": last_execution.completed_at.isoformat() if last_execution.completed_at else None,
-                "duration_ms": last_execution.duration_ms,
-                "error": last_execution.error
-            } if last_execution else None
+            # last_execution is the slim dict from get_latest_execution_per_schedule
+            # (#1265): only dashboard fields, timestamps already ISO-normalised.
+            "last_execution": last_execution
         }
         schedule_list.append(schedule_data)
 

--- a/src/backend/routers/ops.py
+++ b/src/backend/routers/ops.py
@@ -450,12 +450,15 @@ async def list_all_schedules(
     if enabled_only:
         schedules = [s for s in schedules if s.enabled]
 
+    # #1265: one bulk query for the latest execution of every schedule, instead
+    # of a get_schedule_executions() call per schedule (N+1 that grew with the
+    # total schedule count across the fleet).
+    latest_by_schedule = db.get_latest_execution_per_schedule([s.id for s in schedules])
+
     # Build response with schedule details
     schedule_list = []
     for schedule in schedules:
-        # Get recent executions for this schedule
-        recent_executions = db.get_schedule_executions(schedule.id, limit=5)
-        last_execution = recent_executions[0] if recent_executions else None
+        last_execution = latest_by_schedule.get(schedule.id)
 
         schedule_data = {
             "id": schedule.id,

--- a/src/backend/services/agent_service/stats.py
+++ b/src/backend/services/agent_service/stats.py
@@ -8,7 +8,8 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime
+from typing import Optional
 
 import httpx
 from fastapi import HTTPException
@@ -17,6 +18,7 @@ from models import User
 from database import db
 from services.docker_service import get_agent_container
 from services.docker_utils import container_reload, container_stats
+from utils.helpers import iso_cutoff
 from .helpers import get_accessible_agents
 
 logger = logging.getLogger(__name__)
@@ -147,65 +149,57 @@ def invalidate_agent_stats_cache(agent_name: str) -> None:
     entry.gen += 1
 
 
-async def _fetch_single_agent_context(agent: dict, client: httpx.AsyncClient) -> dict:
-    """Fetch context stats for a single agent (used for concurrent fetching)."""
+async def _fetch_single_agent_context(
+    agent: dict,
+    client: httpx.AsyncClient,
+    last_activity: Optional[dict],
+    active_cutoff: str,
+) -> dict:
+    """Fetch context stats for one running agent (used for concurrent fetching).
+
+    #1265: this coroutine now performs ONLY the genuinely-async HTTP call so
+    asyncio.gather actually runs concurrently. The previous blocking work —
+    a per-agent Docker container lookup and a per-agent DB query — used to run
+    on the event-loop thread and serialised the whole "concurrent" fan-out
+    (10 agents x ~1-2s = the reported 20s). The container hostname is now
+    derived from the agent name (Docker DNS resolves `agent-{name}` on the
+    shared network, the same convention list_all_agents_fast trusts), and the
+    latest activity is pre-fetched in one bulk query by the caller.
+    """
     agent_name = agent["name"]
     status = agent["status"]
 
-    # Initialize default stats
     stats = {
         "name": agent_name,
         "status": status,
-        "activityState": "offline",
+        "activityState": "idle",
         "contextPercent": 0,
         "contextUsed": 0,
         "contextMax": 200000,
-        "lastActivityTime": None
+        "lastActivityTime": None,
     }
 
-    # Only fetch context stats for running agents
-    if status != "running":
-        return stats
-
-    # Fetch context stats from agent's internal API
+    # Fetch context window stats from the agent's internal API. No Docker call:
+    # the container is reachable at `agent-{name}:8000` via Docker DNS.
     try:
-        container = get_agent_container(agent_name)
-        if container:
-            agent_url = f"http://{container.name}:8000/api/chat/session"
-            response = await client.get(agent_url)
-            if response.status_code == 200:
-                session_data = response.json()
-                stats["contextPercent"] = session_data.get("context_percent", 0)
-                stats["contextUsed"] = session_data.get("context_tokens", 0)
-                stats["contextMax"] = session_data.get("context_window", 200000)
+        agent_url = f"http://agent-{agent_name}:8000/api/chat/session"
+        response = await client.get(agent_url)
+        if response.status_code == 200:
+            session_data = response.json()
+            stats["contextPercent"] = session_data.get("context_percent", 0)
+            stats["contextUsed"] = session_data.get("context_tokens", 0)
+            stats["contextMax"] = session_data.get("context_window", 200000)
     except Exception as e:
         logger.debug(f"Error fetching context stats for {agent_name}: {e}")
 
-    # Determine active/idle state based on recent activity
-    try:
-        cutoff_time = (datetime.utcnow() - timedelta(seconds=60)).isoformat()
-        recent_activities = db.get_agent_activities(
-            agent_name=agent_name,
-            limit=1
-        )
-
-        if recent_activities and len(recent_activities) > 0:
-            last_activity = recent_activities[0]
-            activity_time = last_activity.get("created_at")
-            stats["lastActivityTime"] = activity_time
-
-            if activity_time and activity_time > cutoff_time:
-                if last_activity.get("activity_state") == "started":
-                    stats["activityState"] = "active"
-                else:
-                    stats["activityState"] = "idle"
-            else:
-                stats["activityState"] = "idle"
-        else:
-            stats["activityState"] = "idle"
-    except Exception as e:
-        logger.debug(f"Error determining activity state for {agent_name}: {e}")
-        stats["activityState"] = "idle"
+    # Determine active/idle state from the pre-fetched latest activity (no DB
+    # call here — that query is batched once for all agents by the caller).
+    if last_activity:
+        activity_time = last_activity.get("created_at")
+        stats["lastActivityTime"] = activity_time
+        if (activity_time and activity_time > active_cutoff
+                and last_activity.get("activity_state") == "started"):
+            stats["activityState"] = "active"
 
     return stats
 
@@ -253,8 +247,18 @@ async def get_agents_context_stats_logic(
     # Fetch running agent stats concurrently using a shared client
     running_stats = []
     if running_agents:
+        # #1265: one bulk query for every running agent's latest activity,
+        # instead of a per-agent query inside each (now truly concurrent) task.
+        running_names = [a["name"] for a in running_agents]
+        latest_activity = db.get_latest_activity_for_agents(running_names)
+        active_cutoff = iso_cutoff(minutes=1)
         async with httpx.AsyncClient(timeout=2.0) as client:
-            tasks = [_fetch_single_agent_context(agent, client) for agent in running_agents]
+            tasks = [
+                _fetch_single_agent_context(
+                    agent, client, latest_activity.get(agent["name"]), active_cutoff
+                )
+                for agent in running_agents
+            ]
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
         for i, result in enumerate(results):

--- a/src/backend/services/agent_service/stats.py
+++ b/src/backend/services/agent_service/stats.py
@@ -252,7 +252,13 @@ async def get_agents_context_stats_logic(
         running_names = [a["name"] for a in running_agents]
         latest_activity = db.get_latest_activity_for_agents(running_names)
         active_cutoff = iso_cutoff(minutes=1)
-        async with httpx.AsyncClient(timeout=2.0) as client:
+        # #1265: we deliberately no longer do a per-agent Docker lookup to pre-check
+        # liveness (that blocking call was the bottleneck). To keep a stale-`running`
+        # agent (container died between the status snapshot and now) from eating the
+        # full read timeout, cap the CONNECT timeout tightly — a dead in-network host
+        # fails connect fast — while still allowing a slow-but-alive agent 2s to reply.
+        timeout = httpx.Timeout(2.0, connect=0.5)
+        async with httpx.AsyncClient(timeout=timeout) as client:
             tasks = [
                 _fetch_single_agent_context(
                     agent, client, latest_activity.get(agent["name"]), active_cutoff

--- a/src/backend/services/slot_service.py
+++ b/src/backend/services/slot_service.py
@@ -266,17 +266,25 @@ class SlotService:
         Returns:
             Dict mapping agent_name to {"max": N, "active": M}
         """
-        result = {}
+        if not agent_capacities:
+            return {}
 
-        for agent_name, max_tasks in agent_capacities.items():
-            slots_key = self._slots_key(agent_name)
-            active_count = self.redis.zcard(slots_key)
-            result[agent_name] = {
-                "max": max_tasks,
-                "active": active_count
-            }
+        # #1265: one pipelined round-trip instead of an N+1 ZCARD per agent
+        # (Dashboard polls this for the whole fleet every few seconds).
+        agent_names = list(agent_capacities.keys())
+        try:
+            pipe = self.redis.pipeline(transaction=False)
+            for agent_name in agent_names:
+                pipe.zcard(self._slots_key(agent_name))
+            counts = pipe.execute()
+        except Exception:  # noqa: BLE001 — fail open to zero active (slot meter is advisory here)
+            logger.debug("slots: bulk zcard pipeline failed", exc_info=True)
+            counts = [0] * len(agent_names)
 
-        return result
+        return {
+            agent_name: {"max": agent_capacities[agent_name], "active": counts[idx] or 0}
+            for idx, agent_name in enumerate(agent_names)
+        }
 
     async def _cleanup_stale_slots_for_agent(
         self, agent_name: str, default_slot_ttl: int = None

--- a/tests/unit/test_1265_dashboard_perf.py
+++ b/tests/unit/test_1265_dashboard_perf.py
@@ -104,9 +104,11 @@ def test_latest_execution_picks_newest_per_schedule(sched_ops):
     out = sched_ops.get_latest_execution_per_schedule(["s1", "s2"])
 
     assert set(out.keys()) == {"s1", "s2"}
-    assert out["s1"].id == "s1-new"          # newest started_at wins
-    assert out["s1"].status == "failed"
-    assert out["s2"].id == "s2-only"
+    assert out["s1"]["id"] == "s1-new"          # newest started_at wins
+    assert out["s1"]["status"] == "failed"
+    assert out["s2"]["id"] == "s2-only"
+    # slim projection: only dashboard fields, no large TEXT blobs (#1265 review fix)
+    assert set(out["s1"]) == {"id", "status", "started_at", "completed_at", "duration_ms", "error"}
 
 
 def test_latest_execution_empty_input_returns_empty(sched_ops):

--- a/tests/unit/test_1265_dashboard_perf.py
+++ b/tests/unit/test_1265_dashboard_perf.py
@@ -1,0 +1,182 @@
+"""Tests for #1265 Dashboard/timeline fleet-scale perf fixes.
+
+Covers the bulk DB methods that replaced per-agent / per-schedule N+1
+fan-out on the Dashboard load path, plus the timeline SQL-side access
+filter:
+
+  * ScheduleOperations.get_latest_execution_per_schedule (bulk, /ops/schedules)
+  * ActivityOperations.get_latest_activity_for_agents (bulk, /context-stats)
+  * ActivityOperations.get_activities_in_range(agent_names=...) (timeline)
+
+Same backend-agnostic harness + sys.modules pollution defence as
+tests/unit/test_schedule_analytics.py — runs on SQLite always, and on
+PostgreSQL when TEST_POSTGRES_URL is set (the window functions are the
+reason to exercise both).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import (  # noqa: E402
+    db_backend,
+    seed_user,
+    seed_schedule,
+    seed_execution,
+    _engine,
+)
+
+_STUBBED_MODULE_NAMES = ["db.schedules", "db.activities", "db.users", "db.agents"]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    names = _STUBBED_MODULE_NAMES + ["db.connection"]
+    saved = {n: sys.modules.get(n) for n in names}
+    db_pkg = sys.modules.get("db")
+    saved_attrs = (
+        {n.split(".", 1)[1]: getattr(db_pkg, n.split(".", 1)[1], None) for n in names}
+        if db_pkg is not None
+        else {}
+    )
+    for name in _STUBBED_MODULE_NAMES:
+        sys.modules.pop(name, None)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+        for attr, value in saved_attrs.items():
+            if value is None:
+                if db_pkg is not None and hasattr(db_pkg, attr):
+                    delattr(db_pkg, attr)
+            elif db_pkg is not None:
+                setattr(db_pkg, attr, value)
+
+
+def _seed_activity(activity_id, agent_name, created_at, state="started"):
+    from sqlalchemy import text
+    with _engine().begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO agent_activities "
+                "(id, agent_name, activity_type, activity_state, started_at, "
+                " triggered_by, created_at) "
+                "VALUES (:id, :a, 'chat_start', :st, :ca, 'user', :ca)"
+            ),
+            {"id": activity_id, "a": agent_name, "st": state, "ca": created_at},
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_latest_execution_per_schedule
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sched_ops(db_backend):
+    seed_user(1, "owner", "user")
+    from db.schedules import ScheduleOperations
+    from db.users import UserOperations
+    from db.agents import AgentOperations
+    user_ops = UserOperations()
+    agent_ops = AgentOperations(user_ops)
+    return ScheduleOperations(user_ops, agent_ops)
+
+
+def test_latest_execution_picks_newest_per_schedule(sched_ops):
+    seed_schedule("s1")
+    seed_schedule("s2")
+    seed_execution("s1", started_at="2026-01-01T10:00:00.000000Z", status="success", exec_id="s1-old")
+    seed_execution("s1", started_at="2026-01-02T10:00:00.000000Z", status="failed", exec_id="s1-new")
+    seed_execution("s2", started_at="2026-01-01T09:00:00.000000Z", status="success", exec_id="s2-only")
+
+    out = sched_ops.get_latest_execution_per_schedule(["s1", "s2"])
+
+    assert set(out.keys()) == {"s1", "s2"}
+    assert out["s1"].id == "s1-new"          # newest started_at wins
+    assert out["s1"].status == "failed"
+    assert out["s2"].id == "s2-only"
+
+
+def test_latest_execution_empty_input_returns_empty(sched_ops):
+    assert sched_ops.get_latest_execution_per_schedule([]) == {}
+
+
+def test_latest_execution_schedule_without_runs_absent(sched_ops):
+    seed_schedule("s1")
+    seed_schedule("s2")
+    seed_execution("s1", exec_id="s1-only")
+
+    out = sched_ops.get_latest_execution_per_schedule(["s1", "s2"])
+
+    assert "s1" in out
+    assert "s2" not in out                   # no executions -> absent, not None entry
+
+
+# ---------------------------------------------------------------------------
+# get_latest_activity_for_agents
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def act_ops(db_backend):
+    from db.activities import ActivityOperations
+    return ActivityOperations()
+
+
+def test_latest_activity_picks_newest_per_agent(act_ops):
+    _seed_activity("a1-old", "agent-1", "2026-01-01T10:00:00.000000Z", state="completed")
+    _seed_activity("a1-new", "agent-1", "2026-01-02T10:00:00.000000Z", state="started")
+    _seed_activity("a2", "agent-2", "2026-01-01T08:00:00.000000Z", state="started")
+
+    out = act_ops.get_latest_activity_for_agents(["agent-1", "agent-2"])
+
+    assert out["agent-1"]["id"] == "a1-new"
+    assert out["agent-1"]["activity_state"] == "started"
+    assert out["agent-2"]["id"] == "a2"
+
+
+def test_latest_activity_empty_input_returns_empty(act_ops):
+    assert act_ops.get_latest_activity_for_agents([]) == {}
+
+
+def test_latest_activity_unknown_agent_absent(act_ops):
+    _seed_activity("a1", "agent-1", "2026-01-01T10:00:00.000000Z")
+    out = act_ops.get_latest_activity_for_agents(["agent-1", "ghost"])
+    assert "agent-1" in out and "ghost" not in out
+
+
+# ---------------------------------------------------------------------------
+# get_activities_in_range(agent_names=...) — timeline access filter
+# ---------------------------------------------------------------------------
+
+def test_timeline_agent_names_none_returns_all(act_ops):
+    _seed_activity("a1", "agent-1", "2026-01-01T10:00:00.000000Z")
+    _seed_activity("a2", "agent-2", "2026-01-01T11:00:00.000000Z")
+
+    rows = act_ops.get_activities_in_range(agent_names=None)
+    names = {r["agent_name"] for r in rows}
+    assert names == {"agent-1", "agent-2"}
+
+
+def test_timeline_agent_names_subset_filters_in_sql(act_ops):
+    _seed_activity("a1", "agent-1", "2026-01-01T10:00:00.000000Z")
+    _seed_activity("a2", "agent-2", "2026-01-01T11:00:00.000000Z")
+
+    rows = act_ops.get_activities_in_range(agent_names=["agent-1"])
+    assert {r["agent_name"] for r in rows} == {"agent-1"}
+
+
+def test_timeline_agent_names_empty_returns_nothing(act_ops):
+    _seed_activity("a1", "agent-1", "2026-01-01T10:00:00.000000Z")
+    assert act_ops.get_activities_in_range(agent_names=[]) == []


### PR DESCRIPTION
## Summary

Fixes the 20s+ Dashboard/timeline metric load on 10+ agent fleets (#1265). Profiling showed the bottleneck was **not** the endpoints named in the issue but (a) blocking calls serializing the event loop on `context-stats`, and (b) several per-agent / per-schedule N+1 query patterns that grow with fleet size.

## Root cause & fixes

| Path | Problem | Fix |
|------|---------|-----|
| `context-stats` (`stats.py`) | `_fetch_single_agent_context` was `async` but ran a **blocking** Docker container lookup + per-agent DB query on the event-loop thread → `asyncio.gather` was effectively serial (10 × ~1-2s = the 20s) | Coroutine now does only the async HTTP call; container host derived as `agent-{name}` (Docker DNS, no Docker call); latest activity fetched once via new bulk `get_latest_activity_for_agents` window query |
| `/api/agents/slots` | per-agent Redis `ZCARD` loop | one pipelined round-trip (mirrors `heartbeat_status_bulk`) |
| `/api/ops/schedules` | per-schedule `get_schedule_executions` loop | one `get_latest_execution_per_schedule` window query |
| `/api/activities/timeline` | fleet-wide `ORDER BY created_at DESC` with no `created_at` index; `limit*2` over-fetch + Python-side access filter | added `idx_activities_created` (schema.py + migration); access filter pushed into SQL (`agent_name IN ...`); exact `limit` |
| `db/monitoring.py`, `stats.py` | Invariant #16 (`datetime.utcnow()` vs ISO-Z columns) | `iso_cutoff()` |

No new cache layer → no freshness/invalidation risk (AC #5).

## Testing

- New `tests/unit/test_1265_dashboard_perf.py` (9 tests) covering the three bulk methods + timeline access filter — runs on SQLite and Postgres via the #300 harness.
- Window-function constructs verified on SQLite; full affected unit suites (schedules, monitoring, migrations, slots, stats-cache, sync-health) pass: 125 passed.

## Remaining AC

- [ ] Documented before/after per-endpoint timings at 1/5/10/20 agents (needs a seeded multi-agent fleet — will add to this PR).

Related to #1265