### PR TITLE
feat(ui): admin control to enable fleet-health monitoring + clearer empty-chart states (#1409)

### DIFF
--- a/src/frontend/src/components/MonitoringPanel.vue
+++ b/src/frontend/src/components/MonitoringPanel.vue
@@ -18,6 +18,28 @@
         {{ monitoringStore.enabled ? 'Monitoring Active' : 'Monitoring Disabled' }}
       </span>
 
+      <!--
+        Admin-only enable/disable of the SERVER-SIDE monitoring loop (#1409).
+        Distinct from the client-side auto-refresh toggle below (clock icon):
+        this persists via POST /api/monitoring/{enable,disable} and survives a
+        backend restart (#1121). Non-admins never see it (Health tab is
+        admin-gated; keep parity).
+      -->
+      <button
+        v-if="isAdmin"
+        @click="toggleMonitoring"
+        :disabled="togglingMonitoring"
+        class="px-3 py-1.5 text-sm rounded-lg disabled:opacity-50 transition-colors"
+        :class="monitoringStore.enabled
+          ? 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
+          : 'bg-status-success-600 hover:bg-status-success-700 text-white'"
+        :title="monitoringStore.enabled
+          ? 'Stop the fleet-health monitoring loop (persists across restarts)'
+          : 'Start the fleet-health monitoring loop (persists across restarts)'"
+      >
+        {{ togglingMonitoring ? 'Working…' : (monitoringStore.enabled ? 'Disable monitoring' : 'Enable monitoring') }}
+      </button>
+
       <span v-if="autoRefreshEnabled" class="text-xs text-gray-500 dark:text-gray-400">
         Auto-refresh: {{ refreshCountdown }}s
       </span>
@@ -47,6 +69,17 @@
         class="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg disabled:opacity-50"
       >
         {{ triggeringCheck ? 'Checking...' : 'Check All' }}
+      </button>
+    </div>
+
+    <!-- Monitoring enable/disable error (#1409) -->
+    <div
+      v-if="monitoringError"
+      class="mb-4 px-4 py-2 rounded-lg bg-status-danger-50 dark:bg-status-danger-900/20 text-status-danger-700 dark:text-status-danger-300 text-sm flex items-center justify-between"
+    >
+      <span>{{ monitoringError }}</span>
+      <button @click="monitoringError = ''" class="ml-3 text-status-danger-500 hover:text-status-danger-700" title="Dismiss">
+        <XCircleIcon class="w-4 h-4" />
       </button>
     </div>
 
@@ -246,6 +279,9 @@ const isAdmin = computed(() => authStore.role === 'admin')
 const statusFilter = ref('')
 const triggeringCheck = ref(false)
 const checkingAgent = ref(null)
+// #1409: server-side monitoring-loop enable/disable (admin-only)
+const togglingMonitoring = ref(false)
+const monitoringError = ref('')
 const autoRefreshEnabled = ref(true)
 const refreshCountdown = ref(30)
 let refreshInterval = null
@@ -311,6 +347,28 @@ function toggleAutoRefresh() {
   autoRefreshEnabled.value = !autoRefreshEnabled.value
   if (autoRefreshEnabled.value) {
     refreshCountdown.value = 30
+  }
+}
+
+async function toggleMonitoring() {
+  // Start/stop the persisted server-side monitoring loop (#1409 / #1121).
+  monitoringError.value = ''
+  const turningOn = !monitoringStore.enabled
+  togglingMonitoring.value = true
+  try {
+    if (turningOn) {
+      await monitoringStore.enableMonitoring()
+    } else {
+      await monitoringStore.disableMonitoring()
+    }
+    // Reflect the new loop state in the summary/health data.
+    await refreshAll()
+  } catch (err) {
+    monitoringError.value = turningOn
+      ? 'Failed to enable monitoring. Check your permissions and try again.'
+      : 'Failed to disable monitoring. Please try again.'
+  } finally {
+    togglingMonitoring.value = false
   }
 }
 

--- a/src/frontend/src/components/OverviewPanel.vue
+++ b/src/frontend/src/components/OverviewPanel.vue
@@ -30,6 +30,9 @@ const executionsStore = useExecutionsStore()
 
 const agentName = computed(() => props.agent?.name)
 const isRunning = computed(() => props.agent?.status === 'running')
+// #1409: admins get an actionable CTA in the empty health state; others get
+// plain guidance (only admins can enable the monitoring loop).
+const isAdmin = computed(() => authStore.role === 'admin')
 
 // Shared palette — bucket order must match db `_BUCKET_ORDER` (#1107).
 // An *analogous cool* ramp (indigo → violet → blue → sky → cyan → teal →
@@ -333,8 +336,14 @@ onMounted(() => {
         <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
       </div>
 
-      <div v-else-if="!hasExecutions" class="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
-        No executions in the last {{ window }}.
+      <div v-else-if="!hasExecutions" class="py-12 px-6 text-center">
+        <svg class="w-10 h-10 mx-auto text-gray-300 dark:text-gray-600 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 3v18h18M7 15l4-4 3 3 5-6" />
+        </svg>
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-300">No runs in the last {{ window }}</p>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-sm mx-auto">
+          Executions show up here after this agent runs a chat, schedule, or task.
+        </p>
       </div>
 
       <div v-else class="p-5 grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -461,9 +470,25 @@ onMounted(() => {
           <TrendLineChart :dates="healthTrend.dates" :series="latencySeries" :y-min="0" :height="120" :value-format="(v) => (v == null ? '—' : v + 'ms')" :axis-format="(v) => v + 'ms'" />
         </div>
       </div>
-      <p v-else class="text-xs text-gray-400 py-1">
-        No health data available — the monitoring service may be off.
-      </p>
+      <div v-else class="py-8 px-6 text-center">
+        <svg class="w-10 h-10 mx-auto text-gray-300 dark:text-gray-600 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 12h4l3 8 4-16 3 8h4" />
+        </svg>
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-300">No health data yet</p>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-sm mx-auto">
+          Fleet-health monitoring is off, so uptime and latency aren't being recorded for this agent.
+        </p>
+        <router-link
+          v-if="isAdmin"
+          :to="{ path: '/operations', query: { tab: 'health' } }"
+          class="mt-3 inline-flex items-center text-xs font-medium text-action-primary-600 dark:text-action-primary-400 hover:underline"
+        >
+          Enable it in Operations → Health →
+        </router-link>
+        <p v-else class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+          An admin can enable it in Operations → Health.
+        </p>
+      </div>
     </div>
 
     <!-- 5. Recent activity -->


### PR DESCRIPTION
Closes the UI gap left by #1121: the fleet-health monitoring loop is a persisted, **default-OFF** setting with backend + Pinia plumbing already present — but nothing in the UI called it, and the dependent charts showed a bare line of gray "no data" text. Frontend-only (no backend/store changes).

## A. Enable/disable control — `MonitoringPanel.vue` (Operations → Health)

- **Admin-gated** button beside the status pill → `monitoringStore.enableMonitoring()` / `disableMonitoring()`, with a **loading** state ("Working…") and a **dismissible error banner** on failure (the store `console.error`s + rethrows; this surfaces it).
- Refreshes status after toggling so the summary cards reflect the new loop state.
- **Persists across restart** via the existing `POST /api/monitoring/{enable,disable}` (#1121) — no new endpoint.
- Kept visually + semantically **distinct from the client-side auto-refresh toggle** (clock icon) per the issue's note — the new button explicitly says "Enable/Disable monitoring" and its tooltip notes persistence.

## B. Friendlier empty states — `OverviewPanel.vue`

- **Health trend**: real empty state (icon + heading + explanation) replacing the one-liner. When monitoring is off, **admins** get a CTA linking to `Operations → Health` (`?tab=health`); **non-admins** get plain guidance ("An admin can enable it in Operations → Health.").
- **Executions**: now explains *when* data appears — "Executions show up here after this agent runs a chat, schedule, or task." — instead of only "No executions in the last {window}."
- Dark-mode aware, **design-system tokens** (`npm run check:tokens` clean); the loading spinner state is preserved and stays distinct from empty.

## Verification

- Both SFCs compile via `@vue/compiler-sfc`; `check:tokens` exits 0.
- Full `vite build` currently fails on a **pre-existing, unrelated** missing dep (`mermaid` in `AgentWorkspace.vue`) — not touched here.
- Not automated: the repo's frontend tests are Playwright e2e (gated behind the `ui` label) needing a live stack + admin; the enable→restart→still-on persistence check and visual empty states are best verified there / manually. Happy to add an e2e if you want the `ui` suite extended.

Related to #1409
Follows #1121 (backend default-OFF + lifespan wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)