### PR TITLE
docs: add architecture explainer video to README and video library

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A short teaser of the live interface — the full, zoomable detail is in [the sc
 **Watch more:**
 
 - [Trinity Demo](https://youtu.be/ivljtZqsxeo) — full platform walkthrough
+- [Trinity Architecture Explained](https://youtu.be/XDLOq1crF9w) — animated explainer (4:44): one scheduled task followed end to end through the container, gate, delegation, approval, audit, and breaker machinery
 - [From Zero to Deployed AI Agent](https://youtu.be/-TSZyekDS6o) — your first Trinity agent in 30 minutes
 - [Plugins + Trinity: Build and Deploy Agents in Cursor](https://youtu.be/amqiysdlEWY) — the plugin workflow end-to-end
 - [Loops Engineering with Trinity](https://youtu.be/q3YvFYtuhec) — bounded autonomous work loops in practice

--- a/docs/user-docs/videos.md
+++ b/docs/user-docs/videos.md
@@ -6,6 +6,7 @@ Workshops, demos, and deep-dives on building and running autonomous agents with 
 
 ## Start Here — Platform Overview
 
+- [Trinity Architecture Explained](https://youtu.be/XDLOq1crF9w) — *Jul 2026* · animated explainer (4:44): one scheduled task end to end — container, gate, delegation, approval, audit, breakers
 - [Trinity v0.8.0 — Release Tour](https://youtu.be/wxCC6QGtLMA) — *Jul 2026* · voice replies across channels, Brain Orb, Grid dashboard, enterprise identity
 - [Trinity Platform Demo](https://youtu.be/ivljtZqsxeo) — *May 2026* · full UI walkthrough, end to end
 - [The Multi-Agent Platform I Run My Company On](https://youtu.be/8j6q-kABRqc) — *May 2026* · live fleet tour: delegation, memory, observability


### PR DESCRIPTION
## Summary

- Add the new animated architecture explainer video ([youtu.be/XDLOq1crF9w](https://youtu.be/XDLOq1crF9w), 4:44) to the README **Watch more** list
- Add the same video at the top of **Start Here — Platform Overview** in `docs/user-docs/videos.md` (newest-first)

Docs-only change, no code touched. Same change is proposed against `main` in a sibling PR so the public landing README carries the link before the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)