### PR TITLE
docs(enterprise): explain the private feature catalog + runtime verification in ENTERPRISE.md

### DIFF
--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -8,8 +8,19 @@ git submodule** at `src/backend/enterprise/`.
 
 This document covers the *generic installation mechanism only*: how the
 optional submodule mounts, how the backend detects it, and how to verify which
-edition an instance is running. The catalog of enterprise capabilities and
-their designs are documented privately in the enterprise repository.
+edition an instance is running.
+
+**Why there's no feature catalog here.** By a standing open-core rule
+(trinity-enterprise#45, enforced by
+`.github/workflows/enterprise-docs-guard.yml`), this public repo documents the
+*seam* — never the *catalog* of which capabilities are paid, their private
+`enterprise_*` schema, or the monetization rationale. Entitled customers and
+core-team members find the per-module catalog and designs in the private
+enterprise repository (`docs/memory/ENTERPRISE_DOCS.md` there). For a live,
+edition-specific answer to "what's actually enabled on this instance," ask the
+running backend: `GET /api/version` and `GET /api/settings/feature-flags` both
+report the enterprise feature-ids *your* build has registered (empty in an
+OSS-only build).
 
 ## How the seam works
 


### PR DESCRIPTION
## What
`docs/ENTERPRISE.md` is our public open-core install/verify doc. It correctly documents the **seam mechanism** but never explained where the feature-level OSS↔enterprise split lives — or why it's deliberately not in this public repo.

This adds a short, compliant **"Why there's no feature catalog here"** note:
- the standing rule **trinity-enterprise#45** (enforced by `.github/workflows/enterprise-docs-guard.yml`) keeps the paid-feature catalog, private `enterprise_*` schema, and monetization rationale out of this public repo;
- entitled customers / core team find the per-module catalog in the private enterprise repo;
- for a live, edition-specific answer, the note points at `GET /api/version` and `GET /api/settings/feature-flags`, which report the registered enterprise feature-ids (empty in an OSS-only build).

## Not in this PR (by design)
- No named features / no `enterprise_*` schema — stays **mechanism-only** per #45. I re-ran the `enterprise-docs-guard` grep locally over `docs/` + `CLAUDE.md` + the seam files: **green** (no hits).
- The actual feature-catalog reconciliation (the private docs had drifted — listed 4 modules; reality is 8) lives in the **private** companion PR `Abilityai/trinity-enterprise#129`.

## Test
- Reproduced `enterprise-docs-guard.yml`'s exact pattern grep → no forbidden tokens introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
