### PR TITLE
fix(git): per-agent GitHub PAT now propagates to existing containers (#1264)

### DIFF
--- a/src/backend/routers/git.py
+++ b/src/backend/routers/git.py
@@ -591,12 +591,28 @@ async def set_agent_github_pat(
     if not success:
         raise HTTPException(status_code=500, detail="Failed to save PAT")
 
+    # #1264: propagate to the running container so the PAT takes effect WITHOUT a
+    # restart — inject GITHUB_PAT into .env (adding the line if the container was
+    # created tokenless) and re-template the live git remote. Best-effort: a
+    # stopped agent picks it up on next start (relaxed lifecycle injection +
+    # startup self-heal).
+    from services.github_pat_propagation_service import propagate_pat_to_single_agent
+    propagation = await propagate_pat_to_single_agent(agent_name, pat)
+
+    if propagation.get("applied"):
+        note = "PAT applied to the running agent — git operations will use it immediately."
+    elif propagation.get("reason") == "agent_not_running":
+        note = "PAT saved. Start the agent for it to take effect in git operations."
+    else:
+        note = "PAT saved, but live propagation did not complete; restart the agent to apply it."
+
     return {
         "message": "GitHub PAT configured successfully",
         "agent_name": agent_name,
         "github_username": username,
         "source": "agent",
-        "note": "Restart agent for new PAT to be used in git operations"
+        "propagation": propagation,
+        "note": note,
     }
 
 

--- a/src/backend/routers/git.py
+++ b/src/backend/routers/git.py
@@ -599,8 +599,13 @@ async def set_agent_github_pat(
     from services.github_pat_propagation_service import propagate_pat_to_single_agent
     propagation = await propagate_pat_to_single_agent(agent_name, pat)
 
-    if propagation.get("applied"):
+    # #1264 review: the live git process authenticates from the remote URL, so
+    # only `remote_updated` means git ops work *immediately*. An env-only update
+    # (or a stopped agent) takes effect on the next restart.
+    if propagation.get("remote_updated"):
         note = "PAT applied to the running agent — git operations will use it immediately."
+    elif propagation.get("env_updated"):
+        note = "PAT saved to the agent; it will take effect on the next restart."
     elif propagation.get("reason") == "agent_not_running":
         note = "PAT saved. Start the agent for it to take effect in git operations."
     else:

--- a/src/backend/services/agent_service/helpers.py
+++ b/src/backend/services/agent_service/helpers.py
@@ -442,6 +442,24 @@ def check_guardrails_env_matches(container, agent_name: str) -> bool:
         return False
 
 
+def needs_per_agent_pat_injection(agent_name: str) -> bool:
+    """#1264: True when the agent has a **per-agent** GitHub PAT configured AND
+    git sync — i.e. the container SHOULD carry that token.
+
+    Gated on ``db.get_agent_github_pat`` (the per-agent PAT only), NOT
+    ``get_github_pat_for_agent`` (which falls back to the global platform PAT).
+    Using the global fallback here would force-recreate / inject into every
+    tokenless git agent the moment an operator sets a global PAT — that's #211's
+    deliberate opt-in `.env` path, not this one's job, and is out of #1264 scope.
+
+    Shared by the recreate matcher (:func:`check_github_pat_env_matches`) and the
+    lifecycle recreate inject gate so the two predicates cannot drift — if they
+    did, the matcher could keep requesting a recreate the inject never satisfies
+    (infinite recreate loop).
+    """
+    return bool(db.get_agent_github_pat(agent_name)) and bool(db.get_git_config(agent_name))
+
+
 def check_github_pat_env_matches(container, agent_name: str) -> bool:
     """
     Check if container's GITHUB_PAT env var matches the effective PAT for this agent.
@@ -453,19 +471,18 @@ def check_github_pat_env_matches(container, agent_name: str) -> bool:
     env_list = container.attrs.get("Config", {}).get("Env", [])
     env_dict = {e.split("=", 1)[0]: e.split("=", 1)[1] for e in env_list if "=" in e}
 
-    current_pat = get_github_pat_for_agent(agent_name)
-
     container_pat = env_dict.get("GITHUB_PAT")
     if not container_pat:
-        # #1264: a tokenless container that now has an effective PAT AND git sync
-        # configured genuinely mismatches desired state — recreation re-injects
-        # the token (crud.py) so the remote can authenticate. Without this, a
-        # per-agent PAT set after a tokenless creation never reached the env.
-        if current_pat and db.get_git_config(agent_name):
-            return False
-        # Otherwise the agent doesn't use GITHUB_PAT — no update needed.
-        return True
+        # #1264: a tokenless container needs a recreate ONLY when a per-agent PAT
+        # is configured (so creation/recreate will inject it). A global-only PAT
+        # must NOT force tokenless agents to recreate — see
+        # needs_per_agent_pat_injection. Recreate converges in one pass because
+        # the lifecycle inject gate uses the SAME predicate.
+        return not needs_per_agent_pat_injection(agent_name)
 
+    # Container already has a token — keep it in sync with the effective PAT
+    # (per-agent first, then the global fallback for already-tokened containers).
+    current_pat = get_github_pat_for_agent(agent_name)
     if not current_pat:
         # No PAT configured anywhere — can't update, leave as-is
         return True

--- a/src/backend/services/agent_service/helpers.py
+++ b/src/backend/services/agent_service/helpers.py
@@ -453,12 +453,19 @@ def check_github_pat_env_matches(container, agent_name: str) -> bool:
     env_list = container.attrs.get("Config", {}).get("Env", [])
     env_dict = {e.split("=", 1)[0]: e.split("=", 1)[1] for e in env_list if "=" in e}
 
+    current_pat = get_github_pat_for_agent(agent_name)
+
     container_pat = env_dict.get("GITHUB_PAT")
     if not container_pat:
-        # Agent doesn't use GITHUB_PAT — no update needed
+        # #1264: a tokenless container that now has an effective PAT AND git sync
+        # configured genuinely mismatches desired state — recreation re-injects
+        # the token (crud.py) so the remote can authenticate. Without this, a
+        # per-agent PAT set after a tokenless creation never reached the env.
+        if current_pat and db.get_git_config(agent_name):
+            return False
+        # Otherwise the agent doesn't use GITHUB_PAT — no update needed.
         return True
 
-    current_pat = get_github_pat_for_agent(agent_name)
     if not current_pat:
         # No PAT configured anywhere — can't update, leave as-is
         return True

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -25,7 +25,7 @@ from services.docker_utils import (
 from services.agent_service.helpers import validate_base_image
 from services.settings_service import get_anthropic_api_key, get_github_pat, get_agent_full_capabilities, get_agent_default_resources
 from services.skill_service import skill_service
-from .helpers import check_shared_folder_mounts_match, check_api_key_env_matches, check_github_pat_env_matches, check_resource_limits_match, check_full_capabilities_match, check_guardrails_env_matches
+from .helpers import check_shared_folder_mounts_match, check_api_key_env_matches, check_github_pat_env_matches, check_resource_limits_match, check_full_capabilities_match, check_guardrails_env_matches, needs_per_agent_pat_injection
 from .file_sharing import check_public_folder_mount_matches
 from .read_only import inject_read_only_hooks, remove_read_only_hooks
 
@@ -382,13 +382,14 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
         env_vars.pop('CLAUDE_CODE_OAUTH_TOKEN', None)
 
     # Update GITHUB_PAT using per-agent PAT first, then platform PAT.
-    if db.get_git_config(agent_name):  # #1264: gate on git config, not GITHUB_PAT presence
+    if env_vars.get('GITHUB_PAT') or needs_per_agent_pat_injection(agent_name):
         from routers.git import get_github_pat_for_agent
         current_pat = get_github_pat_for_agent(agent_name)
         if current_pat:
-            # #1264: a tokenless container (PAT configured after creation) now
-            # receives the effective per-agent PAT on restart; startup.sh then
-            # re-templates the remote so fetch/push authenticate.
+            # #1264: refresh an existing token, or newly inject when a PER-AGENT
+            # PAT is set (needs_per_agent_pat_injection — same gate the recreate
+            # matcher uses, so they converge). A global-only PAT is NOT injected
+            # into a previously-tokenless container (that stays #211's opt-in path).
             env_vars['GITHUB_PAT'] = current_pat
 
     # GUARD-001: re-serialise guardrails overrides into env so startup.sh

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -381,11 +381,14 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
         env_vars.pop('ANTHROPIC_API_KEY', None)
         env_vars.pop('CLAUDE_CODE_OAUTH_TOKEN', None)
 
-    # Update GITHUB_PAT using per-agent PAT first, then platform PAT
-    if env_vars.get('GITHUB_PAT'):
+    # Update GITHUB_PAT using per-agent PAT first, then platform PAT.
+    if db.get_git_config(agent_name):  # #1264: gate on git config, not GITHUB_PAT presence
         from routers.git import get_github_pat_for_agent
         current_pat = get_github_pat_for_agent(agent_name)
         if current_pat:
+            # #1264: a tokenless container (PAT configured after creation) now
+            # receives the effective per-agent PAT on restart; startup.sh then
+            # re-templates the remote so fetch/push authenticate.
             env_vars['GITHUB_PAT'] = current_pat
 
     # GUARD-001: re-serialise guardrails overrides into env so startup.sh

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -25,7 +25,7 @@ from services.docker_utils import (
 from services.agent_service.helpers import validate_base_image
 from services.settings_service import get_anthropic_api_key, get_github_pat, get_agent_full_capabilities, get_agent_default_resources
 from services.skill_service import skill_service
-from .helpers import check_shared_folder_mounts_match, check_api_key_env_matches, check_github_pat_env_matches, check_resource_limits_match, check_full_capabilities_match, check_guardrails_env_matches, needs_per_agent_pat_injection
+from .helpers import check_shared_folder_mounts_match, check_api_key_env_matches, check_github_pat_env_matches, check_resource_limits_match, check_full_capabilities_match, check_guardrails_env_matches
 from .file_sharing import check_public_folder_mount_matches
 from .read_only import inject_read_only_hooks, remove_read_only_hooks
 
@@ -382,15 +382,17 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
         env_vars.pop('CLAUDE_CODE_OAUTH_TOKEN', None)
 
     # Update GITHUB_PAT using per-agent PAT first, then platform PAT.
-    if env_vars.get('GITHUB_PAT') or needs_per_agent_pat_injection(agent_name):
+    _per_agent_pat = bool(db.get_agent_github_pat(agent_name)) and bool(db.get_git_config(agent_name))
+    if env_vars.get('GITHUB_PAT') or _per_agent_pat:
         from routers.git import get_github_pat_for_agent
         current_pat = get_github_pat_for_agent(agent_name)
         if current_pat:
-            # #1264: refresh an existing token, or newly inject when a PER-AGENT
-            # PAT is set (needs_per_agent_pat_injection — same gate the recreate
-            # matcher uses, so they converge). A global-only PAT is NOT injected
-            # into a previously-tokenless container (that stays #211's opt-in path).
             env_vars['GITHUB_PAT'] = current_pat
+    # NB: gated on db.get_agent_github_pat (NOT the global fallback) so a global-
+    # only PAT is never injected into a previously-tokenless container (#211's
+    # opt-in path); kept in sync with the recreate matcher so the two converge.
+    # Inlined via db rather than importing the helper, so a test stubbing
+    # services.agent_service.helpers can't break this module's import (#1271 CI).
 
     # GUARD-001: re-serialise guardrails overrides into env so startup.sh
     # can render the runtime config with the latest values.

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -170,6 +170,48 @@ def generate_working_branch(agent_name: str, instance_id: str) -> str:
     return f"trinity/{agent_name}/{instance_id}"
 
 
+async def update_remote_pat(agent_name: str, github_pat: str, github_repo: str) -> bool:
+    """Re-template a running agent's ``origin`` remote to embed ``github_pat`` (#1264).
+
+    A per-agent PAT configured *after* the container/git was set up never reaches
+    the live remote — it stays frozen with an empty password
+    (``https://x-access-token:@github.com/...``) in the persisted workspace
+    volume, so every fetch/push fails. This rewrites ``remote.origin.url`` in the
+    container's git dir to the authenticated URL, idempotently (set-url if origin
+    exists, else add). The startup.sh self-heal does the same on restart; this is
+    the no-restart path used by ``set_agent_github_pat``.
+
+    Returns True on success. Best-effort: returns False (never raises) if the
+    container isn't running, has no git dir, or the command fails.
+    """
+    if not github_pat or not github_repo:
+        return False
+    container_name = f"agent-{agent_name}"
+    try:
+        git_dir = await _detect_git_dir(container_name)
+        url = _git_remote_url(github_pat, github_repo)
+        # Same idempotent set-url/add pattern as initialize_github_sync (step 3).
+        cmd = (
+            f"git remote get-url origin >/dev/null 2>&1 && "
+            f"git remote set-url origin {url} || git remote add origin {url}"
+        )
+        result = await execute_command_in_container(
+            container_name=container_name,
+            command=f'bash -c "cd {git_dir} && {cmd}"',
+            timeout=30,
+        )
+        ok = result.get("exit_code", 1) == 0
+        if not ok:
+            logger.warning(
+                "update_remote_pat: set-url failed for %s: %s",
+                agent_name, result.get("output", "")[:200],
+            )
+        return ok
+    except Exception as e:  # noqa: BLE001 — best-effort, container may be down
+        logger.warning("update_remote_pat: error for %s: %s", agent_name, e)
+        return False
+
+
 # ============================================================================
 # S4 — Persistent State Allowlist (abilityai/trinity#383)
 # ============================================================================

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -165,6 +165,19 @@ def _git_remote_url(github_pat: str, github_repo: str) -> str:
     return f"{scheme}://oauth2:{github_pat}@{host_path}/{github_repo}.git"
 
 
+def _remote_seturl_subcommand(url: str) -> str:
+    """Idempotent `origin` set-url/add shell subcommand, with the (token-bearing)
+    URL shell-quoted (#1264 review). Shared by ``initialize_github_sync`` and
+    ``update_remote_pat`` so the templating logic lives in one place; the
+    ``shlex.quote`` is defense-in-depth (canonical PATs are ``[A-Za-z0-9_]``,
+    but ``set_agent_github_pat`` accepts arbitrary input)."""
+    q = shlex.quote(url)
+    return (
+        f"git remote get-url origin >/dev/null 2>&1 && "
+        f"git remote set-url origin {q} || git remote add origin {q}"
+    )
+
+
 def generate_working_branch(agent_name: str, instance_id: str) -> str:
     """Generate a working branch name for an agent instance."""
     return f"trinity/{agent_name}/{instance_id}"
@@ -174,12 +187,13 @@ async def update_remote_pat(agent_name: str, github_pat: str, github_repo: str) 
     """Re-template a running agent's ``origin`` remote to embed ``github_pat`` (#1264).
 
     A per-agent PAT configured *after* the container/git was set up never reaches
-    the live remote — it stays frozen with an empty password
-    (``https://x-access-token:@github.com/...``) in the persisted workspace
-    volume, so every fetch/push fails. This rewrites ``remote.origin.url`` in the
-    container's git dir to the authenticated URL, idempotently (set-url if origin
-    exists, else add). The startup.sh self-heal does the same on restart; this is
-    the no-restart path used by ``set_agent_github_pat``.
+    the live remote — it stays frozen with an empty password (e.g.
+    ``https://x-access-token:@github.com/...``) in the persisted workspace
+    volume, so every fetch/push fails. This rewrites ``remote.origin.url`` to the
+    authenticated ``oauth2:<pat>@`` URL (``_git_remote_url``, same scheme
+    startup.sh uses), idempotently (set-url if origin exists, else add). The
+    startup.sh self-heal does the same on restart; this is the no-restart path
+    used by ``set_agent_github_pat``.
 
     Returns True on success. Best-effort: returns False (never raises) if the
     container isn't running, has no git dir, or the command fails.
@@ -189,12 +203,7 @@ async def update_remote_pat(agent_name: str, github_pat: str, github_repo: str) 
     container_name = f"agent-{agent_name}"
     try:
         git_dir = await _detect_git_dir(container_name)
-        url = _git_remote_url(github_pat, github_repo)
-        # Same idempotent set-url/add pattern as initialize_github_sync (step 3).
-        cmd = (
-            f"git remote get-url origin >/dev/null 2>&1 && "
-            f"git remote set-url origin {url} || git remote add origin {url}"
-        )
+        cmd = _remote_seturl_subcommand(_git_remote_url(github_pat, github_repo))
         result = await execute_command_in_container(
             container_name=container_name,
             command=f'bash -c "cd {git_dir} && {cmd}"',
@@ -920,9 +929,7 @@ async def initialize_git_in_container(
         ('git config --global user.name "Trinity Agent"', True),
         ('git config --global init.defaultBranch main', True),
         ('git init', True),
-        (f'git remote get-url origin >/dev/null 2>&1 && '
-         f'git remote set-url origin {_git_remote_url(github_pat, github_repo)} || '
-         f'git remote add origin {_git_remote_url(github_pat, github_repo)}', True),
+        (_remote_seturl_subcommand(_git_remote_url(github_pat, github_repo)), True),
         ('git fetch origin', False),  # Optional — remote may be empty
     ]
 

--- a/src/backend/services/github_pat_propagation_service.py
+++ b/src/backend/services/github_pat_propagation_service.py
@@ -55,6 +55,58 @@ def _env_has_github_pat(env_content: str) -> bool:
     return bool(_GITHUB_PAT_LINE_RE.search(env_content))
 
 
+async def propagate_pat_to_single_agent(agent_name: str, pat: str) -> dict:
+    """Push a newly-set per-agent PAT into a running container with no restart (#1264).
+
+    Unlike :func:`_propagate_to_agent` (the global-PAT path, which *skips* an
+    agent whose ``.env`` lacks a ``GITHUB_PAT`` line), this ADDS the line when
+    missing — the #1264 case is a container created without any token. It then
+    re-templates the live git remote so the frozen empty-password remote
+    (``https://x-access-token:@…``) is fixed immediately and fetch/push work.
+
+    Best-effort and non-fatal: a stopped agent picks the PAT up on next start via
+    the relaxed lifecycle injection + the startup.sh self-heal. Returns a small
+    status dict for the set-PAT API response.
+    """
+    from services import git_service
+
+    running = {a.name for a in list_all_agents_fast() if a.status == "running"}
+    if agent_name not in running:
+        return {"applied": False, "reason": "agent_not_running"}
+
+    env_updated = False
+    base_url = f"http://agent-{agent_name}:8000"
+    async with httpx.AsyncClient(timeout=AGENT_HTTP_TIMEOUT_SECONDS) as client:
+        try:
+            read_resp = await client.get(
+                f"{base_url}/api/credentials/read", params={"paths": ".env"}
+            )
+            read_resp.raise_for_status()
+            env_content = read_resp.json().get("files", {}).get(".env") or ""
+            patched = _patch_env_github_pat(env_content, pat)  # adds the line if absent
+            inject_resp = await client.post(
+                f"{base_url}/api/credentials/inject", json={"files": {".env": patched}}
+            )
+            inject_resp.raise_for_status()
+            env_updated = True
+        except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            logger.warning("single-agent PAT .env inject failed for %s: %s", agent_name, e)
+
+    # Re-template the live remote so an existing clone picks up the token now.
+    git_config = db.get_git_config(agent_name)
+    github_repo = getattr(git_config, "github_repo", None) if git_config else None
+    remote_updated = (
+        await git_service.update_remote_pat(agent_name, pat, github_repo)
+        if github_repo else False
+    )
+
+    return {
+        "applied": env_updated or remote_updated,
+        "env_updated": env_updated,
+        "remote_updated": remote_updated,
+    }
+
+
 async def _propagate_to_agent(
     agent_name: str,
     new_pat: str,

--- a/src/backend/services/github_pat_propagation_service.py
+++ b/src/backend/services/github_pat_propagation_service.py
@@ -20,7 +20,7 @@ import httpx
 
 from database import db
 from models import AgentPropagationStatus, GithubPatPropagationResult
-from services.docker_service import list_all_agents_fast
+from services.docker_service import list_all_agents_fast, get_agent_container
 
 logger = logging.getLogger(__name__)
 
@@ -110,9 +110,10 @@ async def propagate_pat_to_single_agent(agent_name: str, pat: str) -> dict:
     status dict for the set-PAT API response.
     """
     from services import git_service
-    from services.docker_service import get_agent_container
 
     # #1264 review: query the single container instead of enumerating the fleet.
+    # get_agent_container is a module-level import (above) so it's patchable as a
+    # stable module global, not resolved from sys.modules at call time.
     container = get_agent_container(agent_name)
     if container is None or container.status != "running":
         return {"applied": False, "reason": "agent_not_running"}

--- a/src/backend/services/github_pat_propagation_service.py
+++ b/src/backend/services/github_pat_propagation_service.py
@@ -55,46 +55,80 @@ def _env_has_github_pat(env_content: str) -> bool:
     return bool(_GITHUB_PAT_LINE_RE.search(env_content))
 
 
+async def _apply_pat_to_env(
+    client: httpx.AsyncClient,
+    base_url: str,
+    pat: str,
+    *,
+    add_if_missing: bool,
+) -> str:
+    """Read an agent's ``.env``, patch the ``GITHUB_PAT`` line, write it back.
+
+    Shared by the global-PAT path (:func:`_propagate_to_agent`, ``add_if_missing
+    =False`` — skip agents that never set up a token) and the per-agent path
+    (:func:`propagate_pat_to_single_agent`, ``add_if_missing=True`` — the #1264
+    case is a container with no ``GITHUB_PAT`` line yet). Returns ``"updated"`` or
+    ``"skipped_no_pat"``; raises httpx errors for the caller to classify.
+    """
+    read_resp = await client.get(
+        f"{base_url}/api/credentials/read",
+        params={"paths": ".env"},
+        timeout=AGENT_HTTP_TIMEOUT_SECONDS,
+    )
+    read_resp.raise_for_status()
+    env_content = read_resp.json().get("files", {}).get(".env")
+
+    if env_content is None:
+        if not add_if_missing:
+            return "skipped_no_pat"
+        env_content = ""
+    elif not _env_has_github_pat(env_content) and not add_if_missing:
+        return "skipped_no_pat"
+
+    patched = _patch_env_github_pat(env_content, pat)
+    inject_resp = await client.post(
+        f"{base_url}/api/credentials/inject",
+        json={"files": {".env": patched}},
+        timeout=AGENT_HTTP_TIMEOUT_SECONDS,
+    )
+    inject_resp.raise_for_status()
+    return "updated"
+
+
 async def propagate_pat_to_single_agent(agent_name: str, pat: str) -> dict:
     """Push a newly-set per-agent PAT into a running container with no restart (#1264).
 
-    Unlike :func:`_propagate_to_agent` (the global-PAT path, which *skips* an
-    agent whose ``.env`` lacks a ``GITHUB_PAT`` line), this ADDS the line when
-    missing — the #1264 case is a container created without any token. It then
-    re-templates the live git remote so the frozen empty-password remote
-    (``https://x-access-token:@…``) is fixed immediately and fetch/push work.
+    Adds the ``GITHUB_PAT`` line when absent (the #1264 case is a container
+    created without any token) and re-templates the live git remote so the frozen
+    empty-password remote is fixed immediately and fetch/push work. The live git
+    process authenticates from the remote URL (not the env var), so
+    ``remote_updated`` is the load-bearing part of the immediate fix; the ``.env``
+    write only takes effect on the next restart.
 
     Best-effort and non-fatal: a stopped agent picks the PAT up on next start via
     the relaxed lifecycle injection + the startup.sh self-heal. Returns a small
     status dict for the set-PAT API response.
     """
     from services import git_service
+    from services.docker_service import get_agent_container
 
-    running = {a.name for a in list_all_agents_fast() if a.status == "running"}
-    if agent_name not in running:
+    # #1264 review: query the single container instead of enumerating the fleet.
+    container = get_agent_container(agent_name)
+    if container is None or container.status != "running":
         return {"applied": False, "reason": "agent_not_running"}
 
     env_updated = False
     base_url = f"http://agent-{agent_name}:8000"
     async with httpx.AsyncClient(timeout=AGENT_HTTP_TIMEOUT_SECONDS) as client:
         try:
-            read_resp = await client.get(
-                f"{base_url}/api/credentials/read", params={"paths": ".env"}
-            )
-            read_resp.raise_for_status()
-            env_content = read_resp.json().get("files", {}).get(".env") or ""
-            patched = _patch_env_github_pat(env_content, pat)  # adds the line if absent
-            inject_resp = await client.post(
-                f"{base_url}/api/credentials/inject", json={"files": {".env": patched}}
-            )
-            inject_resp.raise_for_status()
+            await _apply_pat_to_env(client, base_url, pat, add_if_missing=True)
             env_updated = True
         except (httpx.HTTPStatusError, httpx.RequestError) as e:
             logger.warning("single-agent PAT .env inject failed for %s: %s", agent_name, e)
 
     # Re-template the live remote so an existing clone picks up the token now.
     git_config = db.get_git_config(agent_name)
-    github_repo = getattr(git_config, "github_repo", None) if git_config else None
+    github_repo = git_config.github_repo if git_config else None
     remote_updated = (
         await git_service.update_remote_pat(agent_name, pat, github_repo)
         if github_repo else False
@@ -112,40 +146,11 @@ async def _propagate_to_agent(
     new_pat: str,
     client: httpx.AsyncClient,
 ) -> AgentPropagationStatus:
-    """Read .env from one agent, patch GITHUB_PAT, write it back."""
+    """Read .env from one agent, patch GITHUB_PAT, write it back (global-PAT path)."""
     base_url = f"http://agent-{agent_name}:8000"
     try:
-        read_resp = await client.get(
-            f"{base_url}/api/credentials/read",
-            params={"paths": ".env"},
-            timeout=AGENT_HTTP_TIMEOUT_SECONDS,
-        )
-        read_resp.raise_for_status()
-        env_content = read_resp.json().get("files", {}).get(".env")
-
-        if env_content is None:
-            return AgentPropagationStatus(
-                agent_name=agent_name,
-                status="skipped_no_pat",
-            )
-
-        if not _env_has_github_pat(env_content):
-            return AgentPropagationStatus(
-                agent_name=agent_name,
-                status="skipped_no_pat",
-            )
-
-        patched = _patch_env_github_pat(env_content, new_pat)
-
-        inject_resp = await client.post(
-            f"{base_url}/api/credentials/inject",
-            json={"files": {".env": patched}},
-            timeout=AGENT_HTTP_TIMEOUT_SECONDS,
-        )
-        inject_resp.raise_for_status()
-
-        return AgentPropagationStatus(agent_name=agent_name, status="updated")
-
+        status = await _apply_pat_to_env(client, base_url, new_pat, add_if_missing=False)
+        return AgentPropagationStatus(agent_name=agent_name, status=status)
     except httpx.HTTPStatusError as e:
         error = f"agent returned {e.response.status_code}: {e.response.text[:200]}"
         logger.warning("GITHUB_PAT propagation failed for %s: %s", agent_name, error)

--- a/tests/test_github_pat_propagation_unit.py
+++ b/tests/test_github_pat_propagation_unit.py
@@ -44,6 +44,9 @@ sys.modules["services"] = _fake_services_pkg
 
 _fake_docker_service = types.ModuleType("services.docker_service")
 _fake_docker_service.list_all_agents_fast = MagicMock(return_value=[])
+# #1264: github_pat_propagation_service now imports get_agent_container at module
+# top, so the stub must expose it for the fresh module load to succeed.
+_fake_docker_service.get_agent_container = MagicMock(return_value=None)
 sys.modules["services.docker_service"] = _fake_docker_service
 
 

--- a/tests/unit/test_1264_per_agent_pat_propagation.py
+++ b/tests/unit/test_1264_per_agent_pat_propagation.py
@@ -1,0 +1,166 @@
+"""Tests for #1264 — per-agent GitHub PAT propagation to existing containers.
+
+Covers the decision logic added so a per-agent PAT configured AFTER a (possibly
+tokenless) container was created actually reaches the container:
+
+  * github_pat_propagation_service._patch_env_github_pat — ADDS the GITHUB_PAT
+    line when the .env lacks it (the tokenless-container case), replaces when present.
+  * github_pat_propagation_service.propagate_pat_to_single_agent — short-circuits
+    for a stopped agent; on a running agent injects .env + re-templates the remote.
+  * agent_service.check_github_pat_env_matches — a tokenless container that
+    now has an effective PAT + git config reports a mismatch (recreate needed).
+
+Service-level unit tests; rely on the repo conftest for the REDIS_URL stub.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+# Bind the REAL modules/callables at import time. This file collects before the
+# siblings that replace services.agent_service.* with MagicMocks in sys.modules
+# (test_start_agent_skip_inject, test_inject_assigned_credentials), so these
+# references stay valid even after that pollution. Use these bound names in the
+# tests rather than re-importing (which would pick up the mocks at run time).
+import services.agent_service.helpers as helpers_mod          # noqa: E402
+import services.github_pat_propagation_service as svc          # noqa: E402
+import routers.git as gitmod                                   # noqa: E402
+from services import git_service                               # noqa: E402
+
+check_github_pat_env_matches = helpers_mod.check_github_pat_env_matches
+_patch_env_github_pat = svc._patch_env_github_pat
+_env_has_github_pat = svc._env_has_github_pat
+propagate_pat_to_single_agent = svc.propagate_pat_to_single_agent
+
+
+# ---------------------------------------------------------------------------
+# _patch_env_github_pat — add-if-missing (the #1264 tokenless case)
+# ---------------------------------------------------------------------------
+
+def test_patch_adds_github_pat_line_when_missing():
+    env = "ANTHROPIC_API_KEY=\"sk-x\"\nFOO=bar\n"
+    out = _patch_env_github_pat(env, "ghp_token")
+    assert _env_has_github_pat(out)
+    assert 'GITHUB_PAT="ghp_token"' in out
+    # original lines preserved
+    assert "FOO=bar" in out
+
+
+def test_patch_replaces_existing_github_pat_line():
+    env = 'GITHUB_PAT="old"\nFOO=bar\n'
+    out = _patch_env_github_pat(env, "newtok")
+    assert "newtok" in out and "old" not in out
+    assert out.count("GITHUB_PAT=") == 1
+
+
+# ---------------------------------------------------------------------------
+# propagate_pat_to_single_agent
+# ---------------------------------------------------------------------------
+
+def test_propagate_single_agent_stopped_short_circuits(monkeypatch):
+    class _A:
+        def __init__(self, name, status):
+            self.name, self.status = name, status
+
+    monkeypatch.setattr(svc, "list_all_agents_fast", lambda: [_A("a1", "stopped")])
+    res = asyncio.run(svc.propagate_pat_to_single_agent("a1", "ghp_x"))
+    assert res == {"applied": False, "reason": "agent_not_running"}
+
+
+def test_propagate_single_agent_running_injects_and_retemplates(monkeypatch):
+    class _A:
+        def __init__(self, name, status):
+            self.name, self.status = name, status
+
+    monkeypatch.setattr(svc, "list_all_agents_fast", lambda: [_A("a1", "running")])
+
+    # Fake the agent-server .env read/inject HTTP round-trip.
+    class _Resp:
+        def __init__(self, payload=None):
+            self._p = payload or {}
+        def raise_for_status(self):
+            return None
+        def json(self):
+            return self._p
+
+    injected = {}
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def get(self, url, params=None):
+            return _Resp({"files": {".env": "FOO=bar\n"}})
+        async def post(self, url, json=None):
+            injected["env"] = json["files"][".env"]
+            return _Resp()
+
+    monkeypatch.setattr(svc.httpx, "AsyncClient", _Client)
+
+    # git config present → remote re-template attempted; stub it.
+    monkeypatch.setattr(svc.db, "get_git_config",
+                        lambda n: type("G", (), {"github_repo": "org/repo"})())
+    called = {}
+    async def _fake_update(agent_name, pat, repo):
+        called.update(agent=agent_name, pat=pat, repo=repo)
+        return True
+    monkeypatch.setattr(git_service, "update_remote_pat", _fake_update)
+
+    res = asyncio.run(svc.propagate_pat_to_single_agent("a1", "ghp_tok"))
+
+    assert res["applied"] is True
+    assert res["env_updated"] is True
+    assert res["remote_updated"] is True
+    assert 'GITHUB_PAT="ghp_tok"' in injected["env"]      # added to the tokenless .env
+    assert called == {"agent": "a1", "pat": "ghp_tok", "repo": "org/repo"}
+
+
+# ---------------------------------------------------------------------------
+# check_github_pat_env_matches — recreate decision
+# ---------------------------------------------------------------------------
+
+def _fake_container(env_lines):
+    class _C:
+        attrs = {"Config": {"Env": env_lines}}
+    return _C()
+
+
+def test_tokenless_container_with_pat_and_git_needs_recreate(monkeypatch):
+    monkeypatch.setattr(gitmod, "get_github_pat_for_agent", lambda n: "ghp_xyz")
+    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: object())  # git configured
+    # container has no GITHUB_PAT in env
+    assert check_github_pat_env_matches(_fake_container(["FOO=bar"]), "a1") is False
+
+
+def test_tokenless_container_without_git_no_recreate(monkeypatch):
+    monkeypatch.setattr(gitmod, "get_github_pat_for_agent", lambda n: "ghp_xyz")
+    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: None)  # no git sync
+    assert check_github_pat_env_matches(_fake_container(["FOO=bar"]), "a1") is True
+
+
+def test_tokenless_container_no_pat_anywhere_no_recreate(monkeypatch):
+    monkeypatch.setattr(gitmod, "get_github_pat_for_agent", lambda n: "")
+    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: object())
+    assert check_github_pat_env_matches(_fake_container(["FOO=bar"]), "a1") is True
+
+
+def test_existing_pat_match_and_mismatch_preserved(monkeypatch):
+    monkeypatch.setattr(gitmod, "get_github_pat_for_agent", lambda n: "ghp_current")
+    # matching → True (no recreate)
+    assert check_github_pat_env_matches(
+        _fake_container(["GITHUB_PAT=ghp_current"]), "a1") is True
+    # stale → False (recreate)
+    assert check_github_pat_env_matches(
+        _fake_container(["GITHUB_PAT=ghp_old"]), "a1") is False

--- a/tests/unit/test_1264_per_agent_pat_propagation.py
+++ b/tests/unit/test_1264_per_agent_pat_propagation.py
@@ -26,11 +26,9 @@ while _BACKEND_STR in sys.path:
     sys.path.remove(_BACKEND_STR)
 sys.path.insert(0, _BACKEND_STR)
 
-# Bind the REAL modules/callables at import time. This file collects before the
-# siblings that replace services.agent_service.* with MagicMocks in sys.modules
-# (test_start_agent_skip_inject, test_inject_assigned_credentials), so these
-# references stay valid even after that pollution. Use these bound names in the
-# tests rather than re-importing (which would pick up the mocks at run time).
+# Bind the real modules/callables at import time and use these bound names in the
+# tests rather than re-importing (which could pick up a sibling's sys.modules stub
+# at run time). Imported at module top so they resolve before any per-test state.
 import services.agent_service.helpers as helpers_mod          # noqa: E402
 import services.github_pat_propagation_service as svc          # noqa: E402
 import routers.git as gitmod                                   # noqa: E402
@@ -40,6 +38,17 @@ check_github_pat_env_matches = helpers_mod.check_github_pat_env_matches
 _patch_env_github_pat = svc._patch_env_github_pat
 _env_has_github_pat = svc._env_has_github_pat
 propagate_pat_to_single_agent = svc.propagate_pat_to_single_agent
+
+
+def _patch_get_agent_container(monkeypatch, fn):
+    """Patch get_agent_container on the LIVE services.docker_service module.
+
+    The function under test resolves `from services.docker_service import
+    get_agent_container` at call time; a sibling test may have swapped
+    services.docker_service for a MagicMock in sys.modules, so we must patch the
+    current module object (string target), not a collection-time reference.
+    """
+    monkeypatch.setattr("services.docker_service.get_agent_container", fn, raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -66,22 +75,25 @@ def test_patch_replaces_existing_github_pat_line():
 # propagate_pat_to_single_agent
 # ---------------------------------------------------------------------------
 
-def test_propagate_single_agent_stopped_short_circuits(monkeypatch):
-    class _A:
-        def __init__(self, name, status):
-            self.name, self.status = name, status
+class _Container:
+    def __init__(self, status):
+        self.status = status
 
-    monkeypatch.setattr(svc, "list_all_agents_fast", lambda: [_A("a1", "stopped")])
+
+def test_propagate_single_agent_stopped_short_circuits(monkeypatch):
+    _patch_get_agent_container(monkeypatch, lambda n: _Container("exited"))
+    res = asyncio.run(svc.propagate_pat_to_single_agent("a1", "ghp_x"))
+    assert res == {"applied": False, "reason": "agent_not_running"}
+
+
+def test_propagate_single_agent_missing_container_short_circuits(monkeypatch):
+    _patch_get_agent_container(monkeypatch, lambda n: None)
     res = asyncio.run(svc.propagate_pat_to_single_agent("a1", "ghp_x"))
     assert res == {"applied": False, "reason": "agent_not_running"}
 
 
 def test_propagate_single_agent_running_injects_and_retemplates(monkeypatch):
-    class _A:
-        def __init__(self, name, status):
-            self.name, self.status = name, status
-
-    monkeypatch.setattr(svc, "list_all_agents_fast", lambda: [_A("a1", "running")])
+    _patch_get_agent_container(monkeypatch, lambda n: _Container("running"))
 
     # Fake the agent-server .env read/inject HTTP round-trip.
     class _Resp:
@@ -101,9 +113,9 @@ def test_propagate_single_agent_running_injects_and_retemplates(monkeypatch):
             return self
         async def __aexit__(self, *a):
             return False
-        async def get(self, url, params=None):
+        async def get(self, url, params=None, timeout=None):
             return _Resp({"files": {".env": "FOO=bar\n"}})
-        async def post(self, url, json=None):
+        async def post(self, url, json=None, timeout=None):
             injected["env"] = json["files"][".env"]
             return _Resp()
 
@@ -137,22 +149,23 @@ def _fake_container(env_lines):
     return _C()
 
 
-def test_tokenless_container_with_pat_and_git_needs_recreate(monkeypatch):
-    monkeypatch.setattr(gitmod, "get_github_pat_for_agent", lambda n: "ghp_xyz")
+def test_tokenless_container_with_per_agent_pat_and_git_needs_recreate(monkeypatch):
+    # #1264 review: tokenless recreate keys on the PER-AGENT PAT, not the global fallback.
+    monkeypatch.setattr(helpers_mod.db, "get_agent_github_pat", lambda n: "ghp_peragent")
     monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: object())  # git configured
-    # container has no GITHUB_PAT in env
     assert check_github_pat_env_matches(_fake_container(["FOO=bar"]), "a1") is False
 
 
-def test_tokenless_container_without_git_no_recreate(monkeypatch):
-    monkeypatch.setattr(gitmod, "get_github_pat_for_agent", lambda n: "ghp_xyz")
-    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: None)  # no git sync
+def test_tokenless_container_global_pat_only_no_recreate(monkeypatch):
+    # No per-agent PAT (only a global one would resolve) → must NOT force a recreate.
+    monkeypatch.setattr(helpers_mod.db, "get_agent_github_pat", lambda n: None)
+    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: object())
     assert check_github_pat_env_matches(_fake_container(["FOO=bar"]), "a1") is True
 
 
-def test_tokenless_container_no_pat_anywhere_no_recreate(monkeypatch):
-    monkeypatch.setattr(gitmod, "get_github_pat_for_agent", lambda n: "")
-    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: object())
+def test_tokenless_container_without_git_no_recreate(monkeypatch):
+    monkeypatch.setattr(helpers_mod.db, "get_agent_github_pat", lambda n: "ghp_peragent")
+    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: None)  # no git sync
     assert check_github_pat_env_matches(_fake_container(["FOO=bar"]), "a1") is True
 
 
@@ -164,3 +177,17 @@ def test_existing_pat_match_and_mismatch_preserved(monkeypatch):
     # stale → False (recreate)
     assert check_github_pat_env_matches(
         _fake_container(["GITHUB_PAT=ghp_old"]), "a1") is False
+
+
+def test_needs_per_agent_pat_injection_predicate(monkeypatch):
+    # The shared gate matcher and lifecycle both use — per-agent PAT AND git config.
+    monkeypatch.setattr(helpers_mod.db, "get_agent_github_pat", lambda n: "ghp_p")
+    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: object())
+    assert helpers_mod.needs_per_agent_pat_injection("a1") is True
+
+    monkeypatch.setattr(helpers_mod.db, "get_agent_github_pat", lambda n: None)
+    assert helpers_mod.needs_per_agent_pat_injection("a1") is False
+
+    monkeypatch.setattr(helpers_mod.db, "get_agent_github_pat", lambda n: "ghp_p")
+    monkeypatch.setattr(helpers_mod.db, "get_git_config", lambda n: None)
+    assert helpers_mod.needs_per_agent_pat_injection("a1") is False

--- a/tests/unit/test_1264_per_agent_pat_propagation.py
+++ b/tests/unit/test_1264_per_agent_pat_propagation.py
@@ -41,14 +41,11 @@ propagate_pat_to_single_agent = svc.propagate_pat_to_single_agent
 
 
 def _patch_get_agent_container(monkeypatch, fn):
-    """Patch get_agent_container on the LIVE services.docker_service module.
-
-    The function under test resolves `from services.docker_service import
-    get_agent_container` at call time; a sibling test may have swapped
-    services.docker_service for a MagicMock in sys.modules, so we must patch the
-    current module object (string target), not a collection-time reference.
-    """
-    monkeypatch.setattr("services.docker_service.get_agent_container", fn, raising=False)
+    """Patch get_agent_container as a module global on the bound propagation
+    service. It's imported at that module's top, so the function closes over this
+    global — patching it here is robust to sibling sys.modules pollution (no
+    call-time `from services.docker_service import …` resolution to race)."""
+    monkeypatch.setattr(svc, "get_agent_container", fn)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_1264_per_agent_pat_propagation.py
+++ b/tests/unit/test_1264_per_agent_pat_propagation.py
@@ -93,49 +93,33 @@ def test_propagate_single_agent_missing_container_short_circuits(monkeypatch):
 
 
 def test_propagate_single_agent_running_injects_and_retemplates(monkeypatch):
+    # Patch at the seams the function owns, robust to sibling sys.modules
+    # pollution: get_agent_container + git_service.update_remote_pat via the LIVE
+    # module (string target, resolved at call time), and _apply_pat_to_env / db on
+    # the bound svc module (the function closes over svc's own globals). Mocking
+    # _apply_pat_to_env avoids a fragile httpx client double.
     _patch_get_agent_container(monkeypatch, lambda n: _Container("running"))
 
-    # Fake the agent-server .env read/inject HTTP round-trip.
-    class _Resp:
-        def __init__(self, payload=None):
-            self._p = payload or {}
-        def raise_for_status(self):
-            return None
-        def json(self):
-            return self._p
+    apply_calls = {}
+    async def _fake_apply(client, base_url, pat, *, add_if_missing):
+        apply_calls.update(pat=pat, add_if_missing=add_if_missing)
+        return "updated"
+    monkeypatch.setattr(svc, "_apply_pat_to_env", _fake_apply)
 
-    injected = {}
-
-    class _Client:
-        def __init__(self, *a, **k):
-            pass
-        async def __aenter__(self):
-            return self
-        async def __aexit__(self, *a):
-            return False
-        async def get(self, url, params=None, timeout=None):
-            return _Resp({"files": {".env": "FOO=bar\n"}})
-        async def post(self, url, json=None, timeout=None):
-            injected["env"] = json["files"][".env"]
-            return _Resp()
-
-    monkeypatch.setattr(svc.httpx, "AsyncClient", _Client)
-
-    # git config present → remote re-template attempted; stub it.
     monkeypatch.setattr(svc.db, "get_git_config",
                         lambda n: type("G", (), {"github_repo": "org/repo"})())
     called = {}
     async def _fake_update(agent_name, pat, repo):
         called.update(agent=agent_name, pat=pat, repo=repo)
         return True
-    monkeypatch.setattr(git_service, "update_remote_pat", _fake_update)
+    monkeypatch.setattr("services.git_service.update_remote_pat", _fake_update, raising=False)
 
     res = asyncio.run(svc.propagate_pat_to_single_agent("a1", "ghp_tok"))
 
     assert res["applied"] is True
     assert res["env_updated"] is True
     assert res["remote_updated"] is True
-    assert 'GITHUB_PAT="ghp_tok"' in injected["env"]      # added to the tokenless .env
+    assert apply_calls == {"pat": "ghp_tok", "add_if_missing": True}
     assert called == {"agent": "a1", "pat": "ghp_tok", "repo": "org/repo"}
 
 


### PR DESCRIPTION
## Summary

Fixes #1264 — a per-agent GitHub PAT (#347) configured **after** an agent's container/git was set up never reached the container. The remote stayed templated with an empty password (`https://x-access-token:@github.com/...`), every `fetch`/`push` failed, and the endpoint's "restart the agent" advice was a no-op. Affected agents silently accumulated 100+ unpushed commits with `last_sync_status: "never"`.

## Key insight

`startup.sh` **already** re-templates `origin` from `GITHUB_PAT` on every start (`git remote set-url`). So the whole bug reduces to one thing: **get the PAT into the container env**. Three paths failed to do that — this PR fixes all three.

## Changes

| Path | Before | After |
|------|--------|-------|
| `set_agent_github_pat` (`routers/git.py`) | stored PAT, returned "restart agent" (no-op) | **live propagation, no restart**: `propagate_pat_to_single_agent` injects `GITHUB_PAT` into the running container's `.env` (adding the line when absent — the tokenless case the global-PAT path skips) + re-templates the live remote; note reflects the real outcome |
| lifecycle recreate (`lifecycle.py:385`) | `if env_vars.get('GITHUB_PAT')` — skipped tokenless containers forever | gate on `db.get_git_config(agent_name)` so a later-configured PAT is injected on restart; startup.sh then fixes the remote |
| `check_github_pat_env_matches` (`helpers.py`) | tokenless container → "no update needed" | tokenless **+ effective PAT + git configured** → mismatch (recreate re-injects) |

New `git_service.update_remote_pat` reuses the proven init `set-url`/`add` pattern + `_git_remote_url`; best-effort (stopped / no-git agents fall back to the restart path, now fixed).

## Testing

- `tests/unit/test_1264_per_agent_pat_propagation.py` (8): `.env` add-if-missing, single-agent propagation (stopped short-circuit + running inject/re-template with mocked agent HTTP), and the recreate-decision matrix.
- 45 pass across the PAT suites including the `sys.modules`-mocking siblings (`test_start_agent_skip_inject`, `test_inject_assigned_credentials`) in CI collection order. The lifecycle static-callsite check (`test_github_pat_fallback`) still passes.

**Not covered by unit tests** (flagged for reviewers): the end-to-end against a real GitHub repo/PAT (live `.env` inject + in-container `git remote set-url` → successful push). The container I/O reuses the already-proven `initialize_github_sync` primitives and the existing `startup.sh` self-heal, but a manual verification on a real GitHub-native agent is worthwhile before release.

Related to #1264