### PR TITLE
fix(git-sync): bound agent .git bloat — maintenance repack + ignore conventions + size observability (#1596, PR-1)

### DIFF
--- a/docker/base-image/agent_server/routers/git.py
+++ b/docker/base-image/agent_server/routers/git.py
@@ -95,6 +95,7 @@ _SYNC_STATE_DEFAULT: Dict = {
     "last_sync_at": None,
     "last_error_summary": None,
     "consecutive_failures": 0,
+    "git_dir_bytes": None,  # #1596: last-measured .git on-disk size
 }
 
 
@@ -124,11 +125,14 @@ def _write_sync_state_file(
     last_sync_status: str,
     last_sync_at: Optional[str] = None,
     last_error_summary: Optional[str] = None,
+    git_dir_bytes: Optional[int] = None,
 ) -> Dict:
     """Persist one sync outcome.
 
     consecutive_failures is bumped on `failed`, reset on `success`, untouched
     on `never`. last_error_summary is cleared on success, kept on never.
+    git_dir_bytes (#1596) is updated when measured; a None here preserves the
+    last known value.
     """
     prior = _read_sync_state_file(home_dir)
 
@@ -140,6 +144,9 @@ def _write_sync_state_file(
         prior["last_error_summary"] = None
     # else 'never' — leave counters alone
 
+    if git_dir_bytes is not None:
+        prior["git_dir_bytes"] = git_dir_bytes
+
     prior["last_sync_status"] = last_sync_status
     prior["last_sync_at"] = last_sync_at or datetime.now(timezone.utc).isoformat()
 
@@ -149,8 +156,68 @@ def _write_sync_state_file(
     return prior
 
 
+# #1596: auto-sync commits the workspace on every heartbeat and never ran git
+# maintenance, so `git gc --auto` (which only stacks incremental packs under this
+# write pattern) let one agent's .git reach 44GB / 2,267 packs. Consolidate when
+# the pack count crosses a threshold — bounded work, self-throttling (a healthy
+# repo with few packs is a no-op). Non-destructive: repack rewrites packs +
+# prunes redundant/unreachable objects; it does NOT rewrite reachable history
+# (an opt-in squash policy is a separate follow-up).
+_GIT_MAINTENANCE_PACK_THRESHOLD = int(os.getenv("GIT_MAINTENANCE_PACK_THRESHOLD", "20"))
+
+
+def _count_git_packs(home_dir: Path) -> int:
+    try:
+        return sum(1 for _ in (home_dir / ".git" / "objects" / "pack").glob("*.pack"))
+    except Exception:
+        return 0
+
+
+def _git_dir_bytes(home_dir: Path) -> Optional[int]:
+    """#1596: on-disk size of the agent's ``.git`` (observability). Uses ``du -sb``
+    (a fast C tree walk — safe even at millions of objects). None on any error."""
+    git_dir = home_dir / ".git"
+    if not git_dir.exists():
+        return None
+    try:
+        res = subprocess.run(
+            ["du", "-sb", str(git_dir)],
+            capture_output=True, text=True, timeout=60, check=True,
+        )
+        return int(res.stdout.split()[0])
+    except Exception:
+        return None
+
+
+def _maybe_run_git_maintenance(home_dir: Path) -> Optional[str]:
+    """#1596: consolidate .git when packs pile up. Best-effort, non-fatal — a
+    failed/skipped maintenance never fails the sync. Returns a short status."""
+    packs = _count_git_packs(home_dir)
+    if packs < _GIT_MAINTENANCE_PACK_THRESHOLD:
+        return None
+    try:
+        # -a: repack ALL objects into a single pack; -d: delete now-redundant
+        # packs; -l: local only (don't pull remote packs). Then gc prunes loose
+        # + unreachable garbage immediately.
+        subprocess.run(
+            ["git", "repack", "-adl", "-q"],
+            cwd=str(home_dir), capture_output=True, text=True, timeout=1800, check=True,
+        )
+        subprocess.run(
+            ["git", "gc", "--quiet", "--prune=now"],
+            cwd=str(home_dir), capture_output=True, text=True, timeout=600, check=False,
+        )
+        after = _count_git_packs(home_dir)
+        logger.info("git maintenance: consolidated %d packs -> %d", packs, after)
+        return f"repacked {packs}->{after}"
+    except Exception as exc:  # never let maintenance break the sync loop
+        logger.warning("git maintenance failed (non-fatal): %s", exc)
+        return "failed"
+
+
 def _run_auto_sync_once(home_dir: Path) -> Dict:
-    """One auto-sync cycle: stage, commit if dirty, push. Records outcome.
+    """One auto-sync cycle: stage, commit if dirty, push, maybe consolidate .git.
+    Records outcome.
 
     Intentionally minimal — heavy conflict handling stays in the operator-
     initiated `sync_to_github` endpoint. Auto-sync is a heartbeat, not a
@@ -186,8 +253,17 @@ def _run_auto_sync_once(home_dir: Path) -> Dict:
                                     last_sync_at=now, last_error_summary=err)
             return {"status": "failed", "error": err}
 
-        _write_sync_state_file(home_dir, "success", last_sync_at=now)
-        return {"status": "success"}
+        # #1596: consolidate .git when packs pile up (self-throttling, non-fatal),
+        # then record the resulting .git size so operators can watch the curve.
+        maintenance = _maybe_run_git_maintenance(home_dir)
+        _write_sync_state_file(
+            home_dir, "success", last_sync_at=now,
+            git_dir_bytes=_git_dir_bytes(home_dir),
+        )
+        result = {"status": "success"}
+        if maintenance:
+            result["maintenance"] = maintenance
+        return result
 
     except subprocess.CalledProcessError as exc:
         err = _summarize_git_error(exc.stderr or exc.stdout or str(exc))

--- a/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
+++ b/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
@@ -162,6 +162,24 @@ credentials.json
 # Large generated content - DO NOT COMMIT
 content/
 
+# Bulk data / deps / cache / index dirs - DO NOT COMMIT (#1596)
+# These churn on every run and bloat .git unboundedly under auto-sync.
+# Git sync is for code + state, not datasets/indexes/deps — those belong
+# in data_paths (#1169). Negate per-repo if genuinely needed (e.g. !keep.db).
+node_modules/
+.venv/
+venv/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.ipynb_checkpoints/
+*.sqlite
+*.sqlite3
+*.db
+
 # Claude Code - commit commands/skills/agents, exclude runtime data
 .claude.json
 .claude.json.backup

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -543,9 +543,9 @@ Declared runtime data (SQLite DBs, datasets) over the **existing durable home vo
 
 ### Git Sync Health (#389/#390)
 
-**Agent side:** 15-min `auto_sync` heartbeat loop in the agent server (gated by `GIT_SYNC_AUTO`; default-on for non-source-mode GitHub-template agents) stages/commits/pushes in-container changes and writes the outcome to `.trinity/sync-state.json` (S1a).
+**Agent side:** 15-min `auto_sync` heartbeat loop in the agent server (gated by `GIT_SYNC_AUTO`; default-on for non-source-mode GitHub-template agents) stages/commits/pushes in-container changes and writes the outcome to `.trinity/sync-state.json` (S1a). **Bloat controls (#1596):** after a successful push the loop runs a self-throttling consolidating **repack** (`git repack -adl` + `git gc --prune=now`) once the pack count crosses `GIT_MAINTENANCE_PACK_THRESHOLD` (default 20) — bounding the pack/loose/garbage growth that let one agent's `.git` reach 44 GB (non-destructive; does NOT rewrite reachable history). It also measures `.git` on-disk size (`du -sb`) into `sync-state.json.git_dir_bytes`. The fleet-wide default `.gitignore` (`git_service._GITIGNORE_PATTERNS`, merged into each agent on sync) now also excludes bulk data/deps/caches (`node_modules/`, `.venv/`, `__pycache__/`, `*.sqlite`/`*.db`, …) so churny non-source files aren't auto-committed going forward (an opt-in history-squash policy for existing bloat is a deferred follow-up).
 
-**Backend side** (details in [git-sync-health.md](feature-flows/git-sync-health.md)): `SyncHealthService` polls git-enabled agents every 60s, upserts `agent_sync_state` (`consecutive_failures` ++ on fail / reset on success; `ahead_working`/`behind_working` expose working-branch divergence, P6), emits `sync_failing` operator-queue entries at ≥3 failures (S1). Powers the dashboard sync dot, `GET /api/agents/sync-health`, and `GET /api/fleet/sync-audit` — whose `duplicate_binding` flag marks agents sharing a `(github_repo, working_branch)` pair (§P5 silent-clobber setup) (S6, #390).
+**Backend side** (details in [git-sync-health.md](feature-flows/git-sync-health.md)): `SyncHealthService` polls git-enabled agents every 60s, upserts `agent_sync_state` (`consecutive_failures` ++ on fail / reset on success; `ahead_working`/`behind_working` expose working-branch divergence, P6; `git_dir_bytes` carries the agent's `.git` size for the bloat curve, #1596), emits `sync_failing` operator-queue entries at ≥3 failures (S1). Powers the dashboard sync dot, `GET /api/agents/sync-health` (now incl. `git_dir_bytes`), and `GET /api/fleet/sync-audit` — whose `duplicate_binding` flag marks agents sharing a `(github_repo, working_branch)` pair (§P5 silent-clobber setup) (S6, #390).
 
 **Recovery (S3, #384):** `POST /api/agents/{name}/git/reset-to-main-preserve-state` adopts `origin/main`, snapshots the S4 persistent-state allowlist first, overlays it back, force-with-lease pushes — safe recovery for parallel-history deadlock (P2/P3). 409 with `X-Conflict-Type: agent_busy | no_git_config | no_remote_main`. Per-agent toggles: auto-sync flag and freeze-schedules-if-sync-failing flag (see API Endpoints).
 
@@ -1660,6 +1660,7 @@ CREATE TABLE agent_sync_state (
     behind_main INTEGER DEFAULT 0,
     ahead_working INTEGER DEFAULT 0,       -- #389 P6: working-branch divergence
     behind_working INTEGER DEFAULT 0,
+    git_dir_bytes INTEGER,                 -- #1596: agent .git on-disk size (bloat curve)
     last_check_at TEXT,
     updated_at TEXT NOT NULL,
     FOREIGN KEY (agent_name) REFERENCES agent_ownership(agent_name)

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -2811,6 +2811,21 @@ def _migrate_enterprise_connectors_table(cursor, conn):
     conn.commit()
 
 
+def _migrate_agent_sync_state_git_dir_bytes(cursor, conn):
+    """Add git_dir_bytes to agent_sync_state (#1596).
+
+    Records the agent's `.git` on-disk size (measured by the auto-sync heartbeat)
+    so operators can watch workspace-repo bloat before the disk fills. Nullable —
+    populated on the next sync of a git-enabled agent.
+    """
+    _safe_add_column(
+        cursor,
+        "agent_sync_state",
+        "git_dir_bytes",
+        "ALTER TABLE agent_sync_state ADD COLUMN git_dir_bytes INTEGER",
+    )
+
+
 MIGRATIONS = [
     ("agent_sharing", _migrate_agent_sharing_table),
     ("schedule_executions_observability", _migrate_schedule_executions_observability),
@@ -2901,4 +2916,5 @@ MIGRATIONS = [
     ("agent_ownership_ephemeral", _migrate_agent_ownership_ephemeral),
     ("agent_ownership_tts_channel_flags", _migrate_agent_ownership_tts_channel_flags),
     ("schedule_executions_source_channel", _migrate_schedule_executions_source_channel),
+    ("agent_sync_state_git_dir_bytes", _migrate_agent_sync_state_git_dir_bytes),
 ]

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -681,6 +681,7 @@ TABLES = {
             behind_main INTEGER DEFAULT 0,
             ahead_working INTEGER DEFAULT 0,
             behind_working INTEGER DEFAULT 0,
+            git_dir_bytes INTEGER,
             last_check_at TEXT,
             updated_at TEXT NOT NULL,
             FOREIGN KEY (agent_name) REFERENCES agent_ownership(agent_name)

--- a/src/backend/db/sync_state.py
+++ b/src/backend/db/sync_state.py
@@ -31,6 +31,7 @@ _COLUMNS = (
     "behind_main",
     "ahead_working",
     "behind_working",
+    "git_dir_bytes",  # #1596: agent .git on-disk size (bloat observability)
     "last_check_at",
     "updated_at",
 )
@@ -72,6 +73,7 @@ class SyncStateOperations:
         behind_main: Optional[int] = None,
         ahead_working: Optional[int] = None,
         behind_working: Optional[int] = None,
+        git_dir_bytes: Optional[int] = None,
         last_check_at: Optional[str] = None,
     ) -> Dict:
         """Upsert a sync-state row.
@@ -110,6 +112,7 @@ class SyncStateOperations:
             "behind_main": _merged("behind_main", behind_main) or 0,
             "ahead_working": _merged("ahead_working", ahead_working) or 0,
             "behind_working": _merged("behind_working", behind_working) or 0,
+            "git_dir_bytes": _merged("git_dir_bytes", git_dir_bytes),  # #1596
             "last_check_at": last_check_at or now,
             "updated_at": now,
         }

--- a/src/backend/db/tables.py
+++ b/src/backend/db/tables.py
@@ -597,6 +597,7 @@ agent_sync_state = Table(
     Column("behind_main", Integer),
     Column("ahead_working", Integer),
     Column("behind_working", Integer),
+    Column("git_dir_bytes", Integer),  # #1596: agent .git on-disk size
     Column("last_check_at", Text),
     Column("updated_at", Text),
 )

--- a/src/backend/migrations/versions/0019_agent_sync_state_git_dir_bytes.py
+++ b/src/backend/migrations/versions/0019_agent_sync_state_git_dir_bytes.py
@@ -1,0 +1,33 @@
+"""agent_sync_state.git_dir_bytes — workspace .git size (#1596)
+
+Adds ``git_dir_bytes`` (nullable INTEGER) on the PostgreSQL backend. The
+auto-sync heartbeat measures the agent's ``.git`` on-disk size and reports it via
+``GET /api/git/status``; ``SyncHealthService`` persists it here so operators can
+watch workspace-repo bloat before the disk fills (git-sync data churn, #1596).
+Mirrors the SQLite ``agent_sync_state_git_dir_bytes`` migration in
+``db/migrations.py`` and the DDL in ``db/schema.py`` / MetaData in ``db/tables.py``.
+
+Fresh PG builds already get the column via ``0001_baseline``; ``ADD COLUMN IF NOT
+EXISTS`` keeps this a no-op there.
+
+Revision ID: 0019_agent_sync_state_git_dir_bytes
+Revises: 0018_schedule_executions_source_channel
+Create Date: 2026-07-13
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0019_agent_sync_state_git_dir_bytes"
+down_revision = "0018_schedule_executions_source_channel"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE agent_sync_state ADD COLUMN IF NOT EXISTS git_dir_bytes INTEGER"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agent_sync_state DROP COLUMN IF EXISTS git_dir_bytes")

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -274,6 +274,7 @@ async def get_all_sync_health(
             "behind_main": (row or {}).get("behind_main") or 0,
             "ahead_working": (row or {}).get("ahead_working") or 0,
             "ahead_main": (row or {}).get("ahead_main") or 0,
+            "git_dir_bytes": (row or {}).get("git_dir_bytes"),  # #1596 bloat curve
         })
     return {"agents": entries}
 

--- a/src/backend/services/fleet_audit_service.py
+++ b/src/backend/services/fleet_audit_service.py
@@ -59,6 +59,7 @@ async def build_fleet_sync_audit(agent_names: Optional[List[str]] = None) -> Dic
             "unpushed_commits": unpushed,
             "dirty_tree": dirty_tree,
             "duplicate_binding": name in duplicates,
+            "git_dir_bytes": state.get("git_dir_bytes"),  # #1596 workspace .git size
         })
 
     entries.sort(key=lambda e: e["name"])

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -895,6 +895,26 @@ _GITIGNORE_PATTERNS: Tuple[str, ...] = (
     ".trinity-clone-tmp/",  # #1439 transient full-history clone staging dir (removed post-merge; ignored so a crash-orphaned copy — incl. its PAT-bearing .git/config — is never committed)
     # Large generated content
     "content/",
+    # #1596: bulk data / dependency / cache / index dirs that churn on every
+    # run and bloat `.git` unboundedly under auto-sync. Git sync is for code +
+    # state, not datasets/indexes/deps — those belong in `data_paths` (#1169) or
+    # stay local. Merged into existing agents on sync, which also untracks any
+    # already-committed matches (stops future churn; doesn't shrink history).
+    # An agent that genuinely needs one committed can negate it in its own
+    # `.gitignore` (e.g. `!keep.db`).
+    "node_modules/",
+    ".venv/",
+    "venv/",
+    "__pycache__/",
+    "*.pyc",
+    "*.pyo",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    ".ipynb_checkpoints/",
+    "*.sqlite",
+    "*.sqlite3",
+    "*.db",
     # Claude Code runtime — commit commands/skills/agents, exclude runtime data
     ".claude.json",
     ".claude.json.backup",

--- a/src/backend/services/sync_health_service.py
+++ b/src/backend/services/sync_health_service.py
@@ -135,6 +135,7 @@ class SyncHealthService:
             behind_main=payload.get("behind_main") or payload.get("behind") or 0,
             ahead_working=payload.get("ahead_working") or 0,
             behind_working=payload.get("behind_working") or 0,
+            git_dir_bytes=sync_state.get("git_dir_bytes"),  # #1596 bloat observability
             last_check_at=utc_now_iso(),
         )
 

--- a/tests/unit/test_1596_git_sync_observability.py
+++ b/tests/unit/test_1596_git_sync_observability.py
@@ -1,0 +1,68 @@
+"""#1596 — git-sync bloat mitigations (backend slice).
+
+Covers the observability chain (agent .git size persisted to agent_sync_state)
+and the default-.gitignore conventions that stop bulk data/deps/caches from being
+auto-committed. The agent-side maintenance repack + .git-size measurement live in
+the base image (docker/base-image/agent_server/routers/git.py) and are exercised
+by the image build / live sync, not here.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _ops():
+    from db.sync_state import SyncStateOperations
+    return SyncStateOperations()
+
+
+class TestGitDirBytesRoundTrip:
+    def test_upsert_and_read_git_dir_bytes(self, db_backend):
+        ops = _ops()
+        ops.upsert("a1", last_sync_status="success", git_dir_bytes=47244640256)  # ~44 GiB
+        row = ops.get("a1")
+        assert row["git_dir_bytes"] == 47244640256
+
+    def test_partial_update_preserves_git_dir_bytes(self, db_backend):
+        ops = _ops()
+        ops.upsert("a1", last_sync_status="success", git_dir_bytes=1000)
+        # A later failed sync that doesn't re-measure must keep the last value.
+        ops.upsert("a1", last_sync_status="failed", last_error_summary="push failed")
+        row = ops.get("a1")
+        assert row["git_dir_bytes"] == 1000
+        assert row["last_sync_status"] == "failed"
+
+    def test_list_all_surfaces_the_field(self, db_backend):
+        ops = _ops()
+        ops.upsert("a1", last_sync_status="success", git_dir_bytes=42)
+        rows = {r["agent_name"]: r for r in ops.list_all()}
+        assert rows["a1"]["git_dir_bytes"] == 42
+
+
+class TestDefaultGitignoreConventions:
+    def test_bulk_data_patterns_present(self):
+        from services.git_service import _GITIGNORE_PATTERNS
+        for pat in (
+            "node_modules/", ".venv/", "venv/", "__pycache__/",
+            "*.pyc", ".pytest_cache/", "*.sqlite", "*.sqlite3", "*.db",
+        ):
+            assert pat in _GITIGNORE_PATTERNS, f"{pat} missing from default .gitignore (#1596)"
+
+    def test_still_ignores_credentials_and_content(self):
+        # Guard against a copy-paste that drops the pre-existing safety rules.
+        from services.git_service import _GITIGNORE_PATTERNS
+        for pat in (".env", ".mcp.json", "content/", "*.pem"):
+            assert pat in _GITIGNORE_PATTERNS


### PR DESCRIPTION
## Problem (P1 — disk exhaustion)

Git-sync auto-commit (`agent_server/routers/git.py::_run_auto_sync_once`) does `git add -A` → commit → push every 15-min heartbeat. Under skills that write churny data files, `.git` grew unboundedly: **one agent's `.git` reached 44 GB / 2,267 packs / 4.26M objects**; the fleet hit ~110 GB and the host 90%.

## ⚠️ Root cause update (see #1595) — scope narrowed; destructive prong dropped

Further investigation (credit: parallel work on **#1595 / #1505**) found the **true** root cause is **not** reachable history retention — it's that **git maintenance can never complete inside agent containers**: git's detached `gc --auto` reparents to PID 1, the #817 orphan sweeper **SIGKILLs** it (a bare SIGKILL, so it leaves stale `.lock`/`gc.pid` litter), and every subsequent gc then aborts on the stale lock — permanently disabling maintenance for that repo. **~97% of the bloat is unreachable garbage, not committed history** (a plain non-destructive `git gc --prune=now` took one agent 44 GB → 1.6 GB, `fsck` clean, HEAD unchanged).

Consequence for this PR:
- The **destructive history-compaction** prong originally proposed here was **dropped** — it solves the wrong problem (unreachable garbage needs no history rewrite) and is unsafe (a long rebase/gc on a big repo is itself SIGKILLed mid-operation by the same sweeper).
- The **load-bearing fix lives in #1595** (sweeper SIGTERM-then-SIGKILL + allowlist git maintenance + stale-lock cleanup), tracked separately to avoid conflicting edits to the sweeper.

## This PR — the non-destructive prongs that stand on their own

### 1. Maintenance repack (agent side)
After a successful push, `_maybe_run_git_maintenance` runs `git repack -adl` + `git gc --prune=now` once the pack count crosses `GIT_MAINTENANCE_PACK_THRESHOLD` (default 20). Self-throttling, best-effort, non-destructive. **Note:** its reliability on large repos depends on the #1595 sweeper fix (an in-container git process is currently sweep-exposed) — it fully self-heals small/medium repos now and all repos once #1595 lands.

### 2. Ignore conventions
`git_service._GITIGNORE_PATTERNS` now also excludes `node_modules/`, `.venv/`, `venv/`, `__pycache__/`, `*.pyc`/`*.pyo`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `.ipynb_checkpoints/`, `*.sqlite`/`*.sqlite3`/`*.db`. Merged into each agent on sync (also **untracks** already-committed matches). Datasets/indexes belong in `data_paths` (#1169).

### 3. Observability
- Agent measures `.git` size (`du -sb`) into `sync-state.json.git_dir_bytes`, returned via `GET /api/git/status`.
- New `agent_sync_state.git_dir_bytes` column (dual migration: SQLite + Alembic `0019`); `SyncHealthService` persists it; surfaced on `GET /api/agents/sync-health`, `GET /api/fleet/sync-audit`, and the per-agent sync-state endpoint.

## Acceptance criteria

- [x] Maintenance: consolidating repack bounds pack count + reclaims loose/garbage (non-destructive).
- [x] Ignore conventions: default `.gitignore` excludes data/cache/venv/index/deps.
- [x] Observability: `.git` size in sync health + fleet audit.
- [ ] **Moved to #1595 (real root cause):** sweeper SIGTERM-then-SIGKILL + git-maintenance allowlist + stale-lock cleanup — the change that lets maintenance actually run.
- [ ] Deferred: warn-on-large-file auto-commit guardrail.

## Tests

`tests/unit/test_1596_git_sync_observability.py` — `git_dir_bytes` round-trips + a partial (failed) update preserves the last size; the default `.gitignore` includes the bulk-data set **and** keeps the pre-existing credential/`content/` safety rules. Schema + Alembic parity green.

## Deploy note

Agent-side maintenance + `.git`-size measurement land on a **base-image rebuild** + agent recreate. The DB/backend surfacing works immediately. Full de-bloat of the existing 44 GB agents comes from **#1595** (fix the sweeper so `gc --prune=now` can run to completion); this PR bounds future growth and gives operators the size curve.

Related to #1596 · root cause #1595 · #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
