### PR TITLE
feat(ui): standardize cost display — whole-dollar, comma separators, compact $1.2K (trinity-enterprise#92)

### DIFF
--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -341,14 +341,14 @@
       <!-- Today's cost -->
       <div class="flex items-center space-x-1">
         <span class="text-gray-400 dark:text-gray-500">Today</span>
-        <span class="font-mono text-gray-700 dark:text-gray-300">${{ formatCost(tokenStats.cost_24h) }}</span>
+        <span class="font-mono text-gray-700 dark:text-gray-300">{{ formatCost(tokenStats.cost_24h) }}</span>
       </div>
       <!-- Trend vs 7d average -->
       <div v-if="tokenStats.avg_daily_cost > 0" class="flex items-center space-x-1">
         <span
           :class="trendClass"
           class="flex items-center space-x-0.5 font-mono"
-          :title="`7d avg: $${formatCost(tokenStats.avg_daily_cost)}/day`"
+          :title="`7d avg: ${formatCost(tokenStats.avg_daily_cost)}/day`"
         >
           <!-- Arrow icon -->
           <svg v-if="tokenStats.trend_cost_pct > 5" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -366,7 +366,7 @@
       <!-- Lifetime cost -->
       <div class="ml-auto flex items-center space-x-1 text-gray-400 dark:text-gray-500">
         <span>Lifetime</span>
-        <span class="font-mono text-gray-600 dark:text-gray-400">${{ formatCost(tokenStats.lifetime_cost) }}</span>
+        <span class="font-mono text-gray-600 dark:text-gray-400">{{ formatCost(tokenStats.lifetime_cost) }}</span>
         <span class="text-gray-300 dark:text-gray-600">·</span>
         <span class="font-mono">{{ tokenStats.lifetime_executions }} runs</span>
       </div>
@@ -666,7 +666,7 @@ function saveName() {
   nameError.value = ''
 }
 
-const { formatBytes, formatUptime, formatRelativeTime } = useFormatters()
+const { formatBytes, formatUptime, formatRelativeTime, formatCost } = useFormatters()
 
 // Token stats helpers (issue #250)
 const tokenCostSparkline = computed(() => {
@@ -680,11 +680,6 @@ const tokenCostSparklineMax = computed(() => {
   return Math.max(...vals, 0.0001)
 })
 
-function formatCost(val) {
-  if (!val || val === 0) return '0.00'
-  if (val < 0.01) return val.toFixed(4)
-  return val.toFixed(2)
-}
 
 function formatTrendPct(pct) {
   if (!pct) return '—'

--- a/src/frontend/src/components/AgentNode.vue
+++ b/src/frontend/src/components/AgentNode.vue
@@ -155,7 +155,7 @@
         <span :class="successRateColorClass" class="font-medium">{{ executionStats.successRate }}%</span>
         <template v-if="executionStats.totalCost > 0">
           <span class="text-gray-300 dark:text-gray-600">·</span>
-          <span class="font-medium text-gray-700 dark:text-gray-300">${{ executionStats.totalCost.toFixed(2) }}</span>
+          <span class="font-medium text-gray-700 dark:text-gray-300">{{ formatCostCompact(executionStats.totalCost) }}</span>
         </template>
         <template v-if="lastExecutionDisplay">
           <span class="text-gray-300 dark:text-gray-600">·</span>
@@ -231,6 +231,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { formatCostCompact } from '../composables/useFormatters'
 import { useRouter } from 'vue-router'
 import { Handle, Position } from '@vue-flow/core'
 import AgentAvatar from './AgentAvatar.vue'

--- a/src/frontend/src/components/AgentTile.vue
+++ b/src/frontend/src/components/AgentTile.vue
@@ -103,7 +103,7 @@
       </span>
       <span v-if="hasTasks" class="t-stats">
         <b>{{ stats.taskCount }}</b> tasks <span class="dim">·</span>
-        <b>${{ (stats.totalCost || 0).toFixed(2) }}</b> <span class="dim">·</span>
+        <b>{{ formatCostCompact(stats.totalCost || 0) }}</b> <span class="dim">·</span>
         {{ lastExecutionDisplay }}
       </span>
       <span v-else class="t-stats empty">No tasks (24h)</span>
@@ -147,6 +147,7 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { formatCostCompact } from '../composables/useFormatters'
 import AgentAvatar from './AgentAvatar.vue'
 import RuntimeBadge from './RuntimeBadge.vue'
 import RunningStateToggle from './RunningStateToggle.vue'

--- a/src/frontend/src/components/ExecutionsPanel.vue
+++ b/src/frontend/src/components/ExecutionsPanel.vue
@@ -51,7 +51,7 @@
       <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
         <p class="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">Cost</p>
         <p class="text-base font-semibold text-gray-900 dark:text-white">
-          {{ store.stats ? '$' + store.stats.total_cost.toFixed(2) : '—' }}
+          {{ store.stats ? formatCostCompact(store.stats.total_cost) : '—' }}
         </p>
       </div>
     </div>
@@ -245,7 +245,7 @@
               <!-- Meta row -->
               <div class="mt-1 flex flex-wrap items-center gap-3 text-xs text-gray-400 dark:text-gray-500">
                 <span v-if="row.duration_ms">{{ formatDuration(row.duration_ms) }}</span>
-                <span v-if="row.cost != null">${{ row.cost.toFixed(3) }}</span>
+                <span v-if="row.cost != null">{{ formatCost(row.cost) }}</span>
                 <span v-if="row.context_used">{{ formatTokens(row.context_used) }}</span>
                 <span v-if="row.error_summary" class="text-status-danger-600 dark:text-status-danger-400 truncate max-w-xs">{{ row.error_summary }}</span>
               </div>
@@ -285,6 +285,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { formatCost, formatCostCompact } from '../composables/useFormatters'
 import axios from 'axios'
 import { useExecutionsStore } from '../stores/executions'
 import { useAuthStore } from '../stores/auth'

--- a/src/frontend/src/components/LoopsPanel.vue
+++ b/src/frontend/src/components/LoopsPanel.vue
@@ -300,7 +300,7 @@
                     <td class="py-1.5 pr-4">
                       <span :class="runStatusClass(run.status)">{{ run.status }}</span>
                     </td>
-                    <td class="py-1.5 pr-4 text-gray-600 dark:text-gray-400">{{ formatCost(run.cost) }}</td>
+                    <td class="py-1.5 pr-4 text-gray-600 dark:text-gray-400">{{ run.cost != null ? formatCost(run.cost) : '—' }}</td>
                     <td class="py-1.5 pr-4 text-gray-600 dark:text-gray-400">{{ formatDuration(run.duration_ms) }}</td>
                     <td class="py-1.5 text-gray-600 dark:text-gray-400">
                       <span v-if="run.error" class="text-status-danger-600 dark:text-status-danger-400">{{ run.error }}</span>
@@ -330,6 +330,7 @@
 import { ref, reactive, onMounted, onUnmounted, watch } from 'vue'
 import { useLoopsStore } from '../stores/loops'
 import { renderMarkdown } from '../utils/markdown'
+import { formatCost } from '../composables/useFormatters'
 import ModelSelector from './ModelSelector.vue'
 
 const props = defineProps({
@@ -477,10 +478,6 @@ function formatSeconds(secs) {
   return `${h}h ${m}m`
 }
 
-function formatCost(cost) {
-  if (cost === null || cost === undefined) return '—'
-  return `$${cost.toFixed(4)}`
-}
 
 function formatDuration(ms) {
   if (ms === null || ms === undefined) return '—'

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -206,7 +206,7 @@
                   <span :class="getSuccessRateClass(row.executionStats.successRate)" class="font-medium">{{ Math.round(row.executionStats.successRate || 0) }}%</span>
                   <template v-if="row.executionStats.totalCost > 0">
                     <span class="text-gray-300 dark:text-gray-600">·</span>
-                    <span class="font-medium">${{ row.executionStats.totalCost.toFixed(2) }}</span>
+                    <span class="font-medium">{{ formatCostCompact(row.executionStats.totalCost) }}</span>
                   </template>
                 </template>
                 <template v-else>
@@ -385,6 +385,7 @@
 
 <script setup>
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
+import { formatCostCompact } from '../composables/useFormatters'
 import { useRouter } from 'vue-router'
 import { parseUTC, getTimestampMs, formatLocalTime } from '@/utils/timestamps'
 import AutonomyToggle from './AutonomyToggle.vue'

--- a/src/frontend/src/components/ScheduleAnalyticsCard.vue
+++ b/src/frontend/src/components/ScheduleAnalyticsCard.vue
@@ -57,7 +57,7 @@
         <div class="px-3 py-2 rounded bg-gray-50 dark:bg-gray-800/50">
           <div class="text-xs text-gray-500 dark:text-gray-400">Cost</div>
           <div class="text-sm font-semibold text-gray-900 dark:text-white">
-            ${{ data.cost.total.toFixed(4) }}
+            {{ formatCostCompact(data.cost.total) }}
           </div>
         </div>
         <div class="px-3 py-2 rounded bg-gray-50 dark:bg-gray-800/50">
@@ -121,7 +121,7 @@
             v-for="bucket in data.timeline"
             :key="bucket.date"
             class="flex-1 flex flex-col items-stretch group relative min-w-[2px]"
-            :title="`${bucket.date} • ${bucket.success} ok / ${bucket.failed} fail • $${bucket.cost.toFixed(4)}`"
+            :title="`${bucket.date} • ${bucket.success} ok / ${bucket.failed} fail • ${formatCost(bucket.cost)}`"
           >
             <!-- Tooltip -->
             <div
@@ -132,7 +132,7 @@
                 <span class="text-status-success-400">{{ bucket.success }}</span>
                 /
                 <span class="text-status-danger-400">{{ bucket.failed }}</span>
-                · ${{ bucket.cost.toFixed(4) }}
+                · {{ formatCost(bucket.cost) }}
               </div>
             </div>
 
@@ -171,6 +171,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
+import { formatCost, formatCostCompact } from '../composables/useFormatters'
 import api from '../api'
 import { useFormatters } from '../composables/useFormatters'
 

--- a/src/frontend/src/components/SchedulesPanel.vue
+++ b/src/frontend/src/components/SchedulesPanel.vue
@@ -598,7 +598,7 @@
                 </div>
                 <!-- Cost -->
                 <span v-if="exec.cost" class="text-gray-500 dark:text-gray-400 font-mono">
-                  ${{ exec.cost.toFixed(4) }}
+                  {{ formatCost(exec.cost) }}
                 </span>
                 <span v-if="exec.duration_ms" class="text-gray-400 dark:text-gray-500">{{ formatDuration(exec.duration_ms) }}</span>
                 <span
@@ -658,7 +658,7 @@
             </div>
             <div>
               <p class="text-xs text-gray-500 dark:text-gray-400">Cost</p>
-              <p class="text-sm font-medium font-mono dark:text-white">${{ selectedExecution.cost?.toFixed(4) || '0.0000' }}</p>
+              <p class="text-sm font-medium font-mono dark:text-white">{{ formatCost(selectedExecution.cost) }}</p>
             </div>
             <div>
               <p class="text-xs text-gray-500 dark:text-gray-400">Context Used</p>
@@ -758,6 +758,7 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted, onUnmounted, watch } from 'vue'
+import { formatCost } from '../composables/useFormatters'
 import axios from 'axios'
 import ConfirmDialog from './ConfirmDialog.vue'
 import ModelSelector from './ModelSelector.vue'

--- a/src/frontend/src/components/TasksPanel.vue
+++ b/src/frontend/src/components/TasksPanel.vue
@@ -75,7 +75,7 @@
       </div>
       <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
         <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Total Cost</p>
-        <p class="text-base font-semibold text-gray-900 dark:text-white font-mono">${{ totalCost.toFixed(4) }}</p>
+        <p class="text-base font-semibold text-gray-900 dark:text-white font-mono">{{ formatCostCompact(totalCost) }}</p>
       </div>
       <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
         <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Avg Duration</p>
@@ -237,7 +237,7 @@
               <div class="flex items-center space-x-4 mt-2 text-xs text-gray-500 dark:text-gray-400">
                 <span v-if="task.model_used" class="font-mono bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">{{ task.model_used }}</span>
                 <span v-if="task.duration_ms" class="font-mono">{{ formatDuration(task.duration_ms) }}</span>
-                <span v-if="task.cost" class="font-mono">${{ task.cost.toFixed(4) }}</span>
+                <span v-if="task.cost" class="font-mono">{{ formatCost(task.cost) }}</span>
                 <div v-if="task.context_used && task.context_max" class="flex items-center space-x-1">
                   <div class="w-16 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
                     <div
@@ -486,7 +486,7 @@
                       </div>
                       <div class="flex items-center space-x-3 font-mono">
                         <span>{{ entry.duration }}</span>
-                        <span class="text-action-primary-600 dark:text-action-primary-400">${{ entry.cost }}</span>
+                        <span class="text-action-primary-600 dark:text-action-primary-400">{{ entry.cost }}</span>
                       </div>
                     </div>
                   </div>
@@ -524,6 +524,7 @@
 import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
+import { formatCost, formatCostCompact } from '../composables/useFormatters'
 import ModelSelector from './ModelSelector.vue'
 
 // Template ref for highlighted task element
@@ -1055,7 +1056,7 @@ function parseExecutionLog(log) {
         type: 'result',
         numTurns: msg.num_turns || msg.numTurns || '-',
         duration: msg.duration_ms ? formatDuration(msg.duration_ms) : (msg.duration || '-'),
-        cost: msg.cost_usd?.toFixed(4) || msg.total_cost_usd?.toFixed(4) || '0.0000'
+        cost: formatCost(msg.cost_usd ?? msg.total_cost_usd ?? 0)
       })
       continue
     }

--- a/src/frontend/src/components/UnifiedActivityPanel.vue
+++ b/src/frontend/src/components/UnifiedActivityPanel.vue
@@ -31,7 +31,7 @@
             <span v-if="activity.totals?.calls > 0">
               {{ activity.totals.calls }} call{{ activity.totals.calls !== 1 ? 's' : '' }}
             </span>
-            <span v-if="sessionCost > 0">${{ sessionCost.toFixed(4) }}</span>
+            <span v-if="sessionCost > 0">{{ formatCost(sessionCost) }}</span>
             <span v-if="elapsedTime">{{ elapsedTime }}</span>
           </div>
 
@@ -208,6 +208,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { formatCost } from '../composables/useFormatters'
 import { useAgentsStore } from '../stores/agents'
 
 const props = defineProps({

--- a/src/frontend/src/components/process/TrendChart.vue
+++ b/src/frontend/src/components/process/TrendChart.vue
@@ -34,7 +34,7 @@
               <span class="text-status-danger-400">{{ item.failed_count }}</span>
             </div>
             <div v-else-if="chartType === 'cost'">
-              ${{ item.total_cost.toFixed(2) }}
+              {{ formatCost(item.total_cost) }}
             </div>
             <div v-else>
               {{ item.success_rate.toFixed(1) }}%
@@ -102,6 +102,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { formatCost } from '../../composables/useFormatters'
 
 const props = defineProps({
   title: {

--- a/src/frontend/src/composables/useFormatters.js
+++ b/src/frontend/src/composables/useFormatters.js
@@ -1,3 +1,47 @@
+// ===========================================================================
+// Cost formatting (#92) — the single, canonical way to render a USD cost.
+// Do NOT inline `toFixed` on cost values or add local `formatCost` helpers;
+// import these instead. Both return a string WITH the `$` (no separate prefix).
+// ===========================================================================
+const _usdWhole = new Intl.NumberFormat('en-US', {
+  style: 'currency', currency: 'USD', maximumFractionDigits: 0,
+})
+const _usdCompact = new Intl.NumberFormat('en-US', {
+  style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 1,
+})
+
+/**
+ * Default cost format: whole dollars with US comma separators (`$1,200`, `$12`).
+ * Sub-dollar amounts keep 2-decimal precision (`$0.04`) since per-execution costs
+ * are usually < $1 — a tiny positive that rounds to $0.00 shows `<$0.01`. `$0`
+ * for zero/blank/invalid.
+ * @param {number} value
+ * @returns {string}
+ */
+export const formatCost = (value) => {
+  const n = Number(value)
+  if (!Number.isFinite(n) || n === 0) return '$0'
+  const abs = Math.abs(n)
+  if (abs < 1) {
+    if (abs < 0.005) return n > 0 ? '<$0.01' : '>-$0.01'
+    return `${n < 0 ? '-' : ''}$${abs.toFixed(2)}`
+  }
+  return _usdWhole.format(n)
+}
+
+/**
+ * Compact cost for tight surfaces (stat cards, table cells, node badges):
+ * `$1.2K`, `$3.4M` from ≥ $1,000; below that it matches {@link formatCost}.
+ * @param {number} value
+ * @returns {string}
+ */
+export const formatCostCompact = (value) => {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return '$0'
+  if (Math.abs(n) >= 1000) return _usdCompact.format(n)
+  return formatCost(n)
+}
+
 /**
  * Composable for shared formatting functions
  * Used across agent-related components
@@ -235,6 +279,9 @@ export function useFormatters() {
     formatDuration,
     formatDate,
     formatSource,
-    getContextBarColor
+    getContextBarColor,
+    // Cost (#92)
+    formatCost,
+    formatCostCompact
   }
 }

--- a/src/frontend/src/stores/observability.js
+++ b/src/frontend/src/stores/observability.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import axios from 'axios'
+import { formatCost } from '../composables/useFormatters'
 
 export const useObservabilityStore = defineStore('observability', {
   state: () => ({
@@ -50,7 +51,7 @@ export const useObservabilityStore = defineStore('observability', {
      * Format total cost as currency
      */
     formattedTotalCost() {
-      return `$${this.totals.total_cost.toFixed(4)}`
+      return formatCost(this.totals.total_cost)
     },
 
     /**
@@ -91,7 +92,7 @@ export const useObservabilityStore = defineStore('observability', {
         .map(([model, cost]) => ({
           model: this.formatModelName(model),
           cost: cost,
-          formattedCost: `$${cost.toFixed(4)}`
+          formattedCost: formatCost(cost)
         }))
         .sort((a, b) => b.cost - a.cost)
     },

--- a/src/frontend/src/views/Agents.vue
+++ b/src/frontend/src/views/Agents.vue
@@ -566,7 +566,7 @@
                     <span class="font-medium text-gray-700 dark:text-gray-300">{{ getExecutionStats(agent.name).taskCount }} tasks</span>
                     <template v-if="getExecutionStats(agent.name).totalCost > 0">
                       <span class="text-gray-300 dark:text-gray-600">·</span>
-                      <span class="font-medium text-gray-700 dark:text-gray-300">${{ getExecutionStats(agent.name).totalCost.toFixed(2) }}</span>
+                      <span class="font-medium text-gray-700 dark:text-gray-300">{{ formatCostCompact(getExecutionStats(agent.name).totalCost) }}</span>
                     </template>
                   </template>
                   <span v-else class="text-gray-400 dark:text-gray-500">--</span>
@@ -700,6 +700,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { formatCostCompact } from '../composables/useFormatters'
 import { useAgentsStore } from '../stores/agents'
 import { useNetworkStore } from '../stores/network'
 import NavBar from '../components/NavBar.vue'

--- a/src/frontend/src/views/ExecutionDetail.vue
+++ b/src/frontend/src/views/ExecutionDetail.vue
@@ -133,7 +133,7 @@
             </div>
             <div class="min-w-0 flex-1">
               <p class="text-xs font-medium text-gray-500 dark:text-gray-400">Cost</p>
-              <p class="text-lg font-semibold text-gray-900 dark:text-white">${{ (execution.cost || 0).toFixed(4) }}</p>
+              <p class="text-lg font-semibold text-gray-900 dark:text-white">{{ formatCost(execution.cost || 0) }}</p>
             </div>
           </div>
         </div>
@@ -387,7 +387,7 @@
                   </div>
                   <div class="flex items-center space-x-3 font-mono">
                     <span>{{ entry.duration }}</span>
-                    <span class="text-action-primary-600 dark:text-action-primary-400">${{ entry.cost }}</span>
+                    <span class="text-action-primary-600 dark:text-action-primary-400">{{ entry.cost }}</span>
                   </div>
                 </div>
               </div>
@@ -404,6 +404,7 @@ import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from 'axios'
 import { renderMarkdown } from '../utils/markdown'
+import { formatCost } from '../composables/useFormatters'
 import { useAuthStore } from '../stores/auth'
 
 const route = useRoute()
@@ -859,7 +860,7 @@ function parseExecutionLog(log) {
         type: 'result',
         numTurns: msg.num_turns || msg.numTurns || '-',
         duration: msg.duration_ms ? formatDuration(msg.duration_ms) : (msg.duration || '-'),
-        cost: msg.cost_usd?.toFixed(4) || msg.total_cost_usd?.toFixed(4) || '0.0000'
+        cost: formatCost(msg.cost_usd ?? msg.total_cost_usd ?? 0)
       })
       continue
     }


### PR DESCRIPTION
Standardizes cost formatting across the UI. One canonical formatter in `composables/useFormatters.js`; every cost site migrated; the two duplicated local `formatCost` helpers removed; no inline `cost.toFixed()` left.

## The formatter
- **`formatCost(v)`** — whole dollars, US comma separators: `$1,200`, `$12`, `$345,678` (`Intl.NumberFormat('en-US')`). **Sub-dollar rule** (AC): per-execution costs are usually < $1, so below $1 keeps 2-decimal precision (`$0.04`); a tiny positive that rounds to $0.00 shows `<$0.01`; zero/blank/invalid → `$0`.
- **`formatCostCompact(v)`** — `$1.2K` / `$3.4M` from ≥ $1,000 (below that = `formatCost`), for space-constrained surfaces (stat cards, table cells, node/card badges).
- Both return the string **with `$`** — template `$` prefixes dropped at migration sites.

## Migrated (14 files + the formatter)
AgentHeader, AgentNode, AgentTile, ExecutionsPanel, LoopsPanel, ReplayTimeline, ScheduleAnalyticsCard, SchedulesPanel, TasksPanel, UnifiedActivityPanel, process/TrendChart, views/Agents, views/ExecutionDetail, stores/observability. Compact on cards/badges/totals; default elsewhere; "unset" values (loop budget, run cost) keep an explicit `—`.

## AC coverage
- [x] Single shared formatter, only way costs are formatted; local helpers + inline toFixed removed
- [x] Default `$1,200`/`$12`/`$345,678`
- [x] Compact `$1.2K`/`$3.4M` from ≥ $1,000
- [x] All listed sites migrated (+ ExecutionDetail, found during the sweep)
- [x] Sub-dollar rule decided + applied (2-decimals below $1, `<$0.01` for tiny)
- [x] Presentation-only; API untouched; dark mode/layout unaffected (string swaps only)

## Testing
No frontend test framework in the repo. Verified via: all changed SFCs + store compile clean (`@vue/compiler-sfc`), and a direct eval of the formatter — `$0` / `$0.04` / `<$0.01` / `$1,200` / `$1.2K` / `$1.5M` all correct.

Fixes Abilityai/trinity-enterprise#92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
