### PR TITLE
feat(mcp): A2A control tools — exposure, card, allow-list, endpoints (ent#160)

### DIFF
--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -2215,4 +2215,97 @@ export class TrinityClient {
       requestId,
     );
   }
+
+  // ==========================================================================
+  // A2A control plane (trinity-enterprise#160)
+  // The management endpoints (config/exposure/allow-list/endpoints) proxy the
+  // ENTITLEMENT-GATED enterprise router (`/api/enterprise/a2a/*`) — a 403 in an
+  // unentitled build, a 404 in an OSS-only build. The served card is the OSS
+  // #737 endpoint.
+  // ==========================================================================
+
+  /** Full A2A control state for one agent (exposure, card URL, allow-list, endpoints). */
+  async getA2AConfig(name: string): Promise<unknown> {
+    return this.request<unknown>(
+      "GET",
+      `/api/enterprise/a2a/${encodeURIComponent(name)}/config`,
+    );
+  }
+
+  /** Toggle whether the agent is exposed over A2A. */
+  async setA2AExposure(name: string, enabled: boolean): Promise<unknown> {
+    return this.request<unknown>(
+      "PUT",
+      `/api/enterprise/a2a/${encodeURIComponent(name)}/exposure`,
+      { enabled },
+    );
+  }
+
+  /** The served A2A Agent Card JSON (OSS #737 endpoint). */
+  async getA2ACard(name: string): Promise<unknown> {
+    return this.request<unknown>(
+      "GET",
+      `/api/agents/${encodeURIComponent(name)}/a2a/agent-card`,
+    );
+  }
+
+  /** Add and/or remove inbound identities on the agent's A2A allow-list. */
+  async updateA2AInboundAllowlist(
+    name: string,
+    body: { add?: string[]; remove?: string[] },
+  ): Promise<unknown> {
+    return this.request<unknown>(
+      "POST",
+      `/api/enterprise/a2a/${encodeURIComponent(name)}/inbound-allowlist`,
+      body,
+    );
+  }
+
+  /** Register (or update by name) an outbound external A2A endpoint. */
+  async registerA2AEndpoint(
+    name: string,
+    body: { name: string; url: string; credentials?: string },
+  ): Promise<unknown> {
+    return this.request<unknown>(
+      "POST",
+      `/api/enterprise/a2a/${encodeURIComponent(name)}/endpoints`,
+      body,
+    );
+  }
+
+  /** List the agent's registered outbound endpoints (credentials never returned). */
+  async listA2AEndpoints(name: string): Promise<unknown> {
+    return this.request<unknown>(
+      "GET",
+      `/api/enterprise/a2a/${encodeURIComponent(name)}/endpoints`,
+    );
+  }
+
+  /** Remove one outbound endpoint by id. */
+  async removeA2AEndpoint(name: string, endpointId: string): Promise<unknown> {
+    return this.request<unknown>(
+      "DELETE",
+      `/api/enterprise/a2a/${encodeURIComponent(name)}/endpoints/${encodeURIComponent(endpointId)}`,
+    );
+  }
+
+  /**
+   * Best-effort {agent_name: a2a_exposed} map for surfacing on list_agents /
+   * get_agent. Returns {} on any failure (OSS-only 404, unentitled 403) so the
+   * caller simply omits the field.
+   */
+  async getA2AExposedMap(agentNames?: string[]): Promise<Record<string, boolean>> {
+    try {
+      const q = agentNames && agentNames.length
+        ? `?agents=${encodeURIComponent(agentNames.join(","))}`
+        : "";
+      const res = await this.request<Record<string, boolean>>(
+        "GET",
+        `/api/enterprise/a2a/exposed${q}`,
+      );
+      return res && typeof res === "object" ? res : {};
+    } catch {
+      return {};
+    }
+  }
 }

--- a/src/mcp-server/src/server.ts
+++ b/src/mcp-server/src/server.ts
@@ -32,6 +32,7 @@ import { createLoopTools } from "./tools/loops.js";
 import { createOperatorQueueTools } from "./tools/operator_queue.js";
 import { createConnectorTools } from "./tools/connector.js";
 import { createGitTools } from "./tools/git.js";
+import { createA2ATools } from "./tools/a2a.js";
 import { withAudit } from "./audit.js";
 import type { McpAuthContext } from "./types.js";
 
@@ -268,6 +269,7 @@ export async function createServer(config: ServerConfig = {}) {
     createVoipTools(client, requireApiKey),       // VoIP telephony — call_user (VOIP-001, #1056)
     createOperatorQueueTools(client, requireApiKey), // Operator queue read + respond (OPS-001, #1101/#1104)
     createGitTools(client, requireApiKey),           // Direct git status/sync/log/pull/sync-state/reset (#905)
+    createA2ATools(client, requireApiKey),           // A2A control plane — exposure/card/allow-list/endpoints (ent#160)
   ];
   // Operator tools: hidden from connector-scoped keys.
   for (const group of toolGroups) {

--- a/src/mcp-server/src/tools/a2a.test.ts
+++ b/src/mcp-server/src/tools/a2a.test.ts
@@ -1,0 +1,170 @@
+/**
+ * trinity-enterprise#160 — A2A control MCP tools.
+ *
+ * Pins the tool-layer contract for the 7 A2A management tools:
+ *   - each tool proxies the matching TrinityClient method with the right args;
+ *   - honest gating: an unentitled 403 ("not licensed") and an OSS-only 404
+ *     become a structured { success:false, not_entitled/not_found } — never a
+ *     silent success;
+ *   - human-only 403 (agent-scoped key on a mutation) → { human_only:true };
+ *   - outbound credentials are NEVER echoed in tool output;
+ *   - set_a2a_inbound_allowlist with neither add nor remove is rejected client-side.
+ *
+ * Drives the real tool execute() with a fake TrinityClient (requireApiKey=false
+ * → getClient() returns the fake directly, same seam as git.test.ts).
+ *
+ * Runner: node:test → `node --import tsx --test src/tools/*.test.ts`.
+ */
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { createA2ATools } from "./a2a.js";
+import type { TrinityClient } from "../client.js";
+
+type Recorded = { method: string; args: unknown[] };
+
+function makeTools(calls: Recorded[], overrides: Partial<TrinityClient> = {}) {
+  const fake: Partial<TrinityClient> = {
+    getBaseUrl: () => "http://localhost:8000",
+    getA2AConfig: async (name: string) => {
+      calls.push({ method: "getA2AConfig", args: [name] });
+      return { agent_name: name, a2a_exposed: false, inbound_allowlist: [], outbound_endpoints: [] };
+    },
+    setA2AExposure: async (name: string, enabled: boolean) => {
+      calls.push({ method: "setA2AExposure", args: [name, enabled] });
+      return { agent_name: name, a2a_exposed: enabled };
+    },
+    getA2ACard: async (name: string) => {
+      calls.push({ method: "getA2ACard", args: [name] });
+      return { name, protocolVersion: "1.0" };
+    },
+    updateA2AInboundAllowlist: async (name: string, body: unknown) => {
+      calls.push({ method: "updateA2AInboundAllowlist", args: [name, body] });
+      return { agent_name: name, inbound_allowlist: ["did:a"] };
+    },
+    registerA2AEndpoint: async (name: string, body: unknown) => {
+      calls.push({ method: "registerA2AEndpoint", args: [name, body] });
+      // The backend NEVER returns the credential — only has_credentials.
+      return { id: "ep1", agent_name: name, name: (body as { name: string }).name, url: (body as { url: string }).url, has_credentials: true };
+    },
+    listA2AEndpoints: async (name: string) => {
+      calls.push({ method: "listA2AEndpoints", args: [name] });
+      return [{ id: "ep1", name: "partner", url: "https://x/a2a", has_credentials: true }];
+    },
+    removeA2AEndpoint: async (name: string, id: string) => {
+      calls.push({ method: "removeA2AEndpoint", args: [name, id] });
+      return { status: "removed", endpoint_id: id };
+    },
+    ...overrides,
+  };
+  return createA2ATools(fake as TrinityClient, false);
+}
+
+describe("ent#160 A2A tools — proxy the right client method", () => {
+  it("get_agent_a2a_config proxies getA2AConfig", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls);
+    const out = JSON.parse(await tools.get_agent_a2a_config.execute({ agent_name: "bot" }, {}));
+    assert.equal(calls[0].method, "getA2AConfig");
+    assert.deepEqual(calls[0].args, ["bot"]);
+    assert.equal(out.success, true);
+    assert.equal(out.config.agent_name, "bot");
+  });
+
+  it("set_agent_a2a_exposure proxies setA2AExposure(name, enabled)", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls);
+    const out = JSON.parse(await tools.set_agent_a2a_exposure.execute({ agent_name: "bot", enabled: true }, {}));
+    assert.deepEqual(calls[0], { method: "setA2AExposure", args: ["bot", true] });
+    assert.equal(out.config.a2a_exposed, true);
+  });
+
+  it("get_agent_a2a_card proxies the OSS served-card endpoint", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls);
+    const out = JSON.parse(await tools.get_agent_a2a_card.execute({ agent_name: "bot" }, {}));
+    assert.equal(calls[0].method, "getA2ACard");
+    assert.equal(out.card.protocolVersion, "1.0");
+  });
+
+  it("set_a2a_inbound_allowlist forwards add/remove", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls);
+    await tools.set_a2a_inbound_allowlist.execute({ agent_name: "bot", add: ["did:a"], remove: ["did:b"] }, {});
+    assert.equal(calls[0].method, "updateA2AInboundAllowlist");
+    assert.deepEqual(calls[0].args[1], { add: ["did:a"], remove: ["did:b"] });
+  });
+
+  it("list_a2a_endpoints + remove_a2a_endpoint proxy correctly", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls);
+    await tools.list_a2a_endpoints.execute({ agent_name: "bot" }, {});
+    const rm = JSON.parse(await tools.remove_a2a_endpoint.execute({ agent_name: "bot", endpoint_id: "ep1" }, {}));
+    assert.equal(calls[0].method, "listA2AEndpoints");
+    assert.deepEqual(calls[1], { method: "removeA2AEndpoint", args: ["bot", "ep1"] });
+    assert.equal(rm.result.status, "removed");
+  });
+});
+
+describe("ent#160 A2A tools — credentials never echoed", () => {
+  it("register_a2a_endpoint returns has_credentials, never the secret", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls);
+    const raw = await tools.register_a2a_endpoint.execute(
+      { agent_name: "bot", name: "partner", url: "https://x/a2a", credentials: "SUPER-SECRET-XYZ" },
+      {},
+    );
+    // The credential is forwarded to the client (which encrypts it) ...
+    assert.equal((calls[0].args[1] as { credentials?: string }).credentials, "SUPER-SECRET-XYZ");
+    // ... but MUST NOT appear anywhere in the tool's returned payload.
+    assert.equal(raw.includes("SUPER-SECRET-XYZ"), false);
+    const out = JSON.parse(raw);
+    assert.equal(out.endpoint.has_credentials, true);
+    assert.equal("credentials" in out.endpoint, false);
+  });
+});
+
+describe("ent#160 A2A tools — honest gating", () => {
+  it("empty allow-list update is rejected client-side (no backend call)", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls);
+    const out = JSON.parse(await tools.set_a2a_inbound_allowlist.execute({ agent_name: "bot" }, {}));
+    assert.equal(out.success, false);
+    assert.equal(out.invalid, true);
+    assert.equal(calls.length, 0);
+  });
+
+  it("unentitled 403 → not_entitled (never silent success)", async () => {
+    const calls: Recorded[] = [];
+    const tools = makeTools(calls, {
+      getA2AConfig: async () => {
+        throw new Error("Request failed: 403 - Enterprise feature 'a2a' is not licensed for this instance.");
+      },
+    });
+    const out = JSON.parse(await tools.get_agent_a2a_config.execute({ agent_name: "bot" }, {}));
+    assert.equal(out.success, false);
+    assert.equal(out.not_entitled, true);
+  });
+
+  it("OSS-only 404 → not_found", async () => {
+    const tools = makeTools([], {
+      getA2AConfig: async () => {
+        throw new Error("Request failed: 404 - Not Found");
+      },
+    });
+    const out = JSON.parse(await tools.get_agent_a2a_config.execute({ agent_name: "bot" }, {}));
+    assert.equal(out.success, false);
+    assert.equal(out.not_found, true);
+  });
+
+  it("human-only 403 (agent-scoped key on a mutation) → human_only", async () => {
+    const tools = makeTools([], {
+      setA2AExposure: async () => {
+        throw new Error("Request failed: 403 - This operation is human-only; agent-scoped keys cannot perform it");
+      },
+    });
+    const out = JSON.parse(await tools.set_agent_a2a_exposure.execute({ agent_name: "bot", enabled: true }, {}));
+    assert.equal(out.success, false);
+    assert.equal(out.human_only, true);
+  });
+});

--- a/src/mcp-server/src/tools/a2a.ts
+++ b/src/mcp-server/src/tools/a2a.ts
@@ -1,0 +1,224 @@
+/**
+ * A2A Control Tools (trinity-enterprise#160)
+ *
+ * The MCP surface for the A2A interoperability *management* plane — the third
+ * surface (Invariant #13) alongside the enterprise backend router
+ * (`/api/enterprise/a2a/*`) and the config UI (#158). Distinct from the runtime
+ * outbound call (`call_a2a_agent`, abilityai/trinity#736): these tools toggle
+ * exposure, read the served card, manage the inbound allow-list, and register
+ * outbound endpoints.
+ *
+ * Gating is enforced at the backend it proxies:
+ *  - every management route is `requires_entitlement("a2a")` → a 403 in an
+ *    unentitled build, a 404 in an OSS-only build. Either way these tools return
+ *    a structured `{ success: false, not_entitled: true }` — never a silent
+ *    success.
+ *  - mutating routes (exposure, allow-list, endpoints) are owner/admin AND
+ *    human-only (`reject_agent_principal`) — an agent-scoped key gets a 403.
+ *  - outbound credentials are write-only: they are accepted on register but the
+ *    backend never returns them (only `has_credentials`), so no tool echoes a
+ *    secret back.
+ */
+
+import { z } from "zod";
+import { TrinityClient } from "../client.js";
+import type { McpAuthContext } from "../types.js";
+
+export function createA2ATools(client: TrinityClient, requireApiKey: boolean) {
+  const getClient = (authContext?: McpAuthContext): TrinityClient => {
+    if (requireApiKey) {
+      if (!authContext?.mcpApiKey) {
+        throw new Error("MCP API key authentication required but no API key found in request context");
+      }
+      const userClient = new TrinityClient(client.getBaseUrl());
+      userClient.setToken(authContext.mcpApiKey);
+      return userClient;
+    }
+    return client;
+  };
+
+  /** Uniform error → structured result with honest gating flags (never throws). */
+  const fail = (error: unknown): string => {
+    const message = error instanceof Error ? error.message : String(error);
+    const flags: Record<string, boolean> = {};
+    // Unentitled build (403 "not licensed") or OSS-only build (404, route absent).
+    if (/not licensed/i.test(message) || /\ba2a\b/i.test(message) && /\b403\b/.test(message)) {
+      flags.not_entitled = true;
+    }
+    if (/\b404\b/.test(message) && !flags.not_entitled) flags.not_found = true;
+    if (/human-only/i.test(message)) flags.human_only = true;
+    if (/\b403\b/.test(message) && !flags.not_entitled && !flags.human_only) flags.not_authorized = true;
+    if (/\b422\b/.test(message)) flags.invalid = true;
+    return JSON.stringify({ success: false, error: message, ...flags }, null, 2);
+  };
+
+  const ok = (data: unknown): string => JSON.stringify({ success: true, ...(data as object) }, null, 2);
+
+  return {
+    // ========================================================================
+    get_agent_a2a_config: {
+      name: "get_agent_a2a_config",
+      description:
+        "Get an agent's A2A (agent-to-agent) control state: whether it is exposed over A2A, " +
+        "its public Agent Card URL, advertised skills, the inbound identity allow-list, and the " +
+        "registered outbound endpoints (credentials are never returned — only whether each has any). " +
+        "Enterprise feature; returns { not_entitled: true } if A2A is not licensed for this instance.",
+      parameters: z.object({
+        agent_name: z.string().describe("The agent whose A2A config to read."),
+      }),
+      execute: async (params: { agent_name: string }, context?: { session?: McpAuthContext }) => {
+        try {
+          return ok({ config: await getClient(context?.session).getA2AConfig(params.agent_name) });
+        } catch (e) {
+          return fail(e);
+        }
+      },
+    },
+
+    // ========================================================================
+    set_agent_a2a_exposure: {
+      name: "set_agent_a2a_exposure",
+      description:
+        "Toggle whether an agent is exposed over A2A (agent-to-agent interoperability). " +
+        "Owner/admin and human-only — an agent-scoped key is rejected. " +
+        "Enterprise feature; returns { not_entitled: true } if A2A is not licensed.",
+      parameters: z.object({
+        agent_name: z.string().describe("The agent to expose or unexpose."),
+        enabled: z.boolean().describe("true to expose the agent over A2A, false to unexpose."),
+      }),
+      execute: async (params: { agent_name: string; enabled: boolean }, context?: { session?: McpAuthContext }) => {
+        try {
+          return ok({ config: await getClient(context?.session).setA2AExposure(params.agent_name, params.enabled) });
+        } catch (e) {
+          return fail(e);
+        }
+      },
+    },
+
+    // ========================================================================
+    get_agent_a2a_card: {
+      name: "get_agent_a2a_card",
+      description:
+        "Return the served A2A Agent Card JSON for an agent (the OSS discovery card). " +
+        "Read access follows the standard agent-access gate.",
+      parameters: z.object({
+        agent_name: z.string().describe("The agent whose Agent Card to fetch."),
+      }),
+      execute: async (params: { agent_name: string }, context?: { session?: McpAuthContext }) => {
+        try {
+          return ok({ card: await getClient(context?.session).getA2ACard(params.agent_name) });
+        } catch (e) {
+          return fail(e);
+        }
+      },
+    },
+
+    // ========================================================================
+    set_a2a_inbound_allowlist: {
+      name: "set_a2a_inbound_allowlist",
+      description:
+        "Manage which external identities may task an agent over A2A inbound. Provide `add` and/or " +
+        "`remove` (identity strings — e.g. a caller URL, client id, or key id). Owner/admin and human-only. " +
+        "Enterprise feature; returns { not_entitled: true } if A2A is not licensed.",
+      parameters: z.object({
+        agent_name: z.string().describe("The agent whose inbound allow-list to modify."),
+        add: z.array(z.string()).optional().describe("Identities to add to the allow-list."),
+        remove: z.array(z.string()).optional().describe("Identities to remove from the allow-list."),
+      }),
+      execute: async (
+        params: { agent_name: string; add?: string[]; remove?: string[] },
+        context?: { session?: McpAuthContext },
+      ) => {
+        if (!params.add?.length && !params.remove?.length) {
+          return JSON.stringify(
+            { success: false, error: "Provide at least one identity in 'add' or 'remove'.", invalid: true },
+            null, 2,
+          );
+        }
+        try {
+          const config = await getClient(context?.session).updateA2AInboundAllowlist(params.agent_name, {
+            add: params.add,
+            remove: params.remove,
+          });
+          return ok({ config });
+        } catch (e) {
+          return fail(e);
+        }
+      },
+    },
+
+    // ========================================================================
+    register_a2a_endpoint: {
+      name: "register_a2a_endpoint",
+      description:
+        "Register (or update by name) an outbound external A2A endpoint an agent may call — this feeds " +
+        "the runtime call_a2a_agent (abilityai/trinity#736). Optional `credentials` are stored encrypted " +
+        "and NEVER returned by any read. Owner/admin and human-only. " +
+        "Enterprise feature; returns { not_entitled: true } if A2A is not licensed.",
+      parameters: z.object({
+        agent_name: z.string().describe("The calling agent that owns this outbound endpoint."),
+        name: z.string().min(1).max(200).describe("Operator-facing label for the endpoint (unique per agent)."),
+        url: z.string().describe("The external A2A endpoint / Agent Card URL (http/https)."),
+        credentials: z.string().max(8192).optional().describe(
+          "Optional secret (token/API key) for calling the endpoint. Stored encrypted; never echoed back.",
+        ),
+      }),
+      execute: async (
+        params: { agent_name: string; name: string; url: string; credentials?: string },
+        context?: { session?: McpAuthContext },
+      ) => {
+        try {
+          const endpoint = await getClient(context?.session).registerA2AEndpoint(params.agent_name, {
+            name: params.name,
+            url: params.url,
+            credentials: params.credentials,
+          });
+          return ok({ endpoint });
+        } catch (e) {
+          return fail(e);
+        }
+      },
+    },
+
+    // ========================================================================
+    list_a2a_endpoints: {
+      name: "list_a2a_endpoints",
+      description:
+        "List an agent's registered outbound A2A endpoints (credentials are never returned — only " +
+        "has_credentials). Enterprise feature; returns { not_entitled: true } if A2A is not licensed.",
+      parameters: z.object({
+        agent_name: z.string().describe("The agent whose outbound endpoints to list."),
+      }),
+      execute: async (params: { agent_name: string }, context?: { session?: McpAuthContext }) => {
+        try {
+          return ok({ endpoints: await getClient(context?.session).listA2AEndpoints(params.agent_name) });
+        } catch (e) {
+          return fail(e);
+        }
+      },
+    },
+
+    // ========================================================================
+    remove_a2a_endpoint: {
+      name: "remove_a2a_endpoint",
+      description:
+        "Remove one outbound A2A endpoint by id. Owner/admin and human-only. " +
+        "Enterprise feature; returns { not_entitled: true } if A2A is not licensed.",
+      parameters: z.object({
+        agent_name: z.string().describe("The agent that owns the endpoint."),
+        endpoint_id: z.string().describe("The id of the endpoint to remove (from list_a2a_endpoints)."),
+      }),
+      execute: async (
+        params: { agent_name: string; endpoint_id: string },
+        context?: { session?: McpAuthContext },
+      ) => {
+        try {
+          const result = await getClient(context?.session).removeA2AEndpoint(params.agent_name, params.endpoint_id);
+          return ok({ result });
+        } catch (e) {
+          return fail(e);
+        }
+      },
+    },
+  };
+}

--- a/src/mcp-server/src/tools/agents.ts
+++ b/src/mcp-server/src/tools/agents.ts
@@ -9,6 +9,27 @@ import { TrinityClient } from "../client.js";
 import type { McpAuthContext } from "../types.js";
 
 /**
+ * ent#160: decorate agents in place with `a2a_exposed` (mirrors mcp_exposed,
+ * #846). Best-effort — the exposure map is served by the ENTITLEMENT-GATED
+ * enterprise router, so `getA2AExposedMap` returns {} on an OSS-only (404) or
+ * unentitled (403) instance and the field is simply omitted. Never throws.
+ */
+async function enrichA2AExposed(
+  apiClient: TrinityClient,
+  agents: Array<{ name: string; a2a_exposed?: boolean }>,
+): Promise<void> {
+  if (!agents.length) return;
+  try {
+    const map = await apiClient.getA2AExposedMap(agents.map((a) => a.name));
+    for (const a of agents) {
+      if (Object.prototype.hasOwnProperty.call(map, a.name)) a.a2a_exposed = map[a.name];
+    }
+  } catch {
+    // Best-effort only — never let A2A surfacing break the agent listing.
+  }
+}
+
+/**
  * Create agent management tools with the given client
  * @param client - Base Trinity client (provides base URL, no auth when requireApiKey=true)
  * @param requireApiKey - Whether API key authentication is enabled
@@ -52,6 +73,10 @@ export function createAgentTools(
         const apiClient = getClient(authContext);
         const agents = await apiClient.listAgents();
 
+        // ent#160: best-effort a2a_exposed surfacing (mirrors mcp_exposed, #846).
+        // getA2AExposedMap swallows OSS-404 / unentitled-403 → {} → field omitted.
+        await enrichA2AExposed(apiClient, agents);
+
         // Phase 11.1: System-scoped keys see all agents (no filtering)
         if (authContext?.scope === "system") {
           console.log(`[list_agents] System agent - showing all ${agents.length} agents`);
@@ -93,6 +118,8 @@ export function createAgentTools(
         const authContext = context?.session;
         const apiClient = getClient(authContext);
         const agent = await apiClient.getAgent(name);
+        // ent#160: best-effort a2a_exposed surfacing (mirrors mcp_exposed, #846).
+        await enrichA2AExposed(apiClient, [agent as { name: string }]);
         return JSON.stringify(agent, null, 2);
       },
     },


### PR DESCRIPTION
## Summary

The **MCP surface** for the A2A interoperability management plane — the third surface (Invariant #13) over the entitlement-gated enterprise backend (trinity-enterprise#160, `/api/enterprise/a2a/*`). Distinct from the runtime `call_a2a_agent` (#736); this is the **management** plane (toggle exposure, read the served card, manage inbound allow-list, register outbound endpoints).

## Changes

- **New `src/mcp-server/src/tools/a2a.ts`** — 7 tools:
  `get_agent_a2a_config`, `set_agent_a2a_exposure`, `get_agent_a2a_card` (proxies the OSS #737 served-card endpoint), `set_a2a_inbound_allowlist`, `register_a2a_endpoint`, `list_a2a_endpoints`, `remove_a2a_endpoint`.
- **Honest gating**: an unentitled `403` ("not licensed") or an OSS-only `404` returns a structured `{ not_entitled | not_found }` — **never a silent success**. Mutations are owner/admin + human-only, enforced at the backend (an agent-scoped key → `403 human_only`). Outbound credentials are write-only: the backend returns only `has_credentials`, so no tool echoes a secret.
- **`client.ts`**: 8 A2A methods. `getA2AExposedMap` swallows OSS-404 / unentitled-403 → `{}`.
- **`agents.ts`**: `list_agents`/`get_agent` best-effort merge `a2a_exposed` (mirrors `mcp_exposed`, #846) — omitted in editions without A2A, so **no OSS↔enterprise coupling** and the private table is never read by OSS code.
- **`server.ts`**: register the tool group (connector-denied visibility, like the other operator tools).

## Consumer safety

The tool code is edition-agnostic and ships in the public repo (the endpoints it calls are entitlement-gated). On an OSS-only or unentitled instance every tool returns a structured `not_entitled`/`not_found` result and `a2a_exposed` is simply absent — no errors, no coupling.

## Test Plan

- [x] `npm test` → **100 passed** (10 new in `src/tools/a2a.test.ts`: proxy contract, credentials-never-echoed, entitlement/human-only/404 gating)
- [x] `npm run build` (tsc) clean

## Companion PR

Backend (private): **trinity-enterprise#161** — the `enterprise.backend.a2a` module + `/api/enterprise/a2a/*` router. Must merge for these tools to have endpoints to call.

Related to trinity-enterprise#160

🤖 Generated with [Claude Code](https://claude.com/claude-code)