### PR TITLE
test: fix dev test-suite drift + harness bugs (no product changes)

### DIFF
--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -441,11 +441,12 @@ class TestTimelineForDashboard:
         assert_status(response, 200)
         activities = response.json().get("activities", [])
 
-        # Valid trigger types for Dashboard color coding.
-        # #1260: include "loop" (#740/#1150) and "voip" (#1056) — real trigger
-        # values added after this test was written.
-        valid_triggers = {"schedule", "agent", "manual", "user", "mcp", "public",
-                          "fan_out", "loop", "voip", None}
+        # Valid trigger types for Dashboard color coding. Derive from the canonical
+        # source of truth (db/schedules._TRIGGER_BUCKETS — the Dashboard bucket map)
+        # rather than a hand-maintained literal set, so this test doesn't drift every
+        # time a trigger/channel value is added (webhook, telegram/slack/whatsapp, etc.).
+        from db.schedules import _TRIGGER_BUCKETS
+        valid_triggers = set(_TRIGGER_BUCKETS) | {None}
 
         for activity in activities:
             triggered_by = activity.get("triggered_by")

--- a/tests/test_canary_invariants.py
+++ b/tests/test_canary_invariants.py
@@ -593,6 +593,14 @@ class _CanaryTempDB:
             ).first()
         return int(row[0]) if row else 0
 
+    def get_setting_value(self, key: str, default=None):
+        # No settings table in the B-01 temp DB; mirror the real facade's
+        # empty-store return so callers that leak onto this stub via the
+        # module-level `from database import db` reference (settings_service.
+        # get_setting <- task_execution_service.get_platform_default_model)
+        # get a clean fallback instead of an AttributeError.
+        return default
+
 
 def _reload_canary_with_temp_db(fake_redis, monkeypatch):
     """Evict + reimport the canary modules and install the controlled `database`

--- a/tests/test_event_subscriptions.py
+++ b/tests/test_event_subscriptions.py
@@ -334,7 +334,12 @@ class TestCreateSubscription:
     def test_create_subscription_nonexistent_source(
         self, api_client: TrinityApiClient, created_agent
     ):
-        """Create subscription with nonexistent source agent returns 400."""
+        """Create subscription with nonexistent source agent returns 403.
+
+        #186 enumeration-safety: "source not found" (was 400) is collapsed into
+        the "not permitted" 403 so the body's source_agent can't be used as an
+        existence oracle (commit 34ddf71a). Mirrors the [403, 404] sibling tests.
+        """
         response = api_client.post(
             f"/api/agents/{created_agent['name']}/event-subscriptions",
             json={
@@ -343,7 +348,7 @@ class TestCreateSubscription:
                 "target_message": "Test",
             },
         )
-        assert_status(response, 400)
+        assert_status(response, 403)
 
     def test_create_subscription_missing_fields(
         self, api_client: TrinityApiClient, created_agent

--- a/tests/test_files_guardrail_bypass.py
+++ b/tests/test_files_guardrail_bypass.py
@@ -104,7 +104,7 @@ class TestAisecC2ExactReproduction:
             pytest.skip("Agent server not ready")
         assert_status(response, 400)
         body = response.json()
-        assert "Disallowed file path" in body.get("detail", "")
+        assert "Disallowed credential file path" in body.get("detail", "")
         assert ".mcp.json.template" in body.get("detail", "")
 
 

--- a/tests/test_mcp_validator_endpoint.py
+++ b/tests/test_mcp_validator_endpoint.py
@@ -212,7 +212,7 @@ class TestMcpTemplateStillBlocked:
         # Path-layer rejection happens BEFORE agent contact, so no 503 skip
         assert_status(response, 400)
         body = response.json()
-        assert "Disallowed file path" in body.get("detail", "")
+        assert "Disallowed credential file path" in body.get("detail", "")
         assert ".mcp.json.template" in body.get("detail", "")
 
 

--- a/tests/test_platform_prompt_unit.py
+++ b/tests/test_platform_prompt_unit.py
@@ -307,7 +307,7 @@ def test_builder_returns_empty_string_on_internal_error(monkeypatch):
 
 
 def test_compose_includes_platform_context_and_caller(monkeypatch):
-    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda: "PLATFORM")
+    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda **_kwargs: "PLATFORM")
     ctx = ExecutionContext(agent_name="oracle", triggered_by="chat")
     out = compose_system_prompt(execution_context=ctx, caller_prompt="CALLER MEMORY")
     assert out.startswith("PLATFORM")
@@ -318,14 +318,14 @@ def test_compose_includes_platform_context_and_caller(monkeypatch):
 
 
 def test_compose_without_execution_context(monkeypatch):
-    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda: "PLATFORM")
+    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda **_kwargs: "PLATFORM")
     out = compose_system_prompt(execution_context=None, caller_prompt="CALLER")
     assert "## Execution Context" not in out
     assert "PLATFORM" in out and "CALLER" in out
 
 
 def test_compose_respects_disabled_flag(monkeypatch):
-    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda: "PLATFORM")
+    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda **_kwargs: "PLATFORM")
     ctx = ExecutionContext(agent_name="oracle", triggered_by="chat")
     out = compose_system_prompt(
         execution_context=ctx,
@@ -336,7 +336,7 @@ def test_compose_respects_disabled_flag(monkeypatch):
 
 
 def test_compose_auto_fills_collaborators(monkeypatch):
-    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda: "PLATFORM")
+    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda **_kwargs: "PLATFORM")
     monkeypatch.setattr(pps, "_resolve_collaborators", lambda name: ["buddy-1"])
     ctx = ExecutionContext(agent_name="oracle", triggered_by="chat")
     out = compose_system_prompt(execution_context=ctx)
@@ -344,7 +344,7 @@ def test_compose_auto_fills_collaborators(monkeypatch):
 
 
 def test_compose_builder_failure_falls_back_to_platform(monkeypatch):
-    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda: "PLATFORM")
+    monkeypatch.setattr(pps, "get_platform_system_prompt", lambda **_kwargs: "PLATFORM")
     monkeypatch.setattr(pps, "build_execution_context", lambda ctx: "")
     ctx = ExecutionContext(agent_name="oracle", triggered_by="chat")
     out = compose_system_prompt(execution_context=ctx, caller_prompt="CALLER")

--- a/tests/test_whatsapp_integration.py
+++ b/tests/test_whatsapp_integration.py
@@ -243,17 +243,21 @@ def _pending_login_matches(binding_id: int, phone: str, email: str) -> bool:
     The adapter calls `_set_pending_login` AFTER `db.create_login_code`, so
     observing the code in the DB does not imply the pending key is also set.
     Tests must wait for THIS before POSTing `/login <code>`.
+
+    Read through the backend container's own Redis client (the same
+    `get_redis_client()` the adapter uses) rather than a bare `redis-cli GET`:
+    the platform now runs Redis with mandatory ACL auth (#589), so an
+    unauthenticated `redis-cli` returns `NOAUTH Authentication required.` with
+    exit code 0 — which a naive stdout comparison silently treats as a
+    never-matching value. Going through the backend uses the authenticated
+    `REDIS_URL` (correct user + DB) with no hardcoded password.
     """
-    result = subprocess.run(
-        [
-            "docker", "exec", "-i", "trinity-redis", "redis-cli",
-            "GET", f"whatsapp_pending_login:{binding_id}:{phone}",
-        ],
-        capture_output=True, text=True, timeout=10,
+    script = (
+        "from adapters.whatsapp_adapter import _get_pending_login; "
+        f"val = _get_pending_login({binding_id}, {phone!r}); "
+        f"print({_OUTPUT_MARKER!r}); print(val or '')"
     )
-    if result.returncode != 0:
-        return False
-    return result.stdout.strip() == email.lower()
+    return _backend_py(script) == email.lower()
 
 
 def _access_request(agent_name: str, email: str) -> Optional[dict]:

--- a/tests/unit/test_fork_to_own.py
+++ b/tests/unit/test_fork_to_own.py
@@ -97,6 +97,17 @@ class TestForkToOwnRequestModel:
 
 
 def _load_fork_module():
+    # Importing the agent_service package runs its __init__, which eagerly pulls
+    # in helpers.py -> `from services.docker_service import list_all_agents_fast`.
+    # Under full-suite ordering another test can leave a bare `services.docker_service`
+    # stub in sys.modules that only exposes `list_all_agents` (not `_fast`); after a
+    # crud_env teardown deletes the cached submodules, the fresh package re-import then
+    # fails with ImportError. Backfill the attribute defensively so this fixture never
+    # depends on cross-file stub completeness. (`list_all_agents_fast` is a real symbol
+    # in services.docker_service; this only guards against a leaked stub.)
+    ds = sys.modules.get("services.docker_service")
+    if ds is not None and not hasattr(ds, "list_all_agents_fast"):
+        ds.list_all_agents_fast = lambda *a, **kw: []
     import services.agent_service.fork_to_own as f2o
     return f2o
 


### PR DESCRIPTION
## Summary

A full-suite run on `dev` (Docker, local) surfaced **38 failures + 2 errors**. Every one was root-caused to a **stale test or a test-harness issue — zero product regressions**. This PR is **test-files-only (0 lines of production code)**.

Verified after fixes: **74 unit + 162 integration = 236 passed** across the touched files.

## Fixes (what drifted, why)

| Cluster | Fix | Root cause |
|---|---|---|
| `test_platform_prompt_unit` (5) | stub lambdas accept `**_kwargs` | production compose path now forwards `runtime=` (#1187) |
| `test_cb_probe_execution_close` (7) | add `get_setting_value` to `_CanaryTempDB` | canary temp-DB stub leaks onto module-level `from database import db`; under full-suite order it serviced `get_platform_default_model` and `AttributeError`'d |
| `test_fork_to_own` (2 errors) | defensive `list_all_agents_fast` backfill | leaked bare `services.docker_service` stub (same `sys.modules` cross-file leak class) |
| `test_files_guardrail_bypass`, `test_mcp_validator_endpoint` (2) | assert `"Disallowed credential file path"` | intentional message wording change (#1305) |
| `test_event_subscriptions` (1) | expect **403** not 400 | intentional #186 enumeration-safety collapse (commit `34ddf71a`) |
| `test_activities` (1) | derive valid triggers from canonical `_TRIGGER_BUCKETS` | hard-coded allow-set drifted behind `webhook` / channel triggers; now tied to source of truth |
| `test_whatsapp_integration` (4) | read pending-login Redis via backend's authed client | bare `redis-cli GET` fails `NOAUTH` (Redis ACL mandatory since #589) but exits 0, defeating the `returncode` guard. **Product code verified correct.** |

Clusters 1–3 pass in isolation and only failed under full-suite ordering (`sys.modules` leakage). A durable follow-up would harden the `tests/unit/conftest.py` sys.modules baseline restore — out of scope here.

## ⚠️ Not in this diff (environment, not code)

Running the full suite locally still shows a handful of failures/skips that are **not** fixed by this PR because they are environmental — a clean CI run is unaffected:

- **9 unit failures** (`bcrypt` 72-byte error ×3, `ModuleNotFoundError: PIL` ×6) — a **drifted local `tests/.venv`** (bcrypt 5.0.0, no Pillow). `requirements-test.txt` already pins `bcrypt>=4.2.0,<5` and `Pillow>=11.1.0`. **Resync your local venv:** `cd tests && .venv/bin/pip install -r requirements-test.txt`.
- **~60 infra-broken skips** ("Agent server not ready", "testfix container not found", 429s) — the shared test agent was never ready (`TEST_AGENT_NAME` unset, no `testfix` fixture). Needs a persistent test agent.
- **4 quota failures** (`test_dynamic_thinking_status` async ×3, one 429) — the real Claude subscription hit its usage cap during the 50-min run.
- **3 environmental** (`workspace_available`/`auto_switch` defaults, `agent_rename` name collision) — pass in a clean CI env / fresh DB; code defaults are correct.

## Test plan

- [x] `pytest` on all touched files (leak-order preserved for canary→cb_probe): 236 passed
- [x] Confirmed diff touches **no** `src/backend/` production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
