### PR TITLE
fix(security): credential encryption key rotation (#267)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ SECRET_KEY=
 # SECURITY: If lost, all encrypted credentials become unrecoverable!
 CREDENTIAL_ENCRYPTION_KEY=
 
+# Optional decrypt-only fallback used ONLY during key rotation (#267): set it to
+# the PREVIOUS CREDENTIAL_ENCRYPTION_KEY while the line above holds the new one,
+# run scripts/deploy/rotate-credential-key.py --apply, then remove this line.
+# See docs/migrations/CREDENTIAL_KEY_ROTATION.md. Leave empty in normal operation.
+CREDENTIAL_ENCRYPTION_KEY_SECONDARY=
+
 # Internal API Secret - Used for scheduler-to-backend communication (C-003)
 # Generate with: openssl rand -hex 32
 # Falls back to SECRET_KEY if not set

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,7 @@ services:
       # prod (the #1039 packaging-gap class).
       - SLACK_SOCKET_CONNECTION_COUNT=${SLACK_SOCKET_CONNECTION_COUNT:-2}
       - CREDENTIAL_ENCRYPTION_KEY=${CREDENTIAL_ENCRYPTION_KEY:-}
+      - CREDENTIAL_ENCRYPTION_KEY_SECONDARY=${CREDENTIAL_ENCRYPTION_KEY_SECONDARY:-}  # #267 rotation fallback
       # Agent auth master (#1159) - backend derives each agent's in-container
       # :8000 auth token from this; .env alone is inert in prod, so forward it
       # explicitly. Backend hard-fails on first agent call if unset.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       - DB_MAX_OVERFLOW=${DB_MAX_OVERFLOW:-20}
       # Credential Encryption
       - CREDENTIAL_ENCRYPTION_KEY=${CREDENTIAL_ENCRYPTION_KEY:-}
+      - CREDENTIAL_ENCRYPTION_KEY_SECONDARY=${CREDENTIAL_ENCRYPTION_KEY_SECONDARY:-}  # #267 rotation fallback
       # Internal API shared secret (C-003) - for scheduler/agent communication
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
       # Agent auth master (#1159) - backend derives each agent's in-container

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -176,7 +176,7 @@
 - `compatibility/` - Agent compatibility validation package (spec/collector/static_checks/ai_checks/fixes) — see [Agent Compatibility Validation](#agent-compatibility-validation-668)
 
 *Auth & Credentials:*
-- `credential_encryption.py` - AES-256-GCM encryption for `.credentials.enc` and DB-persisted tokens (CRED-002, Invariant #12)
+- `credential_encryption.py` - AES-256-GCM encryption for `.credentials.enc` and DB-persisted tokens (CRED-002, Invariant #12). Supports **online key rotation** (#267): an optional decrypt-only `CREDENTIAL_ENCRYPTION_KEY_SECONDARY` (the previous key) keeps old-key ciphertext readable while new writes use the primary; `rewrap()` + `scripts/deploy/rotate-credential-key.py` re-encrypt persisted DB secrets onto the new key (runbook `docs/migrations/CREDENTIAL_KEY_ROTATION.md`)
 - `subscription_service.py` - Subscription management (SUB-002)
 - `ssh_service.py` - Ephemeral SSH credential generation
 - `email_service.py` - Email sending for verification codes

--- a/docs/migrations/CREDENTIAL_KEY_ROTATION.md
+++ b/docs/migrations/CREDENTIAL_KEY_ROTATION.md
@@ -1,0 +1,76 @@
+# Credential Encryption Key Rotation (#267)
+
+Trinity encrypts persisted secrets — agent `.credentials.enc` archives and the
+DB token columns (Invariant #12) — with AES-256-GCM under a single master key,
+`CREDENTIAL_ENCRYPTION_KEY`. Before #267 there was **no way to rotate it**:
+changing the key bricked every existing secret. This runbook rotates the key
+**online, with zero downtime and no data loss**, using a decrypt-only secondary
+key plus a re-encryption sweep.
+
+## When to rotate
+- The key may have been exposed (it is passed as an env var — visible in
+  `docker inspect` / `/proc/<pid>/environ`, the finding behind #267).
+- Routine hygiene (e.g. annual).
+
+> Moving the key off a plaintext env var entirely (Docker/Swarm secrets or an
+> external secret manager) is **out of scope** here and tracked separately — this
+> document covers *rotation*, which is the gap #267 closes.
+
+## How it works
+- `CREDENTIAL_ENCRYPTION_KEY` is the **primary** key: every new write encrypts
+  with it.
+- `CREDENTIAL_ENCRYPTION_KEY_SECONDARY` (optional) is a **decrypt-only** fallback.
+  During rotation it holds the **old** key, so ciphertext written under the old
+  key still opens while the primary is the new key.
+- `scripts/deploy/rotate-credential-key.py` re-encrypts (`rewrap`) every DB
+  secret onto the primary. Once it completes, nothing depends on the old key and
+  the secondary can be removed.
+
+## Procedure
+
+```bash
+# 0. Back up the DB first.
+scripts/deploy/backup-database.sh
+
+# 1. Generate the NEW key.
+NEW=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+
+# 2. In .env, set the new key primary and the CURRENT key secondary:
+#      CREDENTIAL_ENCRYPTION_KEY=<NEW>
+#      CREDENTIAL_ENCRYPTION_KEY_SECONDARY=<the previous CREDENTIAL_ENCRYPTION_KEY>
+#    (Both forwarded to the backend by docker-compose.)
+
+# 3. Restart the backend so it loads both keys.
+docker compose up -d backend
+
+#    At this point the platform is fully functional: old secrets decrypt via the
+#    secondary, all NEW writes already use the new key.
+
+# 4. Dry-run the sweep (no writes) — review the counts.
+docker compose exec backend python scripts/deploy/rotate-credential-key.py
+
+# 5. Apply — re-encrypt all DB secrets onto the new key.
+docker compose exec backend python scripts/deploy/rotate-credential-key.py --apply
+
+# 6. Remove CREDENTIAL_ENCRYPTION_KEY_SECONDARY from .env and restart.
+docker compose up -d backend
+```
+
+## Agent `.credentials.enc` files
+These live **inside agent containers**, not the DB, so the sweep does not touch
+them. While the secondary key is configured they keep decrypting under the old
+key; each re-encrypts onto the new key on its **next credential operation**
+(`inject` / `export`, or auto-export on the next sync). To force-migrate an
+agent immediately, re-inject its credentials or run an export. (Automating an
+in-container re-encryption pass is a fast-follow.)
+
+## Safety notes
+- The sweep is **idempotent** and safe to re-run.
+- Rows that are not a readable envelope (e.g. a legacy plaintext Slack `xoxb-`
+  token awaiting #453 re-encryption) are **skipped, never corrupted** — they
+  re-encrypt on the next backend restart.
+- Keep the backup from step 0 until you have verified agents and channels work
+  after step 6.
+- Decryption is **fail-open across keys only** in the sense that it *tries* both;
+  a value that opens under neither key surfaces a clear error rather than silent
+  data loss.

--- a/scripts/deploy/rotate-credential-key.py
+++ b/scripts/deploy/rotate-credential-key.py
@@ -44,7 +44,7 @@ from services.credential_encryption import (  # noqa: E402
 )
 
 # (table, primary-key column, encrypted column) — keep in sync with Invariant #12.
-SECRET_COLUMNS = [
+ENCRYPTED_COLUMNS = [
     ("subscription_credentials", "id", "encrypted_credentials"),
     ("nevermined_agent_config", "id", "encrypted_credentials"),
     ("agent_git_config", "id", "github_pat_encrypted"),
@@ -80,17 +80,17 @@ def rotate(apply: bool) -> int:
     total_migrated = total_skipped = 0
 
     with engine.begin() as conn:
-        for table, pk, col in SECRET_COLUMNS:
+        for table, pk, col in ENCRYPTED_COLUMNS:
             if not _table_exists(conn, table):
                 print(f"  {table:28} — absent, skipped")
                 continue
             rows = conn.execute(
-                text(f"SELECT {pk} AS pk, {col} AS secret FROM {table} WHERE {col} IS NOT NULL")
+                text(f"SELECT {pk} AS pk, {col} AS enc_value FROM {table} WHERE {col} IS NOT NULL")
             ).mappings().all()
             migrated = skipped = 0
             for row in rows:
                 try:
-                    rewrapped = svc.rewrap(row["secret"])
+                    rewrapped = svc.rewrap(row["enc_value"])
                 except Exception as e:
                     skipped += 1
                     print(f"    [skip] {table}.{pk}={row['pk']}: not a readable envelope ({e})")

--- a/scripts/deploy/rotate-credential-key.py
+++ b/scripts/deploy/rotate-credential-key.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Credential encryption key rotation sweep (#267).
+
+Re-encrypts every persisted secret onto the PRIMARY key
+(``CREDENTIAL_ENCRYPTION_KEY``), decrypting via the rotation fallback
+(``CREDENTIAL_ENCRYPTION_KEY_SECONDARY``) when a row was written under the
+previous key. Run it during a maintenance window as the final step of the
+rotation runbook (docs/migrations/CREDENTIAL_KEY_ROTATION.md).
+
+    # 1. set the NEW key primary, the OLD key secondary, restart backend
+    # 2. dry-run (no writes) — see what would migrate
+    python scripts/deploy/rotate-credential-key.py
+    # 3. apply
+    python scripts/deploy/rotate-credential-key.py --apply
+    # 4. remove CREDENTIAL_ENCRYPTION_KEY_SECONDARY, restart
+
+Scope: the eight AES-256-GCM-wrapped DB token columns (Invariant #12). Agent
+``.credentials.enc`` files live inside agent containers and re-encrypt onto the
+primary key on their next credential operation (or `inject`/`export`); they keep
+opening via the secondary key until then, so they are intentionally out of this
+DB sweep. Rows that are not a valid envelope (legacy plaintext, e.g. a Slack
+``xoxb-`` token awaiting the #453 re-encrypt) are skipped, never corrupted.
+
+Idempotent and safe to re-run: a row already on the primary key round-trips to an
+equivalent envelope.
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+_BACKEND = str(Path(__file__).resolve().parent.parent.parent / "src" / "backend")
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+from sqlalchemy import text  # noqa: E402
+
+from db.engine import get_engine  # noqa: E402
+from services.credential_encryption import (  # noqa: E402
+    CredentialEncryptionService,
+    ENCRYPTION_KEY_ENV,
+    SECONDARY_ENCRYPTION_KEY_ENV,
+)
+
+# (table, primary-key column, encrypted column) — keep in sync with Invariant #12.
+SECRET_COLUMNS = [
+    ("subscription_credentials", "id", "encrypted_credentials"),
+    ("nevermined_agent_config", "id", "encrypted_credentials"),
+    ("agent_git_config", "id", "github_pat_encrypted"),
+    ("slack_workspaces", "id", "bot_token"),
+    ("slack_link_connections", "id", "slack_bot_token"),
+    ("telegram_bindings", "id", "bot_token_encrypted"),
+    ("whatsapp_bindings", "id", "auth_token_encrypted"),
+    ("voip_bindings", "id", "auth_token_encrypted"),
+]
+
+
+def _table_exists(conn, table: str) -> bool:
+    try:
+        conn.execute(text(f"SELECT 1 FROM {table} LIMIT 1"))
+        return True
+    except Exception:
+        return False
+
+
+def rotate(apply: bool) -> int:
+    if not os.getenv(ENCRYPTION_KEY_ENV):
+        print(f"ERROR: {ENCRYPTION_KEY_ENV} is not set — nothing to rotate onto.")
+        return 2
+    if not os.getenv(SECONDARY_ENCRYPTION_KEY_ENV):
+        print(
+            f"WARNING: {SECONDARY_ENCRYPTION_KEY_ENV} is not set. Rows written under a "
+            f"previous key will fail to decrypt and be skipped. Set it to the OLD key "
+            f"if you are mid-rotation."
+        )
+
+    svc = CredentialEncryptionService()
+    engine = get_engine()
+    total_migrated = total_skipped = 0
+
+    with engine.begin() as conn:
+        for table, pk, col in SECRET_COLUMNS:
+            if not _table_exists(conn, table):
+                print(f"  {table:28} — absent, skipped")
+                continue
+            rows = conn.execute(
+                text(f"SELECT {pk} AS pk, {col} AS secret FROM {table} WHERE {col} IS NOT NULL")
+            ).mappings().all()
+            migrated = skipped = 0
+            for row in rows:
+                try:
+                    rewrapped = svc.rewrap(row["secret"])
+                except Exception as e:
+                    skipped += 1
+                    print(f"    [skip] {table}.{pk}={row['pk']}: not a readable envelope ({e})")
+                    continue
+                if apply:
+                    conn.execute(
+                        text(f"UPDATE {table} SET {col} = :v WHERE {pk} = :k"),
+                        {"v": rewrapped, "k": row["pk"]},
+                    )
+                migrated += 1
+            total_migrated += migrated
+            total_skipped += skipped
+            print(f"  {table:28} {migrated:4} re-encrypted, {skipped} skipped")
+
+        if not apply:
+            # Roll the (no-op) transaction back explicitly for clarity in dry-run.
+            conn.rollback()
+
+    verb = "re-encrypted" if apply else "would re-encrypt (dry-run)"
+    print(f"\n{total_migrated} secrets {verb}; {total_skipped} skipped.")
+    if not apply:
+        print("Dry-run only — re-run with --apply to write.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Rotate credential encryption key (#267).")
+    ap.add_argument("--apply", action="store_true", help="Write changes (default: dry-run).")
+    args = ap.parse_args()
+    print(f"Credential key rotation sweep ({'APPLY' if args.apply else 'DRY-RUN'})\n")
+    return rotate(apply=args.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/services/credential_encryption.py
+++ b/src/backend/services/credential_encryption.py
@@ -32,8 +32,15 @@ from services.agent_auth import agent_httpx_client
 
 logger = logging.getLogger(__name__)
 
-# Encryption key environment variable
+# Encryption key environment variable (primary — used for ALL new writes)
 ENCRYPTION_KEY_ENV = "CREDENTIAL_ENCRYPTION_KEY"
+
+# Optional secondary key (#267) — DECRYPT-ONLY fallback used during key rotation.
+# Set it to the *previous* key while CREDENTIAL_ENCRYPTION_KEY holds the new one:
+# existing ciphertext still decrypts (via the secondary), new writes use the
+# primary, and `scripts/deploy/rotate-credential-key.py` re-encrypts persisted
+# secrets onto the primary. Once the sweep completes the secondary can be removed.
+SECONDARY_ENCRYPTION_KEY_ENV = "CREDENTIAL_ENCRYPTION_KEY_SECONDARY"
 
 # Default credential files to look for
 DEFAULT_CREDENTIAL_FILES = [".env", ".mcp.json"]
@@ -100,6 +107,7 @@ class CredentialEncryptionService:
         """
         self._key = key
         self._aesgcm: Optional[AESGCM] = None
+        self._aesgcm_secondary: Optional[AESGCM] = None  # #267 rotation fallback
 
     @property
     def key(self) -> bytes:
@@ -134,6 +142,31 @@ class CredentialEncryptionService:
         if self._aesgcm is None:
             self._aesgcm = AESGCM(self.key)
         return self._aesgcm
+
+    @property
+    def aesgcm_secondary(self) -> Optional[AESGCM]:
+        """Decrypt-only cipher for the previous key during rotation (#267).
+
+        Returns None when ``CREDENTIAL_ENCRYPTION_KEY_SECONDARY`` is unset, so a
+        single-key deployment behaves exactly as before. An invalid secondary is
+        logged and ignored (it must never break the primary decrypt path)."""
+        if self._aesgcm_secondary is not None:
+            return self._aesgcm_secondary
+        key_hex = os.getenv(SECONDARY_ENCRYPTION_KEY_ENV)
+        if not key_hex:
+            return None
+        try:
+            key_bytes = bytes.fromhex(key_hex)
+            if len(key_bytes) != 32:
+                raise ValueError(f"must be 32 bytes (64 hex chars), got {len(key_bytes)}")
+        except ValueError as e:
+            logger.warning(
+                "Ignoring invalid %s (rotation decrypt-fallback disabled): %s",
+                SECONDARY_ENCRYPTION_KEY_ENV, e,
+            )
+            return None
+        self._aesgcm_secondary = AESGCM(key_bytes)
+        return self._aesgcm_secondary
 
     def encrypt(self, files: Dict[str, str]) -> str:
         """
@@ -196,11 +229,19 @@ class CredentialEncryptionService:
         except (KeyError, ValueError) as e:
             raise ValueError(f"Invalid encrypted data structure: {e}")
 
-        # Decrypt
+        # Decrypt with the primary key; during rotation (#267) fall back to the
+        # decrypt-only secondary key so ciphertext written under the previous key
+        # still opens. GCM's auth tag makes a wrong key a clean failure.
         try:
             plaintext = self.aesgcm.decrypt(nonce, ciphertext, None)
-        except Exception as e:
-            raise ValueError(f"Decryption failed - wrong key or corrupted data: {e}")
+        except Exception as primary_err:
+            secondary = self.aesgcm_secondary
+            if secondary is None:
+                raise ValueError(f"Decryption failed - wrong key or corrupted data: {primary_err}")
+            try:
+                plaintext = secondary.decrypt(nonce, ciphertext, None)
+            except Exception:
+                raise ValueError(f"Decryption failed - wrong key or corrupted data: {primary_err}")
 
         # Parse decrypted JSON
         try:
@@ -229,6 +270,18 @@ class CredentialEncryptionService:
         if isinstance(data, dict) and data.get(_ARCHIVE_V2_MARKER):
             return data.get("files", {}), data.get("files_b64", {})
         return data, {}
+
+    def rewrap(self, encrypted: str) -> str:
+        """Re-encrypt an existing envelope under the PRIMARY key (#267).
+
+        Decrypts with whichever key works (primary or rotation secondary) and
+        re-encrypts with the primary. Works uniformly for single-secret DB
+        tokens and v2 `.credentials.enc` archives — both ride the same envelope
+        through ``encrypt``/``decrypt``. Idempotent: an envelope already on the
+        primary key round-trips to an equivalent envelope (fresh nonce). The
+        re-encryption sweep (`scripts/deploy/rotate-credential-key.py`) calls
+        this per persisted secret to migrate the fleet onto a rotated key."""
+        return self.encrypt(self.decrypt(encrypted))
 
     async def read_agent_credential_files(
         self,

--- a/tests/unit/test_267_credential_key_rotation.py
+++ b/tests/unit/test_267_credential_key_rotation.py
@@ -1,0 +1,89 @@
+"""
+Credential encryption key rotation (#267).
+
+Before #267 the AES-256-GCM master key (`CREDENTIAL_ENCRYPTION_KEY`) had no
+rotation path: changing it bricked every `.credentials.enc` and DB token. #267
+adds a decrypt-only secondary key + a `rewrap()` primitive so an operator can
+rotate the key online (old key decrypts, new key encrypts) and then sweep
+persisted secrets onto the new key.
+
+These pin the service primitive (the sweep script composes it):
+  - single-key behavior is unchanged when no secondary is set (back-compat);
+  - secondary key decrypts ciphertext written under the previous key;
+  - `rewrap` migrates an old-key envelope onto the primary;
+  - a wrong/absent key still fails closed;
+  - an invalid secondary is ignored, never breaking the primary path.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = str(Path(__file__).resolve().parent.parent.parent / "src" / "backend")
+while _BACKEND in sys.path:
+    sys.path.remove(_BACKEND)
+sys.path.insert(0, _BACKEND)
+
+from services.credential_encryption import (  # noqa: E402
+    CredentialEncryptionService,
+    SECONDARY_ENCRYPTION_KEY_ENV,
+)
+
+pytestmark = pytest.mark.unit
+
+KEY_A = "11" * 32  # 64 hex chars = 32 bytes
+KEY_B = "22" * 32
+SECRET = {"bot_token": "xoxb-super-secret"}
+
+
+@pytest.fixture(autouse=True)
+def _clear_secondary(monkeypatch):
+    monkeypatch.delenv(SECONDARY_ENCRYPTION_KEY_ENV, raising=False)
+
+
+def test_single_key_roundtrip_unchanged():
+    svc = CredentialEncryptionService(key=KEY_A)
+    assert svc.decrypt(svc.encrypt(SECRET)) == SECRET
+    assert svc.aesgcm_secondary is None  # no fallback configured
+
+
+def test_secondary_key_decrypts_old_ciphertext(monkeypatch):
+    old = CredentialEncryptionService(key=KEY_A).encrypt(SECRET)
+    # Rotate: primary = new key B, secondary = old key A.
+    monkeypatch.setenv(SECONDARY_ENCRYPTION_KEY_ENV, KEY_A)
+    svc_b = CredentialEncryptionService(key=KEY_B)
+    assert svc_b.decrypt(old) == SECRET  # opened via the fallback
+
+
+def test_rewrap_migrates_onto_primary(monkeypatch):
+    old = CredentialEncryptionService(key=KEY_A).encrypt(SECRET)
+    monkeypatch.setenv(SECONDARY_ENCRYPTION_KEY_ENV, KEY_A)
+    migrated = CredentialEncryptionService(key=KEY_B).rewrap(old)
+
+    # After rewrap the new envelope opens under the primary key ALONE — proving
+    # it no longer depends on the old key (so the secondary can be retired).
+    monkeypatch.delenv(SECONDARY_ENCRYPTION_KEY_ENV, raising=False)
+    assert CredentialEncryptionService(key=KEY_B).decrypt(migrated) == SECRET
+    # ...and the ORIGINAL ciphertext does NOT open under B alone.
+    with pytest.raises(ValueError):
+        CredentialEncryptionService(key=KEY_B).decrypt(old)
+
+
+def test_wrong_key_without_secondary_fails_closed():
+    old = CredentialEncryptionService(key=KEY_A).encrypt(SECRET)
+    with pytest.raises(ValueError, match="Decryption failed"):
+        CredentialEncryptionService(key=KEY_B).decrypt(old)
+
+
+def test_invalid_secondary_is_ignored(monkeypatch):
+    monkeypatch.setenv(SECONDARY_ENCRYPTION_KEY_ENV, "not-hex-garbage")
+    svc = CredentialEncryptionService(key=KEY_A)
+    # invalid secondary disabled (not raised), primary still works
+    assert svc.aesgcm_secondary is None
+    assert svc.decrypt(svc.encrypt(SECRET)) == SECRET
+
+
+def test_rewrap_idempotent_on_primary():
+    svc = CredentialEncryptionService(key=KEY_A)
+    enc = svc.encrypt(SECRET)
+    assert svc.decrypt(svc.rewrap(enc)) == SECRET


### PR DESCRIPTION
## Summary
CSO finding #3 (HIGH): `CREDENTIAL_ENCRYPTION_KEY` — the AES-256-GCM master for **all** agent `.credentials.enc` files **and** 8 DB token columns (Invariant #12) — had **no rotation path**. Changing it bricked every existing secret. This adds an **online, zero-downtime** rotation mechanism.

## How it works
- **Decrypt-only secondary key.** `CREDENTIAL_ENCRYPTION_KEY_SECONDARY` (set to the *previous* key during rotation) lets old-key ciphertext keep opening while every new write uses the primary. Unset → single-key behavior is byte-for-byte unchanged.
- **`rewrap(envelope)`** decrypts with whichever key works and re-encrypts onto the primary — uniform for single-secret DB tokens and v2 `.credentials.enc` archives.
- **Sweep** `scripts/deploy/rotate-credential-key.py` re-encrypts the 8 DB secret columns. Dry-run by default, `--apply` to write; idempotent; legacy-plaintext rows (e.g. a Slack `xoxb-` token pre-#453) are **skipped, never corrupted**.
- **Runbook** `docs/migrations/CREDENTIAL_KEY_ROTATION.md`; compose forwards the new var; `.env.example` documents it.

## Out of scope (deferred, as agreed when scoping)
- Moving the key **off a plaintext env var** (Docker/Swarm secrets or external manager) — the "visible in `docker inspect`" half; an infra change, separate issue.
- An **in-container `.credentials.enc` re-encryption pass** — those re-encrypt onto the new key on their next credential op (they keep opening via the secondary meanwhile); documented in the runbook.

## Changes
- `src/backend/services/credential_encryption.py` — secondary decrypt-fallback + `rewrap()`
- `scripts/deploy/rotate-credential-key.py`, `docs/migrations/CREDENTIAL_KEY_ROTATION.md`
- `docker-compose.yml` / `.prod.yml`, `.env.example`, `docs/memory/architecture.md`
- `tests/unit/test_267_credential_key_rotation.py`

## Test Plan
- [x] Unit (6): single-key back-compat, secondary decrypts old ciphertext, `rewrap` migrates onto primary (and old ciphertext no longer opens under new-key-only), wrong-key fails closed, invalid secondary ignored, rewrap idempotent
- [x] **Live**: `rewrap`+decrypt-equal over all **7 real encrypted rows** in the running DB — 0 skipped
- [x] Service imports clean in the backend container

Related to #267 (epic #1054 Security Hardening)