### PR TITLE
feat(channels): make proactive message rate limits admin-configurable (#1609)

### DIFF
--- a/docs/memory/requirements/public-access.md
+++ b/docs/memory/requirements/public-access.md
@@ -191,7 +191,7 @@
   - `GET /api/agents/{name}/telegram/groups` — List group configs
   - `PUT /api/agents/{name}/telegram/groups/{id}` — Update group config (trigger mode, welcome settings)
   - `DELETE /api/agents/{name}/telegram/groups/{id}` — Remove group config (deactivates)
-  - `POST /api/agents/{name}/telegram/groups/{chat_id}/messages` — Proactive group messaging (rate limited: 10/hr/group, 100/hr/agent)
+  - `POST /api/agents/{name}/telegram/groups/{chat_id}/messages` — Proactive group messaging (rate limited: 10/hr/group, 100/hr/agent by default — admin-configurable, #1609)
 - **MCP Tools**:
   - `list_channel_groups` — List Telegram groups the agent is connected to
   - `send_group_message` — Send proactive message to a group (supports Telegram HTML, max 4096 chars)
@@ -404,6 +404,15 @@
   converges the stored snapshot to settled. A divergent
   client header never forks execution; an underivable key (missing token/body) disables dedup (fail-open,
   never a constant collision).
+
+### Configurable Proactive Message Rate Limits (#1609)
+- **Status**: ✅ Implemented (2026-07-14)
+- **GitHub Issue**: #1609
+- **Description**: The anti-spam caps on **agent-initiated** ("proactive") channel sends — introduced hardcoded by #349/#350/#321 — are admin-configurable. **Inbound replies (DM/@mention/thread via the channel adapters) are NEVER subject to these caps**; only agent-initiated sends are.
+- **Five caps** (per hour, shipped defaults reproduce prior behavior exactly): Slack per-channel (10) / per-agent (100); Telegram per-group (10) / per-agent (100); proactive-DM per-recipient (10).
+- **Config**: `settings_service.get_proactive_rate_limit(key)` — runtime-resolved from `system_settings` (no cache, `--workers 2`-consistent, no migration; #506 shape), fail-open to the shipped default. `0 = unlimited` (disables that cap; the PUT warns). Read at request time by `routers/slack.py`, `routers/telegram.py`, and `services/proactive_message_service.py`.
+- **Endpoints**: `GET/PUT /api/settings/proactive-rate-limits` (admin; registered before the `/{key}` catch-all, which rejects these keys; range-validated `[0, 1000000]` with a named 422; audit-logged). Surfaced in Settings → General ("Proactive message limits" card).
+- **Limiter unification**: Telegram's bespoke per-process in-memory bucket migrated to the shared Redis sliding-window limiter (`services/rate_limiter.py`, #1023) — matching Slack and fixing multi-worker inconsistency. 429 messages name which cap fired.
 
 ### 23.4 Admin Configuration
 - **Status**: ✅ Implemented (2026-03-04)

--- a/docs/user-docs/faq/channels-and-messaging.md
+++ b/docs/user-docs/faq/channels-and-messaging.md
@@ -89,3 +89,9 @@ Calls are rate-limited to 5 per owner and destination number per 60 seconds, cap
 ## How does Trinity know who is messaging my agent from a channel?
 
 The verified email is the identity across every channel: a user verified on Telegram, WhatsApp, or a public link, or identified via Slack workspace OAuth, is the same person to Trinity everywhere. That email is checked against the agent's access policy — open access lets anyone chat, while restricted agents admit only the owner, admins, and emails on the shared-access list, with everyone else generating a pending access request. Approving a user once admits them on all channels. The Sharing tab also shows a client roster of external channel users who have messaged the agent. For the approval flow and policy details, see [Access Control](../sharing-and-access/access-control.md).
+
+## Can I change how many proactive messages my agent can send?
+
+Yes. An admin can tune the anti-spam caps on **agent-initiated** ("proactive") sends under **Settings → General → Proactive message limits**: Slack per-channel and per-agent, Telegram per-group and per-agent, and proactive direct messages per recipient — each a per-hour limit. The shipped defaults are 10/hour per channel/group/recipient and 100/hour per agent, so nothing changes until you raise them. Set a value to **0** to make that cap unlimited (the guardrail is disabled and the save warns you). Changes take effect immediately, with no restart. This is the setting to raise for a legitimate high-volume agent — for example, one that posts a Slack message for each inbound support request.
+
+Note: these caps apply only to messages the agent *starts*. **Replies to inbound messages** (a DM, an @mention, or a thread reply through a channel) are never limited by them.

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -743,6 +743,19 @@ class MaxParallelTasksCeilingUpdate(BaseModel):
     value: int
 
 
+class ProactiveRateLimitsUpdate(BaseModel):
+    """Body for PUT /api/settings/proactive-rate-limits (#1609).
+
+    All optional — only provided caps change. Each is an int per hour; ``0`` =
+    unlimited. Range ([0, MAX]) is enforced in the router with a named 422.
+    """
+    slack_proactive_per_channel: Optional[int] = None
+    slack_proactive_per_agent: Optional[int] = None
+    telegram_proactive_per_group: Optional[int] = None
+    telegram_proactive_per_agent: Optional[int] = None
+    proactive_dm_per_recipient: Optional[int] = None
+
+
 class AgentCapacityUpdate(BaseModel):
     """Body for PUT /api/agents/{name}/capacity (CAPACITY-001, #506)."""
     max_parallel_tasks: int

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -1570,7 +1570,10 @@ async def update_proactive_rate_limits_setting(
     """
     require_admin(current_user)
 
-    updated, warnings = [], []
+    # Validate ALL provided fields BEFORE writing any — a mixed valid/invalid body
+    # must be all-or-nothing (a 422 leaves every cap unchanged), not partially
+    # applied.
+    pending = {}
     for key in PROACTIVE_RATE_LIMIT_DEFAULTS:
         value = getattr(body, key, None)
         if value is None:
@@ -1580,6 +1583,10 @@ async def update_proactive_rate_limits_setting(
                 status_code=422,
                 detail=f"{key} must be an integer between 0 and {PROACTIVE_RATE_LIMIT_MAX} (0 = unlimited)",
             )
+        pending[key] = value
+
+    updated, warnings = [], []
+    for key, value in pending.items():
         db.set_setting(key, str(value))
         updated.append(key)
         if value == 0:

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -18,6 +18,7 @@ from models import (
     AgentDefaultAccessPolicyUpdate,
     AgentDefaultResourcesUpdate,
     AgentQuotaUpdate,
+    ProactiveRateLimitsUpdate,
     ApiKeyTest,
     ApiKeyUpdate,
     BrainOrbSettingsUpdate,
@@ -57,6 +58,10 @@ from services.settings_service import (
     MAX_PARALLEL_TASKS_CEILING_MIN,
     MAX_PARALLEL_TASKS_CEILING_MAX,
     get_max_parallel_tasks_ceiling,
+    PROACTIVE_RATE_LIMIT_DEFAULTS,
+    PROACTIVE_RATE_LIMIT_DESCRIPTIONS,
+    PROACTIVE_RATE_LIMIT_MAX,
+    get_proactive_rate_limit,
 )
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
@@ -1526,6 +1531,80 @@ async def update_max_parallel_tasks_ceiling_setting(
     }
 
 
+@router.get("/proactive-rate-limits")
+async def get_proactive_rate_limits_setting(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Effective proactive channel-message caps (#1609).
+
+    Admin-only. The five agent-INITIATED anti-spam caps (Slack per-channel /
+    per-agent, Telegram per-group / per-agent, proactive-DM per-recipient),
+    per hour. ``0`` = unlimited. Inbound replies are never subject to these.
+    """
+    require_admin(current_user)
+    limits = {
+        key: {
+            "value": get_proactive_rate_limit(key),
+            "default": default,
+            "is_default": get_proactive_rate_limit(key) == default
+                          and settings_service.get_setting(key) is None,
+            "description": PROACTIVE_RATE_LIMIT_DESCRIPTIONS.get(key, ""),
+        }
+        for key, default in PROACTIVE_RATE_LIMIT_DEFAULTS.items()
+    }
+    return {"limits": limits, "max": PROACTIVE_RATE_LIMIT_MAX, "window_hours": 1}
+
+
+@router.put("/proactive-rate-limits")
+async def update_proactive_rate_limits_setting(
+    body: ProactiveRateLimitsUpdate,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Set proactive channel-message caps (#1609).
+
+    Admin-only. Only provided fields change; each must be an int in
+    ``[0, MAX]`` (``0`` = unlimited, which is warned in the response). Named
+    422 on bad input. Audit-logged. Runtime-resolved — no restart.
+    """
+    require_admin(current_user)
+
+    updated, warnings = [], []
+    for key in PROACTIVE_RATE_LIMIT_DEFAULTS:
+        value = getattr(body, key, None)
+        if value is None:
+            continue
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0 or value > PROACTIVE_RATE_LIMIT_MAX:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{key} must be an integer between 0 and {PROACTIVE_RATE_LIMIT_MAX} (0 = unlimited)",
+            )
+        db.set_setting(key, str(value))
+        updated.append(key)
+        if value == 0:
+            warnings.append(f"{key} is now UNLIMITED — the anti-spam guardrail is disabled for it.")
+
+    if updated:
+        await platform_audit_service.log(
+            event_type=AuditEventType.CONFIGURATION,
+            event_action="settings_change",
+            source="api",
+            actor_user=current_user,
+            actor_ip=request.client.host if request.client else None,
+            endpoint=str(request.url.path),
+            request_id=getattr(request.state, "request_id", None),
+            details={"setting": "proactive_rate_limits", "action": "update", "updated": updated},
+        )
+
+    return {
+        "success": True,
+        "updated": updated,
+        "warnings": warnings,
+        "limits": {key: get_proactive_rate_limit(key) for key in PROACTIVE_RATE_LIMIT_DEFAULTS},
+    }
+
+
 # ============================================================================
 # Brain Orb Feature Flags (trinity-enterprise#85 — admin-configurable)
 # ============================================================================
@@ -1811,6 +1890,16 @@ async def update_setting(
             detail=(
                 "max_parallel_tasks_ceiling must be set via "
                 "PUT /api/settings/max-parallel-tasks-ceiling (range-validated 1–32)"
+            ),
+        )
+
+    # #1609: proactive caps go through the dedicated range-validated route.
+    if key in PROACTIVE_RATE_LIMIT_DEFAULTS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{key} must be set via PUT /api/settings/proactive-rate-limits "
+                f"(range-validated 0–{PROACTIVE_RATE_LIMIT_MAX}, 0 = unlimited)"
             ),
         )
 

--- a/src/backend/routers/slack.py
+++ b/src/backend/routers/slack.py
@@ -24,7 +24,7 @@ from models import SlackChannelMessageRequest, SlackEventResponse, User
 from services import rate_limiter
 from services.slack_service import slack_service
 from db_models import SlackConnectionStatus, SlackOAuthInitResponse
-from services.settings_service import get_slack_signing_secret
+from services.settings_service import get_slack_signing_secret, get_proactive_rate_limit
 from services.platform_audit_service import platform_audit_service, AuditEventType
 
 logger = logging.getLogger(__name__)
@@ -612,10 +612,9 @@ async def set_agent_as_slack_dm_default(
 # Proactive channel messaging (#350 Phase 3) — parallels Telegram #349
 # =============================================================================
 
-# Mirror the Telegram proactive caps (10/hr/channel, 100/hr/agent) via the
-# shared sliding-window limiter (#1023) rather than a bespoke bucket.
-_SLACK_PROACTIVE_PER_CHANNEL = 10
-_SLACK_PROACTIVE_PER_AGENT = 100
+# Proactive caps via the shared sliding-window limiter (#1023). The per-channel /
+# per-agent limits are admin-configurable (#1609) — sourced from settings at
+# request time (0 = unlimited). Window is fixed at 1 hour.
 _SLACK_PROACTIVE_WINDOW = 3600
 _SLACK_MESSAGE_MAX = 4000
 
@@ -682,17 +681,22 @@ async def send_agent_slack_channel_message(
     if not target:
         raise HTTPException(status_code=404, detail="Channel not found or not bound to this agent")
 
-    # Rate limit: per-channel then per-agent (fail-open inside the limiter).
-    rate_limiter.enforce(
-        f"slack_proactive:{name}:{channel_id}",
-        _SLACK_PROACTIVE_PER_CHANNEL, _SLACK_PROACTIVE_WINDOW,
-        detail="Too many messages to this channel.",
-    )
-    rate_limiter.enforce(
-        f"slack_proactive:{name}",
-        _SLACK_PROACTIVE_PER_AGENT, _SLACK_PROACTIVE_WINDOW,
-        detail="Too many proactive messages from this agent.",
-    )
+    # Rate limit: per-channel then per-agent, caps sourced from settings (#1609;
+    # 0 = unlimited → skip). Fail-open inside the limiter.
+    per_channel = get_proactive_rate_limit("slack_proactive_per_channel")
+    per_agent = get_proactive_rate_limit("slack_proactive_per_agent")
+    if per_channel > 0:
+        rate_limiter.enforce(
+            f"slack_proactive:{name}:{channel_id}",
+            per_channel, _SLACK_PROACTIVE_WINDOW,
+            detail=f"Too many messages to this channel (cap {per_channel}/hour).",
+        )
+    if per_agent > 0:
+        rate_limiter.enforce(
+            f"slack_proactive:{name}",
+            per_agent, _SLACK_PROACTIVE_WINDOW,
+            detail=f"Too many proactive messages from this agent (cap {per_agent}/hour).",
+        )
 
     bot_token = db.get_slack_workspace_bot_token(target["team_id"])
     if not bot_token:

--- a/src/backend/routers/telegram.py
+++ b/src/backend/routers/telegram.py
@@ -23,6 +23,8 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request, Depends
 
 from database import db
+from services import rate_limiter
+from services.settings_service import get_proactive_rate_limit
 from dependencies import get_current_user, OwnedAgentByName
 from models import (
     TelegramBindingResponse,
@@ -338,52 +340,11 @@ async def delete_telegram_group(
 # Proactive Group Messaging (Issue #349)
 # =========================================================================
 
-# Rate limiting constants
-_PROACTIVE_RATE_LIMIT_PER_GROUP = 10     # messages per hour per group
-_PROACTIVE_RATE_LIMIT_PER_AGENT = 100    # messages per hour per agent
+# Proactive caps via the shared sliding-window limiter (#1023) — Redis-backed, so
+# consistent across workers (the old per-process in-memory bucket was not). The
+# per-group / per-agent limits are admin-configurable (#1609), sourced from
+# settings at request time (0 = unlimited). Window fixed at 1 hour.
 _PROACTIVE_RATE_LIMIT_WINDOW = 3600      # 1 hour in seconds
-
-# In-memory rate limit buckets (agent:group → timestamps)
-_proactive_rate_buckets: dict = {}
-
-
-def _check_proactive_rate_limit(agent_name: str, chat_id: str) -> tuple[bool, str]:
-    """
-    Check rate limits for proactive messaging.
-
-    Returns (allowed, error_message). If not allowed, error_message explains why.
-    """
-    import time
-
-    now = time.time()
-    window = _PROACTIVE_RATE_LIMIT_WINDOW
-
-    # Clean old entries
-    group_key = f"{agent_name}:{chat_id}"
-    agent_key = f"{agent_name}:*"
-
-    # Group-level check
-    group_bucket = _proactive_rate_buckets.get(group_key, [])
-    group_bucket = [t for t in group_bucket if now - t < window]
-    _proactive_rate_buckets[group_key] = group_bucket
-
-    if len(group_bucket) >= _PROACTIVE_RATE_LIMIT_PER_GROUP:
-        return False, f"Rate limited: max {_PROACTIVE_RATE_LIMIT_PER_GROUP} messages/hour to this group"
-
-    # Agent-level check (sum across all groups)
-    agent_total = 0
-    for key, bucket in list(_proactive_rate_buckets.items()):
-        if key.startswith(f"{agent_name}:"):
-            cleaned = [t for t in bucket if now - t < window]
-            _proactive_rate_buckets[key] = cleaned
-            agent_total += len(cleaned)
-
-    if agent_total >= _PROACTIVE_RATE_LIMIT_PER_AGENT:
-        return False, f"Rate limited: max {_PROACTIVE_RATE_LIMIT_PER_AGENT} proactive messages/hour"
-
-    # Allow and record
-    _proactive_rate_buckets[group_key] = group_bucket + [now]
-    return True, ""
 
 
 @auth_router.post("/{agent_name}/telegram/groups/{chat_id}/messages")
@@ -409,10 +370,21 @@ async def send_telegram_group_message(
     if not target_group:
         raise HTTPException(status_code=404, detail="Group not found or not active for this agent")
 
-    # Check rate limits
-    allowed, error_msg = _check_proactive_rate_limit(agent_name, chat_id)
-    if not allowed:
-        raise HTTPException(status_code=429, detail=error_msg)
+    # Rate limit: per-group then per-agent, caps from settings (#1609; 0 = skip).
+    per_group = get_proactive_rate_limit("telegram_proactive_per_group")
+    per_agent = get_proactive_rate_limit("telegram_proactive_per_agent")
+    if per_group > 0:
+        rate_limiter.enforce(
+            f"telegram_proactive:{agent_name}:{chat_id}",
+            per_group, _PROACTIVE_RATE_LIMIT_WINDOW,
+            detail=f"Too many messages to this group (cap {per_group}/hour).",
+        )
+    if per_agent > 0:
+        rate_limiter.enforce(
+            f"telegram_proactive:{agent_name}",
+            per_agent, _PROACTIVE_RATE_LIMIT_WINDOW,
+            detail=f"Too many proactive messages from this agent (cap {per_agent}/hour).",
+        )
 
     # Validate message length
     if not request.message or not request.message.strip():

--- a/src/backend/services/proactive_message_service.py
+++ b/src/backend/services/proactive_message_service.py
@@ -18,6 +18,7 @@ from typing import Optional, Literal
 from database import db
 from services import idempotency_service
 from services.platform_audit_service import platform_audit_service, AuditEventType
+from services.settings_service import get_proactive_rate_limit  # #1609
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,6 @@ class ProactiveMessageService:
     def _check_rate_limit(self, agent_name: str, recipient_email: str) -> bool:
         """Check if sending is allowed under rate limits. Returns True if OK."""
         # #1609: admin-configurable per-recipient cap; 0 = unlimited.
-        from services.settings_service import get_proactive_rate_limit
         limit = get_proactive_rate_limit("proactive_dm_per_recipient")
         if limit <= 0:
             return True

--- a/src/backend/services/proactive_message_service.py
+++ b/src/backend/services/proactive_message_service.py
@@ -21,8 +21,11 @@ from services.platform_audit_service import platform_audit_service, AuditEventTy
 
 logger = logging.getLogger(__name__)
 
-# Rate limiting configuration
-RATE_LIMIT_MAX_PER_HOUR = 10  # messages per recipient per hour
+# Rate limiting configuration. The per-recipient cap is admin-configurable
+# (#1609) — sourced from settings at check time via
+# ``settings_service.get_proactive_rate_limit("proactive_dm_per_recipient")``
+# (0 = unlimited). RATE_LIMIT_MAX_PER_HOUR remains the shipped default there.
+RATE_LIMIT_MAX_PER_HOUR = 10  # messages per recipient per hour (default)
 RATE_LIMIT_WINDOW_SECONDS = 3600  # 1 hour
 
 
@@ -94,6 +97,12 @@ class ProactiveMessageService:
 
     def _check_rate_limit(self, agent_name: str, recipient_email: str) -> bool:
         """Check if sending is allowed under rate limits. Returns True if OK."""
+        # #1609: admin-configurable per-recipient cap; 0 = unlimited.
+        from services.settings_service import get_proactive_rate_limit
+        limit = get_proactive_rate_limit("proactive_dm_per_recipient")
+        if limit <= 0:
+            return True
+
         redis = self._get_redis()
         if not redis:
             # Redis unavailable — allow (degraded mode)
@@ -105,7 +114,7 @@ class ProactiveMessageService:
             count = redis.get(key)
             if count is None:
                 return True
-            return int(count) < RATE_LIMIT_MAX_PER_HOUR
+            return int(count) < limit
         except Exception as e:
             logger.warning(f"Rate limit check failed: {e}")
             return True

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -710,6 +710,62 @@ def get_max_parallel_tasks_ceiling() -> int:
     return parsed
 
 
+# ============================================================================
+# Proactive channel-message rate limits (#1609)
+# ============================================================================
+#
+# Admin-tunable anti-spam caps on agent-INITIATED ("proactive") sends —
+# introduced hardcoded by #349/#350/#321. Inbound replies (DM/@mention/thread
+# via the channel adapters) are NEVER gated by these. All share a fixed 1-hour
+# window (as shipped). ``0`` = unlimited (disabled), matching the agent-quota
+# convention; the PUT warns when a cap is disabled. Runtime-resolved (no cache,
+# ``--workers 2``-consistent, no migration — same rationale as #506).
+
+PROACTIVE_RATE_LIMIT_WINDOW_SECONDS = 3600  # 1 hour, fixed (matches #349/#350/#321)
+# key → shipped default (the pre-#1609 hardcoded value). Defaults reproduce
+# current behavior exactly.
+PROACTIVE_RATE_LIMIT_DEFAULTS = {
+    "slack_proactive_per_channel": 10,
+    "slack_proactive_per_agent": 100,
+    "telegram_proactive_per_group": 10,
+    "telegram_proactive_per_agent": 100,
+    "proactive_dm_per_recipient": 10,
+}
+PROACTIVE_RATE_LIMIT_DESCRIPTIONS = {
+    "slack_proactive_per_channel": "Max proactive Slack messages per hour to a single channel (0 = unlimited)",
+    "slack_proactive_per_agent": "Max proactive Slack messages per hour across all channels for one agent (0 = unlimited)",
+    "telegram_proactive_per_group": "Max proactive Telegram messages per hour to a single group (0 = unlimited)",
+    "telegram_proactive_per_agent": "Max proactive Telegram messages per hour across all groups for one agent (0 = unlimited)",
+    "proactive_dm_per_recipient": "Max proactive direct messages per hour to a single recipient (0 = unlimited)",
+}
+PROACTIVE_RATE_LIMIT_MAX = 1_000_000  # sanity upper bound
+
+
+def get_proactive_rate_limit(key: str) -> int:
+    """Fail-open read-through for a #1609 proactive cap (per hour).
+
+    Returns the configured integer (``0`` = unlimited → callers skip the limiter),
+    the shipped default on an absent/garbage value, clamped into ``[0, MAX]`` so
+    a stray store value can neither fail-closed the channel nor overflow. No
+    per-process cache (``--workers 2`` consistency), fail-open on a settings-read
+    failure so a proactive send is never blocked by a DB hiccup.
+    """
+    default = PROACTIVE_RATE_LIMIT_DEFAULTS.get(key, 0)
+    try:
+        raw = settings_service.get_setting(key)
+    except Exception:
+        return default
+    if raw is None:
+        return default
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if parsed < 0:
+        return default
+    return min(parsed, PROACTIVE_RATE_LIMIT_MAX)
+
+
 def clamp_to_ceiling(n: int) -> int:
     """Clamp a per-agent concurrency cap to the fleet ceiling (#506).
 

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -281,6 +281,44 @@
                   </p>
                 </div>
 
+                <!-- Proactive message limits (#1609) — admin-tunable per-hour caps on agent-INITIATED channel sends -->
+                <div v-if="isAdmin" class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
+                  <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">Proactive message limits</h3>
+                  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    Per-hour caps on messages an agent <span class="font-medium">initiates</span> to Slack, Telegram, and direct messages (anti-spam).
+                    Replies to inbound messages are never limited by these. Set <span class="font-medium">0</span> to disable a cap (unlimited).
+                  </p>
+                  <div class="mt-3 space-y-2.5">
+                    <div v-for="row in PROACTIVE_ROWS" :key="row.key" class="flex items-center gap-3">
+                      <input
+                        type="number"
+                        min="0"
+                        :max="proactiveMax"
+                        v-model.number="proactiveLimits[row.key]"
+                        :disabled="savingProactive"
+                        class="block w-28 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
+                      />
+                      <div class="min-w-0">
+                        <div class="text-sm text-gray-700 dark:text-gray-300">{{ row.label }}</div>
+                        <div class="text-xs text-gray-400">{{ row.hint }}</div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="mt-3 flex items-center gap-3">
+                    <button
+                      @click="saveProactiveLimits"
+                      :disabled="savingProactive"
+                      class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >Save</button>
+                    <span v-if="proactiveSaveSuccess" class="inline-flex items-center text-sm text-status-success-600 dark:text-status-success-400">
+                      <svg class="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                      Saved
+                    </span>
+                  </div>
+                  <p v-for="w in proactiveWarnings" :key="w" class="mt-1 text-xs text-status-warning-600 dark:text-status-warning-400">⚠ {{ w }}</p>
+                  <p v-if="proactiveError" class="mt-1 text-sm text-status-danger-600 dark:text-status-danger-400">{{ proactiveError }}</p>
+                </div>
+
                 <!-- Brain Orb platform flags (trinity-enterprise#85) -->
                 <div v-if="isAdmin" class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
                   <h3 class="text-sm font-medium text-gray-900 dark:text-white">Brain Orb</h3>
@@ -2382,6 +2420,21 @@ const maxParallelTasksCeiling = ref(10)
 const ceilingMin = ref(1)
 const ceilingMax = ref(32)
 const savingCeiling = ref(false)
+
+// #1609: admin-tunable proactive channel-message caps (per hour; 0 = unlimited).
+const PROACTIVE_ROWS = [
+  { key: 'slack_proactive_per_channel', label: 'Slack — per channel', hint: 'Proactive messages/hour to one Slack channel' },
+  { key: 'slack_proactive_per_agent', label: 'Slack — per agent', hint: 'Across all Slack channels for one agent' },
+  { key: 'telegram_proactive_per_group', label: 'Telegram — per group', hint: 'Proactive messages/hour to one Telegram group' },
+  { key: 'telegram_proactive_per_agent', label: 'Telegram — per agent', hint: 'Across all Telegram groups for one agent' },
+  { key: 'proactive_dm_per_recipient', label: 'Direct messages — per recipient', hint: 'Proactive DMs/hour to one recipient' },
+]
+const proactiveLimits = ref({})
+const proactiveMax = ref(1000000)
+const savingProactive = ref(false)
+const proactiveSaveSuccess = ref(false)
+const proactiveError = ref('')
+const proactiveWarnings = ref([])
 const ceilingSaveSuccess = ref(false)
 const ceilingError = ref('')
 
@@ -2575,6 +2628,7 @@ async function loadSettings() {
       loadPlatformDefaultModel(),
       loadDefaultAccessPolicy(),
       loadMaxParallelTasksCeiling(),
+      loadProactiveLimits(),
       loadBrainOrbSettings(),
       loadElevenLabsSettings(),
       loadApiKeyStatus(),
@@ -2856,6 +2910,37 @@ async function saveMaxParallelTasksCeiling() {
     await loadMaxParallelTasksCeiling()
   } finally {
     savingCeiling.value = false
+  }
+}
+
+// #1609: proactive channel-message caps
+async function loadProactiveLimits() {
+  try {
+    const { data } = await axios.get('/api/settings/proactive-rate-limits', { headers: authStore.authHeader })
+    const next = {}
+    for (const key of Object.keys(data.limits || {})) next[key] = data.limits[key].value
+    proactiveLimits.value = next
+    if (data.max) proactiveMax.value = data.max
+  } catch {
+    // non-critical; card shows the shipped defaults
+  }
+}
+
+async function saveProactiveLimits() {
+  savingProactive.value = true
+  proactiveSaveSuccess.value = false
+  proactiveError.value = ''
+  proactiveWarnings.value = []
+  try {
+    const { data } = await axios.put('/api/settings/proactive-rate-limits', { ...proactiveLimits.value }, { headers: authStore.authHeader })
+    proactiveWarnings.value = data.warnings || []
+    proactiveSaveSuccess.value = true
+    setTimeout(() => { proactiveSaveSuccess.value = false }, 3000)
+    await loadProactiveLimits()
+  } catch (e) {
+    proactiveError.value = e.response?.data?.detail || 'Failed to save proactive message limits'
+  } finally {
+    savingProactive.value = false
   }
 }
 

--- a/tests/unit/test_1609_proactive_rate_limits.py
+++ b/tests/unit/test_1609_proactive_rate_limits.py
@@ -96,8 +96,11 @@ class TestProactiveDmEnforcement:
         return ProactiveMessageService()
 
     def _set_limit(self, monkeypatch, value):
-        import services.settings_service as ss
-        monkeypatch.setattr(ss, "get_proactive_rate_limit", lambda *_a, **_kw: value)
+        # Patch the name as bound in the CONSUMER module (proactive_message_service
+        # imports get_proactive_rate_limit at module level), which is robust to
+        # sys.modules identity quirks in the full suite.
+        import services.proactive_message_service as pms
+        monkeypatch.setattr(pms, "get_proactive_rate_limit", lambda *_a, **_kw: value)
 
     def test_zero_limit_is_unlimited_and_skips_redis(self, svc, monkeypatch):
         self._set_limit(monkeypatch, 0)

--- a/tests/unit/test_1609_proactive_rate_limits.py
+++ b/tests/unit/test_1609_proactive_rate_limits.py
@@ -1,0 +1,77 @@
+"""Unit tests for the #1609 configurable proactive-message rate-limit getter.
+
+Covers `settings_service.get_proactive_rate_limit`: shipped-default fallback,
+parse/garbage/negative fallback, the `0 = unlimited` pass-through, the upper
+clamp, and fail-open on a settings-read error — all isolated from the DB by
+monkeypatching `get_setting`. (`src/backend` on sys.path via
+tests/unit/conftest.py.)
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def ss():
+    from services import settings_service as _ss
+    return _ss
+
+
+def _patch_raw(monkeypatch, ss, value):
+    monkeypatch.setattr(ss.settings_service, "get_setting", lambda *_a, **_kw: value)
+
+
+class TestProactiveRateLimitGetter:
+    def test_shipped_defaults(self, ss, monkeypatch):
+        # Absent value → the pre-#1609 hardcoded default per key.
+        _patch_raw(monkeypatch, ss, None)
+        assert ss.get_proactive_rate_limit("slack_proactive_per_channel") == 10
+        assert ss.get_proactive_rate_limit("slack_proactive_per_agent") == 100
+        assert ss.get_proactive_rate_limit("telegram_proactive_per_group") == 10
+        assert ss.get_proactive_rate_limit("telegram_proactive_per_agent") == 100
+        assert ss.get_proactive_rate_limit("proactive_dm_per_recipient") == 10
+
+    def test_configured_value(self, ss, monkeypatch):
+        _patch_raw(monkeypatch, ss, "42")
+        assert ss.get_proactive_rate_limit("slack_proactive_per_channel") == 42
+
+    def test_zero_is_unlimited_passthrough(self, ss, monkeypatch):
+        # 0 must survive (callers treat it as "skip the limiter"), not fall back.
+        _patch_raw(monkeypatch, ss, "0")
+        assert ss.get_proactive_rate_limit("slack_proactive_per_agent") == 0
+
+    def test_garbage_falls_back_to_default(self, ss, monkeypatch):
+        _patch_raw(monkeypatch, ss, "not-a-number")
+        assert ss.get_proactive_rate_limit("telegram_proactive_per_group") == 10
+
+    def test_negative_falls_back_to_default(self, ss, monkeypatch):
+        _patch_raw(monkeypatch, ss, "-5")
+        assert ss.get_proactive_rate_limit("proactive_dm_per_recipient") == 10
+
+    def test_over_max_is_clamped(self, ss, monkeypatch):
+        _patch_raw(monkeypatch, ss, str(ss.PROACTIVE_RATE_LIMIT_MAX + 999))
+        assert ss.get_proactive_rate_limit("slack_proactive_per_channel") == ss.PROACTIVE_RATE_LIMIT_MAX
+
+    def test_fail_open_on_read_error(self, ss, monkeypatch):
+        def _boom(*_a, **_kw):
+            raise RuntimeError("settings DB down")
+        monkeypatch.setattr(ss.settings_service, "get_setting", _boom)
+        # A read failure must degrade to the shipped default, never raise.
+        assert ss.get_proactive_rate_limit("slack_proactive_per_agent") == 100
+
+    def test_unknown_key_defaults_to_zero(self, ss, monkeypatch):
+        _patch_raw(monkeypatch, ss, None)
+        assert ss.get_proactive_rate_limit("nonexistent_key") == 0
+
+    def test_defaults_map_matches_shipped_constants(self, ss):
+        # Guards the "zero behavior change on upgrade" AC: the registry defaults
+        # are exactly the pre-#1609 hardcoded values.
+        assert ss.PROACTIVE_RATE_LIMIT_DEFAULTS == {
+            "slack_proactive_per_channel": 10,
+            "slack_proactive_per_agent": 100,
+            "telegram_proactive_per_group": 10,
+            "telegram_proactive_per_agent": 100,
+            "proactive_dm_per_recipient": 10,
+        }

--- a/tests/unit/test_1609_proactive_rate_limits.py
+++ b/tests/unit/test_1609_proactive_rate_limits.py
@@ -75,3 +75,61 @@ class TestProactiveRateLimitGetter:
             "telegram_proactive_per_agent": 100,
             "proactive_dm_per_recipient": 10,
         }
+
+
+class _FakeRedis:
+    """Minimal redis stub — a per-key integer counter for the DM limiter."""
+    def __init__(self, counts=None):
+        self._counts = dict(counts or {})
+    def get(self, key):
+        v = self._counts.get(key)
+        return None if v is None else str(v)
+
+
+class TestProactiveDmEnforcement:
+    """The proactive-DM per-recipient cap now sources its limit from settings
+    (#1609) and treats 0 as unlimited. Exercises the real `_check_rate_limit`."""
+
+    @pytest.fixture
+    def svc(self):
+        from services.proactive_message_service import ProactiveMessageService
+        return ProactiveMessageService()
+
+    def _set_limit(self, monkeypatch, value):
+        import services.settings_service as ss
+        monkeypatch.setattr(ss, "get_proactive_rate_limit", lambda *_a, **_kw: value)
+
+    def test_zero_limit_is_unlimited_and_skips_redis(self, svc, monkeypatch):
+        self._set_limit(monkeypatch, 0)
+        # Redis must not even be consulted when the cap is disabled.
+        def _boom():
+            raise AssertionError("redis should not be touched when unlimited")
+        monkeypatch.setattr(svc, "_get_redis", _boom)
+        assert svc._check_rate_limit("atlas", "bob@example.com") is True
+
+    def test_under_configured_limit_allows(self, svc, monkeypatch):
+        self._set_limit(monkeypatch, 10)
+        key = svc._rate_limit_key("atlas", "bob@example.com")
+        monkeypatch.setattr(svc, "_get_redis", lambda: _FakeRedis({key: 9}))
+        assert svc._check_rate_limit("atlas", "bob@example.com") is True
+
+    def test_at_configured_limit_blocks(self, svc, monkeypatch):
+        self._set_limit(monkeypatch, 10)
+        key = svc._rate_limit_key("atlas", "bob@example.com")
+        monkeypatch.setattr(svc, "_get_redis", lambda: _FakeRedis({key: 10}))
+        assert svc._check_rate_limit("atlas", "bob@example.com") is False
+
+    def test_limit_is_sourced_from_settings_not_the_constant(self, svc, monkeypatch):
+        # Configured cap of 3: 2 allows, 3 blocks — proving the enforce reads the
+        # setting, not the hardcoded RATE_LIMIT_MAX_PER_HOUR (10).
+        self._set_limit(monkeypatch, 3)
+        key = svc._rate_limit_key("atlas", "bob@example.com")
+        monkeypatch.setattr(svc, "_get_redis", lambda: _FakeRedis({key: 2}))
+        assert svc._check_rate_limit("atlas", "bob@example.com") is True
+        monkeypatch.setattr(svc, "_get_redis", lambda: _FakeRedis({key: 3}))
+        assert svc._check_rate_limit("atlas", "bob@example.com") is False
+
+    def test_redis_down_fails_open(self, svc, monkeypatch):
+        self._set_limit(monkeypatch, 10)
+        monkeypatch.setattr(svc, "_get_redis", lambda: None)
+        assert svc._check_rate_limit("atlas", "bob@example.com") is True

--- a/tests/unit/test_telegram_webhook_backfill.py
+++ b/tests/unit/test_telegram_webhook_backfill.py
@@ -132,6 +132,10 @@ def _load_settings_module():
         MAX_PARALLEL_TASKS_CEILING_MIN=1,
         MAX_PARALLEL_TASKS_CEILING_MAX=32,
         get_max_parallel_tasks_ceiling=MagicMock(return_value=10),
+        PROACTIVE_RATE_LIMIT_DEFAULTS={},  # #1609
+        PROACTIVE_RATE_LIMIT_DESCRIPTIONS={},
+        PROACTIVE_RATE_LIMIT_MAX=1000000,
+        get_proactive_rate_limit=MagicMock(return_value=10),
     )
     # settings.py module-level imports VALID_CPU/VALID_MEMORY from the
     # container-spec module (#1197); stub it so the standalone load completes.


### PR DESCRIPTION
The proactive channel-messaging caps (Slack/Telegram **10/hr/channel + 100/hr/agent**, proactive-DM **10/hr/recipient**) were hardcoded constants — anti-spam guardrails (#349/#350/#321) that couldn't be tuned, which blocked legitimate high-volume autonomous use (e.g. an agent posting a Slack message per inbound support request). This makes them admin-configurable with the current values as defaults, following the **#506 `max_parallel_tasks_ceiling`** shape.

## Changes

- **`settings_service.get_proactive_rate_limit(key)`** — runtime-resolved from `system_settings` (no cache, `--workers 2`-consistent, **no migration**), fail-open to the shipped default, clamped `[0, 1_000_000]`. **`0 = unlimited`**. Five keys, defaults == the pre-#1609 hardcoded values.
- **`GET/PUT /api/settings/proactive-rate-limits`** — admin-only, **audit-logged**, per-field validation with a named **422**, `0` warned as disabling the guardrail. The 5 keys are blocked from the generic `/{key}` PUT (dedicated validated route). `ProactiveRateLimitsUpdate` model.
- **Enforce sites source the caps from settings at request time** (`0` → skip the limiter): `routers/slack.py`, `routers/telegram.py`, `services/proactive_message_service.py`. **429 details name which cap fired.**
- **Telegram limiter unification**: migrated its bespoke per-process in-memory bucket to the shared **Redis sliding-window limiter** (`rate_limiter.py`, #1023) — matches Slack and **fixes multi-worker inconsistency**.
- **Settings → General**: "Proactive message limits" card (5 inputs, `0 = unlimited`, and the inbound-not-gated note).

## Acceptance criteria

- [x] Three cap families admin-configurable, read at request time via `settings_service` (no restart, `--workers 2`-consistent)
- [x] Current values (10/100/10) remain defaults — zero behavior change on upgrade (`test_defaults_map_matches_shipped_constants`)
- [x] Range-validated with a named 422; **decision documented**: `0` = disabled/unlimited is allowed and **warned** (chosen over a floor because raising/removing the cap is the whole point for high-volume agents)
- [x] Telegram's in-memory bucket → shared sliding-window limiter (also fixes multi-worker)
- [x] Surfaced in the admin Settings UI (not `.env`-only), showing effective values
- [x] 429s name which cap fired
- [x] Settings changes audit-logged
- [x] Docs: requirements area (`public-access.md`) + user FAQ note that caps are configurable and **inbound replies are not subject to them**

## Verification

`tests/unit/test_1609_proactive_rate_limits.py` — **9 passed** (defaults/parse/`0`-unlimited/clamp/fail-open/defaults-parity). All changed backend files compile; `Settings.vue` compiles clean via `@vue/compiler-sfc`. Built in an isolated worktree; not yet exercised against a live stack (natural next step).

Closes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)