### PR TITLE
fix(ui): Dashboard Timeline tile leads with the display name, slug beneath (#1641)

### DIFF
--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -163,12 +163,12 @@
                     <span
                       class="text-sm font-semibold text-gray-900 dark:text-white truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400"
                       @click="navigateToAgent(row.name)"
-                      :title="agentNameTooltip(agentsStore.agentRefForSlug(row.name))"
+                      :title="agentNameTooltip({ name: row.name, display_label: row.displayLabel })"
                     >
-                      {{ agentDisplayName(agentsStore.agentRefForSlug(row.name)) }}
+                      {{ agentDisplayName({ name: row.name, display_label: row.displayLabel }) }}
                     </span>
                     <span
-                      v-if="hasDistinctLabel(agentsStore.agentRefForSlug(row.name))"
+                      v-if="hasDistinctLabel({ name: row.name, display_label: row.displayLabel })"
                       class="text-[10px] text-gray-400 dark:text-gray-500 truncate leading-none"
                     >{{ row.name }}</span>
                   </div>
@@ -764,6 +764,11 @@ const agentRows = computed(() => {
 
     return {
       name: agent.name,
+      // #1641: the human label rides on the row, sourced from the same
+      // networkStore agent / node data this tile is already built from — the
+      // Dashboard populates networkStore, NOT agentsStore, so resolving off the
+      // agents store here renders the slug for everyone.
+      displayLabel: agent.display_label || nodeData.display_label || null,
       status: agent.status,
       activities: bars,
       hasActivity,

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -155,13 +155,23 @@
                     ]"
                     :style="{ backgroundColor: getStatusDotColor(row) }"
                   ></div>
-                  <span
-                    class="text-sm font-semibold text-gray-900 dark:text-white truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400"
-                    @click="navigateToAgent(row.name)"
-                    :title="agentNameTooltip(agentsStore.agentRefForSlug(row.name))"
-                  >
-                    {{ row.name }}
-                  </span>
+                  <!-- #1641: roomy tile → display name primary, slug as a small
+                       secondary line (only when a distinct label is set, so an
+                       unlabelled agent renders exactly as before). Avatar +
+                       navigate + toggle all still key on row.name (the slug). -->
+                  <div class="flex flex-col min-w-0 leading-tight">
+                    <span
+                      class="text-sm font-semibold text-gray-900 dark:text-white truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400"
+                      @click="navigateToAgent(row.name)"
+                      :title="agentNameTooltip(agentsStore.agentRefForSlug(row.name))"
+                    >
+                      {{ agentDisplayName(agentsStore.agentRefForSlug(row.name)) }}
+                    </span>
+                    <span
+                      v-if="hasDistinctLabel(agentsStore.agentRefForSlug(row.name))"
+                      class="text-[10px] text-gray-400 dark:text-gray-500 truncate leading-none"
+                    >{{ row.name }}</span>
+                  </div>
                   <span
                     v-if="row.isSystemAgent"
                     class="ml-1.5 px-1 py-0.5 text-[10px] font-semibold rounded bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-900/50 dark:text-accent-purple-300 flex-shrink-0"
@@ -388,7 +398,7 @@ import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import { formatCostCompact } from '../composables/useFormatters'
 import { useRouter } from 'vue-router'
 import { useAgentsStore } from '../stores/agents'
-import { agentNameTooltip } from '../utils/agentName'
+import { agentNameTooltip, agentDisplayName, hasDistinctLabel } from '../utils/agentName'
 import { parseUTC, getTimestampMs, formatLocalTime } from '@/utils/timestamps'
 import AutonomyToggle from './AutonomyToggle.vue'
 import CapacityMeter from './CapacityMeter.vue'


### PR DESCRIPTION
## What

The Dashboard **Timeline** view's compact agent tiles were naming agents by the **slug** (e.g. `a2a-demo`), with the display name only in the hover tooltip. Spotted live: an agent labelled "Zeta Ops" still read `a2a-demo` on its tile.

That was the dense-table treatment #1643 applied when it bucketed `ReplayTimeline` with the operational rows. But this tile is **roomy** — `lg` avatar, three rows, autonomy toggle, capacity meter, 72px tall — so by the #964 render rule it's a roomy surface: **lead with the display name, keep the slug visible as secondary text.**

## Change

`ReplayTimeline.vue` name cell → a tight two-line stack:
- **display name** on the name line (`agentDisplayName`)
- the **slug** as a small muted line directly beneath — rendered **only when a distinct label is set** (`hasDistinctLabel`), so an unlabelled agent is byte-identical to before (slug on one line, no second row).

The hover tooltip still carries `label · slug`. `row.name` (the slug) still drives the avatar, `navigateToAgent`, and `toggleAutonomy` — display-only change.

## Verified on the live instance

With `a2a-demo` labelled "Zeta Ops" and `slack-tester` labelled "TOM Marketing":

```
a2a-demo      → primary "Zeta Ops"        slug line "a2a-demo"
slack-tester  → primary "TOM Marketing"   slug line "slack-tester"
cornelius     → primary "cornelius"       (no second line — unlabelled)
```

SFC compiles via `@vue/compiler-sfc`; behavior confirmed against the real fleet from `/api/agents`.

## Scope

Partially addresses **#1641** (roomy surfaces, #964 follow-up 3/5) and corrects the `ReplayTimeline` classification from #1643. Kept off the #1642 PR (pickers/search/sort) since it's a different surface class.

Related to #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
