### PR TITLE
feat(whatsapp): outbound media attachments via Twilio MediaUrl (#1315)

### DIFF
--- a/docs/memory/feature-flows/whatsapp-integration.md
+++ b/docs/memory/feature-flows/whatsapp-integration.md
@@ -1,7 +1,7 @@
 # WhatsApp Integration via Twilio (WHATSAPP-001)
 
-**Issues**: #299 (Phase 1), #467 (Phase 2)
-**Status**: Phase 2 — unified access control wired (#311)
+**Issues**: #299 (Phase 1), #467 (Phase 2), #1315 (Phase 3 — outbound media)
+**Status**: Phase 3 partial — outbound media attachments shipped (#1315)
 **Extends**: SLACK-002 `ChannelAdapter` abstraction
 
 Adds WhatsApp as a per-agent channel via Twilio's Programmable Messaging API.
@@ -31,10 +31,18 @@ no platform-level Twilio account required.
 - Markdown → WhatsApp-native syntax conversion in `send_response` so agent
   markdown (`**bold**`, `[text](url)`) renders correctly
 
+### In scope (Phase 3 — #1315, outbound media, shipped)
+- Outbound media attachments: `WhatsAppAdapter.send_response` delivers
+  `ChannelResponse.files` as Twilio `MediaUrl` (one message per file), reusing
+  FILES-001 storage to mint a public `?sig=` URL Twilio fetches server-side.
+  Gated on `file_sharing_enabled`; text-link fallback when undeliverable as
+  media. See *Flow: Outbound media attachments* below.
+
 ### Deferred
-- **Phase 3** — SMS on the same Twilio binding, WhatsApp Business templates
-  (for outbound-first messaging outside 24h window), interactive buttons,
-  voice-note transcription
+- **Phase 3 (remaining)** — SMS on the same Twilio binding, WhatsApp Business
+  templates (for outbound-first messaging outside 24h window), interactive
+  buttons, voice-note transcription, and promoting FILES-001 share URLs already
+  present in `response.text` to `MediaUrl` (#1315 option b)
 - **Out of scope** — WhatsApp group chats (Twilio's WhatsApp API does not
   support them)
 
@@ -63,6 +71,7 @@ no platform-level Twilio account required.
 | Settings back-fill | `src/backend/routers/settings.py` (piggybacks on `public_chat_url` save) |
 | UI panel | `src/frontend/src/components/WhatsAppChannelPanel.vue` |
 | UI mount | `src/frontend/src/components/SharingPanel.vue` |
+| Outbound media (#1315) | `src/backend/services/agent_shared_files_service.py::create_share_from_bytes` (FILES-001 reuse) |
 | New dependency | `twilio==9.10.5` (in `docker/backend/Dockerfile`) |
 
 ## Flow: Inbound WhatsApp message
@@ -179,6 +188,64 @@ correctly. Conversions:
 
 Implemented as a pure static method on `WhatsAppAdapter`; also exposed via
 `format_response` for non-send callsites (e.g. proactive delivery).
+
+## Flow: Outbound media attachments (#1315)
+
+Agents can attach files to a reply. `ChannelMessageRouter._extract_outbound_files`
+already pulls large fenced code blocks (csv/json/etc., ≤500 KB each, ≤2 MB total,
+≤5 files) out of the response text into `ChannelResponse.files` (`OutboundFile`,
+bytes in memory). WhatsApp delivers them as Twilio `MediaUrl` attachments.
+
+Twilio fetches a `MediaUrl` **server-side from the public internet** — it cannot
+upload bytes the way Slack does. So each file is persisted to FILES-001 storage
+and its public `?sig=` download URL is handed to Twilio.
+
+```
+WhatsAppAdapter.send_response(channel_id, response)
+        │
+        ▼
+_prepare_outbound_media(agent_name, response.files)   ← per-file isolated
+   gate: db.get_file_sharing_enabled(agent_name)       (off → text-only + WARN)
+   for each OutboundFile:
+     create_share_from_bytes(agent_name, f.content,    ← FILES-001 reuse
+         display_name=f.filename, expires_in=3600,      (1h TTL; reaper purges)
+         created_by=agent_name)  → {url, mime_type, size_bytes}
+       · HTTPException/any error → WARN + skip (never aborts text or siblings)
+     classify:
+       · url not https://         → text-link fallback (public_chat_url unset)
+       · mime unsupported          → text-link fallback
+       · size > WhatsApp cap       → text-link fallback
+       · else                      → MediaUrl
+   → (media_urls, fallback_links)
+        │
+        ▼
+body = markdown(agent_text) + "\n\n" + fallback links (verbatim, NOT markdownized)
+   1. send text body first (chunked) — survives total media failure
+   2. one _send_message(..., media_url=...) per file  (WhatsApp = 1 media/msg)
+```
+
+Key decisions (#1315):
+- **Why FILES-001 + URL, not direct upload**: Twilio's WhatsApp send only accepts
+  a publicly-fetchable `MediaUrl`. The unauthenticated `/api/files/{id}?sig=`
+  endpoint (192-bit token, constant-time compare, `attachment` + `nosniff`) is
+  exactly that. `create_share_from_bytes` is the bytes-input twin of
+  `create_share`; both share `_persist_and_register` (MIME-blocklist → quota →
+  disk-check → persist → DB → URL).
+- **Short 1h TTL** (`_OUTBOUND_MEDIA_EXPIRES_IN`): Twilio fetches the URL within
+  seconds; the cleanup-service reaper (`_sweep_shared_files`) purges expired
+  shares, so the public link doesn't linger. NOT revoke-after-send — Twilio's
+  fetch is async *after* the POST 2xx, so revoking on the ack would race it.
+- **Caps** (`_outbound_media_cap_for_mime`): image/audio/video ≈5 MB, documents
+  (`text/*` + json/xml/pdf/yaml/sql/js) ≈16 MB; `application/octet-stream` /
+  unknown → undeliverable → text link. Classified on the *detected* MIME (the
+  download endpoint serves `Content-Type: mime_type`, which Twilio reads to
+  render the media), not the code-fence `language` hint.
+- **`file_sharing_enabled` gate**: outbound media reuses the same public storage
+  + quota as the `share_file` MCP tool, so it honors the same per-agent toggle.
+  Off → files are not delivered as media (the `(see attached: …)` placeholder
+  text remains) + WARN.
+- **Idempotency**: none added — `twilio_webhook` dedups inbound by `MessageSid`
+  before dispatch, so `send_response` (and each mint) runs exactly once.
 
 ## Flow: Proactive messaging (`_deliver_whatsapp`)
 

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -1165,12 +1165,14 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
   - Empty TwiML (`<Response/>`) returned to Twilio ack; response delivered asynchronously via REST (no TwiML body response path)
 - **Phase 2 (deferred)**:
   - `#311` unified access control: `/login <email>` command flow, verified-email gate, `access_requests` pipeline (schema columns `verified_email`/`verified_at` shipped up-front so Phase 2 is application-only)
+- **Phase 3 (partial)**:
+  - **Outbound media attachments (shipped — #1315)**: `WhatsAppAdapter.send_response` delivers `ChannelResponse.files` as Twilio `MediaUrl` attachments — one message per file (WhatsApp permits a single media per message), text sent first. Each file is persisted to FILES-001 storage via `create_share_from_bytes` and handed to Twilio as its public `?sig=` URL (Twilio fetches it server-side). Gated on the per-agent `file_sharing_enabled` toggle. Short 1h share TTL (the cleanup-service reaper purges expired shares). Graceful text-link fallback when `public_chat_url` is unset/non-HTTPS, the MIME is unsupported, or the file exceeds WhatsApp caps (image/audio/video ≈5 MB, documents ≈16 MB) — never silently dropped.
 - **Phase 3 (deferred)**:
   - SMS on the same Twilio binding (drop `whatsapp:` prefix)
   - Message templates for outbound-first conversations outside the 24h customer-service window (Twilio Content Builder)
   - Interactive buttons and list messages (Twilio Content API)
   - Voice-note transcription (Whisper API)
-  - Outbound file sharing
+  - Promoting FILES-001 share URLs already present in `response.text` to `MediaUrl` (#1315 option b)
 - **Out of scope**:
   - WhatsApp group chats — not supported by Twilio's WhatsApp API
   - Meta Cloud API direct integration — future alternative; not this PR

--- a/src/backend/adapters/whatsapp_adapter.py
+++ b/src/backend/adapters/whatsapp_adapter.py
@@ -18,6 +18,7 @@ from typing import List, Optional
 from urllib.parse import urlparse
 
 import httpx
+from fastapi import HTTPException
 
 from database import db
 from adapters.base import (
@@ -25,8 +26,11 @@ from adapters.base import (
     ChannelResponse,
     FileAttachment,
     NormalizedMessage,
+    OutboundFile,
 )
+from services.agent_shared_files_service import create_share_from_bytes
 from services.email_service import EmailService
+from services.settings_service import get_public_chat_url
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +45,54 @@ _TWILIO_MEDIA_ALLOWED_HOST_SUFFIXES = (".twilio.com",)
 
 # Pending-login TTL (matches verification-code expiry)
 _PENDING_LOGIN_TTL = 600  # 10 minutes
+
+# Outbound media (#1315): files are persisted to FILES-001 storage and handed to
+# Twilio as a public `?sig=` MediaUrl, which Twilio fetches server-side within
+# seconds of the send. A short TTL keeps the public link alive just long enough
+# for that fetch (+ Twilio retries) — the cleanup service reaps expired shares,
+# so the blob doesn't linger. NOT revoke-after-send: Twilio fetches the URL
+# *asynchronously* after the POST 2xx, so revoking on the API ack would race it.
+_OUTBOUND_MEDIA_EXPIRES_IN = 3600  # 1 hour
+
+# Twilio WhatsApp outbound media byte caps (per Twilio docs): image/audio/video
+# ≈5 MB, documents ≈16 MB. Outbound files today are text artifacts (documents,
+# ≤500 KB each via message_router caps), so the document cap is the operative
+# one; the media caps are defensive for future binary attachments.
+_WA_MEDIA_CAP_BYTES = 5 * 1024 * 1024
+_WA_DOC_CAP_BYTES = 16 * 1024 * 1024
+
+# MIME types deliverable as WhatsApp *documents* beyond the broad `text/*` match.
+_WA_DOC_MIME_ALLOWLIST = frozenset({
+    "application/json",
+    "application/xml",
+    "application/pdf",
+    "application/x-yaml",
+    "application/yaml",
+    "application/sql",
+    "application/javascript",
+    "application/x-ndjson",
+})
+
+
+def _outbound_media_cap_for_mime(mime: str) -> Optional[int]:
+    """Return the WhatsApp outbound byte cap for a MIME type, or None if the type
+    is not deliverable as media.
+
+    image/audio/video → 5 MB; documents (``text/*`` + a small allowlist of
+    structured types) → 16 MB. ``application/octet-stream`` / unknown is treated
+    as undeliverable (Twilio would reject it) → caller falls back to a text link.
+    """
+    mime = (mime or "").lower().split(";")[0].strip()
+    if not mime or mime == "application/octet-stream":
+        return None
+    top = mime.split("/")[0]
+    if top in ("image", "audio", "video"):
+        return _WA_MEDIA_CAP_BYTES
+    if top == "text":
+        return _WA_DOC_CAP_BYTES
+    if mime in _WA_DOC_MIME_ALLOWLIST:
+        return _WA_DOC_CAP_BYTES
+    return None
 
 
 def _get_pending_login_key(binding_id: int, user_id: str) -> str:
@@ -239,7 +291,15 @@ class WhatsAppAdapter(ChannelAdapter):
         response: ChannelResponse,
         thread_id: Optional[str] = None,
     ) -> None:
-        """Send a WhatsApp message via Twilio REST API."""
+        """Send a WhatsApp message via Twilio REST API.
+
+        Outbound files (``ChannelResponse.files``, #1315) are persisted to
+        FILES-001 storage and delivered as Twilio ``MediaUrl`` attachments — one
+        message per file (WhatsApp permits a single media per message). Text is
+        always sent *first* so the reply survives even if every media send fails;
+        files that can't be delivered as media (no public URL / unsupported MIME /
+        oversized) degrade to a download link appended to the text body.
+        """
         composite = response.metadata.get("bot_token") or ""
         agent_name = response.metadata.get("agent_name", "")
 
@@ -256,24 +316,138 @@ class WhatsAppAdapter(ChannelAdapter):
             logger.error("[WHATSAPP] No binding for agent=%s when sending response", agent_name)
             return
 
-        text = response.text or ""
-        if not text.strip():
+        # Persist + classify outbound files (per-file isolated; never raises).
+        media_urls, fallback_links = self._prepare_outbound_media(agent_name, response.files)
+
+        # Build the text body: convert the agent's markdown FIRST, then append any
+        # download links verbatim. Links must NOT pass through markdown conversion
+        # — a `__` in a `?sig=` token (base64url alphabet) would be mis-rendered as
+        # *bold* and corrupt the URL.
+        body_parts: List[str] = []
+        agent_text = response.text or ""
+        if agent_text.strip():
+            body_parts.append(self._markdown_to_whatsapp(agent_text))
+        if fallback_links:
+            body_parts.append("\n".join(f"📎 {name}: {url}" for name, url in fallback_links))
+        body = "\n\n".join(body_parts).strip()
+
+        if not body and not media_urls:
             return
 
-        # Agents emit standard markdown; WhatsApp uses its own syntax.
-        text = self._markdown_to_whatsapp(text)
+        if body:
+            for chunk in self._split_message(body):
+                await self._send_message(
+                    account_sid=account_sid,
+                    auth_token=auth_token,
+                    from_number=binding["from_number"],
+                    messaging_service_sid=binding.get("messaging_service_sid"),
+                    to_number=channel_id,
+                    body=chunk,
+                )
 
-        chunks = self._split_message(text)
-
-        for chunk in chunks:
-            await self._send_message(
+        # One media message per file — WhatsApp allows only a single media per message.
+        for media_url in media_urls:
+            result = await self._send_message(
                 account_sid=account_sid,
                 auth_token=auth_token,
                 from_number=binding["from_number"],
                 messaging_service_sid=binding.get("messaging_service_sid"),
                 to_number=channel_id,
-                body=chunk,
+                body="",
+                media_url=media_url,
             )
+            if result is None:
+                logger.warning(
+                    "[WHATSAPP] outbound media message rejected by Twilio (to=%s) — "
+                    "likely outside the 24h session window (63016) or unsupported media",
+                    _mask_phone(channel_id),
+                )
+
+    def _prepare_outbound_media(
+        self, agent_name: str, files: List["OutboundFile"]
+    ) -> tuple:
+        """Persist each outbound file to FILES-001 storage and classify it for
+        delivery.
+
+        Returns ``(media_urls, fallback_links)`` where ``media_urls`` are absolute
+        HTTPS ``?sig=`` URLs to send as Twilio ``MediaUrl`` and ``fallback_links``
+        are ``(filename, url)`` pairs to append to the text body (no public URL /
+        unsupported MIME / oversized).
+
+        Per-file isolation: a rejected or failed file (quota/disk/MIME-blocked,
+        ``HTTPException``, or any error) is logged and skipped — it never aborts
+        the text reply or its sibling files (#1315).
+        """
+        media_urls: List[str] = []
+        fallback_links: List[tuple] = []
+        if not files:
+            return media_urls, fallback_links
+
+        # Outbound media reuses FILES-001 public storage — gate on the same
+        # per-agent toggle. Off → text-only delivery (placeholder text remains).
+        if not db.get_file_sharing_enabled(agent_name):
+            logger.warning(
+                "[WHATSAPP] file sharing disabled for agent=%s; %d outbound file(s) not delivered as media",
+                agent_name, len(files),
+            )
+            return media_urls, fallback_links
+
+        for f in files:
+            try:
+                share = create_share_from_bytes(
+                    agent_name,
+                    f.content,
+                    display_name=f.filename,
+                    expires_in=_OUTBOUND_MEDIA_EXPIRES_IN,
+                    created_by=agent_name,
+                )
+            except HTTPException as e:
+                logger.warning(
+                    "[WHATSAPP] outbound file '%s' rejected (%s); skipping",
+                    f.filename, getattr(e, "detail", e),
+                )
+                continue
+            except Exception as e:
+                logger.warning(
+                    "[WHATSAPP] outbound file '%s' persist failed: %s; skipping",
+                    f.filename, e,
+                )
+                continue
+
+            url = share.get("url") or ""
+            mime = share.get("mime_type") or "application/octet-stream"
+            size = share.get("size_bytes") or 0
+
+            # Twilio fetches the MediaUrl from the public internet — a relative or
+            # non-HTTPS URL (public_chat_url unset) is unreachable. Degrade to a link.
+            if not url.lower().startswith("https://"):
+                logger.warning(
+                    "[WHATSAPP] public_chat_url not configured for HTTPS fetch; "
+                    "delivering '%s' as a text link instead of media",
+                    f.filename,
+                )
+                fallback_links.append((f.filename, url))
+                continue
+
+            cap = _outbound_media_cap_for_mime(mime)
+            if cap is None:
+                logger.warning(
+                    "[WHATSAPP] unsupported outbound media type '%s' for '%s'; delivering as text link",
+                    mime, f.filename,
+                )
+                fallback_links.append((f.filename, url))
+                continue
+            if size > cap:
+                logger.warning(
+                    "[WHATSAPP] outbound file '%s' (%d bytes, %s) exceeds WhatsApp cap %d; delivering as text link",
+                    f.filename, size, mime, cap,
+                )
+                fallback_links.append((f.filename, url))
+                continue
+
+            media_urls.append(url)
+
+        return media_urls, fallback_links
 
     def format_response(self, text: str) -> str:
         """Expose markdown conversion for non-send code paths (e.g. proactive)."""
@@ -514,17 +688,22 @@ class WhatsAppAdapter(ChannelAdapter):
         messaging_service_sid: Optional[str],
         to_number: str,
         body: str,
+        media_url: Optional[str] = None,
     ) -> Optional[dict]:
         """POST a single message to Twilio's Messages endpoint.
 
         Prefers MessagingServiceSid if configured (handles sender selection
-        server-side); falls back to explicit From.
+        server-side); falls back to explicit From. When ``media_url`` is set the
+        message carries a WhatsApp attachment (Twilio fetches the URL
+        server-side); ``Body`` is omitted when empty so a media-only message is
+        valid (#1315).
         """
         url = f"{TWILIO_API_BASE}/2010-04-01/Accounts/{account_sid}/Messages.json"
-        data = {
-            "To": to_number,
-            "Body": body,
-        }
+        data = {"To": to_number}
+        if body:
+            data["Body"] = body
+        if media_url:
+            data["MediaUrl"] = media_url
         if messaging_service_sid:
             data["MessagingServiceSid"] = messaging_service_sid
         else:

--- a/src/backend/services/agent_shared_files_service.py
+++ b/src/backend/services/agent_shared_files_service.py
@@ -294,22 +294,8 @@ def check_disk_space(needed_bytes: int, *, root: str = "/data", min_free: int = 
         )
 
 
-async def create_share(
-    agent_name: str,
-    filename: str,
-    *,
-    display_name: Optional[str] = None,
-    expires_in: Optional[int] = None,
-    created_by: Optional[str] = None,
-) -> dict:
-    """
-    End-to-end: extract → validate → persist → DB insert → return URL payload.
-    """
-    # --- flag gate ---
-    if not db.get_file_sharing_enabled(agent_name):
-        raise HTTPException(status_code=403, detail="FEATURE_DISABLED: file sharing is not enabled for this agent")
-
-    # --- expiration ---
+def _validate_expires_in(expires_in: Optional[int]) -> int:
+    """Normalise + bounds-check the requested share lifetime."""
     if expires_in is None:
         expires_in = DEFAULT_EXPIRES_IN
     if expires_in < MIN_EXPIRES_IN or expires_in > MAX_EXPIRES_IN:
@@ -317,12 +303,28 @@ async def create_share(
             status_code=400,
             detail=f"INVALID_EXPIRATION: expires_in must be between {MIN_EXPIRES_IN} and {MAX_EXPIRES_IN}",
         )
+    return expires_in
 
-    # --- path ---
-    container_path = validate_publish_path(filename)
 
-    # --- extract ---
-    data, basename = await extract_from_agent(agent_name, container_path)
+def _persist_and_register(
+    agent_name: str,
+    data: bytes,
+    *,
+    basename: str,
+    display_name: Optional[str],
+    expires_in: int,
+    created_by: Optional[str],
+) -> dict:
+    """
+    Shared tail of the share pipeline: MIME-detect → blocklist → quota →
+    disk-check → persist to disk → DB insert → mint URL.
+
+    Operates on in-memory bytes that have *already* been obtained. The two
+    public entry points differ only in where ``data`` comes from:
+    ``create_share`` extracts it from the agent container; ``create_share_from_bytes``
+    receives it from the caller (e.g. outbound channel media, #1315). Keeping the
+    DB-failure cleanup (``os.unlink``) here means both paths get it for free.
+    """
     size_bytes = len(data)
 
     # --- MIME ---
@@ -383,3 +385,74 @@ async def create_share(
         "size_bytes": size_bytes,
         "mime_type": mime_type,
     }
+
+
+async def create_share(
+    agent_name: str,
+    filename: str,
+    *,
+    display_name: Optional[str] = None,
+    expires_in: Optional[int] = None,
+    created_by: Optional[str] = None,
+) -> dict:
+    """
+    End-to-end: extract → validate → persist → DB insert → return URL payload.
+    """
+    # --- flag gate ---
+    if not db.get_file_sharing_enabled(agent_name):
+        raise HTTPException(status_code=403, detail="FEATURE_DISABLED: file sharing is not enabled for this agent")
+
+    # --- expiration ---
+    expires_in = _validate_expires_in(expires_in)
+
+    # --- path ---
+    container_path = validate_publish_path(filename)
+
+    # --- extract ---
+    data, basename = await extract_from_agent(agent_name, container_path)
+
+    return _persist_and_register(
+        agent_name,
+        data,
+        basename=basename,
+        display_name=display_name,
+        expires_in=expires_in,
+        created_by=created_by,
+    )
+
+
+def create_share_from_bytes(
+    agent_name: str,
+    data: bytes,
+    *,
+    display_name: str,
+    expires_in: Optional[int] = None,
+    created_by: Optional[str] = None,
+) -> dict:
+    """
+    Persist already-in-memory bytes as a public share and mint a download URL —
+    the outbound-channel-media counterpart to ``create_share`` (#1315).
+
+    Same MIME-blocklist / quota / disk / DB pipeline as ``create_share``; the
+    bytes come from the caller (e.g. ``ChannelResponse.files`` artifacts) rather
+    than being extracted from the agent container. Used by channels like WhatsApp
+    that deliver media by URL (Twilio fetches the public ``?sig=`` URL
+    server-side) instead of uploading bytes directly.
+
+    Raises ``HTTPException`` (403 gate / 400 expiry / 413 quota / 507 disk /
+    400 MIME-blocked) exactly like ``create_share`` — callers must isolate it so
+    one rejected file never aborts a whole response.
+    """
+    if not db.get_file_sharing_enabled(agent_name):
+        raise HTTPException(status_code=403, detail="FEATURE_DISABLED: file sharing is not enabled for this agent")
+
+    expires_in = _validate_expires_in(expires_in)
+
+    return _persist_and_register(
+        agent_name,
+        data,
+        basename=display_name,
+        display_name=display_name,
+        expires_in=expires_in,
+        created_by=created_by,
+    )

--- a/tests/unit/test_whatsapp_outbound_media.py
+++ b/tests/unit/test_whatsapp_outbound_media.py
@@ -1,0 +1,408 @@
+"""
+Unit tests for WhatsApp outbound media attachments (#1315).
+
+The WhatsApp adapter delivers `ChannelResponse.files` to users by persisting
+each file into FILES-001 storage (`create_share_from_bytes`) and handing Twilio
+the public `?sig=` URL as a `MediaUrl`. Text is always sent first; files that
+can't be delivered as media degrade to a download link appended to the text.
+
+Covers:
+- `_outbound_media_cap_for_mime` MIME→cap classification (pure logic)
+- `_prepare_outbound_media`: gate-off, happy path, no-public-URL / unsupported /
+  oversized text-link fallback, per-file isolation on HTTPException
+- `send_response`: text-first ordering, empty-text + file, persist-failure keeps
+  text, multi-file fan-out, gate-off keeps text
+- `_send_message`: MediaUrl payload construction (body omitted when empty)
+- `create_share_from_bytes` service entry: flag gate (403), expiry bounds (400),
+  delegation to the shared persist helper
+
+Modules:
+- src/backend/adapters/whatsapp_adapter.py
+- src/backend/services/agent_shared_files_service.py
+Issue: https://github.com/abilityai/trinity/issues/1315
+
+Env + sys.path are configured by tests/unit/conftest.py.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import adapters.whatsapp_adapter as wa_mod
+from adapters.whatsapp_adapter import (
+    WhatsAppAdapter,
+    _WA_DOC_CAP_BYTES,
+    _WA_MEDIA_CAP_BYTES,
+    _OUTBOUND_MEDIA_EXPIRES_IN,
+    _outbound_media_cap_for_mime,
+)
+from adapters.base import ChannelResponse, OutboundFile
+
+AGENT = "wa-agent"
+_PUBLIC_URL = "https://trinity.example.com/api/files/abc-123?sig=tok"
+
+
+def _binding():
+    return {"from_number": "whatsapp:+14155238886", "messaging_service_sid": None}
+
+
+def _share(url=_PUBLIC_URL, mime="text/csv", size=1234):
+    """Mimic the create_share_from_bytes return dict."""
+    return {"file_id": "abc-123", "url": url, "mime_type": mime, "size_bytes": size,
+            "expires_at": "2026-01-01T00:00:00+00:00"}
+
+
+def _file(name="response_1.csv", content=b"a,b,c\n1,2,3\n", lang="csv"):
+    return OutboundFile(filename=name, content=content, language=lang)
+
+
+def _response(text="here you go", files=None):
+    return ChannelResponse(
+        text=text,
+        files=files or [],
+        metadata={"bot_token": "AC0000:authtoken", "agent_name": AGENT},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _outbound_media_cap_for_mime — pure classification
+# ---------------------------------------------------------------------------
+
+class TestMediaCapForMime:
+    @pytest.mark.parametrize("mime,expected", [
+        ("text/csv", _WA_DOC_CAP_BYTES),
+        ("text/plain", _WA_DOC_CAP_BYTES),
+        ("text/plain; charset=utf-8", _WA_DOC_CAP_BYTES),  # params stripped
+        ("TEXT/CSV", _WA_DOC_CAP_BYTES),                    # case-insensitive
+        ("application/json", _WA_DOC_CAP_BYTES),
+        ("application/xml", _WA_DOC_CAP_BYTES),
+        ("application/pdf", _WA_DOC_CAP_BYTES),
+        ("application/x-yaml", _WA_DOC_CAP_BYTES),
+        ("image/png", _WA_MEDIA_CAP_BYTES),
+        ("image/jpeg", _WA_MEDIA_CAP_BYTES),
+        ("audio/mpeg", _WA_MEDIA_CAP_BYTES),
+        ("video/mp4", _WA_MEDIA_CAP_BYTES),
+    ])
+    def test_supported_types(self, mime, expected):
+        assert _outbound_media_cap_for_mime(mime) == expected
+
+    @pytest.mark.parametrize("mime", [
+        "application/octet-stream",  # unknown / magic failed
+        "",
+        None,
+        "application/zip",
+        "application/x-tar",
+    ])
+    def test_unsupported_types(self, mime):
+        assert _outbound_media_cap_for_mime(mime) is None
+
+    def test_media_cap_below_doc_cap(self):
+        # image/audio/video (~5MB) are stricter than documents (~16MB)
+        assert _WA_MEDIA_CAP_BYTES < _WA_DOC_CAP_BYTES
+
+
+# ---------------------------------------------------------------------------
+# _prepare_outbound_media — persist + classify
+# ---------------------------------------------------------------------------
+
+class TestPrepareOutboundMedia:
+    def setup_method(self):
+        self.adapter = WhatsAppAdapter()
+
+    def test_no_files_short_circuits(self):
+        with patch.object(wa_mod.db, "get_file_sharing_enabled") as gate:
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [])
+        assert media == [] and fallback == []
+        gate.assert_not_called()
+
+    def test_gate_off_skips_all(self):
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=False), \
+             patch.object(wa_mod, "create_share_from_bytes") as mint:
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [_file()])
+        assert media == [] and fallback == []
+        mint.assert_not_called()  # never persist when file sharing is disabled
+
+    def test_happy_path_media_url(self):
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes", return_value=_share()) as mint:
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [_file()])
+        assert media == [_PUBLIC_URL]
+        assert fallback == []
+        # minted with the short outbound TTL and agent-as-creator
+        _, kwargs = mint.call_args
+        assert kwargs["expires_in"] == _OUTBOUND_MEDIA_EXPIRES_IN
+        assert kwargs["created_by"] == AGENT
+        assert kwargs["display_name"] == "response_1.csv"
+
+    def test_relative_url_falls_back_to_link(self):
+        rel = _share(url="/api/files/abc-123?sig=tok")  # public_chat_url unset
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes", return_value=rel):
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [_file()])
+        assert media == []
+        assert fallback == [("response_1.csv", "/api/files/abc-123?sig=tok")]
+
+    def test_non_https_url_falls_back_to_link(self):
+        http = _share(url="http://trinity.example.com/api/files/x?sig=tok")
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes", return_value=http):
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [_file()])
+        assert media == []
+        assert fallback and fallback[0][0] == "response_1.csv"
+
+    def test_unsupported_mime_falls_back_to_link(self):
+        zip_share = _share(mime="application/octet-stream")
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes", return_value=zip_share):
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [_file()])
+        assert media == []
+        assert fallback == [("response_1.csv", _PUBLIC_URL)]
+
+    def test_oversized_falls_back_to_link(self):
+        big = _share(mime="image/png", size=_WA_MEDIA_CAP_BYTES + 1)
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes", return_value=big):
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [_file()])
+        assert media == []
+        assert fallback == [("response_1.csv", _PUBLIC_URL)]
+
+    def test_httpexception_isolated_per_file(self):
+        # File 1 raises (quota), file 2 succeeds — file 2 must still be delivered.
+        def mint(agent, content, **kwargs):
+            if kwargs["display_name"] == "bad.csv":
+                raise HTTPException(status_code=413, detail="QUOTA_EXCEEDED")
+            return _share()
+
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes", side_effect=mint):
+            media, fallback = self.adapter._prepare_outbound_media(
+                AGENT, [_file(name="bad.csv"), _file(name="good.csv")]
+            )
+        assert media == [_PUBLIC_URL]   # the good file survived
+        assert fallback == []           # the rejected file is dropped, not linked
+
+    def test_unexpected_exception_isolated(self):
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes", side_effect=RuntimeError("boom")):
+            media, fallback = self.adapter._prepare_outbound_media(AGENT, [_file()])
+        assert media == [] and fallback == []  # swallowed, never raises
+
+    def test_multi_file(self):
+        with patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(wa_mod, "create_share_from_bytes",
+                          side_effect=[_share(url="https://h/1?sig=a"),
+                                       _share(url="https://h/2?sig=b")]):
+            media, fallback = self.adapter._prepare_outbound_media(
+                AGENT, [_file(name="a.csv"), _file(name="b.csv")]
+            )
+        assert media == ["https://h/1?sig=a", "https://h/2?sig=b"]
+        assert fallback == []
+
+
+# ---------------------------------------------------------------------------
+# send_response — orchestration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSendResponse:
+    def setup_method(self):
+        self.adapter = WhatsAppAdapter()
+
+    async def _run(self, response, *, sharing=True, share_ret=None, share_exc=None):
+        send = AsyncMock(return_value={"sid": "SM1"})
+        mint_kwargs = {}
+        if share_exc is not None:
+            mint_kwargs["side_effect"] = share_exc
+        else:
+            mint_kwargs["return_value"] = share_ret if share_ret is not None else _share()
+        with patch.object(wa_mod.db, "get_whatsapp_binding", return_value=_binding()), \
+             patch.object(wa_mod.db, "get_file_sharing_enabled", return_value=sharing), \
+             patch.object(wa_mod, "create_share_from_bytes", **mint_kwargs), \
+             patch.object(WhatsAppAdapter, "_send_message", send):
+            await self.adapter.send_response("whatsapp:+15551234567", response)
+        return send
+
+    async def test_text_then_media_ordering(self):
+        send = await self._run(_response(text="hi", files=[_file()]))
+        assert send.await_count == 2
+        # first call = text (Body, no MediaUrl); second = media (MediaUrl, empty body)
+        first = send.await_args_list[0].kwargs
+        second = send.await_args_list[1].kwargs
+        assert first["body"] == "hi" and first.get("media_url") is None
+        assert second["media_url"] == _PUBLIC_URL and second["body"] == ""
+
+    async def test_empty_text_with_file_sends_only_media(self):
+        send = await self._run(_response(text="", files=[_file()]))
+        assert send.await_count == 1
+        assert send.await_args_list[0].kwargs["media_url"] == _PUBLIC_URL
+
+    async def test_no_text_no_deliverable_files_sends_nothing(self):
+        # gate off + empty text → nothing to send
+        send = await self._run(_response(text="", files=[_file()]), sharing=False)
+        send.assert_not_awaited()
+
+    async def test_persist_failure_keeps_text(self):
+        send = await self._run(
+            _response(text="still here", files=[_file()]),
+            share_exc=HTTPException(status_code=507, detail="INSUFFICIENT_STORAGE"),
+        )
+        assert send.await_count == 1
+        assert send.await_args_list[0].kwargs["body"] == "still here"
+        assert send.await_args_list[0].kwargs.get("media_url") is None
+
+    async def test_no_public_url_appends_link_to_text(self):
+        rel = _share(url="/api/files/x?sig=tok")
+        send = await self._run(_response(text="report:", files=[_file()]), share_ret=rel)
+        # only a text message — relative URL can't be a MediaUrl
+        assert send.await_count == 1
+        body = send.await_args_list[0].kwargs["body"]
+        assert "/api/files/x?sig=tok" in body
+        assert "report:" in body
+        assert send.await_args_list[0].kwargs.get("media_url") is None
+
+    async def test_gate_off_sends_text_only(self):
+        send = await self._run(_response(text="just text", files=[_file()]), sharing=False)
+        assert send.await_count == 1
+        assert send.await_args_list[0].kwargs["body"] == "just text"
+
+    async def test_multi_file_fan_out(self):
+        share_ret = _share(url="https://h/f?sig=z")
+        send = await self._run(
+            _response(text="two files", files=[_file(name="a.csv"), _file(name="b.csv")]),
+            share_ret=share_ret,
+        )
+        # 1 text + 2 media messages
+        assert send.await_count == 3
+        assert send.await_args_list[0].kwargs["body"] == "two files"
+        assert all(c.kwargs["media_url"] == "https://h/f?sig=z"
+                   for c in send.await_args_list[1:])
+
+    async def test_missing_credentials_no_send(self):
+        send = AsyncMock()
+        resp = ChannelResponse(text="hi", metadata={"bot_token": "", "agent_name": AGENT})
+        with patch.object(WhatsAppAdapter, "_send_message", send):
+            await self.adapter.send_response("whatsapp:+1555", resp)
+        send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _send_message — Twilio payload construction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSendMessagePayload:
+    async def _post_data(self, **kwargs):
+        captured = {}
+
+        class _Resp:
+            status_code = 201
+            text = "{}"
+            def json(self):
+                return {"sid": "SM1"}
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                return False
+            async def post(self, url, data=None, auth=None):
+                captured["url"] = url
+                captured["data"] = data
+                captured["auth"] = auth
+                return _Resp()
+
+        with patch.object(wa_mod.httpx, "AsyncClient", _Client):
+            await WhatsAppAdapter._send_message(
+                account_sid="AC1", auth_token="tok",
+                from_number="whatsapp:+1444", messaging_service_sid=None,
+                to_number="whatsapp:+1555", **kwargs,
+            )
+        return captured["data"], captured["auth"]
+
+    async def test_text_only_no_media_url(self):
+        data, auth = await self._post_data(body="hello")
+        assert data["Body"] == "hello"
+        assert "MediaUrl" not in data
+        assert data["From"] == "whatsapp:+1444"
+        assert auth == ("AC1", "tok")
+
+    async def test_media_only_omits_empty_body(self):
+        data, _ = await self._post_data(body="", media_url="https://h/x?sig=t")
+        assert data["MediaUrl"] == "https://h/x?sig=t"
+        assert "Body" not in data  # empty body omitted so media-only is valid
+
+    async def test_messaging_service_sid_prefers_over_from(self):
+        captured = {}
+
+        class _Resp:
+            status_code = 201
+            text = "{}"
+            def json(self):
+                return {}
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                return False
+            async def post(self, url, data=None, auth=None):
+                captured["data"] = data
+                return _Resp()
+
+        with patch.object(wa_mod.httpx, "AsyncClient", _Client):
+            await WhatsAppAdapter._send_message(
+                account_sid="AC1", auth_token="tok",
+                from_number="whatsapp:+1444", messaging_service_sid="MG9",
+                to_number="whatsapp:+1555", body="hi", media_url="https://h/x?sig=t",
+            )
+        assert captured["data"]["MessagingServiceSid"] == "MG9"
+        assert "From" not in captured["data"]
+        assert captured["data"]["MediaUrl"] == "https://h/x?sig=t"
+
+
+# ---------------------------------------------------------------------------
+# create_share_from_bytes — service entry point
+# ---------------------------------------------------------------------------
+
+class TestCreateShareFromBytes:
+    def setup_method(self):
+        import services.agent_shared_files_service as svc
+        self.svc = svc
+
+    def test_gate_off_raises_403(self):
+        with patch.object(self.svc.db, "get_file_sharing_enabled", return_value=False), \
+             patch.object(self.svc, "_persist_and_register") as persist:
+            with pytest.raises(HTTPException) as ei:
+                self.svc.create_share_from_bytes(AGENT, b"data", display_name="x.csv")
+        assert ei.value.status_code == 403
+        persist.assert_not_called()
+
+    def test_bad_expiry_raises_400(self):
+        with patch.object(self.svc.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(self.svc, "_persist_and_register") as persist:
+            with pytest.raises(HTTPException) as ei:
+                self.svc.create_share_from_bytes(
+                    AGENT, b"data", display_name="x.csv", expires_in=10**9,
+                )
+        assert ei.value.status_code == 400
+        persist.assert_not_called()
+
+    def test_happy_path_delegates_to_persist(self):
+        sentinel = {"file_id": "f1", "url": _PUBLIC_URL}
+        with patch.object(self.svc.db, "get_file_sharing_enabled", return_value=True), \
+             patch.object(self.svc, "_persist_and_register", return_value=sentinel) as persist:
+            out = self.svc.create_share_from_bytes(
+                AGENT, b"a,b\n1,2\n", display_name="data.csv",
+                expires_in=3600, created_by=AGENT,
+            )
+        assert out is sentinel
+        _, kwargs = persist.call_args
+        assert kwargs["basename"] == "data.csv"
+        assert kwargs["display_name"] == "data.csv"
+        assert kwargs["expires_in"] == 3600
+        assert kwargs["created_by"] == AGENT


### PR DESCRIPTION
## Summary
- WhatsApp agents can now **send files to users**. `WhatsAppAdapter.send_response` delivers `ChannelResponse.files` as Twilio `MediaUrl` attachments (one message per file, **text sent first**), reaching parity with the Slack adapter — previously these files were silently dropped.
- Twilio fetches a `MediaUrl` server-side, so each file is persisted to FILES-001 storage and handed to Twilio as its public `?sig=` URL. New `create_share_from_bytes()` is the bytes-input twin of `create_share`; both now share the extracted `_persist_and_register` helper (MIME-blocklist → quota → disk-check → persist → DB → URL).
- Gated on the per-agent `file_sharing_enabled` toggle; short **1h** share TTL (the existing cleanup-service reaper purges expired shares).

## Changes
- `src/backend/adapters/whatsapp_adapter.py` — `_prepare_outbound_media` (persist + classify, per-file isolated), `send_response` restructure (markdown-convert text first, append download links verbatim, then one media message per file), `_send_message` gains `media_url`, MIME-cap helper + constants.
- `src/backend/services/agent_shared_files_service.py` — extract `_persist_and_register` + `_validate_expires_in`; add `create_share_from_bytes`. `create_share` behavior unchanged.
- `tests/unit/test_whatsapp_outbound_media.py` — 42 tests.
- `docs/memory/requirements.md`, `docs/memory/feature-flows/whatsapp-integration.md` — outbound-media flow documented.

## Design notes
- **Caps** (image/audio/video ≈5 MB, documents ≈16 MB) are checked on the **detected** MIME (the download endpoint serves `Content-Type: mime_type`, which Twilio reads to render media), not the code-fence `language` hint. `application/octet-stream`/unknown → text-link fallback.
- **Graceful degradation, never silent drop**: no public HTTPS `public_chat_url` / unsupported MIME / oversized → the file's download link is appended to the text body + WARN log.
- **Per-file isolation**: a rejected or failed file (quota/disk/MIME `HTTPException`, or any error) is logged and skipped — it never aborts the text reply or sibling files.
- **No revoke-after-send**: Twilio fetches the URL *asynchronously* after the POST 2xx, so short-TTL + the existing reaper is the correct bound (revoking on the ack would race the fetch).
- **No new idempotency**: `twilio_webhook` dedups inbound by `MessageSid` before dispatch, so `send_response` (and each mint) runs exactly once.
- v1 scope = deliver `ChannelResponse.files` artifacts only; promoting in-text FILES-001 URLs to `MediaUrl` is deferred (#1315 option b). Telegram has the same outbound-drop bug but uses direct `sendDocument` (no URL needed) — tracked as a follow-up.

## Test Plan
- [x] New tests pass: `pytest tests/unit/test_whatsapp_outbound_media.py` (42 passed)
- [x] FILES-001 / channel-router regression green (359 passed across whatsapp/slack/telegram/message_router/twilio/shared-file tests)
- [ ] Manual: WhatsApp agent with `file_sharing_enabled` + public HTTPS `public_chat_url` returns a csv/json code-fence → user receives the file inline

Fixes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)