### PR TITLE
fix(reliability): honest per-agent circuit-breaker toggle in Settings (#1712)

### DIFF
--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -56,7 +56,12 @@ jobs:
     # Per-PR diff job — no base/head exists on a push, so skip there.
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The suite runs ~7-8 min on a normal runner, but GitHub's shared runners
+    # vary ~2-2.5x; a slow one was hitting the old 15-min cap at ~78% done and
+    # getting killed (a spurious red — the tests were all passing). 25 gives real
+    # headroom for the slow tail without masking a genuine hang (pytest-timeout
+    # still bounds any single test).
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/src/frontend/src/components/ReliabilityPanel.vue
+++ b/src/frontend/src/components/ReliabilityPanel.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="p-6">
+    <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Reliability — dispatch circuit breaker</h3>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      When this agent's task dispatch keeps failing with auth/billing errors, the
+      breaker trips and fast-fails new tasks (instead of burning retries) until it
+      recovers. Opt-in per agent (#526).
+    </p>
+
+    <div v-if="statusLoading" class="text-sm text-gray-400">Loading…</div>
+
+    <div v-else>
+      <!-- Honest state when the platform-wide master switch is OFF (#1712).
+           We name the reason (global flag) and the remedy (an admin sets it),
+           rather than silently accepting the toggle and reporting success. -->
+      <div
+        v-if="!globalEnabled"
+        class="mb-4 rounded-md bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 p-3"
+      >
+        <p class="text-sm font-medium text-amber-900 dark:text-amber-200">Globally disabled — this toggle won't take effect yet</p>
+        <p class="mt-1 text-xs text-amber-800 dark:text-amber-300">
+          The platform-wide dispatch breaker is off, so per-agent breakers never
+          engage regardless of this setting.
+          <span class="font-medium">Remedy:</span> an admin must set
+          <code class="font-mono text-[11px] bg-amber-100 dark:bg-amber-800/60 px-1 py-0.5 rounded">DISPATCH_BREAKER_ENABLED=true</code>
+          in the platform environment (then restart). Your choice below is saved
+          and applies automatically once that's on.
+        </p>
+      </div>
+
+      <!-- Toggle — stays operable even when globally off (the owner may pre-set
+           their preference), but the state above makes the inertness explicit. -->
+      <div class="flex items-start gap-3">
+        <label class="relative inline-flex items-center cursor-pointer mt-0.5">
+          <input
+            type="checkbox"
+            class="sr-only peer"
+            :checked="enabled"
+            :disabled="toggleLoading"
+            @change="onToggle($event.target.checked)"
+          />
+          <div class="w-11 h-6 bg-gray-200 dark:bg-gray-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-action-primary-600"></div>
+        </label>
+        <div class="min-w-0">
+          <p class="text-sm text-gray-900 dark:text-gray-100">
+            Enable the dispatch breaker for this agent
+            <span
+              v-if="enabled && !globalEnabled"
+              class="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-300"
+            >saved · inactive</span>
+            <span
+              v-else-if="enabled && globalEnabled"
+              class="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300"
+            >active</span>
+          </p>
+          <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            Both this toggle <em>and</em> the platform-wide flag must be on for the breaker to engage.
+          </p>
+          <p v-if="lastMessage" class="mt-1 text-xs" :class="lastMessageOk ? 'text-green-600 dark:text-green-400' : 'text-amber-700 dark:text-amber-400'">
+            {{ lastMessage }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import api from '../api'
+
+const props = defineProps({
+  agentName: { type: String, required: true },
+  // Positional (message, type) — same contract as the other settings panels.
+  notify: { type: Function, default: null },
+})
+
+function notifyUser(message, type = 'success') {
+  if (props.notify) props.notify(message, type)
+}
+
+const enabled = ref(false)
+const globalEnabled = ref(true)   // assume-on until we learn otherwise, so we
+                                  // never flash a false "globally disabled" banner
+const statusLoading = ref(false)
+const toggleLoading = ref(false)
+const lastMessage = ref('')
+const lastMessageOk = ref(true)
+
+async function load() {
+  statusLoading.value = true
+  try {
+    const { data } = await api.get(`/api/agents/${props.agentName}/circuit-breaker`)
+    // #1712: consume config.global_enabled from the endpoint rather than
+    // inferring — honest state on every (re)load, including a persisted-but-inert "on".
+    enabled.value = !!data?.config?.enabled
+    globalEnabled.value = !!data?.config?.global_enabled
+  } catch (e) {
+    notifyUser('Failed to load circuit-breaker settings.', 'error')
+  } finally {
+    statusLoading.value = false
+  }
+}
+
+async function onToggle(next) {
+  toggleLoading.value = true
+  lastMessage.value = ''
+  try {
+    const { data } = await api.put(`/api/agents/${props.agentName}/circuit-breaker`, { enabled: next })
+    enabled.value = !!data?.enabled
+    globalEnabled.value = !!data?.global_enabled
+    if (data?.warning) {
+      // The endpoint tells us the save is inert while the global flag is off —
+      // surface it as the outcome, not a plain "Saved" (the #1712 honesty gap).
+      lastMessage.value = data.warning
+      lastMessageOk.value = false
+    } else {
+      lastMessage.value = next ? 'Enabled.' : 'Disabled.'
+      lastMessageOk.value = true
+    }
+  } catch (e) {
+    notifyUser('Failed to update the circuit breaker.', 'error')
+    await load()  // re-sync the toggle to the true persisted state
+  } finally {
+    toggleLoading.value = false
+  }
+}
+
+onMounted(load)
+</script>

--- a/src/frontend/src/components/settings/SettingsPanel.vue
+++ b/src/frontend/src/components/settings/SettingsPanel.vue
@@ -9,9 +9,10 @@
 
     Growth path (each a follow-up PR, endpoints already exist):
       Behavior/Execution (/autonomy, /read-only, /timeout, model, /capacity),
-      Resources (/resources), Reliability (/circuit-breaker),
+      Resources (/resources),
       Compute/Auth (api-key, /github-pat), Git sync (/git/auto-sync,
       /git/freeze-schedules-if-failing).
+    Reliability (/circuit-breaker) shipped as the ReliabilityPanel section (#1712).
   -->
   <div class="space-y-4">
     <!-- Section 1: Guardrails -->
@@ -27,6 +28,11 @@
     <!-- Section 3: Expose via MCP (#846) -->
     <section class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden p-6">
       <McpExposedPanel :agent-name="agentName" :notify="notify" />
+    </section>
+
+    <!-- Section 4: Reliability — dispatch circuit breaker (#526; honest toggle #1712) -->
+    <section class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <ReliabilityPanel :agent-name="agentName" :notify="notify" />
     </section>
 
     <!-- Section 4: Voice replies (ent#117) — agent-level enable + voice selection.
@@ -45,6 +51,7 @@
 import GuardrailsPanel from '../GuardrailsPanel.vue'
 import CapacityPanel from '../CapacityPanel.vue'
 import McpExposedPanel from '../McpExposedPanel.vue'
+import ReliabilityPanel from '../ReliabilityPanel.vue'
 import VoiceRepliesControl from '../VoiceRepliesControl.vue'
 
 defineProps({

--- a/tests/unit/test_1712_circuit_breaker_honest_toggle.py
+++ b/tests/unit/test_1712_circuit_breaker_honest_toggle.py
@@ -1,0 +1,71 @@
+"""#1712 — the per-agent circuit-breaker toggle must tell the honest truth.
+
+The dispatch breaker is two-tier: the per-agent `circuit_breaker_enabled` opt-in
+AND the platform-wide `DISPATCH_BREAKER_ENABLED` master switch must BOTH be on.
+The endpoint already returns `config.global_enabled` (GET) and a `warning` (PUT)
+when a toggle is inert. The residual (#1712) was the frontend: it reported
+success and said nothing. `ReliabilityPanel.vue` is the honest owner-facing
+control; these static guards fail if it loses the honesty again.
+
+Static, like the #1709 UI-caller guard — a passing endpoint contract can't catch
+a UI that ignores it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_FE = Path(__file__).resolve().parents[2] / "src" / "frontend" / "src"
+_PANEL = _FE / "components" / "ReliabilityPanel.vue"
+_SETTINGS = _FE / "components" / "settings" / "SettingsPanel.vue"
+
+
+@pytest.fixture(scope="module")
+def panel_src() -> str:
+    assert _PANEL.exists(), f"ReliabilityPanel.vue not found at {_PANEL}"
+    return _PANEL.read_text(encoding="utf-8")
+
+
+def test_panel_consumes_global_enabled_not_inferred(panel_src):
+    """AC: the frontend consumes `config.global_enabled` from the endpoint rather
+    than inferring the state."""
+    assert "global_enabled" in panel_src, (
+        "ReliabilityPanel must read config.global_enabled from the endpoint — "
+        "otherwise it can't tell the owner the breaker is globally disabled (#1712)."
+    )
+
+
+def test_panel_surfaces_the_endpoint_warning(panel_src):
+    """AC: it does not silently accept and report success — the PUT's `warning`
+    (inert-while-global-off) is surfaced as the outcome."""
+    assert "warning" in panel_src, (
+        "ReliabilityPanel must surface the PUT response's `warning` field so a "
+        "save made while the global flag is off isn't reported as plain success."
+    )
+
+
+def test_panel_names_the_reason_and_remedy(panel_src):
+    """AC: the UI names the reason (the global flag) and the remedy (an admin sets
+    it) — not only a disabled control."""
+    assert "DISPATCH_BREAKER_ENABLED" in panel_src, (
+        "ReliabilityPanel must name DISPATCH_BREAKER_ENABLED (the reason) and that "
+        "an admin sets it (the remedy) — a disabled toggle with no explanation is "
+        "the #1712 complaint."
+    )
+    assert "admin" in panel_src.lower()
+
+
+def test_panel_calls_the_circuit_breaker_endpoint(panel_src):
+    """The toggle drives the real endpoint (both GET to read state and PUT to set)."""
+    assert "/circuit-breaker" in panel_src
+
+
+def test_panel_is_wired_into_the_settings_tab():
+    """A component nobody renders is as inert as the bug it fixes — the panel must
+    be mounted in the agent Settings tab."""
+    settings = _SETTINGS.read_text(encoding="utf-8")
+    assert "ReliabilityPanel" in settings, (
+        "SettingsPanel.vue must render ReliabilityPanel — otherwise the honest "
+        "circuit-breaker toggle has no home (#1712)."
+    )


### PR DESCRIPTION
## What

The per-agent dispatch breaker is two-tier — per-agent `circuit_breaker_enabled` **and** the platform-wide `DISPATCH_BREAKER_ENABLED` must both be on. The endpoint already returns `config.global_enabled` (GET) and a `warning` (PUT) when a toggle is inert (#1491/#1499). The residual #1712 gap was the **UI**: there was no owner-facing toggle at all (a growth-path TODO in `SettingsPanel`), so the "control that reports success and does nothing" had no honest surface.

## Change — new `ReliabilityPanel.vue` (agent Settings tab)

- **Consumes `config.global_enabled`** from the endpoint (doesn't infer) → honest state on every load, including a persisted-but-inert "on".
- **Global flag OFF → names reason + remedy:** an amber notice explains the platform-wide breaker is off and that **an admin must set `DISPATCH_BREAKER_ENABLED=true`** in the environment. The toggle stays operable (owner may pre-set the preference) with a **"saved · inactive"** badge — it does *not* silently accept-and-succeed.
- **On save while global-off**, surfaces the endpoint's `warning` as the outcome (not a plain "Saved"). When both flags are on → **"active"** badge.

No change to gating semantics — `config.py` untouched, both flags still required.

## Open question (global default) — decided

Keep `DISPATCH_BREAKER_ENABLED=false` for this release. Flipping it to `true` would start engaging the breaker for any **already-opted-in** agent mid-freeze — a runtime behaviour change needing soak. The honest UI removes the confusion without that risk. Revisit post-freeze. (Recorded on #1712.)

## AC coverage

| AC | Status |
|----|--------|
| Global-off → toggle communicates it's globally disabled (no silent success) | ✅ |
| UI names the reason + remedy (not only disabled) | ✅ |
| Frontend consumes `config.global_enabled` | ✅ |
| Honest state on reload (no persisted-but-inert "on") | ✅ |
| Admins keep a discoverable path to the global setting | ✅ (names the env flag + who sets it) |
| No change to gating semantics | ✅ |

## Verified live

On this install `DISPATCH_BREAKER_ENABLED` is off → `GET .../circuit-breaker` returns `config.global_enabled:false`; `PUT {enabled:true}` returns the inert `warning`, which the panel surfaces. Static guards (`test_1712_*`) fail if the panel drops the `global_enabled` read, the warning surface, the reason/remedy copy, or its mount. Both SFCs compile.

Related to #1712 · #1487 · #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
