### PR TITLE
feat(mcp): one-click Copy connection config on the Expose-via-MCP panel (#1575)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -642,6 +642,13 @@ never bypassed.
 - `mcp_exposed` is surfaced on `GET /api/agents` / MCP `list_agents`. Dual-track
   migration (SQLite `agent_ownership_mcp_exposed` + Alembic
   `0009_agent_ownership_mcp_exposed`).
+- **Connect surface (#1575):** the Expose-via-MCP panel (`components/McpExposedPanel.vue`)
+  gains a one-click **Copy connection config** action when exposed — it reuses the
+  existing [MCP connector](feature-flows/mcp-connector.md) (scoped `scope='connector'`
+  key + playbooks-as-tools + `build_snippets`) to hand an external client a
+  ready-to-paste `.mcp.json` with a least-privilege, agent-scoped, revocable key
+  already embedded. No new endpoint/key type — the connector endpoints are reused
+  (owner-only, keys already list in Settings → MCP Keys, revoke severs the connection).
 
 ### Brain Orb — Self-Rendering Mind page (#58, trinity-enterprise)
 

--- a/docs/memory/feature-flows/mcp-connector.md
+++ b/docs/memory/feature-flows/mcp-connector.md
@@ -21,6 +21,7 @@ the public repo and the entitlement gate was dropped front and back. Part B
 | MCP tools | `src/mcp-server/src/tools/connector.ts` | `list_playbooks` / `run_playbook` / `ask` — `connectorOnly` `canAccess` (already OSS) |
 | Auth fence | `src/backend/dependencies.py` | `_enforce_connector_scope` / `_reject_connector_principal` — edition-agnostic (already OSS) |
 | UI | `components/ConnectorChannelPanel.vue` + `ExposedToolsPanel.vue` | in `SharingPanel.vue`, un-gated (#118) |
+| UI (2nd surface) | `components/McpExposedPanel.vue` "Connect an external client" section | #1575: one-click **Copy connection config** on the #846 Expose-via-MCP panel (Settings tab), shown when `mcp_exposed` is on. Reuses the SAME connector endpoints (`GET/POST/DELETE /connector[/key]`) + `ExposedToolsPanel` picker — mint-or-reuse the scoped key, copy the `.mcp.json` (with the live key embedded, via `utils/clipboard.copyToClipboard`), regenerate/revoke. No new backend/key/endpoint. Copy-once secret: an existing key re-copies the placeholder config and offers "Regenerate & copy" for a fresh live key |
 
 ## Endpoints (all under `/api/agents`)
 

--- a/src/frontend/src/components/ConnectorChannelPanel.vue
+++ b/src/frontend/src/components/ConnectorChannelPanel.vue
@@ -85,7 +85,17 @@
           <div v-for="s in freshSnippets" :key="s.client">
             <div class="flex items-center justify-between mb-1">
               <span class="text-xs font-medium text-gray-700 dark:text-gray-200">{{ s.label }}</span>
-              <button type="button" @click="copy(s.content)" class="text-xs text-action-primary-600 hover:underline">Copy</button>
+              <button
+                type="button"
+                @click="copy(s.content, s.client)"
+                class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded transition-all duration-300"
+                :class="copied === s.client
+                  ? 'bg-status-success-600 text-white ring-2 ring-status-success-400 shadow-sm shadow-status-success-500/40 copied-btn-flash'
+                  : 'text-action-primary-600 hover:underline'"
+              >
+                <svg v-if="copied === s.client" class="h-3.5 w-3.5 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                {{ copied === s.client ? 'Copied!' : 'Copy' }}
+              </button>
             </div>
             <pre class="text-xs bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 overflow-x-auto"><code>{{ s.content }}</code></pre>
             <p v-if="s.note" class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ s.note }}</p>
@@ -99,8 +109,9 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
 import api from '../api'
+import { copyToClipboard } from '../utils/clipboard'
 import ExposedToolsPanel from './ExposedToolsPanel.vue'
 
 const props = defineProps({
@@ -174,15 +185,45 @@ const toggleEnabled = async () => {
   }
 }
 
-const copy = async (text) => {
-  try {
-    await navigator.clipboard.writeText(text)
-    notify('Copied to clipboard.')
-  } catch {
-    notify('Copy failed — select and copy manually.', true)
-  }
+// Transient per-snippet "Copied!" affordance — holds the copied snippet's
+// client id for ~1.6s so the button flashes green. One shared timer.
+const copied = ref('')
+let copiedTimer = null
+const flashCopied = (id) => {
+  copied.value = id
+  if (copiedTimer) clearTimeout(copiedTimer)
+  copiedTimer = setTimeout(() => { copied.value = '' }, 1600)
+}
+
+const copy = async (text, id = '') => {
+  const ok = await copyToClipboard(text)
+  if (ok && id) flashCopied(id)
+  notify(ok ? 'Copied to clipboard.' : 'Copy failed — select and copy manually.', !ok)
 }
 
 watch(() => props.agentName, () => loadStatus())
 onMounted(() => loadStatus())
+onUnmounted(() => { if (copiedTimer) clearTimeout(copiedTimer) })
 </script>
+
+<style scoped>
+.copied-pop {
+  animation: copied-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes copied-pop {
+  0% { transform: scale(0.4); opacity: 0; }
+  60% { transform: scale(1.15); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+.copied-btn-flash {
+  animation: copied-btn-flash 0.55s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes copied-btn-flash {
+  0% { transform: scale(1); box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55); }
+  40% { transform: scale(1.06); box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.28); }
+  100% { transform: scale(1); box-shadow: 0 0 0 10px rgba(34, 197, 94, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .copied-pop, .copied-btn-flash { animation: none; }
+}
+</style>

--- a/src/frontend/src/components/McpExposedPanel.vue
+++ b/src/frontend/src/components/McpExposedPanel.vue
@@ -79,10 +79,12 @@
             type="button"
             @click="mintAndCopy"
             :disabled="connectorBusy"
-            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50"
+            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md text-white disabled:opacity-50 transition-colors duration-300"
+            :class="copied === 'config' ? 'bg-status-success-600 hover:bg-status-success-600' : 'bg-action-primary-600 hover:bg-action-primary-700'"
           >
-            <svg v-if="!connectorBusy" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 4h8a2 2 0 012 2v6a2 2 0 01-2 2h-8a2 2 0 01-2-2v-6a2 2 0 012-2z"/></svg>
-            {{ connectorBusy ? 'Generating…' : 'Copy connection config' }}
+            <svg v-if="copied === 'config'" class="h-4 w-4 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+            <svg v-else-if="!connectorBusy" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 4h8a2 2 0 012 2v6a2 2 0 01-2 2h-8a2 2 0 01-2-2v-6a2 2 0 012-2z"/></svg>
+            {{ copied === 'config' ? 'Copied!' : (connectorBusy ? 'Generating…' : 'Copy connection config') }}
           </button>
           <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
             Generates a scoped key and copies a ready-to-paste
@@ -113,8 +115,12 @@
                   type="button"
                   @click="copyExistingConfig"
                   :disabled="connectorBusy"
-                  class="px-3 py-1.5 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
-                >Copy config</button>
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md disabled:opacity-50 transition-colors duration-300"
+                  :class="copied === 'existing' ? 'bg-status-success-100 dark:bg-status-success-900/40 text-status-success-700 dark:text-status-success-300' : 'text-gray-700 dark:text-gray-200 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'"
+                >
+                  <svg v-if="copied === 'existing'" class="h-3.5 w-3.5 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                  {{ copied === 'existing' ? 'Copied!' : 'Copy config' }}
+                </button>
                 <button
                   type="button"
                   @click="mintAndCopy"
@@ -160,7 +166,15 @@
             <div v-for="s in freshSnippets" :key="s.client">
               <div class="flex items-center justify-between mb-1">
                 <span class="text-xs font-medium text-gray-700 dark:text-gray-200">{{ s.label }}</span>
-                <button type="button" @click="copyText(s.content)" class="text-xs text-action-primary-600 hover:underline">Copy</button>
+                <button
+                  type="button"
+                  @click="copyText(s.content, s.client)"
+                  class="inline-flex items-center gap-1 text-xs hover:underline transition-colors duration-300"
+                  :class="copied === s.client ? 'text-status-success-600 dark:text-status-success-400' : 'text-action-primary-600'"
+                >
+                  <svg v-if="copied === s.client" class="h-3 w-3 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                  {{ copied === s.client ? 'Copied!' : 'Copy' }}
+                </button>
               </div>
               <pre class="text-xs bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 overflow-x-auto"><code>{{ s.content }}</code></pre>
               <p v-if="s.note" class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ s.note }}</p>
@@ -173,7 +187,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useAgentsStore } from '../stores/agents'
 import api from '../api'
 import { copyToClipboard } from '../utils/clipboard'
@@ -201,6 +215,18 @@ const connectorLoading = ref(false)
 const connectorBusy = ref(false)
 const connectorAccessDenied = ref(false)
 const freshSnippets = ref([])
+
+// Transient "Copied!" affordance — holds the id of the last-copied target
+// ('config' | 'existing' | a snippet client) for ~1.6s, then clears. One shared
+// timer so rapid clicks across buttons don't overlap.
+const copied = ref('')
+let copiedTimer = null
+function flashCopied(id) {
+  copied.value = id
+  if (copiedTimer) clearTimeout(copiedTimer)
+  copiedTimer = setTimeout(() => { copied.value = '' }, 1600)
+}
+onUnmounted(() => { if (copiedTimer) clearTimeout(copiedTimer) })
 
 // The `.mcp.json` block is the canonical one-click paste target; fall back to
 // the first snippet if the client shape ever changes.
@@ -274,13 +300,14 @@ async function mintAndCopy() {
     const snippets = data.snippets || []
     freshSnippets.value = snippets
     const cfg = pickConfigSnippet(snippets)
-    const copied = cfg ? await copyToClipboard(cfg.content) : false
+    const didCopy = cfg ? await copyToClipboard(cfg.content) : false
+    if (didCopy) flashCopied('config')
     await loadConnector()
     notifyUser(
-      copied
+      didCopy
         ? 'Connection config copied — contains a live key, shown only once.'
         : 'Connection key generated — copy the config below.',
-      copied ? 'success' : 'info'
+      didCopy ? 'success' : 'info'
     )
   } catch (e) {
     notifyUser(e.response?.data?.detail || `Failed to generate connection config: ${e.message}`, 'error')
@@ -297,12 +324,13 @@ async function copyExistingConfig() {
     notifyUser('No connection config available — regenerate the key.', 'error')
     return
   }
-  const copied = await copyToClipboard(cfg.content)
+  const didCopy = await copyToClipboard(cfg.content)
+  if (didCopy) flashCopied('existing')
   notifyUser(
-    copied
+    didCopy
       ? 'Config copied (key placeholder). Use “Regenerate & copy” to embed a live key.'
       : 'Copy failed — select and copy manually.',
-    copied ? 'success' : 'error'
+    didCopy ? 'success' : 'error'
   )
 }
 
@@ -320,10 +348,27 @@ async function revokeKey() {
   }
 }
 
-async function copyText(text) {
+async function copyText(text, id = '') {
   const ok = await copyToClipboard(text)
+  if (ok && id) flashCopied(id)
   notifyUser(ok ? 'Copied to clipboard.' : 'Copy failed — select and copy manually.', ok ? 'success' : 'error')
 }
 
 onMounted(loadStatus)
 </script>
+
+<style scoped>
+/* Checkmark "pop" when a copy succeeds — scales/fades in, respects
+   reduced-motion. */
+.copied-pop {
+  animation: copied-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes copied-pop {
+  0% { transform: scale(0.4); opacity: 0; }
+  60% { transform: scale(1.15); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .copied-pop { animation: none; }
+}
+</style>

--- a/src/frontend/src/components/McpExposedPanel.vue
+++ b/src/frontend/src/components/McpExposedPanel.vue
@@ -79,12 +79,14 @@
             type="button"
             @click="mintAndCopy"
             :disabled="connectorBusy"
-            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md text-white disabled:opacity-50 transition-colors duration-300"
-            :class="copied === 'config' ? 'bg-status-success-600 hover:bg-status-success-600' : 'bg-action-primary-600 hover:bg-action-primary-700'"
+            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold rounded-md text-white disabled:opacity-50 transition-all duration-300"
+            :class="copied === 'config'
+              ? 'bg-status-success-600 hover:bg-status-success-600 ring-2 ring-status-success-400 ring-offset-2 ring-offset-white dark:ring-offset-gray-900 shadow-lg shadow-status-success-500/40 copied-btn-flash'
+              : 'bg-action-primary-600 hover:bg-action-primary-700'"
           >
-            <svg v-if="copied === 'config'" class="h-4 w-4 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+            <svg v-if="copied === 'config'" class="h-5 w-5 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
             <svg v-else-if="!connectorBusy" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 4h8a2 2 0 012 2v6a2 2 0 01-2 2h-8a2 2 0 01-2-2v-6a2 2 0 012-2z"/></svg>
-            {{ copied === 'config' ? 'Copied!' : (connectorBusy ? 'Generating…' : 'Copy connection config') }}
+            {{ copied === 'config' ? 'Copied to clipboard!' : (connectorBusy ? 'Generating…' : 'Copy connection config') }}
           </button>
           <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
             Generates a scoped key and copies a ready-to-paste
@@ -115,10 +117,12 @@
                   type="button"
                   @click="copyExistingConfig"
                   :disabled="connectorBusy"
-                  class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md disabled:opacity-50 transition-colors duration-300"
-                  :class="copied === 'existing' ? 'bg-status-success-100 dark:bg-status-success-900/40 text-status-success-700 dark:text-status-success-300' : 'text-gray-700 dark:text-gray-200 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'"
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-semibold rounded-md disabled:opacity-50 transition-all duration-300"
+                  :class="copied === 'existing'
+                    ? 'bg-status-success-600 text-white ring-2 ring-status-success-400 shadow-md shadow-status-success-500/40 copied-btn-flash'
+                    : 'text-gray-700 dark:text-gray-200 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'"
                 >
-                  <svg v-if="copied === 'existing'" class="h-3.5 w-3.5 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                  <svg v-if="copied === 'existing'" class="h-4 w-4 copied-pop" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
                   {{ copied === 'existing' ? 'Copied!' : 'Copy config' }}
                 </button>
                 <button
@@ -368,7 +372,19 @@ onMounted(loadStatus)
   60% { transform: scale(1.15); opacity: 1; }
   100% { transform: scale(1); opacity: 1; }
 }
+
+/* Whole-button flash on copy — a quick pop plus an outward ring pulse so the
+   state change is unmissable, then settles into the steady green. */
+.copied-btn-flash {
+  animation: copied-btn-flash 0.55s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes copied-btn-flash {
+  0% { transform: scale(1); box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55); }
+  40% { transform: scale(1.06); box-shadow: 0 0 0 8px rgba(34, 197, 94, 0.28); }
+  100% { transform: scale(1); box-shadow: 0 0 0 12px rgba(34, 197, 94, 0); }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .copied-pop { animation: none; }
+  .copied-pop, .copied-btn-flash { animation: none; }
 }
 </style>

--- a/src/frontend/src/components/McpExposedPanel.vue
+++ b/src/frontend/src/components/McpExposedPanel.vue
@@ -42,12 +42,142 @@
       Tool name:
       <code class="font-mono text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">{{ status.tool_name }}</code>
     </div>
+
+    <!-- Connect an external client (#1575) — one-click, ready-to-paste config
+         with a least-privilege, agent-scoped, revocable key already embedded.
+         Reuses the per-agent MCP connector (scope='connector' key); the config
+         exposes this agent's chat plus the owner-selected playbooks as tools. -->
+    <div
+      v-if="status.enabled && !connectorAccessDenied"
+      class="mt-5 pt-5 border-t border-gray-200 dark:border-gray-700"
+    >
+      <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
+        Connect an external client
+      </h4>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+        Copy a ready-to-paste config (Claude Code, Cursor, Claude Desktop) with a
+        scoped API key already embedded — no separate key steps. The key reaches
+        only this agent and is revocable below.
+      </p>
+
+      <!-- Loading connector state -->
+      <div
+        v-if="connectorLoading"
+        class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400"
+      >
+        <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+        Loading connection…
+      </div>
+
+      <template v-else>
+        <!-- No key yet: one click mints + copies a live config -->
+        <div v-if="!connector.has_key">
+          <button
+            type="button"
+            @click="mintAndCopy"
+            :disabled="connectorBusy"
+            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50"
+          >
+            <svg v-if="!connectorBusy" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 4h8a2 2 0 012 2v6a2 2 0 01-2 2h-8a2 2 0 01-2-2v-6a2 2 0 012-2z"/></svg>
+            {{ connectorBusy ? 'Generating…' : 'Copy connection config' }}
+          </button>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
+            Generates a scoped key and copies a ready-to-paste
+            <code class="font-mono">.mcp.json</code>. The key is shown only once.
+          </p>
+        </div>
+
+        <!-- Key exists: reuse; secret is copy-once, so re-copy is placeholder + regenerate -->
+        <div v-else class="space-y-3">
+          <div class="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div class="flex items-center justify-between gap-2 flex-wrap">
+              <div class="flex items-center gap-2 text-sm">
+                <span
+                  class="inline-block w-2.5 h-2.5 rounded-full"
+                  :class="connector.enabled ? 'bg-status-success-500' : 'bg-gray-400 dark:bg-gray-600'"
+                ></span>
+                <span class="text-gray-900 dark:text-gray-100">
+                  Connection key
+                  <code class="text-xs">{{ connector.key_prefix }}…</code>
+                </span>
+                <span
+                  v-if="!connector.enabled"
+                  class="px-1.5 py-0.5 text-xs rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+                >Disabled</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <button
+                  type="button"
+                  @click="copyExistingConfig"
+                  :disabled="connectorBusy"
+                  class="px-3 py-1.5 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
+                >Copy config</button>
+                <button
+                  type="button"
+                  @click="mintAndCopy"
+                  :disabled="connectorBusy"
+                  class="px-3 py-1.5 text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50"
+                >{{ connectorBusy ? 'Working…' : 'Regenerate & copy' }}</button>
+                <button
+                  type="button"
+                  @click="revokeKey"
+                  :disabled="connectorBusy"
+                  class="px-3 py-1.5 text-sm font-medium rounded-md text-white bg-status-danger-600 hover:bg-status-danger-700 disabled:opacity-50"
+                >Revoke</button>
+              </div>
+            </div>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
+              The live key is shown only when generated. “Copy config” copies the
+              config with a placeholder — use “Regenerate &amp; copy” to embed a
+              fresh live key (this invalidates the old one). Revoking severs any
+              connected client.
+            </p>
+          </div>
+
+          <!-- Owner-selected playbooks exposed as tools (reuses the connector allow-list) -->
+          <ExposedToolsPanel :agent-name="agentName" />
+        </div>
+
+        <!-- One-time secret + per-client snippets after mint/regenerate -->
+        <div
+          v-if="freshSnippets.length"
+          class="mt-3 p-4 rounded-lg border border-state-autonomous-200 dark:border-state-autonomous-800/40 bg-state-autonomous-50 dark:bg-state-autonomous-900/20"
+        >
+          <div class="flex items-center justify-between mb-2">
+            <p class="text-sm font-medium text-state-autonomous-900 dark:text-state-autonomous-200">
+              Copied to clipboard — this config contains a live key, shown only once.
+            </p>
+            <button
+              type="button"
+              @click="freshSnippets = []"
+              class="text-xs text-gray-500 dark:text-gray-400 hover:underline"
+            >Dismiss</button>
+          </div>
+          <div class="space-y-3">
+            <div v-for="s in freshSnippets" :key="s.client">
+              <div class="flex items-center justify-between mb-1">
+                <span class="text-xs font-medium text-gray-700 dark:text-gray-200">{{ s.label }}</span>
+                <button type="button" @click="copyText(s.content)" class="text-xs text-action-primary-600 hover:underline">Copy</button>
+              </div>
+              <pre class="text-xs bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 overflow-x-auto"><code>{{ s.content }}</code></pre>
+              <p v-if="s.note" class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ s.note }}</p>
+            </div>
+          </div>
+        </div>
+      </template>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useAgentsStore } from '../stores/agents'
+import api from '../api'
+import { copyToClipboard } from '../utils/clipboard'
+import ExposedToolsPanel from './ExposedToolsPanel.vue'
 
 const props = defineProps({
   agentName: { type: String, required: true },
@@ -65,14 +195,43 @@ const status = ref({ enabled: false, tool_name: '' })
 const statusLoading = ref(false)
 const toggleLoading = ref(false)
 
+// --- Connect-an-external-client state (#1575) ---
+const connector = ref({ has_key: false, enabled: false, key_prefix: null, mcp_url: null, snippets: [] })
+const connectorLoading = ref(false)
+const connectorBusy = ref(false)
+const connectorAccessDenied = ref(false)
+const freshSnippets = ref([])
+
+// The `.mcp.json` block is the canonical one-click paste target; fall back to
+// the first snippet if the client shape ever changes.
+function pickConfigSnippet(snippets) {
+  if (!Array.isArray(snippets) || !snippets.length) return null
+  return snippets.find((s) => s.client === 'claude-code-json') || snippets[0]
+}
+
 async function loadStatus() {
   statusLoading.value = true
   try {
     status.value = await agentsStore.getMcpExposedStatus(props.agentName)
+    if (status.value.enabled) await loadConnector()
   } catch (e) {
     notifyUser(`Failed to load MCP exposure status: ${e.message}`, 'error')
   } finally {
     statusLoading.value = false
+  }
+}
+
+async function loadConnector() {
+  connectorLoading.value = true
+  connectorAccessDenied.value = false
+  try {
+    const { data } = await api.get(`/api/agents/${props.agentName}/connector`)
+    connector.value = data
+  } catch (e) {
+    if (e.response?.status === 403) connectorAccessDenied.value = true
+    else notifyUser(e.response?.data?.detail || `Failed to load connection config: ${e.message}`, 'error')
+  } finally {
+    connectorLoading.value = false
   }
 }
 
@@ -91,6 +250,8 @@ async function onToggle(enabled) {
         : 'No longer exposed via MCP.',
       'success'
     )
+    if (enabled) await loadConnector()
+    else freshSnippets.value = []
   } catch (e) {
     notifyUser(
       e.response?.data?.detail || `Failed to toggle MCP exposure: ${e.message}`,
@@ -101,6 +262,67 @@ async function onToggle(enabled) {
   } finally {
     toggleLoading.value = false
   }
+}
+
+// Mint (or regenerate) the scoped key and copy the ready-to-paste config in one
+// click — this is the moment the live secret exists, so it's the only path that
+// yields a paste-and-it-works config.
+async function mintAndCopy() {
+  connectorBusy.value = true
+  try {
+    const { data } = await api.post(`/api/agents/${props.agentName}/connector/key`)
+    const snippets = data.snippets || []
+    freshSnippets.value = snippets
+    const cfg = pickConfigSnippet(snippets)
+    const copied = cfg ? await copyToClipboard(cfg.content) : false
+    await loadConnector()
+    notifyUser(
+      copied
+        ? 'Connection config copied — contains a live key, shown only once.'
+        : 'Connection key generated — copy the config below.',
+      copied ? 'success' : 'info'
+    )
+  } catch (e) {
+    notifyUser(e.response?.data?.detail || `Failed to generate connection config: ${e.message}`, 'error')
+  } finally {
+    connectorBusy.value = false
+  }
+}
+
+// Re-copy for an existing key: the live secret is copy-once, so this copies the
+// placeholder config (correct URL/transport) and points the user at Regenerate.
+async function copyExistingConfig() {
+  const cfg = pickConfigSnippet(connector.value.snippets)
+  if (!cfg) {
+    notifyUser('No connection config available — regenerate the key.', 'error')
+    return
+  }
+  const copied = await copyToClipboard(cfg.content)
+  notifyUser(
+    copied
+      ? 'Config copied (key placeholder). Use “Regenerate & copy” to embed a live key.'
+      : 'Copy failed — select and copy manually.',
+    copied ? 'success' : 'error'
+  )
+}
+
+async function revokeKey() {
+  connectorBusy.value = true
+  try {
+    await api.delete(`/api/agents/${props.agentName}/connector/key`)
+    freshSnippets.value = []
+    await loadConnector()
+    notifyUser('Connection key revoked — any connected client is now severed.', 'success')
+  } catch (e) {
+    notifyUser(e.response?.data?.detail || `Failed to revoke key: ${e.message}`, 'error')
+  } finally {
+    connectorBusy.value = false
+  }
+}
+
+async function copyText(text) {
+  const ok = await copyToClipboard(text)
+  notifyUser(ok ? 'Copied to clipboard.' : 'Copy failed — select and copy manually.', ok ? 'success' : 'error')
 }
 
 onMounted(loadStatus)


### PR DESCRIPTION
## What & why

Adds a one-click **Copy connection config** to the #846 *Expose via MCP* panel: it hands an external MCP client a ready-to-paste `.mcp.json` with a **least-privilege, agent-scoped, revocable API key already embedded** — so "enable → copy → paste → it works" is one flow, no separate key-minting step.

## Key finding (recorded before building)

The hard parts of #1575 — an **agent-scoped scoped key**, **owner-selected playbooks exposed as tools**, and **copy-paste `.mcp.json`/CLI snippets with the key embedded** — already ship as the **per-agent MCP connector** (ent#46 → OSS #118), but only on the **Sharing** tab. Rather than build a duplicate credential system (which the issue itself warns against: *"Do not embed a fleet-wide user key"*), this PR **reuses the connector** and surfaces it on the exposure panel. Baseline state was captured before any change and the direction was confirmed with the maintainer.

## Implementation (frontend-only — no new endpoint or key type)

`src/frontend/src/components/McpExposedPanel.vue` gains a **"Connect an external client"** section, shown when `mcp_exposed` is on:

- **One-click "Copy connection config"** → `POST /api/agents/{name}/connector/key` mints (auto-enables) the scoped `scope='connector'` key and copies the `.mcp.json` snippet in a single action, via the robust `utils/clipboard.copyToClipboard`. This is the only moment the live secret exists.
- **Copy-once integrity**: with an existing key, *Copy config* copies the placeholder config + offers *Regenerate & copy* for a fresh live key; *Revoke* (`DELETE .../connector/key`) severs any connected client.
- **Playbooks as tools**: embeds the existing `ExposedToolsPanel` (owner picks which `user_invocable` playbooks the connection exposes; reuses the connector allow-list).
- Reuses `GET/PUT/POST/DELETE /api/agents/{name}/connector[/key]` — all `OwnedAgentByName` (owner-only; 403 for non-owners) and already registered without colliding with the `/{name}` catch-all.

## Acceptance criteria

- [x] Copy-config action on the exposure panel, owner/admin only (gated on `mcp_exposed`).
- [x] Mints/reuses a **user-owned, agent-scoped, least-privilege** key and returns a ready-to-paste `.mcp.json` with the key **embedded**, copied to the clipboard.
- [x] Owner selects which playbooks the connection exposes (invocable as tools; unselected excluded).
- [x] Key appears in **Settings → MCP Keys** (connector keys already list there) and **revoke severs** the connection.
- [x] Safe default OFF (section only appears once exposed); live-key warning + copy-once affordance.
- [x] Honest status: shows whether a key exists (reuse vs mint), offers regenerate/revoke; last-used via MCP Keys.
- [x] Graceful chat-only config when no playbooks selected; MCP URL auto-resolved (`resolve_mcp_url`).
- [x] Owner-only mint (403 non-owner); no new endpoint so Invariant #4 N/A; no new MCP/agent-server surface (reuses connector).
- [ ] **Deferred (documented)**: a 422 on an *invalid playbook name* — the picker only offers live `user_invocable` playbooks, so the invalid path is UI-unreachable; left to the connector's read-time filter.

## Verification

- `McpExposedPanel.vue` compiles clean via `@vue/compiler-sfc` (script + template).
- Full `vite build` is blocked by a **pre-existing unrelated** missing `mermaid` dep in `AgentWorkspace.vue` (not touched here).
- Live click-through / `ui`-labeled Playwright e2e needs the running frontend+backend stack (not up in this environment), so it's a follow-up under the `ui` label. The reused connector endpoints are already covered.

## Docs

`feature-flows/mcp-connector.md` gains a 2nd-surface row; the architecture #846 block notes the connect surface.

Related to #1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1575
