### PR TITLE
fix: add Claude Fable 5 / Sonnet 5 to the platform default and public-channel model lists (#1660)

### DIFF
--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -33,6 +33,8 @@ _PLATFORM_MODEL_CACHE_TTL = 60.0
 # this set after it was saved is treated as unset (→ platform default) by
 # `db.get_public_channel_model`, matching the #1080 graceful-degradation posture.
 PUBLIC_CHANNEL_MODELS = frozenset({
+    "claude-fable-5",
+    "claude-sonnet-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -254,7 +254,9 @@
                       class="block flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-action-primary-500 focus:border-action-primary-500 dark:bg-gray-700 dark:text-white text-sm"
                     >
                       <option value="claude-sonnet-4-6">Claude Sonnet 4.6 — Fast + smart (recommended)</option>
-                      <option value="claude-opus-4-8">Claude Opus 4.8 — Most capable</option>
+                      <option value="claude-fable-5">Claude Fable 5 — Most capable, longest tasks (latest)</option>
+                      <option value="claude-sonnet-5">Claude Sonnet 5 — Fast + smart, 1M context (latest)</option>
+                      <option value="claude-opus-4-8">Claude Opus 4.8 — Most capable Opus</option>
                       <option value="claude-opus-4-7">Claude Opus 4.7</option>
                       <option value="claude-opus-4-6">Claude Opus 4.6</option>
                     </select>

--- a/tests/unit/test_1660_model_list_drift.py
+++ b/tests/unit/test_1660_model_list_drift.py
@@ -1,0 +1,133 @@
+"""Drift guard for the hand-synced model lists (#1660).
+
+`ModelSelector.vue` is the de-facto canonical picker (#1080). Two other lists are
+kept in sync with it **by hand** — there is no shared Python/Vue model registry:
+
+  1. `services/settings_service.PUBLIC_CHANNEL_MODELS` — server-validated whitelist
+     for the per-agent public-channel override (#894); current-gen only (no legacy).
+  2. The platform default-model `<option>` list in `views/Settings.vue` — the admin
+     fleet-wide default; Opus/Sonnet tiers only (#1080 AC), so Haiku is deliberately
+     absent and is NOT asserted here.
+
+The #1660 bug: ModelSelector gained the Claude 5 presets and neither list followed,
+so an admin couldn't pick them as the platform default and the public-channel PUT
+422'd them. These tests assert the current lineup reaches all three lists.
+
+Deliberately narrow: this pins the *current-generation* models by name rather than
+diffing whole lists, because the three lists are legitimately different sizes
+(legacy is picker-only; Haiku is public-channel-only). Adding the next generation
+means adding it here too — that failure is the point.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND = _PROJECT_ROOT / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+_MODEL_SELECTOR = _PROJECT_ROOT / "src" / "frontend" / "src" / "components" / "ModelSelector.vue"
+_SETTINGS_VUE = _PROJECT_ROOT / "src" / "frontend" / "src" / "views" / "Settings.vue"
+
+# The Claude 5 family — the generation #1660 found missing. Every list below must
+# offer these; they are current-gen and Opus/Sonnet-tier-equivalent, so they belong
+# in all three (unlike Haiku, which is public-channel-only by #1080).
+CLAUDE_5 = ("claude-fable-5", "claude-sonnet-5")
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing source file: {path}"
+    return path.read_text()
+
+
+def _model_selector_presets() -> set[str]:
+    """Every `value:` in ModelSelector.vue's PRESET_MODELS array."""
+    src = _read(_MODEL_SELECTOR)
+    block = re.search(r"const PRESET_MODELS = \[(.*?)\n\]", src, re.S)
+    assert block, "PRESET_MODELS array not found in ModelSelector.vue — did it move?"
+    values = set(re.findall(r"value:\s*'([^']+)'", block.group(1)))
+    assert values, "PRESET_MODELS parsed but yielded no values — parse is broken"
+    return values
+
+
+def _settings_default_model_options() -> set[str]:
+    """Every `<option value="...">` in the platform default-model <select>."""
+    src = _read(_SETTINGS_VUE)
+    block = re.search(
+        r'<select\s+v-model="platformDefaultModelValue".*?</select>', src, re.S
+    )
+    assert block, "platform default-model <select> not found in Settings.vue — did it move?"
+    values = set(re.findall(r'<option value="([^"]+)"', block.group(0)))
+    assert values, "default-model <select> parsed but yielded no options — parse is broken"
+    return values
+
+
+@pytest.mark.parametrize("model", CLAUDE_5)
+def test_claude_5_is_offered_in_model_selector(model):
+    assert model in _model_selector_presets(), (
+        f"{model} missing from ModelSelector.vue PRESET_MODELS"
+    )
+
+
+@pytest.mark.parametrize("model", CLAUDE_5)
+def test_claude_5_is_valid_for_public_channels(model):
+    """#1660: the public-channel override PUT 422'd the Claude 5 models."""
+    from services.settings_service import is_valid_public_channel_model
+
+    assert is_valid_public_channel_model(model), (
+        f"{model} missing from PUBLIC_CHANNEL_MODELS — "
+        f"PUT /api/agents/{{name}}/public-channel-model would 422 it"
+    )
+
+
+@pytest.mark.parametrize("model", CLAUDE_5)
+def test_claude_5_is_selectable_as_platform_default(model):
+    """#1660: an admin could not pick Claude 5 as the fleet default."""
+    assert model in _settings_default_model_options(), (
+        f"{model} missing from the platform default-model dropdown in Settings.vue"
+    )
+
+
+def test_public_channel_whitelist_is_a_subset_of_the_picker():
+    """Every server-accepted model must be offered by the canonical picker.
+
+    A model the backend accepts but the picker never shows is unreachable via the
+    UI — that direction of drift is a bug even though it fails 'open'.
+    """
+    from services.settings_service import PUBLIC_CHANNEL_MODELS
+
+    orphaned = set(PUBLIC_CHANNEL_MODELS) - _model_selector_presets()
+    assert not orphaned, (
+        f"PUBLIC_CHANNEL_MODELS accepts models absent from ModelSelector.vue: "
+        f"{sorted(orphaned)}"
+    )
+
+
+def test_platform_default_dropdown_is_a_subset_of_the_picker():
+    """The admin dropdown must not offer a model the canonical picker dropped."""
+    orphaned = _settings_default_model_options() - _model_selector_presets()
+    assert not orphaned, (
+        f"Settings.vue default-model dropdown offers models absent from "
+        f"ModelSelector.vue: {sorted(orphaned)}"
+    )
+
+
+def test_platform_default_value_is_selectable():
+    """The hardcoded fallback must itself be offered in the dropdown.
+
+    Otherwise a fresh install renders a blank <select> (Vue drops a v-model value
+    with no matching <option>).
+    """
+    from services.settings_service import PLATFORM_DEFAULT_MODEL_VALUE
+
+    assert PLATFORM_DEFAULT_MODEL_VALUE in _settings_default_model_options(), (
+        f"PLATFORM_DEFAULT_MODEL_VALUE ({PLATFORM_DEFAULT_MODEL_VALUE!r}) is not an "
+        f"option in the platform default-model dropdown"
+    )


### PR DESCRIPTION
## Summary

`ModelSelector.vue` gained the Claude 5 presets (`claude-fable-5`, `claude-sonnet-5`); the two hand-synced lists never followed. So an admin couldn't pick either as the platform default, and the per-agent public-channel override (#894) rejected them with a 422.

- `settings_service.PUBLIC_CHANNEL_MODELS` — add both models
- `Settings.vue` platform default-model dropdown — offer both (recommended default unchanged: Sonnet 4.6, `PLATFORM_DEFAULT_MODEL_VALUE` untouched)
- New drift guard pinning the current lineup across all three lists

## Changes

| File | Change |
|------|--------|
| `src/backend/services/settings_service.py` | +2 entries in `PUBLIC_CHANNEL_MODELS` |
| `src/frontend/src/views/Settings.vue` | +2 `<option>`s in the default-model `<select>` |
| `tests/unit/test_1660_model_list_drift.py` | new — 9 tests |

## On the drift guard

The three lists are **subsets by policy, not identity**, so the guard pins the current generation rather than diffing whole lists:

- `ModelSelector` `PRESET_MODELS` (9) — display list; the field is free-text, so it enforces nothing
- `PUBLIC_CHANNEL_MODELS` (7) — current-gen, server-validated. Haiku is in **on purpose** (#894 wanted a cheap model for public traffic)
- `Settings.vue` dropdown (6) — Opus/Sonnet tiers. Haiku is out **on purpose** (#1080 AC: "includes the current Opus/Sonnet options")

It also asserts both subset directions (neither list may offer a model the picker dropped) and that `PLATFORM_DEFAULT_MODEL_VALUE` is itself an option — a fallback with no matching `<option>` renders a blank `<select>`.

## Test Plan

- [x] `pytest tests/unit/test_1660_model_list_drift.py -v` → 9 passed
- [x] Guard is not vacuous: 4 failed / 5 passed on the pre-fix tree
- [x] `pytest tests/unit/test_894_public_channel_model.py tests/unit/test_platform_default_model_regression.py` → 25 passed
- [ ] Manual: Settings → General offers Fable 5 / Sonnet 5; setting Fable 5 as a per-agent public-channel override saves without a 422

## Known gaps (not in scope, worth filing)

- **`platform_default_model` has no server-side validation.** It's written via the generic `PUT /api/settings/{key}`, so the dropdown is the only restriction — an admin can curl any string. The public-channel override *is* server-validated, so the two surfaces disagree. Reconciling it is a breaking change (it'd 422 the existing `[1m]` extended-context opt-in and legacy defaults, and break `tests/test_platform_default_model.py:217`), so it belongs in its own issue.
- **A saved default outside the dropdown renders a blank `<select>`** (Vue drops an unmatched `v-model` value). Pre-existing; reachable today via a legacy, Haiku, or `[1m]` default.
- **The lists stay hand-synced.** #1080 already noted a shared catalog as "worth considering, out of scope"; this guard is the workaround, not the fix.

Fixes #1660

Generated with [Claude Code](https://claude.com/claude-code)