### PR TITLE
feat(enterprise): Client Portal — My Agents roster + chat (trinity-enterprise#78)

### DIFF
--- a/src/backend/dependencies.py
+++ b/src/backend/dependencies.py
@@ -170,6 +170,45 @@ def decode_mfa_challenge(token: str) -> Optional[dict]:
     return {"username": username, "mode": payload.get("mode", "prod")}
 
 
+# Scope marker for the Client Portal session token (enterprise `client_portal`,
+# epic #78). A portal client is a *verified email*, NOT a `users` row — this
+# token carries only the email and is fenced OUT of every platform endpoint
+# (get_current_user / decode_token reject it, mirroring MFA_CHALLENGE_SCOPE). It
+# only authorizes the entitled portal endpoints, which resolve identity via
+# `decode_portal_session`. Edition-agnostic: OSS owns the mint/decode primitive
+# + the fence; the enterprise module decides *when* to mint one (after email-code
+# verification of a client whose email has a share). No new secret — same
+# SECRET_KEY/ALGORITHM, so a backend restart invalidates portal sessions too.
+PORTAL_SESSION_SCOPE = "portal_session"
+PORTAL_SESSION_EXPIRE_HOURS = 12
+
+
+def create_portal_session_token(email: str, mode: str = "prod") -> str:
+    """Mint a Client Portal session token for a verified email. Carries no
+    ``sub`` (no platform identity) — only the email + the portal scope."""
+    return create_access_token(
+        data={"scope": PORTAL_SESSION_SCOPE, "email": email.lower()},
+        expires_delta=timedelta(hours=PORTAL_SESSION_EXPIRE_HOURS),
+        mode=mode,
+    )
+
+
+def decode_portal_session(token: str) -> Optional[str]:
+    """Validate a portal session token. Returns the verified email if the token
+    is a non-expired, non-revoked portal-scoped token; ``None`` otherwise. Used
+    by the entitled portal endpoints to resolve the client identity."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        return None
+    if payload.get("scope") != PORTAL_SESSION_SCOPE:
+        return None
+    if is_token_revoked(payload.get("jti")):
+        return None
+    email = payload.get("email")
+    return email.lower() if email else None
+
+
 def decode_token(token: str) -> Optional[dict]:
     """
     Decode a JWT token without FastAPI dependency.
@@ -189,6 +228,11 @@ def decode_token(token: str) -> Optional[dict]:
 
         # #5 — a half-authenticated 2FA challenge token is not a session token.
         if payload.get("scope") == MFA_CHALLENGE_SCOPE:
+            return None
+
+        # #78 — a Client Portal session token is not a platform session. It only
+        # authorizes the entitled portal endpoints (via decode_portal_session).
+        if payload.get("scope") == PORTAL_SESSION_SCOPE:
             return None
 
         # #187 — a token revoked via logout is no longer valid (also for WS).
@@ -234,6 +278,13 @@ async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)
         # authorizes /api/enterprise/2fa/login/*; the second factor must be
         # completed there to obtain a real access token.
         if payload.get("scope") == MFA_CHALLENGE_SCOPE:
+            raise credentials_exception
+
+        # #78 — a Client Portal session token is fenced OUT of every platform
+        # endpoint. It carries no `sub` (so the check below would reject it
+        # anyway), but reject explicitly so a portal token can never resolve to
+        # a platform principal even if the claim shape changes.
+        if payload.get("scope") == PORTAL_SESSION_SCOPE:
             raise credentials_exception
 
         # #187 — reject a token revoked via logout.

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -173,6 +173,12 @@ const routes = [
     component: () => import('../views/enterprise/Audit.vue'),
     meta: { requiresAuth: true, requiresEntitlement: 'audit', title: 'Audit Log' }
   },
+  {
+    path: '/enterprise/client-portal',
+    name: 'EnterpriseClientPortal',
+    component: () => import('../views/enterprise/ClientPortal.vue'),
+    meta: { requiresAuth: true, requiresEntitlement: 'client_portal', title: 'Client Portal' }
+  },
   // Mobile Admin PWA (MOB-001) — standalone, no NavBar
   {
     path: '/m',

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -179,6 +179,16 @@ const routes = [
     component: () => import('../views/enterprise/ClientPortal.vue'),
     meta: { requiresAuth: true, requiresEntitlement: 'client_portal', title: 'Client Portal' }
   },
+  {
+    // Public client-facing portal — a client signs in with a verified email
+    // (no platform account) and sees the agents shared with them. Standalone
+    // (no NavBar / platform chrome), no requiresAuth. Backend 404s in
+    // OSS/unentitled builds; the page shows its sign-in / empty state.
+    path: '/portal',
+    name: 'ClientPortalPublic',
+    component: () => import('../views/Portal.vue'),
+    meta: { title: 'Client Portal' }
+  },
   // Mobile Admin PWA (MOB-001) — standalone, no NavBar
   {
     path: '/m',

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -1,0 +1,41 @@
+/**
+ * Client Portal store (enterprise `client_portal`, epic #78 / #79).
+ *
+ * Domain store for the client-facing portal surface. First slice: the
+ * "My Agents" roster (agents shared with the signed-in email) + the operator
+ * exposure config. Backed by the gated `/api/enterprise/client-portal/*`
+ * endpoints — 404 in OSS/unentitled builds, but the route guard
+ * (`requiresEntitlement: 'client_portal'`) keeps this store off those builds.
+ */
+import { defineStore } from 'pinia'
+import axios from 'axios'
+import { useAuthStore } from './auth'
+
+export const useClientPortalStore = defineStore('clientPortal', {
+  state: () => ({
+    clientEmail: null,
+    agents: [],
+    loading: false,
+    error: null,
+  }),
+
+  actions: {
+    async fetchRoster() {
+      this.loading = true
+      this.error = null
+      try {
+        const authStore = useAuthStore()
+        const { data } = await axios.get('/api/enterprise/client-portal/my-agents', {
+          headers: authStore.authHeader,
+        })
+        this.clientEmail = data.client_email || null
+        this.agents = data.agents || []
+      } catch (err) {
+        this.error = err.response?.data?.detail || 'Failed to load your agents.'
+        this.agents = []
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+})

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -11,26 +11,65 @@ import { defineStore } from 'pinia'
 import axios from 'axios'
 import { useAuthStore } from './auth'
 
+const PORTAL_TOKEN_KEY = 'trinity.portalToken'
+
 export const useClientPortalStore = defineStore('clientPortal', {
   state: () => ({
     clientEmail: null,
     agents: [],
     loading: false,
     error: null,
+    // A portal session token (verified email, no platform account). When set,
+    // it authenticates the portal endpoints; else we fall back to the platform
+    // login (operator preview). Persisted so a client stays signed in.
+    portalToken: localStorage.getItem(PORTAL_TOKEN_KEY) || null,
   }),
 
+  getters: {
+    // Portal-session token wins; otherwise the operator's platform auth header.
+    authHeader() {
+      if (this.portalToken) return { Authorization: `Bearer ${this.portalToken}` }
+      const authStore = useAuthStore()
+      return authStore.authHeader
+    },
+    isClientSignedIn: (state) => !!state.portalToken,
+  },
+
   actions: {
+    // Step 1 — request a 6-digit code. Always resolves (generic response); the
+    // backend reveals nothing about whether the email has access.
+    async requestCode(email) {
+      await axios.post('/api/enterprise/client-portal/auth/request', { email })
+    },
+
+    // Step 2 — verify the code → portal session token (persisted).
+    async verifyCode(email, code) {
+      const { data } = await axios.post('/api/enterprise/client-portal/auth/verify', { email, code })
+      this.portalToken = data.token
+      this.clientEmail = data.email
+      localStorage.setItem(PORTAL_TOKEN_KEY, data.token)
+      return data
+    },
+
+    signOut() {
+      this.portalToken = null
+      this.clientEmail = null
+      this.agents = []
+      localStorage.removeItem(PORTAL_TOKEN_KEY)
+    },
+
     async fetchRoster() {
       this.loading = true
       this.error = null
       try {
-        const authStore = useAuthStore()
         const { data } = await axios.get('/api/enterprise/client-portal/my-agents', {
-          headers: authStore.authHeader,
+          headers: this.authHeader,
         })
         this.clientEmail = data.client_email || null
         this.agents = data.agents || []
       } catch (err) {
+        // An expired/invalid portal token → drop it so the sign-in form returns.
+        if (err.response?.status === 401 && this.portalToken) this.signOut()
         this.error = err.response?.data?.detail || 'Failed to load your agents.'
         this.agents = []
       } finally {

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100">
+    <!-- Top bar -->
+    <header class="border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+      <div class="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <span class="text-xl">🪟</span>
+          <span class="font-semibold">Client Portal</span>
+        </div>
+        <button
+          v-if="store.isClientSignedIn"
+          class="text-sm text-gray-500 hover:text-gray-800 dark:hover:text-gray-200"
+          @click="store.signOut()"
+        >Sign out</button>
+      </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-4 py-10">
+      <!-- ============ SIGN-IN ============ -->
+      <div v-if="!store.isClientSignedIn" class="max-w-sm mx-auto">
+        <h1 class="text-xl font-semibold mb-1">Sign in to your agents</h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
+          Enter the email an operator shared agents with. We'll send you a 6-digit code.
+        </p>
+
+        <!-- Step 1: email -->
+        <form v-if="step === 'email'" @submit.prevent="onRequest" class="space-y-3">
+          <input
+            v-model="email"
+            type="email"
+            required
+            placeholder="you@example.com"
+            class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm focus:ring-action-primary-500 focus:border-action-primary-500"
+          />
+          <button
+            type="submit"
+            :disabled="busy || !email"
+            class="w-full rounded-lg bg-action-primary-600 hover:bg-action-primary-700 text-white text-sm px-4 py-2 disabled:opacity-50"
+          >{{ busy ? 'Sending…' : 'Send code' }}</button>
+        </form>
+
+        <!-- Step 2: code -->
+        <form v-else @submit.prevent="onVerify" class="space-y-3">
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            If <span class="font-medium text-gray-700 dark:text-gray-300">{{ email }}</span> has access,
+            a code is on its way. Enter it below.
+          </p>
+          <input
+            v-model="code"
+            inputmode="numeric"
+            maxlength="6"
+            placeholder="6-digit code"
+            class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm tracking-widest text-center focus:ring-action-primary-500 focus:border-action-primary-500"
+          />
+          <button
+            type="submit"
+            :disabled="busy || code.length < 6"
+            class="w-full rounded-lg bg-action-primary-600 hover:bg-action-primary-700 text-white text-sm px-4 py-2 disabled:opacity-50"
+          >{{ busy ? 'Verifying…' : 'Verify & continue' }}</button>
+          <button type="button" class="w-full text-xs text-gray-400 hover:text-gray-600" @click="step = 'email'; code = ''">
+            ← use a different email
+          </button>
+        </form>
+
+        <p v-if="error" class="mt-3 text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
+      </div>
+
+      <!-- ============ ROSTER ============ -->
+      <div v-else>
+        <div class="mb-4">
+          <h1 class="text-xl font-semibold">Your Agents</h1>
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            Shared with <span class="font-medium text-gray-700 dark:text-gray-300">{{ store.clientEmail }}</span>.
+          </p>
+        </div>
+
+        <div v-if="store.loading" class="text-center py-16">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
+        </div>
+
+        <div v-else-if="store.agents.length === 0" class="text-center py-16 border border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
+          <div class="text-4xl mb-3">🗂️</div>
+          <p class="text-sm text-gray-600 dark:text-gray-300 font-medium">No agents shared with you yet</p>
+        </div>
+
+        <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div
+            v-for="a in store.agents"
+            :key="a.name"
+            class="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4"
+          >
+            <div class="flex items-center gap-3">
+              <div
+                class="h-12 w-12 rounded-full flex items-center justify-center text-white font-semibold"
+                :style="{ background: tint(a.name) }"
+              >{{ initials(a.name) }}</div>
+              <div class="min-w-0">
+                <div class="font-medium truncate">{{ a.name }}</div>
+                <div class="text-xs text-gray-500 dark:text-gray-400 truncate"><span v-if="a.owner">by {{ a.owner }}</span></div>
+              </div>
+            </div>
+            <div class="mt-3 flex items-center justify-between">
+              <span class="text-[11px] text-gray-400"><span v-if="a.shared_at">shared {{ formatDate(a.shared_at) }}</span></span>
+              <button
+                class="text-xs px-2.5 py-1 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 cursor-not-allowed"
+                disabled
+                title="Chat over a portal session arrives in the next slice"
+              >Chat — soon</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useClientPortalStore } from '@/stores/clientPortal'
+
+const store = useClientPortalStore()
+const step = ref('email')
+const email = ref('')
+const code = ref('')
+const busy = ref(false)
+const error = ref(null)
+
+async function onRequest() {
+  busy.value = true
+  error.value = null
+  try {
+    await store.requestCode(email.value.trim().toLowerCase())
+    step.value = 'code'
+  } catch (err) {
+    error.value = err.response?.data?.detail || 'Could not send a code. Try again.'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onVerify() {
+  busy.value = true
+  error.value = null
+  try {
+    await store.verifyCode(email.value.trim().toLowerCase(), code.value.trim())
+    await store.fetchRoster()
+  } catch (err) {
+    error.value = err.response?.status === 401
+      ? 'Invalid or expired code.'
+      : (err.response?.data?.detail || 'Verification failed.')
+  } finally {
+    busy.value = false
+  }
+}
+
+function initials(name) {
+  const p = (name || '?').replace(/[^A-Za-z0-9]+/g, ' ').trim().split(' ')
+  return ((p[0]?.[0] || '') + (p[1]?.[0] || p[0]?.[1] || '')).toUpperCase() || '?'
+}
+function tint(name) {
+  let h = 0
+  for (let i = 0; i < (name || '').length; i++) h = (h * 31 + name.charCodeAt(i)) % 360
+  return `hsl(${h}, 45%, 45%)`
+}
+function formatDate(iso) {
+  try { return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) }
+  catch { return iso }
+}
+
+onMounted(() => { if (store.isClientSignedIn) store.fetchRoster() })
+</script>

--- a/src/frontend/src/views/enterprise/ClientPortal.vue
+++ b/src/frontend/src/views/enterprise/ClientPortal.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="max-w-5xl mx-auto px-4 py-8">
+    <!-- Header -->
+    <div class="mb-6">
+      <div class="flex items-center gap-2 mb-1">
+        <span class="text-2xl">🪟</span>
+        <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">Your Agents</h1>
+      </div>
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        The agents shared with
+        <span v-if="store.clientEmail" class="font-medium text-gray-700 dark:text-gray-300">{{ store.clientEmail }}</span>
+        <span v-else>your account</span>.
+        <span class="text-gray-400">Client Portal preview — chat &amp; documents arrive in a later slice.</span>
+      </p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="store.loading" class="text-center py-16">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
+      <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">Loading your agents…</p>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="store.error" class="rounded-lg border border-status-danger-200 dark:border-status-danger-800 bg-status-danger-50 dark:bg-status-danger-900/30 p-4 text-sm text-status-danger-700 dark:text-status-danger-300">
+      {{ store.error }}
+      <button class="ml-2 underline" @click="store.fetchRoster()">Retry</button>
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="store.agents.length === 0" class="text-center py-16 border border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
+      <div class="text-4xl mb-3">🗂️</div>
+      <p class="text-sm text-gray-600 dark:text-gray-300 font-medium">No agents shared with you yet</p>
+      <p class="text-xs text-gray-400 mt-1">When an operator shares an agent with your email, it appears here.</p>
+    </div>
+
+    <!-- Roster grid -->
+    <div v-else>
+      <div class="mb-3 text-xs text-gray-400">
+        {{ store.agents.length }} agent{{ store.agents.length === 1 ? '' : 's' }} shared with you
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div
+          v-for="a in store.agents"
+          :key="a.name"
+          class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 flex flex-col"
+        >
+          <div class="flex items-center gap-3">
+            <!-- Avatar or initials tile -->
+            <img
+              v-if="a.avatar_url && !failed[a.name]"
+              :src="a.avatar_url"
+              :alt="a.name"
+              class="h-12 w-12 rounded-full object-cover bg-gray-100 dark:bg-gray-700"
+              @error="failed[a.name] = true"
+            />
+            <div
+              v-else
+              class="h-12 w-12 rounded-full flex items-center justify-center text-white font-semibold"
+              :style="{ background: tint(a.name) }"
+            >{{ initials(a.name) }}</div>
+
+            <div class="min-w-0">
+              <div class="font-medium text-gray-900 dark:text-white truncate">{{ a.name }}</div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 truncate">
+                <span v-if="a.owner">by {{ a.owner }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-3 flex items-center justify-between">
+            <span class="text-[11px] text-gray-400">
+              <span v-if="a.shared_at">shared {{ formatDate(a.shared_at) }}</span>
+            </span>
+            <button
+              class="text-xs px-2.5 py-1 rounded-md bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed"
+              disabled
+              title="Chat arrives in a later Client Portal slice"
+            >Chat — soon</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, onMounted } from 'vue'
+import { useClientPortalStore } from '@/stores/clientPortal'
+
+const store = useClientPortalStore()
+const failed = reactive({})   // avatar_url that 401'd / failed → fall back to initials
+
+function initials(name) {
+  const parts = (name || '?').replace(/[^A-Za-z0-9]+/g, ' ').trim().split(' ')
+  return ((parts[0]?.[0] || '') + (parts[1]?.[0] || parts[0]?.[1] || '')).toUpperCase() || '?'
+}
+
+// Deterministic tint from the name so tiles are stable + distinguishable.
+function tint(name) {
+  let h = 0
+  for (let i = 0; i < (name || '').length; i++) h = (h * 31 + name.charCodeAt(i)) % 360
+  return `hsl(${h}, 45%, 45%)`
+}
+
+function formatDate(iso) {
+  try { return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) }
+  catch { return iso }
+}
+
+onMounted(() => store.fetchRoster())
+</script>

--- a/src/frontend/src/views/enterprise/ClientPortal.vue
+++ b/src/frontend/src/views/enterprise/ClientPortal.vue
@@ -72,23 +72,27 @@
               <span v-if="a.shared_at">shared {{ formatDate(a.shared_at) }}</span>
             </span>
             <button
-              class="text-xs px-2.5 py-1 rounded-md bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed"
-              disabled
-              title="Chat arrives in a later Client Portal slice"
-            >Chat — soon</button>
+              class="text-xs px-2.5 py-1 rounded-md bg-action-primary-600 hover:bg-action-primary-700 text-white"
+              @click="chatAgent = a"
+            >Chat</button>
           </div>
         </div>
       </div>
     </div>
+
+    <!-- Chat drawer -->
+    <PortalChat v-if="chatAgent" :agent="chatAgent" @close="chatAgent = null" />
   </div>
 </template>
 
 <script setup>
-import { reactive, onMounted } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
+import PortalChat from './PortalChat.vue'
 
 const store = useClientPortalStore()
 const failed = reactive({})   // avatar_url that 401'd / failed → fall back to initials
+const chatAgent = ref(null)   // the agent whose chat drawer is open
 
 function initials(name) {
   const parts = (name || '?').replace(/[^A-Za-z0-9]+/g, ' ').trim().split(' ')

--- a/src/frontend/src/views/enterprise/Index.vue
+++ b/src/frontend/src/views/enterprise/Index.vue
@@ -81,6 +81,15 @@ const features = [
     entitlement: 'audit',
     soon: false,
   },
+  {
+    id: 'client_portal',
+    title: 'Client Portal',
+    icon: '🪟',
+    description: 'Client-facing surface: the agents shared with your email, in one place. Configurable public or private (VPN/LAN) exposure.',
+    route: '/enterprise/client-portal',
+    entitlement: 'client_portal',
+    soon: false,
+  },
 ]
 
 const cards = computed(() =>

--- a/src/frontend/src/views/enterprise/PortalChat.vue
+++ b/src/frontend/src/views/enterprise/PortalChat.vue
@@ -1,0 +1,119 @@
+<template>
+  <!-- Slide-over chat drawer -->
+  <div class="fixed inset-0 z-40 flex justify-end">
+    <!-- Backdrop -->
+    <div class="absolute inset-0 bg-black/30" @click="$emit('close')"></div>
+
+    <div class="relative z-50 w-full max-w-md h-full bg-white dark:bg-gray-900 shadow-xl flex flex-col">
+      <!-- Header -->
+      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <div class="min-w-0">
+          <div class="font-medium text-gray-900 dark:text-white truncate">{{ agent.name }}</div>
+          <div class="text-xs text-gray-400 truncate"><span v-if="agent.owner">by {{ agent.owner }}</span></div>
+        </div>
+        <button class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 text-xl leading-none" @click="$emit('close')" aria-label="Close">×</button>
+      </div>
+
+      <!-- Messages -->
+      <div ref="scrollEl" class="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        <div v-if="messages.length === 0 && !sending" class="text-center text-sm text-gray-400 mt-10">
+          Start chatting with <span class="font-medium">{{ agent.name }}</span>.
+        </div>
+
+        <div v-for="(m, i) in messages" :key="i" :class="m.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
+          <div
+            v-if="m.role === 'user'"
+            class="max-w-[80%] rounded-2xl rounded-br-sm bg-action-primary-600 text-white px-3 py-2 text-sm whitespace-pre-wrap"
+          >{{ m.content }}</div>
+          <div
+            v-else
+            class="max-w-[85%] rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm prose-portal"
+            v-html="render(m.content)"
+          ></div>
+        </div>
+
+        <div v-if="sending" class="flex justify-start">
+          <div class="rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-3 py-2">
+            <span class="inline-flex gap-1">
+              <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay:0ms"></span>
+              <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay:150ms"></span>
+              <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay:300ms"></span>
+            </span>
+          </div>
+        </div>
+
+        <div v-if="error" class="text-xs text-status-danger-600 dark:text-status-danger-400">{{ error }}</div>
+      </div>
+
+      <!-- Composer -->
+      <div class="border-t border-gray-200 dark:border-gray-700 p-3">
+        <form class="flex items-end gap-2" @submit.prevent="send">
+          <textarea
+            v-model="input"
+            rows="1"
+            placeholder="Message…"
+            class="flex-1 resize-none rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:ring-action-primary-500 focus:border-action-primary-500 max-h-32"
+            @keydown.enter.exact.prevent="send"
+          ></textarea>
+          <button
+            type="submit"
+            class="shrink-0 rounded-lg bg-action-primary-600 hover:bg-action-primary-700 text-white text-sm px-4 py-2 disabled:opacity-50"
+            :disabled="sending || !input.trim()"
+          >Send</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, nextTick } from 'vue'
+import { useAgentsStore } from '@/stores/agents'
+import { renderMarkdown } from '@/utils/markdown'
+
+const props = defineProps({
+  agent: { type: Object, required: true },   // { name, owner }
+})
+defineEmits(['close'])
+
+const agentsStore = useAgentsStore()
+const messages = ref([])
+const input = ref('')
+const sending = ref(false)
+const error = ref(null)
+const scrollEl = ref(null)
+
+const render = (c) => renderMarkdown(c || '')
+
+async function scrollDown() {
+  await nextTick()
+  if (scrollEl.value) scrollEl.value.scrollTop = scrollEl.value.scrollHeight
+}
+
+async function send() {
+  const text = input.value.trim()
+  if (!text || sending.value) return
+  error.value = null
+  messages.value.push({ role: 'user', content: text })
+  input.value = ''
+  sending.value = true
+  await scrollDown()
+  try {
+    const data = await agentsStore.sendChatMessage(props.agent.name, text)
+    messages.value.push({ role: 'assistant', content: data.response || '(no response)' })
+  } catch (err) {
+    error.value = err.response?.data?.detail || 'Message failed. The agent may be stopped.'
+  } finally {
+    sending.value = false
+    await scrollDown()
+  }
+}
+</script>
+
+<style scoped>
+.prose-portal :deep(p) { margin: 0.25rem 0; }
+.prose-portal :deep(pre) { overflow-x: auto; background: rgba(0,0,0,0.06); padding: 0.5rem; border-radius: 0.375rem; }
+.prose-portal :deep(code) { font-size: 0.8em; }
+.prose-portal :deep(ul) { list-style: disc; padding-left: 1.25rem; }
+.prose-portal :deep(a) { text-decoration: underline; }
+</style>


### PR DESCRIPTION
Showable Client Portal slices (epic #78), gated by `client_portal` (backend module in trinity-enterprise#91). OSS-bundle Vue, hidden in OSS/unentitled builds via `requiresEntitlement`.

## Slice 1 — "My Agents" roster
- `views/enterprise/ClientPortal.vue` — card grid of agents shared with the signed-in email (avatar or deterministic initials tile, owner, shared date). Loading/empty/error states, dark mode, avatar→initials fallback.
- Route `/enterprise/client-portal` (`meta.requiresEntitlement: 'client_portal'`), `stores/clientPortal.js` `fetchRoster()`, catalogue card in `views/enterprise/Index.vue`.

## Slice 2 — chat with a rostered agent
- `views/enterprise/PortalChat.vue` — slide-over chat drawer (user/assistant bubbles, typing indicator, Enter-to-send). Assistant markdown via `utils/markdown.js` (DOMPurify, H-005).
- Roster card "Chat" button opens the drawer.
- **No new backend**: reuses OSS `POST /api/agents/{name}/chat` (`agentsStore.sendChatMessage`), already authorized for a user whose email is on the agent's `agent_sharing` list — the roster set. Portal stays the gated surface; chat is the OSS capability a shared user already has.

## Identity (both slices)
Uses platform email login as the client identity. The true verified-email portal session (a client is not a `users` row — #78's hard line) is a later slice, as are documents + voice.

## Testing (live PG instance, running stack)
- Roster: a share to `viewer@example.com` surfaces exactly those agents (owner + date); email-scoped; excludes deleted/system. 11/11 enterprise unit tests.
- Chat: as the shared user, a rostered agent replied through the portal's endpoint ("Hey there, friend!").
- Frontend served live (container, :5199): both SFCs transform clean; route guard passes (`client_portal` entitled); `/api` proxy reaches backend.

Depends on trinity-enterprise#91 (endpoint + entitlement). Safe to land first — hidden until the module registers `client_portal`.

Related to trinity-enterprise#78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)