### PR TITLE
test: re-pin entitlement seam to audit+SSO now that SSO-OIDC landed (#1447)

### DIFF
--- a/tests/unit/test_847_entitlement_seam.py
+++ b/tests/unit/test_847_entitlement_seam.py
@@ -236,9 +236,15 @@ def test_main_py_uses_conditional_enterprise_import():
 # -----------------------------------------------------------------------------
 
 
-def test_submodule_registers_audit_not_sso():
-    """#941: the enterprise submodule swaps the SSO PoC for `audit`
-    registration. SSO returns later with a real implementation.
+def test_submodule_registers_audit_and_sso():
+    """The enterprise submodule registers `audit` (UI-gating only, via a direct
+    `register_module("audit")`) and — since SSO-OIDC (#32) landed via #1303 — a
+    real SSO implementation, wired the same way as the other real modules
+    (`from .sso import register as register_sso` + `register_sso(app)`, which
+    self-registers the `sso` feature_id inside `.sso.register`).
+
+    This replaces the earlier `not_sso` pin from the #910/#941 era, when only
+    the removed SSO PoC stub existed and the `.sso` package was asserted absent.
 
     Static check on `src/backend/enterprise/backend/__init__.py`. The
     submodule may not be checked out in every CI job (OSS-only build),
@@ -255,10 +261,13 @@ def test_submodule_registers_audit_not_sso():
         "enterprise submodule must call register_module(\"audit\") so the "
         "/enterprise/audit dashboard route is entitled in licensed deploys"
     )
-    assert 'register_module("sso")' not in src, (
-        "SSO PoC stub registration was removed in #910/#941 scope expansion; "
-        "the call must not return without a real implementation"
+    # SSO-OIDC (#32) landed in the submodule via #1303. It self-registers the
+    # `sso` feature_id inside `.sso.register` (mirroring the other real modules),
+    # so `register_module("sso")` is NOT called here in __init__.py — the pin is
+    # on the import + registration call instead.
+    assert "from .sso import register as register_sso" in src, (
+        "SSO-OIDC (#32) is implemented — __init__.py must import the .sso package"
     )
-    assert "from .sso" not in src, (
-        "SSO submodule import was removed; the .sso package is deleted"
+    assert "register_sso(app)" in src, (
+        "SSO-OIDC must be registered on the enterprise app via register_sso(app)"
     )


### PR DESCRIPTION
## Summary
`test_submodule_registers_audit_not_sso` pinned the enterprise submodule's `__init__.py` to *"no `.sso` import"* — a stale assertion from the #910/#941 era, when only the removed SSO PoC stub existed. Real SSO-OIDC (#32) has since landed via #1303, so the pin **failed on every entitled clone with the submodule mounted** (CI is unaffected — it skips when the submodule is absent, which is exactly where this trains people to ignore red tests).

## Changes
`tests/unit/test_847_entitlement_seam.py` — update the pin to the current contract:
- keep the direct `register_module("audit")` assertion (UI-gating module)
- replace the two `.sso`-absence assertions with presence checks on `from .sso import register as register_sso` + `register_sso(app)` (SSO self-registers its `sso` feature_id inside `.sso.register`, so `register_module("sso")` is intentionally **not** called in `__init__.py`)
- rename `..._not_sso` → `..._and_sso` and refresh the docstring

## Test Plan
Verified locally against a mounted entitled clone (via the `trinity-backend` image, which carries all deps):
- [x] **Passes** with the enterprise submodule mounted — `1 passed`
- [x] **Skips cleanly** without it (OSS-only build) — `1 skipped`
- [x] Single test node changed; no other tests affected

CI skips this test by design (the OSS unit suite has no submodule; guarded by `build-without-submodule.yml`), so the mounted-pass evidence above is the authoritative check.

Fixes #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
