### PR TITLE
test: fix Group A deterministic test-suite failures (#1260)

### DIFF
--- a/tests/git-sync/test_s7_reserve_instance_id.py
+++ b/tests/git-sync/test_s7_reserve_instance_id.py
@@ -28,6 +28,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
+import sqlalchemy.exc as sa_exc
+
 import pytest
 
 
@@ -387,8 +389,18 @@ class TestReserveAndGenerateInstanceId:
             def create_git_config(self, *args, **kwargs):
                 calls["inserts"] += 1
                 if calls["inserts"] == 1:
-                    raise sqlite3.IntegrityError(
-                        "UNIQUE constraint failed: idx_git_config_repo_branch_unique"
+                    # #1260: production (db.create_git_config) goes through the
+                    # SQLAlchemy engine, so a unique-constraint violation surfaces
+                    # as sqlalchemy.exc.IntegrityError (wrapping the sqlite3 one) —
+                    # which is exactly what reserve_and_generate_instance_id
+                    # catches (#300). Raising the bare sqlite3 error never tripped
+                    # the retry path.
+                    raise sa_exc.IntegrityError(
+                        "INSERT INTO agent_git_config ...",
+                        {},
+                        sqlite3.IntegrityError(
+                            "UNIQUE constraint failed: idx_git_config_repo_branch_unique"
+                        ),
                     )
                 self.created.append(kwargs)
                 return types.SimpleNamespace(**kwargs)

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -441,8 +441,11 @@ class TestTimelineForDashboard:
         assert_status(response, 200)
         activities = response.json().get("activities", [])
 
-        # Valid trigger types for Dashboard color coding
-        valid_triggers = {"schedule", "agent", "manual", "user", "mcp", "public", "fan_out", None}
+        # Valid trigger types for Dashboard color coding.
+        # #1260: include "loop" (#740/#1150) and "voip" (#1056) — real trigger
+        # values added after this test was written.
+        valid_triggers = {"schedule", "agent", "manual", "user", "mcp", "public",
+                          "fan_out", "loop", "voip", None}
 
         for activity in activities:
             triggered_by = activity.get("triggered_by")

--- a/tests/test_cb_probe_execution_close.py
+++ b/tests/test_cb_probe_execution_close.py
@@ -56,9 +56,13 @@ def _install_sanitizer_stub() -> None:
     sanitizer.sanitize_text = lambda x: x
     sanitizer.sanitize_dict = lambda x: x
     sys.modules["utils.credential_sanitizer"] = sanitizer
+    return sanitizer
 
 
-_install_sanitizer_stub()
+# Keep a module-level handle to the complete stub so the autouse fixture can
+# re-assert it after cross-file pollution (#1260: previously referenced an
+# unbound `_sanitizer_mod`, raising NameError at setup for all tests here).
+_sanitizer_mod = _install_sanitizer_stub()
 
 sys.modules.setdefault("database", MagicMock())
 

--- a/tests/test_platform_default_model.py
+++ b/tests/test_platform_default_model.py
@@ -59,7 +59,7 @@ class TestGetPlatformDefaultModelUnit:
         sys.modules.pop("services.settings_service", None)
 
         import importlib
-        import src.backend.services.settings_service as svc_module
+        import services.settings_service as svc_module
         importlib.reload(svc_module)
 
         svc = svc_module.SettingsService()
@@ -81,7 +81,7 @@ class TestGetPlatformDefaultModelUnit:
         sys.modules.pop("services.settings_service", None)
 
         import importlib
-        import src.backend.services.settings_service as svc_module
+        import services.settings_service as svc_module
         importlib.reload(svc_module)
 
         svc = svc_module.SettingsService()
@@ -106,7 +106,7 @@ class TestGetPlatformDefaultModelUnit:
         sys.modules.pop("services.settings_service", None)
 
         import importlib
-        import src.backend.services.settings_service as svc_module
+        import services.settings_service as svc_module
         importlib.reload(svc_module)
 
         svc = svc_module.SettingsService()


### PR DESCRIPTION
## Summary

Fixes the **Group A** (deterministic, clearly test-side) failures from #1260. No product changes — these are fixture/import/stale-assertion bugs.

| Item | File | Fix |
|------|------|-----|
| A1 | `test_cb_probe_execution_close.py` | `_restore_complete_stubs` referenced an unbound `_sanitizer_mod` → `NameError` at setup for all 10 tests. Bind it module-level from `_install_sanitizer_stub()` (now returns the stub). |
| A2 | `tests/git-sync/test_s7_reserve_instance_id.py` | `_FlakyDb` raised `sqlite3.IntegrityError`, but `reserve_and_generate_instance_id` catches `sqlalchemy.exc.IntegrityError` (db goes through the SQLAlchemy engine, #300) so the retry never fired. Raise `sqlalchemy.exc.IntegrityError` wrapping the sqlite3 one. **Verify-first done:** `db.create_git_config` uses `get_engine().begin()`, so the wrapped exception is what escapes — prod's `except` is correct, not widened. |
| A3 | `test_platform_default_model.py` | `import src.backend.services.settings_service` → `import services.settings_service` (package-relative; `ModuleNotFoundError: 'src'` when run from `tests/`). |
| A4 | `test_activities.py` | Timeline trigger-value set now includes `loop` (#740/#1150) and `voip` (#1056). |
| A5 | lint baseline | **Already green on `dev`** (216/237, no new violations) — no change needed. |

## Validation
- A2 retry test (`test_db_insert_failure_triggers_retry`): **passes**.
- A1 / A3: collect clean — `NameError` and `ModuleNotFoundError` gone (the remaining `ConnectError`s are conftest fixtures needing a live backend, the out-of-scope harness issue noted in #1260, run in CI against the live stack).
- `lint_sys_modules` green.

Scope: Group A only (deterministic). Groups B (env-coupled), C (isolation), D (flaky) intentionally left for follow-up.

Related to #1260