### PR TITLE
refactor(open-core): degeneralize enterprise-loader comment + guard the seam files (#1461)

### DIFF
--- a/.github/workflows/enterprise-docs-guard.yml
+++ b/.github/workflows/enterprise-docs-guard.yml
@@ -1,10 +1,15 @@
 # Enterprise-docs disclosure guard (trinity-enterprise#45)
 #
-# Fails the build if a public doc reintroduces enterprise/paid-feature
-# specifics: named paid features (SIEM/SCIM/...), private `enterprise_*`
-# table/schema identifiers, or per-module internals. Public docs may describe
-# the GENERIC open-core seam only (entitlement registry + conditional module
-# registration) — never the catalog of which capabilities are paid.
+# Fails the build if a public doc — OR a public open-core SEAM FILE — reintroduces
+# enterprise/paid-feature specifics: named paid features (SIEM/SCIM/...), private
+# `enterprise_*` table/schema identifiers, or per-module internals. Public docs and
+# seam-file comments may describe the GENERIC open-core seam only (entitlement
+# registry + conditional module registration) — never the catalog of which
+# capabilities are paid.
+#
+# Seam files are grepped because a comment there is unguarded prose that can name
+# the paid catalog just as a doc can (#1461 — the register_enterprise loader comment
+# was the one public enumeration of the module catalog for months).
 #
 # Out of scope by design: point-in-time historical records
 # (docs/archive/**, docs/releases/**, docs/security-reports/**) — those are
@@ -16,12 +21,16 @@ on:
     paths:
       - 'docs/**'
       - 'CLAUDE.md'
+      - 'src/backend/main.py'
+      - 'src/backend/services/entitlement_service.py'
       - '.github/workflows/enterprise-docs-guard.yml'
   push:
     branches: [dev, main]
     paths:
       - 'docs/**'
       - 'CLAUDE.md'
+      - 'src/backend/main.py'
+      - 'src/backend/services/entitlement_service.py'
 
 # Least privilege: the guard only checks out and greps — no writes.
 permissions:
@@ -32,23 +41,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Scan live public docs for enterprise disclosure
+      - name: Scan live public docs + open-core seam files for enterprise disclosure
         run: |
           set -uo pipefail
           # Genuinely-private identifiers: named paid features + private schema +
           # per-module paths. Word-boundaried where the token is also a common word.
           PATTERN='\bSIEM\b|\bSCIM\b|enterprise_siem|enterprise_user_2fa|enterprise_2fa|enterprise_sso|two_factor|2fa_recovery_codes'
+          # The open-core seam files: public code whose comments must stay generic
+          # (the entitlement mechanism), never naming the paid catalog (#1461).
+          SEAM_FILES='src/backend/main.py src/backend/services/entitlement_service.py'
           # Live docs only — exclude historical/point-in-time trees and this guard.
-          HITS=$(grep -rniE "$PATTERN" docs/ CLAUDE.md \
+          HITS=$(grep -rniE "$PATTERN" docs/ CLAUDE.md $SEAM_FILES \
                    --exclude-dir=archive \
                    --exclude-dir=releases \
                    --exclude-dir=security-reports \
                    2>/dev/null || true)
           if [ -n "$HITS" ]; then
-            echo "::error::Enterprise/paid-feature detail found in public docs (trinity-enterprise#45)."
-            echo "Public docs describe the generic open-core seam only. Move specifics to trinity-enterprise/docs/."
+            echo "::error::Enterprise/paid-feature detail found in a public doc or seam file (trinity-enterprise#45)."
+            echo "Public docs and seam-file comments describe the generic open-core seam only. Move specifics to trinity-enterprise/docs/."
             echo "--------------------------------------------------------------------"
             echo "$HITS"
             exit 1
           fi
-          echo "OK — no enterprise/paid-feature disclosure in live public docs."
+          echo "OK — no enterprise/paid-feature disclosure in live public docs or seam files."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Enterprise **feature designs, paid-module schema, and the open-core gating/monet
 
 - New enterprise design → write it in `trinity-enterprise/docs/`, not here.
 - Touching the seam in public docs → describe the mechanism, never enumerate the modules behind it.
-- `.github/workflows/enterprise-docs-guard.yml` greps live public docs for paid-feature/private-schema tokens and fails the build on a hit; keep historical point-in-time docs (`docs/archive/`, `docs/releases/`, `docs/security-reports/`) out of scope (covered by the separate git-history-scrub follow-up).
+- `.github/workflows/enterprise-docs-guard.yml` greps live public docs **and the open-core seam files** (`src/backend/main.py`, `src/backend/services/entitlement_service.py` — a code comment can name the catalog just as a doc can, #1461) for paid-feature/private-schema tokens and fails the build on a hit; keep historical point-in-time docs (`docs/archive/`, `docs/releases/`, `docs/security-reports/`) out of scope (covered by the separate git-history-scrub follow-up).
 
 ---
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -955,19 +955,24 @@ app.include_router(ws_tickets_router)  # WebSocket auth tickets (#550)
 # at `src/backend/enterprise/`, repo `Abilityai/trinity-enterprise`).
 # The submodule is OPTIONAL: customers running the public repo without
 # enterprise access clone without it, and the ImportError below silently
-# no-ops. When mounted, `register_enterprise(app)` installs the SSO /
-# SCIM / SIEM routers under `/api/enterprise/*`. The function is
+# no-ops. When mounted, `register_enterprise(app)` installs the private
+# enterprise routers under `/api/enterprise/*`. The function is
 # idempotent (guards on `app.state.enterprise_registered`). Entitlement
 # gating happens per-endpoint via `requires_entitlement(feature_id)`
 # from `dependencies.py` — endpoints are mounted unconditionally and
 # the gate decides whether to serve them. This keeps the wiring
 # deterministic regardless of license state.
 #
+# The specific paid modules the submodule installs are intentionally NOT
+# enumerated here — this is a PUBLIC repo, and the paid-feature catalog
+# lives only in the private enterprise repo (trinity-enterprise#45). This
+# comment (and entitlement_service.py) are grepped by the enterprise-docs
+# guard, so keep it to the generic seam. See `docs/ENTERPRISE.md`.
+#
 # Import path is `enterprise.backend.register_enterprise`: the private
 # repo is restructured into `backend/` and `frontend/` subdirs so the
 # same repo can be dual-mounted (`src/backend/enterprise/` for Python,
-# `src/frontend/src/enterprise/` for Vite). See
-# `docs/planning/ENTERPRISE_ARCHITECTURE.md` for rationale.
+# `src/frontend/src/enterprise/` for Vite).
 try:
     from enterprise.backend import register_enterprise  # type: ignore[import-not-found]
     register_enterprise(app)


### PR DESCRIPTION
## Problem
The #847 `register_enterprise` loader comment in `src/backend/main.py` enumerated the specific paid modules the private submodule installs. The enterprise-docs guard (`enterprise-docs-guard.yml`) greps only `docs/` + `CLAUDE.md`, so code comments were unguarded — this was the one surviving public enumeration of the paid catalog. Flagged twice during /review of #1448.

## Changes (both acceptance criteria)

**AC1 — reword to the generic mechanism:**
- `installs the SSO / SCIM / SIEM routers` → `installs the private enterprise routers under /api/enterprise/*`; added an inline note that the catalog is private (trinity-enterprise#45) and that the file is now guard-grepped.
- Fixed a dead pointer: `docs/planning/ENTERPRISE_ARCHITECTURE.md` doesn't exist in the public repo → repointed to the public generic-seam doc `docs/ENTERPRISE.md` (shipped in #1448).

**AC2 — decision: yes, extend the guard to the seam files.** Cheap and closes the exact gap. Added `src/backend/main.py` + `src/backend/services/entitlement_service.py` to both the workflow's `paths` triggers and its grep target. `entitlement_service.py` is already clean (generic `feature_id` strings, no hardcoded names). Updated the CLAUDE.md standing rule to say the guard now covers seam files.

## Verification
- Guard grep **PASSes** on the reworded tree (docs + CLAUDE.md + both seam files).
- Negative test: an injected `# installs the SCIM router` line in a seam file is **caught** by the pattern — proving the new seam coverage actually fires.
- `main.py` parses (`ast.parse`), comment-only change.
- YAML valid (`yaml.safe_load`).

Fixes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
