### PR TITLE
fix(whatsapp): webhook routes to backend, not frontend (#1281)

### DIFF
--- a/src/frontend/src/components/WhatsAppChannelPanel.vue
+++ b/src/frontend/src/components/WhatsAppChannelPanel.vue
@@ -84,7 +84,7 @@
       <!-- Ops prerequisite notice -->
       <div class="p-3 rounded-lg text-xs bg-state-autonomous-50 dark:bg-state-autonomous-900/30 text-state-autonomous-800 dark:text-state-autonomous-200">
         <strong>Deployment prerequisite:</strong> Cloudflare Tunnel ingress must route
-        <code class="font-mono">/api/whatsapp/webhook/*</code> to the frontend service.
+        <code class="font-mono">/api/whatsapp/webhook/*</code> to the <strong>backend</strong> service (<code class="font-mono">http://backend:8000</code>).
         See <em>docs/requirements/PUBLIC_EXTERNAL_ACCESS_SETUP.md</em>.
       </div>
 


### PR DESCRIPTION
## What

Text-only fix in `WhatsAppChannelPanel.vue`. The "Deployment prerequisite" notice told operators to route `/api/whatsapp/webhook/*` to the **frontend service** — wrong. That path is a backend FastAPI route (Twilio HMAC-SHA1 verified); following the instruction literally points Cloudflare Tunnel ingress at the static SPA, where inbound WhatsApp messages are silently dropped.

Corrected to the **backend** service (`http://backend:8000`), matching the cited `docs/requirements/PUBLIC_EXTERNAL_ACCESS_SETUP.md` (which already maps `/api/whatsapp/webhook/*` → `http://backend:8000`).

## Notes
- Isolated to the one line (swept the other channel panels — no equivalent misdirection).
- `vite build` passes.
- Default setups were unaffected (standard tunnel ingress already routes correctly); this only misled operators who followed the on-screen text.

Related to #1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)