### PR TITLE
feat(slack): channel identity, proactive messaging, and per-agent bot icon (#350 Phase 1 & 3, #292)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -207,8 +207,8 @@
 **Channel Adapters (`adapters/`)** — pluggable external messaging (SLACK-002, Invariant #9):
 
 - `base.py` - `ChannelAdapter` ABC, `NormalizedMessage`, `ChannelResponse` models
-- `message_router.py` - `ChannelMessageRouter`: rate limiting, agent resolution, execution pipeline; injects MEM-001 per-user memory into `execute_task(system_prompt=…)` gated on `verified_email and not is_group` (#895)
-- `slack_adapter.py` - DMs, @mentions, thread replies, agent identity via `chat:write.customize`
+- `message_router.py` - `ChannelMessageRouter`: rate limiting, agent resolution, execution pipeline; injects MEM-001 per-user memory into `execute_task(system_prompt=…)` gated on `verified_email and not is_group` (#895); calls the adapter's async `enrich_message` hook then prepends a `[Channel: #x]\n[From: …]` identity prefix for enriched channel (non-DM) messages (#350)
+- `slack_adapter.py` - DMs, @mentions, thread replies, agent identity via `chat:write.customize`; `enrich_message` resolves sender display name + channel name via `users.info`/`conversations.info` so the agent sees who/where (best-effort, #350)
 - `transports/slack_socket.py` - Socket Mode: N concurrent WebSockets per `SLACK_SOCKET_CONNECTION_COUNT` (default 2, range 1–10), per-client watchdog, envelope-ID dedup ring (#244)
 - `transports/slack_webhook.py` - HTTP webhook transport (production fallback)
 - `telegram_adapter.py` - DMs, group chats (@mention/observe modes), voice transcription, /login flow
@@ -262,7 +262,7 @@ FastMCP, Streamable HTTP transport, port 8080. API-key auth via `Authorization: 
 | `notifications.ts` (1) | `send_notification` | Agent-to-platform notifications |
 | `events.ts` (4) | `emit_event`, `subscribe_to_event`, `list_event_subscriptions`, `delete_event_subscription` | Agent event pub/sub (EVT-001) |
 | `docs.ts` (1) | `get_agent_requirements` | Agent documentation |
-| `channels.ts` (2) | `list_channel_groups`, `send_group_message` | Channel group discovery and proactive group messaging (#349) |
+| `channels.ts` (2) | `list_channel_groups`, `send_group_message` | Channel group discovery and proactive group messaging — Telegram (#349) and Slack channels (#350); `channel_type: telegram\|slack`, Slack send accepts optional `thread_ts` |
 | `messages.ts` (1) | `send_message` | Proactive user messaging by verified email (#321) |
 | `files.ts` (1) | `share_file` | Publish file from `/home/developer/public/`, return download URL (FILES-001) |
 | `pipelines.ts` (2) | `list_agent_pipelines`, `get_agent_pipeline_state` | Read-only introspection of an agent's self-published pipelines (`~/.trinity/pipelines/*.yaml` + `~/.trinity/pipeline-state/<id>/<instance>.json`) over the **existing** `agent_files` surface — no backend/DB change (Invariant #8). Strict `^[A-Za-z0-9._-]+$` id validation (path-traversal guard), hardened YAML parse (size cap + dup-key + alias guard), latest-instance by mtime, only-404→empty (#919) |

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -207,7 +207,7 @@
 **Channel Adapters (`adapters/`)** — pluggable external messaging (SLACK-002, Invariant #9):
 
 - `base.py` - `ChannelAdapter` ABC, `NormalizedMessage`, `ChannelResponse` models
-- `message_router.py` - `ChannelMessageRouter`: rate limiting, agent resolution, execution pipeline; injects MEM-001 per-user memory into `execute_task(system_prompt=…)` gated on `verified_email and not is_group` (#895); calls the adapter's async `enrich_message` hook then prepends a `[Channel: #x]\n[From: …]` identity prefix for enriched channel (non-DM) messages (#350)
+- `message_router.py` - `ChannelMessageRouter`: rate limiting, agent resolution, execution pipeline; injects MEM-001 per-user memory into `execute_task(system_prompt=…)` gated on `verified_email and not is_group` (#895); calls the adapter's async `enrich_message` hook then prepends a `[Channel: #x]\n[From: …]` identity prefix for enriched channel (non-DM) messages (#350); passes the agent's public avatar URL as `agent_avatar_url` so channels with a per-message bot icon render it (Slack `icon_url`, best-effort — #292)
 - `slack_adapter.py` - DMs, @mentions, thread replies, agent identity via `chat:write.customize`; `enrich_message` resolves sender display name + channel name via `users.info`/`conversations.info` so the agent sees who/where (best-effort, #350)
 - `transports/slack_socket.py` - Socket Mode: N concurrent WebSockets per `SLACK_SOCKET_CONNECTION_COUNT` (default 2, range 1–10), per-client watchdog, envelope-ID dedup ring (#244)
 - `transports/slack_webhook.py` - HTTP webhook transport (production fallback)

--- a/src/backend/adapters/base.py
+++ b/src/backend/adapters/base.py
@@ -129,6 +129,25 @@ class ChannelAdapter(ABC):
         Returns agent name, or None if no agent is configured for this channel/user.
         """
 
+    async def enrich_message(self, message: NormalizedMessage) -> None:
+        """
+        Enrich a parsed message with async-fetched sender/channel identity (#350).
+
+        ``parse_message`` is synchronous and, on some channels (Slack), the raw
+        event carries only opaque IDs — resolving a display name / channel name
+        needs an async API call. The router calls this once after resolving the
+        agent, so an adapter can populate ``message.metadata`` in place with:
+          - ``channel_name`` — human channel name (drives the ``[Channel: #x]``
+            context prefix; presence gates that prefix, so DMs stay clean)
+          - ``sender_display_name`` / ``sender_username`` — attribution
+
+        Default: no-op — channels whose event already carries identity
+        (Telegram) need nothing here. Override in concrete adapters. Must be
+        best-effort (never raise): the router still handles the message if
+        enrichment fails.
+        """
+        return None
+
     async def indicate_processing(self, message: NormalizedMessage) -> None:
         """
         Show a processing indicator to the user.

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -160,6 +160,34 @@ def _format_channel_identity(message: NormalizedMessage) -> str:
     return "\n".join(parts)
 
 
+def _agent_avatar_url(agent_name: str) -> Optional[str]:
+    """Best-effort public URL to an agent's avatar for a channel bot icon (#292).
+
+    Slack (and any channel supporting a per-message icon) needs a publicly
+    fetchable URL. Returns None when no public base URL is configured; a
+    private/unreachable base is harmless — the channel simply falls back to its
+    default icon. Cache-busts with ``avatar_updated_at`` when available so the
+    channel refetches after an avatar change. The avatar endpoint 404s cleanly
+    for avatar-less agents, so we don't gate on existence.
+    """
+    try:
+        base = settings_service.get_public_chat_url()
+        if not base:
+            return None
+        url = f"{base.rstrip('/')}/api/agents/{agent_name}/avatar"
+        identity = db.get_avatar_identity(agent_name)
+        updated_at = identity.get("updated_at") if identity else None
+        if updated_at:
+            # digits-only cache-bust token from the ISO timestamp
+            ver = "".join(ch for ch in str(updated_at) if ch.isdigit())
+            if ver:
+                url = f"{url}?v={ver}"
+        return url
+    except Exception:  # noqa: BLE001 — icon is best-effort, never blocks a reply
+        logger.debug("[#292] avatar URL build failed for %s", agent_name, exc_info=True)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Simple in-memory rate limiter with periodic pruning
 # ---------------------------------------------------------------------------
@@ -593,6 +621,12 @@ class ChannelMessageRouter:
 
         logger.debug(f"[ROUTER:{channel}] Step 12 - sending response")
         response_metadata = {"bot_token": bot_token, "agent_name": agent_name}
+        # #292: hand the agent's avatar to channels that render a per-message bot
+        # icon (Slack `icon_url`). Best-effort — None when the agent has no
+        # avatar or no public base URL is set; adapters ignore it otherwise.
+        avatar_url = _agent_avatar_url(agent_name)
+        if avatar_url:
+            response_metadata["agent_avatar_url"] = avatar_url
         if is_group:
             response_metadata["is_group"] = True
         await adapter.send_response(

--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -128,6 +128,38 @@ def _format_group_sender(message: NormalizedMessage) -> str:
     return "\n".join(parts)
 
 
+def _format_channel_identity(message: NormalizedMessage) -> str:
+    """Format channel + sender identity for a non-group channel message (#350).
+
+    Driven by metadata an adapter's ``enrich_message`` populated
+    (``channel_name`` / ``sender_display_name`` / ``sender_username``). Returns
+    a prefix like::
+
+        [Channel: #engineering]
+        [From: John Smith (@johndoe)]
+
+    Gated on ``channel_name`` presence, so this fires only for channel messages
+    (Slack #channel), never DMs or channels without enrichment (empty string ⇒
+    context unchanged).
+    """
+    channel_name = message.metadata.get("channel_name")
+    if not channel_name:
+        return ""
+
+    parts = [f"[Channel: #{channel_name}]"]
+    display = message.metadata.get("sender_display_name")
+    username = message.metadata.get("sender_username")
+    if display and username:
+        parts.append(f"[From: {display} (@{username})]")
+    elif display:
+        parts.append(f"[From: {display}]")
+    elif username:
+        parts.append(f"[From: @{username}]")
+    else:
+        parts.append(f"[From: User {message.sender_id}]")
+    return "\n".join(parts)
+
+
 # ---------------------------------------------------------------------------
 # Simple in-memory rate limiter with periodic pruning
 # ---------------------------------------------------------------------------
@@ -262,6 +294,11 @@ class ChannelMessageRouter:
             return
         agent_name, bot_token = resolved
 
+        # 2a. Enrich with async-fetched sender/channel identity (#350). No-op on
+        # channels whose event already carries identity (Telegram); Slack fills
+        # in display name + channel name here. Best-effort — never raises.
+        await adapter.enrich_message(message)
+
         # 2b. Transcribe Telegram voice notes in place (no-op elsewhere).
         message = await self._maybe_transcribe_voice(adapter, message, bot_token, channel)
 
@@ -313,6 +350,12 @@ class ChannelMessageRouter:
             context_prompt = f"{sender_context}\n\n{message.text}"
         else:
             context_prompt = db.build_public_chat_context(session_id, message.text)
+            # #350: prepend channel + sender identity for channel (non-DM)
+            # messages so the agent knows who is speaking. Empty for DMs and
+            # un-enriched channels → context unchanged.
+            identity_prefix = _format_channel_identity(message)
+            if identity_prefix:
+                context_prompt = f"{identity_prefix}\n\n{context_prompt}"
         logger.debug(f"[ROUTER:{channel}] Step 7 - context built ({len(context_prompt)} chars, group={is_group})")
 
         # 7b. Handle file uploads — download via adapter, copy into agent container.

--- a/src/backend/adapters/slack_adapter.py
+++ b/src/backend/adapters/slack_adapter.py
@@ -243,6 +243,42 @@ class SlackAdapter(ChannelAdapter):
 
         return None
 
+    async def enrich_message(self, message: NormalizedMessage) -> None:
+        """Resolve sender display name (+ channel name for channel messages) so
+        the agent knows who is speaking (#350).
+
+        Slack events carry only opaque IDs (``U123``/``C123``); this fetches the
+        display identity via the Web API and writes it into ``message.metadata``.
+        ``channel_name`` is set only for non-DM (channel) messages — its presence
+        is what makes the router prepend the ``[Channel: #x]`` context, so DMs
+        stay clean. Best-effort: any failure leaves the bare IDs in place.
+        """
+        try:
+            team_id = message.metadata.get("team_id")
+            if not team_id:
+                return
+            bot_token = db.get_slack_workspace_bot_token(team_id)
+            if not bot_token:
+                return
+
+            if message.sender_id:
+                user_info = await slack_service.get_user_info(bot_token, message.sender_id)
+                if user_info:
+                    display = user_info.get("real_name") or user_info.get("display_name")
+                    if display:
+                        message.metadata["sender_display_name"] = display
+                    if user_info.get("name"):
+                        message.metadata["sender_username"] = user_info["name"]
+
+            # Channel name only for channel (non-DM) messages — gates the
+            # [Channel: #x] prefix; DMs intentionally have no channel context.
+            if not message.metadata.get("is_dm") and message.channel_id:
+                channel_info = await slack_service.get_channel_info(bot_token, message.channel_id)
+                if channel_info and channel_info.get("name"):
+                    message.metadata["channel_name"] = channel_info["name"]
+        except Exception as e:  # noqa: BLE001 — enrichment is best-effort (#350)
+            logger.debug(f"[SlackAdapter] enrich_message failed: {e}", exc_info=True)
+
     # =========================================================================
     # Slack-specific: message parsing
     # =========================================================================

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1857,6 +1857,9 @@ class DatabaseManager:
     def get_slack_channel_for_agent(self, team_id, agent_name):
         return self._slack_channel_ops.get_channel_for_agent(team_id, agent_name)
 
+    def get_slack_channels_for_agent(self, agent_name):
+        return self._slack_channel_ops.get_channels_for_agent(agent_name)
+
     def unbind_slack_agent(self, team_id, agent_name):
         return self._slack_channel_ops.unbind_agent(team_id, agent_name)
 

--- a/src/backend/db/slack_channels.py
+++ b/src/backend/db/slack_channels.py
@@ -320,6 +320,31 @@ class SlackChannelOperations:
             return None
         return self._row_to_channel_agent(row)
 
+    def get_channels_for_agent(self, agent_name: str) -> List[dict]:
+        """All channel bindings for an agent across every workspace (#350).
+
+        Powers the MCP ``list_channel_groups`` discovery + proactive-send target
+        validation. Cross-workspace (no ``team_id`` filter), so an agent bound in
+        multiple Slack workspaces sees them all.
+        """
+        stmt = (
+            select(
+                slack_channel_agents.c.id,
+                slack_channel_agents.c.team_id,
+                slack_channel_agents.c.slack_channel_id,
+                slack_channel_agents.c.slack_channel_name,
+                slack_channel_agents.c.agent_name,
+                slack_channel_agents.c.is_dm_default,
+                slack_channel_agents.c.created_by,
+                slack_channel_agents.c.created_at,
+            )
+            .where(slack_channel_agents.c.agent_name == agent_name)
+            .order_by(slack_channel_agents.c.created_at.asc())
+        )
+        with get_engine().connect() as conn:
+            rows = conn.execute(stmt).all()
+        return [self._row_to_channel_agent(row) for row in rows]
+
     def unbind_agent(self, team_id: str, agent_name: str) -> bool:
         """Remove an agent's channel binding.
 

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -2137,6 +2137,12 @@ class TelegramGroupMessageRequest(BaseModel):
     message: str
 
 
+class SlackChannelMessageRequest(BaseModel):
+    """Request model for proactive Slack channel messaging (#350)."""
+    message: str
+    thread_ts: Optional[str] = None  # optionally reply in an existing thread
+
+
 # =============================================================================
 # Users Models (routers/users.py)
 # =============================================================================

--- a/src/backend/routers/slack.py
+++ b/src/backend/routers/slack.py
@@ -20,7 +20,8 @@ from fastapi.responses import RedirectResponse
 
 from database import db
 from dependencies import get_current_user
-from models import SlackEventResponse, User
+from models import SlackChannelMessageRequest, SlackEventResponse, User
+from services import rate_limiter
 from services.slack_service import slack_service
 from db_models import SlackConnectionStatus, SlackOAuthInitResponse
 from services.settings_service import get_slack_signing_secret
@@ -604,4 +605,113 @@ async def set_agent_as_slack_dm_default(
         "workspace_name": workspace.get("team_name"),
         "previous": previous,
         "new_default": name,
+    }
+
+
+# =============================================================================
+# Proactive channel messaging (#350 Phase 3) — parallels Telegram #349
+# =============================================================================
+
+# Mirror the Telegram proactive caps (10/hr/channel, 100/hr/agent) via the
+# shared sliding-window limiter (#1023) rather than a bespoke bucket.
+_SLACK_PROACTIVE_PER_CHANNEL = 10
+_SLACK_PROACTIVE_PER_AGENT = 100
+_SLACK_PROACTIVE_WINDOW = 3600
+_SLACK_MESSAGE_MAX = 4000
+
+
+@auth_router.get("/api/agents/{name}/slack/channels")
+async def list_agent_slack_channels(
+    name: str,
+    current_user: User = Depends(get_current_user),
+):
+    """List the Slack channels an agent is bound to (#350).
+
+    Backs the MCP ``list_channel_groups`` discovery tool. Any user with access
+    to the agent may list; proactive send is owner-gated separately.
+    """
+    if not db.can_user_access_agent(current_user.username, name):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    # team_id → workspace name, resolved once for labelling.
+    ws_names = {ws["team_id"]: ws.get("team_name") for ws in db.get_all_slack_workspaces()}
+    channels = [
+        {
+            "channel_type": "slack",
+            "channel_id": c["slack_channel_id"],
+            "channel_name": c.get("slack_channel_name"),
+            "team_id": c["team_id"],
+            "workspace_name": ws_names.get(c["team_id"]),
+            "is_dm_default": c.get("is_dm_default", False),
+        }
+        for c in db.get_slack_channels_for_agent(name)
+    ]
+    return {"channels": channels, "count": len(channels)}
+
+
+@auth_router.post("/api/agents/{name}/slack/channels/{channel_id}/messages")
+async def send_agent_slack_channel_message(
+    name: str,
+    channel_id: str,
+    request: SlackChannelMessageRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Send a proactive message to a Slack channel the agent is bound to (#350).
+
+    Owner-gated. Rate limited (10/hr/channel, 100/hr/agent) to prevent spam.
+    Posts via ``chat.postMessage`` with the agent's identity, optionally in a
+    thread.
+    """
+    if not db.can_user_share_agent(current_user.username, name):
+        raise HTTPException(status_code=403, detail="Only owners can send channel messages")
+
+    text = (request.message or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Message cannot be empty")
+    if len(text) > _SLACK_MESSAGE_MAX:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Message exceeds {_SLACK_MESSAGE_MAX} character limit",
+        )
+
+    # Validate the channel is actually bound to this agent (also yields team_id).
+    target = next(
+        (c for c in db.get_slack_channels_for_agent(name) if c["slack_channel_id"] == channel_id),
+        None,
+    )
+    if not target:
+        raise HTTPException(status_code=404, detail="Channel not found or not bound to this agent")
+
+    # Rate limit: per-channel then per-agent (fail-open inside the limiter).
+    rate_limiter.enforce(
+        f"slack_proactive:{name}:{channel_id}",
+        _SLACK_PROACTIVE_PER_CHANNEL, _SLACK_PROACTIVE_WINDOW,
+        detail="Too many messages to this channel.",
+    )
+    rate_limiter.enforce(
+        f"slack_proactive:{name}",
+        _SLACK_PROACTIVE_PER_AGENT, _SLACK_PROACTIVE_WINDOW,
+        detail="Too many proactive messages from this agent.",
+    )
+
+    bot_token = db.get_slack_workspace_bot_token(target["team_id"])
+    if not bot_token:
+        raise HTTPException(status_code=500, detail="Failed to retrieve Slack bot token")
+
+    ok, error = await slack_service.send_message(
+        bot_token=bot_token,
+        channel=channel_id,
+        text=text,
+        username=name,  # per-message agent identity (chat:write.customize)
+        thread_ts=request.thread_ts,
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=f"Slack send failed: {error}")
+
+    return {
+        "sent": True,
+        "channel_type": "slack",
+        "channel_id": channel_id,
+        "channel_name": target.get("slack_channel_name"),
+        "thread_ts": request.thread_ts,
     }

--- a/src/backend/services/slack_service.py
+++ b/src/backend/services/slack_service.py
@@ -345,6 +345,69 @@ class SlackService:
             logger.error(f"Failed to get Slack user email: {e}")
             return None
 
+    async def get_user_info(
+        self,
+        bot_token: str,
+        user_id: str
+    ) -> Optional[dict]:
+        """
+        Fetch a user's display identity (#350).
+
+        Returns ``{"real_name", "display_name", "name"}`` (any may be empty),
+        or None on error. Requires ``users:read`` scope. Best-effort — the
+        caller degrades to the bare user ID when this returns None.
+        """
+        try:
+            response = await self.client.get(
+                f"{self.SLACK_API_BASE}/users.info",
+                headers={"Authorization": f"Bearer {bot_token}"},
+                params={"user": user_id}
+            )
+            data = response.json()
+            if not data.get("ok"):
+                logger.warning(f"Failed to get Slack user info: {data.get('error')}")
+                return None
+            user = data.get("user", {})
+            profile = user.get("profile", {})
+            return {
+                "real_name": profile.get("real_name") or user.get("real_name"),
+                "display_name": profile.get("display_name"),
+                "name": user.get("name"),
+            }
+        except Exception as e:
+            logger.error(f"Failed to get Slack user info: {e}")
+            return None
+
+    async def get_channel_info(
+        self,
+        bot_token: str,
+        channel_id: str
+    ) -> Optional[dict]:
+        """
+        Fetch a channel's name (#350).
+
+        Returns ``{"name", "is_private"}`` or None on error. Requires
+        ``channels:read`` / ``groups:read`` scope. Best-effort.
+        """
+        try:
+            response = await self.client.get(
+                f"{self.SLACK_API_BASE}/conversations.info",
+                headers={"Authorization": f"Bearer {bot_token}"},
+                params={"channel": channel_id}
+            )
+            data = response.json()
+            if not data.get("ok"):
+                logger.warning(f"Failed to get Slack channel info: {data.get('error')}")
+                return None
+            channel = data.get("channel", {})
+            return {
+                "name": channel.get("name"),
+                "is_private": channel.get("is_private", False),
+            }
+        except Exception as e:
+            logger.error(f"Failed to get Slack channel info: {e}")
+            return None
+
     async def open_dm_channel(
         self,
         bot_token: str,

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -1956,6 +1956,48 @@ export class TrinityClient {
     );
   }
 
+  /**
+   * List the Slack channels an agent is bound to (#350)
+   */
+  async listSlackChannels(agentName: string): Promise<{
+    channels: Array<{
+      channel_type: string;
+      channel_id: string;
+      channel_name: string | null;
+      team_id: string;
+      workspace_name: string | null;
+      is_dm_default: boolean;
+    }>;
+    count: number;
+  }> {
+    return this.request(
+      "GET",
+      `/api/agents/${encodeURIComponent(agentName)}/slack/channels`
+    );
+  }
+
+  /**
+   * Send a proactive message to a Slack channel (#350)
+   */
+  async sendSlackChannelMessage(
+    agentName: string,
+    channelId: string,
+    message: string,
+    threadTs?: string
+  ): Promise<{
+    sent: boolean;
+    channel_type: string;
+    channel_id: string;
+    channel_name?: string | null;
+    thread_ts?: string | null;
+  }> {
+    return this.request(
+      "POST",
+      `/api/agents/${encodeURIComponent(agentName)}/slack/channels/${encodeURIComponent(channelId)}/messages`,
+      threadTs ? { message, thread_ts: threadTs } : { message }
+    );
+  }
+
   // ============================================================================
   // Sequential Agent Loops (#740)
   // ============================================================================

--- a/src/mcp-server/src/tools/channels.ts
+++ b/src/mcp-server/src/tools/channels.ts
@@ -66,8 +66,8 @@ export function createChannelTools(
         "Returns group IDs, names, and configuration for each group. " +
         "Use this to discover which groups you can send proactive messages to.",
       parameters: z.object({
-        channel_type: z.enum(["telegram"])
-          .describe("Channel type to list groups for. Currently only 'telegram' is supported."),
+        channel_type: z.enum(["telegram", "slack"])
+          .describe("Channel type to list groups for: 'telegram' groups or 'slack' channels."),
         agent_name: z.string().optional()
           .describe(
             "Agent name to list groups for. Required for user-scoped API keys. " +
@@ -76,7 +76,7 @@ export function createChannelTools(
       }),
       execute: async (
         params: {
-          channel_type: "telegram";
+          channel_type: "telegram" | "slack";
           agent_name?: string;
         },
         context?: { session?: McpAuthContext }
@@ -112,6 +112,25 @@ export function createChannelTools(
             }, null, 2);
           }
 
+          if (params.channel_type === "slack") {
+            const result = await apiClient.listSlackChannels(agentName);
+            const groups = result.channels.map(c => ({
+              channel_type: "slack",
+              chat_id: c.channel_id,
+              chat_title: c.channel_name || "Unnamed Channel",
+              workspace_name: c.workspace_name,
+              is_dm_default: c.is_dm_default,
+            }));
+
+            return JSON.stringify({
+              success: true,
+              agent_name: agentName,
+              channel_type: params.channel_type,
+              groups,
+              count: groups.length,
+            }, null, 2);
+          }
+
           return JSON.stringify({
             success: false,
             error: `Unsupported channel type: ${params.channel_type}`,
@@ -137,12 +156,14 @@ export function createChannelTools(
         "Use this to broadcast updates, alerts, or information to groups you're connected to. " +
         "Rate limited to prevent spam: 10 messages/hour/group, 100 messages/hour/agent.",
       parameters: z.object({
-        channel_type: z.enum(["telegram"])
-          .describe("Channel type. Currently only 'telegram' is supported."),
+        channel_type: z.enum(["telegram", "slack"])
+          .describe("Channel type: 'telegram' group or 'slack' channel."),
         chat_id: z.string()
           .describe("The group/channel ID to send the message to. Get this from list_channel_groups."),
         message: z.string().max(4096)
-          .describe("Message text to send (max 4096 characters). Telegram HTML formatting is supported."),
+          .describe("Message text to send (max 4096 characters). Telegram supports HTML; Slack supports mrkdwn."),
+        thread_ts: z.string().optional()
+          .describe("Slack only: post in an existing thread (the parent message's ts). Ignored for Telegram."),
         agent_name: z.string().optional()
           .describe(
             "Agent name to send as. Required for user-scoped API keys. " +
@@ -151,9 +172,10 @@ export function createChannelTools(
       }),
       execute: async (
         params: {
-          channel_type: "telegram";
+          channel_type: "telegram" | "slack";
           chat_id: string;
           message: string;
+          thread_ts?: string;
           agent_name?: string;
         },
         context?: { session?: McpAuthContext }
@@ -198,6 +220,24 @@ export function createChannelTools(
               chat_id: result.chat_id,
               group_title: result.group_title,
               message_id: result.message_id,
+            }, null, 2);
+          }
+
+          if (params.channel_type === "slack") {
+            const result = await apiClient.sendSlackChannelMessage(
+              agentName,
+              params.chat_id,
+              params.message.trim(),
+              params.thread_ts
+            );
+
+            return JSON.stringify({
+              success: result.sent,
+              agent_name: agentName,
+              channel_type: params.channel_type,
+              chat_id: result.channel_id,
+              group_title: result.channel_name,
+              thread_ts: result.thread_ts,
             }, null, 2);
           }
 

--- a/tests/unit/test_350_slack_identity.py
+++ b/tests/unit/test_350_slack_identity.py
@@ -22,7 +22,7 @@ if str(_BACKEND) not in sys.path:
 pytestmark = pytest.mark.unit
 
 from adapters.base import NormalizedMessage  # noqa: E402
-from adapters.message_router import _format_channel_identity  # noqa: E402
+from adapters.message_router import _agent_avatar_url, _format_channel_identity  # noqa: E402
 
 
 def _msg(metadata: dict) -> NormalizedMessage:
@@ -131,6 +131,40 @@ def test_enrich_best_effort_swallows_errors():
         _run(adapter.enrich_message(msg))
     # Nothing crashed; identity simply absent for the failed call.
     assert "sender_display_name" not in msg.metadata
+
+
+# ---------------------------------------------------------------------------
+# _agent_avatar_url — best-effort bot icon (#292)
+# ---------------------------------------------------------------------------
+
+def test_avatar_url_with_cache_bust():
+    with patch("adapters.message_router.settings_service") as mock_settings, \
+         patch("adapters.message_router.db") as mock_db:
+        mock_settings.get_public_chat_url.return_value = "https://trinity.example.com/"
+        mock_db.get_avatar_identity.return_value = {"updated_at": "2026-07-02T10:00:00Z"}
+        url = _agent_avatar_url("research-agent")
+    assert url == "https://trinity.example.com/api/agents/research-agent/avatar?v=20260702100000"
+
+
+def test_avatar_url_without_updated_at_has_no_version():
+    with patch("adapters.message_router.settings_service") as mock_settings, \
+         patch("adapters.message_router.db") as mock_db:
+        mock_settings.get_public_chat_url.return_value = "https://trinity.example.com"
+        mock_db.get_avatar_identity.return_value = None
+        url = _agent_avatar_url("sales-ops")
+    assert url == "https://trinity.example.com/api/agents/sales-ops/avatar"
+
+
+def test_avatar_url_none_when_no_public_base():
+    with patch("adapters.message_router.settings_service") as mock_settings:
+        mock_settings.get_public_chat_url.return_value = ""
+        assert _agent_avatar_url("a") is None
+
+
+def test_avatar_url_best_effort_on_error():
+    with patch("adapters.message_router.settings_service") as mock_settings:
+        mock_settings.get_public_chat_url.side_effect = RuntimeError("boom")
+        assert _agent_avatar_url("a") is None
 
 
 def test_enrich_no_token_is_noop():

--- a/tests/unit/test_350_slack_identity.py
+++ b/tests/unit/test_350_slack_identity.py
@@ -1,0 +1,145 @@
+"""Unit tests for #350 Phase 1 — Slack channel/user identity in agent context.
+
+Covers:
+- `message_router._format_channel_identity` — the pure prefix builder (channel
+  messages get `[Channel: #x]\\n[From: ...]`; DMs / un-enriched → empty).
+- `SlackAdapter.enrich_message` — populates sender/channel identity into
+  `message.metadata` via a mocked slack_service, best-effort.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytestmark = pytest.mark.unit
+
+from adapters.base import NormalizedMessage  # noqa: E402
+from adapters.message_router import _format_channel_identity  # noqa: E402
+
+
+def _msg(metadata: dict) -> NormalizedMessage:
+    return NormalizedMessage(
+        sender_id="U123",
+        text="hi",
+        channel_id="C123",
+        timestamp="",
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_channel_identity — pure
+# ---------------------------------------------------------------------------
+
+def test_channel_message_full_identity():
+    out = _format_channel_identity(_msg({
+        "channel_name": "engineering",
+        "sender_display_name": "John Smith",
+        "sender_username": "johndoe",
+    }))
+    assert out == "[Channel: #engineering]\n[From: John Smith (@johndoe)]"
+
+
+def test_channel_message_display_only():
+    out = _format_channel_identity(_msg({
+        "channel_name": "general", "sender_display_name": "Jane",
+    }))
+    assert out == "[Channel: #general]\n[From: Jane]"
+
+
+def test_channel_message_username_only():
+    out = _format_channel_identity(_msg({
+        "channel_name": "general", "sender_username": "jane",
+    }))
+    assert out == "[Channel: #general]\n[From: @jane]"
+
+
+def test_channel_message_no_identity_falls_back_to_id():
+    out = _format_channel_identity(_msg({"channel_name": "general"}))
+    assert out == "[Channel: #general]\n[From: User U123]"
+
+
+def test_dm_or_unenriched_returns_empty():
+    # No channel_name (DM or enrichment failed) → no prefix, context unchanged.
+    assert _format_channel_identity(_msg({"is_dm": True})) == ""
+    assert _format_channel_identity(_msg({})) == ""
+
+
+# ---------------------------------------------------------------------------
+# SlackAdapter.enrich_message — populates metadata (mocked API)
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_enrich_channel_message_sets_channel_and_sender():
+    from adapters.slack_adapter import SlackAdapter
+    adapter = SlackAdapter()
+    msg = _msg({"team_id": "T1", "is_dm": False})
+
+    with patch("adapters.slack_adapter.db") as mock_db, \
+         patch("adapters.slack_adapter.slack_service") as mock_svc:
+        mock_db.get_slack_workspace_bot_token.return_value = "xoxb-test"
+        mock_svc.get_user_info = AsyncMock(return_value={
+            "real_name": "John Smith", "display_name": "JS", "name": "johndoe",
+        })
+        mock_svc.get_channel_info = AsyncMock(return_value={"name": "engineering", "is_private": False})
+        _run(adapter.enrich_message(msg))
+
+    assert msg.metadata["sender_display_name"] == "John Smith"
+    assert msg.metadata["sender_username"] == "johndoe"
+    assert msg.metadata["channel_name"] == "engineering"
+
+
+def test_enrich_dm_does_not_set_channel_name():
+    from adapters.slack_adapter import SlackAdapter
+    adapter = SlackAdapter()
+    msg = _msg({"team_id": "T1", "is_dm": True})
+
+    with patch("adapters.slack_adapter.db") as mock_db, \
+         patch("adapters.slack_adapter.slack_service") as mock_svc:
+        mock_db.get_slack_workspace_bot_token.return_value = "xoxb-test"
+        mock_svc.get_user_info = AsyncMock(return_value={"real_name": "John", "name": "john"})
+        mock_svc.get_channel_info = AsyncMock(return_value={"name": "should-not-fetch"})
+        _run(adapter.enrich_message(msg))
+
+    assert msg.metadata.get("sender_display_name") == "John"
+    assert "channel_name" not in msg.metadata  # DMs never get a channel prefix
+    mock_svc.get_channel_info.assert_not_called()
+
+
+def test_enrich_best_effort_swallows_errors():
+    from adapters.slack_adapter import SlackAdapter
+    adapter = SlackAdapter()
+    msg = _msg({"team_id": "T1", "is_dm": False})
+
+    with patch("adapters.slack_adapter.db") as mock_db, \
+         patch("adapters.slack_adapter.slack_service") as mock_svc:
+        mock_db.get_slack_workspace_bot_token.return_value = "xoxb-test"
+        mock_svc.get_user_info = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_svc.get_channel_info = AsyncMock(return_value={"name": "eng"})
+        # Must not raise — enrichment is best-effort.
+        _run(adapter.enrich_message(msg))
+    # Nothing crashed; identity simply absent for the failed call.
+    assert "sender_display_name" not in msg.metadata
+
+
+def test_enrich_no_token_is_noop():
+    from adapters.slack_adapter import SlackAdapter
+    adapter = SlackAdapter()
+    msg = _msg({"team_id": "T1", "is_dm": False})
+    with patch("adapters.slack_adapter.db") as mock_db, \
+         patch("adapters.slack_adapter.slack_service") as mock_svc:
+        mock_db.get_slack_workspace_bot_token.return_value = None
+        mock_svc.get_user_info = AsyncMock()
+        _run(adapter.enrich_message(msg))
+    mock_svc.get_user_info.assert_not_called()

--- a/tests/unit/test_message_router_access_gate.py
+++ b/tests/unit/test_message_router_access_gate.py
@@ -38,6 +38,7 @@ def _make_adapter(channel: str = "telegram") -> MagicMock:
     a.channel_type = channel
     # awaited methods
     a.get_agent_name = AsyncMock(return_value="agent1")
+    a.enrich_message = AsyncMock(return_value=None)  # #350 async identity hook
     a.handle_verification = AsyncMock(return_value=True)
     a.resolve_verified_email = AsyncMock(return_value=None)
     a.is_group_verified = AsyncMock(return_value=False)


### PR DESCRIPTION
Advances epic **#350** (Slack channel behavior, parallel to the shipped Telegram #349). Lands the two phases that reuse existing shared infra and need **no OAuth re-consent**. Observation mode (Phase 2) is split to sub-issue **#1413** (needs new `channels:history` scopes → Slack app re-install, `message`-event subscription, a dual-track migration).

## Phase 1 — user identity (AC: agent sees `[Channel: #name] [From: Display Name (@username)]`)

- New async `ChannelAdapter.enrich_message` hook (default no-op) — `parse_message` is sync, but Slack events carry only opaque IDs, so identity needs an async API call. The router calls it once after agent resolution.
- `SlackAdapter.enrich_message` resolves sender display name (`users.info`) + channel name (`conversations.info`) into `message.metadata`; **best-effort** (degrades to bare IDs, never raises).
- `message_router._format_channel_identity` prepends the identity block for enriched **channel (non-DM)** messages. **Gated on `channel_name` presence** — so DMs, un-enriched channels, and Telegram are unchanged, and I deliberately do **not** flip `is_group` (that would change the email-access-gate/group-bypass semantics — out of scope).
- `slack_service`: `get_user_info` / `get_channel_info`.

## Phase 3 — proactive channel messaging (AC: `list_channel_groups` + `send_group_message` for Slack, rate-limited)

- Backend: `GET /api/agents/{name}/slack/channels` (list bound channels) and `POST /api/agents/{name}/slack/channels/{channel_id}/messages` — owner-gated, rate-limited **10/hr/channel + 100/hr/agent** via the shared limiter (#1023), optional `thread_ts`, posts via `chat.postMessage` with the agent identity.
- `db.get_slack_channels_for_agent` (cross-workspace); `SlackChannelMessageRequest` in `models.py` (Invariant #14).
- MCP `list_channel_groups` / `send_group_message` now accept `channel_type: "telegram" | "slack"` (+ Slack `thread_ts`); new `TrinityClient` methods. The `chat_with_agent`/tool bodies are untouched.

## Tests

`tests/unit/test_350_slack_identity.py` — 9 cases (identity-prefix builder incl. DM/empty cases, enrichment metadata population, DM-skips-channel, best-effort error swallow, no-token no-op). Updated the access-gate test double for the new async hook. Full run: **81 passed** across the router + slack suites. MCP `tsc` clean for the changed files (only a pre-existing unrelated `yaml` dep error remains).

## Scope notes

- **Phase 2 (observation) → #1413.**
- Backend `is_group` semantics unchanged (access-gate safety).
- No OAuth scope changes in this PR.

Related to #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR — #292 (Slack bot icon)

Bundled per request (same adapter, same Slack identity surface). The bot **username** was already correct (`send_response` passes `username=agent_name` since #63; `chat:write.customize` is in the requested scopes) — the gap was the **icon**: nothing populated `agent_avatar_url`, so `icon_url` was always None. `message_router` now attaches a best-effort public avatar URL (`{public_chat_url}/api/agents/{name}/avatar`, cache-busted by `avatar_updated_at`) which the Slack adapter forwards as `icon_url`. Channels, DMs, threads. Best-effort (None without a public base URL; 404s fall back to the default icon). 4 unit cases added.

Related to #292