### PR TITLE
docs(voip): genericize moved-issue reference in feature-flow

### DIFF
--- a/docs/memory/feature-flows/voip-telephony.md
+++ b/docs/memory/feature-flows/voip-telephony.md
@@ -177,7 +177,7 @@ forwards it. The full `VOIP_*` set is wired into the `backend.environment:` bloc
 of **both** `docker-compose.yml` (dev) and `docker-compose.prod.yml` (prod, which
 launches standalone with no base-compose merge), plus the `VOICE_*` flags for
 parity, and is documented in `.env.example`. Omitting these from the prod compose
-was the original packaging gap (same class as #1039's `LOG_*` no-op) — the
+was the original packaging gap (same class as the `LOG_*` data-retention no-op) — the
 supported `.env` lever did nothing because it never reached the container. The
 enterprise prod overlay (`docker-compose.prod.enterprise.yml`) inherits this env
 block, so no separate wiring is needed there.


### PR DESCRIPTION
Follow-up to the open-core enterprise tracker split (issues migrated public → private).

`#1039` (configurable data-retention) moved to the private `trinity-enterprise` tracker, so the reference in `docs/memory/feature-flows/voip-telephony.md` would deep-link a private issue from a public doc. Replaced it with a generic description (`the LOG_* data-retention no-op`) — same meaning, no dangling cross-repo link.

Docs-only, single line. The companion `.claude` (trinity-dev) reconciliation — DEVELOPMENT_WORKFLOW / OSS_VS_ENTERPRISE / ROADMAP / roadmap·roadmap-plan·groom·validate-pr skills — was committed and pushed to `trinity-dev/main` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)