### PR TITLE
fix(git-sync): exempt template-committed .trinity convention files from the gitignore untrack sweep (trinity-enterprise#76)

### DIFF
--- a/src/backend/services/compatibility/static_checks.py
+++ b/src/backend/services/compatibility/static_checks.py
@@ -321,7 +321,11 @@ def c_s004(snap):  # .claude/projects/ ignored
 
 
 def c_s005(snap):  # .trinity/ ignored
-    return _ok(".trinity/ is gitignored") if _has_ignore(snap, ".trinity/", ".trinity") \
+    # ".trinity/*" satisfies the same intent: Brain-Orb templates use it with a
+    # "!.trinity/brain-orb/" re-include so committed hooks stay tracked while
+    # runtime state stays ignored (trinity-enterprise#76). Git can't re-include
+    # under a dir-form exclusion, so the star-form is the only committable shape.
+    return _ok(".trinity/ is gitignored") if _has_ignore(snap, ".trinity/", ".trinity", ".trinity/*") \
         else _fail(".trinity/ is not excluded — platform runtime state would be committed")
 
 

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -946,12 +946,19 @@ def _build_rm_cached_ignored_command(git_dir: str) -> str:
     (bash can't hold NUL bytes), then a NUL-delimited pipe to xargs so paths
     with spaces or unicode survive the round-trip. Working-tree files are
     left alone; only the index is touched.
+
+    ``.trinity/brain-orb/`` is exempt: Brain-Orb-capable templates COMMIT their
+    convention hooks there (trinity-enterprise#76), while the fleet-wide
+    ``.trinity/`` ignore appended above makes them look ignored-but-tracked —
+    without the pathspec exclusion the first push would untrack the hooks and
+    push their deletion, so a later re-clone/recreate boots hookless.
     """
+    hook_exempt = '":!.trinity/brain-orb"'
     script = (
         f"cd {shlex.quote(git_dir)} && "
-        "ignored=$(git ls-files -ci --exclude-standard) && "
+        f"ignored=$(git ls-files -ci --exclude-standard -- . {hook_exempt}) && "
         'if [ -n "$ignored" ]; then '
-        "git ls-files -ci -z --exclude-standard | "
+        f"git ls-files -ci -z --exclude-standard -- . {hook_exempt} | "
         "xargs -0 git rm --cached --quiet -r --; "
         "fi"
     )

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -947,18 +947,20 @@ def _build_rm_cached_ignored_command(git_dir: str) -> str:
     with spaces or unicode survive the round-trip. Working-tree files are
     left alone; only the index is touched.
 
-    ``.trinity/brain-orb/`` is exempt: Brain-Orb-capable templates COMMIT their
-    convention hooks there (trinity-enterprise#76), while the fleet-wide
-    ``.trinity/`` ignore appended above makes them look ignored-but-tracked —
-    without the pathspec exclusion the first push would untrack the hooks and
-    push their deletion, so a later re-clone/recreate boots hookless.
+    ``.trinity/brain-orb/`` and ``.trinity/setup.sh`` are exempt: Brain-Orb /
+    setup-convention templates COMMIT those files (trinity-enterprise#76), while
+    the fleet-wide ``.trinity/`` ignore appended above makes them look
+    ignored-but-tracked — without the pathspec exclusions the first push would
+    untrack them and push the deletion, so a later re-clone/recreate boots
+    hookless and never runs its startup setup (verified live: the e2e Push
+    swept setup.sh before the second exemption was added).
     """
-    hook_exempt = '":!.trinity/brain-orb"'
+    exempt = '":!.trinity/brain-orb" ":!.trinity/setup.sh"'
     script = (
         f"cd {shlex.quote(git_dir)} && "
-        f"ignored=$(git ls-files -ci --exclude-standard -- . {hook_exempt}) && "
+        f"ignored=$(git ls-files -ci --exclude-standard -- . {exempt}) && "
         'if [ -n "$ignored" ]; then '
-        f"git ls-files -ci -z --exclude-standard -- . {hook_exempt} | "
+        f"git ls-files -ci -z --exclude-standard -- . {exempt} | "
         "xargs -0 git rm --cached --quiet -r --; "
         "fi"
     )

--- a/tests/unit/test_compatibility_checks.py
+++ b/tests/unit/test_compatibility_checks.py
@@ -192,6 +192,17 @@ class TestStaticChecks:
         assert _run_one("S-002", snap)[0] == "fail"   # .mcp.json not ignored
         assert _run_one("S-005", snap)[0] == "fail"   # .trinity/ not ignored
 
+    def test_s005_accepts_star_form_trinity_ignore(self):
+        # Brain-Orb templates ship `.trinity/*` + `!.trinity/brain-orb/` so the
+        # committed hooks stay tracked (trinity-enterprise#76). The star form
+        # satisfies the same "runtime state isn't committed" intent — S-005
+        # must not flag it (its auto-fix would re-append the dir form).
+        snap = good_snapshot()
+        snap["files"][".gitignore"] = _f(
+            ".env\n.mcp.json\n.trinity/*\n!.trinity/brain-orb/\n"
+        )
+        assert _run_one("S-005", snap)[0] == "pass"
+
     def test_blanket_claude_exclusion_g001(self):
         snap = good_snapshot()
         snap["files"][".gitignore"] = _f(".claude/\n")

--- a/tests/unit/test_github_init_gitignore.py
+++ b/tests/unit/test_github_init_gitignore.py
@@ -261,3 +261,72 @@ def test_rm_cached_for_newly_ignored_files(tmp_path):
     # touches the index, never the user's files.
     assert cache_file.exists(), "rm --cached must not delete the on-disk file"
     assert session_file.exists(), "rm --cached must not delete the on-disk file"
+
+
+def test_rm_cached_exempts_brain_orb_hooks(tmp_path):
+    """Template-committed Brain Orb hooks survive the gitignore migration
+    (trinity-enterprise#76). The fleet merge appends `.trinity/`, which makes
+    the committed `.trinity/brain-orb/*` hooks ignored-but-tracked; the
+    rm-cached sweep must exempt exactly that directory — untracking the hooks
+    would commit+push their deletion, so a later re-clone boots hookless.
+    Sibling `.trinity/` files must STILL be swept (the exemption is surgical).
+    """
+    gs = _load_git_service()
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=10,
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("config", "commit.gpgsign", "false")
+
+    hook = tmp_path / ".trinity" / "brain-orb" / "action"
+    leaked_state = tmp_path / ".trinity" / "runtime-state.yaml"
+    for f, content in [(hook, "#!/usr/bin/env python3\n"), (leaked_state, "x: 1\n")]:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content)
+
+    # Template shape: parent star-ignored, hook dir re-included (a dir-form
+    # `.trinity/` exclusion can't be re-included under, so templates use `*`).
+    (tmp_path / ".gitignore").write_text(".trinity/*\n!.trinity/brain-orb/\n")
+    git("add", str(hook))
+    git("add", "-f", str(leaked_state))  # simulate an old agent that committed state
+    git("commit", "-q", "-m", "template ships brain-orb hooks")
+
+    tracked_before = set(git("ls-files").stdout.splitlines())
+    assert ".trinity/brain-orb/action" in tracked_before
+    assert ".trinity/runtime-state.yaml" in tracked_before
+
+    # Run the real migration: fleet merge (appends `.trinity/`) + rm-cached.
+    for build in (
+        gs._build_gitignore_merge_command,
+        gs._build_rm_cached_ignored_command,
+    ):
+        result = subprocess.run(
+            build(str(tmp_path)),
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, (
+            f"command failed: {build.__name__}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+
+    tracked_after = set(git("ls-files").stdout.splitlines())
+    assert ".trinity/brain-orb/action" in tracked_after, (
+        f"brain-orb hook was untracked by the sweep; tracked={tracked_after}"
+    )
+    assert ".trinity/runtime-state.yaml" not in tracked_after, (
+        f"sibling .trinity/ state must still be swept; tracked={tracked_after}"
+    )
+    assert hook.exists() and leaked_state.exists()

--- a/tests/unit/test_github_init_gitignore.py
+++ b/tests/unit/test_github_init_gitignore.py
@@ -289,20 +289,26 @@ def test_rm_cached_exempts_brain_orb_hooks(tmp_path):
     git("config", "commit.gpgsign", "false")
 
     hook = tmp_path / ".trinity" / "brain-orb" / "action"
+    setup = tmp_path / ".trinity" / "setup.sh"
     leaked_state = tmp_path / ".trinity" / "runtime-state.yaml"
-    for f, content in [(hook, "#!/usr/bin/env python3\n"), (leaked_state, "x: 1\n")]:
+    for f, content in [(hook, "#!/usr/bin/env python3\n"),
+                       (setup, "#!/bin/bash\n"),
+                       (leaked_state, "x: 1\n")]:
         f.parent.mkdir(parents=True, exist_ok=True)
         f.write_text(content)
 
-    # Template shape: parent star-ignored, hook dir re-included (a dir-form
-    # `.trinity/` exclusion can't be re-included under, so templates use `*`).
-    (tmp_path / ".gitignore").write_text(".trinity/*\n!.trinity/brain-orb/\n")
-    git("add", str(hook))
+    # Template shape: parent star-ignored, setup.sh + hook dir re-included (a
+    # dir-form `.trinity/` exclusion can't be re-included under, so templates
+    # use `*`).
+    (tmp_path / ".gitignore").write_text(
+        ".trinity/*\n!.trinity/setup.sh\n!.trinity/brain-orb/\n")
+    git("add", str(hook), str(setup))
     git("add", "-f", str(leaked_state))  # simulate an old agent that committed state
     git("commit", "-q", "-m", "template ships brain-orb hooks")
 
     tracked_before = set(git("ls-files").stdout.splitlines())
     assert ".trinity/brain-orb/action" in tracked_before
+    assert ".trinity/setup.sh" in tracked_before
     assert ".trinity/runtime-state.yaml" in tracked_before
 
     # Run the real migration: fleet merge (appends `.trinity/`) + rm-cached.
@@ -326,7 +332,11 @@ def test_rm_cached_exempts_brain_orb_hooks(tmp_path):
     assert ".trinity/brain-orb/action" in tracked_after, (
         f"brain-orb hook was untracked by the sweep; tracked={tracked_after}"
     )
+    assert ".trinity/setup.sh" in tracked_after, (
+        f"setup.sh was untracked by the sweep (caught live in the #76 e2e Push); "
+        f"tracked={tracked_after}"
+    )
     assert ".trinity/runtime-state.yaml" not in tracked_after, (
         f"sibling .trinity/ state must still be swept; tracked={tracked_after}"
     )
-    assert hook.exists() and leaked_state.exists()
+    assert hook.exists() and setup.exists() and leaked_state.exists()


### PR DESCRIPTION
## Summary
- Brain-Orb-capable templates (e.g. `github:Abilityai/cornelius`) COMMIT their convention files — the `.trinity/brain-orb/{scopes,scope,search,action}` hooks and `.trinity/setup.sh`. The fleet gitignore migration (`_migrate_workspace_gitignore`, run on every operator Push) appends the fleet-wide `.trinity/` ignore and then `git rm --cached`s ignored-but-tracked files — untracking those files and pushing their deletion, so a later re-clone/recreate boots hookless and never runs startup setup.
- `_build_rm_cached_ignored_command` now pathspec-exempts `.trinity/brain-orb` and `.trinity/setup.sh` from both the emptiness probe and the removal pipe; sibling `.trinity/` runtime files are still swept.
- Compatibility check S-005 additionally accepts the `.trinity/*` star form — the only shape a template can commit re-included hooks under (git cannot re-include beneath a dir-form exclusion) — so the compat panel doesn't flag Brain-Orb templates and its auto-fix doesn't churn.

## Changes
- `src/backend/services/git_service.py` — sweep exemptions (probe + removal pipe)
- `src/backend/services/compatibility/static_checks.py` — S-005 accepts `.trinity/*`
- `tests/unit/test_github_init_gitignore.py` — real-git regression test (hooks + setup.sh survive the merge+sweep; sibling state still swept; working tree untouched)
- `tests/unit/test_compatibility_checks.py` — S-005 star-form snapshot test

## Test Plan
- [x] `pytest tests/unit/test_github_init_gitignore.py tests/unit/test_compatibility_checks.py` — 43 passed
- [x] Live e2e: created `cornelius-e2e` from `github:Abilityai/cornelius`, ran an operator Push through this backend — all 6 hook files + `setup.sh` stayed tracked, the vault capture committed, non-exempt `.trinity/` state was swept. (The pre-fix backend reproduced the bug: the first Push deleted `setup.sh` — caught live, second exemption added.)

Part of abilityai/trinity-enterprise#76 (Brain Orb full cycle from the public cornelius template — agent-side kit shipped in `Abilityai/cornelius@1ce85bd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)