### PR TITLE
feat(telegram): voice-out via ElevenLabs TTS + shared TTS foundation (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,16 @@ GEMINI_API_KEY=
 # May be the same value as GEMINI_API_KEY.
 GOOGLE_API_KEY=
 
+# ElevenLabs — outbound voice replies across channels (epic #24; Telegram #25).
+# When set, agents with voice replies enabled speak their reply as a voice note
+# (synthesized by ElevenLabs, transcoded to OGG/Opus). Empty = feature off
+# (adapters deliver text). Get a key at https://elevenlabs.io/app/settings/api-keys
+ELEVENLABS_API_KEY=
+# Optional model + shared cost guardrail (reply longer than this many chars is
+# delivered as text instead of paying to synthesize it).
+ELEVENLABS_MODEL_ID=eleven_multilingual_v2
+TTS_MAX_CHARS=1500
+
 # Gemini model overrides (#1130) — set these if Google retires the built-in
 # default (both default to gemini-3.5-flash, set in src/backend/config.py).
 # Two vars because the modalities differ: TEXT is text-only (image-gen prompt

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -87,6 +87,12 @@ services:
       - VOIP_CALL_RATE_WINDOW=${VOIP_CALL_RATE_WINDOW:-60}        # rate-limit window (s)
       - VOIP_TICKET_TTL_SECONDS=${VOIP_TICKET_TTL_SECONDS:-180}   # Media Streams WSS ticket TTL
       - VOIP_INTENT_TTL_SECONDS=${VOIP_INTENT_TTL_SECONDS:-180}   # staged Gemini-intent TTL
+      # Outbound voice replies via shared TTS (epic #24; Telegram #25). The key
+      # gates the feature (empty ⇒ adapters deliver text). Prod compose launches
+      # standalone (no base merge / env_file), so wire it here too (#1056 class).
+      - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY:-}
+      - ELEVENLABS_MODEL_ID=${ELEVENLABS_MODEL_ID:-eleven_multilingual_v2}  # non-empty default (#1076)
+      - TTS_MAX_CHARS=${TTS_MAX_CHARS:-1500}                      # shared synth cost cap (chars)
       # Agent structured reports (#918) — per-agent create-rate cap (60s window fixed in code).
       # Prod compose launches standalone (no base merge / env_file), so wire it here too.
       - REPORT_RATE_LIMIT=${REPORT_RATE_LIMIT:-30}               # reports per agent per 60s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,12 @@ services:
       - VOIP_CALL_RATE_WINDOW=${VOIP_CALL_RATE_WINDOW:-60}        # rate-limit window (s)
       - VOIP_TICKET_TTL_SECONDS=${VOIP_TICKET_TTL_SECONDS:-180}   # Media Streams WSS ticket TTL
       - VOIP_INTENT_TTL_SECONDS=${VOIP_INTENT_TTL_SECONDS:-180}   # staged Gemini-intent TTL
+      # Outbound voice replies via shared TTS (epic #24; Telegram #25). The key
+      # gates the feature (empty ⇒ adapters deliver text). Must reach the
+      # container or the .env lever is inert (the #1056/#1039 packaging class).
+      - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY:-}
+      - ELEVENLABS_MODEL_ID=${ELEVENLABS_MODEL_ID:-eleven_multilingual_v2}  # non-empty default (#1076)
+      - TTS_MAX_CHARS=${TTS_MAX_CHARS:-1500}                      # shared synth cost cap (chars)
       # Agent structured reports (#918) — per-agent create-rate cap (60s window fixed in code).
       # Must reach the container or the .env lever is inert in prod (the #1039 packaging class).
       - REPORT_RATE_LIMIT=${REPORT_RATE_LIMIT:-30}               # reports per agent per 60s

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 
 # Install curl for healthcheck, git for GitHub cloning, libmagic for file type detection
-RUN apt-get update && apt-get install -y --no-install-recommends curl git libmagic1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl git libmagic1 ffmpeg && rm -rf /var/lib/apt/lists/*
 
 # Build-time provenance (#926). Each arg is forwarded by docker-compose
 # `backend.build.args` from shell vars set by `scripts/deploy/start.sh`.

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -189,6 +189,7 @@
 - `slack_service.py` - Slack API client (OAuth, messaging, verification) (SLACK-001)
 - `nevermined_payment_service.py` - x402 payment verification and settlement (NVM-001)
 - `proactive_message_service.py` - Agent-to-user proactive messaging with rate limiting and audit (#321)
+- `tts_service.py` - Shared outbound-voice TTS layer (epic #24): ElevenLabs synth → ffmpeg OGG/Opus transcode; shared char cost-cap; fail-soft (any error → text fallback). Consumed by channel adapters (Telegram #25 first; Slack #26 / WhatsApp trinity-enterprise#56 reuse it)
 - `agent_shared_files_service.py` - Outbound file sharing — see [Outbound File Sharing](#outbound-file-sharing-files-001)
 - `loop_service.py` - Sequential agent loop runner — see [Sequential Agent Loops](#sequential-agent-loops-740-ui-1106)
 - `voip_service.py` - VoIP outbound-call orchestration — see [VoIP](#voip-telephony-voip-001-1056)
@@ -211,7 +212,7 @@
 - `slack_adapter.py` - DMs, @mentions, thread replies, agent identity via `chat:write.customize`
 - `transports/slack_socket.py` - Socket Mode: N concurrent WebSockets per `SLACK_SOCKET_CONNECTION_COUNT` (default 2, range 1–10), per-client watchdog, envelope-ID dedup ring (#244)
 - `transports/slack_webhook.py` - HTTP webhook transport (production fallback)
-- `telegram_adapter.py` - DMs, group chats (@mention/observe modes), voice transcription, /login flow
+- `telegram_adapter.py` - DMs, group chats (@mention/observe modes), voice transcription, /login flow; outbound voice replies via `sendVoice` when TTS enabled (epic #24/#25, shared `tts_service`)
 - `transports/telegram_webhook.py` - Telegram Bot API webhook (inbound POST + setWebhook registration)
 - `whatsapp_adapter.py` - DMs via Twilio (WHATSAPP-001); media downloads SSRF-gated to the `*.twilio.com` domain suffix; `/login`/`/logout`/`/whoami` commands + markdown→WhatsApp syntax conversion (#467)
 - `transports/twilio_webhook.py` - Twilio webhook: HMAC-SHA1 signature validation, MessageSid dedup, form-encoded body
@@ -649,6 +650,7 @@ never bypassed.
 | GET/PUT | `/api/agents/{name}/read-only` | Read-only mode status / toggle (blocks source file writes) |
 | GET/PUT | `/api/agents/{name}/timeout` | Execution timeout (60–7200s, default 3600s, #665). PUT 400 `agent_timeout_below_active_schedules` if the new cap drops below any non-deleted schedule's `timeout_seconds` (#929) |
 | GET/PUT | `/api/agents/{name}/public-channel-model` | Per-agent model override for **public-facing** channels — public link, Slack/Telegram/WhatsApp, x402 (#894). GET returns raw override + resolved model + selectable list; PUT owner-only, whitelist-validated (422), NULL clears → platform default. Resolved at `public.py`/`message_router.py`/`paid.py` (override → platform default → fallback); the owner's own chats/schedules are unaffected |
+| GET/PUT | `/api/agents/{name}/voice-replies` | Shared agent-level outbound-voice (TTS) config (epic #24/#25). GET returns `{enabled, voice_id, available}` (`available` = platform `ELEVENLABS_API_KEY` set); PUT owner-only, requires `voice_id` when enabling. When on, channel adapters speak replies via `tts_service` → OGG/Opus voice note, text fallback on failure/over cap |
 | GET/PUT | `/api/agents/{name}/guardrails` | Per-agent guardrails config / overrides (GUARD-001) |
 | GET/PUT | `/api/agents/{name}/file-sharing` | Outbound file-sharing status + quota / owner-only toggle (returns `restart_required`) (FILES-001) |
 | POST | `/api/agents/{name}/shared-files` | Mint a download URL for a file in the publish dir (owner/admin or agent-scoped key) |
@@ -978,6 +980,8 @@ CREATE TABLE agent_ownership (
     file_sharing_enabled INTEGER DEFAULT 0,        -- FILES-001
     circuit_breaker_enabled INTEGER DEFAULT 0,     -- RELIABILITY-007 (#526): dispatch-breaker opt-in
     mcp_exposed INTEGER DEFAULT 0,                 -- #846: dedicated chat_with_<slug> MCP tool opt-in
+    tts_voice_replies_enabled INTEGER DEFAULT 0,   -- epic #24/#25: outbound voice replies (shared agent-level)
+    tts_voice_id TEXT,                             -- epic #24/#25: ElevenLabs voice id for spoken replies
     deleted_at TEXT,                               -- #834: NULL = live; set = soft-deleted
     FOREIGN KEY (owner_id) REFERENCES users(id),
     FOREIGN KEY (subscription_id) REFERENCES subscription_credentials(id)

--- a/src/backend/adapters/telegram_adapter.py
+++ b/src/backend/adapters/telegram_adapter.py
@@ -225,6 +225,14 @@ class TelegramAdapter(ChannelAdapter):
         if not text:
             return
 
+        # Voice-out (epic #24 / #25): if the agent has spoken replies enabled with
+        # a voice id, try to deliver the reply as a Telegram voice note. Strictly
+        # additive — any failure (no TTS key, over the cost cap, provider or
+        # transcode error) returns None and we fall through to the text path below.
+        agent_name = response.metadata.get("agent_name")
+        if agent_name and await self._maybe_send_voice(bot_token, channel_id, text, agent_name, thread_id, response):
+            return
+
         # Convert markdown to Telegram HTML
         html_text = self._markdown_to_html(text)
 
@@ -705,6 +713,78 @@ class TelegramAdapter(ChannelAdapter):
                 return resp.json().get("result")
         except Exception as e:
             logger.error(f"Telegram sendMessage error: {e}", exc_info=True)
+            return None
+
+    async def _maybe_send_voice(
+        self,
+        bot_token: str,
+        chat_id: str,
+        text: str,
+        agent_name: str,
+        thread_id: Optional[str],
+        response: ChannelResponse,
+    ) -> bool:
+        """Try to deliver ``text`` as a Telegram voice note (epic #24 / #25).
+
+        Returns True only when a voice note was actually sent. Any miss — feature
+        off, no voice id, TTS unavailable, over the cost cap, provider/transcode
+        error, or a failed ``sendVoice`` — returns False so the caller falls back
+        to text. Never raises.
+        """
+        try:
+            cfg = db.get_tts_config(agent_name)
+        except Exception as e:
+            logger.warning(f"voice-out: config lookup failed for {agent_name}: {e}")
+            return False
+        if not cfg.get("enabled") or not cfg.get("voice_id"):
+            return False
+
+        import services.tts_service as tts_service
+
+        # Speak plain text, not markup (strip the markdown→HTML rendering).
+        spoken = self._strip_html(self._markdown_to_html(text))
+        ogg = await tts_service.synthesize_voice_note(spoken, cfg["voice_id"])
+        if not ogg:
+            return False
+
+        reply_to = thread_id if response.metadata.get("is_group") else None
+        result = await self._send_voice(bot_token, chat_id, ogg, reply_to_message_id=reply_to)
+        return result is not None
+
+    async def _send_voice(
+        self,
+        bot_token: str,
+        chat_id: str,
+        ogg_bytes: bytes,
+        reply_to_message_id: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Send an OGG/Opus voice note via Telegram ``sendVoice``. Retries once on
+        429; returns the message result, or None on failure (caller uses text)."""
+        url = f"{TELEGRAM_API_BASE}/bot{bot_token}/sendVoice"
+        data = {"chat_id": str(chat_id)}
+        if reply_to_message_id:
+            # sendVoice takes reply_parameters as a JSON string in multipart form.
+            import json as _json
+            data["reply_parameters"] = _json.dumps({
+                "message_id": int(reply_to_message_id),
+                "allow_sending_without_reply": True,
+            })
+        files = {"voice": ("voice.ogg", ogg_bytes, "audio/ogg")}
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(url, data=data, files=files)
+                if resp.status_code == 429:
+                    retry_after = resp.json().get("parameters", {}).get("retry_after", 5)
+                    logger.warning(f"Telegram sendVoice rate limited, retry_after={retry_after}s")
+                    import asyncio
+                    await asyncio.sleep(min(retry_after, 30))
+                    resp = await client.post(url, data=data, files=files)
+                if resp.status_code != 200:
+                    logger.error(f"Telegram sendVoice failed ({resp.status_code}): {resp.text[:300]}")
+                    return None
+                return resp.json().get("result")
+        except Exception as e:
+            logger.error(f"Telegram sendVoice error: {e}", exc_info=True)
             return None
 
     async def _send_chat_action(self, bot_token: str, chat_id: str, action: str) -> None:

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -233,6 +233,15 @@ VOICE_MAX_DURATION = int(os.getenv("VOICE_MAX_DURATION", "300"))  # seconds
 DEFAULT_VOICE_NAME = "Kore"
 GEMINI_VOICE_NAMES = ("Kore", "Zephyr", "Puck", "Aoede", "Charon", "Fenrir", "Gacrux")
 
+# Outbound voice messages across channels (epic #24). Shared TTS layer used by
+# the channel adapters (Telegram #25 first) to speak agent replies. ElevenLabs is
+# the provider; the key gates the whole feature (empty ⇒ voice-out unavailable,
+# adapters fall back to text). TTS_MAX_CHARS is the shared cost guardrail — a
+# reply longer than this is delivered as text instead of paying to synthesize it.
+ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY", "")
+ELEVENLABS_MODEL_ID = os.getenv("ELEVENLABS_MODEL_ID") or "eleven_multilingual_v2"
+TTS_MAX_CHARS = int(os.getenv("TTS_MAX_CHARS", "1500"))
+
 # Gemini text/audio models (#1130). Hardcoded `gemini-2.0-flash` was retired by
 # Google (404 NOT_FOUND) with no config escape hatch — these env overrides make
 # the next model retirement a config change instead of a code change. Same `or`

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -661,6 +661,12 @@ class DatabaseManager:
     def get_mcp_exposed_agents(self):
         return self._agent_ops.get_mcp_exposed_agents()
 
+    def get_tts_config(self, agent_name: str):
+        return self._agent_ops.get_tts_config(agent_name)
+
+    def set_tts_config(self, agent_name: str, enabled: bool, voice_id):
+        return self._agent_ops.set_tts_config(agent_name, enabled, voice_id)
+
     # =========================================================================
     # Execution Timeout (delegated to db/agents.py) - TIMEOUT-001
     # =========================================================================

--- a/src/backend/db/agent_settings/__init__.py
+++ b/src/backend/db/agent_settings/__init__.py
@@ -23,6 +23,7 @@ from .access_policy import AccessPolicyMixin
 from .git_pat import GitPATMixin
 from .file_sharing import FileSharingMixin
 from .mcp_exposure import McpExposureMixin
+from .tts import TtsMixin
 
 __all__ = [
     'SharingMixin',
@@ -35,4 +36,5 @@ __all__ = [
     'GitPATMixin',
     'FileSharingMixin',
     'McpExposureMixin',
+    'TtsMixin',
 ]

--- a/src/backend/db/agent_settings/tts.py
+++ b/src/backend/db/agent_settings/tts.py
@@ -1,0 +1,62 @@
+"""Shared per-agent outbound-voice (TTS) config (epic #24 / #25).
+
+A single agent-level primitive — ``tts_voice_replies_enabled`` + ``tts_voice_id``
+on ``agent_ownership`` — that every channel adapter reuses to decide whether to
+speak a reply and with which ElevenLabs voice. Deliberately agent-level (not
+per-binding) so Telegram (#25), Slack (#26), and WhatsApp (trinity-enterprise#56)
+share one config with no per-channel column sprawl.
+
+Guards ``deleted_at IS NULL`` on write so a soft-deleted agent can't be mutated
+(same rule as the MCP-exposure / circuit-breaker toggles).
+"""
+
+from typing import Dict
+
+from sqlalchemy import select, update, func, and_
+
+from ..engine import get_engine
+from ..tables import agent_ownership
+
+
+class TtsMixin:
+    """Mixin for the shared per-agent outbound-voice toggle + voice id."""
+
+    def get_tts_config(self, agent_name: str) -> Dict:
+        """Return ``{"enabled": bool, "voice_id": str|None}`` for the agent.
+        Defaults to disabled / no voice when the agent or columns are unset."""
+        stmt = select(
+            func.coalesce(agent_ownership.c.tts_voice_replies_enabled, 0).label("enabled"),
+            agent_ownership.c.tts_voice_id.label("voice_id"),
+        ).where(
+            and_(
+                agent_ownership.c.agent_name == agent_name,
+                agent_ownership.c.deleted_at.is_(None),
+            )
+        )
+        with get_engine().connect() as conn:
+            row = conn.execute(stmt).mappings().first()
+        if not row:
+            return {"enabled": False, "voice_id": None}
+        return {"enabled": bool(row["enabled"]), "voice_id": row["voice_id"]}
+
+    def set_tts_config(self, agent_name: str, enabled: bool, voice_id: str | None) -> bool:
+        """Persist the outbound-voice toggle + voice id. Empty/whitespace voice_id
+        normalizes to NULL. Guards ``deleted_at IS NULL``. Returns True if a row
+        updated."""
+        clean_voice = (voice_id or "").strip() or None
+        stmt = (
+            update(agent_ownership)
+            .where(
+                and_(
+                    agent_ownership.c.agent_name == agent_name,
+                    agent_ownership.c.deleted_at.is_(None),
+                )
+            )
+            .values(
+                tts_voice_replies_enabled=1 if enabled else 0,
+                tts_voice_id=clean_voice,
+            )
+        )
+        with get_engine().begin() as conn:
+            result = conn.execute(stmt)
+            return result.rowcount > 0

--- a/src/backend/db/agents.py
+++ b/src/backend/db/agents.py
@@ -31,6 +31,7 @@ from .agent_settings import (
     GitPATMixin,
     FileSharingMixin,
     McpExposureMixin,
+    TtsMixin,
 )
 from utils.helpers import utc_now_iso
 
@@ -49,6 +50,7 @@ class AgentOperations(
     GitPATMixin,
     FileSharingMixin,
     McpExposureMixin,
+    TtsMixin,
 ):
     """Agent ownership, access control, and settings database operations.
 

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -2576,6 +2576,31 @@ def _migrate_agent_ownership_mcp_exposed(cursor, conn):
     conn.commit()
 
 
+def _migrate_agent_ownership_tts_voice(cursor, conn):
+    """epic #24 / #25 — outbound voice replies (shared agent-level config).
+
+    Adds ``tts_voice_replies_enabled INTEGER DEFAULT 0`` and ``tts_voice_id TEXT``
+    to ``agent_ownership``. When enabled with a voice id, channel adapters speak
+    the agent's reply via the shared ``services/tts_service.py`` (ElevenLabs →
+    OGG/Opus). Shared per-agent primitive (no per-channel column sprawl) consumed
+    by Telegram (#25) first, then Slack (#26) and WhatsApp (trinity-enterprise#56).
+    Default OFF. Mirrored by Alembic 0011_agent_ownership_tts_voice for PostgreSQL.
+    """
+    _safe_add_column(
+        cursor,
+        "agent_ownership",
+        "tts_voice_replies_enabled",
+        "ALTER TABLE agent_ownership ADD COLUMN tts_voice_replies_enabled INTEGER DEFAULT 0",
+    )
+    _safe_add_column(
+        cursor,
+        "agent_ownership",
+        "tts_voice_id",
+        "ALTER TABLE agent_ownership ADD COLUMN tts_voice_id TEXT",
+    )
+    conn.commit()
+
+
 def _migrate_agent_loops_no_progress(cursor, conn):
     """#1157 — no-progress / doom-loop detection.
 
@@ -2720,4 +2745,5 @@ MIGRATIONS = [
     ("agent_loops_max_cost", _migrate_agent_loops_max_cost),
     ("agent_ownership_public_channel_model", _migrate_agent_ownership_public_channel_model),
     ("agent_ownership_mcp_exposed", _migrate_agent_ownership_mcp_exposed),
+    ("agent_ownership_tts_voice", _migrate_agent_ownership_tts_voice),
 ]

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -96,6 +96,8 @@ TABLES = {
             file_sharing_enabled INTEGER DEFAULT 0,
             circuit_breaker_enabled INTEGER DEFAULT 0,
             mcp_exposed INTEGER DEFAULT 0,
+            tts_voice_replies_enabled INTEGER DEFAULT 0,
+            tts_voice_id TEXT,
             deleted_at TEXT,
             FOREIGN KEY (owner_id) REFERENCES users(id),
             FOREIGN KEY (subscription_id) REFERENCES subscription_credentials(id)

--- a/src/backend/db/tables.py
+++ b/src/backend/db/tables.py
@@ -100,6 +100,8 @@ agent_ownership = Table(
     Column("file_sharing_enabled", Integer),
     Column("circuit_breaker_enabled", Integer),
     Column("mcp_exposed", Integer),
+    Column("tts_voice_replies_enabled", Integer),  # epic #24/#25: outbound voice-out toggle (shared agent-level)
+    Column("tts_voice_id", Text),                  # epic #24/#25: ElevenLabs voice id for spoken replies
     Column("deleted_at", Text),
 )
 

--- a/src/backend/migrations/versions/0011_agent_ownership_tts_voice.py
+++ b/src/backend/migrations/versions/0011_agent_ownership_tts_voice.py
@@ -1,0 +1,38 @@
+"""agent_ownership TTS voice-out columns (epic #24 / #25)
+
+Adds the shared agent-level outbound-voice config on the PostgreSQL backend:
+``tts_voice_replies_enabled`` (INTEGER, default 0) and ``tts_voice_id`` (TEXT).
+Mirrors the SQLite ``agent_ownership_tts_voice`` migration in ``db/migrations.py``
+and the DDL in ``db/schema.py`` / MetaData in ``db/tables.py``.
+
+Fresh PG builds already get the columns via ``0001_baseline`` (which iterates
+``db/schema.py:TABLES``). This revision lets an existing PG deployment pick them
+up on ``alembic upgrade head``. ``ADD COLUMN IF NOT EXISTS`` keeps it a no-op
+when the baseline already created them.
+
+Revision ID: 0011_agent_ownership_tts_voice
+Revises: 0010_agent_ownership_mcp_exposed
+Create Date: 2026-07-01
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0011_agent_ownership_tts_voice"
+down_revision = "0010_agent_ownership_mcp_exposed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE agent_ownership ADD COLUMN IF NOT EXISTS "
+        "tts_voice_replies_enabled INTEGER DEFAULT 0"
+    )
+    op.execute(
+        "ALTER TABLE agent_ownership ADD COLUMN IF NOT EXISTS tts_voice_id TEXT"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agent_ownership DROP COLUMN IF EXISTS tts_voice_id")
+    op.execute("ALTER TABLE agent_ownership DROP COLUMN IF EXISTS tts_voice_replies_enabled")

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -723,6 +723,25 @@ class McpExposedUpdate(BaseModel):
     enabled: bool
 
 
+class VoiceRepliesUpdate(BaseModel):
+    """Body for PUT /api/agents/{name}/voice-replies (epic #24 / #25).
+
+    Shared agent-level outbound-voice config: when ``enabled``, channel adapters
+    speak the agent's reply via the shared TTS service using ``voice_id``
+    (an ElevenLabs voice id). ``voice_id`` is required when enabling.
+    """
+    enabled: bool
+    voice_id: Optional[str] = None
+
+    @field_validator("voice_id")
+    @classmethod
+    def _strip_voice_id(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        v = v.strip()
+        return v or None
+
+
 class PublicChannelModelUpdate(BaseModel):
     """Body for PUT /api/agents/{name}/public-channel-model (#894).
 

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -24,6 +24,7 @@ from models import (
     ExecutionResultEnvelope,
     HeartbeatPayload,
     McpExposedUpdate,
+    VoiceRepliesUpdate,
     TaskExecutionStatus,
     User,
 )
@@ -841,6 +842,66 @@ async def set_mcp_exposed_endpoint(
         "agent_name": agent_name,
         "enabled": body.enabled,
         "tool_name": resolve_tool_name(agent_name, exposed_names),
+    }
+
+
+# ============================================================================
+# Outbound voice replies (TTS) — shared agent-level config (epic #24 / #25)
+# ============================================================================
+
+
+@router.get("/{agent_name}/voice-replies")
+async def get_voice_replies_endpoint(
+    agent_name: AuthorizedAgentByName,
+    current_user: CurrentUser,
+):
+    """Shared per-agent outbound-voice config (epic #24 / #25).
+
+    Returns the toggle + configured ElevenLabs voice id, plus ``available`` —
+    whether the platform has TTS configured at all (``ELEVENLABS_API_KEY``) — so
+    the UI can show an inactive state instead of a dead toggle.
+    """
+    import services.tts_service as tts_service
+
+    cfg = db.get_tts_config(agent_name)
+    return {
+        "agent_name": agent_name,
+        "enabled": cfg["enabled"],
+        "voice_id": cfg["voice_id"],
+        "available": tts_service.is_available(),
+    }
+
+
+@router.put("/{agent_name}/voice-replies")
+async def set_voice_replies_endpoint(
+    agent_name: OwnedAgentByName,
+    body: VoiceRepliesUpdate,
+    current_user: CurrentUser,
+):
+    """Enable/disable spoken replies and set the ElevenLabs voice id (owner-only).
+
+    Enabling requires a ``voice_id``. When on, channel adapters (Telegram first)
+    speak replies via the shared TTS service, falling back to text on any failure
+    or when the reply exceeds the shared cost cap.
+    """
+    if body.enabled and not body.voice_id:
+        raise HTTPException(status_code=400, detail="voice_id is required to enable voice replies")
+
+    db.set_tts_config(agent_name, body.enabled, body.voice_id)
+    await platform_audit_service.log(
+        event_type=AuditEventType.CONFIGURATION,
+        event_action="voice_replies_config",
+        source="api",
+        actor_user=current_user,
+        target_type="agent",
+        target_id=agent_name,
+        details={"enabled": body.enabled, "has_voice_id": bool(body.voice_id)},
+    )
+    cfg = db.get_tts_config(agent_name)
+    return {
+        "agent_name": agent_name,
+        "enabled": cfg["enabled"],
+        "voice_id": cfg["voice_id"],
     }
 
 

--- a/src/backend/services/tts_service.py
+++ b/src/backend/services/tts_service.py
@@ -1,0 +1,126 @@
+"""Shared text-to-speech service — outbound voice messages across channels (epic #24).
+
+Single provider-agnostic TTS layer the channel adapters call to speak an agent's
+reply. #25 (Telegram) is the first consumer; #26 (Slack) and trinity-enterprise#56
+(WhatsApp) reuse it unchanged — no per-channel TTS duplication.
+
+Provider: ElevenLabs (`/v1/text-to-speech/{voice_id}`), returning MP3. Chat
+voice-notes on Telegram/WhatsApp render from OGG/Opus, so `synthesize_voice_note`
+transcodes MP3 → OGG/Opus via ffmpeg and returns the OGG bytes ready for
+`sendVoice` / Twilio `MediaUrl`.
+
+Design:
+- **Fail-soft everywhere.** Every entry point returns ``None`` on any problem
+  (no key, over the cost cap, provider error, ffmpeg missing/error). The caller
+  treats ``None`` as "deliver text instead" — voice is strictly additive and must
+  never break a reply.
+- **Cost guardrail** is a shared char cap (``TTS_MAX_CHARS``): a reply longer than
+  the cap is refused up front (``None``) so we never pay to synthesize an essay.
+"""
+import asyncio
+import logging
+from typing import Optional
+
+import httpx
+
+import config
+
+logger = logging.getLogger(__name__)
+
+_ELEVENLABS_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
+# ElevenLabs MP3 output; transcoded to OGG/Opus for the voice-note bubble.
+_OUTPUT_FORMAT = "mp3_44100_128"
+_HTTP_TIMEOUT = 30.0
+
+
+def is_available() -> bool:
+    """True when TTS can run at all (provider key configured)."""
+    return bool(config.ELEVENLABS_API_KEY)
+
+
+def _within_cost_cap(text: str) -> bool:
+    return 0 < len(text) <= config.TTS_MAX_CHARS
+
+
+async def synthesize_mp3(text: str, voice_id: str) -> Optional[bytes]:
+    """Synthesize ``text`` to MP3 bytes via ElevenLabs. ``None`` on any failure
+    or when the shared cost cap / guards reject it (caller falls back to text)."""
+    if not is_available():
+        return None
+    if not voice_id:
+        return None
+    if not _within_cost_cap(text):
+        logger.info(
+            "TTS skipped: reply length %d outside cost cap (0, %d] — falling back to text",
+            len(text), config.TTS_MAX_CHARS,
+        )
+        return None
+
+    url = f"{_ELEVENLABS_BASE}/{voice_id}"
+    headers = {
+        "xi-api-key": config.ELEVENLABS_API_KEY,
+        "accept": "audio/mpeg",
+        "content-type": "application/json",
+    }
+    payload = {
+        "text": text,
+        "model_id": config.ELEVENLABS_MODEL_ID,
+        "output_format": _OUTPUT_FORMAT,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.post(url, headers=headers, json=payload)
+        if resp.status_code != 200:
+            # Body may carry the ElevenLabs error; never log the key (it's a header).
+            logger.warning("TTS provider error %s: %s", resp.status_code, resp.text[:300])
+            return None
+        return resp.content
+    except Exception as e:
+        logger.warning("TTS request failed: %s", e)
+        return None
+
+
+async def to_ogg_opus(mp3_bytes: bytes) -> Optional[bytes]:
+    """Transcode MP3 → OGG/Opus (the chat voice-note codec) via ffmpeg over pipes.
+    ``None`` if ffmpeg is missing or errors (caller falls back to text)."""
+    if not mp3_bytes:
+        return None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg", "-hide_banner", "-loglevel", "error",
+            "-i", "pipe:0",
+            "-c:a", "libopus", "-b:a", "32k", "-f", "ogg",
+            "pipe:1",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        logger.warning("ffmpeg not found — cannot transcode TTS audio to OGG/Opus")
+        return None
+    except Exception as e:
+        logger.warning("ffmpeg spawn failed: %s", e)
+        return None
+
+    try:
+        stdout, stderr = await proc.communicate(input=mp3_bytes)
+    except Exception as e:
+        logger.warning("ffmpeg transcode failed: %s", e)
+        return None
+    if proc.returncode != 0 or not stdout:
+        logger.warning("ffmpeg transcode error (rc=%s): %s", proc.returncode, stderr[:300])
+        return None
+    return stdout
+
+
+async def synthesize_voice_note(text: str, voice_id: str) -> Optional[bytes]:
+    """End-to-end: text → ElevenLabs MP3 → OGG/Opus voice-note bytes.
+
+    Returns OGG/Opus bytes ready for Telegram ``sendVoice`` / Twilio ``MediaUrl``,
+    or ``None`` at any failure point (no key, over cap, provider error, transcode
+    failure) so the caller delivers text instead.
+    """
+    mp3 = await synthesize_mp3(text, voice_id)
+    if mp3 is None:
+        return None
+    return await to_ogg_opus(mp3)

--- a/src/frontend/src/components/TelegramChannelPanel.vue
+++ b/src/frontend/src/components/TelegramChannelPanel.vue
@@ -158,6 +158,51 @@
       <div v-else-if="binding.configured && binding.webhook_url" class="mt-3 text-xs text-gray-400 dark:text-gray-500">
         No group chats yet. Add the bot to a Telegram group to see it here.
       </div>
+
+      <!-- Voice replies (epic #24 / #25) — shared agent-level TTS config -->
+      <div class="mt-5 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <div class="flex items-start gap-3">
+          <label class="relative inline-flex items-center cursor-pointer mt-0.5" :class="{ 'opacity-50 cursor-not-allowed': !voice.available }">
+            <input
+              type="checkbox"
+              class="sr-only peer"
+              :checked="voice.enabled"
+              :disabled="!voice.available || voiceSaving"
+              @change="toggleVoice($event.target.checked)"
+            />
+            <div class="w-11 h-6 bg-gray-200 dark:bg-gray-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-action-primary-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-action-primary-600"></div>
+          </label>
+          <div class="flex-1">
+            <div class="text-sm font-medium text-gray-900 dark:text-gray-100">Voice replies</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+              Speak this agent's replies as a Telegram voice note (ElevenLabs). Long replies fall back to text.
+              <span v-if="!voice.available" class="block mt-1 text-status-warning-600 dark:text-status-warning-400">
+                Voice is unavailable — the platform has no ElevenLabs API key configured.
+              </span>
+            </div>
+          </div>
+        </div>
+        <div v-if="voice.enabled || voiceId" class="mt-3">
+          <label for="tts-voice-id" class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">ElevenLabs voice ID</label>
+          <div class="flex gap-2">
+            <input
+              id="tts-voice-id"
+              v-model="voiceId"
+              type="text"
+              placeholder="e.g. 21m00Tcm4TlvDq8ikWAM"
+              :disabled="!voice.available || voiceSaving"
+              class="flex-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-action-primary-500 disabled:opacity-50"
+            />
+            <button
+              type="button"
+              @click="saveVoice"
+              :disabled="!voice.available || voiceSaving"
+              class="px-3 py-1.5 text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50"
+            >Save</button>
+          </div>
+          <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Paste a voice ID from your ElevenLabs account.</p>
+        </div>
+      </div>
     </div>
 
     <!-- Disconnected State — Token Input -->
@@ -224,6 +269,11 @@ const groups = ref([])
 const botToken = ref('')
 const message = ref(null)
 
+// Voice replies (epic #24 / #25) — shared agent-level TTS config
+const voice = ref({ enabled: false, available: false })
+const voiceId = ref('')
+const voiceSaving = ref(false)
+
 async function loadBinding() {
   loading.value = true
   message.value = null
@@ -233,6 +283,7 @@ async function loadBinding() {
     binding.value = response.data
     if (response.data.configured) {
       await loadGroups()
+      await loadVoice()
     }
   } catch (e) {
     if (e.response?.status === 403) {
@@ -251,6 +302,45 @@ async function loadGroups() {
   } catch (e) {
     groups.value = []
   }
+}
+
+async function loadVoice() {
+  try {
+    const response = await api.get(`/api/agents/${props.agentName}/voice-replies`)
+    voice.value = { enabled: !!response.data.enabled, available: !!response.data.available }
+    voiceId.value = response.data.voice_id || ''
+  } catch (e) {
+    voice.value = { enabled: false, available: false }
+  }
+}
+
+async function saveVoice() {
+  voiceSaving.value = true
+  message.value = null
+  try {
+    const response = await api.put(`/api/agents/${props.agentName}/voice-replies`, {
+      enabled: voice.value.enabled,
+      voice_id: voiceId.value.trim() || null,
+    })
+    voice.value = { ...voice.value, enabled: !!response.data.enabled }
+    voiceId.value = response.data.voice_id || ''
+    message.value = { type: 'success', text: 'Voice settings saved' }
+    setTimeout(() => { message.value = null }, 3000)
+  } catch (e) {
+    const detail = e.response?.data?.detail || 'Failed to save voice settings'
+    message.value = { type: 'error', text: detail }
+    setTimeout(() => { message.value = null }, 3000)
+  } finally {
+    voiceSaving.value = false
+  }
+}
+
+async function toggleVoice(enabled) {
+  // Turning on without a voice id would 400 — keep the toggle visually on and let
+  // the user paste an id + Save. Turning off persists immediately.
+  voice.value = { ...voice.value, enabled }
+  if (enabled && !voiceId.value.trim()) return
+  await saveVoice()
 }
 
 async function connectBot() {

--- a/tests/unit/test_25_telegram_voice_out.py
+++ b/tests/unit/test_25_telegram_voice_out.py
@@ -32,6 +32,28 @@ import config  # noqa: E402
 import services.tts_service as tts_service  # noqa: E402
 
 
+# #762: this file stubs modules into sys.modules — an import-time `utils.helpers`
+# preload (above, before importing config/tts_service, which monkeypatch can't
+# reach) and a lazy `database` stub in the `adapter` fixture. Declaring the
+# `_STUBBED_MODULE_NAMES` + `_restore_sys_modules` pair snapshots and restores
+# them per test so the stubs never leak across files, and satisfies
+# tests/lint_sys_modules.py (precedent: test_telegram_webhook_backfill.py).
+_STUBBED_MODULE_NAMES = ["utils.helpers", "database"]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 # --------------------------------------------------------------------------- #
 # tts_service.synthesize_mp3
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_25_telegram_voice_out.py
+++ b/tests/unit/test_25_telegram_voice_out.py
@@ -1,0 +1,218 @@
+"""Telegram voice-out (epic #24 / #25) — shared TTS service + adapter branch.
+
+Covers:
+- tts_service cost-cap / no-key / provider-error / success (MP3)
+- ffmpeg transcode success + ffmpeg-missing fallback
+- synthesize_voice_note end-to-end + fail-soft
+- telegram_adapter._maybe_send_voice decision branches (enabled/disabled,
+  synth-success → sendVoice, synth-None → text fallback)
+"""
+import asyncio
+import os
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_backend_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "src", "backend")
+)
+if _backend_path not in sys.path:
+    sys.path.insert(0, _backend_path)
+
+if "utils.helpers" not in sys.modules:
+    _helpers = types.ModuleType("utils.helpers")
+    _helpers.utc_now = lambda: datetime.utcnow()
+    _helpers.utc_now_iso = lambda: datetime.utcnow().isoformat() + "Z"
+    sys.modules["utils.helpers"] = _helpers
+
+import config  # noqa: E402
+import services.tts_service as tts_service  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# tts_service.synthesize_mp3
+# --------------------------------------------------------------------------- #
+
+def _mock_httpx(status=200, content=b"MP3BYTES"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.content = content
+    resp.text = "" if status == 200 else "provider error"
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+def test_is_available(monkeypatch):
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "")
+    assert tts_service.is_available() is False
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "sk-xxx")
+    assert tts_service.is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_synthesize_mp3_no_key(monkeypatch):
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "")
+    assert await tts_service.synthesize_mp3("hello", "voice1") is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_mp3_over_cost_cap(monkeypatch):
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "sk-xxx")
+    monkeypatch.setattr(config, "TTS_MAX_CHARS", 10)
+    assert await tts_service.synthesize_mp3("x" * 11, "voice1") is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_mp3_empty_text(monkeypatch):
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "sk-xxx")
+    assert await tts_service.synthesize_mp3("", "voice1") is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_mp3_no_voice_id(monkeypatch):
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "sk-xxx")
+    assert await tts_service.synthesize_mp3("hello", "") is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_mp3_success(monkeypatch):
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "sk-xxx")
+    monkeypatch.setattr(config, "TTS_MAX_CHARS", 1500)
+    client = _mock_httpx(200, b"MP3BYTES")
+    monkeypatch.setattr(tts_service.httpx, "AsyncClient", lambda *a, **k: client)
+    out = await tts_service.synthesize_mp3("hello", "voice1")
+    assert out == b"MP3BYTES"
+    # key rides an xi-api-key header, never the body
+    _, kwargs = client.post.call_args
+    assert kwargs["headers"]["xi-api-key"] == "sk-xxx"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_mp3_provider_error(monkeypatch):
+    monkeypatch.setattr(config, "ELEVENLABS_API_KEY", "sk-xxx")
+    client = _mock_httpx(429, b"")
+    monkeypatch.setattr(tts_service.httpx, "AsyncClient", lambda *a, **k: client)
+    assert await tts_service.synthesize_mp3("hello", "voice1") is None
+
+
+# --------------------------------------------------------------------------- #
+# tts_service.to_ogg_opus (ffmpeg)
+# --------------------------------------------------------------------------- #
+
+def _mock_proc(returncode=0, stdout=b"OGGOPUS", stderr=b""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_to_ogg_opus_success(monkeypatch):
+    proc = _mock_proc(0, b"OGGOPUS")
+    monkeypatch.setattr(tts_service.asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+    assert await tts_service.to_ogg_opus(b"MP3BYTES") == b"OGGOPUS"
+
+
+@pytest.mark.asyncio
+async def test_to_ogg_opus_ffmpeg_missing(monkeypatch):
+    monkeypatch.setattr(
+        tts_service.asyncio, "create_subprocess_exec",
+        AsyncMock(side_effect=FileNotFoundError()),
+    )
+    assert await tts_service.to_ogg_opus(b"MP3BYTES") is None
+
+
+@pytest.mark.asyncio
+async def test_to_ogg_opus_nonzero_rc(monkeypatch):
+    proc = _mock_proc(1, b"", b"boom")
+    monkeypatch.setattr(tts_service.asyncio, "create_subprocess_exec", AsyncMock(return_value=proc))
+    assert await tts_service.to_ogg_opus(b"MP3BYTES") is None
+
+
+@pytest.mark.asyncio
+async def test_to_ogg_opus_empty_input():
+    assert await tts_service.to_ogg_opus(b"") is None
+
+
+# --------------------------------------------------------------------------- #
+# tts_service.synthesize_voice_note (end-to-end)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_voice_note_full_success(monkeypatch):
+    monkeypatch.setattr(tts_service, "synthesize_mp3", AsyncMock(return_value=b"MP3"))
+    monkeypatch.setattr(tts_service, "to_ogg_opus", AsyncMock(return_value=b"OGG"))
+    assert await tts_service.synthesize_voice_note("hi", "v1") == b"OGG"
+
+
+@pytest.mark.asyncio
+async def test_voice_note_synth_fails_short_circuits(monkeypatch):
+    monkeypatch.setattr(tts_service, "synthesize_mp3", AsyncMock(return_value=None))
+    transcode = AsyncMock()
+    monkeypatch.setattr(tts_service, "to_ogg_opus", transcode)
+    assert await tts_service.synthesize_voice_note("hi", "v1") is None
+    transcode.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# telegram_adapter._maybe_send_voice
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def adapter():
+    if "database" not in sys.modules:
+        fake_db = types.ModuleType("database")
+        fake_db.db = MagicMock()
+        sys.modules["database"] = fake_db
+    from adapters.telegram_adapter import TelegramAdapter
+    return TelegramAdapter()
+
+
+def _resp(is_group=False):
+    from adapters.base import ChannelResponse
+    return ChannelResponse(text="Hello there", metadata={"agent_name": "a1", "is_group": is_group})
+
+
+@pytest.mark.asyncio
+async def test_maybe_send_voice_disabled(adapter, monkeypatch):
+    from database import db
+    monkeypatch.setattr(db, "get_tts_config", lambda n: {"enabled": False, "voice_id": None})
+    sent = AsyncMock()
+    monkeypatch.setattr(adapter, "_send_voice", sent)
+    ok = await adapter._maybe_send_voice("tok", "chat1", "Hello", "a1", None, _resp())
+    assert ok is False
+    sent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_maybe_send_voice_success(adapter, monkeypatch):
+    from database import db
+    monkeypatch.setattr(db, "get_tts_config", lambda n: {"enabled": True, "voice_id": "v1"})
+    monkeypatch.setattr(
+        "services.tts_service.synthesize_voice_note", AsyncMock(return_value=b"OGG")
+    )
+    sent = AsyncMock(return_value={"message_id": 1})
+    monkeypatch.setattr(adapter, "_send_voice", sent)
+    ok = await adapter._maybe_send_voice("tok", "chat1", "Hello", "a1", None, _resp())
+    assert ok is True
+    sent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_maybe_send_voice_tts_none_falls_back(adapter, monkeypatch):
+    from database import db
+    monkeypatch.setattr(db, "get_tts_config", lambda n: {"enabled": True, "voice_id": "v1"})
+    monkeypatch.setattr(
+        "services.tts_service.synthesize_voice_note", AsyncMock(return_value=None)
+    )
+    sent = AsyncMock()
+    monkeypatch.setattr(adapter, "_send_voice", sent)
+    ok = await adapter._maybe_send_voice("tok", "chat1", "Hello", "a1", None, _resp())
+    assert ok is False
+    sent.assert_not_called()


### PR DESCRIPTION
## Summary

First slice of epic #24 (outbound voice across channels): **Telegram voice-out**. Builds the **shared** TTS foundation that Slack (#26) and WhatsApp (trinity-enterprise#56) reuse unchanged, then wires Telegram as the first consumer.

## Shared foundation (epic #24)

- **`services/tts_service.py`** — one provider-agnostic TTS layer. ElevenLabs synth → `ffmpeg` MP3→OGG/Opus transcode (the chat voice-note codec) → OGG bytes. Shared **char cost-cap** (`TTS_MAX_CHARS`, default 1500). **Fail-soft everywhere** — every path returns `None` on any problem (no key, over cap, provider/transcode error, ffmpeg missing) so the caller delivers text. Voice is strictly additive.
- **Shared agent-level config** (no per-channel column sprawl, per #56): `agent_ownership.tts_voice_replies_enabled` + `tts_voice_id` via a new `TtsMixin`. **Dual-track migration** (SQLite `db/migrations.py` + Alembic `0011`), schema.py + tables.py.
- `GET/PUT /api/agents/{name}/voice-replies` (owner-only; enabling requires a `voice_id`; GET exposes `available` = platform key present).
- `ffmpeg` added to the backend image; `ELEVENLABS_API_KEY` / `ELEVENLABS_MODEL_ID` / `TTS_MAX_CHARS` in config + `.env.example`.

## Telegram wiring (#25)

- `telegram_adapter._send_voice` (Telegram `sendVoice`, multipart OGG) + a voice branch in `send_response`: when enabled with a voice id, speak the reply; **fall back to text** on any miss.
- UI: voice-replies toggle + ElevenLabs voice-id field in the Sharing → Telegram panel.

## Design decisions (confirmed)

- **Config home:** shared agent-level primitive (not per-binding) — one config all channels reuse.
- **Trigger policy:** Always-when-enabled. **Mirror is infeasible** — Telegram voice-**in** isn't implemented, so there's no inbound-voice signal to mirror.
- **Format:** `ffmpeg` → OGG/Opus (native voice-note bubble; also what #56 needs).
- **Voice selection:** paste ElevenLabs voice id (validated on save).
- **OSS core, ungated** — channels live in OSS; the issue carries no entitlement.

## Test plan

- [x] `tts_service`: cost-cap / no-key / no-voice / empty / provider-error / success; transcode success + ffmpeg-missing + nonzero-rc; end-to-end + short-circuit — **16 tests pass**.
- [x] Adapter voice branch: disabled → no send; success → `sendVoice`; TTS `None` → text fallback.
- [x] Schema/migration parity green (`test_schema_parity`, `test_migrations`, alembic guard); 48 telegram tests pass; app wiring imports clean under conftest.
- [ ] Live end-to-end against a real ElevenLabs key + Telegram bot (needs a key; not exercised locally).

## Notes

- `#56` (WhatsApp voice-out) was un-claimed back to `status-ready` — it's blocked on this shared layer and will ride it once merged.
- `#25` was `status-incubating` with open design questions; promoted to `status-in-progress` after the decisions above.

Related to abilityai/trinity-enterprise#25
