### PR TITLE
fix(scheduler): soft-deleted agent's schedules stop firing on the sync path (#1427)

### DIFF
--- a/src/scheduler/database.py
+++ b/src/scheduler/database.py
@@ -265,16 +265,37 @@ class SchedulerDatabase:
     def list_all_schedules(self) -> List[Schedule]:
         """List all schedules (enabled and disabled) for sync detection.
 
-        Excludes soft-deleted (#834 Phase 1b).
+        Excludes schedules that are themselves soft-deleted (#834 Phase 1b).
+
+        A schedule whose *parent agent* is soft-deleted (`agent_ownership.
+        deleted_at`) is reported as **disabled** here (#1427): soft-deleting an
+        agent leaves the child schedule row untouched (enabled=1, deleted_at
+        NULL, same updated_at), so the sync's transition diff saw no change and
+        never removed the already-registered APScheduler job — it kept firing
+        into a nonexistent container (ConnectError every cron tick). Folding the
+        agent's soft-delete into the reported `enabled` makes the existing
+        enabled→disabled transition remove the job, and — because agent recovery
+        clears `agent_ownership.deleted_at` — the disabled→enabled transition
+        re-adds it. Symmetric with #834 recovery; no schedule-row mutation.
+        `list_all_enabled_schedules` already applies this join at startup; this
+        closes the same gap on the live-sync path.
         """
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
-                SELECT * FROM agent_schedules
-                WHERE deleted_at IS NULL
-                ORDER BY agent_name, name
+                SELECT s.*, ao.deleted_at AS _agent_deleted_at
+                FROM agent_schedules s
+                LEFT JOIN agent_ownership ao ON ao.agent_name = s.agent_name
+                WHERE s.deleted_at IS NULL
+                ORDER BY s.agent_name, s.name
             """)
-            return [self._row_to_schedule(row) for row in cursor.fetchall()]
+            schedules = []
+            for row in cursor.fetchall():
+                schedule = self._row_to_schedule(row)
+                if row["_agent_deleted_at"] is not None:
+                    schedule.enabled = False
+                schedules.append(schedule)
+            return schedules
 
     def list_agent_schedules(self, agent_name: str) -> List[Schedule]:
         """List all schedules for a specific agent.

--- a/tests/scheduler_tests/test_1427_soft_deleted_agent_schedules.py
+++ b/tests/scheduler_tests/test_1427_soft_deleted_agent_schedules.py
@@ -1,0 +1,85 @@
+"""Soft-deleted agent's schedule stops firing on the live-sync path (#1427).
+
+Soft-deleting an agent leaves its child schedule row untouched (enabled=1,
+deleted_at NULL, same updated_at). The sync loop's `list_all_schedules()` used
+to filter only the schedule's own `deleted_at`, so the transition diff saw no
+change and never removed the already-registered APScheduler job — it kept
+firing into the now-nonexistent container (ConnectError every cron tick, 26
+failures on eu2). `list_all_schedules()` now reports such a schedule as
+disabled (folding the agent's `agent_ownership.deleted_at`), so the existing
+enabled→disabled transition removes the job, and agent recovery flips it back.
+"""
+
+import sys
+import sqlite3
+from pathlib import Path
+
+_src_path = str(Path(__file__).resolve().parent.parent.parent / "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+import pytest  # noqa: E402
+
+
+def _set_agent_deleted(db_path: str, agent_name: str, deleted_at):
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE agent_ownership SET deleted_at = ? WHERE agent_name = ?",
+            (deleted_at, agent_name),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _enabled_by_id(schedules):
+    return {s.id: s.enabled for s in schedules}
+
+
+class TestSoftDeletedAgentSchedules:
+    def test_live_agent_schedules_report_enabled(self, db_with_data):
+        en = _enabled_by_id(db_with_data.list_all_schedules())
+        assert en["schedule-1"] is True
+        assert en["schedule-2"] is True
+        assert en["schedule-3"] is False  # was created disabled
+
+    def test_soft_deleted_agent_schedules_report_disabled(self, db_with_data):
+        """The fix: enabled schedules of a soft-deleted agent flip to disabled in
+        the sync view (→ the sync removes their jobs), without touching the rows."""
+        _set_agent_deleted(db_with_data.database_path, "test-agent", "2026-06-29T00:00:00Z")
+
+        en = _enabled_by_id(db_with_data.list_all_schedules())
+        # Present in the sync set (row not deleted) but reported disabled → jobs removed.
+        assert en["schedule-1"] is False
+        assert en["schedule-2"] is False
+        assert en["schedule-3"] is False
+
+        # The rows themselves are untouched (recoverable per #834).
+        conn = sqlite3.connect(db_with_data.database_path)
+        try:
+            rows = dict(conn.execute(
+                "SELECT id, enabled FROM agent_schedules WHERE agent_name='test-agent'"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert rows["schedule-1"] == 1 and rows["schedule-2"] == 1  # DB enabled unchanged
+
+    def test_recovery_reenables_in_sync_view(self, db_with_data):
+        """Clearing agent_ownership.deleted_at (agent recovery) flips the schedules
+        back to enabled → the disabled→enabled transition re-adds the jobs."""
+        path = db_with_data.database_path
+        _set_agent_deleted(path, "test-agent", "2026-06-29T00:00:00Z")
+        assert _enabled_by_id(db_with_data.list_all_schedules())["schedule-1"] is False
+
+        _set_agent_deleted(path, "test-agent", None)  # recover
+        en = _enabled_by_id(db_with_data.list_all_schedules())
+        assert en["schedule-1"] is True
+        assert en["schedule-2"] is True
+
+    def test_soft_deleted_agent_excluded_from_enabled_startup_set(self, db_with_data):
+        """Sanity: the startup load (`list_all_enabled_schedules`) already drops
+        them entirely — this test guards that the two paths agree."""
+        _set_agent_deleted(db_with_data.database_path, "test-agent", "2026-06-29T00:00:00Z")
+        ids = {s.id for s in db_with_data.list_all_enabled_schedules()}
+        assert "schedule-1" not in ids and "schedule-2" not in ids


### PR DESCRIPTION
## Summary

On eu2, agent `ff-scorer` was soft-deleted (`agent_ownership.deleted_at` set, container removed) but its schedule `ff-auto` stayed `enabled=1` / `deleted_at IS NULL`, so the scheduler kept dispatching it into the nonexistent container — **26 failed executions (`HTTP error: ConnectError`)** over three days, polluting failure analytics.

## Root cause

Soft-deleting an agent (#834) leaves the child schedule row untouched (enabled=1, deleted_at NULL, **same `updated_at`**). The standalone scheduler's live-sync (`_sync_agent_schedules`) reads `list_all_schedules()`, whose query filtered only the schedule's **own** `deleted_at` — **no `agent_ownership` join**. So the transition diff saw no change and never removed the already-registered APScheduler job; it kept firing every cron tick.

`list_all_enabled_schedules()` (the *startup* load) already joins `agent_ownership` and skips these — the gap was only on the live-sync path a running scheduler uses after the agent is deleted mid-run.

## Fix (`src/scheduler/database.py`)

`list_all_schedules()` now `LEFT JOIN`s `agent_ownership` and reports a schedule as **disabled** when its parent agent is soft-deleted. This makes the existing `enabled→disabled` transition in `_sync_agent_schedules` **remove the job** — and because agent recovery clears `agent_ownership.deleted_at`, the `disabled→enabled` transition **re-adds** it. Symmetric with #834 recovery, **no schedule-row mutation, no recovery churn**. The method is called only by the sync loop, so the effective-enabled override is contained to the sync view.

Companion to #1423 (same #834 gap on the webhook trigger path).

## Acceptance criteria
- [x] A soft-deleted agent's enabled schedule stops firing (job removed on next sync).
- [x] Recovering the agent restores firing.
- [x] Child rows preserved (recoverable per #834) — no `agent_schedules.deleted_at` set.

## Verification
`tests/scheduler_tests/test_1427_soft_deleted_agent_schedules.py` (4, against the real `SchedulerDatabase` + schema):
- live agent → schedules report enabled;
- soft-deleted agent → enabled schedules report **disabled** (→ sync removes jobs) while the DB rows stay `enabled=1`;
- recovery (clear `deleted_at`) → re-enabled;
- parity with `list_all_enabled_schedules` (startup set already excludes them).

*Note:* verified at the sync-view/DB layer (the exact fix point); the full running-scheduler loop reconciliation (`enabled→disabled` ⇒ `_remove_job`) is pre-existing, covered behavior. The issue also flagged that `PUT .../schedules/{id}` is accepted for a soft-deleted agent — left as-is (out of scope; not the firing bug).

Related to #1427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1427
