### PR TITLE
feat(cleanup): add operator_queue retention sweep (#1142)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -464,7 +464,7 @@ Backend orchestration in `services/subscription_auto_switch.py`: `_hot_reload_su
 
 **Admin recovery (Phase 1c):** metadata-only (`deleted_at → NULL`) via `/api/admin/soft-deleted/*`. Agent recovery does NOT recreate the container (`needs_container_recreate=true`; operator runs `POST /api/agents/{name}/start`); schedule recovery rejoins the firing list next poll if enabled. Audit `agent_lifecycle:recover` / `schedule_recover`. Models `SoftDeletedAgent`/`SoftDeletedSchedule`.
 
-**Cleanup Service sweeps** (every 5 min): #772 retention — nulls `schedule_executions.execution_log` past `execution_log_retention_days` (default 30), DELETEs terminal `schedule_executions` past `execution_row_retention_days` (default 90), DELETEs `agent_health_checks` past `health_check_retention_days` (default 7). #834 purges — hard-deletes `agent_ownership` rows soft-deleted past `agent_soft_delete_retention_days` (default 180, `0`=off), cascading children via the #816 `purge_agent_ownership`/`cascade_delete` primitive; hard-deletes `agent_schedules` past `schedule_soft_delete_retention_days` (default 30, `0`=off) via `purge_schedule()`, cascading its `schedule_executions`. Each sweep capped at 5000 rows/cycle; `0` disables; `PRAGMA wal_checkpoint(TRUNCATE)` when any sweep reclaims rows. Also purges expired `idempotency_keys`. **Startup hook (#740):** one-shot `mark_orphan_loops_interrupted()` flips `agent_loops` rows left `queued`/`running` after a restart to `interrupted` (`stop_reason="interrupted"`); no auto-resume.
+**Cleanup Service sweeps** (every 5 min): #772 retention — nulls `schedule_executions.execution_log` past `execution_log_retention_days` (default 30), DELETEs terminal `schedule_executions` past `execution_row_retention_days` (default 90), DELETEs `agent_health_checks` past `health_check_retention_days` (default 7). #834 purges — hard-deletes `agent_ownership` rows soft-deleted past `agent_soft_delete_retention_days` (default 180, `0`=off), cascading children via the #816 `purge_agent_ownership`/`cascade_delete` primitive; hard-deletes `agent_schedules` past `schedule_soft_delete_retention_days` (default 30, `0`=off) via `purge_schedule()`, cascading its `schedule_executions`. **#1142 operator_queue retention** — DELETEs terminal `operator_queue` rows (acknowledged/cancelled/expired) past `operator_queue_retention_days` (default 90, `0`=off); `responded` rows use a more generous fixed floor (`OPERATOR_QUEUE_RESPONDED_MIN_RETENTION_DAYS`, 30d — they still carry an operator answer the 5s write-back loop must deliver), `pending` never deleted (`db.prune_operator_queue_terminal_items`, select-ids-then-delete, capped). This is the automatic complement to #1017's manual Clear-All (which only *hid* via `cleared_at`). Each sweep capped at 5000 rows/cycle; `0` disables; `PRAGMA wal_checkpoint(TRUNCATE)` when any sweep reclaims rows. Also purges expired `idempotency_keys`. **Startup hook (#740):** one-shot `mark_orphan_loops_interrupted()` flips `agent_loops` rows left `queued`/`running` after a restart to `interrupted` (`stop_reason="interrupted"`); no auto-resume.
 
 ### Ephemeral "Ghost" Agents (trinity-enterprise#69)
 
@@ -944,7 +944,7 @@ Generalises #868 to agent scope (`db/schedules.py:get_agent_analytics`); read-on
 | GET | `/api/operator-queue` | List queue items (filters: status, type, priority, agent_name, since) |
 | GET | `/api/operator-queue/stats` | Counts by status/type/priority/agent |
 | POST | `/api/operator-queue/bulk-cancel` | Cancel listed pending items (`{ids: [...]}`, 1–500, ids-scoped so a sync race can't cancel unseen items); returns `{cancelled, skipped}`; audit-logged (#1017) |
-| POST | `/api/operator-queue/clear-resolved` | Hide terminal rows (acknowledged/cancelled/expired) by setting `cleared_at` — NOT a DELETE (the 5s sync loop would resurrect items whose agent-file entry still says `pending`); `responded` kept visible until delivered; actual deletion deferred to the retention sweep (#1142); returns `{cleared}`; audit-logged (#1017) |
+| POST | `/api/operator-queue/clear-resolved` | Hide terminal rows (acknowledged/cancelled/expired) by setting `cleared_at` — NOT a DELETE (the 5s sync loop would resurrect items whose agent-file entry still says `pending`); `responded` kept visible until delivered; actual row deletion is the automatic retention sweep's job (`operator_queue_retention_days`, #1142); returns `{cleared}`; audit-logged (#1017) |
 | GET | `/api/operator-queue/{id}` | Single item |
 | POST | `/api/operator-queue/{id}/respond` / `/cancel` | Submit operator response / cancel pending item. Respond returns **409** if the item left `pending` under the caller (race vs bulk-cancel, #1017) |
 | GET | `/api/operator-queue/agents/{name}` | Items for one agent |
@@ -1636,7 +1636,7 @@ CREATE TABLE operator_queue (
     responded_by_email TEXT,
     responded_at TEXT,
     acknowledged_at TEXT,
-    cleared_at TEXT,                    -- #1017: NULL = visible; set = hidden by Clear All (deletion deferred to retention sweep #1142)
+    cleared_at TEXT,                    -- #1017: NULL = visible; set = hidden by Clear All (rows deleted by the #1142 retention sweep past operator_queue_retention_days)
     FOREIGN KEY (responded_by_id) REFERENCES users(id)
 );
 CREATE INDEX idx_operator_queue_agent ON operator_queue(agent_name);

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -2202,6 +2202,12 @@ class DatabaseManager:
     def create_operator_queue_item(self, agent_name, item):
         return self._operator_queue_ops.create_item(agent_name, item)
 
+    def prune_operator_queue_terminal_items(self, retention_days, responded_retention_days, limit=5000):
+        # #1142: retention sweep for terminal operator-queue rows.
+        return self._operator_queue_ops.prune_terminal_items(
+            retention_days, responded_retention_days, limit
+        )
+
     def get_operator_queue_item(self, item_id):
         return self._operator_queue_ops.get_item(item_id)
 

--- a/src/backend/db/operator_queue.py
+++ b/src/backend/db/operator_queue.py
@@ -16,7 +16,7 @@ import json
 from typing import Optional, List, Dict, Set
 from datetime import datetime
 
-from sqlalchemy import select, update, func, and_, case
+from sqlalchemy import select, update, func, and_, or_, case, delete
 
 from .engine import get_engine, make_insert
 from .tables import operator_queue
@@ -344,6 +344,64 @@ class OperatorQueueOperations:
         with get_engine().begin() as conn:
             result = conn.execute(
                 update(operator_queue).where(and_(*conds)).values(cleared_at=now)
+            )
+            return result.rowcount
+
+    def prune_terminal_items(
+        self,
+        retention_days: int,
+        responded_retention_days: int,
+        limit: int = 5000,
+    ) -> int:
+        """#1142: hard-DELETE old terminal operator-queue rows (retention sweep).
+
+        The counterpart to #1017's ``clear_resolved_items`` (which only *hides*
+        via ``cleared_at`` because the 5s sync loop would resurrect a deleted row
+        still ``pending`` in the agent file). By retention age those rows are long
+        settled, so they can be removed:
+
+        - ``acknowledged`` / ``cancelled`` / ``expired`` older than ``retention_days``;
+        - ``responded`` only older than the more generous ``responded_retention_days``
+          — the write-back loop still has to deliver the operator's answer to the
+          agent file, and a stopped agent picks it up on restart, so a young
+          ``responded`` row must survive. ``pending`` rows are never deleted.
+
+        Age is measured on ``created_at`` (always set). Capped at ``limit`` rows
+        per call (select-ids-then-delete, portable across SQLite/PostgreSQL). A
+        disabled window (``retention_days <= 0``) prunes nothing. Returns the
+        count deleted.
+        """
+        if retention_days <= 0 or limit <= 0:
+            return 0
+        terminal_cutoff = iso_cutoff(hours=retention_days * 24)
+        # `responded` never uses a shorter window than the terminal one.
+        resp_days = max(responded_retention_days, retention_days)
+        responded_cutoff = iso_cutoff(hours=resp_days * 24)
+
+        id_stmt = (
+            select(operator_queue.c.id)
+            .where(
+                or_(
+                    and_(
+                        operator_queue.c.status.in_(
+                            ("acknowledged", "cancelled", "expired")
+                        ),
+                        operator_queue.c.created_at < terminal_cutoff,
+                    ),
+                    and_(
+                        operator_queue.c.status == "responded",
+                        operator_queue.c.created_at < responded_cutoff,
+                    ),
+                )
+            )
+            .limit(limit)
+        )
+        with get_engine().begin() as conn:
+            ids = [r[0] for r in conn.execute(id_stmt).all()]
+            if not ids:
+                return 0
+            result = conn.execute(
+                delete(operator_queue).where(operator_queue.c.id.in_(ids))
             )
             return result.rowcount
 

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -72,6 +72,12 @@ MAX_ERROR_MESSAGE_LENGTH = 2000  # Issue #286: truncate combined error messages
 # 90-day row-delete sweep on the same fleet that's roughly one cycle.
 RETENTION_CHUNK_SIZE_PER_CYCLE = 5000
 
+# Issue #1142: `responded` operator_queue rows carry an operator answer the 5s
+# write-back loop still has to deliver to the agent file (a stopped agent picks
+# it up on restart), so they are never deleted younger than this generous floor —
+# independent of a shorter operator_queue_retention_days set for terminal rows.
+OPERATOR_QUEUE_RESPONDED_MIN_RETENTION_DAYS = 30
+
 # trinity-enterprise#69: ephemeral ghost GC bounds. Discards do serial Docker
 # I/O (stop/remove) — cap per cycle + per-discard timeout so a burst of expired
 # ghosts can't stall the watchdog/slot sweeps for the whole fleet.
@@ -198,6 +204,8 @@ class CleanupReport:
     # ephemeral containers reclaimed (Docker-as-truth pass)
     ephemeral_agents_discarded: int = 0
     ephemeral_orphans_reclaimed: int = 0
+    # Issue #1142: terminal operator_queue rows deleted past their retention window
+    operator_queue_pruned: int = 0
 
     @property
     def total(self) -> int:
@@ -209,7 +217,7 @@ class CleanupReport:
                 self.health_checks_pruned + self.soft_deleted_agents_purged +
                 self.soft_deleted_schedules_purged + self.idempotency_keys_purged +
                 self.agent_reports_pruned + self.ephemeral_agents_discarded +
-                self.ephemeral_orphans_reclaimed)
+                self.ephemeral_orphans_reclaimed + self.operator_queue_pruned)
 
     def to_dict(self) -> Dict:
         return {
@@ -229,6 +237,7 @@ class CleanupReport:
             "soft_deleted_schedules_purged": self.soft_deleted_schedules_purged,
             "idempotency_keys_purged": self.idempotency_keys_purged,
             "agent_reports_pruned": self.agent_reports_pruned,
+            "operator_queue_pruned": self.operator_queue_pruned,
             "total": self.total,
         }
 
@@ -296,6 +305,7 @@ class CleanupService:
         self._sweep_rate_limit_events()
         self._sweep_shared_files(report)
         self._sweep_retention_772(report)
+        self._sweep_operator_queue_retention(report)
         await self._sweep_soft_deleted_agents(report)
         await self._sweep_ephemeral_agents(report)
         self._sweep_soft_deleted_schedules(report)
@@ -560,6 +570,45 @@ class CleanupService:
             except Exception as e:
                 logger.error(f"[Cleanup] Error pruning agent_reports: {e}")
 
+    def _sweep_operator_queue_retention(self, report: CleanupReport) -> None:
+        """4c-quinquies. Issue #1142: delete terminal operator_queue rows past
+        their retention window. `operator_queue` was the one #772-adjacent table
+        with no automatic sweep — terminal rows (acknowledged/cancelled/expired)
+        accumulated forever; #1017's Clear All only *hid* them. `responded` rows
+        are protected by a more generous floor (they still carry an undelivered
+        operator answer). `0` disables; capped per cycle like the other sweeps.
+        """
+        try:
+            from services.settings_service import OPS_SETTINGS_DEFAULTS
+            raw = db.get_setting_value(
+                "operator_queue_retention_days",
+                OPS_SETTINGS_DEFAULTS.get("operator_queue_retention_days", "90"),
+            )
+            try:
+                days = max(int(raw), 0)
+            except (TypeError, ValueError):
+                days = 0
+        except Exception as e:
+            logger.error(f"[Cleanup] Error reading operator_queue retention setting: {e}")
+            days = 0
+
+        if days <= 0:
+            return
+        try:
+            pruned = db.prune_operator_queue_terminal_items(
+                retention_days=days,
+                responded_retention_days=OPERATOR_QUEUE_RESPONDED_MIN_RETENTION_DAYS,
+                limit=RETENTION_CHUNK_SIZE_PER_CYCLE,
+            )
+            report.operator_queue_pruned = pruned
+            if pruned > 0:
+                logger.info(
+                    f"[Cleanup] Deleted {pruned} terminal operator_queue rows "
+                    f"older than their retention window (#1142)"
+                )
+        except Exception as e:
+            logger.error(f"[Cleanup] Error pruning operator_queue: {e}")
+
     async def _sweep_soft_deleted_agents(self, report: CleanupReport) -> None:
         """4c-bis. Issue #834 Phase 1a: hard-purge soft-deleted agents past
         their retention window. `purge_agent_ownership` runs the #816
@@ -786,7 +835,8 @@ class CleanupService:
                            + report.soft_deleted_agents_purged
                            + report.soft_deleted_schedules_purged
                            + report.idempotency_keys_purged
-                           + report.agent_reports_pruned)
+                           + report.agent_reports_pruned
+                           + report.operator_queue_pruned)  # #1142
         if retention_total > 0:
             try:
                 _wal_checkpoint_truncate()

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -82,6 +82,10 @@ OPS_SETTINGS_DEFAULTS = {
     # Issue #918: retention for agent_reports. Rows older than this many days
     # are deleted by the cleanup sweep. "0" disables the sweep.
     "agent_reports_retention_days": "90",
+    # Issue #1142: retention for terminal operator_queue rows
+    # (acknowledged/cancelled/expired). "0" disables the sweep. `responded` rows
+    # get a more generous fixed floor (never deleted younger than #772's guard).
+    "operator_queue_retention_days": "90",
 }
 
 # Descriptions for each ops setting
@@ -101,6 +105,7 @@ OPS_SETTINGS_DESCRIPTIONS = {
     "agent_soft_delete_retention_days": "Days to retain soft-deleted agents before hard-purge (default: 180, 0 = disabled, #834)",
     "schedule_soft_delete_retention_days": "Days to retain soft-deleted schedules before hard-purge (default: 30, 0 = disabled, #834)",
     "agent_reports_retention_days": "Days to retain agent_reports rows (default: 90, 0 = disabled, #918)",
+    "operator_queue_retention_days": "Days to retain terminal operator_queue rows (acknowledged/cancelled/expired; default: 90, 0 = disabled, #1142)",
 }
 
 

--- a/tests/unit/test_1142_operator_queue_retention.py
+++ b/tests/unit/test_1142_operator_queue_retention.py
@@ -1,0 +1,110 @@
+"""#1142 — operator_queue retention sweep (real-engine).
+
+`prune_terminal_items` hard-deletes settled operator-queue rows past their
+retention window: acknowledged/cancelled/expired past `retention_days`, and
+`responded` only past the more generous `responded_retention_days` floor.
+`pending` rows and young rows are never deleted; a disabled window prunes
+nothing; per-cycle cap is honored. Backend-agnostic via `db_harness`.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import (  # noqa: E402
+    db_backend,
+    run as _hrun,
+    count as _hcount,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _days_ago_iso(n: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=n)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _insert(item_id: str, status: str, created_at: str, agent: str = "a1") -> None:
+    _hrun(
+        "INSERT INTO operator_queue "
+        "(id, agent_name, type, status, priority, title, question, created_at) "
+        "VALUES (:id, :ag, 'question', :st, 'medium', 't', 'q', :ca)",
+        id=item_id, ag=agent, st=status, ca=created_at,
+    )
+
+
+def _ops():
+    from db.operator_queue import OperatorQueueOperations
+    return OperatorQueueOperations()
+
+
+@pytest.fixture
+def seeded(db_backend):
+    # Terminal statuses, old + recent; responded old/mid/recent; pending old.
+    _insert("ack-old", "acknowledged", _days_ago_iso(120))
+    _insert("ack-new", "acknowledged", _days_ago_iso(3))
+    _insert("cancel-old", "cancelled", _days_ago_iso(120))
+    _insert("expire-old", "expired", _days_ago_iso(120))
+    _insert("resp-veryold", "responded", _days_ago_iso(120))
+    _insert("resp-mid", "responded", _days_ago_iso(40))   # past terminal(7) but < responded floor(30)? 40>30 → deleted
+    _insert("resp-recent", "responded", _days_ago_iso(10))
+    _insert("pending-old", "pending", _days_ago_iso(120))
+    return db_backend
+
+
+def _remaining() -> set:
+    from db.engine import get_engine
+    from sqlalchemy import text
+    with get_engine().connect() as conn:
+        return {r[0] for r in conn.execute(text("SELECT id FROM operator_queue")).all()}
+
+
+def test_terminal_purged_responded_protected(seeded):
+    # retention_days=7 (terminal), responded floor=30.
+    deleted = _ops().prune_terminal_items(retention_days=7, responded_retention_days=30)
+    remaining = _remaining()
+
+    # Old terminal rows gone.
+    assert "ack-old" not in remaining
+    assert "cancel-old" not in remaining
+    assert "expire-old" not in remaining
+    # Recent terminal kept (younger than 7d).
+    assert "ack-new" in remaining
+    # responded: past the 30d floor gone, within it kept.
+    assert "resp-veryold" not in remaining   # 120d
+    assert "resp-mid" not in remaining        # 40d > 30d floor
+    assert "resp-recent" in remaining         # 10d < 30d floor
+    # pending is NEVER deleted, regardless of age.
+    assert "pending-old" in remaining
+    assert deleted == 5
+
+
+def test_disabled_window_prunes_nothing(seeded):
+    before = _hcount("operator_queue")
+    assert _ops().prune_terminal_items(retention_days=0, responded_retention_days=30) == 0
+    assert _hcount("operator_queue") == before
+
+
+def test_responded_floor_never_shorter_than_terminal(db_backend):
+    # Even if responded_retention_days is set smaller, terminal window is the floor.
+    _insert("r", "responded", _days_ago_iso(60))
+    # terminal=90, responded arg=1 → effective responded window = max(1,90)=90 → 60<90 kept.
+    assert _ops().prune_terminal_items(retention_days=90, responded_retention_days=1) == 0
+    assert "r" in _remaining()
+
+
+def test_per_cycle_cap_is_honored(db_backend):
+    for i in range(10):
+        _insert(f"old-{i}", "acknowledged", _days_ago_iso(120))
+    deleted = _ops().prune_terminal_items(retention_days=7, responded_retention_days=30, limit=4)
+    assert deleted == 4
+    assert _hcount("operator_queue") == 6

--- a/tests/unit/test_cleanup_inner_sweeps.py
+++ b/tests/unit/test_cleanup_inner_sweeps.py
@@ -65,6 +65,7 @@ def _configure_db(db):
     db.purge_schedule.return_value = True
     db.idempotency_purge_expired.return_value = 11  # RELIABILITY-006 / #525
     db.prune_agent_reports.return_value = 3  # #918 agent_reports retention
+    db.prune_operator_queue_terminal_items.return_value = 8  # #1142 operator_queue retention
 
 
 def _run(svc):
@@ -96,7 +97,8 @@ def test_happy_path_runs_all_sweeps_and_populates_report():
     assert report.soft_deleted_schedules_purged == 2
     assert report.idempotency_keys_purged == 11
     assert report.agent_reports_pruned == 3  # #918
-    assert report.total == 8 + 9 + 1 + 2 + 3 + 4 + 2 + 5 + 6 + 7 + 1 + 2 + 11 + 3
+    assert report.operator_queue_pruned == 8  # #1142
+    assert report.total == 8 + 9 + 1 + 2 + 3 + 4 + 2 + 5 + 6 + 7 + 1 + 2 + 11 + 3 + 8  # +8 #1142
     # retention reclaimed rows ⇒ WAL checkpoint fires
     wal.assert_called_once()
     # cycle counter advanced
@@ -160,6 +162,7 @@ def test_wal_checkpoint_skipped_when_no_retention_work():
         db.find_soft_deleted_schedules_past_retention.return_value = []
         db.idempotency_purge_expired.return_value = 0
         db.prune_agent_reports.return_value = 0  # #918
+        db.prune_operator_queue_terminal_items.return_value = 0  # #1142
         _run(svc)
     wal.assert_not_called()
 
@@ -187,6 +190,7 @@ def test_wal_checkpoint_fires_when_only_agent_reports_pruned():
         db.find_soft_deleted_schedules_past_retention.return_value = []
         db.idempotency_purge_expired.return_value = 0
         db.prune_agent_reports.return_value = 4  # #918 — the only work this cycle
+        db.prune_operator_queue_terminal_items.return_value = 0  # #1142
         _run(svc)
     wal.assert_called_once()
 


### PR DESCRIPTION
## Problem

`operator_queue` was the one #772-adjacent table with **no automatic retention** — terminal rows (`acknowledged`/`cancelled`/`expired`) accumulate forever. #1017 added a manual **Clear All** (`POST /operator-queue/clear-resolved`), but it only *hides* rows via `cleared_at` (a DELETE would let the 5s sync loop resurrect a row still `pending` in the agent file). Unbounded growth should be handled automatically like the other tables.

## Fix (mirrors the #772/#834/#918 pattern)

- **`db/operator_queue.prune_terminal_items(retention_days, responded_retention_days, limit)`** — hard-DELETEs `acknowledged`/`cancelled`/`expired` past `retention_days`, and `responded` **only** past a more generous floor (those rows still carry an operator answer the write-back loop must deliver; a stopped agent picks it up on restart). `pending` is never deleted. Age on `created_at`; **select-ids-then-delete** so the LIMIT is portable across SQLite + PostgreSQL; capped per cycle. Disabled window (`<=0`) prunes nothing.
- **`cleanup_service._sweep_operator_queue_retention`** — reads `operator_queue_retention_days` (default **90**, `0`=off), passes the fixed `OPERATOR_QUEUE_RESPONDED_MIN_RETENTION_DAYS=30` floor, 5000/cycle cap; wired into the cycle and the WAL-checkpoint trigger. New `operator_queue_pruned` report field.
- Setting `operator_queue_retention_days` (+ description) and facade delegator `db.prune_operator_queue_terminal_items`.
- Docs: architecture.md cleanup-sweeps paragraph + the `clear-resolved` endpoint / `operator_queue.cleared_at` notes (which already pointed at "#1142").

## Acceptance criteria

- [x] Sweep wired into the cleanup cycle with a config knob + docs (architecture.md).
- [x] Terminal statuses purged past window; `responded` protected by a generous age guard (never shorter than the terminal window).
- [x] Capped per cycle; `0` disables.

## Tests

`tests/unit/test_1142_operator_queue_retention.py` — **4, real-engine `db_harness`** (SQLite + PG-capable): terminal rows purged past the window, `responded` protected by the 30d floor **and** never deleted younger than the terminal window, `pending` never deleted, disabled window is a no-op, per-cycle cap honored. The #1026 `test_cleanup_inner_sweeps.py` characterization test updated for the new sweep (mock + report/total/WAL assertions).

```
10 passed (new + characterization)
```
Run in a throwaway container off `trinity-backend:latest`. No schema change (reuses the existing `operator_queue` table).

Related to #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1142
