### PR TITLE
docs(user-docs): sync dashboard Grid view + fork-to-own; fix broken links

### DIFF
--- a/docs/user-docs/advanced/dynamic-dashboards.md
+++ b/docs/user-docs/advanced/dynamic-dashboards.md
@@ -45,4 +45,4 @@ Agents control their dashboard entirely by writing to `dashboard.yaml` in their 
 
 ## See Also
 
-- [Agent Detail Page](/docs/user-docs/core/agent-detail.md)
+- [Managing Agents](../agents/managing-agents.md)

--- a/docs/user-docs/agents/creating-agents.md
+++ b/docs/user-docs/agents/creating-agents.md
@@ -75,6 +75,17 @@ Authorization: Bearer <token>
 create_agent(name="my-agent", template="github:Org/repo@branch")
 ```
 
+### Fork-to-Own Templates
+
+Some templates are meant to be *owned* by the person deploying them, not run directly from the shared upstream repo. A template opts into this by declaring `fork_to_own: required` in its `template.yaml`. When you create an agent from such a template, Trinity copies the template into **your own** GitHub repository before building the container:
+
+1. Trinity creates a destination repo under your account (**private by default**) using your GitHub PAT.
+2. The template's default branch — with full history — is pushed into it. Your new agent's `origin` is this repo, so everything the agent commits stays in a repo you control.
+3. Your PAT is saved as the agent's per-agent token, so restarts and recreations never fall back to a shared platform token.
+4. A read-only `upstream` remote points back at the original template, so pulling in later template updates is a single `git pull upstream <branch>`.
+
+**Prerequisite:** configure a GitHub PAT with repo-creation scope before creating the agent (see [GitHub PAT Setup](../integrations/github-pat-setup.md)). If the destination repo name is already taken, Trinity reuses it when it's empty or already holds the template's exact tip; if it's bound to another live agent or contains unrelated data, creation fails with a conflict so nothing is overwritten.
+
 ## For Agents
 
 Agents created from templates inherit:
@@ -94,6 +105,6 @@ The agent's container is labeled so it can be discovered and managed by the plat
 
 ## See Also
 
-- [Credential Injection](../credentials/injecting-credentials.md) -- How credentials are supplied to agents
-- [Agent Templates](../getting-started/templates.md) -- Browsing and managing templates
-- [Scheduling](../automation/schedules.md) -- Running agents on a schedule
+- [Credential Management](../credentials/credential-management.md) -- How credentials are supplied to agents
+- [GitHub PAT Setup](../integrations/github-pat-setup.md) -- Required for private templates and fork-to-own
+- [Scheduling](../automation/scheduling.md) -- Running agents on a schedule

--- a/docs/user-docs/collaboration/agent-network.md
+++ b/docs/user-docs/collaboration/agent-network.md
@@ -64,6 +64,6 @@ Agents can share files via Docker volumes:
 
 ## See Also
 
-- [Event Subscriptions](../features/event-subscriptions.md) -- Pub/sub for inter-agent pipelines
-- [System Manifests](../features/system-manifests.md) -- Deploy multi-agent systems from a single file
-- [Scheduling](../features/scheduling.md) -- Automated agent execution
+- [Event Subscriptions](./event-subscriptions.md) -- Pub/sub for inter-agent pipelines
+- [System Manifest](./system-manifest.md) -- Deploy multi-agent systems from a single file
+- [Scheduling](../automation/scheduling.md) -- Automated agent execution

--- a/docs/user-docs/credentials/oauth-credentials.md
+++ b/docs/user-docs/credentials/oauth-credentials.md
@@ -36,5 +36,5 @@ Agents do not need to handle OAuth flows directly. Trinity manages token acquisi
 
 ## See Also
 
-- [Managing Credentials](./managing-credentials.md)
-- [MCP Configuration](../mcp/mcp-configuration.md)
+- [Credential Management](./credential-management.md)
+- [MCP Server](../integrations/mcp-server.md)

--- a/docs/user-docs/operations/dashboard.md
+++ b/docs/user-docs/operations/dashboard.md
@@ -1,12 +1,22 @@
 # Dashboard
 
-The main Dashboard at `/` provides a real-time agent network graph and timeline view for monitoring all agents and their activities.
+The main Dashboard at `/` monitors all agents and their activities in real time. Switch between three view modes with the toggle in the top-right — **Grid**, **Graph**, and **Timeline**. Timeline is the default; your choice persists per browser in `localStorage['trinity-dashboard-view']`.
 
 > 📺 **Watch:** [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) *(May 2026)* · [all videos](../videos.md)
 
 ## How It Works
 
-### Graph View (default)
+### Grid View
+
+A magnetic tile canvas — the fleet as a grid of agent cards rather than a graph or a timeline. Each agent is a five-zone tile showing its avatar, runtime badge, and inline **Running** and **Autonomy** toggles, plus live status chips (git sync health, pending operator-queue items).
+
+1. Drag a tile to move it; drop it onto another tile to **swap** positions. The layout snaps to an unbounded lattice and is saved per user.
+2. **Tidy** re-packs the tiles into a compact arrangement without losing your ordering.
+3. **Reset** restores the default auto-generated layout.
+4. Pan by dragging the background; zoom with the scroll wheel or pinch. Tiles are keyboard-navigable.
+5. Tile metrics hydrate lazily as they scroll into view, so large fleets stay responsive.
+
+### Graph View
 
 ![Trinity Dashboard — Graph view showing 13 agents as a live network](../images/dashboard-graph-view.png)
 
@@ -19,12 +29,11 @@ The main Dashboard at `/` provides a real-time agent network graph and timeline 
 7. Capacity meter shows parallel execution slot usage.
 8. Tag clouds group agents visually — click a cloud to filter to that group.
 
-### Timeline View
+### Timeline View (default)
 
 ![Trinity Dashboard — Timeline view showing live executions across oracle and market agents](../images/dashboard-timeline-live.png)
 
-1. Toggle between Graph and Timeline via the mode switch in the top-right.
-2. Timeline shows execution boxes per agent, arranged chronologically.
+1. Timeline shows execution boxes per agent, arranged chronologically.
 3. Color-coded by trigger type: Manual (green), MCP (pink), Scheduled (purple), Agent-Triggered (cyan), Paid (yellow), Public (teal).
 4. Each row shows the agent's success rate, total cost, and parallel slot count.
 5. Live streaming: running executions show progress in real-time with a "Live" indicator.


### PR DESCRIPTION
## Summary

Syncs `docs/user-docs/` to dev state since the last docs pass (2026-07-03, #1438). All changes are edits to existing pages — no new files, no index changes.

### Content updates
- **`operations/dashboard.md`** — Corrects the stale default (Timeline is the default view, not Graph, per `network.js`) and documents the new **Grid view**: a magnetic tile canvas with five-zone agent tiles (avatar, runtime badge, Running/Autonomy toggles, live sync-health + operator-queue chips), drag/swap, Tidy/Reset, pan-zoom, and lazy hydration (trinity-enterprise#47).
- **`agents/creating-agents.md`** — Adds a **Fork-to-Own Templates** section: a template declaring `fork_to_own: required` is copied into the user's own private GitHub repo at creation via their PAT, with a read-only `upstream` remote for pulling template updates and reuse-or-409 collision handling (trinity-enterprise#93).

### Link hygiene
Fixes **9 broken internal links** (scan now returns 0) across `creating-agents.md`, `advanced/dynamic-dashboards.md`, `collaboration/agent-network.md`, and `credentials/oauth-credentials.md`.

### Deliberately excluded
Enterprise-gated paid modules are kept out of public user-docs per the CLAUDE.md standing rule: the fleet-wide **permissions matrix** (ent#84, `requires: 'permissions_matrix'`), **Client Portal** (ent#78), and **Brain Orb** (#85/#102/#103). No release-note work — v0.7.0 is current and its What's New already exists.

## Verification
- Broken internal links: **0** (was 9)
- Public-safety greps on `guides/deploying/`: **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)