### PR TITLE
fix(recovery): rebuild missing container on start for recovered agents (#1559)

### DIFF
--- a/src/backend/routers/admin_recovery.py
+++ b/src/backend/routers/admin_recovery.py
@@ -144,13 +144,14 @@ async def recover_agent(
             f"Agent {agent_name} recovered: all relational state "
             f"(chat history, schedules, sharing, permissions, "
             f"credentials config) is restored and the agent is visible "
-            f"again. The Docker container was removed at soft-delete and "
-            f"is NOT recreated by recovery — bringing the agent back "
-            f"online (container recreate from the preserved workspace "
-            f"volume) is tracked as #834 Phase 2. Until then the agent "
-            f"shows status=stopped with needs_start=true."
+            f"again. The Docker container was removed at soft-delete; "
+            f"call POST /api/agents/{agent_name}/start to bring it back "
+            f"online — start now rebuilds the missing container from the "
+            f"preserved workspace volume and persisted config (#1559)."
         ),
         "agent_name": agent_name,
+        # #1559: honored by start_agent_internal, which rebuilds the container
+        # from persisted state when it finds a live agent with no container.
         "needs_container_recreate": True,
     }
 

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -17,6 +17,7 @@ from database import db
 from services.docker_service import (
     docker_client,
     get_agent_container,
+    get_next_available_port,
 )
 from services.docker_utils import (
     container_stop, container_remove, container_start, container_reload,
@@ -27,6 +28,7 @@ from services.settings_service import get_anthropic_api_key, get_github_pat, get
 from services.skill_service import skill_service
 from .helpers import check_shared_folder_mounts_match, check_api_key_env_matches, check_github_pat_env_matches, check_resource_limits_match, check_full_capabilities_match, check_guardrails_env_matches, check_agent_auth_token_env_matches, is_claude_runtime
 from services.agent_auth import derive_agent_token
+from utils.helpers import utc_now_iso
 from .file_sharing import check_public_folder_mount_matches
 from .read_only import inject_read_only_hooks, remove_read_only_hooks
 
@@ -252,7 +254,15 @@ async def start_agent_internal(agent_name: str) -> dict:
     """
     container = get_agent_container(agent_name)
     if not container:
-        raise HTTPException(status_code=404, detail="Agent not found")
+        # #1559: no container, but a live (non-soft-deleted) agent_ownership row
+        # means this is a recovered agent whose container was removed at
+        # soft-delete. Rebuild it from persisted config + the surviving workspace
+        # volume instead of dead-ending on 404 (the soft-delete recovery gap).
+        # A genuinely nonexistent agent (no ownership row) still 404s.
+        owner = db.get_agent_owner(agent_name)
+        if not owner:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        container = await recreate_missing_container(agent_name)
 
     # Check if container needs recreation for shared folders, API key, resource limits, or capabilities
     await container_reload(container)
@@ -499,6 +509,43 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
             if vol_name:
                 volumes[vol_name] = {"bind": dest, "mode": "rw" if m.get("RW", True) else "ro"}
 
+    return await _provision_folders_and_run_agent_container(
+        agent_name,
+        image=image,
+        env_vars=env_vars,
+        labels=labels,
+        base_volumes=volumes,
+        ssh_port=ssh_port,
+        cpu=cpu,
+        memory=memory,
+        full_capabilities=full_capabilities,
+    )
+
+
+async def _provision_folders_and_run_agent_container(
+    agent_name: str,
+    *,
+    image: str,
+    env_vars: dict,
+    labels: dict,
+    base_volumes: dict,
+    ssh_port: int,
+    cpu,
+    memory,
+    full_capabilities: bool,
+):
+    """Shared tail for every container (re)build: add DB-driven shared/public
+    folder mounts onto ``base_volumes`` then run the container with the full
+    security posture (cap-drop ALL, AppArmor, noexec tmpfs, resource limits).
+
+    Extracted so `recreate_container_with_updated_config` (spec from the old
+    container) and `recreate_missing_container` (spec from persisted DB state
+    after a soft-delete recovery, #1559) share one canonical run path — the
+    security envelope can never drift between them (AC: "goes through the
+    supported creation path, not a hand-rolled docker run").
+    """
+    volumes = dict(base_volumes)
+
     # Add shared folder mounts based on current config
     shared_config = db.get_shared_folder_config(agent_name)
     if shared_config:
@@ -605,3 +652,197 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
 
     logger.info(f"Recreated container for agent {agent_name} with updated configuration")
     return new_container
+
+
+async def _read_template_yaml_from_volume(agent_name: str) -> dict:
+    """Read the agent's `template.yaml` off its persisted workspace volume
+    without a running container (#1559).
+
+    After a soft-delete the container (and its `trinity.agent-type` /
+    `trinity.agent-runtime` labels) is gone, but the workspace volume — which
+    carries the committed `template.yaml` — survives. A throwaway, network-less
+    base-image container `cat`s the file. Tolerant: any failure (missing file,
+    unparseable) returns `{}` so the caller falls back to safe defaults.
+    """
+    volume_name = f"agent-{agent_name}-workspace"
+    try:
+        out = await containers_run(
+            "trinity-agent-base:latest",
+            command=["cat", "/home/developer/template.yaml"],
+            volumes={volume_name: {"bind": "/home/developer", "mode": "ro"}},
+            remove=True,
+            network_disabled=True,
+        )
+        text = out.decode("utf-8") if isinstance(out, (bytes, bytearray)) else str(out)
+        import yaml as _yaml
+        data = _yaml.safe_load(text)
+        return data if isinstance(data, dict) else {}
+    except Exception as e:  # noqa: BLE001 — best-effort; defaults cover the gap
+        logger.warning(
+            "Could not read template.yaml from volume for %s: %s", agent_name, e
+        )
+        return {}
+
+
+async def recreate_missing_container(agent_name: str):
+    """Rebuild a container for an existing agent that has **no** container —
+    the soft-delete recovery gap (#1559).
+
+    Soft delete removes the container but keeps the `agent-<name>-workspace`
+    volume and every relational row. Recovery clears `deleted_at` but nothing
+    could bring the agent back online: `start` 404'd (no container) and
+    `recreate_container_with_updated_config` needs an `old_container` to copy
+    config from. This reconstructs the container spec from persisted state
+    (`agent_ownership` + `agent_git_config` + the volume's `template.yaml`),
+    reuses the existing volume (never recreated — no data loss), and runs it
+    through the same `_provision_folders_and_run_agent_container` tail as a
+    normal recreate, so the full security posture (cap-drop, no-new-privileges
+    via AppArmor+cap model, noexec tmpfs, derived TRINITY_AGENT_AUTH_TOKEN) is
+    identical. startup.sh sees `.git` already on the volume and skips the clone.
+
+    Caller must confirm a live `agent_ownership` row exists first — this does
+    NOT create ownership/child rows, only the container.
+    """
+    image = "trinity-agent-base:latest"
+    validate_base_image(image)
+
+    tmpl = await _read_template_yaml_from_volume(agent_name)
+    agent_type = tmpl.get("type") or "business-assistant"
+    runtime_cfg = tmpl.get("runtime", {})
+    if isinstance(runtime_cfg, dict):
+        runtime = (runtime_cfg.get("type") or "claude-code").lower()
+        runtime_model = runtime_cfg.get("model") or ""
+    elif isinstance(runtime_cfg, str):
+        runtime = runtime_cfg.lower()
+        runtime_model = ""
+    else:
+        runtime = "claude-code"
+        runtime_model = ""
+    template_name = tmpl.get("_template") or ""  # display-only; label field
+
+    # --- Resource limits: per-agent DB override → system defaults ---
+    system_defaults = get_agent_default_resources()
+    db_limits = db.get_resource_limits(agent_name) or {}
+    cpu = normalize_cpu(db_limits.get("cpu") or system_defaults["cpu"], system_defaults["cpu"])
+    memory = normalize_memory(db_limits.get("memory") or system_defaults["memory"], system_defaults["memory"])
+    full_capabilities = get_agent_full_capabilities()
+    ssh_port = get_next_available_port()
+
+    # --- Base env (mirrors crud.create_agent_internal's baked set) ---
+    env_vars = {
+        "AGENT_NAME": agent_name,
+        "AGENT_TYPE": agent_type,
+        "CREDENTIALS_FILE": "/config/credentials.json",
+        "ENABLE_SSH": "true",
+        "ENABLE_AGENT_UI": "true",
+        "AGENT_SERVER_PORT": "8000",
+        "AGENT_RUNTIME": runtime,
+        "AGENT_RUNTIME_MODEL": runtime_model,
+        "TMPDIR": AGENT_DEFAULT_TMPDIR,
+    }
+
+    # OpenTelemetry (default on) — same wiring as create.
+    if os.getenv("OTEL_ENABLED", "1") == "1":
+        env_vars["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+        env_vars["OTEL_METRICS_EXPORTER"] = os.getenv("OTEL_METRICS_EXPORTER", "otlp")
+        env_vars["OTEL_LOGS_EXPORTER"] = os.getenv("OTEL_LOGS_EXPORTER", "otlp")
+        env_vars["OTEL_EXPORTER_OTLP_PROTOCOL"] = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        env_vars["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.getenv("OTEL_COLLECTOR_ENDPOINT", "http://trinity-otel-collector:4317")
+        env_vars["OTEL_METRIC_EXPORT_INTERVAL"] = os.getenv("OTEL_METRIC_EXPORT_INTERVAL", "60000")
+
+    # Mint a fresh agent-scoped MCP key (the old key's plaintext is unrecoverable
+    # — only the hash is stored). Same wiring as create: enables collab +
+    # heartbeat. Owner resolved from the ownership row.
+    owner = db.get_agent_owner(agent_name) or {}
+    owner_username = owner.get("owner_username") or owner.get("username")
+    try:
+        if owner_username:
+            agent_mcp_key = db.create_agent_mcp_api_key(
+                agent_name, owner_username, description="recovery-recreate"
+            )
+            if agent_mcp_key:
+                env_vars["TRINITY_MCP_URL"] = os.getenv("TRINITY_MCP_URL", "http://mcp-server:8080/mcp")
+                env_vars["TRINITY_MCP_API_KEY"] = agent_mcp_key.api_key
+                env_vars["TRINITY_BACKEND_URL"] = os.getenv("TRINITY_BACKEND_URL", "http://backend:8000")
+    except Exception as e:  # noqa: BLE001 — non-fatal; agent still boots
+        logger.warning("Could not mint MCP key on recovery recreate for %s: %s", agent_name, e)
+
+    # Auth env (subscription token / platform key), GitHub PAT, guardrails,
+    # stall-limit, per-agent auth token — reuse the exact create/recreate rules.
+    _apply_persisted_auth_env(agent_name, env_vars, runtime)
+
+    labels = {
+        "trinity.platform": "agent",
+        "trinity.agent-name": agent_name,
+        "trinity.agent-type": agent_type,
+        "trinity.ssh-port": str(ssh_port),
+        "trinity.cpu": cpu,
+        "trinity.memory": memory,
+        "trinity.created": utc_now_iso(),
+        "trinity.template": template_name,
+        "trinity.agent-runtime": runtime,
+        "trinity.full-capabilities": str(full_capabilities).lower(),
+    }
+
+    base_volumes = {f"agent-{agent_name}-workspace": {"bind": "/home/developer", "mode": "rw"}}
+
+    logger.info("Rebuilding missing container for recovered agent %s (#1559)", agent_name)
+    return await _provision_folders_and_run_agent_container(
+        agent_name,
+        image=image,
+        env_vars=env_vars,
+        labels=labels,
+        base_volumes=base_volumes,
+        ssh_port=ssh_port,
+        cpu=cpu,
+        memory=memory,
+        full_capabilities=full_capabilities,
+    )
+
+
+def _apply_persisted_auth_env(agent_name: str, env_vars: dict, runtime: str) -> None:
+    """Set auth-related env from persisted DB state, mirroring the refresh block
+    in `recreate_container_with_updated_config` (subscription token vs platform
+    key, per-agent GitHub PAT, guardrails, stall-limit, derived agent token)."""
+    if not is_claude_runtime(runtime):
+        env_vars.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+        env_vars.pop("ANTHROPIC_API_KEY", None)
+    else:
+        subscription_id = db.get_agent_subscription_id(agent_name)
+        if subscription_id:
+            token = db.get_subscription_token(subscription_id)
+            if token:
+                env_vars["CLAUDE_CODE_OAUTH_TOKEN"] = token
+            env_vars.pop("ANTHROPIC_API_KEY", None)
+        elif db.get_use_platform_api_key(agent_name):
+            env_vars["ANTHROPIC_API_KEY"] = get_anthropic_api_key()
+            env_vars.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+        else:
+            env_vars.pop("ANTHROPIC_API_KEY", None)
+            env_vars.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+
+    # Per-agent GitHub PAT (opt-in), plus GITHUB_REPO / GIT_SYNC from git config.
+    git_config = db.get_git_config(agent_name)
+    if git_config:
+        from routers.git import get_github_pat_for_agent
+        pat = get_github_pat_for_agent(agent_name)
+        repo = git_config.get("github_repo") if isinstance(git_config, dict) else getattr(git_config, "github_repo", None)
+        if pat and repo:
+            env_vars["GITHUB_REPO"] = repo
+            env_vars["GITHUB_PAT"] = pat
+            env_vars["GIT_SYNC_ENABLED"] = "true"
+            _git_base = os.getenv("TRINITY_GIT_BASE_URL")
+            if _git_base:
+                env_vars["TRINITY_GIT_BASE_URL"] = _git_base
+
+    guardrails_override = db.get_guardrails_config(agent_name)
+    if guardrails_override:
+        import json as _json
+        env_vars["AGENT_GUARDRAILS"] = _json.dumps(guardrails_override)
+
+    _stall_limit = (os.getenv("AGENT_TOOL_STALL_LIMIT_S") or "").strip()
+    if _stall_limit:
+        env_vars["AGENT_TOOL_STALL_LIMIT_S"] = _stall_limit
+
+    # #1159: per-agent in-container auth token (fail-closed: raises if secret unset).
+    env_vars["TRINITY_AGENT_AUTH_TOKEN"] = derive_agent_token(agent_name)

--- a/tests/unit/test_agent_readiness_probe.py
+++ b/tests/unit/test_agent_readiness_probe.py
@@ -47,7 +47,8 @@ def wait_for_agent_ready(monkeypatch):
     stubs = {
         "database": types.SimpleNamespace(db=None),
         "services.docker_service": types.SimpleNamespace(
-            docker_client=None, get_agent_container=lambda _n: None
+            docker_client=None, get_agent_container=lambda _n: None,
+            get_next_available_port=lambda: 2222,  # added to lifecycle.py import (#1559 recreate path)
         ),
         "services.docker_utils": types.SimpleNamespace(
             container_stop=None, container_remove=None, container_start=None,

--- a/tests/unit/test_start_agent_skip_inject.py
+++ b/tests/unit/test_start_agent_skip_inject.py
@@ -225,3 +225,72 @@ class TestStartAgentSkipInject:
         recreate.assert_awaited_once()
         inject_creds.assert_awaited_once_with("agent-c")
         inject_skills.assert_awaited_once_with("agent-c")
+
+
+# ── #1559: soft-delete recovery rebuilds the missing container ─────────────
+class TestRecoverRecreate1559:
+    """start_agent_internal must rebuild a missing container for a recovered
+    (live, non-soft-deleted) agent instead of dead-ending on 404 — and still
+    404 for a genuinely nonexistent agent.
+    Issue: https://github.com/abilityai/trinity/issues/1559
+    """
+    pytestmark = pytest.mark.unit
+
+    def test_start_404s_when_no_container_and_no_owner(self):
+        _mock_docker_service.get_agent_container.return_value = None
+        _mock_db.get_agent_owner.return_value = None
+        try:
+            _run(_mod.start_agent_internal("ghost"))
+            assert False, "expected 404"
+        except _HTTPException as e:
+            assert e.status_code == 404
+
+    def test_start_rebuilds_when_container_missing_but_live(self):
+        # First lookup: no container. Recovered agent → ownership row exists.
+        _mock_docker_service.get_agent_container.return_value = None
+        _mock_db.get_agent_owner.return_value = {"owner_username": "bob"}
+
+        rebuilt = _make_container("created")  # fresh → injection should run
+        recreate = AsyncMock(return_value=rebuilt)
+        inject_creds = AsyncMock(return_value={"status": "success"})
+        inject_skills = AsyncMock(return_value={"status": "success"})
+
+        with patch.object(_mod, "recreate_missing_container", recreate), \
+             patch.object(_mod, "wait_for_agent_ready", AsyncMock()), \
+             patch.object(_mod, "inject_assigned_credentials", inject_creds), \
+             patch.object(_mod, "inject_assigned_skills", inject_skills):
+            result = _run(_mod.start_agent_internal("revived"))
+
+        recreate.assert_awaited_once_with("revived")
+        _mock_docker_utils.container_start.assert_awaited()  # actually started
+        assert result["message"] == "Agent revived started"
+
+    def test_recreate_missing_container_reconstructs_spec_from_volume(self):
+        _mock_db.get_agent_owner.return_value = {"owner_username": "bob"}
+        _mock_db.get_resource_limits.return_value = {}
+        _mock_db.create_agent_mcp_api_key.return_value = Mock(api_key="trinity_mcp_x")
+
+        provision = AsyncMock(return_value=_make_container("created"))
+        tmpl = AsyncMock(return_value={"type": "researcher", "runtime": {"type": "codex"}})
+
+        with patch.object(_mod, "_provision_folders_and_run_agent_container", provision), \
+             patch.object(_mod, "_read_template_yaml_from_volume", tmpl), \
+             patch.object(_mod, "_apply_persisted_auth_env", Mock()), \
+             patch.object(_mod, "get_next_available_port", Mock(return_value=2245)), \
+             patch.object(_mod, "get_agent_full_capabilities", Mock(return_value=False)), \
+             patch.object(_mod, "get_agent_default_resources",
+                          Mock(return_value={"cpu": "2", "memory": "4g"})), \
+             patch.object(_mod, "validate_base_image", Mock()):
+            _run(_mod.recreate_missing_container("proj"))
+
+        provision.assert_awaited_once()
+        kwargs = provision.call_args.kwargs
+        # Existing workspace volume reused (never recreated), mounted at home.
+        assert kwargs["base_volumes"] == {
+            "agent-proj-workspace": {"bind": "/home/developer", "mode": "rw"}
+        }
+        # type + runtime recovered from the volume's template.yaml.
+        assert kwargs["labels"]["trinity.agent-type"] == "researcher"
+        assert kwargs["labels"]["trinity.agent-runtime"] == "codex"
+        assert kwargs["env_vars"]["AGENT_RUNTIME"] == "codex"
+        assert kwargs["env_vars"]["AGENT_NAME"] == "proj"


### PR DESCRIPTION
## Problem

Admin soft-delete recovery (#834 Phase 1c) could restore the `agent_ownership` row but **never bring the agent back online**. `recover_agent` deferred container creation to the operator; the only endpoint it deferred to — `POST /api/agents/{name}/start` → `start_agent_internal` — 404s when the container is gone (`get_agent_container` → None). And `recreate_container_with_updated_config` needs an `old_container` to copy config from, which never exists after a delete. Net: a recovered agent was visible, held all its child rows, and could never start.

## Fix

**`start` auto-recreates a missing container for a live agent** (the AC's option 2):

- `start_agent_internal`: when there's no container **but a live `agent_ownership` row exists** (recovered agent), rebuild it instead of 404. A genuinely nonexistent agent (no ownership row) still 404s. (`db.get_agent_owner` already filters soft-deleted rows, so a *not-yet-recovered* agent correctly still 404s — you must recover first.)
- **`recreate_missing_container(agent_name)`**: reconstructs the container spec from persisted state — `agent_ownership` (resources, capabilities, subscription, PAT, guardrails) + `agent_git_config` (repo/PAT) + the surviving **volume's `template.yaml`** for `type`/`runtime` (labels are gone with the container; the volume survives). Reuses the existing `agent-<name>-workspace` volume — **never recreated, no data loss**; `startup.sh` sees `.git` and skips the clone.
- Extracted the shared **folder-provision + secured `containers_run` tail** into `_provision_folders_and_run_agent_container()`, used by *both* recreate paths — so the full security posture (cap-drop ALL, AppArmor, noexec tmpfs, derived `TRINITY_AGENT_AUTH_TOKEN`, resource limits) is byte-identical and can't drift. **Not a hand-rolled `docker run`** (AC).
- `recover_agent`: message now points to `start` (which rebuilds); `needs_container_recreate` is honored by that path.

## AC coverage

- [x] Recovery restores a **startable** agent (start recreates the missing container from persisted config)
- [x] Existing workspace volume reused, never recreated (base_volumes pins `agent-<name>-workspace`; volume_get, no volume_create)
- [x] Full security posture via the shared supported path (not hand-rolled)
- [x] Subscription / resource limits / capabilities / guardrails / PAT survive (sourced from `agent_ownership` + `agent_git_config`)
- [x] `needs_container_recreate` honored by `start_agent_internal`
- [~] Regression: unit-tested the rebuild wiring + config reconstruction with a mocked docker/db layer (below). The full "reaches running + /stats 200" assertion needs a real container — I'll verify that against the local stack and report (per review).

## Tests (`tests/unit/test_start_agent_skip_inject.py::TestRecoverRecreate1559`)

- `start` 404s when there's no container **and** no ownership row;
- `start` **rebuilds** (calls `recreate_missing_container`) when the container is missing but the agent is live, then actually starts;
- `recreate_missing_container` reconstructs `type`/`runtime` from the volume's `template.yaml` and pins the existing workspace volume as the base mount.

All green locally (`test_start_agent_skip_inject.py`, `test_admin_recovery.py`).

## Note on MCP key

The old agent-scoped MCP key's plaintext is unrecoverable (only the hash is stored), so the rebuild **mints a fresh** agent-scoped key — same wiring as create; enables collab + heartbeat.

Related to #1559
