### PR TITLE
feat(mcp): make per-agent MCP connector OSS-core (trinity-enterprise#118 Part A)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -87,6 +87,7 @@
 - `auth.py` - Admin login (username OR registered email + password, #82), email auth, token validation
 - `users.py` - User management, roles (ROLE-001); `PUT /me/email` self-service sign-in email (#82 transition)
 - `mcp_keys.py` - MCP API key management
+- `connector.py` - Per-agent MCP connector: config + scoped-key mint/regenerate/revoke + exposed-playbook allow-list (`/api/agents/{name}/connector*`). OSS-core (ent#46 → #118); see [mcp-connector.md](feature-flows/mcp-connector.md)
 - `setup.py` - First-time setup wizard; **required** admin email (sign-in identity) + opt-in hosted intake (trinity-enterprise#38, #82). Setup token removed — no token, no Redis dependency for setup; the unauthenticated first-run window is an operator responsibility (deploy behind a tunnel/VPN until setup completes) (trinity-enterprise#49)
 
 *Scheduling & Execution:*

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -184,6 +184,7 @@
 | MCP Orchestration | [mcp-orchestration.md](feature-flows/mcp-orchestration.md) | 62 MCP tools for agent orchestration |
 | MCP Git Tools | [mcp-git-tools.md](feature-flows/mcp-git-tools.md) | Deterministic git tools over MCP + request-id audit correlation (#905) |
 | MCP Agent Exposure | [mcp-agent-exposure.md](feature-flows/mcp-agent-exposure.md) | Per-agent opt-in dedicated `chat_with_<slug>` MCP tool, dynamically poll-reconciled (#846) |
+| MCP Connector | [mcp-connector.md](feature-flows/mcp-connector.md) | Per-agent MCP connector — expose playbooks as tools to an external AI client via a scoped key; OSS-core (ent#46 → #118) |
 | Trinity CLI | [cli-tool.md](feature-flows/cli-tool.md) | Python Click CLI with multi-instance profiles, mirroring core MCP tools as shell commands |
 | Trinity Connect | [trinity-connect.md](feature-flows/trinity-connect.md) | Local-remote agent sync via WebSocket |
 | Write User Memory | [write-user-memory.md](feature-flows/write-user-memory.md) | Per-user memory write MCP tool (MEM-001, #888) |

--- a/docs/memory/feature-flows/mcp-connector.md
+++ b/docs/memory/feature-flows/mcp-connector.md
@@ -1,0 +1,66 @@
+# Per-Agent MCP Connector (ent#46; OSS-core since #118)
+
+Expose one agent as a per-agent MCP connector: an end user adds it to their AI
+client (Claude Code, Cursor, Claude Desktop) in one line, and the agent's
+`user_invocable` playbooks become MCP tools. The agent holds all credentials
+server-side; only a scoped, revocable key reaches the client.
+
+Shipped entitlement-gated in v0.8.0 (`mcp_connector`); **relocated into OSS core
+by #118** — the router/service/db moved from the private enterprise submodule into
+the public repo and the entitlement gate was dropped front and back. Part B
+(email-auth onboarding, #848) is deferred pending design sign-off.
+
+## Layers
+
+| Layer | File | Notes |
+|-------|------|-------|
+| Router | `src/backend/routers/connector.py` | `/api/agents/{name}/connector*`, mounted unconditionally in `main.py` (no `requires_entitlement`) |
+| Service (pure) | `src/backend/services/connector_service.py` | `build_snippets`, `resolve_exposed_playbooks`, `connector_name` |
+| DB | `src/backend/db/connector.py` (`ConnectorOperations`) | config CRUD + key mint/regenerate/revoke; facade delegators on `database.py` (`db.get_connector_config`, …) |
+| Models | `src/backend/models.py` | `ConnectorConfigUpdate/Status/KeySecret/Playbook/ClientSnippet` (Invariant #14) |
+| MCP tools | `src/mcp-server/src/tools/connector.ts` | `list_playbooks` / `run_playbook` / `ask` — `connectorOnly` `canAccess` (already OSS) |
+| Auth fence | `src/backend/dependencies.py` | `_enforce_connector_scope` / `_reject_connector_principal` — edition-agnostic (already OSS) |
+| UI | `components/ConnectorChannelPanel.vue` + `ExposedToolsPanel.vue` | in `SharingPanel.vue`, un-gated (#118) |
+
+## Endpoints (all under `/api/agents`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/{name}/connector` | `OwnedAgentByName` | Owner status: enabled, allow-list, `has_key`, `key_prefix`, `mcp_url`, snippets (placeholder key) |
+| PUT | `/{name}/connector` | `OwnedAgentByName` | Set enable + `exposed_playbooks` (or `expose_all_playbooks` to clear the allow-list) |
+| POST | `/{name}/connector/key` | `OwnedAgentByName` | Mint/regenerate the scoped key — **secret returned once**; auto-enables; snippets embed the real key. Atomic delete-old + insert-new (single-active-key invariant) |
+| DELETE | `/{name}/connector/key` | `OwnedAgentByName` | Revoke all connector-scoped keys (idempotent) |
+| GET | `/{name}/connector/playbooks` | `AuthorizedAgentByName` (accepts a `scope='connector'` key) | Effective exposed playbooks the connector advertises |
+
+## Key + policy
+
+- **Scoped key**: a row in the OSS `mcp_api_keys` table with `scope='connector'`,
+  `agent_name` bound. Generated/hashed via `McpKeyOperations` so
+  `validate_mcp_api_key` recognizes it. The OSS auth fence fences a connector key
+  to exactly `POST /{agent}/chat` + `GET /{agent}/connector/playbooks` — it cannot
+  reach owner ops or any other agent.
+- **Allow-list** (`enterprise_connectors.exposed_playbooks`, JSON array; NULL ⇒ all
+  `user_invocable`): `resolve_exposed_playbooks` drops `user_invocable:false`
+  unconditionally (even if explicitly listed); `automation:gated` is passed through
+  as advisory metadata (not a filter).
+
+## Schema / migration
+
+`enterprise_connectors` (one row per agent: `enabled`, `exposed_playbooks`,
+`created_at`, `updated_at`). The name is **kept from the enterprise era** so an
+existing enterprise install adopts its data with zero migration (`CREATE TABLE IF
+NOT EXISTS` on the same name — no data copy, no duplicate-table drift). Dual-track:
+SQLite `db/migrations.py:enterprise_connectors_table` + Alembic
+`0015_enterprise_connectors`; DDL in `db/schema.py`, MetaData in `db/tables.py`;
+delete/rename cascade via the `enterprise_connectors` `AGENT_REF`. The enterprise
+Alembic `0006_mcp_connector` is neutralized to a no-op (its descendant
+`0007` keeps the chain).
+
+## Deferred — Part B (email-auth onboarding, #848)
+
+An external user on the agent's `agent_sharing` allow-list authenticates from their
+MCP client via the email 6-digit-code flow (`request_login`/`verify_login` MCP
+tools) and uses the connector **without a pre-minted key**, seeing only the exposed
+playbooks of agents shared with their email. Blocked on #848's open design questions
+(persistent key vs transient session; post-login tool visibility; whitelist-only vs
+open signup). Not built.

--- a/docs/memory/requirements/mcp.md
+++ b/docs/memory/requirements/mcp.md
@@ -32,6 +32,21 @@
 - **Key Features**: `GET/PUT/DELETE /api/settings/mcp-url` endpoints, URL validation (requires `http(s)://` and `/mcp` suffix), Settings UI section with save/reset, auto-detect fallback when not configured
 - **Flow**: `docs/memory/feature-flows/platform-settings.md`
 
+### 7.5 Per-Agent MCP Connector (ent#46; OSS-core since #118)
+- **Status**: ✅ Implemented — OSS-core (relocated from the enterprise submodule by #118; originally ent#46/#55/#51)
+- **GitHub Issue**: trinity-enterprise#118 (OSS-core move); ent#46 / ent#55 (original)
+- **Description**: Expose a single agent as a per-agent MCP connector — an end user adds it to their AI client (Claude Code, Cursor, Claude Desktop) in one line, turning the agent's `user_invocable` playbooks into MCP tools. The agent holds all credentials server-side; only a scoped, revocable key reaches the client. Available in **every edition** (no `mcp_connector` entitlement).
+- **Key Features**:
+  - Owner CRUD under `/api/agents/{name}/connector*`: `GET`/`PUT` config (enable toggle + exposed-playbook allow-list), `POST /connector/key` (mint/regenerate — secret returned once, auto-enables), `DELETE /connector/key` (revoke). `GET /connector/playbooks` is connector-key-readable.
+  - Scoped key = a row in the OSS `mcp_api_keys` table with `scope='connector'`, bound to the agent; validated by the existing OSS auth fence (`dependencies._enforce_connector_scope`) which fences a connector key to exactly `POST /{agent}/chat` + `GET /{agent}/connector/playbooks`.
+  - Per-client copy-paste setup snippets (`services/connector_service.build_snippets`): Claude Code CLI + `.mcp.json`, Cursor, Claude Desktop.
+  - Exposed-playbook allow-list (ent#55): `enterprise_connectors.exposed_playbooks` JSON array (NULL ⇒ all `user_invocable`); `user_invocable:false` playbooks are **never** exposed even if listed; `automation:gated` passed through as advisory metadata.
+  - MCP proxy tools (`src/mcp-server/src/tools/connector.ts`, already OSS): `list_playbooks`, `run_playbook`, `ask` — visible only to `scope='connector'` sessions.
+  - UI: `ConnectorChannelPanel.vue` + `ExposedToolsPanel.vue` in the Sharing tab, shown to all agent owners (un-gated).
+- **Schema**: `enterprise_connectors` (name kept for zero-migration adoption of existing enterprise installs) — dual-track (SQLite `db/migrations.py:enterprise_connectors_table` + Alembic `0015_enterprise_connectors`).
+- **Deferred (Part B, blocked on #848 design sign-off)**: email-auth onboarding — inline `request_login`/`verify_login` MCP tools so an external user on the agent's sharing allow-list connects with just their email (no pre-minted key). Tracked separately.
+- **Flow**: `docs/memory/feature-flows/mcp-connector.md`
+
 ---
 
 ## 32. A2A Agent Discoverability (#737)

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -113,6 +113,7 @@ from db.chat import ChatOperations
 from db.sessions import SessionOperations
 from db.activities import ActivityOperations
 from db.reports import ReportOperations
+from db.connector import ConnectorOperations
 from db.permissions import PermissionOperations
 from db.shared_folders import SharedFolderOperations
 from db.agent_shared_files import AgentSharedFilesOperations
@@ -332,6 +333,7 @@ class DatabaseManager:
         self._session_ops = SessionOperations()
         self._activity_ops = ActivityOperations()
         self._report_ops = ReportOperations()
+        self._connector_ops = ConnectorOperations()
         self._permission_ops = PermissionOperations(self._user_ops, self._agent_ops)
         self._shared_folder_ops = SharedFolderOperations(self._permission_ops)
         self._agent_shared_files_ops = AgentSharedFilesOperations()
@@ -666,6 +668,32 @@ class DatabaseManager:
 
     def get_mcp_exposed_agents(self):
         return self._agent_ops.get_mcp_exposed_agents()
+
+    # =========================================================================
+    # Per-agent MCP connector (ent#46; OSS-core since #118)
+    # =========================================================================
+    def get_connector_config(self, agent_name: str):
+        return self._connector_ops.get_config(agent_name)
+
+    def upsert_connector_config(self, agent_name, enabled=None, exposed_playbooks=None, *, clear_playbooks=False):
+        return self._connector_ops.upsert_config(
+            agent_name, enabled=enabled, exposed_playbooks=exposed_playbooks, clear_playbooks=clear_playbooks
+        )
+
+    def delete_connector_config(self, agent_name: str):
+        return self._connector_ops.delete_config(agent_name)
+
+    def mint_connector_key(self, agent_name, user_id):
+        return self._connector_ops.mint_key(agent_name, user_id)
+
+    def get_connector_key_prefix(self, agent_name):
+        return self._connector_ops.get_key_prefix(agent_name)
+
+    def revoke_connector_key(self, agent_name):
+        return self._connector_ops.revoke_key(agent_name)
+
+    def regenerate_connector_key(self, agent_name, user_id):
+        return self._connector_ops.regenerate_key(agent_name, user_id)
 
     def get_tts_config(self, agent_name: str):
         return self._agent_ops.get_tts_config(agent_name)

--- a/src/backend/db/agent_cleanup.py
+++ b/src/backend/db/agent_cleanup.py
@@ -159,6 +159,11 @@ AGENT_REFS: List[AgentRef] = [
     # tenant's reports (cross-tenant disclosure).
     AgentRef("agent_reports",                "agent_name",        Policy.CASCADE),
 
+    # Per-agent MCP connector config (ent#46, OSS-core #118). The scoped
+    # connector KEY is an mcp_api_keys row (scope='connector') already covered
+    # by the mcp_api_keys refs below; this is the config row.
+    AgentRef("enterprise_connectors",        "agent_name",        Policy.CASCADE),
+
     # --- Channel adapters (encrypted bot tokens — security-relevant) -------
     AgentRef("slack_channel_agents",         "agent_name",        Policy.CASCADE),
     AgentRef("slack_active_threads",         "agent_name",        Policy.CASCADE),

--- a/src/backend/db/connector.py
+++ b/src/backend/db/connector.py
@@ -1,0 +1,218 @@
+"""Data-access for the per-agent MCP connector (ent#46; OSS-core since #118).
+
+Owns the ``enterprise_connectors`` config row (one per agent: enabled + the
+exposed-playbook allow-list), and mints/reads/revokes the scoped connector key as
+a row in the OSS ``mcp_api_keys`` table with ``scope='connector'``. Key generation
++ hashing reuse ``McpKeyOperations`` so ``validate_mcp_api_key`` recognizes the key
+unchanged.
+
+Relocated verbatim from the private ``enterprise/backend/mcp_connector/db.py``
+when the connector became OSS-core (#118). The table keeps its original
+``enterprise_connectors`` name so existing enterprise installs adopt their data
+with zero migration (see #118). SQLAlchemy Core so it runs on SQLite + PostgreSQL.
+"""
+from __future__ import annotations
+
+import json
+from typing import List, Optional
+
+from sqlalchemy import select, insert, update, delete
+
+from .engine import get_engine
+from .tables import mcp_api_keys, enterprise_connectors
+from .mcp_keys import McpKeyOperations
+from utils.helpers import utc_now_iso
+
+_SCOPE = "connector"
+
+
+def _decode_playbooks(raw: Optional[str]) -> Optional[List[str]]:
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+        return value if isinstance(value, list) else None
+    except (ValueError, TypeError):
+        return None
+
+
+class ConnectorOperations:
+    """Config CRUD (enterprise_connectors) + scoped-key mint/revoke (mcp_api_keys)."""
+
+    # ---- Connector config (enterprise_connectors) -------------------------
+
+    def get_config(self, agent_name: str) -> Optional[dict]:
+        """Return ``{enabled, exposed_playbooks, created_at, updated_at}`` or None."""
+        stmt = select(
+            enterprise_connectors.c.enabled,
+            enterprise_connectors.c.exposed_playbooks,
+            enterprise_connectors.c.created_at,
+            enterprise_connectors.c.updated_at,
+        ).where(enterprise_connectors.c.agent_name == agent_name)
+        with get_engine().connect() as conn:
+            row = conn.execute(stmt).mappings().first()
+        if not row:
+            return None
+        return {
+            "enabled": bool(row["enabled"]),
+            "exposed_playbooks": _decode_playbooks(row["exposed_playbooks"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def upsert_config(
+        self,
+        agent_name: str,
+        enabled: Optional[bool] = None,
+        exposed_playbooks: Optional[List[str]] = None,
+        *,
+        clear_playbooks: bool = False,
+    ) -> dict:
+        """Create or update the connector config; only provided fields change."""
+        now = utc_now_iso()
+        encoded = (
+            None
+            if clear_playbooks or exposed_playbooks is None
+            else json.dumps(list(exposed_playbooks))
+        )
+        with get_engine().begin() as conn:
+            existing = conn.execute(
+                select(
+                    enterprise_connectors.c.enabled,
+                    enterprise_connectors.c.exposed_playbooks,
+                    enterprise_connectors.c.created_at,
+                ).where(enterprise_connectors.c.agent_name == agent_name)
+            ).mappings().first()
+
+            if existing:
+                new_enabled = enabled if enabled is not None else bool(existing["enabled"])
+                if clear_playbooks:
+                    new_playbooks = None
+                elif exposed_playbooks is not None:
+                    new_playbooks = encoded
+                else:
+                    new_playbooks = existing["exposed_playbooks"]
+                conn.execute(
+                    update(enterprise_connectors)
+                    .where(enterprise_connectors.c.agent_name == agent_name)
+                    .values(
+                        enabled=1 if new_enabled else 0,
+                        exposed_playbooks=new_playbooks,
+                        updated_at=now,
+                    )
+                )
+                created_at = existing["created_at"]
+            else:
+                new_enabled = bool(enabled)
+                new_playbooks = None if clear_playbooks else encoded
+                conn.execute(
+                    insert(enterprise_connectors).values(
+                        agent_name=agent_name,
+                        enabled=1 if new_enabled else 0,
+                        exposed_playbooks=new_playbooks,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
+                created_at = now
+
+        return {
+            "enabled": new_enabled,
+            "exposed_playbooks": _decode_playbooks(new_playbooks),
+            "created_at": created_at,
+            "updated_at": now,
+        }
+
+    def delete_config(self, agent_name: str) -> bool:
+        with get_engine().begin() as conn:
+            result = conn.execute(
+                delete(enterprise_connectors).where(
+                    enterprise_connectors.c.agent_name == agent_name
+                )
+            )
+            return result.rowcount > 0
+
+    # ---- Connector key (mcp_api_keys, scope='connector') ------------------
+
+    def mint_key(self, agent_name: str, user_id: int) -> dict:
+        """Insert a fresh connector key bound to ``agent_name``; secret returned once."""
+        api_key = McpKeyOperations._generate_mcp_api_key()
+        key_hash = McpKeyOperations._hash_api_key(api_key)
+        key_id = McpKeyOperations._generate_id()
+        now = utc_now_iso()
+        with get_engine().begin() as conn:
+            conn.execute(
+                insert(mcp_api_keys).values(
+                    id=key_id,
+                    name=f"connector-{agent_name}-key",
+                    description=f"Connector key for agent {agent_name}",
+                    key_prefix=api_key[:20],
+                    key_hash=key_hash,
+                    created_at=now,
+                    user_id=user_id,
+                    agent_name=agent_name,
+                    scope=_SCOPE,
+                    is_active=1,
+                )
+            )
+        return {"api_key": api_key, "key_prefix": api_key[:20]}
+
+    def get_key_prefix(self, agent_name: str) -> Optional[str]:
+        """Active connector key's masked prefix, or None (never the secret)."""
+        stmt = (
+            select(mcp_api_keys.c.key_prefix)
+            .where(
+                mcp_api_keys.c.agent_name == agent_name,
+                mcp_api_keys.c.scope == _SCOPE,
+                mcp_api_keys.c.is_active == 1,
+            )
+            .order_by(mcp_api_keys.c.created_at.desc())
+            .limit(1)
+        )
+        with get_engine().connect() as conn:
+            row = conn.execute(stmt).first()
+            return row[0] if row else None
+
+    def revoke_key(self, agent_name: str) -> bool:
+        """Delete all connector-scoped keys for the agent (idempotent)."""
+        with get_engine().begin() as conn:
+            result = conn.execute(
+                delete(mcp_api_keys).where(
+                    mcp_api_keys.c.agent_name == agent_name,
+                    mcp_api_keys.c.scope == _SCOPE,
+                )
+            )
+            return result.rowcount > 0
+
+    def regenerate_key(self, agent_name: str, user_id: int) -> dict:
+        """Revoke the old key(s) + mint a new one in ONE transaction.
+
+        Atomic so two concurrent regenerates can't interleave into two active
+        connector keys for one agent — a single key is the invariant.
+        """
+        api_key = McpKeyOperations._generate_mcp_api_key()
+        key_hash = McpKeyOperations._hash_api_key(api_key)
+        key_id = McpKeyOperations._generate_id()
+        now = utc_now_iso()
+        with get_engine().begin() as conn:
+            conn.execute(
+                delete(mcp_api_keys).where(
+                    mcp_api_keys.c.agent_name == agent_name,
+                    mcp_api_keys.c.scope == _SCOPE,
+                )
+            )
+            conn.execute(
+                insert(mcp_api_keys).values(
+                    id=key_id,
+                    name=f"connector-{agent_name}-key",
+                    description=f"Connector key for agent {agent_name}",
+                    key_prefix=api_key[:20],
+                    key_hash=key_hash,
+                    created_at=now,
+                    user_id=user_id,
+                    agent_name=agent_name,
+                    scope=_SCOPE,
+                    is_active=1,
+                )
+            )
+        return {"api_key": api_key, "key_prefix": api_key[:20]}

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -2723,6 +2723,29 @@ def _migrate_agent_reports_table(cursor, conn):
     print("Created agent_reports table (#918)")
 
 
+def _migrate_enterprise_connectors_table(cursor, conn):
+    """Create enterprise_connectors table (per-agent MCP connector, ent#46 → OSS #118).
+
+    Config row per agent: enabled + exposed-playbook allow-list. Schema is also in
+    db/schema.py for fresh installs; this handles existing installs. Idempotent —
+    ``CREATE TABLE IF NOT EXISTS`` on the SAME name the enterprise module used, so an
+    existing enterprise install adopts its data unchanged (zero data migration, no
+    duplicate-table drift, #118). Mirrored by Alembic 0015_enterprise_connectors for PG.
+    """
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS enterprise_connectors (
+            agent_name TEXT PRIMARY KEY,
+            enabled INTEGER NOT NULL DEFAULT 0,
+            exposed_playbooks TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+
+
 MIGRATIONS = [
     ("agent_sharing", _migrate_agent_sharing_table),
     ("schedule_executions_observability", _migrate_schedule_executions_observability),
@@ -2809,4 +2832,5 @@ MIGRATIONS = [
     ("agent_ownership_tts_voice", _migrate_agent_ownership_tts_voice),
     ("agent_ownership_public_channel_prompt", _migrate_agent_ownership_public_channel_prompt),
     ("public_chat_messages_sender", _migrate_public_chat_messages_sender),
+    ("enterprise_connectors_table", _migrate_enterprise_connectors_table),
 ]

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -139,6 +139,19 @@ TABLES = {
         )
     """,
 
+    # Per-agent MCP connector config (ent#46; OSS-core since #118). Kept the
+    # `enterprise_connectors` name so existing enterprise installs adopt their data
+    # with zero migration. The scoped key lives in mcp_api_keys (scope='connector').
+    "enterprise_connectors": """
+        CREATE TABLE IF NOT EXISTS enterprise_connectors (
+            agent_name TEXT PRIMARY KEY,
+            enabled INTEGER NOT NULL DEFAULT 0,
+            exposed_playbooks TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+    """,
+
     "email_whitelist": """
         CREATE TABLE IF NOT EXISTS email_whitelist (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/backend/db/tables.py
+++ b/src/backend/db/tables.py
@@ -134,6 +134,21 @@ mcp_api_keys = Table(
     Column("scope", Text),
 )
 
+# Per-agent MCP connector config (ent#46; OSS-core since #118). One row per agent:
+# `enabled` + `exposed_playbooks` (JSON array of playbook names; NULL = all
+# user_invocable). The scoped connector KEY is a row in `mcp_api_keys`
+# (scope='connector'), not here. Name kept from the enterprise era so existing
+# installs adopt their data with zero migration.
+enterprise_connectors = Table(
+    "enterprise_connectors",
+    metadata,
+    Column("agent_name", Text, primary_key=True),
+    Column("enabled", Integer),
+    Column("exposed_playbooks", Text),
+    Column("created_at", Text),
+    Column("updated_at", Text),
+)
+
 email_whitelist = Table(
     "email_whitelist",
     metadata,

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -85,6 +85,7 @@ from routers.system_views import router as system_views_router
 from routers.notifications import router as notifications_router, set_websocket_manager as set_notifications_ws_manager, set_filtered_websocket_manager as set_notifications_filtered_ws_manager
 from routers.reports import router as reports_router
 from services.report_service import set_websocket_manager as set_reports_ws_manager, set_filtered_websocket_manager as set_reports_filtered_ws_manager
+from routers.connector import router as connector_router  # per-agent MCP connector (ent#46, OSS-core #118)
 from routers.subscriptions import router as subscriptions_router
 from routers.monitoring import router as monitoring_router, set_websocket_manager as set_monitoring_ws_manager, set_filtered_websocket_manager as set_monitoring_filtered_ws_manager
 from routers.slack import public_router as slack_public_router, auth_router as slack_auth_router
@@ -938,6 +939,7 @@ app.include_router(tags_router)  # Agent Tags (ORG-001)
 app.include_router(system_views_router)  # System Views (ORG-001 Phase 2)
 app.include_router(notifications_router)  # Agent Notifications (NOTIF-001)
 app.include_router(reports_router)  # Agent Reports (#918)
+app.include_router(connector_router)  # Per-agent MCP connector (ent#46, OSS-core #118)
 app.include_router(messages_router)  # Proactive Messaging (#321)
 app.include_router(public_memory_router)  # MEM-001 write path (#888)
 app.include_router(subscriptions_router)  # Subscription Management (SUB-001)

--- a/src/backend/migrations/versions/0015_enterprise_connectors.py
+++ b/src/backend/migrations/versions/0015_enterprise_connectors.py
@@ -1,0 +1,42 @@
+"""enterprise_connectors table — per-agent MCP connector (ent#46 → OSS-core #118)
+
+Config row per agent: enabled + exposed-playbook allow-list. Relocated from the
+enterprise submodule into OSS core (#118). The table keeps its ``enterprise_connectors``
+name so an existing enterprise PG install — which created it via the enterprise
+Alembic line (``enterprise/.../0006_mcp_connector``) — adopts its data with zero
+migration. Mirrors the SQLite ``enterprise_connectors_table`` migration in
+``db/migrations.py`` and the DDL in ``db/schema.py``.
+
+Fresh PG builds already get this table because ``0001_baseline`` iterates
+``db/schema.py:TABLES``. ``CREATE TABLE IF NOT EXISTS`` keeps it a no-op when
+baseline (or the enterprise line) already created it.
+
+Revision ID: 0015_enterprise_connectors
+Revises: 0014_agent_schedules_webhook_auth
+Create Date: 2026-07-09
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0015_enterprise_connectors"
+down_revision = "0014_agent_schedules_webhook_auth"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS enterprise_connectors (
+            agent_name TEXT PRIMARY KEY,
+            enabled INTEGER NOT NULL DEFAULT 0,
+            exposed_playbooks TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS enterprise_connectors")

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -824,6 +824,60 @@ class McpExposedUpdate(BaseModel):
     enabled: bool
 
 
+# ---------------------------------------------------------------------------
+# Per-agent MCP connector (ent#46; OSS-core since #118)
+# ---------------------------------------------------------------------------
+
+class ConnectorConfigUpdate(BaseModel):
+    """Body for PUT /api/agents/{name}/connector.
+
+    ``exposed_playbooks=None`` leaves the allow-list unchanged; an explicit list
+    sets it; ``expose_all_playbooks=True`` resets it to "all user_invocable".
+    """
+    enabled: Optional[bool] = None
+    exposed_playbooks: Optional[List[str]] = None
+    expose_all_playbooks: Optional[bool] = None
+
+
+class ConnectorClientSnippet(BaseModel):
+    """A copy-paste-ready connector config for one AI client."""
+    client: str
+    label: str
+    format: str            # 'shell' | 'json'
+    content: str           # the literal block to copy (key pre-embedded)
+    note: Optional[str] = None
+
+
+class ConnectorPlaybook(BaseModel):
+    """A playbook exposed by the connector as an MCP tool."""
+    name: str
+    description: Optional[str] = None
+    argument_hint: Optional[str] = None
+    automation: Optional[str] = None
+
+
+class ConnectorStatus(BaseModel):
+    """Response for GET .../connector (owner view)."""
+    agent_name: str
+    enabled: bool = False
+    exposed_playbooks: Optional[List[str]] = None
+    has_key: bool = False
+    key_prefix: Optional[str] = None
+    mcp_url: Optional[str] = None
+    snippets: List[ConnectorClientSnippet] = Field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class ConnectorKeySecret(BaseModel):
+    """Response when minting/regenerating the key — secret returned once."""
+    agent_name: str
+    api_key: str
+    key_prefix: str
+    mcp_url: Optional[str] = None
+    snippets: List[ConnectorClientSnippet] = Field(default_factory=list)
+
+
 class VoiceRepliesUpdate(BaseModel):
     """Body for PUT /api/agents/{name}/voice-replies (epic #24 / #25).
 

--- a/src/backend/routers/connector.py
+++ b/src/backend/routers/connector.py
@@ -1,0 +1,140 @@
+"""FastAPI router for the per-agent MCP connector (ent#46; OSS-core since #118).
+
+Exposes a single agent as a per-agent MCP connector: an end user adds it to their
+AI client (Claude Code, Cursor, Claude Desktop) in one line, turning the agent's
+``user_invocable`` playbooks into MCP tools. The agent holds all credentials
+server-side; only a scoped, revocable key (``mcp_api_keys`` ``scope='connector'``)
+reaches the client.
+
+Agent-scoped endpoints under ``/api/agents/{name}/connector*`` (Invariant #15).
+Owner-facing CRUD (config / mint-regenerate / revoke) uses ``OwnedAgentByName``.
+The connector-key-readable ``/playbooks`` uses ``AuthorizedAgentByName`` — which
+accepts a ``scope='connector'`` key fenced to its bound agent (the OSS auth fence
+in ``dependencies.py``).
+
+Relocated from the private ``enterprise/backend/mcp_connector/router.py`` when the
+connector became OSS-core (#118): the ``requires_entitlement('mcp_connector')``
+gate is removed and the router is mounted unconditionally in ``main.py``.
+"""
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from typing import List
+
+from dependencies import (
+    get_current_user,
+    OwnedAgentByName,
+    AuthorizedAgentByName,
+)
+from models import (
+    User,
+    ConnectorConfigUpdate,
+    ConnectorStatus,
+    ConnectorKeySecret,
+    ConnectorPlaybook,
+)
+from database import db
+from services.docker_service import get_agent_container
+from services.docker_utils import container_reload
+from services.agent_auth import agent_httpx_client
+from services.connector_service import build_snippets, resolve_exposed_playbooks
+from routers.settings import resolve_mcp_url
+
+router = APIRouter(prefix="/api/agents", tags=["mcp_connector"])
+
+_KEY_PLACEHOLDER = "<CONNECTOR_KEY>"
+
+
+def _status(agent_name: str, request: Request) -> ConnectorStatus:
+    cfg = db.get_connector_config(agent_name)
+    key_prefix = db.get_connector_key_prefix(agent_name)
+    mcp_url = resolve_mcp_url(request)
+    return ConnectorStatus(
+        agent_name=agent_name,
+        enabled=bool(cfg["enabled"]) if cfg else False,
+        exposed_playbooks=cfg["exposed_playbooks"] if cfg else None,
+        has_key=key_prefix is not None,
+        key_prefix=key_prefix,
+        mcp_url=mcp_url,
+        snippets=build_snippets(agent_name, mcp_url, _KEY_PLACEHOLDER) if key_prefix else [],
+        created_at=cfg["created_at"] if cfg else None,
+        updated_at=cfg["updated_at"] if cfg else None,
+    )
+
+
+async def _fetch_live_playbooks(agent_name: str) -> List[dict]:
+    container = get_agent_container(agent_name)
+    if not container:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    await container_reload(container)
+    if container.status != "running":
+        raise HTTPException(status_code=503, detail="Agent is not running.")
+    try:
+        url = f"http://agent-{agent_name}:8000/api/skills"
+        async with agent_httpx_client(agent_name, timeout=10.0) as client:
+            resp = await client.get(url)
+            if resp.status_code == 200:
+                return resp.json().get("skills", [])
+            raise HTTPException(status_code=resp.status_code, detail=f"Agent error: {resp.text}")
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="Agent is starting up, please try again")
+    except httpx.ConnectError:
+        raise HTTPException(status_code=503, detail="Could not connect to agent")
+
+
+@router.get("/{agent_name}/connector", response_model=ConnectorStatus)
+async def get_connector(agent_name: OwnedAgentByName, request: Request):
+    return _status(agent_name, request)
+
+
+@router.put("/{agent_name}/connector", response_model=ConnectorStatus)
+async def update_connector(agent_name: OwnedAgentByName, body: ConnectorConfigUpdate, request: Request):
+    db.upsert_connector_config(
+        agent_name,
+        enabled=body.enabled,
+        exposed_playbooks=body.exposed_playbooks,
+        clear_playbooks=bool(body.expose_all_playbooks),
+    )
+    return _status(agent_name, request)
+
+
+@router.post("/{agent_name}/connector/key", response_model=ConnectorKeySecret)
+async def regenerate_connector_key(
+    agent_name: OwnedAgentByName,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Mint/regenerate the scoped key — returns the secret once; old key invalidated.
+
+    Enabling the connector too, so a freshly-keyed connector is usable.
+    """
+    secret = db.regenerate_connector_key(agent_name, current_user.id)
+    cfg = db.get_connector_config(agent_name)
+    if not cfg or not cfg["enabled"]:
+        db.upsert_connector_config(agent_name, enabled=True)
+    mcp_url = resolve_mcp_url(request)
+    return ConnectorKeySecret(
+        agent_name=agent_name,
+        api_key=secret["api_key"],
+        key_prefix=secret["key_prefix"],
+        mcp_url=mcp_url,
+        snippets=build_snippets(agent_name, mcp_url, secret["api_key"]),
+    )
+
+
+@router.delete("/{agent_name}/connector/key")
+async def revoke_connector_key(agent_name: OwnedAgentByName):
+    db.revoke_connector_key(agent_name)
+    return {"revoked": True, "agent_name": agent_name}
+
+
+@router.get("/{agent_name}/connector/playbooks", response_model=List[ConnectorPlaybook])
+async def list_connector_playbooks(agent_name: AuthorizedAgentByName):
+    """Exposed playbooks (allow-list ∩ user_invocable) the connector advertises."""
+    cfg = db.get_connector_config(agent_name)
+    if cfg and not cfg["enabled"]:
+        raise HTTPException(status_code=403, detail="Connector is disabled for this agent")
+    live = await _fetch_live_playbooks(agent_name)
+    allow = cfg["exposed_playbooks"] if cfg else None
+    return resolve_exposed_playbooks(live, allow)

--- a/src/backend/services/connector_service.py
+++ b/src/backend/services/connector_service.py
@@ -1,0 +1,93 @@
+"""Pure helpers for the per-agent MCP connector (ent#46; OSS-core since #118).
+
+(a) build copy-paste-ready connector configuration per AI client with the scoped
+key pre-embedded, and (b) resolve an agent's exposed playbooks against its
+allow-list + the ``user_invocable`` exclusion.
+
+No DB or HTTP — the router owns persistence and the MCP-URL lookup. Relocated
+verbatim from the private ``enterprise/backend/mcp_connector/service.py`` (#118).
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Optional
+
+from models import ConnectorClientSnippet, ConnectorPlaybook
+
+
+def connector_name(agent_name: str) -> str:
+    """A safe MCP-server name for ``claude mcp add <name>`` / config keys."""
+    slug = re.sub(r"[^a-z0-9]+", "-", agent_name.lower()).strip("-")
+    return f"trinity-{slug or 'agent'}"
+
+
+def build_snippets(agent_name: str, mcp_url: str, api_key: str) -> List[ConnectorClientSnippet]:
+    """Per-client connector config blocks with the key pre-embedded."""
+    name = connector_name(agent_name)
+    auth = f"Bearer {api_key}"
+
+    claude_code_cli = (
+        f'claude mcp add --transport http {name} {mcp_url} '
+        f'--header "Authorization: {auth}"'
+    )
+    mcp_json = {
+        "mcpServers": {
+            name: {"type": "http", "url": mcp_url, "headers": {"Authorization": auth}}
+        }
+    }
+    mcp_json_block = json.dumps(mcp_json, indent=2)
+    desktop_block = json.dumps({"url": mcp_url, "headers": {"Authorization": auth}}, indent=2)
+
+    return [
+        ConnectorClientSnippet(
+            client="claude-code", label="Claude Code", format="shell",
+            content=claude_code_cli,
+            note="Run in your terminal, then restart Claude Code (or run /mcp).",
+        ),
+        ConnectorClientSnippet(
+            client="claude-code-json", label="Claude Code (.mcp.json)", format="json",
+            content=mcp_json_block,
+            note="Add to .mcp.json under mcpServers if you prefer a config file.",
+        ),
+        ConnectorClientSnippet(
+            client="cursor", label="Cursor", format="json",
+            content=mcp_json_block,
+            note="Add to .cursor/mcp.json (project) or ~/.cursor/mcp.json (global).",
+        ),
+        ConnectorClientSnippet(
+            client="claude-desktop", label="Claude Desktop / claude.ai", format="json",
+            content=desktop_block,
+            note="Add as a Connector: paste the URL and Authorization header.",
+        ),
+    ]
+
+
+def resolve_exposed_playbooks(
+    live_playbooks: List[dict],
+    exposed_allow_list: Optional[List[str]],
+) -> List[ConnectorPlaybook]:
+    """Filter the agent's live playbooks to what the connector exposes.
+
+    1. ``user_invocable == False`` playbooks are NEVER exposed.
+    2. ``exposed_allow_list is None`` ⇒ expose all remaining; else only listed.
+    """
+    allow = set(exposed_allow_list) if exposed_allow_list is not None else None
+    out: List[ConnectorPlaybook] = []
+    for pb in live_playbooks:
+        if not pb.get("user_invocable", True):
+            continue
+        name = pb.get("name")
+        if not name:
+            continue
+        if allow is not None and name not in allow:
+            continue
+        out.append(
+            ConnectorPlaybook(
+                name=name,
+                description=pb.get("description"),
+                argument_hint=pb.get("argument_hint"),
+                automation=pb.get("automation"),
+            )
+        )
+    return out

--- a/src/frontend/src/components/SharingPanel.vue
+++ b/src/frontend/src/components/SharingPanel.vue
@@ -202,9 +202,8 @@
           <VoipChannelPanel :agent-name="agentName" />
         </ChannelConfigRow>
 
-        <!-- MCP connector (ent#46) — gated on the mcp_connector entitlement -->
+        <!-- MCP connector (ent#46) — OSS-core since #118 (un-gated) -->
         <ChannelDisclosure
-          v-if="enterpriseStore.isEntitled('mcp_connector')"
           title="MCP connector"
           subtitle="Add this agent to an AI client; playbooks become tools"
           icon="🔌"
@@ -285,7 +284,6 @@ import { useAuthStore } from '../stores/auth'
 import { useAgentsStore } from '../stores/agents'
 import { useNotification } from '../composables'
 import { useSessionsStore } from '../stores/sessions'
-import { useEnterpriseStore } from '../stores/enterprise'
 import ChannelDisclosure from './ChannelDisclosure.vue'
 import ChannelConfigRow from './ChannelConfigRow.vue'
 import PublicLinksPanel from './PublicLinksPanel.vue'
@@ -315,10 +313,6 @@ const { showNotification } = useNotification()
 const sessionsStore = useSessionsStore()
 const agentsStore = useAgentsStore()
 sessionsStore.loadFeatureFlags()
-
-// MCP connector visibility (ent#46) — gated on the `mcp_connector` entitlement.
-const enterpriseStore = useEnterpriseStore()
-enterpriseStore.loadFeatureFlags()
 
 const loadAgent = () => {
   emit('agent-updated')

--- a/tests/unit/test_118_mcp_connector_oss.py
+++ b/tests/unit/test_118_mcp_connector_oss.py
@@ -1,0 +1,156 @@
+"""Tests for the per-agent MCP connector — OSS-core since #118 (was ent#46).
+
+Covers the pure service helpers (snippet builder + playbook resolution), the
+connector config CRUD, and the connector-key minting — including the contract
+that a key minted here validates through ``validate_mcp_api_key`` as
+``scope='connector'``.
+
+Runs against a throwaway sqlite seeded with the OSS ``users`` + ``mcp_api_keys``
++ ``enterprise_connectors`` tables. No entitlement wiring — the feature is OSS-core.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def conn_db(tmp_path, monkeypatch):
+    """Fresh sqlite: OSS users + mcp_api_keys + enterprise_connectors tables."""
+    db_file = tmp_path / "trinity-connector.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+
+    from db.engine import get_engine
+    from db.tables import metadata as oss_metadata, users, mcp_api_keys, enterprise_connectors
+    oss_metadata.create_all(get_engine(), tables=[users, mcp_api_keys, enterprise_connectors])
+
+    from sqlalchemy import insert
+    with get_engine().begin() as conn:
+        conn.execute(insert(users).values(
+            id=1, username="owner", role="creator", email="owner@example.com",
+            created_at="2026-01-01T00:00:00Z", updated_at="2026-01-01T00:00:00Z",
+        ))
+    yield str(db_file)
+
+
+def _ops():
+    from db.connector import ConnectorOperations
+    return ConnectorOperations()
+
+
+# ---------------------------------------------------------------------------
+# Pure service helpers
+# ---------------------------------------------------------------------------
+
+class TestService:
+    def _live(self):
+        return [
+            {"name": "cso", "description": "audit", "user_invocable": True, "automation": "gated", "argument_hint": "[--x]"},
+            {"name": "internal-only", "user_invocable": False},
+            {"name": "commit", "user_invocable": True},
+        ]
+
+    def test_allow_list_filters(self):
+        from services.connector_service import resolve_exposed_playbooks
+        out = resolve_exposed_playbooks(self._live(), ["cso"])
+        assert [p.name for p in out] == ["cso"]
+        assert out[0].argument_hint == "[--x]"
+
+    def test_none_exposes_all_user_invocable(self):
+        from services.connector_service import resolve_exposed_playbooks
+        out = resolve_exposed_playbooks(self._live(), None)
+        assert {p.name for p in out} == {"cso", "commit"}
+
+    def test_user_invocable_false_never_exposed_even_if_listed(self):
+        from services.connector_service import resolve_exposed_playbooks
+        out = resolve_exposed_playbooks(self._live(), ["internal-only", "cso"])
+        assert [p.name for p in out] == ["cso"]
+
+    def test_snippets_embed_key_and_url(self):
+        from services.connector_service import build_snippets, connector_name
+        assert connector_name("My Agent!") == "trinity-my-agent"
+        snips = build_snippets("agent-1", "http://localhost:8080/mcp", "trinity_mcp_SECRET")
+        assert {"claude-code", "cursor", "claude-desktop"} <= {s.client for s in snips}
+        for s in snips:
+            assert "trinity_mcp_SECRET" in s.content and "http://localhost:8080/mcp" in s.content
+
+
+# ---------------------------------------------------------------------------
+# Config CRUD
+# ---------------------------------------------------------------------------
+
+class TestConfig:
+    def test_absent_then_enable(self, conn_db):
+        cdb = _ops()
+        assert cdb.get_config("agent-1") is None
+        cfg = cdb.upsert_config("agent-1", enabled=True)
+        assert cfg["enabled"] is True
+        assert cfg["exposed_playbooks"] is None
+        assert cdb.get_config("agent-1")["enabled"] is True
+
+    def test_allow_list_roundtrip_and_partial_update(self, conn_db):
+        cdb = _ops()
+        cdb.upsert_config("agent-1", enabled=True, exposed_playbooks=["cso", "commit"])
+        assert cdb.get_config("agent-1")["exposed_playbooks"] == ["cso", "commit"]
+        cfg = cdb.upsert_config("agent-1", enabled=False)
+        assert cfg["enabled"] is False and cfg["exposed_playbooks"] == ["cso", "commit"]
+        assert cdb.upsert_config("agent-1", clear_playbooks=True)["exposed_playbooks"] is None
+
+    def test_delete_config(self, conn_db):
+        cdb = _ops()
+        cdb.upsert_config("agent-1", enabled=True)
+        assert cdb.delete_config("agent-1") is True
+        assert cdb.get_config("agent-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Connector key (rows in mcp_api_keys, scope='connector')
+# ---------------------------------------------------------------------------
+
+class TestKey:
+    def test_mint_get_revoke(self, conn_db):
+        cdb = _ops()
+        secret = cdb.mint_key("agent-1", user_id=1)
+        assert secret["api_key"].startswith("trinity_mcp_")
+        assert cdb.get_key_prefix("agent-1") == secret["api_key"][:20]
+        assert cdb.revoke_key("agent-1") is True
+        assert cdb.get_key_prefix("agent-1") is None
+
+    def test_validates_as_connector_scope(self, conn_db):
+        cdb = _ops()
+        from db.mcp_keys import McpKeyOperations
+        ops = McpKeyOperations(None)  # validate doesn't touch user_ops
+        secret = cdb.mint_key("agent-1", user_id=1)
+        info = ops.validate_mcp_api_key(secret["api_key"])
+        assert info is not None
+        assert info["scope"] == "connector"
+        assert info["agent_name"] == "agent-1"
+
+    def test_regenerate_invalidates_old(self, conn_db):
+        cdb = _ops()
+        from db.mcp_keys import McpKeyOperations
+        ops = McpKeyOperations(None)
+        old = cdb.mint_key("agent-1", user_id=1)
+        new = cdb.regenerate_key("agent-1", user_id=1)
+        assert new["api_key"] != old["api_key"]
+        assert ops.validate_mcp_api_key(old["api_key"]) is None
+        assert ops.validate_mcp_api_key(new["api_key"]) is not None
+
+    def test_regenerate_keeps_exactly_one_active_key(self, conn_db):
+        cdb = _ops()
+        from db.engine import get_engine
+        from db.tables import mcp_api_keys
+        from sqlalchemy import select, func
+        cdb.mint_key("agent-1", user_id=1)
+        cdb.regenerate_key("agent-1", user_id=1)
+        cdb.regenerate_key("agent-1", user_id=1)
+        with get_engine().connect() as conn:
+            n = conn.execute(
+                select(func.count()).select_from(mcp_api_keys).where(
+                    mcp_api_keys.c.agent_name == "agent-1",
+                    mcp_api_keys.c.scope == "connector",
+                )
+            ).scalar()
+        assert n == 1


### PR DESCRIPTION
## Summary

Relocates the per-agent MCP connector (ent#46/#55/#51, shipped v0.8.0 entitlement-gated as `mcp_connector`) from the private enterprise submodule into **OSS core**, un-gated. Per Eugene's decision (2026-07-09) this is a platform-adoption surface, not a paid module. **Part A** of trinity-enterprise#118; the paired enterprise removal is `trinity-enterprise` PR (linked below). Part B (email-auth onboarding, #848) is deferred pending design sign-off.

## What moved (mostly relocation + un-gate)
- **Backend** (router → service → db, Invariants #1/#2/#14): `routers/connector.py` (mounted unconditionally, no `requires_entitlement`), `services/connector_service.py`, `db/connector.py` (`ConnectorOperations` + facade delegators), 5 models in `models.py`.
- **Schema**: `enterprise_connectors` re-homed onto OSS dual-track — `db/tables.py`, `db/schema.py`, `db/migrations.py:enterprise_connectors_table` + Alembic `0015_enterprise_connectors`. **Name kept** so existing enterprise installs adopt their data with zero migration (`CREATE TABLE IF NOT EXISTS`, no duplicate-table drift). Delete/rename cascade via an `enterprise_connectors` `AGENT_REF`.
- **Frontend**: `ConnectorChannelPanel` un-gated in `SharingPanel.vue` (dropped `isEntitled('mcp_connector')` + now-unused enterprise-store wiring).
- Already-OSS, unchanged: `connector.ts` proxy tools, the connector-scope auth fence in `dependencies.py`, `ExposedToolsPanel.vue`.

## Acceptance criteria (Part A)
- [x] Full connector works in an OSS-only build (mint/regenerate/revoke, snippets, enable toggle, allow-list).
- [x] Backend relocated to OSS core; table re-homed to OSS dual-track with zero-migration adoption.
- [x] `ConnectorChannelPanel.vue` un-gated.
- [x] `mcp_connector` removed from the entitlement registry (paired enterprise PR deletes `register_module`).
- [x] Public docs: requirements `mcp.md` §7.5 + `feature-flows/mcp-connector.md` + architecture/index.

## Testing
`tests/unit/test_118_mcp_connector_oss.py` — 11 passed (service helpers, config CRUD, key mint/regenerate/revoke, `scope='connector'` validate contract). Guards green: schema-parity, alembic-parity, revision-id-length, models-centralized. SharingPanel.vue compiles.

## Coordination notes
- **Merge with the enterprise PR** (removes the private module + `mcp_connector` registration) so the router isn't double-mounted at runtime.
- **Alembic**: this adds `0015_enterprise_connectors` (down_revision `0014`). The voice PR #1551... (correction) — the voice-replies branch also uses `0015/0016`; whichever merges second must rebase its revision's `down_revision`. Flagging for the merge order.

Related to trinity-enterprise#118

🤖 Generated with [Claude Code](https://claude.com/claude-code)