### PR TITLE
fix(agent): scope headless stall-watchdog to mcp__ + configurable limit (#1369)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -97,6 +97,11 @@ services:
       # agent container mount spec. noexec,nosuid stay fixed; only size tunes.
       # Existing agents pick up a change on recreate, not restart.
       - AGENT_TMP_SIZE=${AGENT_TMP_SIZE:-512m}
+      # Headless per-tool stall-watchdog ceiling (#1369) — seconds; scoped to
+      # mcp__* tools. Threaded into agent containers by crud.py/lifecycle.py, so
+      # it must reach the backend here or the .env lever is inert (#1039 class).
+      # Default (1800s) lives agent-side; 0/negative disables. Recreate to apply.
+      - AGENT_TOOL_STALL_LIMIT_S=${AGENT_TOOL_STALL_LIMIT_S:-}
       # #946 pull-pilot routing flag (observability mirror of the mcp-server gate).
       - MCP_AGENT_CHAT_PULL_ENABLED=${MCP_AGENT_CHAT_PULL_ENABLED:-false}
       # Correlated-failure / thundering-herd controls (#1085) — re-delivery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,11 @@ services:
       # agent container mount spec. noexec,nosuid stay fixed; only size tunes.
       # Existing agents pick up a change on recreate, not restart.
       - AGENT_TMP_SIZE=${AGENT_TMP_SIZE:-512m}
+      # Headless per-tool stall-watchdog ceiling (#1369) — seconds; scoped to
+      # mcp__* tools. Threaded into agent containers by crud.py/lifecycle.py, so
+      # it must reach the backend here or the .env lever is inert (#1039 class).
+      # Default (1800s) lives agent-side; 0/negative disables. Recreate to apply.
+      - AGENT_TOOL_STALL_LIMIT_S=${AGENT_TOOL_STALL_LIMIT_S:-}
       # OpenTelemetry Configuration (Optional)
       - OTEL_ENABLED=${OTEL_ENABLED:-0}
       - OTEL_COLLECTOR_ENDPOINT=${OTEL_COLLECTOR_ENDPOINT:-http://trinity-otel-collector:4317}

--- a/docker/base-image/agent_server/services/headless_executor.py
+++ b/docker/base-image/agent_server/services/headless_executor.py
@@ -73,23 +73,66 @@ _JSONL_PERSIST_THRESHOLD_S = 600
 # timeout). The stall limit is intentionally generous — "tool running" is
 # not "tool stalled" — so only a genuinely wedged call trips it.
 _WAIT_POLL_S = 2.0
-_STALL_LIMIT_S = 300.0
+
+# #1369: default per-tool stall ceiling (was a flat hard-coded 300s, which
+# killed legitimately long internal MCP calls). Operator-configurable via
+# AGENT_TOOL_STALL_LIMIT_S; <=0 disables the watchdog (the execution_timeout
+# budget stays the backstop). The watchdog is also scoped to opaque MCP
+# (``mcp__*``) tools only — built-ins (Bash/Read/Task/sub-agents) return on
+# their own and are already bounded by execution_timeout_seconds, so a long
+# (progressing) built-in must never be killed here. A genuinely hung built-in
+# or a hang *inside* a Task sub-agent (which surfaces as an open ``Task`` in
+# the parent log) now falls to the execution_timeout backstop rather than this
+# 300s kill — the accepted interim tradeoff (see #1369).
+_STALL_LIMIT_DEFAULT_S = 1800.0
+
+
+def _resolve_stall_limit_s() -> float:
+    """Resolved per-run stall ceiling (seconds).
+
+    Read fresh per run (not a module constant) so it honors the container env
+    and is monkeypatchable in tests. ``AGENT_TOOL_STALL_LIMIT_S`` overrides the
+    default; a missing/blank value uses the default; a non-numeric value falls
+    back to the default with a warning (a typo must not brick the executor).
+    A value ``<= 0`` means *disabled* and is handled at the call site — it is
+    NOT passed into ``_open_tool_exceeding`` (where ``> 0`` would fire instantly).
+    """
+    raw = os.environ.get("AGENT_TOOL_STALL_LIMIT_S")
+    if raw is None or not raw.strip():
+        return _STALL_LIMIT_DEFAULT_S
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "[Headless Task] Invalid AGENT_TOOL_STALL_LIMIT_S=%r — using default %.0fs",
+            raw, _STALL_LIMIT_DEFAULT_S,
+        )
+        return _STALL_LIMIT_DEFAULT_S
 
 
 def _open_tool_exceeding(ctx: HeadlessRunContext, limit_s: float) -> Optional[str]:
-    """Name of a tool_use open (no matching tool_result) for > ``limit_s``, else None.
+    """Name of an ``mcp__*`` tool_use open (no tool_result) for > ``limit_s``, else None.
 
     #970 stall-watchdog signal. Reuses the stream parser's existing
     bookkeeping — ``tool_start_times`` (set on every tool_use) and the
     ``execution_log`` tool_result entries that close them. A hung stdio
     MCP ``tools/call`` never emits a tool_result, so its tool_use stays
     open: the only externally-visible signal that claude is wedged.
+
+    #1369: only ``mcp__*`` tools are considered. Built-ins return on their
+    own and are bounded by execution_timeout, so they are exempt here. The
+    caller must only invoke this with ``limit_s > 0`` (a ``<= 0`` limit would
+    match every open tool).
     """
     log = list(ctx.execution_log)  # snapshot — reader thread mutates concurrently
     completed = {e.id for e in log if e.type == "tool_result"}
     now = datetime.now()
     for e in log:
         if e.type == "tool_use" and e.id not in completed:
+            # Scope to opaque MCP stdio calls; None-safe (a tool_use with no
+            # name must not crash the poll loop).
+            if not (e.tool or "").startswith("mcp__"):
+                continue
             started = ctx.tool_start_times.get(e.id)
             if started and (now - started).total_seconds() > limit_s:
                 return e.tool
@@ -252,10 +295,13 @@ class HeadlessRunContext:
     stdout_exc: List[BaseException] = field(default_factory=list)
     # #1094: which termination path fired, so the terminal 504 carries a
     # distinct reason instead of always claiming the max-duration timeout.
-    #   "stall_no_output" — a tool produced no result for >_STALL_LIMIT_S
+    #   "stall_no_output" — an mcp__ tool produced no result for >stall_limit_s
     #   "max_duration"    — the effective_timeout budget was genuinely exhausted
     termination_reason: Optional[str] = None
     stalled_tool: Optional[str] = None
+    # #1369: the per-run resolved stall ceiling actually applied, so the
+    # terminal-504 wording reports the configured value (not a stale constant).
+    stall_limit_s: float = _STALL_LIMIT_DEFAULT_S
     # #1025 (salvaged from #980): True when the drain returned anything other
     # than "completed" (budget_exceeded / errored / leaked) — a reader thread
     # may still be alive and mutating the shared buffers below, so
@@ -664,11 +710,19 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
     #       result instead of burning the budget. The result IS success, so
     #       set return_code=0 — genuine errors were already classified into
     #       metadata.error_type from the stream and are surfaced in finalize.
-    #   (b) stall watchdog — an open tool_use with no tool_result for
-    #       >_STALL_LIMIT_S. Claude Code has no per-MCP-tool timeout, so a
-    #       hung tools/call would otherwise wedge until the full budget.
+    #   (b) stall watchdog — an open mcp__ tool_use with no tool_result for
+    #       >stall_limit (AGENT_TOOL_STALL_LIMIT_S). Claude Code has no per-MCP-
+    #       tool timeout, so a hung tools/call would otherwise wedge until the
+    #       full budget. Scoped to mcp__* and disable-able (#1369).
     #   (c) effective_timeout budget — unchanged backstop.
     deadline = time.monotonic() + ctx.effective_timeout
+    # #1369: resolve the stall ceiling once per run. <=0 disables the per-tool
+    # watchdog (the deadline backstop still applies). Disable is gated HERE, not
+    # by passing 0 down — _open_tool_exceeding's `> limit_s` would otherwise
+    # match every open tool and fire instantly.
+    stall_limit = _resolve_stall_limit_s()
+    ctx.stall_limit_s = stall_limit
+    stall_enabled = stall_limit > 0
     stalled_tool: Optional[str] = None
     try:
         while True:
@@ -684,7 +738,8 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
                     _terminate_process_group(process, graceful_timeout=2, pgid=ctx.process_pgid, execution_tag=ctx.task_session_id)
                     ctx.return_code = 0
                     break
-                stalled_tool = _open_tool_exceeding(ctx, _STALL_LIMIT_S)
+                if stall_enabled:
+                    stalled_tool = _open_tool_exceeding(ctx, stall_limit)
                 if stalled_tool or time.monotonic() >= deadline:
                     raise
     except subprocess.TimeoutExpired:
@@ -697,7 +752,7 @@ def _run_headless_subprocess(ctx: HeadlessRunContext) -> None:
         else:
             ctx.termination_reason = "max_duration"
         reason = (
-            f"tool '{stalled_tool}' stalled with no result for >{_STALL_LIMIT_S:.0f}s"
+            f"tool '{stalled_tool}' stalled with no result for >{stall_limit:.0f}s"
             if stalled_tool
             else f"timed out after {ctx.effective_timeout}s"
         )
@@ -1174,7 +1229,7 @@ async def execute_headless_task(
                 if ctx.termination_reason == "stall_no_output":
                     logger.error(
                         f"[Headless Task] Task {ctx.task_session_id} killed by stall "
-                        f"watchdog (tool '{ctx.stalled_tool}' silent >{_STALL_LIMIT_S:.0f}s)"
+                        f"watchdog (tool '{ctx.stalled_tool}' silent >{ctx.stall_limit_s:.0f}s)"
                     )
                     raise HTTPException(
                         status_code=504,
@@ -1182,7 +1237,7 @@ async def execute_headless_task(
                             ctx,
                             (
                                 f"Killed: tool '{ctx.stalled_tool}' produced no output "
-                                f"for {_STALL_LIMIT_S:.0f}s (stall watchdog)"
+                                f"for {ctx.stall_limit_s:.0f}s (stall watchdog)"
                             ),
                             "stall_no_output",
                             stalled_tool=ctx.stalled_tool,

--- a/docker/base-image/agent_server/services/headless_executor.py
+++ b/docker/base-image/agent_server/services/headless_executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import subprocess
 import threading
@@ -96,18 +97,24 @@ def _resolve_stall_limit_s() -> float:
     back to the default with a warning (a typo must not brick the executor).
     A value ``<= 0`` means *disabled* and is handled at the call site — it is
     NOT passed into ``_open_tool_exceeding`` (where ``> 0`` would fire instantly).
+    Non-finite values (``inf``/``nan``) parse as floats but would silently make
+    the watchdog inert/disabled, so they fall back to the default too — only a
+    deliberate ``<= 0`` disables.
     """
     raw = os.environ.get("AGENT_TOOL_STALL_LIMIT_S")
     if raw is None or not raw.strip():
         return _STALL_LIMIT_DEFAULT_S
     try:
-        return float(raw)
+        val = float(raw)
     except (TypeError, ValueError):
+        val = math.nan
+    if not math.isfinite(val):
         logger.warning(
             "[Headless Task] Invalid AGENT_TOOL_STALL_LIMIT_S=%r — using default %.0fs",
             raw, _STALL_LIMIT_DEFAULT_S,
         )
         return _STALL_LIMIT_DEFAULT_S
+    return val
 
 
 def _open_tool_exceeding(ctx: HeadlessRunContext, limit_s: float) -> Optional[str]:

--- a/docs/memory/requirements.md
+++ b/docs/memory/requirements.md
@@ -534,6 +534,21 @@ Trinity is autonomous agent orchestration and infrastructure — sovereign infra
   - API: `GET/PUT /api/agents/{name}/timeout`
   - Validation: 60-7200s (1 min to 2 hours)
 - **Flow**: `docs/memory/feature-flows/parallel-capacity.md` (updated), `docs/memory/feature-flows/task-execution-service.md` (updated)
+- **Headless per-tool stall watchdog (#1369, 2026-06-29)**: the headless executor's
+  per-tool stall watchdog (`headless_executor.py`) — which kills an execution when a
+  `tool_use` has no `tool_result` for too long (introduced #970/#973 to bound a hung
+  stdio MCP `tools/call`; reason-labeled `stall_no_output` by #1094) — is now (a)
+  **scoped to `mcp__*` tools only** so legitimately long built-ins (`Bash`/`Read`/`Task`
+  sub-agents, already bounded by `execution_timeout_seconds`) are never stall-killed, and
+  (b) **operator-configurable** via `AGENT_TOOL_STALL_LIMIT_S` (default **1800s**, raised
+  from the old flat 300s; `0`/negative = disabled, relying on the execution-timeout
+  backstop). The value is read per-run inside the agent container and threaded from the
+  backend env at create/recreate (`crud.py`/`lifecycle.py`) — creation-time like
+  `AGENT_TMP_SIZE`, so existing agents pick up a change on **recreate**, not a plain
+  restart. Tradeoff: a genuinely hung built-in (or a hang *inside* a `Task` sub-agent,
+  which surfaces as an open `Task` in the parent log) now falls to the execution-timeout
+  budget instead of the 300s kill. Superseded long-term by the pull/work-stealing model
+  (#1081/#1083), which retires the watchdog entirely.
 
 ### 10.8 Persistent Task Backlog (BACKLOG-001)
 - **Status**: ✅ Implemented (2026-04-13); internalized behind `CapacityManager` (#428, 2026-04-26)

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -522,6 +522,14 @@ async def create_agent_internal(
         'TMPDIR': AGENT_DEFAULT_TMPDIR,
     }
 
+    # #1369: operator-configurable headless per-tool stall-watchdog ceiling.
+    # Only propagate when the backend env sets it — an unset value leaves the
+    # agent-side default (1800s). Baked at create like AGENT_TMP_SIZE; existing
+    # agents pick up a change on their next recreate (not a plain restart).
+    _stall_limit = (os.getenv('AGENT_TOOL_STALL_LIMIT_S') or '').strip()
+    if _stall_limit:
+        env_vars['AGENT_TOOL_STALL_LIMIT_S'] = _stall_limit
+
     # GUARD-001: per-agent guardrails overrides (empty by default; baseline
     # is always applied inside the container).
     _guardrails = db.get_guardrails_config(config.name)

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -422,6 +422,16 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
     else:
         env_vars.pop('AGENT_GUARDRAILS', None)
 
+    # #1369: refresh the operator-configurable headless stall-watchdog ceiling
+    # from the CURRENT backend env on every recreate (set or clear, mirroring the
+    # guardrails idiom above), so changing/unsetting AGENT_TOOL_STALL_LIMIT_S
+    # takes effect on recreate rather than persisting a stale baked value.
+    _stall_limit = (os.getenv('AGENT_TOOL_STALL_LIMIT_S') or '').strip()
+    if _stall_limit:
+        env_vars['AGENT_TOOL_STALL_LIMIT_S'] = _stall_limit
+    else:
+        env_vars.pop('AGENT_TOOL_STALL_LIMIT_S', None)
+
     # #1159: refresh the per-agent auth token. Deterministic from agent_name, so
     # this re-derives under the CURRENT name — the load-bearing part of the
     # rename fix (a renamed container otherwise keeps derive(old_name) and 401s

--- a/tests/unit/test_1094_stall_termination_reason.py
+++ b/tests/unit/test_1094_stall_termination_reason.py
@@ -104,7 +104,8 @@ def test_stall_sets_stall_no_output_reason(patched_loop):
     """An open tool_use silent past the stall limit records
     termination_reason='stall_no_output' and the offending tool name."""
     monkeypatch = patched_loop
-    monkeypatch.setattr(he, "_STALL_LIMIT_S", 0.0)
+    # Tiny POSITIVE limit trips the open mcp tool immediately (#1369: 0 disables).
+    monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "0.01")
     _install_popen(monkeypatch, _FakePopen([_TOOL_USE_LINE], never_exits=True))
     ctx = _ctx(effective_timeout=30)  # large — budget must NOT be what fires
 

--- a/tests/unit/test_headless_executor_970_timeout.py
+++ b/tests/unit/test_headless_executor_970_timeout.py
@@ -156,6 +156,67 @@ class TestOpenToolExceeding:
         }
         assert he._open_tool_exceeding(ctx, 300) == "mcp__x__hang"
 
+    # --- #1369: scope to mcp__*, exempt built-ins, None-safe --------------
+
+    def test_builtin_tool_exempt_even_when_long_open(self):
+        """A long-running built-in (Bash / Task sub-agent) is NOT a stall — it is
+        bounded by execution_timeout, not the per-tool watchdog (#1369)."""
+        for builtin in ("Bash", "Task", "Read", "WebFetch"):
+            ctx = _ctx()
+            ctx.execution_log = [_tool_use_entry("t1", builtin)]
+            ctx.tool_start_times = {"t1": datetime.now() - timedelta(seconds=4000)}
+            assert he._open_tool_exceeding(ctx, 300) is None, builtin
+
+    def test_builtin_open_but_mcp_stalled_flags_only_mcp(self):
+        ctx = _ctx()
+        ctx.execution_log = [
+            _tool_use_entry("b", "Bash"),
+            _tool_use_entry("m", "mcp__srv__call"),
+        ]
+        now = datetime.now()
+        ctx.tool_start_times = {
+            "b": now - timedelta(seconds=4000),   # long Bash, exempt
+            "m": now - timedelta(seconds=400),    # stalled mcp, caught
+        }
+        assert he._open_tool_exceeding(ctx, 300) == "mcp__srv__call"
+
+    def test_blank_or_non_mcp_name_not_flagged(self):
+        """A non-mcp__ name (incl. an empty string) is exempt and must not crash
+        — the `(e.tool or "")` guard keeps a falsy name from raising."""
+        ctx = _ctx()
+        ctx.execution_log = [_tool_use_entry("t1", "")]
+        ctx.tool_start_times = {"t1": datetime.now() - timedelta(seconds=400)}
+        assert he._open_tool_exceeding(ctx, 300) is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_stall_limit_s (env-configurable ceiling, #1369)
+# ---------------------------------------------------------------------------
+
+class TestResolveStallLimit:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("AGENT_TOOL_STALL_LIMIT_S", raising=False)
+        assert he._resolve_stall_limit_s() == he._STALL_LIMIT_DEFAULT_S
+
+    def test_default_when_blank(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "   ")
+        assert he._resolve_stall_limit_s() == he._STALL_LIMIT_DEFAULT_S
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "600")
+        assert he._resolve_stall_limit_s() == 600.0
+
+    def test_invalid_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "not-a-number")
+        assert he._resolve_stall_limit_s() == he._STALL_LIMIT_DEFAULT_S
+
+    def test_zero_and_negative_pass_through_as_disabled_sentinel(self, monkeypatch):
+        # <=0 is returned verbatim; the call site (not the helper) gates disable.
+        monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "0")
+        assert he._resolve_stall_limit_s() == 0.0
+        monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "-5")
+        assert he._resolve_stall_limit_s() == -5.0
+
 
 # ---------------------------------------------------------------------------
 # Wait-loop branches via _run_headless_subprocess
@@ -190,10 +251,12 @@ class TestWaitLoop:
         assert any("finalizing early" in r.getMessage() for r in caplog.records)
 
     def test_stall_watchdog_raises_for_open_tool(self, patched_loop, caplog):
-        """An open tool_use with no result for >_STALL_LIMIT_S raises
-        TimeoutExpired well before the budget."""
+        """An open mcp__ tool_use with no result for >stall_limit raises
+        TimeoutExpired well before the budget (#970)."""
         monkeypatch, _term = patched_loop
-        monkeypatch.setattr(he, "_STALL_LIMIT_S", 0.0)
+        # A tiny POSITIVE limit makes the open mcp tool trip immediately.
+        # (0 means *disabled* under #1369 — see the disable-path test.)
+        monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "0.01")
         _install_popen(monkeypatch, _FakePopen([_TOOL_USE_LINE], never_exits=True))
         ctx = _ctx(effective_timeout=30)  # large — must NOT be what fires
 
@@ -205,6 +268,25 @@ class TestWaitLoop:
 
         assert elapsed < 5.0, "stall should fire fast, not at the 30s budget"
         assert any("stalled with no result" in r.getMessage() for r in caplog.records)
+        assert ctx.termination_reason == "stall_no_output"
+
+    def test_stall_watchdog_disabled_falls_to_budget(self, patched_loop, caplog):
+        """#1369: AGENT_TOOL_STALL_LIMIT_S=0 disables the per-tool watchdog; an
+        open mcp__ tool is NOT stall-killed — only the execution_timeout budget
+        bounds it (termination_reason 'max_duration', not 'stall_no_output')."""
+        monkeypatch, _term = patched_loop
+        monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "0")
+        monkeypatch.setattr(he, "_WAIT_POLL_S", 0.1)
+        _install_popen(monkeypatch, _FakePopen([_TOOL_USE_LINE], never_exits=True))
+        ctx = _ctx(effective_timeout=0.3)  # the budget is what must fire
+
+        with caplog.at_level(logging.ERROR, logger=he.logger.name):
+            with pytest.raises(subprocess.TimeoutExpired):
+                he._run_headless_subprocess(ctx)
+
+        assert ctx.termination_reason == "max_duration"
+        assert ctx.stalled_tool is None
+        assert any("timed out after" in r.getMessage() for r in caplog.records)
 
     def test_natural_exit_still_returns_real_code(self, patched_loop):
         """Regression: a process that exits on its own is unchanged."""

--- a/tests/unit/test_headless_executor_970_timeout.py
+++ b/tests/unit/test_headless_executor_970_timeout.py
@@ -210,6 +210,13 @@ class TestResolveStallLimit:
         monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "not-a-number")
         assert he._resolve_stall_limit_s() == he._STALL_LIMIT_DEFAULT_S
 
+    def test_non_finite_falls_back_to_default(self, monkeypatch):
+        # inf/nan parse as floats but would silently make the watchdog
+        # inert/disabled — they must fall back to the default, not pass through.
+        for bad in ("inf", "-inf", "Infinity", "nan", "NaN"):
+            monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", bad)
+            assert he._resolve_stall_limit_s() == he._STALL_LIMIT_DEFAULT_S, bad
+
     def test_zero_and_negative_pass_through_as_disabled_sentinel(self, monkeypatch):
         # <=0 is returned verbatim; the call site (not the helper) gates disable.
         monkeypatch.setenv("AGENT_TOOL_STALL_LIMIT_S", "0")


### PR DESCRIPTION
## Summary
- The headless per-tool **stall watchdog** killed the whole execution when any `tool_use` had no `tool_result` for a flat hardcoded 300s — indistinguishable "hung" vs "legitimately slow", so long sub-agents (`Task`), internal MCP calls (`mcp__trinity__chat_with_agent`/`fan_out`), and long `Bash` steps died at 5 min (`terminal_reason=stall_no_output`).
- Now **scoped to `mcp__*` tools** (built-ins exempt — already bounded by `execution_timeout_seconds`) **and operator-configurable** via `AGENT_TOOL_STALL_LIMIT_S` (default raised 300s→1800s; `0`=disabled).
- #970 phantom-2h-hang protection preserved; #1094 `stall_no_output` reason preserved.

## Changes
- `docker/base-image/agent_server/services/headless_executor.py` — `_resolve_stall_limit_s()` (per-run, env-read, invalid→default); `_open_tool_exceeding` scoped to `mcp__*` + `(e.tool or "")` None/blank-safe; disable **gated at the call site** (passing `0` into the helper would fire instantly); kill wording threads the resolved limit (carried on `ctx.stall_limit_s`).
- `src/backend/services/agent_service/crud.py` + `lifecycle.py` — thread `AGENT_TOOL_STALL_LIMIT_S` from backend env into the container (set on create; set/clear on recreate, mirroring the `AGENT_GUARDRAILS` idiom).
- `tests/unit/test_headless_executor_970_timeout.py` + `test_1094_stall_termination_reason.py` — built-in exemption, mcp-only flagging, blank-name safety, env resolver (default/blank/valid/invalid/disabled), disable-path falls to budget, and the two existing tests migrated off the removed constant.
- `docs/memory/requirements.md` — documented under TIMEOUT-001.

## Acceptance criteria
- [x] Legit long-running tool (sub-agent/MCP/`Bash`) >300s with progress no longer killed
- [x] #970 genuine-hang protection preserved (hung stdio `mcp__` `tools/call` still bounded; test)
- [x] Stall limit operator-configurable (`AGENT_TOOL_STALL_LIMIT_S`); `0`/unset documented
- [x] Built-ins (≥`Bash`) not subject to the aggressive MCP kill (scoped to `mcp__*`)
- [x] No regression to #970 (test); `stall_no_output` reason preserved (#1094)

## Test Plan
- [x] `pytest tests/unit/test_headless_executor_970_timeout.py tests/unit/test_1094_stall_termination_reason.py` → 20 passed; full headless suite 65 passed
- [ ] **Rollout**: agent-internal change — needs `./scripts/deploy/build-base-image.sh` + container **recreate** (not a plain restart; env baked at create). Default is *raised*, so no recreated agent regresses to a tighter kill; un-migrated agents keep 300s. Mixed-fleet safe (no backend↔agent protocol change).

## Tradeoff (called out)
Exempting built-ins means a genuinely hung `Bash`/`Task` — or a hang *inside* a `Task` sub-agent (surfaces as an open `Task` in the parent log) — now falls to the `execution_timeout` budget instead of the 300s kill. Accepted interim; the pull/work-stealing model (#1081/#1083) retires this watchdog entirely.

Related to #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #1369