### PR TITLE
fix(access): restore the proactive-messaging toggle lost in the Access-tab redesign (#1577)

### DIFF
--- a/docs/memory/feature-flows/proactive-messaging.md
+++ b/docs/memory/feature-flows/proactive-messaging.md
@@ -58,38 +58,55 @@ Enables agents to send proactive messages to specific users by verified email ac
 
 ## Frontend Layer
 
-### SharingPanel Toggle (#376)
+### Access-tab Toggle (#376, relocated #1317 → restored #1577)
 
-The `allow_proactive` flag is managed via a toggle switch in the Team Sharing section of the Sharing tab.
+The `allow_proactive` flag is managed via a per-operator toggle in the **Access tab**
+(`AccessPanel.vue`). *(History: the toggle originally lived in the Sharing tab's Team
+Sharing section (`SharingPanel.vue`, #377); the #1317 Access-tab redesign replaced that
+markup and silently dropped the toggle — a UI-only regression restored in #1577.)*
 
-**Location**: `src/frontend/src/components/SharingPanel.vue`
+**Location**: `src/frontend/src/components/AccessPanel.vue` (operator roster rows).
 
-**UI Structure** (lines 124-149):
+**State source**: `GET /api/agents/{name}/access` already returns `allow_proactive`
+per row (`AgentOperatorAccess`, `db/agent_settings/sharing.py:get_agent_operator_access`),
+so the panel reads the persisted flag from the roster it already loads — no extra fetch.
+Pending (unresolved-email) invites are toggleable too: the flag rides on the
+`agent_sharing` row, which exists before the email resolves to an account. The owner is
+not in the operator roster and is always allowed (a static note states this).
+
+**UI Structure**:
 ```vue
-<li v-for="share in shares" :key="share.id">
+<li v-for="op in operators" :key="op.email">
+  <!-- … name / status / role … -->
   <div class="flex items-center gap-4">
-    <!-- Proactive messaging toggle -->
-    <label title="Agent can/cannot send proactive messages">
+    <label :title="proactiveTitle(op)">
       <span>Proactive</span>
-      <switch :checked="share.allow_proactive" @click="toggleProactive(share)" />
+      <input type="checkbox" :checked="op.allow_proactive"
+             :disabled="savingProactive === op.email"
+             @change="onToggleProactive(op, $event.target.checked)" />
     </label>
-    <button @click="removeShare(...)">Remove</button>
+    <button @click="removeOperator(op.email)">Remove</button>
   </div>
 </li>
 ```
 
-**Toggle Handler** (lines 224-240):
+**Toggle Handler** (honest status — reflects the server's confirmed value, reverts on
+failure; no optimistic-only flip):
 ```javascript
-const toggleProactive = async (share) => {
-  await axios.put(
-    `/api/agents/${props.agentName}/shares/proactive`,
-    { email: share.shared_with_email, allow_proactive: !share.allow_proactive },
-    { headers: authStore.authHeader }
-  )
-  share.allow_proactive = !share.allow_proactive
-  showNotification(share.allow_proactive ? 'Proactive messaging enabled' : 'Proactive messaging disabled', 'success')
+async function onToggleProactive(op, next) {
+  const prev = op.allow_proactive
+  try {
+    const res = await agentsStore.setProactive(agentName, op.email, next)   // PUT .../shares/proactive
+    op.allow_proactive = !!res.allow_proactive
+  } catch (e) {
+    op.allow_proactive = prev
+    message.value = { type: 'error', text: '…' }
+  }
 }
 ```
+
+The `setProactive` store action (`stores/agents.js`) issues
+`PUT /api/agents/{name}/shares/proactive { email, allow_proactive }`.
 
 **Model** (`src/backend/db_models.py:53-60`):
 ```python

--- a/src/frontend/src/components/AccessPanel.vue
+++ b/src/frontend/src/components/AccessPanel.vue
@@ -88,13 +88,41 @@
             <span v-if="op.last_active"> · last active {{ formatLastActive(op.last_active) }}</span>
           </p>
         </div>
-        <button
-          @click="removeOperator(op.email)"
-          :disabled="removing === op.email"
-          class="ml-3 shrink-0 text-sm text-status-danger-600 dark:text-status-danger-400 hover:underline disabled:opacity-50"
-        >{{ removing === op.email ? 'Removing…' : 'Remove' }}</button>
+        <div class="ml-3 flex items-center gap-4 shrink-0">
+          <!-- #1577: per-recipient proactive-messaging toggle (allow_proactive
+               on agent_sharing). The flag rides on the sharing row, which exists
+               pre-resolution, so a pending invite can be pre-authorized too. -->
+          <label
+            class="flex items-center gap-2 cursor-pointer select-none"
+            :title="proactiveTitle(op)"
+          >
+            <span class="text-xs text-gray-500 dark:text-gray-400">Proactive</span>
+            <span class="relative inline-flex items-center">
+              <input
+                type="checkbox"
+                class="sr-only peer"
+                :checked="op.allow_proactive"
+                :disabled="savingProactive === op.email"
+                @change="onToggleProactive(op, $event.target.checked)"
+              />
+              <div class="w-9 h-5 bg-gray-200 dark:bg-gray-700 rounded-full peer peer-checked:bg-action-primary-600 peer-focus:ring-2 peer-focus:ring-action-primary-500 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4 peer-disabled:opacity-50"></div>
+            </span>
+          </label>
+          <button
+            @click="removeOperator(op.email)"
+            :disabled="removing === op.email"
+            class="text-sm text-status-danger-600 dark:text-status-danger-400 hover:underline disabled:opacity-50"
+          >{{ removing === op.email ? 'Removing…' : 'Remove' }}</button>
+        </div>
       </li>
     </ul>
+    <p
+      v-if="!loading && !error && operators.length > 0"
+      class="text-xs text-gray-500 dark:text-gray-400"
+    >
+      <span class="font-medium">Proactive</span> lets the agent message a user without being
+      prompted (e.g. Telegram alerts). The agent owner always receives proactive messages.
+    </p>
   </div>
 </template>
 
@@ -113,6 +141,7 @@ const loading = ref(true)
 const error = ref(false)
 const adding = ref(false)
 const removing = ref('')
+const savingProactive = ref('')   // #1577: email whose proactive toggle is in flight
 const newEmail = ref('')
 const message = ref(null)
 
@@ -155,6 +184,29 @@ async function removeOperator(email) {
   } finally {
     removing.value = ''
   }
+}
+
+// #1577: persist the proactive flag, reflecting the server's confirmed state
+// (no optimistic-only flip). On failure, revert the row and surface the error.
+async function onToggleProactive(op, next) {
+  savingProactive.value = op.email
+  message.value = null
+  const prev = op.allow_proactive
+  try {
+    const res = await agentsStore.setProactive(props.agentName, op.email, next)
+    op.allow_proactive = !!res.allow_proactive
+  } catch (e) {
+    op.allow_proactive = prev  // revert so the toggle matches persisted state
+    message.value = { type: 'error', text: e?.response?.data?.detail || 'Failed to update proactive setting.' }
+  } finally {
+    savingProactive.value = ''
+  }
+}
+
+function proactiveTitle(op) {
+  return op.status === 'pending'
+    ? 'Allow the agent to message this user proactively. Takes effect once they sign in and connect a channel.'
+    : 'Allow the agent to send this user proactive (unprompted) messages.'
 }
 
 function formatLastActive(iso) {

--- a/src/frontend/src/stores/agents.js
+++ b/src/frontend/src/stores/agents.js
@@ -447,6 +447,18 @@ export const useAgentsStore = defineStore('agents', {
       return response.data
     },
 
+    // #1577: toggle the per-recipient allow_proactive flag on an agent_sharing
+    // row (#321/#376). Owner/admin only; returns the persisted state.
+    async setProactive(name, email, allow) {
+      const authStore = useAuthStore()
+      const response = await axios.put(
+        `/api/agents/${name}/shares/proactive`,
+        { email, allow_proactive: allow },
+        { headers: authStore.authHeader }
+      )
+      return response.data
+    },
+
     // Agent Permissions Actions (Phase 9.10)
     async getAgentPermissions(name) {
       const authStore = useAuthStore()

--- a/tests/unit/test_1577_proactive_toggle_guard.py
+++ b/tests/unit/test_1577_proactive_toggle_guard.py
@@ -1,0 +1,53 @@
+"""Regression guard for #1577 — the proactive-messaging toggle must not be
+silently dropped again.
+
+The per-recipient `allow_proactive` toggle was lost when the Sharing tab's Team
+Sharing section was replaced by the Access tab (#1317) — a UI-only regression
+with no test to catch it. This static guard asserts the toggle's UI + endpoint
+wiring survive future panel refactors (the frontend has no JS unit runner, so a
+source-level assertion is the runnable guard here; a full render e2e is a
+`ui`-labeled follow-up).
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parents[2]
+_ACCESS_PANEL = _ROOT / "src" / "frontend" / "src" / "components" / "AccessPanel.vue"
+_AGENTS_STORE = _ROOT / "src" / "frontend" / "src" / "stores" / "agents.js"
+
+
+def test_access_panel_renders_a_proactive_toggle():
+    """The Access-tab operator rows must expose the allow_proactive toggle."""
+    src = _ACCESS_PANEL.read_text()
+    assert "allow_proactive" in src, "AccessPanel lost the allow_proactive binding (#1577)"
+    assert "onToggleProactive" in src, "AccessPanel lost the proactive toggle handler (#1577)"
+    # An actual interactive control bound to the flag (checkbox reflecting state).
+    assert re.search(r'type="checkbox"', src), "proactive toggle control missing"
+    assert ":checked=\"op.allow_proactive\"" in src, "toggle not bound to the persisted flag"
+
+
+def test_toggle_calls_the_proactive_endpoint():
+    """The change handler must persist via the store, which hits the backend
+    PUT .../shares/proactive endpoint (honest status — not optimistic-only)."""
+    panel = _ACCESS_PANEL.read_text()
+    store = _AGENTS_STORE.read_text()
+    # Panel delegates to the store action on toggle…
+    assert "setProactive" in panel, "AccessPanel no longer calls agentsStore.setProactive (#1577)"
+    # …and the store action PUTs to the real backend endpoint with the flag.
+    assert "setProactive" in store, "agents store lost the setProactive action (#1577)"
+    m = re.search(r"async setProactive\s*\(.*?\)\s*\{(.*?)\n    \},", store, re.DOTALL)
+    assert m, "setProactive action not found in agents store"
+    body = m.group(1)
+    assert "shares/proactive" in body, "setProactive must PUT to /shares/proactive"
+    assert "allow_proactive" in body, "setProactive must send the allow_proactive flag"
+
+
+def test_owner_always_allowed_is_communicated():
+    """AC: the owner is always allowed — surfaced so there's no misleading state."""
+    src = _ACCESS_PANEL.read_text()
+    assert re.search(r"owner always receives proactive", src, re.IGNORECASE), \
+        "Access tab should state that the owner always receives proactive messages (#1577)"


### PR DESCRIPTION
## Problem

The per-recipient **Proactive** toggle — the only UI surface for `allow_proactive` on `agent_sharing` (#321/#376) — was silently dropped when the #1317 Access-tab redesign replaced the Sharing tab's Team Sharing rows with `AccessPanel.vue`. No component referenced `allow_proactive` anymore, so operators could only enable proactive messages via a raw API call. Backend (`PUT`/`GET /api/agents/{name}/shares/proactive`, enforcement in `proactive_message_service`) is fully intact — **UI-only regression**.

## Fix

- **`AccessPanel.vue`** — each operator row gets a Proactive toggle:
  - State from the roster the panel already loads: `GET /api/agents/{name}/access` returns `allow_proactive` per row (`AgentOperatorAccess`), so **no extra fetch**.
  - **Honest status**: on change it persists via the store and sets the row to the server's confirmed value; on failure it reverts the toggle and surfaces the error — no optimistic-only flip.
  - **Pending invites** are toggleable (the flag rides on the `agent_sharing` row, which exists before the email resolves to an account), with a tooltip noting delivery starts once they sign in + connect a channel.
  - **Owner**: not in the operator roster, so there's no misleading owner toggle; a static note states the owner is always allowed.
- **`stores/agents.js`** — new `setProactive(name, email, allow)` → `PUT /api/agents/{name}/shares/proactive`.
- **`feature-flows/proactive-messaging.md`** — updated; it still documented the removed `SharingPanel.vue` markup/line numbers.

## Acceptance criteria

- [x] Proactive toggle available again per shared user, on the Access tab where the rows moved.
- [x] Reflects persisted `allow_proactive` on load; PUTs on change with success/failure feedback (honest, revert-on-failure).
- [x] Owner is always allowed — communicated (no misleading owner toggle).
- [x] Pending invites handled — functional (flag persists on `agent_sharing`) with a timing hint.
- [x] `proactive-messaging.md` updated.
- [x] Regression guard so the next panel refactor can't silently drop it.

## Tests

`tests/unit/test_1577_proactive_toggle_guard.py` — **3 static guards** (runnable, no browser): the toggle control + `allow_proactive` binding render, the change handler routes through `setProactive` → `PUT .../shares/proactive` with the flag, and the owner-always-allowed note is present. The frontend has no JS unit runner; a full render e2e under the `ui` label is a follow-up.

```
3 passed
```

Also verified live: Vite HMR'd `AccessPanel.vue` clean; it renders in the Access tab (`AgentDetail.vue`).

Related to #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1577
