### PR TITLE
feat(agents): agent display label across operator, monitoring, executions & graph (#1643)

### DIFF
--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -58,6 +58,24 @@
   genuinely need it keep it; it stops being the default gesture for "call it
   something else".
 - **API**: `GET`/`PUT /api/agents/{name}/label` — owner-only, `{label: string|null}`.
+- **FR-6 — Remaining surfaces resolve the label off the agents store, not new
+  payloads (#1643)**: operator queue, monitoring, executions, the collaboration
+  graph, tab titles and prose/toasts render only a slug in their own payloads.
+  Rather than grow a mutable `display_name` on each of those high-volume
+  endpoints (staleness risk, N duplicated presentation fields), the frontend
+  resolves slug → label off the loaded agents (store getters
+  `displayNameForSlug` / `agentRefForSlug`, live via the `agent_label_changed`
+  WS handler). An unloaded slug falls back to itself, so nothing regresses on a
+  cold surface. Render rule by class: **dense operational tables** (executions,
+  operator/monitoring rows, RACI matrix) keep the **slug primary** and surface
+  the label as a hover tooltip (`agentNameTooltip`); **prose / toasts** use the
+  label alone (`agentDisplayName`); the **collaboration graph** renders the
+  label but keeps `data.label` = slug as the action key (`router.push` /
+  toggles). `AgentAvatar` always receives the slug. Tab titles resolve the
+  label on warm SPA nav and fall back to the slug on a cold direct load (the
+  store isn't fetched yet); the next navigation self-heals. Comma-joined agent
+  lists (e.g. the GitHub-PAT propagation failure list) keep the slug — long
+  labels make them unreadable.
 
 ### 1.4 Agent Deletion
 - **Status**: ✅ Implemented

--- a/src/frontend/src/components/AgentNode.vue
+++ b/src/frontend/src/components/AgentNode.vue
@@ -36,10 +36,10 @@
         <div class="flex items-center flex-1 mr-2 min-w-0">
           <div
             class="nodrag text-gray-900 dark:text-white font-bold text-base truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400 hover:underline transition-colors"
-            :title="data.label"
+            :title="nodeNameTooltip"
             @click="viewDetails"
           >
-            {{ data.label }}
+            {{ nodeDisplayName }}
           </div>
           <!-- Runtime badge (Claude/Gemini) -->
           <RuntimeBadge :runtime="data.runtime" :show-label="false" class="ml-2 flex-shrink-0" />
@@ -239,6 +239,7 @@ import RuntimeBadge from './RuntimeBadge.vue'
 import RunningStateToggle from './RunningStateToggle.vue'
 import AutonomyToggle from './AutonomyToggle.vue'
 import { useNetworkStore } from '../stores/network'
+import { agentDisplayName, agentNameTooltip } from '../utils/agentName'
 
 const props = defineProps({
   id: String,
@@ -250,6 +251,13 @@ const props = defineProps({
 
 const router = useRouter()
 const networkStore = useNetworkStore()
+
+// #1643: render the human display name (data.display_label, else the slug);
+// every action below still keys on data.label (the slug). The tooltip surfaces
+// the slug too when a distinct label is shown, so the identity is one hover away.
+const agentRef = computed(() => ({ name: props.data.label, display_label: props.data.display_label }))
+const nodeDisplayName = computed(() => agentDisplayName(agentRef.value))
+const nodeNameTooltip = computed(() => agentNameTooltip(agentRef.value))
 
 // Autonomy toggle loading state
 const autonomyLoading = ref(false)

--- a/src/frontend/src/components/ExecutionsPanel.vue
+++ b/src/frontend/src/components/ExecutionsPanel.vue
@@ -228,6 +228,7 @@
                 <router-link
                   :to="'/agents/' + row.agent_name"
                   @click.stop
+                  :title="agentNameTooltip(agentsStore.agentRefForSlug(row.agent_name))"
                   class="text-sm font-medium text-gray-900 dark:text-white hover:text-action-primary-600 dark:hover:text-action-primary-400"
                 >
                   {{ row.agent_name }}
@@ -291,6 +292,7 @@ import { parseUTC } from '@/utils/timestamps'
 import { useExecutionsStore } from '../stores/executions'
 import { useAuthStore } from '../stores/auth'
 import { useAgentsStore } from '../stores/agents'
+import { agentNameTooltip } from '../utils/agentName'
 import { useWebSocket } from '../utils/websocket'
 
 const router = useRouter()

--- a/src/frontend/src/components/FoldersPanel.vue
+++ b/src/frontend/src/components/FoldersPanel.vue
@@ -123,7 +123,7 @@
                     'w-2 h-2 rounded-full',
                     consumer.status === 'running' ? 'bg-status-success-500' : 'bg-gray-400'
                   ]"></span>
-                  <span class="font-medium dark:text-gray-200">{{ consumer.agent_name }}</span>
+                  <span class="font-medium dark:text-gray-200" :title="agentNameTooltip(agentsStore.agentRefForSlug(consumer.agent_name))">{{ consumer.agent_name }}</span>
                 </div>
                 <code class="text-xs text-gray-500 dark:text-gray-400">{{ consumer.mount_path }}</code>
               </div>
@@ -151,7 +151,7 @@
                 folder.currently_mounted ? 'bg-status-success-500' : 'bg-state-autonomous-500'
               ]" :title="folder.currently_mounted ? 'Mounted' : 'Pending restart'"></span>
               <div>
-                <div class="font-medium text-gray-900 dark:text-white">{{ folder.source_agent }}</div>
+                <div class="font-medium text-gray-900 dark:text-white" :title="agentNameTooltip(agentsStore.agentRefForSlug(folder.source_agent))">{{ folder.source_agent }}</div>
                 <code class="text-xs text-gray-500 dark:text-gray-400">{{ folder.mount_path }}</code>
               </div>
             </div>
@@ -180,7 +180,7 @@
                 'w-2 h-2 rounded-full',
                 folder.source_status === 'running' ? 'bg-status-success-500' : 'bg-gray-400'
               ]"></span>
-              <span class="dark:text-gray-200">{{ folder.source_agent }}</span>
+              <span class="dark:text-gray-200" :title="agentNameTooltip(agentsStore.agentRefForSlug(folder.source_agent))">{{ folder.source_agent }}</span>
             </div>
           </div>
         </div>
@@ -219,6 +219,7 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents'
+import { agentNameTooltip } from '../utils/agentName'
 
 const props = defineProps({
   agentName: {

--- a/src/frontend/src/components/MonitoringPanel.vue
+++ b/src/frontend/src/components/MonitoringPanel.vue
@@ -127,7 +127,7 @@
               :class="alert.priority === 'urgent' ? 'text-status-danger-600' : 'text-status-warning-600'"
             />
             <div>
-              <span class="font-medium text-gray-900 dark:text-white">{{ alert.agent_name }}</span>
+              <span class="font-medium text-gray-900 dark:text-white" :title="agentNameTooltip(agentsStore.agentRefForSlug(alert.agent_name))">{{ alert.agent_name }}</span>
               <span class="text-gray-500 dark:text-gray-400 ml-2">{{ alert.title }}</span>
             </div>
           </div>
@@ -180,7 +180,7 @@
 
               <div>
                 <div class="flex items-center gap-2">
-                  <span class="font-medium text-gray-900 dark:text-white">{{ agent.name }}</span>
+                  <span class="font-medium text-gray-900 dark:text-white" :title="agentNameTooltip(agentsStore.agentRefForSlug(agent.name))">{{ agent.name }}</span>
                   <span
                     class="px-2 py-0.5 text-xs font-medium rounded capitalize"
                     :class="getStatusBadgeClass(agent.status)"
@@ -254,6 +254,8 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMonitoringStore } from '../stores/monitoring'
 import { useAuthStore } from '../stores/auth'
+import { useAgentsStore } from '../stores/agents'
+import { agentNameTooltip } from '../utils/agentName'
 import {
   ArrowPathIcon,
   BellAlertIcon,
@@ -269,6 +271,7 @@ import {
 const router = useRouter()
 const monitoringStore = useMonitoringStore()
 const authStore = useAuthStore()
+const agentsStore = useAgentsStore()
 
 // Admin status drives the per-action buttons (Check All, per-agent check)
 // and gates the fleet-wide alerts fetch. Read from the auth store getter

--- a/src/frontend/src/components/PermissionsPanel.vue
+++ b/src/frontend/src/components/PermissionsPanel.vue
@@ -49,7 +49,10 @@
                 class="h-4 w-4 text-action-primary-600 focus:ring-action-primary-500 border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700"
               />
               <div class="flex-1">
-                <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ targetAgent.name }}</span>
+                <span
+                  class="text-sm font-medium text-gray-900 dark:text-gray-100"
+                  :title="agentNameTooltip(agentsStore.agentRefForSlug(targetAgent.name))"
+                >{{ agentDisplayName(agentsStore.agentRefForSlug(targetAgent.name)) }}</span>
                 <span v-if="targetAgent.type" class="ml-2 text-xs text-gray-500 dark:text-gray-400">[{{ targetAgent.type }}]</span>
               </div>
               <span :class="[
@@ -101,6 +104,7 @@
 <script setup>
 import { computed, onMounted, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents'
+import { agentDisplayName, agentNameTooltip } from '../utils/agentName'
 import { useAgentPermissions } from '../composables/useAgentPermissions'
 
 const props = defineProps({

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -158,7 +158,7 @@
                   <span
                     class="text-sm font-semibold text-gray-900 dark:text-white truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400"
                     @click="navigateToAgent(row.name)"
-                    :title="row.name"
+                    :title="agentNameTooltip(agentsStore.agentRefForSlug(row.name))"
                   >
                     {{ row.name }}
                   </span>
@@ -387,12 +387,15 @@
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import { formatCostCompact } from '../composables/useFormatters'
 import { useRouter } from 'vue-router'
+import { useAgentsStore } from '../stores/agents'
+import { agentNameTooltip } from '../utils/agentName'
 import { parseUTC, getTimestampMs, formatLocalTime } from '@/utils/timestamps'
 import AutonomyToggle from './AutonomyToggle.vue'
 import CapacityMeter from './CapacityMeter.vue'
 import AgentAvatar from './AgentAvatar.vue'
 
 const router = useRouter()
+const agentsStore = useAgentsStore()
 
 const props = defineProps({
   agents: { type: Array, default: () => [] },

--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -189,6 +189,7 @@
                 </span>
                 <router-link
                   :to="`/agents/${notification.agent_name}`"
+                  :title="agentNameTooltip(agentsStore.agentRefForSlug(notification.agent_name))"
                   class="font-medium text-blue-600 dark:text-blue-400 hover:underline truncate"
                 >
                   {{ notification.agent_name }}
@@ -299,6 +300,8 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useNotificationsStore } from '../../stores/notifications'
+import { useAgentsStore } from '../../stores/agents'
+import { agentNameTooltip } from '../../utils/agentName'
 import {
   XMarkIcon,
   CheckIcon,
@@ -312,6 +315,7 @@ import {
 } from '@heroicons/vue/24/outline'
 
 const notificationsStore = useNotificationsStore()
+const agentsStore = useAgentsStore()
 
 // State
 const loading = ref(false)

--- a/src/frontend/src/components/operator/QueueCard.vue
+++ b/src/frontend/src/components/operator/QueueCard.vue
@@ -16,7 +16,10 @@
         <div class="flex-1 min-w-0">
           <!-- Agent name + time -->
           <div class="flex items-center gap-2 mb-0.5">
-            <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ item.agent_name }}</span>
+            <span
+              class="text-sm font-semibold text-gray-900 dark:text-white"
+              :title="agentNameTooltip(agentsStore.agentRefForSlug(item.agent_name))"
+            >{{ item.agent_name }}</span>
             <span class="text-xs text-gray-400 dark:text-gray-500">&middot;</span>
             <span class="text-xs text-gray-400 dark:text-gray-500">{{ timeAgo(item.created_at) }}</span>
           </div>
@@ -169,6 +172,7 @@ import { ref, computed, watch } from 'vue'
 import { renderMarkdown } from '../../utils/markdown'
 import { useOperatorQueueStore } from '../../stores/operatorQueue'
 import { useAgentsStore } from '../../stores/agents'
+import { agentNameTooltip } from '../../utils/agentName'
 import AgentAvatar from '../AgentAvatar.vue'
 
 const props = defineProps({

--- a/src/frontend/src/components/operator/QueueItemDetail.vue
+++ b/src/frontend/src/components/operator/QueueItemDetail.vue
@@ -45,7 +45,7 @@
 
         <!-- Meta row -->
         <div class="mt-2 flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
-          <span class="inline-flex items-center gap-1">
+          <span class="inline-flex items-center gap-1" :title="agentNameTooltip(agentsStore.agentRefForSlug(item.agent_name))">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
             </svg>
@@ -193,8 +193,11 @@
 import { ref, watch, computed } from 'vue'
 import { renderMarkdown } from '../../utils/markdown'
 import { useOperatorQueueStore } from '../../stores/operatorQueue'
+import { useAgentsStore } from '../../stores/agents'
+import { agentNameTooltip } from '../../utils/agentName'
 
 const store = useOperatorQueueStore()
+const agentsStore = useAgentsStore()
 
 const item = computed(() => store.selectedItem)
 

--- a/src/frontend/src/components/operator/QueueList.vue
+++ b/src/frontend/src/components/operator/QueueList.vue
@@ -82,7 +82,7 @@
 
             <!-- Bottom row: agent + time + status -->
             <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-              <span class="truncate">{{ item.agent_name }}</span>
+              <span class="truncate" :title="agentNameTooltip(agentsStore.agentRefForSlug(item.agent_name))">{{ item.agent_name }}</span>
               <span>&middot;</span>
               <span class="flex-shrink-0">{{ timeAgo(item.created_at) }}</span>
               <span v-if="item.status !== 'pending'" class="flex-shrink-0">
@@ -117,8 +117,11 @@
 <script setup>
 import { h } from 'vue'
 import { useOperatorQueueStore } from '../../stores/operatorQueue'
+import { useAgentsStore } from '../../stores/agents'
+import { agentNameTooltip } from '../../utils/agentName'
 
 const store = useOperatorQueueStore()
+const agentsStore = useAgentsStore()
 
 function priorityColor(priority) {
   const colors = {

--- a/src/frontend/src/components/operator/ResolvedCard.vue
+++ b/src/frontend/src/components/operator/ResolvedCard.vue
@@ -7,7 +7,10 @@
       <!-- Content -->
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2 mb-0.5">
-          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ item.agent_name }}</span>
+          <span
+            class="text-sm font-medium text-gray-700 dark:text-gray-300"
+            :title="agentNameTooltip(agentsStore.agentRefForSlug(item.agent_name))"
+          >{{ item.agent_name }}</span>
           <span class="text-xs text-gray-400 dark:text-gray-500">&middot;</span>
           <span class="text-xs text-gray-400 dark:text-gray-500">{{ timeAgo(item.created_at) }}</span>
         </div>
@@ -47,6 +50,7 @@
 import { computed } from 'vue'
 import { useOperatorQueueStore } from '../../stores/operatorQueue'
 import { useAgentsStore } from '../../stores/agents'
+import { agentNameTooltip } from '../../utils/agentName'
 import AgentAvatar from '../AgentAvatar.vue'
 
 const props = defineProps({

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -17,7 +17,7 @@
           @click="pickerOpen = !pickerOpen"
         >
           <PortalAvatar :name="agent.name" :avatar-url="agent.avatar_url" :size="26" />
-          <span class="font-semibold truncate">{{ agent.name }}</span>
+          <span class="font-semibold truncate">{{ agentDisplayName(agent) }}</span>
           <svg class="w-4 h-4 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
         </button>
         <div
@@ -33,7 +33,7 @@
             <PortalAvatar :name="a.name" :avatar-url="a.avatar_url" :size="28" />
             <span class="min-w-0">
               <span class="block text-sm font-medium truncate">
-                {{ a.name === agent.name ? a.name : `New chat with ${a.name}` }}
+                {{ a.name === agent.name ? agentDisplayName(a) : `New chat with ${agentDisplayName(a)}` }}
               </span>
               <span v-if="a.description" class="block text-xs text-gray-400 truncate">{{ a.description }}</span>
             </span>
@@ -152,7 +152,7 @@
             ref="textarea"
             v-model="input"
             rows="1"
-            :placeholder="listening ? 'Listening…' : `Message ${agent.name}…`"
+            :placeholder="listening ? 'Listening…' : `Message ${agentDisplayName(agent)}…`"
             class="flex-1 resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
             @input="autoGrow"
             @keydown.enter.exact.prevent="send"
@@ -177,6 +177,7 @@
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
 import { renderMarkdown } from '@/utils/markdown'
+import { agentDisplayName } from '@/utils/agentName'
 import PortalAvatar from './PortalAvatar.vue'
 
 const props = defineProps({

--- a/src/frontend/src/components/portal/PortalFilesPanel.vue
+++ b/src/frontend/src/components/portal/PortalFilesPanel.vue
@@ -13,7 +13,7 @@
     >
       <div class="shrink-0 flex items-center justify-between px-4 h-14 border-b border-gray-200 dark:border-gray-800">
         <div class="min-w-0">
-          <div class="font-medium truncate">Files · {{ agent.name }}</div>
+          <div class="font-medium truncate">Files · {{ agentDisplayName(agent) }}</div>
           <div class="text-xs text-gray-400">Send files to the agent or download what it shares</div>
         </div>
         <button class="p-2 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200" aria-label="Close" @click="$emit('close')">
@@ -28,7 +28,7 @@
           :class="[dragging ? 'border-action-primary-500 bg-action-primary-50 dark:bg-action-primary-900/20' : 'border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800', uploading ? 'opacity-60 pointer-events-none' : '']"
         >
           <svg class="w-6 h-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.9A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" /></svg>
-          <span class="font-medium">{{ uploading ? 'Sending…' : `Drop a file, or click to send to ${agent.name}` }}</span>
+          <span class="font-medium">{{ uploading ? 'Sending…' : `Drop a file, or click to send to ${agentDisplayName(agent)}` }}</span>
           <input type="file" class="hidden" :disabled="uploading" @change="onPick" />
         </label>
         <p v-if="uploadMsg" class="mt-2 text-xs" :class="uploadMsg.type === 'error' ? 'text-status-danger-600 dark:text-status-danger-400' : 'text-status-success-600 dark:text-status-success-400'">{{ uploadMsg.text }}</p>
@@ -53,7 +53,7 @@
             </ul>
           </section>
           <section>
-            <h4 class="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-2">Files from {{ agent.name }}</h4>
+            <h4 class="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-2">Files from {{ agentDisplayName(agent) }}</h4>
             <div v-if="error" class="text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</div>
             <div v-else-if="!docs.length" class="text-xs text-gray-400 py-1">Nothing shared with you yet.</div>
             <ul v-else class="space-y-2">
@@ -76,6 +76,7 @@
 <script setup>
 import { ref, onMounted, h } from 'vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
+import { agentDisplayName } from '@/utils/agentName'
 
 const props = defineProps({ agent: { type: Object, required: true } })
 defineEmits(['close'])
@@ -110,7 +111,7 @@ async function upload(file) {
   uploadMsg.value = null
   try {
     const res = await store.uploadDocument(props.agent.name, file)
-    uploadMsg.value = { type: 'success', text: `Sent “${res.filename || file.name}” to ${props.agent.name}.` }
+    uploadMsg.value = { type: 'success', text: `Sent “${res.filename || file.name}” to ${agentDisplayName(props.agent)}.` }
     await refreshUploads()
   } catch (err) {
     uploadMsg.value = { type: 'error', text: err.response?.data?.detail || 'Upload failed.' }

--- a/src/frontend/src/components/process/RoleMatrix.vue
+++ b/src/frontend/src/components/process/RoleMatrix.vue
@@ -72,7 +72,7 @@
               :key="agent"
               class="px-3 py-3 text-center font-medium text-gray-700 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700 min-w-[100px]"
             >
-              <div class="truncate max-w-[120px]" :title="agent">{{ agent }}</div>
+              <div class="truncate max-w-[120px]" :title="agentNameTooltip(agentsStore.agentRefForSlug(agent))">{{ agent }}</div>
             </th>
             <th
               v-if="editMode"
@@ -194,6 +194,12 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
 import { UsersIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
+import { useAgentsStore } from '../../stores/agents';
+import { agentNameTooltip } from '../../utils/agentName';
+
+// #1643: the 100px column header stays slug-only (RACI matrix is machine-facing);
+// the display name is one hover away via the title tooltip. No layout change.
+const agentsStore = useAgentsStore();
 
 const props = defineProps({
   // Steps array: [{ id, name, type, roles: { executor, monitors, informed } }, ...]

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -2,6 +2,20 @@ import { createRouter, createWebHistory } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useSessionsStore } from '../stores/sessions'
+import { useAgentsStore } from '../stores/agents'
+
+// #1643: browser-tab title for an agent-scoped page. The :name param stays the
+// canonical slug (routing/keys); the tab shows the human display name when the
+// agents store is warm, falling back to the slug on a cold direct load (the
+// store isn't fetched yet). SPA navigation self-heals to the label on the next
+// nav. try/catch guards the pre-pinia edge.
+function agentTabTitle(slug) {
+  try {
+    return useAgentsStore().displayNameForSlug(slug)
+  } catch {
+    return slug
+  }
+}
 
 const routes = [
   {
@@ -45,13 +59,14 @@ const routes = [
     name: 'AgentDetail',
     component: () => import('../views/AgentDetail.vue'),
     // #1418 — the :name param IS the canonical agent identifier in Trinity.
-    meta: { requiresAuth: true, title: (to) => to.params.name }
+    // #1643 — the rendered tab title resolves to the display name (slug fallback).
+    meta: { requiresAuth: true, title: (to) => agentTabTitle(to.params.name) }
   },
   {
     path: '/agents/:name/workspace',
     name: 'AgentWorkspace',
     component: () => import('../views/AgentWorkspace.vue'),
-    meta: { requiresAuth: true, title: (to) => `${to.params.name} · Workspace` },
+    meta: { requiresAuth: true, title: (to) => `${agentTabTitle(to.params.name)} · Workspace` },
     beforeEnter: async (to, from) => {
       const sessionsStore = useSessionsStore()
       await sessionsStore.loadFeatureFlags()
@@ -90,7 +105,7 @@ const routes = [
     path: '/agents/:name/executions/:executionId',
     name: 'ExecutionDetail',
     component: () => import('../views/ExecutionDetail.vue'),
-    meta: { requiresAuth: true, title: (to) => `${to.params.name} · Execution` }
+    meta: { requiresAuth: true, title: (to) => `${agentTabTitle(to.params.name)} · Execution` }
   },
   // REMOVED: /files route - file management is now per-agent via Files tab in AgentDetail
   // REMOVED: /credentials route - credentials are now managed per-agent only

--- a/src/frontend/src/stores/agents.js
+++ b/src/frontend/src/stores/agents.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import axios from 'axios'
 import { useAuthStore } from './auth'
 import { useNetworkStore } from './network'
+import { agentDisplayName } from '../utils/agentName'
 
 export const useAgentsStore = defineStore('agents', {
   state: () => ({
@@ -18,6 +19,21 @@ export const useAgentsStore = defineStore('agents', {
   }),
 
   getters: {
+    // #1643: slug → human display name, resolved off the loaded agents.
+    // Operational payloads (executions, operator queue, monitoring) carry only
+    // the slug; this is the single slug→display resolver so those dense surfaces
+    // never grow a mutable presentation field of their own. It stays live via
+    // the agent_label_changed WS handler that updates the cached agent. Unknown
+    // slug (agent not loaded / already gone) → the slug itself.
+    displayNameForSlug() {
+      return (slug) => agentDisplayName(this.agents.find(a => a.name === slug) || slug)
+    },
+    // #1643: the agent object for a slug, or the bare slug when not loaded — feed
+    // it to agentNameTooltip / hasDistinctLabel where a dense row keeps the slug
+    // primary and shows the label on hover.
+    agentRefForSlug() {
+      return (slug) => this.agents.find(a => a.name === slug) || slug
+    },
     // Filter out system agents for regular lists
     userAgents() {
       return this.agents.filter(agent => !agent.is_system)

--- a/src/frontend/src/stores/network.js
+++ b/src/frontend/src/stores/network.js
@@ -508,7 +508,11 @@ export const useNetworkStore = defineStore('network', () => {
         id: systemAgent.name,
         type: 'system-agent',
         data: {
+          // #1643: `label` stays the SLUG — AgentNode keys router.push /
+          // toggleAutonomy / toggleAgentRunning on it. `display_label` is the
+          // human name the node renders; NULL means render the slug.
           label: systemAgent.name,
+          display_label: systemAgent.display_label || null,
           status: systemAgent.status,
           type: systemAgent.type || 'system',
           owner: systemAgent.owner,
@@ -542,7 +546,10 @@ export const useNetworkStore = defineStore('network', () => {
           id: agent.name,
           type: 'agent',
           data: {
+            // #1643: `label` stays the SLUG (node action key); `display_label`
+            // is the rendered human name (NULL → render the slug).
             label: agent.name,
+            display_label: agent.display_label || null,
             status: agent.status,
             owner: agent.owner,
             runtime: agent.runtime || 'claude-code',
@@ -632,6 +639,12 @@ export const useNetworkStore = defineStore('network', () => {
               agent_name: data.name,
               status: data.type === 'agent_started' ? 'running' : 'stopped'
             })
+          } else if (data.type === 'agent_label_changed') {
+            // ent#181/#1643: fields are nested under data.data (agent_* shape)
+            handleAgentLabelChanged({
+              agent_name: data.data?.name,
+              display_label: data.data?.display_label
+            })
           } else if (data.type === 'agent_deleted') {
             handleAgentDeleted(data)
           } else if (data.type === 'agent_activity') {
@@ -716,6 +729,19 @@ export const useNetworkStore = defineStore('network', () => {
     const agent = agents.value.find(a => a.name === event.agent_name)
     if (agent) {
       agent.status = event.status
+    }
+  }
+
+  function handleAgentLabelChanged(event) {
+    // #1643: a label change is a pure re-render — the slug (node id / data.label)
+    // never moves, so only data.display_label updates.
+    const node = nodes.value.find(n => n.id === event.agent_name)
+    if (node) {
+      node.data.display_label = event.display_label || null
+    }
+    const agent = agents.value.find(a => a.name === event.agent_name)
+    if (agent) {
+      agent.display_label = event.display_label || null
     }
   }
 

--- a/src/frontend/src/views/AgentBrainOrb.vue
+++ b/src/frontend/src/views/AgentBrainOrb.vue
@@ -15,7 +15,10 @@
 
       <AgentAvatar :name="agentName" :avatar-url="agent?.avatar_url" size="sm" class="flex-shrink-0" />
 
-      <span class="font-semibold text-sm text-white truncate">{{ agentName }}</span>
+      <span
+        class="font-semibold text-sm text-white truncate"
+        :title="agentNameTooltip(agent || agentName)"
+      >{{ agentDisplayName(agent) || agentName }}</span>
       <span class="text-xs text-gray-500 truncate hidden sm:inline">· The Self-Rendering Mind</span>
 
       <span
@@ -82,6 +85,7 @@ import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useSessionsStore } from '../stores/sessions'
 import AgentAvatar from '../components/AgentAvatar.vue'
+import { agentDisplayName, agentNameTooltip } from '../utils/agentName'
 
 const route = useRoute()
 const authStore = useAuthStore()

--- a/src/frontend/src/views/AgentWorkspace.vue
+++ b/src/frontend/src/views/AgentWorkspace.vue
@@ -15,7 +15,10 @@
 
       <AgentAvatar :name="agentName" :avatar-url="agent?.avatar_url" size="sm" class="flex-shrink-0" />
 
-      <span class="font-semibold text-sm text-white truncate">{{ agentName }}</span>
+      <span
+        class="font-semibold text-sm text-white truncate"
+        :title="agentNameTooltip(agent || agentName)"
+      >{{ agentDisplayName(agent) || agentName }}</span>
 
       <span
         v-if="agent"
@@ -288,6 +291,7 @@ import { useAgentsStore } from '../stores/agents'
 import { useVoiceSession } from '../composables/useVoiceSession'
 import { renderMarkdown } from '../utils/markdown'
 import AgentAvatar from '../components/AgentAvatar.vue'
+import { agentDisplayName, agentNameTooltip } from '../utils/agentName'
 import { VOICES, DEFAULT_VOICE_NAME } from '../constants/voices'
 // Mermaid renders in-parent (not in a sandboxed iframe): the production CSP
 // (script-src 'self') blocks inline scripts in a srcdoc iframe, and CORP blocks

--- a/src/frontend/src/views/Agents.vue
+++ b/src/frontend/src/views/Agents.vue
@@ -1096,8 +1096,8 @@ async function handleReadOnlyToggle(agent) {
       agentReadOnlyStates.value[agent.name] = newState
       showNotification(
         newState
-          ? `Read-only mode enabled for ${agent.name}`
-          : `Read-only mode disabled for ${agent.name}`,
+          ? `Read-only mode enabled for ${agentDisplayName(agent)}`
+          : `Read-only mode disabled for ${agentDisplayName(agent)}`,
         'success'
       )
     }
@@ -1117,7 +1117,7 @@ const toggleAgentRunning = async (agent) => {
     const result = await agentsStore.toggleAgentRunning(agent.name)
     if (result.success) {
       const action = result.status === 'running' ? 'started' : 'stopped'
-      showNotification(`Agent ${agent.name} ${action}`, 'success')
+      showNotification(`Agent ${agentDisplayName(agent)} ${action}`, 'success')
     } else {
       showNotification(result.error || 'Failed to toggle agent', 'error')
     }

--- a/src/frontend/src/views/ExecutionDetail.vue
+++ b/src/frontend/src/views/ExecutionDetail.vue
@@ -30,9 +30,10 @@
               <p class="text-sm text-gray-500 dark:text-gray-400">
                 <router-link
                   :to="{ name: 'AgentDetail', params: { name: agentName } }"
+                  :title="agentNameTooltip(agentsStore.agentRefForSlug(agentName))"
                   class="hover:text-action-primary-600 dark:hover:text-action-primary-400"
                 >
-                  {{ agentName }}
+                  {{ agentsStore.displayNameForSlug(agentName) }}
                 </router-link>
                 <span class="mx-2">/</span>
                 <span class="font-mono text-xs">{{ executionId.substring(0, 8) }}...</span>
@@ -187,9 +188,10 @@
             <span class="text-gray-500 dark:text-gray-400">Source Agent:</span>
             <router-link
               :to="{ name: 'AgentDetail', params: { name: execution.source_agent_name } }"
+              :title="agentNameTooltip(agentsStore.agentRefForSlug(execution.source_agent_name))"
               class="ml-2 text-action-primary-600 dark:text-action-primary-400 font-medium hover:underline"
             >
-              {{ execution.source_agent_name }}
+              {{ agentsStore.displayNameForSlug(execution.source_agent_name) }}
             </router-link>
           </div>
           <!-- MCP Key (for MCP calls) -->
@@ -406,10 +408,13 @@ import axios from 'axios'
 import { renderMarkdown } from '../utils/markdown'
 import { formatCost } from '../composables/useFormatters'
 import { useAuthStore } from '../stores/auth'
+import { useAgentsStore } from '../stores/agents'
+import { agentDisplayName, agentNameTooltip } from '../utils/agentName'
 
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const agentsStore = useAgentsStore()
 
 const agentName = computed(() => route.params.name)
 const executionId = computed(() => route.params.executionId)

--- a/src/frontend/src/views/MobileAdmin.vue
+++ b/src/frontend/src/views/MobileAdmin.vue
@@ -180,7 +180,7 @@
             <div v-else class="ops-list">
               <div v-for="item in queueItems" :key="item.id" class="ops-card">
                 <div class="ops-card-header">
-                  <span class="ops-agent-name">{{ item.agent_name }}</span>
+                  <span class="ops-agent-name" :title="agentNameTooltip(agentsStore.agentRefForSlug(item.agent_name))">{{ item.agent_name }}</span>
                   <span class="ops-priority" :class="'priority-' + item.priority">{{ item.priority }}</span>
                 </div>
                 <div class="ops-card-type">{{ item.request_type }}</div>
@@ -223,7 +223,7 @@
             <div v-else class="ops-list">
               <div v-for="notif in notifications" :key="notif.id" class="ops-card">
                 <div class="ops-card-header">
-                  <span class="ops-agent-name">{{ notif.agent_name }}</span>
+                  <span class="ops-agent-name" :title="agentNameTooltip(agentsStore.agentRefForSlug(notif.agent_name))">{{ notif.agent_name }}</span>
                   <span class="ops-priority" :class="'priority-' + notif.priority">{{ notif.priority }}</span>
                 </div>
                 <p class="ops-card-message">{{ notif.title || notif.message }}</p>
@@ -440,9 +440,12 @@ import { ref, computed, onMounted, onUnmounted, watch, reactive, nextTick } from
 import { useRoute } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
+import { useAgentsStore } from '../stores/agents'
+import { agentNameTooltip } from '../utils/agentName'
 
 const route = useRoute()
 const authStore = useAuthStore()
+const agentsStore = useAgentsStore()
 
 // ─── State ───────────────────────────────────────────────────────────────────
 

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -1284,7 +1284,7 @@
                                       :key="agent.name"
                                       :value="agent.name"
                                     >
-                                      {{ agent.name }}{{ agentSubscriptionMap[agent.name] ? ` (on ${agentSubscriptionMap[agent.name]})` : '' }}
+                                      {{ agentDisplayName(agent) }}{{ agentSubscriptionMap[agent.name] ? ` (on ${agentSubscriptionMap[agent.name]})` : '' }}
                                     </option>
                                   </select>
                                   <button
@@ -2253,6 +2253,8 @@ import { useRole } from '../composables/useRole'
 import { useBuildInfo } from '../composables/useBuildInfo'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
+import { useAgentsStore } from '../stores/agents'
+import { agentDisplayName } from '../utils/agentName'
 import { useSettingsStore } from '../stores/settings'
 import { useSessionsStore } from '../stores/sessions'
 import { useEnterpriseStore } from '../stores/enterprise'
@@ -2266,6 +2268,7 @@ import ConfirmDialog from '../components/ConfirmDialog.vue'
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
+const agentsStore = useAgentsStore()
 const settingsStore = useSettingsStore()
 // trinity-enterprise#85: refreshed after a Brain Orb flag change so the
 // admin's own Brain tab / route gating updates without a page reload.
@@ -3967,7 +3970,7 @@ async function assignAgentToSubscription(subName, agentName) {
 }
 
 async function unassignAgentFromSubscription(agentName) {
-  if (!confirm(`Remove "${agentName}" from this subscription?\n\nIf the agent is running, it will be restarted.`)) return
+  if (!confirm(`Remove "${agentsStore.displayNameForSlug(agentName)}" from this subscription?\n\nIf the agent is running, it will be restarted.`)) return
   unassigningAgent.value = agentName
   error.value = null
   try {


### PR DESCRIPTION
## What

Follow-up **5/5** of the #964 display-name track — spread the agent display label to the surfaces the ent#181 foundation (#1676) didn't reach: operator queue, monitoring, executions, the collaboration graph, tab titles, and prose/toasts.

Builds directly on #1676 (merged to `dev`): `agent_ownership.display_label`, `GET`/`PUT /label`, the `utils/agentName.js` resolver, and the `agent_label_changed` WS handler already ship. **No backend change here.**

## The decision (AC #1)

Dense operational surfaces (executions, operator queue, monitoring) read only the **slug** from their own API payloads. Rather than add a mutable `display_name` to each of those high-volume endpoints — staleness risk + N sources of truth — the label is resolved **on the frontend off the loaded agents**, from one place, staying live via the existing `agent_label_changed` handler:

- `agentsStore.displayNameForSlug(slug)` → label or slug (prose)
- `agentsStore.agentRefForSlug(slug)` → agent object or bare slug (feeds `agentNameTooltip`)

An unloaded slug falls back to itself, so a cold surface never regresses. Recorded as requirements **§1.3.1 FR-6**.

## Render rule by class (#964)

| Class | Rule | Surfaces |
|-------|------|----------|
| Dense operational tables | **slug primary**, label as hover tooltip | ExecutionsPanel · operator QueueCard/QueueList/QueueItemDetail/ResolvedCard/NotificationsPanel · MonitoringPanel (alert + health) · MobileAdmin ops/notif · RoleMatrix (100px, slug-only + tooltip) |
| Prose / toasts | **label alone** | Agents.vue toasts · Settings.vue confirm + subscription option · PortalConversation header/switcher/placeholder · PortalFilesPanel headings/toast |
| Collaboration graph | render label, **`data.label` stays the slug** (action key) | network.js node data (agent + system) + live handler · AgentNode |
| Reviewed case-by-case | label + slug link / tooltip | ExecutionDetail breadcrumb + source-agent · PermissionsPanel · ReplayTimeline · FoldersPanel · AgentWorkspace + AgentBrainOrb headers |

Notes:
- **`AgentAvatar` always receives the slug** (incl. every touched surface).
- **Comma-joined lists** (GitHub-PAT propagation failure list) keep the slug — long labels make them unreadable (per the issue's own note).
- **Tab titles** resolve the label on warm SPA nav; a cold direct load shows the slug (store not fetched yet) and self-heals on the next nav. Explicit tradeoff, not slug-only.
- **Terminal header** stays slug (machine-facing).

## Verification

- All **20** touched SFCs compile via `@vue/compiler-sfc`; the **3** JS files pass `node --check`.
- `npm run build` is blocked by a **pre-existing** unrelated issue (`mermaid` declared but not installed, `AgentWorkspace.vue`) — same as noted on #1676; reproduces with this branch stashed.

## Scope boundary

#1643 depends on the #964 schema/API decision, which #1676 answered as `display_label`. #1639/#1640 (schema/API + endpoint) are now largely **redundant** with #1676 and #1641/#1642 (roomy surfaces / pickers) remain the sibling follow-ups — flagged for reconciliation, not touched here.

Related to #1643

🤖 Generated with [Claude Code](https://claude.com/claude-code)
