### PR TITLE
docs(dependabot): clarify security-update routing to main (#1341)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
 # All version-update PRs target `dev` per the SDLC (feature → dev → main).
 # Note: Dependabot reads this file from the DEFAULT branch (main), so changes
-# here only take effect after a release cut. Security updates ignore
-# target-branch and still go to main by GitHub design.
+# here only take effect after a release cut.
+#
+# SECURITY updates ignore `target-branch` and ALWAYS open against the default
+# branch (main) by GitHub design — `target-branch: dev` cannot redirect them,
+# and closing such a PR just makes Dependabot recreate it against main. So a
+# Dependabot *security* PR against `main` is EXPECTED, not a config misroute
+# (see #1341): let it merge to main as a security fix and it reaches dev on the
+# next release back-merge, or cherry-pick the bump into a dev PR if urgent.
+# Only *version* updates honor the per-entry `target-branch: dev` below.
 updates:
   # GitHub Actions: catch new SHAs for already-pinned third-party actions and
   # flag CVEs in first-party actions. Weekly cadence — security PRs from


### PR DESCRIPTION
Related to #1341

Comment-only clarification in `.github/dependabot.yml`. No behavioral change.

## Context
Investigating #1341 showed the config bug it describes was **already fixed**: `target-branch: dev` is set on all 6 ecosystem entries on both `main` and `dev` (live on `main` since v0.6.1, 2026-06-12). Version-update PRs correctly target `dev`.

The two PRs still on `main` (#1298 form-data, #1324 vite 5→8) are **Dependabot security updates** — created *after* the config was live, branch names lack the `/dev/` segment, and #1324 is a major bump the `patch-and-minor` group would never raise. GitHub routes security updates to the **default branch (main)** by design; `target-branch` can't redirect them, and closing them triggers a recreate loop.

## Change
Expands the header comment to spell out that a security PR against `main` is **expected, not a misroute**, and what to do (let it merge to main as a security fix → reaches dev on the next back-merge, or cherry-pick if urgent). Prevents this from being re-filed as a config bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)