### PR TITLE
feat(ui): link to docs.ability.ai from every Trinity instance

### DIFF
--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -102,6 +102,22 @@
             >· {{ buildInfo.info.value.git_commit_short }}</span>
           </button>
 
+          <!-- Docs link (trinity-enterprise#53) — always-available external
+               link to the public documentation site. opens in a new tab. -->
+          <a
+            href="https://docs.ability.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            title="Documentation (opens docs.ability.ai)"
+            aria-label="Documentation"
+          >
+            <!-- Question-mark-in-circle icon -->
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </a>
+
           <!-- Theme Toggle Button -->
           <button
             @click="cycleTheme"
@@ -193,6 +209,19 @@
                   </button>
                 </div>
               </div>
+              <!-- Documentation link (trinity-enterprise#53) -->
+              <a
+                href="https://docs.ability.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                @click="showUserMenu = false"
+                class="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center"
+              >
+                <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Documentation
+              </a>
               <button
                 @click="handleLogout"
                 class="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center"


### PR DESCRIPTION
## What

Adds an always-available link to the public docs site (**https://docs.ability.ai**) from inside the running app. Closes the missing "opt-in depth" escape hatch — self-hosters had no way to reach the docs from the product.

## Changes

`src/frontend/src/components/NavBar.vue`:
- **Top-right action cluster:** new question-mark icon link, visible on **every** page including mobile (it lives outside the `hidden sm:flex` nav group).
- **User dropdown menu:** labeled "Documentation" entry for clearer discoverability.

Both open in a new tab with `rel="noopener noreferrer"`.

## Scope

Static link only — context-aware per-view deep-linking is explicitly a later enhancement per the issue.

## Acceptance criteria

- [x] A visible, working link to https://docs.ability.ai reachable from anywhere in the app.

## Test

`npx vite build` fails only on a pre-existing unrelated `mermaid` import in `AgentWorkspace.vue` (present on `dev` base, untouched here); the NavBar edit is a plain valid anchor.

Related to Abilityai/trinity-enterprise#53

🤖 Generated with [Claude Code](https://claude.com/claude-code)