### PR TITLE
docs(user-docs): video library + per-page links, v0.6.1 What's New, sync dev features

### DIFF
--- a/docs/user-docs/README.md
+++ b/docs/user-docs/README.md
@@ -4,7 +4,11 @@
 
 ## What's New
 
-- [Release highlights](whats-new/README.md) — user-facing changes per release, newest first ([v0.6.0](whats-new/v0.6.0.md))
+- [Release highlights](whats-new/README.md) — user-facing changes per release, newest first ([v0.6.1](whats-new/v0.6.1.md))
+
+## Watch
+
+- [Video Library](videos.md) — workshops, demos, and deep-dives, newest first
 
 ## Guides
 
@@ -23,8 +27,11 @@
 ## Agents
 
 - [Creating Agents](agents/creating-agents.md) — Templates, GitHub repos, from scratch
+- [Agent Runtimes](agents/agent-runtimes.md) — Claude Code, OpenAI Codex, Gemini CLI
 - [Managing Agents](agents/managing-agents.md) — Start/stop, rename, delete, health
+- [Agent Data & Portability](agents/agent-data.md) — Runtime data paths, export/import across instances
 - [Agent Chat](agents/agent-chat.md) — Chat interface, voice, streaming, history
+- [Agent Session](agents/agent-session.md) — Resumable Claude session with full context
 - [Agent Terminal](agents/agent-terminal.md) — Web terminal, SSH access, mode switching
 - [Agent Files](agents/agent-files.md) — File browser, virtual filesystem, shared folders
 - [Agent Logs](agents/agent-logs.md) — Log viewing, telemetry, Vector aggregation

--- a/docs/user-docs/abilities/agent-dev-plugin.md
+++ b/docs/user-docs/abilities/agent-dev-plugin.md
@@ -2,6 +2,8 @@
 
 Development tools for extending existing agents — skills, memory systems, git-backed state, a GitHub Issues development cycle, and long-running pipelines.
 
+> 📺 **Watch:** [Why Every AI Agent Needs a GitHub Repo](https://youtu.be/R4nNHf6ywEs) *(Apr 2026)* · [3 AI Agents Run My Software Development Pipeline](https://youtu.be/zCDFDhewFkk) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Installation
 
 ```bash

--- a/docs/user-docs/abilities/create-agent-plugin.md
+++ b/docs/user-docs/abilities/create-agent-plugin.md
@@ -2,6 +2,8 @@
 
 Create new Claude Code agents with domain-specific wizards. Each wizard is a domain expert that asks the right questions and builds a fully configured, Trinity-compatible agent.
 
+> 📺 **Watch:** [Build an AI Recruiter Agent](https://youtu.be/K7hFWyFIf-Y) *(Jun 2026)* · [all videos](../videos.md)
+
 ## Installation
 
 ```bash

--- a/docs/user-docs/abilities/dev-methodology-plugin.md
+++ b/docs/user-docs/abilities/dev-methodology-plugin.md
@@ -2,6 +2,8 @@
 
 Documentation-driven development methodology for any codebase. Enforces a structured cycle: context loading, development, testing, documentation, and PR validation.
 
+> 📺 **Watch:** [3 AI Agents Run My Entire Software Development Pipeline](https://youtu.be/zCDFDhewFkk) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Installation
 
 ```bash

--- a/docs/user-docs/abilities/overview.md
+++ b/docs/user-docs/abilities/overview.md
@@ -2,6 +2,8 @@
 
 The official agent development toolkit for Claude Code. Curated plugins covering the full agent lifecycle — from scaffolding and onboarding to deployment, scheduling, and ongoing operations.
 
+> 📺 **Watch:** [Build and Deploy Agents in Cursor](https://youtu.be/amqiysdlEWY) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Quick Start
 
 ```bash

--- a/docs/user-docs/abilities/trinity-plugin.md
+++ b/docs/user-docs/abilities/trinity-plugin.md
@@ -2,6 +2,8 @@
 
 Connect, deploy, operate, and sync agents on the Trinity platform. Six skills covering the complete lifecycle — from first connection to running remote loops and provisioning new instances.
 
+> 📺 **Watch:** [Build Autonomous Loops for Your AI Agents](https://youtu.be/q3YvFYtuhec) *(Jun 2026)* · [all videos](../videos.md)
+
 ## Installation
 
 ```bash

--- a/docs/user-docs/advanced/agent-avatars.md
+++ b/docs/user-docs/advanced/agent-avatars.md
@@ -2,6 +2,8 @@
 
 AI-generated avatars for agents using reference images, emotion variants, and default generation.
 
+> 📺 **Watch:** [Trinity Platform Demo — avatar generation](https://youtu.be/ivljtZqsxeo) *(May 2026)* · [all videos](../videos.md)
+
 ## Features
 
 - **Reference Image** -- Upload a reference image and the avatar is generated in that style.

--- a/docs/user-docs/advanced/dynamic-dashboards.md
+++ b/docs/user-docs/advanced/dynamic-dashboards.md
@@ -2,6 +2,8 @@
 
 Agent-defined dashboards via `dashboard.yaml` with 11 widget types, historical tracking, and sparkline charts.
 
+> 📺 **Watch:** [Why Every AI Agent Needs a GitHub Repo — dashboards](https://youtu.be/R4nNHf6ywEs) *(Apr 2026)* · [Build and Deploy Agents in Cursor](https://youtu.be/amqiysdlEWY) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **dashboard.yaml** -- A YAML file in the agent's workspace defining custom widgets. The agent writes and updates this file to control what appears on its Dashboard tab.

--- a/docs/user-docs/advanced/image-generation.md
+++ b/docs/user-docs/advanced/image-generation.md
@@ -2,6 +2,8 @@
 
 Platform image generation via a two-step Gemini pipeline: prompt refinement then image generation.
 
+> 📺 **Watch:** [I Let AI Agents Build My Entire Webinar](https://youtu.be/WBVbg_bwc_g) *(Dec 2025)* · [all videos](../videos.md)
+
 ## How It Works
 
 1. Submit an image generation request via API.

--- a/docs/user-docs/advanced/voice-chat.md
+++ b/docs/user-docs/advanced/voice-chat.md
@@ -2,6 +2,8 @@
 
 Real-time voice conversations with agents via Gemini 2.5 Flash Native Audio model (~280ms latency). Audio streams bidirectionally through a backend WebSocket proxy. Gemini handles speech-to-speech; Claude Code remains the agent's reasoning engine and is invoked on demand via tool calling.
 
+> 📺 **Watch:** [I Gave My AI Three Years of My Notes — Then Interviewed It](https://youtu.be/xflQTzarEBQ) *(May 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Voice Session** — A live audio session bridged between the browser, Trinity backend, and Gemini Live API. Transcripts are saved to the agent's chat session on close.

--- a/docs/user-docs/agents/agent-chat.md
+++ b/docs/user-docs/agents/agent-chat.md
@@ -2,6 +2,8 @@
 
 The Chat tab in Agent Detail provides a bubble UI for conversing with agents, with persistent history and real-time status updates.
 
+> 📺 **Watch:** [I Gave My AI Three Years of My Notes — Then Interviewed It (voice chat)](https://youtu.be/xflQTzarEBQ) *(May 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Chat Session** -- A conversation thread stored in the database. Each agent can have multiple sessions.

--- a/docs/user-docs/agents/agent-configuration.md
+++ b/docs/user-docs/agents/agent-configuration.md
@@ -39,6 +39,8 @@ Per-agent memory and CPU limits, enforced at the container level (Linux cgroups)
 
 **Fleet-wide defaults (admin):** the default CPU and memory for *new* agent containers are set platform-wide via `GET`/`PUT /api/settings/agent-defaults/resources` (admin-only; CPU 1/2/4/8/16, memory 1g--32g). Changes apply to new containers only -- restart existing agents to pick up new defaults.
 
+**Scratch space (`/tmp`):** each agent's `/tmp` is a RAM-backed tmpfs, hardened `noexec,nosuid`. Its size is operator-configurable via the `AGENT_TMP_SIZE` environment variable on the backend (default `512m`; accepts `<int>m`/`<int>g`); the `noexec,nosuid` flags are fixed. Because the tmpfs counts against the agent's memory limit and blocks execution, heavy build/scratch work (pip and npm installs, compiling extensions) is redirected to a disk-backed `TMPDIR` at `/home/developer/.tmp` on the home volume. The `/tmp` size is applied at container create, so a changed `AGENT_TMP_SIZE` is picked up on recreate, not a plain restart.
+
 ### Execution Timeout
 
 Configurable time limit for agent executions.

--- a/docs/user-docs/agents/agent-data.md
+++ b/docs/user-docs/agents/agent-data.md
@@ -1,0 +1,95 @@
+# Agent Data & Portability
+
+Declare which directories hold an agent's runtime data, keep that data out of git, and export or import it on demand to move an agent between Trinity instances.
+
+## Concepts
+
+An agent's home directory, `/home/developer`, is a durable named Docker volume. It already survives the events that would otherwise wipe a container's filesystem:
+
+- Container recreate (resource, capability, or mount changes)
+- Image upgrade
+- Template re-pull (the platform resets tracked files to `origin/main`; it never wipes untracked files)
+- Subscription auto-switch
+
+So runtime data an agent writes under `data/` — SQLite databases, datasets, generated artifacts — is **already durable** today. There is no separate data volume to provision and no platform schema change involved.
+
+Two problems remain, and this feature solves both:
+
+- **Keeping data out of git.** Runtime data does not belong in the git-synced template repo, where it would bloat the history. Declaring `data_paths` in `template.yaml` adds those paths to the agent's own `.gitignore` automatically.
+- **Portability.** To move an agent to another Trinity instance, you need a way to capture and restore its data. Export/import does this on demand as a tar archive.
+
+## How It Works
+
+### Declaring data paths
+
+Add `data_paths` to the agent's `template.yaml`. Each entry is a glob under `data/`:
+
+```yaml
+data_paths:
+  - data/*.db
+  - data/datasets/**
+```
+
+When the agent is created, Trinity:
+
+1. Records the declaration in `~/.trinity/data-paths.yaml`.
+2. Appends `data/` plus your declared entries to the agent's own `.gitignore`, so the runtime data is never committed.
+
+The append is idempotent and touches only the agent's own `.gitignore` — not any fleet-wide ignore rules. Declaring no `data_paths` is a no-op.
+
+### Exporting data
+
+Export captures everything under `/home/developer/data` as a tar archive with a `manifest.json` (declared data paths plus agent and version metadata). Run it on demand against a **running** agent.
+
+The platform never mounts the agent workspace to do this — it reads the directory out of the container directly, streams it to a temporary file, and returns it as a download.
+
+### Importing data
+
+Import restores a previously exported archive into the target agent's `data/` directory. Restore is allowlisted to `data/**` and guarded against path traversal — entries that escape `data/` (for example `..` or absolute paths) are skipped and reported, never written. Import returns a count of restored and skipped entries.
+
+To move an agent between instances: export from the source agent, recreate the agent on the destination, then import the archive.
+
+## For Agents
+
+All endpoints are owner/admin only. A per-agent operation lock serialises export and import so two operations on the same agent cannot run at once.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/agents/{name}/data/export` | POST | Export `data/` as a tar archive. Query `?format=stream` (default download) or `?format=base64` (inline JSON `{tar_base64}`). |
+| `/api/agents/{name}/data/import` | POST | Import a tar archive into `data/`. Returns `{restored, skipped}`. Accepts `Idempotency-Key`. |
+
+Status codes:
+
+- `409` — export of a stopped agent (no running container), or a concurrent export/import on the same agent.
+- `413` — the data exceeds the export size cap (`AGENT_DATA_EXPORT_MAX_BYTES`); for `?format=base64`, the response directs you to the streaming download instead.
+
+See [Backend API Docs](http://localhost:8000/docs) for full request/response schemas.
+
+### MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `export_agent_data({ name })` | Export the agent's `data/` directory. |
+| `import_agent_data({ name, tar_base64 })` | Restore a base64-encoded tar archive into the agent's `data/`. |
+
+### Template Fields
+
+| Field | Description |
+|-------|-------------|
+| `data_paths` | List of globs under `data/` that hold runtime data. Auto-appended to the agent's `.gitignore`; surfaces in export manifests. Default: empty. |
+
+## Limitations
+
+The following are planned (PR2) and not yet available:
+
+- **Scheduled background snapshots with retention.** Export/import is on demand only today.
+- **SQLite-quiesce pre-snapshot hook.** A `~/.trinity/pre-snapshot` hook to produce a consistent point-in-time copy of a live SQLite database (currently an export is a plain filesystem read).
+- **Rename/purge snapshot cascade.** Snapshot directories are not yet cleaned up when an agent is renamed or purged.
+- **System-agent `data_paths`.** System agents are out of scope.
+
+## See Also
+
+- [Agent Files](agent-files.md)
+- [Managing Agents](managing-agents.md)
+- [GitHub Sync](../integrations/github-sync.md)
+- [MCP Server](../integrations/mcp-server.md)

--- a/docs/user-docs/agents/agent-runtimes.md
+++ b/docs/user-docs/agents/agent-runtimes.md
@@ -1,0 +1,66 @@
+# Agent Runtimes
+
+Trinity agents run on a pluggable runtime — the CLI harness that executes the agent inside its container. Trinity supports Claude Code (default), Gemini CLI, and OpenAI Codex.
+
+## Concepts
+
+**Runtime** -- The execution engine inside the agent container. Each runtime is a different coding-agent CLI with its own auth model, system-prompt file, and capabilities. A template picks one; if none is declared, the agent uses Claude Code.
+
+**Harness** -- Another name for the runtime. The harness reads the agent's system prompt, calls tools and MCP servers, and produces responses, which Trinity treats identically regardless of which runtime ran them.
+
+## How It Works
+
+A template selects the runtime in `template.yaml`:
+
+```yaml
+runtime:
+  type: codex          # claude-code (default) | gemini-cli | codex
+  model: gpt-5.1-codex # optional model override
+```
+
+The runtime is fixed when the agent is created. To change it, recreate the agent from a template that declares a different runtime — there is no post-creation switch.
+
+On the Agent Detail page, a runtime badge shows which runtime the agent is using. Chat works the same across all runtimes. For Codex agents, the **Session** tab is hidden (Codex does not support session resume); the **Chat** tab remains, with full conversation continuity.
+
+### Runtime Comparison
+
+| | Claude Code (default) | Gemini CLI | OpenAI Codex |
+|---|---|---|---|
+| Auth model | Claude subscription / OAuth, or platform API key | Gemini API key | `OPENAI_API_KEY` (Codex skips Claude-subscription auto-assign) |
+| System-prompt file | `CLAUDE.md` | `CLAUDE.md` | `AGENTS.md` |
+| Chat continuity | Yes | Yes | Yes |
+| Session tab resume | Yes | Yes | No (Session tab hidden) |
+| MCP support | Yes | Yes | Yes |
+| Cost reporting | Actual | Actual | Estimated |
+
+Safety controls apply across all runtimes: read-only mode and credential redaction work the same regardless of runtime. Codex enforces read-only through its own sandbox (`--sandbox read-only`) rather than the Claude tool-use hook.
+
+## For Agents
+
+Set the runtime in the template's `template.yaml`:
+
+| Field | Values | Default | Notes |
+|-------|--------|---------|-------|
+| `runtime.type` | `claude-code`, `gemini-cli`, `codex` | `claude-code` | Selects the harness |
+| `runtime.model` | runtime-specific model id (e.g. `gpt-5.1-codex`) | runtime default | Optional override |
+
+A Codex agent reads its identity and instructions from `AGENTS.md`. Trinity mirrors the template's `CLAUDE.md` into `AGENTS.md` at startup, so a single instruction file works across runtimes.
+
+Trinity's MCP tools are available to Codex agents. Codex references tools by their bare name (no `mcp__trinity__` prefix); Trinity adjusts the platform prompt automatically so the agent calls them correctly.
+
+There is no API or MCP endpoint to switch an agent's runtime after creation. See the full API reference at `http://localhost:8000/docs`.
+
+## Limitations
+
+- **Codex Session-tab resume is not supported.** The Session tab is hidden for Codex agents; use the Chat tab, which keeps conversation continuity.
+- **No runtime switch after creation.** Recreate the agent from a different template to change runtimes — a post-creation runtime-switch endpoint is planned.
+- **Codex cost is estimated**, not metered exactly.
+- **Codex vision/image input and SSE streaming are out of scope** for the current release (planned).
+
+## See Also
+
+- [Creating Agents](creating-agents.md) -- Selecting a runtime via the template
+- [Session Tab](agent-session.md) -- Resume-based chat (Claude/Gemini only)
+- [Chat](agent-chat.md) -- Standard chat, available on all runtimes
+- [Subscription Credentials](../credentials/subscription-credentials.md) -- Claude-subscription auto-assignment (skipped for Codex)
+- [MCP Server](../integrations/mcp-server.md) -- Tools available to all runtimes

--- a/docs/user-docs/agents/agent-session.md
+++ b/docs/user-docs/agents/agent-session.md
@@ -2,6 +2,8 @@
 
 The Session tab in Agent Detail is a `--resume`-default chat surface that lives alongside the existing Chat tab. Each new message reattaches to the same Claude Code session, so the agent retains tool-result memory, mid-skill state, and reasoning state across turns — strictly more capable than Chat's stateless text-replay model.
 
+> 📺 **Watch:** [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) *(May 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Session** -- A conversation thread with a Claude Code working memory attached. The visible message log is stored separately from the working memory and survives Reset.

--- a/docs/user-docs/agents/creating-agents.md
+++ b/docs/user-docs/agents/creating-agents.md
@@ -2,6 +2,8 @@
 
 Agents are created from templates or from scratch. Each agent runs as an isolated Docker container with its own filesystem, credentials, and MCP server configuration.
 
+> 📺 **Watch:** [Build an AI Recruiter Agent](https://youtu.be/K7hFWyFIf-Y) *(Jun 2026)* · [Build and Deploy Agents in Cursor](https://youtu.be/amqiysdlEWY) *(Apr 2026)* · [From Zero to Deployed](https://youtu.be/-TSZyekDS6o) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 **Template sources** define where agent blueprints come from:
@@ -20,10 +22,11 @@ Agents are created from templates or from scratch. Each agent runs as an isolate
 | `.mcp.json.template` | MCP config template with `${VAR}` placeholders for credential injection |
 | `.env.example` | Example credentials file listing required environment variables |
 
-**Runtime options** control which CLI the agent uses:
+**Runtime options** control which CLI the agent uses. An agent's runtime — Claude Code, OpenAI Codex, or Gemini CLI — is chosen via `runtime.type` in `template.yaml` (see [Agent Runtimes](agent-runtimes.md)):
 
 - `claude-code` (default)
-- `gemini-cli` (set via `runtime.type` in `template.yaml`)
+- `codex`
+- `gemini-cli`
 
 ## How It Works
 
@@ -37,6 +40,14 @@ When you create an agent, Trinity performs these steps in order:
 6. If API subscriptions exist, one is auto-assigned via round-robin (fewest agents first).
 7. The agent starts automatically.
 8. The container is labeled for fleet management: `trinity.platform=agent`, `trinity.agent-name`, `trinity.agent-type`, `trinity.template`.
+
+### Compatibility Validation
+
+Once an agent is running, Trinity validates its workspace against best-practice conventions and surfaces the results in the **Overview** tab on the Agent Detail page. This is advisory — it never blocks creation or deployment.
+
+The check covers things like a present and valid `template.yaml`, a non-gitignored `.claude/` directory, defined playbooks, and accidentally committed secrets, grouped into findings ranked HARD / SOFT / INFO. Claude-specific checks (such as `CLAUDE.md` and `.claude/` skills) are skipped for Codex and Gemini agents.
+
+The 10 gitignore-related findings offer a one-click **Fix** button: Trinity rewrites the agent's `.gitignore` in place. The change is uncommitted until the agent's next git sync. Re-run the analysis at any time with **Re-run analysis**.
 
 ### UI Flow
 

--- a/docs/user-docs/automation/abilities-marketplace.md
+++ b/docs/user-docs/automation/abilities-marketplace.md
@@ -2,6 +2,8 @@
 
 The abilities marketplace is a curated collection of Claude Code plugins covering the full agent lifecycle — from scaffolding and onboarding to deployment, scheduling, and ongoing operations.
 
+> 📺 **Watch:** [Build and Deploy Agents in Cursor](https://youtu.be/amqiysdlEWY) *(Apr 2026)* · [Building Agents — Playbooks, Plugins, Deployment](https://youtu.be/MDxRZBikf70) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Plugin marketplace** — A registry of versioned plugin packages hosted at `github.com/abilityai/abilities`. Claude Code's `/plugin marketplace add` command connects to it.

--- a/docs/user-docs/automation/agent-loops.md
+++ b/docs/user-docs/automation/agent-loops.md
@@ -4,6 +4,8 @@ Run the same task against one agent repeatedly, in order, with a bounded run cou
 
 Loops are the sequential counterpart to [Fan-Out](fan-out.md) (parallel batch) and a single chat turn (one-shot).
 
+> 📺 **Watch:** [Build Autonomous Loops for Your AI Agents](https://youtu.be/q3YvFYtuhec) *(Jun 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Loop** — A server-managed sequence of up to `max_runs` task executions against one agent. Iterations run strictly one at a time, in order.

--- a/docs/user-docs/automation/approvals.md
+++ b/docs/user-docs/automation/approvals.md
@@ -2,6 +2,8 @@
 
 Human-in-the-loop approval gates surfaced through the Operating Room queue. Agents that need authorization for a sensitive action write an approval item; an operator approves or rejects from the UI; the agent reads the decision back and continues.
 
+> 📺 **Watch:** [Trinity Platform Demo — operator queue & approvals](https://youtu.be/ivljtZqsxeo) *(May 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Approval item** — A row in the operator queue with `type=approval`. Created by the agent, consumed by an operator.

--- a/docs/user-docs/automation/scheduling.md
+++ b/docs/user-docs/automation/scheduling.md
@@ -2,6 +2,8 @@
 
 Cron-based automation for agents using APScheduler. Schedule recurring tasks with timezone support, execution history, and manual triggers.
 
+> 📺 **Watch:** [Trinity Platform Demo](https://youtu.be/ivljtZqsxeo) *(May 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Schedule** -- A cron expression paired with a message or task sent to an agent at the specified times.

--- a/docs/user-docs/automation/skills-and-playbooks.md
+++ b/docs/user-docs/automation/skills-and-playbooks.md
@@ -2,6 +2,8 @@
 
 Platform-managed skills that can be assigned to agents and invoked from the UI via the Playbooks tab or chat autocomplete.
 
+> 📺 **Watch:** [Building Agents — Playbooks, Plugins, Deployment](https://youtu.be/MDxRZBikf70) *(Apr 2026)* · [Build an AI Recruiter Agent](https://youtu.be/K7hFWyFIf-Y) *(Jun 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Skill** -- A reusable capability defined as a markdown file (`SKILL.md`) stored in the platform's skills library. Skills contain instructions, tools, and procedures that agents can execute.

--- a/docs/user-docs/cli/trinity-cli.md
+++ b/docs/user-docs/cli/trinity-cli.md
@@ -2,6 +2,8 @@
 
 Command-line interface for managing Trinity agents from your terminal. Provides the same capabilities as the MCP server but invoked via shell commands.
 
+> 📺 **Watch:** [From Zero to Deployed AI Agent](https://youtu.be/-TSZyekDS6o) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Installation
 
 ```bash

--- a/docs/user-docs/collaboration/agent-network.md
+++ b/docs/user-docs/collaboration/agent-network.md
@@ -2,6 +2,8 @@
 
 Agents communicate with each other via Trinity's MCP server, enabling orchestrator-worker patterns, delegation chains, and multi-agent systems.
 
+> 📺 **Watch:** [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) *(May 2026)* · [How We Automate Our Own Ops & Marketing](https://youtu.be/DDhSdwJ1sx8) *(Mar 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 **Agent-to-Agent Communication** -- Agents call each other through Trinity MCP tools using agent-scoped API keys. The `chat_with_agent` MCP tool sends a message to another agent and returns the response.
@@ -11,6 +13,8 @@ Agents communicate with each other via Trinity's MCP server, enabling orchestrat
 **Collaboration Dashboard** -- A real-time visual graph on the Dashboard showing agents as nodes and communication as animated edges. Built with Vue Flow.
 
 **DAG Visualization** -- The network graph shows agent relationships with live activity indicators, success rate bars, and context usage.
+
+**Pull-Pilot Routing (experimental)** -- An alternative routing path for agent-to-agent `chat_with_agent` calls, behind a default-OFF flag (`MCP_AGENT_CHAT_PULL_ENABLED`). When enabled, a sequential agent-to-agent call is dispatched through Trinity's durable async task path instead of a held synchronous call: the caller gets an immediate receipt with an `execution_id` and polls `get_execution_result(id)` for the result. This is an opt-in proof-of-concept for pull/work-stealing coordination. It does not change human chat, parallel calls, or self-calls. Leave it off unless you are piloting it.
 
 ## How It Works
 

--- a/docs/user-docs/collaboration/agent-permissions.md
+++ b/docs/user-docs/collaboration/agent-permissions.md
@@ -2,6 +2,8 @@
 
 Explicit permission model controlling which agents can communicate with which. Restrictive by default -- no agent can call another without explicit permission.
 
+> 📺 **Watch:** [Trinity Platform Demo](https://youtu.be/ivljtZqsxeo) *(May 2026)* · [all videos](../videos.md)
+
 ## How It Works
 
 ![Agent Permissions tab showing the agent collaboration list with Allow All / Allow None controls](../images/agent-permissions-tab.png)

--- a/docs/user-docs/credentials/subscription-credentials.md
+++ b/docs/user-docs/credentials/subscription-credentials.md
@@ -2,11 +2,13 @@
 
 Share Claude Max/Pro subscription tokens across multiple agents, with automatic assignment, health monitoring, and auto-switch on rate limits.
 
+> 📺 **Watch:** [Trinity Platform Demo](https://youtu.be/ivljtZqsxeo) *(May 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Subscription** -- A Claude Max or Pro subscription token registered with Trinity. Stored encrypted (AES-256-GCM). Injected as an environment variable to assigned agents.
 - **Round-Robin Assignment** -- New agents automatically get a subscription assigned. The subscription with the fewest agents is selected first, with alphabetical tie-break.
-- **Auto-Switch (SUB-003)** -- When an agent hits repeated rate-limit (429) errors, Trinity automatically switches it to a different subscription.
+- **Auto-Switch (SUB-003)** -- When an agent hits a rate-limit (429) or auth-class failure, Trinity automatically switches it to a different subscription. The new token is applied via a **hot-reload** of the running container -- no container recreate -- so in-flight executions keep running. Default ON; toggle it off in the Subscriptions section of Settings.
 
 ## How It Works
 
@@ -54,7 +56,8 @@ Share Claude Max/Pro subscription tokens across multiple agents, with automatic 
 ## Limitations
 
 - Requires `CREDENTIAL_ENCRYPTION_KEY` in `.env`. Without it, subscription features are unavailable.
-- Auto-switch depends on rate-limit detection. If an agent does not surface 429 errors through standard logging, auto-switch will not trigger.
+- Auto-switch depends on failure detection. If an agent does not surface 429 or auth-class errors through standard logging, auto-switch will not trigger.
+- Hot-reload applies the new token to the **next** Claude subprocess; turns already in flight finish on the previous token. On older agent base images that lack the hot-reload endpoint, the switch falls back to recreating the container (which drops in-flight executions).
 - Round-robin assignment considers only agent count, not agent activity or usage volume.
 
 ## See Also

--- a/docs/user-docs/getting-started/help.md
+++ b/docs/user-docs/getting-started/help.md
@@ -33,6 +33,34 @@ curl -X POST \
 
 No authentication required. The bot uses Vertex AI Search with Gemini to generate answers from the onboarding documentation.
 
+## Report a Bug, Request a Feature, or Send Feedback
+
+Use the floating **Help widget** to file a report without leaving Trinity. The widget has four tabs:
+
+- **Ask** -- Query the docs Q&A bot (above).
+- **Bug** -- Report something that isn't working.
+- **Feature** -- Request a new capability.
+- **Feedback** -- Send general feedback privately to the Trinity team.
+
+### How it works
+
+1. Pick the **Bug**, **Feature**, or **Feedback** tab.
+2. Enter a title and description. Optionally leave a contact email if you want a reply.
+3. Review the **see-before-send** screen, which shows exactly what will be submitted.
+4. Confirm to send. Nothing is submitted until you confirm.
+
+### Where reports go
+
+- **Bug** and **Feature** reports are filed as public, labelled GitHub issues in [`abilityai/trinity`](https://github.com/abilityai/trinity/issues). The success screen links to the created issue.
+- **Feedback** is private -- it is emailed to the Trinity team only and never made public.
+- Every report also emails the team. A contact email you provide rides only the private team email (as the reply-to) and is never written into the public issue.
+
+### What's captured
+
+Each report includes a small diagnostics bundle to speed up triage: app version and git commit, the current page, browser user agent, viewport, OS, and the last few console errors or warnings. Tokens, credentials, emails, and private IP addresses are automatically scrubbed -- both before you review and again on the server -- so secrets aren't exposed in a public issue. You see the already-scrubbed payload on the review screen.
+
+Your self-hosted instance never stores a GitHub token; reports post to an Ability.ai-operated intake endpoint that files the issue on your behalf. Operators can disable the report tabs or repoint the intake URL at build time.
+
 ## Other Resources
 
 | Resource | Description |

--- a/docs/user-docs/getting-started/overview.md
+++ b/docs/user-docs/getting-started/overview.md
@@ -2,9 +2,11 @@
 
 Trinity is an autonomous agent orchestration and infrastructure platform — sovereign infrastructure for deploying, orchestrating, and governing fleets of autonomous AI agents on your own hardware.
 
+> 📺 **Watch:** [Trinity Platform Demo](https://youtu.be/ivljtZqsxeo) *(May 2026)* · [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) *(May 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
-**Autonomous Agent** -- An AI system that plans and executes tasks independently. Each agent runs as an isolated Docker container with pre-installed runtimes (Python 3.11, Node.js 20, Go 1.21, Claude Code). Agents persist memory across sessions, delegate to other agents, and run on schedules without human intervention.
+**Autonomous Agent** -- An AI system that plans and executes tasks independently. Each agent runs as an isolated Docker container with pre-installed languages (Python 3.11, Node.js 20, Go 1.21) and a pluggable agent runtime: Claude Code, OpenAI Codex, or Gemini CLI (see [Agent Runtimes](../agents/agent-runtimes.md)). Agents persist memory across sessions, delegate to other agents, and run on schedules without human intervention.
 
 **Agent Container** -- An isolated Docker container with standardized interfaces for credentials, tools, and MCP server integrations.
 
@@ -77,7 +79,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/agents
 ### Platform Capabilities
 
 - Create agents from GitHub templates or local directories
-- Multi-runtime support: Claude Code, Gemini CLI
+- Multi-runtime support: Claude Code, OpenAI Codex, Gemini CLI (see [Agent Runtimes](../agents/agent-runtimes.md))
 - Credential management with encryption and hot-reload
 - Agent-to-agent collaboration via MCP tool calls
 - Cron-based scheduling with execution history and per-schedule timeouts

--- a/docs/user-docs/getting-started/quick-start.md
+++ b/docs/user-docs/getting-started/quick-start.md
@@ -2,6 +2,8 @@
 
 Create and interact with a Trinity agent using the Web UI, API, or MCP tools.
 
+> 📺 **Watch:** [Build an AI Recruiter Agent — zero to deployed](https://youtu.be/K7hFWyFIf-Y) *(Jun 2026)* · [From Zero to Deployed AI Agent](https://youtu.be/-TSZyekDS6o) *(Apr 2026)* · [all videos](../videos.md)
+
 ## How It Works
 
 1. Open http://localhost and log in as admin.

--- a/docs/user-docs/getting-started/setup.md
+++ b/docs/user-docs/getting-started/setup.md
@@ -2,6 +2,8 @@
 
 Install Trinity, create your admin account, and start managing agents in minutes.
 
+> 📺 **Watch:** [I Built a DevOps Agent That Deploys Other Agents](https://youtu.be/8RozanPd14Y) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Admin Account** -- The primary account with full platform access, authenticated by username and password. Created automatically from `ADMIN_PASSWORD` in `.env`.
@@ -31,7 +33,7 @@ Install Trinity, create your admin account, and start managing agents in minutes
    # Edit .env and set ADMIN_PASSWORD to a strong password (min 12 chars)
    ```
 
-   The `admin` account is created automatically from this value on first start. If you leave it blank, a one-time setup token is printed to the backend logs — paste it into the setup wizard that appears on first visit.
+   The `admin` account is created automatically from this value on first start. If you leave it blank, a one-time setup token is printed to the backend logs (`docker compose logs backend | grep "Setup token"`) — paste it into the setup wizard that appears on first visit. The token is shared across backend workers, so the single value printed in the logs always works regardless of how many workers are running. If the setup wizard shows a "waiting for Redis" state, the token store is temporarily unreachable; setup resumes automatically once Redis recovers, with no restart needed.
 
 3. Start all services:
 

--- a/docs/user-docs/guides/building-agents.md
+++ b/docs/user-docs/guides/building-agents.md
@@ -2,6 +2,8 @@
 
 Use the **abilities** plugins to create, develop, and deploy agents to Trinity — all from your terminal.
 
+> 📺 **Watch:** [Build an AI Recruiter Agent](https://youtu.be/K7hFWyFIf-Y) *(Jun 2026)* · [Build and Deploy Agents in Cursor](https://youtu.be/amqiysdlEWY) *(Apr 2026)* · [From Zero to Deployed](https://youtu.be/-TSZyekDS6o) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Prerequisites
 
 - **Claude Code** installed — `npm install -g @anthropic-ai/claude-code`

--- a/docs/user-docs/guides/deploying-trinity.md
+++ b/docs/user-docs/guides/deploying-trinity.md
@@ -2,6 +2,8 @@
 
 Trinity runs your agents 24/7 with scheduling, monitoring, and multi-agent coordination. Choose cloud-hosted for simplicity or self-hosted for complete control.
 
+> 📺 **Watch:** [I Built a DevOps Agent That Deploys Other Agents](https://youtu.be/8RozanPd14Y) *(Apr 2026)* · [Control My DGX Spark From Anywhere](https://youtu.be/epDBrEtg4nE) *(Jan 2026)* · [all videos](../videos.md)
+
 ## Cloud vs Self-Hosted
 
 | | Cloud Hosted (ability.ai) | Self Hosted |

--- a/docs/user-docs/guides/deploying/ops-agent.md
+++ b/docs/user-docs/guides/deploying/ops-agent.md
@@ -2,6 +2,8 @@
 
 The Trinity Ops Agent is a Claude Code agent for operating a Trinity instance — health checks, log tailing, restarts, updates, rollbacks, diagnostics, and agent management — all from a single `.env` pointed at any server.
 
+> 📺 **Watch:** [I Built a DevOps Agent That Deploys Other Agents](https://youtu.be/8RozanPd14Y) *(Apr 2026)* · [all videos](../../videos.md)
+
 ## When to Use
 
 Use the ops agent instead of raw Docker commands for day-to-day Trinity operations. It codifies production runbook knowledge into repeatable skills that improve over time as new versions are published.

--- a/docs/user-docs/guides/deploying/single-server.md
+++ b/docs/user-docs/guides/deploying/single-server.md
@@ -108,6 +108,14 @@ Create the directory before starting:
 mkdir -p /srv/trinity-data
 ```
 
+### Database backend
+
+Trinity stores all platform state in **SQLite** by default, in `trinity.db` under your `TRINITY_DATA_PATH` bind mount (`/data/trinity.db` inside the container). This is the only database backend you need to configure — the steps above are complete as written.
+
+On every backend boot, a versioned migration runner brings the SQLite schema up to date. The runner is crash-safe and concurrency-safe: a cross-process lock serialises it so multiple workers and the scheduler cannot race each other, and table rebuilds run inside a transaction that rolls back cleanly on a mid-migration crash. If a migration is still pending or has failed, the backend's `/health` endpoint returns `503` with a `migrations` block (`applied`, `expected`, `first_pending`) naming the stuck migration — so a 503 from `curl http://localhost:8000/health` during an upgrade is actionable, not opaque.
+
+A PostgreSQL backend is being introduced as the next step in this work, with Postgres migrations handled by Alembic instead of the SQLite runner. **It is not yet a user-selectable backend** — there is no supported environment variable to point a deployment at Postgres today. The migration-runner safety work above is the groundwork that makes that switch possible; until it lands, run on the default SQLite backend.
+
 ## 3. Build the Base Agent Image
 
 ```bash

--- a/docs/user-docs/guides/using-trinity.md
+++ b/docs/user-docs/guides/using-trinity.md
@@ -2,6 +2,8 @@
 
 A quick tour of the web UI — dashboard, agent management, chat, and day-to-day operations.
 
+> 📺 **Watch:** [Trinity Platform Demo — full UI walkthrough](https://youtu.be/ivljtZqsxeo) *(May 2026)* · [all videos](../videos.md)
+
 ## Logging In
 
 - **Admin login** — Enter username `admin` and the password set via `ADMIN_PASSWORD` in `.env` before first boot (self-hosted) or the one chosen at signup (cloud). There is no first-visit password wizard.

--- a/docs/user-docs/integrations/github-sync.md
+++ b/docs/user-docs/integrations/github-sync.md
@@ -2,6 +2,8 @@
 
 Keep agents in sync with GitHub (or self-hosted Git) repositories using two modes: Source mode (pull-only, default) and Working Branch mode (bidirectional).
 
+> 📺 **Watch:** [Why Every AI Agent Needs a GitHub Repo](https://youtu.be/R4nNHf6ywEs) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Source Mode** (default): Pull-only. The agent pulls from the repo but never pushes. Used for deploying agent code from a canonical source.

--- a/docs/user-docs/integrations/mcp-server.md
+++ b/docs/user-docs/integrations/mcp-server.md
@@ -2,6 +2,8 @@
 
 Trinity's MCP server exposes 80 tools for agent orchestration via the Model Context Protocol, enabling programmatic control from Claude Code, other MCP clients, or agent-to-agent communication.
 
+> 📺 **Watch:** [From Zero to Deployed AI Agent — MCP setup](https://youtu.be/-TSZyekDS6o) *(Apr 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **Model Context Protocol (MCP)** — An open standard for tool-based AI integrations. Trinity implements an MCP server that exposes agent management as callable tools.

--- a/docs/user-docs/integrations/telegram-integration.md
+++ b/docs/user-docs/integrations/telegram-integration.md
@@ -2,6 +2,8 @@
 
 Connect agents to Telegram bots. Supports direct messages, group chats, @mentions, and reply threading.
 
+> 📺 **Watch:** [Build an AI Recruiter Agent — Telegram bot setup](https://youtu.be/K7hFWyFIf-Y) *(Jun 2026)* · [all videos](../videos.md)
+
 ## Concepts
 
 - **1:1 Mapping** -- Each agent has its own dedicated Telegram bot. Bots cannot be shared across agents.

--- a/docs/user-docs/operations/dashboard.md
+++ b/docs/user-docs/operations/dashboard.md
@@ -2,6 +2,8 @@
 
 The main Dashboard at `/` provides a real-time agent network graph and timeline view for monitoring all agents and their activities.
 
+> 📺 **Watch:** [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) *(May 2026)* · [all videos](../videos.md)
+
 ## How It Works
 
 ### Graph View (default)

--- a/docs/user-docs/videos.md
+++ b/docs/user-docs/videos.md
@@ -1,0 +1,67 @@
+# Trinity Video Library
+
+Workshops, demos, and deep-dives on building and running autonomous agents with Trinity. Grouped by topic, **newest first** within each group.
+
+> New recordings land most weeks. For the full archive and live sessions, see [ability.ai/workshops](https://www.ability.ai/workshops).
+
+## Start Here — Platform Overview
+
+- [Trinity Platform Demo](https://youtu.be/ivljtZqsxeo) — *May 2026* · full UI walkthrough, end to end
+- [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) — *May 2026* · live fleet tour: delegation, memory, observability
+- [The Sovereign AI Setup That Changed Everything](https://youtu.be/2QH-jeVn2ak) — *Feb 2026*
+- [The Platform That Runs My Entire Business](https://youtu.be/i-4_7tcui30) — *Feb 2026*
+- [Trinity: Secure Infrastructure for Autonomous AI Agents at Scale](https://youtu.be/SWpNphnuPpQ) — *Jan 2026*
+- [Why I Stopped Renting AI Agents (And Built My Own)](https://youtu.be/qFmObXw7YSI) — *Jan 2026* · the sovereign-vs-SaaS case
+- [Trinity: Sovereign Infrastructure for Autonomous AI Agents](https://youtu.be/tZ4TN9ySMBE) — *Dec 2025*
+
+## Building & Deploying Agents
+
+- [Build an AI Recruiter Agent with Trinity + Claude Code](https://youtu.be/K7hFWyFIf-Y) — *Jun 2026* · zero to deployed, channel-exposed agent
+- [I Built a DevOps Agent That Deploys Other Agents](https://youtu.be/8RozanPd14Y) — *Apr 2026* · provision and self-host a Trinity instance
+- [Why Every AI Agent Needs a GitHub Repo](https://youtu.be/R4nNHf6ywEs) — *Apr 2026* · git-as-state, backlog work loops, dashboards
+- [3 AI Agents Run My Entire Software Development Pipeline](https://youtu.be/zCDFDhewFkk) — *Apr 2026* · the dev-methodology SDLC
+- [Plugins + Trinity: Build and Deploy Agents in Cursor](https://youtu.be/amqiysdlEWY) — *Apr 2026* · no terminal required
+- [Building Agents — Playbooks, Plugins, Deployment](https://youtu.be/MDxRZBikf70) — *Apr 2026*
+- [From Zero to Deployed AI Agent](https://youtu.be/-TSZyekDS6o) — *Apr 2026* · your first Trinity agent
+- [My Dev Workflow for a Large System Using Claude Code](https://youtu.be/z_feLdNGLSA) — *Dec 2025*
+
+## Automation & Loops
+
+- [Build Autonomous Loops for Your AI Agents](https://youtu.be/q3YvFYtuhec) — *Jun 2026* · loops vs. schedules, stop signals, failure modes
+
+## Multi-Agent Orchestration
+
+- [How We Automate Our Own Ops & Marketing](https://youtu.be/DDhSdwJ1sx8) — *Mar 2026* · a real multi-agent business system, live
+- [Building AI Agent Swarms That Actually Scale (Mrinal Wadhwa)](https://youtu.be/S2HQZeFdRWY) — *Feb 2026* · architecture deep-dive
+
+## Memory & Knowledge Agents (Cornelius)
+
+- [I Gave My AI Agent an Unconscious Mind](https://youtu.be/QUZ5ZgB5f6E) — *Jun 2026* · autonomous perception → deliberation loops
+- [I Let Cornelius Analyze the Hantavirus Outbreak](https://youtu.be/DIcLdZ-UESk) — *May 2026* · structured analytical reasoning loop
+- [I Gave My AI Three Years of My Notes. Then I Interviewed It.](https://youtu.be/xflQTzarEBQ) — *May 2026* · voice chat with a knowledge agent
+- [I Gave My AI Agent a Brain — Here's What Happened](https://youtu.be/yD3w1GBFtvY) — *Feb 2026* · memory as a shared, evolving service
+- [Second Brain AI Agent with Swappable Brains](https://youtu.be/7WoOIMMEOfI) — *Nov 2025*
+- [AI Second Brain with Claude Code and Obsidian](https://youtu.be/Jsh_XbUynx0) — *Oct 2025* · the original build
+
+## Use Cases & Case Studies
+
+- [How I Built an Agent That Makes Movies While I Sleep](https://youtu.be/CblJsMI9ekU) — *Feb 2026* · long-running creative production + heartbeat
+- [Investigative Analysis of Epstein Files Using an AI Agent](https://youtu.be/8a9p60kOWgU) — *Jan 2026* · knowledge graph over a messy corpus
+- [Control My DGX Spark From Anywhere](https://youtu.be/epDBrEtg4nE) — *Jan 2026* · Trinity on local/edge hardware over Tailscale
+- [I Let AI Agents Build My Entire Webinar](https://youtu.be/WBVbg_bwc_g) — *Dec 2025* · agent as a daily-work collaborator
+- [How AI Agents Power Our B2B Marketing Pipeline](https://youtu.be/ux_q9LMuM3w) — *Nov 2025*
+- [From Transcript to Scheduled Posts in 30 Minutes](https://youtu.be/z09JPgZ7viQ) — *Nov 2025* · the content pipeline, short cut
+- [My Secret Content Creation Pipeline: Video to Multi-Platform Posts](https://youtu.be/eAXk4U3uqOY) — *Nov 2025*
+
+## Concepts & Strategy
+
+- [How to Implement AI Support Without Risking Customer Trust](https://youtu.be/FiXGRotpff4) — *Mar 2026* · phased, safe rollout methodology
+- [Prompt Engineering Is Dead — Context Engineering Explained](https://youtu.be/8pa5QyY6HdA) — *Dec 2025*
+- [Why 95% of Companies Fail to Implement AI Automation](https://youtu.be/51ZKT0zp_ZY) — *Nov 2025*
+- [Context Rot in LLMs — Building Resilient AI Agents](https://youtu.be/wIz9X-csrs4) — *Oct 2025*
+
+## See Also
+
+- [Getting Started — Overview](getting-started/overview.md)
+- [Building Agents](guides/building-agents.md)
+- [Getting Help](getting-started/help.md)

--- a/docs/user-docs/whats-new/README.md
+++ b/docs/user-docs/whats-new/README.md
@@ -4,4 +4,5 @@ User-facing highlights for each Trinity release — what changed and why it matt
 
 ## Releases
 
+- [v0.6.1](v0.6.1.md) — 2026-06-12 · UI/UX + reliability; unified Operations area, Agent Overview dashboard, sequential loops, VoIP phone calls, secure-by-default access.
 - [v0.6.0](v0.6.0.md) — 2026-06-01 · Reliability + security release; stateful Session chat and experimental Voice Workspace.

--- a/docs/user-docs/whats-new/v0.6.1.md
+++ b/docs/user-docs/whats-new/v0.6.1.md
@@ -1,0 +1,56 @@
+# What's New in Trinity v0.6.1
+
+*Released 2026-06-12*
+
+A UI/UX-and-reliability release. The biggest change is how you watch your fleet: Health, Ops, and Executions are now one **Operations** area, and every agent opens to a new **Overview dashboard**. Sequential **agent loops** ship end-to-end (start one from the UI or from Claude Code), agents can now **place phone calls** over voice (beta), new agents are **secure by default**, and the model list adds **Opus 4.8**.
+
+## Improvements
+
+- **One Operations area** — Health, the operator queue, and Executions are consolidated into a single tabbed **Operations** page, with a unified notification badge and a per-tab **Clear All**. Old `/monitoring`, `/executions`, and `/operating-room` links redirect here automatically.
+- **Agent Overview dashboard** — Each agent now opens to an Overview tab: activity trends, success rate, context use, and recent activity at a glance. Tabs that don't fit collapse into a **More** menu instead of scrolling off-screen.
+- **Sequential agent loops** — Run the same task against an agent repeatedly with a bounded run count and an optional stop signal, from the new **Loops** tab or via MCP / Claude Code.
+- **Agents can place phone calls (beta)** — An agent can dial out and hold a live voice conversation over the phone. Off by default; an admin enables it.
+- **Per-schedule and per-playbook analytics** — Duration, token, and tool-call distributions for each schedule and playbook.
+- **Read the operator queue from MCP** — New tools let agents and scripts read pending operator-queue items, broadly or by agent name.
+- **Faster failure detection** — Agents push a lightweight heartbeat, so the platform notices an unresponsive agent quickly.
+- **Secure-by-default access** — Newly created agents default to "require verified email." Existing agents keep their current policy; admins set the fleet-wide default in **Settings → Agent Defaults**.
+- **Settings tab** — The per-agent **Guardrails** tab is now a sectioned **Settings** home for agent configuration.
+- **Refreshed model list** — Adds Opus 4.8 and removes end-of-life models across the app.
+- **Loops shown distinctly** — Timeline and execution charts display loop runs as their own category instead of folding them into Scheduled.
+
+## Fixes
+
+- **No more false "0 tool calls" failures** — Long tasks whose child processes held the output pipe are no longer mislabeled as empty failures.
+- **Subscription auto-switch no longer kills running work** — Switching a rate-limited subscription drains in-flight executions instead of dropping them.
+- **Phone and voice connect reliably** — Fixed a call-answer failure and a "model is required" voice error on Docker-compose deploys.
+- **Fleet health survives restarts** — The health-monitoring loop now resumes automatically after a backend restart instead of staying off.
+- **Accurate timeout messages** — A run stopped by the watchdog is no longer mislabeled "timed out."
+- **More build/scratch space for agents** — Agents no longer run out of temporary space during pip, npm, or build steps.
+- **Reliable resource configuration** — CPU/memory display, dialog pre-selection, and the apply flow are fixed.
+- **Telegram voice and image generation work again** — Removed a retired model that was returning 404s.
+- **Accurate notification count** — The navigation badge shows the real pending count instead of capping at 1.
+- **Approval notifications** — A requester is now notified when their channel-access request is approved.
+- **Correct version display** — The version endpoint shows the real build version instead of "unknown."
+- **Operator sessions protected** — The orphan sweeper no longer kills active operator terminal sessions.
+
+## Security & Hardening
+
+- Unified, consistent request rate limiting across endpoints.
+- Removed an embedded credential from the `trinity init` CLI command and published a patched CLI.
+- Resolved critical and high-severity dependency advisories.
+
+## Upgrade Notes
+
+- **Re-login required** after the platform restarts, and MCP clients need to reconnect.
+- **New agents default to "require verified email."** Existing agents are unchanged; change the default in **Settings → Agent Defaults**.
+- **Per-task timeout override removed.** Task dispatch now uses the agent's execution-timeout setting; schedule-level timeouts are unaffected.
+- **Update your bookmarks.** `/monitoring`, `/executions`, `/operating-room`, and `/events` now redirect to `/operations`.
+- **Self-hosted operators:** no special migration beyond the standard upgrade — agents pick up the new temp-directory default on their next restart.
+
+## See Also
+
+- [Operations Page](../operations/operating-room.md)
+- [Agent Loops](../automation/agent-loops.md)
+- [VoIP Telephony](../advanced/voip-telephony.md)
+- [Video Library](../videos.md)
+- [Release notes (technical)](../../releases/v0.6.1.md)


### PR DESCRIPTION
## Summary

Two things, landed together against `dev`:

1. **Video enrichment** — a new `docs/user-docs/videos.md` library (35 published videos, grouped by topic, newest-first) plus `📺 Watch` callouts on 32 feature pages and a README "Watch" section. Each callout links the most relevant videos, prioritizing newer ones.
2. **Doc sync** — the user docs had drifted behind `dev`. This adds the missing user-facing `whats-new/v0.6.1.md` and documents the dev-only features that shipped since the last sync.

## New pages
- `agents/agent-runtimes.md` — Claude Code / OpenAI Codex / Gemini CLI runtimes (#1187)
- `agents/agent-data.md` — `data_paths` + on-demand export/import portability (#1169)
- `whats-new/v0.6.1.md` — user-facing release highlights (no issue numbers/codenames)
- `videos.md` — the video library

## Updated pages
- `creating-agents` (compatibility validation + auto-fix, #668), `help` (in-app bug reporting, #1116), `subscription-credentials` (hot-reload rotation, #1089), `agent-network` (experimental pull-pilot routing, #946), `agent-configuration` (`AGENT_TMP_SIZE`, #1231), `single-server` (Postgres migration-runner groundwork — **not yet a user-selectable backend**, #1160), `overview` + `setup` (multi-runtime framing, setup-token notes), README index (+ the previously-orphaned `agent-session`).

## Notes
- Deliberately **not** documented (no user surface): agent-server auth hardening (#1159), status-as-projection refactor (#1082). TOTP login (#1247) left for when the enterprise UI ships publicly.
- Verified: `v0.6.1` carries no issue numbers; deploy guides pass the public-safety scan; all new-page links resolve; no secrets/PII/internal IPs in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
