### PR TITLE
fix(auth): default-deny public self-signup on /api/access/request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ ANTHROPIC_API_KEY=
 # Users enter email → receive 6-digit code → login
 # Whitelist emails in Settings → Email Whitelist
 
+# Public self-signup (trinity-enterprise#10) — DISABLED by default (secure).
+# When false, POST /api/access/request returns 403 and never auto-whitelists,
+# so the email whitelist stays authoritative. Set to true ONLY if you want
+# frictionless CLI onboarding (`trinity:connect`) where anyone who can reach
+# the backend can add their own email to the login whitelist.
+PUBLIC_ACCESS_REQUESTS_ENABLED=false
+
 # Email service provider: console (dev), smtp, sendgrid, resend
 EMAIL_PROVIDER=console
 

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1418,6 +1418,7 @@ CREATE INDEX idx_idempotency_created ON idempotency_keys(created_at);
 - Email whitelist controls who can login via email; admin login always available for 'admin'.
 - **4-tier role hierarchy** (ROLE-001): `user` < `operator` < `creator` < `admin`. Agent creation requires `creator`+. Enforced via `require_role()` in `dependencies.py`.
 - **Whitelist-driven role on first login** (#314): new email users inherit the `default_role` on their `email_whitelist` row (fallback `user`). Callsites pass explicit intent — `/share` and access-request approvals → `user` (chat-only grant); public `/api/access/request` self-signup → `user`; admin whitelist UI → caller-specified. Owners promote collaborators explicitly via `PUT /api/users/{username}/role`. Closes a privilege escalation where any access grant silently promoted the recipient to `creator`.
+- **Public self-signup is default-OFF** (trinity-enterprise#10): the unauthenticated `POST /api/access/request` returns **403** unless an operator opts in via `PUBLIC_ACCESS_REQUESTS_ENABLED` (env) or the `public_access_requests_enabled` system setting. When off it never auto-whitelists, so the email whitelist stays authoritative against self-enrollment. Login-code requests for already-whitelisted emails are unaffected.
 
 ### 2. MCP API Keys (User → MCP Server)
 

--- a/docs/memory/feature-flows/cli-tool.md
+++ b/docs/memory/feature-flows/cli-tool.md
@@ -68,7 +68,7 @@ User runs `trinity init [--profile name]`
   → If unreachable: prompt for new URL (up to 3 attempts)
   → Derive profile name from hostname (or use --profile)
   → Prompt: email
-  → POST /api/access/request {email}     ← NEW ENDPOINT (auto-whitelist)
+  → POST /api/access/request {email}     ← self-signup (403 unless operator enabled it; ent#10)
   → POST /api/auth/email/request {email} ← existing email auth
   → Prompt: 6-digit code
   → POST /api/auth/email/verify {email, code}
@@ -114,13 +114,15 @@ Instance URL:
 
 ```
 Request:  {"email": "user@example.com"}
-Response: {"success": true, "message": "Access granted", "already_registered": false}
+Response: {"success": true, "message": "Email added to the access whitelist", "already_registered": false}
 ```
 
-- Auto-adds email to whitelist via `db.add_to_whitelist(email, added_by="admin", source="cli", default_role="user")` — #314 defaults public self-signup to `user`; owners promote via `PUT /api/users/{username}/role`.
+- **Disabled by default** (trinity-enterprise#10, secure default): returns **403** unless the operator opts in via `PUBLIC_ACCESS_REQUESTS_ENABLED=true` (env) or the `public_access_requests_enabled` system setting. When off it does NOT whitelist — the email whitelist stays authoritative against self-enrollment. `trinity:connect` frictionless onboarding requires the operator to enable this flag.
+- When enabled, auto-adds email to whitelist via `db.add_to_whitelist(email, added_by="admin", source="cli", default_role="user")` — #314 defaults public self-signup to `user`; owners promote via `PUT /api/users/{username}/role`.
 - Idempotent: returns `already_registered: true` if exists
 - Rate limited: reuses `check_login_rate_limit(client_ip)` — 5 req / 10 min per IP
-- Requires: setup completed, email auth enabled
+- Requires: setup completed, email auth enabled, **and** self-signup flag enabled
+- Login-code requests for already-whitelisted emails (`POST /api/auth/email/request`) are unaffected by the flag.
 
 ## HTTP Client
 

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -10,6 +10,14 @@ from urllib.parse import urlparse
 # Can also be set via system_settings table (key: "email_auth_enabled", value: "true"/"false")
 EMAIL_AUTH_ENABLED = os.getenv("EMAIL_AUTH_ENABLED", "true").lower() == "true"
 
+# Public self-signup gate (trinity-enterprise#10). When OFF (the secure
+# default), the unauthenticated POST /api/access/request endpoint returns 403 —
+# it does NOT auto-whitelist arbitrary emails. Operators who want frictionless
+# CLI onboarding (`trinity:connect`) opt in explicitly via this env var or the
+# system_settings key "public_access_requests_enabled". Does not affect login
+# code requests for already-whitelisted emails (separate endpoint).
+PUBLIC_ACCESS_REQUESTS_ENABLED = os.getenv("PUBLIC_ACCESS_REQUESTS_ENABLED", "false").lower() == "true"
+
 # JWT Settings
 # SECURITY: SECRET_KEY must be set via environment variable in production
 # Generate with: openssl rand -hex 32

--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -16,6 +16,7 @@ from config import (
     ALGORITHM,
     ACCESS_TOKEN_EXPIRE_MINUTES,
     EMAIL_AUTH_ENABLED,
+    PUBLIC_ACCESS_REQUESTS_ENABLED,
     REDIS_URL,
 )
 from database import db
@@ -547,10 +548,17 @@ async def verify_email_login_code(request: Request):
 @router.post("/api/access/request")
 async def request_access(request: Request):
     """
-    Request access to this Trinity instance.
+    Public self-signup for this Trinity instance (CLI onboarding).
 
-    Unauthenticated endpoint. Auto-approves the email by adding it to the
-    whitelist. Idempotent — returns success if already whitelisted.
+    Unauthenticated. **Disabled by default** (trinity-enterprise#10): when the
+    `public_access_requests_enabled` setting / `PUBLIC_ACCESS_REQUESTS_ENABLED`
+    env is not explicitly enabled, this returns 403 and does NOT whitelist the
+    email — the email whitelist stays authoritative against self-enrollment.
+    When an operator opts in, the submitted email is auto-added to the login
+    whitelist (role `user`) for frictionless onboarding. Idempotent.
+
+    This does not affect login-code requests for already-whitelisted emails
+    (POST /api/auth/email/request), which remain available regardless of the flag.
 
     Rate limit: 5 requests per 10 minutes per IP.
     """
@@ -559,6 +567,20 @@ async def request_access(request: Request):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="setup_required"
+        )
+
+    # Secure default (trinity-enterprise#10): public self-signup is OFF unless the
+    # operator explicitly enables it. Env default via PUBLIC_ACCESS_REQUESTS_ENABLED;
+    # overridable at runtime via the system_settings key. When off, do NOT
+    # auto-whitelist — return 403 so the whitelist remains the real access gate.
+    self_signup_setting = db.get_setting_value(
+        "public_access_requests_enabled", str(PUBLIC_ACCESS_REQUESTS_ENABLED).lower()
+    )
+    if self_signup_setting.lower() != "true":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Public access requests are disabled on this instance. "
+                   "Ask an administrator to add your email to the whitelist."
         )
 
     # Check if email auth is enabled (access request only makes sense with email auth)
@@ -585,7 +607,7 @@ async def request_access(request: Request):
     # Auto-approve: add to whitelist if not already present
     if db.is_email_whitelisted(email):
         record_login_attempt(client_ip, success=True)
-        return {"success": True, "message": "Access granted", "already_registered": True}
+        return {"success": True, "message": "Email already on the access whitelist", "already_registered": True}
 
     try:
         # Public self-signup — default to `user`. Owners who want a collaborator
@@ -601,5 +623,5 @@ async def request_access(request: Request):
         )
 
     record_login_attempt(client_ip, success=True)
-    logger.info(f"CLI access granted: {email}")
-    return {"success": True, "message": "Access granted", "already_registered": False}
+    logger.info(f"CLI self-signup (operator-enabled): {email} added to access whitelist")
+    return {"success": True, "message": "Email added to the access whitelist", "already_registered": False}

--- a/tests/test_cli_access_request.py
+++ b/tests/test_cli_access_request.py
@@ -2,7 +2,12 @@
 CLI Access Request Tests (test_cli_access_request.py)
 
 Tests for the POST /api/access/request endpoint (CLI-002).
-Auto-approve whitelist registration for CLI onboarding.
+
+trinity-enterprise#10: public self-signup is now DISABLED by default (secure
+default). The endpoint returns 403 unless an operator explicitly enables it via
+the `public_access_requests_enabled` system setting / env. These tests cover
+both states: the default-closed gate, and the operator-enabled auto-whitelist
+behaviour (toggled per-test via the admin settings endpoint and restored).
 
 FAST TESTS - No agent creation required.
 """
@@ -19,144 +24,127 @@ from utils.assertions import (
     assert_has_fields,
 )
 
+_SETTING_KEY = "public_access_requests_enabled"
+
 
 def _unique_email():
     """Generate a unique test email to avoid whitelist collisions."""
     return f"cli-test-{uuid.uuid4().hex[:8]}@example.com"
 
 
-class TestAccessRequestEndpoint:
-    """Tests for POST /api/access/request."""
+def _set_self_signup(api_client: TrinityApiClient, enabled: bool):
+    """Toggle the public-self-signup setting via the admin endpoint."""
+    return api_client.put(
+        f"/api/settings/{_SETTING_KEY}",
+        json={"value": "true" if enabled else "false"},
+    )
 
-    def test_access_request_grants_new_email(self, unauthenticated_client: TrinityApiClient):
-        """New email is auto-whitelisted and returns already_registered=False."""
+
+class TestAccessRequestDisabledByDefault:
+    """trinity-enterprise#10: default-closed gate must reject self-signup."""
+
+    def test_disabled_returns_403(self, api_client: TrinityApiClient,
+                                  unauthenticated_client: TrinityApiClient):
+        """With self-signup disabled, the endpoint returns 403 and does not whitelist."""
+        # Ensure the secure default is in effect for this instance.
+        if _set_self_signup(api_client, False).status_code != 200:
+            pytest.skip("Cannot toggle public_access_requests_enabled (admin endpoint unavailable)")
+
         email = _unique_email()
         response = unauthenticated_client.post(
             "/api/access/request",
             json={"email": email},
             auth=False,
         )
+        assert_status(response, 403)
 
+        # The email must NOT have been added to the whitelist (the actual gate;
+        # /api/auth/email/request 200s even for unknown emails to prevent
+        # enumeration, so we check the authoritative whitelist directly).
+        wl = api_client.get("/api/settings/email-whitelist")
+        if wl.status_code == 200:
+            data = wl.json()
+            entries = data if isinstance(data, list) else data.get("emails", [])
+            present = {
+                (e.get("email") if isinstance(e, dict) else e) for e in entries
+            }
+            assert email not in present, "Disabled self-signup must not whitelist the email"
+
+
+@pytest.fixture
+def self_signup_enabled(api_client: TrinityApiClient):
+    """Enable public self-signup for the duration of a test, then restore off."""
+    resp = _set_self_signup(api_client, True)
+    if resp.status_code != 200:
+        pytest.skip("Cannot toggle public_access_requests_enabled (admin endpoint unavailable)")
+    try:
+        yield
+    finally:
+        _set_self_signup(api_client, False)
+
+
+class TestAccessRequestEnabled:
+    """Operator-enabled frictionless self-signup (opt-in)."""
+
+    def test_access_request_grants_new_email(self, self_signup_enabled, unauthenticated_client: TrinityApiClient):
+        """New email is auto-whitelisted and returns already_registered=False."""
+        email = _unique_email()
+        response = unauthenticated_client.post(
+            "/api/access/request", json={"email": email}, auth=False,
+        )
         assert_status(response, 200)
         data = assert_json_response(response)
         assert_has_fields(data, ["success", "message", "already_registered"])
         assert data["success"] is True
         assert data["already_registered"] is False
 
-    def test_access_request_idempotent(self, unauthenticated_client: TrinityApiClient):
+    def test_access_request_idempotent(self, self_signup_enabled, unauthenticated_client: TrinityApiClient):
         """Calling twice for same email returns already_registered=True."""
         email = _unique_email()
-
-        # First call
-        unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": email},
-            auth=False,
-        )
-
-        # Second call
-        response = unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": email},
-            auth=False,
-        )
-
+        unauthenticated_client.post("/api/access/request", json={"email": email}, auth=False)
+        response = unauthenticated_client.post("/api/access/request", json={"email": email}, auth=False)
         assert_status(response, 200)
-        data = response.json()
-        assert data["success"] is True
-        assert data["already_registered"] is True
+        assert response.json()["already_registered"] is True
 
-    def test_access_request_missing_email(self, unauthenticated_client: TrinityApiClient):
-        """Missing email returns 400."""
-        response = unauthenticated_client.post(
-            "/api/access/request",
-            json={},
-            auth=False,
-        )
-
+    def test_access_request_missing_email(self, self_signup_enabled, unauthenticated_client: TrinityApiClient):
+        """Missing email returns 400 (validation runs once the gate is open)."""
+        response = unauthenticated_client.post("/api/access/request", json={}, auth=False)
         assert_status(response, 400)
 
-    def test_access_request_empty_email(self, unauthenticated_client: TrinityApiClient):
-        """Empty email returns 400."""
-        response = unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": ""},
-            auth=False,
-        )
-
-        assert_status(response, 400)
-
-    def test_access_request_invalid_email(self, unauthenticated_client: TrinityApiClient):
+    def test_access_request_invalid_email(self, self_signup_enabled, unauthenticated_client: TrinityApiClient):
         """Email without @ returns 400."""
         response = unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": "not-an-email"},
-            auth=False,
+            "/api/access/request", json={"email": "not-an-email"}, auth=False,
         )
-
         assert_status(response, 400)
 
-    def test_access_request_normalizes_email(self, unauthenticated_client: TrinityApiClient):
+    def test_access_request_normalizes_email(self, self_signup_enabled, unauthenticated_client: TrinityApiClient):
         """Email is lowercased — uppercase variant returns already_registered."""
         base = uuid.uuid4().hex[:8]
-        email_lower = f"cli-test-{base}@example.com"
-        email_upper = f"CLI-TEST-{base}@EXAMPLE.COM"
-
-        # Register lowercase
         unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": email_lower},
-            auth=False,
+            "/api/access/request", json={"email": f"cli-test-{base}@example.com"}, auth=False,
         )
-
-        # Check uppercase is recognized as same
         response = unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": email_upper},
-            auth=False,
+            "/api/access/request", json={"email": f"CLI-TEST-{base}@EXAMPLE.COM"}, auth=False,
         )
-
         assert_status(response, 200)
-        data = response.json()
-        assert data["already_registered"] is True
+        assert response.json()["already_registered"] is True
 
-    def test_access_request_response_fields(self, unauthenticated_client: TrinityApiClient):
+    def test_access_request_response_fields(self, self_signup_enabled, unauthenticated_client: TrinityApiClient):
         """Response has exactly the expected fields."""
         email = _unique_email()
-        response = unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": email},
-            auth=False,
-        )
-
+        response = unauthenticated_client.post("/api/access/request", json={"email": email}, auth=False)
         assert_status(response, 200)
-        data = response.json()
-        assert set(data.keys()) == {"success", "message", "already_registered"}
+        assert set(response.json().keys()) == {"success", "message", "already_registered"}
 
-    def test_access_request_whitelists_for_login(
-        self, unauthenticated_client: TrinityApiClient
-    ):
+    def test_access_request_whitelists_for_login(self, self_signup_enabled, unauthenticated_client: TrinityApiClient):
         """After access request, email can request a login code (proves whitelist works)."""
         email = _unique_email()
-
-        # Register
-        reg_response = unauthenticated_client.post(
-            "/api/access/request",
-            json={"email": email},
-            auth=False,
-        )
-        assert_status(reg_response, 200)
-
-        # Now request login code — should succeed (not silently fail)
-        login_response = unauthenticated_client.post(
-            "/api/auth/email/request",
-            json={"email": email},
-            auth=False,
-        )
-
-        assert_status(login_response, 200)
-        data = login_response.json()
-        assert data["success"] is True
+        reg = unauthenticated_client.post("/api/access/request", json={"email": email}, auth=False)
+        assert_status(reg, 200)
+        login = unauthenticated_client.post("/api/auth/email/request", json={"email": email}, auth=False)
+        assert_status(login, 200)
+        assert login.json()["success"] is True
 
 
 class TestAccessRequestCleanup:
@@ -164,7 +152,9 @@ class TestAccessRequestCleanup:
 
     def test_cleanup_test_emails(self, api_client: TrinityApiClient):
         """Remove any cli-test-* emails from whitelist (best-effort cleanup)."""
-        # List whitelist
+        # Ensure self-signup is left disabled after the suite.
+        _set_self_signup(api_client, False)
+
         response = api_client.get("/api/settings/email-whitelist")
         if response.status_code != 200:
             pytest.skip("Cannot access whitelist endpoint")

--- a/tests/unit/test_ent10_access_request_gate.py
+++ b/tests/unit/test_ent10_access_request_gate.py
@@ -1,0 +1,101 @@
+"""Offline unit test for the public self-signup gate (trinity-enterprise#10).
+
+Exercises routers.auth.request_access directly with a stubbed db + fake Request,
+so it runs without a live backend. Asserts the secure default (403 when the
+`public_access_requests_enabled` setting is off, with NO whitelist write) and
+the operator-enabled path (auto-whitelist).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import routers.auth as auth  # noqa: E402
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+        self.client = type("C", (), {"host": "1.2.3.4"})()
+
+    async def json(self):
+        return self._payload
+
+
+class _FakeDb:
+    def __init__(self, *, self_signup, whitelisted=False):
+        self._self_signup = self_signup
+        self._whitelisted = whitelisted
+        self.added = []
+
+    def get_setting_value(self, key, default=None):
+        if key == "setup_completed":
+            return "true"
+        if key == "email_auth_enabled":
+            return "true"
+        if key == "public_access_requests_enabled":
+            return "true" if self._self_signup else "false"
+        return default
+
+    def is_email_whitelisted(self, email):
+        return self._whitelisted
+
+    def add_to_whitelist(self, email, **kwargs):
+        self.added.append((email, kwargs))
+
+
+@pytest.fixture(autouse=True)
+def _patch_auth(monkeypatch):
+    # No-op the rate-limit side effects so the handler is pure-logic here.
+    monkeypatch.setattr(auth, "check_login_rate_limit", lambda ip: None, raising=False)
+    monkeypatch.setattr(auth, "record_login_attempt", lambda ip, success: None, raising=False)
+
+
+def test_self_signup_disabled_returns_403_and_does_not_whitelist(monkeypatch):
+    fake_db = _FakeDb(self_signup=False)
+    monkeypatch.setattr(auth, "db", fake_db)
+
+    with pytest.raises(auth.HTTPException) as exc:
+        asyncio.run(auth.request_access(_FakeRequest({"email": "evil@example.com"})))
+
+    assert exc.value.status_code == 403
+    assert fake_db.added == [], "disabled self-signup must not whitelist anyone"
+
+
+def test_self_signup_enabled_whitelists_new_email(monkeypatch):
+    fake_db = _FakeDb(self_signup=True, whitelisted=False)
+    monkeypatch.setattr(auth, "db", fake_db)
+
+    result = asyncio.run(auth.request_access(_FakeRequest({"email": "Friend@Example.com"})))
+
+    assert result["success"] is True
+    assert result["already_registered"] is False
+    assert "granted" not in result["message"].lower()  # wording no longer claims an admin decision
+    assert fake_db.added and fake_db.added[0][0] == "friend@example.com"  # normalized
+    assert fake_db.added[0][1].get("default_role") == "user"  # #314: never creator
+
+
+def test_self_signup_enabled_idempotent_for_existing(monkeypatch):
+    fake_db = _FakeDb(self_signup=True, whitelisted=True)
+    monkeypatch.setattr(auth, "db", fake_db)
+
+    result = asyncio.run(auth.request_access(_FakeRequest({"email": "known@example.com"})))
+
+    assert result["already_registered"] is True
+    assert fake_db.added == []  # already present → no re-add
+
+
+def test_self_signup_enabled_rejects_invalid_email(monkeypatch):
+    fake_db = _FakeDb(self_signup=True)
+    monkeypatch.setattr(auth, "db", fake_db)
+
+    with pytest.raises(auth.HTTPException) as exc:
+        asyncio.run(auth.request_access(_FakeRequest({"email": "not-an-email"})))
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary

`POST /api/access/request` (unauthenticated) auto-whitelisted any submitted email (role `user`), letting anyone who can reach the backend self-enroll and then log in via email OTP — so the email whitelist was **not authoritative** against self-enrollment, despite the "request access" naming implying admin approval.

**Fix — secure default:** gate the endpoint behind `PUBLIC_ACCESS_REQUESTS_ENABLED` (env) / the `public_access_requests_enabled` system setting, **default CLOSED**. When off → `403`, no whitelist write. The gate runs before body parsing so a disabled instance never processes self-signup input.

## Product decision (recorded per AC)
Keep frictionless auto-whitelist **behind the flag** rather than building a full admin-approval pending flow — minimal and non-breaking for opt-in (`trinity:connect`) users. A real pending flow can later build on the existing #311 `access_requests` precedent. Flipping the default off **is** a behavior change for anyone who relied on open self-signup — they set the flag to re-enable.

## Acceptance criteria
- [x] Flag gates the endpoint, default closed → 403 when disabled.
- [x] Product decision recorded (flag-gated auto-approve; pending-flow deferred).
- [x] Disabled → non-whitelisted email is **not** whitelisted (verified in tests).
- [x] Response wording no longer says "Access granted".
- [x] Already-whitelisted emails can still request login codes regardless of the flag (separate endpoint, untouched).
- [x] Tests: default rejects (403, no whitelist); enabling is explicit and covered.
- [x] CLI onboarding docs updated (cli-tool flow, architecture, `.env.example`).

## Testing
- `tests/unit/test_ent10_access_request_gate.py` (offline, 4 tests): 403 + no-whitelist when off; auto-whitelist (normalized email, role `user`) when on; idempotent; 400 validation once open. **All pass.**
- `tests/test_cli_access_request.py` rewritten: default-closed `403` (+ asserts the email isn't whitelisted via the admin list), and an operator-enabled class that toggles the setting via `PUT /api/settings/{key}` and restores it.
- `lint_sys_modules` green.

Related to trinity-enterprise#10