### PR TITLE
docs(announcements): record closed-loop-forecasting research announcement

### DIFF
--- a/docs/user-docs/dev-announcements/2026-07-14-142049.md
+++ b/docs/user-docs/dev-announcements/2026-07-14-142049.md
@@ -1,0 +1,35 @@
+---
+date: 2026-07-14T14:20:49
+channel: discord:updates, slack:updates, telegram:updates, twitter:trinity, twitter:default, github:announcements
+---
+
+**New open research: A Measurably Self-Improving Multi-Agent Forecasting System — Five Feedback Loops, No Retraining**
+
+Six months of a deployed multi-agent forecasting system running 24/7 on Trinity: 96,161 logged predictions, 73,552 resolved, average Brier score ≈ 0.196 (typical human forecaster: 0.26). It improves through five closed feedback loops — noise-adaptive calibration, surprise-driven insight extraction, knowledge retrieval, hidden-state hypothesis injection, and abduction into commissioned falsifiable predictions — with zero model retraining. Architecture: the Cleon orchestrator routes calibration and insights to a fleet of specialized oracle agents, with the Cornelius knowledge graph accumulating surprises across domains. The paper also reports the loops that moved *against* their feedback.
+
+Authors: Eugene Vyborov (Ability AI), Dmytro Filatov (DeepXhub / Aimech Technologies)
+
+📄 Paper: https://github.com/abilityai/trinity/tree/main/research/closed-loop-forecasting
+🎥 Video walkthrough: https://youtu.be/_BFKrp9GnNQ
+
+---
+
+## Twitter variants (280-char)
+
+**trinity account** (https://x.com/i/status/2077020368951267826):
+
+Self-improving multi-agent forecasting: 5 feedback loops, zero retraining. 96,161 predictions, 73,552 resolved, Brier ~0.196 — running 24/7 on Trinity.
+Paper: https://github.com/abilityai/trinity/tree/main/research/closed-loop-forecasting
+Video: https://youtu.be/_BFKrp9GnNQ
+
+**default account** (https://x.com/i/status/2077020413251432750):
+
+Six months ago I started building an AI forecasting system that improves itself. 96k predictions later: Brier ~0.196, 5 feedback loops, zero retraining.
+Video: https://youtu.be/_BFKrp9GnNQ
+Paper: https://github.com/abilityai/trinity/tree/main/research/closed-loop-forecasting
+
+---
+
+## GitHub Discussion
+
+https://github.com/Abilityai/trinity/discussions/1611 — long-form variant with the five loops itemized, the headline numbers, and the Cleon/oracles/Cornelius architecture summary.


### PR DESCRIPTION
## Summary

Adds the timestamped announcement record for the closed-loop-forecasting research publication, per the `/announce` skill convention (`docs/user-docs/dev-announcements/`).

The announcement was delivered 2026-07-14 to all 6 configured channels:

| Channel | Result |
|---|---|
| discord:updates | HTTP 204 |
| slack:updates | ts=1784035179.148139 |
| telegram:updates | message_id=7586 |
| twitter:trinity | https://x.com/i/status/2077020368951267826 |
| twitter:default | https://x.com/i/status/2077020413251432750 |
| github:announcements | https://github.com/Abilityai/trinity/discussions/1611 |

Content: the open research paper **"A Measurably Self-Improving Multi-Agent Forecasting System: Five Feedback Loops, No Retraining"** (`research/closed-loop-forecasting/`) + video walkthrough (https://youtu.be/_BFKrp9GnNQ).

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)