### PR TITLE
fix(logs): retention can delete archived originals — rw mount + dir ownership (#1478)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -197,12 +197,19 @@ services:
       # Read-only access to Vector's logs so log_archive_service.py (reads
       # /data/logs) can run in prod. Mirrors docker-compose.yml; without it the
       # forwarded LOG_* knobs are inert (LOG_DIR not found) — the #1039 class.
-      - trinity-logs:/data/logs:ro
+      # #1478: MUST be read-WRITE — log_archive_service archives then unlink()s
+      # the originals. A ':ro' mount lets archiving succeed but every delete fail
+      # (Errno 30), so the volume grows unbounded (~900MB/day on a busy instance).
+      # Vector is still the sole writer of new log lines; the backend only reads
+      # + deletes archived originals.
+      - trinity-logs:/data/logs
     depends_on:
       redis:
         condition: service_healthy
       vector:
         condition: service_healthy  # Ensure Vector is ready before backend starts agents
+      logs-init:
+        condition: service_completed_successfully  # #1478: dir owned by UID 1000 before retention runs
     networks:
       - trinity-platform   # Redis, scheduler, vector, OTel
       - trinity-agent      # Frontend, mcp-server, agent containers, cloudflared
@@ -407,6 +414,21 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+
+  # #1478: one-shot that makes the shared logs volume dir owned by UID 1000 so the
+  # backend (non-root) can unlink retention-archived originals. Vector writes new
+  # log files as root; deleting a file needs write on the *directory*, not the file,
+  # so chowning just the dir (fast, not -R) is enough. Runs as root (needs CAP_CHOWN,
+  # so no cap_drop); exits immediately; backend waits on completion.
+  logs-init:
+    image: alpine:3.20
+    container_name: trinity-logs-init
+    command: ["sh", "-c", "chown 1000:1000 /data/logs && chmod 775 /data/logs"]
+    volumes:
+      - trinity-logs:/data/logs
+    restart: "no"
+    networks:
+      - trinity-platform
 
   # Vector - centralized log aggregation from all containers
   vector:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,13 +201,15 @@ services:
       - ./config/process-docs:/app/config/process-docs:ro  # Process documentation
       - agent-configs:/agent-configs
       - trinity-data:/data
-      - trinity-logs:/data/logs:ro  # Read-only access to Vector logs
+      - trinity-logs:/data/logs  # rw: log_archive_service must delete archived originals (#1478); Vector is the sole writer of new lines
       - trinity-archives:/data/archives  # Log archives storage
     depends_on:
       redis:
         condition: service_healthy   # Wait for ACL load + auth-aware healthcheck
       vector:
         condition: service_healthy  # Ensure Vector is ready before backend starts agents
+      logs-init:
+        condition: service_completed_successfully  # #1478: dir owned by UID 1000 before retention runs
     networks:
       - trinity-platform   # Redis, scheduler, vector, OTel
       - trinity-agent      # Frontend, mcp-server, agent containers
@@ -436,6 +438,21 @@ services:
       start_period: 10s
     mem_limit: 512m
     cpus: 1
+
+  # #1478: one-shot that makes the shared logs volume dir owned by UID 1000 so the
+  # backend (non-root) can unlink retention-archived originals. Vector writes new
+  # log files as root; deleting a file needs write on the *directory*, not the file,
+  # so chowning just the dir (fast, not -R) is enough. Runs as root (needs CAP_CHOWN,
+  # so no cap_drop); exits immediately; backend waits on completion.
+  logs-init:
+    image: alpine:3.20
+    container_name: trinity-logs-init
+    command: ["sh", "-c", "chown 1000:1000 /data/logs && chmod 775 /data/logs"]
+    volumes:
+      - trinity-logs:/data/logs
+    restart: "no"
+    networks:
+      - trinity-platform
 
   # Vector - centralized log aggregation from all containers
   vector:

--- a/src/backend/services/log_archive_service.py
+++ b/src/backend/services/log_archive_service.py
@@ -47,6 +47,24 @@ class LogArchiveService:
         # Ensure temp archive directory exists for compression staging
         TEMP_ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
 
+        # #1478: retention archives then unlink()s the originals. If the logs
+        # volume is mounted read-only on this container the archive succeeds but
+        # every delete fails (Errno 30) and the volume grows unbounded. Surface
+        # that once at startup instead of only as silent per-file errors at
+        # cleanup_hour.
+        try:
+            if LOG_DIR.exists() and not os.access(LOG_DIR, os.W_OK):
+                logger.warning(
+                    "Log directory %s is NOT writable — retention will archive old "
+                    "logs but cannot delete the originals, so disk usage grows "
+                    "unbounded (Issue #1478). Mount the logs volume read-write on "
+                    "the backend container (docker-compose: 'trinity-logs:/data/logs', "
+                    "not ':ro').",
+                    LOG_DIR,
+                )
+        except OSError:
+            pass  # never block startup on a permission probe
+
         # Schedule nightly archival
         self.scheduler.add_job(
             self.archive_old_logs,


### PR DESCRIPTION
Closes #1478.

## Problem
`LOG_RETENTION_DAYS` archived old logs but **never freed disk** — every delete failed `Errno 30: Read-only file system`, volume grew unbounded (~900MB/day; eu2 hit 32G).

## Two blocking layers (both fixed)
1. **Read-only mount** — `docker-compose.prod.yml` **and** `docker-compose.yml` both mounted `trinity-logs:/data/logs:ro` on the backend (the issue assumed dev was rw — it wasn't). → changed to **rw**. Vector stays the sole writer of new lines; backend only reads (gzip) + deletes archived originals.
2. **Directory ownership** — Vector runs as root and creates `/data/logs` root:root 0755, so even rw the backend (UID 1000) can't `unlink` (deleting needs write on the *directory*). Vector can't self-fix (`cap_drop: ALL` → no CAP_CHOWN). → added a one-shot **`logs-init`** container (root alpine) that `chown 1000:1000` + `chmod 775` the dir before the backend starts (`depends_on: service_completed_successfully`). Chowns the dir only (fast, not -R); Vector's future root-owned files stay deletable via the writable dir.

Plus: `log_archive_service.start()` now logs a **WARNING** if `LOG_DIR` isn't writable — visible at startup instead of silent per-file errors at cleanup_hour.

## Verified live (dev)
- Reproduced `:ro`: `touch /data/logs/... → Read-only file system`.
- After fix: dir `1000:1000 775`; backend writes; **a root-owned file in /data/logs is deletable by UID 1000** (Errno 30 gone). `logs-init` exits 0.

## Notes
- `logs-init` runs as root (needs CAP_CHOWN) but uses a **stock alpine** image, not a Trinity-built one — Invariant #17 ("Trinity-built images non-root") doesn't apply; it's ephemeral (exits immediately).
- Alternative considered: run Vector as UID 1000 — rejected because Vector needs root for the Docker-socket / file log sources (dev override reads root-owned `/var/lib/docker`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)