### PR TITLE
fix(sanitizer): linear KEY=value redaction — the #1661 CPU spin is the regex, not the pipe

### DIFF
--- a/docker/base-image/agent_server/utils/credential_sanitizer.py
+++ b/docker/base-image/agent_server/utils/credential_sanitizer.py
@@ -71,6 +71,51 @@ SECRET_VALUE_PATTERNS = [
 
 # Compiled patterns for performance
 _sensitive_var_re = [re.compile(p, re.IGNORECASE) for p in SENSITIVE_VAR_PATTERNS]
+
+# --- #1661: linear KEY=value redaction -------------------------------------
+# The patterns above describe VARIABLE NAMES (`.*TOKEN.*` means "a name
+# containing TOKEN"). Stage 3 below used to compose each one into a
+# LINE-scanning regex — `(.*TOKEN.*)=(["\']?)([^\s"\']+)\2` — i.e. two
+# unbounded `.*` around a literal, re-scanned from every offset of the line.
+# Cost was superlinear in line length: ~6.8s for `.*TOKEN.*` alone on an 8 KB
+# line, ~10 CPU-minutes on the 44 KB tool-result lines that triggered #1661.
+# That is what pegged a core: the agent-server reader thread was not blocked on
+# a pipe, it was *computing* — which is why the #728/#1502 pipe fixes never
+# helped, and why it "self-cleared" (the regex eventually finished).
+#
+# One linear pass instead: find `key=value` pairs, then test the (short) key.
+# The key is bounded by delimiters, and the lookbehind stops the engine from
+# retrying every offset inside a long unbroken token (a 44 KB base64 blob would
+# otherwise reintroduce quadratic cost).
+_KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
+
+# A name pattern must match a SUFFIX of the key, not the whole key: the old
+# composed regex could start matching mid-token, so `DB_.*` redacted
+# `MY_DB_PASS=x`. Anchoring with \Z reproduces exactly that (a `fullmatch`
+# rewrite would silently redact LESS — a leak, not a speedup).
+_SENSITIVE_KEY_SUFFIX_RE = [
+    re.compile(r'(?:' + p + r')\Z', re.IGNORECASE) for p in SENSITIVE_VAR_PATTERNS
+]
+
+
+def _is_sensitive_kv_key(key: str) -> bool:
+    """True if `key` (a short `KEY=` name) names a credential."""
+    return any(r.search(key) for r in _SENSITIVE_KEY_SUFFIX_RE)
+
+
+def _redact_kv_match(match: "re.Match") -> str:
+    """Redact the value of a sensitive `key=value` pair, keep everything else.
+
+    Mirrors the old replacement byte-for-byte: the value (and its quotes, which
+    the old `\1=` replacement also dropped) becomes the placeholder; text
+    around the pair is untouched.
+    """
+    key = match.group(1)
+    if _is_sensitive_kv_key(key):
+        return f"{key}={REDACTION_PLACEHOLDER}"
+    return match.group(0)
+
+
 _secret_value_re = [re.compile(p) for p in SECRET_VALUE_PATTERNS]
 
 # Cache for known credential values (loaded from environment)
@@ -163,13 +208,10 @@ def sanitize_text(text: str) -> str:
 
     # 3. Redact key=value pairs where key is sensitive
     # Handle: KEY=value, KEY="value", KEY='value'
-    for var_pattern in _sensitive_var_re:
-        # Match: SENSITIVE_VAR=somevalue or SENSITIVE_VAR="somevalue"
-        kv_pattern = re.compile(
-            r'(' + var_pattern.pattern + r')=(["\']?)([^\s"\']+)\2',
-            re.IGNORECASE
-        )
-        result = kv_pattern.sub(r'\1=' + REDACTION_PLACEHOLDER, result)
+    # #1661: ONE linear pass (see _KV_LINE_RE) — this used to compile a
+    # line-scanning regex per name pattern, which cost CPU-minutes on a large
+    # line and pegged a core.
+    result = _KV_LINE_RE.sub(_redact_kv_match, result)
 
     return result
 

--- a/docker/base-image/agent_server/utils/credential_sanitizer.py
+++ b/docker/base-image/agent_server/utils/credential_sanitizer.py
@@ -87,6 +87,13 @@ _sensitive_var_re = [re.compile(p, re.IGNORECASE) for p in SENSITIVE_VAR_PATTERN
 # The key is bounded by delimiters, and the lookbehind stops the engine from
 # retrying every offset inside a long unbroken token (a 44 KB base64 blob would
 # otherwise reintroduce quadratic cost).
+# The lookbehind is load-bearing, not decoration: it is what keeps this LINEAR.
+# Without it the engine retries the key at every offset inside a long non-matching
+# run, which is exactly the quadratic shape this issue is about. CodeQL reports
+# `py/polynomial-redos` here because its model ignores lookbehinds; the adversarial
+# cases it names (`!`*n, `!=`+`!=!`*n) are pinned as tests in
+# tests/unit/test_1661_sanitizer_linear.py and run in ~1ms at 64 KB. Do not
+# "simplify" the lookbehind away.
 _KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
 
 # A name pattern must match a SUFFIX of the key, not the whole key: the old

--- a/src/backend/utils/credential_sanitizer.py
+++ b/src/backend/utils/credential_sanitizer.py
@@ -55,6 +55,48 @@ SENSITIVE_KEY_PATTERNS = [
 _secret_value_re = [re.compile(p) for p in SECRET_VALUE_PATTERNS]
 _sensitive_key_re = [re.compile(p, re.IGNORECASE) for p in SENSITIVE_KEY_PATTERNS]
 
+# --- #1661: linear KEY=value redaction -------------------------------------
+# The patterns above describe KEY NAMES (`.*TOKEN.*` means "a name containing
+# TOKEN"). The stage below used to compose each one into a LINE-scanning regex
+# — `(.*TOKEN.*)=(["\']?)([^\s"\']+)\2` — i.e. two unbounded `.*` around a
+# literal, re-scanned from every offset of the line. Cost was superlinear in
+# line length: ~6.8s for `.*TOKEN.*` alone on an 8 KB line, ~10 CPU-minutes on a
+# 44 KB line. Agent-side this pegged a core (#1661); here it burns backend CPU
+# on the same input, since this layer sanitizes execution logs before DB write.
+#
+# One linear pass instead: find `key=value` pairs, then test the (short) key.
+# The lookbehind stops the engine retrying every offset inside a long unbroken
+# token (a 44 KB base64 blob would otherwise reintroduce quadratic cost).
+_KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
+
+# A name pattern must match a SUFFIX of the key, not the whole key: the old
+# composed regex could start matching mid-token, so `DB_.*` redacted
+# `MY_DB_PASS=x`. Anchoring with \Z reproduces exactly that (a `fullmatch`
+# rewrite would silently redact LESS — a leak, not a speedup).
+_SENSITIVE_KEY_SUFFIX_RE = [
+    re.compile(r'(?:' + p + r')\Z', re.IGNORECASE) for p in SENSITIVE_KEY_PATTERNS
+]
+
+
+def _is_sensitive_kv_key(key: str) -> bool:
+    """True if `key` (a short `KEY=` name) names a credential."""
+    return any(r.search(key) for r in _SENSITIVE_KEY_SUFFIX_RE)
+
+
+def _redact_kv_match(match: "re.Match") -> str:
+    """Redact the value of a sensitive `key=value` pair, keep everything else.
+
+    Mirrors the old replacement byte-for-byte: the value (and its quotes, which
+    the old `\1=` replacement also dropped) becomes the placeholder; text
+    around the pair is untouched.
+    """
+    key = match.group(1)
+    if _is_sensitive_kv_key(key):
+        return f"{key}={REDACTION_PLACEHOLDER}"
+    return match.group(0)
+
+
+
 REDACTION_PLACEHOLDER = "***REDACTED***"
 
 
@@ -77,13 +119,10 @@ def sanitize_text(text: str) -> str:
     for pattern in _secret_value_re:
         result = pattern.sub(REDACTION_PLACEHOLDER, result)
 
-    # Redact key=value pairs where key is sensitive
-    for key_pattern in _sensitive_key_re:
-        kv_pattern = re.compile(
-            r'(' + key_pattern.pattern + r')=(["\']?)([^\s"\']+)\2',
-            re.IGNORECASE
-        )
-        result = kv_pattern.sub(r'\1=' + REDACTION_PLACEHOLDER, result)
+    # Redact key=value pairs where key is sensitive.
+    # #1661: ONE linear pass (see _KV_LINE_RE) — this used to compile a
+    # line-scanning regex per key pattern, costing CPU-minutes on a large line.
+    result = _KV_LINE_RE.sub(_redact_kv_match, result)
 
     return result
 

--- a/src/backend/utils/credential_sanitizer.py
+++ b/src/backend/utils/credential_sanitizer.py
@@ -67,6 +67,13 @@ _sensitive_key_re = [re.compile(p, re.IGNORECASE) for p in SENSITIVE_KEY_PATTERN
 # One linear pass instead: find `key=value` pairs, then test the (short) key.
 # The lookbehind stops the engine retrying every offset inside a long unbroken
 # token (a 44 KB base64 blob would otherwise reintroduce quadratic cost).
+# The lookbehind is load-bearing, not decoration: it is what keeps this LINEAR.
+# Without it the engine retries the key at every offset inside a long non-matching
+# run, which is exactly the quadratic shape this issue is about. CodeQL reports
+# `py/polynomial-redos` here because its model ignores lookbehinds; the adversarial
+# cases it names (`!`*n, `!=`+`!=!`*n) are pinned as tests in
+# tests/unit/test_1661_sanitizer_linear.py and run in ~1ms at 64 KB. Do not
+# "simplify" the lookbehind away.
 _KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
 
 # A name pattern must match a SUFFIX of the key, not the whole key: the old

--- a/tests/unit/test_1661_sanitizer_linear.py
+++ b/tests/unit/test_1661_sanitizer_linear.py
@@ -91,6 +91,33 @@ class TestLinearCost:
         assert large_dt < max(small_dt * 40, 0.5)
 
     @pytest.mark.parametrize("mod", BOTH)
+    @pytest.mark.parametrize(
+        "attack",
+        [
+            pytest.param(lambda n: "!" * n, id="many-bangs"),
+            pytest.param(lambda n: "!=" + "!=!" * (n // 3), id="bang-equals-bang"),
+            pytest.param(lambda n: 'K="' + "x" * n, id="unterminated-quote"),
+            pytest.param(lambda n: "x" * n + "=", id="trailing-equals-no-value"),
+            pytest.param(lambda n: "a= " * (n // 3), id="missing-values"),
+            pytest.param(lambda n: '=' * n, id="all-equals"),
+        ],
+    )
+    def test_adversarial_inputs_stay_linear(self, mod, attack):
+        """Guards the ReDoS surface of `_KV_LINE_RE` — including the two strings
+        CodeQL's `py/polynomial-redos` names (`!`*n, and `!=` + `!=!`*n).
+
+        The linearity comes from the lookbehind: it stops the engine retrying
+        the key at every offset inside a long token, which is what would make
+        `([^\s"\'=]+)=` quadratic on a non-matching run. CodeQL does not model
+        the lookbehind, so it reports this as polynomial; these cases are the
+        executable proof that it is not — and the reason the lookbehind must not
+        be "simplified away" by a later edit.
+        """
+        start = time.perf_counter()
+        mod.sanitize_text(attack(64_000))
+        assert time.perf_counter() - start < 1.0
+
+    @pytest.mark.parametrize("mod", BOTH)
     def test_one_giant_unbroken_token(self, mod):
         """A 200 KB base64-ish blob with no delimiters. The key charset is
         delimiter-bounded, so the engine must not retry every offset inside it."""

--- a/tests/unit/test_1661_sanitizer_linear.py
+++ b/tests/unit/test_1661_sanitizer_linear.py
@@ -1,0 +1,185 @@
+"""Unit tests for the linear KEY=value redaction in both credential sanitizers (#1661).
+
+The sanitizers' name patterns describe VARIABLE NAMES (`.*TOKEN.*` = "a name
+containing TOKEN"), but stage 3 composed each one into a LINE-scanning regex:
+
+    (.*TOKEN.*)=(["\']?)([^\s"\']+)\2
+
+Two unbounded `.*` around a literal, re-scanned from every offset of the line.
+That had two consequences, and this module pins both fixes:
+
+1. **Cost** — superlinear in line length (~6.8s for `.*TOKEN.*` alone on an 8 KB
+   line; ~10 CPU-minutes on a 44 KB tool-result line). Agent-side that pegged a
+   core: the reader thread was not blocked on a pipe, it was *computing* — which
+   is why the #728/#1502 pipe fixes never covered this path, and why the spin
+   "self-cleared" once the regex finally finished.
+
+2. **Correctness (security)** — greedy `.*` spans to the LAST `=` on the line, so
+   on a multi-pair line the old code redacted the WRONG pair and left the real
+   credential in place. `GH_TOKEN=supersecret PLAIN=harmless` redacted
+   `harmless`. Stages 1-2 (known values / value-shaped patterns) hide this for
+   many real keys, which is why it went unnoticed.
+
+Both sanitizer copies (backend + agent-server) carried the same flaw and are
+tested here together.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_project_root = Path(__file__).resolve().parents[2]
+
+
+def _load(path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, str(_project_root / path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+AGENT = _load(
+    "docker/base-image/agent_server/utils/credential_sanitizer.py",
+    "_cs_agent_1661",
+)
+BACKEND = _load("src/backend/utils/credential_sanitizer.py", "_cs_backend_1661")
+
+BOTH = [pytest.param(AGENT, id="agent"), pytest.param(BACKEND, id="backend")]
+
+
+def _big_line(n_chars: int) -> str:
+    """A tool-result-shaped line: prose with env-ish tokens, no real secrets."""
+    unit = "Loaded DATABASE_URL config and GH_TOKEN refs while scanning. "
+    return (unit * ((n_chars // len(unit)) + 1))[:n_chars]
+
+
+class TestLinearCost:
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_44kb_line_is_fast(self, mod):
+        """The #1661 line size. Was ~10 CPU-minutes; the budget here is
+        deliberately loose (1s) — it fails on a return to superlinear cost, not
+        on ordinary machine noise."""
+        line = _big_line(44_000)
+        start = time.perf_counter()
+        mod.sanitize_text(line)
+        assert time.perf_counter() - start < 1.0
+
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_cost_stays_linear_as_the_line_grows(self, mod):
+        """8x the input must not cost ~300x the time (the old curve was ~n^2.5).
+
+        Asserts the SHAPE, not a wall-clock number, so it holds on slow CI."""
+        small = _big_line(8_000)
+        large = _big_line(64_000)
+
+        t0 = time.perf_counter()
+        for _ in range(3):
+            mod.sanitize_text(small)
+        small_dt = (time.perf_counter() - t0) / 3
+
+        t0 = time.perf_counter()
+        for _ in range(3):
+            mod.sanitize_text(large)
+        large_dt = (time.perf_counter() - t0) / 3
+
+        # Linear would be ~8x. Allow 40x for constant factors/noise; the old
+        # implementation was ~300x+ here and would blow this budget outright.
+        assert large_dt < max(small_dt * 40, 0.5)
+
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_one_giant_unbroken_token(self, mod):
+        """A 200 KB base64-ish blob with no delimiters. The key charset is
+        delimiter-bounded, so the engine must not retry every offset inside it."""
+        start = time.perf_counter()
+        mod.sanitize_text("A" * 200_000)
+        assert time.perf_counter() - start < 1.0
+
+
+class TestMultiPairRedaction:
+    """The security half: every sensitive pair on a line is redacted, and only
+    those. The old code redacted the last pair on the line instead."""
+
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_secret_redacted_and_harmless_kept(self, mod):
+        out = mod.sanitize_text("GH_TOKEN=supersecret PLAIN=harmless")
+        assert "supersecret" not in out
+        assert "PLAIN=harmless" in out
+
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_realistic_env_dump_line(self, mod):
+        out = mod.sanitize_text(
+            "env: ANTHROPIC_API_KEY=sk-ant-realkey123456 LOG_LEVEL=debug"
+        )
+        assert "sk-ant-realkey123456" not in out
+        assert "LOG_LEVEL=debug" in out
+
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_every_sensitive_pair_on_the_line(self, mod):
+        out = mod.sanitize_text(
+            "DB_PASSWORD=hunter2 HOST=localhost GH_TOKEN=ghp_abc PORT=5432"
+        )
+        assert "hunter2" not in out
+        assert "ghp_abc" not in out
+        assert "HOST=localhost" in out
+        assert "PORT=5432" in out
+
+
+class TestPreservedSemantics:
+    """Behaviour pinned from the pre-#1661 implementation on the single-pair
+    lines it handled correctly — a faster filter that redacts LESS is a leak."""
+
+    @pytest.mark.parametrize("mod", BOTH)
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("GH_TOKEN=abc123secret", "GH_TOKEN=***REDACTED***"),
+            # `ANTHROPIC_.*` matches a SUFFIX of the key — the old composed
+            # regex could start matching mid-token, so this was redacted before
+            # and must stay redacted. (A `fullmatch` rewrite would quietly stop
+            # redacting it: less redaction is a leak, not a speedup.)
+            ("MY_ANTHROPIC_KEY=secret1", "MY_ANTHROPIC_KEY=***REDACTED***"),
+            ("some prose GH_TOKEN=abc123 more", "some prose GH_TOKEN=***REDACTED*** more"),
+            # Non-identifier characters in the key.
+            ("my.token=abc123", "my.token=***REDACTED***"),
+            # Case-insensitive name matching.
+            ("lowercase_token=abc123", "lowercase_token=***REDACTED***"),
+            ("TOKEN=abc", "TOKEN=***REDACTED***"),
+            # Not a credential name — left alone.
+            ("NOTHING_SENSITIVE=plainvalue", "NOTHING_SENSITIVE=plainvalue"),
+        ],
+    )
+    def test_single_pair_contract(self, mod, text, expected):
+        assert mod.sanitize_text(text) == expected
+
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_quoted_value_with_space_is_unchanged(self, mod):
+        """Documents a PRE-EXISTING gap rather than a new one: the value charset
+        `[^\\s"\\']+` never matched across a space, so a quoted multi-word value
+        was not redacted before this change either. Pinned so the behaviour is a
+        decision, not a surprise (stages 1-2 still catch value-shaped secrets)."""
+        assert mod.sanitize_text('GH_TOKEN="quoted secret"') == 'GH_TOKEN="quoted secret"'
+
+    @pytest.mark.parametrize("mod", BOTH)
+    def test_key_suffix_matching_helper(self, mod):
+        assert mod._is_sensitive_kv_key("GH_TOKEN") is True
+        assert mod._is_sensitive_kv_key("ANTHROPIC_API_KEY") is True
+        # Suffix, not whole-key: the name pattern starts matching mid-token.
+        assert mod._is_sensitive_kv_key("MY_ANTHROPIC_KEY") is True
+        assert mod._is_sensitive_kv_key("HOST") is False
+        assert mod._is_sensitive_kv_key("PORT") is False
+
+    def test_the_two_copies_carry_different_pattern_lists(self):
+        """Not a bug this issue fixes — pinned so the asymmetry is visible.
+
+        The agent-side list is a superset (it adds `DB_.*`, `REDIS_.*`,
+        `SLACK_.*`, ...), so `MY_DB_PASS=x` is redacted agent-side and NOT by
+        the backend layer. Both copies got the identical #1661 treatment; the
+        lists themselves are untouched here, since widening the backend's list
+        changes what gets redacted and belongs in its own change.
+        """
+        assert AGENT._is_sensitive_kv_key("MY_DB_PASS") is True
+        assert BACKEND._is_sensitive_kv_key("MY_DB_PASS") is False


### PR DESCRIPTION
Fixes #1661. **The spinning thread was never blocked on a pipe — it was computing.** That is why the #728 and #1502 pipe fixes are present in the affected image and do not cover this path.

Related to #1661

## Root cause

The sanitizers' patterns describe **variable names** (`.*TOKEN.*` = "a name containing TOKEN"), but stage 3 composed each one into a **line-scanning** regex:

```
(.*TOKEN.*)=(["\']?)([^\s"\']+)\2
```

Two unbounded `.*` around a literal, re-scanned from every offset of the line. Measured on this branch:

| line size | `sanitize_text` (before) |
|---|---|
| 1 KB | 45 ms |
| 2 KB | 274 ms |
| 4 KB | 1 501 ms |
| 8 KB | **8 572 ms** |

~5.7× per 2× input (≈ n^2.5) → **~10 CPU-minutes for the 44 KB tool-result line** named in the report. `.*TOKEN.*` alone accounts for 6.8s of the 8 KB figure.

The headless reader calls `sanitize_dict(raw_msg)` on **every** parsed message (`headless_executor.py:610`), so one 44 KB tool result puts the reader thread into a ~10-minute C-level regex burn. That single fact explains every observation in the report:

| Reported symptom | Explanation |
|---|---|
| 100% of one core, `R`, `wchan=0`, no syscall, memory flat | a regex in C, not I/O |
| "Reader thread(s) still **busy** after process exit" | busy, literally — computing |
| kill group → 30s wait → 90s budget → "leaked" (#728/#1502) | those make a **blocked** reader EOF; this one was never blocked |
| "Result event lost (stdout pipe race) → soft success" | the result line wasn't lost — the reader hadn't reached it yet |
| spin persists with **no active task**, then self-clears | the regex finishes |
| recurs on the next large-output task; `docker restart` clears it | next big line, same burn |

## Fix

One linear pass: find `key=value` pairs with a delimiter-bounded key, then test the (short) key against the name patterns.

| line size | before | after |
|---|---|---|
| 8 KB | 8 572 ms | **0.4 ms** |
| 44 KB | ~10 min | **1.2 ms** |
| 500 KB | — | 18 ms |
| 200 KB single unbroken token | — | 11.7 ms |

The reader's actual per-message call, `sanitize_dict` on a 44 KB `tool_result`: **1.6 ms**.

## It also fixes a security bug

The greedy `.*` spans to the **last** `=` on the line, so on a multi-pair line the old code redacted the **wrong** pair and left the real credential in place:

```
GH_TOKEN=supersecret PLAIN=harmless
  old -> GH_TOKEN=supersecret PLAIN=***REDACTED***      # leaks the token
  new -> GH_TOKEN=***REDACTED*** PLAIN=harmless

env: ANTHROPIC_API_KEY=sk-ant-realkey123456 LOG_LEVEL=debug
  old -> ... ANTHROPIC_API_KEY=sk-ant-realkey123456 LOG_LEVEL=***REDACTED***
  new -> ... ANTHROPIC_API_KEY=***REDACTED*** LOG_LEVEL=debug
```

Stages 1–2 (known env values; value-shaped patterns like `sk-ant-[…]{20,}`) mask this for many real keys, which is why it went unnoticed — the exposure is a credential whose *value* matches nothing known, on a line with 2+ pairs.

**Suffix matching is preserved deliberately.** The old regex could start matching mid-token, so `ANTHROPIC_.*` redacts `MY_ANTHROPIC_KEY=x`. A `fullmatch` rewrite would quietly redact *less* — a leak, not a speedup — so the key test is anchored with `\Z` to reproduce the old reach exactly.

## Scope

- **Both copies fixed.** The backend layer has the identical flaw and sanitizes execution logs before DB write, so it burned backend CPU on the same input.
- **Pattern lists untouched.** They differ (agent-side is a superset: `DB_.*`, `REDIS_.*`, …), so `MY_DB_PASS=x` is redacted agent-side but not backend-side. That asymmetry predates this issue and is now pinned by a test — widening a list changes what gets redacted and belongs in its own change.
- **Not addressed** (the upstream trigger, which the report itself suggests isolating): the stdio MCP child interleaving on claude's stdout pipe. This fix removes the CPU burn and the drain/leak/soft-success cascade; the interleave remains its own fault.

## Verification

31 new tests (`tests/unit/test_1661_sanitizer_linear.py`) covering both copies: 44 KB budget, a shape assertion that 8× input isn't ~300× time (the old curve), the giant-unbroken-token case, multi-pair redaction, and the single-pair behaviour contract captured from the *pre-fix* implementation. 510 passing across the sanitizer/executor suites; the 117 existing sanitizer tests pass unchanged.

Along the way I also reproduced the `safe_close_pipes` ↔ `readline()` deadlock the log line mentions (`close()` never returns while a reader is mid-`readline`) — real, but it leaves the reader **blocked at 0% CPU**, so it is not the spin. Noting it as a separate latent issue rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
