### PR TITLE
fix(auth): JWT revocation on logout (#187)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -756,7 +756,8 @@ Token lifecycle: `secrets.token_urlsafe(32)` stored in `agent_schedules.webhook_
 | GET | `/api/auth/mode` | Auth mode config (unauthenticated) |
 | POST | `/api/token` | Admin login — `username` accepts `admin` OR the admin's registered email + password (#82); form-encoded |
 | POST | `/api/auth/email/request` / `/verify` | Request email code / verify and login |
-| GET | `/api/auth/validate` | Validate JWT (for nginx auth_request) |
+| POST | `/api/auth/logout` | Revoke the caller's JWT — blacklists its `jti` in Redis until the token's own expiry, so an exfiltrated 7-day token dies on logout (#187). Idempotent; MCP-key callers are a no-op (keys revoke via key management) |
+| GET | `/api/auth/validate` | Validate JWT (for nginx auth_request) — also rejects a `jti` revoked via logout (#187) |
 | GET | `/api/users/me` | Current user |
 | PUT | `/api/users/me/email` | Bind a sign-in email to the caller's own account (#82 transition; 409 if taken). No verification email sent |
 | GET | `/api/users` | List users with roles (admin-only; exposes `suspended_at` read-only) (ROLE-001) |
@@ -1640,6 +1641,7 @@ CREATE INDEX idx_agent_reports_created ON agent_reports(created_at);  -- retenti
 | **Admin** (secondary) | Password → `POST /api/token` | JWT with `mode: "admin"` |
 
 - Email whitelist controls who can login via email; admin login always available for 'admin'.
+- **JWT revocation on logout** (#187): every access token carries a random `jti`; `POST /api/auth/logout` writes `jwt:revoked:{jti}` to Redis with a TTL equal to the token's remaining life, and `get_current_user` / `decode_token` (WS) / `/api/auth/validate` (nginx) reject a revoked `jti`. Closes the "exfiltrated 7-day token survives logout" gap (pentest 3.3.4). Fail-open (Redis down or a legacy no-`jti` token → not revoked), so the check can never lock out a valid session; backend restart still rotates `SECRET_KEY` and invalidates everything. Token-lifetime reduction + refresh tokens deferred (separate issue).
 - **4-tier role hierarchy** (ROLE-001): `user` < `operator` < `creator` < `admin`. Agent creation requires `creator`+. Enforced via `require_role()` in `dependencies.py`.
 - **Whitelist-driven role on first login** (#314): new email users inherit the `default_role` on their `email_whitelist` row (fallback `user`). Callsites pass explicit intent — `/share` and access-request approvals → `user` (chat-only grant); public `/api/access/request` self-signup → `user`; admin whitelist UI → caller-specified. Owners promote collaborators explicitly via `PUT /api/users/{username}/role`. Closes a privilege escalation where any access grant silently promoted the recipient to `creator`.
 - **Public self-signup is default-OFF** (trinity-enterprise#10): the unauthenticated `POST /api/access/request` returns **403** unless an operator opts in via `PUBLIC_ACCESS_REQUESTS_ENABLED` (env) or the `public_access_requests_enabled` system setting. When off it never auto-whitelists, so the email whitelist stays authoritative against self-enrollment. Login-code requests for already-whitelisted emails are unaffected.

--- a/src/backend/dependencies.py
+++ b/src/backend/dependencies.py
@@ -1,7 +1,9 @@
 """
 FastAPI dependencies for the Trinity backend.
 """
-from datetime import datetime, timedelta
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Annotated
 from fastapi import Depends, HTTPException, status, Request, Path
 from fastapi.security import OAuth2PasswordBearer
@@ -10,6 +12,53 @@ from passlib.context import CryptContext
 from models import User
 from config import SECRET_KEY, ALGORITHM
 from database import db
+from redis_breaker_util import get_breaker_redis
+
+logger = logging.getLogger(__name__)
+
+# JWT revocation (#187): a logged-out token's `jti` is stored in Redis until it
+# would have expired anyway, so the 7-day token can be killed early. Fail-open
+# — if Redis is unreachable the check is skipped (a revoked token would then
+# pass until natural expiry), matching the platform-wide fail-open posture; the
+# threat (UnderDefense 3.3.4) is Low/CVSS 2.0 and backend restarts already
+# rotate SECRET_KEY (invalidating every token).
+_JWT_REVOKED_PREFIX = "jwt:revoked:"
+
+
+def revoke_token_jti(jti: str, exp_ts: Optional[int]) -> None:
+    """Blacklist a token's `jti` until its own expiry (best-effort, fail-open).
+
+    TTL is the token's remaining lifetime, so the key self-expires exactly when
+    the token would — no unbounded growth, no separate sweep.
+    """
+    if not jti:
+        return
+    r = get_breaker_redis()
+    if r is None:
+        return
+    now = int(datetime.now(timezone.utc).timestamp())
+    ttl = (int(exp_ts) - now) if exp_ts else 0
+    if ttl <= 0:
+        return  # already expired — nothing to revoke
+    try:
+        r.setex(f"{_JWT_REVOKED_PREFIX}{jti}", ttl, "1")
+    except Exception as exc:  # pragma: no cover — fail-open
+        logger.warning(f"[auth] revoke_token_jti failed (fail-open): {exc}")
+
+
+def is_token_revoked(jti: Optional[str]) -> bool:
+    """True if this `jti` was revoked via logout. Fail-open → False on no jti
+    (legacy token minted before #187) or Redis error."""
+    if not jti:
+        return False
+    r = get_breaker_redis()
+    if r is None:
+        return False
+    try:
+        return r.exists(f"{_JWT_REVOKED_PREFIX}{jti}") > 0
+    except Exception as exc:  # pragma: no cover — fail-open
+        logger.warning(f"[auth] is_token_revoked failed (fail-open): {exc}")
+        return False
 
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -73,7 +122,8 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None, m
         expire = datetime.utcnow() + timedelta(minutes=15)
     to_encode.update({
         "exp": expire,
-        "mode": mode  # Track auth mode to prevent dev/prod token mixing
+        "mode": mode,  # Track auth mode to prevent dev/prod token mixing
+        "jti": secrets.token_urlsafe(16),  # #187: per-token id for revocation
     })
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
@@ -141,6 +191,10 @@ def decode_token(token: str) -> Optional[dict]:
         if payload.get("scope") == MFA_CHALLENGE_SCOPE:
             return None
 
+        # #187 — a token revoked via logout is no longer valid (also for WS).
+        if is_token_revoked(payload.get("jti")):
+            return None
+
         # Get full user record from database
         user = db.get_user_by_username(username)
         if not user:
@@ -180,6 +234,10 @@ async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)
         # authorizes /api/enterprise/2fa/login/*; the second factor must be
         # completed there to obtain a real access token.
         if payload.get("scope") == MFA_CHALLENGE_SCOPE:
+            raise credentials_exception
+
+        # #187 — reject a token revoked via logout.
+        if is_token_revoked(payload.get("jti")):
             raise credentials_exception
 
         user = db.get_user_by_username(username)

--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -20,7 +20,15 @@ from config import (
     REDIS_URL,
 )
 from database import db
-from dependencies import authenticate_user, create_access_token
+from dependencies import (
+    authenticate_user,
+    create_access_token,
+    get_current_user,
+    is_token_revoked,
+    oauth2_scheme,
+    revoke_token_jti,
+)
+from models import User
 
 logger = logging.getLogger(__name__)
 
@@ -373,7 +381,7 @@ async def validate_token(request: Request):
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         username: str = payload.get("sub")
         user = db.get_user_by_username(username) if username else None
-        if username is None or user is None:
+        if username is None or user is None or is_token_revoked(payload.get("jti")):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid token",
@@ -386,6 +394,28 @@ async def validate_token(request: Request):
             detail="Invalid token",
             headers={"WWW-Authenticate": "Bearer"}
         )
+
+
+@router.post("/api/auth/logout")
+async def logout(
+    current_user: User = Depends(get_current_user),
+    token: str = Depends(oauth2_scheme),
+):
+    """Revoke the caller's JWT so it can no longer be used (#187).
+
+    `get_current_user` guarantees the bearer is a valid, non-revoked session
+    token (an MCP API key authenticates too, but carries no `jti` — logging out
+    a key is a no-op here; keys are revoked via key management). We then stamp
+    its `jti` into the Redis blacklist until the token's own expiry, so an
+    exfiltrated 7-day token stops working immediately on logout. Idempotent.
+    """
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        # Not a JWT (e.g. an MCP API key) — nothing to revoke by jti.
+        return {"status": "logged_out"}
+    revoke_token_jti(payload.get("jti"), payload.get("exp"))
+    return {"status": "logged_out"}
 
 
 # =========================================================================

--- a/src/frontend/src/stores/auth.js
+++ b/src/frontend/src/stores/auth.js
@@ -352,7 +352,16 @@ export const useAuthStore = defineStore('auth', {
     },
 
     // Logout
-    logout() {
+    async logout() {
+      // #187: revoke the token server-side first so an exfiltrated copy stops
+      // working immediately. Best-effort — never block local logout if the
+      // call fails (the Authorization header is still set at this point).
+      try {
+        await axios.post('/api/auth/logout')
+      } catch (e) {
+        // ignore — proceed to clear local state regardless
+      }
+
       this.token = null
       this.user = null
       this.isAuthenticated = false

--- a/tests/unit/test_187_jwt_revocation.py
+++ b/tests/unit/test_187_jwt_revocation.py
@@ -1,0 +1,88 @@
+"""
+JWT revocation on logout (#187 — UnderDefense pentest 3.3.4).
+
+Before #187 a JWT was valid for its full 7-day life with no server-side
+revocation: an exfiltrated token kept working through logout / password change.
+#187 adds a per-token `jti` and a Redis blacklist keyed on it, stamped by
+`POST /api/auth/logout` until the token's own expiry. These tests pin:
+
+  - every minted access token carries a `jti`;
+  - revoke → the jti reads back as revoked;
+  - the blacklist TTL never outlives the token (past-exp revoke is a no-op);
+  - fail-open: no jti (legacy token) and Redis-down both read as NOT revoked,
+    so the check can never lock out a legitimate session.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import fakeredis
+import pytest
+
+_BACKEND_STR = str(Path(__file__).resolve().parent.parent.parent / "src" / "backend")
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+import dependencies  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    r = fakeredis.FakeStrictRedis(decode_responses=True)
+    monkeypatch.setattr(dependencies, "get_breaker_redis", lambda: r)
+    return r
+
+
+def _exp_in(seconds: int) -> int:
+    return int((datetime.now(timezone.utc) + timedelta(seconds=seconds)).timestamp())
+
+
+def test_minted_token_carries_jti():
+    from jose import jwt
+    from config import SECRET_KEY, ALGORITHM
+
+    token = dependencies.create_access_token({"sub": "alice"}, timedelta(minutes=5))
+    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    assert payload.get("jti")  # non-empty per-token id
+
+
+def test_revoke_then_revoked(fake_redis):
+    jti = "tok-abc"
+    assert dependencies.is_token_revoked(jti) is False
+    dependencies.revoke_token_jti(jti, _exp_in(3600))
+    assert dependencies.is_token_revoked(jti) is True
+
+
+def test_revocation_ttl_bounded_by_token_expiry(fake_redis):
+    """The blacklist key self-expires no later than the token would."""
+    jti = "tok-ttl"
+    dependencies.revoke_token_jti(jti, _exp_in(120))
+    ttl = fake_redis.ttl(f"{dependencies._JWT_REVOKED_PREFIX}{jti}")
+    assert 0 < ttl <= 120
+
+
+def test_already_expired_revoke_is_noop(fake_redis):
+    """Revoking an already-expired token writes nothing (no unbounded keys)."""
+    jti = "tok-expired"
+    dependencies.revoke_token_jti(jti, _exp_in(-10))
+    assert dependencies.is_token_revoked(jti) is False
+    assert fake_redis.exists(f"{dependencies._JWT_REVOKED_PREFIX}{jti}") == 0
+
+
+def test_missing_jti_is_failopen(fake_redis):
+    """A legacy token minted before #187 (no jti) is never treated as revoked."""
+    assert dependencies.is_token_revoked(None) is False
+    assert dependencies.is_token_revoked("") is False
+    dependencies.revoke_token_jti(None, _exp_in(60))  # no crash, no key
+    assert fake_redis.keys(f"{dependencies._JWT_REVOKED_PREFIX}*") == []
+
+
+def test_redis_down_is_failopen(monkeypatch):
+    """Redis unreachable → revoke is a no-op and the check returns False, so a
+    valid session is never locked out by an infra outage."""
+    monkeypatch.setattr(dependencies, "get_breaker_redis", lambda: None)
+    dependencies.revoke_token_jti("tok-x", _exp_in(60))  # no crash
+    assert dependencies.is_token_revoked("tok-x") is False


### PR DESCRIPTION
## Summary
Closes the pentest 3.3.4 gap: 7-day JWTs had **no server-side revocation** and there was no logout endpoint — an exfiltrated token kept working through logout / password change for its full life.

- Every access token now carries a random **`jti`** (`create_access_token`).
- New **`POST /api/auth/logout`** blacklists the caller's `jti` in Redis with TTL = the token's remaining life (self-expiring, no sweep). Idempotent; MCP-key callers are a no-op.
- **`get_current_user`**, **`decode_token`** (WebSocket), and **`/api/auth/validate`** (nginx auth_request) all reject a revoked `jti`.
- Frontend `store.logout()` calls the endpoint best-effort before clearing local state.

**Fail-open by design** — Redis down or a legacy no-`jti` token → treated as *not* revoked, so the check can never lock out a valid session; a backend restart still rotates `SECRET_KEY` and invalidates everything.

## Out of scope (deferred, separate issue)
Reducing `ACCESS_TOKEN_EXPIRE_MINUTES` (7d) + a refresh-token flow — a larger UX change. This PR delivers the revocation mechanism the issue's core asks for.

## Changes
- `src/backend/dependencies.py` — `jti` claim, `revoke_token_jti` / `is_token_revoked` (fail-open Redis), revocation checks in `get_current_user` + `decode_token`
- `src/backend/routers/auth.py` — `POST /api/auth/logout`; `jti` check in `/api/auth/validate`
- `src/frontend/src/stores/auth.js` — async `logout()` calls the revoke endpoint first
- `docs/memory/architecture.md`, `tests/unit/test_187_jwt_revocation.py`

## Test Plan
- [x] Unit: `pytest tests/unit/test_187_jwt_revocation.py` — 6 pass (jti minted, revoke→revoked, TTL ≤ token life, past-exp no-op, fail-open on no-jti + Redis-down)
- [x] **Live e2e**: login → `/api/users/me` 200 → `POST /api/auth/logout` 200 → same token `/api/users/me` **401** AND `/api/auth/validate` **401**
- [x] Existing auth tests unaffected (`test_connector_auth` green)

Related to #187 (epic #1054 Security Hardening)