### PR TITLE
feat(agents): agent display name in pickers, search, and sort (#1642)

### DIFF
--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -76,6 +76,23 @@
   store isn't fetched yet); the next navigation self-heals. Comma-joined agent
   lists (e.g. the GitHub-PAT propagation failure list) keep the slug — long
   labels make them unreadable.
+- **FR-7 — Findable by display name: pickers, search, sort (#1642)**: the
+  picker surface class carries the slug **inline** — `<option>`s render
+  `Display name (slug)` via `agentOptionLabel` (else the bare slug), and the
+  `<option>` **value stays the slug** so filtering/selection never keys on the
+  label. Six dropdowns: `ExecutionsPanel`, `ReportsPanelFleet`, operator
+  `QueueList` + `NotificationsPanel`, `FileManager`, `Settings` (subscription
+  assignment). `Agents.vue` name search matches **both** the slug and the
+  display name (case-insensitive) — otherwise typing "TOM" against a
+  `tom-marketing-ops` slug returns nothing. **Sort-key decision (AC):** the
+  "Name (A-Z / Z-A)" sort orders by the **display name when set, else the slug**
+  (`agentDisplayName`, in the store's `_getSortedAgents`) — sorting by the slug
+  while the row renders the label would order the list by an invisible key. Every
+  per-agent lookup (`getActivityState`/tags/stats/router actions) still keys on
+  `agent.name`; only the option label, the search predicate, and the sort
+  comparator changed. No store-shape change — the label is resolved off the
+  loaded agents (FR-6 resolvers), so `agentNames`/`availableAgents` stay
+  slug-string arrays.
 
 ### 1.4 Agent Deletion
 - **Status**: ✅ Implemented

--- a/src/frontend/src/components/ExecutionsPanel.vue
+++ b/src/frontend/src/components/ExecutionsPanel.vue
@@ -70,7 +70,7 @@
               : 'border border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'"
           >
             <option value="">All agents</option>
-            <option v-for="name in agentNames" :key="name" :value="name">{{ name }}</option>
+            <option v-for="name in agentNames" :key="name" :value="name">{{ agentOptionLabel(agentsStore.agentRefForSlug(name)) }}</option>
           </select>
           <svg class="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
         </div>
@@ -292,7 +292,7 @@ import { parseUTC } from '@/utils/timestamps'
 import { useExecutionsStore } from '../stores/executions'
 import { useAuthStore } from '../stores/auth'
 import { useAgentsStore } from '../stores/agents'
-import { agentNameTooltip } from '../utils/agentName'
+import { agentNameTooltip, agentOptionLabel } from '../utils/agentName'
 import { useWebSocket } from '../utils/websocket'
 
 const router = useRouter()

--- a/src/frontend/src/components/ReportsPanelFleet.vue
+++ b/src/frontend/src/components/ReportsPanelFleet.vue
@@ -24,7 +24,7 @@
         @change="store.setFilter('agent', $event.target.value)"
       >
         <option value="">All agents</option>
-        <option v-for="name in agentNames" :key="name" :value="name">{{ name }}</option>
+        <option v-for="name in agentNames" :key="name" :value="name">{{ agentOptionLabel(agentsStore.agentRefForSlug(name)) }}</option>
       </select>
       <select
         :value="store.filters.report_type"
@@ -100,6 +100,7 @@
 import { computed, onMounted, onUnmounted } from 'vue'
 import { useFleetReportsStore } from '../stores/reports'
 import { useAgentsStore } from '../stores/agents'
+import { agentOptionLabel } from '../utils/agentName'
 import ReportRenderer from './reports/ReportRenderer.vue'
 
 const store = useFleetReportsStore()

--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -13,7 +13,7 @@
           >
             <option value="">All Agents</option>
             <option v-for="agent in availableAgents" :key="agent" :value="agent">
-              {{ agent }}
+              {{ agentOptionLabel(agentsStore.agentRefForSlug(agent)) }}
             </option>
           </select>
         </div>
@@ -301,7 +301,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useNotificationsStore } from '../../stores/notifications'
 import { useAgentsStore } from '../../stores/agents'
-import { agentNameTooltip } from '../../utils/agentName'
+import { agentNameTooltip, agentOptionLabel } from '../../utils/agentName'
 import {
   XMarkIcon,
   CheckIcon,

--- a/src/frontend/src/components/operator/QueueList.vue
+++ b/src/frontend/src/components/operator/QueueList.vue
@@ -32,7 +32,7 @@
           class="flex-1 text-xs rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-blue-500 focus:border-blue-500"
         >
           <option value="">All Agents</option>
-          <option v-for="name in store.agentNames" :key="name" :value="name">{{ name }}</option>
+          <option v-for="name in store.agentNames" :key="name" :value="name">{{ agentOptionLabel(agentsStore.agentRefForSlug(name)) }}</option>
         </select>
         <select
           :value="store.filters.status"
@@ -118,7 +118,7 @@
 import { h } from 'vue'
 import { useOperatorQueueStore } from '../../stores/operatorQueue'
 import { useAgentsStore } from '../../stores/agents'
-import { agentNameTooltip } from '../../utils/agentName'
+import { agentNameTooltip, agentOptionLabel } from '../../utils/agentName'
 
 const store = useOperatorQueueStore()
 const agentsStore = useAgentsStore()

--- a/src/frontend/src/stores/agents.js
+++ b/src/frontend/src/stores/agents.js
@@ -67,11 +67,16 @@ export const useAgentsStore = defineStore('agents', {
           case 'created_asc':
             sorted.sort((a, b) => new Date(a.created || 0) - new Date(b.created || 0))
             break
+          // #1642: "Name (A-Z/Z-A)" sorts by what the user sees — the display
+          // name when set, else the slug (agentDisplayName). Sorting by the slug
+          // while the row renders the label would order the list by an invisible
+          // key. Actions still key on the slug elsewhere; only the sort comparator
+          // changes.
           case 'name_asc':
-            sorted.sort((a, b) => a.name.localeCompare(b.name))
+            sorted.sort((a, b) => agentDisplayName(a).localeCompare(agentDisplayName(b)))
             break
           case 'name_desc':
-            sorted.sort((a, b) => b.name.localeCompare(a.name))
+            sorted.sort((a, b) => agentDisplayName(b).localeCompare(agentDisplayName(a)))
             break
           case 'status':
             sorted.sort((a, b) => (b.status === 'running' ? 1 : 0) - (a.status === 'running' ? 1 : 0))

--- a/src/frontend/src/utils/agentName.js
+++ b/src/frontend/src/utils/agentName.js
@@ -53,3 +53,20 @@ export function agentNameTooltip(agent) {
   if (!hasDistinctLabel(agent)) return shown
   return `${shown} · ${agent.name}`
 }
+
+/**
+ * Label for an agent in a `<select>`/picker `<option>` (#1642). An `<option>`
+ * renders a single text line and can't carry a tooltip or a second field, so
+ * disambiguation goes inline: `Display name (slug)` when a distinct label is
+ * set, else the bare slug. The `<option>` **value** stays the slug — this is
+ * the display text only. Pickers are the surface class where "which agent is
+ * this?" matters most, hence the slug rides along here rather than being
+ * dropped (§1.3.1 FR-4, the #964 render rule).
+ * @param {{name?: string, display_label?: string|null}|string|null|undefined} agent
+ * @returns {string}
+ */
+export function agentOptionLabel(agent) {
+  const shown = agentDisplayName(agent)
+  if (!hasDistinctLabel(agent)) return shown
+  return `${shown} (${agent.name})`
+}

--- a/src/frontend/src/views/Agents.vue
+++ b/src/frontend/src/views/Agents.vue
@@ -829,10 +829,14 @@ const totalAgentCount = computed(() => {
 const displayAgents = computed(() => {
   let agents = isAdmin.value ? agentsStore.sortedAgentsWithSystem : agentsStore.sortedAgents
 
-  // Filter by name
+  // Filter by name — #1642: match BOTH the slug and the display name, so typing
+  // "TOM" finds an agent labelled "TOM" whose slug is `tom-marketing-ops`.
   const nameQuery = filterName.value.trim().toLowerCase()
   if (nameQuery) {
-    agents = agents.filter(agent => agent.name.toLowerCase().includes(nameQuery))
+    agents = agents.filter(agent =>
+      agent.name.toLowerCase().includes(nameQuery) ||
+      agentDisplayName(agent).toLowerCase().includes(nameQuery)
+    )
   }
 
   // Filter by status

--- a/src/frontend/src/views/FileManager.vue
+++ b/src/frontend/src/views/FileManager.vue
@@ -33,7 +33,7 @@
                 :key="agent.name"
                 :value="agent.name"
               >
-                {{ agent.name }}
+                {{ agentOptionLabel(agent) }}
               </option>
             </select>
             <button
@@ -282,6 +282,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useAgentsStore } from '@/stores/agents'
+import { agentOptionLabel } from '@/utils/agentName'
 import NavBar from '@/components/NavBar.vue'
 import FileTreeNode from '@/components/file-manager/FileTreeNode.vue'
 import FilePreview from '@/components/file-manager/FilePreview.vue'

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -1292,7 +1292,7 @@
                                       :key="agent.name"
                                       :value="agent.name"
                                     >
-                                      {{ agentDisplayName(agent) }}{{ agentSubscriptionMap[agent.name] ? ` (on ${agentSubscriptionMap[agent.name]})` : '' }}
+                                      {{ agentOptionLabel(agent) }}{{ agentSubscriptionMap[agent.name] ? ` (on ${agentSubscriptionMap[agent.name]})` : '' }}
                                     </option>
                                   </select>
                                   <button
@@ -2262,7 +2262,7 @@ import { useBuildInfo } from '../composables/useBuildInfo'
 import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useAgentsStore } from '../stores/agents'
-import { agentDisplayName } from '../utils/agentName'
+import { agentDisplayName, agentOptionLabel } from '../utils/agentName'
 import { useSettingsStore } from '../stores/settings'
 import { useSessionsStore } from '../stores/sessions'
 import { apiErrorMessage } from '../utils/apiError'


### PR DESCRIPTION
## What

Follow-up **4/5** of the #964 display-name track — make agents findable by their display name. Builds on the `display_label` foundation (#1676) and the frontend resolvers from #1643 (#1687), both already in `dev`.

## Changes (per the ACs)

- **Pickers carry the slug inline.** New `agentOptionLabel(agent)` → `Display name (slug)` when a distinct label is set, else the bare slug. Wired into all **six** `<option>` dropdowns — `ExecutionsPanel`, `ReportsPanelFleet`, operator `QueueList` + `NotificationsPanel`, `FileManager`, `Settings` (subscription assignment). Every `<option>` **value stays the slug**, so filter/select never keys on the label.
- **Search matches both fields.** `Agents.vue` name filter now matches slug **or** display name (case-insensitive) — fixes the exact bug in the issue: typing "TOM" against a `tom-marketing-ops` slug returned nothing.
- **Sort key — decided + documented (AC).** "Name (A-Z / Z-A)" sorts by the **display name when set, else the slug** (`agentDisplayName`, in the store's `_getSortedAgents`). Rationale: sorting by the slug while the row renders the label orders the list by an invisible key. (Recorded on #1642 and in requirements §1.3.1 FR-7.)

## Design decision — no store-shape change

The issue's AC suggested reshaping `agentNames` / `availableAgents` (bare slug-string arrays) into `{name, display_label}` objects. I took the lower-blast-radius path instead: resolve the label off the loaded agents via the FR-6 resolvers (`agentRefForSlug`), which stay live through the `agent_label_changed` WS handler. This keeps every existing consumer of those getters working, mirrors how #1643 solved "payloads only carry the slug", and degrades gracefully (an unloaded slug renders as itself). Same visible outcome — `Display (slug)` in the dropdowns — without touching four components' data contracts.

Every per-agent lookup (`getActivityState` / tags / stats / router actions) still keys on `agent.name`; only the option label, the search predicate, and the sort comparator changed.

## Verification

All 7 touched SFCs compile via `@vue/compiler-sfc`; the 2 JS files pass `node --check`; `agentOptionLabel` / the sort comparator / the dual-field search unit-verified (labelled → `TOM (tom-mktg)`, unlabelled → slug, sort orders by visible name, search matches both).

Related to #1642

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Fixes #1642
