### PR TITLE
fix(ui): slim the Overview executions-by-type bars

### DIFF
--- a/src/frontend/src/components/StackedBarChart.vue
+++ b/src/frontend/src/components/StackedBarChart.vue
@@ -74,20 +74,20 @@ function showLabel(i) {
       <div
         v-for="(d, i) in data"
         :key="d.date"
-        class="relative flex-1 flex flex-col-reverse justify-start min-w-0"
+        class="relative flex-1 flex flex-col-reverse justify-start items-center min-w-0"
         @mouseenter="hover = i"
         @mouseleave="hover = null"
       >
         <!-- baseline tick for empty days so the axis reads as continuous -->
         <div
           v-if="!d.total"
-          class="w-full rounded-sm bg-gray-200 dark:bg-gray-700"
+          class="w-full max-w-[56px] rounded-sm bg-gray-200 dark:bg-gray-700"
           style="height: 2px"
         ></div>
         <div
           v-for="b in bucketsForDay(d)"
           :key="b"
-          class="w-full first:rounded-t-sm"
+          class="w-full max-w-[56px] first:rounded-t-md"
           :style="{
             height: segHeight(d, b) + 'px',
             backgroundColor: colorFor(b),


### PR DESCRIPTION
## What

The Agent Detail → **Overview** tab's *Executions by type* stacked bar chart rendered each day as a full-width column with only a 1px gap. On a busy agent (e.g. mostly-scheduled work) that reads as a solid wall of cyan rather than a chart.

This is a minimal, presentation-only tweak in `StackedBarChart.vue`:

- **Cap each bar at `max-w-[56px]`** and **center it** inside its column (`items-center`), so bars are slimmer and breathe.
- The empty-day baseline tick gets the same cap so it lines up with the bars instead of spanning full width.
- Soften the top corner (`rounded-t-sm` → `rounded-t-md`).

The column stays `flex-1`, so per-day spacing, the full-width hover hit-area, and the tooltip are all unchanged. Wider windows (14d/30d) already thin naturally; the cap only matters at 7d.

## Scope

- 1 file, 3 class changes. No JS, no props, no `OverviewPanel` change, no backend.
- No behavior/data change — purely visual.

## Before / after

Before: full-width columns, 1px gap → wall of color.
After: bars capped at 56px, centered, softer top.

_(throwaway comparison mockup reviewed locally; 44px was too sparse, 56px chosen)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)