### PR TITLE
fix(portal): Help widget overlaps the portal chat Send button

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -7,19 +7,22 @@
       </KeepAlive>
     </router-view>
 
-    <!-- Help chat widget (authenticated users only) -->
-    <HelpChatWidget v-if="authStore.isAuthenticated" />
+    <!-- Help chat widget (authenticated users only; hidden on standalone
+         client-facing surfaces like the portal where it overlaps the composer) -->
+    <HelpChatWidget v-if="authStore.isAuthenticated && !route.meta.hideHelpWidget" />
   </div>
 </template>
 
 <script setup>
 import { onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from './stores/auth'
 import { useThemeStore } from './stores/theme'
 import { useWebSocket } from './utils/websocket'
 import HelpChatWidget from './components/HelpChatWidget.vue'
 
+const route = useRoute()
 const authStore = useAuthStore()
 const themeStore = useThemeStore()
 const { connect } = useWebSocket()

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -177,7 +177,10 @@ const routes = [
     path: '/enterprise/client-portal',
     name: 'EnterpriseClientPortal',
     component: () => import('../views/enterprise/ClientPortal.vue'),
-    meta: { requiresAuth: true, requiresEntitlement: 'client_portal', title: 'Client Portal' }
+    // hideHelpWidget: the platform "Trinity Help" widget (bottom-right) overlaps
+    // the client chat composer's Send button and isn't relevant to a portal
+    // client — keep it off this standalone surface.
+    meta: { requiresAuth: true, requiresEntitlement: 'client_portal', title: 'Client Portal', hideHelpWidget: true }
   },
   {
     // Public client-facing portal — a client signs in with a verified email
@@ -187,7 +190,9 @@ const routes = [
     path: '/portal',
     name: 'ClientPortalPublic',
     component: () => import('../views/Portal.vue'),
-    meta: { title: 'Client Portal' }
+    // hideHelpWidget: the operator-only help widget would overlap the portal
+    // chat's Send button (and is meaningless to a client) — off here.
+    meta: { title: 'Client Portal', hideHelpWidget: true }
   },
   // Mobile Admin PWA (MOB-001) — standalone, no NavBar
   {


### PR DESCRIPTION
## Problem

The global **Trinity Help** chat widget (`components/HelpChatWidget.vue`, mounted in `App.vue`) is `fixed bottom-6 right-6 z-50`. On the **client portal** its floating button sits directly over the chat composer's **Send** button, blocking it. (Visible to an operator who's also logged into the platform in the same browser — the widget is auth-gated, so a real portal client wouldn't see it, but it shouldn't be on that surface regardless.)

## Fix

The Help widget is an operator / platform-docs surface — irrelevant to a portal client. Gate it off the standalone portal routes:

- `router/index.js`: add `hideHelpWidget: true` to the `ClientPortalPublic` (`/portal`) and `EnterpriseClientPortal` route metas.
- `App.vue`: render the widget only when `authStore.isAuthenticated && !route.meta.hideHelpWidget` (via `useRoute`).

Chosen over globally repositioning the widget (bottom-left), which would affect every page and could collide elsewhere. This keeps the widget exactly where it is everywhere else and simply removes it from the client-facing portal.

## Verification

- `App.vue` compiles clean (`@vue/compiler-sfc`); Vite reloaded both files on the running stack. On `/portal` the Help button no longer renders, freeing the Send button; unaffected on all other routes.

Discovered while testing the portal file-attachment work (Refs Abilityai/trinity-enterprise#144 / PR #1587) — kept as a separate, minimal PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1598
