### PR TITLE
docs(user-docs): sync to dev state 2026-07-03 — v0.7.0 What's New + post-release features

### DIFF
--- a/docs/user-docs/README.md
+++ b/docs/user-docs/README.md
@@ -1,10 +1,10 @@
 # Trinity User Documentation
 
-> Auto-generated from source code. Run `/generate-user-docs` to update. Last sync: 2026-06-11.
+> Auto-generated from source code. Run `/generate-user-docs` to update. Last sync: 2026-07-03.
 
 ## What's New
 
-- [Release highlights](whats-new/README.md) — user-facing changes per release, newest first ([v0.6.1](whats-new/v0.6.1.md))
+- [Release highlights](whats-new/README.md) — user-facing changes per release, newest first ([v0.7.0](whats-new/v0.7.0.md))
 
 ## Watch
 
@@ -71,7 +71,7 @@
 
 ## Sharing and Access
 
-- [Agent Sharing](sharing-and-access/agent-sharing.md) — Share with users, access levels
+- [Agent Sharing & Access](sharing-and-access/agent-sharing.md) — Access tab (operators), Sharing tab (external clients, channels, client roster)
 - [Access Control](sharing-and-access/access-control.md) — Cross-channel email verification, access requests
 - [Public Links](sharing-and-access/public-links.md) — Public chat URLs, email verification, session memory
 - [Tags and Organization](sharing-and-access/tags-and-organization.md) — Tags, filtering, system views
@@ -84,7 +84,7 @@
 - [Slack Integration](integrations/slack-integration.md) — Multi-agent channels, DMs, thread routing
 - [Telegram Integration](integrations/telegram-integration.md) — Bot setup, group chats, privacy mode, trigger modes
 - [WhatsApp Integration](integrations/whatsapp-integration.md) — Twilio binding, sandbox setup, email verification
-- [MCP Server](integrations/mcp-server.md) — 80 MCP tools, API keys, tool categories
+- [MCP Server](integrations/mcp-server.md) — 93 MCP tools, API keys, dedicated per-agent tools
 - [A2A Agent Card](integrations/a2a-protocol.md) — A2A v1.0 discovery for external orchestrators
 - [Nevermined Payments](integrations/nevermined-payments.md) — x402 payment monetization
 
@@ -108,6 +108,7 @@
 ## Advanced
 
 - [Voice Chat](advanced/voice-chat.md) — Real-time voice via Gemini Live API
+- [Voice Replies](advanced/voice-replies.md) — Agents speak channel replies as voice notes (ElevenLabs TTS)
 - [VoIP Telephony](advanced/voip-telephony.md) — Agents place outbound phone calls via Twilio + Gemini Live
 - [Image Generation](advanced/image-generation.md) — Gemini two-step image pipeline
 - [Agent Avatars](advanced/agent-avatars.md) — AI-generated avatars, emotion variants

--- a/docs/user-docs/advanced/voice-chat.md
+++ b/docs/user-docs/advanced/voice-chat.md
@@ -61,6 +61,10 @@ Set a custom voice system prompt for an agent by placing a file named `voice-age
 
 If no file is present, Trinity auto-generates a prompt from the agent's template info and falls back to a generic prompt.
 
+### Per-Agent Voice
+
+Each agent has a persisted Gemini voice (default **Kore**) that applies to both this browser voice overlay and outbound [VoIP calls](voip-telephony.md#the-agents-voice) — the full selectable list and the UI picker are documented there. Read or set it via `GET`/`PUT /api/agents/{name}/voice/name` (PUT is owner-only; an empty value reverts to the default).
+
 ## Tool Calling
 
 When Gemini encounters a request that requires complex reasoning, file access, or external actions, it calls the `run_task` function:
@@ -128,6 +132,7 @@ All canvas content is sanitized before display (DOMPurify, the same trust model 
 | `/api/agents/{name}/voice/status` | GET | Get current session state |
 | `/api/agents/{name}/voice/{session_id}/panel` | GET | Current workspace canvas state (`type`, `content`, `title`, `updated_at`); polled by the canvas |
 | `/api/agents/{name}/voice/prompt` | GET / PUT | Read or set the per-agent voice system prompt |
+| `/api/agents/{name}/voice/name` | GET / PUT | Read (with `available_voices`) or set the persisted per-agent Gemini voice |
 | `/ws/voice/{session_id}` | WebSocket | Bidirectional audio bridge |
 
 ### WebSocket Message Types

--- a/docs/user-docs/advanced/voice-replies.md
+++ b/docs/user-docs/advanced/voice-replies.md
@@ -1,0 +1,71 @@
+# Voice Replies (Outbound TTS)
+
+Agents can speak their channel replies as voice notes. When enabled, replies on Telegram, Slack, and WhatsApp are synthesized to audio with ElevenLabs and delivered in the channel's native voice format; long replies and any synthesis failure fall back to plain text automatically.
+
+This is the *outbound* counterpart of inbound voice transcription (users sending voice notes *to* the agent, covered in each channel's doc).
+
+## Concepts
+
+- **Voice ID** — An ElevenLabs voice identifier (e.g. `21m00Tcm4TlvDq8ikWAM`) from your ElevenLabs account. It selects the voice the agent speaks with.
+- **One setting, all channels** — Voice replies are configured once per agent and apply to Telegram, Slack, and WhatsApp simultaneously.
+- **Fail-soft** — Voice is strictly additive. If the platform key is missing, the reply exceeds the character cap, or synthesis/transcoding/upload fails for any reason, the reply is delivered as text. A voice problem never loses a message.
+
+## How It Works
+
+1. The platform admin sets `ELEVENLABS_API_KEY` in `.env` (without it, the toggle is disabled with "Voice is unavailable" shown).
+2. Open the agent's **Sharing** tab → **Channels** → open any channel's **Configure/Manage** dialog.
+3. Find the **Voice replies** toggle ("Speak this agent's replies as a voice note (ElevenLabs). Long replies fall back to text.").
+4. Paste an **ElevenLabs voice ID** and click **Save**, then enable the toggle. Enabling requires a voice ID.
+5. The agent's replies on all connected channels now arrive as voice notes. Markdown is stripped before speaking.
+
+### Per-Channel Delivery
+
+| Channel | Delivery format |
+|---------|-----------------|
+| Telegram | OGG/Opus voice note (`sendVoice`); in groups it replies to the triggering message |
+| Slack | Inline MP3 clip uploaded into the thread (Slack renders MP3 with a built-in player) |
+| WhatsApp | OGG voice note delivered via Twilio media (hosted transiently by Trinity for ~1 hour) |
+
+WhatsApp voice notes work even when the agent's file-sharing toggle is off — voice replies are gated only by their own toggle.
+
+### When Text Is Used Instead
+
+- The reply is longer than the platform character cap (`TTS_MAX_CHARS`, default 1,500 characters).
+- The platform has no `ELEVENLABS_API_KEY`.
+- Synthesis, transcoding, hosting, or upload fails for any reason.
+
+## Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ELEVENLABS_API_KEY` | Platform-wide ElevenLabs key; gates the whole feature | — (empty = unavailable) |
+| `ELEVENLABS_MODEL_ID` | ElevenLabs model used for synthesis | `eleven_multilingual_v2` |
+| `TTS_MAX_CHARS` | Character cap; longer replies fall back to text | `1500` |
+
+ffmpeg must be present on the backend (bundled in the standard images) for the OGG voice-note transcode used by Telegram and WhatsApp.
+
+## For Agents
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/agents/{name}/voice-replies` | GET | `{enabled, voice_id, available}` — `available` reflects the platform ElevenLabs key |
+| `/api/agents/{name}/voice-replies` | PUT | Owner-only. `{enabled, voice_id}`; enabling requires a `voice_id` |
+
+## Limitations
+
+- Voice replies cover the messaging channels (Telegram, Slack, WhatsApp) — not the web chat UI or public links.
+- The voice is an ElevenLabs voice; it is unrelated to the Gemini voice used for [Voice Chat](voice-chat.md) and [VoIP calls](voip-telephony.md).
+- Synthesis cost accrues on your ElevenLabs account per character spoken.
+
+## See Also
+
+**Trinity docs:**
+
+- [Telegram Integration](../integrations/telegram-integration.md) · [Slack Integration](../integrations/slack-integration.md) · [WhatsApp Integration](../integrations/whatsapp-integration.md)
+- [Voice Chat](voice-chat.md) — live spoken conversation in the browser (Gemini)
+- [VoIP Telephony](voip-telephony.md) — outbound phone calls (Gemini)
+
+**External references:**
+
+- [ElevenLabs: Voices](https://elevenlabs.io/docs/capabilities/voices) — finding and creating voice IDs
+- [ElevenLabs: Text to Speech API](https://elevenlabs.io/docs/api-reference/text-to-speech/convert) — the synthesis primitive Trinity calls

--- a/docs/user-docs/advanced/voip-telephony.md
+++ b/docs/user-docs/advanced/voip-telephony.md
@@ -23,11 +23,13 @@ This release is **outbound only** — agents place calls; they do not answer inc
 
 ## How It Works
 
-There is no UI for VoIP yet — binding configuration and call triggering are API/MCP-only.
-
 ### 1. Configure the Agent's Twilio Binding
 
-The agent **owner** configures the binding:
+The agent **owner** configures the binding — either in the UI or via the API.
+
+**UI:** open the agent's **Sharing** tab → **Channels** → **Voice calls** row → **Configure** (the row appears only when VoIP is enabled platform-wide). The dialog ("Voice Calls (Twilio / VoIP)") takes the Twilio Account SID, Auth Token, From Number, and an optional daily call cap. Once connected, an **Enable/Disable** control flips calling on and off without re-entering credentials, and an **Agent voice** picker selects the Gemini voice used on calls (see below).
+
+**API:**
 
 ```bash
 curl -X PUT http://localhost:8000/api/agents/my-agent/voip \
@@ -46,7 +48,11 @@ curl -X PUT http://localhost:8000/api/agents/my-agent/voip \
 - **From number** — a voice-capable Twilio number in E.164 format.
 - **Daily call cap** — optional per-agent override of the platform default (50 calls/day).
 
-`GET` the same endpoint to check binding status (returns the Twilio account's display name when configured); `DELETE` removes the binding.
+`GET` the same endpoint to check binding status (returns the Twilio account's display name when configured); `DELETE` removes the binding. `PUT /api/agents/{name}/voip/enabled` with `{"enabled": false}` disables calling in place — the binding and credentials are kept, and outbound calls are refused until re-enabled.
+
+### The Agent's Voice
+
+Calls speak with the agent's persisted Gemini voice, shared with the in-app voice overlay. Pick it in the VoIP dialog's **Agent voice** selector or via `PUT /api/agents/{name}/voice/name`. Available voices: **Kore** (firm, the default), **Zephyr** (bright), **Puck** (upbeat), **Aoede** (breezy), **Charon** (informational), **Fenrir** (excitable), and **Gacrux** (mature). Clearing the setting reverts to Kore.
 
 ### 2. Place a Call
 
@@ -90,6 +96,8 @@ The optional `context` (up to 2,000 characters) becomes the call's purpose in th
 | `/api/agents/{name}/voip` | GET | Binding status (owner-only) |
 | `/api/agents/{name}/voip` | PUT | Configure Twilio voice binding — validates credentials with Twilio, encrypts the Auth Token (owner-only) |
 | `/api/agents/{name}/voip` | DELETE | Remove the binding (owner-only) |
+| `/api/agents/{name}/voip/enabled` | PUT | Enable/disable calling without re-entering credentials (owner-only; 404 if no binding) |
+| `/api/agents/{name}/voice/name` | GET / PUT | The agent's persisted Gemini voice (PUT owner-only; applies to VoIP calls and the in-app voice overlay) |
 | `/api/agents/{name}/voip/call` | POST | Place an outbound call; returns `{call_id, status: "ringing", to_number, twilio_call_sid, chat_session_id}` |
 | `/api/voip/voice/{call_id}` | WebSocket | Twilio Media Streams audio bridge (ticket-authed, used by Twilio — not called directly) |
 
@@ -128,7 +136,7 @@ curl -X POST http://localhost:8000/api/agents/my-agent/voip/call \
 ## Limitations
 
 - **Outbound only** — Agents cannot receive calls in this release.
-- **No web UI** — Binding setup and call history are API-only for now.
+- **No call history UI** — Binding setup is in the Sharing tab, but call logs are API-only for now.
 - **10-minute cap** — Calls end automatically at `VOIP_MAX_CALL_DURATION`.
 - **Public deployment required** — Twilio must reach your instance over WSS; VoIP does not work on a localhost-only install.
 - **Owner pays** — Calls bill to the agent owner's Twilio account at Twilio's voice rates.

--- a/docs/user-docs/agents/agent-chat.md
+++ b/docs/user-docs/agents/agent-chat.md
@@ -2,6 +2,13 @@
 
 The Chat tab in Agent Detail provides a bubble UI for conversing with agents, with persistent history and real-time status updates.
 
+The tab carries a **Session mode** toggle (top-right of the chat surface, default **on**):
+
+- **Session mode on** — each turn resumes the same Claude session, preserving working memory across turns. This surface is documented in [Agent Session](agent-session.md).
+- **Session mode off** — the classic stateless chat documented on this page: each turn replays the visible transcript as text.
+
+Your choice persists per user (in the browser, across all agents). The toggle is hidden — and the tab always uses classic chat — when the Session surface is unavailable: the platform `session_tab_enabled` flag is off, or the agent runs a runtime without resume support (Codex).
+
 > 📺 **Watch:** [I Gave My AI Three Years of My Notes — Then Interviewed It (voice chat)](https://youtu.be/xflQTzarEBQ) *(May 2026)* · [all videos](../videos.md)
 
 ## Concepts
@@ -13,7 +20,7 @@ The Chat tab in Agent Detail provides a bubble UI for conversing with agents, wi
 
 ## How It Works
 
-1. Open an agent's detail page and click the **Chat** tab.
+1. Open an agent's detail page and click the **Chat** tab. (For the classic surface described below, switch **Session mode** off.)
 2. Select an existing session from the dropdown or click **New Chat**.
 3. Type a message and press Enter.
 4. The agent processes the message -- the status label updates in real-time (e.g., "Reading files...", "Running tests...").
@@ -51,7 +58,7 @@ Voice chat is available directly from the Chat tab.
 ### Continue as Chat
 
 - From the Execution Detail page, click **Continue as Chat**.
-- This opens the Chat tab with a resume banner showing execution context.
+- This opens the Chat tab (temporarily in classic mode, without changing your saved Session-mode preference) with a resume banner showing execution context.
 - Uses `--resume {session_id}` for native session continuity.
 
 ### Session Management
@@ -81,6 +88,7 @@ Voice chat is available directly from the Chat tab.
 
 ## See Also
 
+- [Agent Session](agent-session.md) — the Session-mode surface of this tab
 - Backend API Docs: http://localhost:8000/docs (full request/response schemas)
 - [Creating Agents](creating-agents.md)
 - [Managing Agents](managing-agents.md)

--- a/docs/user-docs/agents/agent-configuration.md
+++ b/docs/user-docs/agents/agent-configuration.md
@@ -8,7 +8,15 @@ Each agent has independent configuration options that control its behavior, reso
 
 ### The Settings Tab
 
-The Agent Detail page has a **Settings** tab (visible to owners only) -- a sectioned home for per-agent configuration. Its first section is **Guardrails** (see [Agent Guardrails](agent-guardrails.md)); more configuration sections will move here over time. Until then, the settings below are managed from the agent header controls, toggles on the Dashboard and Agents pages, or the API.
+The Agent Detail page has a **Settings** tab (visible to owners only) -- a sectioned home for per-agent configuration. Current sections: **Guardrails** (see [Agent Guardrails](agent-guardrails.md)), **Parallel Capacity** (below), and **Expose via MCP** (publish the agent as a dedicated MCP tool — see [MCP Server](../integrations/mcp-server.md#dedicated-agent-tools-expose-via-mcp)). The remaining settings below are managed from the agent header controls, toggles on the Dashboard and Agents pages, or the API.
+
+### Parallel Capacity
+
+How many tasks the agent may run concurrently (`max_parallel_tasks`, default 3). Work beyond the limit queues and drains as slots free up.
+
+- Set it in the Settings tab's **Parallel Capacity** section; the panel shows current slot usage ("using X / Y slots").
+- **Fleet ceiling (admin):** an admin caps the whole fleet via `GET`/`PUT /api/settings/max-parallel-tasks-ceiling` (default 10, range 1–32). Owners pick any value up to the ceiling. If an agent's stored value exceeds a later-lowered ceiling, the stored value is kept but the *effective* limit is clamped to the ceiling — the panel shows a notice when this applies.
+- API: `GET /api/agents/{name}/capacity` returns the stored value, the ceiling, and the effective limit.
 
 ### Autonomy Mode
 
@@ -93,6 +101,9 @@ Set via `runtime.type` in `template.yaml`.
 
 - `claude-code` (default)
 - `gemini-cli`
+- `codex` (OpenAI Codex)
+
+See [Agent Runtimes](agent-runtimes.md) for capability differences (session resume, cost reporting, MCP support).
 
 ## For Agents
 

--- a/docs/user-docs/agents/agent-session.md
+++ b/docs/user-docs/agents/agent-session.md
@@ -1,6 +1,6 @@
 # Agent Session
 
-The Session tab in Agent Detail is a `--resume`-default chat surface that lives alongside the existing Chat tab. Each new message reattaches to the same Claude Code session, so the agent retains tool-result memory, mid-skill state, and reasoning state across turns — strictly more capable than Chat's stateless text-replay model.
+**Session mode** is the default surface of the unified **Chat** tab in Agent Detail (toggle at the top-right; the former separate Session tab merged into Chat). Each new message reattaches to the same Claude Code session, so the agent retains tool-result memory, mid-skill state, and reasoning state across turns — strictly more capable than classic chat's stateless text-replay model. Old `?tab=session` links open the Chat tab in session mode.
 
 > 📺 **Watch:** [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) *(May 2026)* · [all videos](../videos.md)
 
@@ -20,19 +20,21 @@ Both buttons sit in the Session toolbar. They look similar; they aren't:
 | **Reset memory** | Kept | Cleared (next turn is cold) | Continues on the same session | You want a fresh line of thought but want to keep the conversation transcript with the agent |
 | **+ New Session** | New (empty) | New (cold) | New (zero) | You're starting a different conversation entirely — different topic, different cost bucket |
 
-## When to use Session vs Chat
+## When to use Session mode vs classic chat
 
-| Use Session for... | Use Chat for... |
+| Use Session mode for... | Use classic chat for... |
 |---|---|
 | Long, multi-turn reasoning or planning | One-shot questions |
 | Multi-step skills where mid-skill state matters | Voice conversations |
 | Cases where you want the agent to remember tool outputs across turns | Quick file-bearing questions where memory across turns isn't important |
 
-The two surfaces share nothing — separate tables, separate sessions, separate cost tracking. Switching between them does not transfer state.
+The two surfaces share nothing — separate tables, separate sessions, separate cost tracking. Flipping the toggle does not transfer state.
+
+Session mode is unavailable (the toggle hides and classic chat is used) when the platform `session_tab_enabled` flag is off or the agent runs a runtime without `--resume` support (Codex).
 
 ## How It Works
 
-1. Open an agent's detail page and click the **Session** tab.
+1. Open an agent's detail page and click the **Chat** tab; make sure **Session mode** is on (the default).
 2. Click **+ New Session** or pick an existing session from the dropdown.
 3. Type a message and press Enter. The agent processes the message; subsequent turns reattach to the same Claude Code session UUID.
 4. Watch the session subtitle for `X% last cache` — the size of the most recent assistant turn's cache as a fraction of the model window.
@@ -129,9 +131,9 @@ When to reset:
 
 | Limitation | Detail |
 |---|---|
-| **Voice mic not wired into Session** | Voice writes to the Chat tables, not the Session tables. The mic is hidden on the Session tab. Use the Chat tab for voice. |
+| **Voice mic not wired into Session mode** | Voice writes to the classic chat tables, not the Session tables. The mic is hidden in session mode. Switch Session mode off for voice. |
 | **Agent restore from backup may force fresh sessions** | The platform backup covers SQLite (session rows + messages) but not the Docker volumes that hold Claude Code's JSONL files. After a DR restore, every session's first turn will trigger a memory-loss fallback (one cold turn under a new UUID). The visible message log is preserved. |
-| **Long Session turns may surface phantom errors in browsers** | The turn endpoint is synchronous. If the browser tab is suspended mid-turn (laptop sleep, tab freeze), the user may see a phantom error toast even though the work succeeded server-side. Refresh the page after the agent's typical completion time — the assistant message will appear if it landed in the DB. |
+| **Long turns survive a severed browser connection** | The turn endpoint is synchronous; if the browser tab is suspended mid-turn (laptop sleep, tab freeze), the UI reconciles against server state when it wakes instead of showing a false "failed to send" — the assistant message appears once the turn lands. Very long turns may still take a moment to reconcile after the tab resumes. |
 | **Stdout pipe race recovery is best-effort** | When a child subprocess inherits Claude Code's stdout, the final result event line can occasionally be lost. The system soft-recovers (treats accumulated assistant text as success), but cost and duration columns will be NULL for these recovered turns. The reply is correct; the metrics are missing. |
 
 ## For Agents
@@ -152,6 +154,6 @@ All Session endpoints return 404 when the `session_tab_enabled` feature flag is 
 
 ## See Also
 
-- [Agent Chat](agent-chat.md) — the parallel chat surface
+- [Agent Chat](agent-chat.md) — the classic (stateless) surface of the same tab
 - [Agent Configuration](agent-configuration.md)
 - [Creating Agents](creating-agents.md)

--- a/docs/user-docs/api-reference/authentication.md
+++ b/docs/user-docs/api-reference/authentication.md
@@ -4,7 +4,7 @@ Trinity supports three authentication methods: admin password login, email verif
 
 ## Concepts
 
-- **JWT Token** -- All authenticated API calls require a Bearer token in the `Authorization` header. Tokens use HS256 signing, are valid for 7 days, and are invalidated when the backend restarts.
+- **JWT Token** -- All authenticated API calls require a Bearer token in the `Authorization` header. Tokens use HS256 signing, are valid for 7 days, and are invalidated when the backend restarts. Logging out revokes the token immediately (server-side blacklist until its natural expiry) — an exfiltrated token dies with the session instead of living out its 7 days.
 - **MCP API Key** -- Keys prefixed with `trinity_mcp_` also work as Bearer tokens. Used for MCP server authentication and agent-to-agent communication.
 - **Agent-Scoped Key** -- An MCP API key restricted to a specific agent, used for agent-to-agent calls.
 
@@ -12,7 +12,7 @@ Trinity supports three authentication methods: admin password login, email verif
 
 ### Admin Login
 
-Send a form-encoded POST (not JSON) to the token endpoint:
+Send a form-encoded POST (not JSON) to the token endpoint. The `username` field accepts `admin` **or** the admin's registered email address:
 
 ```bash
 curl -s -X POST http://localhost:8000/api/token \
@@ -46,7 +46,8 @@ MCP API keys (`trinity_mcp_*`) can be used in the same way as JWT tokens.
 | `/api/auth/email/request` | POST | None | Request email verification code |
 | `/api/auth/email/verify` | POST | None | Verify email code, returns token |
 | `/api/auth/mode` | GET | None | Get auth mode configuration |
-| `/api/auth/validate` | GET | JWT | Validate current token |
+| `/api/auth/logout` | POST | JWT | Revoke the current token immediately (idempotent; no-op for MCP keys) |
+| `/api/auth/validate` | GET | JWT | Validate current token (rejects revoked tokens) |
 | `/api/users/me` | GET | JWT | Get current user info |
 | `/api/setup/status` | GET | None | First-time setup status |
 | `/api/health` | GET | None | Health check |
@@ -62,4 +63,4 @@ The following endpoints do not require a Bearer token:
 ## See Also
 
 - [Backend API docs](http://localhost:8000/docs) -- Interactive Swagger UI
-- [MCP Server](../mcp-server.md) -- MCP API key usage and agent-to-agent auth
+- [MCP Server](../integrations/mcp-server.md) -- MCP API key usage and agent-to-agent auth

--- a/docs/user-docs/automation/scheduling.md
+++ b/docs/user-docs/automation/scheduling.md
@@ -59,12 +59,22 @@ Cron-based automation for agents using APScheduler. Schedule recurring tasks wit
 | `/api/agents/{name}/schedules/{id}/trigger` | POST | Manual trigger |
 | `/api/agents/{name}/schedules/{id}/executions` | GET | Execution history |
 | `/api/agents/{name}/schedules/{id}/analytics` | GET | Per-schedule analytics (see below) |
+| `/api/agents/{name}/schedules/analytics-summary` | GET | Per-schedule performance rollup for the whole agent (`?window=7d\|14d\|30d`) |
 
 ## Per-Schedule Analytics
 
 Each schedule has an analytics view summarizing how it has been performing over a selectable time window.
 
-### In the UI
+### At-a-Glance Scorecards
+
+Performance shows up in two places without opening any analytics card:
+
+- **Schedules tab** — each schedule row carries inline stats: 7-day success rate, average duration, and a last-run status dot.
+- **Agent Overview tab** — a **"Schedules performance"** section rolls up every schedule for the selected window (success rate, average duration, run count, tool-call count per schedule) and deep-links to the Schedules tab. Tool counts are sampled over the newest runs.
+
+Both are fed by one endpoint: `GET /api/agents/{name}/schedules/analytics-summary?window=7d|14d|30d` — one row per schedule, including zero-run schedules.
+
+### Detailed Analytics Card
 
 1. Open the agent's Schedules tab.
 2. Click **Show execution history** on a schedule.

--- a/docs/user-docs/credentials/credential-management.md
+++ b/docs/user-docs/credentials/credential-management.md
@@ -27,11 +27,42 @@ Add, edit, and hot-reload credentials on agents without restarting them.
 .mcp.json               # Generated at runtime from template + .env
 ```
 
+### Which Files Can Be Injected
+
+Injection accepts a curated set of credential file types, not just `.env`. Anything outside the allow-list — and anything on the deny-list — is rejected with a 400.
+
+**Allowed:**
+
+| Path | Typical use |
+|------|-------------|
+| `.env`, `.credentials.enc`, `.mcp.json` | Core credential files (workspace root only) |
+| `.config/gcloud/**` | Google Cloud SDK credentials / service-account JSON |
+| `.kube/config` | Kubernetes kubeconfig |
+| `*.pem`, `*.key`, `*.crt`, `*.cert`, `*.p12`, `*.pfx` | TLS certificates and private keys |
+| `.ssh/id_*` | SSH key pairs (keys only — not `authorized_keys` or `config`) |
+
+**Always blocked** (deny takes precedence): anything executed or sourced at startup — shell startup files (`.bashrc`, `.profile`, `.zshrc`, …), agent instruction files (`CLAUDE.md`, `AGENTS.md`, `.claude/**`), `.mcp.json.template`, `.ssh/authorized_keys` / `.ssh/config`, `.git/**` and `.gitconfig`, anything under `bin/`, plus absolute paths and `..` traversal. `.mcp.json` content is structurally validated before it is written.
+
+**Binary credentials** (certificates, keystores, service-account bundles) round-trip as base64 via the `files_b64` field on the inject endpoint.
+
 ### Export and Import
 
-- **Export** creates an encrypted `.credentials.enc` file for backup.
-- **Import** decrypts and injects credentials from an encrypted file.
+- **Export** creates an encrypted `.credentials.enc` file for backup. It captures the **full injected credential set** — every allow-listed credential file present in the agent (discovered live), text and binary alike — not just `.env` and `.mcp.json`.
+- **Import** decrypts and injects credentials from an encrypted file. The archive is re-validated against the same path policy on the way in.
 - **Auto-import** runs on agent startup via `POST /api/internal/decrypt-and-inject`.
+
+### Rotating the Encryption Key
+
+The platform encryption key (`CREDENTIAL_ENCRYPTION_KEY`) can be rotated online, with zero downtime and no data loss:
+
+1. Back up the database (`scripts/deploy/backup-database.sh`).
+2. Generate a new key: `python3 -c "import secrets; print(secrets.token_hex(32))"`.
+3. In `.env`, set the new key as `CREDENTIAL_ENCRYPTION_KEY` and move the previous key to `CREDENTIAL_ENCRYPTION_KEY_SECONDARY` (a decrypt-only fallback).
+4. Restart the backend — existing secrets keep decrypting via the secondary key; all new writes use the new key.
+5. Re-encrypt persisted secrets onto the new key: `docker compose exec backend python scripts/deploy/rotate-credential-key.py` (dry-run), then re-run with `--apply`.
+6. Remove `CREDENTIAL_ENCRYPTION_KEY_SECONDARY` from `.env` and restart.
+
+The sweep re-encrypts every database-persisted token (subscriptions, channel bot tokens, GitHub PATs, payment credentials). Per-agent `.credentials.enc` files re-encrypt onto the new key on their next credential operation; they keep opening via the secondary key until then. Full runbook: `docs/migrations/CREDENTIAL_KEY_ROTATION.md`.
 
 ### Security
 
@@ -58,5 +89,6 @@ Credential values are never logged. All operations use structured logging with v
 
 ## See Also
 
-- [Agent Detail Page](../agents/agent-detail.md)
-- [CRED-002 Feature Flow](../../memory/feature-flows/credential-injection.md)
+- [Agent Configuration](../agents/agent-configuration.md)
+- [Subscription Credentials](subscription-credentials.md)
+- [OAuth Credentials](oauth-credentials.md)

--- a/docs/user-docs/credentials/subscription-credentials.md
+++ b/docs/user-docs/credentials/subscription-credentials.md
@@ -9,6 +9,7 @@ Share Claude Max/Pro subscription tokens across multiple agents, with automatic 
 - **Subscription** -- A Claude Max or Pro subscription token registered with Trinity. Stored encrypted (AES-256-GCM). Injected as an environment variable to assigned agents.
 - **Round-Robin Assignment** -- New agents automatically get a subscription assigned. The subscription with the fewest agents is selected first, with alphabetical tie-break.
 - **Auto-Switch (SUB-003)** -- When an agent hits a rate-limit (429) or auth-class failure, Trinity automatically switches it to a different subscription. The new token is applied via a **hot-reload** of the running container -- no container recreate -- so in-flight executions keep running. Default ON; toggle it off in the Subscriptions section of Settings.
+- **Hot-Reload Rotation** -- Manual token changes hot-reload the same way: re-registering a subscription with a fresh token pushes the new token to every running agent on that subscription, and reassigning an agent from one subscription to another swaps the token in place. In-flight turns finish on the old token; the next turn uses the new one. Container recreation is only needed for image, template, or auth-*mode* changes (e.g. switching between subscription and API key).
 
 ## How It Works
 
@@ -63,4 +64,4 @@ Share Claude Max/Pro subscription tokens across multiple agents, with automatic 
 ## See Also
 
 - [Credential Management](credential-management.md)
-- [Settings Page](../settings.md)
+- [First-Time Setup](../getting-started/setup.md) — the Settings page overview

--- a/docs/user-docs/getting-started/setup.md
+++ b/docs/user-docs/getting-started/setup.md
@@ -6,7 +6,7 @@ Install Trinity, create your admin account, and start managing agents in minutes
 
 ## Concepts
 
-- **Admin Account** -- The primary account with full platform access, authenticated by username and password. Created automatically from `ADMIN_PASSWORD` in `.env`.
+- **Admin Account** -- The primary account with full platform access. Created either from `ADMIN_PASSWORD` in `.env` at first boot, or through the first-run setup form in the browser. The admin signs in with the username `admin` **or** their registered email address, plus the password.
 - **Email Login** -- A passwordless authentication method where users receive a one-time code via email. Requires an email service to be configured.
 
 ## How It Works
@@ -26,14 +26,17 @@ Install Trinity, create your admin account, and start managing agents in minutes
    cd trinity
    ```
 
-2. Set `ADMIN_PASSWORD` in `.env` before first boot:
+2. Optionally set `ADMIN_PASSWORD` in `.env` before first boot:
 
    ```bash
    cp .env.example .env
-   # Edit .env and set ADMIN_PASSWORD to a strong password (min 12 chars)
+   # Optionally set ADMIN_PASSWORD to a strong password (min 12 chars)
    ```
 
-   The `admin` account is created automatically from this value on first start. If you leave it blank, a one-time setup token is printed to the backend logs (`docker compose logs backend | grep "Setup token"`) — paste it into the setup wizard that appears on first visit. The token is shared across backend workers, so the single value printed in the logs always works regardless of how many workers are running. If the setup wizard shows a "waiting for Redis" state, the token store is temporarily unreachable; setup resumes automatically once Redis recovers, with no restart needed.
+   - **If set**, the `admin` account is created automatically from this value on first start and no setup screen appears.
+   - **If left blank**, the first visit to the web UI shows a one-page **"Create your admin account"** form: enter your **admin email** (required — this becomes your sign-in identity), a password (12+ characters with uppercase, lowercase, number, and special character; a live strength meter guides you), confirm it, and optionally your company name. An optional checkbox opts you in to occasional security and product update emails from the Trinity team; it sends only your email and company name, nothing else, and can be disabled entirely on air-gapped installs via `OPERATOR_INTAKE_ENABLED=false` or `DO_NOT_TRACK=1`. The form works exactly once — it disables itself permanently after the admin account is created.
+
+   > **Security note:** until setup completes, the setup form is reachable without authentication. On an internet-facing server, keep the instance behind a tunnel, VPN, or firewall until you have completed first-time setup.
 
 3. Start all services:
 
@@ -47,7 +50,7 @@ Install Trinity, create your admin account, and start managing agents in minutes
 
 ### Logging In
 
-**Admin login:** Enter username `admin` and the `ADMIN_PASSWORD` you set in `.env`.
+**Admin login:** Enter username `admin` **or the admin email you registered at setup**, plus the password. (Admins created via `ADMIN_PASSWORD` in `.env` have no registered email at first; bind one later with `PUT /api/users/me/email` to enable email + password sign-in.)
 
 **Email login (passwordless):** Enter your email address, receive a 6-digit verification code, and submit it to log in. This requires email service configuration. The admin manages allowed email addresses under Settings > Email Whitelist.
 
@@ -140,5 +143,5 @@ The following endpoints do not require authentication:
 - [Quick Start](quick-start.md) -- After setup, a **guided onboarding wizard** opens on
   your first Dashboard visit to launch your first agent (relaunch any time at
   `http://localhost/?onboarding=1`).
-- [Overview](../overview.md) -- Platform overview and core concepts.
+- [Overview](overview.md) -- Platform overview and core concepts.
 - [Creating Agents](../agents/creating-agents.md) -- Deploy your first agent.

--- a/docs/user-docs/guides/deploying/backup-and-restore.md
+++ b/docs/user-docs/guides/deploying/backup-and-restore.md
@@ -13,6 +13,7 @@
 | Component | Back up? | Where it lives | Notes |
 |---|---|---|---|
 | `trinity.db` (SQLite) | **Yes — primary target** | Named volume `trinity_trinity-data` (dev) or bind-mount at `TRINITY_DATA_PATH` (prod) | Agents, schedules, chat history, credentials metadata, audit log |
+| PostgreSQL database | **Yes — if `DATABASE_URL` is set** | Bundled `trinity-postgres` container (dev) or your managed PostgreSQL (prod) | Same contents as `trinity.db`; back up with `pg_dump` (see below) instead of a file copy |
 | `.env` file | **Yes** | Host filesystem | **Not in git.** Losing it means losing `CREDENTIAL_ENCRYPTION_KEY`, which makes all encrypted credentials unrecoverable. |
 | Agent code | Not separately | Git repositories | Each agent's code lives in a git repo — already versioned there. |
 | Redis data | Not separately | Named volume `trinity_redis-data` | Ephemeral: JWT tokens, capacity counters. All regenerated on next start. |
@@ -47,6 +48,14 @@ docker run --rm \
 > ```
 
 The volume name prefix `trinity_` comes from the Docker Compose project name (the directory name). If you cloned Trinity into a differently-named directory, the prefix will differ — check with `docker volume ls | grep trinity`.
+
+> **PostgreSQL deployments:** if your instance runs with `DATABASE_URL` set, the state lives in PostgreSQL, not `trinity.db`. Back it up with `pg_dump` instead:
+> ```bash
+> # Bundled dev container
+> docker exec trinity-postgres pg_dump -U trinity trinity > ~/backups/trinity-pg-$(date +%Y%m%d-%H%M%S).sql
+> # Managed/external PostgreSQL: use your provider's snapshot tooling or pg_dump against the host
+> ```
+> Restore with `psql -U trinity trinity < backup.sql` into an empty database (services stopped first).
 
 ### Step 2: Back Up `.env`
 

--- a/docs/user-docs/guides/deploying/local-development.md
+++ b/docs/user-docs/guides/deploying/local-development.md
@@ -170,6 +170,19 @@ All platform state is stored in Docker named volumes. These survive `docker comp
 
 The volume name prefix `trinity_` comes from the Compose project name (the directory name, `trinity`).
 
+### Optional: PostgreSQL Backend
+
+SQLite is the zero-config default for local development, but the dev compose ships a bundled PostgreSQL container behind a profile (note: **SQLite support ends September 1, 2026** — production instances should run PostgreSQL; see [single-server.md](single-server.md#database-backend)):
+
+```bash
+# In .env:
+#   POSTGRES_PASSWORD=your-postgres-password
+#   DATABASE_URL=postgresql://trinity:your-postgres-password@postgres:5432/trinity
+docker compose --profile postgres up -d
+```
+
+The host in the URL is the compose service name `postgres` (Docker DNS). The switch is non-destructive — comment `DATABASE_URL` out and the next restart is back on SQLite (each backend keeps its own data).
+
 ## Troubleshooting
 
 **`ModuleNotFoundError` on backend startup** — A Python dependency was added since your last build. Rebuild:

--- a/docs/user-docs/guides/deploying/single-server.md
+++ b/docs/user-docs/guides/deploying/single-server.md
@@ -110,11 +110,23 @@ mkdir -p /srv/trinity-data
 
 ### Database backend
 
-Trinity stores all platform state in **SQLite** by default, in `trinity.db` under your `TRINITY_DATA_PATH` bind mount (`/data/trinity.db` inside the container). This is the only database backend you need to configure — the steps above are complete as written.
+Trinity stores platform state in **SQLite** by default, in `trinity.db` under your `TRINITY_DATA_PATH` bind mount (`/data/trinity.db` inside the container). SQLite works with zero configuration — but **PostgreSQL is now the recommended backend for production**, and **SQLite support ends September 1, 2026** (after that date it stops receiving schema migrations and fixes).
 
-On every backend boot, a versioned migration runner brings the SQLite schema up to date. The runner is crash-safe and concurrency-safe: a cross-process lock serialises it so multiple workers and the scheduler cannot race each other, and table rebuilds run inside a transaction that rolls back cleanly on a mid-migration crash. If a migration is still pending or has failed, the backend's `/health` endpoint returns `503` with a `migrations` block (`applied`, `expected`, `first_pending`) naming the stuck migration — so a 503 from `curl http://localhost:8000/health` during an upgrade is actionable, not opaque.
+To run on PostgreSQL, set one variable in `.env`:
 
-A PostgreSQL backend is being introduced as the next step in this work, with Postgres migrations handled by Alembic instead of the SQLite runner. **It is not yet a user-selectable backend** — there is no supported environment variable to point a deployment at Postgres today. The migration-runner safety work above is the groundwork that makes that switch possible; until it lands, run on the default SQLite backend.
+```
+DATABASE_URL=postgresql://trinity:your-postgres-password@your-db-host:5432/trinity
+```
+
+Both the backend and the scheduler pick it up. Notes for the prod compose:
+
+- `docker-compose.prod.yml` ships **no bundled PostgreSQL service** — point `DATABASE_URL` at an operator-managed instance (a managed cloud database or your own PostgreSQL server). The bundled `--profile postgres` container exists only in the dev compose.
+- Selection is non-sticky and non-destructive: comment `DATABASE_URL` out and the next restart is back on SQLite.
+- A fresh PostgreSQL database is initialized automatically on first boot (Alembic-managed migrations).
+- **Migrating an existing SQLite instance?** Use the Trinity Ops Agent's `/migrate-to-postgres` skill ([ops-agent guide](ops-agent.md)) — a validate-then-cutover flow that never writes to your SQLite file, so rollback is one line. New-instance setup details: `docs/POSTGRESQL_SETUP.md` in the repo.
+- On PostgreSQL, back up with `pg_dump` instead of copying `trinity.db` — see [Backup and Restore](backup-and-restore.md).
+
+On every backend boot, a versioned migration runner brings the schema up to date (the bespoke SQLite runner or Alembic for PostgreSQL). The runner is crash-safe and concurrency-safe: a cross-process lock serialises it so multiple workers and the scheduler cannot race each other, and table rebuilds run inside a transaction that rolls back cleanly on a mid-migration crash. If a migration is still pending or has failed, the backend's `/health` endpoint returns `503` with a `migrations` block (`applied`, `expected`, `first_pending`) naming the stuck migration — so a 503 from `curl http://localhost:8000/health` during an upgrade is actionable, not opaque.
 
 ## 3. Build the Base Agent Image
 

--- a/docs/user-docs/guides/deploying/upgrading.md
+++ b/docs/user-docs/guides/deploying/upgrading.md
@@ -46,6 +46,8 @@ sqlite3 ~/backups/trinity-<timestamp>.db ".tables"
 # Expected: a list of table names, no errors
 ```
 
+> **PostgreSQL deployments** (instances running with `DATABASE_URL` set): back up with `pg_dump` instead of copying `trinity.db` — see [Backup and Restore](backup-and-restore.md). PostgreSQL schema migrations run automatically on backend boot, same as SQLite.
+
 ### Step 2: Pull Latest Changes
 
 ```bash

--- a/docs/user-docs/integrations/mcp-server.md
+++ b/docs/user-docs/integrations/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-Trinity's MCP server exposes 80 tools for agent orchestration via the Model Context Protocol, enabling programmatic control from Claude Code, other MCP clients, or agent-to-agent communication.
+Trinity's MCP server exposes 93 tools for agent orchestration via the Model Context Protocol, enabling programmatic control from Claude Code, other MCP clients, or agent-to-agent communication.
 
 > 📺 **Watch:** [From Zero to Deployed AI Agent — MCP setup](https://youtu.be/-TSZyekDS6o) *(Apr 2026)* · [all videos](../videos.md)
 
@@ -44,7 +44,7 @@ Add Trinity as an MCP server in your Claude Code configuration:
 
 | Module | Tools | Description |
 |--------|-------|-------------|
-| `agents.ts` | 19 | Agent lifecycle, credentials, SSH, local deploy, GitHub sync, per-agent PAT |
+| `agents.ts` | 22 | Agent lifecycle, credentials, SSH, local deploy, GitHub sync, per-agent PAT, runtime-data export/import, compatibility report |
 | `chat.ts` | 4 | Chat (gateway-timeout safe), fan-out, history, logs |
 | `schedules.ts` | 8 | Schedule CRUD and execution history |
 | `executions.ts` | 3 | Execution queries, async polling, activity monitoring |
@@ -57,13 +57,29 @@ Add Trinity as an MCP server in your Claude Code configuration:
 | `notifications.ts` | 1 | Agent-to-platform notifications |
 | `events.ts` | 4 | Agent event pub/sub |
 | `docs.ts` | 1 | Agent documentation |
-| `channels.ts` | 2 | Channel group discovery + proactive group messaging |
+| `channels.ts` | 2 | Channel group discovery + proactive group messaging (Telegram and Slack) |
 | `messages.ts` | 1 | Proactive user messaging by verified email |
 | `files.ts` | 1 | `share_file` — publish file to a signed download URL |
 | `memory.ts` | 1 | `write_user_memory` — per-user memory blob, isolated server-side |
 | `loops.ts` | 3 | `run_agent_loop`, `get_loop_status`, `stop_loop` — sequential bounded task loops |
 | `voip.ts` | 1 | `call_user` — outbound phone call (flag-gated, requires a per-agent voice binding) |
-| `operator_queue.ts` | 2 | `list_operator_queue`, `get_operator_queue_item` — read-only Operating Room queue |
+| `operator_queue.ts` | 3 | `list_operator_queue`, `get_operator_queue_item`, `respond_to_operator_queue` — read and resolve Operating Room queue items |
+| `git.ts` | 6 | Deterministic git operations — status, sync, log, pull, sync-state, and the destructive reset-to-main recovery |
+| `pipelines.ts` | 2 | Read-only introspection of an agent's self-published pipelines |
+| `reports.ts` | 1 | `report` — publish a structured report to the dashboard |
+
+### Dedicated Agent Tools (Expose via MCP)
+
+An owner can publish an agent as its own first-class MCP tool. On the agent's **Settings** tab, the **Expose via MCP** section has a toggle; when enabled, the MCP server registers a dedicated `chat_with_<slug>` tool (the slug is derived from the agent name, with a short suffix on name collisions — the resolved tool name is shown next to the toggle).
+
+- No restart needed — the MCP server picks up the change on its next poll, and connected MCP clients see the tool appear (or disappear) within a few seconds.
+- The tool behaves exactly like `chat_with_agent` with the agent name pre-filled, including idempotency and timeout handling.
+- Exposure publishes the *tool*, not access: callers still need ownership or a share to actually chat with the agent.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/agents/{name}/mcp-exposed` | GET | Exposure flag + the resolved `tool_name` |
+| `/api/agents/{name}/mcp-exposed` | PUT | Toggle exposure (`{"enabled": true}`, owner-only) |
 
 ### Key Tools Worth Knowing
 

--- a/docs/user-docs/integrations/slack-integration.md
+++ b/docs/user-docs/integrations/slack-integration.md
@@ -4,7 +4,7 @@ Connect agents to Slack workspaces. Supports DMs, @mentions in channels, multi-a
 
 ## Concepts
 
-- **Channel Adapter** -- Pluggable abstraction for external messaging platforms. Slack is the first implementation; Telegram and Discord are planned.
+- **Channel Adapter** -- Pluggable abstraction for external messaging platforms. Slack, Telegram, and WhatsApp are implemented on the same interface.
 - **Socket Mode** -- Default transport using a WebSocket connection. No public URL required. Configured via a Slack App Token (`xapp-...`).
 - **Webhook Mode** -- HTTP webhook transport for production environments (fallback option).
 - **Multi-Agent Routing** -- Multiple agents can share one Slack workspace. Each agent is bound to a dedicated channel. DMs are routed to a default agent; @mentions in channels route to the bound agent.
@@ -23,8 +23,8 @@ Connect agents to Slack workspaces. Supports DMs, @mentions in channels, multi-a
 ### Per-Agent Channel Binding (Agent Sharing Tab)
 
 1. Open the agent detail page and select the **Sharing** tab.
-2. In the Slack Channel section, click **Create Channel**.
-3. A dedicated Slack channel is created and bound to this agent.
+2. Under **Channels**, click **Configure** on the **Slack** row — the Slack configuration opens in a dialog.
+3. Click **Create Channel**. A dedicated Slack channel is created and bound to this agent.
 4. All messages in that channel are routed to the bound agent.
 5. To disconnect, click **Unbind**.
 
@@ -54,6 +54,24 @@ Transport -> Adapter -> Router -> Agent -> Response
 | @mention in channel | Bound agent for that channel |
 | Thread reply (no @mention) | Same agent that was originally mentioned |
 
+### Agent Identity in Channels
+
+- **The agent sees who's talking and where.** Channel (non-DM) messages reach the agent with an identity prefix such as `[Channel: #engineering]` / `[From: John Smith (@johndoe)]`, so it can address people by name and adapt to the room. DMs stay clean — no prefix.
+- **The agent replies as itself.** Replies post with the agent's name and its avatar as the per-message bot icon (via the `chat:write.customize` scope), so multiple agents in one workspace are visually distinct.
+
+### Voice Replies (Outbound)
+
+The agent can speak its replies as inline MP3 voice clips uploaded into the thread (Slack renders MP3 with a built-in player). Enable the shared **Voice replies** toggle inside the Slack dialog — see [Voice Replies](../advanced/voice-replies.md).
+
+### Proactive Channel Messages
+
+Agents can post to their bound Slack channels without waiting to be mentioned — for scheduled digests, alerts, or follow-ups:
+
+- MCP tools: `list_channel_groups(channel_type: "slack")` discovers the agent's bound channels; `send_group_message(channel_type: "slack", chat_id, message, thread_ts?)` posts to one, optionally into an existing thread via `thread_ts`.
+- REST: `GET /api/agents/{name}/slack/channels` lists bound channels; `POST /api/agents/{name}/slack/channels/{channel_id}/messages` posts (owner-gated).
+- Rate limits: 10 messages/hour per channel, 100/hour per agent. Message cap 4,000 characters.
+- Proactive posts carry the agent's identity (name + avatar icon), same as replies.
+
 ### Rate Limiting
 
 | Setting | Default |
@@ -79,6 +97,8 @@ Rate limit and timeout values are configurable via settings (`channel_rate_limit
 | `/api/agents/{name}/slack/channel` | POST | Create and bind channel |
 | `/api/agents/{name}/slack/channel` | DELETE | Unbind channel |
 | `/api/agents/{name}/slack/channel/dm-default` | PUT | Set this agent as the DM default for its workspace |
+| `/api/agents/{name}/slack/channels` | GET | List channels bound to this agent (for proactive messaging) |
+| `/api/agents/{name}/slack/channels/{channel_id}/messages` | POST | Post a proactive message to a bound channel (owner-gated, rate-limited) |
 
 ## Limitations
 
@@ -89,5 +109,13 @@ Rate limit and timeout values are configurable via settings (`channel_rate_limit
 
 ## See Also
 
-- [Channel Adapters](../../memory/feature-flows/slack-channel-adapter.md)
-- [Agent Sharing](../agents/sharing.md)
+**Trinity docs:**
+
+- [Agent Sharing & Access](../sharing-and-access/agent-sharing.md) — the Sharing tab that hosts the Slack dialog
+- [Voice Replies](../advanced/voice-replies.md) — spoken replies across channels
+- [Telegram Integration](telegram-integration.md) · [WhatsApp Integration](whatsapp-integration.md)
+
+**External references:**
+
+- [Slack: Socket Mode](https://api.slack.com/apis/socket-mode) — the default transport (no public URL needed)
+- [Slack: chat.postMessage](https://api.slack.com/methods/chat.postMessage) — the message-posting primitive, including `username`/`icon_url` customization

--- a/docs/user-docs/integrations/telegram-integration.md
+++ b/docs/user-docs/integrations/telegram-integration.md
@@ -56,9 +56,9 @@ By default, Telegram bots have **Privacy Mode enabled**. This means:
 ### Connect Bot to Agent (Agent Detail -> Sharing Tab)
 
 1. Open the agent detail page
-2. Select the **Sharing** tab
-3. In the Telegram section, paste your bot token
-4. Click **Connect Bot**
+2. Select the **Sharing** tab and find the **Telegram** row under **Channels**
+3. Click **Configure** — the Telegram configuration opens in a dialog
+4. Paste your bot token and click **Connect Bot**
 5. Trinity validates the token and registers the webhook
 
 After connecting:
@@ -94,6 +94,10 @@ Voice notes sent to the bot are automatically transcribed with Google Gemini 2.0
 | Config required | `GEMINI_API_KEY` set on the backend |
 
 If transcription fails or `GEMINI_API_KEY` is not configured, the agent receives a placeholder such as `[Voice message received — transcription failed]` so the conversation still progresses.
+
+### Voice Replies (Outbound)
+
+The agent can also *speak its replies* as Telegram voice notes (OGG/Opus via `sendVoice`; in groups the note replies to the triggering message). This is a per-agent setting shared across all messaging channels — enable it with the **Voice replies** toggle inside the Telegram dialog. See [Voice Replies](../advanced/voice-replies.md) for setup and fallback behavior.
 
 ### Bot Commands
 

--- a/docs/user-docs/integrations/whatsapp-integration.md
+++ b/docs/user-docs/integrations/whatsapp-integration.md
@@ -24,7 +24,9 @@ Add the following path rule in your Cloudflare Tunnel dashboard so Twilio webhoo
 
 | Route | Backend |
 |-------|---------|
-| `/api/whatsapp/webhook/*` | `http://frontend:80` (or `http://backend:8000` if routing directly) |
+| `/api/whatsapp/webhook/*` | `http://backend:8000` |
+
+The webhook is a backend FastAPI route (Twilio-signature verified). Routing it to the frontend service silently drops inbound messages — point it at the backend.
 
 Without this rule, Twilio webhooks return 404 at the Cloudflare edge and never reach Trinity. The UI shows a yellow notice as a reminder.
 
@@ -58,8 +60,8 @@ You need three values from Twilio: **Account SID**, **Auth Token**, and a **What
 ### Connect WhatsApp to an Agent
 
 1. Open the agent detail page
-2. Select the **Sharing** tab
-3. Scroll to the **WhatsApp (Twilio)** section
+2. Select the **Sharing** tab and find the **WhatsApp** row under **Channels**
+3. Click **Configure** — the WhatsApp (Twilio) configuration opens in a dialog
 4. Enter:
    - **Twilio Account SID** — starts with `AC`, 34 characters long
    - **Auth Token** — from the Twilio Console (stored encrypted)
@@ -96,6 +98,25 @@ On the connected state, click **Verify** to confirm the stored credentials are s
 ### Disconnect
 
 Click **Disconnect** to remove the binding. The Twilio sender is not affected — only the Trinity configuration is removed.
+
+### Outbound Media & Files
+
+Agents can deliver files and images in their WhatsApp replies, not just text. Each file is hosted transiently by Trinity (~1 hour) and sent as a Twilio media attachment — one message per file, since WhatsApp allows a single media item per message. The text reply always goes out first, so it survives even if a media send fails.
+
+| File type | Delivered as | Size cap |
+|-----------|--------------|----------|
+| Images, audio, video | Native media | 5 MB |
+| Text and structured documents (txt, JSON, XML, PDF, YAML, SQL, …) | Document | 16 MB |
+| Unknown binary types | Not deliverable as media | — |
+
+Rules:
+
+- Outbound media requires the agent's **file-sharing** toggle to be on (Sharing tab → Distribution → File sharing) and a configured **Public Chat URL** (media links must be HTTPS).
+- A file that is oversized, of an unsupported type, or otherwise undeliverable degrades to a `📎 name: url` download link appended to the text reply — it never blocks the reply or other files.
+
+### Voice Replies (Outbound)
+
+The agent can speak its replies as WhatsApp voice notes (OGG, delivered via Twilio media). Enable the shared **Voice replies** toggle inside the WhatsApp dialog — see [Voice Replies](../advanced/voice-replies.md). Voice notes work even when the file-sharing toggle is off; they are gated only by their own setting.
 
 ## User Commands
 
@@ -182,7 +203,7 @@ Go to **Settings → Public Chat URL** and enter your Trinity instance's public 
 
 ### Twilio webhook returns 404
 
-The Cloudflare Tunnel ingress rule for `/api/whatsapp/webhook/*` is missing or misconfigured. Add it in the Cloudflare dashboard pointing to the frontend or backend service.
+The Cloudflare Tunnel ingress rule for `/api/whatsapp/webhook/*` is missing or misconfigured. Add it in the Cloudflare dashboard pointing to the **backend** service (`http://backend:8000`).
 
 ### HMAC signature validation fails
 
@@ -205,5 +226,6 @@ Twilio returns 401 if the AccountSid/AuthToken combination is invalid. Re-copy t
 
 - [Telegram Integration](telegram-integration.md)
 - [Slack Integration](slack-integration.md)
+- [Voice Replies](../advanced/voice-replies.md)
 - [Access Control](../sharing-and-access/access-control.md)
-- [Agent Sharing](../sharing-and-access/agent-sharing.md)
+- [Agent Sharing & Access](../sharing-and-access/agent-sharing.md)

--- a/docs/user-docs/operations/executions.md
+++ b/docs/user-docs/operations/executions.md
@@ -21,7 +21,7 @@ View, monitor, and manage task executions across all agents. Executions are crea
 | `fan_out` | Fan-out to multiple agents |
 | `loop` | Sequential agent loop iteration |
 
-**Execution Status** -- Every execution moves through a lifecycle: `queued` -> `running` -> `success`, `failed`, `error`, `cancelled`, or `skipped`.
+**Execution Status** -- Every execution moves through a lifecycle: `queued` -> `running` -> `success`, `failed`, `error`, `cancelled`, or `skipped`. A run you stop yourself terminates as `cancelled` — a distinct state, not a failure: it has its own filter option and badge in the Executions list, and renders neutral (not red) on the activity timeline.
 
 **Parallel Capacity** -- Each agent has a configurable slot system (default: 3 concurrent slots). Slot TTL equals the agent timeout plus a 5-minute buffer. When all slots are occupied, new executions queue until a slot frees up.
 

--- a/docs/user-docs/operations/monitoring.md
+++ b/docs/user-docs/operations/monitoring.md
@@ -37,9 +37,9 @@ The tab shows summary cards (Total Agents, Healthy, Degraded, Unhealthy, Critica
 
 ### Enabling Monitoring
 
-The periodic health-check loop is **disabled by default**. A status badge at the top of the Health tab shows the current state: "Monitoring Active" or "Monitoring Disabled".
+The periodic health-check loop is **disabled by default**. A status badge at the top of the Health tab shows the current state: "Monitoring Active" or "Monitoring Disabled", with an **Enable monitoring** / **Disable monitoring** button next to it (admin only) — no API call needed.
 
-Enable or disable it via the API (admin only):
+The same control is available via the API (admin only):
 
 ```
 POST /api/monitoring/enable

--- a/docs/user-docs/sharing-and-access/access-control.md
+++ b/docs/user-docs/sharing-and-access/access-control.md
@@ -45,15 +45,17 @@ This default is **on** out of the box (secure-by-default). It applies at agent-c
 
 ### Access Modes
 
-**Restrictive (default)**: Only owner, admins, and explicitly shared users can chat. Others see "Your access request is pending approval."
+The Sharing tab presents this as a single **Restricted ↔ Open** switch under "Who can chat with this agent?":
 
-**Open access**: Any user with a verified email can chat immediately. Enable via the **Open access** toggle.
+**🔒 Restricted (default)**: Only owner, admins, and explicitly approved users can chat. Others see "Your access request is pending approval."
+
+**🌐 Open**: Any user with a verified email can chat immediately.
 
 ### Approving Access Requests
 
 When someone requests access:
 
-1. Their request appears in the **Sharing** tab under "Pending access requests."
+1. Their request appears in the **Sharing** tab as a "Pending requests" list under the Restricted/Open switch.
 2. Click **Approve** to grant access (adds them to the share list).
 3. Click **Deny** to reject.
 

--- a/docs/user-docs/sharing-and-access/agent-sharing.md
+++ b/docs/user-docs/sharing-and-access/agent-sharing.md
@@ -1,35 +1,80 @@
-# Agent Sharing
+# Agent Sharing & Access
 
-Share agents with team members via email. Shared users get access to interact with the agent but cannot modify its configuration.
+Two owner-only tabs on the Agent Detail page control who can reach an agent: the **Access** tab manages *Trinity operators* (platform users — your teammates), and the **Sharing** tab manages *external clients* (outside users reaching the agent through Slack, Telegram, WhatsApp, voice calls, or public links).
 
-## How It Works
+## Concepts
 
-1. Open the agent detail page and click the **Sharing** tab (visible to the owner only).
-2. Enter the email address of the person you want to share with.
-3. Click **Share**. The email is automatically added to the platform whitelist.
-4. The shared user can now see and interact with the agent (chat, tasks, view files).
+- **Operator** — A Trinity platform user. Operators log into the Trinity UI and get interact-level access to agents shared with them.
+- **External client** — Someone without a Trinity account who reaches the agent through a channel (Slack, Telegram, WhatsApp, a phone call) or a public link. Identified by verified email.
+- **Access policy** — The per-agent Restricted/Open switch controlling whether unknown verified users may chat. See [Access Control](access-control.md) for the cross-channel verification model.
 
-### Proactive Messaging
+## Access Tab — Trinity Operators
 
-Enable agents to send proactive messages (via Telegram, Slack, or web) to shared users:
+The **Access** tab lists platform users with access to this agent.
 
-1. In the Sharing tab, find the user in the shared list.
-2. Toggle **Allow Proactive** to enable/disable proactive messaging for that user.
-3. When enabled, the agent can initiate contact with that user without waiting for them to message first.
+1. Open the agent detail page and click the **Access** tab (owner only).
+2. Enter a teammate's email and click **Add operator**. The email is also added to the platform login whitelist.
+3. Each row shows a status badge:
+   - **Active** — the email resolved to an existing Trinity account (shows username, role, and last-active time).
+   - **Pending** — no account yet ("Invited — no account yet"); the entry activates automatically once the person logs in for the first time.
+4. Click **Remove** on a row to revoke access.
 
-## Access Levels
+### Access Levels
 
 | Level | Permissions |
 |-------|-------------|
 | **Owner** | Full control -- create, delete, configure, share, manage credentials and schedules. |
-| **Shared** | Interact only -- chat, run tasks, view files and logs. Cannot modify config, credentials, or permissions. |
+| **Shared operator** | Interact only -- chat, run tasks, view files and logs. Cannot modify config, credentials, or permissions. |
 | **Admin** | Full access to all agents regardless of ownership. |
 
-### Access Control Enforcement
+Enforcement notes:
 
 - All API endpoints check ownership or sharing status before granting access.
 - Shared users see only their own chat messages. Admins see all messages.
 - Deleting an agent cascades to remove all associated sharing records.
+
+## Sharing Tab — External Clients
+
+The **Sharing** tab is organized around "who outside the team can reach this agent, and through what." Sections, top to bottom:
+
+### Who can chat with this agent?
+
+A single **Restricted ↔ Open** control:
+
+- **🔒 Restricted** — only approved people chat. Unknown verified users generate a pending access request you approve or deny right below the switch.
+- **🌐 Open** — anyone with a verified email chats immediately.
+
+This is the same cross-channel policy described in [Access Control](access-control.md) — approving a request admits that email on every channel at once.
+
+### Public chat model
+
+Pick the Claude model used for **public-facing** conversations only — the public link, Slack/Telegram/WhatsApp channels, and paid chat. Your own authenticated chats and scheduled runs are unaffected. The default option ("Use platform default") inherits the platform-wide model; selecting a model overrides it for this agent's public surfaces.
+
+### Additional instructions — public & channel chats only
+
+A free-text field (up to 4,000 characters) injected into the agent's system prompt **for outside audiences only**: public links, Slack/Telegram/WhatsApp, and paid chat. It does not affect your own authenticated chats, scheduled runs, loops, or agent-to-agent calls. Use it to set tone, disclosure rules, or scope limits for strangers without touching the agent's core instructions. Leave empty to disable. (Voice/VoIP has its own prompt — see [Voice Chat](../advanced/voice-chat.md).)
+
+### Channels
+
+Compact status rows for **Slack**, **Telegram**, **WhatsApp**, and **Voice calls** (when VoIP is enabled platform-wide). Each row shows a connection status dot and a **Configure** (not connected) or **Manage** (connected) button that opens the channel's full configuration in a dialog. Per-channel setup guides:
+
+- [Slack Integration](../integrations/slack-integration.md)
+- [Telegram Integration](../integrations/telegram-integration.md)
+- [WhatsApp Integration](../integrations/whatsapp-integration.md)
+- [VoIP Telephony](../advanced/voip-telephony.md)
+
+Each channel dialog also carries the shared **Voice replies** toggle — see [Voice Replies](../advanced/voice-replies.md).
+
+### Client roster — who's reaching this agent
+
+A read-only table of external channel users who have messaged the agent, aggregated across Telegram and WhatsApp (more channels to follow): client name, channel, verified email, message count, and last-active time, ordered by most recent. The roster is database-sourced, so it renders even when the agent container is stopped.
+
+### Distribution
+
+Two collapsible panels for distributing the agent's output rather than granting access:
+
+- **Public links** — shareable chat URLs; see [Public Links](public-links.md).
+- **File sharing** — signed download URLs for files the agent publishes.
 
 ## For Agents
 
@@ -38,7 +83,16 @@ Enable agents to send proactive messages (via Telegram, Slack, or web) to shared
 | `/api/agents/{name}/share` | POST | Share agent with an email address |
 | `/api/agents/{name}/share/{email}` | DELETE | Remove a share |
 | `/api/agents/{name}/shares` | GET | List all shares for an agent |
+| `/api/agents/{name}/access` | GET | Operator roster (active + pending) for the Access tab |
+| `/api/agents/{name}/clients` | GET | External client roster (owner-only, read-only) |
+| `/api/agents/{name}/public-prompt` | GET / PUT | Public/channel-only custom instructions (owner-only, ≤4000 chars; empty clears) |
+| `/api/agents/{name}/public-channel-model` | GET / PUT | Public-channel model override (owner-only; null clears to platform default) |
+
+See [Backend API Docs](http://localhost:8000/docs) for full request/response schemas.
 
 ## See Also
 
-- [Email Whitelist](../settings/email-whitelist.md) -- manage which emails can access the platform.
+- [Access Control](access-control.md) — cross-channel email verification and access requests
+- [Public Links](public-links.md) — shareable chat URLs
+- [Voice Replies](../advanced/voice-replies.md) — spoken replies on Slack, Telegram, and WhatsApp
+- [MCP Server](../integrations/mcp-server.md) — exposing an agent as a dedicated MCP tool

--- a/docs/user-docs/sharing-and-access/public-links.md
+++ b/docs/user-docs/sharing-and-access/public-links.md
@@ -12,7 +12,7 @@ Shareable URLs that let unauthenticated users chat with agents. Supports optiona
 
 ## How It Works
 
-1. Open the agent detail page and go to the **Sharing** tab.
+1. Open the agent detail page and go to the **Sharing** tab. Public links live under **Distribution → Public links**.
 2. Click **Create Public Link**.
 3. Configure the link: email verification on/off, rate limits, custom welcome message.
 4. Copy the generated URL and share it with recipients.
@@ -20,6 +20,10 @@ Shareable URLs that let unauthenticated users chat with agents. Supports optiona
 6. If email verification is enabled: the user enters their email, receives a verification code, verifies, then chats.
 7. Conversations persist -- the user can return later and continue where they left off.
 8. Click **New Conversation** to start a fresh session.
+
+### Model and Instructions for Public Chats
+
+Two per-agent settings on the Sharing tab shape public-link conversations (and channel chats) without touching the agent's core configuration: the **Public chat model** override and the **Additional instructions — public & channel chats only** field. Both apply to public links, Slack/Telegram/WhatsApp, and paid chat — never to the owner's own chats or schedules. See [Agent Sharing & Access](agent-sharing.md#public-chat-model).
 
 ### Chat History for Logged-In Users
 

--- a/docs/user-docs/whats-new/README.md
+++ b/docs/user-docs/whats-new/README.md
@@ -4,5 +4,6 @@ User-facing highlights for each Trinity release — what changed and why it matt
 
 ## Releases
 
+- [v0.7.0](v0.7.0.md) — 2026-06-23 · PostgreSQL goes to production (SQLite end-of-support dated); OpenAI Codex runtime, portable agent data, credential hot-reload, agent isolation hardening.
 - [v0.6.1](v0.6.1.md) — 2026-06-12 · UI/UX + reliability; unified Operations area, Agent Overview dashboard, sequential loops, VoIP phone calls, secure-by-default access.
 - [v0.6.0](v0.6.0.md) — 2026-06-01 · Reliability + security release; stateful Session chat and experimental Voice Workspace.

--- a/docs/user-docs/whats-new/v0.7.0.md
+++ b/docs/user-docs/whats-new/v0.7.0.md
@@ -1,0 +1,50 @@
+# What's New in Trinity v0.7.0
+
+*Released 2026-06-23*
+
+Trinity now runs on **PostgreSQL** as the recommended production database. SQLite stays the zero-config default for local development and evaluation, but production instances should plan the move — SQLite support ends **September 1, 2026**. Alongside the database work, this release adds a second agent runtime (OpenAI Codex), portable agent data, credential rotation without restarts, and a broad batch of execution-reliability fixes.
+
+## Improvements
+
+- **PostgreSQL for production** — Point Trinity at PostgreSQL with a single `DATABASE_URL` variable; both the backend and the scheduler switch over. A bundled `postgres` compose profile stands up the database container for you. The setting is non-destructive: comment it out and you're back on SQLite at the next restart. To migrate an existing SQLite instance, the Trinity Ops Agent ships a `/migrate-to-postgres` skill — a validate-then-cutover flow that never writes to your SQLite file, so rollback is always one line.
+- **OpenAI Codex runtime** — Agents can now run on OpenAI Codex as an alternative engine to Claude Code. Pick the runtime in the agent template; existing agents are unaffected and default to Claude Code.
+- **Portable agent data** — Templates can declare data paths (databases, datasets) that survive upgrades, and you can export or import an agent's runtime data as an archive. Moving an agent to another instance is now: template + encrypted credentials + data export.
+- **Credential rotation without restarts** — Rotating an agent's subscription token now hot-reloads the running container. In-flight work finishes on the old token; the next task uses the new one. Container recreation is only needed for image or template changes.
+- **Agent compatibility report** — Trinity checks a running agent's workspace against ~100 best-practice rules and shows findings on the agent's Overview tab, with one-click fixes for common issues like missing gitignore entries.
+- **Per-schedule performance scorecards** — Each schedule now shows its success rate, average duration, and cost — inline on the Schedules tab and rolled up in a "Schedules performance" section on the agent Overview.
+- **In-app bug reporting** — Report a bug directly from the floating Help widget; reports are routed to the Trinity team without leaving the app.
+- **Respond to approvals programmatically** — Agents and scripts can now answer, approve, or deny pending operator-queue items through MCP tools, not just read them.
+- **WhatsApp attachments** — Agents can deliver files and images in WhatsApp replies, not just text.
+- **Admin email sign-in** — The admin account can log in with its registered email address and password, not only the `admin` username.
+- **Clean cancellations** — Cancelling a running task now stops it cleanly and records it as *cancelled*, distinct from *failed*.
+
+## Fixes
+
+- **First-time setup works reliably on fresh installs** — the one-time setup code was sometimes lost or inconsistent across server workers.
+- **GitHub token updates reach running agents** — setting or changing an agent's GitHub token no longer requires recreating the container for pushes to work.
+- **Dashboard loads fast with large fleets** — the dashboard and timeline no longer take 20+ seconds to load metrics with ten or more agents.
+- **Agents no longer silently run out of scratch space** — the temporary directory that broke autonomous git commits when full is now configurable, and heavy build caches are redirected to persistent disk.
+- **Timeouts keep their telemetry** — a task that hits its timeout no longer loses its cost, context, and tool-call data.
+- **No more empty "failed" rows on slow dispatch** — the scheduler records a meaningful error instead of a blank failure when an agent is slow to accept a task.
+- **Avatar generation failures now say why** — instead of a generic "failed to generate avatar."
+- **UI polish** — the agent panel no longer changes width when switching to the Chat tab, the Build Info dialog shows real values in local development, and a light-theme hover artifact on the agent list is gone.
+- **v0.6.1 regressions fixed** — two settings screens that returned server errors (the operations auth report and per-agent capabilities) work again.
+
+## Security & Hardening
+
+- **Agents are isolated from each other at the API level.** Every call to an agent's internal server now requires a per-agent authentication token, closing a path where one compromised agent could reach a sibling agent's credentials over the shared network. Existing agents pick up their token through one automatic recreation pass after the upgrade.
+- **Database migrations are crash-safe** — a failure mid-migration now rolls back cleanly instead of leaving a partially rebuilt table, and multiple server processes can no longer race the migration runner.
+
+## Upgrade Notes
+
+- **Production databases:** PostgreSQL is now the recommended backend. Opt in by setting `DATABASE_URL`; SQLite remains the default until **September 1, 2026**. See the [PostgreSQL setup guide](../../POSTGRESQL_SETUP.md), or use the Ops Agent's `/migrate-to-postgres` for an existing instance.
+- **Agent authentication:** the start script auto-generates a new `AGENT_AUTH_SECRET` (like `SECRET_KEY`). Existing agents go through one self-reconciling recreation pass to receive their per-agent token — no manual action needed.
+- **Runtimes:** existing agents stay on Claude Code; no action required.
+
+## See Also
+
+- [Agent Runtimes](../agents/agent-runtimes.md)
+- [Agent Data & Portability](../agents/agent-data.md)
+- [Subscription Credentials](../credentials/subscription-credentials.md)
+- [Scheduling](../automation/scheduling.md)
+- [Release notes (technical)](../../releases/0.7.0.md)


### PR DESCRIPTION
## Summary

Syncs `docs/user-docs/` with everything user-facing that landed since the last docs sync on 2026-06-22 (123 commits, including the v0.7.0 release). All content is code-derived — endpoints, UI labels, and behaviors were verified against routers, Vue components, and config rather than commit messages. 27 files: 2 new, 25 updated. Docs-only; no code changes.

### New pages
- **`whats-new/v0.7.0.md`** — user-facing release highlights (PostgreSQL for production + SQLite end-of-support 2026-09-01, Codex runtime, portable agent data, credential hot-reload, agent-isolation hardening). Indexed in both READMEs. (`docs/releases/v0.6.2.md` is an unreleased draft folded into 0.7.0, so it intentionally gets no What's New page.)
- **`advanced/voice-replies.md`** — canonical outbound-TTS page shared by Telegram/Slack/WhatsApp (epic #24); channel docs cross-reference it instead of repeating it.

### Major updates
- **`agent-sharing.md` rewritten** for the Access-tab/Sharing-tab split: operator roster (active vs pending), Restricted↔Open control, client roster, channel config dialogs, public chat model (#894), public-only custom instructions (#1205).
- **`setup.md`** — the removed setup-token flow is gone from the docs; now documents the one-page admin-account form (required email as sign-in identity, opt-in updates) and the pre-setup network-restriction responsibility. Verified `ADMIN_PASSWORD` in `.env` still bypasses the wizard.
- **`agent-chat.md` / `agent-session.md`** — unified Chat tab with Session-mode toggle (#1112); severed-turn reconcile replaces the phantom-error limitation (#1377).
- **Deploy spokes** — `DATABASE_URL`/Postgres path + SQLite EOL (#300/#1183/#1278); fixes `single-server.md`'s stale claim that Postgres "is not yet user-selectable"; `pg_dump` backup notes in backup/upgrade guides; bundled `--profile postgres` recipe for local dev.
- **`whatsapp-integration.md`** — corrects the tunnel-route advice to `backend:8000` (the doc reproduced the exact misconfiguration fixed in #1281); adds outbound media (#1315).
- **`mcp-server.md`** — tool catalog corrected to 93 tools (counted from source); operator-queue respond tool (#1104); dedicated `chat_with_<slug>` exposure (#846). The MCP connector panel is enterprise-entitlement-gated and deliberately not documented.
- **Smaller**: Slack channel identity/bot icon/proactive messages (#350, #292), VoIP config panel + persisted voice incl. Gacrux, curated credential file types (#1305), online key rotation (#267), hot-reload token rotation (#1089), fleet parallel-tasks ceiling (#506), monitoring UI toggle (#1409), JWT logout revocation (#187), cancelled execution state (#679), schedule scorecards (#1115), Codex in the runtime list (#1187). Four pre-existing broken relative links fixed.

## Verification

- `grep -nE '#[0-9]+|AISEC|RELIABILITY-[0-9]|CRED-[0-9]|[A-Z]+-00[0-9]'` on `whats-new/` → zero hits (no issue numbers/codenames in user-facing release notes)
- Enterprise-docs-guard pattern grep across `docs/user-docs/` → zero hits
- Deploy-guide public-safety greps (ssh/tailnet/IPs/instance dirs) → zero hits
- All relative links in changed files resolve
- No secrets/PII; placeholders only

🤖 Generated with [Claude Code](https://claude.com/claude-code)