### PR TITLE
feat(github): wire the managed agent PAT for the gh CLI + REST API, not just git (#1574)

### DIFF
--- a/docker/base-image/Dockerfile
+++ b/docker/base-image/Dockerfile
@@ -45,6 +45,17 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
     apt-get install -y --no-install-recommends docker-ce-cli && \
     rm -rf /var/lib/apt/lists/*
 
+# GitHub CLI (#1574): the managed PAT (GH_TOKEN/GITHUB_TOKEN, exported by
+# startup.sh) authenticates `gh` + the REST API, not just git — but `gh` must be
+# present. Install from GitHub's official apt repo (mirrors the docker-ce-cli
+# stanza above).
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g @anthropic-ai/claude-code@latest
 
 # Install Gemini CLI for multi-runtime support

--- a/docker/base-image/startup.sh
+++ b/docker/base-image/startup.sh
@@ -22,6 +22,16 @@ AGENT_TMPDIR="${TMPDIR:-/home/developer/.tmp}"
 mkdir -p "${AGENT_TMPDIR}" 2>/dev/null && chmod 700 "${AGENT_TMPDIR}" 2>/dev/null || \
     echo "Warning: could not create TMPDIR ${AGENT_TMPDIR}; scratch will fall back to /tmp"
 
+# #1574: the managed PAT authenticates git (via the origin URL) AND the `gh` CLI
+# + REST API, which read GH_TOKEN/GITHUB_TOKEN. Export them from GITHUB_PAT so
+# every child process (agent server, terminal shells) auto-authenticates. Gated on
+# a resolved PAT — never an empty token that makes `gh` look logged-in but broken.
+# (Older baked images set only GITHUB_PAT; this belt covers them without recreate.)
+if [ -n "${GITHUB_PAT}" ]; then
+    export GH_TOKEN="${GITHUB_PAT}"
+    export GITHUB_TOKEN="${GITHUB_PAT}"
+fi
+
 # Initialize from GitHub repository if specified
 if [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_PAT}" ]; then
     echo "Initializing agent from GitHub repository: ${GITHUB_REPO}"

--- a/docs/user-docs/integrations/github-pat-setup.md
+++ b/docs/user-docs/integrations/github-pat-setup.md
@@ -22,48 +22,37 @@ A GitHub PAT is required for:
 | Clone from public templates | No |
 | Pull from public repos (read-only) | No |
 
-> **"Requires PAT" ≠ "auto-wired."** The token needs the right scopes for each row above — but for Issues, PRs, and other **GitHub CLI / REST-API** work, Trinity does **not** wire the token the way it does for `git`. See [What the PAT Authenticates](#what-the-pat-authenticates-git-vs-the-gh-cli) below before you rely on `gh`.
+> **The token needs the right scopes for each row above.** As of #1574 Trinity wires the managed token for **both** `git` **and** the `gh` CLI / REST API — but wiring only makes the token *available*; it can't grant scopes the token lacks. A git-contents-only PAT still 403s on Issues/PRs.
 
-## What the PAT Authenticates: Git vs. the `gh` CLI
+## What the PAT Authenticates: Git **and** the `gh` CLI (#1574)
 
-Trinity wires the token for **git transport only**. When an agent has a GitHub repo and a resolved PAT (per-agent override or the platform PAT), Trinity:
+When an agent has a GitHub repo and a resolved PAT (per-agent override or the platform PAT), Trinity:
 
-- bakes the token into the agent repo's `origin` remote URL (`https://oauth2:<token>@github.com/...`), and
-- exposes it inside the container as the **`GITHUB_PAT`** environment variable (and in the agent's `.env`).
+- bakes the token into the agent repo's `origin` remote URL (`https://oauth2:<token>@github.com/...`) for **git**, and
+- exposes it inside the container as **`GITHUB_PAT`** *and* **`GH_TOKEN`** / **`GITHUB_TOKEN`** — the variables the `gh` CLI and GitHub REST API read.
 
-That is enough for `git clone`, `git push`, and `git pull` against the agent's own repo to work automatically — which is what Source Mode, Working Branch Mode, and scheduled commits rely on.
-
-It is **not** enough for the GitHub CLI or the REST API:
+So both work automatically:
 
 | Operation | Auto-authenticated by Trinity's token? |
 |-----------|----------------------------------------|
 | `git` push / pull / clone (agent's own repo) | **Yes** — token is in the remote URL |
-| `gh issue`, `gh pr`, `gh api`, `gh repo` … | **No** — see below |
-| GitHub REST API via `curl` / a github MCP server | **Only if the agent passes `$GITHUB_PAT` itself** |
+| `gh issue`, `gh pr`, `gh api`, `gh repo` … | **Yes** — `GH_TOKEN`/`GITHUB_TOKEN` are set, and `gh` is preinstalled in the base image |
+| GitHub REST API via `curl` / a github MCP server | **Yes** — `$GITHUB_PAT` (or `$GITHUB_TOKEN`) is in the environment |
 
-Two reasons `gh` doesn't "just work":
-
-1. **`gh` reads `GH_TOKEN` / `GITHUB_TOKEN`, not `GITHUB_PAT`.** Trinity sets `GITHUB_PAT`; it does not set the variables `gh` looks for, and it does not run `gh auth login`. The token isn't in a `.git-credentials` file either — it lives only in the remote URL — so `gh` can't discover it from git config.
-2. **`gh` is not installed in the default agent base image.** An agent that wants it must install it, or its template must add it.
-
-> **Setting the PAT will not fix a `gh` failure.** The `set_agent_github_pat` MCP tool and the **Settings → GitHub Personal Access Token** field only change which token **`git`** uses. They do not install `gh`, set `GH_TOKEN`, or authenticate the CLI/REST API. A `gh: not logged in` error, or a 401/403 from `gh`/the REST API, is **not** solved by setting or rotating the PAT.
-
-### Making an agent's `gh` / API calls work today
-
-The token is already present as `$GITHUB_PAT`, so an agent (or its template) can use it explicitly:
+Inside an agent with a valid PAT you can just run:
 
 ```bash
-# GitHub CLI — install gh once, then authenticate from the env var
-gh auth login --with-token <<< "$GITHUB_PAT"
-# ...or per-command, no persistent login:
-GH_TOKEN="$GITHUB_PAT" gh issue list
-
-# REST API directly — no gh needed
-curl -H "Authorization: Bearer $GITHUB_PAT" \
-  https://api.github.com/repos/OWNER/REPO/issues
+gh auth status          # → authenticated
+gh issue list -R OWNER/REPO
+gh api /user
+curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
 ```
 
-**The token still needs the right scopes for the operation.** A PAT scoped only for git contents can push code but will 403 on Issues/PRs. For issue management, make sure the token carries `repo` (classic) or **Issues: Read and write** (fine-grained) — see the scope tables above.
+No `gh auth login`, no per-command `GH_TOKEN="$GITHUB_PAT" …` prefix.
+
+**Scopes still matter.** A PAT scoped only for git contents can push code but will 403 on Issues/PRs. For issue management, make sure the token carries `repo` (classic) or **Issues: Read and write** (fine-grained) — see the scope tables above. Wiring makes the token available; it does not grant missing scopes.
+
+> **Older agents:** the `gh` binary ships in the agent base image — an agent created before this change picks it up on the next **base-image rebuild + recreate**. `git` keeps working regardless; the `GH_TOKEN`/`GITHUB_TOKEN` env vars are also injected on the next agent restart/recreate.
 
 ## Who Owns the Platform PAT
 

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -836,6 +836,11 @@ async def create_agent_internal(
     if github_repo_for_agent and github_pat_for_agent:
         env_vars['GITHUB_REPO'] = github_repo_for_agent
         env_vars['GITHUB_PAT'] = github_pat_for_agent
+        # #1574: the SAME managed token also authenticates the `gh` CLI and the
+        # REST API (which read GH_TOKEN/GITHUB_TOKEN), not just git. Gated
+        # identically to GITHUB_PAT — never set for a tokenless agent.
+        env_vars['GH_TOKEN'] = github_pat_for_agent
+        env_vars['GITHUB_TOKEN'] = github_pat_for_agent
         # Phase 7: Enable git sync for GitHub-native agents
         env_vars['GIT_SYNC_ENABLED'] = 'true'
         # Dev/self-host: propagate optional git base-URL override to agent container

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -442,6 +442,16 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
         current_pat = get_github_pat_for_agent(agent_name)
         if current_pat:
             env_vars['GITHUB_PAT'] = current_pat
+    # #1574: mirror the resolved PAT onto GH_TOKEN/GITHUB_TOKEN so the `gh` CLI +
+    # REST API authenticate too — always tracking the final GITHUB_PAT, and never
+    # set when no token resolved (identical gating, no empty/broken credential).
+    _resolved_pat = env_vars.get('GITHUB_PAT')
+    if _resolved_pat:
+        env_vars['GH_TOKEN'] = _resolved_pat
+        env_vars['GITHUB_TOKEN'] = _resolved_pat
+    else:
+        env_vars.pop('GH_TOKEN', None)
+        env_vars.pop('GITHUB_TOKEN', None)
     # NB: gated on db.get_agent_github_pat (NOT the global fallback) so a global-
     # only PAT is never injected into a previously-tokenless container (#211's
     # opt-in path); kept in sync with the recreate matcher so the two converge.

--- a/src/backend/services/github_pat_propagation_service.py
+++ b/src/backend/services/github_pat_propagation_service.py
@@ -31,25 +31,36 @@ AGENT_HTTP_TIMEOUT_SECONDS = 30.0
 # Captures everything up to (and including) the newline so we can replace cleanly.
 _GITHUB_PAT_LINE_RE = re.compile(r'(?m)^[ \t]*GITHUB_PAT=.*$')
 
+# #1574: the same managed token also authenticates the `gh` CLI + REST API, which
+# read GH_TOKEN/GITHUB_TOKEN. The no-restart propagation keeps all three in sync in
+# the agent's .env so a next-start / .env-sourcing shell has them too (the live git
+# remote-URL rewrite remains the load-bearing immediate fix — see the callers).
+_TOKEN_ENV_KEYS = ("GITHUB_PAT", "GH_TOKEN", "GITHUB_TOKEN")
 
-def _format_pat_line(pat: str) -> str:
-    """Format a GITHUB_PAT line matching the agent's own .env writer.
+
+def _format_pat_line(pat: str, key: str = "GITHUB_PAT") -> str:
+    """Format a `KEY="value"` .env line matching the agent's own .env writer.
 
     The agent writes credentials as `KEY="value"` with embedded double quotes
     escaped (see docker/base-image/agent_server/routers/credentials.py).
     """
     escaped = pat.replace('"', '\\"')
-    return f'GITHUB_PAT="{escaped}"'
+    return f'{key}="{escaped}"'
 
 
 def _patch_env_github_pat(env_content: str, new_pat: str) -> str:
-    """Return env_content with the GITHUB_PAT line replaced."""
-    new_line = _format_pat_line(new_pat)
-    if _GITHUB_PAT_LINE_RE.search(env_content):
-        return _GITHUB_PAT_LINE_RE.sub(new_line, env_content, count=1)
-    # Caller should have filtered this case, but keep the behavior explicit.
-    suffix = "" if env_content.endswith("\n") else "\n"
-    return f"{env_content}{suffix}{new_line}\n"
+    """Return env_content with GITHUB_PAT (and the #1574 gh mirrors) set to
+    ``new_pat`` — each key replaced in place if present, else appended."""
+    out = env_content
+    for key in _TOKEN_ENV_KEYS:
+        line_re = re.compile(rf'(?m)^[ \t]*{key}=.*$')
+        new_line = _format_pat_line(new_pat, key)
+        if line_re.search(out):
+            out = line_re.sub(new_line, out, count=1)
+        else:
+            suffix = "" if (out == "" or out.endswith("\n")) else "\n"
+            out = f"{out}{suffix}{new_line}\n"
+    return out
 
 
 def _env_has_github_pat(env_content: str) -> bool:

--- a/src/mcp-server/src/tools/agents.ts
+++ b/src/mcp-server/src/tools/agents.ts
@@ -922,9 +922,13 @@ export function createAgentTools(
       description:
         "Set a per-agent GitHub Personal Access Token. " +
         "The PAT is validated against GitHub API before saving and encrypted at rest. " +
-        "When set, git operations for this agent will use this PAT instead of the global PAT. " +
+        "When set, this agent uses this PAT (instead of the global PAT) for git AND " +
+        "for the `gh` CLI / GitHub REST API — the container exposes it as GITHUB_PAT " +
+        "plus GH_TOKEN/GITHUB_TOKEN, so `gh` and `gh api` auto-authenticate (#1574). " +
+        "The token must carry the scopes the operation needs (e.g. `repo`, or Issues: " +
+        "Read and write) — wiring makes it available but cannot grant missing scopes. " +
         "To clear the PAT and revert to global, pass an empty string. " +
-        "Note: Agent must be restarted for git operations to use the new PAT.",
+        "Note: Agent must be restarted for the new PAT to take effect.",
       parameters: z.object({
         agent_name: z
           .string()

--- a/tests/unit/test_1574_gh_token_wiring.py
+++ b/tests/unit/test_1574_gh_token_wiring.py
@@ -1,0 +1,95 @@
+"""#1574 — the managed GitHub PAT must also authenticate the `gh` CLI + REST API.
+
+Trinity injects the resolved PAT as GITHUB_PAT (git). This wires the SAME token as
+GH_TOKEN/GITHUB_TOKEN (what `gh` + the REST API read) at every point GITHUB_PAT is
+injected, installs `gh` in the base image, and keeps the credential sanitizer
+covering the new vars.
+
+- `_patch_env_github_pat` (the no-restart .env propagation) is unit-tested directly.
+- The create / recreate / startup / Dockerfile wiring is asserted at source level
+  (static guards) so a future refactor can't silently drop a site.
+"""
+import os
+import sys
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND = _ROOT / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+class TestEnvPropagationPatcher:
+    """The no-restart .env patch mirrors the PAT onto GH_TOKEN/GITHUB_TOKEN."""
+
+    def _patch(self):
+        from services.github_pat_propagation_service import _patch_env_github_pat
+        return _patch_env_github_pat
+
+    def test_adds_gh_token_vars_when_absent(self):
+        patch = self._patch()
+        out = patch('FOO="bar"\nGITHUB_PAT="ghp_old"\n', "ghp_new")
+        assert 'GITHUB_PAT="ghp_new"' in out
+        assert 'GH_TOKEN="ghp_new"' in out
+        assert 'GITHUB_TOKEN="ghp_new"' in out
+        assert 'FOO="bar"' in out            # unrelated lines preserved
+        assert 'ghp_old' not in out
+
+    def test_replaces_all_three_in_place(self):
+        patch = self._patch()
+        env = 'GITHUB_PAT="a"\nGH_TOKEN="a"\nGITHUB_TOKEN="a"\nKEEP="1"\n'
+        out = patch(env, "b")
+        assert out.count('="b"') == 3
+        assert '"a"' not in out
+        assert 'KEEP="1"' in out
+
+    def test_does_not_touch_lookalike_keys(self):
+        patch = self._patch()
+        out = patch('SOME_GITHUB_PAT_LIKE="not-this"\nGITHUB_PAT="old"\n', "new")
+        assert 'SOME_GITHUB_PAT_LIKE="not-this"' in out
+        assert 'GITHUB_PAT="new"' in out
+
+    def test_value_is_mirrored_not_diverged(self):
+        patch = self._patch()
+        out = patch('GITHUB_PAT="old"\n', "tok123")
+        for key in ("GITHUB_PAT", "GH_TOKEN", "GITHUB_TOKEN"):
+            assert f'{key}="tok123"' in out
+
+
+class TestWiringSites:
+    """Every GITHUB_PAT injection point also sets the gh vars (static guard)."""
+
+    def test_create_path_sets_gh_vars(self):
+        src = (_BACKEND / "services" / "agent_service" / "crud.py").read_text()
+        assert "env_vars['GH_TOKEN']" in src
+        assert "env_vars['GITHUB_TOKEN']" in src
+
+    def test_recreate_path_sets_gh_vars(self):
+        src = (_BACKEND / "services" / "agent_service" / "lifecycle.py").read_text()
+        assert "GH_TOKEN" in src and "GITHUB_TOKEN" in src
+
+    def test_startup_exports_gh_vars_from_pat(self):
+        sh = (_ROOT / "docker" / "base-image" / "startup.sh").read_text()
+        assert 'export GH_TOKEN="${GITHUB_PAT}"' in sh
+        assert 'export GITHUB_TOKEN="${GITHUB_PAT}"' in sh
+
+    def test_base_image_installs_gh(self):
+        df = (_ROOT / "docker" / "base-image" / "Dockerfile").read_text()
+        assert "cli.github.com/packages" in df
+        assert re.search(r"install -y[^\n]*\bgh\b", df), "gh not apt-installed in base image"
+
+
+class TestSanitizerCoversNewVars:
+    """The credential sanitizer must redact GH_TOKEN / GITHUB_TOKEN values."""
+
+    def test_token_pattern_matches_new_vars(self):
+        from utils.credential_sanitizer import SENSITIVE_KEY_PATTERNS
+        compiled = [re.compile(p, re.IGNORECASE) for p in SENSITIVE_KEY_PATTERNS]
+        for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+            assert any(rx.fullmatch(var) or rx.match(var) for rx in compiled), \
+                f"{var} not covered by the credential sanitizer key patterns"


### PR DESCRIPTION
## Problem

Trinity injects the resolved GitHub PAT as `GITHUB_PAT` and bakes it into the git `origin` URL — authenticating **git** (clone/push/pull) but **not** the `gh` CLI or REST API, which read `GH_TOKEN`/`GITHUB_TOKEN`. So agents doing GitHub CLI/API work (issue triage, `gh api`, PR creation) had to prefix every command with `GH_TOKEN="$GITHUB_PAT" gh …`, and `gh` wasn't even installed in the base image.

## Fix (wiring-only — same token, two consumers)

Expose `GH_TOKEN` + `GITHUB_TOKEN` = the resolved PAT at **every** point `GITHUB_PAT` is set today, gated identically (only when a repo + PAT resolve — never an empty token that makes `gh` look logged-in but broken):

- **create** (`services/agent_service/crud.py`) and **recreate** (`lifecycle.py`) — baked into the container env (so terminals/`docker exec` see them);
- **no-restart `.env` propagation** (`github_pat_propagation_service._patch_env_github_pat`) — now patches/adds all three keys in sync;
- **`startup.sh`** — exports them from `GITHUB_PAT` so child processes (agent server, shells) auto-authenticate; this also covers **older baked images** that carry only `GITHUB_PAT`, with no recreate.

Plus: **install `gh`** in the agent base image (`docker/base-image/Dockerfile`) from GitHub's official apt repo.

Honest surfaces: the `set_agent_github_pat` MCP tool description and `docs/user-docs/integrations/github-pat-setup.md` now state the managed token covers `gh`/REST too (the old "setting the PAT won't fix a `gh` failure" warning is replaced), keeping the **scope caveat** — wiring makes the token available, it can't grant scopes the token lacks. The credential sanitizer already masks `GH_TOKEN`/`GITHUB_TOKEN` (`.*TOKEN.*` + `GITHUB_.*`, asserted).

## Acceptance criteria

- [x] Container exposes `GH_TOKEN`/`GITHUB_TOKEN` = the PAT alongside `GITHUB_PAT`.
- [x] Wired at the same 4 points as `GITHUB_PAT` (create, recreate, `.env` propagation, startup).
- [x] `gh` installed in the base image via the official apt repo.
- [x] Graceful fallback: no PAT / no repo → gh vars **not** set (no empty/broken credential).
- [x] `gh auth status` / `gh issue list` work in an agent with a valid PAT (given scopes) — enabled by env + the preinstalled binary.
- [x] MCP tool description + user docs updated; scope caveat kept.
- [x] Token stays masked in transcripts (sanitizer covers the new vars — test).

## Tests

`tests/unit/test_1574_gh_token_wiring.py` — the `.env` patcher mirrors the PAT onto all three keys (replace-in-place / append, lookalike-key-safe, value mirrored); static guards that create/recreate/`startup.sh`/`Dockerfile` each wire the gh vars; sanitizer covers `GH_TOKEN`/`GITHUB_TOKEN`.

```
1574 tests: all pass
```
(Run in a throwaway container off `trinity-backend:latest`. Note: an unrelated pre-existing test `test_github_pat_propagation_unit::test_non_running_agents_ignored` fails on clean `dev` too — a mock-leak flake, not touched here.)

## Deploy note

The `gh` binary lands only on a **base-image rebuild** (`scripts/deploy/build-base-image.sh`); existing agents pick it up on rebuild + recreate. The env vars are harmless on older images — git keeps working, `gh` is simply absent until rebuilt. OSS-core (edition-agnostic dev ergonomics).

Related to #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1574
