### PR TITLE
fix: ephemeral budget gate no longer counts the execution's own pre-created row (#1601)

### DIFF
--- a/docs/memory/feature-flows/ephemeral-agents.md
+++ b/docs/memory/feature-flows/ephemeral-agents.md
@@ -88,8 +88,12 @@ recorded accepted-risk follow-up.
   `terminal+running+queued ≥ max_executions` raises
   `EphemeralBudgetExhausted` — nothing admitted or enqueued. Covers every
   admission surface through the one facade (`/chat` + `/task` + scheduler +
-  a2a + loop iterations). Fail-open on DB error. Routers map it to **410
-  Gone** (`ephemeral_budget_exhausted`); `execute_task` maps it to a FAILED
+  a2a + loop iterations). The count **excludes the row being admitted**
+  (#1601: `/task` + scheduler pre-create a RUNNING row before `acquire` —
+  counting it denied a `max_executions=1` ghost its first run; racing
+  sibling admissions still see each other, so the overshoot bound holds).
+  Fail-open on DB error. Routers map it to **410 Gone**
+  (`ephemeral_budget_exhausted`); `execute_task` maps it to a FAILED
   row with `TaskExecutionErrorCode.EPHEMERAL_EXHAUSTED`.
 - **Terminal hook**: `_maybe_discard_exhausted_ephemeral` — spawned via
   `_spawn_bg` after a CAS-won terminal in `apply_result` (both branches,
@@ -168,11 +172,12 @@ database.py.
 
 ## Testing
 
-`tests/unit/test_69_ephemeral_agents.py` (40 tests, db_harness — real engine,
+`tests/unit/test_69_ephemeral_agents.py` (42 tests, db_harness — real engine,
 never a wholesale-mocked `database`): column live-select; mixin accessors
 round-trips incl. purge-refuses-durable + cascade read-back; facade
 delegations; acquire-gate deny matrix (expired/exhausted/active-counted,
-fail-open) proven to fire BEFORE slot work; key-fence allow/deny matrix;
+fail-open) proven to fire BEFORE slot work, incl. own-row exclusion at both
+the DB and gate layers (#1601); key-fence allow/deny matrix;
 Part 2 guard matrix (name+key-id); budget hook fail-open + trigger; discard
 full-path + idempotent re-run + half-discarded resume + lock contention +
 audit-row read-back; atomic quota INCR-with-cap + Redis-down fallback.

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -419,8 +419,10 @@ class DatabaseManager:
     def mark_ephemeral_discard_intent(self, agent_name: str):
         return self._agent_ops.mark_ephemeral_discard_intent(agent_name)
 
-    def count_ephemeral_budget_usage(self, agent_name: str):
-        return self._agent_ops.count_ephemeral_budget_usage(agent_name)
+    def count_ephemeral_budget_usage(self, agent_name: str, exclude_execution_id=None):
+        return self._agent_ops.count_ephemeral_budget_usage(
+            agent_name, exclude_execution_id=exclude_execution_id
+        )
 
     def find_discardable_ephemeral_agents(self, limit: int = 50):
         return self._agent_ops.find_discardable_ephemeral_agents(limit)

--- a/src/backend/db/agent_settings/ephemeral.py
+++ b/src/backend/db/agent_settings/ephemeral.py
@@ -95,12 +95,22 @@ class EphemeralMixin:
             )
             return result.rowcount > 0
 
-    def count_ephemeral_budget_usage(self, agent_name: str) -> Dict[str, int]:
+    def count_ephemeral_budget_usage(
+        self, agent_name: str, exclude_execution_id: Optional[str] = None
+    ) -> Dict[str, int]:
         """Budget usage counters for the admission gate + terminal hook.
 
         Single-pass conditional aggregation: ``terminal`` = consumed budget
         (success/failed/cancelled), ``active`` = queued/running/pending_retry
         (counted at admission so concurrency can't overshoot the budget).
+
+        ``exclude_execution_id`` (#1601): the admission gate passes the id of
+        the execution being admitted so its OWN pre-created row (the /task
+        and scheduler paths write a RUNNING row before ``acquire``) never
+        counts against the budget — otherwise a ``max_executions=1`` ghost
+        denies its first run. Paths that acquire before creating the row are
+        unaffected (the id isn't in the table yet). The terminal discard hook
+        omits it — the just-finished row must count.
         """
         terminal_statuses = [s.value for s in _BUDGET_TERMINAL_STATUSES]
         active_statuses = [s.value for s in _ACTIVE_STATUSES]
@@ -124,6 +134,8 @@ class EphemeralMixin:
                 0,
             ).label("active"),
         ).where(schedule_executions.c.agent_name == agent_name)
+        if exclude_execution_id:
+            stmt = stmt.where(schedule_executions.c.id != exclude_execution_id)
         with get_engine().connect() as conn:
             row = conn.execute(stmt).mappings().first()
         return {

--- a/src/backend/services/capacity_manager.py
+++ b/src/backend/services/capacity_manager.py
@@ -298,7 +298,13 @@ class CapacityManager:
             _max_exec = _eph.get("ephemeral_max_executions")
             if _max_exec:
                 try:
-                    _usage = _db.count_ephemeral_budget_usage(agent_name)
+                    # #1601: exclude the row being admitted — the /task and
+                    # scheduler paths pre-create a RUNNING row before acquire,
+                    # and counting it against the budget denies a
+                    # max_executions=1 ghost its first (only) run.
+                    _usage = _db.count_ephemeral_budget_usage(
+                        agent_name, exclude_execution_id=execution_id
+                    )
                 except Exception as e:  # pragma: no cover - defensive
                     logger.warning(
                         f"[Capacity] ephemeral budget count failed for {agent_name}: {e}"

--- a/tests/unit/test_69_ephemeral_agents.py
+++ b/tests/unit/test_69_ephemeral_agents.py
@@ -190,6 +190,27 @@ def test_budget_usage_counts_terminal_and_active(agent_ops):
     assert usage == {"terminal": 3, "active": 2}
 
 
+def test_budget_usage_excludes_admitted_row(agent_ops):
+    """#1601: the admission gate excludes the execution's own pre-created
+    RUNNING row so it never counts against the budget."""
+    _register_ghost(agent_ops)
+    seed_schedule("s1", agent_name="ghost-ab12")
+    seed_execution("s1", "ghost-ab12", exec_id="e1", status="success")
+    seed_execution("s1", "ghost-ab12", exec_id="e5", status="running")
+
+    # Own running row excluded → active drops to 0, terminal untouched.
+    usage = agent_ops.count_ephemeral_budget_usage(
+        "ghost-ab12", exclude_execution_id="e5"
+    )
+    assert usage == {"terminal": 1, "active": 0}
+
+    # Excluding an id not in the table is a no-op (acquire-before-create paths).
+    usage = agent_ops.count_ephemeral_budget_usage(
+        "ghost-ab12", exclude_execution_id="e-not-created-yet"
+    )
+    assert usage == {"terminal": 1, "active": 1}
+
+
 def test_find_discardable_by_ttl_and_budget(agent_ops):
     # Expired TTL ghost
     _register_ghost(agent_ops, name="ghost-old", max_executions=None,
@@ -287,7 +308,14 @@ def test_database_manager_delegations_exist():
     mgr.mark_ephemeral_discard_intent("a")
     mgr._agent_ops.mark_ephemeral_discard_intent.assert_called_once_with("a")
     mgr.count_ephemeral_budget_usage("a")
-    mgr._agent_ops.count_ephemeral_budget_usage.assert_called_once_with("a")
+    mgr._agent_ops.count_ephemeral_budget_usage.assert_called_once_with(
+        "a", exclude_execution_id=None
+    )
+    mgr._agent_ops.count_ephemeral_budget_usage.reset_mock()
+    mgr.count_ephemeral_budget_usage("a", exclude_execution_id="e9")
+    mgr._agent_ops.count_ephemeral_budget_usage.assert_called_once_with(
+        "a", exclude_execution_id="e9"
+    )
     mgr.find_discardable_ephemeral_agents(7)
     mgr._agent_ops.find_discardable_ephemeral_agents.assert_called_once_with(7)
     mgr.count_live_ephemeral_agents_for_owner(1)
@@ -364,7 +392,7 @@ async def test_acquire_denies_budget_exhausted_counting_active(gated_capacity, m
     # terminal+active >= max: 2 terminal + 1 running == 3 → deny (overshoot bound)
     monkeypatch.setattr(
         db, "count_ephemeral_budget_usage",
-        lambda name: {"terminal": 2, "active": 1},
+        lambda name, exclude_execution_id=None: {"terminal": 2, "active": 1},
     )
     with pytest.raises(EphemeralBudgetExhausted) as exc:
         await gated_capacity.acquire(
@@ -395,12 +423,58 @@ async def test_acquire_passes_durable_and_underbudget_ghost(gated_capacity, monk
     )
     monkeypatch.setattr(
         db, "count_ephemeral_budget_usage",
-        lambda name: {"terminal": 1, "active": 0},
+        lambda name, exclude_execution_id=None: {"terminal": 1, "active": 0},
     )
     result = await gated_capacity.acquire(
         agent_name="ghost-a", execution_id="e2", max_concurrent=1
     )
     assert result.state == "admitted"
+
+
+@pytest.mark.asyncio
+async def test_acquire_gate_excludes_own_precreated_row(gated_capacity, monkeypatch):
+    """#1601: the /task and scheduler paths pre-create a RUNNING row before
+    acquire — the gate must exclude that row or a max_executions=1 ghost
+    denies its first (only) run."""
+    from database import db
+    from services.capacity_manager import EphemeralBudgetExhausted
+
+    gated_capacity._slots.acquire_slot = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        db, "get_agent_ephemeral_info",
+        lambda name: {
+            "is_ephemeral": True,
+            "ephemeral_expires_at": "2099-01-01T00:00:00.000000Z",
+            "ephemeral_max_executions": 1,
+        },
+    )
+
+    seen = {}
+
+    def fake_count(name, exclude_execution_id=None):
+        seen["exclude"] = exclude_execution_id
+        # Simulates the real table: one active row (the caller's own,
+        # pre-created RUNNING) which vanishes from the count when excluded.
+        if exclude_execution_id == "e-self":
+            return {"terminal": 0, "active": 0}
+        return {"terminal": 0, "active": 1}
+
+    monkeypatch.setattr(db, "count_ephemeral_budget_usage", fake_count)
+
+    # Fresh max_executions=1 ghost admits its own first run.
+    result = await gated_capacity.acquire(
+        agent_name="ghost-a", execution_id="e-self", max_concurrent=1
+    )
+    assert result.state == "admitted"
+    assert seen["exclude"] == "e-self"  # gate passed its own id through
+
+    # A DIFFERENT execution racing the same last budget slot still denies:
+    # the first run's row is active and not its own.
+    with pytest.raises(EphemeralBudgetExhausted) as exc:
+        await gated_capacity.acquire(
+            agent_name="ghost-a", execution_id="e-other", max_concurrent=1
+        )
+    assert exc.value.reason == "budget_exhausted"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- The `/task` and scheduler paths pre-create the execution row with `status=RUNNING` **before** `execute_task` → `CapacityManager.acquire`, so the #69 ephemeral admission gate's `terminal + active` count included the row being admitted: a `max_executions=1` ghost denied its first (only) run with 410 `ephemeral_budget_exhausted`, and every N-budget ghost lost its final run. Found by the live activation smoke required by trinity-enterprise#148.
- Fix: `acquire` already knows the `execution_id` being admitted — thread it through as `count_ephemeral_budget_usage(exclude_execution_id=...)` and exclude that row from the count. Paths that acquire before creating the row are unaffected (the id isn't in the table yet — exclusion is a no-op). The terminal discard hook keeps the un-excluded count (the just-finished row must count).
- Concurrency overshoot bound preserved: two racing admissions for the last budget slot each exclude only their own row, so they still see each other and both deny.

## Changes

- `src/backend/db/agent_settings/ephemeral.py` — optional `exclude_execution_id` on `count_ephemeral_budget_usage`
- `src/backend/services/capacity_manager.py` — gate passes the admitted `execution_id`
- `src/backend/database.py` — facade delegation carries the kwarg
- `tests/unit/test_69_ephemeral_agents.py` — new: DB-layer exclusion (own row / unknown id no-op) + gate-level #1601 scenario (own row admits, racing sibling still denies, id threaded through); existing monkeypatched doubles updated to the new signature

## Test plan

- [x] `tests/unit/test_69_ephemeral_agents.py` — **42 passed** (40 existing + 2 new)
- [x] Adjacent units: `test_capacity_manager.py`, `test_backlog.py` — 101 passed combined
- [x] Live verification on the local stack: pre-fix, a fresh `max_executions=1` ghost 410'd its first `/task`; post-fix the same flow admits, runs (`SMOKE-OK`), and hard-discards via the terminal hook within seconds (container removed, ownership purged, audit `ephemeral_discard` row)

Fixes #1601

🤖 Generated with [Claude Code](https://claude.com/claude-code)