### PR TITLE
feat(ui): loading skeletons for Dashboard & timeline (#1266)

### DIFF
--- a/src/frontend/src/components/SkeletonLoader.vue
+++ b/src/frontend/src/components/SkeletonLoader.vue
@@ -1,0 +1,61 @@
+<template>
+  <!--
+    Reusable loading skeleton (trinity-enterprise#1266 / #1266).
+    Communicates "loading" instead of a frozen/empty UI while metrics load.
+    Dark-mode aware; reserves layout space to avoid shift when real content
+    replaces it. Variants:
+      - rows  : stacked shimmer bars (timeline rows, lists, cards)
+      - nodes : scattered node-card placeholders (collaboration graph)
+  -->
+  <div
+    class="skeleton-loader w-full"
+    role="status"
+    aria-busy="true"
+    aria-label="Loading"
+  >
+    <!-- rows: timeline / list / card placeholders -->
+    <div v-if="variant === 'rows'" class="flex flex-col" :style="{ gap }">
+      <div
+        v-for="n in count"
+        :key="n"
+        class="animate-pulse bg-gray-200 dark:bg-gray-700 rounded-md w-full"
+        :style="{ height }"
+      ></div>
+    </div>
+
+    <!-- nodes: collaboration-graph placeholders -->
+    <div
+      v-else-if="variant === 'nodes'"
+      class="flex flex-wrap items-center justify-center gap-10 p-8"
+    >
+      <div
+        v-for="n in count"
+        :key="n"
+        class="flex flex-col items-center gap-2 animate-pulse"
+      >
+        <div
+          class="rounded-full bg-gray-200 dark:bg-gray-700"
+          :style="{ width: nodeSize, height: nodeSize }"
+        ></div>
+        <div class="h-3 w-16 rounded bg-gray-200 dark:bg-gray-700"></div>
+      </div>
+    </div>
+
+    <span class="sr-only">Loading…</span>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  // 'rows' (stacked bars) | 'nodes' (graph node placeholders)
+  variant: { type: String, default: 'rows' },
+  // number of placeholder rows / nodes to render
+  count: { type: Number, default: 3 },
+  // height of each row bar (rows variant)
+  height: { type: String, default: '1.5rem' },
+  // gap between row bars (rows variant)
+  gap: { type: String, default: '0.5rem' },
+  // diameter of each node circle (nodes variant)
+  nodeSize: { type: String, default: '3.5rem' },
+})
+</script>

--- a/src/frontend/src/stores/network.js
+++ b/src/frontend/src/stores/network.js
@@ -32,6 +32,13 @@ export const useNetworkStore = defineStore('network', () => {
   const activityRefreshInterval = ref(null) // Interval ID for activity refresh (fallback)
   const websocketHeartbeatInterval = ref(null) // Interval ID for WebSocket keepalive ping
   const runningToggleLoading = ref({}) // Map of agent name -> boolean (loading state for start/stop)
+  // #1266 perceived-performance: initial fleet load can take 20s+ (#1265), so the
+  // Dashboard/timeline render skeletons off these flags instead of looking frozen.
+  // `loading` starts true so the very first paint is a skeleton, not the empty
+  // "No agents" state; `loadError` keeps a failed load distinct from an infinite
+  // skeleton or a real empty fleet.
+  const loading = ref(true)       // true while the initial agents/fleet fetch is in flight
+  const loadError = ref(false)    // true when the last agents fetch failed
   const schedules = ref([]) // Enabled schedules for timeline markers
   // #306 Redis Streams reconnect replay: remember the last event id we saw so
   // a network blip replays missed events instead of dropping them.
@@ -129,6 +136,8 @@ export const useNetworkStore = defineStore('network', () => {
   }
 
   async function fetchAgents() {
+    loading.value = true
+    loadError.value = false
     try {
       const params = {}
       if (filterTags.value.length > 0) {
@@ -144,6 +153,11 @@ export const useNetworkStore = defineStore('network', () => {
       await fetchPermissionEdges()
     } catch (error) {
       console.error('Failed to fetch agents:', error)
+      loadError.value = true
+    } finally {
+      // Always clear loading so a failed/empty load shows its own state, never an
+      // infinite skeleton (#1266).
+      loading.value = false
     }
   }
 
@@ -1663,6 +1677,8 @@ export const useNetworkStore = defineStore('network', () => {
 
   return {
     // State
+    loading,        // #1266 initial-load flag (drives Dashboard/timeline skeletons)
+    loadError,      // #1266 distinct failed-load state
     agents,
     nodes,
     edges,

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -189,12 +189,31 @@
         </div>
 
     <!-- Timeline View (only visible in timeline mode) -->
-    <ReplayTimeline
-      v-if="isTimelineMode"
-      :agents="agents"
-      :nodes="nodes"
-      :events="historicalCollaborations"
-      :timeline-start="timelineStart"
+    <template v-if="isTimelineMode">
+      <!-- Loading skeleton (#1266): immediate feedback while fleet/timeline data loads -->
+      <div
+        v-if="isFleetLoading && agents.length === 0"
+        class="flex-1 min-h-0 overflow-hidden bg-white dark:bg-gray-800 px-4 py-4"
+      >
+        <SkeletonLoader variant="rows" :count="8" height="2.5rem" gap="0.5rem" />
+      </div>
+      <!-- Error state (#1266): distinct from an empty timeline / infinite skeleton -->
+      <div
+        v-else-if="fleetLoadError && agents.length === 0"
+        class="flex-1 min-h-0 flex flex-col items-center justify-center text-center px-4"
+      >
+        <p class="text-sm text-gray-600 dark:text-gray-300">Couldn't load timeline data.</p>
+        <button
+          @click="refreshAll"
+          class="mt-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+        >Retry</button>
+      </div>
+      <ReplayTimeline
+        v-else
+        :agents="agents"
+        :nodes="nodes"
+        :events="historicalCollaborations"
+        :timeline-start="timelineStart"
       :timeline-end="timelineEnd"
       :current-event-index="currentEventIndex"
       :total-events="totalEvents"
@@ -213,13 +232,35 @@
       @stop="handleStop"
       @speed-change="handleSpeedChange"
       @toggle-autonomy="handleToggleAutonomy"
-    />
+      />
+    </template>
 
     <!-- Graph Canvas - Full Height (expands to fill remaining space) - Hidden in Timeline mode -->
     <div v-if="!isTimelineMode" class="relative bg-white dark:bg-gray-800 shadow-sm dark:shadow-gray-900 flex-1 min-h-0">
+      <!-- Loading skeleton (#1266): graph node placeholders instead of the "No agents" empty state -->
+      <div
+        v-if="isFleetLoading && nodes.length === 0"
+        class="absolute inset-0 flex items-center justify-center"
+      >
+        <SkeletonLoader variant="nodes" :count="5" />
+      </div>
+      <!-- Error state (#1266): distinct from loading and from a genuinely empty fleet -->
+      <div
+        v-else-if="fleetLoadError && nodes.length === 0"
+        class="absolute inset-0 flex items-center justify-center"
+      >
+        <div class="text-center">
+          <h3 class="text-sm font-medium text-gray-900 dark:text-gray-100">Couldn't load agents</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Something went wrong fetching the fleet.</p>
+          <button
+            @click="refreshAll"
+            class="mt-4 inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700"
+          >Retry</button>
+        </div>
+      </div>
       <!-- Empty state -->
       <div
-        v-if="nodes.length === 0"
+        v-else-if="nodes.length === 0"
         class="absolute inset-0 flex items-center justify-center"
       >
         <div class="text-center">
@@ -431,6 +472,7 @@
 import NavBar from '@/components/NavBar.vue'
 import HostTelemetry from '@/components/HostTelemetry.vue'
 import ReplayTimeline from '@/components/ReplayTimeline.vue'
+import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import SystemViewsSidebar from '@/components/SystemViewsSidebar.vue'
 import SystemViewEditor from '@/components/SystemViewEditor.vue'
 import axios from 'axios'
@@ -492,6 +534,8 @@ const {
   totalCollaborationCount,
   timeRangeHours,
   isLoadingHistory,
+  loading: isFleetLoading,
+  loadError: fleetLoadError,
   contextStats,
   executionStats,
   slotStats,


### PR DESCRIPTION
## What

Adds lightweight loading states so the Dashboard graph and timeline don't look frozen/dead while the initial fleet metrics load (20s+ on 10+ agent fleets, #1265). The perceived-performance half of the #1265/#1266 pair.

## Changes
- **`SkeletonLoader.vue`** (new) — one reusable, dark-mode-aware, accessible (`role=status`/`aria-busy`) skeleton. `rows` variant (timeline/lists) + `nodes` variant (collaboration graph). Reserves space → no layout shift.
- **`stores/network.js`** — `loading` (defaults `true`, so first paint is a skeleton not the "No agents" empty state) + `loadError`, toggled in `fetchAgents` (`finally`-cleared so a failed load never shows an infinite skeleton).
- **`Dashboard.vue`** — graph canvas and timeline render **skeleton → error → empty → content** off those flags. Retry reuses the existing `refreshAll`.

## Acceptance criteria
- [x] Dashboard graph shows skeleton placeholders (node variant) while loading, not blank/empty
- [x] Timeline shows skeleton rows instead of a frozen empty area
- [x] Loading appears immediately on navigation (flag defaults true + set synchronously in `fetchAgents`); clears when data arrives
- [x] No layout shift — skeletons fill the same `absolute inset-0` / `flex-1` regions and reserve row heights
- [x] Dark-mode aware (`bg-gray-200 dark:bg-gray-700`), consistent with existing styling
- [x] Error state is distinct from loading and from a genuinely empty fleet (3-way branch + Retry)

## Notes
- Frontend-only; pairs with backend perf in #1265.
- `vite build` passes; reuses the existing `refreshAll` for retry per store=domain convention.

Related to #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)