### PR TITLE
fix(webhooks): public webhook won't fire schedules of soft-deleted agents (#1423)

### DIFF
--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -831,11 +831,29 @@ class ScheduleOperations:
         return token
 
     def get_schedule_by_webhook_token(self, token: str) -> Optional[Schedule]:
-        """Look up a schedule by its webhook token (O(1) via index)."""
-        stmt = select(agent_schedules).where(
-            and_(
-                agent_schedules.c.webhook_token == token,
-                agent_schedules.c.deleted_at.is_(None),
+        """Look up a schedule by its webhook token (O(1) via index).
+
+        Applies the same two soft-delete filters as `list_all_enabled_schedules`
+        (#834, #1423): skip a soft-deleted *schedule* (`agent_schedules.deleted_at`)
+        AND a schedule whose *agent* is soft-deleted (`agent_ownership.deleted_at`).
+        Without the agent join, a webhook could still fire a schedule of a
+        soft-deleted (recoverable) agent during the retention window — the exact
+        hole the cron path guards against.
+        """
+        stmt = (
+            select(agent_schedules)
+            .select_from(
+                agent_schedules.join(
+                    agent_ownership,
+                    agent_ownership.c.agent_name == agent_schedules.c.agent_name,
+                )
+            )
+            .where(
+                and_(
+                    agent_schedules.c.webhook_token == token,
+                    agent_schedules.c.deleted_at.is_(None),
+                    agent_ownership.c.deleted_at.is_(None),
+                )
             )
         )
         with get_engine().connect() as conn:

--- a/tests/test_webhook_triggers.py
+++ b/tests/test_webhook_triggers.py
@@ -273,3 +273,52 @@ class TestWebhookTrigger:
             assert resp.status_code == 404
         finally:
             _delete_schedule(api_client, test_agent_name, sid)
+
+    def test_soft_deleted_agent_webhook_returns_404_then_recovers(
+        self, api_client: TrinityApiClient
+    ):
+        """#1423: a webhook must not fire a schedule whose *agent* is soft-deleted.
+
+        Soft-deleting the agent → the token lookup joins agent_ownership and
+        excludes it → 404 (so no scheduler dispatch, no execution row). Admin
+        recovery clears agent_ownership.deleted_at → the same token fires again.
+        Uses a throwaway agent so the shared fixture agent is untouched; the
+        webhook 404 gate needs only the ownership row, not a running container.
+        """
+        import httpx
+        agent = f"test-1423-{uuid.uuid4().hex[:6]}"
+        created = api_client.post("/api/agents", json={"name": agent})
+        if created.status_code not in (200, 201):
+            pytest.skip(f"could not create throwaway agent: {created.text}")
+
+        sid = None
+        try:
+            sid = _create_test_schedule(api_client, agent)["id"]
+            token = api_client.post(
+                f"/api/agents/{agent}/schedules/{sid}/webhook"
+            ).json()["webhook_url"].split("/api/webhooks/")[1]
+
+            # Sanity: token fires while the agent is live (202 dispatched, or 503
+            # if the scheduler is down — never 404).
+            live = httpx.post(f"http://localhost:8000/api/webhooks/{token}", timeout=15.0)
+            assert live.status_code in (202, 503), live.text
+
+            # Soft-delete the agent (child schedule row keeps deleted_at NULL).
+            assert api_client.delete(f"/api/agents/{agent}").status_code in (200, 204)
+
+            # The token must now 404 — the agent-ownership guard (#1423).
+            gone = httpx.post(f"http://localhost:8000/api/webhooks/{token}", timeout=15.0)
+            assert gone.status_code == 404, (
+                f"soft-deleted agent's webhook should 404, got {gone.status_code}"
+            )
+
+            # Admin recovery clears deleted_at → the token resolves again.
+            rec = api_client.post(f"/api/admin/soft-deleted/agents/{agent}/recover")
+            assert rec.status_code == 200, rec.text
+            back = httpx.post(f"http://localhost:8000/api/webhooks/{token}", timeout=15.0)
+            assert back.status_code != 404, "recovered agent's webhook should fire again"
+            assert back.status_code in (202, 503), back.text
+        finally:
+            if sid:
+                _delete_schedule(api_client, agent, sid)
+            api_client.delete(f"/api/agents/{agent}")


### PR DESCRIPTION
## Summary

`get_schedule_by_webhook_token()` filtered only `agent_schedules.deleted_at IS NULL` — it did **not** check whether the schedule's **agent** was soft-deleted (`agent_ownership.deleted_at`). So `POST /api/webhooks/{token}` could still fire a schedule belonging to a soft-deleted (recoverable) agent throughout the retention window (default 180 days), re-opening exactly the hole the cron path guards against and violating the #834 soft-delete invariant that *schedules stop firing immediately*.

The cron path (`list_all_enabled_schedules()`, a few methods above) already JOINs `agent_ownership` and filters `agent_ownership.deleted_at IS NULL`; the webhook lookup just skipped that guard.

## Fix (`src/backend/db/schedules.py`)

One-method parity fix: add the `agent_ownership` join + `agent_ownership.c.deleted_at.is_(None)` predicate to `get_schedule_by_webhook_token()`, mirroring `list_all_enabled_schedules()`. A soft-deleted agent's token now returns **no schedule → the router 404s before any scheduler dispatch**, so no `schedule_executions` row is created. Admin recovery (`agent_ownership.deleted_at → NULL`) restores triggering.

## Acceptance criteria
- [x] `get_schedule_by_webhook_token()` returns nothing when the owning agent is soft-deleted.
- [x] `POST /api/webhooks/{token}` for a soft-deleted agent's schedule → 404, no execution row (404 is before dispatch).
- [x] Recovering the agent restores webhook triggering.
- [x] Regression test in `tests/test_webhook_triggers.py`.

## Verification — live, against a running backend
```
live webhook            -> 202
soft-delete agent       -> 200
webhook (soft-deleted)  -> 404   <-- the fix
recover agent           -> 200
webhook (recovered)     -> 202   <-- fires again
```
Plus `tests/test_webhook_triggers.py::TestWebhookTrigger::test_soft_deleted_agent_webhook_returns_404_then_recovers` (uses a throwaway agent so the shared fixture is untouched).

Related to #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1423
