### PR TITLE
fix(webhooks): pre-auth per-IP rate limit + request-body cap (#1424)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -214,6 +214,11 @@ VOIP_INTENT_TTL_SECONDS=180       # staged Gemini-session intent TTL
 # Agent structured reports (#918)
 REPORT_RATE_LIMIT=30              # max reports an agent may create per 60s window
 
+# Public webhook triggers (#1023, #1424) — 60s windows fixed in code
+WEBHOOK_RATE_LIMIT=10             # triggers per token per 60s
+WEBHOOK_IP_RATE_LIMIT=60          # pre-auth requests per IP per 60s (unknown-token flood guard)
+WEBHOOK_MAX_BODY_BYTES=16384      # request-body size cap in bytes (413 over)
+
 # ===========================================
 # SERVICE URLS (Usually no need to change)
 # ===========================================

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -97,6 +97,11 @@ services:
       # Agent structured reports (#918) — per-agent create-rate cap (60s window fixed in code).
       # Prod compose launches standalone (no base merge / env_file), so wire it here too.
       - REPORT_RATE_LIMIT=${REPORT_RATE_LIMIT:-30}               # reports per agent per 60s
+      # Public webhook trigger hardening (#1023, #1424) — 60s windows fixed in code.
+      # Prod compose launches standalone (no base merge / env_file), so wire it here too.
+      - WEBHOOK_RATE_LIMIT=${WEBHOOK_RATE_LIMIT:-10}             # triggers per token per 60s
+      - WEBHOOK_IP_RATE_LIMIT=${WEBHOOK_IP_RATE_LIMIT:-60}       # pre-auth requests per IP per 60s
+      - WEBHOOK_MAX_BODY_BYTES=${WEBHOOK_MAX_BODY_BYTES:-16384}  # request-body cap (413 over)
       - GITHUB_PAT=${GITHUB_PAT}
       # Host paths for volumes (used when creating agent containers)
       - HOST_TEMPLATES_PATH=${HOST_TEMPLATES_PATH:-${PWD}/config/agent-templates}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,11 @@ services:
       # Agent structured reports (#918) — per-agent create-rate cap (60s window fixed in code).
       # Must reach the container or the .env lever is inert in prod (the #1039 packaging class).
       - REPORT_RATE_LIMIT=${REPORT_RATE_LIMIT:-30}               # reports per agent per 60s
+      # Public webhook trigger hardening (#1023, #1424) — 60s windows fixed in code.
+      # Must reach the container or the .env lever is inert (the #1056/#1039 packaging class).
+      - WEBHOOK_RATE_LIMIT=${WEBHOOK_RATE_LIMIT:-10}             # triggers per token per 60s
+      - WEBHOOK_IP_RATE_LIMIT=${WEBHOOK_IP_RATE_LIMIT:-60}       # pre-auth requests per IP per 60s
+      - WEBHOOK_MAX_BODY_BYTES=${WEBHOOK_MAX_BODY_BYTES:-16384}  # request-body cap (413 over)
       - GITHUB_PAT=${GITHUB_PAT:-}
       - HOST_TEMPLATES_PATH=${PWD}/config/agent-templates
       # Agent /tmp tmpfs size (#1231) — read by capabilities.py to build the

--- a/src/backend/routers/webhooks.py
+++ b/src/backend/routers/webhooks.py
@@ -24,6 +24,7 @@ from fastapi.responses import JSONResponse
 from models import CONTEXT_MAX_CHARS, WebhookTriggerRequest
 
 from database import db
+from routers.public import _get_client_ip
 from services.platform_audit_service import platform_audit_service, AuditEventType
 from services import idempotency_service
 from services import rate_limiter
@@ -38,6 +39,21 @@ SCHEDULER_URL = os.getenv("SCHEDULER_URL", "http://scheduler:8001")
 # used to live here.
 WEBHOOK_RATE_LIMIT = int(os.getenv("WEBHOOK_RATE_LIMIT", "10"))
 WEBHOOK_RATE_WINDOW = 60  # seconds
+
+# Pre-auth per-IP rate limit (#1424). Applied BEFORE the token regex/DB lookup so
+# a flood of well-formed-but-unknown tokens on this unauthenticated, world-reachable
+# route is throttled — the per-token limit above only engages once a token resolves.
+# Uses the trusted-proxy-aware client IP (routers.public._get_client_ip) so callers
+# can't spoof X-Forwarded-For to dodge it, and legit callers behind our nginx don't
+# all collapse into one bucket. Generous vs the per-token limit so normal valid-token
+# traffic is never falsely blocked. Fail-open (shared limiter).
+WEBHOOK_IP_RATE_LIMIT = int(os.getenv("WEBHOOK_IP_RATE_LIMIT", "60"))
+WEBHOOK_IP_RATE_WINDOW = 60  # seconds
+
+# Max accepted request-body size (#1424). The optional `context` is already ≤4000
+# chars; 16 KiB comfortably covers that (UTF-8 worst case) plus JSON framing and the
+# small `metadata` dict, while capping the unauthenticated read amplification surface.
+WEBHOOK_MAX_BODY_BYTES = int(os.getenv("WEBHOOK_MAX_BODY_BYTES", str(16 * 1024)))
 
 # Webhook tokens are secrets.token_urlsafe(32) — exactly 43 chars (CSO OBS-2).
 # Tightened from {20,60}: prior regex was a defense-in-depth early-reject;
@@ -55,7 +71,6 @@ router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
 async def trigger_webhook(
     webhook_token: str,
     request: Request,
-    body: Optional[WebhookTriggerRequest] = None,
     idempotency_key: Optional[str] = Header(None),
 ):
     """
@@ -67,6 +82,18 @@ async def trigger_webhook(
     Returns 202 Accepted immediately; execution runs asynchronously.
     Poll GET /api/agents/{name}/executions to track the result.
     """
+    # Pre-auth per-IP rate limit (#1424) — enforced FIRST, before the regex/DB
+    # steps, so a flood of well-formed-but-unknown tokens is throttled even
+    # though the per-token limiter below never engages for them. Trusted-proxy
+    # aware so X-Forwarded-For can't be spoofed to bypass it. Fail-open.
+    caller_ip = _get_client_ip(request)
+    rate_limiter.enforce(
+        f"webhook_ip:{caller_ip}",
+        WEBHOOK_IP_RATE_LIMIT,
+        WEBHOOK_IP_RATE_WINDOW,
+        detail="Too many webhook requests from this address.",
+    )
+
     # Reject obviously malformed tokens before hitting the DB
     if not _TOKEN_RE.match(webhook_token):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
@@ -92,6 +119,49 @@ async def trigger_webhook(
         detail="Webhook rate limit exceeded.",
     )
 
+    # Read + size-cap the body BEFORE parsing (#1424). Fast-reject on the
+    # Content-Length hint, then read the stream with a hard byte ceiling so a
+    # missing/lying header (or chunked encoding) can't force us to buffer an
+    # arbitrarily large body — we bail at cap+one chunk. The body is no longer a
+    # typed FastAPI param, so no full parse happens before this gate, and the
+    # same bytes feed the idempotency key below (single read).
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            declared = int(content_length)
+        except ValueError:
+            declared = None
+        if declared is not None and declared > WEBHOOK_MAX_BODY_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Request body too large",
+            )
+    chunks: list[bytes] = []
+    received = 0
+    try:
+        async for chunk in request.stream():
+            received += len(chunk)
+            if received > WEBHOOK_MAX_BODY_BYTES:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="Request body too large",
+                )
+            chunks.append(chunk)
+    except HTTPException:
+        raise
+    except Exception:
+        chunks = []
+    raw_body = b"".join(chunks)
+    body: Optional[WebhookTriggerRequest] = None
+    if raw_body.strip():
+        try:
+            body = WebhookTriggerRequest.model_validate_json(raw_body)
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid webhook request body",
+            )
+
     # Build the message: base schedule message + optional caller context.
     # Framed as data (not instructions) to reduce prompt injection surface.
     message = schedule.message
@@ -106,16 +176,10 @@ async def trigger_webhook(
                 f"---"
             )
 
-    # Trigger execution via the scheduler service
-    caller_ip = request.client.host if request.client else "unknown"
-
     # RELIABILITY-006 (#525): idempotency gate. External senders retry on 5xx
     # and perceived timeouts; without a key we auto-derive one from
     # (token, body_hash) so naive re-deliveries don't fire the schedule twice.
-    try:
-        raw_body = await request.body()
-    except Exception:
-        raw_body = b""
+    # `raw_body` was read + size-capped above (single read).
     idem_key = idempotency_key or idempotency_service.derive_webhook_key(
         webhook_token, raw_body
     )

--- a/tests/test_webhook_triggers.py
+++ b/tests/test_webhook_triggers.py
@@ -255,6 +255,62 @@ class TestWebhookTrigger:
         finally:
             _delete_schedule(api_client, test_agent_name, sid)
 
+    def test_oversized_body_returns_413(
+        self, api_client: TrinityApiClient, test_agent_name: str
+    ):
+        """A body over the size cap is rejected (413) before it is parsed (#1424)."""
+        import httpx
+        schedule = _create_test_schedule(api_client, test_agent_name)
+        sid = schedule["id"]
+        try:
+            gen_resp = api_client.post(
+                f"/api/agents/{test_agent_name}/schedules/{sid}/webhook"
+            )
+            webhook_url = gen_resp.json()["webhook_url"]
+            token = webhook_url.split("/api/webhooks/")[1]
+
+            # ~20 KB raw body — over the 16 KiB cap; rejected on Content-Length
+            # before any JSON parse (so 413, not 422).
+            resp = httpx.post(
+                f"http://localhost:8000/api/webhooks/{token}",
+                content=b'{"metadata": {"blob": "' + b"y" * 20000 + b'"}}',
+                headers={"Content-Type": "application/json"},
+                timeout=15.0,
+            )
+            assert resp.status_code == 413, (
+                f"Expected 413 for oversized body, got {resp.status_code}"
+            )
+        finally:
+            _delete_schedule(api_client, test_agent_name, sid)
+
+    def test_invalid_token_flood_is_rate_limited(self):
+        """A flood of well-formed-but-unknown tokens is throttled per-IP (#1424).
+
+        The per-token limiter never engages for unknown tokens; the pre-auth
+        per-IP limit must (429 + Retry-After). Isolated to its own bucket via
+        X-Real-IP (127.0.0.1 is a trusted proxy, so _get_client_ip honors it).
+        """
+        import httpx
+        # WEBHOOK_IP_RATE_LIMIT default is 60/60s; send enough to cross it.
+        headers = {"X-Real-IP": "203.0.113.77"}
+        saw_429 = False
+        retry_after_ok = True
+        for _ in range(70):
+            resp = httpx.post(
+                "http://localhost:8000/api/webhooks/" + "Z" * 43,
+                headers=headers,
+                timeout=15.0,
+            )
+            if resp.status_code == 429:
+                saw_429 = True
+                retry_after_ok = "Retry-After" in resp.headers
+                break
+            assert resp.status_code == 404, (
+                f"Pre-429 requests should 404 (unknown token), got {resp.status_code}"
+            )
+        assert saw_429, "Per-IP rate limit did not trigger 429 within 70 requests"
+        assert retry_after_ok, "429 response is missing the Retry-After header"
+
     def test_old_token_invalid_after_regenerate(
         self, api_client: TrinityApiClient, test_agent_name: str
     ):

--- a/tests/unit/test_1424_webhook_hardening.py
+++ b/tests/unit/test_1424_webhook_hardening.py
@@ -1,0 +1,149 @@
+"""Public-webhook pre-auth hardening (#1424).
+
+The public, unauthenticated ``POST /api/webhooks/{token}`` had no per-IP /
+pre-auth rate limit (a flood of well-formed-but-unknown tokens hit the DB
+unthrottled) and no request-body size cap. This exercises the fix with an
+in-process FastAPI ``TestClient`` — no live backend, no Redis (the shared
+limiter falls back to its in-process window) — so it runs anywhere the backend
+package imports.
+
+Guarded checks:
+  * a per-IP limit fires BEFORE the token DB lookup (flood of unknown tokens is
+    throttled, and the DB is not consulted once throttled);
+  * the per-token limit is preserved for a valid token;
+  * an over-sized body is rejected (413) before it is parsed.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+# Backend config raises at import without these; keep DB side effects in a temp
+# file so importing `database` can't touch a real /data volume.
+os.environ.setdefault("REDIS_URL", "redis://u:p@localhost:6379")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TRINITY_DB_PATH", os.path.join(tempfile.gettempdir(), "trinity_1424_test.db"))
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from routers import webhooks  # noqa: E402
+from services import rate_limiter  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeSchedule:
+    def __init__(self):
+        self.id = "sched-1"
+        self.agent_name = "agent-x"
+        self.name = "nightly"
+        self.message = "do the thing"
+        self.webhook_enabled = True
+
+
+_VALID_TOKEN = "V" * 43
+_UNKNOWN_TOKEN = "U" * 43
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Isolate the limiter window per test (in-process fallback, no Redis).
+    rate_limiter.clear_inprocess()
+    rate_limiter.reset_redis_client()
+    # Never actually reach Redis — force the deterministic in-process path.
+    monkeypatch.setattr(rate_limiter, "_get_redis", lambda: None)
+
+    lookups = {"count": 0}
+
+    def _fake_lookup(token):
+        lookups["count"] += 1
+        return _FakeSchedule() if token == _VALID_TOKEN else None
+
+    monkeypatch.setattr(webhooks.db, "get_schedule_by_webhook_token", _fake_lookup)
+
+    app = FastAPI()
+    app.include_router(webhooks.router)
+    c = TestClient(app)
+    c.lookups = lookups
+    return c
+
+
+def test_ip_flood_of_unknown_tokens_is_throttled_before_db(client, monkeypatch):
+    """A flood of well-formed-but-unknown tokens 429s on the per-IP limit, and
+    once throttled the token DB lookup is not consulted (limit is pre-auth)."""
+    monkeypatch.setattr(webhooks, "WEBHOOK_IP_RATE_LIMIT", 3)
+
+    statuses = []
+    for _ in range(6):
+        r = client.post(f"/api/webhooks/{_UNKNOWN_TOKEN}")
+        statuses.append(r.status_code)
+
+    # First few pass the IP gate (→404 unknown token), then the gate trips.
+    assert 429 in statuses, statuses
+    first_429 = statuses.index(429)
+    assert first_429 <= 3
+    # Every request after the first 429 is also 429 (window stays saturated).
+    assert all(s == 429 for s in statuses[first_429:]), statuses
+    # The DB was consulted only for the requests that passed the IP gate — never
+    # for a throttled one (proves the limit sits BEFORE the lookup).
+    assert client.lookups["count"] == first_429
+    # 429 carries Retry-After.
+    r = client.post(f"/api/webhooks/{_UNKNOWN_TOKEN}")
+    assert r.status_code == 429
+    assert "retry-after" in {k.lower() for k in r.headers}
+
+
+class _InFlightReplay:
+    """A benign idempotency decision → the handler returns 409 without dispatching
+    to the scheduler (lets us probe the gates before dispatch)."""
+    replay = True
+    in_flight = True
+    snapshot = None
+
+
+def _short_circuit_dispatch(monkeypatch):
+    async def _noop_log(*a, **k):
+        return None
+
+    monkeypatch.setattr(webhooks.platform_audit_service, "log", _noop_log)
+    monkeypatch.setattr(webhooks.idempotency_service, "begin", lambda *a, **k: _InFlightReplay())
+
+
+def test_per_token_limit_preserved_for_valid_token(client, monkeypatch):
+    """The existing per-token limit still engages for a resolved token."""
+    # Roomy IP budget; tight per-token budget so the token gate is what trips.
+    monkeypatch.setattr(webhooks, "WEBHOOK_IP_RATE_LIMIT", 1000)
+    monkeypatch.setattr(webhooks, "WEBHOOK_RATE_LIMIT", 2)
+    _short_circuit_dispatch(monkeypatch)
+
+    statuses = [client.post(f"/api/webhooks/{_VALID_TOKEN}").status_code for _ in range(5)]
+    # Allowed calls short-circuit to 409 (in-flight replay); once the per-token
+    # window saturates the gate returns 429.
+    assert 429 in statuses, statuses
+    assert statuses.index(429) <= 2, statuses
+
+
+def test_oversized_body_rejected_with_413(client, monkeypatch):
+    """A body over the cap is rejected (413) before parsing."""
+    monkeypatch.setattr(webhooks, "WEBHOOK_IP_RATE_LIMIT", 1000)
+    monkeypatch.setattr(webhooks, "WEBHOOK_MAX_BODY_BYTES", 100)
+    r = client.post(
+        f"/api/webhooks/{_VALID_TOKEN}",
+        content=b'{"context": "' + b"x" * 500 + b'"}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert r.status_code == 413, r.text
+
+
+def test_small_valid_body_passes_the_size_gate(client, monkeypatch):
+    """A within-cap body clears the 413 gate (reaches dispatch → benign 409)."""
+    monkeypatch.setattr(webhooks, "WEBHOOK_IP_RATE_LIMIT", 1000)
+    _short_circuit_dispatch(monkeypatch)
+    r = client.post(f"/api/webhooks/{_VALID_TOKEN}", json={"context": "small"})
+    # Past the 413 gate → hits the idempotency short-circuit, not a size rejection.
+    assert r.status_code == 409, r.text


### PR DESCRIPTION
## Summary

The public, unauthenticated `POST /api/webhooks/{token}` applied its rate limit **only after** a valid token resolved (keyed `webhook:{token}`). A request with a well-formed-but-unknown 43-char token passed the regex, hit the DB, and 404'd **with no throttle** — an unauthenticated resource-amplification / DoS surface on a world-reachable route. Separately, `request.body()` read the full body with no size cap.

Neither forges a trigger (the `token_urlsafe(32)` token is unguessable), but both are unauthenticated DoS surfaces.

## Fix (`src/backend/routers/webhooks.py`)

- **Pre-auth per-IP limit** at the TOP of `trigger_webhook`, **before** the regex/DB lookup, so an invalid-token flood is throttled (429 + `Retry-After`). Reuses the shared sliding-window limiter (`services/rate_limiter.py`, #1023) and the trusted-proxy-aware `_get_client_ip` (`routers.public`, the same helper `files.py` already reuses) so `X-Forwarded-For` can't be spoofed to bypass it and legit callers behind nginx don't collapse into one bucket. Generous (60/min) vs the per-token limit; **fail-open**.
- **Body size cap:** drop the typed body param and read `request.stream()` with a hard ceiling — Content-Length fast-reject **plus** bail at cap+one chunk, so a missing/lying/chunked length can't force unbounded buffering. Oversized → **413 before any parse**. The optional JSON is then parsed manually (422 on bad body). The same bytes feed the idempotency key (single read — replaces the prior second `request.body()`).
- Per-token limit and the existing 422-on-oversized-`context` behaviour are preserved.

## Acceptance criteria
- [x] Per-IP limit enforced **before** the token DB lookup, reusing `rate_limiter` (429 + Retry-After).
- [x] Existing per-token limit preserved for valid tokens.
- [x] Oversized body rejected (413) before it is read/parsed fully (16 KiB cap, env-overridable).
- [x] Limiter stays fail-open (Redis down never blocks legit triggers).
- [x] Tests for invalid-token flood + oversized body.

## Tests
- `tests/unit/test_1424_webhook_hardening.py` — **4, TestClient, no live server, verified passing** in `trinity-backend:latest`: IP flood throttled **before** the DB lookup (asserts the lookup count to prove ordering) + `Retry-After`; per-token limit still engages; 413 on oversized; small body clears the gate.
- `tests/test_webhook_triggers.py` — live smoke for the 413 and invalid-token-flood (429) paths.

## Verification
```
# in trinity-backend:latest, no live stack needed
python -m pytest tests/unit/test_1424_webhook_hardening.py -v   # 4 passed
```

Fixes #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
