### PR TITLE
fix(tests): un-quarantine and fix the 15 unmasked unit failures (#1103)

### DIFF
--- a/docker/base-image/startup.sh
+++ b/docker/base-image/startup.sh
@@ -25,7 +25,7 @@ mkdir -p "${AGENT_TMPDIR}" 2>/dev/null && chmod 700 "${AGENT_TMPDIR}" 2>/dev/nul
 # Initialize from GitHub repository if specified
 if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
     echo "Initializing agent from GitHub repository: ${GITHUB_REPO}"
-    cd /home/developer
+    cd /home/developer || exit 1
 
     # Clone the repository using PAT authentication.
     # TRINITY_GIT_BASE_URL defaults to https://github.com; overridable for
@@ -45,7 +45,7 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
             # We only fetch to update remote refs - no checkout, no branch change
             echo "Repository already exists on persistent volume - skipping clone"
             echo "Running git fetch to sync with remote..."
-            cd /home/developer
+            cd /home/developer || exit 1
             CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
             echo "Current branch: ${CURRENT_BRANCH} (preserved from previous run)"
             # Update remote URL with current PAT (may have changed since last start)
@@ -79,7 +79,7 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
             CLONE_EXIT=$?
             if [ $CLONE_EXIT -eq 0 ]; then
             echo "Repository cloned successfully with git history"
-            cd /home/developer
+            cd /home/developer || exit 1
 
             # Configure git user for commits
             git config user.email "trinity-agent@ability.ai"
@@ -139,6 +139,7 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
                 echo "ERROR: Failed to clone GitHub repository: ${GITHUB_REPO}"
                 echo "Exit code: ${CLONE_EXIT}"
                 # Sanitize output to avoid leaking PAT in logs
+                # shellcheck disable=SC2001  # regex char-class [^@]; ${//} glob can't express it
                 echo "Clone output: $(echo "${CLONE_OUTPUT}" | sed "s|oauth2:[^@]*@|oauth2:***@|g")"
                 echo "=========================================="
                 echo "Possible causes:"
@@ -178,18 +179,18 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
 
             # Copy all files from the cloned repo to the working directory
             # Using rsync-like behavior with cp
-            cd /tmp/repo-clone
-
-            # Copy everything except .git directory
-            for item in $(ls -A | grep -v "^\.git$"); do
-                echo "Copying ${item}..."
-                cp -r "${item}" /home/developer/ 2>/dev/null || true
-            done
+            # Copy everything except .git directory. Absolute paths via find
+            # -print0 / read -d '' so odd filenames can't word-split (SC2010/SC2045).
+            find /tmp/repo-clone -mindepth 1 -maxdepth 1 ! -name '.git' -print0 |
+                while IFS= read -r -d '' item; do
+                    echo "Copying $(basename "${item}")..."
+                    cp -r "${item}" /home/developer/ 2>/dev/null || true
+                done
 
             # Clean up the clone
             rm -rf /tmp/repo-clone
 
-            cd /home/developer
+            cd /home/developer || exit 1
 
             # Create initialization marker to prevent re-cloning on restart
             touch /home/developer/.trinity-initialized
@@ -199,6 +200,7 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
             echo "=========================================="
             echo "ERROR: Failed to clone GitHub repository: ${GITHUB_REPO}"
             echo "Exit code: ${SHALLOW_EXIT}"
+            # shellcheck disable=SC2001  # regex char-class [^@]; ${//} glob can't express it
             echo "Clone output: $(echo "${SHALLOW_OUTPUT}" | sed "s|oauth2:[^@]*@|oauth2:***@|g")"
             echo "=========================================="
             echo "Possible causes:"
@@ -214,7 +216,7 @@ if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
 # Initialize from local template if specified (fallback)
 elif [ -n "${TEMPLATE_NAME}" ] && [ -d "/template" ]; then
     echo "Initializing agent from local template: ${TEMPLATE_NAME}"
-    cd /home/developer
+    cd /home/developer || exit 1
 
     # Check if workspace is already initialized (persistent volume has files from previous start)
     if [ -f "/home/developer/.trinity-initialized" ]; then
@@ -223,12 +225,12 @@ elif [ -n "${TEMPLATE_NAME}" ] && [ -d "/template" ]; then
         # Copy ALL template files to workspace (including template.yaml - it's a required Trinity file)
         # This ensures custom directories (src/, lib/, docs/, etc.) are included
         echo "Copying template files..."
-        cd /template
-        for item in $(ls -A); do
-            echo "  Copying ${item}..."
-            cp -r "${item}" /home/developer/ 2>/dev/null || true
-        done
-        cd /home/developer
+        find /template -mindepth 1 -maxdepth 1 -print0 |
+            while IFS= read -r -d '' item; do
+                echo "  Copying $(basename "${item}")..."
+                cp -r "${item}" /home/developer/ 2>/dev/null || true
+            done
+        cd /home/developer || exit 1
 
         # Make scripts executable if present
         if [ -d "/home/developer/scripts" ]; then
@@ -249,7 +251,7 @@ fi
 # Copy generated credential files (with real values, generated by backend)
 if [ -d "/generated-creds" ]; then
     echo "Copying generated credential files..."
-    cd /home/developer
+    cd /home/developer || exit 1
 
     # Copy .mcp.json with real credentials
     if [ -f "/generated-creds/.mcp.json" ]; then
@@ -264,7 +266,8 @@ if [ -d "/generated-creds" ]; then
     fi
 
     # Copy any other generated config files (preserving directory structure)
-    for file in $(find /generated-creds -type f ! -name ".mcp.json" ! -name ".env" 2>/dev/null); do
+    find /generated-creds -type f ! -name ".mcp.json" ! -name ".env" -print0 2>/dev/null |
+        while IFS= read -r -d '' file; do
         # Get relative path from /generated-creds
         rel_path="${file#/generated-creds/}"
 
@@ -288,7 +291,8 @@ if [ -d "/generated-creds" ]; then
     # The path structure inside credential-files/ maps to the target path in /home/developer/
     if [ -d "/generated-creds/credential-files" ]; then
         echo "Copying credential files..."
-        for file in $(find /generated-creds/credential-files -type f 2>/dev/null); do
+        find /generated-creds/credential-files -type f -print0 2>/dev/null |
+            while IFS= read -r -d '' file; do
             # Get path relative to credential-files/
             rel_path="${file#/generated-creds/credential-files/}"
             target_dir=$(dirname "$rel_path")
@@ -378,7 +382,8 @@ fi
 # writable layer), so a DB-driven recreate cleanly reverts to the freshly-baked
 # Config.Env token — no marker logic needed.
 if [ -s /var/lib/trinity/oauth-token ]; then
-    export CLAUDE_CODE_OAUTH_TOKEN="$(cat /var/lib/trinity/oauth-token)"
+    CLAUDE_CODE_OAUTH_TOKEN="$(cat /var/lib/trinity/oauth-token)"
+    export CLAUDE_CODE_OAUTH_TOKEN
     echo "Applied rotated subscription token from durable override"
 fi
 
@@ -400,7 +405,7 @@ fi
 # === Auto-Import Encrypted Credentials ===
 # If .credentials.enc exists but .env doesn't, decrypt and inject credentials
 # This enables portable credential storage via git-committed encrypted files
-cd /home/developer
+cd /home/developer || exit 1
 if [ -f ".credentials.enc" ] && [ ! -f ".env" ]; then
     echo "Found .credentials.enc without .env - attempting auto-import..."
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,6 +24,16 @@ os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
 # deterministic master so any test exercising agent_client / helpers / the
 # residual inline callers gets a token instead of a RuntimeError.
 os.environ.setdefault("AGENT_AUTH_SECRET", "0" * 64)
+# #1103: tests that run `git commit` in temp repos (git-sync reset/pull paths)
+# fail with "Author identity unknown" on a CI runner that has no global
+# `git config user.email/name`. Provide a process-wide committer identity via
+# the standard git env vars so those commits succeed without each throwaway
+# repo (or the code under test) having to `git config`. Harmless for tests
+# that never invoke git.
+os.environ.setdefault("GIT_AUTHOR_NAME", "Trinity Test")
+os.environ.setdefault("GIT_AUTHOR_EMAIL", "test@example.com")
+os.environ.setdefault("GIT_COMMITTER_NAME", "Trinity Test")
+os.environ.setdefault("GIT_COMMITTER_EMAIL", "test@example.com")
 
 # database.py instantiates `db = DatabaseManager()` at import, which calls
 # init_database() and tries to mkdir(/data). On the host that path is

--- a/tests/unit/test_git_pull_branch.py
+++ b/tests/unit/test_git_pull_branch.py
@@ -33,8 +33,13 @@ def _get_pull_branch(current_branch: str, home_dir: Path) -> str:
 
 def _init_repo_with_remote(local_dir: str, remote_dir: str) -> None:
     """Initialize a local git repo with a bare remote and an initial commit."""
-    subprocess.run(["git", "init", "--bare"], cwd=remote_dir, capture_output=True, timeout=10)
-    subprocess.run(["git", "init"], cwd=local_dir, capture_output=True, timeout=10)
+    # #1103: force the default branch to `main`. `git init` defaults to `master`
+    # on stock git (no init.defaultBranch), so `git push -u origin main` below
+    # would push a non-existent ref and origin/main would never exist — which is
+    # exactly why _get_pull_branch fell back to the working branch and these
+    # tests failed once the suite actually ran.
+    subprocess.run(["git", "init", "--bare", "-b", "main"], cwd=remote_dir, capture_output=True, timeout=10)
+    subprocess.run(["git", "init", "-b", "main"], cwd=local_dir, capture_output=True, timeout=10)
     subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=local_dir, capture_output=True, timeout=10)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=local_dir, capture_output=True, timeout=10)
     subprocess.run(["git", "remote", "add", "origin", remote_dir], cwd=local_dir, capture_output=True, timeout=10)
@@ -59,7 +64,6 @@ class TestGetPullBranch:
         shutil.rmtree(self.tmpdir, ignore_errors=True)
         shutil.rmtree(self.remote_dir, ignore_errors=True)
 
-    @pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
     def test_trinity_branch_returns_main(self):
         """trinity/* branch with origin/main should return 'main'."""
         subprocess.run(
@@ -94,7 +98,6 @@ class TestGetPullBranch:
         result = _get_pull_branch("feature/my-feature", self.home_dir)
         assert result == "feature/my-feature"
 
-    @pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
     def test_trinity_branch_deep_nesting(self):
         """trinity/ prefix with multiple path segments should still return main."""
         result = _get_pull_branch("trinity/agent-name/instance-id", self.home_dir)
@@ -115,11 +118,14 @@ class TestGitPullFromMainEndToEnd:
         """Set up a local repo with remote, mimicking a Trinity agent."""
         self._temp_dirs: list[str] = []
 
-        # Create a bare "remote" (like GitHub)
+        # Create a bare "remote" (like GitHub). `-b main` so the clone below
+        # inherits `main` as its default branch instead of stock git's
+        # `master`; otherwise `git push -u origin main` pushes a non-existent
+        # ref and origin/main never exists (#1103).
         self.remote_dir = tempfile.mkdtemp()
         self._temp_dirs.append(self.remote_dir)
         subprocess.run(
-            ["git", "init", "--bare"],
+            ["git", "init", "--bare", "-b", "main"],
             cwd=self.remote_dir,
             capture_output=True, timeout=10
         )
@@ -194,7 +200,6 @@ class TestGitPullFromMainEndToEnd:
             cwd=pusher_dir, capture_output=True, timeout=10
         )
 
-    @pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
     def test_detects_upstream_changes_on_main(self):
         """After pushing to main, agent on working branch should see commits behind."""
         self._push_commit_to_main()
@@ -217,7 +222,6 @@ class TestGitPullFromMainEndToEnd:
         behind_count = int(result.stdout.strip())
         assert behind_count == 1, f"Expected 1 commit behind, got {behind_count}"
 
-    @pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
     def test_pull_from_main_brings_changes(self):
         """Pulling from origin/main should bring upstream changes into working branch."""
         self._push_commit_to_main()
@@ -258,7 +262,6 @@ class TestGitPullFromMainEndToEnd:
         behind_count = int(result.stdout.strip())
         assert behind_count == 0, "Old behavior should show 0 behind (bug confirmed)"
 
-    @pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
     def test_force_reset_to_main(self):
         """Force reset to origin/main should bring working branch to main's state."""
         self._push_commit_to_main()

--- a/tests/unit/test_orphaned_execution_recovery.py
+++ b/tests/unit/test_orphaned_execution_recovery.py
@@ -86,12 +86,17 @@ def _set_agent_registry(execution_ids: list[str]):
 # ── Tests ─────────────────────────────────────────────────────────────────
 @pytest.fixture(autouse=True)
 def _reset_mocks():
-    _mock_db.reset_mock()
-    _mock_capacity.reset_mock()
-    _mock_capacity.release.reset_mock()
-    _mock_capacity.release_if_matches.reset_mock()
-    _mock_docker_svc.reset_mock()
-    _mock_agent_client.reset_mock()
+    # #1103: reset return_value AND side_effect, not just call records. Plain
+    # reset_mock() leaves configured return_value/side_effect in place, so a
+    # side_effect set by one test (e.g. get_agent_container.side_effect in
+    # test_multiple_agents_mixed, or get.side_effect=_AgentClientError) bled into
+    # later tests under random ordering — side_effect wins over return_value, so
+    # the recovery counts came out wrong ("assert 3 == 2"). These tests share
+    # module-level mocks, so the reset must be total.
+    for m in (
+        _mock_db, _mock_capacity, _mock_docker_svc, _mock_agent_client,
+    ):
+        m.reset_mock(return_value=True, side_effect=True)
 
 
 class TestRecoverOrphanedExecutions:
@@ -140,7 +145,6 @@ class TestRecoverOrphanedExecutions:
         assert result["recovered"] == 1
         _mock_capacity.release.assert_awaited_once_with("agent-beta", "exec-2")
 
-    @pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
     def test_in_registry_left_alone(self):
         _mock_db.get_running_executions.return_value = [
             _make_execution("exec-3", "agent-gamma")
@@ -155,7 +159,6 @@ class TestRecoverOrphanedExecutions:
         assert result["still_running"] == 1
         _mock_db.mark_execution_failed_by_watchdog.assert_not_called()
 
-    @pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
     def test_multiple_agents_mixed(self):
         _mock_db.get_running_executions.return_value = [
             _make_execution("exec-a", "agent-up"),

--- a/tests/unit/test_reset_preserve_state_guardrails.py
+++ b/tests/unit/test_reset_preserve_state_guardrails.py
@@ -372,7 +372,6 @@ def test_refuses_when_no_remote_main(tmp_path: Path):
     assert result["error"] == "no_remote_main"
 
 
-@pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
 def test_empty_allowlist_is_safe_noop(tmp_path: Path):
     """Empty allowlist → no files preserved, but reset + commit still run.
 
@@ -393,7 +392,6 @@ def test_empty_allowlist_is_safe_noop(tmp_path: Path):
     assert (worker / "template.conf").read_text() == "v2\n"
 
 
-@pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
 def test_success_preserves_workspace_and_overlays_main(tmp_path: Path):
     """Full happy path: workspace/** survives; template.conf adopts main."""
     worker = _setup_parallel_history(tmp_path)
@@ -418,7 +416,6 @@ def test_success_preserves_workspace_and_overlays_main(tmp_path: Path):
     assert subject == "Adopt main baseline, preserve state"
 
 
-@pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
 def test_success_pushes_with_force_with_lease(tmp_path: Path):
     """Opting in to the push step uses --force-with-lease and updates remote."""
     worker = _setup_parallel_history(tmp_path)

--- a/tests/unit/test_self_hosted_git_url.py
+++ b/tests/unit/test_self_hosted_git_url.py
@@ -224,7 +224,6 @@ def test_startup_sh_strips_trailing_slash_in_base_url():
     assert out == "https://oauth2:p@gitea.example.com/o/r.git"
 
 
-@pytest.mark.skip(reason="pre-existing failure unmasked by #300 collection-abort fix; tracked in #1103")
 def test_startup_sh_shellcheck_clean():
     """shellcheck must still be happy with startup.sh (skipped if not installed)."""
     if shutil.which("shellcheck") is None:


### PR DESCRIPTION
## Summary
Removes the `@pytest.mark.skip` quarantines (added in #300 to keep CI green once the suite ran) and fixes each underlying failure at **root cause** — not by editing assertions to match current behavior. `theme-reliability`. 11 markers across 5 files; `test_backlog`(3)+`test_929`(1) were already un-quarantined on dev.

## Fixes
- **Git identity** (reset 3 + git_pull EndToEnd 3): `tests/unit/conftest.py` sets `GIT_AUTHOR/COMMITTER_*` so in-test `git commit` works on a runner with no global git identity.
- **`_get_pull_branch` drift (5)** — *production was correct*: repos `push -u origin main` but `git init` defaults to `master`, so `origin/main` never existed → correct working-branch fallback. Fixed with `git init -b main` (local + bare).
- **Orphaned recovery (2)** — *assertions were correct*: shared mocks reset with plain `reset_mock()` kept `side_effect`, bleeding across tests under random order ("assert 3==2"). Fixed with `reset_mock(return_value=True, side_effect=True)`; stable across 5 seeds.
- **shellcheck (1)**: `startup.sh` now exit 0 — fragile loops → `find -print0|while read` (SC2010/2045/2044), 8 `cd` `|| exit 1` (SC2164), SC2155 export split, SC2001 documented-disable on regex `sed`. `bash -n` clean.

## Verification
79 passed over the 5 affected files × 3 random seeds; shellcheck 0.10.0 exit 0; full unit suite **2755 passed**, no regressions (the `test_1115`/`test_admin_email_login` failures are pre-existing on dev — reproduce with this branch's conftest stashed).

## Out of scope (issue follow-ups)
Pre-existing `test_1115`/`test_admin_email_login` failures + collection errors (separate triage); Postgres CI service + collection-error CI guard (follow-ups 2 & 3, separate PR).

Related to #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)