### PR TITLE
ci: raise backend-unit-test pytest timeout 15m → 25m (stop spurious runner-variance cancels)

### DIFF
--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -56,7 +56,12 @@ jobs:
     # Per-PR diff job — no base/head exists on a push, so skip there.
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The suite runs ~7-8 min on a normal runner, but GitHub's shared runners
+    # vary ~2-2.5x; a slow one was hitting the old 15-min cap at ~78% done and
+    # getting killed (a spurious red — the tests were all passing). 25 gives real
+    # headroom for the slow tail without masking a genuine hang (pytest-timeout
+    # still bounds any single test).
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Raises the `backend-unit-test.yml` pytest matrix job's `timeout-minutes` **15 → 25**.

## Why

The suite runs **~7-8 min** on a normal GitHub runner, but the shared runners vary **~2-2.5×**. A slow one sits at ~78% of the suite (all tests passing — pure dots in the log) when it hits the 15-min cap and gets **killed**. That surfaces as a red `pytest (…, seed …) fail` **plus** a `regression diff` fail — even though the diff itself reports **"✅ No new failures."**

Seen **three times this cycle** on PRs that can't possibly break pytest:
- **#1700** — Timeline tile (frontend-only)
- **#1712** — circuit-breaker toggle (frontend + one static file-reading test)
- **#1708** — installer/docs (zero Python)

Each needed a manual empty-commit/branch patch. This fixes it fleet-wide so no PR flakes on runner variance.

## Safety

25 min covers the observed ~19-min worst case with margin, and does **not** mask a genuine hang — `pytest-timeout` still bounds any single test. One-line, workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)