### PR TITLE
fix(tests): stop sys.modules leaks + load AGENT_AUTH_SECRET in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,13 @@ if _dot_env_754.exists():
     try:
         from dotenv import dotenv_values as _dotenv_values_754
         _env_vals_754 = _dotenv_values_754(_dot_env_754)
-        # INTERNAL_API_SECRET / SECRET_KEY have no earlier default — setdefault
-        # is fine (the caller's explicit export still wins).
-        for _k754 in ("INTERNAL_API_SECRET", "SECRET_KEY"):
+        # INTERNAL_API_SECRET / SECRET_KEY / AGENT_AUTH_SECRET have no earlier
+        # default — setdefault is fine (the caller's explicit export still wins).
+        # AGENT_AUTH_SECRET (#1159) is auto-generated into .env by start.sh; the
+        # backend's derive_agent_token() raises without it, so tests that mint
+        # per-agent auth tokens (circuit breaker, monitoring, watchdog, PAT
+        # propagation) need it loaded here too.
+        for _k754 in ("INTERNAL_API_SECRET", "SECRET_KEY", "AGENT_AUTH_SECRET"):
             _v754 = _env_vals_754.get(_k754)
             if _v754:
                 _os_589.environ.setdefault(_k754, _v754)

--- a/tests/integration/test_monitoring_service.py
+++ b/tests/integration/test_monitoring_service.py
@@ -127,13 +127,23 @@ sys.modules["services.agent_client"] = agent_client
 _AC_SPEC.loader.exec_module(agent_client)
 
 
-# Stub `database` so monitoring_service.py's `from database import db` works.
+# Stub `database`, `services.docker_service`, and `services.docker_utils` ONLY
+# for the monitoring_service module load below, then restore the real
+# sys.modules entries. These are imported lazily inside health-check functions
+# and are never exercised by the tests, so the stubs are needed only to satisfy
+# imports during exec_module. Leaving them installed permanently leaks a bare
+# `services.docker_utils` (no `container_get_archive`) into later test files
+# such as test_whatsapp_adapter, breaking their imports with
+# "cannot import name 'container_get_archive' ... (unknown location)" (#211).
+# `services.agent_client` (loaded above) is the REAL module and IS used at test
+# runtime by check_network_health's lazy import, so it deliberately stays.
+_CONFINED_KEYS = ("database", "services.docker_service", "services.docker_utils")
+_saved_mods = {k: sys.modules.get(k) for k in _CONFINED_KEYS}
+
 _fake_database = types.ModuleType("database")
 _fake_database.db = MagicMock()
 sys.modules["database"] = _fake_database
 
-# Stub `services.docker_service` and `services.docker_utils` (imported lazily
-# inside health check functions; harmless to stub since we never call them).
 _fake_docker_service = types.ModuleType("services.docker_service")
 _fake_docker_service.docker_client = None
 _fake_docker_service.get_agent_container = MagicMock(return_value=None)
@@ -151,6 +161,15 @@ _MS_SPEC = importlib.util.spec_from_file_location(
 )
 monitoring_service = importlib.util.module_from_spec(_MS_SPEC)
 _MS_SPEC.loader.exec_module(monitoring_service)
+
+# monitoring_service now holds its own bound references (db, lazy importers);
+# restore the real sys.modules entries so the fakes don't leak into later
+# test files. agent_client is intentionally NOT restored (real + needed).
+for _k, _v in _saved_mods.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
 
 
 pytestmark = pytest.mark.integration

--- a/tests/test_github_pat_propagation_unit.py
+++ b/tests/test_github_pat_propagation_unit.py
@@ -31,23 +31,30 @@ if "utils.helpers" not in sys.modules:
     sys.modules["utils.helpers"] = _helpers
 
 
-# Stub heavy dependencies before importing the service under test so we don't
-# need docker / redis / a live DB to import it. We bypass `services/__init__.py`
-# entirely by loading the service module directly from its file path.
+# Stub heavy dependencies so the service module loads without docker / redis /
+# a live DB, bypassing services/__init__.py. These stubs are installed ONLY for
+# the duration of the `service` fixture (via patch.dict), never permanently:
+# a permanent sys.modules install of the fake `services` package leaks into
+# later test modules — e.g. test_whatsapp_adapter then fails importing
+# container_get_archive from services.docker_utils against the fake namespace
+# (#211 sys.modules-pollution fix).
 _fake_database = types.ModuleType("database")
 _fake_database.db = MagicMock()
-sys.modules.setdefault("database", _fake_database)
 
 _fake_services_pkg = types.ModuleType("services")
 _fake_services_pkg.__path__ = [os.path.join(_backend_path, "services")]
-sys.modules["services"] = _fake_services_pkg
 
 _fake_docker_service = types.ModuleType("services.docker_service")
 _fake_docker_service.list_all_agents_fast = MagicMock(return_value=[])
 # #1264: github_pat_propagation_service now imports get_agent_container at module
 # top, so the stub must expose it for the fresh module load to succeed.
 _fake_docker_service.get_agent_container = MagicMock(return_value=None)
-sys.modules["services.docker_service"] = _fake_docker_service
+
+_STUB_MODULES = {
+    "database": _fake_database,
+    "services": _fake_services_pkg,
+    "services.docker_service": _fake_docker_service,
+}
 
 
 def _load_service():
@@ -77,10 +84,29 @@ def cleanup_after_test():
 
 @pytest.fixture
 def service():
-    """Fresh service module with stubs in place."""
-    if "services.github_pat_propagation_service" in sys.modules:
-        del sys.modules["services.github_pat_propagation_service"]
-    return _load_service()
+    """Fresh service module loaded under confined sys.modules stubs.
+
+    The heavy-dependency stubs are installed only for this fixture, and exactly
+    the keys we touch are restored on teardown. This is a deliberate per-key
+    save/restore rather than ``patch.dict(sys.modules, ...)``: patch.dict does a
+    global ``sys.modules.clear()`` + rebuild on exit, which corrupts unrelated
+    real modules (e.g. ``services.docker_utils`` for the later
+    test_whatsapp_adapter file → ``cannot import container_get_archive ...
+    (unknown location)``). Scoping the restore to our own keys keeps the fake
+    ``services`` package from leaking without disturbing anything else (#211).
+    """
+    _stub_keys = (*_STUB_MODULES, "services.github_pat_propagation_service")
+    _saved = {k: sys.modules.get(k) for k in _stub_keys}
+    sys.modules.update(_STUB_MODULES)
+    sys.modules.pop("services.github_pat_propagation_service", None)
+    try:
+        yield _load_service()
+    finally:
+        for k in _stub_keys:
+            if _saved[k] is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = _saved[k]
 
 
 # ---------------------------------------------------------------------------
@@ -142,7 +168,7 @@ def _agent(name: str, status: str = "running"):
 def _make_async_client(read_responses: dict, inject_responses: dict):
     """Build an AsyncMock httpx.AsyncClient that routes per-URL."""
 
-    async def _get(url, params=None, timeout=None):
+    async def _get(url, params=None, timeout=None, headers=None):
         agent = url.split("http://agent-")[1].split(":")[0]
         resp = read_responses[agent]
         r = MagicMock()
@@ -150,7 +176,7 @@ def _make_async_client(read_responses: dict, inject_responses: dict):
         r.json = MagicMock(return_value=resp)
         return r
 
-    async def _post(url, json=None, timeout=None):
+    async def _post(url, json=None, timeout=None, headers=None):
         agent = url.split("http://agent-")[1].split(":")[0]
         behavior = inject_responses[agent]
         if isinstance(behavior, Exception):


### PR DESCRIPTION
## Summary

A clean-install full-suite run surfaced 118 failures; the two largest clusters (~89 failures) were **test-harness bugs, not product regressions**. This PR fixes them. All are test-only changes (3 files).

## Root causes & fixes

**1. `AGENT_AUTH_SECRET` not loaded by `conftest.py`**
`start.sh` auto-generates `AGENT_AUTH_SECRET` into `.env` (#1159), but `conftest.py` only loaded `SECRET_KEY` / `INTERNAL_API_SECRET`. Without it, `derive_agent_token()` raises `RuntimeError`, failing every test that mints a per-agent auth token (circuit breaker, monitoring, watchdog, github_pat propagation). → Added it to the `.env`-loading loop (**31 failures**).

**2. `sys.modules` pollution in `test_github_pat_propagation_unit.py`**
The module installed fake `services` / `database` / `services.docker_service` into `sys.modules` **permanently, with no teardown**, leaking into later files — `test_whatsapp_adapter` then failed importing `container_get_archive` from `services.docker_utils`. → Confined the stubs to the `service` fixture via per-key save/restore. (`patch.dict`'s global `sys.modules.clear()` corrupts unrelated modules, so it's unusable here.)

**3. Stale httpx mock in the same file (#1159 drift)**
A second bug under the `AGENT_AUTH` error: the service now sends `headers=build_agent_auth_headers(...)`, but the test's mock `_get`/`_post` didn't accept `headers` → `TypeError` into the catch-all. → Mock now accepts the kwarg.

**4. A *second*, independent `sys.modules` polluter in `test_monitoring_service.py`**
It installed a **bare** fake `services.docker_utils` (no `container_get_archive`) permanently — the literal source of the WhatsApp `(unknown location)` ImportError, independent of #2. `monitoring + whatsapp` reproduced all 54 failures on its own. → Confined the `database` / `docker_service` / `docker_utils` stubs to the module load; kept the real `services.agent_client` (needed at runtime). (Together #2–#4 = the **54-failure WhatsApp cluster**.)

## Validation

| Scenario | Result |
|---|---|
| github_pat alone | 11 passed |
| whatsapp alone | 67 passed |
| monitoring alone | 13 passed |
| circuit_breaker + monitoring (Redis reachable) | 47 passed |
| **All 5 affected files** | **168 passed, 0 failed** |
| **All 5, reversed collection order** | **168 passed, 0 failed** |

Order-robust by construction — no permanent `sys.modules` leaks remain in these files.

## Scope

Test-only (`tests/`). No product code touched. Remaining clean-install failures (stale assertions, unit-env hygiene, ~3 genuine product items) are out of scope and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)