### PR TITLE
test(brain-orb): close coverage gaps — owner gate, idempotency, hooks, flags, route wiring (ent#61)

### DIFF
--- a/tests/test_brain_orb_api.py
+++ b/tests/test_brain_orb_api.py
@@ -1,0 +1,83 @@
+"""
+Brain Orb route-wiring smoke tests (#58/#61, trinity-enterprise).
+
+The unit suite (tests/unit/test_brain_orb.py) mounts routers/agent_brain_orb.py on a
+synthetic FastAPI app with dependency overrides — deliberately no live backend. That
+leaves two wiring classes it structurally cannot catch (the #1069 escape class):
+
+  * the router actually being registered in src/backend/main.py — a dropped
+    include_router would 404 every brain-orb route while the unit suite stays green;
+  * the real auth dependency + path-param chain (AuthorizedAgentByName /
+    OwnedAgentByName) resolving through the real app.
+
+These tests hit the running backend and need NO agent and NO Brain Orb flags:
+
+  * an unauthenticated call must be rejected by the auth chain (401) — an
+    unregistered route would instead 404 with FastAPI's literal "Not Found";
+  * an authenticated call against a nonexistent agent must 404 from the real
+    dependency ("Agent not found") or handler (flag gate) — never the bare
+    routing "Not Found".
+"""
+
+import pytest
+
+from utils.api_client import TrinityApiClient
+from utils.assertions import assert_status, assert_status_in
+
+# Deliberately nonexistent: these tests assert wiring, not agent behavior.
+_AGENT = "smoke-brain-orb-no-such-agent"
+# FastAPI's unmatched-route detail, verbatim — seeing it means the route isn't wired.
+_ROUTING_404_DETAIL = "Not Found"
+
+pytestmark = pytest.mark.smoke
+
+
+class TestBrainOrbRouteWiring:
+    """Real-app registration + auth-chain smoke for the brain-orb proxy routes."""
+
+    def test_data_unauthenticated_rejected_not_unrouted(
+        self, unauthenticated_client: TrinityApiClient
+    ):
+        """No auth → 401 from the real dependency chain. An unregistered router
+        would return 404 'Not Found' instead — the exact regression this guards."""
+        response = unauthenticated_client.get(
+            f"/api/agents/{_AGENT}/brain-orb/data", auth=False
+        )
+        assert_status_in(response, [401, 403])
+
+    def test_data_authenticated_reaches_dependency(self, api_client: TrinityApiClient):
+        """Authenticated read resolves AuthorizedAgentByName + path params end-to-end:
+        the nonexistent agent 404s from the dependency ('Agent not found') or, were
+        the agent real with the flag off, from the handler — never from routing."""
+        response = api_client.get(f"/api/agents/{_AGENT}/brain-orb/data")
+        assert_status(response, 404)
+        assert response.json().get("detail") != _ROUTING_404_DETAIL
+
+    def test_action_unauthenticated_rejected_not_unrouted(
+        self, unauthenticated_client: TrinityApiClient
+    ):
+        """Same registration proof for the write surface (POST /action)."""
+        response = unauthenticated_client.post(
+            f"/api/agents/{_AGENT}/brain-orb/action",
+            json={"action": "capture", "body": "smoke"},
+            auth=False,
+        )
+        assert_status_in(response, [401, 403])
+
+    def test_action_authenticated_reaches_dependency(self, api_client: TrinityApiClient):
+        """The one write route resolves OwnedAgentByName end-to-end; the 404 detail
+        comes from the dependency/handler chain, never bare routing."""
+        response = api_client.post(
+            f"/api/agents/{_AGENT}/brain-orb/action",
+            json={"action": "capture", "body": "smoke"},
+        )
+        assert_status(response, 404)
+        assert response.json().get("detail") != _ROUTING_404_DETAIL
+
+    def test_voice_token_route_wired(self, api_client: TrinityApiClient):
+        """POST /voice-token is registered and auth-gated (it never contacts the
+        agent, so with flags default-OFF the handler itself 404s; a real detail
+        string proves the route + dependencies resolved)."""
+        response = api_client.post(f"/api/agents/{_AGENT}/brain-orb/voice-token")
+        assert_status(response, 404)
+        assert response.json().get("detail") != _ROUTING_404_DETAIL

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1296,3 +1296,45 @@ class TestMaxParallelTasksCeiling:
             "/api/settings/max_parallel_tasks_ceiling", json={"value": "999"}
         )
         assert_status(response, 422)
+
+
+class TestFeatureFlagsBrainOrb:
+    """GET /api/settings/feature-flags — Brain Orb gating keys (#58/#60/#61).
+
+    The three brain_orb_* flags gate the orb page, the client-held voice tile, and
+    the KB-write surface in the frontend; no prior test asserted they exist, so a
+    renamed/dropped key would silently hide the feature. Values are env-dependent
+    (all default OFF), so assert presence/type and the compound-gate invariant,
+    never specific values.
+    """
+
+    pytestmark = pytest.mark.smoke
+
+    ENDPOINT = "/api/settings/feature-flags"
+
+    def test_feature_flags_requires_auth(self, unauthenticated_client: TrinityApiClient):
+        """feature-flags is any-auth-user, not public — unauthenticated gets 401."""
+        response = unauthenticated_client.get(self.ENDPOINT, auth=False)
+        assert_status(response, 401)
+
+    def test_brain_orb_flags_present_and_boolean(self, api_client: TrinityApiClient):
+        """All three brain_orb_* keys exist and are booleans."""
+        response = api_client.get(self.ENDPOINT)
+        assert_status(response, 200)
+        flags = response.json()
+        for key in (
+            "brain_orb_available",
+            "brain_orb_voice_available",
+            "brain_orb_write_available",
+        ):
+            assert key in flags, f"missing feature flag: {key}"
+            assert isinstance(flags[key], bool), f"{key} must be boolean, got {flags[key]!r}"
+
+    def test_brain_orb_write_implies_available(self, api_client: TrinityApiClient):
+        """Kill-switch layering (#61): brain_orb_write_available = WRITE && ENABLED,
+        so it can never be true while the master brain_orb_available flag is false —
+        holds under any env configuration."""
+        flags = api_client.get(self.ENDPOINT).json()
+        assert not (flags["brain_orb_write_available"] and not flags["brain_orb_available"]), (
+            "brain_orb_write_available must be gated on brain_orb_available"
+        )

--- a/tests/unit/test_brain_orb.py
+++ b/tests/unit/test_brain_orb.py
@@ -935,3 +935,244 @@ def test_agent_server_action_body_too_large_413(agent_env):
     r = agent_env.client.post("/api/brain-orb/action",
                               json={"action": "capture", "body": "x" * 1_100_000})
     assert r.status_code == 413
+
+
+# ==========================================================================
+# Coverage gaps closed 2026-07-02 (/update-tests review)
+# ==========================================================================
+
+# --- backend: the Phase-2 mutating route gets the same owner-gate proof its
+# --- Phase-4 siblings have (incomplete-fix-chain escape class) ---------------
+
+def test_scope_post_owner_gate_403(client):
+    """POST /scope is OwnedAgentByName like every other mutating brain-orb route —
+    a non-owner gets 403 before any agent call (only the Phase-4 routes had this)."""
+    _deny_owner(client)
+    agent_req = AsyncMock()
+    with patch.object(bo, "_agent_request", agent_req):
+        r = client.post(_SCOPE_URL, json={"tokens": ["core"]})
+    assert r.status_code == 403
+    agent_req.assert_not_called()
+
+
+def test_postprocess_put_body_too_large_413(client):
+    """PUT /postprocess is capped at 64 KiB (review F4 — the small-config cap, not
+    the 1 MiB transcript cap), rejected before any agent call."""
+    agent_req = AsyncMock()
+    with patch.object(bo, "_agent_request", agent_req):
+        r = client.put(_POSTPROC_URL, json={"enabled": True, "prompt": "x" * 70_000})
+    assert r.status_code == 413
+    agent_req.assert_not_called()
+
+
+# --- backend: idempotency semantics beyond the replay/409 happy paths --------
+
+def test_action_idempotency_key_folds_verb(client):
+    """The stored key folds the action verb (route docstring contract) — a client
+    reusing one Idempotency-Key across verbs must claim two distinct keys, so a
+    `link` can never replay a `capture` snapshot."""
+    from services.idempotency_service import IdempotencyDecision
+    fresh = IdempotencyDecision(enabled=True, replay=False, in_flight=False,
+                                scope="agent:cornelius", key="k")
+    with patch.object(bo, "_agent_request", AsyncMock(return_value=_resp(200, b'{"ok":true}'))), \
+         patch.object(bo.idempotency_service, "begin", return_value=fresh) as begin, \
+         patch.object(bo.idempotency_service, "complete"), \
+         patch.object(bo.platform_audit_service, "log", AsyncMock()):
+        client.post(_ACTION_URL, json={"action": "capture", "body": "x"},
+                    headers={"Idempotency-Key": "k9"})
+        client.post(_ACTION_URL, json={"action": "link", "from": "A", "to": "B"},
+                    headers={"Idempotency-Key": "k9"})
+    keys = [c.args[1] for c in begin.call_args_list]
+    assert keys == ["brain_orb_action:capture:k9", "brain_orb_action:link:k9"]
+
+
+def test_action_agent_error_releases_idempotency_claim(client):
+    """An agent-side failure (502 map / 504 timeout) releases the in-flight claim so
+    a retry with the same key isn't wedged on 409 — only the 429 path was covered."""
+    from services.idempotency_service import IdempotencyDecision
+    fresh = IdempotencyDecision(enabled=True, replay=False, in_flight=False,
+                                scope="agent:cornelius", key="k")
+    cases = (
+        (AsyncMock(return_value=_resp(500)), 502),                                  # agent error
+        (AsyncMock(side_effect=HTTPException(status_code=504, detail="t")), 504),   # timeout
+    )
+    for agent_req, expected in cases:
+        with patch.object(bo, "_agent_request", agent_req), \
+             patch.object(bo.idempotency_service, "begin", return_value=fresh), \
+             patch.object(bo.idempotency_service, "fail") as fail, \
+             patch.object(bo.rate_limiter, "enforce"):
+            r = client.post(_ACTION_URL, json={"action": "capture", "body": "x"},
+                            headers={"Idempotency-Key": "k"})
+        assert r.status_code == expected
+        fail.assert_called_once_with(fresh)
+
+
+def test_action_success_completes_claim_with_snapshot(client):
+    """A successful write completes the claim with the PARSED agent response, so a
+    later replay serves the real snapshot (not None / raw bytes)."""
+    from services.idempotency_service import IdempotencyDecision
+    fresh = IdempotencyDecision(enabled=True, replay=False, in_flight=False,
+                                scope="agent:cornelius", key="k")
+    with patch.object(bo, "_agent_request", AsyncMock(return_value=_resp(200, b'{"ok":true,"title":"t"}'))), \
+         patch.object(bo.idempotency_service, "begin", return_value=fresh), \
+         patch.object(bo.idempotency_service, "complete") as complete, \
+         patch.object(bo.platform_audit_service, "log", AsyncMock()):
+        r = client.post(_ACTION_URL, json={"action": "capture", "body": "x"},
+                        headers={"Idempotency-Key": "k"})
+    assert r.status_code == 200
+    complete.assert_called_once_with(fresh, None, {"ok": True, "title": "t"})
+
+
+def test_action_without_idempotency_key_skips_dedup(client):
+    """No Idempotency-Key header ⇒ begin() gets key=None (dedup disabled, Invariant
+    #18 fail-open) and the write still executes normally."""
+    with patch.object(bo, "_agent_request", AsyncMock(return_value=_resp(200, b'{"ok":true}'))), \
+         patch.object(bo.idempotency_service, "begin",
+                      wraps=bo.idempotency_service.begin) as begin, \
+         patch.object(bo.platform_audit_service, "log", AsyncMock()):
+        r = client.post(_ACTION_URL, json={"action": "capture", "body": "x"})
+    assert r.status_code == 200
+    assert begin.call_args.args[1] is None
+
+
+# --- backend: audit sink failure never masks a completed write (review F5) ---
+
+def test_action_audit_failure_never_masks_write(client):
+    """A failing audit sink must not 500 a COMPLETED write — the client would retry
+    with a fresh idempotency key and double-write (review F5, _safe_audit)."""
+    with patch.object(bo, "_agent_request", AsyncMock(return_value=_resp(200, b'{"ok":true}'))), \
+         patch.object(bo.platform_audit_service, "log",
+                      AsyncMock(side_effect=RuntimeError("audit sink down"))):
+        r = client.post(_ACTION_URL, json={"action": "capture", "body": "x"})
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_refresh_audit_failure_never_masks(client):
+    """Same F5 guarantee on the refresh route (its own _safe_audit call site)."""
+    with patch.object(bo, "_agent_request", AsyncMock(return_value=_resp(200, b'{"ok":true}'))), \
+         patch.object(bo.platform_audit_service, "log",
+                      AsyncMock(side_effect=RuntimeError("audit sink down"))):
+        r = client.post(_REFRESH_URL)
+    assert r.status_code == 200
+
+
+# --- agent-server: _run_hook hardening branches never exercised --------------
+
+def test_agent_server_hook_output_too_large_502(agent_env, monkeypatch):
+    """A hook flooding stdout past _MAX_HOOK_OUT → 502, never buffered through
+    (cap shrunk so the test stays fast)."""
+    monkeypatch.setattr(agent_env.asbo, "_MAX_HOOK_OUT", 1024)
+    _write_hook(agent_env.scopes_hook, '#!/usr/bin/env python3\nprint("a" * 2048)\n')
+    r = agent_env.client.get("/api/brain-orb/scopes")
+    assert r.status_code == 502
+
+
+def test_agent_server_hook_not_executable_404(agent_env):
+    """A hook file that exists but lacks +x is 'not supported' (404, the _hook_ready
+    branch) — never a 5xx from trying to exec it."""
+    agent_env.scopes_hook.write_text('#!/bin/sh\necho "{}"\n')  # deliberately no chmod
+    r = agent_env.client.get("/api/brain-orb/scopes")
+    assert r.status_code == 404
+
+
+def test_agent_server_scope_body_too_large_413(agent_env):
+    """The agent-server enforces its own 64 KiB _MAX_HOOK_BODY on /scope (defense in
+    depth below the backend cap; only /action's 1 MiB cap was tested)."""
+    _write_hook(agent_env.scope_hook, '#!/bin/sh\ncat >/dev/null\necho "{}"\n')
+    r = agent_env.client.post("/api/brain-orb/scope", json={"tokens": ["x" * 70_000]})
+    assert r.status_code == 413
+
+
+def test_agent_server_search_body_too_large_413(agent_env):
+    _write_hook(agent_env.search_hook, '#!/bin/sh\ncat >/dev/null\necho "{}"\n')
+    r = agent_env.client.post("/api/brain-orb/tool", json={"query": "x" * 70_000})
+    assert r.status_code == 413
+
+
+# --- agent-server: postprocess config semantics (#73) ------------------------
+
+def test_agent_server_postprocess_put_invalid_json_400(agent_env):
+    r = agent_env.client.put("/api/brain-orb/postprocess", data=b"{not json",
+                             headers={"Content-Type": "application/json"})
+    assert r.status_code == 400
+
+
+def test_agent_server_postprocess_prompt_truncated_8000(agent_env):
+    """The stored prompt is hard-capped at 8000 chars on write — both the PUT echo
+    and the subsequent GET reflect the truncation."""
+    r = agent_env.client.put("/api/brain-orb/postprocess",
+                             json={"enabled": True, "prompt": "p" * 9000})
+    assert r.status_code == 200
+    assert len(r.json()["prompt"]) == 8000
+    g = agent_env.client.get("/api/brain-orb/postprocess")
+    assert len(g.json()["prompt"]) == 8000
+
+
+def test_agent_server_postprocess_md_fallback(agent_env):
+    """Legacy voice-postprocess.md is a prompt-only read fallback when no JSON config
+    exists — enabled derives from the prompt being non-empty."""
+    agent_env.asbo._POSTPROCESS_MD.write_text("summarize the session\n")
+    g = agent_env.client.get("/api/brain-orb/postprocess")
+    assert g.status_code == 200
+    assert g.json() == {"enabled": True, "prompt": "summarize the session"}
+
+
+def test_agent_server_postprocess_corrupt_json_degrades(agent_env):
+    """A corrupt JSON config never 500s — GET falls through to the .md fallback and
+    then to safe defaults."""
+    agent_env.asbo._POSTPROCESS_CONFIG.write_text("{corrupt")
+    g = agent_env.client.get("/api/brain-orb/postprocess")
+    assert g.status_code == 200
+    assert g.json() == {"enabled": False, "prompt": ""}
+
+
+# --- mint service: system instruction + token windows ------------------------
+
+def test_build_system_instruction_clauses_and_prompt_cap():
+    """readonly vs write clause selection; the persisted agent voice prompt is
+    prefixed and hard-capped at _AGENT_PROMPT_MAX; whitespace-only prompt ignored."""
+    import services.brain_orb_voice_service as svc
+
+    ro = svc._build_system_instruction(None, can_write=False)
+    rw = svc._build_system_instruction(None, can_write=True)
+    assert ro.endswith(svc._ORB_VOICE_READONLY_CLAUSE)
+    assert rw.endswith(svc._ORB_VOICE_WRITE_CLAUSE)
+    assert svc._ORB_VOICE_WRITE_CLAUSE not in ro
+
+    long_prompt = "p" * (svc._AGENT_PROMPT_MAX + 500)
+    out = svc._build_system_instruction(long_prompt, can_write=False)
+    prefix, sep, rest = out.partition("\n\n")
+    assert sep == "\n\n"
+    assert prefix == "p" * svc._AGENT_PROMPT_MAX   # capped, prompt-injection bloat bound
+    assert rest == ro
+
+    assert svc._build_system_instruction("   ", can_write=False) == ro
+
+
+def test_mint_service_new_session_window_shorter_than_expiry(monkeypatch):
+    """The token must be SPENT (session opened) within the short new-session window
+    even though the session itself may run VOICE_MAX_DURATION — a leaked token that
+    isn't used almost immediately is dead."""
+    import services.brain_orb_voice_service as svc
+    captured = {}
+
+    class _FakeAuthTokens:
+        def create(self, *, config):
+            captured["config"] = config
+            return types.SimpleNamespace(name="auth_tokens/t")
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            self.auth_tokens = _FakeAuthTokens()
+
+    monkeypatch.setattr(svc, "_client", None)
+    monkeypatch.setattr(svc, "GEMINI_API_KEY", "k")
+    monkeypatch.setattr(svc.genai, "Client", _FakeClient)
+
+    asyncio.run(svc.mint_voice_token("cornelius", voice_name="Kore", agent_prompt=None))
+    cfg = captured["config"]
+    # Both stamps derive from the same `now`, so the delta is exact.
+    delta = (cfg.expire_time - cfg.new_session_expire_time).total_seconds()
+    assert delta == svc.VOICE_MAX_DURATION - svc._NEW_SESSION_WINDOW_SECONDS
+    assert cfg.new_session_expire_time < cfg.expire_time


### PR DESCRIPTION
## Summary

`/update-tests` review of the Brain Orb Phase 1–4b surface (stacked on #1389, the open brain-orb chain PR — the tests import `routers/agent_brain_orb.py`, which doesn't exist on `dev` yet). **26 new tests; 103 total across the three files, all passing against the live backend.**

### `tests/unit/test_brain_orb.py` (+18, file total 95)
- **`POST /scope` owner-gate 403** — the one `OwnedAgentByName` route missing the non-owner proof its Phase-4 siblings had (the incomplete-fix-chain escape class from the 2026-06-27 bug-escape analysis)
- **`PUT /postprocess` 413** body cap (review F4)
- **Idempotency semantics**: stored key folds the action verb (a reused client key can't replay a different verb's snapshot); claim released on agent 502/504 so retries aren't wedged on 409; success completes with the parsed snapshot; missing header = fail-open (Invariant #18)
- **Audit-sink failure never masks a completed write** (review F5) on `/action` and `/refresh`
- **Agent-server `_run_hook` hardening**: stdout over `_MAX_HOOK_OUT` → 502; hook present-but-not-executable → 404; `scope`/`tool` 64 KiB body caps
- **Postprocess config (#73)**: invalid JSON 400, 8000-char prompt truncation, legacy `.md` fallback, corrupt-JSON degrades to defaults (never 500)
- **Voice mint**: `_build_system_instruction` clause selection + 2000-char prompt cap; new-session window < token expiry

### `tests/test_settings.py` (+3, SMOKE)
First coverage of any brain-orb feature-flag key: `brain_orb_available` / `brain_orb_voice_available` / `brain_orb_write_available` present + boolean; **write ⇒ available** compound-gate invariant (kill-switch layering, holds under any env); endpoint requires auth.

### `tests/test_brain_orb_api.py` (new, 5, SMOKE)
Live-backend **route-wiring** proof (#1069 escape class): the unit suite mounts the router on a synthetic app with overridden dependencies, so only these prove `main.py` registration (unauthenticated → 401, not routing 404) and the real `AuthorizedAgentByName`/`OwnedAgentByName` chain (authenticated 404s carry a real dependency/handler detail, never FastAPI's bare "Not Found"). Needs no agent and no flags.

## Test plan
- `pytest unit/test_brain_orb.py -v` → 95 passed (no backend needed)
- `pytest test_brain_orb_api.py test_settings.py::TestFeatureFlagsBrainOrb -v` → 8 passed (live backend)
- Run the unit file in its **own** pytest invocation — backend imports shadow `tests/utils` via `sys.modules['utils']` for integration files collected in the same session (pre-existing collision, documented in the test-runner catalog)

Test-runner catalog (`.claude/agents/test-runner.md`) updated in the trinity-dev submodule — rides separately with the next submodule sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)