### PR TITLE
feat(executions): propagate cancelled terminal status end-to-end (#679)

### DIFF
--- a/docker/base-image/agent_server/routers/chat.py
+++ b/docker/base-image/agent_server/routers/chat.py
@@ -157,12 +157,49 @@ async def execute_task(request: ParallelTaskRequest):
             persist_session=bool(request.persist_session),  # Session tab: write JSONL for future --resume
             images=request.images,  # Vision images from channel adapters (#562)
         )
+    except HTTPException as exc:
+        # #679 (F3): a terminated turn that surfaces a non-auth/non-rate terminal
+        # is a user cancel, not a failure. SIGINT→graceful-exit-0 with no output,
+        # or SIGKILL escalation, lands here as a 504 (signal exits) / 502 (empty
+        # result) / 500 — relabel ALL of them to a `cancelled` 200, mirroring the
+        # async result-callback's `_is_auth_or_rate` guard. 503/429/auth and any
+        # unterminated terminal re-raise unchanged (Issue 6/C6) so SUB-003 + the
+        # AUTH dispatch breaker still fire. The label is what matters — the cancel
+        # is non-billable, so we drop metadata (dict detail → empty response).
+        is_cancel = (
+            exc.status_code not in (503, 429)
+            and bool(request.execution_id)
+            and get_process_registry().was_terminated(request.execution_id)
+        )
+        # #679 (F4): a cancel is neutral for the failure counter (never trips the
+        # dispatch breaker); a genuine failure still increments it.
+        agent_state.record_task_finish(success=None if is_cancel else False)
+        if is_cancel:
+            logger.info(f"[Task] Task {request.execution_id} cancelled by user (status {exc.status_code})")
+            return {
+                "response": exc.detail if isinstance(exc.detail, str) else "",
+                "execution_log": [],
+                "metadata": {},
+                "session_id": None,
+                "status": "cancelled",
+                "timestamp": datetime.now().isoformat(),
+            }
+        raise
     except BaseException:
         agent_state.record_task_finish(success=False)
         raise
-    agent_state.record_task_finish(success=True)
 
-    logger.info(f"[Task] Task {session_id} completed successfully")
+    # #679 graceful path: Claude catches SIGINT, emits a final message, and exits
+    # 0 — the return code can't distinguish that from genuine success. Cross-check
+    # the cancel marker, keyed off the backend `execution_id` (NEVER the returned
+    # session_id, which can differ on a resumed/forked turn). Compute BEFORE
+    # record_task_finish so the cancel is recorded neutrally (F4).
+    cancelled = bool(request.execution_id) and get_process_registry().was_terminated(request.execution_id)
+    agent_state.record_task_finish(success=None if cancelled else True)
+    if cancelled:
+        logger.info(f"[Task] Task {request.execution_id} cancelled by user")
+    else:
+        logger.info(f"[Task] Task {session_id} completed successfully")
 
     # raw_messages contains the full Claude Code JSON stream (init, assistant, user, result)
     # This is the complete execution transcript showing thinking, tool calls, and results
@@ -171,6 +208,7 @@ async def execute_task(request: ParallelTaskRequest):
         "execution_log": raw_messages,  # Full JSON transcript from Claude Code
         "metadata": metadata.model_dump(),
         "session_id": session_id,
+        "status": "cancelled" if cancelled else "success",
         "timestamp": datetime.now().isoformat()
     }
 

--- a/docker/base-image/agent_server/services/process_registry.py
+++ b/docker/base-image/agent_server/services/process_registry.py
@@ -31,6 +31,13 @@ logger = logging.getLogger(__name__)
 # with comfortable headroom for backend slowness.
 RECENTLY_COMPLETED_TTL_SECONDS = 300  # 5 minutes
 
+# Issue #679: window during which a just-terminated execution is still surfaced
+# as "cancelled by user" to the chat handler / async result callback. Mirrors
+# RECENTLY_COMPLETED_TTL_SECONDS — the marker is best-effort observability (the
+# DB CANCELLED write is the durable authority), so it just needs to comfortably
+# outlast the gap between a SIGINT send and the turn's graceful exit + finalize.
+TERMINATED_TTL_SECONDS = 300  # 5 minutes
+
 
 class ProcessRegistry:
     """
@@ -59,6 +66,12 @@ class ProcessRegistry:
         # read. Capped indirectly by traffic — at agent's ~10 concurrent
         # max with 5 min retention this is a few dozen entries at peak.
         self._recently_completed: Dict[str, float] = {}
+        # Issue #679: execution_id -> unix timestamp when terminate() sent a
+        # kill-signal. Read (not popped) by was_terminated() so the chat handler
+        # and async result callback can label a graceful-exit-0 / SIGKILL→504
+        # turn as "cancelled". Lazy TTL eviction on read; cleared on register()
+        # so a reused execution_id (#678 in-line retry) can't inherit the label.
+        self._terminated: Dict[str, float] = {}
 
     def register(self, execution_id: str, process: subprocess.Popen, metadata: dict = None):
         """
@@ -78,6 +91,10 @@ class ProcessRegistry:
             # Initialize log streaming structures
             self._log_subscribers[execution_id] = []
             self._log_buffers[execution_id] = []
+            # Issue #679 (C10): clear any stale cancel marker so an execution_id
+            # reused by the #678 in-line reader-race retry can't inherit the
+            # previous attempt's "cancelled" label.
+            self._terminated.pop(execution_id, None)
             logger.info(f"[ProcessRegistry] Registered execution {execution_id}")
 
     def unregister(self, execution_id: str):
@@ -149,6 +166,15 @@ class ProcessRegistry:
             # grandchildren don't linger holding our pipe FDs.
             logger.info(f"[ProcessRegistry] Sending SIGINT to execution {execution_id} (process group)")
             _signal_process_tree(process, signal.SIGINT, pgid=pgid)
+
+            # Issue #679: record the cancel marker immediately after a successful
+            # SIGINT send — still-running branch only (NOT already_finished /
+            # not_found, handled above; NOT on signal-failure, which raises into
+            # the `except` below and skips this). The send is causally before the
+            # subprocess's graceful exit, so was_terminated() is set before the
+            # chat handler observes execute_headless returning — race-free.
+            with self._lock:
+                self._terminated[execution_id] = time.time()
 
             try:
                 process.wait(timeout=graceful_timeout)
@@ -299,6 +325,22 @@ class ProcessRegistry:
             for eid in expired:
                 del self._recently_completed[eid]
             return list(self._recently_completed.keys())
+
+    def was_terminated(self, execution_id: str) -> bool:
+        """Issue #679: True if terminate() sent a kill-signal for this execution
+        within the last TERMINATED_TTL_SECONDS.
+
+        Read-only — it does NOT consume the marker, so the graceful-exit relabel
+        path and a later SIGKILL→504 check both observe it. Expired entries are
+        dropped lazily here (mirrors list_recently_completed_ids); no separate
+        sweeper needed.
+        """
+        cutoff = time.time() - TERMINATED_TTL_SECONDS
+        with self._lock:
+            expired = [eid for eid, ts in self._terminated.items() if ts < cutoff]
+            for eid in expired:
+                del self._terminated[eid]
+            return execution_id in self._terminated
 
     def cleanup_finished(self) -> int:
         """

--- a/docker/base-image/agent_server/services/result_callback.py
+++ b/docker/base-image/agent_server/services/result_callback.py
@@ -30,12 +30,13 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set
 
 import httpx
 from fastapi import HTTPException
 
 from ..state import agent_state
+from .process_registry import get_process_registry
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +176,33 @@ def _envelope_from_http_exception(exc: HTTPException) -> Dict:
 
 
 # ---------------------------------------------------------------------------
+# #679 cancel relabel
+# ---------------------------------------------------------------------------
+def _cancelled_override(envelope: Dict) -> Dict:
+    """Relabel a terminal envelope as a user cancel (#679).
+
+    Keeps whatever response/metadata/session_id/execution_log the turn produced
+    (Claude emits a graceful final message on SIGINT) and drops ``error_code`` so
+    the backend doesn't treat the cancel as an agent failure. The backend maps
+    ``status:"cancelled"`` → ``CANCELLED`` (never a billable success)."""
+    overridden = dict(envelope)
+    overridden["status"] = "cancelled"
+    overridden["terminal_reason"] = "cancelled"
+    overridden["error_code"] = None
+    return overridden
+
+
+def _is_auth_or_rate(envelope: Dict) -> bool:
+    """Issue 6 / C6: an auth (503) or rate-limit (429) terminal must NOT be
+    relabelled cancelled even if the execution was terminated — the backend's
+    AUTH dispatch breaker / SUB-003 still need to record it on the async path."""
+    return (
+        envelope.get("error_code") == "auth"
+        or envelope.get("terminal_reason") in ("auth", "rate_limit")
+    )
+
+
+# ---------------------------------------------------------------------------
 # Delivery
 # ---------------------------------------------------------------------------
 async def _deliver(
@@ -253,12 +281,12 @@ async def _run_and_report(request, backend_url: str, mcp_key: str, dispatch_mono
             images=request.images,
         )
         envelope = _success_envelope(response_text, raw_messages, metadata, session_id)
-        agent_state.record_task_finish(success=True)
+        finish_success: Optional[bool] = True
     except HTTPException as exc:
-        agent_state.record_task_finish(success=False)
+        finish_success = False
         envelope = _envelope_from_http_exception(exc)
     except BaseException as exc:  # noqa: BLE001 — any failure must still report a terminal
-        agent_state.record_task_finish(success=False)
+        finish_success = False
         envelope = {
             "status": "failed",
             "error": str(exc)[:500] or type(exc).__name__,
@@ -266,6 +294,26 @@ async def _run_and_report(request, backend_url: str, mcp_key: str, dispatch_mono
             "terminal_reason": "error",
             "metadata": {},
         }
+
+    # #679: a graceful exit-0 OR a SIGKILL→504 for a turn the operator cancelled
+    # must be relabelled `cancelled` so the backend writes CANCELLED — never a
+    # billable success, never a breaker-counting failure. Auth/rate envelopes are
+    # excluded (C6) so the AUTH dispatch breaker + SUB-003 still record on async.
+    if (
+        execution_id
+        and get_process_registry().was_terminated(execution_id)
+        and not _is_auth_or_rate(envelope)
+    ):
+        envelope = _cancelled_override(envelope)
+        # #679 (F4) parity with the sync path: a cancel is NEUTRAL for the
+        # consecutive_failures health counter — never trips or resets the
+        # dispatch breaker (#526). Recorded after the relabel decision so the
+        # graceful-cancel (was True) and the 504/502-cancel (was False) agree.
+        finish_success = None
+
+    # Recorded once, after the cancel decision, so the health counter matches the
+    # final terminal label.
+    agent_state.record_task_finish(success=finish_success)
 
     _persist(execution_id, {"agent_name": agent_name, "envelope": envelope})
 

--- a/docker/base-image/agent_server/state.py
+++ b/docker/base-image/agent_server/state.py
@@ -76,14 +76,22 @@ class AgentState:
             self.active_task_count += 1
             self.last_task_at = datetime.now(timezone.utc).isoformat()
 
-    def record_task_finish(self, success: bool) -> None:
-        """Mark an execution as finished. Resets the consecutive-failure
-        counter on success, increments it on failure — this is the signal the
-        dispatch circuit breaker (#526) consumes."""
+    def record_task_finish(self, success: Optional[bool]) -> None:
+        """Mark an execution as finished. Resets the consecutive-failure counter
+        on success, increments it on failure — this is the signal the dispatch
+        circuit breaker (#526) consumes.
+
+        #679 (F4): ``success=None`` is a NEUTRAL finish (a user cancel) — the
+        task still finishes (decrement the active count, stamp last_task_at) but
+        the failure counter is left untouched. A cancel is neither a failure (it
+        must not push a healthy agent toward an open breaker) nor a success (it
+        proves nothing about agent health), so it must not reset OR increment."""
         with self._health_lock:
             if self.active_task_count > 0:
                 self.active_task_count -= 1
             self.last_task_at = datetime.now(timezone.utc).isoformat()
+            if success is None:
+                return
             if success:
                 self.consecutive_failures = 0
             else:

--- a/docs/security-reports/cso-diff-2026-06-22-679.md
+++ b/docs/security-reports/cso-diff-2026-06-22-679.md
@@ -1,0 +1,108 @@
+# CSO Security Audit
+
+**Mode**: diff
+**Scope**: branch `AndriiPasternak31/autoplan-issue-679` (working-tree changes vs `origin/dev`)
+**Issue**: #679 — agent chat cancellation (propagate a `cancelled` terminal status end-to-end)
+**Date**: 2026-06-22
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Secrets | 0 | 0 | 0 | 0 |
+| Dependencies | 0 | 0 | 0 | 0 |
+| Auth Boundaries | 0 | 0 | 0 | 0 |
+| Injection | 0 | 0 | 0 | 0 |
+| Platform Patterns | 0 | 0 | 0 | 2 |
+| Configuration | 0 | 0 | 0 | 0 |
+
+## What the change does
+
+Introduces a third terminal outcome — `cancelled` — alongside `success`/`failed`, so an
+operator-initiated cancel is no longer mis-recorded as either a billable success or an agent
+failure:
+
+- **Agent server** (`agent_server/`): `ProcessRegistry` records a `_terminated[execution_id]`
+  marker on a successful SIGINT send; `was_terminated()` (read-only, 300s lazy TTL, cleared on
+  `register()`) lets the chat handler + async result callback relabel a graceful-exit-0 or a
+  SIGKILL→504 turn as `status:"cancelled"`.
+- **Backend**: `ExecutionResultEnvelope.status` 3-way map (`success`→SUCCESS,
+  `cancelled`→CANCELLED, else→FAILED) in the async callback (`routers/agents.py`) and the sync
+  applier (`task_execution_service.py`); consumers (`message_router`, `chat`, `paid`, `public`,
+  `validation_service`) treat `cancelled` as non-delivery.
+
+## Findings
+
+### CRITICAL
+None.
+
+### HIGH
+None.
+
+### MEDIUM
+None.
+
+### LOW / INFORMATIONAL
+
+1. **Paid cancel returns partial response (no charge) — not exploitable by the payer.**
+   `routers/paid.py` now skips settlement for a `cancelled` turn (correctly fixing the
+   charge-on-cancel money bug) and still returns `exec_result.response` in the 200 body. A
+   theoretical free-ride ("let the agent work, then cancel to dodge payment") is **not reachable**:
+   the terminate endpoint is owner-only (`get_authorized_agent` + `get_current_user`), so the x402
+   payer cannot self-trigger a cancel. Only the agent owner can cancel, and returning their own
+   agent's partial output to the payer for free is benign. No action required.
+
+2. **Auth/rate-vs-cancel relabel guard is agent-side only (defense-in-depth gap, within trust model).**
+   `result_callback._is_auth_or_rate()` correctly prevents an honest agent from relabelling a 503
+   auth / 429 rate terminal as `cancelled` (so the AUTH dispatch breaker + SUB-003 still fire). The
+   backend callback (`agent_execution_result`) mapped `status:"cancelled"`→CANCELLED **unconditionally**
+   — it did not re-apply that guard. A compromised agent could therefore POST
+   `status:"cancelled", error_code:"auth"` to dodge the breaker. This grants **no new capability**:
+   the same authenticated endpoint (agent's own MCP key) already lets a compromised agent self-report
+   SUCCESS/FAILED, and cross-tenant isolation is intact (ownership 404 + agent-scoped-key gate). The
+   dispatch breaker's threat model is honest-agent fault containment, not a malicious agent.
+
+   **RESOLVED (2026-06-22, confirmed worth doing by Codex consult):** the backend callback now
+   mirrors `_is_auth_or_rate` — a `cancelled` payload carrying `error_code == "auth"` or a
+   `terminal_reason` of `auth`/`rate_limit` is mapped to FAILED (not CANCELLED), preserving the
+   invariant "an auth/rate terminal is never reclassified as cancellation" regardless of caller
+   image. The win is operational (buggy/mixed-version agents can't silently disarm the breaker /
+   SUB-003), not anti-malicious. Tests added in `tests/unit/test_679_callback_cancel.py`
+   (3 guard cases + a genuine-cancel regression guard); full #679 suite green (50 passed).
+   *Scope note:* the sync path (`task_execution_service.py`) was intentionally left unchanged —
+   the agent-server only emits `cancelled` there on a 504-after-terminate or graceful exit-0
+   (auth/rate re-raises as 503/429 and never reaches a `cancelled` label), so there is no body
+   signal to guard. Finding 1 (paid partial-response) was assessed and **SKIPPED** — not
+   payer-triggerable (terminate is owner-only), so it is an owner choice, not a platform issue.
+
+## Verifications (clean)
+
+- **Secrets**: no hardcoded credentials in added lines or new `test_679_*` files. No `.env`/manifest changes.
+- **Dependencies**: no `requirements*/package*.json` changes — zero new packages.
+- **Auth boundaries**:
+  - `terminate_agent_execution` — owner-only (`get_authorized_agent` + `get_current_user`); unchanged.
+  - `agent_execution_result` (async callback) — agent's own MCP key (`authorize_heartbeat`,
+    `track_usage=False`) + ownership(404) + `dispatched_async` marker(409) + body-size(413) all preserved;
+    the new CANCELLED branch sits **after** every gate.
+  - Replay gate: `_AUTHORITATIVE_TERMINALS` includes `CANCELLED`, so a late callback on a cancelled
+    row short-circuits to `{replayed:true}` with no write.
+- **CAS contract** (`db/schedules.py:update_execution_status`): CANCELLED is a non-success terminal
+  write guarded against overwriting any already-terminal row; SUCCESS is blocked over an existing
+  CANCELLED (#671). Both cancel races (terminate-first / callback-first) resolve to a single
+  authoritative CANCELLED. Verified consistent with the new 3-way maps.
+- **Injection**: `execution_id` is used only as a dict key (process registry) and a parameterized
+  SQLAlchemy lookup (`db.get_execution`); no string-built SQL, no `subprocess`/`os.system`/`eval`
+  with user input, no path traversal. Unknown future `status` values fall through to FAILED (safe default).
+- **DoS / memory**: `_terminated` dict bounded by traffic (300s lazy TTL eviction, cleared on
+  `register`) — mirrors the existing `_recently_completed` map; no unbounded growth.
+- **Exception hygiene**: no new broad `except: pass` / silent swallows; the agent-server handler
+  re-raises 503/429/auth and unterminated 504s unchanged.
+- **Configuration**: no new routes, no CORS wildcard, no debug flags.
+
+## Recommendation
+
+**CLEAR** — no CRITICAL or HIGH findings. The two LOW items were taken to a Codex consult for an
+independent worth-resolving judgment: **Finding 2 RESOLVED** (backend callback now mirrors the
+auth/rate-vs-cancel guard; tests added, suite green), **Finding 1 SKIPPED** (owner-only cancel,
+not payer-triggerable — an owner choice, not a platform issue). The cancel-billing change fixes
+(does not introduce) a money bug. Safe to proceed.

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -436,9 +436,11 @@ class ChannelMessageRouter:
                 images=image_data or None,
             )
 
-            if result.status == "failed":
+            if result.status in ("failed", "cancelled"):
+                # #679: a CANCELLED turn is non-delivery — surface the cancel
+                # notice instead of posting the empty response as if it succeeded.
                 error_msg = result.error or "Unknown error"
-                logger.error(f"[ROUTER:{channel}] Step 9 - task failed: {error_msg}")
+                logger.info(f"[ROUTER:{channel}] Step 9 - task {result.status}: {error_msg}")
                 await adapter.indicate_done(message)
 
                 # Reply with the actual error if available, otherwise generic message

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -584,16 +584,20 @@ class ExecutionResultEnvelope(BaseModel):
     carries the same shape the synchronous ``/api/task`` response does (cost_usd,
     context_window, token counts, compact_events, session_id).
 
+    ``status`` is free-form ``str`` (not an enum) for forward-compatibility: the
+    backend maps ``success``→SUCCESS, ``cancelled``→CANCELLED (#679), and every
+    other value (incl. an unknown future status) →FAILED.
+
     Field caps bound abuse from a buggy/compromised agent while staying well
     above a legitimate large transcript (the sync path already accepts these):
     enforced in the router after parse so the failure is a clean 413, not a
     Pydantic 422 (the agent's retry logic special-cases status codes).
     """
-    status: str = Field(..., description="'success' or 'failed'")
+    status: str = Field(..., description="'success', 'failed', or 'cancelled'")
     response: Optional[str] = None
     error: Optional[str] = None
     error_code: Optional[str] = None
-    terminal_reason: Optional[str] = None  # completed|max_duration|stall_no_output|auth|empty_result
+    terminal_reason: Optional[str] = None  # completed|max_duration|stall_no_output|auth|empty_result|cancelled
     metadata: Optional[Dict] = None
     execution_log: Optional[List] = None
     session_id: Optional[str] = None

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -933,11 +933,30 @@ async def agent_execution_result(
             raise HTTPException(status_code=413, detail="execution_log too large")
 
     # ---- Build the normalized terminal + apply -----------------------------
-    status = (
-        TaskExecutionStatus.SUCCESS
-        if payload.status == "success"
-        else TaskExecutionStatus.FAILED
+    # #679: 3-way map — success→SUCCESS, cancelled→CANCELLED, everything else
+    # (incl. unknown forward-compat values) →FAILED. CANCELLED flows through
+    # apply_result (release_slot=True); the replay gate above already short-
+    # circuits a terminate-wrote-first CANCELLED row, and the reverse race
+    # (callback CANCELLED first) makes the later terminate write a CAS no-op.
+    #
+    # Finding 2 (CSO 2026-06-22): an auth/rate terminal must NOT be reclassified
+    # as a clean cancellation even when the agent labels it "cancelled". The
+    # agent side already guards this (result_callback._is_auth_or_rate), but the
+    # callback is the backend trust boundary — a buggy or mixed-version agent
+    # that POSTs status:"cancelled" carrying error_code:"auth" (or an auth/
+    # rate_limit terminal_reason) would otherwise silently dodge the AUTH
+    # dispatch breaker / SUB-003 auto-switch. Mirror the guard so the invariant
+    # ("auth/rate is never cancellation") holds regardless of the caller image.
+    is_auth_or_rate = (
+        payload.error_code == TaskExecutionErrorCode.AUTH.value
+        or payload.terminal_reason in ("auth", "rate_limit")
     )
+    if payload.status == "success":
+        status = TaskExecutionStatus.SUCCESS
+    elif payload.status == "cancelled" and not is_auth_or_rate:
+        status = TaskExecutionStatus.CANCELLED
+    else:
+        status = TaskExecutionStatus.FAILED
     error_code = None
     if payload.error_code:
         try:

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -1780,7 +1780,9 @@ async def execute_parallel_task(
         # Side effects (collaboration activity, chat session persist) were
         # handled by _run_async_task_with_persistence inside the drain — do
         # NOT repeat them. Just translate failure and build the response.
-        if result.status == "failed":
+        # #679: CANCELLED is non-success — surface it cleanly (503 with the
+        # cancel notice) rather than returning an empty success-shaped body.
+        if result.status in ("failed", "cancelled"):
             if "at capacity" in (result.error or ""):
                 raise HTTPException(
                     status_code=429,
@@ -1836,7 +1838,9 @@ async def execute_parallel_task(
         )
 
     # Handle failure — translate to HTTP errors
-    if result.status == "failed":
+    # #679: CANCELLED is non-success — surface it cleanly rather than returning
+    # an empty success-shaped body (result.error is "Execution cancelled by user").
+    if result.status in ("failed", "cancelled"):
         if "at capacity" in (result.error or ""):
             raise HTTPException(
                 status_code=429,
@@ -2411,8 +2415,12 @@ async def terminate_agent_execution(
             except Exception as e:
                 logger.warning(f"[Terminate] Failed to force-release capacity for {name}: {e}")
 
-            # Update database execution record if provided
-            if task_execution_id:
+            # #679 (Issue 7): write CANCELLED only when we actually terminated a
+            # running turn. On `already_finished` the agent's genuine terminal
+            # already stands — the cancel arrived too late — so we leave the real
+            # terminal in place (deterministic; "agent self-report is
+            # authoritative"). Capacity is still force-released above in both cases.
+            if task_execution_id and result.get("status") == "terminated":
                 db.update_execution_status(
                     execution_id=task_execution_id,
                     status=TaskExecutionStatus.CANCELLED,

--- a/src/backend/routers/paid.py
+++ b/src/backend/routers/paid.py
@@ -199,15 +199,24 @@ async def paid_chat(agent_name: str, request_body: PaidChatRequest, request: Req
             },
         )
 
-    if exec_result.status == "failed":
-        # Don't settle — caller keeps credits
+    if exec_result.status in ("failed", "cancelled"):
+        # Don't settle — caller keeps credits. #679: a CANCELLED turn must NOT
+        # settle either — settling on cancel is the charge-on-cancel money bug.
+        is_cancelled = exec_result.status == "cancelled"
         return JSONResponse(
             status_code=200,
             content={
                 "response": exec_result.response,
                 "execution_id": exec_result.execution_id,
-                "status": "failed",
-                "payment": {"settled": False, "reason": "Execution failed — no charge"},
+                "status": "cancelled" if is_cancelled else "failed",
+                "payment": {
+                    "settled": False,
+                    "reason": (
+                        "Execution cancelled — no charge"
+                        if is_cancelled
+                        else "Execution failed — no charge"
+                    ),
+                },
             },
         )
 

--- a/src/backend/routers/public.py
+++ b/src/backend/routers/public.py
@@ -622,7 +622,10 @@ async def public_chat(
         images=_pub_image_data,
     )
 
-    if result.status == "failed":
+    if result.status in ("failed", "cancelled"):
+        # #679: a CANCELLED turn is non-delivery, not a success-like empty
+        # response. It falls through to the generic 502 below (its error text
+        # matches no capacity/timeout branch) — the operator stopped the work.
         error = result.error or ""
         if "at capacity" in error:
             raise HTTPException(
@@ -957,8 +960,10 @@ async def _execute_public_chat_background(
                         user_email=verified_email,
                         session_id=chat_session_id,
                     ))
-        elif result.status == "failed":
-            logger.error(f"[PublicChatAsync] Task failed for {agent_name}: {result.error}")
+        elif result.status in ("failed", "cancelled"):
+            # #679: non-delivery — only a SUCCESS turn with a response is posted
+            # to the public session above; a cancelled turn writes nothing.
+            logger.info(f"[PublicChatAsync] Task {result.status} for {agent_name}: {result.error}")
     except Exception as e:
         logger.error(f"[PublicChatAsync] Background execution error for {agent_name}: {e}")
 
@@ -1047,8 +1052,11 @@ async def public_execution_status(
     return {
         "execution_id": execution.id,
         "status": execution.status,
-        "response": execution.response if execution.status in ("success", "failed") else None,
-        "error": execution.error if execution.status == "failed" else None,
+        # #679 (F2): a CANCELLED execution carries a real status + a
+        # "cancelled by user" error; surface both like failed/success so the
+        # public poller gets a reason instead of a silent null body.
+        "response": execution.response if execution.status in ("success", "failed", "cancelled") else None,
+        "error": execution.error if execution.status in ("failed", "cancelled") else None,
     }
 
 

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -1033,6 +1033,31 @@ class TaskExecutionService:
             response_data = response.json()
             metadata = response_data.get("metadata", {})
 
+            # ---- #679 cancel cross-validation -----------------------------
+            # A cancel-aware agent labels a SIGINT-graceful-exit-0 / SIGKILL→504
+            # turn with status:"cancelled" in its 200 reply. The HTTP return code
+            # alone can't distinguish that from a genuine success, so trust the
+            # label: finalize CANCELLED via the shared applier (never a billable
+            # SUCCESS row — defense-in-depth over the #671 CAS). An old agent
+            # image omits `status` → .get() is None → the SUCCESS path below is
+            # unchanged. release_slot=False: the `finally` owns the sync slot.
+            if response_data.get("status") == "cancelled":
+                cancelled_envelope = TerminalEnvelope(
+                    execution_id=execution_id,
+                    status=TaskExecutionStatus.CANCELLED,
+                    error="Execution cancelled by user",
+                    metadata=metadata,
+                    retry_count=retry_count,
+                    previous_attempt_cost=previous_attempt_cost,
+                )
+                return await self.apply_result(
+                    agent_name,
+                    cancelled_envelope,
+                    activity_id=activity_id,
+                    breaker_enabled=breaker_enabled,
+                    release_slot=False,
+                )
+
             # ---- 5/6/7. Apply the SUCCESS terminal ------------------------
             # The terminal write + side-effects (sanitize, cost rollup, CAS,
             # activity completion, breaker reset) live in apply_result so the
@@ -1410,7 +1435,10 @@ class TaskExecutionService:
         if eid:
             won = db.update_execution_status(
                 execution_id=eid,
-                status=TaskExecutionStatus.FAILED,
+                # #679: honor envelope.status so this non-success applier also
+                # finalizes CANCELLED (and any future non-success terminal). A
+                # no-op for every current caller — all still pass FAILED.
+                status=envelope.status,
                 error=envelope.error,
                 cost=salvage_cost,
                 context_used=salvage_context,
@@ -1436,7 +1464,9 @@ class TaskExecutionService:
 
         return TaskExecutionResult(
             execution_id=eid or "",
-            status=TaskExecutionStatus.FAILED,
+            # #679: mirror the persisted status (CANCELLED for a cancel terminal,
+            # FAILED otherwise) so callers branch on the real outcome.
+            status=envelope.status,
             response="",
             error=envelope.error,
             error_code=envelope.error_code,

--- a/src/backend/services/validation_service.py
+++ b/src/backend/services/validation_service.py
@@ -271,11 +271,13 @@ class ValidationService:
         """
         raw_response = result.response or ""
 
-        # Check for execution failure
-        if result.status == "failed":
+        # Check for execution failure. #679: a CANCELLED validation turn never
+        # actually validated anything — treat it as a non-success ERROR, not an
+        # empty response to be parsed as a validation verdict.
+        if result.status in ("failed", "cancelled"):
             return ValidationResult(
                 status=ValidationStatus.ERROR,
-                summary=f"Validation execution failed: {result.error or 'Unknown error'}",
+                summary=f"Validation execution {result.status}: {result.error or 'Unknown error'}",
                 items=[],
                 raw_response=raw_response,
             )

--- a/tests/test_execution_termination.py
+++ b/tests/test_execution_termination.py
@@ -266,6 +266,91 @@ class TestTerminateRunningExecution:
         task_thread.join(timeout=10)
 
 
+class TestCancelLabeledNotSuccess:
+    """#679: a cancelled /task must finalize CANCELLED — never a billable SUCCESS.
+
+    Claude catches SIGINT, emits a graceful final message, and exits 0, so the
+    HTTP return code alone can't tell a cancel from a real success. This E2E
+    proves the end-to-end label (agent reply status:cancelled → backend cross-
+    validation → CANCELLED row) holds against a real agent container. Runs in
+    /verify-local's agent-exercise stage.
+    """
+
+    @pytest.mark.slow
+    @pytest.mark.requires_agent
+    def test_cancelled_task_row_is_cancelled_not_success(
+        self,
+        api_client: TrinityApiClient,
+        created_agent
+    ):
+        agent_name = created_agent['name']
+        execution_id = None
+
+        def start_task():
+            try:
+                api_client.post(
+                    f"/api/agents/{agent_name}/task",
+                    json={"message": (
+                        "Write an extremely detailed, comprehensive analysis of "
+                        "the entire history of computing, decade by decade, with "
+                        "at least 30 paragraphs. Take your time and be thorough."
+                    )},
+                    timeout=180.0,
+                )
+            except Exception:
+                pass  # interrupted by termination
+
+        task_thread = threading.Thread(target=start_task)
+        task_thread.start()
+
+        # Capture the running execution_id.
+        max_wait = 20
+        start_time = time.time()
+        while time.time() - start_time < max_wait:
+            running = api_client.get(f"/api/agents/{agent_name}/executions/running")
+            if running.status_code == 200:
+                execs = running.json().get("executions", [])
+                if execs:
+                    execution_id = execs[0].get("execution_id")
+                    if execution_id:
+                        break
+            time.sleep(0.3)
+
+        if not execution_id:
+            task_thread.join(timeout=5)
+            pytest.skip("Could not capture execution_id (task finished too fast)")
+
+        # Cancel it.
+        terminate_response = api_client.post(
+            f"/api/agents/{agent_name}/executions/{execution_id}/terminate"
+        )
+        task_thread.join(timeout=30)
+
+        if terminate_response.status_code != 200:
+            pytest.skip("Termination did not succeed")
+        if terminate_response.json().get("status") == "already_finished":
+            # The cancel landed after the turn finished on its own — its genuine
+            # terminal stands (Issue 7). Not the case under test.
+            pytest.skip("Task already finished before cancel landed")
+
+        # Poll the row to a terminal state and assert it's CANCELLED — and
+        # explicitly NOT success (the no-billable-success guarantee, #679).
+        deadline = time.time() + 30
+        status = None
+        while time.time() < deadline:
+            detail = api_client.get(f"/api/agents/{agent_name}/executions/{execution_id}")
+            if detail.status_code == 200:
+                status = detail.json().get("status")
+                if status in ("cancelled", "success", "failed"):
+                    break
+            time.sleep(0.5)
+
+        assert status == "cancelled", (
+            f"A cancelled /task must finalize CANCELLED, got {status!r} "
+            f"(a 'success' here is the #679 charge-on-cancel / false-success bug)"
+        )
+
+
 class TestRunningExecutionDetails:
     """Tests for running execution list details."""
 

--- a/tests/unit/test_679_agent_chat_cancel.py
+++ b/tests/unit/test_679_agent_chat_cancel.py
@@ -1,0 +1,185 @@
+"""Unit tests for #679: the agent-side ``/api/task`` handler labels a cancelled
+turn (``execute_task`` in ``agent_server.routers.chat``).
+
+Two cancel shapes:
+  * Graceful — Claude catches SIGINT, emits a final message, exits 0.
+    ``execute_headless`` returns normally; the handler cross-checks the
+    ``was_terminated`` marker (keyed off ``request.execution_id``, NEVER the
+    returned ``session_id``) and labels ``status:"cancelled"``.
+  * SIGKILL — Claude ignored SIGINT, terminate() escalated to SIGKILL, and
+    ``execute_headless`` raised HTTPException 504. The handler swallows the
+    **504 only** when terminated → 200 ``status:"cancelled"``; 503/429/etc. and
+    unterminated 504s re-raise (Issue 6/C6 — keep SUB-003 + the AUTH breaker firing).
+
+The conftest preloads the agent_server namespace package.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import agent_server.routers.chat as chat_mod  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _req(**over):
+    base = dict(
+        message="do the thing", model="sonnet", allowed_tools=None,
+        system_prompt=None, timeout_seconds=300, max_turns=None,
+        execution_id="exec-1", resume_session_id=None, persist_session=False,
+        images=None, async_result=False,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _runtime(*, returns=None, raises=None):
+    rt = MagicMock()
+    if raises is not None:
+        rt.execute_headless = AsyncMock(side_effect=raises)
+    else:
+        rt.execute_headless = AsyncMock(return_value=returns)
+    return rt
+
+
+def _ok_return(session_id="sess-DIFFERENT"):
+    """A normal execute_headless 4-tuple: (response, raw_messages, metadata, session_id)."""
+    md = MagicMock()
+    md.model_dump.return_value = {"cost_usd": 0.03}
+    return ("final answer", [{"type": "result"}], md, session_id)
+
+
+def _drive(request, *, runtime, was_terminated):
+    """Run execute_task with runtime/registry/result_callback/agent_state mocked."""
+    registry = MagicMock()
+    registry.was_terminated.return_value = was_terminated
+
+    with (
+        patch.object(chat_mod, "get_runtime", return_value=runtime),
+        patch.object(chat_mod, "get_process_registry", return_value=registry),
+        patch.object(chat_mod, "agent_state", MagicMock()),
+        patch.object(chat_mod.result_callback, "try_spawn_async", return_value=False),
+    ):
+        return asyncio.run(chat_mod.execute_task(request)), registry
+
+
+class TestGracefulPath:
+    def test_graceful_cancel_labels_cancelled(self):
+        # Marker is keyed off execution_id; the returned session_id differs and
+        # must NOT be used for the lookup.
+        reply, registry = _drive(
+            _req(execution_id="exec-1"),
+            runtime=_runtime(returns=_ok_return(session_id="sess-DIFFERENT")),
+            was_terminated=True,
+        )
+        assert reply["status"] == "cancelled"
+        registry.was_terminated.assert_called_once_with("exec-1")
+
+    def test_normal_success_labels_success(self):
+        reply, registry = _drive(
+            _req(execution_id="exec-1"),
+            runtime=_runtime(returns=_ok_return()),
+            was_terminated=False,
+        )
+        assert reply["status"] == "success"
+        assert reply["response"] == "final answer"
+
+    def test_execution_id_none_labels_success_without_lookup(self):
+        reply, registry = _drive(
+            _req(execution_id=None),
+            runtime=_runtime(returns=_ok_return()),
+            was_terminated=True,  # would be cancelled IF it were keyed wrong
+        )
+        assert reply["status"] == "success"
+        registry.was_terminated.assert_not_called()
+
+
+class TestSigkillPath:
+    def test_504_terminated_returns_200_cancelled(self):
+        reply, registry = _drive(
+            _req(execution_id="exec-1"),
+            runtime=_runtime(raises=HTTPException(status_code=504, detail="timed out")),
+            was_terminated=True,
+        )
+        assert reply["status"] == "cancelled"
+        assert reply["response"] == "timed out"     # string detail surfaced
+        assert reply["execution_log"] == []
+        assert reply["metadata"] == {}
+        assert reply["session_id"] is None
+
+    def test_503_terminated_reraises(self):
+        # C6: a 503-auth must propagate so SUB-003 + the AUTH dispatch breaker fire.
+        with pytest.raises(HTTPException) as ei:
+            _drive(
+                _req(execution_id="exec-1"),
+                runtime=_runtime(raises=HTTPException(status_code=503, detail="auth")),
+                was_terminated=True,
+            )
+        assert ei.value.status_code == 503
+
+    def test_429_terminated_reraises(self):
+        with pytest.raises(HTTPException) as ei:
+            _drive(
+                _req(execution_id="exec-1"),
+                runtime=_runtime(raises=HTTPException(status_code=429, detail="rate")),
+                was_terminated=True,
+            )
+        assert ei.value.status_code == 429
+
+    def test_504_not_terminated_reraises(self):
+        # A genuine timeout (no cancel) must keep its 504.
+        with pytest.raises(HTTPException) as ei:
+            _drive(
+                _req(execution_id="exec-1"),
+                runtime=_runtime(raises=HTTPException(status_code=504, detail="timed out")),
+                was_terminated=False,
+            )
+        assert ei.value.status_code == 504
+
+
+class TestNonSignalTerminatedRelabel:
+    """#679 F3: the sync relabel must mirror the async path's breadth — ANY
+    non-auth/non-rate terminal for a terminated turn is a cancel, not a failure.
+    A terminated turn that exits 0 with empty output surfaces a 502 (#678
+    empty-result) or 500; before F3 the sync path only caught 504, so those wrote
+    FAILED and could lose the CAS race to the terminate handler's CANCELLED write
+    (leaving a user-cancel persisted as FAILED). The structured 502 detail is a
+    dict, so the relabel drops it to an empty response (cancel is non-billable)."""
+
+    def test_502_terminated_returns_200_cancelled(self):
+        reply, _registry = _drive(
+            _req(execution_id="exec-1"),
+            runtime=_runtime(raises=HTTPException(
+                status_code=502, detail={"message": "empty result", "metadata": {"cost_usd": 0.04}}
+            )),
+            was_terminated=True,
+        )
+        assert reply["status"] == "cancelled"
+        assert reply["response"] == ""          # dict detail → empty (no billable salvage)
+        assert reply["metadata"] == {}
+        assert reply["session_id"] is None
+
+    def test_500_terminated_returns_200_cancelled(self):
+        reply, _registry = _drive(
+            _req(execution_id="exec-1"),
+            runtime=_runtime(raises=HTTPException(status_code=500, detail="empty response")),
+            was_terminated=True,
+        )
+        assert reply["status"] == "cancelled"
+        assert reply["response"] == "empty response"   # string detail surfaced as the label
+
+    def test_502_not_terminated_reraises(self):
+        # A genuine empty-result (no cancel) must keep its 502 so the #678
+        # inline reader-race retry / FAILED accounting still fire.
+        with pytest.raises(HTTPException) as ei:
+            _drive(
+                _req(execution_id="exec-1"),
+                runtime=_runtime(raises=HTTPException(status_code=502, detail={"message": "empty"})),
+                was_terminated=False,
+            )
+        assert ei.value.status_code == 502

--- a/tests/unit/test_679_backend_cancel.py
+++ b/tests/unit/test_679_backend_cancel.py
@@ -1,0 +1,225 @@
+"""Unit tests for #679 backend finalization:
+
+(a) ``apply_result`` honors ``envelope.status`` on the failure-style branch — a
+    CANCELLED envelope writes/returns CANCELLED, and a FAILED envelope still
+    writes/returns FAILED (the generalization is a no-op for every current
+    caller — CRITICAL regression).
+(b) ``execute_task`` sync cross-validation — a 200 agent reply carrying
+    ``status:"cancelled"`` finalizes CANCELLED (never SUCCESS), while a 200 with
+    no ``status`` (old image) is unchanged SUCCESS (backward-compat regression).
+
+Pure unit tests — no backend. Mocks mirror test_1083_apply_result.py and
+test_terminal_write_cas_gate.py.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _await(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _make_execution(status: str):
+    ex = MagicMock()
+    ex.id = "exec-679"
+    ex.status = status
+    return ex
+
+
+# ---------------------------------------------------------------------------
+# (a) apply_result honors envelope.status
+# ---------------------------------------------------------------------------
+def _run_apply(envelope, *, cas_won=True, activity_id="act-1", release_slot=False):
+    from services.task_execution_service import TaskExecutionService
+
+    mock_db = MagicMock()
+    mock_db.update_execution_status.return_value = cas_won
+    mock_db.get_execution.return_value = _make_execution("cancelled")
+
+    mock_activity = MagicMock(complete_activity=AsyncMock())
+    mock_capacity = MagicMock(release=AsyncMock())
+    mock_record = AsyncMock()
+
+    with (
+        patch("services.task_execution_service.db", mock_db),
+        patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+        patch("services.task_execution_service.activity_service", mock_activity),
+        patch("services.task_execution_service._record_dispatch_terminal", mock_record),
+    ):
+        svc = TaskExecutionService()
+        result = _await(
+            svc.apply_result(
+                "test-agent", envelope, activity_id=activity_id,
+                breaker_enabled=False, release_slot=release_slot,
+            )
+        )
+    return result, (mock_db, mock_activity, mock_capacity, mock_record)
+
+
+class TestApplyResultHonorsStatus:
+    pytestmark = pytest.mark.unit
+
+    def test_cancelled_envelope_writes_and_returns_cancelled(self):
+        from services.task_execution_service import TerminalEnvelope, TaskExecutionStatus
+        from models import ActivityState
+
+        env = TerminalEnvelope(
+            execution_id="exec-679",
+            status=TaskExecutionStatus.CANCELLED,
+            error="Execution cancelled by user",
+            metadata={"cost_usd": 0.05, "input_tokens": 100, "context_window": 200000},
+        )
+        result, (mdb, mact, mcap, mrec) = _run_apply(env)
+
+        assert mdb.update_execution_status.call_args.kwargs["status"] == TaskExecutionStatus.CANCELLED
+        assert result.status == TaskExecutionStatus.CANCELLED
+        assert result.error == "Execution cancelled by user"
+        # cost salvaged from metadata so the cancelled row records real spend.
+        assert mdb.update_execution_status.call_args.kwargs["cost"] == 0.05
+        # Activity still completes FAILED; a cancel is not an AUTH failure → no breaker.
+        assert mact.complete_activity.await_args.kwargs["status"] == ActivityState.FAILED
+        mrec.assert_not_awaited()
+
+    def test_failed_envelope_still_failed_regression(self):
+        """CRITICAL: the generalization must be a no-op for the existing FAILED caller."""
+        from services.task_execution_service import (
+            TerminalEnvelope, TaskExecutionStatus,
+        )
+
+        env = TerminalEnvelope(
+            execution_id="exec-679",
+            status=TaskExecutionStatus.FAILED,
+            error="agent said no",
+            metadata={"cost_usd": 0.02},
+        )
+        result, (mdb, *_rest) = _run_apply(env)
+        assert mdb.update_execution_status.call_args.kwargs["status"] == TaskExecutionStatus.FAILED
+        assert result.status == TaskExecutionStatus.FAILED
+
+    def test_cancelled_release_slot_gated_on_cas(self):
+        from services.task_execution_service import TerminalEnvelope, TaskExecutionStatus
+
+        env = TerminalEnvelope(
+            execution_id="exec-679", status=TaskExecutionStatus.CANCELLED, error="x",
+            metadata={},
+        )
+        # Won → released.
+        _r, (_mdb, _ma, mcap, _mr) = _run_apply(env, cas_won=True, release_slot=True)
+        mcap.release.assert_awaited_once_with("test-agent", "exec-679")
+        # Lost CAS → not released.
+        _r2, (_mdb2, _ma2, mcap2, _mr2) = _run_apply(env, cas_won=False, release_slot=True)
+        mcap2.release.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# (b) execute_task sync cross-validation
+# ---------------------------------------------------------------------------
+def _agent_response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+def _run_execute_task(response_payload: dict):
+    from services.task_execution_service import TaskExecutionService
+
+    mock_db = MagicMock()
+    mock_db.get_max_parallel_tasks.return_value = 3
+    mock_db.get_execution.return_value = _make_execution("running")
+    mock_db.update_execution_status.return_value = True  # CAS won
+
+    mock_capacity = MagicMock()
+    admitted = MagicMock()
+    admitted.state = "admitted"
+    mock_capacity.acquire = AsyncMock(return_value=admitted)
+    mock_capacity.release = AsyncMock()
+
+    mock_circuit = MagicMock()
+    mock_circuit.allow_request.return_value = True
+
+    mock_activity = MagicMock(
+        track_activity=AsyncMock(return_value="act-001"),
+        complete_activity=AsyncMock(),
+    )
+
+    with (
+        patch("services.task_execution_service.db", mock_db),
+        patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
+        patch("services.task_execution_service.activity_service", mock_activity),
+        patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
+        patch("services.task_execution_service.agent_post_with_retry",
+              AsyncMock(return_value=_agent_response(response_payload))),
+        patch("services.task_execution_service.dispatch_breaker_active", return_value=False),
+        patch("services.task_execution_service._record_dispatch_terminal", AsyncMock()),
+    ):
+        svc = TaskExecutionService()
+        result = _await(
+            svc.execute_task(
+                agent_name="test-agent",
+                message="hello",
+                triggered_by="schedule",
+                execution_id="exec-679",
+                timeout_seconds=300,
+                model="sonnet",
+            )
+        )
+    return result, mock_db
+
+
+class TestSyncCrossValidation:
+    pytestmark = pytest.mark.unit
+
+    def test_200_status_cancelled_finalizes_cancelled(self):
+        from services.task_execution_service import TaskExecutionStatus
+
+        result, mock_db = _run_execute_task({
+            "status": "cancelled",
+            "response": "stopped mid-task",
+            "session_id": None,
+            "metadata": {"cost_usd": 0.03, "context_window": 200000},
+            "execution_log": [],
+        })
+        assert result.status == TaskExecutionStatus.CANCELLED
+        assert mock_db.update_execution_status.call_args.kwargs["status"] == TaskExecutionStatus.CANCELLED
+
+    def test_200_without_status_unchanged_success(self):
+        """Backward-compat: an old agent image omits `status` → SUCCESS path."""
+        from services.task_execution_service import TaskExecutionStatus
+
+        result, mock_db = _run_execute_task({
+            "response": "done",
+            "session_id": "sess-1",
+            "metadata": {"cost_usd": 0.01, "input_tokens": 100, "context_window": 200000},
+            "execution_log": [],
+        })
+        assert result.status == TaskExecutionStatus.SUCCESS
+        assert mock_db.update_execution_status.call_args.kwargs["status"] == TaskExecutionStatus.SUCCESS
+
+    def test_200_status_success_explicit_is_success(self):
+        from services.task_execution_service import TaskExecutionStatus
+
+        result, _mdb = _run_execute_task({
+            "status": "success",
+            "response": "done",
+            "session_id": "sess-1",
+            "metadata": {"cost_usd": 0.01, "context_window": 200000},
+            "execution_log": [],
+        })
+        assert result.status == TaskExecutionStatus.SUCCESS

--- a/tests/unit/test_679_callback_cancel.py
+++ b/tests/unit/test_679_callback_cancel.py
@@ -1,0 +1,180 @@
+"""Unit tests for #679 on the fire-and-forget result-callback endpoint (#1083):
+``routers.agents.agent_execution_result`` maps a ``cancelled`` envelope to the
+CANCELLED terminal (3-way status map: success→SUCCESS, cancelled→CANCELLED,
+else→FAILED).
+
+Mirrors test_1083_callback_endpoint.py.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytestmark = pytest.mark.unit
+
+
+def _await(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _FakeRequest:
+    def __init__(self, auth_header="Bearer k"):
+        self.headers = {"Authorization": auth_header}
+
+
+def _execution(*, agent_name="agent-a", status="running", claude_session_id="dispatched_async"):
+    return SimpleNamespace(
+        id="exec-1", agent_name=agent_name, status=status,
+        claude_session_id=claude_session_id,
+    )
+
+
+def _drive(payload, *, execution=None, apply_status="cancelled"):
+    from routers.agents import agent_execution_result
+
+    if execution is None:
+        execution = _execution()
+    mock_db = MagicMock()
+    mock_db.validate_mcp_api_key.return_value = {"scope": "agent", "agent_name": "agent-a"}
+    mock_db.get_execution.return_value = execution
+    mock_db.get_open_activity_id_for_execution.return_value = "act-1"
+    apply_mock = AsyncMock(return_value=SimpleNamespace(status=apply_status))
+    svc = MagicMock(apply_result=apply_mock)
+    with (
+        patch("routers.agents.db", mock_db),
+        patch("services.heartbeat_service.authorize_heartbeat", return_value=True),
+        patch("services.task_execution_service.get_task_execution_service", return_value=svc),
+        patch("services.task_execution_service.dispatch_breaker_active", return_value=False),
+    ):
+        resp = _await(
+            agent_execution_result("agent-a", "exec-1", payload, _FakeRequest())
+        )
+    return resp, apply_mock
+
+
+def test_cancelled_payload_maps_to_cancelled_envelope():
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import TaskExecutionStatus
+
+    payload = ExecutionResultEnvelope(
+        status="cancelled", response="stopped", terminal_reason="cancelled",
+        metadata={"cost_usd": 0.03},
+    )
+    resp, apply_mock = _drive(payload)
+
+    apply_mock.assert_awaited_once()
+    envelope = apply_mock.await_args.args[1]
+    assert envelope.status == TaskExecutionStatus.CANCELLED
+    # release_slot=True (the callback owns the lease)
+    assert apply_mock.await_args.kwargs["release_slot"] is True
+    assert resp["status"] == "cancelled"
+
+
+def test_success_payload_still_maps_to_success():
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import TaskExecutionStatus
+
+    payload = ExecutionResultEnvelope(status="success", response="done", metadata={})
+    _resp, apply_mock = _drive(payload, apply_status="success")
+    assert apply_mock.await_args.args[1].status == TaskExecutionStatus.SUCCESS
+
+
+def test_failed_payload_still_maps_to_failed():
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import TaskExecutionStatus
+
+    payload = ExecutionResultEnvelope(status="failed", error="boom", metadata={})
+    _resp, apply_mock = _drive(payload, apply_status="failed")
+    assert apply_mock.await_args.args[1].status == TaskExecutionStatus.FAILED
+
+
+def test_unknown_status_maps_to_failed():
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import TaskExecutionStatus
+
+    payload = ExecutionResultEnvelope(status="weird", error="?", metadata={})
+    _resp, apply_mock = _drive(payload, apply_status="failed")
+    assert apply_mock.await_args.args[1].status == TaskExecutionStatus.FAILED
+
+
+def test_cancelled_row_already_terminal_is_replayed_noop():
+    """A terminate-wrote-first race: the row is already CANCELLED → idempotent
+    replay ACK, apply_result not re-run (CANCELLED ∈ _AUTHORITATIVE_TERMINALS)."""
+    from models import ExecutionResultEnvelope
+
+    payload = ExecutionResultEnvelope(status="cancelled", metadata={})
+    resp, apply_mock = _drive(payload, execution=_execution(status="cancelled"))
+    assert resp["replayed"] is True
+    apply_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# #679 Finding 2 (CSO 2026-06-22): backend-side auth/rate-vs-cancel guard.
+# The callback is the backend trust boundary — a buggy or mixed-version agent
+# that POSTs status:"cancelled" carrying an auth/rate terminal must NOT be
+# reclassified as a clean cancellation (which would silently dodge the AUTH
+# dispatch breaker / SUB-003 auto-switch). Mirrors result_callback._is_auth_or_rate.
+# ---------------------------------------------------------------------------
+def test_cancelled_with_auth_error_code_maps_to_failed():
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import (
+        TaskExecutionErrorCode,
+        TaskExecutionStatus,
+    )
+
+    payload = ExecutionResultEnvelope(
+        status="cancelled", error="no api key", error_code="auth", metadata={},
+    )
+    _resp, apply_mock = _drive(payload, apply_status="failed")
+    envelope = apply_mock.await_args.args[1]
+    assert envelope.status == TaskExecutionStatus.FAILED
+    # error_code preserved so the AUTH dispatch breaker still records the failure
+    assert envelope.error_code == TaskExecutionErrorCode.AUTH
+
+
+def test_cancelled_with_rate_limit_terminal_reason_maps_to_failed():
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import TaskExecutionStatus
+
+    payload = ExecutionResultEnvelope(
+        status="cancelled", error="rate limited", terminal_reason="rate_limit", metadata={},
+    )
+    _resp, apply_mock = _drive(payload, apply_status="failed")
+    assert apply_mock.await_args.args[1].status == TaskExecutionStatus.FAILED
+
+
+def test_cancelled_with_auth_terminal_reason_maps_to_failed():
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import TaskExecutionStatus
+
+    payload = ExecutionResultEnvelope(
+        status="cancelled", terminal_reason="auth", metadata={},
+    )
+    _resp, apply_mock = _drive(payload, apply_status="failed")
+    assert apply_mock.await_args.args[1].status == TaskExecutionStatus.FAILED
+
+
+def test_genuine_cancelled_still_maps_to_cancelled():
+    """Regression guard: a real cancel (no auth/rate signal) still → CANCELLED."""
+    from models import ExecutionResultEnvelope
+    from services.task_execution_service import TaskExecutionStatus
+
+    payload = ExecutionResultEnvelope(
+        status="cancelled", response="stopped", terminal_reason="cancelled", metadata={},
+    )
+    _resp, apply_mock = _drive(payload)
+    assert apply_mock.await_args.args[1].status == TaskExecutionStatus.CANCELLED

--- a/tests/unit/test_679_callers.py
+++ b/tests/unit/test_679_callers.py
@@ -1,0 +1,141 @@
+"""Unit tests for #679 caller-audit: CANCELLED is treated as non-success at
+every ``execute_task`` status-branching caller.
+
+The two highest-value testable units:
+  * ``routers.paid.paid_chat`` — a CANCELLED turn must NOT settle payment
+    (closes the charge-on-cancel money bug — CRITICAL).
+  * ``services.validation_service._parse_validation_response`` — a CANCELLED
+    validation turn is a non-success ERROR, not an empty verdict.
+
+The remaining inverse-gate sites (public sync/async, message_router, chat) are a
+mechanical ``== "failed"`` → ``in ("failed", "cancelled")`` broadening; the loop
+caller is covered in test_loop_service.py, and the end-to-end cancel→CANCELLED
+flow is exercised by the agent-exercise stage of /verify-local.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytestmark = pytest.mark.unit
+
+
+def _await(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# paid.py — no settle on cancel (CRITICAL money bug)
+# ---------------------------------------------------------------------------
+class _PaidRequest:
+    def __init__(self):
+        self.headers = {"payment-signature": "tok-abc"}
+        self.base_url = "http://localhost/"
+
+
+def _drive_paid(exec_status: str):
+    """Drive paid_chat to the post-execute branch with a scripted result status.
+    Returns (response_json, settle_mock)."""
+    import routers.paid as paid
+
+    config = SimpleNamespace(
+        enabled=True, nvm_environment="testnet", credits_per_request=1,
+    )
+    mock_db = MagicMock()
+    mock_db.get_nevermined_config_with_key.return_value = {
+        "config": config, "nvm_api_key": "nvm-key",
+    }
+    mock_db.log_nevermined_payment.return_value = None
+
+    verify_result = SimpleNamespace(
+        success=True, payer="0xpayer", agent_request_id="req-1", error=None,
+    )
+    settle_mock = AsyncMock(return_value=SimpleNamespace(
+        success=True, tx_hash="0xtx", remaining_balance=10, error=None,
+    ))
+    payment_service = MagicMock(
+        verify_payment=AsyncMock(return_value=verify_result),
+        settle_payment=settle_mock,
+    )
+
+    exec_result = SimpleNamespace(
+        status=exec_status, response="partial work", execution_id="exec-1",
+    )
+    task_service = MagicMock(execute_task=AsyncMock(return_value=exec_result))
+
+    with (
+        patch.object(paid, "NEVERMINED_AVAILABLE", True),
+        patch.object(paid, "db", mock_db),
+        patch.object(paid, "get_nevermined_payment_service", return_value=payment_service),
+        patch.object(paid, "get_task_execution_service", return_value=task_service),
+    ):
+        resp = _await(paid.paid_chat("agent-a", SimpleNamespace(message="hi", session_id=None), _PaidRequest()))
+    # The success path returns a plain dict; the failed/cancelled path returns a
+    # JSONResponse (whose body is the JSON we want to inspect).
+    if hasattr(resp, "body"):
+        import json as _json
+        body = _json.loads(bytes(resp.body).decode())
+    else:
+        body = resp
+    return body, settle_mock
+
+
+def test_paid_cancelled_does_not_settle():
+    body, settle_mock = _drive_paid("cancelled")
+    settle_mock.assert_not_awaited()  # the money bug: no charge on cancel
+    assert body["status"] == "cancelled"
+    assert body["payment"]["settled"] is False
+
+
+def test_paid_failed_does_not_settle():
+    body, settle_mock = _drive_paid("failed")
+    settle_mock.assert_not_awaited()
+    assert body["status"] == "failed"
+    assert body["payment"]["settled"] is False
+
+
+def test_paid_success_does_settle():
+    """Regression: a genuine success still settles (the change didn't over-broaden)."""
+    body, settle_mock = _drive_paid("success")
+    settle_mock.assert_awaited_once()
+    assert body["status"] == "success"
+    assert body["payment"]["settled"] is True
+
+
+# ---------------------------------------------------------------------------
+# validation_service — cancel → ERROR (non-success), not an empty verdict
+# ---------------------------------------------------------------------------
+def _validation_result(status: str):
+    return SimpleNamespace(status=status, response="", error="Execution cancelled by user")
+
+
+def test_validation_cancelled_is_error_not_parsed():
+    from services.validation_service import ValidationService
+    from services.validation_service import ValidationStatus
+
+    svc = ValidationService.__new__(ValidationService)  # no __init__ deps needed
+    out = svc._parse_validation_response(_validation_result("cancelled"))
+    assert out.status == ValidationStatus.ERROR
+    assert "cancelled" in out.summary.lower()
+
+
+def test_validation_failed_is_error():
+    from services.validation_service import ValidationService, ValidationStatus
+
+    svc = ValidationService.__new__(ValidationService)
+    out = svc._parse_validation_response(_validation_result("failed"))
+    assert out.status == ValidationStatus.ERROR

--- a/tests/unit/test_679_cancel_neutral_finish.py
+++ b/tests/unit/test_679_cancel_neutral_finish.py
@@ -1,0 +1,137 @@
+"""Unit tests for #679 (F4): a user cancel is neither a success nor a failure
+for the agent's ``consecutive_failures`` health counter.
+
+``AgentState.record_task_finish`` feeds ``consecutive_failures``, which the
+dispatch circuit breaker (#526) and ``/health`` consume. Before F4 the two
+cancel sub-paths disagreed: the SIGKILL→504 branch recorded ``success=False``
+(incrementing the counter — operator cancels could trip the breaker on a healthy
+agent) while the graceful-exit-0 branch recorded ``success=True`` (resetting it).
+F4 makes a cancel NEUTRAL: it finishes the task (decrement active count, stamp
+last_task_at) but touches neither counter, on BOTH sub-paths.
+
+The conftest preloads the agent_server namespace package.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import agent_server.routers.chat as chat_mod
+from agent_server.state import AgentState
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# (a) state-level: record_task_finish(None) is neutral
+# ---------------------------------------------------------------------------
+class TestNeutralFinish:
+    def test_none_leaves_failure_counter_unchanged(self):
+        st = AgentState()
+        st.consecutive_failures = 2
+        st.record_task_start()
+        before = st.consecutive_failures
+        st.record_task_finish(success=None)
+        assert st.consecutive_failures == before          # neither reset nor incremented
+        assert st.active_task_count == 0                   # task still finished
+        assert st.last_task_at is not None
+
+    def test_false_still_increments(self):
+        st = AgentState()
+        st.consecutive_failures = 2
+        st.record_task_finish(success=False)
+        assert st.consecutive_failures == 3
+
+    def test_true_still_resets(self):
+        st = AgentState()
+        st.consecutive_failures = 5
+        st.record_task_finish(success=True)
+        assert st.consecutive_failures == 0
+
+
+# ---------------------------------------------------------------------------
+# (b) execute_task records NEUTRAL for a cancel, success/failure otherwise
+# ---------------------------------------------------------------------------
+def _req(**over):
+    base = dict(
+        message="do the thing", model="sonnet", allowed_tools=None,
+        system_prompt=None, timeout_seconds=300, max_turns=None,
+        execution_id="exec-1", resume_session_id=None, persist_session=False,
+        images=None, async_result=False,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _runtime(*, returns=None, raises=None):
+    rt = MagicMock()
+    if raises is not None:
+        rt.execute_headless = AsyncMock(side_effect=raises)
+    else:
+        rt.execute_headless = AsyncMock(return_value=returns)
+    return rt
+
+
+def _ok_return():
+    md = MagicMock()
+    md.model_dump.return_value = {"cost_usd": 0.03}
+    return ("final answer", [{"type": "result"}], md, "sess-1")
+
+
+def _drive(request, *, runtime, was_terminated):
+    """Run execute_task; return the agent_state mock so callers inspect
+    record_task_finish."""
+    registry = MagicMock()
+    registry.was_terminated.return_value = was_terminated
+    state_mock = MagicMock()
+
+    with (
+        patch.object(chat_mod, "get_runtime", return_value=runtime),
+        patch.object(chat_mod, "get_process_registry", return_value=registry),
+        patch.object(chat_mod, "agent_state", state_mock),
+        patch.object(chat_mod.result_callback, "try_spawn_async", return_value=False),
+    ):
+        try:
+            asyncio.run(chat_mod.execute_task(request))
+        except HTTPException:
+            pass
+    return state_mock
+
+
+def _finish_kwarg(state_mock):
+    """The `success=` value passed to the single record_task_finish call."""
+    call = state_mock.record_task_finish.call_args
+    assert call is not None, "record_task_finish was never called"
+    if call.kwargs:
+        return call.kwargs.get("success")
+    return call.args[0]
+
+
+class TestExecuteTaskNeutralAccounting:
+    def test_graceful_cancel_records_neutral(self):
+        st = _drive(_req(), runtime=_runtime(returns=_ok_return()), was_terminated=True)
+        assert _finish_kwarg(st) is None
+
+    def test_success_records_true(self):
+        st = _drive(_req(), runtime=_runtime(returns=_ok_return()), was_terminated=False)
+        assert _finish_kwarg(st) is True
+
+    def test_504_cancel_records_neutral(self):
+        st = _drive(
+            _req(),
+            runtime=_runtime(raises=HTTPException(status_code=504, detail="t")),
+            was_terminated=True,
+        )
+        assert _finish_kwarg(st) is None
+
+    def test_genuine_failure_records_false(self):
+        st = _drive(
+            _req(),
+            runtime=_runtime(raises=HTTPException(status_code=500, detail="boom")),
+            was_terminated=False,
+        )
+        assert _finish_kwarg(st) is False

--- a/tests/unit/test_679_public_poll_cancel.py
+++ b/tests/unit/test_679_public_poll_cancel.py
@@ -1,0 +1,81 @@
+"""Unit tests for #679 (F2): the public async poll endpoint
+(``public_execution_status`` in ``routers.public``) must surface the cancel
+reason for a CANCELLED execution.
+
+Before F2 the poller returned ``{"status":"cancelled","response":null,"error":null}``
+— the row already carries the ``cancelled`` status and a "cancelled by user"
+error, but the GET suppressed both because the conditions only matched
+``("success","failed")`` / ``"failed"``. A public caller polling after a cancel
+got no reason. F2 surfaces ``error`` (and ``response``) for cancelled too.
+
+Pure unit test — no running backend; the four request-scoped helpers are mocked.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytestmark = pytest.mark.unit
+
+
+def _await(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _execution(status: str, *, response: str | None, error: str | None):
+    ex = MagicMock()
+    ex.id = "exec-679"
+    ex.agent_name = "pub-agent"
+    ex.status = status
+    ex.response = response
+    ex.error = error
+    return ex
+
+
+def _poll(execution):
+    import routers.public as public_mod
+
+    with (
+        patch.object(public_mod, "_get_client_ip", return_value="1.2.3.4"),
+        patch.object(public_mod, "check_public_link_rate_limit", MagicMock()),
+        patch.object(public_mod, "_validate_public_link", return_value={"agent_name": "pub-agent"}),
+        patch.object(public_mod, "db", MagicMock(get_execution=MagicMock(return_value=execution))),
+    ):
+        return _await(
+            public_mod.public_execution_status(
+                token="tok", execution_id="exec-679", request=MagicMock()
+            )
+        )
+
+
+def test_cancelled_surfaces_error_and_response():
+    out = _poll(_execution("cancelled", response="partial work", error="Execution cancelled by user"))
+    assert out["status"] == "cancelled"
+    assert out["error"] == "Execution cancelled by user"
+    assert out["response"] == "partial work"
+
+
+def test_failed_still_surfaces_error_regression():
+    out = _poll(_execution("failed", response=None, error="boom"))
+    assert out["status"] == "failed"
+    assert out["error"] == "boom"
+
+
+def test_running_hides_response_and_error():
+    out = _poll(_execution("running", response=None, error=None))
+    assert out["status"] == "running"
+    assert out["response"] is None
+    assert out["error"] is None

--- a/tests/unit/test_679_result_callback_cancel.py
+++ b/tests/unit/test_679_result_callback_cancel.py
@@ -1,0 +1,205 @@
+"""Unit tests for #679 on the async fire-and-forget path (#1083): the agent-side
+``result_callback._run_and_report`` relabels a cancelled turn before delivery.
+
+After the turn's envelope is built (success or HTTPException), the handler
+post-checks the ``was_terminated`` marker and, unless the envelope is an
+auth/rate terminal (Issue 6/C6 — keep the AUTH dispatch breaker / SUB-003 firing
+on async too), overrides it to ``cancelled``. Covers graceful exit-0 AND
+SIGKILL→504.
+
+The conftest preloads the agent_server namespace package.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from agent_server.services import result_callback as rc  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _req(**over):
+    base = dict(
+        message="hi", model="sonnet", allowed_tools=None, system_prompt=None,
+        timeout_seconds=300, max_turns=None, execution_id="exec-1",
+        resume_session_id=None, persist_session=False, images=None,
+        async_result=True,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _success_runtime():
+    md = MagicMock()
+    md.model_dump.return_value = {"cost_usd": 0.04, "session_id": "meta-sess"}
+    rt = MagicMock()
+    rt.execute_headless = AsyncMock(return_value=("final answer", [{"t": 1}], md, "sess-1"))
+    return rt
+
+
+def _raising_runtime(exc):
+    rt = MagicMock()
+    rt.execute_headless = AsyncMock(side_effect=exc)
+    return rt
+
+
+def _run(request, *, runtime, was_terminated):
+    """Drive _run_and_report, returning the envelope handed to _deliver."""
+    reg = MagicMock()
+    reg.was_terminated.return_value = was_terminated
+    deliver = AsyncMock(return_value=True)
+    with (
+        patch("agent_server.services.runtime_adapter.get_runtime", return_value=runtime),
+        patch.object(rc, "get_process_registry", return_value=reg),
+        patch.object(rc, "_persist", MagicMock()),
+        patch.object(rc, "_delete", MagicMock()),
+        patch.object(rc, "_deliver", deliver),
+        patch.object(rc, "agent_state", MagicMock(agent_name="agent-a")),
+    ):
+        asyncio.run(rc._run_and_report(request, "http://b", "k", time.monotonic()))
+    assert deliver.await_count == 1
+    return deliver.call_args.args[2]
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+class TestHelpers:
+    def test_cancelled_override_keeps_payload_drops_error_code(self):
+        env = {
+            "status": "failed", "error": "boom", "error_code": "timeout",
+            "terminal_reason": "max_duration", "metadata": {"cost_usd": 0.02},
+            "response": "partial", "session_id": "s1", "execution_log": [{"t": 1}],
+        }
+        out = rc._cancelled_override(env)
+        assert out["status"] == "cancelled"
+        assert out["terminal_reason"] == "cancelled"
+        assert out["error_code"] is None
+        # response / metadata / session_id / execution_log preserved
+        assert out["response"] == "partial"
+        assert out["metadata"] == {"cost_usd": 0.02}
+        assert out["session_id"] == "s1"
+        assert out["execution_log"] == [{"t": 1}]
+
+    @pytest.mark.parametrize("env,expected", [
+        ({"error_code": "auth", "terminal_reason": "auth"}, True),
+        ({"error_code": None, "terminal_reason": "rate_limit"}, True),
+        ({"error_code": None, "terminal_reason": "max_duration"}, False),
+        ({"status": "success", "terminal_reason": "completed"}, False),
+        ({"error_code": None, "terminal_reason": "empty_result"}, False),
+    ])
+    def test_is_auth_or_rate(self, env, expected):
+        assert rc._is_auth_or_rate(env) is expected
+
+
+# ---------------------------------------------------------------------------
+# _run_and_report relabel
+# ---------------------------------------------------------------------------
+class TestRunAndReportCancel:
+    def test_success_terminated_overrides_to_cancelled(self):
+        env = _run(_req(), runtime=_success_runtime(), was_terminated=True)
+        assert env["status"] == "cancelled"
+        assert env["terminal_reason"] == "cancelled"
+        assert env["response"] == "final answer"  # graceful final message kept
+
+    def test_504_terminated_overrides_to_cancelled(self):
+        env = _run(
+            _req(),
+            runtime=_raising_runtime(HTTPException(status_code=504, detail="timed out")),
+            was_terminated=True,
+        )
+        assert env["status"] == "cancelled"
+        assert env["terminal_reason"] == "cancelled"
+
+    def test_503_auth_terminated_stays_auth_failed(self):
+        # C6: the AUTH dispatch breaker must still record on the async path.
+        env = _run(
+            _req(),
+            runtime=_raising_runtime(HTTPException(status_code=503, detail="Authentication failure")),
+            was_terminated=True,
+        )
+        assert env["status"] == "failed"
+        assert env["error_code"] == "auth"
+
+    def test_429_rate_terminated_stays_failed(self):
+        env = _run(
+            _req(),
+            runtime=_raising_runtime(HTTPException(status_code=429, detail="rate limited")),
+            was_terminated=True,
+        )
+        assert env["status"] == "failed"
+        assert env["terminal_reason"] == "rate_limit"
+
+    def test_success_not_terminated_keeps_success(self):
+        env = _run(_req(), runtime=_success_runtime(), was_terminated=False)
+        assert env["status"] == "success"
+
+    def test_504_not_terminated_keeps_failed(self):
+        env = _run(
+            _req(),
+            runtime=_raising_runtime(HTTPException(status_code=504, detail="timed out")),
+            was_terminated=False,
+        )
+        assert env["status"] == "failed"
+        assert env["terminal_reason"] == "max_duration"
+
+
+def _run_capture_state(request, *, runtime, was_terminated):
+    """Like _run but returns the `success=` value handed to record_task_finish,
+    so F4 (neutral cancel accounting) can be asserted on the async path."""
+    reg = MagicMock()
+    reg.was_terminated.return_value = was_terminated
+    state = MagicMock(agent_name="agent-a")
+    with (
+        patch("agent_server.services.runtime_adapter.get_runtime", return_value=runtime),
+        patch.object(rc, "get_process_registry", return_value=reg),
+        patch.object(rc, "_persist", MagicMock()),
+        patch.object(rc, "_delete", MagicMock()),
+        patch.object(rc, "_deliver", AsyncMock(return_value=True)),
+        patch.object(rc, "agent_state", state),
+    ):
+        asyncio.run(rc._run_and_report(request, "http://b", "k", time.monotonic()))
+    call = state.record_task_finish.call_args
+    assert call is not None, "record_task_finish was never called"
+    return call.kwargs.get("success") if call.kwargs else call.args[0]
+
+
+class TestRunAndReportNeutralAccounting:
+    """#679 F4 parity on the async path: a cancel must not touch the
+    consecutive_failures counter the dispatch breaker (#526) reads — neither the
+    graceful-exit-0 cancel (was wrongly counted as success) nor the 504/502
+    cancel (was wrongly counted as failure)."""
+
+    def test_success_terminated_records_neutral(self):
+        assert _run_capture_state(_req(), runtime=_success_runtime(), was_terminated=True) is None
+
+    def test_504_terminated_records_neutral(self):
+        assert _run_capture_state(
+            _req(),
+            runtime=_raising_runtime(HTTPException(status_code=504, detail="t")),
+            was_terminated=True,
+        ) is None
+
+    def test_503_auth_terminated_records_failure(self):
+        # C6: auth stays a failure so the AUTH breaker still counts it.
+        assert _run_capture_state(
+            _req(),
+            runtime=_raising_runtime(HTTPException(status_code=503, detail="Authentication failure")),
+            was_terminated=True,
+        ) is False
+
+    def test_success_not_terminated_records_success(self):
+        assert _run_capture_state(_req(), runtime=_success_runtime(), was_terminated=False) is True
+
+    def test_failure_not_terminated_records_failure(self):
+        assert _run_capture_state(
+            _req(),
+            runtime=_raising_runtime(HTTPException(status_code=500, detail="boom")),
+            was_terminated=False,
+        ) is False

--- a/tests/unit/test_679_terminate_already_finished.py
+++ b/tests/unit/test_679_terminate_already_finished.py
@@ -1,0 +1,117 @@
+"""Unit test for #679 (Issue 7 / Codex C3): the backend terminate handler must
+NOT write CANCELLED when the agent reports ``already_finished``.
+
+``routers.chat.terminate_agent_execution`` proxies a terminate to the agent.
+When the agent says ``terminated`` the turn was running and we cancelled it →
+write CANCELLED. When the agent says ``already_finished`` the turn reached its
+own genuine terminal a moment before the cancel landed — the agent's self-report
+is authoritative, so we leave the real terminal in place (deterministic; "the
+cancel was too late"). Capacity is force-released in both cases (unchanged).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytestmark = pytest.mark.unit
+
+
+def _await(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _FakeAgentResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, *a, **kw):
+        return self._response
+
+
+def _drive_terminate(agent_status: str):
+    """Drive terminate_agent_execution with the agent returning `agent_status`.
+    Returns the mock_db so the caller can inspect update_execution_status."""
+    import routers.chat as chat
+
+    mock_db = MagicMock()
+    mock_db.get_execution.return_value = SimpleNamespace(status="running")  # not QUEUED
+
+    container = MagicMock()
+    container.status = "running"
+
+    capacity = MagicMock()
+    capacity.force_release = AsyncMock(
+        return_value=SimpleNamespace(was_running=True, slots_cleared=1)
+    )
+
+    activity = MagicMock(track_activity=AsyncMock())
+    agent_resp = _FakeAgentResponse(200, {"status": agent_status, "returncode": 0})
+
+    with (
+        patch.object(chat, "db", mock_db),
+        patch.object(chat, "get_agent_container", return_value=container),
+        patch.object(chat, "get_capacity_manager", return_value=capacity),
+        patch.object(chat, "activity_service", activity),
+        patch.object(chat.httpx, "AsyncClient", lambda *a, **kw: _FakeClient(agent_resp)),
+    ):
+        result = _await(
+            chat.terminate_agent_execution(
+                execution_id="exec-1",
+                task_execution_id="exec-1",
+                name="agent-a",
+                current_user=SimpleNamespace(id=1, email="u@e.com", username="u"),
+            )
+        )
+    return result, mock_db, capacity
+
+
+def _cancelled_writes(mock_db):
+    from services.task_execution_service import TaskExecutionStatus
+
+    return [
+        c for c in mock_db.update_execution_status.call_args_list
+        if c.kwargs.get("status") == TaskExecutionStatus.CANCELLED
+    ]
+
+
+def test_terminated_writes_cancelled():
+    result, mock_db, capacity = _drive_terminate("terminated")
+    assert len(_cancelled_writes(mock_db)) == 1
+    capacity.force_release.assert_awaited_once()  # capacity released
+
+
+def test_already_finished_does_not_write_cancelled():
+    """Issue 7: the agent's genuine terminal stands — no CANCELLED overwrite."""
+    result, mock_db, capacity = _drive_terminate("already_finished")
+    assert _cancelled_writes(mock_db) == []
+    # Capacity is still force-released on already_finished (unchanged behavior).
+    capacity.force_release.assert_awaited_once()

--- a/tests/unit/test_679_terminated_marker.py
+++ b/tests/unit/test_679_terminated_marker.py
@@ -1,0 +1,186 @@
+"""Unit tests for #679: the agent-side ``_terminated`` marker in
+``process_registry``.
+
+When an operator cancels a running task, ``terminate()`` SIGINTs the Claude
+subprocess. Claude catches SIGINT, emits a graceful final message, and exits 0 —
+indistinguishable from a genuine success by return code alone. The ``_terminated``
+marker (mirroring ``_recently_completed``) lets the chat handler relabel that
+turn ``cancelled``.
+
+The marker is recorded **after a successful SIGINT send, still-running branch
+only** — never on ``already_finished``/``not_found``/signal-failure (C2), and is
+cleared on ``register()`` so a #678 in-line retry reusing the execution_id can't
+inherit a stale cancel label (C10). Read-not-pop so both the graceful relabel and
+a later SIGKILL→504 check see it.
+
+Module under test: docker/base-image/agent_server/services/process_registry.py
+Mirrors the import shim in tests/unit/test_recently_completed_buffer.py.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_AGENT_SERVER_DIR = _PROJECT_ROOT / "docker" / "base-image" / "agent_server"
+
+_STUBBED_MODULE_NAMES = [
+    "agent_server",
+    "agent_server.services",
+    "agent_server.utils",
+    "agent_server.services.process_registry",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot/restore sys.modules so the namespace stubs we inject for the
+    import shim don't leak into other tests (gated by tests/lint_sys_modules.py)."""
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+def _import_process_registry():
+    if "agent_server" not in sys.modules:
+        stub = types.ModuleType("agent_server")
+        stub.__path__ = [str(_AGENT_SERVER_DIR)]
+        sys.modules["agent_server"] = stub
+    if "agent_server.services" not in sys.modules:
+        stub = types.ModuleType("agent_server.services")
+        stub.__path__ = [str(_AGENT_SERVER_DIR / "services")]
+        sys.modules["agent_server.services"] = stub
+    if "agent_server.utils" not in sys.modules:
+        stub = types.ModuleType("agent_server.utils")
+        stub.__path__ = [str(_AGENT_SERVER_DIR / "utils")]
+        sys.modules["agent_server.utils"] = stub
+    import agent_server.services.process_registry as pr_mod  # noqa: WPS433
+    return pr_mod
+
+
+def _fake_process(pid: int = 1234, *, running: bool = True, returncode: int = 0) -> MagicMock:
+    p = MagicMock(spec=subprocess.Popen)
+    p.pid = pid
+    p.poll.return_value = None if running else returncode
+    p.wait.return_value = returncode
+    p.returncode = returncode
+    return p
+
+
+def _quiet_signals(pr_mod, monkeypatch, *, signal_raises: bool = False):
+    """Stub the process-group signal + cgroup-sweep helpers so terminate() runs
+    without touching real processes. Returns the SIGINT/SIGKILL mock."""
+    sig = MagicMock()
+    if signal_raises:
+        sig.side_effect = OSError("no such process")
+    monkeypatch.setattr(pr_mod, "_signal_process_tree", sig)
+    monkeypatch.setattr(pr_mod, "kill_cgroup_orphans", MagicMock(return_value=0))
+    return sig
+
+
+@pytest.mark.unit
+class TestTerminatedMarker:
+    def test_terminate_marks_after_successful_signal(self, monkeypatch):
+        pr_mod = _import_process_registry()
+        _quiet_signals(pr_mod, monkeypatch)
+        reg = pr_mod.ProcessRegistry()
+        reg.register("exec-1", _fake_process(running=True))
+
+        assert reg.was_terminated("exec-1") is False  # not yet terminated
+        result = reg.terminate("exec-1")
+        assert result["success"] is True
+        assert reg.was_terminated("exec-1") is True
+
+    def test_terminate_does_not_mark_on_signal_failure(self, monkeypatch):
+        """C2: a SIGINT send that raises must NOT mark the turn cancelled —
+        the kill-signal never landed, so the turn will exit on its own terms."""
+        pr_mod = _import_process_registry()
+        _quiet_signals(pr_mod, monkeypatch, signal_raises=True)
+        reg = pr_mod.ProcessRegistry()
+        reg.register("exec-1", _fake_process(running=True))
+
+        result = reg.terminate("exec-1")
+        assert result["success"] is False
+        assert result["reason"] == "error"
+        assert reg.was_terminated("exec-1") is False
+
+    def test_terminate_does_not_mark_on_already_finished(self, monkeypatch):
+        pr_mod = _import_process_registry()
+        _quiet_signals(pr_mod, monkeypatch)
+        reg = pr_mod.ProcessRegistry()
+        reg.register("exec-1", _fake_process(running=False, returncode=0))
+
+        result = reg.terminate("exec-1")
+        assert result["reason"] == "already_finished"
+        assert reg.was_terminated("exec-1") is False
+
+    def test_terminate_does_not_mark_on_not_found(self, monkeypatch):
+        pr_mod = _import_process_registry()
+        _quiet_signals(pr_mod, monkeypatch)
+        reg = pr_mod.ProcessRegistry()
+
+        result = reg.terminate("ghost")
+        assert result["reason"] == "not_found"
+        assert reg.was_terminated("ghost") is False
+
+    def test_register_clears_stale_marker(self, monkeypatch):
+        """C10: an execution_id reused by the #678 in-line retry must not inherit
+        the prior attempt's cancel label."""
+        pr_mod = _import_process_registry()
+        reg = pr_mod.ProcessRegistry()
+        reg._terminated["exec-1"] = time.time()
+        assert reg.was_terminated("exec-1") is True
+
+        reg.register("exec-1", _fake_process(running=True))
+        assert reg.was_terminated("exec-1") is False
+
+    def test_was_terminated_is_read_not_pop(self, monkeypatch):
+        """Read, not pop — the SIGKILL→504 path checks the same marker after the
+        graceful-relabel path already read it."""
+        pr_mod = _import_process_registry()
+        reg = pr_mod.ProcessRegistry()
+        reg._terminated["exec-1"] = time.time()
+        assert reg.was_terminated("exec-1") is True
+        assert reg.was_terminated("exec-1") is True  # still set on the second read
+
+    def test_marker_evicts_past_ttl(self, monkeypatch):
+        pr_mod = _import_process_registry()
+        monkeypatch.setattr(pr_mod, "TERMINATED_TTL_SECONDS", 0.05)
+        reg = pr_mod.ProcessRegistry()
+        reg._terminated["exec-1"] = time.time()
+        assert reg.was_terminated("exec-1") is True
+
+        time.sleep(0.1)
+        assert reg.was_terminated("exec-1") is False
+        assert "exec-1" not in reg._terminated  # cleared, not just filtered
+
+    def test_multi_execution_isolation(self, monkeypatch):
+        pr_mod = _import_process_registry()
+        _quiet_signals(pr_mod, monkeypatch)
+        reg = pr_mod.ProcessRegistry()
+        reg.register("exec-a", _fake_process(running=True))
+        reg.register("exec-b", _fake_process(running=True))
+
+        reg.terminate("exec-a")
+        assert reg.was_terminated("exec-a") is True
+        assert reg.was_terminated("exec-b") is False
+
+    def test_ttl_sized_for_observability_window(self):
+        """The marker is best-effort observability; the TTL must comfortably
+        cover a worst-case backend finalize delay (same posture as
+        RECENTLY_COMPLETED_TTL_SECONDS)."""
+        pr_mod = _import_process_registry()
+        assert pr_mod.TERMINATED_TTL_SECONDS >= 120

--- a/tests/unit/test_loop_service.py
+++ b/tests/unit/test_loop_service.py
@@ -464,6 +464,33 @@ class TestFailure:
         assert loop["runs_completed"] == 2  # second iteration counted, even though it failed
         assert len(ts.calls) == 2
 
+    def test_cancelled_iteration_stops_loop(self, loop_module):
+        """#679: a CANCELLED iteration is non-success — the loop must stop (the
+        else branch finalizes it), never continue treating cancel as success."""
+        ls, db, ts = loop_module
+        ts.results = [
+            _Result(status="cancelled", response="", error="Execution cancelled by user",
+                    error_code=None),
+            _Result(response="should not run"),
+        ]
+
+        async def go():
+            service = ls.LoopService()
+            row = await service.start_loop(
+                agent_name="a1", message_template="m", max_runs=3,
+            )
+            handle = service._handles.get(row["id"])
+            if handle is not None:
+                await handle.task
+            return row["id"]
+
+        loop_id = _run(go())
+        loop = db.get_loop(loop_id)
+        assert loop["status"] == "failed"       # stops, not treated as success
+        assert loop["stop_reason"] == "error"
+        assert loop["runs_completed"] == 1
+        assert len(ts.calls) == 1               # the 2nd iteration never ran
+
     def test_iteration_exception_aborts_loop(self, loop_module):
         ls, db, ts = loop_module
 


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #671. Surfaces a third terminal outcome —
`cancelled` — end-to-end so an operator-initiated cancel is never recorded as a
billable success or an agent failure. Closes the residual gap the original
report (#671) asked for: make the container task-runner aware a cancel happened
and propagate it through the backend.

> ⚠️ **Issue state note:** #679 was auto-closed as COMPLETED by today's
> `Release: v0.7.0` (#1319) via a stale `status-in-dev` label — but the actual
> implementation was never merged to `dev` or `main` (only its predecessor #671
> / PR #681 is in history). This PR carries the real code. The issue may need
> reopening, or to be left closed and picked up by the next release — owner's call.

## What changed

**Agent server** (`docker/base-image/agent_server/`)
- `ProcessRegistry` records a `_terminated[execution_id]` marker on a successful
  SIGINT send; `was_terminated()` (read-only, 300s lazy TTL, cleared on
  `register()` so a #678 reused id can't inherit the label) lets the sync chat
  handler and the async result callback relabel a graceful-exit-0 / SIGKILL→504
  turn as `status:"cancelled"`.
- `record_task_finish` now accepts a **neutral** finish (`success=None`): a
  cancel neither resets nor increments the dispatch-breaker (#526) failure
  counter — it proves nothing about agent health.

**Backend**
- 3-way status map (`success`→SUCCESS, `cancelled`→CANCELLED, else→FAILED) in the
  async callback (`routers/agents.py`) and the sync applier
  (`task_execution_service`). An **auth/rate** terminal is never reclassified as
  a cancellation — guarded at the backend trust boundary too, not just agent-side
  (CSO finding 2), so a buggy/mixed-version agent can't disarm the AUTH breaker /
  SUB-003.
- Consumers (`message_router`, `chat`, `paid`, `public`, `validation_service`)
  treat `cancelled` as non-delivery. `paid.py` no longer settles on a cancel
  (fixes a charge-on-cancel money bug). `public_execution_status` surfaces the
  cancel reason to the poller instead of a silent null body.
- `terminate` writes CANCELLED **only** when it actually stopped a running turn;
  on `already_finished` the agent's real terminal stands (Issue 7).

## Testing

- **85 unit tests pass locally** — 9 new `test_679_*` suites (64 cases) covering
  the terminated marker, neutral finish, sync/async relabel, backend 3-way map,
  callback auth/rate guard, caller non-delivery handling, terminate-already-
  finished, and public-poll surfacing.
- `tests/test_execution_termination.py` integration additions (+85 lines, 17
  cases) — run by CI against a live stack.
- **CSO diff audit: CLEAR** (`docs/security-reports/cso-diff-2026-06-22-679.md`)
  — 0 critical/high; 2 LOW, finding 2 resolved (backend guard), finding 1 skipped
  (owner-only cancel, not payer-triggerable).

## Notes

- Touches `docker/base-image/**` → **base-image rebuild + rollout required**
  after merge (forward-compatible: an old agent image omits `status` → unchanged
  SUCCESS path).

Refs #679
