### PR TITLE
fix(execution): scheduled slash-command referencing a missing skill silently no-ops as success (#1410)

### DIFF
--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -19,6 +19,7 @@ Lifecycle:
 import asyncio
 import json
 import logging
+import re
 from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -41,6 +42,7 @@ from services.dispatch_breaker import DispatchBreaker
 from services.platform_audit_service import AuditEventType, platform_audit_service
 from services.settings_service import settings_service
 from utils.credential_sanitizer import sanitize_dict, sanitize_execution_log, sanitize_response, sanitize_text
+from utils.helpers import utc_now_iso
 from services.platform_prompt_service import (
     ExecutionContext,
     compose_system_prompt,
@@ -88,6 +90,7 @@ class TaskExecutionErrorCode(str, Enum):
     CIRCUIT_OPEN = "circuit_open"   # Circuit breaker open — agent known unhealthy (#767)
     RECONCILED = "reconciled"       # Terminal write lost the CAS; row reflects another writer's terminal (#671/H4)
     LEASE_EXPIRED = "lease_expired" # Fire-and-forget lease expired — no callback before slot TTL (#1083)
+    SKILL_NOT_FOUND = "skill_not_found"  # Slash-command message didn't resolve to an installed skill (#1410)
 
 
 @dataclass
@@ -233,6 +236,126 @@ def _is_reader_race_signature(detail) -> bool:
         return False
     msg = (detail.get("message") or "").lower()
     return "result message" in msg
+
+
+# ---------------------------------------------------------------------------
+# Unresolved slash-command detection (#1410)
+# ---------------------------------------------------------------------------
+
+# Triggers with no human watching the reply — an unresolved-command run here is
+# invisible without an explicit signal, so it earns an Operating Room alert. An
+# interactive-ish trigger (a user's /task, mcp, or public turn) still classifies
+# as FAILED but the caller already sees the "Unknown command" reply, so no alert.
+_AUTONOMOUS_TRIGGERS = frozenset(
+    {"schedule", "webhook", "loop", "event", "fan_out", "agent"}
+)
+
+# The agent runtime (Claude Code) answers a slash-command that doesn't resolve
+# to an installed skill with a normal, successful assistant turn — e.g.
+# "Unknown command: /generate". Anchored at the start of the (stripped)
+# response so an agent that merely mentions the phrase mid-prose is never
+# matched.
+_UNRESOLVED_COMMAND_RE = re.compile(
+    r"^\s*unknown (?:slash )?command:\s*(/\S+)", re.IGNORECASE
+)
+
+
+def detect_unresolved_slash_command(
+    message: Optional[str], response: Optional[str]
+) -> Optional[str]:
+    """Return the offending command when *message* was a slash-command
+    invocation and *response* is the runtime's unresolved-command reply (#1410).
+
+    A scheduled/triggered ``/foo`` whose skill is absent from the container
+    comes back as a successful $0 turn ("Unknown command: /foo"), so the
+    execution would otherwise record as SUCCESS and blend into legitimate
+    skipped/$0 runs — masking a dead agent function indefinitely. Detection is
+    gated on the SENT message being a slash-command so a normal turn that
+    happens to echo the phrase is never misclassified. Returns ``None`` when it
+    is not this specific shape.
+    """
+    if not message or not response:
+        return None
+    if not message.lstrip().startswith("/"):
+        return None
+    match = _UNRESOLVED_COMMAND_RE.match(response)
+    return match.group(1) if match else None
+
+
+async def _alert_skill_not_found(
+    agent_name: str,
+    command: str,
+    execution_id: Optional[str],
+    triggered_by: str,
+) -> None:
+    """Raise an Operating Room item + notification when a scheduled/triggered
+    slash-command no-ops because its skill is missing (#1410).
+
+    Best-effort and idempotent-per-series: skips creation when a pending
+    ``skill_not_found`` item already exists for this agent+command, so a
+    recurring schedule doesn't flood the queue between operator responses.
+    Never raises — a failed alert must not turn the (already-FAILED) terminal
+    write into an exception.
+    """
+    try:
+        existing = db.list_operator_queue_items(
+            status="pending", type="skill_not_found", agent_name=agent_name
+        )
+        already = any(
+            (it.get("context") or {}).get("command") == command for it in existing
+        )
+        if already:
+            return
+
+        now = utc_now_iso()
+        title = "Scheduled command references a missing skill"
+        question = (
+            f"{agent_name}'s scheduled command '{command}' did not resolve to an "
+            f"installed skill — the run no-opped ('Unknown command'). The agent's "
+            f"scheduled function is not executing. Install the skill "
+            f"(.claude/skills/{command.lstrip('/').split()[0]}/SKILL.md) or fix the "
+            f"schedule's command."
+        )
+        item = {
+            "id": f"skill-not-found-{agent_name}-{now}",
+            "agent_name": agent_name,
+            "type": "skill_not_found",
+            "status": "pending",
+            "priority": "high",
+            "title": title,
+            "question": question,
+            "context": {
+                "command": command,
+                "triggered_by": triggered_by,
+                "execution_id": execution_id or "",
+            },
+            "created_at": now,
+        }
+        db.create_operator_queue_item(agent_name, item)
+
+        try:
+            from db_models import NotificationCreate
+
+            db.create_notification(
+                agent_name,
+                NotificationCreate(
+                    notification_type="alert",
+                    title=title,
+                    message=question,
+                    priority="high",
+                    category="error",
+                    metadata={"command": command, "execution_id": execution_id or ""},
+                ),
+            )
+        except Exception:  # noqa: BLE001 — notification is a secondary surface
+            logger.debug("[#1410] skill_not_found notification skipped", exc_info=True)
+
+        logger.warning(
+            "[#1410] skill_not_found alert raised for %s: command=%s execution=%s",
+            agent_name, command, execution_id,
+        )
+    except Exception:  # noqa: BLE001 — alerting must never break the terminal write
+        logger.exception("[#1410] failed to raise skill_not_found alert for %s", agent_name)
 
 
 # ---------------------------------------------------------------------------
@@ -1238,6 +1361,55 @@ class TaskExecutionService:
                 return await self.apply_result(
                     agent_name,
                     cancelled_envelope,
+                    activity_id=activity_id,
+                    breaker_enabled=breaker_enabled,
+                    release_slot=False,
+                )
+
+            # ---- #1410: unresolved slash-command guard --------------------
+            # A scheduled/triggered `/foo` whose skill is missing from the
+            # container comes back as a successful $0 turn ("Unknown command:
+            # /foo"). Left as SUCCESS it blends into legitimate skipped/$0 runs
+            # and a dead agent function stays invisible. Finalize it as FAILED
+            # (SKILL_NOT_FOUND) so it flows through the standard failure
+            # observability (executions list, success-rate analytics, health)
+            # and raise a best-effort operator alert. Not counted as AUTH, so
+            # the dispatch breaker is untouched. (The #1083 fire-and-forget path
+            # finalizes agent-side via the result callback and bypasses this
+            # sync branch; it's default-OFF, so scheduled runs today are sync —
+            # async coverage is a follow-up that needs the sent message threaded
+            # into the terminal envelope.)
+            unresolved_command = detect_unresolved_slash_command(
+                message, response_data.get("response")
+            )
+            if unresolved_command:
+                logger.warning(
+                    "[#1410] %s: command '%s' did not resolve to an installed "
+                    "skill (execution %s, triggered_by=%s) — recording FAILED",
+                    agent_name, unresolved_command, execution_id, triggered_by,
+                )
+                if triggered_by in _AUTONOMOUS_TRIGGERS:
+                    _spawn_bg(
+                        _alert_skill_not_found(
+                            agent_name, unresolved_command, execution_id, triggered_by
+                        )
+                    )
+                skill_not_found_envelope = TerminalEnvelope(
+                    execution_id=execution_id,
+                    status=TaskExecutionStatus.FAILED,
+                    error=(
+                        f"Command '{unresolved_command}' did not resolve to an "
+                        f"installed skill (agent runtime replied 'Unknown command')"
+                    ),
+                    error_code=TaskExecutionErrorCode.SKILL_NOT_FOUND,
+                    metadata=metadata,
+                    retry_count=retry_count,
+                    previous_attempt_cost=previous_attempt_cost,
+                    execution_time_ms=execution_time_ms,
+                )
+                return await self.apply_result(
+                    agent_name,
+                    skill_not_found_envelope,
                     activity_id=activity_id,
                     breaker_enabled=breaker_enabled,
                     release_slot=False,

--- a/tests/unit/test_1410_unresolved_slash_command.py
+++ b/tests/unit/test_1410_unresolved_slash_command.py
@@ -1,0 +1,101 @@
+"""Unit tests for #1410 — a scheduled slash-command referencing a missing skill
+must not silently record as success.
+
+When a scheduled/triggered `/foo` does not resolve to an installed skill, the
+agent runtime (Claude Code) replies with a normal, successful assistant turn
+("Unknown command: /foo"). Left as SUCCESS + $0 this blends into legitimate
+skipped/$0 runs and a dead agent function stays invisible. `execute_task` now
+detects that specific shape and finalizes the execution as FAILED
+(``SKILL_NOT_FOUND``).
+
+These are pure unit tests over the module-level detector — no backend needed.
+
+Module under test:
+    src/backend/services/task_execution_service.py::detect_unresolved_slash_command
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytestmark = pytest.mark.unit
+
+from services.task_execution_service import (  # noqa: E402
+    TaskExecutionErrorCode,
+    detect_unresolved_slash_command,
+)
+
+
+# ---------------------------------------------------------------------------
+# Positive: slash-command sent + runtime unknown-command reply -> offending cmd
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "message,response,expected",
+    [
+        ("/generate", "Unknown command: /generate", "/generate"),
+        ("/generate weekly", "Unknown command: /generate", "/generate"),
+        ("  /generate  ", "Unknown command: /generate", "/generate"),
+        # case-insensitive + "slash" variant + leading whitespace in the reply
+        ("/foo", "unknown command: /foo", "/foo"),
+        ("/foo", "Unknown slash command: /foo", "/foo"),
+        ("/foo", "\n  Unknown command: /foo\n", "/foo"),
+    ],
+)
+def test_detects_unresolved_command(message, response, expected):
+    assert detect_unresolved_slash_command(message, response) == expected
+
+
+# ---------------------------------------------------------------------------
+# Negative: must NOT misclassify legitimate turns
+# ---------------------------------------------------------------------------
+
+def test_non_slash_message_never_matches():
+    """A normal prose turn that merely echoes the phrase is not a broken
+    slash-command invocation — the gate is the SENT message being a command."""
+    assert (
+        detect_unresolved_slash_command(
+            "explain the error 'Unknown command: /x'",
+            "Unknown command: /x",
+        )
+        is None
+    )
+
+
+def test_phrase_mid_response_not_matched():
+    """Anchored at the start — a slash-command whose skill produced real output
+    that happens to contain the phrase later is a genuine success."""
+    assert (
+        detect_unresolved_slash_command(
+            "/generate",
+            "Report generated. Note: an earlier draft said 'Unknown command'.",
+        )
+        is None
+    )
+
+
+def test_legit_success_response_not_matched():
+    assert detect_unresolved_slash_command("/generate", "Report generated OK.") is None
+
+
+@pytest.mark.parametrize(
+    "message,response",
+    [
+        (None, "Unknown command: /x"),
+        ("/x", None),
+        ("", ""),
+        ("/x", ""),
+    ],
+)
+def test_missing_inputs_return_none(message, response):
+    assert detect_unresolved_slash_command(message, response) is None
+
+
+def test_skill_not_found_error_code_exists():
+    assert TaskExecutionErrorCode.SKILL_NOT_FOUND.value == "skill_not_found"


### PR DESCRIPTION
## Summary

Fixes the silent-failure / observability gap in #1410: a scheduled slash-command (e.g. `/generate`) whose skill is **not installed** in the agent container comes back as a normal successful assistant turn (`Unknown command: /generate`), so the execution was recorded as `status=success`, `$0`, ~1–10s — indistinguishable from a legitimate skip. No failure, no alert, no health signal → a dead agent function can run for days while every dashboard shows the schedule "succeeding". (Field-observed: agents ran a broken `/generate` for ~12 days, found only by manual transcript inspection.)

## Change

`TaskExecutionService.execute_task` now detects this specific shape on the SUCCESS path and:

1. **Classifies correctly** (issue ask #1) — finalizes the execution as **FAILED** with a new `TaskExecutionErrorCode.SKILL_NOT_FOUND`, routing it through the standard failure observability (executions list, success-rate analytics, fleet health) instead of masking it as skipped/`$0`.
2. **Alerts** (issue ask #2) — for **autonomous** triggers (`schedule`/`webhook`/`loop`/`event`/`fan_out`/`agent`), where no human sees the reply, raises a best-effort **Operating Room item + notification**, idempotent per `agent+command` so a recurring schedule can't flood the queue. Interactive-ish triggers still classify as FAILED but skip the alert (the caller already sees the reply).

### Precision / safety

- Detection is **gated on the SENT message being a slash-command** (`/…`) and the reply matching `^\s*unknown (?:slash )?command:\s*(/\S+)` (anchored) — so a normal turn that merely echoes the phrase mid-prose is never misclassified.
- `SKILL_NOT_FOUND` is **not** an AUTH code, so the dispatch breaker (#526) is untouched.
- Alert helper never raises — a failed alert can't turn the (already-FAILED) terminal write into an exception.
- Interactive UI/MCP chat uses `routers/chat.py`'s own inline path and never reaches this branch.

### Scope / follow-ups

- The #1083 fire-and-forget path finalizes agent-side via the result callback and bypasses this sync branch; it is **default-OFF** (scheduled runs are sync today), so async coverage is a documented follow-up (needs the sent message threaded into the terminal envelope).
- Issue asks #3 (pre-flight skill check) and #4 (skill/schedule drift health check) are not in this PR — deferred as separate enhancements; this PR closes the core silent-success misclassification + alerting.

## Tests

`tests/unit/test_1410_unresolved_slash_command.py` — 14 pure-unit cases: positive matches (args, whitespace, case-insensitive, `slash` variant), negatives (non-slash message, phrase mid-response, legit success, missing inputs), and the new error-code presence. Related task-exec suites (`test_792_subscription_retry`, `test_terminal_write_cas_gate`, `test_chat_dispatched_marker`) still pass.

Related to #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)