### PR TITLE
fix(ui): Trinity favicon + browser-tab title (abilityai/trinity#1416)

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -2,9 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <link rel="icon" type="image/svg+xml" href="/vite.svg">
+    <link rel="icon" type="image/svg+xml" href="/icons/trinity-mobile.svg">
+    <link rel="alternate icon" href="/icons/trinity-mobile-192.png" type="image/png">
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon-mobile.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Claude Agent Manager</title>
+    <title>Trinity — Agent Orchestration</title>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## Summary
- Replace the leftover Vite scaffold favicon (`/vite.svg` — missing from `public/`, so browsers rendered a generic globe) with the existing Trinity SVG icon, plus a PNG `alternate icon` fallback for browsers without SVG-favicon support.
- Add an `apple-touch-icon` (`/icons/apple-touch-icon-mobile.png`) so the icon is correct when saved to a home screen / bookmarked.
- Change the stale `<title>` from `Claude Agent Manager` → `Trinity — Agent Orchestration`.

## Changes
- `src/frontend/index.html` — favicon `<link>`s + `<title>` only (2 lines → 4). No new assets: all icons already live in `src/frontend/public/icons/` and are consumed by `public/mobile-manifest.json`.

## Test Plan
- [x] Production `vite build` succeeds; `dist/index.html` references `/icons/trinity-mobile.svg`, `/icons/trinity-mobile-192.png`, `/icons/apple-touch-icon-mobile.png`.
- [x] All three assets copy into `dist/icons/` (what prod nginx serves from `dist/`) — no `dist/vite.svg`, zero `vite.svg` references remain.
- [x] Prod-safe: assets served same-origin from `public/` → `dist/` root; no CSP change needed.
- [ ] Manual: open a tab on the dev/prod build → Trinity icon + "Trinity — Agent Orchestration" title.

Fixes abilityai/trinity#1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)