### PR TITLE
fix(avatar): prevent thinking-token truncation dropping the color-scheme block

### DIFF
--- a/src/backend/services/image_generation_service.py
+++ b/src/backend/services/image_generation_service.py
@@ -252,28 +252,57 @@ class ImageGenerationService:
         """
         url = f"{GEMINI_API_BASE}/{GEMINI_TEXT_MODEL}:generateContent"
 
-        payload = {
-            "system_instruction": {
-                "parts": [{"text": system_prompt}],
-            },
-            "contents": [
-                {
-                    "role": "user",
-                    "parts": [{"text": user_message}],
-                }
-            ],
-            "generationConfig": {
+        def _build_payload(disable_thinking: bool) -> dict:
+            gen_config = {
                 "temperature": 0.7,
-                "maxOutputTokens": 512,
-            },
-        }
+                # #1130 follow-up: GEMINI_TEXT_MODEL defaults to a *thinking* model
+                # (gemini-3.5-flash). Its reasoning phase draws from the output
+                # budget, so a tight cap (was 512) let thinking consume ~491 tokens
+                # and truncate the refined prompt (finishReason=MAX_TOKENS) to a
+                # ~90-char fragment — dropping the AVATAR fixed technical block
+                # (background #1a1f2e/#111827, indigo rim #6366f1, head-and-shoulders
+                # framing, 85mm lens, 5600K key). That block is the sole source of
+                # avatar color-scheme + consistency, so avatars came out wildly
+                # different and off-palette. Generous headroom keeps the full block
+                # intact even when thinking stays on.
+                "maxOutputTokens": 4096,
+            }
+            if disable_thinking:
+                # Prompt refinement is a deterministic rewrite that needs no
+                # chain-of-thought. Disabling thinking makes it fast/cheap and
+                # immune to the budget squeeze above. Not every model allows a zero
+                # budget (e.g. gemini-2.5-pro is thinking-mandatory → HTTP 400), so
+                # the caller retries without this field on a 400.
+                gen_config["thinkingConfig"] = {"thinkingBudget": 0}
+            return {
+                "system_instruction": {
+                    "parts": [{"text": system_prompt}],
+                },
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [{"text": user_message}],
+                    }
+                ],
+                "generationConfig": gen_config,
+            }
 
         response = await self._http.post(
             url,
-            json=payload,
+            json=_build_payload(disable_thinking=True),
             headers={"x-goog-api-key": GEMINI_API_KEY},
             timeout=PROMPT_REFINEMENT_TIMEOUT,
         )
+
+        # A thinking-mandatory model rejects thinkingBudget=0 with a 400; retry once
+        # with thinking on (the 4096-token headroom above prevents truncation).
+        if response.status_code == 400:
+            response = await self._http.post(
+                url,
+                json=_build_payload(disable_thinking=False),
+                headers={"x-goog-api-key": GEMINI_API_KEY},
+                timeout=PROMPT_REFINEMENT_TIMEOUT,
+            )
 
         if response.status_code != 200:
             raise RuntimeError(

--- a/tests/unit/test_image_generation_service.py
+++ b/tests/unit/test_image_generation_service.py
@@ -598,6 +598,73 @@ class TestCallGeminiText:
         call_kwargs = mock_http.post.call_args[1]
         assert call_kwargs["headers"]["x-goog-api-key"] == "my-secret-key"
 
+    @pytest.mark.asyncio
+    async def test_disables_thinking_and_has_output_headroom(self):
+        """Regression guard (#1130 follow-up): the refinement call must disable
+        thinking AND leave generous output headroom, or a thinking model truncates
+        the refined prompt (finishReason=MAX_TOKENS) and drops the AVATAR fixed
+        technical block — the sole source of avatar color-scheme + consistency."""
+        mod = _load_service(api_key="test-key")
+        service = mod.ImageGenerationService()
+
+        mock_http = AsyncMock()
+        mock_http.post.return_value = _make_mock_response(200, FAKE_TEXT_RESPONSE)
+        mock_http.is_closed = False
+        service._client = mock_http
+
+        await service._call_gemini_text("system", "user message")
+
+        gen_config = mock_http.post.call_args[1]["json"]["generationConfig"]
+        # Thinking disabled so reasoning tokens can't eat the output budget.
+        assert gen_config["thinkingConfig"]["thinkingBudget"] == 0
+        # A tight cap (the old 512) is what let thinking squeeze out the block.
+        assert gen_config["maxOutputTokens"] >= 2048
+
+    @pytest.mark.asyncio
+    async def test_retries_without_thinking_config_on_400(self):
+        """A thinking-mandatory model (e.g. gemini-2.5-pro) rejects thinkingBudget=0
+        with HTTP 400. The call must retry once WITHOUT thinkingConfig rather than
+        raise — else refine_prompt's silent fallback would revert to the broken
+        behavior (raw prompt, no technical block)."""
+        mod = _load_service(api_key="test-key")
+        service = mod.ImageGenerationService()
+
+        mock_http = AsyncMock()
+        mock_http.post.side_effect = [
+            _make_mock_response(400, {"error": {"message": "Budget 0 is invalid."}}),
+            _make_mock_response(200, FAKE_TEXT_RESPONSE),
+        ]
+        mock_http.is_closed = False
+        service._client = mock_http
+
+        result = await service._call_gemini_text("system", "user message")
+
+        assert mock_http.post.call_count == 2
+        # Retry drops thinkingConfig but keeps the output headroom.
+        retry_config = mock_http.post.call_args_list[1][1]["json"]["generationConfig"]
+        assert "thinkingConfig" not in retry_config
+        assert retry_config["maxOutputTokens"] >= 2048
+        assert result  # succeeds via the retry, does not raise
+
+    @pytest.mark.asyncio
+    async def test_persistent_400_still_raises(self):
+        """If the retry (thinking off) also 400s, the error propagates — a genuine
+        bad request must not be swallowed."""
+        mod = _load_service(api_key="test-key")
+        service = mod.ImageGenerationService()
+
+        mock_http = AsyncMock()
+        mock_http.post.side_effect = [
+            _make_mock_response(400, {"error": {"message": "Bad request"}}),
+            _make_mock_response(400, {"error": {"message": "Bad request"}}),
+        ]
+        mock_http.is_closed = False
+        service._client = mock_http
+
+        with pytest.raises(RuntimeError, match="400"):
+            await service._call_gemini_text("system", "user message")
+        assert mock_http.post.call_count == 2
+
 
 # =============================================================================
 # _call_gemini_image Tests


### PR DESCRIPTION
## Problem

Agent avatars were coming out wildly inconsistent and off-palette — not following the color scheme.

**Root cause:** Avatar consistency lives entirely in a fixed technical block that the refinement model (`GEMINI_TEXT_MODEL`) is asked to append to every prompt — background `#1a1f2e`/`#111827`, indigo rim `#6366f1`, head-and-shoulders framing, 85mm lens, 5600K key light. The refinement call in `_call_gemini_text` capped `maxOutputTokens` at **512**, but since #1130 the default model is `gemini-3.5-flash`, a **thinking** model whose reasoning phase draws from the output budget. Reasoning consumed **~491 of 512 tokens**, truncating the refined prompt (`finishReason=MAX_TOKENS`) to a ~90-char fragment that dropped the entire technical block. The image model then received only a bare subject description → inconsistent, off-scheme avatars.

This was a silent regression from #1130: the previous default `gemini-2.0-flash` was non-thinking, so all 512 tokens went to visible output and the block survived.

## Fix (`src/backend/services/image_generation_service.py`)

- **Disable thinking** (`thinkingConfig.thinkingBudget=0`) — prompt refinement is a deterministic rewrite that needs no chain-of-thought.
- **Raise `maxOutputTokens` 512 → 4096** — headroom so the block survives even when thinking stays on.
- **Retry once without `thinkingConfig` on HTTP 400** — a thinking-mandatory model (e.g. `gemini-2.5-pro`, in #1130's model list) rejects `budget=0` with a 400. Since `refine_prompt` silently falls back to the raw prompt on any error (the exact trap that hid this bug), an unhandled 400 would re-break avatars on that model.

## Verification

- **End-to-end against the live model:** all 6 technical-block tokens now survive refinement (`#1a1f2e`, `#111827`, `#6366f1`, `head-and-shoulders`, `85mm`, `5600K`) — was **0/6** before.
- **Unit tests:** 3 new regression tests + full suite green (`43 passed`).

```
tests/unit/test_image_generation_service.py::TestCallGeminiText::test_disables_thinking_and_has_output_headroom PASSED
tests/unit/test_image_generation_service.py::TestCallGeminiText::test_retries_without_thinking_config_on_400 PASSED
tests/unit/test_image_generation_service.py::TestCallGeminiText::test_persistent_400_still_raises PASSED
```

## Scope / notes

- Code-only change (no schema) — no dual migration needed.
- Existing already-generated avatars are cached image files; they'll benefit only on regeneration (`POST /api/agents/avatars/generate-defaults` or per-agent Regenerate).
- **Follow-up (not in this PR):** consistency still relies on an LLM copying a verbatim block, which is inherently brittle (the `social` use case was also observed leaking markdown). A more durable design would append the fixed technical block in code after refinement. Happy to do that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
