### PR TITLE
fix(logs): file-source Vector override for Docker Desktop — kills the VM-pegging watch-storm (#1432)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ session-files/
 # Local-only working artifacts (never push)
 saved-conversations/
 tests/manual/
+# Machine-local compose override (#1432 Docker Desktop Vector fix, and any local
+# tweaks). Committed template: docker-compose.override.example.yml
+docker-compose.override.yml
 # gstack tooling state (skill-local artifacts; project-tracked CSO reports
 # live under docs/security-reports/ instead)
 .gstack/

--- a/config/vector.local.yaml
+++ b/config/vector.local.yaml
@@ -1,0 +1,90 @@
+# Vector — LOCAL config for Docker Desktop / VM-based Docker runtimes (#1432)
+#
+# WHY THIS EXISTS
+# The default source (config/vector.yaml) uses Vector's `docker_logs` source,
+# which talks to the Docker log API. On Docker Desktop (macOS confirmed, Windows
+# very likely) and other VM-based runtimes (Colima, Rancher Desktop, Podman
+# machine), that path busy-loops:
+#   * Docker Desktop's virtualized log relay closes a `follow=1` stream right
+#     after flushing backlog instead of transitioning to follow; and
+#   * Vector's `docker_logs` source reconnects-on-stream-end with NO backoff
+#     (hardcoded across Vector 0.43–0.56).
+# The result is a hundreds-per-second "Started/Stopped watching" reconnect storm
+# that re-dumps every container's full log history through the VM — pegging the
+# Docker VM at ~4 cores (~386% CPU observed) and growing the log file GB/day.
+# Native Linux dockerd blocks-to-follow (the stream never closes), so it watches
+# once and follows forever — production is UNAFFECTED and stays on vector.yaml.
+#
+# WHAT THIS DOES
+# Bypasses the Docker log API entirely: it tails the raw json-file container
+# logs on disk (`/var/lib/docker/containers/*/*-json.log`), which is immune to
+# the follow-close bug. Applied via docker-compose.override.yml (see
+# docker-compose.override.example.yml), which also bind-mounts the container-log
+# dir read-only and a checkpoint volume. Prod (`-f docker-compose.prod.yml`)
+# never merges an override file, so it never sees this config.
+#
+# TRADE-OFF
+# The file source keys logs by container ID, not name, so the output is a single
+# ID-keyed `/data/logs/local-*.json` rather than the name-split platform-*.json /
+# agents-*.json the docker_logs enrichment produces. For local dev, prefer
+# `docker compose logs -f <service>` as the primary tail.
+
+# Checkpoint dir so a Vector restart resumes where it left off instead of
+# re-reading (compose mounts trinity-vector-data here).
+data_dir: /vector-data-dir
+
+api:
+  enabled: true            # keep :8686 up so the backend `depends_on` health stays green
+  address: 0.0.0.0:8686
+
+sources:
+  container_files:
+    type: file
+    include:
+      - /var/lib/docker/containers/*/*-json.log
+    read_from: end          # only new lines — never re-ingest history (the GB/day cause)
+
+transforms:
+  parse:
+    type: remap
+    inputs:
+      - container_files
+    source: |
+      # Unwrap the Docker json-file envelope: {"log": "...", "stream": "...", "time": "..."}
+      envelope, err = parse_json(.message)
+      if err == null {
+        .message = string(envelope.log) ?? .message
+        if exists(envelope.stream) { .stream = envelope.stream }
+        if exists(envelope.time) { .timestamp = envelope.time }
+      }
+
+      # Extract the container id from the source file path:
+      #   /var/lib/docker/containers/<id>/<id>-json.log
+      matched, merr = parse_regex(string!(.file), r'/containers/(?P<cid>[0-9a-f]{12,64})/')
+      if merr == null { .container_id = matched.cid }
+
+      # Derive a log level (mirrors config/vector.yaml). The unwrapped line is
+      # often itself JSON (Python/Node structured logs).
+      parsed, perr = parse_json(string!(.message))
+      if perr == null { .parsed = parsed }
+      if exists(.parsed.level) {
+        .level = .parsed.level
+      } else if exists(.parsed.levelname) {
+        .level = .parsed.levelname
+      } else if match(string!(.message), r'(?i)\b(error|err)\b') {
+        .level = "error"
+      } else if match(string!(.message), r'(?i)\b(warn|warning)\b') {
+        .level = "warning"
+      } else {
+        .level = "info"
+      }
+
+sinks:
+  local_logs:
+    type: file
+    inputs:
+      - parse
+    path: /data/logs/local-%Y-%m-%d.json
+    encoding:
+      codec: json
+    compression: none

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,26 @@
+# docker-compose.override.example.yml — LOCAL Docker Desktop / VM-runtime fix (#1432)
+#
+# Copy to docker-compose.override.yml to activate:
+#     cp docker-compose.override.example.yml docker-compose.override.yml
+# `docker compose up` auto-merges any docker-compose.override.yml (no -f needed),
+# so scripts/deploy/start.sh picks it up automatically. start.sh also creates it
+# for you when it detects Docker Desktop (opt out with TRINITY_LOCAL_LOG_SOURCE=docker).
+#
+# It swaps ONLY the Vector config to the on-disk file-source tailer
+# (config/vector.local.yaml) and mounts the raw container-log dir read-only, so the
+# `docker_logs` busy-loop that pegs the Docker VM never engages. Native Linux dockerd
+# is UNAFFECTED and does not need this. Prod (`docker compose -f docker-compose.prod.yml`)
+# passes an explicit -f, which disables override auto-merge — prod never sees this.
+#
+# Compose merges the `volumes:` list by target path, so the config-file mount below
+# replaces the base ./config/vector.yaml mount cleanly; the docker.sock and
+# trinity-logs mounts from docker-compose.yml are inherited unchanged.
+services:
+  vector:
+    volumes:
+      - ./config/vector.local.yaml:/etc/vector/vector.yaml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - trinity-vector-data:/vector-data-dir
+
+volumes:
+  trinity-vector-data:

--- a/docs/QUERYING_LOGS.md
+++ b/docs/QUERYING_LOGS.md
@@ -11,6 +11,40 @@ Trinity uses Vector to aggregate all container logs into daily-rotated JSON file
 
 Files rotate automatically at midnight UTC.
 
+## Docker Desktop (macOS / Windows) — file-source log override (#1432)
+
+> **Applies to Docker Desktop and other VM-based Docker runtimes** (Colima, Rancher
+> Desktop, Podman machine). Native Linux dockerd is unaffected and needs none of this.
+
+Vector's default `docker_logs` source (`config/vector.yaml`) talks to the Docker log
+API. On Docker Desktop that API closes each `follow` stream right after flushing
+backlog, and `docker_logs` reconnects with no backoff — a reconnect storm that pegs
+the Docker VM at ~4 cores and grows the log file GB/day. To avoid it, the local stack
+tails the raw on-disk container logs instead (`config/vector.local.yaml`), which
+bypasses the Docker log API entirely.
+
+**Activation is automatic:** `scripts/deploy/start.sh` detects Docker Desktop and
+creates `docker-compose.override.yml` (from `docker-compose.override.example.yml`),
+which `docker compose up` auto-merges. To do it by hand, or on a runtime start.sh
+doesn't detect:
+
+```bash
+cp docker-compose.override.example.yml docker-compose.override.yml
+./scripts/deploy/start.sh
+```
+
+- **Opt out** (force the default `docker_logs` source): `TRINITY_LOCAL_LOG_SOURCE=docker ./scripts/deploy/start.sh`, or just delete `docker-compose.override.yml`.
+- **Force on** (undetected VM runtime): `TRINITY_LOCAL_LOG_SOURCE=file ./scripts/deploy/start.sh`.
+- **Production is never affected:** prod deploys with an explicit `-f docker-compose.prod.yml`, which disables Compose's override auto-merge, so the override file is never read.
+
+**Trade-off:** the file source keys logs by **container ID**, not name, so the output
+is a single ID-keyed `/data/logs/local-YYYY-MM-DD.json` instead of the name-split
+`platform-*.json` / `agents-*.json`. For everyday local tailing, prefer:
+
+```bash
+docker compose logs -f <service>     # e.g. backend, scheduler, agent-<name>
+```
+
 ## Accessing Logs
 
 Logs are stored in the `trinity-logs` Docker volume. To access them:

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -280,6 +280,8 @@ FastMCP, Streamable HTTP transport, port 8080. API-key auth via `Authorization: 
 
 Vector 0.43.1 (`timberio/vector:0.43.1-alpine`). Captures all container stdout/stderr via Docker socket; routes platform logs to `/data/logs/platform.json` and agent logs to `/data/logs/agents.json`; enriches with container metadata; parses JSON logs. Health: `http://localhost:8686/health`. Query: `docker exec trinity-vector sh -c "tail -50 /data/logs/platform.json" | jq .` (same for `agents.json`).
 
+**Docker Desktop local override (#1432):** the `docker_logs` source busy-loops on Docker Desktop / VM-based runtimes (the virtualized log relay closes each `follow` stream after backlog flush; `docker_logs` reconnects with no backoff → a storm that pegs the Docker VM). Native Linux dockerd is unaffected, so **prod is unchanged**. For local dev, `config/vector.local.yaml` swaps to a `file` source tailing `/var/lib/docker/containers/*/*-json.log` (immune to the follow-close bug), applied via a gitignored `docker-compose.override.yml` (template `docker-compose.override.example.yml`) that `start.sh` auto-creates when it detects Docker Desktop (`TRINITY_LOCAL_LOG_SOURCE=docker|file` overrides). The file source keys by container ID → a single `/data/logs/local-*.json` instead of the name-split files. See [docs/QUERYING_LOGS.md](../QUERYING_LOGS.md).
+
 ### Agent Containers
 
 **Base image** `trinity-agent-base:latest`: Python 3.11, Node.js 20, Go 1.21, Claude Code (latest), common Python packages.

--- a/scripts/deploy/start.sh
+++ b/scripts/deploy/start.sh
@@ -227,6 +227,31 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 export BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
+# --- Docker Desktop Vector log-source fix (#1432) -----------------------------
+# On Docker Desktop / VM-based Docker runtimes, Vector's default `docker_logs`
+# source busy-loops and pegs the Docker VM at ~4 cores. Swap it for an on-disk
+# file source via docker-compose.override.yml (auto-merged by `docker compose up`).
+# Native Linux dockerd is unaffected. Opt out: TRINITY_LOCAL_LOG_SOURCE=docker.
+# Force on: TRINITY_LOCAL_LOG_SOURCE=file. Default: auto-detect Docker Desktop.
+_log_src="${TRINITY_LOCAL_LOG_SOURCE:-auto}"
+if [ "$_log_src" = "auto" ]; then
+    if docker info 2>/dev/null | grep -qi 'Docker Desktop'; then
+        _log_src=file
+    else
+        _log_src=docker
+    fi
+fi
+if [ "$_log_src" = "file" ]; then
+    if [ ! -f docker-compose.override.yml ]; then
+        cp docker-compose.override.example.yml docker-compose.override.yml
+        echo "Docker Desktop detected → using the on-disk Vector log source (#1432)."
+        echo "  Created docker-compose.override.yml. To opt out: delete it, or set"
+        echo "  TRINITY_LOCAL_LOG_SOURCE=docker. Local logs land in /data/logs/local-*.json;"
+        echo "  prefer 'docker compose logs -f <service>' to tail a single service."
+    fi
+fi
+# -----------------------------------------------------------------------------
+
 echo "Starting services..."
 docker compose up -d
 


### PR DESCRIPTION
## Summary

Vector's `docker_logs` source busy-loops on **Docker Desktop** (macOS confirmed, Windows very likely) and other **VM-based Docker runtimes** (Colima, Rancher Desktop, Podman machine): the virtualized log relay closes each `follow=1` stream right after flushing backlog instead of transitioning to follow, and `docker_logs` reconnects-on-stream-end with **no backoff** (hardcoded across Vector 0.43–0.56). The reconnect storm re-dumps every container's full log history through the VM — **pegging the Docker VM at ~4 cores (~386% CPU) and growing the log file GB/day**, within seconds of `./scripts/deploy/start.sh`. It's a first-touch experience killer for every Mac/Windows dev and evaluator. Native Linux dockerd blocks-to-follow (the stream never closes), so **production is unaffected**.

## Fix

A **local-only** file-source Vector that tails the raw on-disk container logs (`/var/lib/docker/containers/*/*-json.log`), bypassing the Docker log API entirely (immune to the follow-close bug). Delivered via a compose override so shared config and prod stay **byte-for-byte unchanged**.

- **`config/vector.local.yaml`** (committed, root-cause header) — `file` source (`read_from: end`), remap unwrapping the json-file `{log,stream,time}` envelope + extracting `container_id` from the path + deriving `level`; file sink to `/data/logs/local-*.json`; `api` on `:8686` so the backend `depends_on` health stays green.
- **`docker-compose.override.example.yml`** (committed template) — swaps *only* the Vector config mount to `vector.local.yaml`, adds the container-log dir (RO) + a checkpoint volume. Compose merges `volumes:` by target path → the base `vector.yaml` mount is cleanly replaced.
- **`.gitignore`** — ignores the live `docker-compose.override.yml` (machine-local).
- **`scripts/deploy/start.sh`** — **auto-detects Docker Desktop** and creates the override (default-on for the affected path). Escape hatch: `TRINITY_LOCAL_LOG_SOURCE=docker` (opt out) / `=file` (force on an undetected VM runtime). Prod uses an explicit `-f docker-compose.prod.yml`, which disables Compose override auto-merge.
- **Docs** — `docs/QUERYING_LOGS.md` + `architecture.md`: activation, opt-out, and the trade-off.

## Decision (AC open item)
Went **default-on via auto-detect** for the Docker Desktop path (the issue's lean), with a committed opt-in template + `TRINITY_LOCAL_LOG_SOURCE` env override — zero-touch first-run relief on Mac/Windows, Linux untouched, prod untouched.

## Acceptance criteria
- [x] `config/vector.local.yaml` committed with file-source config + root-cause header.
- [x] Override pattern documented; the live override file gitignored (template committed).
- [x] `.gitignore` covers `docker-compose.override.yml`.
- [x] With the override active, the stack runs with **no watch-storm** in `docker logs trinity-vector`.
- [x] Prod path provably unaffected (`docker compose -f docker-compose.prod.yml config` → **0** refs to `vector.local.yaml`).
- [x] Docs note the trade-off (ID-keyed `local-*.json`) and point at `docker compose logs -f`.
- [x] Decision made (auto-detect default-on).

## Verification (on Linux — the busy-loop itself is Mac-VM-only, but everything else is verifiable)
- `docker compose config` merges the override cleanly — Vector config mount replaced by target-path, container-dir + checkpoint volume present, **no duplicate/warnings**.
- `docker compose -f docker-compose.prod.yml config` → **0** `vector.local.yaml` refs (prod isolated).
- `vector validate` on `vector.local.yaml` → passes.
- Ran the file source **live**: health up on `:8686`, **zero** "watching" storm, output correct (`container_id` extracted, `{log,stream,time}` envelope unwrapped, `level` derived).

Related: #1131 (same Docker Desktop first-run environment class). Related to #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1432
