### PR TITLE
feat(ui): reusable ExposedToolsPanel — carve playbook exposure picker out of the connector (ent#55)

### DIFF
--- a/src/frontend/src/components/ConnectorChannelPanel.vue
+++ b/src/frontend/src/components/ConnectorChannelPanel.vue
@@ -66,30 +66,11 @@
           </div>
         </div>
 
-        <!-- Exposed playbooks allow-list -->
-        <div>
-          <div class="flex items-center justify-between mb-2">
-            <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100">Exposed playbooks</h4>
-            <label class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
-              <input type="checkbox" v-model="exposeAll" @change="saveAllowList" :disabled="busy" />
-              Expose all
-            </label>
-          </div>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
-            Choose which playbooks the connector advertises as tools. Non-user-invocable playbooks are never exposed.
-          </p>
-          <div v-if="playbooksError" class="text-xs text-gray-500 dark:text-gray-400">{{ playbooksError }}</div>
-          <div v-else-if="availablePlaybooks.length === 0" class="text-xs text-gray-500 dark:text-gray-400">
-            No user-invocable playbooks found for this agent.
-          </div>
-          <ul v-else class="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg">
-            <li v-for="pb in availablePlaybooks" :key="pb.name" class="px-3 py-2 flex items-center gap-2">
-              <input type="checkbox" :value="pb.name" v-model="selected" :disabled="exposeAll || busy" @change="debouncedSaveAllowList" />
-              <span class="text-sm text-gray-900 dark:text-gray-100">{{ pb.name }}</span>
-              <span v-if="pb.description" class="text-xs text-gray-500 dark:text-gray-400 truncate">— {{ pb.description }}</span>
-            </li>
-          </ul>
-        </div>
+        <!-- Exposed-playbooks picker — extracted to a standalone, decoupled
+             component (trinity-enterprise#55) so it can be reused across
+             client-sharing channels and this key block can be swapped for the
+             SSO/OAuth variant without reworking the picker. -->
+        <ExposedToolsPanel :agent-name="agentName" />
       </div>
 
       <!-- One-time secret + per-client snippets (after generate/regenerate) -->
@@ -118,8 +99,9 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import api from '../api'
+import ExposedToolsPanel from './ExposedToolsPanel.vue'
 
 const props = defineProps({
   agentName: { type: String, required: true },
@@ -128,11 +110,7 @@ const props = defineProps({
 const loading = ref(true)
 const busy = ref(false)
 const accessDenied = ref(false)
-const status = ref({ has_key: false, enabled: false, key_prefix: null, exposed_playbooks: null, mcp_url: null })
-const availablePlaybooks = ref([])
-const playbooksError = ref('')
-const selected = ref([])
-const exposeAll = ref(true)
+const status = ref({ has_key: false, enabled: false, key_prefix: null, mcp_url: null })
 const freshSnippets = ref([])
 const message = ref('')
 const messageError = ref(false)
@@ -142,45 +120,17 @@ const notify = (text, isError = false) => {
   messageError.value = isError
 }
 
-const syncAllowListState = () => {
-  // exposed_playbooks === null ⇒ all exposed; else the explicit set.
-  const list = status.value.exposed_playbooks
-  exposeAll.value = list == null
-  selected.value = Array.isArray(list) ? [...list] : []
-}
-
 const loadStatus = async () => {
   loading.value = true
   accessDenied.value = false
   try {
     const { data } = await api.get(`/api/agents/${props.agentName}/connector`)
     status.value = data
-    syncAllowListState()
   } catch (e) {
     if (e.response?.status === 403) accessDenied.value = true
     else notify(e.response?.data?.detail || 'Failed to load connector', true)
   } finally {
     loading.value = false
-  }
-  loadPlaybooks()
-}
-
-const loadPlaybooks = async () => {
-  playbooksError.value = ''
-  try {
-    const { data } = await api.get(`/api/agents/${props.agentName}/playbooks`)
-    availablePlaybooks.value = (data?.skills || []).filter((s) => s.user_invocable !== false)
-    // Prune stale names: an allow-list entry that's no longer a live
-    // user_invocable playbook would otherwise linger and be re-sent forever.
-    if (!exposeAll.value) {
-      const names = new Set(availablePlaybooks.value.map((p) => p.name))
-      selected.value = selected.value.filter((n) => names.has(n))
-    }
-  } catch (e) {
-    availablePlaybooks.value = []
-    playbooksError.value = e.response?.status === 503
-      ? 'Start the agent to choose which playbooks to expose.'
-      : 'Could not load this agent’s playbooks.'
   }
 }
 
@@ -217,36 +167,11 @@ const toggleEnabled = async () => {
   try {
     const { data } = await api.put(`/api/agents/${props.agentName}/connector`, { enabled: !status.value.enabled })
     status.value = data
-    syncAllowListState()
   } catch (e) {
     notify(e.response?.data?.detail || 'Failed to update connector', true)
   } finally {
     busy.value = false
   }
-}
-
-const saveAllowList = async () => {
-  busy.value = true
-  try {
-    const body = exposeAll.value
-      ? { expose_all_playbooks: true }
-      : { exposed_playbooks: selected.value }
-    const { data } = await api.put(`/api/agents/${props.agentName}/connector`, body)
-    status.value = data
-    notify('Exposed playbooks updated.')
-  } catch (e) {
-    notify(e.response?.data?.detail || 'Failed to update playbooks', true)
-  } finally {
-    busy.value = false
-  }
-}
-
-// Coalesce a burst of checkbox toggles into one PUT (each send is the full set,
-// so last-write-wins is safe). The "expose all" toggle saves immediately.
-let saveTimer = null
-const debouncedSaveAllowList = () => {
-  clearTimeout(saveTimer)
-  saveTimer = setTimeout(saveAllowList, 400)
 }
 
 const copy = async (text) => {

--- a/src/frontend/src/components/ExposedToolsPanel.vue
+++ b/src/frontend/src/components/ExposedToolsPanel.vue
@@ -1,0 +1,157 @@
+<template>
+  <!--
+    Exposed-playbooks allow-list picker (trinity-enterprise#55).
+
+    Carved out of ConnectorChannelPanel.vue as a standalone, reusable surface so
+    the same picker can govern any client-sharing channel and the connector's
+    key/config block stays decoupled (the SSO tier can later swap the key block
+    for an OAuth variant without touching this component). Reads/writes the SAME
+    allow-list the connector consumes: enterprise_connectors.exposed_playbooks via
+    GET/PUT /api/agents/{name}/connector. No separate storage.
+  -->
+  <div>
+    <div class="flex items-center justify-between mb-2">
+      <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100">Exposed playbooks</h4>
+      <label class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300 cursor-pointer">
+        <input type="checkbox" v-model="exposeAll" @change="saveAllowList" :disabled="busy" />
+        Expose all
+      </label>
+    </div>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+      Choose which playbooks shared consumers can call as tools. Approval-gated playbooks still
+      require operator sign-off; non-invocable playbooks can never be exposed.
+    </p>
+
+    <!-- Playbooks need a running agent -->
+    <div v-if="playbooksError" class="text-xs text-gray-500 dark:text-gray-400">{{ playbooksError }}</div>
+
+    <!-- Empty state: guidance, not a blank panel -->
+    <div v-else-if="playbooks.length === 0" class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 px-3 py-4 text-center">
+      <p class="text-xs font-medium text-gray-700 dark:text-gray-300">No playbooks to expose</p>
+      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        This agent has no skills under
+        <code class="font-mono text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">.claude/skills/</code>.
+      </p>
+    </div>
+
+    <ul v-else class="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg">
+      <li
+        v-for="pb in playbooks"
+        :key="pb.name"
+        class="px-3 py-2 flex items-center gap-2"
+        :class="{ 'opacity-60': !pb.user_invocable }"
+      >
+        <input
+          type="checkbox"
+          :value="pb.name"
+          v-model="selected"
+          :disabled="exposeAll || busy || !pb.user_invocable"
+          @change="debouncedSaveAllowList"
+        />
+        <span class="text-sm text-gray-900 dark:text-gray-100 font-mono">/{{ pb.name }}</span>
+        <span
+          v-if="pb.automation === 'gated'"
+          class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-state-autonomous-100 dark:bg-state-autonomous-900/40 text-state-autonomous-800 dark:text-state-autonomous-200"
+          title="Runs require operator approval"
+        >approval-gated</span>
+        <span
+          v-if="!pb.user_invocable"
+          class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+          title="Marked user-invocable: false in its SKILL.md — cannot be exposed"
+        >not invocable</span>
+        <span v-if="pb.description" class="text-xs text-gray-500 dark:text-gray-400 truncate">— {{ pb.description }}</span>
+      </li>
+    </ul>
+
+    <p v-if="message" class="mt-2 text-xs" :class="messageError ? 'text-status-danger-600' : 'text-status-success-600'">{{ message }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import api from '../api'
+
+const props = defineProps({
+  agentName: { type: String, required: true },
+})
+
+const playbooks = ref([])
+const playbooksError = ref('')
+const selected = ref([])
+const exposeAll = ref(true)
+const busy = ref(false)
+const message = ref('')
+const messageError = ref(false)
+
+const notify = (text, isError = false) => {
+  message.value = text
+  messageError.value = isError
+}
+
+// exposed_playbooks === null ⇒ all exposed; else the explicit set.
+const syncFromConnector = (exposedPlaybooks) => {
+  exposeAll.value = exposedPlaybooks == null
+  selected.value = Array.isArray(exposedPlaybooks) ? [...exposedPlaybooks] : []
+}
+
+const loadConnectorState = async () => {
+  try {
+    const { data } = await api.get(`/api/agents/${props.agentName}/connector`)
+    syncFromConnector(data.exposed_playbooks)
+  } catch {
+    // 403 (not owner) / not entitled — parent gates visibility; default to all.
+    syncFromConnector(null)
+  }
+}
+
+const loadPlaybooks = async () => {
+  playbooksError.value = ''
+  try {
+    const { data } = await api.get(`/api/agents/${props.agentName}/playbooks`)
+    playbooks.value = data?.skills || []
+    // Prune stale names: an allow-list entry that's no longer a live
+    // user-invocable playbook would otherwise linger and be re-sent forever.
+    if (!exposeAll.value) {
+      const invocable = new Set(playbooks.value.filter((p) => p.user_invocable !== false).map((p) => p.name))
+      selected.value = selected.value.filter((n) => invocable.has(n))
+    }
+  } catch (e) {
+    playbooks.value = []
+    playbooksError.value = e.response?.status === 503
+      ? 'Start the agent to choose which playbooks to expose.'
+      : 'Could not load this agent’s playbooks.'
+  }
+}
+
+const load = async () => {
+  await loadConnectorState()
+  await loadPlaybooks()
+}
+
+const saveAllowList = async () => {
+  busy.value = true
+  try {
+    const body = exposeAll.value
+      ? { expose_all_playbooks: true }
+      : { exposed_playbooks: selected.value }
+    const { data } = await api.put(`/api/agents/${props.agentName}/connector`, body)
+    syncFromConnector(data.exposed_playbooks)
+    notify('Exposed playbooks updated.')
+  } catch (e) {
+    notify(e.response?.data?.detail || 'Failed to update playbooks', true)
+  } finally {
+    busy.value = false
+  }
+}
+
+// Coalesce a burst of checkbox toggles into one PUT (each send is the full set,
+// so last-write-wins is safe). The "expose all" toggle saves immediately.
+let saveTimer = null
+const debouncedSaveAllowList = () => {
+  clearTimeout(saveTimer)
+  saveTimer = setTimeout(saveAllowList, 400)
+}
+
+watch(() => props.agentName, load)
+onMounted(load)
+</script>


### PR DESCRIPTION
## Summary

Carves the "Exposed playbooks" allow-list picker out of `ConnectorChannelPanel.vue` into a standalone, reusable `ExposedToolsPanel.vue` on the Sharing tab (trinity-enterprise#55) — a first-class picker surface, decoupled from the connector's key/config block.

## What changed

- **New `ExposedToolsPanel.vue`** — self-contained picker. Reads/writes the **same** allow-list the connector already consumes: `GET/PUT /api/agents/{name}/connector` → `enterprise_connectors.exposed_playbooks`. **No new backend, no new storage.**
- **`ConnectorChannelPanel.vue`** slimmed (−83/+8): the inline picker + its state/logic (`exposeAll`/`selected`/`availablePlaybooks`/`saveAllowList`/`debouncedSaveAllowList`/`loadPlaybooks`/`syncAllowListState`) are gone; it now composes `<ExposedToolsPanel :agent-name>` in their place. The key block (generate/regenerate/revoke/enable + copy-paste snippets) stays, so the SSO tier can later swap it for an OAuth variant **without touching the picker** (AC#8).

## Design decisions (confirmed with maintainer)

- **Refactor-extract**, not a new allow-list. The allow-list #55 describes already exists in the enterprise `mcp_connector` module; a parallel OSS column would have created a second, competing store. The picker binds to the existing endpoint.
- **Toggle = connector enable/key model**, not #846 `mcp_exposed`. The per-playbook allow-list is a connector concept; `#846`'s `chat_with_<slug>` isn't per-playbook.

## AC coverage

- Standalone reusable component composed into the Sharing tab, owner+entitlement gated (via the enclosing connector disclosure) — AC#1
- Exposure control at top (connector enable/key) — AC#2
- Lists playbooks from `GET /playbooks` w/ name + description — AC#3
- Per-playbook allow-list toggle, persists — AC#4
- `automation: gated` → **approval-gated** badge; `user_invocable: false` → **shown disabled, never exposable** (improves on the old version, which hid them) — AC#5
- Empty state with guidance — AC#6
- Cohesive Sharing-tab styling, dark-mode aware — AC#7
- Key block decoupled from picker in code — AC#8
- No secrets rendered (name/description only) — AC#9

## Test plan

- [x] Both SFCs compile (`vue/compiler-sfc` parse + `compileScript`).
- [x] No dead references left in `ConnectorChannelPanel.vue`.
- [ ] Full `vite build` — blocked locally by a **pre-existing** unrelated gap (`mermaid` declared but not installed; fails identically on clean `dev`). CI has full deps.
- [ ] Manual: Sharing tab → MCP connector (entitled) → generate key → toggle playbooks / Expose all → reload persists; gated badge + disabled non-invocable rows render.

No frontend unit-test harness exists in this repo. Backend untouched.

Related to abilityai/trinity-enterprise#55
