### PR TITLE
fix(agent-server): kill the process group on a budget-exceeded drain (#1502)

### DIFF
--- a/docker/base-image/agent_server/services/subprocess_lifecycle.py
+++ b/docker/base-image/agent_server/services/subprocess_lifecycle.py
@@ -127,6 +127,27 @@ def _drain_bounded(
             "leaked daemon threads (pid=%s). Issue #728.",
             _DRAIN_BUDGET_SECONDS, process.pid,
         )
+        # #1502: #728 unblocked the executor thread but LEFT THE PROCESS GROUP
+        # ALIVE. The leaked reader is blocked reading a pipe a grandchild still
+        # holds open — it spins/pegs a core until the container is restarted.
+        # SIGKILL the whole group so that pipe EOFs, letting the daemon reader
+        # return from readline() and exit, freeing the CPU. Best-effort: never
+        # let cleanup raise into the caller, and only meaningful when the pgid
+        # was captured at spawn (after wait() reaped the parent, a pid lookup
+        # can't reach grandchildren — see terminate_process_group docstring).
+        try:
+            _terminate_process_group(process, 0, pgid=pgid)
+            logger.warning(
+                "[Subprocess] #1502: SIGKILLed the process group (pgid=%s, pid=%s) "
+                "after the budget-exceeded drain so the leaked reader can EOF and "
+                "free the core.",
+                pgid, process.pid,
+            )
+        except Exception as e:  # pragma: no cover — cleanup must never crash the caller
+            logger.warning(
+                "[Subprocess] #1502: group kill after budget-exceed failed "
+                "(pgid=%s, pid=%s): %s", pgid, process.pid, e,
+            )
         return "budget_exceeded"
     # done is set → _target finished, so ``outcome`` is fully settled.
     if outcome == "errored":

--- a/tests/unit/test_drain_bounded.py
+++ b/tests/unit/test_drain_bounded.py
@@ -81,6 +81,56 @@ def test_drain_bounded_returns_within_budget_when_drain_hangs(monkeypatch):
     )
 
 
+def test_drain_bounded_kills_group_on_budget_exceeded(monkeypatch):
+    """#1502: a budget-exceeded drain must SIGKILL the process group so the
+    leaked reader can EOF and stop pegging a core — #728 only unblocked the
+    executor thread and left the group (and its CPU spin) alive."""
+
+    async def _hanging_drain(*args, **kwargs):
+        await asyncio.sleep(600)
+
+    monkeypatch.setattr(
+        "agent_server.services.subprocess_lifecycle._drain_reader_threads",
+        _hanging_drain,
+    )
+    monkeypatch.setattr(
+        "agent_server.services.subprocess_lifecycle._DRAIN_BUDGET_SECONDS",
+        1,
+    )
+    kill = MagicMock()
+    monkeypatch.setattr(
+        "agent_server.services.subprocess_lifecycle._terminate_process_group",
+        kill,
+    )
+
+    process = _make_fake_process()
+    outcome = _drain_bounded(process, MagicMock(spec=threading.Thread), grace=1, pgid=4242)
+
+    assert outcome == "budget_exceeded"
+    kill.assert_called_once()
+    # the captured pgid is forwarded so grandchildren (not just the reaped pid) die
+    _args, _kwargs = kill.call_args
+    assert _kwargs.get("pgid") == 4242 or 4242 in _args
+
+
+def test_drain_bounded_budget_exceed_kill_failure_is_swallowed(monkeypatch):
+    """A failing group-kill on budget-exceed must not raise into the caller."""
+
+    async def _hanging_drain(*args, **kwargs):
+        await asyncio.sleep(600)
+
+    monkeypatch.setattr(
+        "agent_server.services.subprocess_lifecycle._drain_reader_threads", _hanging_drain)
+    monkeypatch.setattr(
+        "agent_server.services.subprocess_lifecycle._DRAIN_BUDGET_SECONDS", 1)
+    monkeypatch.setattr(
+        "agent_server.services.subprocess_lifecycle._terminate_process_group",
+        MagicMock(side_effect=OSError("boom")))
+
+    outcome = _drain_bounded(_make_fake_process(), MagicMock(spec=threading.Thread), pgid=1)
+    assert outcome == "budget_exceeded"  # still returns cleanly
+
+
 def test_drain_bounded_completes_fast_when_drain_is_quick(monkeypatch):
     """When drain_reader_threads finishes quickly, _drain_bounded must not add
     significant latency (no extra sleeping)."""


### PR DESCRIPTION
## Problem
#728 bounded the `safe_close_pipes` TextIOWrapper-lock deadlock with a 90s drain budget — but on budget-exceed `_drain_bounded` only unblocked the executor thread and **left the process group alive**. The leaked reader thread stays blocked reading a pipe a grandchild still holds open, **spinning at ~100% CPU with no visible `claude` child, until the container is restarted** (`terminate` 504s in the meantime).

## Fix
On budget-exceed, `_drain_bounded` now SIGKILLs the whole **process group** (via the already-imported `_terminate_process_group`, forwarding the spawn-captured `pgid`). The pipe EOFs → the daemon reader returns from `readline()` and exits → the core is freed, no container restart needed. Best-effort: the group kill never raises into the caller.

Distinct from #728 (which only unblocked the executor thread). This is the platform-level fix for the residual filed in #1502; the trigger-side mitigation for the Client Portal (images sent as vision instead of read as text) already shipped in trinity-enterprise#104.

## Testing
`tests/unit/test_drain_bounded.py` (+2): a budget-exceeded drain kills the group with the captured pgid; a failing kill is swallowed and still returns `budget_exceeded`. **10 passed** (full file, via the tests venv).

## Deploy note
Agent-server / base-image change — takes effect after a **base-image rebuild + agent recreate** (`scripts/deploy/build-base-image.sh`).

Fixes #1502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
