### PR TITLE
fix(ui): restore the top nav on the enterprise pages (#1636)

### DIFF
--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -177,6 +177,10 @@ const routes = [
     path: '/enterprise/client-portal',
     name: 'EnterpriseClientPortal',
     component: () => import('../views/enterprise/ClientPortal.vue'),
+    // STANDALONE, no NavBar — deliberate (#1636). This is a client-facing
+    // surface, not an operator page: the platform nav would offer a client
+    // links they can't use. The sibling /enterprise pages DO render NavBar;
+    // this one is the exception, like /portal and /m.
     // hideHelpWidget: the platform "Trinity Help" widget (bottom-right) overlaps
     // the client chat composer's Send button and isn't relevant to a portal
     // client — keep it off this standalone surface.

--- a/src/frontend/src/views/enterprise/Audit.vue
+++ b/src/frontend/src/views/enterprise/Audit.vue
@@ -16,6 +16,7 @@
  */
 import { computed, onMounted, ref, watch } from 'vue'
 import { useAuditLogStore } from '../../stores/auditLog'
+import NavBar from '@/components/NavBar.vue'
 
 const store = useAuditLogStore()
 // Direct reactive access — Pinia state is already reactive, and the
@@ -340,693 +341,700 @@ const detailsJson = computed(() => {
 </script>
 
 <template>
-  <div class="audit-dashboard p-6 max-w-7xl mx-auto">
-    <header class="mb-6">
-      <div class="flex items-center gap-3 mb-2">
-        <router-link
-          to="/enterprise"
-          class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-        >
-          ← Enterprise
-        </router-link>
-      </div>
-      <div class="flex items-center gap-3 mb-2">
-        <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Audit Log</h1>
-        <span class="px-2 py-0.5 text-xs font-bold rounded bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200">
-          PRO
-        </span>
-      </div>
-      <p class="text-sm text-gray-500 dark:text-gray-400">
-        Tamper-evident record of administrative actions. Default filter
-        shows the last 24 hours.
-      </p>
+  <!-- NavBar: Trinity has no global chrome (App.vue is <router-view> only),
+       so each authenticated view mounts it itself. Without it this page
+       stranded the user with no way back to the platform (#1636). -->
+  <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
+    <NavBar />
 
-      <!-- Hash-chain verify badge — manual trigger, visible-range only. -->
-      <div class="mt-3 flex items-center gap-2">
-        <span
-          class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded"
-          :class="{
-            'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300':
-              store.verifyState === 'idle',
-            'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200':
-              store.verifyState === 'verifying',
-            'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200':
-              store.verifyState === 'valid',
-            'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200':
-              store.verifyState === 'invalid',
-            'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-200':
-              store.verifyState === 'error',
-          }"
-        >
-          <span v-if="store.verifyState === 'idle'">Hash chain · not verified</span>
-          <span v-else-if="store.verifyState === 'verifying'">Verifying…</span>
-          <span v-else-if="store.verifyState === 'valid'">
-            ✓ Valid · {{ store.verifyResult?.checked || 0 }} entries
-          </span>
-          <span v-else-if="store.verifyState === 'invalid'">
-            ✗ Tamper detected · first invalid id #{{ store.verifyResult?.first_invalid_id }}
-          </span>
-          <span v-else>⚠ Verify failed</span>
-        </span>
-        <button
-          class="px-2 py-0.5 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
-          :disabled="store.verifyState === 'verifying' || store.entries.length === 0"
-          :title="
-            store.entries.length === 0
-              ? 'Load some entries first.'
-              : `Verify ids #${Math.min(...store.entries.map(e => e.id))}–#${Math.max(...store.entries.map(e => e.id))} on this page`
-          "
-          @click="verifyChain"
-        >
-          Verify visible range
-        </button>
-      </div>
-    </header>
-
-    <!-- Stats tiles -->
-    <section class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
-      <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
-        <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-          Total events
-        </div>
-        <div class="text-2xl font-semibold text-gray-900 dark:text-white mt-1">
-          {{ store.statsLoading ? '…' : (store.stats?.total ?? '—') }}
-        </div>
-        <div class="text-[11px] text-gray-400 mt-1">in window</div>
-      </div>
-
-      <button
-        class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-left hover:border-blue-400 transition disabled:opacity-60 disabled:hover:border-gray-200 disabled:cursor-default"
-        :disabled="!store.topEventType"
-        :title="store.topEventType ? `Click to filter by ${store.topEventType.key}` : ''"
-        @click="store.topEventType && drilldownEvent(store.topEventType.key)"
-      >
-        <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-          Top event type
-        </div>
-        <div class="text-lg font-semibold text-gray-900 dark:text-white mt-1 truncate">
-          {{ store.topEventType?.key || '—' }}
-        </div>
-        <div class="text-[11px] text-gray-400 mt-1">
-          {{ store.topEventType ? `${store.topEventType.count} events` : 'no data' }}
-        </div>
-      </button>
-
-      <button
-        class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-left hover:border-blue-400 transition disabled:opacity-60 disabled:hover:border-gray-200 disabled:cursor-default"
-        :disabled="!store.topActorType"
-        :title="store.topActorType ? `Click to filter by actor_type=${store.topActorType.key}` : ''"
-        @click="store.topActorType && store.drilldownFilter('actor_type', store.topActorType.key)"
-      >
-        <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-          Top actor type
-        </div>
-        <div class="text-lg font-semibold text-gray-900 dark:text-white mt-1 truncate">
-          {{ store.topActorType?.key || '—' }}
-        </div>
-        <div class="text-[11px] text-gray-400 mt-1">
-          {{ store.topActorType ? `${store.topActorType.count} events` : 'no data' }}
-        </div>
-      </button>
-
-      <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
-        <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-          Time window
-        </div>
-        <div class="text-sm font-medium text-gray-900 dark:text-white mt-1 break-all">
-          {{ store.timeWindowLabel }}
-        </div>
-        <div class="text-[11px] text-gray-400 mt-1">{{ store.activePreset }}</div>
-      </div>
-    </section>
-
-    <!-- Time-preset chips -->
-    <div class="flex flex-wrap items-center gap-2 mb-4">
-      <span class="text-xs text-gray-500 dark:text-gray-400 mr-1">Time:</span>
-      <button
-        v-for="p in TIME_PRESETS"
-        :key="p.key"
-        class="px-2.5 py-1 text-xs font-medium rounded-full transition"
-        :class="
-          store.activePreset === p.key
-            ? 'bg-blue-600 text-white'
-            : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
-        "
-        @click="applyPreset(p.key)"
-      >
-        {{ p.label }}
-      </button>
-      <span
-        v-if="store.activePreset === 'custom'"
-        class="px-2.5 py-1 text-xs font-medium rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200"
-      >
-        Custom
-      </span>
-    </div>
-
-    <!-- Unified Activity card: foldable, weekly-pattern + calendar tabs (#941 v3.2) -->
-    <section
-      class="mb-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
-    >
-      <!-- Sticky header: fold chevron + title + tab pills + active-tab legend. -->
-      <header class="flex items-center gap-3 flex-wrap p-4 pb-3">
-        <button
-          class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 font-mono text-xs"
-          :aria-expanded="heatmapsOpen"
-          :title="heatmapsOpen ? 'Collapse heatmaps' : 'Expand heatmaps'"
-          @click="heatmapsOpen = !heatmapsOpen"
-        >
-          {{ heatmapsOpen ? '▾' : '▸' }}
-        </button>
-        <div class="flex-shrink-0">
-          <h2 class="text-sm font-medium text-gray-700 dark:text-gray-200">Activity</h2>
-          <p class="text-[11px] text-gray-500 dark:text-gray-400">
-            <template v-if="heatmapTab === 'weekly'">
-              Weekday × hour of day · UTC · honors current filters
-            </template>
-            <template v-else>
-              One cell per UTC day · click a day to filter the dashboard to it
-            </template>
-          </p>
-        </div>
-
-        <!-- Tab pills. Disabled affordance when folded so the user understands
-             clicking a tab unfolds first. -->
-        <div
-          class="inline-flex rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden text-xs"
-          role="tablist"
-        >
-          <button
-            role="tab"
-            :aria-selected="heatmapTab === 'weekly'"
-            class="px-2.5 py-1 transition"
-            :class="
-              heatmapTab === 'weekly'
-                ? 'bg-blue-600 text-white'
-                : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700'
-            "
-            @click="heatmapTab = 'weekly'; heatmapsOpen = true"
+    <div class="audit-dashboard p-6 max-w-7xl mx-auto">
+      <header class="mb-6">
+        <div class="flex items-center gap-3 mb-2">
+          <router-link
+            to="/enterprise"
+            class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
           >
-            Weekly
-          </button>
-          <button
-            role="tab"
-            :aria-selected="heatmapTab === 'calendar'"
-            class="px-2.5 py-1 border-l border-gray-200 dark:border-gray-700 transition"
-            :class="
-              heatmapTab === 'calendar'
-                ? 'bg-blue-600 text-white'
-                : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700'
-            "
-            @click="heatmapTab = 'calendar'; heatmapsOpen = true"
-          >
-            Calendar
-          </button>
+            ← Enterprise
+          </router-link>
         </div>
+        <div class="flex items-center gap-3 mb-2">
+          <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Audit Log</h1>
+          <span class="px-2 py-0.5 text-xs font-bold rounded bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200">
+            PRO
+          </span>
+        </div>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Tamper-evident record of administrative actions. Default filter
+          shows the last 24 hours.
+        </p>
 
-        <div class="flex-1"></div>
-
-        <!-- Legend tracks the active tab's max_count so the swatch ramp matches
-             the cells the user is actually looking at. Hidden when folded. -->
-        <div
-          v-if="heatmapsOpen"
-          class="flex items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400"
-        >
-          <span>Less</span>
-          <template v-if="heatmapTab === 'weekly'">
-            <span class="inline-block w-3 h-3 rounded-sm" :style="heatmapCellStyle(0)" />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="heatmapCellStyle(Math.max(1, Math.round((store.heatmap?.max_count || 0) * 0.25)))"
-            />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="heatmapCellStyle(Math.max(1, Math.round((store.heatmap?.max_count || 0) * 0.5)))"
-            />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="heatmapCellStyle(Math.max(1, Math.round((store.heatmap?.max_count || 0) * 0.75)))"
-            />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="heatmapCellStyle(store.heatmap?.max_count || 1)"
-            />
-          </template>
-          <template v-else>
-            <span class="inline-block w-3 h-3 rounded-sm" :style="calendarCellStyle(0, true)" />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="calendarCellStyle(Math.max(1, Math.round((store.calendar?.max_count || 0) * 0.25)), true)"
-            />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="calendarCellStyle(Math.max(1, Math.round((store.calendar?.max_count || 0) * 0.5)), true)"
-            />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="calendarCellStyle(Math.max(1, Math.round((store.calendar?.max_count || 0) * 0.75)), true)"
-            />
-            <span
-              class="inline-block w-3 h-3 rounded-sm"
-              :style="calendarCellStyle(store.calendar?.max_count || 1, true)"
-            />
-          </template>
-          <span>More</span>
+        <!-- Hash-chain verify badge — manual trigger, visible-range only. -->
+        <div class="mt-3 flex items-center gap-2">
+          <span
+            class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded"
+            :class="{
+              'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300':
+                store.verifyState === 'idle',
+              'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200':
+                store.verifyState === 'verifying',
+              'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200':
+                store.verifyState === 'valid',
+              'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200':
+                store.verifyState === 'invalid',
+              'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-200':
+                store.verifyState === 'error',
+            }"
+          >
+            <span v-if="store.verifyState === 'idle'">Hash chain · not verified</span>
+            <span v-else-if="store.verifyState === 'verifying'">Verifying…</span>
+            <span v-else-if="store.verifyState === 'valid'">
+              ✓ Valid · {{ store.verifyResult?.checked || 0 }} entries
+            </span>
+            <span v-else-if="store.verifyState === 'invalid'">
+              ✗ Tamper detected · first invalid id #{{ store.verifyResult?.first_invalid_id }}
+            </span>
+            <span v-else>⚠ Verify failed</span>
+          </span>
+          <button
+            class="px-2 py-0.5 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+            :disabled="store.verifyState === 'verifying' || store.entries.length === 0"
+            :title="
+              store.entries.length === 0
+                ? 'Load some entries first.'
+                : `Verify ids #${Math.min(...store.entries.map(e => e.id))}–#${Math.max(...store.entries.map(e => e.id))} on this page`
+            "
+            @click="verifyChain"
+          >
+            Verify visible range
+          </button>
         </div>
       </header>
 
-      <!-- Body: tabs share a panel; v-show keeps both DOM trees mounted so
-           switching tabs is instant and table state is preserved. -->
-      <div v-show="heatmapsOpen" class="px-4 pb-4">
-        <!-- Weekly (dow × hour) -->
-        <div v-show="heatmapTab === 'weekly'" role="tabpanel" aria-label="Weekly pattern">
-          <div v-if="store.heatmapLoading" class="text-xs text-gray-500 py-4 text-center">
-            Loading heatmap…
+      <!-- Stats tiles -->
+      <section class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
+        <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+          <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            Total events
           </div>
-          <div
-            v-else-if="(store.heatmap?.total || 0) === 0"
-            class="text-xs text-gray-500 py-4 text-center"
-          >
-            No events in this window.
+          <div class="text-2xl font-semibold text-gray-900 dark:text-white mt-1">
+            {{ store.statsLoading ? '…' : (store.stats?.total ?? '—') }}
           </div>
-          <div v-else class="overflow-x-auto">
-            <table class="text-[10px] text-gray-500 dark:text-gray-400 border-separate" style="border-spacing: 2px">
-              <thead>
-                <tr>
-                  <th class="w-8"></th>
-                  <th
-                    v-for="h in HOURS"
-                    :key="`h-${h}`"
-                    class="font-normal text-center"
-                    style="min-width: 16px"
-                  >
-                    <span v-if="h % 3 === 0">{{ String(h).padStart(2, '0') }}</span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="row in heatmapGrid" :key="row.label">
-                  <td class="pr-1 text-right whitespace-nowrap">{{ row.label }}</td>
-                  <td
-                    v-for="cell in row.hours"
-                    :key="`${row.label}-${cell.hour}`"
-                    class="rounded-sm"
-                    style="width: 16px; height: 16px"
-                    :style="heatmapCellStyle(cell.count)"
-                    :title="heatmapCellTitle(row.label, cell.hour, cell.count)"
-                    :aria-label="heatmapCellTitle(row.label, cell.hour, cell.count)"
-                  ></td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
-              {{ store.heatmap?.total || 0 }} events ·
-              peak {{ store.heatmap?.max_count || 0 }}/hour
-            </p>
-          </div>
+          <div class="text-[11px] text-gray-400 mt-1">in window</div>
         </div>
 
-        <!-- Calendar (per-day, GitHub-style) -->
-        <div v-show="heatmapTab === 'calendar'" role="tabpanel" aria-label="Calendar">
-          <div v-if="store.calendarLoading" class="text-xs text-gray-500 py-4 text-center">
-            Loading calendar…
+        <button
+          class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-left hover:border-blue-400 transition disabled:opacity-60 disabled:hover:border-gray-200 disabled:cursor-default"
+          :disabled="!store.topEventType"
+          :title="store.topEventType ? `Click to filter by ${store.topEventType.key}` : ''"
+          @click="store.topEventType && drilldownEvent(store.topEventType.key)"
+        >
+          <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            Top event type
           </div>
-          <div
-            v-else-if="(store.calendar?.total || 0) === 0"
-            class="text-xs text-gray-500 py-4 text-center"
-          >
-            No events in this window.
+          <div class="text-lg font-semibold text-gray-900 dark:text-white mt-1 truncate">
+            {{ store.topEventType?.key || '—' }}
           </div>
-          <div v-else class="overflow-x-auto">
-            <table class="text-[10px] text-gray-500 dark:text-gray-400 border-separate" style="border-spacing: 2px">
-              <thead>
-                <tr>
-                  <th class="w-8"></th>
-                  <th
-                    v-for="(_w, idx) in calendarGrid.weeks"
-                    :key="`mh-${idx}`"
-                    class="font-normal text-left"
-                    style="min-width: 14px"
-                  >
-                    <span v-for="m in calendarGrid.months.filter(mm => mm.weekIdx === idx)" :key="m.label">
-                      {{ m.label }}
-                    </span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="(dow, dowIdx) in ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']" :key="dow">
-                  <td class="pr-1 text-right whitespace-nowrap">
-                    <span v-if="dowIdx % 2 === 0">{{ dow }}</span>
-                  </td>
-                  <td
-                    v-for="(week, weekIdx) in calendarGrid.weeks"
-                    :key="`c-${weekIdx}-${dowIdx}`"
-                    class="rounded-sm"
-                    :class="week[dowIdx].inRange && week[dowIdx].count > 0 ? 'cursor-pointer' : ''"
-                    style="width: 14px; height: 14px"
-                    :style="calendarCellStyle(week[dowIdx].count, week[dowIdx].inRange)"
-                    :title="calendarCellTitle(week[dowIdx])"
-                    :aria-label="calendarCellTitle(week[dowIdx])"
-                    @click="drilldownDay(week[dowIdx])"
-                  ></td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
-              {{ store.calendar?.total || 0 }} events across
-              {{ store.calendar?.days?.length || 0 }} active day{{ (store.calendar?.days?.length || 0) === 1 ? '' : 's' }} ·
-              peak {{ store.calendar?.max_count || 0 }}/day
-            </p>
+          <div class="text-[11px] text-gray-400 mt-1">
+            {{ store.topEventType ? `${store.topEventType.count} events` : 'no data' }}
           </div>
-        </div>
-      </div>
-    </section>
+        </button>
 
-    <!-- Filter form -->
-    <section
-      class="mb-4 p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
-    >
-      <h2 class="text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
-        Filters
-      </h2>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        <div>
-          <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-            >Event type</label
-          >
-          <select
-            v-model="filters.event_type"
-            class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-          >
-            <option value="">All</option>
-            <option v-for="t in store.distinctEventTypes" :key="t" :value="t">
-              {{ t }}
-            </option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-            >Actor type</label
-          >
-          <select
-            v-model="filters.actor_type"
-            class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-          >
-            <option value="">All</option>
-            <option v-for="t in store.distinctActorTypes" :key="t" :value="t">
-              {{ t }}
-            </option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-            >Actor ID</label
-          >
-          <input
-            v-model="filters.actor_id"
-            type="text"
-            placeholder="user.id or agent_name"
-            class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-          />
-        </div>
-        <div>
-          <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-            >Target type</label
-          >
-          <input
-            v-model="filters.target_type"
-            type="text"
-            placeholder="agent / user / schedule…"
-            class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-          />
-        </div>
-        <div>
-          <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-            >Start (ISO 8601 UTC)</label
-          >
-          <input
-            v-model="filters.start_time"
-            type="text"
-            placeholder="2026-05-25T00:00:00Z"
-            class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-          />
-        </div>
-        <div>
-          <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
-            >End (ISO 8601 UTC)</label
-          >
-          <input
-            v-model="filters.end_time"
-            type="text"
-            placeholder="leave blank for now"
-            class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-          />
-        </div>
-      </div>
-      <div class="mt-3 flex flex-wrap items-center gap-2">
         <button
-          class="px-3 py-1.5 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700"
-          @click="applyFilters"
+          class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-left hover:border-blue-400 transition disabled:opacity-60 disabled:hover:border-gray-200 disabled:cursor-default"
+          :disabled="!store.topActorType"
+          :title="store.topActorType ? `Click to filter by actor_type=${store.topActorType.key}` : ''"
+          @click="store.topActorType && store.drilldownFilter('actor_type', store.topActorType.key)"
         >
-          Apply
+          <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            Top actor type
+          </div>
+          <div class="text-lg font-semibold text-gray-900 dark:text-white mt-1 truncate">
+            {{ store.topActorType?.key || '—' }}
+          </div>
+          <div class="text-[11px] text-gray-400 mt-1">
+            {{ store.topActorType ? `${store.topActorType.count} events` : 'no data' }}
+          </div>
         </button>
+
+        <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+          <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            Time window
+          </div>
+          <div class="text-sm font-medium text-gray-900 dark:text-white mt-1 break-all">
+            {{ store.timeWindowLabel }}
+          </div>
+          <div class="text-[11px] text-gray-400 mt-1">{{ store.activePreset }}</div>
+        </div>
+      </section>
+
+      <!-- Time-preset chips -->
+      <div class="flex flex-wrap items-center gap-2 mb-4">
+        <span class="text-xs text-gray-500 dark:text-gray-400 mr-1">Time:</span>
         <button
-          class="px-3 py-1.5 text-sm font-medium rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
-          @click="resetFilters"
+          v-for="p in TIME_PRESETS"
+          :key="p.key"
+          class="px-2.5 py-1 text-xs font-medium rounded-full transition"
+          :class="
+            store.activePreset === p.key
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
+          "
+          @click="applyPreset(p.key)"
         >
-          Reset
+          {{ p.label }}
         </button>
-        <div class="flex-1"></div>
-        <span class="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">
-          Export current view:
+        <span
+          v-if="store.activePreset === 'custom'"
+          class="px-2.5 py-1 text-xs font-medium rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200"
+        >
+          Custom
         </span>
-        <button
-          class="px-3 py-1.5 text-sm font-medium rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
-          :disabled="store.exporting"
-          title="Download a CSV of the current filter window (uses /api/audit-log/export)."
-          @click="exportAs('csv')"
-        >
-          ⬇ CSV
-        </button>
-        <button
-          class="px-3 py-1.5 text-sm font-medium rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
-          :disabled="store.exporting"
-          title="Download a JSON array of the current filter window."
-          @click="exportAs('json')"
-        >
-          ⬇ JSON
-        </button>
-      </div>
-      <div
-        v-if="store.error"
-        class="mt-2 text-xs text-red-600 dark:text-red-400"
-      >
-        {{ store.error }}
-      </div>
-    </section>
-
-    <!-- Table + detail layout -->
-    <section class="flex gap-4">
-      <div
-        class="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden"
-        :class="store.selectedEntry ? 'lg:max-w-3xl' : ''"
-      >
-        <div v-if="store.loading" class="p-6 text-sm text-gray-500 text-center">
-          Loading…
-        </div>
-        <div
-          v-else-if="!store.entries.length"
-          class="p-6 text-sm text-gray-500 text-center"
-        >
-          {{
-            store.total === 0
-              ? 'No audit entries match these filters.'
-              : 'No results on this page.'
-          }}
-        </div>
-        <table v-else class="w-full text-sm">
-          <thead class="bg-gray-50 dark:bg-gray-900 text-left">
-            <tr class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              <th class="px-3 py-2 font-medium">Timestamp</th>
-              <th class="px-3 py-2 font-medium">Event</th>
-              <th class="px-3 py-2 font-medium">Actor</th>
-              <th class="px-3 py-2 font-medium">Target</th>
-              <th class="px-3 py-2 font-medium">Source</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="entry in store.entries"
-              :key="entry.event_id"
-              class="border-t border-gray-100 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
-              :class="
-                store.selectedEntry?.event_id === entry.event_id
-                  ? 'bg-blue-50 dark:bg-blue-900/20'
-                  : ''
-              "
-              @click="openDetail(entry)"
-            >
-              <td class="px-3 py-2 font-mono text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
-                {{ formatTimestamp(entry.timestamp) }}
-              </td>
-              <td class="px-3 py-2 text-gray-900 dark:text-white">
-                <button
-                  class="font-medium underline-offset-2 hover:underline hover:text-blue-700 dark:hover:text-blue-300"
-                  :title="`Filter by event_type=${entry.event_type}`"
-                  @click.stop="drilldownEvent(entry.event_type)"
-                >
-                  {{ entry.event_type }}
-                </button>
-                <span class="ml-1 text-xs text-gray-500 dark:text-gray-400"
-                  >· {{ entry.event_action }}</span
-                >
-              </td>
-              <td class="px-3 py-2 text-gray-700 dark:text-gray-200">
-                <button
-                  class="underline-offset-2 hover:underline hover:text-blue-700 dark:hover:text-blue-300"
-                  :title="
-                    entry.actor_id
-                      ? `Filter by actor_id=${entry.actor_id}`
-                      : `Filter by actor_type=${entry.actor_type}`
-                  "
-                  @click.stop="drilldownActor(entry)"
-                >
-                  {{ actorLabel(entry) }}
-                </button>
-              </td>
-              <td class="px-3 py-2 text-gray-700 dark:text-gray-200">
-                {{ targetLabel(entry) }}
-              </td>
-              <td class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
-                {{ entry.source }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <footer
-          class="flex items-center justify-between px-4 py-2 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-500 dark:text-gray-400"
-        >
-          <span>{{ store.rangeLabel }}</span>
-          <span class="flex items-center gap-2">
-            <button
-              class="px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-40"
-              :disabled="!store.hasPrev || store.loading"
-              @click="store.prevPage()"
-            >
-              ← Prev
-            </button>
-            <span>Page {{ store.page }} of {{ store.pageCount }}</span>
-            <button
-              class="px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-40"
-              :disabled="!store.hasNext || store.loading"
-              @click="store.nextPage()"
-            >
-              Next →
-            </button>
-          </span>
-        </footer>
       </div>
 
-      <!-- Side detail panel -->
-      <aside
-        v-if="store.selectedEntry"
-        class="hidden lg:block flex-1 max-w-lg rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 overflow-y-auto self-start"
+      <!-- Unified Activity card: foldable, weekly-pattern + calendar tabs (#941 v3.2) -->
+      <section
+        class="mb-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
       >
-        <header class="flex items-start justify-between mb-3">
-          <div>
-            <h3 class="text-base font-medium text-gray-900 dark:text-white">
-              {{ store.selectedEntry.event_type }} ·
-              {{ store.selectedEntry.event_action }}
-            </h3>
-            <p class="text-xs text-gray-500 dark:text-gray-400 font-mono mt-0.5">
-              {{ store.selectedEntry.event_id }}
+        <!-- Sticky header: fold chevron + title + tab pills + active-tab legend. -->
+        <header class="flex items-center gap-3 flex-wrap p-4 pb-3">
+          <button
+            class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 font-mono text-xs"
+            :aria-expanded="heatmapsOpen"
+            :title="heatmapsOpen ? 'Collapse heatmaps' : 'Expand heatmaps'"
+            @click="heatmapsOpen = !heatmapsOpen"
+          >
+            {{ heatmapsOpen ? '▾' : '▸' }}
+          </button>
+          <div class="flex-shrink-0">
+            <h2 class="text-sm font-medium text-gray-700 dark:text-gray-200">Activity</h2>
+            <p class="text-[11px] text-gray-500 dark:text-gray-400">
+              <template v-if="heatmapTab === 'weekly'">
+                Weekday × hour of day · UTC · honors current filters
+              </template>
+              <template v-else>
+                One cell per UTC day · click a day to filter the dashboard to it
+              </template>
             </p>
           </div>
-          <button
-            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-            aria-label="Close detail"
-            @click="closeDetail"
+
+          <!-- Tab pills. Disabled affordance when folded so the user understands
+               clicking a tab unfolds first. -->
+          <div
+            class="inline-flex rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden text-xs"
+            role="tablist"
           >
-            ✕
-          </button>
+            <button
+              role="tab"
+              :aria-selected="heatmapTab === 'weekly'"
+              class="px-2.5 py-1 transition"
+              :class="
+                heatmapTab === 'weekly'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700'
+              "
+              @click="heatmapTab = 'weekly'; heatmapsOpen = true"
+            >
+              Weekly
+            </button>
+            <button
+              role="tab"
+              :aria-selected="heatmapTab === 'calendar'"
+              class="px-2.5 py-1 border-l border-gray-200 dark:border-gray-700 transition"
+              :class="
+                heatmapTab === 'calendar'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700'
+              "
+              @click="heatmapTab = 'calendar'; heatmapsOpen = true"
+            >
+              Calendar
+            </button>
+          </div>
+
+          <div class="flex-1"></div>
+
+          <!-- Legend tracks the active tab's max_count so the swatch ramp matches
+               the cells the user is actually looking at. Hidden when folded. -->
+          <div
+            v-if="heatmapsOpen"
+            class="flex items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400"
+          >
+            <span>Less</span>
+            <template v-if="heatmapTab === 'weekly'">
+              <span class="inline-block w-3 h-3 rounded-sm" :style="heatmapCellStyle(0)" />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="heatmapCellStyle(Math.max(1, Math.round((store.heatmap?.max_count || 0) * 0.25)))"
+              />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="heatmapCellStyle(Math.max(1, Math.round((store.heatmap?.max_count || 0) * 0.5)))"
+              />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="heatmapCellStyle(Math.max(1, Math.round((store.heatmap?.max_count || 0) * 0.75)))"
+              />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="heatmapCellStyle(store.heatmap?.max_count || 1)"
+              />
+            </template>
+            <template v-else>
+              <span class="inline-block w-3 h-3 rounded-sm" :style="calendarCellStyle(0, true)" />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="calendarCellStyle(Math.max(1, Math.round((store.calendar?.max_count || 0) * 0.25)), true)"
+              />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="calendarCellStyle(Math.max(1, Math.round((store.calendar?.max_count || 0) * 0.5)), true)"
+              />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="calendarCellStyle(Math.max(1, Math.round((store.calendar?.max_count || 0) * 0.75)), true)"
+              />
+              <span
+                class="inline-block w-3 h-3 rounded-sm"
+                :style="calendarCellStyle(store.calendar?.max_count || 1, true)"
+              />
+            </template>
+            <span>More</span>
+          </div>
         </header>
 
-        <dl class="grid grid-cols-3 gap-x-3 gap-y-1 text-xs mb-3">
-          <dt class="text-gray-500 dark:text-gray-400">Timestamp</dt>
-          <dd class="col-span-2 font-mono text-gray-900 dark:text-white">
-            {{ store.selectedEntry.timestamp }}
-          </dd>
-
-          <dt class="text-gray-500 dark:text-gray-400">Actor</dt>
-          <dd class="col-span-2 text-gray-900 dark:text-white">
-            {{ store.selectedEntry.actor_type }} ·
-            {{ actorLabel(store.selectedEntry) }}
-          </dd>
-
-          <template v-if="store.selectedEntry.actor_ip">
-            <dt class="text-gray-500 dark:text-gray-400">Actor IP</dt>
-            <dd class="col-span-2 font-mono text-gray-900 dark:text-white">
-              {{ store.selectedEntry.actor_ip }}
-            </dd>
-          </template>
-
-          <template v-if="store.selectedEntry.mcp_key_name">
-            <dt class="text-gray-500 dark:text-gray-400">MCP key</dt>
-            <dd class="col-span-2 text-gray-900 dark:text-white">
-              {{ store.selectedEntry.mcp_key_name }} ({{ store.selectedEntry.mcp_scope || 'unknown scope' }})
-            </dd>
-          </template>
-
-          <dt class="text-gray-500 dark:text-gray-400">Target</dt>
-          <dd class="col-span-2 text-gray-900 dark:text-white">
-            {{ targetLabel(store.selectedEntry) }}
-          </dd>
-
-          <dt class="text-gray-500 dark:text-gray-400">Source</dt>
-          <dd class="col-span-2 text-gray-900 dark:text-white">
-            {{ store.selectedEntry.source }}
-            <span
-              v-if="store.selectedEntry.endpoint"
-              class="text-gray-500 dark:text-gray-400 font-mono"
+        <!-- Body: tabs share a panel; v-show keeps both DOM trees mounted so
+             switching tabs is instant and table state is preserved. -->
+        <div v-show="heatmapsOpen" class="px-4 pb-4">
+          <!-- Weekly (dow × hour) -->
+          <div v-show="heatmapTab === 'weekly'" role="tabpanel" aria-label="Weekly pattern">
+            <div v-if="store.heatmapLoading" class="text-xs text-gray-500 py-4 text-center">
+              Loading heatmap…
+            </div>
+            <div
+              v-else-if="(store.heatmap?.total || 0) === 0"
+              class="text-xs text-gray-500 py-4 text-center"
             >
-              ({{ store.selectedEntry.endpoint }})
+              No events in this window.
+            </div>
+            <div v-else class="overflow-x-auto">
+              <table class="text-[10px] text-gray-500 dark:text-gray-400 border-separate" style="border-spacing: 2px">
+                <thead>
+                  <tr>
+                    <th class="w-8"></th>
+                    <th
+                      v-for="h in HOURS"
+                      :key="`h-${h}`"
+                      class="font-normal text-center"
+                      style="min-width: 16px"
+                    >
+                      <span v-if="h % 3 === 0">{{ String(h).padStart(2, '0') }}</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="row in heatmapGrid" :key="row.label">
+                    <td class="pr-1 text-right whitespace-nowrap">{{ row.label }}</td>
+                    <td
+                      v-for="cell in row.hours"
+                      :key="`${row.label}-${cell.hour}`"
+                      class="rounded-sm"
+                      style="width: 16px; height: 16px"
+                      :style="heatmapCellStyle(cell.count)"
+                      :title="heatmapCellTitle(row.label, cell.hour, cell.count)"
+                      :aria-label="heatmapCellTitle(row.label, cell.hour, cell.count)"
+                    ></td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
+                {{ store.heatmap?.total || 0 }} events ·
+                peak {{ store.heatmap?.max_count || 0 }}/hour
+              </p>
+            </div>
+          </div>
+
+          <!-- Calendar (per-day, GitHub-style) -->
+          <div v-show="heatmapTab === 'calendar'" role="tabpanel" aria-label="Calendar">
+            <div v-if="store.calendarLoading" class="text-xs text-gray-500 py-4 text-center">
+              Loading calendar…
+            </div>
+            <div
+              v-else-if="(store.calendar?.total || 0) === 0"
+              class="text-xs text-gray-500 py-4 text-center"
+            >
+              No events in this window.
+            </div>
+            <div v-else class="overflow-x-auto">
+              <table class="text-[10px] text-gray-500 dark:text-gray-400 border-separate" style="border-spacing: 2px">
+                <thead>
+                  <tr>
+                    <th class="w-8"></th>
+                    <th
+                      v-for="(_w, idx) in calendarGrid.weeks"
+                      :key="`mh-${idx}`"
+                      class="font-normal text-left"
+                      style="min-width: 14px"
+                    >
+                      <span v-for="m in calendarGrid.months.filter(mm => mm.weekIdx === idx)" :key="m.label">
+                        {{ m.label }}
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(dow, dowIdx) in ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']" :key="dow">
+                    <td class="pr-1 text-right whitespace-nowrap">
+                      <span v-if="dowIdx % 2 === 0">{{ dow }}</span>
+                    </td>
+                    <td
+                      v-for="(week, weekIdx) in calendarGrid.weeks"
+                      :key="`c-${weekIdx}-${dowIdx}`"
+                      class="rounded-sm"
+                      :class="week[dowIdx].inRange && week[dowIdx].count > 0 ? 'cursor-pointer' : ''"
+                      style="width: 14px; height: 14px"
+                      :style="calendarCellStyle(week[dowIdx].count, week[dowIdx].inRange)"
+                      :title="calendarCellTitle(week[dowIdx])"
+                      :aria-label="calendarCellTitle(week[dowIdx])"
+                      @click="drilldownDay(week[dowIdx])"
+                    ></td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
+                {{ store.calendar?.total || 0 }} events across
+                {{ store.calendar?.days?.length || 0 }} active day{{ (store.calendar?.days?.length || 0) === 1 ? '' : 's' }} ·
+                peak {{ store.calendar?.max_count || 0 }}/day
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Filter form -->
+      <section
+        class="mb-4 p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+      >
+        <h2 class="text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
+          Filters
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          <div>
+            <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+              >Event type</label
+            >
+            <select
+              v-model="filters.event_type"
+              class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            >
+              <option value="">All</option>
+              <option v-for="t in store.distinctEventTypes" :key="t" :value="t">
+                {{ t }}
+              </option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+              >Actor type</label
+            >
+            <select
+              v-model="filters.actor_type"
+              class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            >
+              <option value="">All</option>
+              <option v-for="t in store.distinctActorTypes" :key="t" :value="t">
+                {{ t }}
+              </option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+              >Actor ID</label
+            >
+            <input
+              v-model="filters.actor_id"
+              type="text"
+              placeholder="user.id or agent_name"
+              class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+          </div>
+          <div>
+            <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+              >Target type</label
+            >
+            <input
+              v-model="filters.target_type"
+              type="text"
+              placeholder="agent / user / schedule…"
+              class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+          </div>
+          <div>
+            <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+              >Start (ISO 8601 UTC)</label
+            >
+            <input
+              v-model="filters.start_time"
+              type="text"
+              placeholder="2026-05-25T00:00:00Z"
+              class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+          </div>
+          <div>
+            <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+              >End (ISO 8601 UTC)</label
+            >
+            <input
+              v-model="filters.end_time"
+              type="text"
+              placeholder="leave blank for now"
+              class="w-full px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+          </div>
+        </div>
+        <div class="mt-3 flex flex-wrap items-center gap-2">
+          <button
+            class="px-3 py-1.5 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700"
+            @click="applyFilters"
+          >
+            Apply
+          </button>
+          <button
+            class="px-3 py-1.5 text-sm font-medium rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+            @click="resetFilters"
+          >
+            Reset
+          </button>
+          <div class="flex-1"></div>
+          <span class="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">
+            Export current view:
+          </span>
+          <button
+            class="px-3 py-1.5 text-sm font-medium rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+            :disabled="store.exporting"
+            title="Download a CSV of the current filter window (uses /api/audit-log/export)."
+            @click="exportAs('csv')"
+          >
+            ⬇ CSV
+          </button>
+          <button
+            class="px-3 py-1.5 text-sm font-medium rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+            :disabled="store.exporting"
+            title="Download a JSON array of the current filter window."
+            @click="exportAs('json')"
+          >
+            ⬇ JSON
+          </button>
+        </div>
+        <div
+          v-if="store.error"
+          class="mt-2 text-xs text-red-600 dark:text-red-400"
+        >
+          {{ store.error }}
+        </div>
+      </section>
+
+      <!-- Table + detail layout -->
+      <section class="flex gap-4">
+        <div
+          class="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden"
+          :class="store.selectedEntry ? 'lg:max-w-3xl' : ''"
+        >
+          <div v-if="store.loading" class="p-6 text-sm text-gray-500 text-center">
+            Loading…
+          </div>
+          <div
+            v-else-if="!store.entries.length"
+            class="p-6 text-sm text-gray-500 text-center"
+          >
+            {{
+              store.total === 0
+                ? 'No audit entries match these filters.'
+                : 'No results on this page.'
+            }}
+          </div>
+          <table v-else class="w-full text-sm">
+            <thead class="bg-gray-50 dark:bg-gray-900 text-left">
+              <tr class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                <th class="px-3 py-2 font-medium">Timestamp</th>
+                <th class="px-3 py-2 font-medium">Event</th>
+                <th class="px-3 py-2 font-medium">Actor</th>
+                <th class="px-3 py-2 font-medium">Target</th>
+                <th class="px-3 py-2 font-medium">Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="entry in store.entries"
+                :key="entry.event_id"
+                class="border-t border-gray-100 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
+                :class="
+                  store.selectedEntry?.event_id === entry.event_id
+                    ? 'bg-blue-50 dark:bg-blue-900/20'
+                    : ''
+                "
+                @click="openDetail(entry)"
+              >
+                <td class="px-3 py-2 font-mono text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                  {{ formatTimestamp(entry.timestamp) }}
+                </td>
+                <td class="px-3 py-2 text-gray-900 dark:text-white">
+                  <button
+                    class="font-medium underline-offset-2 hover:underline hover:text-blue-700 dark:hover:text-blue-300"
+                    :title="`Filter by event_type=${entry.event_type}`"
+                    @click.stop="drilldownEvent(entry.event_type)"
+                  >
+                    {{ entry.event_type }}
+                  </button>
+                  <span class="ml-1 text-xs text-gray-500 dark:text-gray-400"
+                    >· {{ entry.event_action }}</span
+                  >
+                </td>
+                <td class="px-3 py-2 text-gray-700 dark:text-gray-200">
+                  <button
+                    class="underline-offset-2 hover:underline hover:text-blue-700 dark:hover:text-blue-300"
+                    :title="
+                      entry.actor_id
+                        ? `Filter by actor_id=${entry.actor_id}`
+                        : `Filter by actor_type=${entry.actor_type}`
+                    "
+                    @click.stop="drilldownActor(entry)"
+                  >
+                    {{ actorLabel(entry) }}
+                  </button>
+                </td>
+                <td class="px-3 py-2 text-gray-700 dark:text-gray-200">
+                  {{ targetLabel(entry) }}
+                </td>
+                <td class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                  {{ entry.source }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <footer
+            class="flex items-center justify-between px-4 py-2 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-500 dark:text-gray-400"
+          >
+            <span>{{ store.rangeLabel }}</span>
+            <span class="flex items-center gap-2">
+              <button
+                class="px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-40"
+                :disabled="!store.hasPrev || store.loading"
+                @click="store.prevPage()"
+              >
+                ← Prev
+              </button>
+              <span>Page {{ store.page }} of {{ store.pageCount }}</span>
+              <button
+                class="px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-40"
+                :disabled="!store.hasNext || store.loading"
+                @click="store.nextPage()"
+              >
+                Next →
+              </button>
             </span>
-          </dd>
+          </footer>
+        </div>
 
-          <template v-if="store.selectedEntry.request_id">
-            <dt class="text-gray-500 dark:text-gray-400">Request</dt>
+        <!-- Side detail panel -->
+        <aside
+          v-if="store.selectedEntry"
+          class="hidden lg:block flex-1 max-w-lg rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 overflow-y-auto self-start"
+        >
+          <header class="flex items-start justify-between mb-3">
+            <div>
+              <h3 class="text-base font-medium text-gray-900 dark:text-white">
+                {{ store.selectedEntry.event_type }} ·
+                {{ store.selectedEntry.event_action }}
+              </h3>
+              <p class="text-xs text-gray-500 dark:text-gray-400 font-mono mt-0.5">
+                {{ store.selectedEntry.event_id }}
+              </p>
+            </div>
+            <button
+              class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              aria-label="Close detail"
+              @click="closeDetail"
+            >
+              ✕
+            </button>
+          </header>
+
+          <dl class="grid grid-cols-3 gap-x-3 gap-y-1 text-xs mb-3">
+            <dt class="text-gray-500 dark:text-gray-400">Timestamp</dt>
             <dd class="col-span-2 font-mono text-gray-900 dark:text-white">
-              {{ store.selectedEntry.request_id }}
+              {{ store.selectedEntry.timestamp }}
             </dd>
-          </template>
-        </dl>
 
-        <details class="mb-3" open>
-          <summary class="text-xs font-medium text-gray-600 dark:text-gray-300 cursor-pointer">
-            Details JSON
-          </summary>
-          <pre
-            class="mt-2 p-2 rounded bg-gray-50 dark:bg-gray-900 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto"
-          >{{ detailsJson || '(none)' }}</pre>
-        </details>
+            <dt class="text-gray-500 dark:text-gray-400">Actor</dt>
+            <dd class="col-span-2 text-gray-900 dark:text-white">
+              {{ store.selectedEntry.actor_type }} ·
+              {{ actorLabel(store.selectedEntry) }}
+            </dd>
 
-        <details>
-          <summary class="text-xs font-medium text-gray-600 dark:text-gray-300 cursor-pointer">
-            Hash chain
-          </summary>
-          <dl class="mt-2 text-xs grid grid-cols-3 gap-x-3 gap-y-1">
-            <dt class="text-gray-500 dark:text-gray-400">previous_hash</dt>
-            <dd class="col-span-2 font-mono break-all text-gray-900 dark:text-white">
-              {{ store.selectedEntry.previous_hash || '(none)' }}
+            <template v-if="store.selectedEntry.actor_ip">
+              <dt class="text-gray-500 dark:text-gray-400">Actor IP</dt>
+              <dd class="col-span-2 font-mono text-gray-900 dark:text-white">
+                {{ store.selectedEntry.actor_ip }}
+              </dd>
+            </template>
+
+            <template v-if="store.selectedEntry.mcp_key_name">
+              <dt class="text-gray-500 dark:text-gray-400">MCP key</dt>
+              <dd class="col-span-2 text-gray-900 dark:text-white">
+                {{ store.selectedEntry.mcp_key_name }} ({{ store.selectedEntry.mcp_scope || 'unknown scope' }})
+              </dd>
+            </template>
+
+            <dt class="text-gray-500 dark:text-gray-400">Target</dt>
+            <dd class="col-span-2 text-gray-900 dark:text-white">
+              {{ targetLabel(store.selectedEntry) }}
             </dd>
-            <dt class="text-gray-500 dark:text-gray-400">entry_hash</dt>
-            <dd class="col-span-2 font-mono break-all text-gray-900 dark:text-white">
-              {{ store.selectedEntry.entry_hash || '(none)' }}
+
+            <dt class="text-gray-500 dark:text-gray-400">Source</dt>
+            <dd class="col-span-2 text-gray-900 dark:text-white">
+              {{ store.selectedEntry.source }}
+              <span
+                v-if="store.selectedEntry.endpoint"
+                class="text-gray-500 dark:text-gray-400 font-mono"
+              >
+                ({{ store.selectedEntry.endpoint }})
+              </span>
             </dd>
+
+            <template v-if="store.selectedEntry.request_id">
+              <dt class="text-gray-500 dark:text-gray-400">Request</dt>
+              <dd class="col-span-2 font-mono text-gray-900 dark:text-white">
+                {{ store.selectedEntry.request_id }}
+              </dd>
+            </template>
           </dl>
-        </details>
-      </aside>
-    </section>
+
+          <details class="mb-3" open>
+            <summary class="text-xs font-medium text-gray-600 dark:text-gray-300 cursor-pointer">
+              Details JSON
+            </summary>
+            <pre
+              class="mt-2 p-2 rounded bg-gray-50 dark:bg-gray-900 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto"
+            >{{ detailsJson || '(none)' }}</pre>
+          </details>
+
+          <details>
+            <summary class="text-xs font-medium text-gray-600 dark:text-gray-300 cursor-pointer">
+              Hash chain
+            </summary>
+            <dl class="mt-2 text-xs grid grid-cols-3 gap-x-3 gap-y-1">
+              <dt class="text-gray-500 dark:text-gray-400">previous_hash</dt>
+              <dd class="col-span-2 font-mono break-all text-gray-900 dark:text-white">
+                {{ store.selectedEntry.previous_hash || '(none)' }}
+              </dd>
+              <dt class="text-gray-500 dark:text-gray-400">entry_hash</dt>
+              <dd class="col-span-2 font-mono break-all text-gray-900 dark:text-white">
+                {{ store.selectedEntry.entry_hash || '(none)' }}
+              </dd>
+            </dl>
+          </details>
+        </aside>
+      </section>
+    </div>
   </div>
 </template>

--- a/src/frontend/src/views/enterprise/Index.vue
+++ b/src/frontend/src/views/enterprise/Index.vue
@@ -15,6 +15,7 @@
  */
 import { computed, onMounted } from 'vue'
 import { useEnterpriseStore } from '../../stores/enterprise'
+import NavBar from '@/components/NavBar.vue'
 
 const store = useEnterpriseStore()
 
@@ -106,59 +107,67 @@ const totalEntitled = computed(
 </script>
 
 <template>
-  <div class="enterprise-landing p-6 max-w-6xl mx-auto">
-    <header class="mb-8">
-      <div class="flex items-center gap-3 mb-2">
-        <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Enterprise</h1>
-        <span class="px-2 py-0.5 text-xs font-bold rounded bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200">
-          PRO
-        </span>
-      </div>
-      <p class="text-sm text-gray-500 dark:text-gray-400">
-        Compliance-gating features for Trinity Enterprise. See
-        <a href="https://github.com/abilityai/trinity/issues/847" class="underline" target="_blank">#847</a>
-        for the architecture spike.
-      </p>
-      <p class="text-xs text-gray-400 mt-2">
-        {{ totalEntitled }} of {{ cards.length }} features entitled for this instance.
-      </p>
-    </header>
+  <!-- Trinity has no global chrome: App.vue renders only <router-view>, so each
+       authenticated view mounts NavBar itself (Dashboard/Settings/Operations/
+       Templates do). Without it this page had no way back to the platform but
+       the browser's back button (#1636). -->
+  <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
+    <NavBar />
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      <component
-        :is="card.available ? 'router-link' : 'div'"
-        v-for="card in cards"
-        :key="card.id"
-        :to="card.available ? card.route : undefined"
-        class="block rounded-lg border bg-white dark:bg-gray-800 p-5 transition-all"
-        :class="card.available
-          ? 'border-gray-200 dark:border-gray-700 hover:border-blue-400 hover:shadow-md cursor-pointer'
-          : 'border-gray-200 dark:border-gray-700 opacity-70 cursor-not-allowed'"
-      >
-        <div class="flex items-start justify-between mb-3">
-          <span class="text-3xl">{{ card.icon }}</span>
-          <span
-            class="px-2 py-0.5 text-[10px] font-bold rounded uppercase tracking-wider"
-            :class="card.available
-              ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200'
-              : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'"
-          >
-            {{ card.available ? 'Available' : card.entitled ? 'Coming soon' : 'Not licensed' }}
+    <div class="enterprise-landing p-6 max-w-6xl mx-auto">
+      <header class="mb-8">
+        <div class="flex items-center gap-3 mb-2">
+          <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Enterprise</h1>
+          <span class="px-2 py-0.5 text-xs font-bold rounded bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200">
+            PRO
           </span>
         </div>
-        <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-1">
-          {{ card.title }}
-        </h3>
-        <p class="text-sm text-gray-600 dark:text-gray-400">{{ card.description }}</p>
-      </component>
-    </div>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Compliance-gating features for Trinity Enterprise. See
+          <a href="https://github.com/abilityai/trinity/issues/847" class="underline" target="_blank">#847</a>
+          for the architecture spike.
+        </p>
+        <p class="text-xs text-gray-400 mt-2">
+          {{ totalEntitled }} of {{ cards.length }} features entitled for this instance.
+        </p>
+      </header>
 
-    <footer class="mt-10 p-4 rounded bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400">
-      <strong class="block text-gray-900 dark:text-white mb-1">About Trinity Enterprise</strong>
-      Backend modules ship from the private repo
-      <code class="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">Abilityai/trinity-enterprise</code>.
-      Frontend is part of the OSS bundle, gated server-side. See
-      <code class="text-xs">docs/planning/ENTERPRISE_ARCHITECTURE.md</code> for the decision record.
-    </footer>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <component
+          :is="card.available ? 'router-link' : 'div'"
+          v-for="card in cards"
+          :key="card.id"
+          :to="card.available ? card.route : undefined"
+          class="block rounded-lg border bg-white dark:bg-gray-800 p-5 transition-all"
+          :class="card.available
+            ? 'border-gray-200 dark:border-gray-700 hover:border-blue-400 hover:shadow-md cursor-pointer'
+            : 'border-gray-200 dark:border-gray-700 opacity-70 cursor-not-allowed'"
+        >
+          <div class="flex items-start justify-between mb-3">
+            <span class="text-3xl">{{ card.icon }}</span>
+            <span
+              class="px-2 py-0.5 text-[10px] font-bold rounded uppercase tracking-wider"
+              :class="card.available
+                ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200'
+                : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'"
+            >
+              {{ card.available ? 'Available' : card.entitled ? 'Coming soon' : 'Not licensed' }}
+            </span>
+          </div>
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-1">
+            {{ card.title }}
+          </h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400">{{ card.description }}</p>
+        </component>
+      </div>
+
+      <footer class="mt-10 p-4 rounded bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400">
+        <strong class="block text-gray-900 dark:text-white mb-1">About Trinity Enterprise</strong>
+        Backend modules ship from the private repo
+        <code class="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">Abilityai/trinity-enterprise</code>.
+        Frontend is part of the OSS bundle, gated server-side. See
+        <code class="text-xs">docs/planning/ENTERPRISE_ARCHITECTURE.md</code> for the decision record.
+      </footer>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

`/enterprise` and `/enterprise/audit` rendered no top nav — the user landed with no way back to the platform except the browser's back button.

Root cause is as the issue describes: Trinity has no global chrome. `App.vue` renders only `<router-view>`, so every authenticated view mounts `NavBar` itself. The enterprise views never did, so the chrome silently vanished on those routes.

> **Review with `git diff -w`.** The real change is **21 added lines, 0 deletions**. Wrapping each template re-indents its body, which inflates `Audit.vue` to ~1266 lines of pure whitespace churn.

## Changes

- `views/enterprise/Index.vue`, `views/enterprise/Audit.vue` — wrap the existing centred container in the house layout (`min-h-screen` shell → `NavBar` → content), matching `Settings.vue` / `Templates.vue`. The original `p-6 max-w-*` containers are untouched, so spacing is unchanged and there's no double padding.
- `router/index.js` — document the `/enterprise/client-portal` intent (see below).

**Active highlight needed no change.** NavBar's Enterprise link already keys off `$route.path.startsWith('/enterprise')`, so it highlights correctly on both routes once NavBar renders.

**`/enterprise/client-portal` deliberately keeps NO NavBar**, and the route comment now says so rather than leaving it ambiguous: it's a client-facing surface, not an operator page — platform nav would offer a client links they can't use. It sits alongside `/portal` and `/m`. (Ambiguity was the actual bug here: the missing comment is why a reader couldn't tell "standalone by design" from "same defect as its siblings".)

## Scope

The issue floats hoisting NavBar into `App.vue` behind a `meta.standalone` opt-out — *"unless it's the cheaper fix"*. It isn't: **7 views** render NavBar today, so hoisting means touching ~12 files, adding `meta.standalone` to every standalone route, and risking double-nav on every authenticated page. Left as the follow-up the issue describes.

## Verification

Production `vite build` succeeds, and the built output confirms the wiring rather than just the intent:

- `Index-*.js` (contains `enterprise-landing`) → references `NavBar` ✅
- `Audit-*.js` (contains `audit-dashboard`) → references `NavBar` ✅
- `Portal-*.js`, `ClientPortal-*.js`, `MobileAdmin-*.js` → **no** `NavBar` ✅ (standalone surfaces unregressed, AC #5)

Both wrappers use the same `min-h-screen bg-gray-100 dark:bg-gray-900` shell as the rest of the platform, so dark mode inherits the existing behaviour (AC #7).

**Not visually confirmed in a browser** — worth stating plainly. This repo's `docker-compose.override.yml` deliberately repoints the frontend dev server at the `trinity-portal-cleanup` worktree ("so Vite serves the old-client-portal cleanup at localhost:8001"), so localhost:8001 doesn't serve this branch, and I didn't want to disturb that setup. Verification here is build + bundle-level. A reviewer with the override reverted (`docker compose up -d frontend`) can eyeball `/enterprise` and `/enterprise/audit` in a few seconds.

## Interaction with #1637

PR #1637 removes `/enterprise/client-portal` entirely. If it lands first, the route comment added here disappears with the route — no conflict in substance, and the `Index.vue`/`Audit.vue` fixes are independent of it.

## Test Plan

- [x] `vite build` succeeds (production config)
- [x] Enterprise chunks reference NavBar; Portal/ClientPortal/MobileAdmin chunks do not
- [x] Existing `p-6 max-w-*` containers unchanged — no double padding
- [ ] Reviewer: eyeball `/enterprise` + `/enterprise/audit` light/dark with the frontend mount pointed at this branch

Closes #1636
