### PR TITLE
fix(sync-health): exclude soft-deleted agents from list_git_enabled_agents (#1561)

### DIFF
--- a/src/backend/db/schedules.py
+++ b/src/backend/db/schedules.py
@@ -3101,10 +3101,30 @@ class ScheduleOperations:
             return result.rowcount > 0
 
     def list_git_enabled_agents(self) -> List[AgentGitConfig]:
-        """List all agents with git sync enabled."""
+        """List all agents with git sync enabled.
+
+        Joins `agent_ownership` and excludes soft-deleted agents (#1561).
+        `agent_git_config` rows survive soft delete by design, so without this
+        filter the 60s `SyncHealthService` poller (and `GET /api/fleet/sync-audit`)
+        keeps hitting removed containers forever — each `httpx.ConnectError`
+        poisons the transport circuit breaker and eventually drives it to
+        DORMANT + a bogus `circuit_breaker_dormant` alert for an agent that no
+        longer exists. Mirrors the #834 hardening on `list_all_enabled_schedules()`.
+        """
         stmt = (
             select(agent_git_config)
-            .where(agent_git_config.c.sync_enabled == 1)
+            .select_from(
+                agent_git_config.join(
+                    agent_ownership,
+                    agent_ownership.c.agent_name == agent_git_config.c.agent_name,
+                )
+            )
+            .where(
+                and_(
+                    agent_git_config.c.sync_enabled == 1,
+                    agent_ownership.c.deleted_at.is_(None),
+                )
+            )
             .order_by(agent_git_config.c.agent_name)
         )
         with get_engine().connect() as conn:

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -671,7 +671,9 @@ async def get_git_status(agent_name: str) -> Optional[Dict[str, Any]]:
                 return response.json()
             return None
     except Exception as e:
-        print(f"Error getting git status for {agent_name}: {e}")
+        # #1561: structured logging, not a bare print() — otherwise these
+        # failures have no level/timestamp and are invisible to log-based alerting.
+        logger.warning("Error getting git status for %s: %s", agent_name, e)
         return None
 
 

--- a/tests/unit/test_sync_health_service.py
+++ b/tests/unit/test_sync_health_service.py
@@ -221,3 +221,48 @@ class TestBehindWorkingRedFlag:
         from database import db
         row = db.get_sync_state("alpha")
         assert row["behind_working"] == 2
+
+
+class TestSoftDeletedExcluded:
+    """#1561: a soft-deleted agent must never be polled — otherwise the 60s
+    loop hits its removed container forever and each httpx.ConnectError
+    poisons the transport circuit breaker (→ DORMANT + a bogus alert)."""
+
+    @staticmethod
+    def _soft_delete(name: str):
+        _hrun(
+            "UPDATE agent_ownership SET deleted_at = '2026-01-01T11:42:52Z' "
+            "WHERE agent_name = :n",
+            n=name,
+        )
+
+    def test_accessor_excludes_soft_deleted(self, tmp_db, seed_agent):
+        seed_agent("live")
+        seed_agent("dead")
+        self._soft_delete("dead")
+        from database import db
+        names = {c.agent_name for c in db.list_git_enabled_agents()}
+        assert "live" in names
+        assert "dead" not in names, "soft-deleted agent must not be listed"
+
+    @pytest.mark.asyncio
+    async def test_poll_cycle_issues_no_http_to_soft_deleted(
+        self, service, seed_agent
+    ):
+        seed_agent("live")
+        seed_agent("dead")
+        self._soft_delete("dead")
+
+        fake = _status_payload(status="success")
+        spy = AsyncMock(return_value=fake)
+        with patch.object(service, "_fetch_git_status", spy):
+            await service._poll_cycle()
+
+        # Exactly one fetch — the live agent — never the soft-deleted one.
+        polled = {call.args[0] for call in spy.call_args_list}
+        assert polled == {"live"}, f"expected only 'live' polled, got {polled}"
+
+        from database import db
+        # No sync_state row and no operator-queue entry for the dead agent.
+        assert db.get_sync_state("dead") is None
+        assert db.list_operator_queue_items(agent_name="dead") == []


### PR DESCRIPTION
## Problem

`db.list_git_enabled_agents()` selected from `agent_git_config` on `sync_enabled == 1` alone — no `agent_ownership` join, no `deleted_at` filter. Soft delete preserves the `agent_git_config` row, so the 60s `SyncHealthService` poller kept HTTP-polling removed containers **forever**. Each `httpx.ConnectError` is exactly the class that increments the transport circuit breaker → after ~3 min it OPENs, after ~36 min it goes **DORMANT** and emits a bogus `circuit_breaker_dormant` operator-queue alert for an agent that no longer exists. `GET /api/fleet/sync-audit` (same accessor) also listed dead agents.

## Fix

- **`list_git_enabled_agents()`**: join `agent_ownership`, filter `deleted_at IS NULL` — mirrors the #834 hardening on `list_all_enabled_schedules()`. One change fixes both consumers (poller + audit endpoint).
- **`git_service.get_git_status`**: bare `print()` → `logger.warning` (the issue's "minor, same code path" — those failures were invisible to structured logging).

## Audit sweep (acceptance criterion)

`list_git_enabled_agents` was the **sole** background-loop accessor missing the `deleted_at` filter:

| Loop | Enumeration | Soft-deleted excluded? |
|------|-------------|------------------------|
| sync_health (60s) | `list_git_enabled_agents` (DB) | **was the bug — fixed here** |
| monitoring (30s) | `list_all_agents_fast()` (Docker) | ✓ removed container not listed |
| operator_queue (5s) | `list_all_agents_fast()` + running (Docker) | ✓ |
| scheduler | `list_all_enabled_schedules` (DB) | ✓ already hardened (#834) |
| capacity (60s) | `list_agents_with_queued` (DB) | ✓ DB-only backlog drain, no agent HTTP |
| heartbeat (5s) | Redis `seen`, cleared on delete | ✓ |

Every other per-agent HTTP poller enumerates from **Docker**, so removed containers are inherently absent; the remaining DB-driven loops either already filter or make no agent HTTP call. No other offender found.

## Tests

`tests/unit/test_sync_health_service.py::TestSoftDeletedExcluded`:
- accessor excludes a soft-deleted agent (live agent still listed);
- one `_poll_cycle()` polls only the live agent — **zero HTTP to the soft-deleted one**, no `sync_state` row, no operator-queue entry.

Full `test_sync_health_service.py` (9) + `test_fleet_sync_audit.py` / `test_73_sync_health_bulk.py` (13) green locally.

## Scope note

This removes the **source** of breaker poisoning. The **inheritance** side — a stale `agent:circuit:{name}` key surviving delete/recreate — is the companion defect **#1560** and intentionally out of scope here.

Related to #1561
