### PR TITLE
feat(mcp): agent-defined pipeline introspection tools (#919)

### DIFF
--- a/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
+++ b/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
@@ -1245,6 +1245,74 @@ widgets:
 
 ---
 
+## Agent-Defined Pipelines (#919)
+
+If your agent runs a long-running, multi-stage pipeline (e.g. perception → incubation → synthesis → publish → measure), you can make its shape and live state **uniformly discoverable** by Trinity — **without** Trinity owning the DAG, the execution, or the recovery. You own all of that (via schedules, events, the operator queue, and the pre-check hook); Trinity only **reads** two files you publish.
+
+### The file contract
+
+Publish two kinds of file inside your container:
+
+```
+~/.trinity/pipelines/<pipeline_id>.yaml                  # definition (the DAG)
+~/.trinity/pipeline-state/<pipeline_id>/<instance_id>.json  # live state per instance
+```
+
+- **`<pipeline_id>`** and **`<instance_id>`** must match `^[A-Za-z0-9._-]+$` (no `/`, no `..`). Trinity interpolates them into read paths and rejects anything else.
+- **`<instance_id>` SHOULD be time-sortable.** Trinity selects the *latest* instance by the state file's mtime, tie-broken by `instance_id` lexically.
+- Authoritative schemas (validate your files against these):
+  - [`docs/schemas/agent-pipeline.schema.json`](schemas/agent-pipeline.schema.json) — the definition
+  - [`docs/schemas/agent-pipeline-state.schema.json`](schemas/agent-pipeline-state.schema.json) — the state. **Required:** `instance_id`, `current_stage`, `health`, `updated_at` (ISO-8601), `escalations` (array). Trinity reads exactly these for its summary.
+
+Minimal example:
+
+```yaml
+# ~/.trinity/pipelines/research.yaml
+id: research
+name: Daily Research Pipeline
+stages:
+  - id: collect
+  - id: synthesize
+  - id: publish
+```
+
+```json
+// ~/.trinity/pipeline-state/research/2026-06-26T1200.json
+{
+  "instance_id": "2026-06-26T1200",
+  "pipeline_id": "research",
+  "current_stage": "synthesize",
+  "health": "green",
+  "updated_at": "2026-06-26T12:05:00Z",
+  "escalations": []
+}
+```
+
+### Reading it back (MCP tools)
+
+Two thin, read-only MCP tools wrap the existing agent file-browser surface — no new backend endpoint, no Trinity-side DB:
+
+- **`list_agent_pipelines(agent_name)`** — enumerates `pipelines/*.yaml`, each with a health summary from its latest instance (`current_stage`, `health`, `open_escalations`, `updated_at`). Returns `[]` when you publish no pipelines. A *stopped/unreachable* agent surfaces a real error, not an empty list (the files live in the container).
+- **`get_agent_pipeline_state(agent_name, pipeline_id, instance_id?)`** — the full parsed state JSON for one instance; omit `instance_id` for the latest. A missing pipeline/instance returns a clean not-found (never a 500).
+
+`open_escalations` counts `escalations[]` entries that are still open — an entry is open unless it carries `open: false`, `resolved: true`, or `status` in `{resolved, closed, done}`.
+
+### Grouping escalations by pipeline (operator-queue convention)
+
+When you escalate a stuck stage to the **operator queue**, put the pipeline coordinates in the queue item's free-form `context` JSON so escalations group by pipeline in the UI — **no Trinity schema change**:
+
+```json
+{ "pipeline_id": "research", "instance_id": "2026-06-26T1200", "stage": "synthesize" }
+```
+
+### Driving it (agent-side heartbeat — not Trinity)
+
+Stage advancement, retry, and escalation are owned by your agent: run a single `pipeline-tick` skill on a cron schedule, gated by your `~/.trinity/pre-check` hook so it's near-free when nothing needs attention. That heartbeat ships with the **`agent-dev:add-pipeline`** plugin in [`abilityai/abilities`](https://github.com/abilityai/abilities), **not** with Trinity.
+
+> **Adoption note:** these tools ship as MCP + docs only. Existing agents return `[]` until they adopt this file convention — that's by design, not a bug.
+
+---
+
 ## Memory Management
 
 Agents manage their own memory. Trinity provides storage, not strategy. Each agent can implement memory however it sees fit.

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -244,7 +244,7 @@ Channel DB modules: `db/slack_channels.py` (workspace connections, channel-agent
 
 FastMCP, Streamable HTTP transport, port 8080. API-key auth via `Authorization: Bearer` header; FastMCP `authenticate` callback validates keys against the backend and stores an `McpAuthContext` in session: `{userId, userEmail, keyName, agentName?, scope: "user"|"agent", mcpApiKey}`. Agent-to-agent collaboration uses agent-scoped keys for access control.
 
-**Tools** across 20 tool modules (`src/tools/`):
+**Tools** across 21 tool modules (`src/tools/`):
 
 | Module | Tools | Description |
 |--------|-------|-------------|
@@ -264,6 +264,7 @@ FastMCP, Streamable HTTP transport, port 8080. API-key auth via `Authorization: 
 | `channels.ts` (2) | `list_channel_groups`, `send_group_message` | Channel group discovery and proactive group messaging (#349) |
 | `messages.ts` (1) | `send_message` | Proactive user messaging by verified email (#321) |
 | `files.ts` (1) | `share_file` | Publish file from `/home/developer/public/`, return download URL (FILES-001) |
+| `pipelines.ts` (2) | `list_agent_pipelines`, `get_agent_pipeline_state` | Read-only introspection of an agent's self-published pipelines (`~/.trinity/pipelines/*.yaml` + `~/.trinity/pipeline-state/<id>/<instance>.json`) over the **existing** `agent_files` surface — no backend/DB change (Invariant #8). Strict `^[A-Za-z0-9._-]+$` id validation (path-traversal guard), hardened YAML parse (size cap + dup-key + alias guard), latest-instance by mtime, only-404→empty (#919) |
 | `loops.ts` (3) | `run_agent_loop`, `get_loop_status`, `stop_loop` | Sequential bounded task execution (#740) |
 | `memory.ts` (1) | `write_user_memory` | Per-user memory blob; user email resolved server-side from execution_id (MEM-001, #888) |
 | `voip.ts` (1) | `call_user` | Outbound phone call via Twilio Media Streams; server-gated + rate-limited (VOIP-001, #1056) |

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -2432,7 +2432,7 @@ Standalone mobile-friendly admin page for managing agents on the go. Designed as
 ## 34. Agent-Defined Pipelines (#919)
 
 ### 34.1 Standardized Pipeline Introspection Surface (#919)
-- **Status**: 📋 Planned
+- **Status**: ✅ Implemented (2026-06-26)
 - **Implements**: Issue #919
 - **Description**: Trinity-compatible agents that run long-running
   multi-stage pipelines (perception → incubation → synthesis → publish →
@@ -2477,6 +2477,26 @@ Standalone mobile-friendly admin page for managing agents on the go. Designed as
   (expressed as event chains between independent per-agent pipelines);
   GUI editor for `pipeline.yaml`; persisting pipeline state in
   Trinity's database.
+- **Implementation** (2026-06-26): shipped as an **MCP-only** change —
+  `src/mcp-server/src/tools/pipelines.ts` adds the two tools over the
+  **existing** `GET /api/agents/{name}/files` (recursive list) and
+  `/files/download` (read) surfaces via two new thin client methods
+  (`listAgentFiles`/`downloadAgentFile`, sharing a `_fetch` helper). No
+  backend router/service, no agent-server endpoint, no DB table (Invariant
+  #8/#13 satisfied by reuse). Hardening: `pipeline_id`/`instance_id` are
+  zod-validated `^[A-Za-z0-9._-]+$` and reject `..`/`/`/encoded-slashes
+  **before** any download (the download endpoint has no deny-list — a P1
+  traversal guard); definition YAML is parsed with a 256 KiB pre-parse size
+  cap + duplicate-key rejection + alias-expansion guard, and a malformed
+  single file is an item-level error that never aborts the list. Latest
+  instance is selected by state-file mtime (tie-break: lexical
+  `instance_id`), keeping the read fan-out at one download per pipeline
+  (capped at 50 pipelines, truncation logged). Error contract: only a 404
+  maps to empty/not-found; a 400 (agent stopped) or 5xx (unreachable)
+  surfaces as a distinct real error. Authoritative file schemas live in
+  `docs/schemas/agent-pipeline.schema.json` and
+  `agent-pipeline-state.schema.json`; the agent guide documents the
+  contract, the operator-queue `context` convention, and the adoption note.
 ## 35. Enterprise Edition Architecture (#847)
 
 ### 35.1 Open-Core Seam — Private Submodule Integration (#847)

--- a/docs/schemas/agent-pipeline-state.schema.json
+++ b/docs/schemas/agent-pipeline-state.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trinity.abilityai.dev/schemas/agent-pipeline-state.schema.json",
+  "title": "Trinity Agent Pipeline Instance State",
+  "description": "Runtime state of one instance of an agent-defined pipeline, published by the agent at ~/.trinity/pipeline-state/<pipeline_id>/<instance_id>.json. Trinity reads this file via the get_agent_pipeline_state MCP tool (and the latest instance per pipeline via list_agent_pipelines). The agent is the sole writer; Trinity never mutates it. The fields the MCP tools depend on are listed in `required`.",
+  "type": "object",
+  "properties": {
+    "instance_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+$",
+      "description": "Instance identifier. SHOULD equal the <instance_id> in the filename and SHOULD be time-sortable (e.g. an ISO-like or monotonic id) — list/latest selection orders instances by file mtime and tie-breaks on this id lexically. Must match ^[A-Za-z0-9._-]+$."
+    },
+    "pipeline_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+$",
+      "description": "Id of the pipeline this instance belongs to (matches the parent directory / the definition file's id)."
+    },
+    "current_stage": {
+      "type": "string",
+      "description": "Id of the stage the instance is currently in (matches a stage id in the definition)."
+    },
+    "health": {
+      "type": "string",
+      "description": "Coarse health of the instance.",
+      "examples": ["green", "yellow", "red", "blocked", "complete"]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of the last state update. The authoritative semantic 'last touched' time. The agent SHOULD write the file whenever it advances state, so the file mtime tracks this value (the MCP tools select the latest instance by mtime + instance_id, and surface updated_at to the consumer)."
+    },
+    "attempt": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Attempt count for the current stage (drives the agent's retry/escalation policy)."
+    },
+    "blockers": {
+      "type": "array",
+      "description": "Active blockers preventing progress (free-form, agent-defined).",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "escalations": {
+      "type": "array",
+      "description": "Escalations raised for this instance. The MCP layer reports the count of OPEN escalations (an entry is open unless it carries open=false, resolved=true, or status in {resolved, closed, done}; an entry with no recognisable status counts as open). When an escalation is also filed to the operator queue, that queue item's context SHOULD carry { pipeline_id, instance_id, stage }.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "stage": { "type": "string", "description": "Stage the escalation was raised from." },
+          "status": {
+            "type": "string",
+            "description": "Lifecycle status. open|pending|... is treated as open; resolved|closed|done is treated as closed.",
+            "examples": ["open", "resolved", "closed"]
+          },
+          "open": { "type": "boolean", "description": "Explicit open flag (takes precedence over status)." },
+          "resolved": { "type": "boolean", "description": "Explicit resolved flag." },
+          "reason": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "stages": {
+      "type": "object",
+      "description": "Per-stage runtime metrics, keyed by stage id (durations, attempt counts, costs, last error, etc.). Free-form, agent-defined.",
+      "additionalProperties": { "type": "object", "additionalProperties": true }
+    }
+  },
+  "required": ["instance_id", "current_stage", "health", "updated_at", "escalations"],
+  "additionalProperties": true
+}

--- a/docs/schemas/agent-pipeline.schema.json
+++ b/docs/schemas/agent-pipeline.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trinity.abilityai.dev/schemas/agent-pipeline.schema.json",
+  "title": "Trinity Agent Pipeline Definition",
+  "description": "Definition of an agent-defined, long-running multi-stage pipeline, published by the agent at ~/.trinity/pipelines/<pipeline_id>.yaml. Trinity reads this file via the list_agent_pipelines MCP tool to produce a summary; it does NOT own or execute the DAG (Architectural Invariant #8). The agent owns stage advancement, retry, and escalation via its own primitives (schedules, events, operator queue, the pre-check hook). This schema is the authoritative documentation contract; the MCP tool parses the YAML only to summarise name/stages and does not run a hard validator.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+$",
+      "description": "Stable pipeline identifier. SHOULD equal the <pipeline_id> in the filename. Must match ^[A-Za-z0-9._-]+$ (the same grammar the MCP tools enforce on path-interpolated ids)."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable pipeline name."
+    },
+    "description": {
+      "type": "string",
+      "description": "What this pipeline does."
+    },
+    "version": {
+      "type": ["string", "number"],
+      "description": "Definition version, bumped by the agent when the DAG shape changes."
+    },
+    "stages": {
+      "type": "array",
+      "description": "Ordered list of stages in the pipeline (e.g. perception -> incubation -> synthesis -> publish -> measure).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stage identifier, unique within the pipeline. Used as current_stage in the state file."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable stage name."
+          },
+          "description": {
+            "type": "string",
+            "description": "What the stage does."
+          },
+          "preconditions": {
+            "type": "array",
+            "description": "Conditions the agent checks before entering this stage. Free-form; evaluated by the agent, not Trinity.",
+            "items": { "type": "string" }
+          },
+          "transitions": {
+            "type": "array",
+            "description": "Allowed next stages and the conditions that select them. Owned and evaluated by the agent.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "to": { "type": "string", "description": "Target stage id." },
+                "when": { "type": "string", "description": "Condition expression (agent-evaluated)." }
+              },
+              "required": ["to"],
+              "additionalProperties": true
+            }
+          },
+          "retry": {
+            "type": "object",
+            "description": "Per-stage retry policy applied by the agent's heartbeat.",
+            "properties": {
+              "max_attempts": { "type": "integer", "minimum": 0 },
+              "backoff_seconds": { "type": "number", "minimum": 0 }
+            },
+            "additionalProperties": true
+          },
+          "escalation": {
+            "type": "object",
+            "description": "When/how the agent escalates a stuck stage to the operator queue. The queue item's context SHOULD carry { pipeline_id, instance_id, stage } so escalations group by pipeline.",
+            "additionalProperties": true
+          }
+        },
+        "required": ["id"],
+        "additionalProperties": true
+      }
+    },
+    "retry": {
+      "type": "object",
+      "description": "Pipeline-level default retry policy (stages may override).",
+      "additionalProperties": true
+    },
+    "escalation": {
+      "type": "object",
+      "description": "Pipeline-level default escalation policy (stages may override).",
+      "additionalProperties": true
+    }
+  },
+  "required": ["stages"],
+  "additionalProperties": true
+}

--- a/docs/security-reports/cso-2026-06-26-diff.json
+++ b/docs/security-reports/cso-2026-06-26-diff.json
@@ -1,0 +1,107 @@
+{
+  "version": "1.0",
+  "date": "2026-06-26",
+  "mode": "daily",
+  "scope": "diff",
+  "base": "origin/dev (85546c74)",
+  "branch": "AndriiPasternak31/issue-919",
+  "subject": "#919 — agent-defined pipeline introspection MCP tools (list_agent_pipelines, get_agent_pipeline_state)",
+  "phases_run": [0, 1, 2, 3, 4, 5, 6, 7, 9, 12, 13, 14],
+  "changed_surface": {
+    "new_mcp_tools": ["list_agent_pipelines", "get_agent_pipeline_state"],
+    "new_files": [
+      "src/mcp-server/src/tools/pipelines.ts",
+      "src/mcp-server/src/pipelines.test.ts",
+      "docs/schemas/agent-pipeline.schema.json",
+      "docs/schemas/agent-pipeline-state.schema.json"
+    ],
+    "modified_files": [
+      "src/mcp-server/src/client.ts",
+      "src/mcp-server/src/server.ts",
+      "src/mcp-server/src/types.ts",
+      "src/mcp-server/package.json",
+      "src/mcp-server/package-lock.json",
+      "docs/memory/architecture.md",
+      "docs/memory/requirements.md",
+      "docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md"
+    ],
+    "new_backend_endpoints": 0,
+    "new_db_tables": 0,
+    "ci_changes": 0,
+    "dockerfile_changes": 0,
+    "env_changes": 0
+  },
+  "findings": [],
+  "verified_safe": [
+    {
+      "surface": "Path traversal via pipeline_id / instance_id",
+      "sink": "client.downloadAgentFile/listAgentFiles -> GET /api/agents/{name}/files[/download]?path=",
+      "guards": [
+        "MCP idSchema: regex ^[A-Za-z0-9._-]+$ rejects '/', '%', '\\\\'; .refine rejects '..' substring",
+        "Only pipeline_id/instance_id are user-controlled path segments (get_agent_pipeline_state); list_agent_pipelines interpolates no user input (paths come from backend file tree)",
+        "agent-server confines reads via Path(path).resolve() + startswith('/home/developer') — collapses any '..' and cannot escape container home",
+        "backend can_user_access_agent() gates every /files call — user reads only their own accessible agent's files (no cross-tenant reach)"
+      ],
+      "conclusion": "Two independent traversal guards; no cross-tenant exposure. Worst case is reading one's own accessible agent's home files."
+    },
+    {
+      "surface": "YAML parsing of attacker-influenced pipeline definitions",
+      "guard": "parseYamlHardened: 256 KiB size-cap BEFORE parse; uniqueKeys (dup-key reject); maxAliasCount 100 (billion-laughs guard). JS 'yaml' lib instantiates no arbitrary classes (no PyYAML-style RCE surface).",
+      "conclusion": "Hardened; no parse-bomb or code-exec surface."
+    },
+    {
+      "surface": "JSON state parsing",
+      "guard": "readInstanceState size-caps to 256 KiB then JSON.parse; parsed object is read-only (countOpenEscalations) and re-serialized — no Object.assign/merge sink, so no prototype pollution.",
+      "conclusion": "Safe."
+    },
+    {
+      "surface": "Authentication / authorization",
+      "guard": "getClient(context.session) uses the caller's own MCP API key (mirrors files.ts); backend enforces agent ownership/sharing. No new auth surface, no internal-secret endpoint.",
+      "conclusion": "Consistent with existing pattern; access correctly delegated."
+    },
+    {
+      "surface": "client._fetch refactor (extracted from request)",
+      "guard": "auth header + single 401-reauth-retry + error mapping preserved; request() decodes JSON, downloadAgentFile() decodes text. No behavioral/security regression.",
+      "conclusion": "Safe refactor."
+    },
+    {
+      "surface": "Supply chain — new dep 'yaml' ^2.6.1 (resolved 2.9.0)",
+      "guard": "Widely-used pure-JS parser (eemeli/yaml); lockfile updated and tracked; no install/preinstall/postinstall scripts; no known high/critical CVE with a reachable path.",
+      "conclusion": "Low risk."
+    },
+    {
+      "surface": "DoS / fan-out",
+      "guard": "MAX_PIPELINES=50 cap with explicit log on truncation (no silent cap); one download per pipeline via mtime-based latest-instance selection.",
+      "conclusion": "Bounded (DoS is a hard-exclusion category regardless)."
+    },
+    {
+      "surface": "ReDoS",
+      "guard": "ID_PATTERN and httpStatusFromError regexes are linear character-classes — no catastrophic backtracking.",
+      "conclusion": "Safe."
+    }
+  ],
+  "secrets_archaeology": "No secret patterns (sk-, ghp_, xox-, AKIA) introduced in diff. No .env tracked. No hardcoded credentials in new TS.",
+  "filter_stats": {
+    "candidates_considered": 3,
+    "below_gate_demoted": 3,
+    "demoted_notes": [
+      "agent-server prefix check startswith('/home/developer') admits sibling-prefix dirs (e.g. /home/developer-x) — PRE-EXISTING, out of --diff scope, not exploitable (no sibling dir, cannot be created).",
+      "agent_name param is z.string().min(1), not pattern-validated — matches every existing tool; encodeURIComponent + Starlette non-decoding of %2F + backend agent-existence check make it non-exploitable.",
+      "Backend error text echoed in fail() messages — own agent only, negligible info disclosure."
+    ]
+  },
+  "totals": {
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 0,
+    "total": 0
+  },
+  "trend": {
+    "prior_report": "docs/security-reports/cso-2026-06-25-1131-diff.json",
+    "resolved": [],
+    "persistent": [],
+    "new": [],
+    "direction": "clean — no findings at the 8/10 daily gate"
+  }
+}

--- a/docs/security-reports/cso-2026-06-26-diff.md
+++ b/docs/security-reports/cso-2026-06-26-diff.md
@@ -1,0 +1,49 @@
+# CSO Security Audit — `--diff` (daily, 8/10 gate)
+
+**Date:** 2026-06-26 · **Branch:** `AndriiPasternak31/issue-919` · **Base:** `origin/dev` (85546c74)
+**Subject:** #919 — agent-defined pipeline introspection MCP tools (`list_agent_pipelines`, `get_agent_pipeline_state`)
+
+## Result: ✅ No findings at or above the daily confidence gate.
+
+The change is a thin, read-only MCP-layer window over the **existing** `GET /api/agents/{name}/files[/download]` surface — no new backend endpoint, DB table, CI, Dockerfile, or env change. The diff is almost entirely the new `pipelines.ts` tool plus client/types/server wiring and docs.
+
+## Attack-surface census (diff scope)
+
+| Category | Count | Notes |
+|---|---|---|
+| New MCP tools | 2 | `list_agent_pipelines`, `get_agent_pipeline_state` |
+| New backend endpoints | 0 | reuses `agent_files` router |
+| New DB tables | 0 | — |
+| New dependency | 1 | `yaml` ^2.6.1 (→2.9.0) |
+| CI / Docker / `.env` changes | 0 | — |
+
+## Security-sensitive surfaces — all verified safe
+
+1. **Path traversal (`pipeline_id` / `instance_id` → download path).** The only user-controlled path segments are validated by `idSchema`: `^[A-Za-z0-9._-]+$` (rejects `/`, `%`, `\`) **plus** a `.refine` rejecting any `..` substring. `list_agent_pipelines` interpolates no user input — its paths come from the backend file tree. **Defense in depth:** the agent-server confines every read with `Path(path).resolve()` + `startswith("/home/developer")`, collapsing any `..` and barring container-home escape. **No cross-tenant reach:** `can_user_access_agent()` gates each call, so the worst case is reading one's own accessible agent's home files.
+
+2. **YAML parse hardening.** `parseYamlHardened` enforces a 256 KiB cap *before* parse, `uniqueKeys` (duplicate-key reject), and `maxAliasCount: 100` (billion-laughs). The JS `yaml` library instantiates no arbitrary classes — no PyYAML-style RCE surface.
+
+3. **JSON state parse.** Size-capped then `JSON.parse`; the result is only read and re-serialized (no `Object.assign`/merge sink) → no prototype-pollution path.
+
+4. **Auth/authz.** Uses the caller's own MCP API key (mirrors `files.ts`); backend enforces ownership/sharing. No internal-secret endpoint, no new auth surface.
+
+5. **`client._fetch` refactor.** Auth header + single 401-reauth-retry + error mapping preserved; `request()` decodes JSON, `downloadAgentFile()` decodes text. No security regression.
+
+6. **Supply chain.** `yaml` is a widely-used pure-JS parser; lockfile updated and tracked; no install scripts; no reachable high/critical CVE.
+
+7. **DoS / ReDoS.** `MAX_PIPELINES=50` with logged truncation (no silent cap); one download per pipeline. Both regexes are linear character-classes.
+
+8. **Secrets.** No secret patterns introduced; no `.env` tracked; no hardcoded creds.
+
+## Below-gate observations (demoted, not findings)
+
+- **agent-server prefix check** `startswith("/home/developer")` admits sibling-prefix dirs (e.g. `/home/developer-x`) — **pre-existing**, out of `--diff` scope, and not exploitable (no such sibling dir; can't be created).
+- **`agent_name` not pattern-validated** (`z.string().min(1)`) — matches every existing tool; `encodeURIComponent` + Starlette's non-decoding of `%2F` + the backend agent-existence check make it non-exploitable.
+- **Backend error text echoed** in `fail()` messages — own agent only; negligible disclosure.
+
+## Trend
+
+Prior `--diff` report: `cso-2026-06-25-1131-diff.json`. No new, persistent, or resolved findings — clean.
+
+---
+*AI-assisted scan, not a substitute for professional review. Read-only; no code changed.*

--- a/src/mcp-server/package-lock.json
+++ b/src/mcp-server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "fastmcp": "^4.3.2",
+        "yaml": "^2.6.1",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -1124,6 +1125,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1536,6 +1538,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2698,6 +2701,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/src/mcp-server/package.json
+++ b/src/mcp-server/package.json
@@ -21,6 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "fastmcp": "^4.3.2",
+    "yaml": "^2.6.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -24,6 +24,7 @@ import type {
   OperatorQueueItem,
   OperatorQueueListResponse,
   CompatibilityReport,
+  AgentFileTreeResponse,
 } from "./types.js";
 
 /**
@@ -148,14 +149,18 @@ export class TrinityClient {
   }
 
   /**
-   * Public request method for custom API calls
+   * Shared transport: auth header + single 401-reauth-retry + error mapping,
+   * returning the raw `Response` so callers choose how to decode the body
+   * (#919: the JSON `request` path and the plain-text `downloadAgentFile`
+   * path differ only in `.json()` vs `.text()` — they must not duplicate the
+   * auth/retry/error logic).
    */
-  async request<T>(
+  private async _fetch(
     method: string,
     path: string,
     body?: unknown,
     isRetry: boolean = false
-  ): Promise<T> {
+  ): Promise<Response> {
     if (!this.token) {
       throw new Error("Not authenticated. Call authenticate() first or setToken().");
     }
@@ -186,7 +191,7 @@ export class TrinityClient {
       const success = await this.reauthenticate();
       if (success) {
         console.log("Re-authentication successful, retrying request...");
-        return this.request<T>(method, path, body, true);
+        return this._fetch(method, path, body, true);
       }
     }
 
@@ -194,6 +199,20 @@ export class TrinityClient {
       const error = await response.text();
       throw new Error(`API error (${response.status}): ${error}`);
     }
+
+    return response;
+  }
+
+  /**
+   * Public request method for custom API calls
+   */
+  async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    isRetry: boolean = false
+  ): Promise<T> {
+    const response = await this._fetch(method, path, body, isRetry);
 
     // Handle 204 No Content (e.g., successful DELETE)
     if (response.status === 204) {
@@ -760,6 +779,54 @@ export class TrinityClient {
       `/api/agents/${encodeURIComponent(name)}/logs?tail=${lines}`
     );
     return response.logs;
+  }
+
+  // ============================================================================
+  // Agent Workspace Files (#919 — pipeline introspection read surface)
+  // ============================================================================
+
+  /**
+   * Recursively list files under a workspace directory via the existing
+   * `GET /api/agents/{name}/files` surface (no new backend endpoint). Returns
+   * a hierarchical tree; `path` values are relative to `/home/developer` and
+   * each node carries an ISO-8601 `modified` mtime. A missing directory
+   * surfaces as a 404 (mapped to `API error (404): …`) — callers decide
+   * whether that means "empty" or "not found".
+   *
+   * @param name - Agent name
+   * @param path - Directory to list (relative to home, e.g. `.trinity/pipelines`)
+   * @param showHidden - Include dot-prefixed entries (default true here: the
+   *   pipeline paths live under the hidden `.trinity` directory)
+   */
+  async listAgentFiles(
+    name: string,
+    path: string,
+    showHidden: boolean = true
+  ): Promise<AgentFileTreeResponse> {
+    return this.request<AgentFileTreeResponse>(
+      "GET",
+      `/api/agents/${encodeURIComponent(name)}/files` +
+        `?path=${encodeURIComponent(path)}&show_hidden=${showHidden}`
+    );
+  }
+
+  /**
+   * Download a single workspace file as plain text via the existing
+   * `GET /api/agents/{name}/files/download` surface. Uses the shared `_fetch`
+   * (auth + 401-retry + error mapping) but reads the body as text rather than
+   * JSON — the download endpoint returns `PlainTextResponse`.
+   *
+   * @param name - Agent name
+   * @param path - File path (relative to home, e.g.
+   *   `.trinity/pipelines/demo.yaml`)
+   */
+  async downloadAgentFile(name: string, path: string): Promise<string> {
+    const response = await this._fetch(
+      "GET",
+      `/api/agents/${encodeURIComponent(name)}/files/download` +
+        `?path=${encodeURIComponent(path)}`
+    );
+    return response.text();
   }
 
   // ============================================================================

--- a/src/mcp-server/src/pipelines.test.ts
+++ b/src/mcp-server/src/pipelines.test.ts
@@ -1,0 +1,677 @@
+/**
+ * Tests for #919 — agent-defined pipeline introspection MCP tools.
+ *
+ * Covers the pure helpers (id grammar, latest-instance selection, hardened
+ * YAML parse, escalation counting) and the two tools end-to-end against a
+ * mocked TrinityClient: empty case, multi-pipeline parse + latest pick,
+ * zero-instance pipeline, malformed-file item isolation, get_state explicit /
+ * latest / not-found / malformed, the P1 path-traversal rejection, and
+ * error discrimination (stopped 400 / unreachable 503 ≠ empty/not-found).
+ * Also pins that the client's JSON `request` and text `downloadAgentFile`
+ * share one `_fetch` (auth + 401-retry + error mapping).
+ *
+ * Runner: built-in `node:test`. Run via:
+ *   node --import tsx --test src/*.test.ts
+ */
+import { describe, it, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  createPipelineTools,
+  stripExtension,
+  flattenFiles,
+  pickLatestInstanceNode,
+  countOpenEscalations,
+  summarizeDefinition,
+  summarizeInstance,
+  parseYamlHardened,
+  httpStatusFromError,
+  isNotFound,
+} from "./tools/pipelines.js";
+import { TrinityClient } from "./client.js";
+import type { AgentFileNode } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PIPELINES_DIR = ".trinity/pipelines";
+const STATE_DIR = ".trinity/pipeline-state";
+
+const apiErr = (status: number, detail = "") =>
+  new Error(`API error (${status}): ${detail}`);
+
+const fileNode = (
+  name: string,
+  path: string,
+  modified?: string
+): AgentFileNode => ({ name, path, type: "file", modified });
+
+const dirNode = (name: string, children: AgentFileNode[]): AgentFileNode => ({
+  name,
+  path: `${STATE_DIR}/${name}`,
+  type: "directory",
+  children,
+});
+
+const tree = (nodes: AgentFileNode[]) => ({
+  base_path: "/home/developer",
+  requested_path: ".",
+  tree: nodes,
+  total_files: 0,
+  show_hidden: true,
+});
+
+/**
+ * Build the tools over a fake client whose `listAgentFiles`/`downloadAgentFile`
+ * are routed by path. `requireApiKey=false` so getClient() returns the fake
+ * directly. Records every download path so tests can assert the fan-out shape.
+ */
+function makeTools(routes: {
+  list?: (path: string) => Promise<unknown>;
+  download?: (path: string) => Promise<string>;
+}) {
+  const downloadCalls: string[] = [];
+  const listCalls: string[] = [];
+  const fake = {
+    getBaseUrl: () => "http://x",
+    setToken: () => {},
+    listAgentFiles: async (_name: string, path: string) => {
+      listCalls.push(path);
+      if (!routes.list) throw apiErr(404, "Path not found");
+      return routes.list(path);
+    },
+    downloadAgentFile: async (_name: string, path: string) => {
+      downloadCalls.push(path);
+      if (!routes.download) throw apiErr(404, "File not found");
+      return routes.download(path);
+    },
+  };
+  const tools = createPipelineTools(fake as unknown as TrinityClient, false);
+  return { tools, downloadCalls, listCalls };
+}
+
+const run = async (tool: any, params: any): Promise<any> =>
+  JSON.parse(await tool.execute(params, undefined));
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("#919 pure helpers", () => {
+  it("stripExtension drops the last extension", () => {
+    assert.equal(stripExtension("demo.yaml"), "demo");
+    assert.equal(stripExtension("inst-1.json"), "inst-1");
+    assert.equal(stripExtension("noext"), "noext");
+    assert.equal(stripExtension(".hidden"), ".hidden");
+  });
+
+  it("flattenFiles collects files depth-first, skipping dirs", () => {
+    const nodes: AgentFileNode[] = [
+      dirNode("demo", [
+        fileNode("inst-1.json", "a/inst-1.json"),
+        fileNode("inst-2.json", "a/inst-2.json"),
+      ]),
+      fileNode("top.yaml", "top.yaml"),
+    ];
+    assert.deepEqual(
+      flattenFiles(nodes).map((f) => f.name),
+      ["inst-1.json", "inst-2.json", "top.yaml"]
+    );
+    assert.deepEqual(flattenFiles(undefined), []);
+  });
+
+  it("pickLatestInstanceNode selects newest mtime, tie-broken by name desc", () => {
+    const nodes = [
+      fileNode("inst-1.json", "p/inst-1.json", "2026-01-01T00:00:00Z"),
+      fileNode("inst-3.json", "p/inst-3.json", "2026-01-03T00:00:00Z"),
+      fileNode("inst-2.json", "p/inst-2.json", "2026-01-02T00:00:00Z"),
+    ];
+    assert.equal(pickLatestInstanceNode(nodes)?.name, "inst-3.json");
+
+    // Same mtime → lexical filename desc.
+    const tied = [
+      fileNode("inst-a.json", "p/inst-a.json", "2026-01-01T00:00:00Z"),
+      fileNode("inst-c.json", "p/inst-c.json", "2026-01-01T00:00:00Z"),
+      fileNode("inst-b.json", "p/inst-b.json", "2026-01-01T00:00:00Z"),
+    ];
+    assert.equal(pickLatestInstanceNode(tied)?.name, "inst-c.json");
+
+    assert.equal(pickLatestInstanceNode([]), null);
+    // Ignores non-.json entries.
+    assert.equal(
+      pickLatestInstanceNode([fileNode("note.txt", "p/note.txt")]),
+      null
+    );
+  });
+
+  it("countOpenEscalations counts open/unresolved, conservative on unknown", () => {
+    assert.equal(countOpenEscalations({ escalations: [] }), 0);
+    assert.equal(countOpenEscalations({}), 0);
+    assert.equal(countOpenEscalations(null), 0);
+    assert.equal(
+      countOpenEscalations({
+        escalations: [
+          { status: "open" },
+          { status: "resolved" },
+          { resolved: false },
+          { resolved: true },
+          { open: true },
+          { open: false },
+          { note: "no status field" }, // conservative → open
+        ],
+      }),
+      4
+    );
+  });
+
+  it("summarizeDefinition is shape-tolerant", () => {
+    assert.deepEqual(summarizeDefinition(null), { stages: [], stage_count: 0 });
+    const s = summarizeDefinition({
+      name: "Demo",
+      description: "d",
+      version: 2,
+      stages: [{ id: "a" }, { name: "b" }, "c"],
+    });
+    assert.deepEqual(s.stages, ["a", "b", "c"]);
+    assert.equal(s.stage_count, 3);
+    assert.equal(s.name, "Demo");
+  });
+
+  it("summarizeInstance falls back to the filename id and reports escalations", () => {
+    const s = summarizeInstance(
+      {
+        current_stage: "synthesis",
+        health: "green",
+        updated_at: "2026-01-02T00:00:00Z",
+        escalations: [{ status: "open" }],
+      },
+      "inst-2"
+    );
+    assert.equal(s.instance_id, "inst-2");
+    assert.equal(s.current_stage, "synthesis");
+    assert.equal(s.health, "green");
+    assert.equal(s.open_escalations, 1);
+
+    // Prefers the in-file instance_id when present.
+    assert.equal(
+      summarizeInstance({ instance_id: "real" }, "fallback").instance_id,
+      "real"
+    );
+  });
+
+  it("parseYamlHardened parses valid YAML and rejects duplicate keys / oversize", () => {
+    assert.deepEqual(parseYamlHardened("name: Demo\nstages:\n  - id: a\n"), {
+      name: "Demo",
+      stages: [{ id: "a" }],
+    });
+    assert.throws(() => parseYamlHardened("a: 1\na: 2\n")); // uniqueKeys
+    assert.throws(() => parseYamlHardened("foo: [1, 2")); // malformed
+    assert.throws(() => parseYamlHardened("x".repeat(256 * 1024 + 1))); // size cap
+  });
+
+  it("httpStatusFromError / isNotFound parse the client error shape", () => {
+    assert.equal(httpStatusFromError(apiErr(404)), 404);
+    assert.equal(httpStatusFromError(apiErr(503)), 503);
+    assert.equal(httpStatusFromError(new Error("boom")), null);
+    assert.equal(isNotFound(apiErr(404)), true);
+    assert.equal(isNotFound(apiErr(400)), false);
+    assert.equal(isNotFound(apiErr(503)), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_agent_pipelines
+// ---------------------------------------------------------------------------
+
+describe("#919 list_agent_pipelines", () => {
+  it("returns [] when the pipelines dir is absent (404)", async () => {
+    const { tools } = makeTools({}); // list throws 404
+    const out = await run(tools.listAgentPipelines, { agent_name: "a" });
+    assert.deepEqual(out, []);
+  });
+
+  it("returns [] when the pipelines dir is empty", async () => {
+    const { tools } = makeTools({
+      list: async (p) =>
+        p === PIPELINES_DIR ? tree([]) : Promise.reject(apiErr(404)),
+    });
+    const out = await run(tools.listAgentPipelines, { agent_name: "a" });
+    assert.deepEqual(out, []);
+  });
+
+  it("parses N pipelines and picks each latest instance from the tree", async () => {
+    const { tools, downloadCalls } = makeTools({
+      list: async (p) => {
+        if (p === PIPELINES_DIR)
+          return tree([
+            fileNode("demo.yaml", `${PIPELINES_DIR}/demo.yaml`),
+            fileNode("etl.yaml", `${PIPELINES_DIR}/etl.yaml`),
+          ]);
+        if (p === STATE_DIR)
+          return tree([
+            dirNode("demo", [
+              fileNode(
+                "inst-1.json",
+                `${STATE_DIR}/demo/inst-1.json`,
+                "2026-01-01T00:00:00Z"
+              ),
+              fileNode(
+                "inst-2.json",
+                `${STATE_DIR}/demo/inst-2.json`,
+                "2026-01-02T00:00:00Z"
+              ),
+            ]),
+            dirNode("etl", []), // zero instances
+          ]);
+        throw apiErr(404);
+      },
+      download: async (p) => {
+        if (p === `${PIPELINES_DIR}/demo.yaml`)
+          return "name: Demo\nstages:\n  - id: a\n  - id: b\n";
+        if (p === `${PIPELINES_DIR}/etl.yaml`)
+          return "name: ETL\nstages:\n  - extract\n  - load\n";
+        if (p === `${STATE_DIR}/demo/inst-2.json`)
+          return JSON.stringify({
+            instance_id: "inst-2",
+            current_stage: "b",
+            health: "green",
+            updated_at: "2026-01-02T00:00:00Z",
+            escalations: [{ status: "open" }, { status: "resolved" }],
+          });
+        throw apiErr(404, p);
+      },
+    });
+
+    const out = await run(tools.listAgentPipelines, { agent_name: "a" });
+    assert.equal(out.length, 2);
+
+    const demo = out.find((x: any) => x.pipeline_id === "demo");
+    assert.deepEqual(demo.stages, ["a", "b"]);
+    assert.equal(demo.latest.instance_id, "inst-2"); // newest mtime
+    assert.equal(demo.latest.current_stage, "b");
+    assert.equal(demo.latest.open_escalations, 1);
+
+    const etl = out.find((x: any) => x.pipeline_id === "etl");
+    assert.deepEqual(etl.stages, ["extract", "load"]);
+    assert.equal(etl.latest, null); // zero instances
+
+    // Only the LATEST instance is downloaded — never inst-1.
+    assert.ok(downloadCalls.includes(`${STATE_DIR}/demo/inst-2.json`));
+    assert.ok(!downloadCalls.includes(`${STATE_DIR}/demo/inst-1.json`));
+  });
+
+  it("isolates a malformed definition as an item-level error; siblings survive", async () => {
+    const { tools } = makeTools({
+      list: async (p) => {
+        if (p === PIPELINES_DIR)
+          return tree([
+            fileNode("good.yaml", `${PIPELINES_DIR}/good.yaml`),
+            fileNode("bad.yaml", `${PIPELINES_DIR}/bad.yaml`),
+          ]);
+        if (p === STATE_DIR) return tree([]);
+        throw apiErr(404);
+      },
+      download: async (p) => {
+        if (p === `${PIPELINES_DIR}/good.yaml`) return "name: Good\nstages: []\n";
+        if (p === `${PIPELINES_DIR}/bad.yaml`) return "foo: [1, 2"; // malformed
+        throw apiErr(404);
+      },
+    });
+
+    const out = await run(tools.listAgentPipelines, { agent_name: "a" });
+    const good = out.find((x: any) => x.pipeline_id === "good");
+    const bad = out.find((x: any) => x.pipeline_id === "bad");
+    assert.equal(good.error, undefined);
+    assert.equal(good.latest, null);
+    assert.ok(bad.error, "malformed pipeline must carry an item-level error");
+  });
+
+  it("surfaces a stopped agent (400) as a real error, NOT an empty list", async () => {
+    const { tools } = makeTools({
+      list: async () => {
+        throw apiErr(400, "Agent must be running to browse files");
+      },
+    });
+    const out = await run(tools.listAgentPipelines, { agent_name: "a" });
+    assert.equal(out.success, false);
+    assert.match(out.error, /stopped or unreachable/);
+  });
+
+  it("surfaces an unreachable agent (503) as a real error", async () => {
+    const { tools } = makeTools({
+      list: async () => {
+        throw apiErr(503, "Agent server not ready");
+      },
+    });
+    const out = await run(tools.listAgentPipelines, { agent_name: "a" });
+    assert.equal(out.success, false);
+    assert.match(out.error, /stopped or unreachable/);
+  });
+
+  it("a 400 on the state-dir list (not the pipelines list) is also a real error", async () => {
+    const { tools } = makeTools({
+      list: async (p) => {
+        if (p === PIPELINES_DIR)
+          return tree([fileNode("demo.yaml", `${PIPELINES_DIR}/demo.yaml`)]);
+        throw apiErr(400, "Agent must be running"); // state dir
+      },
+    });
+    const out = await run(tools.listAgentPipelines, { agent_name: "a" });
+    assert.equal(out.success, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_agent_pipeline_state
+// ---------------------------------------------------------------------------
+
+describe("#919 get_agent_pipeline_state", () => {
+  it("reads an explicit instance directly (no list call)", async () => {
+    const { tools, listCalls } = makeTools({
+      download: async (p) => {
+        assert.equal(p, `${STATE_DIR}/demo/inst-2.json`);
+        return JSON.stringify({ instance_id: "inst-2", current_stage: "b" });
+      },
+    });
+    const out = await run(tools.getAgentPipelineState, {
+      agent_name: "a",
+      pipeline_id: "demo",
+      instance_id: "inst-2",
+    });
+    assert.equal(out.success, true);
+    assert.equal(out.pipeline_id, "demo");
+    assert.equal(out.instance_id, "inst-2");
+    assert.equal(out.state.current_stage, "b");
+    assert.deepEqual(listCalls, []); // explicit instance never lists
+  });
+
+  it("resolves the latest instance when instance_id is omitted", async () => {
+    const { tools } = makeTools({
+      list: async (p) => {
+        assert.equal(p, `${STATE_DIR}/demo`);
+        return tree([
+          fileNode(
+            "inst-1.json",
+            `${STATE_DIR}/demo/inst-1.json`,
+            "2026-01-01T00:00:00Z"
+          ),
+          fileNode(
+            "inst-2.json",
+            `${STATE_DIR}/demo/inst-2.json`,
+            "2026-01-02T00:00:00Z"
+          ),
+        ]);
+      },
+      download: async (p) => {
+        assert.equal(p, `${STATE_DIR}/demo/inst-2.json`);
+        return JSON.stringify({ current_stage: "done" });
+      },
+    });
+    const out = await run(tools.getAgentPipelineState, {
+      agent_name: "a",
+      pipeline_id: "demo",
+    });
+    assert.equal(out.success, true);
+    assert.equal(out.instance_id, "inst-2");
+    assert.equal(out.state.current_stage, "done");
+  });
+
+  it("returns a clean not-found when the pipeline state dir is absent (404)", async () => {
+    const { tools } = makeTools({
+      list: async () => {
+        throw apiErr(404, "Path not found");
+      },
+    });
+    const out = await run(tools.getAgentPipelineState, {
+      agent_name: "a",
+      pipeline_id: "nope",
+    });
+    assert.equal(out.success, false);
+    assert.match(out.error, /No state found/);
+  });
+
+  it("returns not-found when the pipeline dir exists but has no instances", async () => {
+    const { tools } = makeTools({
+      list: async () => tree([]),
+    });
+    const out = await run(tools.getAgentPipelineState, {
+      agent_name: "a",
+      pipeline_id: "demo",
+    });
+    assert.equal(out.success, false);
+    assert.match(out.error, /no instances/);
+  });
+
+  it("returns not-found when an explicit instance is missing (404 download)", async () => {
+    const { tools } = makeTools({
+      download: async () => {
+        throw apiErr(404, "File not found");
+      },
+    });
+    const out = await run(tools.getAgentPipelineState, {
+      agent_name: "a",
+      pipeline_id: "demo",
+      instance_id: "missing",
+    });
+    assert.equal(out.success, false);
+    assert.match(out.error, /not found/);
+  });
+
+  it("returns a clean error (not a throw) on malformed JSON", async () => {
+    const { tools } = makeTools({
+      download: async () => "{ not valid json",
+    });
+    const out = await run(tools.getAgentPipelineState, {
+      agent_name: "a",
+      pipeline_id: "demo",
+      instance_id: "inst-1",
+    });
+    assert.equal(out.success, false);
+    assert.match(out.error, /not valid JSON/);
+  });
+
+  it("discriminates a stopped agent (400) from not-found", async () => {
+    const { tools } = makeTools({
+      download: async () => {
+        throw apiErr(400, "Agent must be running to download files");
+      },
+    });
+    const out = await run(tools.getAgentPipelineState, {
+      agent_name: "a",
+      pipeline_id: "demo",
+      instance_id: "inst-1",
+    });
+    assert.equal(out.success, false);
+    assert.match(out.error, /Could not read state/);
+    assert.doesNotMatch(out.error, /not found/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [P1 SECURITY] id grammar rejects path traversal BEFORE any download
+// ---------------------------------------------------------------------------
+
+describe("#919 [P1] path-traversal id validation (zod, pre-download)", () => {
+  const { tools } = makeTools({
+    list: async () => {
+      throw new Error("LIST MUST NOT BE CALLED");
+    },
+    download: async () => {
+      throw new Error("DOWNLOAD MUST NOT BE CALLED");
+    },
+  });
+  const schema = tools.getAgentPipelineState.parameters;
+
+  it("accepts safe ids", () => {
+    for (const id of ["demo", "demo_1", "demo-1", "demo.v2", "ABC123"]) {
+      assert.equal(
+        schema.safeParse({ agent_name: "a", pipeline_id: id }).success,
+        true,
+        `expected '${id}' to be accepted`
+      );
+    }
+  });
+
+  it("rejects traversal / separator ids on pipeline_id and instance_id", () => {
+    const bad = [
+      "../../.env",
+      "..",
+      "a/b",
+      "a/../b",
+      ".ssh/id_rsa",
+      "%2e%2e%2fetc",
+      "a%2Fb",
+      "",
+      "foo bar",
+    ];
+    for (const id of bad) {
+      assert.equal(
+        schema.safeParse({ agent_name: "a", pipeline_id: id }).success,
+        false,
+        `expected pipeline_id '${id}' to be rejected`
+      );
+      assert.equal(
+        schema.safeParse({
+          agent_name: "a",
+          pipeline_id: "ok",
+          instance_id: id,
+        }).success,
+        false,
+        `expected instance_id '${id}' to be rejected`
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema-fixture: the docs/schemas/*.json contract is real and its required
+// fields match what the tools depend on. Dependency-free (no ajv): we read
+// each schema, assert it parses + declares draft 2020-12, pin its `required`
+// set, and prove representative fixtures (the E2E fixtures) carry those fields.
+// ---------------------------------------------------------------------------
+
+describe("#919 schema fixtures match the tool contract", () => {
+  const readSchema = (name: string) =>
+    JSON.parse(
+      readFileSync(
+        fileURLToPath(new URL(`../../../docs/schemas/${name}`, import.meta.url)),
+        "utf8"
+      )
+    );
+  const defSchema = readSchema("agent-pipeline.schema.json");
+  const stateSchema = readSchema("agent-pipeline-state.schema.json");
+
+  it("both schemas parse and declare JSON Schema draft 2020-12", () => {
+    assert.match(defSchema.$schema, /draft\/2020-12/);
+    assert.match(stateSchema.$schema, /draft\/2020-12/);
+  });
+
+  it("the state schema requires exactly the fields the tools read", () => {
+    // These five drive latest-instance selection + the health summary. If a
+    // future edit drops one, this fails — the schema is the contract.
+    for (const f of [
+      "instance_id",
+      "current_stage",
+      "health",
+      "updated_at",
+      "escalations",
+    ]) {
+      assert.ok(
+        stateSchema.required.includes(f),
+        `state schema must require '${f}'`
+      );
+    }
+    assert.ok(defSchema.required.includes("stages"), "def schema must require 'stages'");
+  });
+
+  it("the E2E fixtures satisfy the schemas' required sets", () => {
+    const defFixture = parseYamlHardened(
+      "id: demo\nname: Demo\nstages:\n  - id: collect\n  - id: synthesize\n"
+    ) as Record<string, unknown>;
+    const stateFixture = {
+      instance_id: "inst-1",
+      pipeline_id: "demo",
+      current_stage: "synthesize",
+      health: "green",
+      updated_at: "2026-06-26T12:00:00Z",
+      escalations: [],
+    };
+
+    for (const f of defSchema.required) assert.ok(f in defFixture, `def fixture missing '${f}'`);
+    for (const f of stateSchema.required)
+      assert.ok(f in stateFixture, `state fixture missing '${f}'`);
+
+    // And the tools actually consume the fixtures correctly.
+    assert.deepEqual(summarizeDefinition(defFixture).stages, ["collect", "synthesize"]);
+    assert.equal(summarizeInstance(stateFixture, "x").open_escalations, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client transport: JSON `request` + text `downloadAgentFile` share `_fetch`
+// ---------------------------------------------------------------------------
+
+describe("#919 client _fetch shared by JSON + text paths", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function stubFetch(
+    handler: (url: string, init: any) => { status: number; body: string; contentType?: string }
+  ) {
+    globalThis.fetch = (async (url: any, init: any) => {
+      const r = handler(String(url), init);
+      return new Response(r.body, {
+        status: r.status,
+        headers: { "content-type": r.contentType ?? "application/json" },
+      });
+    }) as typeof fetch;
+  }
+
+  it("both paths attach the bearer token and hit the right endpoints", async () => {
+    const seen: Array<{ url: string; auth: string | undefined }> = [];
+    stubFetch((url, init) => {
+      seen.push({ url, auth: init?.headers?.Authorization });
+      if (url.includes("/files/download"))
+        return { status: 200, body: "stage: synth", contentType: "text/plain" };
+      return {
+        status: 200,
+        body: JSON.stringify(tree([])),
+        contentType: "application/json",
+      };
+    });
+
+    const client = new TrinityClient("http://backend:8000");
+    client.setToken("tok-123");
+
+    const listed = await client.listAgentFiles("ag", ".trinity/pipelines", true);
+    assert.equal(listed.total_files, 0); // JSON-decoded
+
+    const text = await client.downloadAgentFile("ag", ".trinity/pipelines/x.yaml");
+    assert.equal(text, "stage: synth"); // text-decoded, NOT JSON.parse'd
+
+    assert.equal(seen.length, 2);
+    assert.ok(seen.every((s) => s.auth === "Bearer tok-123"));
+    assert.ok(seen[0].url.includes("/api/agents/ag/files?path="));
+    assert.ok(seen[1].url.includes("/api/agents/ag/files/download?path="));
+  });
+
+  it("both paths map a non-2xx to the same `API error (NNN)` throw", async () => {
+    stubFetch(() => ({ status: 404, body: "Path not found" }));
+    const client = new TrinityClient("http://backend:8000");
+    client.setToken("tok");
+
+    await assert.rejects(
+      () => client.listAgentFiles("ag", ".trinity/pipelines", true),
+      /API error \(404\)/
+    );
+    await assert.rejects(
+      () => client.downloadAgentFile("ag", ".trinity/pipelines/x.yaml"),
+      /API error \(404\)/
+    );
+  });
+});

--- a/src/mcp-server/src/server.ts
+++ b/src/mcp-server/src/server.ts
@@ -24,6 +24,7 @@ import { createChannelTools } from "./tools/channels.js";
 import { createMessageTools } from "./tools/messages.js";
 import { createVoipTools } from "./tools/voip.js";
 import { createFileTools } from "./tools/files.js";
+import { createPipelineTools } from "./tools/pipelines.js";
 import { createMemoryTools } from "./tools/memory.js";
 import { createLoopTools } from "./tools/loops.js";
 import { createOperatorQueueTools } from "./tools/operator_queue.js";
@@ -224,6 +225,7 @@ export async function createServer(config: ServerConfig = {}) {
     createTagTools(client, requireApiKey),
     createNotificationTools(client, requireApiKey),
     createFileTools(client, requireApiKey),       // FILES-001 — outbound file sharing
+    createPipelineTools(client, requireApiKey),   // #919 — agent-defined pipeline introspection
     createSubscriptionTools(client, requireApiKey),
     createMonitoringTools(client, requireApiKey),
     createNeverminedTools(client, requireApiKey),

--- a/src/mcp-server/src/tools/pipelines.ts
+++ b/src/mcp-server/src/tools/pipelines.ts
@@ -1,0 +1,490 @@
+/**
+ * Agent-Defined Pipeline Introspection (#919)
+ *
+ * Trinity does NOT own the DAG, the execution semantics, or the recovery
+ * policy of an agent's long-running multi-stage pipeline — the agent owns all
+ * of that (Architectural Invariant #8). These two tools are a thin, read-only
+ * window onto a uniform file contract the agent publishes inside its own
+ * container:
+ *
+ *   ~/.trinity/pipelines/<pipeline_id>.yaml                  — definition
+ *   ~/.trinity/pipeline-state/<pipeline_id>/<instance>.json  — runtime state
+ *
+ * They wrap the EXISTING `GET /api/agents/{name}/files` (recursive list) and
+ * `GET /api/agents/{name}/files/download` (read) surfaces — no new backend
+ * endpoint, no DB table, no backend parsing of pipeline semantics. The YAML
+ * definition is parsed here (hardened) only to produce a compact summary; the
+ * authoritative contract lives in docs/schemas/agent-pipeline*.schema.json.
+ */
+
+import { z } from "zod";
+import YAML from "yaml";
+import { TrinityClient } from "../client.js";
+import type { McpAuthContext, AgentFileNode } from "../types.js";
+
+// Canonical file-contract roots, relative to the agent home (/home/developer).
+// Relative paths keep us off a hardcoded home path — the agent-server anchors
+// reads at the WORKDIR home (Decision #7).
+const PIPELINES_DIR = ".trinity/pipelines";
+const PIPELINE_STATE_DIR = ".trinity/pipeline-state";
+
+// Read fan-out cap: at most this many pipelines are summarised in one
+// list_agent_pipelines call. Beyond it we truncate (and log) rather than
+// issuing an unbounded set of downloads. "No silent caps": the drop is logged.
+const MAX_PIPELINES = 50;
+
+// Per-file parse ceiling. Both the YAML definition and the JSON state file are
+// size-capped BEFORE parse so a hostile/oversized file can't drive a parse
+// blow-up. 256 KiB mirrors the agent-compatibility collector's per-file cap.
+const MAX_FILE_BYTES = 256 * 1024;
+
+// Strict id grammar. `pipeline_id`/`instance_id` are interpolated into download
+// paths and the agent-server download endpoint has no deny-list (only a
+// `/home/developer` prefix check), so a `..` segment would read arbitrary home
+// files (.env, .ssh/id_*). The class rejects `/` and `%` (encoded slashes);
+// the refinement additionally rejects `..` (which the class alone would admit,
+// since `.` is allowed). [P1 SECURITY — Decision #4 / T1]
+const ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+const idSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(
+    ID_PATTERN,
+    "must match ^[A-Za-z0-9._-]+$ (no '/', no path separators, no encoded slashes)"
+  )
+  .refine((v) => !v.includes(".."), "must not contain '..' (path traversal)");
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/** Extract the HTTP status from a `TrinityClient` "API error (NNN): …" throw. */
+export function httpStatusFromError(err: unknown): number | null {
+  const msg = err instanceof Error ? err.message : String(err);
+  const m = msg.match(/API error \((\d{3})\)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/** A 404 means "no such file/dir" → empty / not-found. Everything else
+ * (400 agent-stopped, 5xx unreachable) is a real error the caller surfaces so
+ * "no such pipeline" is never confused with "agent down" (Decision #6). */
+export function isNotFound(err: unknown): boolean {
+  return httpStatusFromError(err) === 404;
+}
+
+/** `demo.yaml` → `demo`; `inst-1.json` → `inst-1`. */
+export function stripExtension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  return dot > 0 ? filename.slice(0, dot) : filename;
+}
+
+/** Depth-first collect every `file` node from a recursive file tree. */
+export function flattenFiles(nodes: AgentFileNode[] | undefined): AgentFileNode[] {
+  const out: AgentFileNode[] = [];
+  for (const node of nodes ?? []) {
+    if (node.type === "file") {
+      out.push(node);
+    } else if (node.type === "directory") {
+      out.push(...flattenFiles(node.children));
+    }
+  }
+  return out;
+}
+
+/**
+ * Pick the latest state instance from a set of file nodes, using only the tree
+ * (no content read): newest `modified` mtime first, tie-broken by lexically
+ * descending filename. `updated_at` is the authoritative *semantic* timestamp
+ * and is surfaced in the result, but selection runs off mtime — the physical
+ * write-time the agent stamps on every state update — so the read fan-out
+ * stays at one download per pipeline (Decision #2/#3; instance_ids SHOULD be
+ * time-sortable, which the filename tie-break leans on).
+ */
+export function pickLatestInstanceNode(
+  nodes: AgentFileNode[] | undefined
+): AgentFileNode | null {
+  const jsonFiles = (nodes ?? []).filter(
+    (n) => n.type === "file" && n.name.endsWith(".json")
+  );
+  if (jsonFiles.length === 0) return null;
+  return jsonFiles.slice().sort((a, b) => {
+    const ta = Date.parse(a.modified ?? "");
+    const tb = Date.parse(b.modified ?? "");
+    if (!Number.isNaN(ta) && !Number.isNaN(tb) && ta !== tb) return tb - ta;
+    return b.name.localeCompare(a.name);
+  })[0];
+}
+
+/** Count escalations still open. Conservative: an entry with no recognisable
+ * status counts as open (better to over-report attention than hide it). */
+export function countOpenEscalations(state: unknown): number {
+  const esc = (state as { escalations?: unknown })?.escalations;
+  if (!Array.isArray(esc)) return 0;
+  return esc.filter((e) => {
+    if (e == null || typeof e !== "object") return false;
+    const o = e as Record<string, unknown>;
+    if (typeof o.open === "boolean") return o.open;
+    if (typeof o.resolved === "boolean") return !o.resolved;
+    if (typeof o.status === "string") {
+      return !["resolved", "closed", "done"].includes(o.status.toLowerCase());
+    }
+    return true;
+  }).length;
+}
+
+/** Hardened YAML parse: size-cap first, then parse with duplicate-key
+ * rejection (`uniqueKeys`) and the default alias-expansion guard
+ * (`maxAliasCount`, billion-laughs). JS YAML never instantiates arbitrary
+ * classes, so there is no PyYAML-style code-exec surface to disable. Throws
+ * on oversize or malformed input — the caller turns that into an item-level
+ * error, never aborting the whole list. */
+export function parseYamlHardened(text: string): unknown {
+  if (Buffer.byteLength(text, "utf8") > MAX_FILE_BYTES) {
+    throw new Error(
+      `definition exceeds ${MAX_FILE_BYTES}-byte parse cap`
+    );
+  }
+  return YAML.parse(text, { uniqueKeys: true, maxAliasCount: 100 });
+}
+
+/** Compact, shape-tolerant summary of a parsed pipeline definition. */
+export function summarizeDefinition(def: unknown): {
+  name?: unknown;
+  description?: unknown;
+  version?: unknown;
+  stages: unknown[];
+  stage_count: number;
+} {
+  if (def == null || typeof def !== "object") {
+    return { stages: [], stage_count: 0 };
+  }
+  const d = def as Record<string, unknown>;
+  const stages = Array.isArray(d.stages)
+    ? d.stages
+        .map((s) =>
+          s != null && typeof s === "object"
+            ? ((s as Record<string, unknown>).id ??
+              (s as Record<string, unknown>).name ??
+              null)
+            : s
+        )
+        .filter((x) => x != null)
+    : [];
+  return {
+    name: d.name,
+    description: d.description,
+    version: d.version,
+    stages,
+    stage_count: stages.length,
+  };
+}
+
+/** Health summary lifted from a parsed instance state file. */
+export function summarizeInstance(
+  state: unknown,
+  fallbackInstanceId: string
+): {
+  instance_id: string;
+  current_stage: unknown;
+  health: unknown;
+  updated_at: unknown;
+  open_escalations: number;
+} {
+  const s = (state ?? {}) as Record<string, unknown>;
+  return {
+    instance_id:
+      typeof s.instance_id === "string" && s.instance_id
+        ? s.instance_id
+        : fallbackInstanceId,
+    current_stage: s.current_stage ?? null,
+    health: s.health ?? null,
+    updated_at: s.updated_at ?? null,
+    open_escalations: countOpenEscalations(state),
+  };
+}
+
+const ok = (obj: unknown): string => JSON.stringify(obj, null, 2);
+const fail = (error: string): string =>
+  JSON.stringify({ success: false, error }, null, 2);
+
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+
+export function createPipelineTools(
+  client: TrinityClient,
+  requireApiKey: boolean
+) {
+  /** Pick the right client instance based on auth mode (mirrors files.ts). */
+  const getClient = (authContext?: McpAuthContext): TrinityClient => {
+    if (requireApiKey) {
+      if (!authContext?.mcpApiKey) {
+        throw new Error(
+          "MCP API key authentication required but no API key found in request context"
+        );
+      }
+      const userClient = new TrinityClient(client.getBaseUrl());
+      userClient.setToken(authContext.mcpApiKey);
+      return userClient;
+    }
+    return client;
+  };
+
+  /** Download + parse a single instance state JSON, size-capped. */
+  const readInstanceState = async (
+    apiClient: TrinityClient,
+    agentName: string,
+    path: string
+  ): Promise<unknown> => {
+    const text = await apiClient.downloadAgentFile(agentName, path);
+    if (Buffer.byteLength(text, "utf8") > MAX_FILE_BYTES) {
+      throw new Error(`state file exceeds ${MAX_FILE_BYTES}-byte cap`);
+    }
+    return JSON.parse(text);
+  };
+
+  return {
+    // ========================================================================
+    // list_agent_pipelines — enumerate pipelines + latest-instance health
+    // ========================================================================
+    listAgentPipelines: {
+      name: "list_agent_pipelines",
+      description:
+        "List the agent-defined pipelines an agent publishes under " +
+        "~/.trinity/pipelines/*.yaml, each with a health summary drawn from " +
+        "its latest runtime instance under ~/.trinity/pipeline-state/. " +
+        "Trinity does not own the DAG or execution — this is a read-only view " +
+        "of the agent's own files. Returns [] when the agent publishes no " +
+        "pipelines. The agent must be running (its files live in the " +
+        "container); a stopped or unreachable agent surfaces a real error, " +
+        "not an empty list.",
+      parameters: z.object({
+        agent_name: z
+          .string()
+          .min(1)
+          .describe("Name of the agent whose pipelines to list."),
+      }),
+      execute: async (
+        params: { agent_name: string },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const apiClient = getClient(context?.session);
+        const agentName = params.agent_name;
+        console.log(`[list_agent_pipelines] agent=${agentName}`);
+
+        // Step 1 — discover pipeline definitions. 404 → no pipelines dir → [].
+        let defFiles: AgentFileNode[];
+        try {
+          const tree = await apiClient.listAgentFiles(
+            agentName,
+            PIPELINES_DIR,
+            true
+          );
+          defFiles = flattenFiles(tree.tree).filter(
+            (f) => f.name.endsWith(".yaml") || f.name.endsWith(".yml")
+          );
+        } catch (err) {
+          if (isNotFound(err)) return ok([]);
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`[list_agent_pipelines] list error: ${msg}`);
+          return fail(
+            `Could not read pipelines for '${agentName}' ` +
+              `(agent stopped or unreachable): ${msg}`
+          );
+        }
+
+        if (defFiles.length === 0) return ok([]);
+
+        // Step 2 — one recursive list of all instance state, grouped by
+        // pipeline_id (top-level dirs). A missing state dir (no instances yet)
+        // is a 404 → every pipeline simply has latest=null; a 400/5xx is real.
+        const stateByPipeline = new Map<string, AgentFileNode[]>();
+        try {
+          const stateTree = await apiClient.listAgentFiles(
+            agentName,
+            PIPELINE_STATE_DIR,
+            true
+          );
+          for (const dir of stateTree.tree ?? []) {
+            if (dir.type === "directory") {
+              stateByPipeline.set(dir.name, flattenFiles(dir.children));
+            }
+          }
+        } catch (err) {
+          if (!isNotFound(err)) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(`[list_agent_pipelines] state list error: ${msg}`);
+            return fail(
+              `Could not read pipeline state for '${agentName}' ` +
+                `(agent stopped or unreachable): ${msg}`
+            );
+          }
+        }
+
+        // Cap the fan-out — log (don't silently drop) when truncating.
+        let pipelines = defFiles;
+        if (pipelines.length > MAX_PIPELINES) {
+          console.log(
+            `[list_agent_pipelines] agent=${agentName} truncating ` +
+              `${pipelines.length} → ${MAX_PIPELINES} pipelines`
+          );
+          pipelines = pipelines.slice(0, MAX_PIPELINES);
+        }
+
+        // Step 3 — per pipeline: parse the definition + read its latest
+        // instance. A single malformed file is an item-level error and never
+        // aborts the list.
+        const results = await Promise.all(
+          pipelines.map(async (def) => {
+            const pipelineId = stripExtension(def.name);
+            try {
+              const defText = await apiClient.downloadAgentFile(
+                agentName,
+                def.path
+              );
+              const parsed = parseYamlHardened(defText);
+              const summary = summarizeDefinition(parsed);
+
+              let latest: ReturnType<typeof summarizeInstance> | null = null;
+              const latestNode = pickLatestInstanceNode(
+                stateByPipeline.get(pipelineId)
+              );
+              if (latestNode) {
+                const state = await readInstanceState(
+                  apiClient,
+                  agentName,
+                  latestNode.path
+                );
+                latest = summarizeInstance(
+                  state,
+                  stripExtension(latestNode.name)
+                );
+              }
+              return { pipeline_id: pipelineId, ...summary, latest };
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              return { pipeline_id: pipelineId, error: msg };
+            }
+          })
+        );
+
+        return ok(results);
+      },
+    },
+
+    // ========================================================================
+    // get_agent_pipeline_state — full parsed state for one instance
+    // ========================================================================
+    getAgentPipelineState: {
+      name: "get_agent_pipeline_state",
+      description:
+        "Read the full runtime state JSON for one instance of an agent's " +
+        "pipeline (~/.trinity/pipeline-state/<pipeline_id>/<instance_id>.json). " +
+        "Omit instance_id to get the latest instance. Returns a clean " +
+        "not-found result (never a 500) when the pipeline or instance does " +
+        "not exist; a stopped or unreachable agent surfaces a distinct error.",
+      parameters: z.object({
+        agent_name: z
+          .string()
+          .min(1)
+          .describe("Name of the agent that owns the pipeline."),
+        pipeline_id: idSchema.describe(
+          "Pipeline id (the <pipeline_id> in pipelines/<pipeline_id>.yaml). " +
+            "Must match ^[A-Za-z0-9._-]+$."
+        ),
+        instance_id: idSchema
+          .optional()
+          .describe(
+            "Specific instance id. Omit to return the latest instance. " +
+              "Must match ^[A-Za-z0-9._-]+$ when supplied."
+          ),
+      }),
+      execute: async (
+        params: {
+          agent_name: string;
+          pipeline_id: string;
+          instance_id?: string;
+        },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const apiClient = getClient(context?.session);
+        const { agent_name: agentName, pipeline_id: pipelineId } = params;
+        console.log(
+          `[get_agent_pipeline_state] agent=${agentName} ` +
+            `pipeline=${pipelineId} instance=${params.instance_id ?? "(latest)"}`
+        );
+
+        let targetPath: string;
+        let resolvedInstanceId: string;
+
+        if (params.instance_id) {
+          // Explicit instance — both ids are zod-validated, safe to interpolate.
+          resolvedInstanceId = params.instance_id;
+          targetPath = `${PIPELINE_STATE_DIR}/${pipelineId}/${resolvedInstanceId}.json`;
+        } else {
+          // Latest instance — list the pipeline's state dir and pick newest.
+          let tree;
+          try {
+            tree = await apiClient.listAgentFiles(
+              agentName,
+              `${PIPELINE_STATE_DIR}/${pipelineId}`,
+              true
+            );
+          } catch (err) {
+            if (isNotFound(err)) {
+              return fail(
+                `No state found for pipeline '${pipelineId}' on '${agentName}'.`
+              );
+            }
+            const msg = err instanceof Error ? err.message : String(err);
+            return fail(
+              `Could not read state for '${pipelineId}' on '${agentName}' ` +
+                `(agent stopped or unreachable): ${msg}`
+            );
+          }
+          const latestNode = pickLatestInstanceNode(tree.tree);
+          if (!latestNode) {
+            return fail(
+              `Pipeline '${pipelineId}' on '${agentName}' has no instances.`
+            );
+          }
+          targetPath = latestNode.path;
+          resolvedInstanceId = stripExtension(latestNode.name);
+        }
+
+        // Download + parse the target instance.
+        let state: unknown;
+        try {
+          state = await readInstanceState(apiClient, agentName, targetPath);
+        } catch (err) {
+          if (isNotFound(err)) {
+            return fail(
+              `Instance '${resolvedInstanceId}' of pipeline '${pipelineId}' ` +
+                `not found on '${agentName}'.`
+            );
+          }
+          if (err instanceof SyntaxError) {
+            return fail(
+              `State file for '${resolvedInstanceId}' is not valid JSON.`
+            );
+          }
+          const msg = err instanceof Error ? err.message : String(err);
+          return fail(
+            `Could not read state for '${pipelineId}/${resolvedInstanceId}' ` +
+              `on '${agentName}': ${msg}`
+          );
+        }
+
+        return ok({
+          success: true,
+          agent_name: agentName,
+          pipeline_id: pipelineId,
+          instance_id: resolvedInstanceId,
+          state,
+        });
+      },
+    },
+  };
+}

--- a/src/mcp-server/src/types.ts
+++ b/src/mcp-server/src/types.ts
@@ -339,3 +339,30 @@ export interface CompatibilityReport {
   static_ran_at?: string | null;
   message?: string | null;
 }
+
+// Agent workspace file browser (#919 — agent-pipeline introspection reads
+// these via the existing GET /api/agents/{name}/files surface).
+
+/**
+ * One node in the recursive file tree returned by
+ * `GET /api/agents/{name}/files`. Directories carry `children`; files carry
+ * `size`. `path` is relative to `/home/developer`; `modified` is an ISO-8601
+ * mtime string (used as the tie-breaker for latest-instance selection).
+ */
+export interface AgentFileNode {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  size?: number;
+  modified?: string;
+  children?: AgentFileNode[];
+  file_count?: number;
+}
+
+export interface AgentFileTreeResponse {
+  base_path: string;
+  requested_path: string;
+  tree: AgentFileNode[];
+  total_files: number;
+  show_hidden: boolean;
+}


### PR DESCRIPTION
## Summary

Adds two thin, **read-only** MCP tools that give Trinity a uniform window onto an agent's self-published, long-running multi-stage pipelines — **without** Trinity owning the DAG, execution, or recovery (Architectural Invariant #8). The agent owns all stage advancement, retry, and escalation via its own primitives (schedules, events, the operator queue, the `pre-check` hook); Trinity only **reads** two files the agent publishes inside its container.

| Tool | What it returns |
|------|-----------------|
| `list_agent_pipelines(agent_name)` | Enumerates `~/.trinity/pipelines/*.yaml`, each with a health summary from its **latest** instance (`current_stage`, `health`, `open_escalations`, `updated_at`). `[]` when none published. |
| `get_agent_pipeline_state(agent_name, pipeline_id, instance_id?)` | Full parsed state JSON for one instance; omit `instance_id` for the latest. |

Closes #919

## The file contract

The agent publishes two kinds of file; Trinity reads them, never writes them:

```
~/.trinity/pipelines/<pipeline_id>.yaml                       # definition (the DAG)
~/.trinity/pipeline-state/<pipeline_id>/<instance_id>.json    # live state per instance
```

Authoritative JSON Schemas (draft 2020-12) land in `docs/schemas/`:
- `agent-pipeline.schema.json` — the definition
- `agent-pipeline-state.schema.json` — the state; **required** `instance_id`, `current_stage`, `health`, `updated_at`, `escalations` is exactly what the tools read for their summary, so the schema is the single source of truth (the tests sync against it).

## Design — reuse, not new surface

No new backend router/service, no agent-server endpoint, no DB table (Invariant #8/#13 satisfied by **reuse**). The tools wrap the **existing** `GET /api/agents/{name}/files` (recursive list) and `/files/download` (read) surfaces via two new thin `TrinityClient` methods:

- The client's auth-header + single 401-reauth-retry + error-mapping logic is extracted into a private `_fetch()` returning the raw `Response`, so the JSON `request<T>()` path and the new plain-text `downloadAgentFile()` path differ **only** in `.json()` vs `.text()` and cannot drift on auth/retry/error handling.
- **Latest instance is selected by state-file mtime** (tie-broken on `instance_id` lexically), keeping the read fan-out at **one download per pipeline**. Capped at 50 pipelines, truncation **logged** (no silent cap).

## Security & robustness

- **P1 path-traversal guard.** `pipeline_id`/`instance_id` are interpolated into download paths and the download endpoint has no deny-list (only a `/home/developer` prefix check). They are zod-validated `^[A-Za-z0-9._-]+$` **and** reject any `..` substring **before** any download — defense-in-depth over the agent-server's home-prefix confinement. (CSO `--diff` audit: no findings at/above the daily gate — see `docs/security-reports/cso-2026-06-26-diff.md`.)
- **Hardened YAML parse.** 256 KiB pre-parse size cap + duplicate-key rejection (`uniqueKeys`) + alias-expansion guard (`maxAliasCount`, billion-laughs). The JS `yaml` lib instantiates no arbitrary classes — no PyYAML-style RCE surface. JSON state is size-capped before parse.
- **Error contract.** Only a `404` maps to empty/not-found; a `400` (agent stopped) or `5xx` (unreachable) surfaces as a **distinct real error**, so "no such pipeline" is never confused with "agent down".
- **Failure isolation.** A single malformed definition/state file is an item-level error that never aborts the whole list.

## Testing

`src/mcp-server/src/pipelines.test.ts` — **60 tests, all green** (`node:test`). Covers the pure helpers (id grammar, latest-instance selection, hardened parse, escalation counting, error discrimination), both tools end-to-end against a mocked `TrinityClient` (empty/multi-pipeline/zero-instance/malformed-isolation/explicit-vs-latest/not-found/stopped-vs-unreachable), the P1 traversal rejection (asserts LIST/DOWNLOAD are never called), a schema-fixture contract test, and the shared `_fetch` transport.

```
ℹ tests 60   ℹ pass 60   ℹ fail 0
```

`npm run build` (tsc) is clean.

## Docs

- `architecture.md` — MCP tool catalog 20 → 21 modules + `pipelines.ts` row.
- `requirements.md` §34.1 — status → ✅ Implemented (2026-06-26) + implementation note.
- `TRINITY_COMPATIBLE_AGENT_GUIDE.md` — new "Agent-Defined Pipelines" section: file contract, minimal example, both tools, the `open_escalations` rule, the operator-queue `context` grouping convention, and the agent-side heartbeat ownership.

## Adoption note

Ships as **MCP + docs only**. Existing agents return `[]` until they adopt the file convention — **by design**, not a bug. The agent-side `pipeline-tick` heartbeat ships with the `agent-dev:add-pipeline` plugin in [`abilityai/abilities`](https://github.com/abilityai/abilities), **not** with Trinity.

## Surfaces touched (Invariant #13 — three-surface sync)

- ✅ MCP tool (`tools/pipelines.ts` + `client.ts` + `types.ts` + `server.ts`)
- N/A backend router — reuses existing `agent_files`
- N/A agent server — no internal API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
