### PR TITLE
fix(circuit-breaker): advise when per-agent toggle is inert with the global gate off (#1491)

### DIFF
--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -773,11 +773,22 @@ async def set_circuit_breaker_endpoint(
         target_id=agent_name,
         details={"enabled": body.enabled},
     )
-    return {
+    result = {
         "agent_name": agent_name,
         "enabled": body.enabled,
         "global_enabled": bool(DISPATCH_BREAKER_ENABLED),
     }
+    # #1491: the breaker is two-tier gated — turning the per-agent toggle on
+    # while the platform-wide DISPATCH_BREAKER_ENABLED flag is off saves the
+    # preference but does nothing. Surface a non-fatal advisory so the owner
+    # isn't caught by the "switch is on but nothing happens" trap. The write
+    # still succeeds; the stored preference applies once the global flag flips on.
+    if body.enabled and not DISPATCH_BREAKER_ENABLED:
+        result["warning"] = (
+            "Per-agent toggle saved, but the breaker stays inactive until the "
+            "platform-wide DISPATCH_BREAKER_ENABLED flag is enabled."
+        )
+    return result
 
 
 # ============================================================================

--- a/tests/unit/test_1491_circuit_breaker_advisory.py
+++ b/tests/unit/test_1491_circuit_breaker_advisory.py
@@ -1,0 +1,79 @@
+"""#1491 — PUT /api/agents/{name}/circuit-breaker advisory when the global gate is off.
+
+The dispatch breaker is two-tier gated (global ``DISPATCH_BREAKER_ENABLED`` AND
+the per-agent toggle). Turning the per-agent toggle on while the global flag is
+off saves the preference but does nothing; the PUT handler now returns a
+non-fatal ``warning`` so the owner isn't caught by the "switch is on but nothing
+happens" trap. The write always succeeds and the response is unchanged when the
+global flag is on. Advisory only — no breaker-logic change.
+
+Drives the handler directly with db + audit mocked, toggling
+``config.DISPATCH_BREAKER_ENABLED`` (the handler imports it at call time).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND_DIR = _PROJECT_ROOT / "src" / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+import config  # noqa: E402
+import routers.agents as agents_mod  # noqa: E402
+from models import CircuitBreakerConfigUpdate  # noqa: E402
+
+
+def _call(enabled: bool, global_on: bool, monkeypatch) -> dict:
+    monkeypatch.setattr(config, "DISPATCH_BREAKER_ENABLED", global_on, raising=False)
+    monkeypatch.setattr(agents_mod.db, "set_circuit_breaker_enabled", MagicMock(), raising=False)
+    monkeypatch.setattr(
+        agents_mod.platform_audit_service, "log", AsyncMock(), raising=False
+    )
+    return asyncio.run(
+        agents_mod.set_circuit_breaker_endpoint(
+            agent_name="agent-1",
+            body=CircuitBreakerConfigUpdate(enabled=enabled),
+            current_user=MagicMock(),
+        )
+    )
+
+
+def test_warning_when_enabling_with_global_off(monkeypatch):
+    result = _call(enabled=True, global_on=False, monkeypatch=monkeypatch)
+    assert result["enabled"] is True
+    assert result["global_enabled"] is False
+    assert "warning" in result and "DISPATCH_BREAKER_ENABLED" in result["warning"]
+
+
+def test_no_warning_when_global_on(monkeypatch):
+    result = _call(enabled=True, global_on=True, monkeypatch=monkeypatch)
+    assert result["global_enabled"] is True
+    assert "warning" not in result  # no behavior/response change when the gate is on
+
+
+def test_no_warning_when_disabling(monkeypatch):
+    # Turning the toggle OFF is never inert — no advisory even with global off.
+    result = _call(enabled=False, global_on=False, monkeypatch=monkeypatch)
+    assert result["enabled"] is False
+    assert "warning" not in result
+
+
+def test_write_always_succeeds(monkeypatch):
+    # The stored preference is written regardless of the global flag.
+    setter = MagicMock()
+    monkeypatch.setattr(config, "DISPATCH_BREAKER_ENABLED", False, raising=False)
+    monkeypatch.setattr(agents_mod.db, "set_circuit_breaker_enabled", setter, raising=False)
+    monkeypatch.setattr(agents_mod.platform_audit_service, "log", AsyncMock(), raising=False)
+    asyncio.run(
+        agents_mod.set_circuit_breaker_endpoint(
+            agent_name="agent-1",
+            body=CircuitBreakerConfigUpdate(enabled=True),
+            current_user=MagicMock(),
+        )
+    )
+    setter.assert_called_once_with("agent-1", True)


### PR DESCRIPTION
## Problem
The dispatch breaker is two-tier gated (platform `DISPATCH_BREAKER_ENABLED` **AND** per-agent `circuit_breaker_enabled`). `PUT /api/agents/{name}/circuit-breaker {"enabled":true}` with the global flag off returned a plain 200 — the owner had no signal their toggle was inert.

## Fix
The PUT response now includes a non-fatal `warning` when `enabled=true` is set while the global flag is off. The write still succeeds (the preference applies once the global flag flips on). No advisory when disabling or when the global flag is on — response unchanged there. **Advisory only** — no breaker-logic or gate change.

```json
{ "agent_name": "asdfsdf", "enabled": true, "global_enabled": false,
  "warning": "Per-agent toggle saved, but the breaker stays inactive until the platform-wide DISPATCH_BREAKER_ENABLED flag is enabled." }
```

## Acceptance
- [x] `{"enabled":true}` with global off → 200 + advisory field
- [x] No behavior/response change when the global flag is on
- [ ] "Owner UI toggle reflects the advisory" — **N/A**: no owner-facing breaker *toggle* exists today (the agent-header badge is read-only display). The API now carries the advisory for whenever such a toggle is built.

## Testing
- `tests/unit/test_1491_circuit_breaker_advisory.py` — warning-when-global-off, none-when-global-on, none-when-disabling, write-always-succeeds (4 passed).
- Live: verified the advisory appears/absent per the two cases; toggle reset to off after.

Fixes #1491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
