### PR TITLE
docs(announcements): webinar video announcement record 2026-07-10

### DIFF
--- a/docs/user-docs/dev-announcements/2026-07-10-163302.md
+++ b/docs/user-docs/dev-announcements/2026-07-10-163302.md
@@ -1,0 +1,53 @@
+---
+date: 2026-07-10T16:33:02
+channels:
+  - discord:updates
+  - slack:updates
+  - telegram:updates
+  - twitter:trinity
+  - twitter:default
+  - github:announcements
+links:
+  video: https://youtu.be/8w98dA6hDew
+  twitter_trinity: https://x.com/i/status/2075604101476323653
+  twitter_default: https://x.com/i/status/2075604128298872835
+  github_discussion: https://github.com/Abilityai/trinity/discussions/1569
+---
+
+🎥 New video is out after yesterday's webinar
+
+https://youtu.be/8w98dA6hDew
+
+Building an AI agent for your own use is one thing. Turning it into a secure, scalable product you can hand to a paying client — their own data, their own credentials, their own channel — is a completely different problem. Most agencies and consultants get this wrong.
+
+This webinar walks through the end-to-end pattern for deploying sovereign, isolated AI agents for each of your clients using the open-source Trinity platform — so you can productize your AI capability without turning into your clients' IT department.
+
+In this video, I cover:
+- The 'one agent per client' architecture for total data and credential isolation
+- Deploying Trinity as a sovereign platform inside your own infrastructure for full control
+- Live demo: creating and onboarding a new agent in minutes with Claude Code plugins
+- Connecting client-facing agents to a central, proprietary knowledge base (Cornelius)
+- Exposing agents to clients through familiar channels like Slack, Telegram, and WhatsApp
+- The real guardrails that stop an agent from deleting a production database — permissions, human-gated approvals, and playbooks
+
+Stop building one-off tools. Start building a scalable AI service platform for your entire client roster.
+
+Trinity is free and open source (Apache 2.0).
+
+---
+
+## Twitter variants (280-char)
+
+**trinity account:**
+New video from yesterday's webinar: deploy sovereign, isolated AI agents for every client on the open-source Trinity platform.
+
+One agent per client. Full data + credential isolation. Slack/Telegram/WhatsApp. Real guardrails.
+
+https://youtu.be/8w98dA6hDew
+
+**default account:**
+Building an AI agent for yourself is easy. Handing a secure, isolated one to a paying client — their data, their credentials, their channel — is the hard part.
+
+New webinar video on doing it right with open-source Trinity:
+
+https://youtu.be/8w98dA6hDew


### PR DESCRIPTION
## Summary
Adds the `/announce` record for the post-webinar video announcement sent 2026-07-10.

**Video:** https://youtu.be/8w98dA6hDew — "Deploying sovereign, isolated AI agents for every client" on open-source Trinity.

Delivered to all 6 configured channels:
- Discord (`updates`)
- Slack (`updates`)
- Telegram (`updates`)
- Twitter/X — [trinity](https://x.com/i/status/2075604101476323653) + [default](https://x.com/i/status/2075604128298872835)
- GitHub Discussions — [#1569](https://github.com/Abilityai/trinity/discussions/1569)

## Changes
- `docs/user-docs/dev-announcements/2026-07-10-163302.md` — timestamped record with frontmatter (channels, links) and the as-sent message body + Twitter variants.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)