### PR TITLE
fix: relabel Playbooks "Edit" button to "Edit & Run" (#959)

### DIFF
--- a/docs/memory/feature-flows/playbooks-tab.md
+++ b/docs/memory/feature-flows/playbooks-tab.md
@@ -396,13 +396,13 @@ def scan_skills_directory(skills_dir: Path) -> List[SkillInfo]:
 │  │  PlaybooksPanel.vue │  Display:                                         │
 │  │  (render skills)    │  - Grid of skill cards                           │
 │  └──────────┬──────────┘  - Name, description, automation badge           │
-│             │              - Run / Edit buttons                            │
+│             │              - Run / Edit & Run buttons                      │
 │             │                                                               │
 │  ═══════════╪═══════════════════════════════════════════════════════════  │
 │  One-Click  │  Run with Instructions                                       │
 │  ═══════════╪═══════════════════════════════════════════════════════════  │
 │             │                                                               │
-│  Click "Run" button                    Click "Edit" button                 │
+│  Click "Run" button                    Click "Edit & Run" button           │
 │         │                                      │                           │
 │         ▼                                      ▼                           │
 │  POST /api/agents/{name}/task          emit('run-with-instructions')      │

--- a/src/frontend/src/components/PlaybooksPanel.vue
+++ b/src/frontend/src/components/PlaybooksPanel.vue
@@ -111,16 +111,19 @@
               Run
             </button>
 
-            <!-- Run with Instructions Button -->
+            <!-- Edit & Run Button: prefill the command in the Tasks tab so the
+                 user can add instructions/arguments, then run. Labeled
+                 "Edit & Run" (not "Edit") so it doesn't imply a skill-file
+                 editor — it edits the invocation, not the file (#959). -->
             <button
               @click="runWithInstructions(skill)"
               class="inline-flex items-center justify-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-xs font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-action-primary-500 transition-colors"
-              title="Add instructions before running"
+              title="Add instructions, then run"
             >
               <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
               </svg>
-              Edit
+              Edit &amp; Run
             </button>
           </div>
 


### PR DESCRIPTION
## Summary
- The Playbooks tab's secondary button was labeled **"Edit"** with a pencil icon, implying it opens an editor for the underlying skill file — a surface that doesn't exist. Reporter reasonably read this as "the button does nothing."
- Its actual behavior is to prefill `/<skill> ` into the **Tasks** input and switch to the Tasks tab so you can add instructions/arguments before running.
- Relabeled to **"Edit & Run"** with tooltip *"Add instructions, then run"* so the affordance is honest. The emit/handler/method chain is unchanged — only the user-facing label, tooltip, and an explanatory comment.

## Changes
- `src/frontend/src/components/PlaybooksPanel.vue` — button text `Edit` → `Edit & Run`; tooltip `Add instructions before running` → `Add instructions, then run`; added a `#959` explanatory comment. Pencil icon kept (the label now disambiguates "edit the invocation, then run").
- `docs/memory/feature-flows/playbooks-tab.md` — synced the flow diagram's button labels.

## Root cause
The button (`runWithInstructions`) was never dead — it emits `run-with-instructions`, which `AgentDetail.handlePlaybookRunWithInstructions` turns into a Tasks-tab switch + `initialMessage` prefill (consumed by `TasksPanel`'s `immediate:true` watcher, guarded by `if(newMessage)` so the 100 ms prefill-clear doesn't wipe it). The defect was a misleading **label/affordance**, not broken wiring. Scope was deliberately kept to an honest relabel rather than building a skill-file editor (that would be a separate, larger feature).

## Test Plan
- [x] Vite (dev hot-reload) compiles `PlaybooksPanel.vue` with no error; live-served render emits `" Edit & Run "` + `title:"Add instructions, then run"`.
- [x] Click→behavior chain verified by code trace (emit → handler → Tasks tab + prefill).
- [ ] Manual browser check (needs an agent with ≥1 user-invocable playbook): open agent → **Playbooks** tab → the per-skill card shows **Edit & Run** → click → lands on **Tasks** tab with the input prefilled `/<skill> `. *(Not exercised locally — the only local agent `trinity-system` has 0 playbooks; not provisioning a fixture agent for a label-only change.)*
- No backend change; `tests/test_playbooks.py` (backend skill listing) unaffected. No frontend unit-test harness exists.

Fixes #959