### PR TITLE
fix(ui): stop Agent Detail card jumping on Chat tab switch (#954)

### DIFF
--- a/src/frontend/e2e/agent-detail-chat-width.spec.js
+++ b/src/frontend/e2e/agent-detail-chat-width.spec.js
@@ -1,0 +1,82 @@
+import { test, expect, request } from '@playwright/test'
+
+/**
+ * Agent Detail — Chat tab width parity (#954).
+ *
+ * Switching between the Chat tab and any other tab must NOT shift or resize the
+ * content area. The Chat tab puts the page into a "fullscreen" layout mode
+ * (root becomes a flex column); before #954 the `mx-auto` on <main> collapsed it
+ * to content width in that mode, so the whole tab card jumped left/narrower on
+ * every switch. The fix pins <main> to `w-full max-w-[1400px]` in both modes.
+ *
+ * This measures the tab card's bounding box (the `.rounded-lg` wrapping the tab
+ * strip) on Overview vs Chat and asserts it does not move or change width, then
+ * that it snaps back identically. @interactive — needs a real agent to exist.
+ */
+
+let TEST_AGENT = process.env.TABS_TEST_AGENT || ''
+let api
+
+test.beforeAll(async ({ baseURL }) => {
+  api = await request.newContext({ baseURL })
+  const loginResp = await api.post('/api/token', {
+    form: { username: 'admin', password: process.env.ADMIN_PASSWORD || '' },
+  })
+  if (!loginResp.ok()) throw new Error(`Admin login failed: ${loginResp.status()}`)
+  const token = (await loginResp.json()).access_token
+  const listResp = await api.get('/api/agents', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  const body = await listResp.json()
+  const agents = Array.isArray(body) ? body : body.agents || []
+  const names = agents.map((a) => a.name)
+  if (!TEST_AGENT || !names.includes(TEST_AGENT)) {
+    if (names.length === 0) throw new Error('No agents available to test chat width')
+    TEST_AGENT = names[0]
+  }
+})
+
+test.afterAll(async () => {
+  if (api) await api.dispose()
+})
+
+// Bounding box of the tab card (the .rounded-lg wrapping the OverflowTabs nav).
+async function cardBox(page) {
+  return page.evaluate(() => {
+    const nav = document.querySelector('nav.-mb-px')
+    if (!nav) return null
+    const card = nav.closest('.rounded-lg')
+    if (!card) return null
+    const r = card.getBoundingClientRect()
+    return { x: Math.round(r.x), w: Math.round(r.width) }
+  })
+}
+
+test.describe('Agent Detail chat-tab width parity (#954)', () => {
+  test('@interactive Chat tab does not shift or resize the content card', async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 1000 })
+    await page.goto(`/agents/${TEST_AGENT}`)
+
+    // Overview (default landing tab) baseline.
+    await expect(page.locator('nav.-mb-px')).toBeVisible({ timeout: 15000 })
+    await page.waitForTimeout(300)
+    const overview = await cardBox(page)
+    expect(overview).not.toBeNull()
+
+    // Switch to Chat (fullscreen layout mode).
+    await page.getByRole('button', { name: 'Chat', exact: true }).first().click()
+    await page.waitForTimeout(500)
+    const chat = await cardBox(page)
+
+    // No horizontal shift, no width change (the #954 regression).
+    expect(Math.abs(chat.x - overview.x)).toBeLessThanOrEqual(1)
+    expect(Math.abs(chat.w - overview.w)).toBeLessThanOrEqual(1)
+
+    // Snaps back identically when leaving Chat.
+    await page.getByRole('button', { name: 'Overview', exact: true }).first().click()
+    await page.waitForTimeout(400)
+    const back = await cardBox(page)
+    expect(Math.abs(back.x - overview.x)).toBeLessThanOrEqual(1)
+    expect(Math.abs(back.w - overview.w)).toBeLessThanOrEqual(1)
+  })
+})

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -2,7 +2,11 @@
   <div :class="isFullscreenTab ? 'h-screen overflow-hidden flex flex-col bg-gray-100 dark:bg-gray-900' : 'min-h-screen bg-gray-100 dark:bg-gray-900'">
     <NavBar />
 
-    <main :class="['max-w-[1400px] mx-auto py-2 sm:px-6 lg:px-8', isFullscreenTab ? 'flex-1 flex flex-col overflow-hidden' : 'overflow-visible']">
+    <!-- #954: w-full keeps <main> at its max width in BOTH layout modes. Without it,
+         the fullscreen (Chat) mode makes the root a flex column, and `mx-auto`'s auto
+         inline margins override align-items:stretch on the flex item — collapsing
+         <main> to content width and shifting/narrowing the whole card on tab switch. -->
+    <main :class="['w-full max-w-[1400px] mx-auto py-2 sm:px-6 lg:px-8', isFullscreenTab ? 'flex-1 flex flex-col overflow-hidden' : 'overflow-visible']">
       <div :class="['px-4 sm:px-0 py-2', isFullscreenTab ? 'flex-1 flex flex-col overflow-hidden' : 'overflow-visible']">
         <div v-if="loading" class="text-center py-8">
           <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-action-primary-500 mx-auto"></div>


### PR DESCRIPTION
## Summary

Fixes the Agent Detail content jumping horizontally when switching to/from the **Chat** tab (#954, P1). One-line layout fix, measured before/after.

## Root cause (measured, not guessed)

The Chat tab flips the page into a fullscreen layout — the root becomes `flex flex-col`. `<main>` carries `mx-auto` (auto inline margins). On a flex item, **auto inline margins override `align-items: stretch`**, so `<main>` collapses to its content width and centers, dragging the whole tab card with it.

Measured at 1600px (before fix):
| | card x | card width |
|---|---|---|
| Overview | 189 | 1272 |
| Chat | **359** | **930** |

So the card shifted +170px right and lost 342px width on every switch — the visible jump. (This is separate from #956's scrollbar-gutter shift, which is already fixed and still in place.)

## Fix

Pin `<main>` to `w-full max-w-[1400px]` in **both** layout modes. `w-full` gives it a definite width so auto margins only center (never shrink). Harmless in the non-fullscreen block mode (`width:100%` capped by `max-w` = unchanged); restores full width in fullscreen.

## Verification (Playwright against a live build)

Rebuilt the frontend from this branch and measured Overview↔Chat card box across breakpoints — **zero delta at every one**, and it snaps back identically:

| viewport | overview | chat | back | result |
|---|---|---|---|---|
| 1024 | x96 w881 | x96 w881 | x96 w881 | PASS |
| 1440 | x109 w1272 | x109 w1272 | x109 w1272 | PASS |
| 1600 | x189 w1272 | x189 w1272 | x189 w1272 | PASS |
| 1920 | x349 w1272 | x349 w1272 | x349 w1272 | PASS |

Layout-only change → theme-independent (light/dark unaffected by construction).

## Test

Adds `e2e/agent-detail-chat-width.spec.js` (@interactive) asserting card-box parity across the Chat↔Overview switch. Carrying the `ui` label so `frontend-e2e` runs it.

## AC coverage
- [x] No shift/resize on Chat ↔ other-tab switches
- [x] `scrollbar-gutter` (#956) still in effect (card was already stable pre-switch; this fixes the in-switch collapse)
- [x] Chat content aligns with other tabs
- [x] Light + dark (layout-only)
- [x] `sm`/`lg`/wider-than-1400 breakpoints

Related to abilityai/trinity#954
