### PR TITLE
fix(agents): recovery must mount a renamed agent's real workspace volume (#1665)

### DIFF
--- a/src/backend/services/agent_service/deploy.py
+++ b/src/backend/services/agent_service/deploy.py
@@ -68,6 +68,11 @@ def _prepopulate_workspace_from_template(version_name: str, template_dir: Path) 
     Failures raise HTTPException(500) — partial pre-population would
     leave the deploy in an inconsistent state.
     """
+    # #1665 audit: naming off `version_name` is correct HERE by construction —
+    # a deploy version is a brand-new name whose ownership row doesn't exist
+    # yet (this runs before creation), so there is no pin to resolve and no
+    # rename in its past. Every OTHER "this agent's volume" lookup must go
+    # through `db.get_volume_base_name` (see lifecycle._workspace_volume_name).
     workspace_vol = f"agent-{version_name}-workspace"
     client = docker.from_env()
 

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -555,8 +555,15 @@ async def recreate_container_with_updated_config(agent_name: str, old_container,
         pass
     await container_remove(old_container)
 
-    # Build new volume configuration
-    agent_volume_name = f"agent-{agent_name}-workspace"
+    # Build new volume configuration.
+    #
+    # #1665: deliberately NOT f"agent-{agent_name}-workspace" — a dead
+    # assignment of exactly that name used to sit here and read as though it
+    # were the mount this function uses. It isn't: the mounts are carried
+    # forward from the old container's `Mounts` below, which is what keeps a
+    # renamed agent on its pre-rename volume across a recreate. Anything that
+    # needs to NAME this agent's volume must go through
+    # `_workspace_volume_name` (ownership row), never the current name.
 
     # Start with base volumes - get existing bind mounts
     old_mounts = old_container.attrs.get("Mounts", [])
@@ -723,6 +730,36 @@ async def _provision_folders_and_run_agent_container(
     return new_container
 
 
+def _workspace_volume_name(agent_name: str) -> str:
+    """The name of ``agent_name``'s home volume — resolved, never assumed
+    (#1664/#1665).
+
+    THE rule for every "this agent's volume" lookup: rename keeps the agent's
+    volumes under the pre-rename base, because Docker can rename neither a
+    volume nor its immutable `trinity.agent-name` label. So the agent's CURRENT
+    name is not its volume's name, and f-stringing it is wrong for any agent
+    that was ever renamed. The ownership row is the only record of the pairing
+    (`volume_base_name`, NULL ⇒ never renamed ⇒ the name itself).
+
+    Getting this wrong is silent, not loud: `containers.run` CREATES a missing
+    named volume instead of failing, so a wrong name yields an empty
+    `/home/developer` and a working-looking agent.
+
+    Fail-safe: a DB error falls back to the agent name — the pre-#1665 behavior,
+    and correct for every un-renamed agent — rather than blocking the rebuild.
+    """
+    try:
+        return f"agent-{db.get_volume_base_name(agent_name) or agent_name}-workspace"
+    except Exception as e:  # noqa: BLE001 — never block a rebuild on a DB read
+        logger.warning(
+            "[#1665] could not resolve volume base for %s (%s); "
+            "falling back to the agent name",
+            agent_name,
+            e,
+        )
+        return f"agent-{agent_name}-workspace"
+
+
 async def _read_template_yaml_from_volume(agent_name: str) -> dict:
     """Read the agent's `template.yaml` off its persisted workspace volume
     without a running container (#1559).
@@ -732,8 +769,12 @@ async def _read_template_yaml_from_volume(agent_name: str) -> dict:
     carries the committed `template.yaml` — survives. A throwaway, network-less
     base-image container `cat`s the file. Tolerant: any failure (missing file,
     unparseable) returns `{}` so the caller falls back to safe defaults.
+
+    #1665: resolves the volume through the ownership row — for a renamed agent
+    the current name names no volume, so this silently read nothing and the
+    caller rebuilt on default agent-type/runtime instead of the committed ones.
     """
-    volume_name = f"agent-{agent_name}-workspace"
+    volume_name = _workspace_volume_name(agent_name)
     try:
         out = await containers_run(
             "trinity-agent-base:latest",
@@ -853,7 +894,20 @@ async def recreate_missing_container(agent_name: str):
         "trinity.full-capabilities": str(full_capabilities).lower(),
     }
 
-    base_volumes = {f"agent-{agent_name}-workspace": {"bind": "/home/developer", "mode": "rw"}}
+    # #1664/#1665: resolve the workspace volume through the ownership row, NOT
+    # f"agent-{agent_name}-workspace". Rename keeps the agent's volumes under
+    # the pre-rename base (Docker can rename neither a volume nor its label), so
+    # for a renamed agent the current name points at a volume that does not
+    # exist — and `containers.run` CREATES a missing named volume rather than
+    # failing, so recovery silently rebuilt the agent on an empty
+    # `/home/developer` while its real data (incl. #1169 `data_paths`) sat
+    # unreferenced under the old base. NULL pin ⇒ agent_name (never renamed).
+    base_volumes = {
+        _workspace_volume_name(agent_name): {
+            "bind": "/home/developer",
+            "mode": "rw",
+        }
+    }
 
     logger.info("Rebuilding missing container for recovered agent %s (#1559)", agent_name)
     return await _provision_folders_and_run_agent_container(

--- a/tests/unit/test_start_agent_skip_inject.py
+++ b/tests/unit/test_start_agent_skip_inject.py
@@ -269,6 +269,10 @@ class TestRecoverRecreate1559:
         _mock_db.get_agent_owner.return_value = {"owner_username": "bob"}
         _mock_db.get_resource_limits.return_value = {}
         _mock_db.create_agent_mcp_api_key.return_value = Mock(api_key="trinity_mcp_x")
+        # #1665: never renamed -> the pin is NULL and the base IS the name.
+        # (Stub it: an unstubbed MagicMock attribute is truthy and would be
+        # f-stringed straight into the volume name.)
+        _mock_db.get_volume_base_name.side_effect = lambda n: n
 
         provision = AsyncMock(return_value=_make_container("created"))
         tmpl = AsyncMock(return_value={"type": "researcher", "runtime": {"type": "codex"}})
@@ -294,3 +298,52 @@ class TestRecoverRecreate1559:
         assert kwargs["labels"]["trinity.agent-runtime"] == "codex"
         assert kwargs["env_vars"]["AGENT_RUNTIME"] == "codex"
         assert kwargs["env_vars"]["AGENT_NAME"] == "proj"
+
+    def test_recreate_missing_container_mounts_a_renamed_agents_real_volume(self):
+        """#1665: rename keeps the volume under the pre-rename base, so recovery
+        must resolve it from the ownership row. Naming off the CURRENT name is
+        silent, not loud — `containers.run` creates the missing volume, so the
+        agent came back on an empty /home/developer with its real data (incl.
+        #1169 data_paths) stranded under the old base."""
+        _mock_db.get_agent_owner.return_value = {"owner_username": "bob"}
+        _mock_db.get_resource_limits.return_value = {}
+        _mock_db.create_agent_mcp_api_key.return_value = Mock(api_key="trinity_mcp_x")
+        _mock_db.get_volume_base_name.side_effect = (
+            lambda n: "old-name" if n == "new-name" else n
+        )
+
+        provision = AsyncMock(return_value=_make_container("created"))
+        with patch.object(_mod, "_provision_folders_and_run_agent_container", provision), \
+             patch.object(_mod, "_read_template_yaml_from_volume", AsyncMock(return_value={})), \
+             patch.object(_mod, "_apply_persisted_auth_env", Mock()), \
+             patch.object(_mod, "get_next_available_port", Mock(return_value=2245)), \
+             patch.object(_mod, "get_agent_full_capabilities", Mock(return_value=False)), \
+             patch.object(_mod, "get_agent_default_resources",
+                          Mock(return_value={"cpu": "2", "memory": "4g"})), \
+             patch.object(_mod, "validate_base_image", Mock()):
+            _run(_mod.recreate_missing_container("new-name"))
+
+        assert provision.call_args.kwargs["base_volumes"] == {
+            "agent-old-name-workspace": {"bind": "/home/developer", "mode": "rw"}
+        }
+
+    def test_workspace_volume_name_falls_back_on_a_db_error(self):
+        """A DB hiccup must not block a rebuild — fall back to the agent name,
+        which is the pre-#1665 behavior and correct for every un-renamed agent."""
+        _mock_db.get_volume_base_name.side_effect = RuntimeError("db down")
+        assert _mod._workspace_volume_name("solo") == "agent-solo-workspace"
+
+    def test_template_read_uses_the_resolved_volume(self):
+        """#1665: the same trap one level down — reading template.yaml off the
+        CURRENT name found nothing for a renamed agent, so recovery silently
+        rebuilt on default agent-type/runtime instead of the committed ones."""
+        _mock_db.get_volume_base_name.side_effect = (
+            lambda n: "old-name" if n == "new-name" else n
+        )
+        run = AsyncMock(return_value=b"type: researcher\n")
+        with patch.object(_mod, "containers_run", run):
+            _run(_mod._read_template_yaml_from_volume("new-name"))
+
+        assert run.call_args.kwargs["volumes"] == {
+            "agent-old-name-workspace": {"bind": "/home/developer", "mode": "ro"}
+        }


### PR DESCRIPTION
> **Stacked on #1666** (base is `feature/1664-...`, not `dev`) — it needs the `db.get_volume_base_name` primitive that PR adds. Review/merge #1666 first; GitHub retargets this to `dev` automatically when it lands. The diff shown here is only this fix.

Related to #1665

## The bug

Rename keeps the agent's Docker volumes under the **pre-rename** base — Docker can rename neither a volume nor its immutable `trinity.agent-name` label — so for a renamed agent the **current** name names no volume. `recreate_missing_container` (#1559 soft-delete recovery) f-stringed that current name.

The failure is **silent, not loud**: `containers.run` *creates* a missing named volume rather than erroring, so recovery rebuilt the agent on a brand-new empty `/home/developer` and started it. The agent comes back looking healthy — just empty — while its real data (including #1169 `data_paths`) sits unreferenced under the old base.

Reproduced against a real DB + daemon before the fix:

```
recovery mounts today : agent-r1665-new-workspace
   -> agent sees      : <volume does not exist -> docker CREATES it empty>
resolved via #1664 pin: agent-r1665-old-workspace
   -> agent sees      : the agents real data
```

## The fix — one rule, three sites

**Resolve the volume through the ownership row, never from the agent's name** (`_workspace_volume_name`; NULL pin ⇒ the name itself ⇒ every un-renamed agent is byte-identical to today). Fail-safe: a DB error falls back to the agent name — the pre-#1665 behavior — rather than blocking a rebuild.

| Site | Was | Now |
|---|---|---|
| `recreate_missing_container` | mounted `agent-{current}-workspace` → **empty workspace** | mounts the resolved base → the agent's real data |
| `_read_template_yaml_from_volume` | read the same non-existent volume → `{}` → recovery rebuilt on **default** agent-type/runtime | recovers the committed `researcher`/`codex` |
| `recreate_container_with_updated_config` | a **dead** `agent_volume_name = f"agent-{agent_name}-workspace"` assignment that read as if it were the mount in use | removed + annotated (mounts are carried forward from the old container — that is what keeps a renamed agent on its volume across a recreate) |

The `deploy.py` version-name volume is correct **by construction** (a fresh name, no ownership row yet, no rename in its past) — annotated as audited, not changed.

## Verification (real DB + real Docker, no mocks)

```
1. recovery would mount        : agent-v1665-old-workspace
   agent's /home/developer has : the agents real data
2. template.yaml recovered     : {'type': 'researcher', 'runtime': 'codex'}
3. un-renamed agent unaffected : agent-v1665-old-workspace (no row -> falls back to the name)
```

Tests: 3 new (renamed-agent recovery mounts the real base; the template read resolves too; DB-error fallback), plus 261 passing across the affected suites.

## Notes for review

- **The mock trap, again.** The existing #1559 recreate test mocks the whole `database` module, and an unstubbed MagicMock attribute is *truthy* — it would be f-stringed straight into the volume name. It failed exactly as `test_fork_to_own` did in #1666; stubbed explicitly. Worth knowing for any future `db.*` call added to a create/recreate path.
- **Out of scope, filed as a follow-up:** the audit found a *fourth* site of the same class that this issue did not name — `get_public_volume_name` / `get_shared_volume_name` name off the **live** agent name, and `recreate_container_with_updated_config` deliberately drops the old public/shared mounts and re-adds them by current name. So a rename + any recreate silently empties a renamed agent's publish dir and shared-out folder (data orphaned, not deleted — #1664's union predicate keeps the sweep off the old base). Unlike the workspace, that one is **not** a mechanical swap: an agent renamed in the field may already have data under `agent-{new}-public`, so resolving to the pinned base would orphan *that* instead. It needs an adopt/migrate decision, not a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
