### PR TITLE
fix(channels): persist proactive messages to channel session history (#1600)

### DIFF
--- a/docs/memory/feature-flows/proactive-messaging.md
+++ b/docs/memory/feature-flows/proactive-messaging.md
@@ -15,6 +15,7 @@ Enables agents to send proactive messages to specific users by verified email ac
 - **Mandatory audit logging**: All proactive sends logged via platform_audit_service
 - **Multi-channel delivery**: Auto-selection tries telegram → slack → web. WhatsApp is an explicit-only channel (`channel="whatsapp"`) and not part of `auto` — Twilio's 24-hour session window makes it unreliable for inactive recipients.
 - **MCP tool access**: Agents use `send_message` MCP tool for outreach
+- **History-aware (#1600)**: a delivered message is appended to the recipient's channel session, so the agent's next turn knows what it sent
 
 ## Architecture
 
@@ -160,6 +161,56 @@ actor_id=agent_name
 target_type="user"
 target_id=recipient_email
 ```
+
+### 5. Session-History Persistence (#1600)
+
+A delivered message is appended to the recipient's channel session, so the next
+inbound turn's `build_public_chat_context` includes it. Without this the agent had
+no record of its own outreach — it would repeat itself, contradict the message, or
+fail to parse the reply ("yes, sounds good" — to what?).
+
+```python
+# _send_message_inner, on confirmed delivery only (never on failure — no phantom turn)
+self._persist_outbound(agent_name, recipient_email, text, result)
+  -> db.get_or_create_public_chat_session(agent_name, result.session_identifier, channel)
+  -> db.add_public_chat_message(session_id, "assistant", text,
+                                sender_email=recipient_email,   # DM => single participant (#903)
+                                sender_label=agent_name)
+```
+
+**The session key must equal the inbound one.** Persisting into *a* session is
+useless; it has to be the one the recipient's next message resolves to, or the
+write succeeds and the bug survives invisibly. So each `_deliver_*` sets
+`DeliveryResult.session_identifier` by driving **its own adapter's**
+`get_session_identifier()` with a synthetic DM — never by re-deriving the format
+in the service, which would drift from the adapter:
+
+| Channel | Key | Derived from |
+|---------|-----|--------------|
+| Telegram | `{bot_id}:{user}:{chat}` | binding `bot_id` + chat link's `telegram_user_id` (a DM's chat_id IS the user id) |
+| WhatsApp | `{binding_id}:{phone}` | binding id + chat link's `wa_user_phone` |
+| Slack | `{team}:{user}:{dm_channel}` | workspace `team_id` + looked-up user + opened DM channel (`is_dm=True` selects the DM branch, not the thread branch) |
+
+**The session is created if absent.** `telegram_chat_links.session_id` and
+`whatsapp_chat_links.session_id` look like the natural key but are **never written
+by any code path** — vestigial columns, read in three SELECTs and nowhere else. So
+"reuse the link's session" isn't available; `get_or_create_public_chat_session` with
+the adapter's identifier lands in the same session regardless.
+
+**Attribution (#903)**: role `assistant`, `sender_label` = agent name,
+`sender_email` = the recipient. A proactive send targets ONE verified email — a DM,
+i.e. a single-participant session — so `_assistant_sender_email`'s rule resolves to
+the recipient, keeping sender-filtered MEM-001 summarization in the right user's
+memory.
+
+**Fail-soft**: the message is already delivered when this runs, so a persistence
+error is logged (loudly) and never surfaces as a delivery failure.
+
+**Scope**: `send_access_grant_notification` shares the `_deliver_*` helpers but does
+NOT persist — its history semantics are out of scope (#951). The call sits on the
+`send_message` path, which draws that line structurally rather than with a flag.
+Proactive **group** sends (`send_group_message`, #349/#350) have the same gap and a
+different session model — tracked in #1649.
 
 ## File Locations
 

--- a/src/backend/services/proactive_message_service.py
+++ b/src/backend/services/proactive_message_service.py
@@ -62,6 +62,13 @@ class DeliveryResult:
     channel: str
     message_id: Optional[str] = None
     error: Optional[str] = None
+    # #1600: the recipient's channel-session key, set by the `_deliver_*` helper
+    # on success so the caller can persist the outbound turn into the SAME
+    # session an inbound reply will use. Each helper derives it by calling its
+    # own adapter's `get_session_identifier()` — never by re-deriving the format
+    # here, which would drift from the adapter and silently mint a second
+    # session. None ⇒ the channel can't resolve a session (nothing to persist).
+    session_identifier: Optional[str] = None
 
 
 class ProactiveMessageService:
@@ -275,6 +282,14 @@ class ProactiveMessageService:
                 )
                 if result.success:
                     self._increment_rate_limit(agent_name, recipient_email)
+                    # #1600: record the outbound turn in the recipient's channel
+                    # session so the agent's next turn knows what it sent.
+                    # Deliberately here and not in `_deliver_*`: those helpers are
+                    # shared with `send_access_grant_notification`, whose
+                    # persistence is out of scope (#951). Keeping the call on the
+                    # send_message path draws that line structurally rather than
+                    # with a flag.
+                    self._persist_outbound(agent_name, recipient_email, text, result)
                     await self._audit_send(
                         agent_name, recipient_email, ch, True,
                         message_preview=message_preview
@@ -345,6 +360,72 @@ class ProactiveMessageService:
         )
         return result
 
+    def _persist_outbound(
+        self,
+        agent_name: str,
+        recipient_email: str,
+        text: str,
+        result: DeliveryResult,
+    ) -> None:
+        """Append a delivered proactive message to the recipient's channel history (#1600).
+
+        Without this the agent has no record of its own outreach: the next inbound
+        turn builds context from `build_public_chat_context`, which only ever saw
+        turns the message router persisted. The agent then repeats itself,
+        contradicts the message, or can't parse the reply ("yes, sounds good" — to
+        what?).
+
+        Attribution mirrors router step 11 (#903): role `assistant`, `sender_label`
+        = agent name, and `sender_email` = the recipient. A proactive send always
+        targets ONE verified email — i.e. a DM, a single-participant session — so
+        `_assistant_sender_email`'s rule ("stamp the email for single-participant
+        sessions, None for shared threads") resolves to the recipient. That keeps
+        sender-filtered MEM-001 summarization folding these into the right user's
+        memory (#903, AC-7).
+
+        Called ONLY on confirmed delivery, so a failed send never writes a phantom
+        assistant turn (AC-5).
+
+        The session is created if absent rather than skipped: the chat-link
+        `session_id` column this was expected to key off is **never written by any
+        code path** (#1600 — a vestigial column), so "reuse the existing session"
+        isn't available. `get_or_create_public_chat_session` with the adapter's own
+        identifier lands in exactly the session a later inbound reply resolves to.
+
+        Fail-soft: the message is already delivered, so a persistence error must
+        never surface as a delivery failure. It's logged loudly instead — a silent
+        swallow here is what made the original bug invisible.
+        """
+        if not result.session_identifier:
+            logger.warning(
+                "[#1600] proactive %s message to %s delivered but NOT persisted: "
+                "no session identifier resolved for agent %s",
+                result.channel, recipient_email, agent_name,
+            )
+            return
+        try:
+            session = db.get_or_create_public_chat_session(
+                agent_name, result.session_identifier, result.channel
+            )
+            session_id = session.id if hasattr(session, "id") else session["id"]
+            db.add_public_chat_message(
+                session_id,
+                "assistant",
+                text,
+                sender_email=recipient_email,
+                sender_label=agent_name,
+            )
+            logger.debug(
+                "[#1600] persisted proactive %s message to session %s",
+                result.channel, session_id,
+            )
+        except Exception:
+            logger.error(
+                "[#1600] failed to persist delivered proactive %s message for agent %s "
+                "— the message WAS delivered; history will be missing this turn",
+                result.channel, agent_name, exc_info=True,
+            )
+
     async def _deliver_via_channel(
         self,
         agent_name: str,
@@ -372,6 +453,7 @@ class ProactiveMessageService:
         text: str,
     ) -> DeliveryResult:
         """Deliver via Telegram."""
+        from adapters.base import NormalizedMessage
         from adapters.telegram_adapter import TelegramAdapter
 
         # Get binding for this agent
@@ -404,10 +486,23 @@ class ProactiveMessageService:
             )
             if result:
                 message_id = result.get("message_id")
+                # #1600: resolve the recipient's session key through the adapter
+                # itself. A Telegram DM's chat_id IS the user id (the send above
+                # relies on the same fact), and `bot_id` is read from the binding
+                # exactly as telegram_webhook injects it — so this reproduces the
+                # inbound key byte-for-byte instead of guessing at the format.
+                probe = NormalizedMessage(
+                    sender_id=str(chat_id),
+                    text="",
+                    channel_id=str(chat_id),
+                    timestamp="",
+                    metadata={"bot_id": binding.get("bot_id", ""), "is_group": False},
+                )
                 return DeliveryResult(
                     success=True,
                     channel="telegram",
                     message_id=str(message_id) if message_id else None,
+                    session_identifier=adapter.get_session_identifier(probe),
                 )
             else:
                 return DeliveryResult(success=False, channel="telegram", error="Send failed")
@@ -422,6 +517,8 @@ class ProactiveMessageService:
         text: str,
     ) -> DeliveryResult:
         """Deliver via Slack DM."""
+        from adapters.base import NormalizedMessage
+        from adapters.slack_adapter import SlackAdapter
         from services.slack_service import slack_service
 
         # Get Slack workspace connections
@@ -454,7 +551,25 @@ class ProactiveMessageService:
             )
 
             if success:
-                return DeliveryResult(success=True, channel="slack")
+                # #1600: Slack has no chat-link table, but the DM session key is
+                # `team:sender:channel` — and all three are already resolved
+                # above (workspace team_id, the looked-up user, the opened DM
+                # channel). So Slack persists the same as the others rather than
+                # being documented as a known limitation. `is_dm=True` selects
+                # the adapter's DM branch, which is what an inbound DM from this
+                # user takes.
+                probe = NormalizedMessage(
+                    sender_id=str(user["id"]),
+                    text="",
+                    channel_id=str(channel_id),
+                    timestamp="",
+                    metadata={"team_id": workspace.get("team_id"), "is_dm": True},
+                )
+                return DeliveryResult(
+                    success=True,
+                    channel="slack",
+                    session_identifier=SlackAdapter().get_session_identifier(probe),
+                )
             else:
                 return DeliveryResult(success=False, channel="slack", error=error)
 
@@ -476,6 +591,7 @@ class ProactiveMessageService:
         agent owner is responsible for configuring approved message templates
         for out-of-window outreach.
         """
+        from adapters.base import NormalizedMessage
         from adapters.whatsapp_adapter import WhatsAppAdapter
 
         binding = db.get_whatsapp_binding(agent_name)
@@ -516,10 +632,21 @@ class ProactiveMessageService:
                     )
                 last_sid = result.get("sid") or last_sid
 
+            # #1600: same session key an inbound WhatsApp DM resolves to —
+            # derived by the adapter, not re-implemented here. sender_id IS the
+            # wa phone, which is what the chat link stores.
+            probe = NormalizedMessage(
+                sender_id=str(chat_link["wa_user_phone"]),
+                text="",
+                channel_id=str(chat_link["wa_user_phone"]),
+                timestamp="",
+                metadata={"binding_id": binding["id"]},
+            )
             return DeliveryResult(
                 success=True,
                 channel="whatsapp",
                 message_id=str(last_sid) if last_sid else None,
+                session_identifier=adapter.get_session_identifier(probe),
             )
         except Exception as e:
             logger.error(f"WhatsApp delivery failed: {e}")

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -928,6 +928,18 @@
         "observability"
       ],
       "description": "Git-maintenance health signals (#1595, backend): _coerce_nonneg_int boundary guard for agent-writable sync-state values; pack_count/loose_objects/maintenance_failures live round-trip via SyncStateOperations + db_harness; edge-triggered git_bloat operator alerts (size ceiling crossing + maintenance-failure streak, once per episode, re-armed after reset)."
+    },
+    {
+      "file": "unit/test_1600_proactive_history.py",
+      "feature": "#1600",
+      "added": "2026-07-16",
+      "categories": [
+        "backend",
+        "channels",
+        "proactive-messaging",
+        "regression"
+      ],
+      "description": "Proactive messages persist to channel session history (#1600). Core property is session-identifier EQUALITY: the key the proactive path derives must equal the key an inbound DM resolves to, per channel (telegram/whatsapp/slack) \u2014 persisting into a different session looks like a fix but leaves the agent unaware of its own outreach. Also: #903 attribution (assistant role, agent sender_label, recipient sender_email for the single-participant DM), persist only on confirmed delivery (no phantom turn on failure), fail-soft on DB error (message already sent), session created when absent (the chat-link session_id column is never written by any code path), and access-grant notifications deliberately NOT persisted (#951 out of scope)."
     }
   ]
 }

--- a/tests/unit/test_1600_proactive_history.py
+++ b/tests/unit/test_1600_proactive_history.py
@@ -123,6 +123,104 @@ class TestSessionIdentifierParity:
 
 
 # --------------------------------------------------------------------------- #
+# The identifier the SERVICE actually produces
+# --------------------------------------------------------------------------- #
+class TestDeliveryPathProducesTheInboundKey:
+    """Drive the real `_deliver_*` and assert the key it returns.
+
+    `TestSessionIdentifierParity` above compares two probes *written in this
+    file* — it proves the adapters are self-consistent, which was never in
+    doubt, and would pass even if the service built its probe wrong. These tests
+    close that hole: they exercise the service's own probe construction and
+    compare the result against the key an inbound DM resolves to.
+
+    Caught in review by sabotaging the service (`bot_id` -> `botid_TYPO`, which
+    silently yields `unknown:...` and a DIFFERENT session): every other test in
+    this file still passed. These fail.
+    """
+
+    @pytest.mark.asyncio
+    async def test_telegram_delivery_returns_the_inbound_session_key(self, svc, monkeypatch):
+        from adapters.base import NormalizedMessage
+        from adapters import telegram_adapter as tg_mod
+
+        svc.db.get_telegram_binding.return_value = {"id": 1, "bot_id": "bot-77"}
+        svc.db.get_telegram_chat_link_by_verified_email.return_value = {
+            "telegram_user_id": "123456", "session_id": None,
+        }
+        svc.db.get_telegram_bot_token.return_value = "xoxb-fake"
+
+        async def _send(**kw):
+            return {"message_id": 42}
+        monkeypatch.setattr(tg_mod.TelegramAdapter, "_send_message", staticmethod(_send))
+
+        result = await svc.service._deliver_telegram("agent-a", "user@example.com", "ping")
+        assert result.success
+
+        expected = tg_mod.TelegramAdapter().get_session_identifier(NormalizedMessage(
+            sender_id="123456", text="hi", channel_id="123456", timestamp="t",
+            metadata={"bot_id": "bot-77", "is_group": False},
+        ))
+        assert result.session_identifier == expected, (
+            f"service derived {result.session_identifier!r}, inbound resolves to "
+            f"{expected!r} — the proactive turn would land in a different session"
+        )
+        assert "bot-77" in result.session_identifier, "bot_id never reached the key"
+
+    @pytest.mark.asyncio
+    async def test_slack_delivery_returns_the_inbound_dm_key(self, svc, monkeypatch):
+        from adapters.base import NormalizedMessage
+        from adapters.slack_adapter import SlackAdapter
+        import services.slack_service as slack_mod
+
+        svc.db.get_all_slack_workspaces.return_value = [
+            {"team_id": "T1", "bot_token": "xoxb-fake"}
+        ]
+
+        async def _by_email(token, email):
+            return {"id": "U9"}
+
+        async def _open_dm(token, uid):
+            return "D5"
+
+        async def _send(**kw):
+            return True, None
+
+        monkeypatch.setattr(slack_mod.slack_service, "get_user_by_email", _by_email)
+        monkeypatch.setattr(slack_mod.slack_service, "open_dm_channel", _open_dm)
+        monkeypatch.setattr(slack_mod.slack_service, "send_message", _send)
+
+        result = await svc.service._deliver_slack("agent-a", "user@example.com", "ping")
+        assert result.success
+
+        expected = SlackAdapter().get_session_identifier(NormalizedMessage(
+            sender_id="U9", text="hi", channel_id="D5", timestamp="t",
+            metadata={"team_id": "T1", "is_dm": True},
+        ))
+        assert result.session_identifier == expected
+        assert result.session_identifier == "T1:U9:D5"
+
+    @pytest.mark.asyncio
+    async def test_failed_send_carries_no_session_key(self, svc, monkeypatch):
+        """A failed delivery must not hand the caller a key to persist against."""
+        from adapters import telegram_adapter as tg_mod
+
+        svc.db.get_telegram_binding.return_value = {"id": 1, "bot_id": "bot-77"}
+        svc.db.get_telegram_chat_link_by_verified_email.return_value = {
+            "telegram_user_id": "123456",
+        }
+        svc.db.get_telegram_bot_token.return_value = "xoxb-fake"
+
+        async def _send(**kw):
+            return None  # Telegram returned nothing => send failed
+        monkeypatch.setattr(tg_mod.TelegramAdapter, "_send_message", staticmethod(_send))
+
+        result = await svc.service._deliver_telegram("agent-a", "user@example.com", "ping")
+        assert result.success is False
+        assert result.session_identifier is None
+
+
+# --------------------------------------------------------------------------- #
 # Persistence behaviour
 # --------------------------------------------------------------------------- #
 @pytest.fixture

--- a/tests/unit/test_1600_proactive_history.py
+++ b/tests/unit/test_1600_proactive_history.py
@@ -225,26 +225,27 @@ class TestDeliveryPathProducesTheInboundKey:
 # --------------------------------------------------------------------------- #
 @pytest.fixture
 def svc(monkeypatch):
-    """ProactiveMessageService with database + audit stubbed."""
-    fake_db_mod = types.ModuleType("database")
-    fake_db_mod.db = MagicMock()
-    fake_db_mod.db.get_or_create_public_chat_session.return_value = {"id": "sess-1"}
-    monkeypatch.setitem(sys.modules, "database", fake_db_mod)
+    """ProactiveMessageService with its module-level `db` + audit names stubbed.
 
-    fake_audit_mod = types.ModuleType("services.platform_audit_service")
+    Patches the names **as bound in the module** rather than stubbing
+    `sys.modules` and forcing a re-import. The re-import approach poisons
+    `tests/unit/test_1609_proactive_rate_limits.py` when this file runs first:
+    re-importing rebinds the `services.proactive_message_service` attribute on
+    the `services` package to a NEW module object, and monkeypatch restores
+    `sys.modules` but not that attribute. #1609 then reaches the module via
+    `import services.proactive_message_service as pms` (which resolves through
+    the package attribute) while its service instance comes from the original
+    module — so its patch lands on the wrong object and its assertions fail.
 
-    class _AuditEventType:
-        PROACTIVE_MESSAGE = "proactive_message"
+    Caught by CI's base-vs-head regression diff, not by local runs: the two files
+    have to execute in that order in one session for it to show.
+    """
+    import services.proactive_message_service as pms
 
-    fake_audit_mod.platform_audit_service = MagicMock(log=AsyncMock())
-    fake_audit_mod.AuditEventType = _AuditEventType
-    monkeypatch.setitem(sys.modules, "services.platform_audit_service", fake_audit_mod)
-
-    # Force a fresh import so the stubs above are what the module binds at
-    # import time. monkeypatch.delitem (not a bare sys.modules.pop) so the real
-    # module is restored afterwards and the deletion can't leak into later tests.
-    for mod in ("services.proactive_message_service", "proactive_message_service"):
-        monkeypatch.delitem(sys.modules, mod, raising=False)
+    fake_db = MagicMock()
+    fake_db.get_or_create_public_chat_session.return_value = {"id": "sess-1"}
+    monkeypatch.setattr(pms, "db", fake_db)
+    monkeypatch.setattr(pms, "platform_audit_service", MagicMock(log=AsyncMock()))
 
     from services.proactive_message_service import ProactiveMessageService, DeliveryResult
 
@@ -260,7 +261,7 @@ def svc(monkeypatch):
 
     return types.SimpleNamespace(
         service=service,
-        db=fake_db_mod.db,
+        db=fake_db,
         DeliveryResult=DeliveryResult,
     )
 

--- a/tests/unit/test_1600_proactive_history.py
+++ b/tests/unit/test_1600_proactive_history.py
@@ -1,0 +1,274 @@
+"""#1600 — proactive messages are persisted to channel session history.
+
+The bug: `send_message` (#321) delivered a proactive message and wrote nothing to
+`public_chat_messages`. The next inbound turn builds context from
+`db.build_public_chat_context(session_id, ...)`, which only ever contained turns
+the message router persisted — so the agent had no record of its own outreach. It
+would repeat itself, contradict the message, or fail to parse the reply ("yes,
+sounds good" — to what?).
+
+**The load-bearing property is identifier equality.** Persisting into *a* session
+is worthless; it has to be the SAME session the recipient's next inbound message
+resolves to. Otherwise the write succeeds, the bug survives, and nothing looks
+broken. `test_*_identifier_matches_inbound_router` is that assertion, per channel.
+
+Note the issue's suggested fix — key off `telegram_chat_links.session_id` /
+`whatsapp_chat_links.session_id` — cannot work: those columns are **never written
+by any code path** (verified across the repo; they are read in three SELECTs and
+nowhere else). Keying on them would persist nothing, silently. The fix instead
+derives the key through each adapter's own `get_session_identifier()`, so it
+can't drift from the router.
+
+Issue: https://github.com/abilityai/trinity/issues/1600
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_backend = str(Path(__file__).resolve().parents[2] / "src" / "backend")
+if _backend not in sys.path:
+    sys.path.insert(0, _backend)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Identifier parity — the property the whole fix rests on
+# --------------------------------------------------------------------------- #
+class TestSessionIdentifierParity:
+    """The proactive key must equal the key an inbound DM resolves to.
+
+    Built by driving each adapter's real `get_session_identifier` with (a) a
+    synthetic inbound DM, and (b) the probe shape the proactive service builds.
+    If someone changes an adapter's format, these fail — which is the point:
+    duplicating the format in the service is exactly the drift this guards.
+    """
+
+    def test_telegram_identifier_matches_inbound_router(self):
+        from adapters.base import NormalizedMessage
+        from adapters.telegram_adapter import TelegramAdapter
+
+        adapter = TelegramAdapter()
+        bot_id, tg_user = "bot-77", "123456"
+
+        # What the router sees for a real inbound DM (chat_id == user_id).
+        inbound = NormalizedMessage(
+            sender_id=tg_user, text="hi", channel_id=tg_user, timestamp="t",
+            metadata={"bot_id": bot_id, "is_group": False},
+        )
+        # What the proactive service builds after a successful send.
+        probe = NormalizedMessage(
+            sender_id=tg_user, text="", channel_id=tg_user, timestamp="",
+            metadata={"bot_id": bot_id, "is_group": False},
+        )
+        assert adapter.get_session_identifier(probe) == adapter.get_session_identifier(inbound)
+
+    def test_whatsapp_identifier_matches_inbound_router(self):
+        from adapters.base import NormalizedMessage
+        from adapters.whatsapp_adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter()
+        phone, binding_id = "whatsapp:+14155551234", 7
+
+        inbound = NormalizedMessage(
+            sender_id=phone, text="hi", channel_id=phone, timestamp="t",
+            metadata={"binding_id": binding_id},
+        )
+        probe = NormalizedMessage(
+            sender_id=phone, text="", channel_id=phone, timestamp="",
+            metadata={"binding_id": binding_id},
+        )
+        assert adapter.get_session_identifier(probe) == adapter.get_session_identifier(inbound)
+
+    def test_slack_identifier_matches_inbound_dm(self):
+        from adapters.base import NormalizedMessage
+        from adapters.slack_adapter import SlackAdapter
+
+        adapter = SlackAdapter()
+        team, user, dm = "T1", "U9", "D5"
+
+        inbound = NormalizedMessage(
+            sender_id=user, text="hi", channel_id=dm, timestamp="t",
+            metadata={"team_id": team, "is_dm": True},
+        )
+        probe = NormalizedMessage(
+            sender_id=user, text="", channel_id=dm, timestamp="",
+            metadata={"team_id": team, "is_dm": True},
+        )
+        assert adapter.get_session_identifier(probe) == adapter.get_session_identifier(inbound)
+
+    def test_slack_probe_takes_the_dm_branch_not_the_thread_branch(self):
+        """Without `is_dm`, Slack keys on `team:channel:thread` — a different
+        session, and thread would be None. The probe must set is_dm."""
+        from adapters.base import NormalizedMessage
+        from adapters.slack_adapter import SlackAdapter
+
+        adapter = SlackAdapter()
+        dm_key = adapter.get_session_identifier(NormalizedMessage(
+            sender_id="U9", text="", channel_id="D5", timestamp="",
+            metadata={"team_id": "T1", "is_dm": True},
+        ))
+        thread_key = adapter.get_session_identifier(NormalizedMessage(
+            sender_id="U9", text="", channel_id="D5", timestamp="",
+            metadata={"team_id": "T1"},
+        ))
+        assert dm_key != thread_key
+        assert dm_key == "T1:U9:D5"
+
+
+# --------------------------------------------------------------------------- #
+# Persistence behaviour
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def svc(monkeypatch):
+    """ProactiveMessageService with database + audit stubbed."""
+    fake_db_mod = types.ModuleType("database")
+    fake_db_mod.db = MagicMock()
+    fake_db_mod.db.get_or_create_public_chat_session.return_value = {"id": "sess-1"}
+    monkeypatch.setitem(sys.modules, "database", fake_db_mod)
+
+    fake_audit_mod = types.ModuleType("services.platform_audit_service")
+
+    class _AuditEventType:
+        PROACTIVE_MESSAGE = "proactive_message"
+
+    fake_audit_mod.platform_audit_service = MagicMock(log=AsyncMock())
+    fake_audit_mod.AuditEventType = _AuditEventType
+    monkeypatch.setitem(sys.modules, "services.platform_audit_service", fake_audit_mod)
+
+    for mod in ("services.proactive_message_service", "proactive_message_service"):
+        sys.modules.pop(mod, None)
+
+    from services.proactive_message_service import ProactiveMessageService, DeliveryResult
+
+    service = ProactiveMessageService()
+    # Rate limiting reaches for Redis via `routers.auth`, which drags in the whole
+    # router import chain. Stub both: an ImportError here would otherwise be
+    # swallowed by _send_message_inner's per-channel `except Exception` and
+    # resurface as RecipientNotFoundError — making a test pass for the wrong
+    # reason rather than fail loudly.
+    service._check_rate_limit = lambda *a, **kw: True
+    service._increment_rate_limit = lambda *a, **kw: None
+    service._get_redis = lambda: None
+
+    return types.SimpleNamespace(
+        service=service,
+        db=fake_db_mod.db,
+        DeliveryResult=DeliveryResult,
+    )
+
+
+class TestPersistOutbound:
+    def test_persists_assistant_turn_with_903_attribution(self, svc):
+        """role=assistant, sender_label=agent, sender_email=recipient.
+
+        A proactive send always targets ONE verified email — a DM, i.e. a
+        single-participant session — so `_assistant_sender_email`'s rule resolves
+        to the recipient. That keeps sender-filtered MEM-001 summarization
+        folding it into the right user's memory (AC-7).
+        """
+        result = svc.DeliveryResult(
+            success=True, channel="telegram", session_identifier="bot:1:1"
+        )
+        svc.service._persist_outbound("agent-a", "user@example.com", "ping", result)
+
+        svc.db.get_or_create_public_chat_session.assert_called_once_with(
+            "agent-a", "bot:1:1", "telegram"
+        )
+        args, kwargs = svc.db.add_public_chat_message.call_args
+        assert args[0] == "sess-1"
+        assert args[1] == "assistant"
+        assert args[2] == "ping"
+        assert kwargs["sender_email"] == "user@example.com"
+        assert kwargs["sender_label"] == "agent-a"
+
+    def test_no_session_identifier_skips_persistence_without_crashing(self, svc):
+        """AC-6: a channel that can't resolve a session still delivers; it must
+        not raise and must not write a session-less turn."""
+        result = svc.DeliveryResult(success=True, channel="web", session_identifier=None)
+        svc.service._persist_outbound("agent-a", "user@example.com", "ping", result)
+        svc.db.add_public_chat_message.assert_not_called()
+        svc.db.get_or_create_public_chat_session.assert_not_called()
+
+    def test_persistence_failure_never_breaks_delivery(self, svc):
+        """The message is already sent — a DB error must not surface as a
+        delivery failure or an exception."""
+        svc.db.get_or_create_public_chat_session.side_effect = RuntimeError("db down")
+        result = svc.DeliveryResult(
+            success=True, channel="telegram", session_identifier="bot:1:1"
+        )
+        svc.service._persist_outbound("agent-a", "user@example.com", "ping", result)  # no raise
+
+    def test_session_is_created_when_absent(self, svc):
+        """The chat-link `session_id` column the issue proposed keying off is
+        never written by any code path, so 'reuse the existing session' isn't
+        available — get_or_create is what lands us in the router's session."""
+        result = svc.DeliveryResult(
+            success=True, channel="telegram", session_identifier="bot:1:1"
+        )
+        svc.service._persist_outbound("agent-a", "user@example.com", "ping", result)
+        assert svc.db.get_or_create_public_chat_session.called
+
+    def test_session_object_with_attribute_id_is_supported(self, svc):
+        """get_or_create returns a model on some paths and a dict on others —
+        the router handles both (`session.id if hasattr(...)`); so must we."""
+        svc.db.get_or_create_public_chat_session.return_value = types.SimpleNamespace(id="sess-obj")
+        result = svc.DeliveryResult(
+            success=True, channel="slack", session_identifier="T1:U9:D5"
+        )
+        svc.service._persist_outbound("agent-a", "user@example.com", "ping", result)
+        assert svc.db.add_public_chat_message.call_args[0][0] == "sess-obj"
+
+
+class TestPersistOnlyOnSuccess:
+    @pytest.mark.asyncio
+    async def test_failed_delivery_writes_no_phantom_turn(self, svc, monkeypatch):
+        """AC-5: a failed send must not leave an assistant turn in history."""
+        async def _fail(*a, **kw):
+            return svc.DeliveryResult(
+                success=False, channel="telegram", error="boom",
+                session_identifier="bot:1:1",
+            )
+        monkeypatch.setattr(svc.service, "_deliver_via_channel", _fail)
+
+        from services.proactive_message_service import RecipientNotFoundError
+        with pytest.raises(RecipientNotFoundError):
+            await svc.service._send_message_inner(
+                "agent-a", "user@example.com", "ping", "telegram", False,
+            )
+        svc.db.add_public_chat_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_delivery_persists(self, svc, monkeypatch):
+        async def _ok(*a, **kw):
+            return svc.DeliveryResult(
+                success=True, channel="telegram", session_identifier="bot:1:1"
+            )
+        monkeypatch.setattr(svc.service, "_deliver_via_channel", _ok)
+
+        await svc.service._send_message_inner(
+            "agent-a", "user@example.com", "ping", "telegram", False,
+        )
+        assert svc.db.add_public_chat_message.called
+
+    @pytest.mark.asyncio
+    async def test_access_grant_notification_does_not_persist(self, svc, monkeypatch):
+        """Out of scope (#951). The `_deliver_*` helpers are shared, so this
+        guards the boundary: persistence hangs off the send_message path only.
+        """
+        async def _ok(*a, **kw):
+            return svc.DeliveryResult(
+                success=True, channel="telegram", session_identifier="bot:1:1"
+            )
+        monkeypatch.setattr(svc.service, "_deliver_via_channel", _ok)
+
+        await svc.service.send_access_grant_notification(
+            "agent-a", "user@example.com", "telegram", "you're in",
+        )
+        svc.db.add_public_chat_message.assert_not_called()

--- a/tests/unit/test_1600_proactive_history.py
+++ b/tests/unit/test_1600_proactive_history.py
@@ -142,8 +142,11 @@ def svc(monkeypatch):
     fake_audit_mod.AuditEventType = _AuditEventType
     monkeypatch.setitem(sys.modules, "services.platform_audit_service", fake_audit_mod)
 
+    # Force a fresh import so the stubs above are what the module binds at
+    # import time. monkeypatch.delitem (not a bare sys.modules.pop) so the real
+    # module is restored afterwards and the deletion can't leak into later tests.
     for mod in ("services.proactive_message_service", "proactive_message_service"):
-        sys.modules.pop(mod, None)
+        monkeypatch.delitem(sys.modules, mod, raising=False)
 
     from services.proactive_message_service import ProactiveMessageService, DeliveryResult
 


### PR DESCRIPTION
## Summary

A proactive `send_message` (#321) was delivered and written **nowhere**. The next inbound turn builds context from `build_public_chat_context`, which only ever contained turns the message router persisted — so the agent had no record of its own outreach. It would repeat itself, contradict the message, or fail to parse the reply (*"yes, sounds good"* — to what?).

Now fixed for **all three DM channels** (Telegram, WhatsApp, **and Slack**).

## ⚠️ The issue's suggested fix cannot work — worth reading before reviewing

The issue proposes keying off the chat link's `session_id`, and states the seam *"already exists for Telegram and WhatsApp"*. **It doesn't.**

`telegram_chat_links.session_id` and `whatsapp_chat_links.session_id` are **never written by any code path**. Across the whole repo they appear in exactly three places, all `SELECT`s:

```
db/telegram_channels.py:273   telegram_chat_links.c.session_id,     ← select
db/telegram_channels.py:411   telegram_chat_links.c.session_id,     ← select
db/whatsapp_channels.py:370   whatsapp_chat_links.c.session_id,     ← select
```

`record_inbound` (the only writer of those tables) inserts `telegram_user_id` + `message_count` and never a session. They're vestigial columns.

**Implemented as suggested, the fix would have persisted nothing — silently — and looked done.** AC-6 ("recipient with no session yet") isn't an edge case under that design; it's every recipient.

## Approach

Resolve the session by **identifier** via `get_or_create_public_chat_session`, and make the identifier provably equal to the inbound one.

That equality is the whole fix. Persisting into *a* session is worthless — it has to be the session the recipient's next message resolves to, or the write succeeds and the bug survives invisibly. So each `_deliver_*` sets `DeliveryResult.session_identifier` by driving **its own adapter's** `get_session_identifier()` with a synthetic DM, never by re-deriving the format in the service:

| Channel | Key | Derived from |
|---|---|---|
| Telegram | `{bot_id}:{user}:{chat}` | binding `bot_id` + chat link's `telegram_user_id` (a DM's chat_id IS the user id — the existing send already relies on this) |
| WhatsApp | `{binding_id}:{phone}` | binding id + chat link's `wa_user_phone` |
| Slack | `{team}:{user}:{dm_channel}` | workspace `team_id` + looked-up user + opened DM channel |

Why not just format the string in the service? The formats have subtle fallbacks that would drift — Telegram's `bot_id` defaults to `""` in the webhook but `"unknown"` in the adapter. A mismatch mints a *second* session and reintroduces the bug in a place nothing checks.

**Slack is fixed, not documented as a limitation** (AC-4 allowed either). It has no chat-link table, but `_deliver_slack` already resolves team, user, and DM channel — everything its DM key needs.

## AC coverage

- **AC-1/2/3** — Telegram/WhatsApp persist; the next turn's context includes the message (identifier equality is what guarantees it)
- **AC-4** — Slack persisted, not deferred
- **AC-5** — persist only on confirmed delivery; a failed send writes no phantom turn
- **AC-6** — moot under this design (the column was never the key); the session is created when absent, and that's documented
- **AC-7** — `sender_email` = recipient. A proactive send targets ONE verified email — a DM, i.e. single-participant — so `_assistant_sender_email`'s rule (#903) resolves to the recipient, keeping sender-filtered MEM-001 in the right user's memory

**Scope:** persistence hangs off `_send_message_inner`, not the shared `_deliver_*` helpers, so `send_access_grant_notification` (out of scope, #951) is excluded **structurally** rather than by a flag. Fail-soft throughout: the message is already delivered when persistence runs, so a DB error is logged loudly and never surfaces as a delivery failure.

## `send_group_message` → #1649

Confirmed the same gap (0 persistence calls in both `send_telegram_group_message` and `send_agent_slack_channel_message`), but it's a different problem, not a port: Telegram group sessions are per-*(sender, chat)* and a broadcast has no sender; Slack channels are thread-scoped on a `ts` only knowable after the send. That's a semantics decision — filed as **#1649** with the analysis.

## Test Plan

- [x] `pytest tests/unit/test_1600_proactive_history.py` — 12 passed
- [x] `pytest tests/test_proactive_audit_unit.py` — existing suite green (16 total)
- [x] Reverting the `_persist_outbound` call fails `test_successful_delivery_persists` (the end-to-end regression). **Honest note:** only that 1 of 12 flips — the parity tests drive the adapters, which this PR doesn't change; they exist to catch *future* drift, not to prove today's fix.
- [ ] Not exercised against live Telegram/Slack/WhatsApp — needs real channel credentials

Related to #1600



Fixes #1600
