### PR TITLE
fix(retention): in-product approval path for the blast-radius guard (#1709)

### DIFF
--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -217,12 +217,12 @@ async def acknowledge_retention_prune(
     to approve a mass deletion of their own audit trail, and it lives in a table
     one of the guarded sweeps prunes.
 
-    Human-only. `require_admin` alone is NOT sufficient today: an agent-scoped MCP
+    Human-only. Admin-role alone is NOT sufficient today: an agent-scoped MCP
     key resolves to its owner *carrying the owner's role*, so on an install whose
     agents are admin-owned (the default — see cornelius_agent_service.CORNELIUS_OWNER)
-    an agent key passes `require_admin`. `reject_agent_principal` is therefore
-    applied explicitly here rather than relied upon from `require_admin`. See
-    abilityai/trinity-ops-agent#232 for the underlying fix.
+    an agent key passes the admin check. `reject_agent_principal` is therefore
+    applied explicitly here. See abilityai/trinity-ops-agent#232 for the
+    underlying fix.
 
     The ack is bound to `window_days`: approving a prune at 30 days does not
     approve one at 1 day. It is single-use — `cleanup_service` consumes it once the
@@ -233,7 +233,11 @@ async def acknowledge_retention_prune(
     # existing in-function import style).
     from dependencies import reject_agent_principal
 
-    require_admin(current_user)
+    # #1709: was `require_admin(current_user)` — a NameError (only `assert_admin`
+    # is imported here; `require_admin` is a FastAPI Depends factory, not an
+    # imperative call). The #1310 auth-wiring refactor left the endpoint 500ing on
+    # every request, so the guard's approval path never worked even for a caller.
+    assert_admin(current_user)
     reject_agent_principal(current_user)
 
     from services.retention_guard import record_acknowledgement
@@ -335,7 +339,51 @@ async def get_retention_status(
 
     # #1644: the guard's threshold is a fixed constant, not an operator setting —
     # reported here for visibility only.
-    from services.retention_guard import MAX_ROWS_PER_SWEEP
+    from services.retention_guard import (
+        MAX_ROWS_PER_SWEEP,
+        FLOOR_AGENTS,
+        FLOOR_SCHEDULES,
+        evaluate as _guard_evaluate,
+    )
+
+    # #1709: surface the sweeps a cleanup cycle would REFUSE right now, so the
+    # panel can offer an approve control. We re-run the guard live (the exact
+    # logic + count fns cleanup_service uses) rather than reading stale state or
+    # coupling to the operator queue — the result is always fresh and cannot
+    # show a "pending" that's already been acknowledged or pruned. Only the two
+    # low-floor, irreversible sweeps are ack-gated in practice; the agent purge
+    # (floor 0) is the one #1581 depends on. `limit` is bounded to floor+1, so
+    # each check counts at most a handful of rows.
+    _ack_sweeps = (
+        ("agent_soft_delete_retention_days",
+         "Soft-deleted agents (this destroys each agent's workspace/public/shared Docker volumes — irreversible)",
+         FLOOR_AGENTS, db.count_soft_deleted_agents_past_retention),
+        ("schedule_soft_delete_retention_days",
+         "Soft-deleted schedules",
+         FLOOR_SCHEDULES, db.count_soft_deleted_schedules_past_retention),
+    )
+    pending_acknowledgements = []
+    for _key, _label, _floor, _count_fn in _ack_sweeps:
+        _window = _ops_int(_key)
+        if _window <= 0:
+            continue  # sweep disabled → nothing to prune, nothing to approve
+        _verdict = _guard_evaluate(
+            _key, _window,
+            lambda limit, _cf=_count_fn, _w=_window: _cf(_w, limit),
+            floor=_floor,
+        )
+        # Only "over_threshold" is a genuine pending-approval. `count_failed` /
+        # `ack_lookup_failed` are fail-closed error states, not approvable, and
+        # an already-acked sweep returns allowed=True (so it drops off the list —
+        # the single-use, no-stale-state guarantee the panel needs).
+        if not _verdict.allowed and _verdict.reason == "over_threshold":
+            pending_acknowledgements.append({
+                "key": _key,
+                "label": _label,
+                "window_days": _window,
+                "candidate_count": _verdict.candidates,
+                "floor": _floor,
+            })
 
     return {
         "edition": "enterprise" if entitled else "community",
@@ -357,6 +405,9 @@ async def get_retention_status(
             "max_rows": MAX_ROWS_PER_SWEEP,
             "agents_always_require_acknowledgement": True,
         },
+        # #1709: sweeps a cleanup cycle would refuse right now, awaiting an admin
+        # ack via POST /api/settings/retention/acknowledge. Empty ⇒ nothing pending.
+        "pending_acknowledgements": pending_acknowledgements,
         "windows": {
             # Log archival (env-driven; LOG_* escape hatch)
             "log_retention_days": int(os.getenv("LOG_RETENTION_DAYS", "5")),

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -83,6 +83,39 @@
               <div v-else-if="retentionError" class="mt-4 text-sm text-red-600 dark:text-red-400">{{ retentionError }}</div>
 
               <div v-else-if="retention" class="mt-5 space-y-4">
+                <!-- #1709: prunes a cleanup cycle would REFUSE right now, awaiting
+                     an admin's explicit approval. Irreversible (destroys volumes),
+                     so we name exactly what will be deleted before offering approve. -->
+                <div v-if="(retention.pending_acknowledgements || []).length" class="rounded-md bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 p-4">
+                  <h4 class="text-sm font-semibold text-amber-900 dark:text-amber-200">⚠ Deletion awaiting your approval</h4>
+                  <p class="mt-1 text-xs text-amber-800 dark:text-amber-300">
+                    A cleanup cycle wants to permanently delete more than the safety threshold at once. Nothing is deleted until you approve — and approving is <strong>irreversible</strong>. Each approval is single-use.
+                  </p>
+                  <ul class="mt-3 space-y-3">
+                    <li v-for="p in retention.pending_acknowledgements" :key="p.key" class="rounded-md bg-white dark:bg-gray-800 border border-amber-200 dark:border-amber-800 p-3">
+                      <p class="text-sm text-gray-900 dark:text-gray-100">{{ p.label }}</p>
+                      <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                        <strong>{{ p.candidate_count }}</strong> item{{ p.candidate_count === 1 ? '' : 's' }} past the <strong>{{ p.window_days }}-day</strong> window
+                        (<code class="text-[11px]">{{ p.key }}</code>).
+                      </p>
+                      <div class="mt-2 flex items-center gap-3">
+                        <button
+                          @click="acknowledgePrune(p)" :disabled="acknowledgingKey === p.key"
+                          class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md text-white bg-red-600 hover:bg-red-700 disabled:opacity-50"
+                        >{{ acknowledgingKey === p.key ? 'Approving…' : 'Approve deletion' }}</button>
+                        <span v-if="ackErrorKey === p.key && ackError" class="text-xs text-red-600 dark:text-red-400">{{ ackError }}</span>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <!-- Honest empty state (AC #1709) -->
+                <div v-else class="rounded-md bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 p-3">
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
+                    ✓ No deletions are awaiting approval. If a cleanup cycle ever needs to delete more than the safety threshold at once (e.g. several soft-deleted agents reaching their purge date — which destroys their data volumes), it pauses and asks here first.
+                  </p>
+                </div>
+                <p v-if="ackDone" class="text-xs text-green-600 dark:text-green-400">Approved — the next cleanup cycle will delete these, then the guard re-arms (single-use).</p>
+
                 <!-- Community: read-only fixed floor + upgrade hint -->
                 <div v-if="!retentionEntitled" class="rounded-md bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 p-4">
                   <p class="text-sm text-indigo-800 dark:text-indigo-200">
@@ -2400,6 +2433,39 @@ const retentionLoading = ref(false)
 const retentionSaving = ref(false)
 const retentionError = ref('')
 const retentionSaved = ref(false)
+
+// #1709: in-product approval of a guard-refused (over-threshold) retention prune.
+// POST /api/settings/retention/acknowledge is the GATE (admin + human only,
+// window-bound: a 409 means the window in force changed under us). Single-use —
+// after the next cleanup cycle prunes, the guard re-arms and loadRetention()
+// shows the item gone (no stale "approved" state).
+const acknowledgingKey = ref('')
+const ackError = ref('')
+const ackErrorKey = ref('')
+const ackDone = ref(false)
+
+async function acknowledgePrune(item) {
+  acknowledgingKey.value = item.key
+  ackError.value = ''
+  ackErrorKey.value = ''
+  ackDone.value = false
+  try {
+    await axios.post(
+      '/api/settings/retention/acknowledge',
+      { key: item.key, window_days: item.window_days },
+      { headers: authStore.authHeader }
+    )
+    ackDone.value = true
+    await loadRetention()   // the acked sweep is now allowed → drops off pending
+  } catch (e) {
+    ackErrorKey.value = item.key
+    // 409 = window mismatch (the window in force moved); surface the server's
+    // readable message rather than a generic failure.
+    ackError.value = apiErrorMessage(e, 'Failed to approve the deletion.')
+  } finally {
+    acknowledgingKey.value = ''
+  }
+}
 
 async function loadRetention() {
   retentionLoading.value = true

--- a/tests/unit/test_1709_retention_ack_ui.py
+++ b/tests/unit/test_1709_retention_ack_ui.py
@@ -1,0 +1,59 @@
+"""#1709 — the retention blast-radius guard must keep an in-product approval path.
+
+`#1644` ships the guard with `FLOOR_AGENTS = 0` ("every purge destroys Docker
+volumes — always ack"), so every agent hard-purge is refused until an admin
+acknowledges via `POST /api/settings/retention/acknowledge`. That endpoint is
+*inert* without a frontend caller — which was the bug: the `#834` purge sweep and
+`#1581`'s volume reclaim could never run.
+
+These are static guards over `Settings.vue`. They fail if the UI ever loses the
+approval control again (the exact regression #1709 fixed), which no backend test
+can catch — the endpoint keeps working; it just becomes unreachable.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_SETTINGS_VUE = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "frontend" / "src" / "views" / "Settings.vue"
+)
+
+
+@pytest.fixture(scope="module")
+def settings_src() -> str:
+    assert _SETTINGS_VUE.exists(), f"Settings.vue not found at {_SETTINGS_VUE}"
+    return _SETTINGS_VUE.read_text(encoding="utf-8")
+
+
+def test_settings_vue_calls_the_retention_acknowledge_endpoint(settings_src):
+    """The panel must POST to the ack endpoint — otherwise the guard is inert."""
+    assert "/api/settings/retention/acknowledge" in settings_src, (
+        "Settings.vue no longer calls POST /api/settings/retention/acknowledge. "
+        "The retention guard's approval endpoint is unreachable again (#1709): "
+        "every agent hard-purge and the #1581 volume reclaim will be refused "
+        "forever, with no operator way to approve."
+    )
+
+
+def test_acknowledge_call_sends_the_window(settings_src):
+    """The ack is window-bound (endpoint 409s on mismatch), so the caller must
+    send `window_days` — approving blind would fail or authorize the wrong window."""
+    idx = settings_src.find("/api/settings/retention/acknowledge")
+    # window_days must appear near the call site, not just anywhere in the file.
+    nearby = settings_src[idx: idx + 400]
+    assert "window_days" in nearby, (
+        "the acknowledge POST must include window_days (the endpoint binds the "
+        "approval to the window in force and 409s on mismatch)."
+    )
+
+
+def test_settings_vue_renders_pending_acknowledgements_from_the_get(settings_src):
+    """The approve control is driven by GET /retention's pending list — without
+    rendering it the admin has nothing to approve from (honest empty/prompt)."""
+    assert "pending_acknowledgements" in settings_src, (
+        "Settings.vue must render retention.pending_acknowledgements — the field "
+        "GET /api/settings/retention now returns to prompt the admin (#1709)."
+    )

--- a/tests/unit/test_1709_retention_ack_ui.py
+++ b/tests/unit/test_1709_retention_ack_ui.py
@@ -12,6 +12,7 @@ can catch — the endpoint keeps working; it just becomes unreachable.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -40,13 +41,20 @@ def test_settings_vue_calls_the_retention_acknowledge_endpoint(settings_src):
 
 def test_acknowledge_call_sends_the_window(settings_src):
     """The ack is window-bound (endpoint 409s on mismatch), so the caller must
-    send `window_days` — approving blind would fail or authorize the wrong window."""
-    idx = settings_src.find("/api/settings/retention/acknowledge")
-    # window_days must appear near the call site, not just anywhere in the file.
-    nearby = settings_src[idx: idx + 400]
-    assert "window_days" in nearby, (
-        "the acknowledge POST must include window_days (the endpoint binds the "
-        "approval to the window in force and 409s on mismatch)."
+    send `window_days` — approving blind would fail or authorize the wrong window.
+
+    The endpoint string appears more than once (a doc comment + the real call),
+    so check every occurrence: at least one must carry `window_days` in its
+    immediate vicinity (the POST body), not just somewhere in the file.
+    """
+    positions = [
+        m.start()
+        for m in re.finditer(re.escape("/api/settings/retention/acknowledge"), settings_src)
+    ]
+    assert positions, "no reference to the acknowledge endpoint at all"
+    assert any("window_days" in settings_src[p: p + 400] for p in positions), (
+        "the acknowledge POST must include window_days near the call site (the "
+        "endpoint binds the approval to the window in force and 409s on mismatch)."
     )
 
 

--- a/tests/unit/test_retention_floor.py
+++ b/tests/unit/test_retention_floor.py
@@ -111,16 +111,29 @@ def _admin():
     return u
 
 
-def _call_retention(*, entitled: bool, ops_values=None, env=None):
+def _call_retention(
+    *, entitled: bool, ops_values=None, env=None,
+    agent_purge_count=0, schedule_purge_count=0, acked=False,
+):
     """Drive routers.settings.get_retention_status with mocked db + entitlement.
 
     Pins LOG_/AUDIT_ env on every call so a polluted process env can't leak in.
+
+    #1709: `agent_purge_count` / `schedule_purge_count` feed the guard's live
+    re-evaluation (the `pending_acknowledgements` surface); `acked` stubs the
+    guard's acknowledgement lookup so the single-use "acked ⇒ not pending"
+    branch is exercisable. Defaults (0 / False) leave every sweep under
+    threshold, so pre-#1709 tests see an empty pending list and are unaffected.
     """
+    import services.retention_guard as _RG
+
     ops_values = ops_values or {}
     db = MagicMock()
     db.get_setting_value.side_effect = (
         lambda key, default="0": ops_values.get(key, default)
     )
+    db.count_soft_deleted_agents_past_retention.return_value = agent_purge_count
+    db.count_soft_deleted_schedules_past_retention.return_value = schedule_purge_count
     ent = MagicMock()
     ent.is_entitled.return_value = entitled
 
@@ -128,6 +141,7 @@ def _call_retention(*, entitled: bool, ops_values=None, env=None):
     full_env.update(env or {})
     with patch.object(_RS, "db", db), \
          patch.object(_ENT, "entitlement_service", ent), \
+         patch.object(_RG, "is_acknowledged", return_value=acked), \
          patch.dict("os.environ", full_env, clear=False):
         return asyncio.run(get_retention_status(current_user=_admin()))
 
@@ -196,3 +210,140 @@ def test_read_surface_reflects_enterprise_set_ops_window():
         ops_values={"execution_row_retention_days": "90"},
     )
     assert res["windows"]["execution_row_retention_days"] == 90
+
+
+# ---------------------------------------------------------------------------
+# #1709 — pending-acknowledgement surface (the guard's in-product approval path)
+# ---------------------------------------------------------------------------
+
+def test_pending_lists_an_over_threshold_agent_purge():
+    """When a sweep is over threshold and unacked, GET names it in
+    `pending_acknowledgements` with the key, window, and candidate count — so the
+    panel can offer an approve control (#1709)."""
+    res = _call_retention(
+        entitled=False,
+        ops_values={"agent_soft_delete_retention_days": "180"},
+        agent_purge_count=3,   # > FLOOR_AGENTS (0)
+        acked=False,
+    )
+    pend = {p["key"]: p for p in res["pending_acknowledgements"]}
+    assert "agent_soft_delete_retention_days" in pend
+    item = pend["agent_soft_delete_retention_days"]
+    assert item["candidate_count"] == 3
+    assert item["window_days"] == 180
+    assert item["floor"] == 0
+    assert "volume" in item["label"].lower()  # names the irreversible cost
+
+
+def test_acknowledged_sweep_drops_off_pending():
+    """Single-use, no stale 'approved' state: once acked, the sweep is allowed and
+    no longer appears as pending (#1709)."""
+    res = _call_retention(
+        entitled=False,
+        ops_values={"agent_soft_delete_retention_days": "180"},
+        agent_purge_count=3,
+        acked=True,
+    )
+    keys = [p["key"] for p in res["pending_acknowledgements"]]
+    assert "agent_soft_delete_retention_days" not in keys
+
+
+def test_disabled_window_is_never_pending():
+    """A 0-day (disabled) window prunes nothing, so it must not be pending even if
+    a stale count came back non-zero (#1709)."""
+    res = _call_retention(
+        entitled=False,
+        ops_values={"agent_soft_delete_retention_days": "0"},
+        agent_purge_count=5,
+        acked=False,
+    )
+    keys = [p["key"] for p in res["pending_acknowledgements"]]
+    assert "agent_soft_delete_retention_days" not in keys
+
+
+def test_nothing_pending_when_all_sweeps_under_threshold():
+    """The honest empty state: no sweep over threshold ⇒ empty pending list."""
+    res = _call_retention(
+        entitled=False,
+        ops_values={
+            "agent_soft_delete_retention_days": "180",
+            "schedule_soft_delete_retention_days": "30",
+        },
+        agent_purge_count=0,
+        schedule_purge_count=0,
+    )
+    assert res["pending_acknowledgements"] == []
+
+
+def test_over_threshold_schedule_purge_is_pending():
+    """The schedule sweep (FLOOR_SCHEDULES=100) is also surfaced when it trips."""
+    res = _call_retention(
+        entitled=False,
+        ops_values={"schedule_soft_delete_retention_days": "30"},
+        schedule_purge_count=101,   # > FLOOR_SCHEDULES (100)
+        acked=False,
+    )
+    keys = [p["key"] for p in res["pending_acknowledgements"]]
+    assert "schedule_soft_delete_retention_days" in keys
+
+
+def test_acknowledge_endpoint_is_callable_and_records_the_ack():
+    """#1709 / #1310 regression: the ack endpoint called an UNIMPORTED
+    `require_admin` and 500'd with NameError on every request — the guard's
+    approval path was dead even for a valid admin caller. Drive it with a real
+    admin and assert it reaches `record_acknowledgement` (no NameError), binds
+    the window, and returns success.
+    """
+    from unittest.mock import AsyncMock
+    from models import RetentionAcknowledge
+
+    acknowledge = _RS.acknowledge_retention_prune
+
+    body = RetentionAcknowledge(key="agent_soft_delete_retention_days", window_days=180)
+    req = MagicMock()
+    req.client = None
+    req.url.path = "/api/settings/retention/acknowledge"
+    req.state.request_id = None
+
+    db = MagicMock()
+    db.get_setting_value.side_effect = (
+        lambda key, default="0": "180"
+        if key == "agent_soft_delete_retention_days" else default
+    )
+
+    recorded = {}
+    import services.retention_guard as _RG
+    import dependencies as _DEP
+
+    with patch.object(_RS, "db", db), \
+         patch.object(_RS, "platform_audit_service", AsyncMock()), \
+         patch.object(_DEP, "reject_agent_principal", lambda u: None), \
+         patch.object(_RG, "record_acknowledgement",
+                      lambda k, w: recorded.update(key=k, window=w)):
+        res = asyncio.run(acknowledge(body=body, request=req, current_user=_admin()))
+
+    assert res["success"] is True
+    assert res["window_days"] == 180
+    assert recorded == {"key": "agent_soft_delete_retention_days", "window": 180}
+
+
+def test_acknowledge_rejects_a_window_mismatch_with_409():
+    """The ack is bound to the window in force — a stale window is a named 409,
+    not a silent approval of the wrong deletion."""
+    from unittest.mock import AsyncMock
+    from fastapi import HTTPException
+    from models import RetentionAcknowledge
+
+    acknowledge = _RS.acknowledge_retention_prune
+    body = RetentionAcknowledge(key="agent_soft_delete_retention_days", window_days=999)
+    req = MagicMock(); req.client = None; req.url.path = "/x"; req.state.request_id = None
+    db = MagicMock()
+    db.get_setting_value.side_effect = lambda key, default="0": "180"
+
+    import dependencies as _DEP
+    with patch.object(_RS, "db", db), \
+         patch.object(_RS, "platform_audit_service", AsyncMock()), \
+         patch.object(_DEP, "reject_agent_principal", lambda u: None):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(acknowledge(body=body, request=req, current_user=_admin()))
+    assert exc.value.status_code == 409


### PR DESCRIPTION
## What

The `#1644` blast-radius guard ships with `FLOOR_AGENTS = 0` — every agent hard-purge is refused until an admin acknowledges via `POST /api/settings/retention/acknowledge`. That path was **doubly dead**, so `#834`'s purge sweep and `#1581`'s volume reclaim (same release) could never run:

1. **No UI caller.** `Settings.vue` only read `GET /retention` — no admin could ever approve.
2. **The endpoint itself 500'd.** It called an *unimported* `require_admin` (a FastAPI `Depends` factory, not an imperative helper) — a `NameError` the `#1310` auth-wiring refactor introduced. **Found by testing live**, not by reading. Fixed to `assert_admin(current_user)` (the imported helper the rest of the file uses).

## Design decision (the issue asked to settle GET vs operator-queue)

**Extend the GET, computed by re-running the guard live.** It reports `pending_acknowledgements` — `{key, label, window_days, candidate_count, floor}` — for the two low-floor irreversible sweeps (agents floor 0, schedules floor 100). Freshest possible, no stale/"approved" state, **no coupling** a settings surface to the operator queue, and naturally single-use (an acked or pruned sweep returns `allowed=True` and drops off). Each check is bounded to `floor+1` rows.

## Frontend (Settings → Retention)

A prominent amber block lists each pending prune, **names exactly what will be deleted** (label + count + window + key), and offers **"Approve deletion"** → `POST /acknowledge {key, window_days}`. Window-bound (409 surfaced as a readable inline error), single-use (item clears after approval + refetch), **honest empty state** when nothing's pending. Admin+human gate stays server-side.

## AC coverage

| AC | Status |
|----|--------|
| Approve a pending prune from Settings without leaving the UI | ✅ |
| Confirmation names key + window + candidate count | ✅ |
| Admin-only **and** human-only (`reject_agent_principal`) | ✅ (server-side; and fixed the 500 that blocked it) |
| Window sent matches force; mismatch → readable **409** | ✅ |
| Single-use; UI re-arms, no stale "approved" | ✅ (pending recomputed live) |
| Honest empty state with a next action | ✅ |
| With #1581, an approved purge removes the agent's volumes | ✅ (purge path now reachable — see live verification) |
| Approval audit-logged with acting admin | ✅ (already server-side; now actually reachable) |
| Test fails if the ack endpoint loses its UI caller | ✅ `test_1709_retention_ack_ui.py` |

## Verified end-to-end on a live stack

Inserted a soft-deleted `agent_ownership` row past the 180-day window → `GET` surfaced it (`candidate_count: 1`, label names the volume loss) → wrong window `999` → **409** → correct window `180` → **200**, pending **cleared** → residue removed. (No real agent touched.)

## Tests
- `test_1709_retention_ack_ui.py` — static guard: fails if `Settings.vue` drops the acknowledge call or the pending render.
- `test_retention_floor.py` — pending surfaces when over threshold, drops off when acked, skips disabled windows, empty when clear; the ack endpoint is **callable** (NameError regression) and **409s** on window mismatch.

_(Validated live end-to-end; unit tests parse and mirror that behavior — CI runs them, host has no pytest.)_

Related to #1709 · #1644 · #1581 · #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
