### PR TITLE
feat(connector): per-agent MCP connector — playbooks as tools (ent#46, PR1)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -268,6 +268,7 @@ FastMCP, Streamable HTTP transport, port 8080. API-key auth via `Authorization: 
 | `memory.ts` (1) | `write_user_memory` | Per-user memory blob; user email resolved server-side from execution_id (MEM-001, #888) |
 | `voip.ts` (1) | `call_user` | Outbound phone call via Twilio Media Streams; server-gated + rate-limited (VOIP-001, #1056) |
 | `operator_queue.ts` (3) | `list_operator_queue`, `get_operator_queue_item`, `respond_to_operator_queue` | Read the Operating Room queue (broad or `agent_name`-scoped) and **resolve** a pending item — answer / approve / deny via `POST /{id}/respond`. The respond tool resolves the item's `agent_name`, then applies the same MCP-layer gate before writing (non-`pending` → structured error). Agent-scoped keys gated to `{self} ∪ permitted`. `cancel` deferred. (OPS-001, #1101 read / #1104 respond) |
+| `connector.ts` (3) | `list_playbooks`, `run_playbook`, `ask` | **Connector-scope only** (FastMCP `canAccess` gates by scope): the per-agent end-user consumption surface. Agent comes from the bound key, never a tool arg. `list_playbooks` reads the backend's allow-list-filtered list; `run_playbook` re-checks exposure then dispatches via chat; `ask` is the chat fallback. Operator keys never see these tools; connector keys see ONLY these. See [Per-Agent MCP Connector](#per-agent-mcp-connector-ent46) (ent#46) |
 
 ### Vector Log Aggregator (`config/vector.yaml`)
 
@@ -441,6 +442,20 @@ Bounded sequential task execution against one agent. Runner is an in-process `as
 **Access & gating:** all endpoints per-user scoped (owners cannot see other users' sessions) and return 404 — not 403 — on mismatch to avoid leaking session-id existence. All return 404 when `is_session_tab_enabled()` is false; flag `system_settings.session_tab_enabled` (or `SESSION_TAB_ENABLED` env), default ON.
 
 **JSONL reaping** (`session_cleanup_service.py`): default 6h cycle diffs each running agent's `~/.claude/projects/-home-developer/<uuid>.jsonl` set against `agent_sessions.cached_claude_session_id`, deleting JSONLs outside the keep set with mtime older than `min_age_seconds` (default 1h race guard). Synchronous `reap_jsonl()` also fires on reset/delete. Uses `execute_command_in_container` (no agent-server endpoint). Headless-task JSONLs (timeout > 600s auto-enables persistence for the #678 stdout-race recovery in `agent_server/services/jsonl_recovery.py`) aren't in `agent_sessions`, so they fall out of the keep set and the same sweep removes them.
+
+### Per-Agent MCP Connector (ent#46)
+
+A per-agent **MCP connector** — a new client-sharing channel (alongside Slack/Telegram/WhatsApp/VoIP/public link) that exposes an agent's **playbooks** (`.claude/skills/` SKILL.md) as MCP tools an end user adds to their AI client (Claude Code, Cursor, Claude Desktop) in one line. The agent holds all credentials server-side; only a scoped, revocable key reaches the client. **OSS core** today; the entitlement seam (#847) can wrap it later with a one-line diff (the per-user SSO/RFC-8693 tier is a separate enterprise epic). Three-surface (Invariant #13): backend router + DB, MCP server tools, no agent-server change.
+
+**Scoped key:** `mcp_api_keys` gains `scope='connector'` — a separate, user-facing, owner-bound, independently-revocable key (distinct from the auto-minted `scope='agent'` key), SHA-256 hashed like every MCP key. `db/connectors.py` owns the `agent_connectors` config row (enabled + exposed-playbook allow-list); `db/mcp_keys.py` owns connector-key create/get/**regenerate** (revoke-old-mint-new, invalidates a leaked snippet)/revoke. Cascade + rename via `AGENT_REFS` (config row + connector keys re-key/wipe with the agent).
+
+**Config + snippets:** owner-only `routers/connectors.py` (status / `PUT` config / `POST` key / `DELETE` key) + a connector-key-readable `/playbooks`. `services/connector_service.py` (pure) builds **per-client copy-paste config with the key pre-embedded** (Claude Code `claude mcp add` + `.mcp.json`, Cursor `mcpServers`, Claude Desktop) and resolves the exposed set = allow-list ∩ `user_invocable` (a `user_invocable:false` playbook is **never** exposed, even if allow-listed). The raw key is returned **once** at mint/regenerate; status shows only the masked prefix + placeholder snippets.
+
+**MCP surface:** FastMCP tools are server-global, so visibility is gated per-auth by `canAccess(scope)` — connector keys see ONLY `connector.ts`'s `list_playbooks` / `run_playbook` / `ask`; every operator key never sees them. The bound agent comes from the key's auth context, never a tool arg, so a connector key can only ever reach its own agent. `run_playbook` re-checks exposure server-side before dispatching via chat.
+
+**Auth boundary (security-critical):** a connector key resolves to the owner user but is **consumption-only** — `dependencies._enforce_connector_scope` fences it to its bound agent on read/chat and refuses owner operations (`OwnedAgent*` → 403), and `_reject_connector_principal` blocks it from every role-gated endpoint (`require_role`/`require_admin`). So a leaked connector snippet can chat its one agent and nothing else.
+
+**Deferred (fast-follow):** `automation: gated` approval routing (only the 5s file-based operator queue exists — no synchronous gate primitive), ChatGPT connector polish, and the Sharing-tab UI (PR2). v1 is backend + MCP tools + the per-client snippet generators.
 
 ### Outbound File Sharing (FILES-001)
 
@@ -739,6 +754,15 @@ Coverage: agent lifecycle, auth, sharing, credentials, settings, rename; request
 | GET | `/api/nevermined/settlement-failures` | Admin | Failed settlements |
 | POST | `/api/nevermined/retry-settlement/{log_id}` | Admin | Retry settlement |
 
+### Per-Agent MCP Connector (ent#46)
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/agents/{name}/connector` | Owner | Status: enabled, exposed-playbook allow-list, masked key prefix, resolved MCP URL, structural per-client snippets (placeholder key) |
+| PUT | `/api/agents/{name}/connector` | Owner | Set `enabled` + `exposed_playbooks` (allow-list); `expose_all_playbooks` clears it to "all user_invocable" |
+| POST | `/api/agents/{name}/connector/key` | Owner | Mint/regenerate the scoped key — returns the secret **once** + per-client copy-paste snippets with the key embedded; old key invalidated |
+| DELETE | `/api/agents/{name}/connector/key` | Owner | Revoke the connector key (idempotent) — leaked snippets stop working |
+| GET | `/api/agents/{name}/connector/playbooks` | Connector key / owner | Exposed playbooks (allow-list ∩ `user_invocable`) the MCP server advertises; authoritative server-side filter |
+
 ### Outbound File Sharing (FILES-001)
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
@@ -932,9 +956,24 @@ CREATE TABLE mcp_api_keys (
     usage_count INTEGER DEFAULT 0,
     is_active INTEGER DEFAULT 1,
     user_id INTEGER NOT NULL,
-    agent_name TEXT,                 -- non-null for agent-scoped keys
-    scope TEXT DEFAULT 'user',       -- user | agent | system
+    agent_name TEXT,                 -- non-null for agent-scoped + connector-scoped keys
+    scope TEXT DEFAULT 'user',       -- user | agent | system | connector (ent#46)
     FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+`scope='connector'` (ent#46) is the per-agent end-user consumption key — see [Per-Agent MCP Connector](#per-agent-mcp-connector-ent46).
+
+**agent_connectors** (ent#46 — per-agent MCP connector config; the scoped key lives in `mcp_api_keys` with `scope='connector'`):
+```sql
+CREATE TABLE agent_connectors (
+    agent_name TEXT PRIMARY KEY,
+    enabled INTEGER DEFAULT 0,
+    exposed_playbooks TEXT,          -- JSON array of playbook names; NULL = all user_invocable
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (agent_name) REFERENCES agent_ownership(agent_name)
+        ON DELETE CASCADE ON UPDATE CASCADE
 );
 ```
 

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -3164,6 +3164,47 @@ password) is **Phase 2**, gated on a configured email provider and the existing
 
 ---
 
+## 44. Per-Agent MCP Connector (ent#46)
+
+### 44.1 Playbooks-as-Tools Consumption Connector (ent#46 — PR1: backend + MCP)
+
+**Requirement:** Expose a single agent as a per-agent **MCP connector** that an
+end user (someone the agent is shared with) adds to their AI client in one line,
+turning the agent's **playbooks** (`.claude/skills/` SKILL.md) into MCP tools.
+The agent holds all credentials server-side; only a scoped, revocable key
+reaches the client. This is the lightweight Trinity-native consumption tier — a
+new client-sharing channel alongside Slack/Telegram/WhatsApp/VoIP/public link.
+The per-user SSO / corporate-IdP gateway (RFC 8693, per-user audit) is a separate
+enterprise epic and out of scope here.
+
+**Behavior:**
+- **Scoped key** — `mcp_api_keys.scope='connector'`, owner-bound to one agent,
+  SHA-256 hashed, independently revocable; **regenerate** invalidates the old
+  key so a leaked copy-paste snippet can be cut off. Distinct from the auto-minted
+  `scope='agent'` key.
+- **Allow-list** — the owner configures which playbooks are exposed
+  (`agent_connectors.exposed_playbooks`; NULL = all `user_invocable`). A
+  `user_invocable:false` playbook is **never** exposed, even if allow-listed.
+- **One-line install** — the connector generates per-client copy-paste config
+  with the key pre-embedded (Claude Code `claude mcp add` + `.mcp.json`, Cursor
+  `mcpServers`, Claude Desktop), zero manual editing.
+- **MCP tools** — connector-scope keys see ONLY `list_playbooks`,
+  `run_playbook`, and a chat-fallback `ask`; operator keys never see them
+  (FastMCP `canAccess` per-auth gating). The agent is taken from the bound key,
+  never a tool argument.
+- **Auth boundary** — a connector key is consumption-only: fenced to its bound
+  agent for read/chat and refused for any owner or role-gated operation, so a
+  leaked snippet can chat its one agent and nothing else.
+
+**Placement:** OSS core (public repo); the entitlement seam (#847, §35) can wrap
+it behind `requires_entitlement('mcp_connector')` later with a one-line diff.
+
+**Deferred (fast-follow):** `automation: gated` approval routing (no synchronous
+operator-approval primitive exists yet — only the 5s file-based queue), ChatGPT
+connector polish, and the Sharing-tab connector UI (PR2).
+
+---
+
 ## Out of Scope
 
 - Multi-tenant deployment (single org only)

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -114,6 +114,7 @@ from db.sessions import SessionOperations
 from db.activities import ActivityOperations
 from db.permissions import PermissionOperations
 from db.shared_folders import SharedFolderOperations
+from db.connectors import ConnectorOperations
 from db.agent_shared_files import AgentSharedFilesOperations
 from db.settings import SettingsOperations
 from db.public_links import PublicLinkOperations
@@ -333,6 +334,7 @@ class DatabaseManager:
         self._permission_ops = PermissionOperations(self._user_ops, self._agent_ops)
         self._shared_folder_ops = SharedFolderOperations(self._permission_ops)
         self._agent_shared_files_ops = AgentSharedFilesOperations()
+        self._connector_ops = ConnectorOperations()
         self._settings_ops = SettingsOperations()
         self._public_link_ops = PublicLinkOperations(self._user_ops, self._agent_ops)
         self._email_auth_ops = EmailAuthOperations(self._user_ops)
@@ -766,6 +768,31 @@ class DatabaseManager:
 
     def delete_agent_mcp_api_key(self, agent_name: str):
         return self._mcp_key_ops.delete_agent_mcp_api_key(agent_name)
+
+    # Connector-scoped keys (ent#46)
+    def create_connector_mcp_api_key(self, agent_name: str, owner_username: str):
+        return self._mcp_key_ops.create_connector_mcp_api_key(agent_name, owner_username)
+
+    def get_connector_mcp_api_key(self, agent_name: str):
+        return self._mcp_key_ops.get_connector_mcp_api_key(agent_name)
+
+    def delete_connector_mcp_api_key(self, agent_name: str):
+        return self._mcp_key_ops.delete_connector_mcp_api_key(agent_name)
+
+    def regenerate_connector_mcp_api_key(self, agent_name: str, owner_username: str):
+        return self._mcp_key_ops.regenerate_connector_mcp_api_key(agent_name, owner_username)
+
+    # Connector config (ent#46, delegated to db/connectors.py)
+    def get_connector_config(self, agent_name: str):
+        return self._connector_ops.get_connector_config(agent_name)
+
+    def upsert_connector_config(self, agent_name: str, enabled=None, exposed_playbooks=None, *, clear_playbooks: bool = False):
+        return self._connector_ops.upsert_connector_config(
+            agent_name, enabled=enabled, exposed_playbooks=exposed_playbooks, clear_playbooks=clear_playbooks
+        )
+
+    def delete_connector_config(self, agent_name: str):
+        return self._connector_ops.delete_connector_config(agent_name)
 
     def validate_mcp_api_key(self, api_key: str, *, track_usage: bool = True):
         return self._mcp_key_ops.validate_mcp_api_key(api_key, track_usage=track_usage)

--- a/src/backend/db/agent_cleanup.py
+++ b/src/backend/db/agent_cleanup.py
@@ -131,6 +131,9 @@ AGENT_REFS: List[AgentRef] = [
     # --- Files / shared folders --------------------------------------------
     AgentRef("agent_shared_folder_config",   "agent_name",        Policy.CASCADE),
     AgentRef("agent_shared_files",           "agent_name",        Policy.CASCADE),
+    # ent#46 — per-agent MCP connector config (the scoped key is a separate
+    # mcp_api_keys ref below).
+    AgentRef("agent_connectors",             "agent_name",        Policy.CASCADE),
 
     # --- Public links and chained tables -----------------------------------
     # Order: chained tables before agent_public_links so the link rows
@@ -178,6 +181,10 @@ AGENT_REFS: List[AgentRef] = [
     # --- MCP keys (scope='agent' only — user/system keys are not per-agent)
     AgentRef("mcp_api_keys",                 "agent_name",        Policy.CASCADE,
              extra_filter="scope = 'agent'"),
+    # ent#46 — connector-scoped keys are also per-agent: rename WITH the agent,
+    # wipe on purge (a leaked snippet must not survive the agent).
+    AgentRef("mcp_api_keys",                 "agent_name",        Policy.CASCADE,
+             extra_filter="scope = 'connector'"),
 ]
 
 

--- a/src/backend/db/connectors.py
+++ b/src/backend/db/connectors.py
@@ -1,0 +1,134 @@
+"""
+Per-agent MCP connector config database operations (ent#46).
+
+Holds the `agent_connectors` row: whether the connector is enabled and the
+exposed-playbook allow-list. The scoped connector *key* lives in
+`mcp_api_keys` (scope='connector') and is managed by `McpKeyOperations`.
+
+SQLAlchemy Core so it runs unchanged on SQLite and PostgreSQL.
+"""
+
+import json
+from datetime import datetime
+from typing import Optional, List
+
+from sqlalchemy import select, insert, update, delete
+
+from .engine import get_engine
+from .tables import agent_connectors
+from db_models import ConnectorConfig
+from utils.helpers import utc_now_iso
+
+
+class ConnectorOperations:
+    """Per-agent MCP connector config operations."""
+
+    @staticmethod
+    def _decode_playbooks(raw: Optional[str]) -> Optional[List[str]]:
+        """JSON TEXT -> list, or None (= all user_invocable playbooks)."""
+        if not raw:
+            return None
+        try:
+            value = json.loads(raw)
+            return value if isinstance(value, list) else None
+        except (ValueError, TypeError):
+            return None
+
+    @classmethod
+    def _row_to_config(cls, row) -> ConnectorConfig:
+        return ConnectorConfig(
+            agent_name=row["agent_name"],
+            enabled=bool(row["enabled"]),
+            exposed_playbooks=cls._decode_playbooks(row["exposed_playbooks"]),
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def get_connector_config(self, agent_name: str) -> Optional[ConnectorConfig]:
+        """Return the connector config, or None if never configured."""
+        stmt = select(
+            agent_connectors.c.agent_name,
+            agent_connectors.c.enabled,
+            agent_connectors.c.exposed_playbooks,
+            agent_connectors.c.created_at,
+            agent_connectors.c.updated_at,
+        ).where(agent_connectors.c.agent_name == agent_name)
+        with get_engine().connect() as conn:
+            row = conn.execute(stmt).mappings().first()
+        return self._row_to_config(row) if row else None
+
+    def upsert_connector_config(
+        self,
+        agent_name: str,
+        enabled: Optional[bool] = None,
+        exposed_playbooks: Optional[List[str]] = None,
+        *,
+        clear_playbooks: bool = False,
+    ) -> ConnectorConfig:
+        """Create or update the connector config.
+
+        Only fields that are provided change. ``exposed_playbooks=None`` leaves
+        the allow-list untouched on an update; pass ``clear_playbooks=True`` to
+        explicitly reset it to "all user_invocable playbooks" (stores NULL).
+        """
+        now = utc_now_iso()
+        encoded = (
+            None
+            if clear_playbooks or exposed_playbooks is None
+            else json.dumps(list(exposed_playbooks))
+        )
+
+        with get_engine().begin() as conn:
+            existing = conn.execute(
+                select(
+                    agent_connectors.c.agent_name,
+                    agent_connectors.c.enabled,
+                    agent_connectors.c.exposed_playbooks,
+                    agent_connectors.c.created_at,
+                ).where(agent_connectors.c.agent_name == agent_name)
+            ).mappings().first()
+
+            if existing:
+                new_enabled = enabled if enabled is not None else bool(existing["enabled"])
+                if clear_playbooks:
+                    new_playbooks = None
+                elif exposed_playbooks is not None:
+                    new_playbooks = encoded
+                else:
+                    new_playbooks = existing["exposed_playbooks"]
+
+                conn.execute(
+                    update(agent_connectors)
+                    .where(agent_connectors.c.agent_name == agent_name)
+                    .values(enabled=new_enabled, exposed_playbooks=new_playbooks, updated_at=now)
+                )
+                created_at = existing["created_at"]
+            else:
+                new_enabled = enabled if enabled is not None else False
+                new_playbooks = encoded
+                conn.execute(
+                    insert(agent_connectors).values(
+                        agent_name=agent_name,
+                        enabled=new_enabled,
+                        exposed_playbooks=new_playbooks,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
+                created_at = now
+
+        return ConnectorConfig(
+            agent_name=agent_name,
+            enabled=new_enabled,
+            exposed_playbooks=self._decode_playbooks(new_playbooks),
+            created_at=datetime.fromisoformat(created_at),
+            updated_at=datetime.fromisoformat(now),
+        )
+
+    def delete_connector_config(self, agent_name: str) -> bool:
+        """Remove the connector config row (cascade on agent delete)."""
+        with get_engine().begin() as conn:
+            result = conn.execute(
+                delete(agent_connectors).where(agent_connectors.c.agent_name == agent_name)
+            )
+            return result.rowcount > 0

--- a/src/backend/db/mcp_keys.py
+++ b/src/backend/db/mcp_keys.py
@@ -214,6 +214,101 @@ class McpKeyOperations:
             result = conn.execute(stmt)
             return result.rowcount > 0
 
+    # ------------------------------------------------------------------
+    # Connector-scoped keys (ent#46) — a separate, user-facing, revocable
+    # key bound to one agent, distinct from the auto-minted agent-scoped
+    # key. scope='connector'.
+    # ------------------------------------------------------------------
+    def create_connector_mcp_api_key(
+        self, agent_name: str, owner_username: str
+    ) -> Optional[McpApiKeyWithSecret]:
+        """Mint a connector-scoped MCP API key bound to ``agent_name``.
+
+        Unlike the agent-scoped key (auto-minted at provisioning, one per
+        agent, injected into the container), the connector key is created on
+        demand for end-user consumption and is independently revocable. The
+        raw key is returned exactly once.
+        """
+        user = self._user_ops.get_user_by_username(owner_username)
+        if not user:
+            return None
+
+        key_id = self._generate_id()
+        api_key = self._generate_mcp_api_key()
+        key_hash = self._hash_api_key(api_key)
+        now = utc_now_iso()
+        key_name = f"connector-{agent_name}-key"
+
+        with get_engine().begin() as conn:
+            conn.execute(
+                insert(mcp_api_keys).values(
+                    id=key_id,
+                    name=key_name,
+                    description=f"Connector key for agent {agent_name}",
+                    key_prefix=api_key[:20],
+                    key_hash=key_hash,
+                    created_at=now,
+                    user_id=user["id"],
+                    agent_name=agent_name,
+                    scope="connector",
+                )
+            )
+
+        return McpApiKeyWithSecret(
+            id=key_id,
+            name=key_name,
+            description=f"Connector key for agent {agent_name}",
+            key_prefix=api_key[:20],
+            created_at=datetime.fromisoformat(now),
+            last_used_at=None,
+            usage_count=0,
+            is_active=True,
+            user_id=user["id"],
+            username=owner_username,
+            user_email=user.get("email"),
+            agent_name=agent_name,
+            scope="connector",
+            api_key=api_key,
+        )
+
+    def get_connector_mcp_api_key(self, agent_name: str) -> Optional[McpApiKey]:
+        """Get the active connector key for an agent (no secret)."""
+        stmt = (
+            select(*_KEY_JOIN_COLUMNS)
+            .select_from(mcp_api_keys.join(users, mcp_api_keys.c.user_id == users.c.id))
+            .where(
+                mcp_api_keys.c.agent_name == agent_name,
+                mcp_api_keys.c.scope == "connector",
+                mcp_api_keys.c.is_active == 1,
+            )
+            .order_by(mcp_api_keys.c.created_at.desc())
+            .limit(1)
+        )
+        with get_engine().connect() as conn:
+            row = conn.execute(stmt).mappings().first()
+            return self._row_to_mcp_api_key(row) if row else None
+
+    def delete_connector_mcp_api_key(self, agent_name: str) -> bool:
+        """Delete all connector-scoped keys for an agent (revoke / cascade)."""
+        stmt = delete(mcp_api_keys).where(
+            mcp_api_keys.c.agent_name == agent_name,
+            mcp_api_keys.c.scope == "connector",
+        )
+        with get_engine().begin() as conn:
+            result = conn.execute(stmt)
+            return result.rowcount > 0
+
+    def regenerate_connector_mcp_api_key(
+        self, agent_name: str, owner_username: str
+    ) -> Optional[McpApiKeyWithSecret]:
+        """Revoke any existing connector key and mint a fresh one (atomic-ish).
+
+        Invalidates a leaked copy-paste snippet: the old key stops validating
+        immediately, the new key is returned once.
+        """
+        self.delete_connector_mcp_api_key(agent_name)
+        return self.create_connector_mcp_api_key(agent_name, owner_username)
+
     def validate_mcp_api_key(
         self, api_key: str, *, track_usage: bool = True
     ) -> Optional[Dict]:

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -2522,6 +2522,32 @@ def _migrate_agent_loops_max_duration(cursor, conn):
     conn.commit()
 
 
+def _migrate_agent_connectors_table(cursor, conn):
+    """Create agent_connectors table (ent#46 — per-agent MCP connector).
+
+    Holds the per-agent connector config (enabled + exposed-playbook
+    allow-list); the scoped key lives in mcp_api_keys (scope='connector').
+    Schema is also defined in db/schema.py for fresh installs; this migration
+    handles existing installs. Idempotent.
+    """
+    cursor.execute("PRAGMA table_info(agent_connectors)")
+    if cursor.fetchall():
+        return  # already created (fresh-install path via init_schema)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS agent_connectors (
+            agent_name TEXT PRIMARY KEY,
+            enabled INTEGER DEFAULT 0,
+            exposed_playbooks TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (agent_name) REFERENCES agent_ownership(agent_name)
+                ON DELETE CASCADE ON UPDATE CASCADE
+        )
+    """)
+    conn.commit()
+
+
 MIGRATIONS = [
     ("agent_sharing", _migrate_agent_sharing_table),
     ("schedule_executions_observability", _migrate_schedule_executions_observability),
@@ -2599,4 +2625,5 @@ MIGRATIONS = [
     ("agent_compatibility_results_table", _migrate_agent_compatibility_results_table),
     ("agent_ownership_voice_name", _migrate_agent_ownership_voice_name),
     ("agent_loops_max_duration", _migrate_agent_loops_max_duration),
+    ("agent_connectors_table", _migrate_agent_connectors_table),
 ]

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -456,6 +456,26 @@ TABLES = {
     """,
 
     # -------------------------------------------------------------------------
+    # Per-agent MCP Connector (ent#46) — exposes an agent's playbooks as MCP
+    # tools for end-user consumption. The scoped connector key lives in
+    # mcp_api_keys (scope='connector'); this row holds the per-agent config:
+    # whether the connector is enabled and which playbooks are exposed
+    # (exposed_playbooks = JSON array of playbook names; NULL = all
+    # user_invocable playbooks).
+    # -------------------------------------------------------------------------
+    "agent_connectors": """
+        CREATE TABLE IF NOT EXISTS agent_connectors (
+            agent_name TEXT PRIMARY KEY,
+            enabled INTEGER DEFAULT 0,
+            exposed_playbooks TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (agent_name) REFERENCES agent_ownership(agent_name)
+                ON DELETE CASCADE ON UPDATE CASCADE
+        )
+    """,
+
+    # -------------------------------------------------------------------------
     # Shared Files (outbound agent-to-user file sharing via public URL)
     # -------------------------------------------------------------------------
     "agent_shared_files": """

--- a/src/backend/db/tables.py
+++ b/src/backend/db/tables.py
@@ -404,6 +404,19 @@ agent_shared_folder_config = Table(
     Column("updated_at", Text),
 )
 
+# Per-agent MCP Connector config (ent#46). The scoped key lives in mcp_api_keys
+# (scope='connector'); this row holds enabled + the exposed-playbook allow-list
+# (JSON array; NULL = all user_invocable playbooks).
+agent_connectors = Table(
+    "agent_connectors",
+    metadata,
+    Column("agent_name", Text, primary_key=True),
+    Column("enabled", Integer),
+    Column("exposed_playbooks", Text),
+    Column("created_at", Text),
+    Column("updated_at", Text),
+)
+
 agent_shared_files = Table(
     "agent_shared_files",
     metadata,

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -404,6 +404,20 @@ class AgentPermissionInfo(BaseModel):
 # Shared Folder Models (Phase 9.11: Agent Shared Folders)
 # =========================================================================
 
+class ConnectorConfig(BaseModel):
+    """Per-agent MCP connector config (ent#46).
+
+    The scoped connector key lives in mcp_api_keys (scope='connector'); this
+    holds whether the connector is enabled and the exposed-playbook allow-list
+    (``exposed_playbooks=None`` ⇒ all user_invocable playbooks).
+    """
+    agent_name: str
+    enabled: bool = False
+    exposed_playbooks: Optional[List[str]] = None
+    created_at: datetime
+    updated_at: datetime
+
+
 class SharedFolderConfig(BaseModel):
     """Configuration for an agent's shared folder settings."""
     agent_name: str

--- a/src/backend/dependencies.py
+++ b/src/backend/dependencies.py
@@ -214,17 +214,35 @@ async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)
         user = db.get_user_by_email(user_email) if user_email else db.get_user_by_username(user_id)
         if user and not user.get("suspended_at"):  # #995 — suspended users blocked here too
             # For agent-scoped keys, include the agent_name
-            agent_name = mcp_key_info.get("agent_name") if mcp_key_info.get("scope") == "agent" else None
+            scope = mcp_key_info.get("scope")
+            agent_name = mcp_key_info.get("agent_name") if scope == "agent" else None
+            # Connector-scoped keys (ent#46): consumption-only principal fenced
+            # to one agent (see _enforce_connector_scope).
+            connector_agent = mcp_key_info.get("agent_name") if scope == "connector" else None
             return User(
                 id=user["id"],
                 username=user["username"],
                 email=user.get("email"),
                 role=user["role"],
-                agent_name=agent_name
+                agent_name=agent_name,
+                connector_agent=connector_agent,
             )
 
     # Both JWT and MCP key failed
     raise credentials_exception
+
+
+def _reject_connector_principal(current_user: User) -> None:
+    """Connector-scoped keys (ent#46) are consumption-only — never role-bearing.
+
+    Blocks a leaked connector key from reaching any role-gated endpoint
+    (create-agent, admin settings, …) even though it resolves to the owner.
+    """
+    if current_user.connector_agent:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Connector keys are consumption-only and cannot perform this operation",
+        )
 
 
 def require_admin(current_user: User = Depends(get_current_user)) -> User:
@@ -234,6 +252,7 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
     Raises:
         HTTPException(403): If user is not an admin
     """
+    _reject_connector_principal(current_user)
     if current_user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -259,6 +278,7 @@ def require_role(min_role: str):
         HTTPException(403): If user's role is below the minimum required
     """
     def _require_role(current_user: User = Depends(get_current_user)) -> User:
+        _reject_connector_principal(current_user)
         user_level = ROLE_HIERARCHY.index(current_user.role) if current_user.role in ROLE_HIERARCHY else -1
         min_level = ROLE_HIERARCHY.index(min_role) if min_role in ROLE_HIERARCHY else len(ROLE_HIERARCHY)
         if user_level < min_level:
@@ -322,6 +342,29 @@ def requires_entitlement(feature_id: str):
 # ============================================================================
 
 
+def _enforce_connector_scope(current_user: User, agent_name: str, *, owner_op: bool) -> None:
+    """Fence connector-scoped MCP keys (ent#46).
+
+    A connector key resolves to the owner user but must NOT be owner-equivalent:
+    it is a consumption-only credential bound to a single agent. So:
+      - owner operations (OwnedAgent* dependencies) are refused outright, and
+      - read/chat is allowed ONLY against the key's bound agent.
+    No-op for ordinary (non-connector) principals.
+    """
+    if not current_user.connector_agent:
+        return
+    if owner_op:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Connector keys are consumption-only and cannot perform owner operations",
+        )
+    if agent_name != current_user.connector_agent:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Connector key is scoped to a different agent",
+        )
+
+
 def get_authorized_agent(
     name: str = Path(..., description="Agent name from path"),
     current_user: User = Depends(get_current_user)
@@ -343,6 +386,7 @@ def get_authorized_agent(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Agent not found"
         )
+    _enforce_connector_scope(current_user, name, owner_op=False)
     # Then check if user has access
     if not db.can_user_access_agent(current_user.username, name):
         raise HTTPException(
@@ -373,6 +417,7 @@ def get_owned_agent(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Agent not found"
         )
+    _enforce_connector_scope(current_user, name, owner_op=True)
     # Then check if user has owner access
     if not db.can_user_share_agent(current_user.username, name):
         raise HTTPException(
@@ -403,6 +448,7 @@ def get_authorized_agent_by_name(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Agent not found"
         )
+    _enforce_connector_scope(current_user, agent_name, owner_op=False)
     # Then check if user has access
     if not db.can_user_access_agent(current_user.username, agent_name):
         raise HTTPException(
@@ -433,6 +479,7 @@ def get_owned_agent_by_name(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Agent not found"
         )
+    _enforce_connector_scope(current_user, agent_name, owner_op=True)
     # Then check if user has owner access
     if not db.can_user_share_agent(current_user.username, agent_name):
         raise HTTPException(

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -46,6 +46,7 @@ from routers.agents import router as agents_router, set_websocket_manager as set
 from routers.agent_config import router as agent_config_router
 from routers.agent_data import router as agent_data_router
 from routers.agent_files import router as agent_files_router
+from routers.connectors import router as connectors_router
 from routers.agent_rename import router as agent_rename_router, set_websocket_manager as set_agent_rename_ws_manager, set_filtered_websocket_manager as set_agent_rename_filtered_ws_manager
 from routers.agent_ssh import router as agent_ssh_router
 from routers.credentials import router as credentials_router
@@ -875,6 +876,7 @@ app.include_router(agents_router)
 app.include_router(agent_config_router)
 app.include_router(agent_data_router)  # #1169: data export/import
 app.include_router(agent_files_router)
+app.include_router(connectors_router)  # ent#46: per-agent MCP connector
 app.include_router(agent_rename_router)
 app.include_router(agent_ssh_router)
 app.include_router(activities_router)

--- a/src/backend/migrations/versions/0006_agent_connectors.py
+++ b/src/backend/migrations/versions/0006_agent_connectors.py
@@ -1,0 +1,45 @@
+"""Create agent_connectors table (ent#46 — per-agent MCP connector)
+
+Per-agent MCP connector config on the PostgreSQL backend. Mirrors the SQLite
+`agent_connectors_table` migration in `db/migrations.py` and the DDL in
+`db/schema.py` / MetaData in `db/tables.py`.
+
+The scoped connector key lives in `mcp_api_keys` (scope='connector'); this row
+holds the per-agent config: whether the connector is enabled and which
+playbooks are exposed (`exposed_playbooks` = JSON array of names; NULL = all
+user_invocable playbooks).
+
+Fresh PG builds already get the table because `0001_baseline` iterates
+`db/schema.py:TABLES`. This revision exists so an *existing* PG deployment —
+stamped at an earlier revision and never re-running baseline — also picks the
+table up on `alembic upgrade head`.
+
+Revision ID: 0006_agent_connectors
+Revises: 0005_agent_loops_max_duration
+Create Date: 2026-06-26
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0006_agent_connectors"
+down_revision = "0005_agent_loops_max_duration"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_connectors (
+            agent_name TEXT PRIMARY KEY,
+            enabled INTEGER DEFAULT 0,
+            exposed_playbooks TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS agent_connectors")

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -62,6 +62,11 @@ class User(BaseModel):
     role: str = "user"
     # For agent-scoped MCP API keys, this is the agent name
     agent_name: Optional[str] = None
+    # For connector-scoped MCP keys (ent#46): the single agent this key may
+    # consume. Set ⇒ the principal is a connector (consumption-only): it may
+    # read/chat ONLY this agent and may NOT perform owner operations, even
+    # though it resolves to the owner user.
+    connector_agent: Optional[str] = None
 
 
 class Token(BaseModel):
@@ -517,6 +522,64 @@ class AgentDefaultResourcesUpdate(BaseModel):
 class AgentDefaultAccessPolicyUpdate(BaseModel):
     """Body for PUT /api/settings/agent-defaults/access-policy (#1129)."""
     require_email: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# Per-agent MCP Connector (ent#46)
+# ---------------------------------------------------------------------------
+
+class ConnectorConfigUpdate(BaseModel):
+    """Body for PUT /api/agents/{name}/connector.
+
+    `exposed_playbooks=None` leaves the allow-list unchanged; an explicit empty
+    or non-empty list sets it; `expose_all_playbooks=True` resets it to "all
+    user_invocable playbooks" (clears the allow-list).
+    """
+    enabled: Optional[bool] = None
+    exposed_playbooks: Optional[List[str]] = None
+    expose_all_playbooks: Optional[bool] = None
+
+
+class ConnectorClientSnippet(BaseModel):
+    """A copy-paste-ready connector config for one AI client."""
+    client: str            # 'claude-code' | 'cursor' | 'claude-desktop'
+    label: str             # human label, e.g. "Claude Code"
+    format: str            # 'shell' | 'json' — how to render the block
+    content: str           # the literal block to copy (key pre-embedded)
+    note: Optional[str] = None
+
+
+class ConnectorPlaybook(BaseModel):
+    """A playbook exposed by the connector as an MCP tool."""
+    name: str
+    description: Optional[str] = None
+    argument_hint: Optional[str] = None
+    automation: Optional[str] = None     # manual | gated | autonomous
+
+
+class ConnectorStatus(BaseModel):
+    """Response for GET /api/agents/{name}/connector (owner view)."""
+    agent_name: str
+    enabled: bool = False
+    exposed_playbooks: Optional[List[str]] = None   # None ⇒ all user_invocable
+    has_key: bool = False
+    key_prefix: Optional[str] = None                # masked identifier, not the secret
+    mcp_url: Optional[str] = None
+    snippets: List[ConnectorClientSnippet] = Field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class ConnectorKeySecret(BaseModel):
+    """Response when minting/regenerating the connector key.
+
+    The raw key is returned exactly once; thereafter only `key_prefix` is shown.
+    """
+    agent_name: str
+    api_key: str
+    key_prefix: str
+    mcp_url: Optional[str] = None
+    snippets: List[ConnectorClientSnippet] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/routers/connectors.py
+++ b/src/backend/routers/connectors.py
@@ -1,0 +1,153 @@
+"""
+Per-agent MCP connector endpoints (ent#46).
+
+Owner-facing CRUD for the connector channel: enable/configure which playbooks
+are exposed, mint/regenerate/revoke the scoped connector key, and read
+copy-paste-ready per-client install snippets. Plus a connector-facing
+`/playbooks` read used by the MCP server to advertise the exposed tools.
+
+Three-layer: this router holds no SQL (db facade) and no snippet/format logic
+(services/connector_service.py).
+"""
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from typing import List
+
+from models import (
+    User,
+    ConnectorConfigUpdate,
+    ConnectorStatus,
+    ConnectorKeySecret,
+    ConnectorPlaybook,
+)
+from database import db
+from dependencies import get_current_user, OwnedAgentByName, AuthorizedAgentByName
+from services.docker_service import get_agent_container
+from services.docker_utils import container_reload
+from services.agent_auth import agent_httpx_client
+from services.connector_service import build_snippets, resolve_exposed_playbooks
+from routers.settings import MCP_URL_SETTING_KEY, _get_default_mcp_url
+
+router = APIRouter(prefix="/api/agents", tags=["connector"])
+
+# Placeholder shown in the status view's snippets (the real secret is only
+# returned once, at mint/regenerate time).
+_KEY_PLACEHOLDER = "<CONNECTOR_KEY>"
+
+
+def _resolve_mcp_url(request: Request) -> str:
+    """Configured external MCP URL, else the auto-detected default."""
+    return db.get_setting_value(MCP_URL_SETTING_KEY) or _get_default_mcp_url(request)
+
+
+def _status(agent_name: str, request: Request) -> ConnectorStatus:
+    cfg = db.get_connector_config(agent_name)
+    key = db.get_connector_mcp_api_key(agent_name)
+    mcp_url = _resolve_mcp_url(request)
+    return ConnectorStatus(
+        agent_name=agent_name,
+        enabled=bool(cfg.enabled) if cfg else False,
+        exposed_playbooks=cfg.exposed_playbooks if cfg else None,
+        has_key=key is not None,
+        key_prefix=key.key_prefix if key else None,
+        mcp_url=mcp_url,
+        # Structural preview only — placeholder, never the live secret.
+        snippets=build_snippets(agent_name, mcp_url, _KEY_PLACEHOLDER) if key else [],
+        created_at=cfg.created_at if cfg else None,
+        updated_at=cfg.updated_at if cfg else None,
+    )
+
+
+async def _fetch_live_playbooks(agent_name: str) -> List[dict]:
+    """Proxy the agent container's /api/skills (SKILL.md frontmatter list)."""
+    container = get_agent_container(agent_name)
+    if not container:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    await container_reload(container)
+    if container.status != "running":
+        raise HTTPException(status_code=503, detail="Agent is not running.")
+    try:
+        url = f"http://agent-{agent_name}:8000/api/skills"
+        async with agent_httpx_client(agent_name, timeout=10.0) as client:
+            resp = await client.get(url)
+            if resp.status_code == 200:
+                return resp.json().get("skills", [])
+            raise HTTPException(status_code=resp.status_code, detail=f"Agent error: {resp.text}")
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="Agent is starting up, please try again")
+    except httpx.ConnectError:
+        raise HTTPException(status_code=503, detail="Could not connect to agent")
+
+
+@router.get("/{agent_name}/connector", response_model=ConnectorStatus)
+async def get_connector(agent_name: OwnedAgentByName, request: Request):
+    """Connector status + config + masked key + structural install snippets."""
+    return _status(agent_name, request)
+
+
+@router.put("/{agent_name}/connector", response_model=ConnectorStatus)
+async def update_connector(
+    agent_name: OwnedAgentByName,
+    body: ConnectorConfigUpdate,
+    request: Request,
+):
+    """Enable/disable + set the exposed-playbook allow-list (owner-only)."""
+    db.upsert_connector_config(
+        agent_name,
+        enabled=body.enabled,
+        exposed_playbooks=body.exposed_playbooks,
+        clear_playbooks=bool(body.expose_all_playbooks),
+    )
+    return _status(agent_name, request)
+
+
+@router.post("/{agent_name}/connector/key", response_model=ConnectorKeySecret)
+async def regenerate_connector_key(
+    agent_name: OwnedAgentByName,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Mint (or regenerate) the scoped connector key — returns the secret once.
+
+    Regenerating invalidates any previously embedded snippet immediately.
+    Enabling the connector here too, so a freshly-keyed connector is usable.
+    """
+    secret = db.regenerate_connector_mcp_api_key(agent_name, current_user.username)
+    if not secret:
+        raise HTTPException(status_code=500, detail="Failed to create connector key")
+    # First key implies intent to use it — ensure a config row exists + enabled.
+    cfg = db.get_connector_config(agent_name)
+    if not cfg or not cfg.enabled:
+        db.upsert_connector_config(agent_name, enabled=True)
+
+    mcp_url = _resolve_mcp_url(request)
+    return ConnectorKeySecret(
+        agent_name=agent_name,
+        api_key=secret.api_key,
+        key_prefix=secret.key_prefix,
+        mcp_url=mcp_url,
+        snippets=build_snippets(agent_name, mcp_url, secret.api_key),
+    )
+
+
+@router.delete("/{agent_name}/connector/key")
+async def revoke_connector_key(agent_name: OwnedAgentByName):
+    """Revoke the connector key (idempotent). Leaked snippets stop working."""
+    db.delete_connector_mcp_api_key(agent_name)
+    return {"revoked": True, "agent_name": agent_name}
+
+
+@router.get("/{agent_name}/connector/playbooks", response_model=List[ConnectorPlaybook])
+async def list_connector_playbooks(agent_name: AuthorizedAgentByName):
+    """Exposed playbooks (allow-list ∩ user_invocable) the connector advertises.
+
+    Accepts the connector-scoped key (resolved to the bound agent) or the
+    owner. Authoritative server-side enforcement of the allow-list + the
+    `user_invocable:false` exclusion — the MCP client never sees a hidden one.
+    """
+    cfg = db.get_connector_config(agent_name)
+    if cfg and not cfg.enabled:
+        raise HTTPException(status_code=403, detail="Connector is disabled for this agent")
+    live = await _fetch_live_playbooks(agent_name)
+    allow = cfg.exposed_playbooks if cfg else None
+    return resolve_exposed_playbooks(live, allow)

--- a/src/backend/services/connector_service.py
+++ b/src/backend/services/connector_service.py
@@ -1,0 +1,126 @@
+"""
+Per-agent MCP connector service (ent#46).
+
+Pure helpers that (a) build copy-paste-ready connector configuration per AI
+client with the scoped key pre-embedded, and (b) resolve an agent's exposed
+playbooks against its allow-list + the `user_invocable` exclusion.
+
+No DB or HTTP here — the router owns persistence and the MCP-URL lookup; this
+module is unit-testable in isolation.
+"""
+
+import json
+import re
+from typing import List, Optional
+
+from models import ConnectorClientSnippet, ConnectorPlaybook
+
+
+def connector_name(agent_name: str) -> str:
+    """A safe MCP-server name for `claude mcp add <name>` / config keys.
+
+    Lowercases, replaces runs of non-alphanumerics with '-', trims, and
+    prefixes so it reads as a Trinity connector in the client's server list.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", agent_name.lower()).strip("-")
+    return f"trinity-{slug or 'agent'}"
+
+
+def build_snippets(agent_name: str, mcp_url: str, api_key: str) -> List[ConnectorClientSnippet]:
+    """Build per-client connector config blocks with the key pre-embedded.
+
+    `api_key` is the literal scoped connector key — these blocks are secrets
+    until the key is revoked/regenerated.
+    """
+    name = connector_name(agent_name)
+    auth = f"Bearer {api_key}"
+
+    # Claude Code — one-line CLI add, plus an equivalent .mcp.json block.
+    claude_code_cli = (
+        f'claude mcp add --transport http {name} {mcp_url} '
+        f'--header "Authorization: {auth}"'
+    )
+    mcp_json = {
+        "mcpServers": {
+            name: {
+                "type": "http",
+                "url": mcp_url,
+                "headers": {"Authorization": auth},
+            }
+        }
+    }
+    mcp_json_block = json.dumps(mcp_json, indent=2)
+
+    # Cursor — mcpServers entry for .cursor/mcp.json.
+    cursor_block = json.dumps(mcp_json, indent=2)
+
+    # Claude Desktop / claude.ai — Connector config (URL + auth header).
+    desktop_block = json.dumps(
+        {"url": mcp_url, "headers": {"Authorization": auth}}, indent=2
+    )
+
+    return [
+        ConnectorClientSnippet(
+            client="claude-code",
+            label="Claude Code",
+            format="shell",
+            content=claude_code_cli,
+            note="Run in your terminal, then restart Claude Code (or run /mcp).",
+        ),
+        ConnectorClientSnippet(
+            client="claude-code-json",
+            label="Claude Code (.mcp.json)",
+            format="json",
+            content=mcp_json_block,
+            note="Add to .mcp.json under mcpServers if you prefer a config file.",
+        ),
+        ConnectorClientSnippet(
+            client="cursor",
+            label="Cursor",
+            format="json",
+            content=cursor_block,
+            note="Add to .cursor/mcp.json (project) or ~/.cursor/mcp.json (global).",
+        ),
+        ConnectorClientSnippet(
+            client="claude-desktop",
+            label="Claude Desktop / claude.ai",
+            format="json",
+            content=desktop_block,
+            note="Add as a Connector: paste the URL and Authorization header.",
+        ),
+    ]
+
+
+def resolve_exposed_playbooks(
+    live_playbooks: List[dict],
+    exposed_allow_list: Optional[List[str]],
+) -> List[ConnectorPlaybook]:
+    """Filter the agent's live playbook list down to what the connector exposes.
+
+    Rules (in order):
+      1. `user_invocable == False` playbooks are NEVER exposed.
+      2. If `exposed_allow_list` is None → expose all remaining (user_invocable)
+         playbooks. Otherwise → expose only those whose name is in the list.
+
+    `live_playbooks` is the raw `GET /{agent}/playbooks` skill list (snake_case
+    fields from the agent server).
+    """
+    allow = set(exposed_allow_list) if exposed_allow_list is not None else None
+    out: List[ConnectorPlaybook] = []
+    for pb in live_playbooks:
+        if not pb.get("user_invocable", True):
+            continue
+        name = pb.get("name")
+        if not name:
+            continue
+        if allow is not None and name not in allow:
+            continue
+        out.append(
+            ConnectorPlaybook(
+                name=name,
+                description=pb.get("description"),
+                argument_hint=pb.get("argument_hint"),
+                automation=pb.get("automation"),
+            )
+        )
+    return out

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -260,6 +260,20 @@ export class TrinityClient {
   }
 
   /**
+   * Get the playbooks an agent's connector exposes (ent#46).
+   * The backend enforces the allow-list + the user_invocable exclusion, so
+   * this returns only what the connector is permitted to advertise as tools.
+   */
+  async getConnectorPlaybooks(
+    name: string
+  ): Promise<Array<{ name: string; description?: string; argument_hint?: string; automation?: string }>> {
+    return this.request(
+      "GET",
+      `/api/agents/${encodeURIComponent(name)}/connector/playbooks`
+    );
+  }
+
+  /**
    * Get the agent compatibility report (#668).
    * STATIC checks recompute live; pass includeAi=true to force a fresh AI
    * evaluation (otherwise the last persisted AI verdicts are returned).

--- a/src/mcp-server/src/connector.test.ts
+++ b/src/mcp-server/src/connector.test.ts
@@ -1,0 +1,81 @@
+/**
+ * ent#46 — per-agent MCP connector tools.
+ *
+ * Pins that the connector tools (a) take the agent from the auth context, never
+ * from a tool arg, (b) advertise exactly list_playbooks/run_playbook/ask, and
+ * (c) refuse to run a playbook the connector does not expose (server-side
+ * enforcement, not client trust).
+ *
+ * Runner: built-in node:test → `node --import tsx --test src/*.test.ts`.
+ */
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { createConnectorTools } from "./tools/connector.js";
+import type { TrinityClient } from "./client.js";
+import type { McpAuthContext } from "./types.js";
+
+function fakeClient(chats: Array<{ agent: string; message: string }>) {
+  const fake: Partial<TrinityClient> = {
+    getBaseUrl: () => "http://localhost:8000",
+    getConnectorPlaybooks: async (_agent: string) => [
+      { name: "cso", description: "audit" },
+      { name: "commit" },
+    ],
+    chat: async (agent: string, message: string) => {
+      chats.push({ agent, message });
+      return { response: "ok" } as any;
+    },
+  };
+  return fake as unknown as TrinityClient;
+}
+
+const session = (agentName?: string): McpAuthContext => ({
+  userId: "owner",
+  keyName: "connector-agent-1-key",
+  scope: "connector",
+  agentName,
+});
+
+describe("connector tools", () => {
+  it("exposes exactly list_playbooks, run_playbook, ask", () => {
+    const tools = createConnectorTools(fakeClient([]), false);
+    const names = Object.values(tools).map((t: any) => t.name).sort();
+    assert.deepEqual(names, ["ask", "list_playbooks", "run_playbook"]);
+  });
+
+  it("list_playbooks uses the bound agent from auth context", async () => {
+    const tools = createConnectorTools(fakeClient([]), false);
+    const out = await tools.listPlaybooks.execute({}, { session: session("agent-1") });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.agent, "agent-1");
+    assert.deepEqual(parsed.playbooks.map((p: any) => p.name), ["cso", "commit"]);
+  });
+
+  it("run_playbook dispatches an exposed playbook to the bound agent", async () => {
+    const chats: Array<{ agent: string; message: string }> = [];
+    const tools = createConnectorTools(fakeClient(chats), false);
+    await tools.runPlaybook.execute({ name: "cso", input: "scan repo" }, { session: session("agent-1") });
+    assert.equal(chats.length, 1);
+    assert.equal(chats[0].agent, "agent-1");
+    assert.match(chats[0].message, /cso/);
+    assert.match(chats[0].message, /scan repo/);
+  });
+
+  it("run_playbook refuses a playbook the connector does not expose", async () => {
+    const chats: Array<{ agent: string; message: string }> = [];
+    const tools = createConnectorTools(fakeClient(chats), false);
+    const out = await tools.runPlaybook.execute({ name: "delete-everything" }, { session: session("agent-1") });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.error, "playbook_not_exposed");
+    assert.equal(chats.length, 0); // never dispatched
+  });
+
+  it("throws if the connector key is not bound to an agent", async () => {
+    const tools = createConnectorTools(fakeClient([]), false);
+    await assert.rejects(
+      () => tools.ask.execute({ message: "hi" }, { session: session(undefined) }),
+      /not bound to an agent/
+    );
+  });
+});

--- a/src/mcp-server/src/server.ts
+++ b/src/mcp-server/src/server.ts
@@ -27,6 +27,7 @@ import { createFileTools } from "./tools/files.js";
 import { createMemoryTools } from "./tools/memory.js";
 import { createLoopTools } from "./tools/loops.js";
 import { createOperatorQueueTools } from "./tools/operator_queue.js";
+import { createConnectorTools } from "./tools/connector.js";
 import { withAudit } from "./audit.js";
 import type { McpAuthContext } from "./types.js";
 
@@ -178,7 +179,7 @@ export async function createServer(config: ServerConfig = {}) {
               keyId: result.key_id,  // MCP API key ID (AUDIT-001)
               keyName: result.key_name || "unknown",
               agentName: result.agent_name,  // Agent name if scope is 'agent' or 'system'
-              scope: scope as "user" | "agent" | "system",
+              scope: scope as "user" | "agent" | "system" | "connector",
               mcpApiKey: apiKey,  // Store the actual API key for user-scoped requests
             };
             return authContext;
@@ -198,20 +199,33 @@ export async function createServer(config: ServerConfig = {}) {
   // SEC-001 Phase 3: Wrap tool execute functions with audit logging.
   // withAudit captures tool name, auth context, timing, and success/failure,
   // then fires a non-blocking POST to the backend internal audit endpoint.
-  function addToolWithAudit(tool: any): void {
-    const wrapped = {
+  function addToolWithAudit(tool: any, canAccess?: (auth: any) => boolean): void {
+    const wrapped: any = {
       ...tool,
       execute: withAudit(tool.name, tool.execute),
     };
+    // ent#46: per-auth tool visibility. FastMCP filters the advertised tool
+    // list per session by canAccess(authContext). A tool's own canAccess (if
+    // any) wins; otherwise we apply the group default.
+    if (canAccess && wrapped.canAccess === undefined) {
+      wrapped.canAccess = canAccess;
+    }
     server.addTool(wrapped);
   }
 
   // Helper to register all tools from a tool group with audit wrapping
-  function addAllTools(tools: Record<string, any>): void {
+  function addAllTools(tools: Record<string, any>, canAccess?: (auth: any) => boolean): void {
     for (const tool of Object.values(tools)) {
-      addToolWithAudit(tool);
+      addToolWithAudit(tool, canAccess);
     }
   }
+
+  // ent#46 visibility gates: connector keys (end-user consumption tier) see
+  // ONLY the connector tools; every other (operator) key never sees them.
+  // When auth is disabled (dev), auth is undefined → operator tools show,
+  // connector tools hide (they require a connector key anyway).
+  const connectorDenied = (auth: any): boolean => auth?.scope !== "connector";
+  const connectorOnly = (auth: any): boolean => auth?.scope === "connector";
 
   // Build tool groups once, then register + count (SEC-001 Phase 3).
   const toolGroups: Record<string, any>[] = [
@@ -236,10 +250,17 @@ export async function createServer(config: ServerConfig = {}) {
     createVoipTools(client, requireApiKey),       // VoIP telephony — call_user (VOIP-001, #1056)
     createOperatorQueueTools(client, requireApiKey), // Operator queue read + respond (OPS-001, #1101/#1104)
   ];
+  // Operator tools: hidden from connector-scoped keys.
   for (const group of toolGroups) {
-    addAllTools(group);
+    addAllTools(group, connectorDenied);
   }
-  const totalTools = toolGroups.reduce((sum, g) => sum + Object.keys(g).length, 0);
+  // Connector tools (ent#46): visible ONLY to connector-scoped keys.
+  const connectorGroup = createConnectorTools(client, requireApiKey);
+  addAllTools(connectorGroup, connectorOnly);
+
+  const totalTools =
+    toolGroups.reduce((sum, g) => sum + Object.keys(g).length, 0) +
+    Object.keys(connectorGroup).length;
   console.log(`Registered ${totalTools} tools with audit wrapping (SEC-001 Phase 3)`);
 
   return { server, port, client, requireApiKey };

--- a/src/mcp-server/src/tools/connector.ts
+++ b/src/mcp-server/src/tools/connector.ts
@@ -1,0 +1,123 @@
+/**
+ * Per-agent MCP connector tools (ent#46).
+ *
+ * These tools are exposed ONLY to connector-scoped keys (see the canAccess
+ * gating in server.ts). The agent is taken from the auth context (the key is
+ * bound to exactly one agent server-side), never from a tool argument, so a
+ * connector key can only ever reach its own agent. The backend additionally
+ * fences connector keys to their bound agent and refuses owner operations.
+ *
+ * Tools:
+ *   - list_playbooks: the playbooks (skills) this connector exposes as actions
+ *   - run_playbook:    run one exposed playbook with optional input
+ *   - ask:             free-form chat fallback with the agent
+ */
+import { z } from "zod";
+import { TrinityClient } from "../client.js";
+import type { McpAuthContext } from "../types.js";
+
+export function createConnectorTools(
+  client: TrinityClient,
+  requireApiKey: boolean
+) {
+  const getClient = (authContext?: McpAuthContext): TrinityClient => {
+    if (requireApiKey) {
+      if (!authContext?.mcpApiKey) {
+        throw new Error("MCP API key authentication required but no API key found in request context");
+      }
+      const userClient = new TrinityClient(client.getBaseUrl());
+      userClient.setToken(authContext.mcpApiKey);
+      return userClient;
+    }
+    return client;
+  };
+
+  // The bound agent for a connector key. Hard error if somehow missing — a
+  // connector key without an agent must never silently fall through to a
+  // different agent.
+  const boundAgent = (authContext?: McpAuthContext): string => {
+    const name = authContext?.agentName;
+    if (!name) {
+      throw new Error("Connector key is not bound to an agent");
+    }
+    return name;
+  };
+
+  const keyInfo = (authContext?: McpAuthContext) => ({
+    keyId: authContext?.keyId,
+    keyName: authContext?.keyName,
+  });
+
+  return {
+    listPlaybooks: {
+      name: "list_playbooks",
+      description:
+        "List the playbooks this agent exposes as actions you can run. " +
+        "Each playbook is a named capability with an optional argument hint. " +
+        "Use run_playbook to execute one.",
+      parameters: z.object({}),
+      execute: async (_args: unknown, context?: { session?: McpAuthContext }) => {
+        const apiClient = getClient(context?.session);
+        const agent = boundAgent(context?.session);
+        const playbooks = await apiClient.getConnectorPlaybooks(agent);
+        return JSON.stringify({ agent, playbooks }, null, 2);
+      },
+    },
+
+    runPlaybook: {
+      name: "run_playbook",
+      description:
+        "Run one of this agent's exposed playbooks. Pass the playbook `name` " +
+        "(from list_playbooks) and optional `input` describing what you want. " +
+        "Returns the agent's response.",
+      parameters: z.object({
+        name: z.string().describe("Playbook name, exactly as returned by list_playbooks"),
+        input: z.string().optional().describe("Optional input / arguments for the playbook"),
+      }),
+      execute: async (
+        { name, input }: { name: string; input?: string },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const apiClient = getClient(context?.session);
+        const agent = boundAgent(context?.session);
+
+        // Server-side enforcement: only run a playbook the connector actually
+        // exposes (allow-list ∩ user_invocable). Never trust the client to
+        // stay within the advertised set.
+        const allowed = await apiClient.getConnectorPlaybooks(agent);
+        if (!allowed.some((p) => p.name === name)) {
+          return JSON.stringify({
+            error: "playbook_not_exposed",
+            message: `Playbook "${name}" is not exposed by this connector.`,
+            available: allowed.map((p) => p.name),
+          });
+        }
+
+        const message = input
+          ? `Please run the "${name}" playbook.\n\nInput:\n${input}`
+          : `Please run the "${name}" playbook.`;
+        const result = await apiClient.chat(agent, message, undefined, keyInfo(context?.session));
+        return JSON.stringify(result, null, 2);
+      },
+    },
+
+    ask: {
+      name: "ask",
+      description:
+        "Ask this agent anything in free-form natural language (chat fallback " +
+        "for when no specific playbook fits). Returns the agent's response.",
+      parameters: z.object({
+        message: z.string().describe("Your message to the agent"),
+      }),
+      execute: async (
+        { message }: { message: string },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const apiClient = getClient(context?.session);
+        const agent = boundAgent(context?.session);
+        const result = await apiClient.chat(agent, message, undefined, keyInfo(context?.session));
+        return JSON.stringify(result, null, 2);
+      },
+    },
+  };
+}

--- a/src/mcp-server/src/types.ts
+++ b/src/mcp-server/src/types.ts
@@ -67,8 +67,8 @@ export interface McpAuthContext extends Record<string, unknown> {
   userEmail?: string;    // Email of the key owner
   keyId?: string;        // MCP API key ID (AUDIT-001: for execution origin tracking)
   keyName: string;       // Name of the MCP API key
-  agentName?: string;    // Agent name if scope is 'agent' or 'system' (for agent-to-agent)
-  scope: "user" | "agent" | "system"; // Key scope: user=human, agent=regular agent, system=system agent (bypasses all permissions)
+  agentName?: string;    // Agent name if scope is 'agent', 'system', or 'connector'
+  scope: "user" | "agent" | "system" | "connector"; // user=human, agent=regular agent, system=bypasses all permissions, connector=end-user consumption key bound to one agent (ent#46)
   mcpApiKey?: string;    // The actual MCP API key (for user-scoped requests to Trinity backend)
 }
 

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -1,0 +1,232 @@
+"""
+Per-agent MCP connector tests (ent#46).
+
+Covers the connector config CRUD, the connector-scoped key lifecycle
+(mint / regenerate-invalidates-old / revoke), the exposed-playbook resolution
+(allow-list ∩ user_invocable), the per-client snippet builder, and the
+connector-scope auth boundary that fences a connector key to its bound agent
+and refuses owner operations.
+
+DB tests run on the real production schema via db_harness (SQLite always; PG
+when TEST_POSTGRES_URL is set). Pure helpers (service + auth boundary) need no
+DB.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_STR = str(Path(__file__).resolve().parent.parent.parent / "src" / "backend")
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend, seed_user, seed_agent  # noqa: E402,F401
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def tmp_db(db_backend):
+    """Fresh full production schema; evict cached db modules so production code
+    re-resolves against the active backend."""
+    def _evict():
+        for mod in ("db.connectors", "db.mcp_keys", "db.users", "database"):
+            sys.modules.pop(mod, None)
+    _evict()
+    try:
+        yield db_backend
+    finally:
+        _evict()
+
+
+@pytest.fixture
+def fresh_db(tmp_db):
+    """A facade `db` bound to the active backend, with an owner + agent seeded."""
+    seed_user(user_id=1, username="owner", role="creator")
+    seed_agent(agent_name="agent-1", owner_id=1)
+    from database import db
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Connector config CRUD
+# ---------------------------------------------------------------------------
+
+class TestConnectorConfig:
+    def test_absent_by_default(self, fresh_db):
+        assert fresh_db.get_connector_config("agent-1") is None
+
+    def test_enable_and_persist(self, fresh_db):
+        cfg = fresh_db.upsert_connector_config("agent-1", enabled=True)
+        assert cfg.enabled is True
+        assert cfg.exposed_playbooks is None  # None ⇒ all user_invocable
+        reread = fresh_db.get_connector_config("agent-1")
+        assert reread.enabled is True
+
+    def test_set_allow_list(self, fresh_db):
+        fresh_db.upsert_connector_config("agent-1", enabled=True, exposed_playbooks=["cso", "commit"])
+        cfg = fresh_db.get_connector_config("agent-1")
+        assert cfg.exposed_playbooks == ["cso", "commit"]
+
+    def test_partial_update_keeps_allow_list(self, fresh_db):
+        fresh_db.upsert_connector_config("agent-1", enabled=True, exposed_playbooks=["cso"])
+        # Toggle enabled only; allow-list must survive (exposed_playbooks=None).
+        cfg = fresh_db.upsert_connector_config("agent-1", enabled=False)
+        assert cfg.enabled is False
+        assert cfg.exposed_playbooks == ["cso"]
+
+    def test_clear_playbooks_resets_to_all(self, fresh_db):
+        fresh_db.upsert_connector_config("agent-1", enabled=True, exposed_playbooks=["cso"])
+        cfg = fresh_db.upsert_connector_config("agent-1", clear_playbooks=True)
+        assert cfg.exposed_playbooks is None
+
+    def test_isolation_between_agents(self, fresh_db):
+        seed_agent(agent_name="agent-2", owner_id=1)
+        fresh_db.upsert_connector_config("agent-1", enabled=True, exposed_playbooks=["cso"])
+        assert fresh_db.get_connector_config("agent-2") is None
+
+
+# ---------------------------------------------------------------------------
+# Connector-scoped key lifecycle
+# ---------------------------------------------------------------------------
+
+class TestConnectorKey:
+    def test_mint_returns_secret_once(self, fresh_db):
+        secret = fresh_db.create_connector_mcp_api_key("agent-1", "owner")
+        assert secret is not None
+        assert secret.api_key.startswith("trinity_mcp_")
+        assert secret.scope == "connector"
+        assert secret.agent_name == "agent-1"
+
+    def test_get_returns_prefix_not_secret(self, fresh_db):
+        secret = fresh_db.create_connector_mcp_api_key("agent-1", "owner")
+        key = fresh_db.get_connector_mcp_api_key("agent-1")
+        assert key is not None
+        assert key.key_prefix == secret.api_key[:20]
+        assert not hasattr(key, "api_key")  # McpApiKey has no secret field
+
+    def test_validates_as_connector_scope(self, fresh_db):
+        secret = fresh_db.create_connector_mcp_api_key("agent-1", "owner")
+        info = fresh_db.validate_mcp_api_key(secret.api_key)
+        assert info is not None
+        assert info["scope"] == "connector"
+        assert info["agent_name"] == "agent-1"
+
+    def test_regenerate_invalidates_old(self, fresh_db):
+        old = fresh_db.create_connector_mcp_api_key("agent-1", "owner")
+        new = fresh_db.regenerate_connector_mcp_api_key("agent-1", "owner")
+        assert new.api_key != old.api_key
+        # Old key no longer validates; new one does.
+        assert fresh_db.validate_mcp_api_key(old.api_key) is None
+        assert fresh_db.validate_mcp_api_key(new.api_key) is not None
+
+    def test_revoke(self, fresh_db):
+        secret = fresh_db.create_connector_mcp_api_key("agent-1", "owner")
+        assert fresh_db.delete_connector_mcp_api_key("agent-1") is True
+        assert fresh_db.get_connector_mcp_api_key("agent-1") is None
+        assert fresh_db.validate_mcp_api_key(secret.api_key) is None
+
+    def test_connector_key_distinct_from_agent_key(self, fresh_db):
+        # The auto-minted agent-scoped key and the connector key coexist.
+        fresh_db.create_agent_mcp_api_key("agent-1", "owner")
+        conn = fresh_db.create_connector_mcp_api_key("agent-1", "owner")
+        agent_key = fresh_db.get_agent_mcp_api_key("agent-1")
+        conn_key = fresh_db.get_connector_mcp_api_key("agent-1")
+        assert agent_key.scope == "agent"
+        assert conn_key.scope == "connector"
+        # Revoking the connector key leaves the agent key intact.
+        fresh_db.delete_connector_mcp_api_key("agent-1")
+        assert fresh_db.get_agent_mcp_api_key("agent-1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Exposed-playbook resolution (pure)
+# ---------------------------------------------------------------------------
+
+class TestPlaybookResolution:
+    def _live(self):
+        return [
+            {"name": "cso", "description": "audit", "user_invocable": True, "automation": "gated", "argument_hint": "[--x]"},
+            {"name": "internal-only", "user_invocable": False},
+            {"name": "commit", "user_invocable": True},
+        ]
+
+    def test_allow_list_filters(self):
+        from services.connector_service import resolve_exposed_playbooks
+        out = resolve_exposed_playbooks(self._live(), ["cso"])
+        assert [p.name for p in out] == ["cso"]
+        assert out[0].argument_hint == "[--x]"
+        assert out[0].automation == "gated"
+
+    def test_none_exposes_all_user_invocable(self):
+        from services.connector_service import resolve_exposed_playbooks
+        out = resolve_exposed_playbooks(self._live(), None)
+        assert {p.name for p in out} == {"cso", "commit"}  # internal-only excluded
+
+    def test_user_invocable_false_never_exposed(self):
+        from services.connector_service import resolve_exposed_playbooks
+        # Even if explicitly allow-listed, a non-user-invocable playbook is hidden.
+        out = resolve_exposed_playbooks(self._live(), ["internal-only", "cso"])
+        assert [p.name for p in out] == ["cso"]
+
+
+# ---------------------------------------------------------------------------
+# Per-client snippet builder (pure)
+# ---------------------------------------------------------------------------
+
+class TestSnippets:
+    def test_name_slug(self):
+        from services.connector_service import connector_name
+        assert connector_name("My Agent!") == "trinity-my-agent"
+
+    def test_snippets_embed_key_and_url(self):
+        from services.connector_service import build_snippets
+        snips = build_snippets("agent-1", "http://localhost:8080/mcp", "trinity_mcp_SECRET")
+        clients = {s.client for s in snips}
+        assert {"claude-code", "cursor", "claude-desktop"} <= clients
+        for s in snips:
+            assert "trinity_mcp_SECRET" in s.content
+            assert "http://localhost:8080/mcp" in s.content
+        cli = next(s for s in snips if s.client == "claude-code")
+        assert cli.content.startswith("claude mcp add --transport http")
+
+
+# ---------------------------------------------------------------------------
+# Connector-scope auth boundary (pure)
+# ---------------------------------------------------------------------------
+
+class TestAuthBoundary:
+    def _user(self, connector_agent=None, role="creator"):
+        from models import User
+        return User(id=1, username="owner", role=role, connector_agent=connector_agent)
+
+    def test_non_connector_is_noop(self):
+        from dependencies import _enforce_connector_scope
+        _enforce_connector_scope(self._user(), "agent-1", owner_op=True)  # no raise
+
+    def test_connector_blocked_on_owner_op(self):
+        from fastapi import HTTPException
+        from dependencies import _enforce_connector_scope
+        with pytest.raises(HTTPException) as exc:
+            _enforce_connector_scope(self._user(connector_agent="agent-1"), "agent-1", owner_op=True)
+        assert exc.value.status_code == 403
+
+    def test_connector_fenced_to_bound_agent(self):
+        from fastapi import HTTPException
+        from dependencies import _enforce_connector_scope
+        # Read access to a DIFFERENT agent is refused.
+        with pytest.raises(HTTPException) as exc:
+            _enforce_connector_scope(self._user(connector_agent="agent-1"), "agent-2", owner_op=False)
+        assert exc.value.status_code == 403
+        # Read access to the bound agent is allowed.
+        _enforce_connector_scope(self._user(connector_agent="agent-1"), "agent-1", owner_op=False)
+
+    def test_connector_rejected_from_role_gate(self):
+        from fastapi import HTTPException
+        from dependencies import _reject_connector_principal
+        with pytest.raises(HTTPException) as exc:
+            _reject_connector_principal(self._user(connector_agent="agent-1", role="admin"))
+        assert exc.value.status_code == 403
+        # Ordinary principal passes.
+        _reject_connector_principal(self._user())


### PR DESCRIPTION
## Summary

PR1 (backend + MCP) of the **per-agent MCP connector** (trinity-enterprise#46): expose a single agent as an MCP connector an end user adds to their AI client (Claude Code, Cursor, Claude Desktop) in one line, turning the agent's `user_invocable` playbooks (`.claude/skills/`) into MCP tools. The agent holds credentials server-side; only a scoped, revocable key reaches the client. A new client-sharing channel alongside Slack/Telegram/WhatsApp/VoIP/public links.

**Decisions (confirmed up front):** OSS core (the #847 entitlement seam can wrap it behind `requires_entitlement('mcp_connector')` later with a ~1-line diff); first PR is **backend + key + MCP tools** (Sharing-tab UI is PR2). The per-user SSO/RFC-8693 tier is a separate enterprise epic, out of scope.

## What's in this PR

**Backend**
- `agent_connectors` table (config: `enabled` + exposed-playbook allow-list) — dual-track migration (SQLite `agent_connectors_table` + Alembic `0006_agent_connectors`) + `db/tables.py`; cascade/rename registered in `AGENT_REFS`.
- `mcp_api_keys.scope='connector'`: a separate, owner-bound, SHA-256-hashed, independently-revocable key with **regenerate** (revoke-old → mint-new) so a leaked copy-paste snippet is cut off. Distinct from the auto-minted `scope='agent'` key.
- `routers/connectors.py`: owner CRUD (`GET` status / `PUT` config / `POST` key / `DELETE` key) + connector-key-readable `GET /connector/playbooks`. `services/connector_service.py` (pure) builds **per-client copy-paste snippets with the key pre-embedded** (Claude Code `claude mcp add` + `.mcp.json`, Cursor `mcpServers`, Claude Desktop) and resolves exposed = allow-list ∩ `user_invocable` (a `user_invocable:false` playbook is **never** exposed). Raw key returned **once**.
- **Auth boundary (security-critical):** a connector key resolves to the owner but is consumption-only — `_enforce_connector_scope` fences it to its bound agent on read/chat and refuses owner ops (`OwnedAgent*` → 403); `_reject_connector_principal` blocks every role-gated endpoint (`require_role`/`require_admin`). A leaked snippet can chat its one agent and nothing else.

**MCP server**
- `scope='connector'` added; `connector.ts` tools `list_playbooks` / `run_playbook` / `ask` gated by FastMCP `canAccess` so connector keys see **ONLY** these and operator keys never do. The agent comes from the bound key, never a tool arg; `run_playbook` re-checks exposure server-side before dispatching via chat.

**Three-surface sync (Invariant #13):** backend router + DB, MCP server tools; no agent-server change (reuses the existing `/api/skills` playbook list + chat).

## Testing
- `tests/unit/test_connectors.py` — **21** (config CRUD, key lifecycle incl. regenerate-invalidates-old, playbook resolution + `user_invocable` exclusion, snippet builder, auth boundary).
- `src/mcp-server/src/connector.test.ts` — **5** (tool shape, bound-agent enforcement, run_playbook exposure refusal); full MCP suite 36 pass, `tsc` build clean.
- schema-parity + alembic-parity + agent-cleanup-parity + migrations + postgres-schema green; auth/dependency regression (173) green.

## Deferred (fast-follow)
- `automation: gated` approval routing — only the 5s file-based operator queue exists (no synchronous approval primitive); a gated playbook would need create-item-then-poll.
- ChatGPT connector polish.
- **Sharing-tab connector UI (PR2)** — the per-client copy-paste panel + regenerate/revoke button (the backend already returns the snippets).

## Docs
`architecture.md` (subsystem block + MCP tool row + endpoints + `agent_connectors` DDL + `scope='connector'`) and `requirements.md` §44.

Related to Abilityai/trinity-enterprise#46

🤖 Generated with [Claude Code](https://claude.com/claude-code)