### PR TITLE
feat(settings): admin-configurable Brain Orb flags (trinity-enterprise#85)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -682,12 +682,20 @@ Trinity reads/renders + brokers control. Default OFF — no impact on other agen
   subprocess (timeout-kill, output cap, JSON-parse + non-zero-exit guards); **404 when the
   hook is absent**. Trinity never runs `export_data.py` itself — the agent owns generation +
   scope state (Invariant #8).
-- Platform flags: `brain_orb_available = BRAIN_ORB_ENABLED` (env, default OFF — static
-  render, no Gemini dependency); **`brain_orb_voice_available = BRAIN_ORB_VOICE_ENABLED &&
-  GEMINI_API_KEY`** (default OFF — Phase 3 voice tile, distinct because voice needs a Gemini
-  key). Voice frontend assets are CSP-clean (hand-rolled Gemini client, externalized
-  `voice/voice.js`, same-origin `voice/mic-worklet.js`; `connect-src` already allows `wss:`).
-  No DB change, no migration, no new secret.
+- Platform flags (**runtime-resolved, admin-configurable — trinity-enterprise#85**): the three
+  flags resolve at request time via `settings_service.is_brain_orb_enabled()` /
+  `..._voice_enabled()` / `..._write_enabled()` — `system_settings` row (wins in both
+  directions) → `BRAIN_ORB_*` env var as opt-in fallback → default OFF (one shared
+  `_resolve_bool_flag` helper; fail-open on a settings-read failure; deliberately uncached,
+  #506 `--workers 2` rationale). **Precedence note:** once a stored row exists the env var is
+  ignored until the override is cleared (`PUT /api/settings/brain-orb {clear: [...]}` or
+  generic `DELETE /api/settings/{key}`). Compositions: `brain_orb_available = base`;
+  `brain_orb_voice_available = base && voice && GEMINI_API_KEY` (key stays env-only — secret);
+  `brain_orb_write_available = base && write`; the voice-token mint route gates on
+  `base && voice` too. Admin surface: `GET/PUT /api/settings/brain-orb` (Settings → General
+  panel with per-flag source display). Voice frontend assets are CSP-clean (hand-rolled Gemini
+  client, externalized `voice/voice.js`, same-origin `voice/mic-worklet.js`; `connect-src`
+  already allows `wss:`). No DB change, no migration, no new secret.
 
 ---
 
@@ -745,7 +753,7 @@ Trinity reads/renders + brokers control. Default OFF — no impact on other agen
 | GET | `/api/agents/{name}/brain-orb/data` | Read-only proxy of the agent's Brain Orb `data.json` (`AuthorizedAgentByName`; byte pass-through; 404 when flag off / no export, 503/504 unreachable, 502 agent error). See [Brain Orb](#brain-orb--self-rendering-mind-page-58-trinity-enterprise) (#58) |
 | GET | `/api/agents/{name}/brain-orb/scopes` | List the agent's selectable + active vault scopes for the orb scope panel (`AuthorizedAgentByName`; 404 when unsupported). (#58 Phase 2) |
 | POST | `/api/agents/{name}/brain-orb/scope` | Mutate the active scope set → agent re-export (**`OwnedAgentByName`** — owner/admin; body-capped; 404 when unsupported). (#58 Phase 2) |
-| POST | `/api/agents/{name}/brain-orb/voice-token` | Mint a short-lived, config-locked Gemini Live **ephemeral token** for the client-held voice tile (`AuthorizedAgentByName`; per-(user,agent) rate-limited; 404 when `BRAIN_ORB_VOICE_ENABLED` off, 503 no key, 502 mint error). Response field `ephemeral_token`. (#60 Phase 3) |
+| POST | `/api/agents/{name}/brain-orb/voice-token` | Mint a short-lived, config-locked Gemini Live **ephemeral token** for the client-held voice tile (`AuthorizedAgentByName`; per-(user,agent) rate-limited; 404 when the runtime-resolved base or voice flag is off (#85), 503 no key, 502 mint error). Response field `ephemeral_token`. (#60 Phase 3) |
 | POST | `/api/agents/{name}/brain-orb/tool` | Read-only KB search — proxies to the agent's `~/.trinity/brain-orb/search` hook (`AuthorizedAgentByName`; 404 when unsupported). (#60 Phase 3) |
 | GET | `/api/agents/{name}/compatibility` | Compatibility report (`?include_ai=` forces fresh AI; STATIC live + persisted AI). Non-blocking; `unavailable` when stopped. See [Agent Compatibility Validation](#agent-compatibility-validation-668) (#668) |
 | POST | `/api/agents/{name}/compatibility/fix` | Owner/admin; apply a gitignore auto-fix (`{check_id}`). 400 non-fixable, 409 concurrent fix. Uncommitted until next git sync (#668) |
@@ -946,10 +954,11 @@ Coverage: agent lifecycle, auth, sharing, credentials, settings, rename; request
 | Method | Path | Description |
 |--------|------|-------------|
 | GET/PUT/DELETE | `/api/settings/mcp-url` | Get (any auth user) / set / reset-to-auto-detect (admin-only) MCP server URL |
-| GET | `/api/settings/feature-flags` | Public-safe UI gating flags (any auth user): `session_tab_enabled`, `voice_available` (`VOICE_ENABLED && GEMINI_API_KEY`), `workspace_available` (voice AND `WORKSPACE_ENABLED`, #860), `voip_available` (#1056), `brain_orb_available` (`BRAIN_ORB_ENABLED`, default OFF; gates the Brain Orb page — #58), `brain_orb_voice_available` (`BRAIN_ORB_VOICE_ENABLED && GEMINI_API_KEY`, default OFF; gates the client-held voice tile — #60), `mcp_agent_chat_pull_enabled` (#946 observability-only; routing gate is the MCP server's own `MCP_AGENT_CHAT_PULL_ENABLED`, default OFF), `redelivery_governor_enabled` (#1085 observability-only; default OFF), `enterprise_features` (registered enterprise modules; empty in OSS-only or `TRINITY_OSS_ONLY=1`) (#847) |
+| GET | `/api/settings/feature-flags` | Public-safe UI gating flags (any auth user): `session_tab_enabled`, `voice_available` (`VOICE_ENABLED && GEMINI_API_KEY`), `workspace_available` (voice AND `WORKSPACE_ENABLED`, #860), `voip_available` (#1056), `brain_orb_available` (runtime-resolved: `system_settings` override → `BRAIN_ORB_ENABLED` env opt-in → OFF; gates the Brain Orb page — #58/#85), `brain_orb_voice_available` (`base && voice && GEMINI_API_KEY`, all but the key runtime-resolved, default OFF; gates the client-held voice tile — #60/#85), `mcp_agent_chat_pull_enabled` (#946 observability-only; routing gate is the MCP server's own `MCP_AGENT_CHAT_PULL_ENABLED`, default OFF), `redelivery_governor_enabled` (#1085 observability-only; default OFF), `enterprise_features` (registered enterprise modules; empty in OSS-only or `TRINITY_OSS_ONLY=1`) (#847) |
 | GET/PUT | `/api/settings/agent-defaults/resources` | Fleet-wide default CPU/memory for new containers (admin-only; CPU 1/2/4/8/16, memory 1g–32g) (RES-001) |
 | GET/PUT | `/api/settings/agent-defaults/access-policy` | Fleet-wide default `require_email` for new agents (admin-only, #1129). Stored in `system_settings`, **secure-by-default ON** (code fallback when unset — no migration); seeds `agent_ownership.require_email` at creation (`register_agent_owner`) for **new** agents only, never rewrites existing rows; owners still override per agent via `PUT /api/agents/{name}/access-policy` |
 | GET/PUT | `/api/settings/max-parallel-tasks-ceiling` | Fleet-wide ceiling on per-agent `max_parallel_tasks` (admin-only, #506). Returns `{value, default, min, max}`; PUT range-validated 1–32 (400 otherwise), audit-logged. Stored in `system_settings` (no migration). The generic catch-all `PUT /{key}` is blocked for this key (422 → dedicated route). Clamp is runtime/clamp-on-use — see [Capacity & Backlog](#capacity--backlog-428) |
+| GET/PUT | `/api/settings/brain-orb` | Brain Orb platform flags (admin-only, trinity-enterprise#85). GET: per-flag `{value, source: override\|env\|default}` + `gemini_key_configured` (boolean only — never the key). PUT: partial booleans (`enabled`/`voice_enabled`/`write_enabled`) and/or `clear: [flag,…]` reverting a flag to its env/default (400 on unknown name or set+clear conflict); audit-logged with per-flag old→new. Stored in `system_settings` (no migration); route gates resolve at request time — no restart. Registered before `/{key}` (Invariant #4) — see [Brain Orb](#brain-orb--self-rendering-mind-page-58-trinity-enterprise) |
 
 ### Session Tab
 | Method | Path | Description |

--- a/docs/memory/feature-flows/brain-orb.md
+++ b/docs/memory/feature-flows/brain-orb.md
@@ -75,7 +75,7 @@ Gemini toolCall → voice iframe → postMessage 'orb-tool' → orb.js ORB_TOOLS
 
 **Voice orb animation:** the voice tile renders its own audio-reactive orb (a p5 smoke/core sketch) that breathes when idle and pulses with the spoken audio (`enqueueAudio` connects each output buffer through `outAnalyser`). It was briefly cut with the CDN p5 removal and then restored by vendoring p5 locally — a separate visualization from the main three.js knowledge orb.
 
-**Voice gating:** a new platform flag `brain_orb_voice_available` = `BRAIN_ORB_VOICE_ENABLED && GEMINI_API_KEY` (default OFF) — **distinct** from the static `brain_orb_available` (which has no Gemini dependency). The orb un-hides the voice tile only when the host passes `voiceAvailable:true` in the init handshake (platform flag) AND the agent is brain-orb-capable. The mint route is independently flag-gated (404 when off, 503 when no key), so the flag is UI-only and can't be bypassed.
+**Voice gating:** the platform flag `brain_orb_voice_available` = `base && voice && GEMINI_API_KEY` (default OFF; flags runtime-resolved since #85, see Gating) — **distinct** from the static `brain_orb_available` (which has no Gemini dependency). The orb un-hides the voice tile only when the host passes `voiceAvailable:true` in the init handshake (platform flag) AND the agent is brain-orb-capable. The mint route is independently gated on `base && voice` (404 when either is off, 503 when no key), so the flag is UI-only and can't be bypassed.
 
 **SDK bump (required — the pinned SDK lacked ephemeral tokens):** `google-genai==1.12.1` has **no `auth_tokens` attribute**, so the mint 502'd on the shipped backend; the pin is bumped to **`1.63.0`** (`docker/backend/Dockerfile`). Verified in the local stack: `POST /voice-token` returns a real `auth_tokens/…` token with the model+voice locked and the 11 read/visual/scope tools (zero write tools, no bare `token` field), and `services/gemini_voice.py` (the existing backend-proxied VOICE-001 path) still imports cleanly under 1.63. **Pre-merge:** a live VOICE-001 smoke test (an actual browser voice session) confirming the bump didn't regress `aio.live.connect`.
 
@@ -106,13 +106,13 @@ orb panel open → initActions()
   200 ⇒ body.brain-orb-write added → panel revealed; 403 (non-owner) / 404 (flag off / no hook) ⇒ stays hidden
 ```
 
-**Auth boundary (airtight):** every write route is `OwnedAgentByName` (owner/admin) — a shared user gets 403 and the orb hides the panel. The voice-token mint stays `AuthorizedAgentByName` (shared users may voice-chat), but the mint route computes `can_write = BRAIN_ORB_WRITE_ENABLED and db.can_user_share_agent(user, agent)` and only then folds the `capture_note`/`link_notes` write tools into the **locked** manifest — so a shared-user session gets the read-only Phase-3 manifest, and even a crafted call hits the owner-gated `/action` route. The manifest is a UX affordance; the backend gate is the security boundary.
+**Auth boundary (airtight):** every write route is `OwnedAgentByName` (owner/admin) — a shared user gets 403 and the orb hides the panel. The voice-token mint stays `AuthorizedAgentByName` (shared users may voice-chat), but the mint route computes `can_write = is_brain_orb_write_enabled() and db.can_user_share_agent(user, agent)` and only then folds the `capture_note`/`link_notes` write tools into the **locked** manifest — so a shared-user session gets the read-only Phase-3 manifest, and even a crafted call hits the owner-gated `/action` route. The manifest is a UX affordance; the backend gate is the security boundary.
 
 **Idempotency (Invariant #18, not #1084):** these are user→backend producer POSTs with no `execution_id`, so the effect_guard (`effect:{execution_id}`-scoped) doesn't fit; the trigger-boundary `Idempotency-Key` path is used instead, with the key folded per action verb (`brain_orb_action:{action}:{key}`) so a reused client key can't replay a different verb's snapshot. Dedups the HTTP POST (double-click / retry) — exactly-once at the KB sink remains the agent hook's responsibility.
 
 **Agent convention (Invariant #8):** the agent ships one executable `~/.trinity/brain-orb/action` hook (a fourth sibling next to `scopes`/`scope`/`search`) that dispatches on the request's `action` field (`list` → allow-list, `capture`, `link`) and owns the write semantics; Trinity runs it via the same hardened `_run_hook` and 404s when absent. The backend enum-restricts the verb before forwarding.
 
-**Kill-switch:** `BRAIN_ORB_WRITE_ENABLED` (env, default OFF) — distinct from `BRAIN_ORB_ENABLED` so writes can be disabled without downing the read path or voice tile. Surfaced as `brain_orb_write_available` in `GET /api/settings/feature-flags`; the host relays it to the orb (`writeAvailable`), which only attempts `initActions` when on.
+**Kill-switch:** the write flag (runtime-resolved since #85: `brain_orb_write_enabled` setting → `BRAIN_ORB_WRITE_ENABLED` env opt-in → OFF — flippable from Settings → General without a restart) — distinct from the base flag so writes can be disabled without downing the read path or voice tile. Surfaced as `brain_orb_write_available` (`base && write`) in `GET /api/settings/feature-flags`; the host relays it to the orb (`writeAvailable`), which only attempts `initActions` when on.
 
 ## Phase 4b — voice-transcript capture + post-session processing (#66)
 
@@ -181,8 +181,19 @@ FileResponse(~/resources/agent-visualization/data.json)   (agent owns generation
 
 `brainOrbAvailable = brain_orb_available (platform flag) && template.yaml.capabilities ⊇ 'brain-orb' (per-agent)`.
 
-- Platform flag: `BRAIN_ORB_ENABLED` (env, default OFF) → `brain_orb_available` in `GET /api/settings/feature-flags`. The static render has **no** Gemini dependency, so unlike voice/workspace/voip it is the bare env flag.
-- Voice flag (Phase 3): `BRAIN_ORB_VOICE_ENABLED && GEMINI_API_KEY` → `brain_orb_voice_available` (default OFF) — **distinct** from `brain_orb_available` because the voice tile needs a Gemini key. Un-hides the voice tile only when on AND the agent is brain-orb-capable; the `voice-token` mint route is independently flag-gated.
+- **All three platform flags are runtime-resolved and admin-configurable (trinity-enterprise#85):**
+  `system_settings` row (`brain_orb_enabled` / `brain_orb_voice_enabled` / `brain_orb_write_enabled`,
+  wins in both directions) → `BRAIN_ORB_*` env var as **opt-in** fallback → default OFF. Resolution
+  lives in `settings_service.is_brain_orb_*_enabled()` (one shared `_resolve_bool_flag` helper;
+  fail-open on a settings-read failure so `feature-flags` never 500s; uncached — `--workers 2`,
+  #506 rationale). Admin surface: `GET/PUT /api/settings/brain-orb` (per-flag `{value, source:
+  override|env|default}`; `clear: [flag,…]` reverts a flag to env/default — once a stored row
+  exists the env var is ignored until cleared) + a Settings → General panel. Route gates and
+  `feature-flags` read the resolvers, so an admin flip needs **no restart**; open user sessions
+  pick it up on the next page load (`feature-flags` is fetched at load, not WS-pushed; the
+  admin's own session force-refetches after a save).
+- Base flag → `brain_orb_available` in `GET /api/settings/feature-flags`. The static render has **no** Gemini dependency.
+- Voice flag (Phase 3): `brain_orb_voice_available = base && voice && GEMINI_API_KEY` (the key stays env-only — secret; #85 added the base term so a downed orb never advertises its voice tile). Un-hides the voice tile only when on AND the agent is brain-orb-capable; the `voice-token` mint route gates on `base && voice` itself, so the flag is UI-only and can't be bypassed.
 - Per-agent capability: a **generalizable** `brain-orb` token in the agent's `template.yaml capabilities` list (surfaced by `GET /api/agents/{name}/info`, read frontend-side) — never a hardcoded agent/template name. Mirrors the `sessionAvailable` + `hasDashboard` idioms.
 - The **route guard AND the tab both enforce the per-agent capability** (#60): the guard (`router/index.js beforeEnter`) fetches `GET /api/agents/{name}/info` and redirects to AgentDetail unless the agent declares `brain-orb` (and the platform flag is on) — so the orb is **never launchable on a non-Cornelius agent, even via a raw URL** (a stopped/uncapable agent redirects, not an empty orb). Because the route is capability-gated, the voice tile inside it only needs the platform voice flag.
 
@@ -202,10 +213,11 @@ The data route uses standard `AuthorizedAgentByName` Bearer auth like every othe
 | Tab + capability | `src/frontend/src/views/AgentDetail.vue` (`visibleTabs`, `checkBrainOrbCapability`) |
 | Backend proxy | `src/backend/routers/agent_brain_orb.py` (data/scopes/scope + voice-token/tool + **actions/action** — Phase 4a) |
 | Mint service (Phase 3/4a) | `src/backend/services/brain_orb_voice_service.py` (v1alpha ephemeral token + locked tool manifest; **`can_write` → owner-only capture/link tools**) |
-| Flag (BE) | `src/backend/config.py` (`BRAIN_ORB_ENABLED`, `BRAIN_ORB_VOICE_ENABLED`, **`BRAIN_ORB_WRITE_ENABLED`**), `src/backend/routers/settings.py`, **`docker-compose.yml`** (each flag must be in the backend `environment:` block to reach the container) |
+| Flag (BE) | `src/backend/services/settings_service.py` (`_resolve_bool_flag` + `is_brain_orb_*_enabled` + `BRAIN_ORB_FLAGS` registry — #85; `config.py` holds no constants anymore), `src/backend/routers/settings.py` (feature-flags + `GET/PUT /api/settings/brain-orb`), `src/backend/models.py` (`BrainOrbSettingsUpdate`), **`docker-compose.yml`** (each `BRAIN_ORB_*` env var must be in the backend `environment:` block for the env-fallback leg to reach the container) |
 | Agent-server | `docker/base-image/agent_server/routers/brain_orb.py` (data/scopes/scope + search + **action** hook — Phase 4a) |
 | Flag (FE) | `src/frontend/src/stores/sessions.js` (`brainOrbAvailable`, `brainOrbVoiceAvailable`, **`brainOrbWriteAvailable`**) |
-| Tests | `tests/unit/test_brain_orb.py` |
+| Admin panel (#85) | `src/frontend/src/views/Settings.vue` (General → Brain Orb panel), `src/frontend/src/stores/settings.js` (`get/setBrainOrbSettings`) |
+| Tests | `tests/unit/test_brain_orb.py`, `tests/unit/test_85_brain_orb_settings.py` |
 
 ## Invariants honored
 

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -216,8 +216,9 @@ See [feature-flows/brain-orb.md](../feature-flows/brain-orb.md).
   change. Only mechanical orb edits (externalize, vendor, repoint data fetch, neutralize the
   deferred voice proxy, hide deferred panels). Note bodies are DOMPurify-sanitized (H-005).
 - **FR-2 — Capability gating**: a `/agents/:name/brain` route (lazy + `beforeEnter` platform-flag
-  guard) and a Brain tab shown only when `brain_orb_available` (platform flag `BRAIN_ORB_ENABLED`,
-  default OFF) **AND** the agent's `template.yaml capabilities` list contains the generalizable
+  guard) and a Brain tab shown only when `brain_orb_available` (runtime-resolved platform flag —
+  admin setting → `BRAIN_ORB_ENABLED` env fallback, default OFF; FR-11) **AND** the agent's
+  `template.yaml capabilities` list contains the generalizable
   `brain-orb` token (surfaced by `/api/agents/{name}/info`) — never a hardcoded agent name.
 - **FR-3 — Same-origin iframe host**: `views/AgentBrainOrb.vue` embeds the first-party page in a
   same-origin iframe (not agent-origin → avoids the #979 CSP trap, no Vue rewrite of the renderer).
@@ -308,6 +309,23 @@ See [feature-flows/brain-orb.md](../feature-flows/brain-orb.md).
   control, an "integrating…" state, and a "graph updated · +N notes, +M links" confirmation toast (#68). No DB
   change. **Confirmed on localhost**: capture → refresh folds the note in as a real graph node (`1072 → 1079`),
   and the UI control rebuilds with the confirmation toast.
+- **FR-11 — Admin-configurable platform flags (trinity-enterprise#85)**: the three platform flags
+  (`brain_orb_enabled`, `brain_orb_voice_enabled`, `brain_orb_write_enabled`) are **runtime-resolved**,
+  not import-time env constants: `system_settings` row ("true"/"false", wins in both directions) →
+  `BRAIN_ORB_*` env var honored as **opt-in** fallback → default OFF (the `workspace_enabled` idiom via
+  one shared `_resolve_bool_flag` helper). Resolvers are fail-open (a settings-read failure falls back
+  to the env/default leg — a raise would 500 `feature-flags` and zero every flag in the frontend store)
+  and deliberately uncached (`--workers 2` cross-worker consistency, #506 rationale). All route gates in
+  `routers/agent_brain_orb.py` and the three `feature-flags` values read the resolvers, so an admin flip
+  applies without restart; the voice-token mint additionally composes with the base flag
+  (`base ∧ voice`, closing the base-OFF mint gap) and `brain_orb_voice_available = base ∧ voice ∧
+  GEMINI_API_KEY`. **Admin surface**: `GET/PUT /api/settings/brain-orb` (admin-only, registered before
+  the `/{key}` catch-all) — GET returns per-flag `{value, source: override|env|default}` +
+  `gemini_key_configured`; PUT takes partial booleans and/or `clear: [flag,…]` to **revert a flag to its
+  env/default** (the env var is otherwise dead once a DB override exists), audit-logged with per-flag
+  old→new values. Settings → General hosts the panel (per-flag source display, write-surface warning,
+  post-save `loadFeatureFlags(force)`; other open sessions pick the change up on next page load).
+  GEMINI_API_KEY stays env-only (secret). No migration (`system_settings` KV).
 
 **Still out of scope**: `run_skill` (arbitrary allow-listed headless exec from the orb) — the full exec surface
 with a `template.yaml` allow-list ceiling + #1083 detached-execution integration remains unbuilt; open a fresh

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -257,27 +257,13 @@ GEMINI_TRANSCRIPTION_MODEL = os.getenv("GEMINI_TRANSCRIPTION_MODEL") or "gemini-
 # also requires a per-agent voip_bindings row to function. `voip_available`
 # in GET /api/settings/feature-flags is `VOIP_ENABLED and bool(GEMINI_API_KEY)`.
 VOIP_ENABLED = os.getenv("VOIP_ENABLED", "false").lower() == "true"
-# Brain Orb (#58, trinity-enterprise) — capability-gated per-agent 3D knowledge
-# visualization. Default OFF. The static-render foundation has NO Gemini/voice
-# dependency, so the platform flag is the bare env var (the deferred voice
-# follow-up adds its own GEMINI_API_KEY gate). The per-agent half of the gate is
-# the `brain-orb` capability token in the agent's template.yaml, checked in the
-# frontend. `brain_orb_available` in GET /api/settings/feature-flags == this flag.
-BRAIN_ORB_ENABLED = os.getenv("BRAIN_ORB_ENABLED", "false").lower() == "true"
-# Brain Orb voice tile (#58 Phase 3, trinity-enterprise#60) — the client-held
-# Gemini Live voice surface. DISTINCT from BRAIN_ORB_ENABLED (which gates the
-# static render + scope control, no Gemini dependency): the voice tile also needs
-# a Gemini key, so `brain_orb_voice_available` = BRAIN_ORB_VOICE_ENABLED and
-# bool(GEMINI_API_KEY) (mirrors voice_available). Default OFF. The frontend hides
-# the voice tile unless this is on AND the agent has the `brain-orb` capability.
-BRAIN_ORB_VOICE_ENABLED = os.getenv("BRAIN_ORB_VOICE_ENABLED", "false").lower() == "true"
-# Brain Orb KB-write surface (#58 Phase 4a, trinity-enterprise#61) — owner-gated
-# capture/link actions. DISTINCT from BRAIN_ORB_ENABLED so the write/exec surface
-# has its own kill-switch that does NOT down the Phase-1 read path or the Phase-3
-# voice tile. Default OFF. The write routes 404 unless BRAIN_ORB_ENABLED AND this
-# are both on (and the caller owns the agent). `run_skill` + the transcript
-# pipeline are deferred to Phase 4b (trinity-enterprise#66).
-BRAIN_ORB_WRITE_ENABLED = os.getenv("BRAIN_ORB_WRITE_ENABLED", "false").lower() == "true"
+# Brain Orb flags (trinity-enterprise#58/#60/#61) are RUNTIME-RESOLVED as of #85
+# — no import-time constants here, so a stale module value can never shadow an
+# admin toggle. Resolution lives in services/settings_service.py
+# (is_brain_orb_enabled / is_brain_orb_voice_enabled / is_brain_orb_write_enabled):
+# system_settings override → BRAIN_ORB_ENABLED / BRAIN_ORB_VOICE_ENABLED /
+# BRAIN_ORB_WRITE_ENABLED env opt-in → default OFF. Admin surface:
+# GET/PUT /api/settings/brain-orb.
 # VoIP-specific max call duration (seconds) — deliberately distinct from the
 # inherited 300s VOICE_MAX_DURATION so phone calls aren't silently cut at 5min.
 VOIP_MAX_CALL_DURATION = int(os.getenv("VOIP_MAX_CALL_DURATION", "600"))

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -670,6 +670,21 @@ class AgentCapacityUpdate(BaseModel):
     max_parallel_tasks: int
 
 
+class BrainOrbSettingsUpdate(BaseModel):
+    """Body for PUT /api/settings/brain-orb (trinity-enterprise#85).
+
+    Partial update: only non-None booleans are written. `clear` lists flag
+    names ("enabled" / "voice_enabled" / "write_enabled") whose stored
+    override should be deleted, reverting that flag to its env/default value
+    — without it the BRAIN_ORB_* env var is silently dead once a DB row
+    exists. A flag may not appear in both a boolean field and `clear` (400).
+    """
+    enabled: Optional[bool] = None
+    voice_enabled: Optional[bool] = None
+    write_enabled: Optional[bool] = None
+    clear: Optional[List[str]] = None
+
+
 # Max length for the public/channel custom-instructions fragment (#1205).
 PUBLIC_CHANNEL_PROMPT_MAX_LEN = 4000
 

--- a/src/backend/routers/agent_brain_orb.py
+++ b/src/backend/routers/agent_brain_orb.py
@@ -20,15 +20,18 @@ import logging
 import httpx
 from fastapi import APIRouter, Header, HTTPException, Request, Response
 
-from config import (
-    BRAIN_ORB_ENABLED,
-    BRAIN_ORB_VOICE_ENABLED,
-    BRAIN_ORB_WRITE_ENABLED,
-    GEMINI_API_KEY,
-)
+from config import GEMINI_API_KEY
 from database import db
 from dependencies import AuthorizedAgentByName, CurrentUser, OwnedAgentByName
 from services import brain_orb_voice_service, idempotency_service, rate_limiter
+# Runtime-resolved flags (#85): system_settings override → BRAIN_ORB_* env
+# opt-in → OFF. Imported as module-level names so tests can monkeypatch the
+# gate seam (`monkeypatch.setattr(bo, "is_brain_orb_enabled", ...)`).
+from services.settings_service import (
+    is_brain_orb_enabled,
+    is_brain_orb_voice_enabled,
+    is_brain_orb_write_enabled,
+)
 from services.agent_auth import agent_httpx_client
 from services.docker_service import get_agent_container
 from services.docker_utils import container_reload
@@ -67,7 +70,7 @@ async def _agent_request(agent_name: str, method: str, path: str, *, content: by
     mapped ``HTTPException`` on flag-off (404 — flag is the single source of
     truth), missing/stopped agent (404 / 503), or transport failure (503 / 504).
     """
-    if not BRAIN_ORB_ENABLED:
+    if not is_brain_orb_enabled():
         raise HTTPException(status_code=404, detail="Brain Orb is not enabled")
     container = get_agent_container(agent_name)
     if not container:
@@ -139,8 +142,8 @@ async def post_brain_orb_voice_token(agent_name: AuthorizedAgentByName, current_
     surface, single new-session use, short expiry) are the security envelope; this
     route's job is the JWT gate + a per-user mint budget.
 
-    Gated on the **voice** flag (distinct from ``BRAIN_ORB_ENABLED``): 404 when
-    ``BRAIN_ORB_VOICE_ENABLED`` is off, 503 when no Gemini key, 502 on mint error.
+    Gated on the **base AND voice** flags (both runtime-resolved, #85): 404 when
+    either is off, 503 when no Gemini key, 502 on mint error.
 
     The response field is deliberately named ``ephemeral_token``, never a bare
     ``token`` — defensive/explicit (the voice iframe only ever sees the single-use
@@ -149,7 +152,10 @@ async def post_brain_orb_voice_token(agent_name: AuthorizedAgentByName, current_
     4a); the backend ``/action`` route is the hard gate regardless. The agent is not
     contacted (no container check) — the mint is a Google call, not an agent call.
     """
-    if not BRAIN_ORB_VOICE_ENABLED:
+    # Composed with the base flag (#85): with base OFF the orb is down, so the
+    # mint must be too — otherwise a direct API call could still spin up Gemini
+    # Live sessions on the platform key while the feature is disabled.
+    if not (is_brain_orb_enabled() and is_brain_orb_voice_enabled()):
         raise HTTPException(status_code=404, detail="Brain Orb voice is not enabled")
     if not GEMINI_API_KEY:
         raise HTTPException(status_code=503, detail="Voice is not configured")
@@ -163,7 +169,7 @@ async def post_brain_orb_voice_token(agent_name: AuthorizedAgentByName, current_
     # Phase 4a). The mint route is AuthorizedAgentByName (shared users may voice-chat),
     # so compute owner access here — same predicate OwnedAgentByName enforces. Shared
     # users get the read-only manifest; the backend /action route is the hard gate.
-    can_write = BRAIN_ORB_WRITE_ENABLED and db.can_user_share_agent(current_user.username, agent_name)
+    can_write = is_brain_orb_write_enabled() and db.can_user_share_agent(current_user.username, agent_name)
     try:
         result = await brain_orb_voice_service.mint_voice_token(
             agent_name,
@@ -201,7 +207,7 @@ def _require_write_enabled() -> None:
     """404 unless the KB-write surface flag is on. Combines with ``_agent_request``'s
     ``BRAIN_ORB_ENABLED`` gate so both flags are required. Separate kill-switch so
     writes can be disabled without downing the read path / voice tile (#58 Phase 4a)."""
-    if not BRAIN_ORB_WRITE_ENABLED:
+    if not is_brain_orb_write_enabled():
         raise HTTPException(status_code=404, detail="Brain Orb writes are not enabled")
 
 

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -20,6 +20,7 @@ from models import (
     AgentQuotaUpdate,
     ApiKeyTest,
     ApiKeyUpdate,
+    BrainOrbSettingsUpdate,
     GitHubTemplatesUpdate,
     MaxParallelTasksCeilingUpdate,
     McpUrlUpdate,
@@ -135,14 +136,15 @@ async def get_public_feature_flags(
         GEMINI_API_KEY,
         VOICE_ENABLED,
         VOIP_ENABLED,
-        BRAIN_ORB_ENABLED,
-        BRAIN_ORB_VOICE_ENABLED,
-        BRAIN_ORB_WRITE_ENABLED,
         MCP_AGENT_CHAT_PULL_ENABLED,
         REDELIVERY_GOVERNOR_ENABLED,
     )
     from services.entitlement_service import entitlement_service
     voice_available = VOICE_ENABLED and bool(GEMINI_API_KEY)
+    # Brain Orb flags are RUNTIME-RESOLVED (#85): system_settings override →
+    # BRAIN_ORB_* env opt-in → OFF. An admin flip via PUT /api/settings/brain-orb
+    # is reflected here without a backend restart.
+    brain_orb_enabled = settings_service.is_brain_orb_enabled()
     return {
         "session_tab_enabled": settings_service.is_session_tab_enabled(),
         "voice_available": voice_available,
@@ -151,22 +153,25 @@ async def get_public_feature_flags(
         # Also requires a per-agent voip_bindings row to actually function.
         "voip_available": VOIP_ENABLED and bool(GEMINI_API_KEY),
         # Brain Orb (#58, trinity-enterprise) — gates the per-agent /agents/:name/brain
-        # route + tab. Just the env flag (static render needs no Gemini); the per-agent
-        # capability gate is the template.yaml `brain-orb` token, checked frontend-side.
-        "brain_orb_available": BRAIN_ORB_ENABLED,
+        # route + tab. Static render needs no Gemini; the per-agent capability gate is
+        # the template.yaml `brain-orb` token, checked frontend-side.
+        "brain_orb_available": brain_orb_enabled,
         # Brain Orb voice tile (#58 Phase 3, trinity-enterprise#60) — client-held
-        # Gemini Live. DISTINCT from brain_orb_available: the voice tile also needs a
-        # Gemini key, so gate on BRAIN_ORB_VOICE_ENABLED AND a key (mirrors
-        # voice_available). The frontend un-hides the voice tile only when this is on
-        # AND the agent carries the `brain-orb` capability. Default OFF.
-        "brain_orb_voice_available": BRAIN_ORB_VOICE_ENABLED and bool(GEMINI_API_KEY),
+        # Gemini Live. Composes base AND voice AND a Gemini key (#85 — with base OFF
+        # the orb is down, so voice must read unavailable too; mirrors the write
+        # composition below). The frontend un-hides the voice tile only when this is
+        # on AND the agent carries the `brain-orb` capability. Default OFF.
+        "brain_orb_voice_available": brain_orb_enabled
+        and settings_service.is_brain_orb_voice_enabled()
+        and bool(GEMINI_API_KEY),
         # Brain Orb KB-write surface (#58 Phase 4a, trinity-enterprise#61) — owner-gated
         # capture/link. DISTINCT kill-switch from brain_orb_available so writes can be
         # disabled without downing read/voice. UI-only hint (the write routes independently
         # enforce the flag + owner gate); the orb only attempts initActions when on. The
         # per-agent gate is still owner + the agent shipping a `brain-orb/action` hook.
         # run_skill + the transcript pipeline are Phase 4b (#66). Default OFF.
-        "brain_orb_write_available": BRAIN_ORB_WRITE_ENABLED and BRAIN_ORB_ENABLED,
+        "brain_orb_write_available": settings_service.is_brain_orb_write_enabled()
+        and brain_orb_enabled,
         # Pull-pilot routing for agent→agent MCP chat (#946) — default OFF.
         # Observability-only here: the routing gate is the MCP server's own read
         # of the same env var. Lets an operator confirm, via the API, whether the
@@ -1513,6 +1518,140 @@ async def update_max_parallel_tasks_ceiling_setting(
         "default": MAX_PARALLEL_TASKS_CEILING_DEFAULT,
         "min": MAX_PARALLEL_TASKS_CEILING_MIN,
         "max": MAX_PARALLEL_TASKS_CEILING_MAX,
+    }
+
+
+# ============================================================================
+# Brain Orb Feature Flags (trinity-enterprise#85 — admin-configurable)
+# ============================================================================
+
+def _brain_orb_flag_state() -> Dict[str, Any]:
+    """Per-flag effective value + source for the admin panel.
+
+    `source` tells the UI whether a DB override is active — critical because a
+    stored row makes the BRAIN_ORB_* env var silently dead until cleared:
+    - "override": a system_settings row exists (env ignored)
+    - "env":      no row; the env var opts the flag in
+    - "default":  neither; the code default (OFF) applies
+    """
+    from services.settings_service import BRAIN_ORB_FLAGS
+
+    state: Dict[str, Any] = {}
+    for field, (setting_key, env_var) in BRAIN_ORB_FLAGS.items():
+        stored = db.get_setting_value(setting_key, None)
+        env_on = os.getenv(env_var, "").strip().lower() in ("true", "1", "yes")
+        if stored is not None:
+            value = str(stored).lower() in ("true", "1", "yes")
+            source = "override"
+        else:
+            value = env_on
+            source = "env" if env_on else "default"
+        state[field] = {"value": value, "source": source}
+    return state
+
+
+@router.get("/brain-orb")
+async def get_brain_orb_settings(
+    request: Request,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Get the Brain Orb platform flags with per-flag source (trinity-enterprise#85).
+
+    Admin-only. Registered before the `/{key}` catch-all (Invariant #4).
+    `gemini_key_configured` reflects the env-only GEMINI_API_KEY secret the
+    voice tile additionally requires (boolean only — never the key).
+    """
+    require_admin(current_user)
+
+    from config import GEMINI_API_KEY
+
+    return {
+        "flags": _brain_orb_flag_state(),
+        "gemini_key_configured": bool(GEMINI_API_KEY),
+    }
+
+
+@router.put("/brain-orb")
+async def update_brain_orb_settings(
+    body: BrainOrbSettingsUpdate,
+    request: Request,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Update the Brain Orb platform flags (trinity-enterprise#85).
+
+    Admin-only, audit-logged with per-flag old→new values. Partial update:
+    only provided booleans are written. `clear: [flag,...]` deletes a flag's
+    stored override, reverting it to its env/default value. Takes effect on
+    the next request — route gates resolve at request time, no restart.
+    """
+    require_admin(current_user)
+
+    from config import GEMINI_API_KEY
+    from services.settings_service import BRAIN_ORB_FLAGS
+
+    clear = body.clear or []
+    unknown = [f for f in clear if f not in BRAIN_ORB_FLAGS]
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown flag(s) in clear: {', '.join(sorted(unknown))}. "
+                   f"Valid: {', '.join(BRAIN_ORB_FLAGS)}",
+        )
+    conflict = [f for f in clear if getattr(body, f, None) is not None]
+    if conflict:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Flag(s) both set and cleared: {', '.join(sorted(conflict))}",
+        )
+
+    before = _brain_orb_flag_state()
+    updated = []
+    cleared = []
+    # getattr default: a registry flag missing from the model must read as
+    # "not provided", never AttributeError→500 (drift-guarded by test too).
+    for field, (setting_key, _env_var) in BRAIN_ORB_FLAGS.items():
+        value = getattr(body, field, None)
+        if value is not None:
+            db.set_setting(setting_key, "true" if value else "false")
+            updated.append(field)
+        elif field in clear:
+            db.delete_setting(setting_key)
+            cleared.append(field)
+    after = _brain_orb_flag_state()
+
+    if updated or cleared:
+        # SEC-001: the write flag gates an exec-adjacent surface (the agent's
+        # action hook), so every change must leave a per-flag old→new trace.
+        await platform_audit_service.log(
+            event_type=AuditEventType.CONFIGURATION,
+            event_action="settings_change",
+            source="api",
+            actor_user=current_user,
+            actor_ip=request.client.host if request.client else None,
+            endpoint=str(request.url.path),
+            request_id=getattr(request.state, "request_id", None),
+            details={
+                "setting": "brain_orb_flags",
+                "action": "update",
+                "changes": {
+                    field: {
+                        "old": before[field]["value"],
+                        "new": after[field]["value"],
+                    }
+                    for field in updated + cleared
+                },
+                "cleared": cleared,
+            },
+        )
+
+    return {
+        "success": True,
+        "updated": updated,
+        "cleared": cleared,
+        "flags": after,
+        "gemini_key_configured": bool(GEMINI_API_KEY),
     }
 
 

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -238,6 +238,60 @@ class SettingsService:
         return False
 
     # =========================================================================
+    # Brain Orb feature flags (trinity-enterprise#58/#60/#61; admin-configurable #85)
+    # =========================================================================
+
+    def _resolve_bool_flag(self, setting_key: str, env_var: str, default: bool = False) -> bool:
+        """Shared stored→env→default boolean flag resolution (#85).
+
+        Resolves in this order:
+        1. system_settings row `setting_key` ("true"/"false") — wins in BOTH
+           directions, so an admin toggle overrides the env var until cleared
+        2. `env_var` honored as OPT-IN ("true"/"1"/"yes") — existing deployments
+           with the env flag keep working unchanged
+        3. `default`
+
+        Fail-open (the #506 `clamp_to_ceiling` discipline): a settings-read
+        failure falls back to the env/default leg instead of raising — these
+        resolvers feed GET /api/settings/feature-flags, where an exception
+        would 500 the endpoint and zero EVERY flag in the frontend store.
+
+        Deliberately NO TTL cache: the backend runs `--workers 2`; a cache
+        would let a stale worker keep serving a just-flipped flag (#506
+        rationale). One SQLite read per gate check is negligible at brain-orb
+        QPS — don't "helpfully" add one.
+        """
+        try:
+            stored = self.get_setting(setting_key)
+        except Exception:
+            stored = None
+        if stored is not None:
+            return str(stored).lower() in ("true", "1", "yes")
+        env_val = os.getenv(env_var, "").strip().lower()
+        if env_val in ("true", "1", "yes"):
+            return True
+        return default
+
+    def is_brain_orb_enabled(self) -> bool:
+        """Brain Orb base platform flag — gates the orb page, tab, and every
+        proxied `/brain-orb/*` route (trinity-enterprise#58). Runtime-resolved
+        so an admin toggle applies without a backend restart (#85)."""
+        return self._resolve_bool_flag("brain_orb_enabled", "BRAIN_ORB_ENABLED")
+
+    def is_brain_orb_voice_enabled(self) -> bool:
+        """Brain Orb voice tile flag (trinity-enterprise#60). Voice additionally
+        requires the base flag AND GEMINI_API_KEY (env-only secret) — composed
+        at the consumers, not here."""
+        return self._resolve_bool_flag("brain_orb_voice_enabled", "BRAIN_ORB_VOICE_ENABLED")
+
+    def is_brain_orb_write_enabled(self) -> bool:
+        """Brain Orb KB-write kill-switch (trinity-enterprise#61). Distinct from
+        the base flag so the write/exec surface can be downed without downing
+        read/voice. Write routes also require the base flag (composed at the
+        router)."""
+        return self._resolve_bool_flag("brain_orb_write_enabled", "BRAIN_ORB_WRITE_ENABLED")
+
+    # =========================================================================
     # GitHub Templates (TMPL-001)
     # =========================================================================
 
@@ -356,6 +410,32 @@ def get_slack_app_token() -> str:
 def is_session_tab_enabled() -> bool:
     """Session tab feature flag (Phase 1.6 of SESSION_TAB_2026-04)."""
     return settings_service.is_session_tab_enabled()
+
+
+# Brain Orb flags (trinity-enterprise#85) — the (setting_key, env_var) registry
+# shared by the resolvers above and the dedicated admin routes in
+# routers/settings.py (GET/PUT /api/settings/brain-orb). Field names match the
+# BrainOrbSettingsUpdate model.
+BRAIN_ORB_FLAGS = {
+    "enabled": ("brain_orb_enabled", "BRAIN_ORB_ENABLED"),
+    "voice_enabled": ("brain_orb_voice_enabled", "BRAIN_ORB_VOICE_ENABLED"),
+    "write_enabled": ("brain_orb_write_enabled", "BRAIN_ORB_WRITE_ENABLED"),
+}
+
+
+def is_brain_orb_enabled() -> bool:
+    """Brain Orb base platform flag — runtime-resolved (#85)."""
+    return settings_service.is_brain_orb_enabled()
+
+
+def is_brain_orb_voice_enabled() -> bool:
+    """Brain Orb voice tile flag — runtime-resolved (#85)."""
+    return settings_service.is_brain_orb_voice_enabled()
+
+
+def is_brain_orb_write_enabled() -> bool:
+    """Brain Orb KB-write kill-switch — runtime-resolved (#85)."""
+    return settings_service.is_brain_orb_write_enabled()
 
 
 def get_ops_setting(key: str, as_type: type = str):

--- a/src/frontend/src/components/BrainPanel.vue
+++ b/src/frontend/src/components/BrainPanel.vue
@@ -32,7 +32,8 @@
 
       <template v-if="!writeAvailable">
         <p class="text-sm text-gray-500 dark:text-gray-400">
-          Enable the Brain Orb write surface (<code class="text-xs">BRAIN_ORB_WRITE_ENABLED</code>) to configure post-voice processing.
+          Enable the Brain Orb write surface (Settings → General → Brain Orb → KB-write actions)
+          to configure post-voice processing.
         </p>
       </template>
       <template v-else-if="!running">

--- a/src/frontend/src/stores/settings.js
+++ b/src/frontend/src/stores/settings.js
@@ -84,6 +84,28 @@ export const useSettingsStore = defineStore('settings', {
     },
 
     /**
+     * trinity-enterprise#85: Brain Orb platform flags. Returns
+     * { flags: { enabled|voice_enabled|write_enabled: { value, source } },
+     *   gemini_key_configured }. `source` is override|env|default. Admin-only.
+     */
+    async getBrainOrbSettings() {
+      const response = await axios.get('/api/settings/brain-orb')
+      return response.data
+    },
+
+    /**
+     * trinity-enterprise#85: Update Brain Orb platform flags. `payload` may
+     * carry enabled / voice_enabled / write_enabled booleans and/or a
+     * `clear: [flag,...]` list reverting flags to their env/default value.
+     * Returns the same shape as getBrainOrbSettings plus updated/cleared.
+     * Admin-only; takes effect on the next request — no restart.
+     */
+    async setBrainOrbSettings(payload) {
+      const response = await axios.put('/api/settings/brain-orb', payload)
+      return response.data
+    },
+
+    /**
      * Get a specific setting by key.
      */
     async getSetting(key) {

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -275,6 +275,66 @@
                     ceiling; existing agents above it are clamped at runtime.
                   </p>
                 </div>
+
+                <!-- Brain Orb platform flags (trinity-enterprise#85) -->
+                <div v-if="isAdmin" class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
+                  <h3 class="text-sm font-medium text-gray-900 dark:text-white">Brain Orb</h3>
+                  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    Per-agent 3D knowledge-graph surface for agents with the
+                    <code class="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs">brain-orb</code>
+                    capability. Changes apply immediately — no restart; users with open
+                    sessions pick them up on the next page load.
+                  </p>
+                  <div class="mt-3 space-y-3">
+                    <div v-for="flag in brainOrbFlagRows" :key="flag.key">
+                      <label class="flex items-center justify-between cursor-pointer">
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          {{ flag.label }}
+                          <span
+                            v-if="brainOrb[flag.key].source === 'override'"
+                            class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-action-primary-100 text-action-primary-800 dark:bg-action-primary-900 dark:text-action-primary-200"
+                            title="A stored setting overrides the environment variable"
+                          >override</span>
+                          <span
+                            v-else-if="brainOrb[flag.key].source === 'env'"
+                            class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                            title="Enabled by the environment variable; no stored override"
+                          >env</span>
+                        </span>
+                        <input
+                          type="checkbox"
+                          v-model="brainOrb[flag.key].value"
+                          :disabled="savingBrainOrb"
+                          @change="saveBrainOrbFlag(flag.key, brainOrb[flag.key].value)"
+                          class="h-4 w-4 text-action-primary-600 border-gray-300 dark:border-gray-600 rounded focus:ring-action-primary-500 disabled:opacity-50"
+                        />
+                      </label>
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        {{ flag.hint }}
+                        <template v-if="flag.key === 'voice_enabled' && !brainOrbGeminiKey">
+                          <span class="text-state-autonomous-600 dark:text-state-autonomous-400">
+                            GEMINI_API_KEY is not configured (env-only) — voice stays unavailable even when on.
+                          </span>
+                        </template>
+                        <button
+                          v-if="brainOrb[flag.key].source === 'override'"
+                          @click="clearBrainOrbFlag(flag.key)"
+                          :disabled="savingBrainOrb"
+                          class="ml-1 text-action-primary-600 dark:text-action-primary-400 hover:underline disabled:opacity-50"
+                        >Reset to env/default</button>
+                      </p>
+                    </div>
+                  </div>
+                  <div v-if="brainOrbSaveSuccess" class="mt-2 flex items-center text-sm text-status-success-600 dark:text-status-success-400">
+                    <svg class="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                    Saved
+                  </div>
+                  <p v-if="brainOrbError" class="mt-2 text-sm text-status-danger-600 dark:text-status-danger-400">
+                    {{ brainOrbError }}
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -2002,6 +2062,7 @@ import { useBuildInfo } from '../composables/useBuildInfo'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useSettingsStore } from '../stores/settings'
+import { useSessionsStore } from '../stores/sessions'
 import { useEnterpriseStore } from '../stores/enterprise'
 import NavBar from '../components/NavBar.vue'
 import McpKeysTab from '../components/settings/McpKeysTab.vue'
@@ -2013,6 +2074,9 @@ const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
 const settingsStore = useSettingsStore()
+// trinity-enterprise#85: refreshed after a Brain Orb flag change so the
+// admin's own Brain tab / route gating updates without a page reload.
+const sessionsStore = useSessionsStore()
 // Declared early: visibleTabs (and thus the activeTab initializer below) reads
 // it during setup to gate the enterprise-only Security tab (#5). Declaring it
 // later would hit the temporal dead zone and blank the whole Settings page.
@@ -2234,6 +2298,23 @@ const ceilingMax = ref(32)
 const savingCeiling = ref(false)
 const ceilingSaveSuccess = ref(false)
 const ceilingError = ref('')
+
+// trinity-enterprise#85: Brain Orb platform flags (value + source per flag;
+// source is override|env|default — "override" means the env var is ignored)
+const brainOrb = reactive({
+  enabled: { value: false, source: 'default' },
+  voice_enabled: { value: false, source: 'default' },
+  write_enabled: { value: false, source: 'default' },
+})
+const brainOrbFlagRows = [
+  { key: 'enabled', label: 'Enable Brain Orb', hint: 'Gates the Brain tab, the /brain page, and every brain-orb API route.' },
+  { key: 'voice_enabled', label: 'Voice tile', hint: 'Client-held Gemini Live voice inside the orb. Effective only while Brain Orb is enabled.' },
+  { key: 'write_enabled', label: 'KB-write actions', hint: 'Owner-gated capture/link — enables an exec-adjacent surface on the agent (its action hook). Effective only while Brain Orb is enabled.' },
+]
+const brainOrbGeminiKey = ref(false)
+const savingBrainOrb = ref(false)
+const brainOrbSaveSuccess = ref(false)
+const brainOrbError = ref('')
 const savingPublicUrl = ref(false)
 const publicUrlSaveSuccess = ref(false)
 
@@ -2397,6 +2478,7 @@ async function loadSettings() {
       loadPlatformDefaultModel(),
       loadDefaultAccessPolicy(),
       loadMaxParallelTasksCeiling(),
+      loadBrainOrbSettings(),
       loadApiKeyStatus(),
       loadSlackSettings(),
       loadSlackTransportStatus(),
@@ -2676,6 +2758,49 @@ async function saveMaxParallelTasksCeiling() {
     await loadMaxParallelTasksCeiling()
   } finally {
     savingCeiling.value = false
+  }
+}
+
+// trinity-enterprise#85: Brain Orb platform flags
+function applyBrainOrbState(data) {
+  for (const key of Object.keys(brainOrb)) {
+    if (data.flags?.[key]) brainOrb[key] = data.flags[key]
+  }
+  brainOrbGeminiKey.value = !!data.gemini_key_configured
+}
+
+async function loadBrainOrbSettings() {
+  try {
+    applyBrainOrbState(await settingsStore.getBrainOrbSettings())
+  } catch {
+    // non-critical; panel shows the code defaults (OFF)
+  }
+}
+
+async function saveBrainOrbFlag(key, value) {
+  await putBrainOrbSettings({ [key]: value })
+}
+
+async function clearBrainOrbFlag(key) {
+  await putBrainOrbSettings({ clear: [key] })
+}
+
+async function putBrainOrbSettings(payload) {
+  savingBrainOrb.value = true
+  brainOrbSaveSuccess.value = false
+  brainOrbError.value = ''
+  try {
+    applyBrainOrbState(await settingsStore.setBrainOrbSettings(payload))
+    brainOrbSaveSuccess.value = true
+    setTimeout(() => { brainOrbSaveSuccess.value = false }, 3000)
+    // Refresh the feature flags the rest of THIS session gates on (Brain
+    // tab / route guard); other open sessions update on next page load.
+    sessionsStore.loadFeatureFlags(true).catch(() => {})
+  } catch (e) {
+    brainOrbError.value = e.response?.data?.detail || 'Failed to save Brain Orb settings'
+    await loadBrainOrbSettings()
+  } finally {
+    savingBrainOrb.value = false
   }
 }
 

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -1,6 +1,13 @@
 {
   "test_files": [
     {
+      "file": "unit/test_85_brain_orb_settings.py",
+      "feature": "trinity-enterprise#85",
+      "added": "2026-07-04",
+      "categories": ["backend", "unit", "settings", "brain-orb", "feature-flags"],
+      "description": "Admin-configurable Brain Orb flags (trinity-enterprise#85): _resolve_bool_flag order (stored wins both directions, env opt-in, default OFF, junk-value fail-safe, fail-open on DB error), GET/PUT /api/settings/brain-orb (per-flag source, partial update, clear revert-to-env, set+clear conflict 400, 403 non-admin, audit old→new, /{key} route ordering), generic PUT/DELETE compatibility, brain-orb route gate honoring a real DB flip without restart, and feature-flags composition (voice = base ∧ voice ∧ key; 200 despite brain-orb DB failure)."
+    },
+    {
       "file": "unit/test_1332_cancelled_activity_state.py",
       "feature": "#1332",
       "added": "2026-06-26",

--- a/tests/unit/test_85_brain_orb_settings.py
+++ b/tests/unit/test_85_brain_orb_settings.py
@@ -1,0 +1,329 @@
+"""Unit tests for admin-configurable Brain Orb flags (trinity-enterprise#85).
+
+Covers the three layers the change touches:
+
+  * resolver     — services/settings_service `_resolve_bool_flag` order
+                   (stored wins both directions → env opt-in → OFF), tolerant
+                   parse, and the load-bearing fail-open on a DB read failure
+  * admin routes — GET/PUT /api/settings/brain-orb (payload shape, per-flag
+                   source, partial update, `clear` revert-to-env, validation,
+                   403 non-admin, audit old→new, /{key} route ordering)
+  * consumers    — the brain-orb route gate honors a REAL DB flip without a
+                   restart, and GET /api/settings/feature-flags reflects the
+                   resolved composition (base ∧ voice ∧ key)
+
+True unit tests: no Docker, no running backend. The gate-seam behavior of every
+individual brain-orb route is covered by test_brain_orb.py (which patches the
+resolver names); this file owns the DB-backed resolution itself.
+"""
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import config
+import routers.agent_brain_orb as bo
+import routers.settings as sr
+from database import db
+from dependencies import (
+    get_authorized_agent_by_name,
+    get_current_user,
+    get_owned_agent_by_name,
+)
+from services.settings_service import BRAIN_ORB_FLAGS, settings_service
+
+_URL = "/api/settings/brain-orb"
+_ENV_VARS = tuple(env for _key, env in BRAIN_ORB_FLAGS.values())
+_SETTING_KEYS = tuple(key for key, _env in BRAIN_ORB_FLAGS.values())
+
+
+def _delete_keys():
+    for key in _SETTING_KEYS:
+        db.delete_setting(key)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_brain_orb_state(monkeypatch):
+    """Unit tests share one per-process SQLite (conftest pins TRINITY_DB_PATH),
+    so stored flags MUST be cleaned in a finalizer — inline cleanup would skip
+    on assertion failure and leak state into every later test in the run."""
+    for env in _ENV_VARS:
+        monkeypatch.delenv(env, raising=False)
+    _delete_keys()
+    yield
+    _delete_keys()
+
+
+def _user(role):
+    return types.SimpleNamespace(
+        id=1, username=role, role=role, email=f"{role}@example.com"
+    )
+
+
+@pytest.fixture
+def admin_client():
+    app = FastAPI()
+    app.include_router(sr.router)
+    app.dependency_overrides[get_current_user] = lambda: _user("admin")
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture
+def user_client():
+    app = FastAPI()
+    app.include_router(sr.router)
+    app.dependency_overrides[get_current_user] = lambda: _user("user")
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# --- resolver: stored → env opt-in → default ---------------------------------
+
+def test_resolver_default_off():
+    assert settings_service.is_brain_orb_enabled() is False
+    assert settings_service.is_brain_orb_voice_enabled() is False
+    assert settings_service.is_brain_orb_write_enabled() is False
+
+
+def test_resolver_env_opt_in(monkeypatch):
+    monkeypatch.setenv("BRAIN_ORB_ENABLED", "true")
+    assert settings_service.is_brain_orb_enabled() is True
+    # env is per-flag — siblings stay off
+    assert settings_service.is_brain_orb_voice_enabled() is False
+
+
+def test_resolver_stored_false_beats_env_true(monkeypatch):
+    """The stored value wins in BOTH directions — an admin OFF overrides env ON."""
+    monkeypatch.setenv("BRAIN_ORB_ENABLED", "true")
+    db.set_setting("brain_orb_enabled", "false")
+    assert settings_service.is_brain_orb_enabled() is False
+
+
+def test_resolver_stored_true_without_env():
+    db.set_setting("brain_orb_enabled", "true")
+    assert settings_service.is_brain_orb_enabled() is True
+
+
+def test_resolver_keys_are_independent():
+    db.set_setting("brain_orb_voice_enabled", "true")
+    assert settings_service.is_brain_orb_voice_enabled() is True
+    assert settings_service.is_brain_orb_enabled() is False
+    assert settings_service.is_brain_orb_write_enabled() is False
+
+
+def test_resolver_junk_stored_value_is_off(monkeypatch):
+    """A junk stored value parses to False (feature off, fail-safe) and does
+    NOT fall through to the env leg — premise P4 (generic PUT stays usable)."""
+    monkeypatch.setenv("BRAIN_ORB_ENABLED", "true")
+    db.set_setting("brain_orb_enabled", "banana")
+    assert settings_service.is_brain_orb_enabled() is False
+
+
+def test_resolver_fail_open_falls_back_to_env(monkeypatch):
+    """A settings-read failure must fall back to the env default, never raise —
+    this is load-bearing for GET /api/settings/feature-flags (a 500 there
+    zeroes EVERY flag in the frontend store)."""
+    monkeypatch.setenv("BRAIN_ORB_ENABLED", "true")
+
+    def boom(key, default=None):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(settings_service, "get_setting", boom)
+    assert settings_service.is_brain_orb_enabled() is True
+    monkeypatch.delenv("BRAIN_ORB_ENABLED")
+    assert settings_service.is_brain_orb_enabled() is False
+
+
+# --- dedicated admin routes: GET ---------------------------------------------
+
+def test_get_payload_shape_and_sources(admin_client, monkeypatch):
+    """GET returns per-flag {value, source} — and is NOT captured by the /{key}
+    catch-all (which would 404 'Setting brain-orb not found', Invariant #4)."""
+    monkeypatch.setenv("BRAIN_ORB_VOICE_ENABLED", "true")
+    db.set_setting("brain_orb_enabled", "true")
+
+    r = admin_client.get(_URL)
+    assert r.status_code == 200
+    flags = r.json()["flags"]
+    assert flags["enabled"] == {"value": True, "source": "override"}
+    assert flags["voice_enabled"] == {"value": True, "source": "env"}
+    assert flags["write_enabled"] == {"value": False, "source": "default"}
+    assert isinstance(r.json()["gemini_key_configured"], bool)
+
+
+def test_get_requires_admin(user_client):
+    assert user_client.get(_URL).status_code == 403
+
+
+# --- dedicated admin routes: PUT -----------------------------------------------
+
+def test_put_partial_update_writes_only_that_key(admin_client):
+    r = admin_client.put(_URL, json={"enabled": True})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["updated"] == ["enabled"]
+    assert body["cleared"] == []
+    assert body["flags"]["enabled"] == {"value": True, "source": "override"}
+    assert db.get_setting_value("brain_orb_enabled", None) == "true"
+    assert db.get_setting_value("brain_orb_voice_enabled", None) is None
+    assert db.get_setting_value("brain_orb_write_enabled", None) is None
+
+
+def test_put_clear_reverts_to_env(admin_client, monkeypatch):
+    """`clear` deletes the stored override so the env var speaks again — the
+    revert path both reviewers demanded (env is otherwise dead after a toggle)."""
+    monkeypatch.setenv("BRAIN_ORB_VOICE_ENABLED", "true")
+    db.set_setting("brain_orb_voice_enabled", "false")
+    assert settings_service.is_brain_orb_voice_enabled() is False
+
+    r = admin_client.put(_URL, json={"clear": ["voice_enabled"]})
+    assert r.status_code == 200
+    assert r.json()["cleared"] == ["voice_enabled"]
+    assert r.json()["flags"]["voice_enabled"] == {"value": True, "source": "env"}
+    assert settings_service.is_brain_orb_voice_enabled() is True
+    assert db.get_setting_value("brain_orb_voice_enabled", None) is None
+
+
+def test_put_set_and_clear_conflict_400(admin_client):
+    r = admin_client.put(_URL, json={"enabled": True, "clear": ["enabled"]})
+    assert r.status_code == 400
+    assert "both set and cleared" in r.json()["detail"]
+
+
+def test_put_unknown_clear_name_400(admin_client):
+    r = admin_client.put(_URL, json={"clear": ["bogus"]})
+    assert r.status_code == 400
+    assert "bogus" in r.json()["detail"]
+
+
+def test_put_noop_succeeds_without_audit(admin_client):
+    with patch.object(sr.platform_audit_service, "log", AsyncMock()) as log:
+        r = admin_client.put(_URL, json={})
+    assert r.status_code == 200
+    assert r.json()["updated"] == []
+    assert r.json()["cleared"] == []
+    assert log.await_count == 0
+
+
+def test_put_requires_admin(user_client):
+    assert user_client.put(_URL, json={"enabled": True}).status_code == 403
+
+
+def test_put_audit_carries_per_flag_old_new(admin_client):
+    """The write flag gates an exec-adjacent surface — every change must leave
+    a per-flag old→new trace, not a bare 'update'."""
+    with patch.object(sr.platform_audit_service, "log", AsyncMock()) as log:
+        r = admin_client.put(_URL, json={"write_enabled": True})
+    assert r.status_code == 200
+    assert log.await_count == 1
+    details = log.await_args.kwargs["details"]
+    assert details["setting"] == "brain_orb_flags"
+    assert details["changes"]["write_enabled"] == {"old": False, "new": True}
+
+
+def test_registry_and_model_fields_stay_in_sync():
+    """Drift guard: every BRAIN_ORB_FLAGS registry key must be a
+    BrainOrbSettingsUpdate field — the PUT loop iterates the registry against
+    the model, so a registry-only flag would otherwise surface at runtime."""
+    from models import BrainOrbSettingsUpdate
+
+    assert set(BRAIN_ORB_FLAGS) <= set(BrainOrbSettingsUpdate.model_fields)
+
+
+# --- generic /{key} routes stay usable (premise P4) ---------------------------
+
+def test_generic_put_junk_value_fails_safe(admin_client):
+    r = admin_client.put("/api/settings/brain_orb_enabled", json={"value": "banana"})
+    assert r.status_code == 200  # generic KV write succeeds...
+    assert settings_service.is_brain_orb_enabled() is False  # ...and parses to OFF
+
+
+def test_generic_delete_reverts_to_env(admin_client, monkeypatch):
+    monkeypatch.setenv("BRAIN_ORB_ENABLED", "true")
+    db.set_setting("brain_orb_enabled", "false")
+    r = admin_client.delete("/api/settings/brain_orb_enabled")
+    assert r.status_code == 200
+    assert settings_service.is_brain_orb_enabled() is True
+
+
+# --- consumers: route gate + feature-flags ------------------------------------
+
+def _brain_orb_client():
+    """Brain-orb router WITHOUT resolver patches — gates hit the real DB."""
+    app = FastAPI()
+    app.include_router(bo.router)
+    app.dependency_overrides[get_authorized_agent_by_name] = lambda: "cornelius"
+    app.dependency_overrides[get_owned_agent_by_name] = lambda: "cornelius"
+    app.dependency_overrides[get_current_user] = lambda: _user("admin")
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_route_gate_honors_db_flip_without_restart():
+    """The acceptance criterion: flipping the stored setting changes the gate
+    outcome at request time — no import-time constant, no restart."""
+    client = _brain_orb_client()
+    url = "/api/agents/cornelius/brain-orb/data"
+
+    r = client.get(url)
+    assert r.status_code == 404
+    assert "not enabled" in r.json()["detail"]
+
+    db.set_setting("brain_orb_enabled", "true")
+    # Flag now passes; the request proceeds to container lookup (no Docker in
+    # unit tests → "Agent not found", a DIFFERENT 404 proving the gate opened).
+    with patch.object(bo, "get_agent_container", return_value=None):
+        r = client.get(url)
+    assert r.status_code == 404
+    assert "Agent not found" in r.json()["detail"]
+
+    db.set_setting("brain_orb_enabled", "false")
+    r = client.get(url)
+    assert "not enabled" in r.json()["detail"]
+
+
+def test_feature_flags_reflect_resolved_values(admin_client, monkeypatch):
+    monkeypatch.setattr(config, "GEMINI_API_KEY", "test-key")
+
+    r = admin_client.get("/api/settings/feature-flags")
+    assert r.status_code == 200
+    assert r.json()["brain_orb_available"] is False
+
+    db.set_setting("brain_orb_enabled", "true")
+    db.set_setting("brain_orb_voice_enabled", "true")
+    db.set_setting("brain_orb_write_enabled", "true")
+    body = admin_client.get("/api/settings/feature-flags").json()
+    assert body["brain_orb_available"] is True
+    assert body["brain_orb_voice_available"] is True
+    assert body["brain_orb_write_available"] is True
+
+
+def test_feature_flags_voice_composes_with_base(admin_client, monkeypatch):
+    """base stored-OFF ∧ voice env-ON ∧ key present ⇒ voice reads unavailable —
+    the #85 composition fix (a downed orb must not advertise its voice tile)."""
+    monkeypatch.setattr(config, "GEMINI_API_KEY", "test-key")
+    monkeypatch.setenv("BRAIN_ORB_VOICE_ENABLED", "true")
+    db.set_setting("brain_orb_enabled", "false")
+
+    body = admin_client.get("/api/settings/feature-flags").json()
+    assert body["brain_orb_available"] is False
+    assert body["brain_orb_voice_available"] is False
+    assert body["brain_orb_write_available"] is False
+
+
+def test_feature_flags_survive_brain_orb_db_failure(admin_client, monkeypatch):
+    """A brain-orb settings-read failure must NOT 500 feature-flags — the
+    frontend store zeroes every flag on a non-200 (fail-open, load-bearing)."""
+    real_get = settings_service.get_setting
+
+    def flaky(key, default=None):
+        if key.startswith("brain_orb"):
+            raise RuntimeError("db down")
+        return real_get(key, default)
+
+    monkeypatch.setattr(settings_service, "get_setting", flaky)
+    r = admin_client.get("/api/settings/feature-flags")
+    assert r.status_code == 200
+    assert r.json()["brain_orb_available"] is False

--- a/tests/unit/test_brain_orb.py
+++ b/tests/unit/test_brain_orb.py
@@ -79,10 +79,13 @@ def client(monkeypatch):
     app.dependency_overrides[get_authorized_agent_by_name] = lambda: _AGENT
     app.dependency_overrides[get_owned_agent_by_name] = lambda: _AGENT
     app.dependency_overrides[get_current_user] = lambda: types.SimpleNamespace(id=7, username="u", email="u@example.com")
-    # Flags ON by default; individual tests flip them off. container_reload is async.
-    monkeypatch.setattr(bo, "BRAIN_ORB_ENABLED", True)
-    monkeypatch.setattr(bo, "BRAIN_ORB_VOICE_ENABLED", True)   # #60 Phase 3
-    monkeypatch.setattr(bo, "BRAIN_ORB_WRITE_ENABLED", True)   # #61 Phase 4a
+    # Flags ON by default; individual tests flip them off. Since #85 the gates
+    # are runtime resolvers imported into the router's namespace — patch the
+    # module-level names (the DB-backed resolution itself is covered by
+    # test_85_brain_orb_settings.py). container_reload is async.
+    monkeypatch.setattr(bo, "is_brain_orb_enabled", lambda: True)
+    monkeypatch.setattr(bo, "is_brain_orb_voice_enabled", lambda: True)   # #60 Phase 3
+    monkeypatch.setattr(bo, "is_brain_orb_write_enabled", lambda: True)   # #61 Phase 4a
     monkeypatch.setattr(bo, "GEMINI_API_KEY", "test-key")      # #60 Phase 3
     monkeypatch.setattr(bo, "container_reload", AsyncMock())
     # #61 Phase 4a: the voice-token route resolves owner-ness for can_write. Default
@@ -98,7 +101,7 @@ _URL = f"/api/agents/{_AGENT}/brain-orb/data"
 
 def test_flag_off_returns_404(client, monkeypatch):
     """Platform flag is the single source of truth — off ⇒ 404, never a 5xx."""
-    monkeypatch.setattr(bo, "BRAIN_ORB_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_enabled", lambda: False)
     with patch.object(bo, "get_agent_container", return_value=_running()):
         r = client.get(_URL)
     assert r.status_code == 404
@@ -184,7 +187,7 @@ def test_scopes_success_passes_through(client):
 
 
 def test_scopes_flag_off_404(client, monkeypatch):
-    monkeypatch.setattr(bo, "BRAIN_ORB_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_enabled", lambda: False)
     with patch.object(bo, "get_agent_container", return_value=_running()):
         r = client.get(_SCOPES_URL)
     assert r.status_code == 404
@@ -210,7 +213,7 @@ def test_scope_post_success_passes_through(client):
 
 
 def test_scope_post_flag_off_404(client, monkeypatch):
-    monkeypatch.setattr(bo, "BRAIN_ORB_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_enabled", lambda: False)
     with patch.object(bo, "get_agent_container", return_value=_running()):
         r = client.post(_SCOPE_URL, json={"tokens": []})
     assert r.status_code == 404
@@ -261,8 +264,16 @@ def test_voice_token_success(client):
 
 
 def test_voice_token_flag_off_404(client, monkeypatch):
-    """Gated on the VOICE flag specifically — distinct from BRAIN_ORB_ENABLED."""
-    monkeypatch.setattr(bo, "BRAIN_ORB_VOICE_ENABLED", False)
+    """Voice flag off ⇒ 404 even with the base flag on."""
+    monkeypatch.setattr(bo, "is_brain_orb_voice_enabled", lambda: False)
+    r = client.post(_VOICE_TOKEN_URL)
+    assert r.status_code == 404
+
+
+def test_voice_token_base_flag_off_404(client, monkeypatch):
+    """#85: base OFF ⇒ mint 404 even with voice ON — a disabled orb must not
+    let direct API calls spin up Gemini Live sessions on the platform key."""
+    monkeypatch.setattr(bo, "is_brain_orb_enabled", lambda: False)
     r = client.post(_VOICE_TOKEN_URL)
     assert r.status_code == 404
 
@@ -332,7 +343,7 @@ def test_tool_unsupported_maps_to_404(client):
 
 
 def test_tool_flag_off_404(client, monkeypatch):
-    monkeypatch.setattr(bo, "BRAIN_ORB_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_enabled", lambda: False)
     with patch.object(bo, "get_agent_container", return_value=_running()):
         r = client.post(_TOOL_URL, json={"query": "x"})
     assert r.status_code == 404
@@ -536,7 +547,7 @@ def test_actions_get_success_passes_through(client):
 def test_actions_write_flag_off_404(client, monkeypatch):
     """Distinct kill-switch: BRAIN_ORB_WRITE_ENABLED off ⇒ 404 even though the base
     render flag is on (writes disabled without downing read/voice)."""
-    monkeypatch.setattr(bo, "BRAIN_ORB_WRITE_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_write_enabled", lambda: False)
     with patch.object(bo, "get_agent_container", return_value=_running()):
         r = client.get(_ACTIONS_URL)
     assert r.status_code == 404
@@ -635,7 +646,7 @@ def test_refresh_owner_gate_403(client):
 
 
 def test_refresh_flag_off_404(client, monkeypatch):
-    monkeypatch.setattr(bo, "BRAIN_ORB_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_enabled", lambda: False)
     with patch.object(bo, "get_agent_container", return_value=_running()):
         r = client.post(_REFRESH_URL)
     assert r.status_code == 404
@@ -644,7 +655,7 @@ def test_refresh_flag_off_404(client, monkeypatch):
 def test_refresh_write_flag_off_404(client, monkeypatch):
     """refresh drives the agent action hook, so the write kill-switch must gate it too
     (review F1) — not just BRAIN_ORB_ENABLED."""
-    monkeypatch.setattr(bo, "BRAIN_ORB_WRITE_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_write_enabled", lambda: False)
     agent_req = AsyncMock()
     with patch.object(bo, "_agent_request", agent_req):
         r = client.post(_REFRESH_URL)
@@ -708,7 +719,7 @@ def test_postprocess_owner_gate_403(client):
 
 
 def test_postprocess_write_flag_off_404(client, monkeypatch):
-    monkeypatch.setattr(bo, "BRAIN_ORB_WRITE_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_write_enabled", lambda: False)
     assert client.get(_POSTPROC_URL).status_code == 404
     assert client.put(_POSTPROC_URL, json={"enabled": False, "prompt": ""}).status_code == 404
 
@@ -741,7 +752,7 @@ def test_action_transcript_large_body_allowed(client):
 
 
 def test_action_write_flag_off_404(client, monkeypatch):
-    monkeypatch.setattr(bo, "BRAIN_ORB_WRITE_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_write_enabled", lambda: False)
     r = client.post(_ACTION_URL, json={"action": "capture", "body": "x"})
     assert r.status_code == 404
 
@@ -887,7 +898,7 @@ def test_voice_token_owner_gets_write_manifest(client):
 
 def test_voice_token_write_flag_off_forces_readonly(client, monkeypatch):
     """Even an owner gets can_write=False when the write flag is off."""
-    monkeypatch.setattr(bo, "BRAIN_ORB_WRITE_ENABLED", False)
+    monkeypatch.setattr(bo, "is_brain_orb_write_enabled", lambda: False)
     mint = AsyncMock(return_value={"ephemeral_token": "auth_tokens/x", "tools": []})
     with patch.object(bo.db, "get_voice_name", return_value="Kore"), patch.object(
         bo.db, "get_voice_system_prompt", return_value=None


### PR DESCRIPTION
## Summary
- Converts the three Brain Orb platform flags (base / voice / KB-write) from import-time env constants to **runtime resolvers**: `system_settings` override (wins both directions) → `BRAIN_ORB_*` env opt-in → default OFF — one shared `_resolve_bool_flag` helper, fail-open on a settings-read failure (a 500 in `feature-flags` would zero every flag in the frontend store), deliberately uncached (#506 `--workers 2` rationale).
- Adds the admin surface `GET/PUT /api/settings/brain-orb` (admin-only, registered before the `/{key}` catch-all): per-flag `{value, source: override|env|default}` + `gemini_key_configured` (boolean only); PUT takes partial booleans and/or `clear: [flag,…]` reverting a flag to its env/default — without it the env var is silently dead once a DB row exists. Audit-logged with per-flag old→new values.
- Settings → General gets a Brain Orb panel (per-flag source badges, reset-to-env, write-surface warning, forced `feature-flags` refetch after save). Composition fix: the voice-token mint now gates on `base ∧ voice` and `brain_orb_voice_available = base ∧ voice ∧ GEMINI_API_KEY` — a disabled orb can no longer mint Gemini Live tokens via direct API call. `GEMINI_API_KEY` stays env-only (secret).

## Changes
- `src/backend/services/settings_service.py` — `_resolve_bool_flag` + three resolvers + `BRAIN_ORB_FLAGS` registry
- `src/backend/routers/agent_brain_orb.py` — all gate sites converted to resolvers (module-level names, mechanical test seam)
- `src/backend/routers/settings.py` — feature-flags recompose + dedicated GET/PUT with `clear` semantics and old→new audit
- `src/backend/config.py` — dead constants removed (pointer comment); `src/backend/models.py` — `BrainOrbSettingsUpdate`
- `src/frontend/src/views/Settings.vue`, `stores/settings.js`, `components/BrainPanel.vue` — admin panel + store methods + stale env-var copy fix
- `docs/memory/requirements/core-agent.md` (FR-11), `docs/memory/architecture.md`, `docs/memory/feature-flows/brain-orb.md`
- `tests/unit/test_85_brain_orb_settings.py` (23 tests), `tests/unit/test_brain_orb.py` (resolver-seam conversion + base-off mint test), `tests/registry.json`

No schema migration (`system_settings` KV — #506/#1129 precedent). No MCP-server or agent-server change.

## Test Plan
- [x] `pytest tests/unit/test_85_brain_orb_settings.py -v` — 23 passed (resolver order incl. stored-beats-env both directions, junk-value fail-safe, fail-open on DB error; DB flip changes route-gate outcome without restart; admin routes incl. 403, clear revert, set+clear 400, audit old→new, `/{key}` ordering; feature-flags composition + 200-despite-DB-failure)
- [x] `pytest tests/unit/test_brain_orb.py` — 96 passed after seam conversion
- [x] Settings-adjacent suites (`test_506_max_parallel_ceiling`, `test_models_centralized`, settings-router importers) — 85 passed
- [x] Vue SFC compile check on `Settings.vue` / `BrainPanel.vue`; store JS parse check
- [ ] Manual: flip toggles in Settings → General on a running stack; verify Brain tab appears/disappears on reload with no backend restart

Refs abilityai/trinity-enterprise#85 — private-tracker feature; closing keyword does not cross repos, issue is closed manually at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)