### PR TITLE
fix(tests): conftest no longer deletes real agents named test-* (#1558)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,14 @@
 # Trinity Tests
 
+> ⚠️ **This suite mutates the target instance.** The API fixtures **create and
+> delete real agents** on whatever `TRINITY_API_URL` points at. **Point it at a
+> local dev instance — never staging/production.** Every agent the suite creates
+> is named with the `pytest-ephemeral-` prefix and torn down by name; the suite
+> **never deletes an agent it did not create**. A leftover-sweep for crashed
+> runs is **OFF by default** — enable with `TRINITY_TEST_CLEANUP_SWEEP=1`, and
+> even then it only removes `pytest-ephemeral-` agents on a localhost target
+> (#1558).
+
 ## Quick start
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
 """
 Shared pytest fixtures for Trinity API tests.
 
+⚠️  THIS SUITE MUTATES THE TARGET INSTANCE. The API fixtures CREATE and DELETE
+real agents on whatever ``TRINITY_API_URL`` points at. Point it at a local dev
+instance — never staging/production. Every agent the suite creates is named
+with the ``pytest-ephemeral-`` prefix and is torn down by name; the suite never
+deletes an agent it did not create. The optional leftover-sweep (for crashed
+runs) is OFF by default and, even when enabled, only removes
+``pytest-ephemeral-`` agents on a localhost target (#1558).
+
 OPTIMIZATION NOTES (2025-12-09):
 - Module-scoped agent fixture: Creates ONE agent per test FILE (not per test)
 - Session-scoped shared agent: Single agent for tests that can share
@@ -12,6 +20,9 @@ Configuration:
 - TRINITY_TEST_PASSWORD: Test user password (default: password)
 - TRINITY_MCP_API_KEY: MCP API key for authenticated tests
 - TEST_AGENT_NAME: Pre-existing agent for agent-server tests
+- TRINITY_TEST_CLEANUP_SWEEP: opt-in (1/true) — sweep leftover
+  ``pytest-ephemeral-`` agents from prior crashed runs at session start.
+  Refuses unless TRINITY_API_URL is localhost. Default OFF (#1558).
 """
 
 # Skip test files that require backend context (can't be run from test suite)
@@ -311,7 +322,15 @@ def _restore_sys_modules_baseline_762():
     _restore_invariant_sys_modules()
 
 from utils.api_client import TrinityApiClient, ApiConfig
-from utils.cleanup import ResourceTracker, cleanup_test_agent
+from utils.cleanup import (
+    ResourceTracker,
+    cleanup_test_agent,
+    register_created_agent,
+    session_created_agents,
+    select_sweepable_agents,
+    is_local_target,
+    EPHEMERAL_AGENT_PREFIX,
+)
 
 
 def pytest_configure(config):
@@ -358,28 +377,61 @@ def api_config() -> ApiConfig:
 def api_client(api_config: ApiConfig) -> Generator[TrinityApiClient, None, None]:
     """Create authenticated API client for the test session.
 
-    Also cleans up leftover test agents from prior runs to avoid quota exhaustion.
+    #1558: the previous version deleted EVERY agent named ``test-*`` on the
+    target instance at session start — silent, unprompted data loss that
+    destroyed real user agents. The leftover-sweep is now:
+      - OFF by default (opt-in via ``TRINITY_TEST_CLEANUP_SWEEP``),
+      - localhost-only (refuses staging/prod), and
+      - scoped to the suite's own ``pytest-ephemeral-`` prefix — never the
+        broad ``test-`` a human might use.
+    Agents this session creates are registered and reclaimed by name at the end
+    (belt-and-suspenders over each fixture's own teardown).
     """
+    import sys
+
     client = TrinityApiClient(api_config)
     try:
         client.authenticate()
 
-        # Clean up leftover test agents from prior runs
+        # Opt-in leftover-sweep for crashed prior runs. select_sweepable_agents
+        # is fail-closed: [] unless enabled AND localhost, and only ever returns
+        # provably suite-owned names.
+        sweep_enabled = os.getenv("TRINITY_TEST_CLEANUP_SWEEP", "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+        if sweep_enabled and not is_local_target(api_config.base_url):
+            print(
+                f"\n[conftest] TRINITY_TEST_CLEANUP_SWEEP set but target "
+                f"'{api_config.base_url}' is not localhost — refusing to sweep (#1558)",
+                file=sys.stderr,
+            )
         try:
             response = client.get("/api/agents")
             if response.status_code == 200:
-                agents = response.json()
-                leftover = [a["name"] for a in agents if a["name"].startswith("test-")]
+                names = [a["name"] for a in response.json()]
+                leftover = select_sweepable_agents(
+                    names, api_config.base_url, enabled=sweep_enabled
+                )
                 for name in leftover:
-                    cleanup_test_agent(client, name)
+                    cleanup_test_agent(client, name, require_suite_owned=True)
                 if leftover:
-                    import sys
-                    print(f"\n[conftest] Cleaned up {len(leftover)} leftover test agents", file=sys.stderr)
+                    print(
+                        f"\n[conftest] Swept {len(leftover)} leftover "
+                        f"'{EPHEMERAL_AGENT_PREFIX}' agent(s)",
+                        file=sys.stderr,
+                    )
         except Exception:
             pass  # Best-effort cleanup
 
         yield client
     finally:
+        # Reclaim any agent this session created that a fixture teardown missed
+        # (e.g. a crashed fixture). Only touches registered, suite-owned names.
+        for name in session_created_agents():
+            try:
+                cleanup_test_agent(client, name, require_suite_owned=True)
+            except Exception:
+                pass
         client.close()
 
 
@@ -415,8 +467,16 @@ def ws_ticket(api_client: TrinityApiClient) -> Callable[[], str]:
 
 @pytest.fixture(scope="function")
 def test_agent_name() -> str:
-    """Generate unique test agent name."""
-    return f"test-api-agent-{uuid.uuid4().hex[:8]}"
+    """Generate unique test agent name.
+
+    #1558: uses the dedicated ``pytest-ephemeral-`` prefix (never the broad
+    ``test-``) and registers the name so it's reclaimed at session end even if a
+    test forgets its own teardown. Registering an unused name is harmless — the
+    reclaim is 404-tolerant.
+    """
+    name = f"{EPHEMERAL_AGENT_PREFIX}agent-{uuid.uuid4().hex[:8]}"
+    register_created_agent(name)
+    return name
 
 
 @pytest.fixture(scope="function")
@@ -445,9 +505,11 @@ def test_schedule_name() -> str:
 @pytest.fixture(scope="module")
 def module_agent_name(request) -> str:
     """Generate unique agent name for the module."""
-    # Use module name to create predictable but unique name
+    # Use module name to create predictable but unique name (#1558: ephemeral prefix)
     module_name = request.module.__name__.replace("test_", "").replace("_", "-")[:20]
-    return f"test-{module_name}-{uuid.uuid4().hex[:6]}"
+    name = f"{EPHEMERAL_AGENT_PREFIX}{module_name}-{uuid.uuid4().hex[:6]}"
+    register_created_agent(name)
+    return name
 
 
 @pytest.fixture(scope="module")
@@ -509,7 +571,8 @@ def stopped_agent(
     Creates agent, waits for it to start, then stops it.
     OPTIMIZED: scope="module" - one stopped agent per test file.
     """
-    agent_name = f"test-stopped-{uuid.uuid4().hex[:6]}"
+    agent_name = f"{EPHEMERAL_AGENT_PREFIX}stopped-{uuid.uuid4().hex[:6]}"
+    register_created_agent(agent_name)
 
     # Create the agent
     response = api_client.post(
@@ -558,7 +621,8 @@ def shared_agent(api_client: TrinityApiClient, request) -> Generator[dict, None,
     - Test agent creation/deletion
     - Need a clean agent state
     """
-    agent_name = f"test-shared-session-{uuid.uuid4().hex[:6]}"
+    agent_name = f"{EPHEMERAL_AGENT_PREFIX}shared-{uuid.uuid4().hex[:6]}"
+    register_created_agent(agent_name)
 
     # Create agent
     response = api_client.post(

--- a/tests/testing_utils/cleanup.py
+++ b/tests/testing_utils/cleanup.py
@@ -8,11 +8,91 @@ files stored in agent containers and are cleaned up when agents are deleted.
 """
 
 import re
+import sys
+from urllib.parse import urlparse
 from typing import List, Set
 from .api_client import TrinityApiClient
 
 # Pattern for test resources
 TEST_RESOURCE_PATTERN = re.compile(r"^test-api-.*")
+
+# ---------------------------------------------------------------------------
+# #1558: agent-deletion safety.
+#
+# The suite creates ephemeral agents and must be able to reclaim them without
+# ever touching a user's real agents. Two guarantees:
+#   1. Every agent the suite creates is named with THIS prefix — a namespace no
+#      human would use — so a crashed-run sweep can prove an agent is ours by
+#      name alone (NOT the broad, collision-prone `test-`).
+#   2. Agents created in the current session are registered in a set and torn
+#      down explicitly by name.
+# ---------------------------------------------------------------------------
+EPHEMERAL_AGENT_PREFIX = "pytest-ephemeral-"
+
+# Names of agents this pytest session created (registered at creation time).
+_SESSION_CREATED_AGENTS: Set[str] = set()
+
+# Hosts we consider "local" for the opt-in destructive sweep. Anything else
+# (staging/prod) is refused so pointing the suite at a real instance can never
+# delete its agents.
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0", ""}
+
+
+def register_created_agent(name: str) -> None:
+    """Record an agent the session created, so it can be torn down by name."""
+    if name:
+        _SESSION_CREATED_AGENTS.add(name)
+
+
+def session_created_agents() -> Set[str]:
+    """Snapshot of agents this session created (for end-of-session teardown)."""
+    return set(_SESSION_CREATED_AGENTS)
+
+
+def is_session_created(name: str) -> bool:
+    """True if the session registered ``name`` as one it created."""
+    return name in _SESSION_CREATED_AGENTS
+
+
+def is_local_target(base_url: str) -> bool:
+    """True only when ``base_url`` points at a local instance.
+
+    The destructive leftover-sweep refuses to run against anything else so the
+    suite can never delete agents on staging/production (#1558).
+    """
+    try:
+        host = urlparse(base_url).hostname
+    except Exception:
+        return False
+    return (host or "") in _LOCAL_HOSTS
+
+
+def is_suite_owned_agent(name: str) -> bool:
+    """True if ``name`` was provably created by the suite — either registered
+    this session, or carrying the dedicated ephemeral prefix (which no user
+    agent would use). Never matches the broad ``test-`` prefix (#1558)."""
+    return is_session_created(name) or name.startswith(EPHEMERAL_AGENT_PREFIX)
+
+
+def select_sweepable_agents(
+    agent_names: List[str],
+    base_url: str,
+    *,
+    enabled: bool,
+) -> List[str]:
+    """Pure policy for the startup leftover-sweep (#1558) — no network.
+
+    Returns the subset of ``agent_names`` the suite may safely delete:
+      - empty unless the sweep is explicitly ``enabled`` (opt-in env flag), AND
+      - empty unless ``base_url`` is local (never sweep staging/prod), AND
+      - only names the suite provably owns (``is_suite_owned_agent``).
+
+    A pre-existing ``test-``-prefixed *user* agent is therefore NEVER returned.
+    Unit-tested in tests/unit/test_1558_conftest_agent_sweep_guard.py.
+    """
+    if not enabled or not is_local_target(base_url):
+        return []
+    return [n for n in agent_names if is_suite_owned_agent(n)]
 
 
 def get_test_agents(client: TrinityApiClient) -> List[str]:
@@ -29,8 +109,24 @@ def get_test_agents(client: TrinityApiClient) -> List[str]:
     ]
 
 
-def cleanup_test_agent(client: TrinityApiClient, name: str) -> bool:
-    """Delete a test agent. Returns True if successful."""
+def cleanup_test_agent(
+    client: TrinityApiClient, name: str, *, require_suite_owned: bool = False
+) -> bool:
+    """Delete a test agent. Returns True if successful.
+
+    #1558: pass ``require_suite_owned=True`` (used by any sweep over agents the
+    caller did not create by name) to refuse deleting an agent the session
+    cannot prove it owns — a guard against destroying a user's real agent.
+    Explicit teardown of a just-created agent passes the default (False).
+    """
+    if require_suite_owned and not is_suite_owned_agent(name):
+        print(
+            f"[cleanup] refusing to delete '{name}': not created by this "
+            f"session and lacks the '{EPHEMERAL_AGENT_PREFIX}' prefix (#1558)",
+            file=sys.stderr,
+        )
+        return False
+
     # First try to stop if running
     client.post(f"/api/agents/{name}/stop")
 

--- a/tests/unit/test_1558_conftest_agent_sweep_guard.py
+++ b/tests/unit/test_1558_conftest_agent_sweep_guard.py
@@ -1,0 +1,144 @@
+"""Regression guard for #1558 — the conftest agent-deletion blast radius.
+
+Before this fix, the session-scoped ``api_client`` fixture deleted EVERY agent
+named ``test-*`` on the target instance at startup — silent, unprompted data
+loss that destroyed a developer's real ``test-agent-2``. These tests pin the
+new fail-closed policy in ``tests/utils/cleanup.py`` (pure, no network):
+
+- the sweep NEVER returns a pre-existing ``test-``-prefixed user agent,
+- it is empty unless explicitly enabled AND the target is localhost,
+- ``cleanup_test_agent(require_suite_owned=True)`` refuses a name the session
+  cannot prove it created (no stop/delete call is made).
+"""
+import os
+import sys
+
+import pytest
+
+# The `utils` name is contested: backend has `src/backend/utils/` (helpers, …)
+# and the suite has `tests/utils/` (api_client, cleanup). When this file is
+# collected in isolation, a backend import can bind `sys.modules["utils"]` to
+# the backend package first, hiding `tests/utils/cleanup.py`. Make the tests
+# package win here (mirrors the conftest's own sys.modules surgery, #762 family).
+_TESTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _TESTS_DIR not in sys.path:
+    sys.path.insert(0, _TESTS_DIR)
+_u = sys.modules.get("utils")
+if _u is not None and _TESTS_DIR not in (getattr(_u, "__file__", "") or ""):
+    # Drop the backend `utils` parent binding so `utils.cleanup` re-resolves
+    # under tests/utils. (Backend `utils.helpers` stays cached — it's unrelated.)
+    sys.modules.pop("utils", None)
+
+from utils.cleanup import (
+    EPHEMERAL_AGENT_PREFIX,
+    is_local_target,
+    is_suite_owned_agent,
+    register_created_agent,
+    select_sweepable_agents,
+    cleanup_test_agent,
+    _SESSION_CREATED_AGENTS,
+)
+
+pytestmark = pytest.mark.unit
+
+LOCAL = "http://localhost:8000"
+
+
+class TestSweepPolicy:
+    def test_preexisting_test_agent_is_never_swept(self):
+        """The exact #1558 scenario: a real `test-agent-2` must survive."""
+        names = ["test-agent-2", "testfix", "my-real-agent",
+                 f"{EPHEMERAL_AGENT_PREFIX}agent-abc123"]
+        got = select_sweepable_agents(names, LOCAL, enabled=True)
+        assert got == [f"{EPHEMERAL_AGENT_PREFIX}agent-abc123"]
+        assert "test-agent-2" not in got
+
+    def test_disabled_sweeps_nothing(self):
+        names = [f"{EPHEMERAL_AGENT_PREFIX}agent-x"]
+        assert select_sweepable_agents(names, LOCAL, enabled=False) == []
+
+    def test_non_local_target_refuses_even_when_enabled(self):
+        names = [f"{EPHEMERAL_AGENT_PREFIX}agent-x"]
+        for url in (
+            "https://trinity.example.com",
+            "http://10.0.0.5:8000",
+            "http://staging:8000",
+        ):
+            assert select_sweepable_agents(names, url, enabled=True) == []
+
+    def test_only_ephemeral_prefixed_returned_on_local_enabled(self):
+        names = [
+            f"{EPHEMERAL_AGENT_PREFIX}a", f"{EPHEMERAL_AGENT_PREFIX}b",
+            "test-c", "prod-d",
+        ]
+        got = select_sweepable_agents(names, LOCAL, enabled=True)
+        assert set(got) == {f"{EPHEMERAL_AGENT_PREFIX}a", f"{EPHEMERAL_AGENT_PREFIX}b"}
+
+    def test_session_registered_name_is_reclaimable_even_without_prefix(self):
+        """A registered name is provably suite-created, so it's sweepable."""
+        odd = "weirdly-named-agent-#1558-test"
+        register_created_agent(odd)
+        try:
+            got = select_sweepable_agents([odd, "test-real"], LOCAL, enabled=True)
+            assert odd in got
+            assert "test-real" not in got
+        finally:
+            _SESSION_CREATED_AGENTS.discard(odd)
+
+
+class TestIsLocalTarget:
+    @pytest.mark.parametrize("url", [
+        "http://localhost:8000", "http://127.0.0.1:8000",
+        "http://localhost", "http://0.0.0.0:8000", "http://[::1]:8000",
+    ])
+    def test_local(self, url):
+        assert is_local_target(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "https://trinity.example.com", "http://staging.internal:8000",
+        "http://10.0.0.5", "http://192.168.1.10:8000",
+    ])
+    def test_remote(self, url):
+        assert is_local_target(url) is False
+
+
+class TestSuiteOwnership:
+    def test_ephemeral_prefix_is_not_the_broad_test_prefix(self):
+        # The whole point of #1558: the suite prefix must not collide with a
+        # human's `test-*` agent.
+        assert not EPHEMERAL_AGENT_PREFIX.startswith("test-")
+        assert is_suite_owned_agent(f"{EPHEMERAL_AGENT_PREFIX}x") is True
+        assert is_suite_owned_agent("test-agent-2") is False
+
+
+class TestCleanupRefusal:
+    def test_require_suite_owned_refuses_unknown_name_without_calling_api(self):
+        class ExplodingClient:
+            def post(self, *a, **k):
+                raise AssertionError("stop must not be called for a refused name")
+
+            def delete(self, *a, **k):
+                raise AssertionError("delete must not be called for a refused name")
+
+        assert cleanup_test_agent(
+            ExplodingClient(), "test-agent-2", require_suite_owned=True
+        ) is False
+
+    def test_require_suite_owned_allows_ephemeral_name(self):
+        calls = {"post": 0, "delete": 0}
+
+        class RecordingClient:
+            def post(self, *a, **k):
+                calls["post"] += 1
+                return type("R", (), {"status_code": 200})()
+
+            def delete(self, *a, **k):
+                calls["delete"] += 1
+                return type("R", (), {"status_code": 204})()
+
+        ok = cleanup_test_agent(
+            RecordingClient(), f"{EPHEMERAL_AGENT_PREFIX}agent-z",
+            require_suite_owned=True,
+        )
+        assert ok is True
+        assert calls["delete"] == 1

--- a/tests/unit/test_1558_conftest_agent_sweep_guard.py
+++ b/tests/unit/test_1558_conftest_agent_sweep_guard.py
@@ -20,6 +20,13 @@ import pytest
 # collected in isolation, a backend import can bind `sys.modules["utils"]` to
 # the backend package first, hiding `tests/utils/cleanup.py`. Make the tests
 # package win here (mirrors the conftest's own sys.modules surgery, #762 family).
+# The import-time `utils` re-binding below can leak to sibling tests, so this
+# file uses the blessed snapshot/restore precedent (#762 lint escape hatch): a
+# top-level `_STUBBED_MODULE_NAMES` + an autouse `_restore_sys_modules` fixture
+# (see tests/unit/test_telegram_webhook_backfill.py). The pair both documents
+# the mutation and restores the original binding after every test.
+_STUBBED_MODULE_NAMES = ["utils"]
+
 _TESTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _TESTS_DIR not in sys.path:
     sys.path.insert(0, _TESTS_DIR)
@@ -42,6 +49,21 @@ from utils.cleanup import (
 pytestmark = pytest.mark.unit
 
 LOCAL = "http://localhost:8000"
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Restore the pre-test `utils` binding so the import-time re-resolution
+    above doesn't leak the tests-package `utils` into sibling modules."""
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
 
 
 class TestSweepPolicy:


### PR DESCRIPTION
## Problem (P1, silent data loss)

The session-scoped `api_client` fixture in `tests/conftest.py` enumerated **every agent** on the target instance and deleted any whose name started with `test-`:

```python
leftover = [a["name"] for a in agents if a["name"].startswith("test-")]
for name in leftover:
    cleanup_test_agent(client, name)
```

Because nearly every API test depends on `api_client`, running *any* `tests/*.py` against a live instance destroyed real agents — no confirmation, no opt-in, no URL guard. It already soft-deleted a developer's real `test-agent-2` (bound Telegram bot, chat history, GitHub sync). Any `test-*` agent on staging/prod was one invocation from deletion.

## Fix — fail-closed on every axis

- **Dedicated prefix**: the suite now names every agent it creates `pytest-ephemeral-*` (a namespace no human uses), never the broad `test-`. Renamed all conftest agent generators: `test_agent_name`, `module_agent_name`, `stopped_agent`, `shared_agent`.
- **Session registry**: created names are registered (`register_created_agent`) and reclaimed by name at session end — belt-and-suspenders over each fixture's own teardown.
- **Startup leftover-sweep is now opt-in**: gated behind `TRINITY_TEST_CLEANUP_SWEEP`, **refuses any non-localhost target** (`is_local_target`), and only removes provably suite-owned names. The decision is a pure, fail-closed helper `select_sweepable_agents(names, base_url, *, enabled)` → `[]` unless enabled **and** localhost, then only `pytest-ephemeral-` (or session-registered) names. **Default: no sweep at all.**
- **`cleanup_test_agent(require_suite_owned=True)`** refuses — with no stop/delete call — a name the session can't prove it created. Used by every sweep path.
- **Docs**: the conftest docstring and `tests/README.md` now state plainly that the suite mutates the target instance and must point at localhost.

## Acceptance criteria

- [x] Fixture never deletes an agent it didn't create; the sweep only matches the dedicated `pytest-ephemeral-` prefix (or session-registered names), never broad `test-`.
- [x] Suite-created agents registered in a session set, torn down explicitly by name.
- [x] Destructive sweep is opt-in behind an env flag **and** refuses non-localhost `TRINITY_API_URL`.
- [x] `tests/README` + suite docstring state the suite mutates the target instance.
- [x] Regression test: a pre-existing `test-`-prefixed agent is left untouched.
- [x] (Follow-ons from the issue Notes) generated agents renamed off `test-`; `cleanup_test_agent` refuses names it can't prove the session created.

## Tests

`tests/unit/test_1558_conftest_agent_sweep_guard.py` — **17 cases, pure (no network)**: the exact `test-agent-2`-survives scenario, opt-in/localhost gating, prefix-only selection, `is_local_target` truth table, and the `cleanup_test_agent` refusal path (asserts no API call for an unowned name).

```
17 passed  (run in a throwaway container off trinity-backend:latest)
```

Note: `tests/utils` is a symlink to `tests/testing_utils/` — the changed file is `tests/testing_utils/cleanup.py`.

Related to #1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1558
