### PR TITLE
fix(tests): eliminate order-dependent sys.modules pollution (unblocks v0.8.0 release)

### DIFF
--- a/tests/unit/test_fork_to_own.py
+++ b/tests/unit/test_fork_to_own.py
@@ -525,10 +525,16 @@ def crud_env():
     try:
         yield crud, ctx
     finally:
+        # patch.dict.stop() clears sys.modules and re-populates it from the
+        # pre-start snapshot, so it already UNDOES the in-context purge at
+        # _load_crud (lines above) and restores the real `services.agent_service.*`
+        # modules other test files bound at collection time. Do NOT manually delete
+        # them afterward: that leaves e.g. `services.agent_service.stats` absent, so
+        # a later file's module-level `from services.agent_service import stats`
+        # reference goes stale (a fresh re-import returns a different object) and its
+        # monkeypatch silently misses — the #73 stats-cache tests failed exactly this
+        # way under full-suite ordering. Let patch.dict own the restoration.
         ctx["patcher"].stop()
-        for key in list(sys.modules.keys()):
-            if key == "services.agent_service" or key.startswith("services.agent_service."):
-                del sys.modules[key]
 
 
 def _user():

--- a/tests/unit/test_self_hosted_git_url.py
+++ b/tests/unit/test_self_hosted_git_url.py
@@ -28,6 +28,36 @@ _STARTUP_SH = _PROJECT_ROOT / "docker" / "base-image" / "startup.sh"
 _CRUD_PY = _PROJECT_ROOT / "src" / "backend" / "services" / "agent_service" / "crud.py"
 
 
+# Modules the reload helpers below swap in sys.modules — restored after each test
+# so a fresh import doesn't leak. `_reload_github_service()` deletes + reimports
+# services.github_service (to rebind import-time class attrs like API_BASE) without
+# restoring, leaking a NEW module and a NEW `OwnerType` enum; later files (e.g.
+# test_fork_to_own) then compare their import-time `OwnerType` against the reloaded
+# one by identity and silently skip owner-guard logic ("DID NOT RAISE HTTPException"
+# under full-suite ordering). `_STUBBED_MODULE_NAMES` + `_restore_sys_modules` is
+# the pattern tests/lint_sys_modules.py recognises (#762; precedent:
+# test_telegram_webhook_backfill.py). (`_load_git_service` deletes
+# services.git_service* inside a patch.dict context, which self-restores.)
+_STUBBED_MODULE_NAMES = [
+    "services.github_service",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot sys.modules for the reload helpers before each test and restore
+    after, so the reloaded services.github_service stays file-local."""
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 # ---------------------------------------------------------------------------
 # git_service._git_remote_url — Python helper
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_voice_auth.py
+++ b/tests/unit/test_voice_auth.py
@@ -148,6 +148,22 @@ def _stub_platform_audit():
     sys.modules["services.platform_audit_service"] = mod
 
 
+# Shared service modules whose stubs (installed below for voice.py's import
+# chain) are INCOMPLETE — the template_service stub omits is_trinity_compatible,
+# the docker_service stub omits execute_command_in_container. If they leak past
+# this file they break later unit files whose import chains pull the real symbols
+# (`ImportError: cannot import name '…' (unknown location)`, e.g. test_fork_to_own,
+# test_73_stats_cache). We snapshot them here and restore right after voice.py
+# imports. The `_STUBBED_MODULE_NAMES` list + `_restore_sys_modules` fixture below
+# are the snapshot/restore pattern tests/lint_sys_modules.py recognises (#762;
+# precedent: test_telegram_webhook_backfill.py).
+_STUBBED_MODULE_NAMES = [
+    "services.docker_service",
+    "services.template_service",
+    "services.platform_audit_service",
+]
+_voice_auth_pre_stub = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+
 _voice_service, _FakeVoiceSession = _stub_voice_service()
 _stub_docker_service()
 _stub_template_service()
@@ -166,6 +182,32 @@ voice_router = _ilu.module_from_spec(_spec)
 # Pre-register so relative imports inside voice.py (none right now) would work.
 sys.modules["routers.voice"] = voice_router
 _spec.loader.exec_module(voice_router)
+
+# voice.py has captured what it needs from the stubs; restore the real shared
+# service modules so later unit files see the real ones, not our stubs (see the
+# snapshot above). This is the load-bearing cross-file fix — it runs at import
+# time, which a per-test fixture cannot.
+for _name, _orig in _voice_auth_pre_stub.items():
+    if _orig is not None:
+        sys.modules[_name] = _orig
+    else:
+        sys.modules.pop(_name, None)
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Per-test snapshot/restore safety net for the stubbed shared modules, and
+    the lint-recognised marker (with `_STUBBED_MODULE_NAMES` above) for #762."""
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
 
 from fastapi import HTTPException  # noqa: E402
 from jose import jwt  # noqa: E402


### PR DESCRIPTION
## Why

Cutting **v0.8.0**, the `dev → main` release PR (#1529) is the first time the backend-unit **base/head regression matrix** ran over the full payload (it only fires on PRs, not dev pushes). It surfaced **16 order-dependent failures** in three **new-on-dev** unit files:

- `test_fork_to_own.py` (9 — `ImportError: … (unknown location)`)
- `test_73_stats_cache.py` (6 — monkeypatch missed → assertion)
- `test_186_enumeration_uniformity::test_tier4_config_gets_are_access_gated` (1)

All three **pass in isolation** but fail under full-suite ordering — classic `sys.modules` pollution. **These are test-harness bugs, not product bugs**: the product code (`is_trinity_compatible`, the fork-to-own owner guard, the #73 stats-cache invalidation) is intact.

## The three vectors (each fix only *restores* real modules)

1. **`test_voice_auth.py`** stubbed `services.{docker_service,template_service,platform_audit_service}` at module level and never restored them. The stubs are incomplete (no `is_trinity_compatible` / `execute_command_in_container`), so later files importing those symbols hit `ImportError … (unknown location)`. → snapshot + restore after `voice.py` imports (mirrors the existing pattern in `test_voice_tools.py`).
2. **`test_fork_to_own.py`**'s `crud_env` teardown ran a manual `del sys.modules['services.agent_service.*']` **after** `patch.dict.stop()` — which had already restored the pre-test snapshot. The delete left `services.agent_service.stats` absent, so `test_73`'s module-level `stats_mod` went stale and its monkeypatch silently missed. → removed the redundant/harmful delete; `patch.dict` owns restoration.
3. **`test_self_hosted_git_url.py`**'s `_reload_github_service()` deletes+reimports `services.github_service` without restoring, leaking a fresh `OwnerType` enum; `test_fork_to_own`'s owner guard then compares `OwnerType` by identity across the two module copies and skips (`DID NOT RAISE HTTPException`). → autouse fixture snapshots/restores `services.github_service*` per test.

## Verification

Full unit suite green under **all three CI seeds** (12345 / 67890 / 99999): **3646 passed, 15 skipped** each (locally on Python 3.14; CI runs 3.11 — the release PR re-run is the authoritative check).

Test-only changes (+60/-3). Merges into `dev`; unblocks the v0.8.0 release PR #1529.
