### PR TITLE
fix(chat): self-task inject_result silently no-ops — dict access on Pydantic session (#1457)

### DIFF
--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -1250,7 +1250,7 @@ async def _finalize_self_task(
         try:
             # Validate session exists and belongs to user
             session = db.get_chat_session(request.chat_session_id)
-            if session and session.get("user_id") == user_id:
+            if session and session.user_id == user_id:
                 # Add self-task result as a chat message
                 db.add_chat_message(
                     session_id=request.chat_session_id,

--- a/tests/unit/test_1457_selftask_inject_ownership.py
+++ b/tests/unit/test_1457_selftask_inject_ownership.py
@@ -1,0 +1,131 @@
+"""Unit tests for #1457 — self-task ``inject_result`` must actually inject.
+
+``_finalize_self_task`` (``routers/chat.py``) validated chat-session ownership with
+**dict** access (``session.get("user_id")``) on the value returned by
+``db.get_chat_session()``. After the #1093 SQLAlchemy-Core rewrite that accessor
+returns ``Optional[ChatSession]`` — a Pydantic ``BaseModel`` with no ``.get()`` — so
+the check raised ``AttributeError``, was swallowed by the surrounding
+``except Exception``, and the result was **silently never injected**.
+
+Same class as #1444: a swallowing ``except`` turns the regression into a silent
+no-op, not a crash. Guards:
+  (a) a SUCCESS self-task with ``inject_result=True`` and an **owned**
+      ``chat_session_id`` writes an ``assistant`` message with ``source="self_task"``.
+  (b) a **foreign**-owned ``chat_session_id`` does NOT inject.
+  (c) ``ChatSession`` exposes ``.user_id`` (attribute) and has no ``.get`` — proving
+      the old dict access was structurally wrong, so the ownership branch is really
+      reached, not swallowed.
+
+Pure unit tests — no backend. Mirrors test_1332_cancelled_activity_state.py.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _await(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _success_result():
+    from models import TaskExecutionStatus
+
+    r = MagicMock()
+    r.status = TaskExecutionStatus.SUCCESS
+    r.response = "task done"
+    r.error = None
+    r.cost = 0.02
+    r.context_used = 120
+    r.context_max = 200000
+    return r
+
+
+def _chat_session(*, owner_id: int):
+    """A real ChatSession Pydantic model — has ``.user_id``, has no ``.get()``."""
+    from db_models import ChatSession
+
+    now = datetime(2026, 7, 6, 0, 0, 0)
+    return ChatSession(
+        id="sess-1457",
+        agent_name="test-agent",
+        user_id=owner_id,
+        user_email="owner@example.com",
+        started_at=now,
+        last_message_at=now,
+    )
+
+
+def _run_finalize(*, session, caller_user_id):
+    import routers.chat as chat
+
+    request = MagicMock(inject_result=True, chat_session_id="sess-1457")
+
+    mock_db = MagicMock()
+    mock_db.get_chat_session.return_value = session
+
+    mock_activity = MagicMock(complete_activity=AsyncMock())
+    with (
+        patch.object(chat, "db", mock_db),
+        patch.object(chat, "activity_service", mock_activity),
+        patch.object(chat, "_websocket_manager", None),
+    ):
+        _await(
+            chat._finalize_self_task(
+                is_self_task=True,
+                self_task_activity_id="self-act",
+                agent_name="test-agent",
+                request=request,
+                result=_success_result(),
+                execution_id="exec-1457",
+                user_id=caller_user_id,
+                user_email="caller@example.com",
+                execution_time_ms=999,
+            )
+        )
+    return mock_db
+
+
+class TestSelfTaskInjectOwnership:
+    pytestmark = pytest.mark.unit
+
+    def test_owned_session_injects_self_task_message(self):
+        """SUCCESS + inject_result + owned session → assistant message, source=self_task."""
+        mock_db = _run_finalize(session=_chat_session(owner_id=7), caller_user_id=7)
+
+        mock_db.add_chat_message.assert_called_once()
+        kwargs = mock_db.add_chat_message.call_args.kwargs
+        assert kwargs["role"] == "assistant"
+        assert kwargs["source"] == "self_task"
+        assert kwargs["content"] == "task done"
+        assert kwargs["session_id"] == "sess-1457"
+
+    def test_foreign_session_does_not_inject(self):
+        """Session owned by a different user → ownership check fails, no injection."""
+        mock_db = _run_finalize(session=_chat_session(owner_id=7), caller_user_id=99)
+
+        mock_db.add_chat_message.assert_not_called()
+
+    def test_chat_session_is_attribute_accessed_not_dict(self):
+        """Regression guard: the ownership branch relies on ``.user_id`` (attribute).
+
+        The pre-#1457 ``session.get("user_id")`` raised on a Pydantic model and was
+        swallowed — proving the branch was structurally unreachable.
+        """
+        session = _chat_session(owner_id=7)
+        assert session.user_id == 7
+        assert not hasattr(session, "get")

--- a/tests/unit/test_async_task_persistence.py
+++ b/tests/unit/test_async_task_persistence.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -51,7 +52,11 @@ def _env(result=None):
     activity.complete_activity = AsyncMock()
 
     db = MagicMock()
-    db.get_chat_session.return_value = {"user_id": 7}
+    # #1457: db.get_chat_session returns a ChatSession (pydantic), NOT a dict —
+    # _finalize_self_task reads session.user_id by attribute. A SimpleNamespace
+    # faithfully mirrors that contract (attribute access, no .get); a dict here
+    # made the fixture pass against the buggy `session.get("user_id")` code.
+    db.get_chat_session.return_value = SimpleNamespace(user_id=7)
 
     persist = AsyncMock(return_value="cs1")
     signal = MagicMock()
@@ -128,7 +133,7 @@ def test_self_task_injects_result_into_session():
 def test_self_task_no_inject_when_session_not_owned():
     req = ParallelTaskRequest(message="hi", inject_result=True, chat_session_id="cs9")
     with _env() as m:
-        m["db"].get_chat_session.return_value = {"user_id": 999}  # different owner
+        m["db"].get_chat_session.return_value = SimpleNamespace(user_id=999)  # different owner
         _call(req, user_id=7, user_email="u@e.com",
               is_self_task=True, self_task_activity_id="st1")
     m["db"].add_chat_message.assert_not_called()


### PR DESCRIPTION
## Problem
`_finalize_self_task` (`src/backend/routers/chat.py`) validated chat-session ownership with **dict** access on the value from `db.get_chat_session()`:

```python
if session and session.get("user_id") == user_id:   # ChatSession has no .get()
```

After the #1093 SQLAlchemy-Core rewrite, `db.get_chat_session()` returns `Optional[ChatSession]` (a Pydantic `BaseModel`), not a dict. `session.get(...)` raised `AttributeError`, caught by the surrounding `except Exception` and logged as a warning. **Net effect:** with `inject_result=true`, the self-task result was **never** written into the chat session and the ownership check never ran.

## Fix
One line — attribute access, matching the sibling call-sites (`chat.py:1016`, `:2321`, `:2352`):

```python
if session and session.user_id == user_id:
```

## Regression test
`tests/unit/test_1457_selftask_inject_ownership.py` (pure unit, mirrors `test_1332_*`):
- owned session + SUCCESS + `inject_result=True` → `assistant` message with `source="self_task"`
- foreign-owned session → **no** injection
- guard: `ChatSession` exposes `.user_id` and has no `.get` (old dict access was structurally wrong)

Verified red on the buggy code, green on the fix. `3 passed`.

## Provenance
Found during #1444 review; same class as #1444 — a swallowing `except` turns the regression into a silent no-op.

Fixes #1457

---

## Also fixes #1451 (duplicate of #1457)

#1451 reports the identical defect. Its extra acceptance criterion — audit sibling `get_chat_session` consumers — done, all clean (attribute access, no dict `.get()`):
- `routers/public.py:1110` → `session.agent_name` / `session.user_id` ✅
- `routers/voice.py:54` → `chat_session.id` ✅
- `routers/chat.py:1011` (`if not session`), `:2285`, `:2317` → attribute access ✅
- (`services/agent_client.py` `session.get(...)` is a stats dict, not a `ChatSession` — out of scope)

`_finalize_self_task` was the sole offender.

Related to #1451
