### PR TITLE
fix(tests): pin real modules in TestAcquireCeilingClamp to kill sys.modules-leak flake (#1582)

### DIFF
--- a/tests/unit/test_capacity_manager.py
+++ b/tests/unit/test_capacity_manager.py
@@ -35,6 +35,28 @@ while _BACKEND_STR in sys.path:
 sys.path.insert(0, _BACKEND_STR)
 
 
+# #1582: collection-time capture of the real modules TestAcquireCeilingClamp
+# binds. A sibling's module-level `sys.modules` stub — the #762/#1446 leak
+# family, e.g. `test_fleet_status_resilience` installing a fresh `services`
+# package with a real `__path__` — can otherwise leave `capacity_manager`'s
+# call-time `from services.settings_service import clamp_to_ceiling` reading a
+# DIFFERENT settings_service object than the one a test patched, so the patch
+# is silently never hit (this file sorts before every known leaker, so this
+# import runs leak-free). The autouse fixture re-pins these per test
+# (last-write-wins over any leak) and the test patches the captured object
+# directly — never a bare re-import that could resolve a leaked stub.
+import importlib as _importlib
+
+_REAL_MODULES = {
+    _name: _importlib.import_module(_name)
+    for _name in (
+        "services",
+        "services.settings_service",
+        "services.capacity_manager",
+    )
+}
+
+
 pytestmark = pytest.mark.unit
 
 
@@ -197,9 +219,24 @@ class TestAcquireCeilingClamp:
     facade caller (chat ×3, task_execution_service, …).
     """
 
+    @pytest.fixture(autouse=True)
+    def _pin_real_modules(self, monkeypatch):
+        """#1582: re-pin the real modules into sys.modules for the duration of
+        each test so the code-under-test's call-time import and this test's
+        patch target resolve to the SAME object. monkeypatch auto-restores."""
+        for _name, _mod in _REAL_MODULES.items():
+            monkeypatch.setitem(sys.modules, _name, _mod)
+
     def _patch_ceiling(self, monkeypatch, value):
-        from services import settings_service as ss
-        monkeypatch.setattr(ss, "get_max_parallel_tasks_ceiling", lambda: value)
+        # #1582: patch the CAPTURED real module object directly. `clamp_to_ceiling`
+        # (imported inside acquire from the now-pinned services.settings_service)
+        # reads `get_max_parallel_tasks_ceiling` from this module's globals — so
+        # patching it here is guaranteed to be seen at call time.
+        monkeypatch.setattr(
+            _REAL_MODULES["services.settings_service"],
+            "get_max_parallel_tasks_ceiling",
+            lambda: value,
+        )
 
     def test_acquire_clamps_above_ceiling(self, capacity, slot_service, monkeypatch):
         """max_concurrent=5 with ceiling=2 → slot acquired with max_parallel_tasks=2."""


### PR DESCRIPTION
## Problem

On clean `dev`, the `TestAcquireCeilingClamp` trio flaked order-dependently under `pytest-randomly` (5/7 observed runs), while passing in isolation and under `-p no:randomly`:

```
FAILED test_capacity_manager.py::TestAcquireCeilingClamp::test_acquire_clamps_above_ceiling
FAILED test_capacity_manager.py::TestAcquireCeilingClamp::test_get_slot_state_clamps
FAILED test_capacity_manager.py::TestAcquireCeilingClamp::test_get_all_states_clamps_each
```

## Root cause (the #762/#1446 sys.modules-stub leak family)

`_patch_ceiling` patched `get_max_parallel_tasks_ceiling` on the module reached via `from services import settings_service`. But `capacity_manager.acquire` imports `clamp_to_ceiling` **at call time** from `services.settings_service`, and `clamp_to_ceiling` reads `get_max_parallel_tasks_ceiling` from **its own** module globals. When a sibling's module-level stub — e.g. `test_fleet_status_resilience` installing a fresh `services` package with a real `__path__` — leaves two module objects for `services.settings_service` in play, the patch lands on one object and the code reads the other. The patch is silently never hit, so the clamp assertion sees the unpatched default ceiling.

## Fix

The pattern documented for this leak family (collection-time capture + per-test re-pin):

- Capture the real `services` / `services.settings_service` / `services.capacity_manager` at **collection time** (this file sorts before every known leaker, so the import is leak-free).
- An autouse fixture re-pins them into `sys.modules` per test (monkeypatch auto-restores) so the code-under-test's call-time import and the test's patch target resolve to the **same** object — last-write-wins over any leak.
- `_patch_ceiling` now patches the **captured real module object** directly, never a bare re-import that could resolve a leaked stub.

Source under test is unchanged — this is a test-hermeticity fix only.

## Verification

- `test_capacity_manager.py`: **25/25** passed; trio **4/4**.
- With the known leaker co-resident (`test_fleet_status_resilience.py test_capacity_manager.py`), **32 passed across 6 random seeds** (1, 12345, 777, 42, 99, 2026).
- Full `tests/unit` randomized (`--continue-on-collection-errors`): **111 passed / 0 `TestAcquireCeilingClamp` failures across 5 seeds**.

Run in a throwaway container off `trinity-backend:latest`.

## Note / follow-up

This pins the *consumer* side. The deeper burn-down — converting the module-level `sys.modules.setdefault` stubbers (e.g. `test_fleet_status_resilience`) to auto-restored `mock.patch.dict` fixtures and reducing `tests/lint_sys_modules_baseline.txt` — remains the broader #762/#1446 track; out of scope here.

Related to #1582

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #1582
