### PR TITLE
fix(templates): curate the agent template catalog — hide fixtures, order starters first (#1513)

### DIFF
--- a/config/agent-templates/README.md
+++ b/config/agent-templates/README.md
@@ -8,7 +8,7 @@ Ready-made starting points for deploying an agent to Trinity. Each subdirectory 
 
 - **From a checkout** — copy a template directory, edit its `CLAUDE.md` + `template.yaml`, then deploy it: `cd <copy>/ && trinity deploy .` (see [Deploy an agent](../../AGENTS.md#deploy-an-agent-to-trinity)).
 - **From the web UI** — *Create Agent* → pick a template by `name`.
-- **By reference** — these `name`s are the built-in templates the platform ships; they appear in `GET /api/templates` and `list_templates` (MCP).
+- **By reference** — these `name`s are the built-in templates the platform ships; they appear in `GET /api/templates` and `list_templates` (MCP). Directories marked `hidden: true` in their `template.yaml` (see [Not starting points](#not-starting-points)) are excluded from that catalog but stay deployable by id (e.g. `local:test-echo`).
 
 ## Starter templates
 
@@ -19,9 +19,6 @@ Ready-made starting points for deploying an agent to Trinity. Each subdirectory 
 | `scout` | Market research analyst — discovers trends, analyzes competitors, identifies opportunities |
 | `sage` | Strategic advisor — synthesizes research into actionable recommendations |
 | `scribe` | Content writer — reports, proposals, and client deliverables |
-| `demo-researcher` | Minimal autonomous researcher (gathers + summarizes); good first deploy |
-| `demo-analyst` | Minimal analysis agent — answers strategic questions over research findings |
-| `trinity-system` | Platform operations manager — agent health, lifecycle, fleet management (system-scoped) |
 
 `scout` → `sage` → `scribe` are designed to work as a **consulting team**: Scout researches into a shared folder, Sage strategizes over it, Scribe writes the deliverable. Deploy them together to see agent-to-agent collaboration.
 
@@ -45,4 +42,10 @@ A startup due-diligence pipeline: `dd-intake` parses a pitch deck into structure
 
 ## Not starting points
 
-`test-echo`, `test-counter`, `test-delegator`, `test-codex`, `test-gemini`, `test-leak-hook`, and `sleep-echo` are internal **test/canary fixtures** used by the test suite and the canary harness — not templates to build on.
+These directories are **excluded from the user-facing catalog** (`GET /api/templates` / `list_templates`) — each carries `hidden: true` in its `template.yaml`, so the exclusion is machine-enforced, not a naming convention. They stay deployable by id (e.g. `local:test-echo`) for the test/canary harness and demo scripts.
+
+- **Test/canary fixtures** — `test-echo`, `test-counter`, `test-delegator`, `test-codex`, `test-gemini`, `test-leak-hook`, `sleep-echo`. Used by the test suite and the canary harness; `test-leak-hook` is a deliberately hazardous subprocess-leak repro — do **not** deploy it in production.
+- **Demo fixtures** — `demo-researcher`, `demo-analyst`. A minimal producer→consumer shared-folder pair deployed together by the demo-fleet manifests, not a starting point to build on.
+- **Platform agent** — `trinity-system`. Auto-deployed and deletion-protected platform-operations agent; not something you create yourself.
+
+Adding a new fixture? Set `hidden: true` in its `template.yaml` so it never leaks into the catalog (a unit test guards this — see `tests/unit/test_local_templates_listing.py`).

--- a/config/agent-templates/demo-analyst/template.yaml
+++ b/config/agent-templates/demo-analyst/template.yaml
@@ -1,4 +1,6 @@
 name: demo-analyst
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Analysis Agent
 description: Synthesizes research findings and answers strategic questions
 tagline: Strategic insights from research

--- a/config/agent-templates/demo-researcher/template.yaml
+++ b/config/agent-templates/demo-researcher/template.yaml
@@ -1,4 +1,6 @@
 name: demo-researcher
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Research Agent
 description: Autonomous researcher that gathers and summarizes information on trending topics
 tagline: Discovers trends and opportunities

--- a/config/agent-templates/scribe/template.yaml
+++ b/config/agent-templates/scribe/template.yaml
@@ -14,7 +14,7 @@ capabilities:
 commands:
   - name: report
     description: Create a professional report
-    usage: /report [topic] [format: brief|full|executive]
+    usage: "/report [topic] [format: brief|full|executive]"
   - name: proposal
     description: Draft a client proposal
     usage: /proposal [client] [engagement-type]

--- a/config/agent-templates/sleep-echo/template.yaml
+++ b/config/agent-templates/sleep-echo/template.yaml
@@ -1,4 +1,6 @@
 name: Sleep Echo Agent
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Sleep Echo
 description: Echo agent that sleeps before responding — used by canary harness to manufacture long-lived running rows for E-05 / S-03 coverage
 version: "1.0.0"

--- a/config/agent-templates/test-codex/template.yaml
+++ b/config/agent-templates/test-codex/template.yaml
@@ -1,4 +1,6 @@
 name: test-codex
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Test Codex Agent
 description: Test agent using OpenAI's Codex CLI runtime for validation (#1187)
 version: "1.0.0"

--- a/config/agent-templates/test-counter/template.yaml
+++ b/config/agent-templates/test-counter/template.yaml
@@ -1,4 +1,6 @@
 name: Test Counter Agent
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Test Counter
 description: Counter agent for testing state persistence across messages
 version: "1.0.0"

--- a/config/agent-templates/test-delegator/template.yaml
+++ b/config/agent-templates/test-delegator/template.yaml
@@ -1,4 +1,6 @@
 name: Test Delegator Agent
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Test Delegator
 description: Delegator agent for testing agent-to-agent communication (Pillar II)
 version: "1.0.0"

--- a/config/agent-templates/test-echo/template.yaml
+++ b/config/agent-templates/test-echo/template.yaml
@@ -1,4 +1,6 @@
 name: Test Echo Agent
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Test Echo
 description: Simple echo agent for testing basic chat functionality
 version: "1.0.0"

--- a/config/agent-templates/test-gemini/template.yaml
+++ b/config/agent-templates/test-gemini/template.yaml
@@ -1,4 +1,6 @@
 name: test-gemini
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Test Gemini Agent
 description: Test agent using Google's Gemini CLI runtime for validation
 version: "1.0.0"

--- a/config/agent-templates/test-leak-hook/template.yaml
+++ b/config/agent-templates/test-leak-hook/template.yaml
@@ -1,4 +1,6 @@
 name: Test Subprocess-Leak Hook
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Test Leak Hook
 description: Engineered subprocess-leak harness for Issue #817 regression repro. Spawns a setsid CPU burner from a UserPromptSubmit hook so the burner escapes Claude's pgid and survives terminate_process_group. Intended ONLY for local automated tests — do NOT deploy in production.
 version: "1.0.0"

--- a/config/agent-templates/trinity-system/template.yaml
+++ b/config/agent-templates/trinity-system/template.yaml
@@ -1,4 +1,6 @@
 name: trinity-system
+# Excluded from the user-facing template catalog (GET /api/templates). See README "Not starting points". (#1513)
+hidden: true
 display_name: Trinity System Agent
 description: Platform operations manager responsible for agent health, lifecycle, resource governance, and schedule control. Auto-deployed, deletion-protected, with full access to all Trinity MCP tools.
 version: "1.1.0"

--- a/docs/memory/feature-flows/template-processing.md
+++ b/docs/memory/feature-flows/template-processing.md
@@ -133,6 +133,20 @@ async def list_templates(current_user: User = Depends(get_current_user)):
     # 6. Return merged list
 ```
 
+**Catalog curation (#1513).** `get_local_templates()` excludes any template
+whose `template.yaml` sets `hidden: true` — the internal test/canary fixtures
+(`test-*`, `sleep-echo`) and demo/system agents (`demo-researcher`,
+`demo-analyst`, `trinity-system`). Hidden templates stay resolvable by id via
+`get_local_template()` and creatable by id (the create path resolves by
+directory name), so the canary/test harness is unaffected — only the
+user-facing list hides them. Both `_build_local_template` and `_build_template`
+now surface a coerced-int `priority` (`_coerce_priority`; a present-but-null or
+string value would otherwise `TypeError` the router sort), so the step-5 sort
+actually orders the real starters (`scout`/`sage`/`scribe`, `priority: 20`)
+ahead of the rest. `Templates.vue` renders a **Starter Templates** (local)
+section in addition to GitHub, so it shows the same curated set as
+`CreateAgentModal`.
+
 ### Template Response Schema
 ```json
 {
@@ -615,6 +629,7 @@ Tests: `tests/unit/test_fork_to_own.py` (40 — model validation, orchestrator c
 
 | Date | Changes |
 |------|---------|
+| 2026-07-07 | **Catalog curation (#1513)**: `get_local_templates()` now excludes `hidden: true` fixtures (test/canary/demo/system) from the user-facing list while keeping them creatable by id; `_build_local_template`/`_build_template` surface a coerced-int `priority` so the router sort actually orders real starters first; fixed `scribe/template.yaml` (unquoted `usage:` broke YAML parse → silently dropped from catalog); `Templates.vue` renders a Starter (local) section matching CreateAgentModal. See "Catalog curation" note above. |
 | 2026-07-06 | **Fork-to-own creation (trinity-enterprise#93)**: `fork_to_own: required` template flag → copy into user-owned repo (private by default) at creation; user PAT as per-agent git identity; upstream remote for template updates; featured create-modal cards. New section above. |
 | 2026-02-05 | **CRED-002**: Removed Redis credential_manager references. GitHub PAT now retrieved via `get_github_pat()` from SQLite settings or env var. Removed `initialize_github_pat()` documentation. Updated Security Considerations. |
 | 2026-01-23 | **Full verification**: Updated all line numbers for Templates.vue (16-24, 55-134, 137-216, 218-247, 262-267, 290-296, 299-302, 304-332), CreateAgentModal.vue (191-196, 198, 208-210, 219-230, 263-285), template_service.py (64-103, 106-118, 121-140, 143-225, 228-299, 309-358, 361-380), crud.py (96-144, 145-182), config.py (91-164), and startup.sh (6-125, 127-157, 164-222, 275-286). Added multi-runtime support and shared_folders template config. Updated credential file handling details. |

--- a/src/backend/services/template_service.py
+++ b/src/backend/services/template_service.py
@@ -109,6 +109,27 @@ def _fetch_all_metadata(repos: List[str]) -> Dict[str, dict]:
 # Template Expansion
 # ============================================================================
 
+# Default sort weight for a template that declares no `priority:` (lower =
+# earlier). The router sorts by `(priority, display_name)`.
+_DEFAULT_TEMPLATE_PRIORITY = 100
+
+
+def _coerce_priority(value) -> int:
+    """Return a sortable int priority from a raw template.yaml value.
+
+    The router sorts on `(priority, display_name)`, so a non-int priority
+    would raise `TypeError: '<' not supported between 'NoneType' and 'int'`
+    (a missing key defaults via `.get(..., 100)`, but a present-yet-null or
+    string value slips through and 500s the whole endpoint). Coerce here so
+    every surfaced template carries a real int. `bool` is excluded because
+    `isinstance(True, int)` is True in Python — a `priority: true` typo must
+    not sort as `1`.
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return _DEFAULT_TEMPLATE_PRIORITY
+
+
 def _build_template(repo: str, metadata: dict, admin_override: dict = None) -> dict:
     """Build a full template dict from repo + fetched metadata + optional admin overrides.
 
@@ -141,6 +162,10 @@ def _build_template(repo: str, metadata: dict, admin_override: dict = None) -> d
         "github_repo": repo,
         "github_credential_id": GITHUB_PAT_CREDENTIAL_ID,
         "source": "github",
+        # Surface `priority` so the router's `(priority, display_name)` sort is
+        # honored. Coerced to a real int — a GitHub repo's template.yaml is
+        # untrusted and could set `priority: "high"`, which would 500 the sort.
+        "priority": _coerce_priority(metadata.get("priority")),
         "resources": metadata.get("resources", {"cpu": "2", "memory": "4g"}),
         "skills": metadata.get("skills", []),
         "mcp_servers": metadata.get("mcp_servers", []),
@@ -211,6 +236,17 @@ def _build_local_template(template_dir: Path) -> Optional[dict]:
         "display_name": data.get("display_name") or data.get("name") or name,
         "description": data.get("description") or data.get("tagline") or "",
         "source": "local",
+        # Surface `priority` (coerced int) so the router's
+        # `(priority, display_name)` sort orders real starters ahead of the
+        # rest (scout/sage/scribe declare `priority: 20`; most others omit it
+        # and fall to the default). (#1513)
+        "priority": _coerce_priority(data.get("priority")),
+        # `hidden: true` marks internal test/canary/demo fixtures that must not
+        # appear in the user-facing catalog. Surfaced here (not filtered) so a
+        # single-id resolve — `get_local_template()` / creation-by-id — still
+        # works for the test harness; `get_local_templates()` does the actual
+        # exclusion. (#1513)
+        "hidden": bool(data.get("hidden", False)),
         "resources": data.get("resources", {"cpu": "2", "memory": "4g"}),
         "skills": data.get("skills", []),
         "mcp_servers": list(data.get("credentials", {}).get("mcp_servers", {}).keys())
@@ -232,6 +268,12 @@ def get_local_templates() -> List[dict]:
     Each entry has `id` prefixed `local:<dirname>` and shape matching
     `_build_template` (the GitHub-template builder) so the frontend
     handles both sources identically. (#843)
+
+    Templates marked `hidden: true` in their `template.yaml` — internal
+    test/canary fixtures and demo agents — are excluded from this
+    user-facing catalog. They remain fully resolvable by id via
+    `get_local_template()` and creatable by id (the create path resolves
+    by directory name), so the test/canary harness is unaffected. (#1513)
     """
     templates_dir = _local_templates_dir()
     if not templates_dir.exists():
@@ -242,7 +284,7 @@ def get_local_templates() -> List[dict]:
         if not child.is_dir():
             continue
         entry = _build_local_template(child)
-        if entry is not None:
+        if entry is not None and not entry.get("hidden"):
             out.append(entry)
     return out
 

--- a/src/frontend/src/views/Templates.vue
+++ b/src/frontend/src/views/Templates.vue
@@ -50,6 +50,75 @@
 
         <!-- Templates grid -->
         <div v-else>
+          <!-- Starter (local) Templates Section — same curated set as the
+               Create Agent modal; real starters first (#1513). -->
+          <div v-if="localTemplates.length > 0" class="mb-8">
+            <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4 flex items-center">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              Starter Templates
+              <span class="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">({{ localTemplates.length }})</span>
+            </h2>
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              <div
+                v-for="template in localTemplates"
+                :key="template.id"
+                class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg p-6 hover:shadow-lg dark:hover:shadow-gray-900/50 transition-shadow flex flex-col"
+              >
+                <div class="flex items-start justify-between mb-3">
+                  <div class="flex items-center">
+                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-action-primary-100 dark:bg-action-primary-900/50 flex items-center justify-center">
+                      <svg class="w-5 h-5 text-action-primary-600 dark:text-action-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                    </div>
+                    <div class="ml-3">
+                      <h3 class="text-lg font-medium text-gray-900 dark:text-white">{{ getDisplayName(template) }}</h3>
+                      <p class="text-xs text-gray-500 dark:text-gray-400">Bundled template</p>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Content area that grows -->
+                <div class="flex-grow">
+                  <p class="text-gray-600 dark:text-gray-300 text-sm mb-4 line-clamp-3">
+                    {{ template.description || 'No description available' }}
+                  </p>
+
+                  <!-- Stats row: Skills, MCPs, Credentials -->
+                  <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400 mb-4">
+                    <span v-if="template.skills?.length" class="flex items-center">
+                      <svg class="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                      </svg>
+                      {{ template.skills.length }} skills
+                    </span>
+                    <span v-if="template.mcp_servers?.length" class="flex items-center">
+                      <svg class="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
+                      </svg>
+                      {{ template.mcp_servers.length }} MCPs
+                    </span>
+                    <span v-if="template.required_credentials?.length" class="flex items-center">
+                      <svg class="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+                      </svg>
+                      {{ template.required_credentials.length }} credentials
+                    </span>
+                  </div>
+                </div>
+
+                <button
+                  @click="useTemplate(template)"
+                  class="w-full bg-action-primary-600 hover:bg-action-primary-700 text-white font-bold py-2 px-4 rounded transition-colors mt-auto"
+                >
+                  Use Template
+                </button>
+              </div>
+            </div>
+          </div>
+
           <!-- GitHub Templates Section -->
           <div v-if="githubTemplates.length > 0" class="mb-8">
             <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4 flex items-center">
@@ -188,9 +257,16 @@ const error = ref('')
 const showCreateModal = ref(false)
 const selectedTemplateId = ref('')
 
-// Computed properties to separate GitHub and local templates
+// Computed properties to separate GitHub and local templates. Both sections
+// render from the single `/api/templates` fetch so the Templates tab shows the
+// same curated set as CreateAgentModal — the backend already excludes hidden
+// test/canary/demo fixtures (#1513).
 const githubTemplates = computed(() => {
   return templates.value.filter(t => t.source === 'github')
+})
+
+const localTemplates = computed(() => {
+  return templates.value.filter(t => t.source === 'local' || !t.source)
 })
 
 // Extract display name without "(GitHub)" suffix for cleaner display

--- a/tests/unit/test_local_templates_listing.py
+++ b/tests/unit/test_local_templates_listing.py
@@ -181,3 +181,154 @@ def test_description_falls_back_to_tagline(tmp_path, monkeypatch):
     ts = _load_template_service(monkeypatch, tmp_path)
     t = ts.get_local_templates()[0]
     assert t["description"] == "punchy line"
+
+
+# -----------------------------------------------------------------------------
+# hidden: true — internal fixtures excluded from the catalog (#1513)
+# -----------------------------------------------------------------------------
+
+def test_hidden_template_excluded_from_list(tmp_path, monkeypatch):
+    """A directory whose template.yaml sets `hidden: true` is a test/canary/demo
+    fixture — it must NOT appear in the user-facing catalog list."""
+    _seed_template(tmp_path, "test-echo", body="name: test-echo\nhidden: true")
+    _seed_template(tmp_path, "scout", body="name: scout\ndisplay_name: Scout")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    ids = {t["id"] for t in ts.get_local_templates()}
+    assert ids == {"local:scout"}  # test-echo hidden, scout surfaced
+
+
+def test_hidden_template_still_resolvable_by_id(tmp_path, monkeypatch):
+    """Hiding only affects the LIST — a hidden fixture stays resolvable by id so
+    creation-by-id keeps working for the canary/test harness (#1513)."""
+    _seed_template(tmp_path, "test-echo", body="name: test-echo\nhidden: true")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    t = ts.get_local_template("local:test-echo")
+    assert t is not None
+    assert t["id"] == "local:test-echo"
+    assert t["hidden"] is True
+
+
+def test_hidden_false_and_absent_are_visible(tmp_path, monkeypatch):
+    """`hidden: false` and an omitted `hidden` key are both catalog-visible."""
+    _seed_template(tmp_path, "explicit-false", body="name: explicit-false\nhidden: false")
+    _seed_template(tmp_path, "omitted", body="name: omitted")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    by_id = {t["id"]: t for t in ts.get_local_templates()}
+    assert set(by_id) == {"local:explicit-false", "local:omitted"}
+    assert by_id["local:explicit-false"]["hidden"] is False
+    assert by_id["local:omitted"]["hidden"] is False
+
+
+# -----------------------------------------------------------------------------
+# priority surfacing + coercion — guards the None-in-sort-key 500 (#1513)
+# -----------------------------------------------------------------------------
+
+def test_priority_surfaced_and_coerced_to_int(tmp_path, monkeypatch):
+    """Every surfaced template carries an int `priority`. A present-but-null,
+    string, or bool value must coerce to the default — otherwise the router's
+    `(priority, display_name)` sort raises TypeError and 500s the endpoint."""
+    _seed_template(tmp_path, "has-int", body="name: has-int\npriority: 20")
+    _seed_template(tmp_path, "no-key", body="name: no-key")
+    _seed_template(tmp_path, "null-val", body="name: null-val\npriority: null")
+    _seed_template(tmp_path, "str-val", body="name: str-val\npriority: high")
+    _seed_template(tmp_path, "bool-val", body="name: bool-val\npriority: true")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    by_id = {t["id"]: t for t in ts.get_local_templates()}
+    assert by_id["local:has-int"]["priority"] == 20
+    for id_ in ("local:no-key", "local:null-val", "local:str-val", "local:bool-val"):
+        p = by_id[id_]["priority"]
+        assert isinstance(p, int) and not isinstance(p, bool), f"{id_}: {p!r}"
+        assert p == 100
+
+
+def test_coerce_priority_helper(tmp_path, monkeypatch):
+    """Direct unit coverage of the coercion helper's edge cases."""
+    ts = _load_template_service(monkeypatch, tmp_path)
+    assert ts._coerce_priority(20) == 20
+    assert ts._coerce_priority(0) == 0            # a legit 'highest' — NOT coerced away
+    assert ts._coerce_priority(-5) == -5
+    assert ts._coerce_priority(None) == 100
+    assert ts._coerce_priority("high") == 100
+    assert ts._coerce_priority(True) == 100        # bool is not a valid priority
+    assert ts._coerce_priority(1.5) == 100
+
+
+def test_router_sort_key_never_raises_over_mixed_priority(tmp_path, monkeypatch):
+    """Replicates routers/templates.py's exact sort over a mixed catalog. With
+    coercion in place the key is always `(int, str)`, so the sort orders
+    priority-ascending and never raises — the regression guard for the crash a
+    raw `data.get('priority')` would have shipped (#1513)."""
+    _seed_template(tmp_path, "starter", body="name: starter\ndisplay_name: Starter\npriority: 20")
+    _seed_template(tmp_path, "plain-b", body="name: plain-b\ndisplay_name: Bravo")
+    _seed_template(tmp_path, "plain-a", body="name: plain-a\ndisplay_name: Alpha")
+    _seed_template(tmp_path, "nulled", body="name: nulled\ndisplay_name: Nulled\npriority: null")
+    ts = _load_template_service(monkeypatch, tmp_path)
+
+    templates = ts.get_local_templates()
+    # exact key from routers/templates.py::list_templates
+    templates.sort(key=lambda t: (t.get("priority", 100), t.get("display_name", "")))
+    order = [t["id"] for t in templates]
+
+    # priority 20 leads; the rest (default 100) fall back to display_name order
+    assert order == ["local:starter", "local:plain-a", "local:plain-b", "local:nulled"]
+
+
+# -----------------------------------------------------------------------------
+# Real-catalog convention guard — a future unflagged fixture fails CI (#1513)
+# -----------------------------------------------------------------------------
+
+def _load_ts_real_catalog(monkeypatch):
+    """Load template_service pointed at the REAL config/agent-templates/ dir."""
+    real_dir = _BACKEND.parent.parent / "config" / "agent-templates"
+    return _load_template_service(monkeypatch, real_dir), real_dir
+
+
+def test_real_catalog_hides_all_known_fixtures(monkeypatch):
+    """The shipped catalog must never surface an internal fixture or the
+    auto-deployed system agent — even if a future author forgets `hidden: true`,
+    this convention check fails CI before it leaks to users."""
+    ts, real_dir = _load_ts_real_catalog(monkeypatch)
+    if not real_dir.exists():
+        pytest.skip("config/agent-templates not present in this checkout")
+
+    ids = {t["id"].split(":", 1)[1] for t in ts.get_local_templates()}
+
+    # No fixture (by explicit name or naming convention) may appear.
+    forbidden = {
+        "test-echo", "test-counter", "test-delegator", "test-codex",
+        "test-gemini", "sleep-echo", "test-leak-hook",
+        "demo-researcher", "demo-analyst", "trinity-system",
+    }
+    leaked = forbidden & ids
+    assert not leaked, f"internal fixtures leaked into the catalog: {sorted(leaked)}"
+
+    convention_leaks = {n for n in ids if n.startswith(("test-", "demo-"))}
+    assert not convention_leaks, f"test-/demo- named dirs in catalog: {sorted(convention_leaks)}"
+
+
+def test_real_catalog_surfaces_starters_ahead_of_suite(monkeypatch):
+    """scout/sage/scribe are present and rank ahead of the dd-* suite after the
+    router sort — the priority-surfacing fix, verified end-to-end (#1513).
+    Also guards that scribe's template.yaml parses (a broken YAML would silently
+    drop it from the catalog)."""
+    ts, real_dir = _load_ts_real_catalog(monkeypatch)
+    if not real_dir.exists():
+        pytest.skip("config/agent-templates not present in this checkout")
+
+    templates = ts.get_local_templates()
+    templates.sort(key=lambda t: (t.get("priority", 100), t.get("display_name", "")))
+    order = [t["id"].split(":", 1)[1] for t in templates]
+
+    for starter in ("scout", "sage", "scribe"):
+        assert starter in order, f"starter {starter} missing from catalog"
+
+    dd_positions = [i for i, n in enumerate(order) if n.startswith("dd-")]
+    if dd_positions:
+        last_starter = max(order.index(s) for s in ("scout", "sage", "scribe"))
+        assert last_starter < min(dd_positions), (
+            "real starters must sort ahead of the dd-* suite"
+        )


### PR DESCRIPTION
## Summary
- `GET /api/templates` no longer surfaces internal **test/canary fixtures**, **demo agents**, or the auto-deployed **trinity-system** agent as real user templates — they're excluded via an explicit `hidden: true` `template.yaml` flag (not fragile name-matching), while staying creatable-by-id so the canary/test harness is untouched.
- **Real starters now lead**: both template builders surface a coerced-int `priority`, so the router's `(priority, display_name)` sort orders `scout`/`sage`/`scribe` (priority 20) ahead of the `dd-*` suite.
- The Templates tab and Create Agent modal now show the **same curated set** (Templates.vue was GitHub-only).

## Acceptance criteria (all met)
- [x] Fixtures excluded via an explicit signal (`hidden: true`), not name matching
- [x] Broken `config/agent-templates/cornelius/` stub removed
- [x] Ordering surfaces real starters first; no fixture outranks a genuine starter
- [x] Templates tab + CreateAgentModal show the same curated source
- [x] A test asserts fixtures are excluded (+ a convention guard so they can't silently reappear)

## Changes
- `src/backend/services/template_service.py` — `_coerce_priority()` helper; surface `priority`+`hidden` in `_build_local_template`, `priority` in `_build_template`; filter `hidden` in `get_local_templates()` (LIST only — single-id + creation-by-id preserved).
- `config/agent-templates/*/template.yaml` — `hidden: true` on the 7 test/canary fixtures, 2 demo agents, and `trinity-system`.
- `config/agent-templates/scribe/template.yaml` — **quote the `usage:` value** (an unquoted `format:` colon made the file invalid YAML, so this core starter was silently dropped from the catalog).
- `src/frontend/src/views/Templates.vue` — add a Starter (local) Templates section.
- `config/agent-templates/README.md` + `docs/memory/feature-flows/template-processing.md` — reconcile docs with the hidden set and document the flag.
- `tests/unit/test_local_templates_listing.py` — exclusion, single-id survival, priority coercion, router-sort regression, real-catalog convention guard.

## Notable finds during review
- **Recovered a missing starter**: `scribe` was already absent from the catalog because its `template.yaml` failed to parse — fixed.
- **Prevented a latent 500**: surfacing a raw `priority: null`/`"high"` would `TypeError` the router sort; `_coerce_priority` guards it (with a regression test).
- `cornelius/` carried **no git-tracked files** (its only contents are globally gitignored `.trinity/` hooks) and never appeared in the catalog (no `template.yaml`) — removed the local artifact; produces no diff.

## Test plan
- [x] `pytest tests/unit/test_local_templates_listing.py` — 19 passed (11 existing + 8 new)
- [x] Adjacent template tests unaffected — `test_data_paths_template_surface`, `test_deploy_writable_templates` (5), `test_templates` (5 passed / 3 skipped)
- [x] End-to-end catalog simulation against the real `config/agent-templates/`: fixtures excluded, `scout`/`sage`/`scribe` present and ahead of `dd-*`, hidden fixtures still resolve by id
- [ ] Manual: Templates tab + Create Agent modal render the same curated set

## Follow-up (deferred, out of scope)
- Extract a shared `<TemplateCard>` component — the new local card markup mirrors the GitHub card; deferred to avoid pulling `CreateAgentModal` into a P1 bug fix.

Fixes #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)