### PR TITLE
refactor(docs): agent-readable zero-to-value onboarding (#1280)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ resources:
   memory: "4g"
 ```
 
-Full schema (credentials, runtime selection, metrics, shared folders): [docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md](docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md).
+Full schema (credentials, runtime selection, metrics, shared folders): [docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md](docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md). Rather than author one from scratch, start from a ready-made template — catalog: [config/agent-templates/README.md](config/agent-templates/README.md) (also `GET /api/templates` / `list_templates` over MCP).
 
 **If you are running inside Claude Code** — use the abilities plugins:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,21 @@ Trinity is an autonomous agent orchestration platform: every agent runs in its o
 
 > **Detailed documentation index: [docs/user-docs/README.md](docs/user-docs/README.md)** — guides, agent management, credentials, automation, operations, integrations, and the full API reference live there.
 
+## Using this file
+
+**This is the authoritative entry point for AI agents.** If you are an autonomous agent that just landed in this repository or connected to a Trinity instance, start here. The other root files serve different readers — [`README.md`](README.md) is for humans evaluating Trinity; [`CLAUDE.md`](CLAUDE.md) is the **contributor working agreement** (Rules of Engagement, SDLC, architectural invariants) that Claude Code auto-loads when you edit this codebase. Read `CLAUDE.md` only when your task is "contribute code"; for everything else, this file is the map.
+
+**How to traverse it:** find your task in [Route by task](#route-by-task) → jump to that section → run the commands → stop at the **Done when** signal. Each task is *zero-to-value*: the shortest path from landing to a confirmed useful result, ending in one check you can run to prove you got there. If a step is ambiguous or a link is dead, that is a bug — report it on the [issue tracker](https://github.com/abilityai/trinity/issues).
+
 ## Route by task
 
-| Your task | Path |
-|-----------|------|
-| Deploy yourself (or another agent) to a Trinity instance | [Deploy an agent](#deploy-an-agent-to-trinity) |
-| Stand up a new Trinity instance | [Stand up an instance](#stand-up-a-trinity-instance) |
-| Operate an existing instance (chat, schedules, fleet ops) | [Operate over MCP](#operate-a-trinity-instance-over-mcp) |
-| Evaluate Trinity / summarize it for your operator | [README.md](README.md), then [docs/user-docs/README.md](docs/user-docs/README.md); system design: [docs/memory/architecture.md](docs/memory/architecture.md) |
-| Contribute to Trinity's codebase | [Work on this repository](#work-on-this-repository) — Claude Code also auto-loads [CLAUDE.md](CLAUDE.md) |
+| Your task | Go to | Done when |
+|-----------|-------|-----------|
+| Deploy yourself (or another agent) to a Trinity instance | [Deploy an agent](#deploy-an-agent-to-trinity) | `trinity agents list` (or `GET /api/agents`) shows the agent `running` |
+| Stand up a new Trinity instance | [Stand up an instance](#stand-up-a-trinity-instance) | `curl /health` → `{"status": "healthy"}` |
+| Operate an existing instance (chat, schedules, fleet ops) | [Operate over MCP](#operate-a-trinity-instance-over-mcp) | an MCP tool call (e.g. `list_agents`) returns results over your API key |
+| Evaluate Trinity / summarize it for your operator | [README.md](README.md), then [docs/user-docs/README.md](docs/user-docs/README.md); system design: [docs/memory/architecture.md](docs/memory/architecture.md) | you can state what Trinity is, how to run it, and its license |
+| Contribute to Trinity's codebase | [Work on this repository](#work-on-this-repository) — Claude Code also auto-loads [CLAUDE.md](CLAUDE.md) | tests pass and a PR is open against `dev` |
 
 ## Key facts
 
@@ -50,6 +56,8 @@ Manual install and production deployment: [docs/user-docs/guides/deploying-trini
 
 ## Deploy an agent to Trinity
 
+**Prerequisite:** a running Trinity instance to deploy to — if you don't have one, [Stand up an instance](#stand-up-a-trinity-instance) first (`trinity deploy` against no instance fails with a connection error).
+
 An agent is a directory with `CLAUDE.md` + `template.yaml`. Minimal `template.yaml`:
 
 ```yaml
@@ -83,9 +91,11 @@ trinity init                          # instance URL + email code → JWT + MCP 
 cd my-agent/ && trinity deploy .      # package, upload, create + start the container
 ```
 
-**Verify:** `trinity agents list` shows the agent with status `running`, or:
+**Done when** `trinity agents list` shows the agent with status `running` (uses the key from `trinity init` — no extra token needed). Equivalent raw-API check, deriving a token first:
 
 ```bash
+TOKEN=$(curl -s -X POST http://localhost:8000/api/token \
+  -d 'username=admin&password=YOUR_ADMIN_PASSWORD' | jq -r .access_token)
 curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/agents
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code when working with this repository.
 
 **Repository**: https://github.com/abilityai/trinity (PUBLIC)
 
+> **AI agent orienting in this repo?** [AGENTS.md](AGENTS.md) is the authoritative agent entry point — a task router with key facts, exact commands, and a "done when" check per task. This file is the **contributor working agreement** (Rules of Engagement, SDLC, architectural invariants), auto-loaded by Claude Code when you work on the codebase. Read it when your task is "contribute code"; start at `AGENTS.md` for deploy / operate / evaluate.
+
 ---
 
 ## Current Product Focus

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ pip install trinity-cli                     # or: brew install abilityai/tap/tri
 
 trinity init                                # connect: instance URL + email code → JWT + MCP key
 cd my-agent/ && trinity deploy .            # package, upload, create + start the agent
+trinity agents list                         # verify: the agent shows status "running"
 trinity chat my-agent "Hello, what can you do?"
 trinity logs my-agent                       # container logs
 trinity health fleet                        # fleet overview

--- a/config/agent-templates/README.md
+++ b/config/agent-templates/README.md
@@ -1,0 +1,48 @@
+# Agent template catalog
+
+Ready-made starting points for deploying an agent to Trinity. Each subdirectory is one template — a `CLAUDE.md` (the agent's instructions) plus a `template.yaml` (metadata: `name`, `description`, `type`, `capabilities`, `commands`, `metrics`, `folders`). Pick one as your starting point instead of authoring an agent from scratch.
+
+> New here? The repo's agent entry point is [`AGENTS.md`](../../AGENTS.md) → [Deploy an agent](../../AGENTS.md#deploy-an-agent-to-trinity). Full template schema: [`docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md`](../../docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md).
+
+## How to use a template
+
+- **From a checkout** — copy a template directory, edit its `CLAUDE.md` + `template.yaml`, then deploy it: `cd <copy>/ && trinity deploy .` (see [Deploy an agent](../../AGENTS.md#deploy-an-agent-to-trinity)).
+- **From the web UI** — *Create Agent* → pick a template by `name`.
+- **By reference** — these `name`s are the built-in templates the platform ships; they appear in `GET /api/templates` and `list_templates` (MCP).
+
+## Starter templates
+
+### Single-purpose
+
+| `name` | What it does |
+|--------|--------------|
+| `scout` | Market research analyst — discovers trends, analyzes competitors, identifies opportunities |
+| `sage` | Strategic advisor — synthesizes research into actionable recommendations |
+| `scribe` | Content writer — reports, proposals, and client deliverables |
+| `demo-researcher` | Minimal autonomous researcher (gathers + summarizes); good first deploy |
+| `demo-analyst` | Minimal analysis agent — answers strategic questions over research findings |
+| `trinity-system` | Platform operations manager — agent health, lifecycle, fleet management (system-scoped) |
+
+`scout` → `sage` → `scribe` are designed to work as a **consulting team**: Scout researches into a shared folder, Sage strategizes over it, Scribe writes the deliverable. Deploy them together to see agent-to-agent collaboration.
+
+### Due-diligence suite (coordinated multi-agent)
+
+A startup due-diligence pipeline: `dd-intake` parses a pitch deck into structured data, nine specialists assess one dimension each, and `dd-lead` synthesizes a risk score and recommendation.
+
+| `name` | Dimension |
+|--------|-----------|
+| `dd-intake` | Parse pitch decks → structured data for the specialists |
+| `dd-lead` | Synthesize all findings → risk score + go/no-go |
+| `dd-market` | TAM/SAM/SOM, growth, market headwinds |
+| `dd-tech` | Technology, scalability, IP |
+| `dd-founder` | Background checks, track record, controversy |
+| `dd-traction` | Growth metrics, financial health, data accuracy |
+| `dd-bizmodel` | Revenue model, unit economics, path to profitability |
+| `dd-captable` | Equity structure, dilution, investor reputation |
+| `dd-competitor` | Competitive landscape, market share, threats |
+| `dd-compliance` | Regulatory landscape, compliance, market entry |
+| `dd-legal` | Corporate structure, IP ownership, contracts |
+
+## Not starting points
+
+`test-echo`, `test-counter`, `test-delegator`, `test-codex`, `test-gemini`, `test-leak-hook`, and `sleep-echo` are internal **test/canary fixtures** used by the test suite and the canary harness — not templates to build on.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -5,6 +5,13 @@ Command-line interface for the Trinity Autonomous Agent Orchestration Platform.
 ## Installation
 
 ```bash
+pip install trinity-cli                 # from PyPI (recommended)
+# or: brew install abilityai/tap/trinity-cli
+```
+
+From a source checkout (development / unreleased changes), install editable instead:
+
+```bash
 pip install -e src/cli/
 ```
 


### PR DESCRIPTION
## Summary
Make the repo's canonical entry points **machine-first** so an autonomous agent landing in the repo (or connecting to an instance) can self-orient and reach a useful result with no human translating context.

## Changes
- **AGENTS.md** — added a **"Using this file"** machine-contract header: declares AGENTS.md the authoritative agent entry point, states the `AGENTS` / `CLAUDE` / `README` boundary, explains how to traverse. Rebuilt **Route by task** with explicit **"Done when"** zero-to-value signals per persona. Links the new template catalog from the deploy section.
- **CLAUDE.md** — cross-link into AGENTS.md; framed CLAUDE.md as the **contributor working agreement** (auto-loaded by Claude Code), not the agent landing page.
- **README.md** — added the missing `trinity agents list` verify step to the CLI example.
- **docs/CLI.md** — leads with `pip install trinity-cli` (PyPI); marks `-e src/cli/` as the from-source/dev variant.
- **config/agent-templates/README.md** (new) — machine-readable **starter-template catalog**: groups the 17 real templates (single-purpose + the `dd-*` due-diligence suite) with one-line affordances and how-to-use, and explicitly flags the 7 test/canary fixtures as "not starting points". An agent now self-selects a template instead of `ls`-ing 24 dirs and opening each `template.yaml`.

## Validation (AC#5)
Ran a **context-free agent** through a real zero-to-value task ("deploy an agent and verify it worked") using **only repo files, no human context**:
- **Self-oriented in 2 hops** (README → AGENTS.md) to a correct deploy + verify answer.
- Verdict: *"the routing itself is excellent and is the model other repos should copy."*
- Its friction log produced four doc fixes (undefined `$TOKEN`, conflicting CLI install, missing README verify, unstated deploy prerequisite) — folded back in.

## Acceptance criteria
- [x] Audit agent-facing entry points for readability gaps (via the validation run)
- [x] Define zero-to-value per persona (explicit "Done when" signals)
- [x] Restructure / annotate entry points so an agent self-orients (task router + boundary + template catalog)
- [x] Establish AGENTS.md as the authoritative entry point that cross-links the rest
- [x] Validate with an agent performing a representative task using only repo files

## Notes
- Human docs left intact (agent-first defaults, not removal of human readability).
- Repo-root AGENTS.md is hand-authored; the `CLAUDE.md → AGENTS.md` mirror (#1187) is **per-agent-container** (`startup.sh`), so these repo-root edits are conflict-free.
- The `.claude/` **skills** affordance pass is deliberately **not** here: skills live in the private `trinity-dev` submodule and can't land in a public-repo PR — tracked separately.

Related to #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)