### PR TITLE
docs: v0.8.0 release-tour video — README top, whats-new, video library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@
   <img src="https://img.shields.io/badge/docker-required-blue.svg" alt="Docker">
 </p>
 
+<p align="center">
+  <a href="https://youtu.be/wxCC6QGtLMA">
+    <img src="https://img.youtube.com/vi/wxCC6QGtLMA/maxresdefault.jpg" alt="Trinity v0.8.0 release tour — video" width="640" />
+  </a>
+  <br/>
+  <em>🎬 New — <a href="https://youtu.be/wxCC6QGtLMA">watch the v0.8.0 release tour</a>: agents that speak, the Brain Orb, and the Grid dashboard.</em>
+</p>
+
 ---
 
 ## Run agents like infrastructure

--- a/docs/user-docs/videos.md
+++ b/docs/user-docs/videos.md
@@ -6,6 +6,7 @@ Workshops, demos, and deep-dives on building and running autonomous agents with 
 
 ## Start Here — Platform Overview
 
+- [Trinity v0.8.0 — Release Tour](https://youtu.be/wxCC6QGtLMA) — *Jul 2026* · voice replies across channels, Brain Orb, Grid dashboard, enterprise identity
 - [Trinity Platform Demo](https://youtu.be/ivljtZqsxeo) — *May 2026* · full UI walkthrough, end to end
 - [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) — *May 2026* · live fleet tour: delegation, memory, observability
 - [The Sovereign AI Setup That Changed Everything](https://youtu.be/2QH-jeVn2ak) — *Feb 2026*

--- a/docs/user-docs/whats-new/v0.8.0.md
+++ b/docs/user-docs/whats-new/v0.8.0.md
@@ -2,6 +2,9 @@
 
 *Released 2026-07-08*
 
+[![Watch the v0.8.0 release tour](https://img.youtube.com/vi/wxCC6QGtLMA/maxresdefault.jpg)](https://youtu.be/wxCC6QGtLMA)
+*▶ [Watch the release tour on YouTube](https://youtu.be/wxCC6QGtLMA) — a walkthrough of everything below.*
+
 Trinity's largest release yet. Agents can now **speak** — replies arrive as real voice notes on Telegram, Slack, and WhatsApp — and second-brain agents get the **Brain Orb**, a living 3D map of everything the agent knows, with voice conversation and capture-to-graph writes. Fleet operators get a new **Grid dashboard** and a redesigned sharing model, and the enterprise tier gains its **identity layer**: two-factor authentication, single sign-on, and per-agent operator access control.
 
 ## Improvements


### PR DESCRIPTION
Adds the v0.8.0 release-tour video (https://youtu.be/wxCC6QGtLMA) as a clickable thumbnail at the top of the README, the whats-new page, and the video library index. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)