### PR TITLE
feat(telemetry): local product-event capture — activation funnel, Tier-1 (ent#184)

### DIFF
--- a/docs/PRODUCT_EVENTS.md
+++ b/docs/PRODUCT_EVENTS.md
@@ -1,0 +1,64 @@
+# Local Product Events — Activation Funnel (Tier-1)
+
+Trinity records a small set of **local, anonymous product events** so you — the
+operator — can see how your own first-run users move through setup and reach
+their first value. This is **Tier-1** of a two-tier telemetry model.
+
+> **This data never leaves your instance.** There is no network egress from this
+> layer. Events are written to your local database and read back only by you, on
+> your own admin surface. Sharing anything externally is a separate, explicitly
+> opt-in feature (Tier-2, not enabled by default and not part of this layer).
+
+## What is recorded
+
+**Onboarding-wizard step transitions** (emitted by the first-run wizard):
+
+| Event | Meaning |
+|-------|---------|
+| `setup_started` | The first-run wizard was opened |
+| `setup_step_create` | An intent was picked; advanced to the create form |
+| `setup_step_credential` | The first agent was created; reached the credential step |
+| `setup_completed` | The wizard was finished (opened chat / went to credentials) |
+| `setup_dismissed` | The wizard was closed before creating an agent |
+
+**First-value events** — `first_agent_created`, `first_chat`,
+`first_schedule_created`, `first_channel_connected`. These are **not** captured
+by a separate beacon; they are **derived on read** from data Trinity already
+records (the audit log and agent-activity timeline), so they cost no extra write
+path and survive restarts by construction.
+
+Each event carries:
+
+- a stable, random **installation id** (the same anonymous per-install id used by
+  the operator-intake correlation key — not tied to any user account),
+- a **UTC timestamp**, and
+- optionally a tiny, non-sensitive context blob (e.g. which starter intent was
+  picked). No message contents, credentials, emails, or PII are recorded.
+
+The emit endpoint accepts only the fixed allow-list of event types above; it
+cannot be used to store arbitrary data.
+
+## What is NOT recorded
+
+- No chat/message contents, no agent outputs.
+- No credentials, tokens, API keys, or emails.
+- No IP addresses or user identities beyond the anonymous install id.
+
+## Turning it off
+
+Capture is on by default and is intentionally lightweight (a handful of rows per
+install). Because it never phones home, there is no privacy reason to disable it.
+If you want zero local capture, you can drop the `product_events` rows at any
+time — nothing else depends on them:
+
+```sql
+DELETE FROM product_events;
+```
+
+## Viewing the funnel
+
+The operator-facing **Activation funnel** view (Settings → Activation) shows
+step-by-step activation counts, drop-off between steps, and the first-value
+tiles, with an honest empty state before any data exists. The funnel view is an
+entitlement-gated enterprise surface; the **capture** described above runs in
+every edition.

--- a/docs/memory/requirements/lifecycle-observability.md
+++ b/docs/memory/requirements/lifecycle-observability.md
@@ -323,6 +323,59 @@ endpoint — reports flow agent → MCP → backend.
 
 ---
 
+## 45. Local Product-Event Capture — Activation Funnel, Tier-1 (ent#184)
+
+**Description**: A **local-only** product-event capture layer — the **Tier-1**
+half of the two-tier telemetry model (Tier-2 = opt-in anonymized fleet sharing,
+#758 / trinity-enterprise#12, which builds on this). Tier-1 records
+activation/usage events **on the operator's own instance, default-ON, with zero
+network egress**, so the operator can see where their own first-run users drop
+off. It is *not* a sovereignty concern — nothing leaves the box — and is distinct
+from the identifiable opt-in operator intake (§43.1): this is anonymous,
+instance-local instrumentation keyed by the same `installation_id`.
+
+**Open-core split** (product decision, gating confirmed ent#184): the **capture**
+is OSS-core (the edition-agnostic instrumentation primitive, default-on); the
+operator-facing **activation-funnel view** is an entitlement-gated enterprise
+surface (`telemetry` feature-id). The generic seam is documented here; the funnel
+module's design lives in the private submodule.
+
+- **FR-1 — Event set v1 (OSS capture)**: the genuinely-new client beacons are the
+  onboarding-wizard step transitions — `setup_started`, `setup_step_intro`,
+  `setup_step_create`, `setup_step_credential`, `setup_completed`,
+  `setup_dismissed` — emitted by `components/OnboardingWizard.vue` through
+  `stores/productTelemetry.js` → `POST /api/product-events`. **First-value
+  events** (`first_agent_created`, `first_chat`, `first_schedule_created`,
+  `first_channel_connected`) are **derived on read** from the rows Trinity
+  already writes (`audit_log`, `agent_activities`, `schedule_executions`), never
+  re-emitted — so they survive restart by construction and add no write path.
+- **FR-2 — Storage (OSS)**: a local SQLite/Postgres table `product_events`
+  (`installation_id`, `event_type`, `event_context` optional small JSON,
+  `created_at`; dual-track migration + `db/tables.py` MetaData). The emit
+  endpoint accepts only a **fixed allow-list** of `event_type` values (unknown →
+  422) so the table can't be spammed with arbitrary strings. Rows carry the
+  stable `installation_id` (§43.1) and a UTC timestamp so Tier-2's opt-in
+  **retroactive backfill at consent** can serialize history — the mechanism that
+  rescues early-funnel data despite consent arriving late.
+- **FR-3 — Zero egress**: the capture layer NEVER phones home; the emit endpoint
+  writes one local row and returns. All sharing/consent lives in Tier-2 (#12).
+  Verifiable and documented as local-only in user docs.
+- **FR-4 — Operator funnel view (enterprise-gated)**: an operator-facing
+  activation/funnel panel on an existing admin surface (Settings, admin-only)
+  shows step-by-step activation counts + drop-off with an honest empty state when
+  there's no data yet. It reads a gated enterprise endpoint
+  (`requires_entitlement("telemetry")`) that aggregates `product_events` +
+  derives the first-value events from the OSS tables above. The **panel Vue**
+  ships in the OSS bundle but is hidden unless `telemetry` is in
+  `enterprise_features` (the standard feature-flag gating). Explicitly **NOT** a
+  new standalone analytics dashboard in v1.
+
+**Deferred**: auto-retention sweep for `product_events` (volume is negligible —
+a handful of rows per install); per-user (vs per-install) funnel cohorts;
+Tier-2 opt-in sharing + backfill serialization (#12).
+
+---
+
 ## Ephemeral "Ghost" Agents (trinity-enterprise#69)
 
 **Description**: A disposable-agent lifecycle — an agent is created with a hard

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -113,6 +113,7 @@ from db.chat import ChatOperations
 from db.sessions import SessionOperations
 from db.activities import ActivityOperations
 from db.reports import ReportOperations
+from db.product_events import ProductEventOperations
 from db.reminders import RemindersOperations
 from db.connector import ConnectorOperations
 from db.permissions import PermissionOperations
@@ -432,6 +433,7 @@ class DatabaseManager:
         self._session_ops = SessionOperations()
         self._activity_ops = ActivityOperations()
         self._report_ops = ReportOperations()
+        self._product_event_ops = ProductEventOperations()
         self._reminder_ops = RemindersOperations()
         self._connector_ops = ConnectorOperations()
         self._permission_ops = PermissionOperations(self._user_ops, self._agent_ops)
@@ -1454,6 +1456,24 @@ class DatabaseManager:
 
     def prune_agent_reports(self, retention_days: int = 90, chunk_size: int = 1000):
         return self._report_ops.prune_agent_reports(retention_days, chunk_size)
+
+    # =========================================================================
+    # Local Product-Event Capture Methods (ent#184 — delegated to db/product_events.py)
+    # =========================================================================
+
+    def record_product_event(self, installation_id, event_type, event_context=None):
+        return self._product_event_ops.record_product_event(
+            installation_id, event_type, event_context
+        )
+
+    def count_product_events_by_type(self, since=None):
+        return self._product_event_ops.count_product_events_by_type(since)
+
+    def list_product_events(self, event_type=None, since=None, limit=1000, offset=0):
+        return self._product_event_ops.list_product_events(event_type, since, limit, offset)
+
+    def prune_product_events(self, retention_days, chunk_size=1000):
+        return self._product_event_ops.prune_product_events(retention_days, chunk_size)
 
     # =========================================================================
     # Agent Self-Reminder Methods (#1296 — delegated to db/reminders.py)

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -3083,6 +3083,41 @@ def _migrate_schedule_executions_redelivery_count(cursor, conn):
     conn.commit()
 
 
+def _migrate_product_events_table(cursor, conn):
+    """Create product_events table (ent#184).
+
+    Local product-event capture — activation funnel, Tier-1. Local-only,
+    default-on, zero egress. Records onboarding-wizard step transitions; the
+    first-value events are derived on read from audit_log/agent_activities.
+    Schema is also in db/schema.py for fresh installs; this handles existing
+    installs. Idempotent. Mirrored by the Alembic revision 0029_product_events
+    for PostgreSQL.
+    """
+    cursor.execute("PRAGMA table_info(product_events)")
+    if cursor.fetchall():
+        return  # already created (fresh-install path via init_schema)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS product_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            installation_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            event_context TEXT,
+            created_at TEXT NOT NULL
+        )
+    """)
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_product_events_type_created "
+        "ON product_events(event_type, created_at)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_product_events_created "
+        "ON product_events(created_at)"
+    )
+    conn.commit()
+    print("Created product_events table (ent#184)")
+
+
 MIGRATIONS = [
     ("agent_sharing", _migrate_agent_sharing_table),
     ("schedule_executions_observability", _migrate_schedule_executions_observability),
@@ -3183,4 +3218,5 @@ MIGRATIONS = [
     ("operator_queue_request_id", _migrate_operator_queue_request_id),
     ("users_github_pat", _migrate_users_github_pat),
     ("agent_reminders_table", _migrate_agent_reminders_table),
+    ("product_events_table", _migrate_product_events_table),
 ]

--- a/src/backend/db/product_events.py
+++ b/src/backend/db/product_events.py
@@ -1,0 +1,141 @@
+"""
+Local product-event capture database operations (ent#184).
+
+Tier-1 of the two-tier telemetry model: activation/usage events recorded **on
+the operator's own instance, default-ON, with zero network egress**. Only the
+onboarding-wizard step transitions are emitted here (the genuinely-new client
+beacons); first-value events (first_agent_created, first_chat, ...) are derived
+on read from ``audit_log``/``agent_activities`` and never re-emitted.
+
+SQLAlchemy Core over the ``product_events`` table in ``db/tables.py`` so it runs
+unchanged on SQLite and PostgreSQL. This layer holds the WRITE path + minimal
+read helpers; the operator-facing funnel aggregation is an entitlement-gated
+enterprise surface that reads these rows (open-core split, ent#184).
+"""
+
+import json
+from typing import Dict, List, Optional
+
+from sqlalchemy import select, insert, delete, func
+
+from .engine import get_engine
+from .tables import product_events
+from utils.helpers import utc_now_iso, iso_cutoff
+
+
+class ProductEventOperations:
+    """Local product-event capture operations (ent#184)."""
+
+    def record_product_event(
+        self,
+        installation_id: str,
+        event_type: str,
+        event_context: Optional[Dict] = None,
+    ) -> Dict:
+        """Insert one local product event. Zero egress — one local row.
+
+        ``event_context`` is an optional small dict serialized to JSON. The
+        caller (router) is responsible for allow-listing ``event_type``; this
+        layer just persists.
+        """
+        now = utc_now_iso()
+        ctx = json.dumps(event_context) if event_context else None
+        stmt = insert(product_events).values(
+            installation_id=installation_id,
+            event_type=event_type,
+            event_context=ctx,
+            created_at=now,
+        )
+        with get_engine().begin() as conn:
+            result = conn.execute(stmt)
+        new_id = result.inserted_primary_key[0] if result.inserted_primary_key else None
+        return {
+            "id": new_id,
+            "installation_id": installation_id,
+            "event_type": event_type,
+            "event_context": event_context,
+            "created_at": now,
+        }
+
+    def count_product_events_by_type(self, since: Optional[str] = None) -> Dict[str, int]:
+        """Counts grouped by ``event_type`` (optionally since an ISO cutoff).
+
+        The primitive the enterprise activation-funnel view aggregates over the
+        wizard-step slice. Returns ``{event_type: count}``.
+        """
+        stmt = select(product_events.c.event_type, func.count().label("n"))
+        if since:
+            stmt = stmt.where(product_events.c.created_at >= since)
+        stmt = stmt.group_by(product_events.c.event_type)
+        with get_engine().connect() as conn:
+            return {r["event_type"]: r["n"] for r in conn.execute(stmt).mappings()}
+
+    def list_product_events(
+        self,
+        event_type: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> List[Dict]:
+        """Raw rows (oldest first) for Tier-2 backfill serialization + audit.
+
+        Ordered by ``created_at`` ASC so a later opt-in (#12) can serialize
+        history in chronological order.
+        """
+        stmt = select(product_events)
+        conditions = []
+        if event_type:
+            conditions.append(product_events.c.event_type == event_type)
+        if since:
+            conditions.append(product_events.c.created_at >= since)
+        if conditions:
+            for c in conditions:
+                stmt = stmt.where(c)
+        stmt = (
+            stmt.order_by(product_events.c.created_at.asc())
+            .limit(limit)
+            .offset(offset)
+        )
+        with get_engine().connect() as conn:
+            rows = conn.execute(stmt).mappings().all()
+        return [
+            {
+                "id": r["id"],
+                "installation_id": r["installation_id"],
+                "event_type": r["event_type"],
+                "event_context": json.loads(r["event_context"]) if r["event_context"] else None,
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]
+
+    def prune_product_events(self, retention_days: int, chunk_size: int = 1000) -> int:
+        """Delete product events older than ``retention_days``. ``0`` disables.
+
+        Provided for completeness; not wired into an automatic sweep in v1 (the
+        table is negligible — a handful of rows per install). Chunked so a large
+        table never holds the write lock for the full purge.
+        """
+        if retention_days <= 0 or chunk_size <= 0:
+            return 0
+        cutoff = iso_cutoff(hours=retention_days * 24)
+        total = 0
+        while True:
+            with get_engine().begin() as conn:
+                ids = [
+                    row["id"]
+                    for row in conn.execute(
+                        select(product_events.c.id)
+                        .where(product_events.c.created_at < cutoff)
+                        .limit(chunk_size)
+                    ).mappings()
+                ]
+                if not ids:
+                    break
+                result = conn.execute(
+                    delete(product_events).where(product_events.c.id.in_(ids))
+                )
+                total += result.rowcount
+            if len(ids) < chunk_size:
+                break
+        return total

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -503,6 +503,21 @@ TABLES = {
     """,
 
     # -------------------------------------------------------------------------
+    # Local product-event capture — activation funnel, Tier-1 (ent#184)
+    # Local-only, default-on, zero egress. Wizard step transitions are emitted;
+    # first-value events are derived on read from audit_log/agent_activities.
+    # -------------------------------------------------------------------------
+    "product_events": """
+        CREATE TABLE IF NOT EXISTS product_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            installation_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            event_context TEXT,
+            created_at TEXT NOT NULL
+        )
+    """,
+
+    # -------------------------------------------------------------------------
     # Notifications (NOTIF-001)
     # -------------------------------------------------------------------------
     "agent_notifications": """
@@ -1379,6 +1394,11 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_agent_reports_type ON agent_reports(report_type, created_at DESC)",
     # Serves the retention sweep's `WHERE created_at < cutoff` scan (#918).
     "CREATE INDEX IF NOT EXISTS idx_agent_reports_created ON agent_reports(created_at)",
+
+    # Product-event capture (ent#184): funnel aggregation groups by event_type,
+    # backfill/query orders by created_at.
+    "CREATE INDEX IF NOT EXISTS idx_product_events_type_created ON product_events(event_type, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_product_events_created ON product_events(created_at)",
 
     # Permission indexes
     "CREATE INDEX IF NOT EXISTS idx_permissions_source ON agent_permissions(source_agent)",

--- a/src/backend/db/tables.py
+++ b/src/backend/db/tables.py
@@ -458,6 +458,18 @@ agent_reports = Table(
     Column("created_at", Text),
 )
 
+product_events = Table(
+    # Local product-event capture — activation funnel, Tier-1 (ent#184).
+    # Local-only, default-on, zero egress. INTEGER autoincrement PK.
+    "product_events",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("installation_id", Text),
+    Column("event_type", Text),
+    Column("event_context", Text),
+    Column("created_at", Text),
+)
+
 agent_notifications = Table(
     "agent_notifications",
     metadata,

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -86,6 +86,7 @@ from routers.tags import router as tags_router
 from routers.system_views import router as system_views_router
 from routers.notifications import router as notifications_router, set_websocket_manager as set_notifications_ws_manager, set_filtered_websocket_manager as set_notifications_filtered_ws_manager
 from routers.reports import router as reports_router
+from routers.product_events import router as product_events_router
 from routers.reminders import router as reminders_router
 from services.report_service import set_websocket_manager as set_reports_ws_manager, set_filtered_websocket_manager as set_reports_filtered_ws_manager
 from routers.connector import router as connector_router  # per-agent MCP connector (ent#46, OSS-core #118)
@@ -944,6 +945,7 @@ app.include_router(tags_router)  # Agent Tags (ORG-001)
 app.include_router(system_views_router)  # System Views (ORG-001 Phase 2)
 app.include_router(notifications_router)  # Agent Notifications (NOTIF-001)
 app.include_router(reports_router)  # Agent Reports (#918)
+app.include_router(product_events_router)  # Local product-event capture (ent#184)
 app.include_router(reminders_router)  # Agent Self-Reminders (#1296)
 app.include_router(connector_router)  # Per-agent MCP connector (ent#46, OSS-core #118)
 app.include_router(messages_router)  # Proactive Messaging (#321)

--- a/src/backend/migrations/versions/0029_product_events.py
+++ b/src/backend/migrations/versions/0029_product_events.py
@@ -1,0 +1,52 @@
+"""product_events table (ent#184)
+
+Local product-event capture — activation funnel, Tier-1. Local-only, default-on,
+zero network egress. Records onboarding-wizard step transitions; first-value
+events (first_agent_created, first_chat, ...) are derived on read from
+audit_log/agent_activities, never re-emitted. Mirrors the SQLite
+``product_events_table`` migration in ``db/migrations.py`` and the DDL in
+``db/schema.py`` / MetaData in ``db/tables.py``.
+
+Fresh PG builds already get this table because ``0001_baseline`` iterates
+``db/schema.py:TABLES``. This revision exists so an *existing* PG deployment —
+stamped at an earlier revision and never re-running baseline — also picks the
+table up on ``alembic upgrade head``. ``CREATE TABLE IF NOT EXISTS`` /
+``CREATE INDEX IF NOT EXISTS`` keep it a no-op when baseline already created it.
+
+Revision ID: 0029_product_events
+Revises: 0028_agent_reminders
+Create Date: 2026-07-21
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0029_product_events"
+down_revision = "0028_agent_reminders"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS product_events (
+            id SERIAL PRIMARY KEY,
+            installation_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            event_context TEXT,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_product_events_type_created "
+        "ON product_events(event_type, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_product_events_created "
+        "ON product_events(created_at)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS product_events")

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -346,6 +346,17 @@ class ReportCreate(BaseModel):
         return self
 
 
+class ProductEventCreate(BaseModel):
+    """Request body for a local product-event beacon (ent#184).
+
+    ``event_type`` is validated against a fixed allow-list at the router (unknown
+    → 422) so the local table can't be spammed with arbitrary strings. Local-only,
+    zero egress — one local row per accepted event.
+    """
+    event_type: str = Field(..., min_length=1, max_length=64)
+    context: Optional[Dict] = None  # small optional metadata (byte-capped at the router)
+
+
 class ReportSummary(BaseModel):
     """List-response model — metadata only, never carries ``payload`` (#918)."""
     id: str

--- a/src/backend/routers/product_events.py
+++ b/src/backend/routers/product_events.py
@@ -1,0 +1,77 @@
+"""
+Local product-event capture — activation funnel, Tier-1 (ent#184).
+
+The OSS **capture** half of the two-tier telemetry model: records
+activation/usage events **on the operator's own instance, default-ON, with zero
+network egress**. This endpoint writes exactly ONE local row per accepted event
+and returns — it never phones home. All sharing/consent lives in Tier-2 (#12).
+
+Only the onboarding-wizard step transitions are emitted here (the genuinely-new
+client beacons); first-value events (first_agent_created, first_chat, ...) are
+derived on read from ``audit_log``/``agent_activities`` by the enterprise funnel
+view and are NOT accepted here.
+
+``event_type`` is checked against a fixed allow-list so the local table can't be
+spammed with arbitrary strings. The operator-facing funnel aggregation is an
+entitlement-gated enterprise surface that reads these rows (open-core split).
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from database import db
+from dependencies import get_current_user
+from models import ProductEventCreate, User
+from services.operator_intake_service import get_or_create_installation_id
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/product-events", tags=["product-events"])
+
+# Fixed allow-list of client-emitted event types (ent#184). Keep in lockstep
+# with stores/productTelemetry.js on the frontend. First-value events are
+# DERIVED (enterprise funnel), never emitted, so they are intentionally absent.
+ALLOWED_EVENT_TYPES = frozenset({
+    "setup_started",
+    "setup_step_intro",
+    "setup_step_create",
+    "setup_step_credential",
+    "setup_completed",
+    "setup_dismissed",
+})
+
+# Small cap on the optional context blob — this is a beacon, not a data channel.
+_MAX_CONTEXT_BYTES = 2048
+
+
+@router.post("")
+async def record_product_event(
+    body: ProductEventCreate,
+    current_user: User = Depends(get_current_user),
+):
+    """Record one local product event (ent#184). Local-only, zero egress.
+
+    422 on an unknown ``event_type`` (allow-list) or an over-cap ``context``.
+    Any authenticated user may emit (the onboarding wizard runs for the operator
+    completing first-run).
+    """
+    event_type = body.event_type
+    if event_type not in ALLOWED_EVENT_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"unknown event_type '{event_type}'",
+        )
+
+    context = body.context
+    if context is not None:
+        try:
+            if len(json.dumps(context).encode("utf-8")) > _MAX_CONTEXT_BYTES:
+                raise HTTPException(status_code=422, detail="context too large")
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=422, detail="context must be JSON-serializable")
+
+    installation_id = get_or_create_installation_id()
+    db.record_product_event(installation_id, event_type, context)
+    return {"recorded": True, "event_type": event_type}

--- a/src/frontend/src/components/OnboardingWizard.vue
+++ b/src/frontend/src/components/OnboardingWizard.vue
@@ -154,6 +154,7 @@
 import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import CreateAgentModal from './CreateAgentModal.vue'
+import { useProductTelemetryStore } from '../stores/productTelemetry'
 
 defineProps({
   // Whether platform Claude auth is configured (from feature-flags). Decides
@@ -163,6 +164,10 @@ defineProps({
 const emit = defineEmits(['close', 'deployed'])
 
 const router = useRouter()
+
+// Local product-event funnel (ent#184). Fire-and-forget beacons; never awaited,
+// never blocks the wizard. Zero egress — recorded on this instance only.
+const telemetry = useProductTelemetryStore()
 
 // Intent → starter template. Each maps to a real local template shipped in
 // config/agent-templates. CreateAgentModal falls back to a blank agent if a
@@ -218,6 +223,8 @@ onMounted(() => {
   // Scroll-lock the page behind the modal; restored on unmount.
   document.body.style.overflow = 'hidden'
   nextTick(() => focusable()[0]?.focus())
+  // Funnel: the operator opened the first-run wizard (top of the funnel).
+  telemetry.record('setup_started')
 })
 
 onUnmounted(() => {
@@ -228,6 +235,8 @@ onUnmounted(() => {
 function select(p) {
   selectedTemplate.value = p.template
   step.value = 'create'           // hand off to the real create form
+  // Funnel: picked an intent, advanced to the create form.
+  telemetry.record('setup_step_create', { purpose: p.key })
 }
 
 function onModalClose() {
@@ -241,18 +250,25 @@ function onCreated(agent) {
   createdName.value = agent?.name || ''
   emit('deployed', createdName.value)
   step.value = 'credential'        // lead to the credential they must provide
+  // Funnel: first agent created → reached the credential step.
+  telemetry.record('setup_step_credential')
 }
 
 function dismiss() {
+  // Funnel: an exit with an agent already created counts as completed; a bare
+  // dismiss (X/Escape/backdrop before creating) is a drop-off.
+  telemetry.record(createdName.value ? 'setup_completed' : 'setup_dismissed', { via: 'dismiss' })
   emit('close')
 }
 
 function goToCredentials() {
+  telemetry.record('setup_completed', { via: 'credentials' })
   emit('close')
   router.push({ path: '/settings', query: { tab: 'integrations' } })
 }
 
 function openChat() {
+  telemetry.record('setup_completed', { via: 'chat' })
   emit('close')
   if (createdName.value) {
     router.push({ path: `/agents/${createdName.value}`, query: { tab: 'chat' } })

--- a/src/frontend/src/components/settings/ActivationFunnelPanel.vue
+++ b/src/frontend/src/components/settings/ActivationFunnelPanel.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between gap-3">
+      <div>
+        <h2 class="text-lg font-medium text-gray-900 dark:text-white">Activation funnel</h2>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          First-run activation and first-value events, recorded
+          <span class="font-medium">locally on this instance only</span> — nothing
+          leaves the box. (ent#184)
+        </p>
+      </div>
+      <select
+        v-model.number="windowDays"
+        @change="load"
+        class="text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+        aria-label="Time window"
+      >
+        <option :value="7">Last 7 days</option>
+        <option :value="30">Last 30 days</option>
+        <option :value="90">Last 90 days</option>
+        <option :value="0">All time</option>
+      </select>
+    </div>
+
+    <div class="p-6">
+      <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading…</div>
+
+      <div v-else-if="error" class="text-sm text-status-danger-600 dark:text-status-danger-400">
+        {{ error }}
+      </div>
+
+      <template v-else>
+        <!-- Honest empty state -->
+        <div
+          v-if="isEmpty"
+          class="rounded-md border border-dashed border-gray-300 dark:border-gray-600 p-6 text-center text-sm text-gray-500 dark:text-gray-400"
+        >
+          No activation events recorded yet. Complete the first-run wizard or
+          create an agent, then check back — events are captured locally from the
+          start.
+        </div>
+
+        <template v-else>
+          <!-- Setup funnel -->
+          <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Setup funnel</h3>
+          <ul class="space-y-2">
+            <li v-for="(step, i) in funnel" :key="step.key" class="flex items-center gap-3">
+              <div class="w-40 shrink-0 text-sm text-gray-700 dark:text-gray-300">{{ step.label }}</div>
+              <div class="flex-1 h-6 rounded bg-gray-100 dark:bg-gray-700 overflow-hidden">
+                <div
+                  class="h-full bg-action-primary-500 dark:bg-action-primary-600"
+                  :style="{ width: barWidth(step.count) + '%' }"
+                ></div>
+              </div>
+              <div class="w-24 shrink-0 text-right text-sm tabular-nums text-gray-900 dark:text-gray-100">
+                {{ step.count }}
+                <span v-if="i > 0 && dropOff(i) !== null" class="text-xs text-gray-400 ml-1">
+                  ({{ dropOff(i) }}%↓)
+                </span>
+              </div>
+            </li>
+          </ul>
+
+          <!-- First-value events -->
+          <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mt-6 mb-3">
+            First-value events
+          </h3>
+          <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <div
+              v-for="fv in firstValueRows"
+              :key="fv.key"
+              class="rounded-md border border-gray-200 dark:border-gray-700 p-3 text-center"
+            >
+              <div class="text-2xl font-semibold text-gray-900 dark:text-gray-100 tabular-nums">
+                {{ fv.count }}
+              </div>
+              <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ fv.label }}</div>
+            </div>
+          </div>
+        </template>
+
+        <p class="mt-6 text-xs text-gray-400 dark:text-gray-500">
+          Install {{ installationId }} · local-only, zero network egress.
+        </p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import api from '../../api'
+
+// Labels for the setup-funnel steps (order = funnel order). Mirrors the
+// backend allow-list; the enterprise endpoint returns counts keyed by these.
+const FUNNEL_STEPS = [
+  { key: 'setup_started', label: 'Opened wizard' },
+  { key: 'setup_step_create', label: 'Picked intent' },
+  { key: 'setup_step_credential', label: 'Created first agent' },
+  { key: 'setup_completed', label: 'Completed setup' },
+]
+
+const FIRST_VALUE = [
+  { key: 'first_agent_created', label: 'First agent' },
+  { key: 'first_chat', label: 'First chat' },
+  { key: 'first_schedule_created', label: 'First schedule' },
+  { key: 'first_channel_connected', label: 'First channel' },
+]
+
+const windowDays = ref(30)
+const loading = ref(false)
+const error = ref('')
+const funnelCounts = ref({})
+const firstValueCounts = ref({})
+const installationId = ref('')
+
+const funnel = computed(() =>
+  FUNNEL_STEPS.map((s) => ({ ...s, count: funnelCounts.value[s.key] || 0 }))
+)
+const firstValueRows = computed(() =>
+  FIRST_VALUE.map((s) => ({ ...s, count: firstValueCounts.value[s.key] || 0 }))
+)
+
+const isEmpty = computed(
+  () =>
+    funnel.value.every((s) => s.count === 0) &&
+    firstValueRows.value.every((s) => s.count === 0)
+)
+
+// Bar width relative to the top of the funnel (setup_started).
+function barWidth(count) {
+  const top = funnel.value[0]?.count || 0
+  if (!top) return 0
+  return Math.round((count / top) * 100)
+}
+
+// Drop-off % from the previous step to this one.
+function dropOff(i) {
+  const prev = funnel.value[i - 1]?.count || 0
+  const cur = funnel.value[i]?.count || 0
+  if (!prev) return null
+  return Math.round(((prev - cur) / prev) * 100)
+}
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const r = await api.get('/api/enterprise/telemetry/funnel', {
+      params: { window_days: windowDays.value },
+    })
+    funnelCounts.value = r.data?.funnel || {}
+    firstValueCounts.value = r.data?.first_value || {}
+    installationId.value = r.data?.installation_id || ''
+  } catch (e) {
+    error.value =
+      e?.response?.data?.detail ||
+      'Failed to load activation data. This view requires the telemetry entitlement.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+</script>

--- a/src/frontend/src/stores/productTelemetry.js
+++ b/src/frontend/src/stores/productTelemetry.js
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia'
+import api from '../api'
+
+/**
+ * Local product-event capture — activation funnel, Tier-1 (ent#184).
+ *
+ * Fire-and-forget beacons for the OSS, local-only, zero-egress instrumentation
+ * layer. The only caller today is the onboarding wizard, which records its step
+ * transitions so the operator can see where their own first-run users drop off.
+ *
+ * Design:
+ *   - NEVER blocks or breaks the UI: `record()` swallows every error. A failed
+ *     beacon is invisible by design (mirrors the agent heartbeat philosophy).
+ *   - Goes through the shared api.js client (Invariant #7).
+ *   - `event_type` must be in the backend allow-list (routers/product_events.py).
+ *     Keep this list in lockstep with `ALLOWED_EVENT_TYPES` there.
+ *
+ * First-value events (first_agent_created, first_chat, ...) are NOT emitted here
+ * — they are derived server-side from audit_log/agent_activities by the
+ * enterprise funnel view.
+ */
+export const useProductTelemetryStore = defineStore('productTelemetry', {
+  actions: {
+    /**
+     * Record one local product event. Fire-and-forget — never awaited by the UI.
+     * @param {string} eventType allow-listed event type
+     * @param {object|null} context optional small metadata blob
+     */
+    record(eventType, context = null) {
+      // Do not await — the wizard must never wait on (or fail from) a beacon.
+      api
+        .post('/api/product-events', { event_type: eventType, context })
+        .catch((e) => {
+          // Silent by design; a dropped beacon is not a user-facing failure.
+          if (import.meta?.env?.DEV) {
+            console.debug('[productTelemetry] beacon dropped:', eventType, e?.message || e)
+          }
+        })
+    },
+  },
+})

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -162,6 +162,11 @@
             </div>
           </div>
 
+          <!-- ent#184 — Activation funnel (local product events). Capture is
+               OSS-core; this operator view is entitlement-gated (`telemetry`).
+               The panel fetches the gated enterprise endpoint itself. -->
+          <ActivationFunnelPanel v-if="activeTab === 'activation'" />
+
           <!-- Platform Section -->
           <!-- Admin sign-in email (#82 Phase 1) — lets an existing admin bind a
                real email so they can sign in with email + password, matching
@@ -2306,6 +2311,7 @@ import UserGitHubPatPanel from '../components/settings/UserGitHubPatPanel.vue'
 import AgentPermissionsMatrix from '../components/AgentPermissionsMatrix.vue'
 import TwoFactorPanel from '../components/settings/TwoFactorPanel.vue'
 import SsoPanel from '../components/settings/SsoPanel.vue'
+import ActivationFunnelPanel from '../components/settings/ActivationFunnelPanel.vue'
 import ConfirmDialog from '../components/ConfirmDialog.vue'
 
 const router = useRouter()
@@ -2345,6 +2351,10 @@ const ALL_TABS = [
   { id: 'sso',          label: 'SSO',          adminOnly: true,  requires: 'sso' },
   { id: 'agents',       label: 'Agents',       adminOnly: true  },
   { id: 'retention',    label: 'Retention',    adminOnly: true  },
+  // ent#184 — local product-event activation funnel. Capture is OSS-core;
+  // this operator view is entitlement-gated (`telemetry`), so the tab is hidden
+  // in OSS-only builds. Local-only data, admin-only.
+  { id: 'activation',   label: 'Activation',   adminOnly: true, requires: 'telemetry' },
 ]
 const { isAdmin } = useRole()
 const visibleTabs = computed(() =>

--- a/tests/unit/test_ent184_product_events_db.py
+++ b/tests/unit/test_ent184_product_events_db.py
@@ -1,0 +1,122 @@
+"""Tests for local product-event capture DB operations (ent#184).
+
+Exercises ``ProductEventOperations`` against an ephemeral SQLite via the
+SQLAlchemy Core engine (``db.engine.get_engine`` resolves ``TRINITY_DB_PATH``).
+Same fixture family as test_918_agent_reports_db.py.
+
+Locked behaviour (from the AC):
+  * record → count_by_type / list round-trips the event + optional JSON context.
+  * list is chronological (created_at ASC) so Tier-2 backfill can serialize
+    history in order.
+  * since-filter windows both counts and the list.
+  * prune deletes past the cutoff and is disabled at 0.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+def _make_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE product_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            installation_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            event_context TEXT,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+
+
+@pytest.fixture
+def ops(tmp_path, monkeypatch):
+    db_path = tmp_path / "trinity.db"
+    conn = sqlite3.connect(str(db_path))
+    _make_schema(conn)
+    conn.close()
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_path))
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    try:
+        from db.product_events import ProductEventOperations
+    except ImportError:
+        pytest.skip("backend venv required")
+    return ProductEventOperations()
+
+
+def _backdate(event_id: int, days: int) -> None:
+    from sqlalchemy import update
+    from db.engine import get_engine
+    from db.tables import product_events
+    when = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    with get_engine().begin() as conn:
+        conn.execute(
+            update(product_events).where(product_events.c.id == event_id).values(created_at=when)
+        )
+
+
+def test_record_roundtrips_context(ops):
+    row = ops.record_product_event("inst-1", "setup_step_create", {"purpose": "research"})
+    assert row["event_type"] == "setup_step_create"
+    got = ops.list_product_events(event_type="setup_step_create")
+    assert len(got) == 1
+    assert got[0]["installation_id"] == "inst-1"
+    assert got[0]["event_context"] == {"purpose": "research"}
+
+
+def test_record_null_context(ops):
+    ops.record_product_event("inst-1", "setup_started", None)
+    got = ops.list_product_events()
+    assert got[0]["event_context"] is None
+
+
+def test_count_by_type(ops):
+    ops.record_product_event("inst-1", "setup_started")
+    ops.record_product_event("inst-1", "setup_started")
+    ops.record_product_event("inst-1", "setup_completed")
+    counts = ops.count_product_events_by_type()
+    assert counts == {"setup_started": 2, "setup_completed": 1}
+
+
+def test_list_is_chronological(ops):
+    a = ops.record_product_event("inst-1", "setup_started")
+    b = ops.record_product_event("inst-1", "setup_completed")
+    _backdate(a["id"], 5)   # push the first one into the past
+    _backdate(b["id"], 1)
+    rows = ops.list_product_events()
+    assert [r["event_type"] for r in rows] == ["setup_started", "setup_completed"]
+
+
+def test_since_filter(ops):
+    old = ops.record_product_event("inst-1", "setup_started")
+    ops.record_product_event("inst-1", "setup_completed")  # "now"
+    _backdate(old["id"], 40)
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    assert ops.count_product_events_by_type(since=cutoff) == {"setup_completed": 1}
+    assert len(ops.list_product_events(since=cutoff)) == 1
+
+
+def test_prune(ops):
+    old = ops.record_product_event("inst-1", "setup_started")
+    ops.record_product_event("inst-1", "setup_completed")
+    _backdate(old["id"], 100)
+    # disabled at 0
+    assert ops.prune_product_events(0) == 0
+    assert len(ops.list_product_events()) == 2
+    # 90-day window deletes the backdated row
+    assert ops.prune_product_events(90) == 1
+    remaining = ops.list_product_events()
+    assert [r["event_type"] for r in remaining] == ["setup_completed"]


### PR DESCRIPTION
## ent#184 — Tier-1 local product events (OSS capture + gated view)

**Gating shape (confirmed):** OSS-core **capture** + entitlement-gated **funnel view**. This is the public-repo half; the enterprise funnel backend ships in `trinity-enterprise` (`feature/184-telemetry-funnel`).

### Capture — OSS-core, default-ON, **zero network egress**
- **`product_events`** table (`installation_id`, `event_type`, `event_context`, `created_at`) — `db/schema.py` + `db/tables.py` MetaData + **dual-track migration** (SQLite `product_events_table` + Alembic `0029_product_events`).
- **`POST /api/product-events`** — writes ONE local row and returns; never phones home. `event_type` checked against a **fixed allow-list** (unknown → 422) so the table can't be spammed; `context` byte-capped.
- **`OnboardingWizard.vue`** emits its step transitions (`setup_started` → `setup_step_create` → `setup_step_credential` → `setup_completed`/`setup_dismissed`) via `stores/productTelemetry.js` — fire-and-forget, never blocks/breaks the wizard.
- **First-value events** (`first_agent_created`, `first_chat`, …) are **derived on read** by the enterprise view from `audit_log`/`agent_activities`/`agent_schedules` — never re-emitted, so they survive restart by construction.
- `db/product_events.py` — `ProductEventOperations` (record + count-by-type + chronological list for Tier-2 backfill + optional prune), wired into the facade.

### Funnel view — ships in the OSS bundle, hidden unless entitled
- `components/settings/ActivationFunnelPanel.vue` — step funnel + drop-off % + first-value tiles + **honest empty state**; fetches the gated enterprise endpoint.
- `Settings.vue` gains an admin-only **Activation** tab, `requires: 'telemetry'` → invisible in OSS-only builds (standard feature-flag gating).

### Docs
- Requirements **§45** (`lifecycle-observability.md`) — generic seam only (no enterprise module design in public docs).
- User-facing `docs/PRODUCT_EVENTS.md` — what's recorded, that it never leaves the box, how to view.

### AC coverage
- [x] Wizard step transitions + first-value events recorded/derived locally, default-ON, survive restart
- [x] Operator-facing funnel with step counts / drop-off + honest empty state *(view lands with the enterprise PR)*
- [x] **Zero network egress** — the emit endpoint writes one local row; documented local-only
- [x] Events queryable with timestamps + `installation_id` for #12's opt-in backfill
- [x] Documented in user docs

### Verification
Verified end-to-end on the local Postgres stack: capture POST + allow-list 422 + (with the enterprise submodule mounted) the funnel returning captured steps and derived first-value from real data. `tests/unit/test_ent184_product_events_db.py` — 6 passing.

Related to ent#184 · pairs with trinity-enterprise `feature/184-telemetry-funnel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
