### PR TITLE
fix(operator-queue): normalize reserved-prefix guard against lookalikes (#1631 follow-up)

### DIFF
--- a/docs/security-reports/cso-2026-07-18.md
+++ b/docs/security-reports/cso-2026-07-18.md
@@ -1,0 +1,63 @@
+# CSO Audit — 2026-07-18
+
+- **Mode**: daily (`--diff`), 8/10 confidence gate
+- **Scope**: branch `feature/1631-operator-queue-id-collision` vs `origin/dev` (issue #1631)
+- **Phases run**: 0, 1, 2, 4, 7, 9 (scoped to diff), 12, 13, 14
+
+## Summary
+
+The #1631 change scopes operator-queue request-id uniqueness per agent (surrogate
+uuid PK + agent-authored `request_id` column with `UNIQUE(agent_name, request_id)`).
+Audit found **no CRITICAL/HIGH/MEDIUM findings**. One LOW (guard hardening) was
+surfaced and fixed in-branch. The change is a net security **improvement** — it
+closes a cross-agent write (agent B acknowledging its id flipped agent A's row).
+
+## Findings
+
+| # | Sev | Conf | Status | Category | Finding | File:Line |
+|---|-----|------|--------|----------|---------|-----------|
+| 1 | LOW | 7/10 | VERIFIED → FIXED | AI/Phishing | Reserved-prefix guard was exact-match; an agent could author a lookalike (not hijacking) platform-styled alert | `services/operator_queue_service.py:179` |
+
+### Finding 1 (FIXED in-branch)
+
+**Description.** The reserved-prefix hijack guard used case/whitespace-sensitive
+`req_id.startswith(_RESERVED_ID_PREFIXES)`. An agent could author an item with id
+`Poison-x` (capital P / leading space) that evaded the filter and appeared as a
+platform-styled operator alert with attacker-controlled text.
+
+**Exploit scenario.** A prompt-injected agent writes `{"id": " Poison-abc", "title":
+"Task failed — approve rollback", ...}` to its `~/.trinity/operator-queue.json`. The
+guard doesn't match; the item is created under the agent's own name and shown to the
+operator with platform-looking styling.
+
+**Why LOW.** It **cannot** suppress or overwrite the genuine platform alert — an
+independent refutation proved `evade ∧ collide` is unsatisfiable on the same
+`(agent_name, request_id)` slot (the only colliding string necessarily matches the
+prefix and is rejected). An agent can already author arbitrary operator-queue items,
+so this added only platform-*mimicry* polish, not a new capability. No execution is
+failed, nothing hidden.
+
+**Fix (shipped).** Normalize before the check: `req_id.strip().lower().startswith(...)`.
+The platform mints these prefixes lowercase and unpadded, so a normalized match can
+only be impersonation. Covered by `test_reserved_prefix_guard_folds_case_and_whitespace`.
+
+## Cleared (verified against the diff)
+
+- **SQL injection** — all changed DB code is SQLAlchemy Core, fully parameterized;
+  Alembic `0025` uses static-literal SQL. No interpolation of external input.
+- **XSS** — `request_id` (agent-controlled) renders via Vue `{{ }}` auto-escape, not
+  `v-html`.
+- **Auth boundary** — `item_exists` / `mark_acknowledged` gained a required
+  `agent_name` predicate (strictly tighter). Fixes the cross-agent acknowledge write.
+- **Alert hijack/suppression** — refuted end-to-end; impossible.
+- **New persisted agent data** (`request_id`) — same origin/exposure as the old global
+  `id` it replaces; net-zero new trust surface.
+- **Secrets / CI / infra** — the diff touches no workflow, compose, Dockerfile, `.env`,
+  or credential path.
+
+## STRIDE (delta only)
+
+Only the operator-queue ingest path changed. **Spoofing/Tampering**: an agent forging
+another agent's queue state is now blocked (per-agent scoping). **Repudiation**: reserved-
+prefix rejections log once per (agent, id). **EoP**: the mutating `mark_acknowledged`
+tightened from id-only to (agent, request_id). No new DoS/Info-Disclosure surface.

--- a/src/backend/services/operator_queue_service.py
+++ b/src/backend/services/operator_queue_service.py
@@ -175,8 +175,12 @@ class OperatorQueueSyncService:
 
             # #1631: reject an agent-authored id that impersonates a platform id
             # prefix (hijack/suppress guard). Log once per (agent, id) so it
-            # can't hot-loop the ~5s sync at WARNING.
-            if req_id.startswith(_RESERVED_ID_PREFIXES):
+            # can't hot-loop the ~5s sync at WARNING. Normalize before the check
+            # (case/whitespace-fold) so a lookalike like ` Poison-x` can't slip a
+            # platform-styled alert past the filter — the platform mints these
+            # prefixes lowercase and unpadded, so a normalized id that matches can
+            # only be an impersonation attempt.
+            if req_id.strip().lower().startswith(_RESERVED_ID_PREFIXES):
                 key = (agent_name, req_id)
                 if key not in self._rejected_reserved:
                     if len(self._rejected_reserved) >= _MAX_QUARANTINE_ENTRIES:

--- a/tests/unit/test_1631_operator_queue_agent_scoped_ids.py
+++ b/tests/unit/test_1631_operator_queue_agent_scoped_ids.py
@@ -204,3 +204,20 @@ def test_reserved_prefix_agent_ids_are_rejected_by_sync_loop(monkeypatch):
 
     # Warned exactly once for this (agent, id).
     assert svc._rejected_reserved == {("a", "poison-hijack")}
+
+
+def test_reserved_prefix_guard_folds_case_and_whitespace(monkeypatch):
+    """A lookalike id (` Poison-…`, uppercase/padded) must still be rejected —
+    the platform mints these prefixes lowercase and unpadded, so a normalized
+    match can only be an impersonation attempt (an operator-phishing surface)."""
+    db_mock = MagicMock()
+    db_mock.operator_queue_item_exists.return_value = False
+    db_mock.get_operator_queue_responded_for_agent.return_value = []
+    db_mock.get_operator_queue_terminal_for_agent.return_value = []
+
+    lookalikes = [_item(" Poison-x"), _item("SYNC-FAILING-x"), _item("\tgit-bloat-x")]
+    svc = _wire_sync(monkeypatch, db_mock, lookalikes)
+    asyncio.run(svc._sync_agent("a"))
+
+    # None of the lookalikes were created — all folded onto a reserved prefix.
+    assert db_mock.create_operator_queue_item.call_count == 0


### PR DESCRIPTION
## Summary

Fast-follow to #1684 (merged). The `/cso --diff` audit of the #1631 change found one **LOW**: the reserved-prefix hijack guard (`operator_queue_service.py`) was exact-match (`req_id.startswith(_RESERVED_ID_PREFIXES)`), so a prompt-injected agent could author an item with a **lookalike** id (`Poison-x`, uppercase/leading-space) that evaded the filter and appeared as a **platform-styled** operator alert with attacker text.

- **Not a hijack.** An independent refutation proved collision/suppression is impossible — the only id that can collide with the platform's real `poison-{execution_id}` slot *necessarily* starts with `poison-` and is rejected. Every evasion produces a *different*, non-colliding row. So this is operator-**phishing polish**, not a new capability (an agent can already author arbitrary queue items).
- **Fix:** normalize (`strip().lower()`) before the prefix check. The platform mints these prefixes lowercase and unpadded, so a normalized match can only be impersonation.

This hardening was committed during the audit but **stranded** when #1684 squash-merged mid-`/cso`; landing it on its own branch.

## Changes

- `src/backend/services/operator_queue_service.py` — `strip().lower().startswith(...)` in the reserved-prefix guard.
- `tests/unit/test_1631_operator_queue_agent_scoped_ids.py` — new `test_reserved_prefix_guard_folds_case_and_whitespace` (rejects ` Poison-x`, `SYNC-FAILING-x`, `\tgit-bloat-x`).
- `docs/security-reports/cso-2026-07-18.md` — the audit report.

## Test Plan

- [x] `tests/unit/test_1631_operator_queue_agent_scoped_ids.py` → `6 passed` (5 original + fold-case).
- [x] No behavior change to the legitimate path — agent-authored non-reserved ids are unaffected.

Refs #1631. Hardening follow-up to #1684.

Generated with [Claude Code](https://claude.com/claude-code)