### PR TITLE
feat(voip): add Gacrux to the Gemini Live voice picker

### DIFF
--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -191,7 +191,7 @@ VOICE_MAX_DURATION = int(os.getenv("VOICE_MAX_DURATION", "300"))  # seconds
 # picker). DEFAULT_VOICE_NAME is the historical hardcoded default and the
 # fallback for an unset or no-longer-valid persisted value.
 DEFAULT_VOICE_NAME = "Kore"
-GEMINI_VOICE_NAMES = ("Kore", "Zephyr", "Puck", "Aoede", "Charon", "Fenrir")
+GEMINI_VOICE_NAMES = ("Kore", "Zephyr", "Puck", "Aoede", "Charon", "Fenrir", "Gacrux")
 
 # Gemini text/audio models (#1130). Hardcoded `gemini-2.0-flash` was retired by
 # Google (404 NOT_FOUND) with no config escape hatch — these env overrides make

--- a/src/frontend/src/constants/voices.js
+++ b/src/frontend/src/constants/voices.js
@@ -11,6 +11,7 @@ export const VOICES = [
   { id: 'Aoede', label: 'Aoede — Breezy' },
   { id: 'Charon', label: 'Charon — Informational' },
   { id: 'Fenrir', label: 'Fenrir — Excitable' },
+  { id: 'Gacrux', label: 'Gacrux — Mature' },
 ]
 
 export const VOICE_IDS = VOICES.map((v) => v.id)

--- a/tests/unit/test_28_voip_voice_config.py
+++ b/tests/unit/test_28_voip_voice_config.py
@@ -143,7 +143,7 @@ class TestVoiceConstants:
         assert config.DEFAULT_VOICE_NAME == "Kore"
         assert config.DEFAULT_VOICE_NAME in config.GEMINI_VOICE_NAMES
         assert config.GEMINI_VOICE_NAMES == (
-            "Kore", "Zephyr", "Puck", "Aoede", "Charon", "Fenrir",
+            "Kore", "Zephyr", "Puck", "Aoede", "Charon", "Fenrir", "Gacrux",
         )
 
     def test_frontend_voice_list_matches_backend(self):


### PR DESCRIPTION
## What

Adds the **Gacrux — Mature** prebuilt Gemini Live voice to the per-agent VoIP voice selector on the Sharing tab (`VoipChannelPanel.vue`), which shares its list with the AgentWorkspace per-session picker.

## Why

The VoIP voice picker (added in #1323) shipped with 6 voices; Gacrux was missing. This adds it.

## Changes

The voice list is mirrored across three sources that a parity test keeps in sync, so all three move together:

- `src/frontend/src/constants/voices.js` — single frontend source of truth (feeds both the VoIP picker and the AgentWorkspace picker)
- `src/backend/config.py` `GEMINI_VOICE_NAMES` — write-validation allowlist + read-path fallback
- `tests/unit/test_28_voip_voice_config.py` — hardcoded parity tuple

Appended (not reordered) so `tuple(ids) == GEMINI_VOICE_NAMES` declaration-order parity holds; `DEFAULT_VOICE_NAME` unchanged (`Kore`).

## Verification

Replicated the parity test's exact regex locally: frontend ids `==` backend tuple, default agrees, `Gacrux` present in both. Full pytest run lands in CI (local shell lacks the backend venv).

Follow-up to #1323.