### PR TITLE
fix(ci): stop the Dependency Graph check failing on every release

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,9 +3,10 @@
 ## Quick start
 
 ```bash
-# From repo root — pip resolves the `-e ./src/cli` editable install relative
-# to CWD, so the repo root is the working directory the requirements file
-# assumes (this is also how CI invokes it).
+# From repo root. The local CLI (trinity_cli, used by test_cli_*.py) is installed
+# on demand by the run-*.sh wrappers (via tests/setup-env.sh) — it is kept out of
+# requirements-test.txt so an editable path doesn't red the repo's "Dependency
+# Graph" check on every release.
 python -m venv tests/.venv && source tests/.venv/bin/activate
 pip install -r tests/requirements-test.txt
 bash tests/run-integration.sh   # ~30 sec, 25 tests — verifies env
@@ -65,14 +66,14 @@ docker compose exec backend python -c \
 
 ### `ModuleNotFoundError: No module named 'trinity_cli'`
 
-`tests/requirements-test.txt` includes `-e ./src/cli` (pip resolves the
-path against CWD, not the requirements file — see the comment in the
-file), so a fresh `pip install -r tests/requirements-test.txt` **from the
-repo root** should resolve this. If not:
+The `run-*.sh` wrappers install the editable CLI on demand (via
+`tests/setup-env.sh`). It is kept out of `tests/requirements-test.txt` because
+an `-e ./src/cli` line there breaks GitHub's dependency-graph updater. If you
+invoke pytest directly (without a wrapper), install it yourself:
 
 ```bash
 # From repo root:
-.venv/bin/pip install -e ./src/cli
+tests/.venv/bin/pip install -e ./src/cli
 ```
 
 ### Conductor workspaces: backend mounts the *original* repo, not the worktree

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -50,9 +50,10 @@ bcrypt>=4.2.0,<5
 pydantic-settings>=2.0.0
 google-genai>=1.0.0
 payments-py>=1.0.0
-# CLI package — required for test_cli_admin_login.py and test_cli_profiles.py.
-# Editable so changes to src/cli/ are picked up without reinstall. pip resolves
-# this path against the current working directory (not the requirements file),
-# so `pip install -r tests/requirements-test.txt` must be invoked from the repo
-# root — which is what every CI workflow does.
--e ./src/cli
+# NOTE: trinity-cli (needed by test_cli_*.py) is intentionally NOT listed here.
+# An editable local path (`-e ./src/cli`) breaks GitHub's dependency-graph
+# updater — it resolves `-e` targets relative to THIS file's dir (tests/src/cli,
+# which doesn't exist), erroring the repo's "Dependency Graph" check on every
+# release. The local run-*.sh wrappers install the editable CLI via
+# tests/setup-env.sh instead; unit/ (the #660 one-liner contract) never imports
+# trinity_cli, so CI — which only runs unit/ — is unaffected.

--- a/tests/setup-env.sh
+++ b/tests/setup-env.sh
@@ -23,3 +23,13 @@ if [ -f "$DOTENV" ]; then
         [ -n "$val" ] && [ -z "$current" ] && export "$v=$val"
     done
 fi
+
+# test_cli_*.py imports trinity_cli. The editable CLI install is kept OUT of
+# tests/requirements-test.txt because an `-e ./src/cli` line there breaks
+# GitHub's dependency-graph updater (it resolves the path relative to tests/,
+# not the repo root) and reds the "Dependency Graph" check on every release.
+# Install it on demand here so the run-*.sh wrappers stay self-contained. The
+# import guard makes this a no-op once installed; editable installs reflect
+# src/cli edits live, so there's no reinstall churn.
+python -c "import trinity_cli" 2>/dev/null \
+    || pip install -q -e "$(dirname "$0")/../src/cli"


### PR DESCRIPTION
## Problem

The repo home page shows a red ✗ on the latest `main` commit (v0.7.0). It is **not** the release CI — every real gate passed (unit, container-security, CodeQL, schema-parity, image-smoke). The red comes from GitHub's automatic dependency-graph job (`Dependency Graph` → `update-pip-graph`), which has failed on **every release since v0.6.0** (Jun 1 / Jun 12 / Jun 23).

## Root cause

`-e ./src/cli` in `tests/requirements-test.txt`. pip resolves that editable path against the working dir (repo root → `src/cli` ✓), but Dependabot's dependency-graph resolver resolves it against the manifest's own dir (`tests/src/cli`, which doesn't exist) → the updater errors → the check goes red on the release commit. On Jun 12 the `/src/cli` graph job *passed* while `/tests` failed, isolating it to this line.

## Fix

- Drop the editable line from the scanned manifest (`tests/requirements-test.txt`).
- Install the local CLI on demand from `tests/setup-env.sh`, which every `run-*.sh` wrapper sources — keeps the local suite self-contained (idempotent import-guarded install).
- Update `tests/README.md` to match.

CI only runs `unit/`, which never imports `trinity_cli`, so CI is unaffected and the #660 one-liner contract is preserved.

## Durability note

This must also land on `dev` (or be reconciled main→dev), otherwise the next release will re-introduce `-e ./src/cli` from `dev` and the red returns. Tracking that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)