### PR TITLE
fix(git-sync): ignore .claude/plugins/ so plugin caches aren't auto-committed (#1702)

### DIFF
--- a/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
+++ b/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
@@ -190,6 +190,7 @@ __pycache__/
 .claude/debug/
 .claude/sessions/
 .claude/shell-snapshots/
+.claude/plugins/
 # Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
 
 # Temporary files

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -924,6 +924,12 @@ _GITIGNORE_PATTERNS: Tuple[str, ...] = (
     ".claude/debug/",
     ".claude/sessions/",
     ".claude/shell-snapshots/",
+    # Marketplace plugin caches (#1702): Claude Code copies each installed
+    # plugin (skills/agents/hooks) into ~/.claude/plugins/cache/<plugin>@<ver>/.
+    # Since HOME == the agent's repo root, that lands in the working tree and
+    # the 15-min sync loop commits it (and every plugin update commits another
+    # copy) — repo bloat, same class as #1596. Re-installable, so never in git.
+    ".claude/plugins/",
     # Temporary files
     "*.log",
     "*.tmp",


### PR DESCRIPTION
## What

`_GITIGNORE_PATTERNS` in `git_service.py` ignored six `.claude/*` runtime dirs but **not `.claude/plugins/`**. Claude Code installs marketplace plugins into `~/.claude/plugins/cache/<plugin>@<version>/` (a full copy — skills, agents, hooks). Since an agent's `HOME` **is** its git repo root, that cache lands in the working tree and the 15-min sync loop auto-commits it — and every plugin update commits another copy. Same repo-bloat class as #1596, different writer, on a path users are steered onto (`/plugin marketplace add abilityai/abilities`, `/trinity:onboard`).

## Change

- Added `.claude/plugins/` to the "Claude Code runtime" block of `_GITIGNORE_PATTERNS`.
- Existing agents pick it up through the idempotent gitignore merge on the next Push, and any already-committed cache is untracked via the `git rm --cached` step `_migrate_workspace_gitignore` already runs (#1596) — stops future churn, doesn't shrink history.
- Kept the gitignore block in `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md` in sync — the `test_doc_and_constant_in_sync` guard fails CI if any `_GITIGNORE_PATTERNS` entry is missing from the doc.

## Open question (AC) — resolved

> does plugin *install state* need a committed manifest to survive a container recreate?

**Yes, and it's lost today.** `~/.claude.json` (the plugin manifest) is *also* gitignored, so a recreated agent silently loses its plugins. The right resolution per the AC: **keep the cache ignored** (it's re-installable and doesn't belong in git either way) and **track the persistence gap separately** → filed as **#1704**. This PR does not un-ignore anything.

## Verification

- `.claude/plugins/` is present in both the `_GITIGNORE_PATTERNS` tuple **and** the doc's `gitignore` block → `test_doc_and_constant_in_sync` passes (46 patterns, none missing).
- `git check-ignore` in a real repo confirms `.claude/plugins/cache/abilities@1.0/skills/x.md` is **ignored**.
- The compat static check `S-006` uses a hardcoded subset that doesn't include `plugins`, so its `_GOOD_GITIGNORE` fixture is unaffected (no test churn); the auto-fix still adds the pattern since `fixes.py` reuses `_GITIGNORE_PATTERNS`.
- `git_service.py` parses.

_(No live agent currently has a plugin installed, so the "plugin still loads" half of the AC's live check wasn't reproducible here — but the ignore semantics are proven and the merge/untrack mechanism is the same one #1596 runs in production for the sibling `.claude/*` patterns.)_

Related to #1702 · follow-up #1704

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Fixes #1702
