### PR TITLE
fix(telemetry): cold container-stats cache reports no_data, not running_count 0 (#1617)

### DIFF
--- a/src/backend/routers/telemetry.py
+++ b/src/backend/routers/telemetry.py
@@ -265,8 +265,19 @@ async def get_container_stats(current_user: User = Depends(get_current_user)):
     Non-blocking (#1096): served from a short-TTL cache that is refreshed by a
     background task. The request never waits on the Docker daemon, so a fleet
     of agents can no longer pin a uvicorn worker for ~6s and stall the UI.
-    Adds three fields on top of the original contract: `cached` (bool),
-    `stale` (bool), and `cache_age_seconds` (float|None).
+    Adds four fields on top of the original contract: `cached` (bool),
+    `stale` (bool), `cache_age_seconds` (float|None), and `no_data` (bool).
+
+    Field semantics (#1617):
+    - `stale` is about CACHE FRESHNESS ONLY — the cached payload is older than
+      the TTL and a refresh was scheduled. It does NOT mean Docker is
+      unreachable (that surfaces as HTTP 503 below).
+    - `no_data` is True only on a cold cache (this worker has never completed a
+      refresh); in that case `running_count` is `None`, NOT `0`. A cold cache
+      per uvicorn worker previously returned `running_count: 0`, which is
+      indistinguishable from a healthy "zero containers running" and misled
+      diagnostics. `no_data: True` / `running_count: None` lets consumers tell
+      "not yet measured" from a real zero.
     """
     if not docker_client:
         raise HTTPException(status_code=503, detail="Docker not available")
@@ -277,16 +288,20 @@ async def get_container_stats(current_user: User = Depends(get_current_user)):
 
     # Fresh cache hit — return instantly, no refresh needed.
     if cached is not None and age is not None and age < _CACHE_TTL:
-        return {**cached, "cached": True, "stale": False, "cache_age_seconds": round(age, 1)}
+        return {**cached, "cached": True, "stale": False,
+                "cache_age_seconds": round(age, 1), "no_data": False}
 
     # Cache is stale or cold: kick off an out-of-band refresh and return now.
     _schedule_refresh()
 
     if cached is not None:
         # Serve stale data while the refresh runs (stale-while-revalidate).
-        return {**cached, "cached": True, "stale": True, "cache_age_seconds": round(age, 1)}
+        return {**cached, "cached": True, "stale": True,
+                "cache_age_seconds": round(age, 1), "no_data": False}
 
-    # Cold start (no data computed yet): return an instant, valid, empty
-    # payload. The next poll (a few seconds later) gets real data once the
-    # background refresh completes. No request ever pays the Docker latency.
-    return {**_empty_payload(0), "cached": False, "stale": True, "cache_age_seconds": None}
+    # Cold start (no data computed yet): NO measurement has happened on this
+    # worker. Return running_count=None + no_data=True so a consumer can't
+    # mistake "not yet measured" for a real "zero containers running" (#1617).
+    # The next poll (once the background refresh completes) carries real data.
+    return {**_empty_payload(0), "running_count": None,
+            "cached": False, "stale": True, "cache_age_seconds": None, "no_data": True}

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -93,14 +93,31 @@ class TestContainerTelemetry:
         api_client: TrinityApiClient,
         created_agent
     ):
-        """GET /api/telemetry/containers returns running container count."""
-        response = api_client.get("/api/telemetry/containers")
-        assert_status(response, 200)
-        data = assert_json_response(response)
+        """GET /api/telemetry/containers returns running container count.
 
-        assert "running_count" in data
-        assert isinstance(data["running_count"], int)
-        assert data["running_count"] >= 0
+        #1617: a cold per-worker cache reports running_count=None + no_data=True
+        (not 0). Poll briefly for the background refresh to land a measured
+        count; tolerate the cold shape if it hasn't yet.
+        """
+        import time as _time
+
+        data = None
+        for _ in range(10):
+            response = api_client.get("/api/telemetry/containers")
+            assert_status(response, 200)
+            data = assert_json_response(response)
+            assert "running_count" in data
+            assert "no_data" in data
+            if not data["no_data"]:
+                break
+            _time.sleep(1)
+
+        if data["no_data"]:
+            # Still cold — measurement not yet available; contract still holds.
+            assert data["running_count"] is None
+        else:
+            assert isinstance(data["running_count"], int)
+            assert data["running_count"] >= 0
 
     def test_containers_returns_total_cpu_percent(
         self,
@@ -219,10 +236,24 @@ class TestTelemetryConsistency:
         api_client: TrinityApiClient,
         created_agent
     ):
-        """Running count matches length of containers list."""
-        response = api_client.get("/api/telemetry/containers")
-        assert_status(response, 200)
-        data = response.json()
+        """Running count matches length of containers list.
+
+        #1617: skip the comparison while the cache is cold (no_data=True,
+        running_count=None) — poll briefly for a measured payload first.
+        """
+        import time as _time
+
+        data = None
+        for _ in range(10):
+            response = api_client.get("/api/telemetry/containers")
+            assert_status(response, 200)
+            data = response.json()
+            if not data.get("no_data"):
+                break
+            _time.sleep(1)
+
+        if data.get("no_data"):
+            pytest.skip("container-stats cache still cold (no measured data yet)")
 
         running_count = data.get("running_count", 0)
         containers = data.get("containers", [])

--- a/tests/unit/test_1096_telemetry_cache.py
+++ b/tests/unit/test_1096_telemetry_cache.py
@@ -218,7 +218,10 @@ async def test_cold_start_returns_instant_empty_then_refreshes(monkeypatch):
     # Returned the cold payload — could only happen if compute was NOT awaited.
     assert res["cached"] is False
     assert res["stale"] is True
-    assert res["running_count"] == 0
+    # #1617: a cold cache reports running_count=None + no_data=True, NOT 0, so
+    # it can't be mistaken for a real "zero containers running".
+    assert res["running_count"] is None
+    assert res["no_data"] is True
     assert res["containers"] == []
     assert res["cache_age_seconds"] is None
     assert _ORIGINAL_FIELDS <= set(res)
@@ -229,6 +232,40 @@ async def test_cold_start_returns_instant_empty_then_refreshes(monkeypatch):
     assert telemetry._stats_cache["data"] is not None
     assert telemetry._stats_cache["data"]["running_count"] == 1
     assert telemetry._stats_cache["data"]["total_memory_mb"] == 100.0
+
+
+# ── #1617: cold "no data" is distinguishable from a real "zero running" ──────
+
+@pytest.mark.asyncio
+async def test_cold_no_data_is_distinct_from_real_zero_running(monkeypatch):
+    """The bug: a cold cache returned running_count=0, identical to a healthy
+    fleet with zero containers. After the fix, cold → running_count None /
+    no_data True, while a genuinely-empty fleet (refresh ran, found nothing
+    running) → running_count 0 / no_data False."""
+    # Genuinely-empty fleet: agents exist but none are running.
+    monkeypatch.setattr(
+        telemetry, "list_all_agents_fast",
+        lambda: [_FakeAgent("a", status="exited"), _FakeAgent("b", status="exited")],
+    )
+    monkeypatch.setattr(
+        telemetry, "_get_single_container_stats_sync",
+        lambda name: (_ for _ in ()).throw(AssertionError("no running agent to stat")),
+    )
+
+    # 1) Cold cache → "not yet measured".
+    cold = await telemetry.get_container_stats(current_user=None)
+    assert cold["running_count"] is None
+    assert cold["no_data"] is True
+    assert cold["stale"] is True
+
+    # 2) Let the scheduled refresh complete, then re-query → real zero.
+    assert telemetry._refresh_task is not None
+    await telemetry._refresh_task
+    fresh = await telemetry.get_container_stats(current_user=None)
+    assert fresh["running_count"] == 0        # real "zero containers running"
+    assert fresh["no_data"] is False
+    assert fresh["stale"] is False
+    assert fresh["cached"] is True
 
 
 # ── Stale cache: serve old data now, schedule refresh ───────────────────────


### PR DESCRIPTION
## Summary

`GET /api/telemetry/containers` serves a per-uvicorn-worker, stale-while-revalidate **in-process** cache. The cold-cache branch returned `_empty_payload(0)` — a literal `running_count: 0` with `stale: true` — which is **byte-identical to a healthy "zero containers running"** answer. Because the cache is per worker, consecutive requests could flip between `0` and the true count depending on which worker served them, and a rarely-queried worker kept a cold cache indefinitely (observed `cache_age_seconds: 5726`). In a real incident this read as "the backend lost its Docker connection" and drove a wrong root-cause report (#1617).

## Fix

Make the cold state **self-describing** so it can't be mistaken for a real zero:

- **Cold cache** → `running_count: null` + `no_data: true`.
- **Genuinely-empty fleet** (refresh ran, nothing running) → `running_count: 0` + `no_data: false` (unchanged).
- Fresh + stale branches also carry `no_data: false` for a consistent contract.
- Docstring now states `stale` = **cache freshness only**, not Docker connectivity (unreachable Docker is the existing HTTP 503).

Directly implements suggested fix 1 (`running_count: null` / explicit `no_data`) and #3 (document `stale` semantics) from the issue.

**Deferred (issue's optional "consider"):** moving the cache to Redis for cross-worker consistency. The misleading-diagnostics defect is fully closed by making cold state self-describing; a shared-cache rework is a larger, separate change and out of scope for a P3 diagnostic-quality fix.

## Consumer safety

No in-repo consumer reads `/api/telemetry/containers` — the frontend uses only `/api/telemetry/host`; the `running_count` references in `OverviewPanel`/`network.js`/`executions.js` come from `/api/executions/stats` (a different endpoint/model). The endpoint's only known consumer is external diagnostic tooling (per the issue), so widening the contract with `no_data` + a nullable `running_count` is backward-additive.

## Changes

- `src/backend/routers/telemetry.py`: cold branch → `running_count: null` + `no_data: true`; `no_data: false` on fresh/stale; docstring clarifies `stale` semantics.
- `tests/unit/test_1096_telemetry_cache.py`: update cold-start expectation to the new shape; new `test_cold_no_data_is_distinct_from_real_zero_running` proving cold≠real-zero.
- `tests/test_telemetry.py`: live-API tests poll past the cold window (skip/tolerate `no_data`).

## Test Plan

- [x] `pytest tests/unit/test_1096_telemetry_cache.py -q` → 12 passed
- [x] Router + test modules parse clean
- [ ] Live-API `tests/test_telemetry.py::TestContainerTelemetry` (test-runner suite, needs a running stack)

Fixes #1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)