### PR TITLE
docs(releases): v0.8.0 commit-reconciled addendum

### DIFF
--- a/docs/releases/0.8.0.md
+++ b/docs/releases/0.8.0.md
@@ -3,7 +3,7 @@
 **Released**: 2026-07-08
 **Tag**: `v0.8.0` &nbsp;·&nbsp; **Diff**: [v0.7.0...v0.8.0](https://github.com/abilityai/trinity/compare/v0.7.0...v0.8.0)
 
-Cumulative platform release since v0.7.0 — **110 issues** across the public (`abilityai/trinity`) and private (`abilityai/trinity-enterprise`) trackers. `enterprise#N` references are private-tracker issues; `#N` are public.
+Cumulative platform release since v0.7.0 — **110 issues** across the public (`abilityai/trinity`) and private (`abilityai/trinity-enterprise`) trackers, **plus 8 commit-reconciled items** (addendum below) — ~114 issues' worth of work in total. `enterprise#N` references are private-tracker issues; `#N` are public.
 
 ## Features (50)
 
@@ -129,6 +129,26 @@ Cumulative platform release since v0.7.0 — **110 issues** across the public (`
 - #945 spec: message envelope payload schema (pull coordination)
 - #1360 docs: feature-flows.md index is 527 lines, over the 400-line guideline — condense
 - #1406 docs: split monolithic requirements.md into per-area sub-files and reconcile dev-process references
+
+## Commit-reconciled addendum
+
+Post-release reconciliation of the actual commit payload (previous release PR head → this release PR head) against the label-derived list above surfaced work that shipped in v0.8.0 without being captured by `status-in-dev`:
+
+**Shipped, issue status corrected post-release:**
+- enterprise#107 Default Cornelius agent auto-seeded on fresh installs (Brain-Orb enabled; first-run only) — label automation missed the cross-repo commit ref
+- enterprise#92 Standardized cost display — shared formatter: whole-dollar rounding, US comma separators, compact $1.2K — labeled `status-in-dev` after the close-out sweep
+
+**Shipped, closed outside the release sweep:**
+- enterprise#79 Client Portal — configurable exposure slice (private/VPN deployments)
+- #350 (epic, Phases 1 & 3) Slack channel identity + proactive group messaging — children #292/#903 were listed above; this slice was not
+
+**Shipped in part (issue left open):**
+- enterprise#18 Sharing tab reframed to external-client sharing via channels — core reframe shipped; per-client controls (enterprise#21) remain
+
+**Shipped with no tracker issue:**
+- Gacrux added to the Gemini Live voice picker
+- CodeQL-driven hardening: GitHub repo-URL parsed by hostname (not substring); Brain Orb XSS + vendored three.js alerts resolved; path-containment guard inlined at the file write/unlink sink
+- #1341 Dependabot security-PR targeting documented (docs clarification; closed pre-release without a notes entry)
 
 ## Notable in this release
 


### PR DESCRIPTION
Adds the 8 commit-reconciled items to the durable v0.8.0 notes (per the new /release Step 10b-2). Docs-only. GitHub Release body already carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)