### PR TITLE
fix(ui): per-route browser-tab titles — Trinity — <Page> (abilityai/trinity#1418)

### DIFF
--- a/src/frontend/e2e/browser-tab-titles.spec.js
+++ b/src/frontend/e2e/browser-tab-titles.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+
+// #1418 — per-route browser-tab titles. The router's `afterEach` guard sets
+// `document.title` to `Trinity — <label>` from each route's `meta.title`;
+// unlabeled routes (redirects, catch-all) fall back to the branded default
+// `Trinity — Agent Orchestration` that index.html ships (#1416).
+//
+// Dynamic agent-scoped titles (`meta.title` as a fn of `to.params.name`) are
+// covered by unit logic; here we assert the deterministic static/redirect
+// routes and — critically — that CLIENT-SIDE nav updates the title with no
+// full reload (the whole point of the guard vs a static <title>).
+//
+// @smoke: runs in the `frontend-e2e` CI workflow on every `ui`-labelled PR.
+test.describe('browser tab titles (#1418)', () => {
+  test('@smoke SPA navigation updates the tab title per route', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'Dashboard', exact: true }))
+      .toBeVisible({ timeout: 10000 })
+    await expect(page).toHaveTitle('Trinity — Dashboard')
+
+    // Top-nav clicks are client-side transitions (no reload) — the guard must
+    // still fire and repaint the title.
+    await page.getByRole('link', { name: 'Agents', exact: true }).click()
+    await expect(page).toHaveTitle('Trinity — Agents')
+
+    await page.getByRole('link', { name: 'Templates', exact: true }).click()
+    await expect(page).toHaveTitle('Trinity — Templates')
+  })
+
+  test('@smoke redirect resolves to the destination route title', async ({ page }) => {
+    // /operating-room → /operations (legacy redirect). afterEach fires once for
+    // the FINAL destination, so the title reflects Operations, not a blank hop.
+    await page.goto('/operating-room')
+    await expect(page).toHaveURL(/\/operations/, { timeout: 10000 })
+    await expect(page).toHaveTitle('Trinity — Operations')
+  })
+})

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -7,31 +7,31 @@ const routes = [
     path: '/setup',
     name: 'Setup',
     component: () => import('../views/SetupPassword.vue'),
-    meta: { requiresAuth: false, isSetup: true }
+    meta: { requiresAuth: false, isSetup: true, title: 'Setup' }
   },
   {
     path: '/login',
     name: 'Login',
     component: () => import('../views/Login.vue'),
-    meta: { requiresAuth: false }
+    meta: { requiresAuth: false, title: 'Login' }
   },
   {
     path: '/chat/:token',
     name: 'PublicChat',
     component: () => import('../views/PublicChat.vue'),
-    meta: { requiresAuth: false }
+    meta: { requiresAuth: false, title: 'Chat' }
   },
   {
     path: '/',
     name: 'Dashboard',
     component: () => import('../views/Dashboard.vue'),
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, title: 'Dashboard' }
   },
   {
     path: '/agents',
     name: 'Agents',
     component: () => import('../views/Agents.vue'),
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, title: 'Agents' }
   },
   // #1109 — Health consolidated into the Operations "Health" tab.
   // Redirect preserves bookmarks; the tab is admin-gated inside Operations.vue.
@@ -43,13 +43,14 @@ const routes = [
     path: '/agents/:name',
     name: 'AgentDetail',
     component: () => import('../views/AgentDetail.vue'),
-    meta: { requiresAuth: true }
+    // #1418 — the :name param IS the canonical agent identifier in Trinity.
+    meta: { requiresAuth: true, title: (to) => to.params.name }
   },
   {
     path: '/agents/:name/workspace',
     name: 'AgentWorkspace',
     component: () => import('../views/AgentWorkspace.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, title: (to) => `${to.params.name} · Workspace` },
     beforeEnter: async (to, from, next) => {
       const sessionsStore = useSessionsStore()
       await sessionsStore.loadFeatureFlags()
@@ -64,7 +65,7 @@ const routes = [
     path: '/agents/:name/executions/:executionId',
     name: 'ExecutionDetail',
     component: () => import('../views/ExecutionDetail.vue'),
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, title: (to) => `${to.params.name} · Execution` }
   },
   // REMOVED: /files route - file management is now per-agent via Files tab in AgentDetail
   // REMOVED: /credentials route - credentials are now managed per-agent only
@@ -73,7 +74,7 @@ const routes = [
     path: '/templates',
     name: 'Templates',
     component: () => import('../views/Templates.vue'),
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, title: 'Templates' }
   },
   // Legacy redirect: Events consolidated into the Operations Notifications tab (#1109)
   {
@@ -88,7 +89,7 @@ const routes = [
     path: '/operations',
     name: 'Operations',
     component: () => import('../views/Operations.vue'),
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, title: 'Operations' }
   },
   // Legacy redirects — function form so existing ?tab= deep links survive
   // the hop (a string/object redirect would drop the incoming query).
@@ -110,7 +111,7 @@ const routes = [
     path: '/settings',
     name: 'Settings',
     component: () => import('../views/Settings.vue'),
-    meta: { requiresAuth: true, requiresAdmin: true }
+    meta: { requiresAuth: true, requiresAdmin: true, title: 'Settings' }
   },
   // Legacy redirect for /system-agent -> agents page (consolidated)
   {
@@ -139,20 +140,20 @@ const routes = [
     path: '/enterprise',
     name: 'EnterpriseLanding',
     component: () => import('../views/enterprise/Index.vue'),
-    meta: { requiresAuth: true, requiresAnyEntitlement: true }
+    meta: { requiresAuth: true, requiresAnyEntitlement: true, title: 'Enterprise' }
   },
   {
     path: '/enterprise/audit',
     name: 'EnterpriseAudit',
     component: () => import('../views/enterprise/Audit.vue'),
-    meta: { requiresAuth: true, requiresEntitlement: 'audit' }
+    meta: { requiresAuth: true, requiresEntitlement: 'audit', title: 'Audit Log' }
   },
   // Mobile Admin PWA (MOB-001) — standalone, no NavBar
   {
     path: '/m',
     name: 'MobileAdmin',
     component: () => import('../views/MobileAdmin.vue'),
-    meta: { requiresAuth: false }  // handles its own inline auth
+    meta: { requiresAuth: false, title: 'Mobile' }  // handles its own inline auth
   },
   // Catch-all redirect to dashboard
   {
@@ -264,6 +265,19 @@ router.beforeEach(async (to, from, next) => {
     // Public route, allow access
     next()
   }
+})
+
+// Per-route browser-tab titles (#1418). `meta.title` is a string, or a function
+// of the resolved route for dynamic agent-scoped pages (the :name param is the
+// canonical agent identifier). afterEach fires once per completed navigation —
+// including the final destination of a redirect — so SPA nav updates the tab
+// title with no reload. Routes without a title (redirects, catch-all) fall back
+// to the branded default that index.html ships as the pre-hydration title.
+const BASE_TITLE = 'Trinity'
+router.afterEach((to) => {
+  const raw = to.meta?.title
+  const label = typeof raw === 'function' ? raw(to) : raw
+  document.title = label ? `${BASE_TITLE} — ${label}` : `${BASE_TITLE} — Agent Orchestration`
 })
 
 // Clear setup cache on successful setup


### PR DESCRIPTION
## Summary
- Follow-up to #1416 (PR #1417): that set one **static** `<title>`, so every tab read identically. This gives each route its own tab title so you can tell pages apart with multiple tabs open.
- Add `meta.title` to each named route + a single `router.afterEach` guard that sets `document.title` to `Trinity — <label>`.
- Agent-scoped routes carry the agent name — `Trinity — <name>`, `· Workspace`, `· Execution` (the `:name` param is Trinity's canonical agent identifier). Unlabeled routes (redirects, catch-all) fall back to the branded `Trinity — Agent Orchestration` default.

## Changes
- `src/frontend/src/router/index.js` — `meta.title` per named route (string or fn of the resolved route) + `afterEach` title guard. All existing meta keys preserved.
- `src/frontend/e2e/browser-tab-titles.spec.js` — new `@smoke` Playwright spec: SPA nav updates the title per route, and a legacy redirect resolves to its destination's title.

## Scope notes
- **Frontend-only** — no backend / auth / CSP surface. `document.title` is a plain-text sink (no XSS); agent names are validated regardless.
- `dev`'s router has no Brain Orb route yet (that's unmerged `feature/61` work) — its title lands with that branch.

## Test Plan
- [x] `vite build` compiles the router + full app.
- [x] Title-resolution logic asserted across 8 cases (static / dynamic agent / sub-pages / public / fallback) — all pass.
- [x] Playwright spec discovered + parses (`--list`).
- [ ] CI `frontend-e2e` (`ui` label) runs the `@smoke` titles spec against the live stack.
- [ ] Manual: open several tabs (Dashboard, an agent, Settings) → each shows a distinct `Trinity — …` title.

Fixes abilityai/trinity#1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)