### PR TITLE
feat(telemetry): Tier-2 opt-in fleet sharing — consent + egress + backfill (ent#12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,17 @@ OPERATOR_INTAKE_URL=https://intake.abilityai.dev/v1/operator-intake
 # intake POST — equivalent to OPERATOR_INTAKE_ENABLED=false.
 DO_NOT_TRACK=0
 
+# Tier-2 opt-in fleet telemetry sharing (ent#12). Anonymized aggregate counts,
+# egressed ONLY after explicit admin consent in Settings (default off) AND this
+# config switch. Set to false (or DO_NOT_TRACK=1) as the hard kill switch —
+# consent can then never enable egress (the Settings toggle 409s).
+TELEMETRY_SHARING_ENABLED=true
+# Hosted intake endpoint (override only to self-host the intake).
+TELEMETRY_SHARING_URL=https://intake.abilityai.dev/v1/telemetry-share
+# Heartbeat cadence and the default consent-time backfill window.
+TELEMETRY_SHARING_INTERVAL_HOURS=24
+TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS=30
+
 # Email service provider: console (dev), smtp, sendgrid, resend
 EMAIL_PROVIDER=console
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -202,6 +202,14 @@ services:
       - OPERATOR_INTAKE_ENABLED=${OPERATOR_INTAKE_ENABLED:-true}
       - DO_NOT_TRACK=${DO_NOT_TRACK:-0}
       - OPERATOR_INTAKE_URL=${OPERATOR_INTAKE_URL:-https://intake.abilityai.dev/v1/operator-intake}
+      # Tier-2 opt-in fleet telemetry sharing (ent#12): consent-gated aggregate
+      # egress. TELEMETRY_SHARING_ENABLED=false is the hard kill switch
+      # (DO_NOT_TRACK also disables). URL keeps its FULL non-empty default —
+      # a bare :- would arrive set-but-empty and shadow the code default (#1076).
+      - TELEMETRY_SHARING_ENABLED=${TELEMETRY_SHARING_ENABLED:-true}
+      - TELEMETRY_SHARING_URL=${TELEMETRY_SHARING_URL:-https://intake.abilityai.dev/v1/telemetry-share}
+      - TELEMETRY_SHARING_INTERVAL_HOURS=${TELEMETRY_SHARING_INTERVAL_HOURS:-24}
+      - TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS=${TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS:-30}
       # Internal API shared secret (C-003) - for scheduler/agent communication
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       # Configurable database backend (#300, experimental) — mirrors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,14 @@ services:
       - OPERATOR_INTAKE_ENABLED=${OPERATOR_INTAKE_ENABLED:-true}
       - DO_NOT_TRACK=${DO_NOT_TRACK:-0}
       - OPERATOR_INTAKE_URL=${OPERATOR_INTAKE_URL:-https://intake.abilityai.dev/v1/operator-intake}
+      # Tier-2 opt-in fleet telemetry sharing (ent#12): consent-gated aggregate
+      # egress. TELEMETRY_SHARING_ENABLED=false is the hard kill switch
+      # (DO_NOT_TRACK also disables). URL keeps its FULL non-empty default —
+      # a bare :- would arrive set-but-empty and shadow the code default (#1076).
+      - TELEMETRY_SHARING_ENABLED=${TELEMETRY_SHARING_ENABLED:-true}
+      - TELEMETRY_SHARING_URL=${TELEMETRY_SHARING_URL:-https://intake.abilityai.dev/v1/telemetry-share}
+      - TELEMETRY_SHARING_INTERVAL_HOURS=${TELEMETRY_SHARING_INTERVAL_HOURS:-24}
+      - TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS=${TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS:-30}
       # CORS (comma-separated extra origins)
       - EXTRA_CORS_ORIGINS=${EXTRA_CORS_ORIGINS:-}
       # Slack channel adapter

--- a/docs/PRODUCT_EVENTS.md
+++ b/docs/PRODUCT_EVENTS.md
@@ -62,3 +62,73 @@ step-by-step activation counts, drop-off between steps, and the first-value
 tiles, with an honest empty state before any data exists. The funnel view is an
 entitlement-gated enterprise surface; the **capture** described above runs in
 every edition.
+
+---
+
+# Tier-2 — Opt-in Fleet Sharing (ent#12)
+
+Everything above (Tier-1) is **local only**. Tier-2 is a **separate, opt-in,
+default-off** channel that — *only after you explicitly turn it on* — shares
+**anonymized aggregates** with the Ability-operated hosted intake, so you get
+fleet benchmarks in return ("how does my setup compare?").
+
+> **Nothing is shared until you opt in, and opting out stops it immediately.**
+> Two independent gates must both be on for any egress: your stored consent
+> (Settings → General → **Usage sharing**, default-off) **and** the config switch
+> `TELEMETRY_SHARING_ENABLED` (which honors the cross-tool `DO_NOT_TRACK=1`).
+
+## What is shared (anonymized aggregates only)
+
+A single JSON document on a periodic heartbeat (default every 24h), keyed by the
+anonymous `installation_id`:
+
+```jsonc
+{
+  "installation_id": "…",          // anonymous, random, per-install
+  "schema_version": 1,
+  "shared_at": "…Z",
+  "window_days": 30,               // period the counts cover
+  "backfill": true,                // true on the consent-time history send
+  "instance": {
+    "trinity_version": "…",        // short git commit
+    "edition": "community" | "enterprise",
+    "platform": "Linux",
+    "python_version": "3.13.x"
+  },
+  "enterprise_features": ["…"],    // coarse module ids (already in /api/version)
+  "counts": {                      // COUNTS ONLY
+    "agents": 3,
+    "executions_total": 22,
+    "executions_success": 21,
+    "executions_failed": 1
+  },
+  "activation_funnel": {           // Tier-1 wizard-step counts
+    "setup_started": 1, "setup_step_create": 1,
+    "setup_step_credential": 0, "setup_completed": 0, "setup_dismissed": 0
+  }
+}
+```
+
+**Never shared:** no message/chat content, no prompts, no agent outputs, no
+credentials or tokens, no emails, no user identities, **no agent names** — only
+coarse counts and enums. The exact payload for your instance is **inspectable
+before you consent** in the Settings → Usage sharing panel (expand "Exactly what
+would be shared").
+
+## Retroactive backfill at consent
+
+Because Tier-1 records locally from t=0, turning sharing on offers to include the
+last N days of local history (default 30, your choice) in the first send, so your
+benchmarks are accurate even though consent arrived later. This is disclosed at
+the moment of consent.
+
+## Reversibility
+
+Turn **Usage sharing** off (Settings → General) and egress stops at the next
+heartbeat — no further data leaves. For a hard, air-gapped guarantee set
+`TELEMETRY_SHARING_ENABLED=false` (or `DO_NOT_TRACK=1`): the toggle then can't
+enable egress at all.
+
+The reciprocity benchmark view (Settings → Activation → "Fleet benchmarks") is an
+entitlement-gated enterprise surface; the consent + egress mechanism above is
+OSS-core and available in every edition.

--- a/docs/memory/requirements/lifecycle-observability.md
+++ b/docs/memory/requirements/lifecycle-observability.md
@@ -371,8 +371,57 @@ module's design lives in the private submodule.
   new standalone analytics dashboard in v1.
 
 **Deferred**: auto-retention sweep for `product_events` (volume is negligible —
-a handful of rows per install); per-user (vs per-install) funnel cohorts;
-Tier-2 opt-in sharing + backfill serialization (#12).
+a handful of rows per install); per-user (vs per-install) funnel cohorts.
+
+### 45.1 Tier-2 — Opt-in Fleet Sharing (ent#12)
+
+**Description**: the **opt-in egress** layer on top of Tier-1 (§45). On
+**explicit, default-off, reversible** operator consent, Trinity periodically
+shares **anonymized aggregates** with the Ability-operated hosted intake in
+exchange for reciprocal value (fleet benchmarks). The hosted aggregation/benchmark
+service is a **separate issue**; this covers the client consent + egress +
+backfill + the gated benchmark status surface.
+
+**Open-core split** (gating confirmed ent#12): the **consent + egress + backfill**
+are OSS-core (the sovereignty primitive — the operator's choice to share is
+edition-agnostic, and it mirrors the OSS operator-intake #38 credential-free
+transport); only the **reciprocity benchmark view** is entitlement-gated
+(`telemetry`).
+
+- **FR-1 — Two-gate egress, never without consent**: egress fires only when BOTH
+  the stored `telemetry_sharing_enabled` consent (system_settings, default-off)
+  AND the config switch `TELEMETRY_SHARING_ENABLED` (honors `DO_NOT_TRACK`) are
+  on. Either off ⇒ nothing leaves the box. Both re-checked in `share_now`.
+- **FR-2 — Anonymized aggregates only**: `services/telemetry_sharing_service.py`
+  `build_aggregate_payload` — `installation_id` (anonymous), version/edition/
+  platform/python, coarse `enterprise_features`, agent + execution **counts**, and
+  the Tier-1 activation-funnel counts. **No PII, no content, no prompts, no
+  emails, no agent names.** The exact payload is **inspectable before send** via
+  `GET /api/settings/telemetry-sharing` → `payload_preview` (the Settings panel).
+- **FR-3 — Periodic heartbeat + reversibility**: `TelemetrySharingService` is a
+  sleeps-first background loop (default 24h, jittered) that shares when consent is
+  on; opt-out stops egress at the next heartbeat. Fail-open (a blocked/failed/
+  air-gapped POST never affects the platform). Reuses the operator-intake httpx
+  fire-and-forget transport.
+- **FR-4 — Retroactive backfill at consent**: on the off→on transition the router
+  schedules an immediate fire-and-forget backfill share over a disclosed window
+  (`backfill_days`, default 30) sourced from Tier-1 `product_events`, so late
+  consent still yields accurate benchmarks. Disclosed at the moment of consent.
+- **FR-5 — Consent surfaces**: a value-framed, optional, non-blocking ask in the
+  onboarding wizard (`OnboardingWizard.vue`, hidden when hard-disabled) + a
+  reversible default-off toggle in Settings → General
+  (`components/settings/TelemetrySharingPanel.vue`), each stating exactly what is
+  shared. `PUT /api/settings/telemetry-sharing` is admin + human-only, audit-logged.
+- **FR-6 — Reciprocity carrot (gated, v1 status surface)**: `GET
+  /api/enterprise/telemetry/benchmark` (entitlement-gated) reports whether the
+  operator is sharing and that benchmarks are `pending_hosted_service` until the
+  hosted service lands; the OSS `ActivationFunnelPanel` renders it. Percentiles
+  are computable only for participants, so sharing is structurally the price of
+  the comparison.
+
+**Deferred**: the hosted aggregation/benchmark service (separate issue); v2/v3
+carrots (targeted alerts, live in-app benchmark panel, roadmap influence);
+warm-ask-after-value prompt.
 
 ---
 

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -40,6 +40,28 @@ OPERATOR_INTAKE_URL = os.getenv(
     "OPERATOR_INTAKE_URL", "https://intake.abilityai.dev/v1/operator-intake"
 )
 
+# --- Tier-2 telemetry sharing (ent#12) -----------------------------------
+# The opt-IN fleet-sharing channel (Tier-2) on top of the Tier-1 local capture
+# (ent#184). Egress NEVER fires unless the operator explicitly opted in (the
+# `telemetry_sharing_enabled` system-setting, default-off) AND this hard
+# off-switch is on. `TELEMETRY_SHARING_ENABLED=false` (or the cross-tool
+# `DO_NOT_TRACK=1`) is an operator/air-gapped kill switch that disables egress
+# regardless of any stored consent — the toggle still appears, nothing leaves.
+TELEMETRY_SHARING_ENABLED = (
+    os.getenv("TELEMETRY_SHARING_ENABLED", "true").lower() == "true"
+    and os.getenv("DO_NOT_TRACK", "0").strip().lower() in ("0", "", "false")
+)
+# Same Cloudflare-fronted hosted-intake app as operator intake; a sibling
+# versioned path. The hosted aggregation/benchmark service is a separate issue.
+TELEMETRY_SHARING_URL = os.getenv(
+    "TELEMETRY_SHARING_URL", "https://intake.abilityai.dev/v1/telemetry-share"
+)
+# Periodic share cadence (hours) + default backfill window offered at consent.
+TELEMETRY_SHARING_INTERVAL_HOURS = int(os.getenv("TELEMETRY_SHARING_INTERVAL_HOURS", "24"))
+TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS = int(
+    os.getenv("TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS", "30")
+)
+
 # JWT Settings
 # SECURITY: SECRET_KEY must be set via environment variable in production
 # Generate with: openssl rand -hex 32

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -479,6 +479,19 @@ async def lifespan(app: FastAPI):
             logger.error(f"Error starting session cleanup service: {e}")
     asyncio.create_task(_start_session_cleanup_delayed())
 
+    # ent#12: Tier-2 opt-in telemetry-sharing heartbeat. Sleeps-first (no boot
+    # burst) and is inert unless the operator opted in AND the config switch is
+    # on — a cheap consent read otherwise. Staggered +9s.
+    async def _start_telemetry_sharing_delayed():
+        await asyncio.sleep(9)
+        try:
+            from services.telemetry_sharing_service import telemetry_sharing_service
+            telemetry_sharing_service.start()
+            logger.info("Telemetry-sharing heartbeat started (staggered +9s)")
+        except Exception as e:
+            logger.error(f"Error starting telemetry-sharing service: {e}")
+    asyncio.create_task(_start_telemetry_sharing_delayed())
+
     # Issue #389: Sync health service — 60s poll cadence, staggered +5s.
     async def _start_sync_health_delayed():
         await asyncio.sleep(5)

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -392,6 +392,17 @@ class ReportCreate(BaseModel):
         return self
 
 
+class TelemetrySharingUpdate(BaseModel):
+    """PUT body for Tier-2 opt-in fleet sharing consent (ent#12).
+
+    ``enabled`` is the reversible, default-off consent. ``backfill_days`` (only
+    meaningful on enable) is the disclosed history window included in the
+    consent-time backfill share. Anonymized aggregates only — no PII.
+    """
+    enabled: bool
+    backfill_days: Optional[int] = Field(None, ge=0, le=3650)
+
+
 class ProductEventCreate(BaseModel):
     """Request body for a local product-event beacon (ent#184).
 

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -253,7 +253,7 @@ async def set_telemetry_sharing(
 
     try:
         await platform_audit_service.log(
-            event_type=AuditEventType.SETTINGS,
+            event_type=AuditEventType.CONFIGURATION,
             event_action="telemetry_sharing_consent",
             source="api",
             actor_user=current_user,
@@ -2185,6 +2185,21 @@ async def update_setting(
             detail=(
                 f"{key} must be set via PUT /api/settings/proactive-rate-limits "
                 f"(range-validated 0–{PROACTIVE_RATE_LIMIT_MAX}, 0 = unlimited)"
+            ),
+        )
+
+    # ent#12: telemetry-sharing consent is a human-only decision. The dedicated
+    # PUT /api/settings/telemetry-sharing enforces reject_agent_principal, the
+    # hard-disabled 409, consent_at stamping, and the dedicated audit action —
+    # this generic PUT has none of those, so an admin-owned agent-scoped key
+    # could otherwise flip egress consent (trinity-ops-agent#232 class). Block
+    # the whole key family.
+    if key.startswith("telemetry_sharing_"):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "telemetry_sharing_* must be set via "
+                "PUT /api/settings/telemetry-sharing (admin + human-only, audit-logged)"
             ),
         )
 

--- a/src/backend/routers/settings.py
+++ b/src/backend/routers/settings.py
@@ -4,6 +4,7 @@ System settings routes for the Trinity backend.
 Provides endpoints for managing system-wide configuration like the Trinity prompt.
 Admin-only access for modification, read access for all authenticated users.
 """
+import asyncio
 import logging
 import os
 import re
@@ -30,11 +31,13 @@ from models import (
     RetentionAcknowledge,
     SlackConnectRequest,
     SlackSettingsUpdate,
+    TelemetrySharingUpdate,
     User,
 )
 from database import db, SystemSetting, SystemSettingUpdate
 from dependencies import get_current_user, assert_admin
 from services.platform_audit_service import platform_audit_service, AuditEventType
+from services import telemetry_sharing_service
 
 # Import from settings_service (these are re-exported for backward compatibility)
 from services.settings_service import (
@@ -200,7 +203,70 @@ async def get_public_feature_flags(
         # enterprise-only tabs cleanly without server-side conditional
         # rendering. Mirrors the deny-list pattern of the other flags.
         "enterprise_features": entitlement_service.list_entitled_features(),
+        # ent#12 Tier-2 opt-in sharing — observability only (the egress gate is
+        # the stored consent + config switch). Default-off; the UI reads it to
+        # show the sharing state without a second round-trip. Non-sensitive bool.
+        "telemetry_sharing_enabled": telemetry_sharing_service.is_consent_enabled(),
     }
+
+
+@router.get("/telemetry-sharing")
+async def get_telemetry_sharing(current_user: User = Depends(get_current_user)):
+    """Tier-2 opt-in sharing status + an inspectable preview of the exact
+    anonymized payload that would be sent (ent#12). Admin-only. Local read — no
+    egress. The preview lets the operator see precisely what is shared before
+    consenting (AC: payload documented and inspectable before send)."""
+    assert_admin(current_user)
+    status = telemetry_sharing_service.get_status()
+    # Preview over the configured backfill window — what a consent-time share
+    # would contain. Coarse aggregates only; never any PII.
+    status["payload_preview"] = telemetry_sharing_service.build_aggregate_payload(
+        window_days=status.get("backfill_days"), backfill=True
+    )
+    return status
+
+
+@router.put("/telemetry-sharing")
+async def set_telemetry_sharing(
+    body: TelemetrySharingUpdate,
+    current_user: User = Depends(get_current_user),
+):
+    """Set (or revoke) the Tier-2 sharing consent (ent#12). Admin + human-only.
+    Default-off, reversible. On enable, an immediate backfill share is scheduled
+    (fire-and-forget) so the first send includes the disclosed history window;
+    disabling stops egress at the next heartbeat. Audit-logged."""
+    from dependencies import reject_agent_principal
+    assert_admin(current_user)
+    reject_agent_principal(current_user)
+
+    if telemetry_sharing_service.is_hard_disabled() and body.enabled:
+        raise HTTPException(
+            status_code=409,
+            detail="Telemetry sharing is disabled by configuration "
+            "(TELEMETRY_SHARING_ENABLED / DO_NOT_TRACK); consent cannot enable egress.",
+        )
+
+    was_enabled = telemetry_sharing_service.is_consent_enabled()
+    status = telemetry_sharing_service.set_consent(
+        body.enabled, backfill_days=body.backfill_days
+    )
+
+    try:
+        await platform_audit_service.log(
+            event_type=AuditEventType.SETTINGS,
+            event_action="telemetry_sharing_consent",
+            source="api",
+            actor_user=current_user,
+            details={"enabled": body.enabled, "backfill_days": status.get("backfill_days")},
+        )
+    except Exception:  # audit is best-effort
+        logger.debug("[telemetry-share] audit log failed", exc_info=True)
+
+    # Consent-time backfill: only on the off→on transition, fire-and-forget.
+    if body.enabled and not was_enabled:
+        asyncio.create_task(telemetry_sharing_service.share_now(backfill=True))
+
+    return status
 
 
 @router.post("/retention/acknowledge")

--- a/src/backend/services/telemetry_sharing_service.py
+++ b/src/backend/services/telemetry_sharing_service.py
@@ -1,0 +1,262 @@
+"""
+Tier-2 opt-in fleet telemetry sharing (ent#12).
+
+The **opt-in** egress half of the two-tier telemetry model. Tier-1 (ent#184)
+records anonymous product events **locally, default-on, zero egress**. This layer
+adds — on **explicit, default-off, reversible operator consent** — a periodic
+share of **anonymized aggregates only** to the Ability-operated hosted intake, in
+exchange for reciprocal value (fleet benchmarks; the hosted aggregation/benchmark
+service is a separate issue).
+
+Guarantees:
+- **Never egresses without consent.** Two independent gates: the stored
+  ``telemetry_sharing_enabled`` consent (default-off) AND the hard config switch
+  ``TELEMETRY_SHARING_ENABLED`` (honors ``DO_NOT_TRACK``). Either off ⇒ nothing
+  leaves the box.
+- **Anonymized + coarse.** version / platform / edition / feature list / agent &
+  execution COUNTS / activation-funnel counts. **No PII, no content, no prompts,
+  no emails, no agent names.** The exact payload is inspectable before send
+  (``build_aggregate_payload`` powers the Settings preview).
+- **Fail-open.** A blocked / failed / air-gapped POST never affects the platform;
+  every send is best-effort and swallows.
+- **Reversible.** Opt-out flips the consent setting; the next heartbeat sees it
+  and egress stops immediately.
+
+Reuses the credential-free hosted-intake transport pattern of
+``operator_intake_service`` (#38).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import platform
+import os
+import random
+from typing import Dict, Optional
+
+import httpx
+
+from config import (
+    TELEMETRY_SHARING_ENABLED,
+    TELEMETRY_SHARING_URL,
+    TELEMETRY_SHARING_INTERVAL_HOURS,
+    TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS,
+)
+from database import db
+from services.operator_intake_service import get_or_create_installation_id
+from utils.helpers import utc_now_iso, iso_cutoff
+
+logger = logging.getLogger(__name__)
+
+_HTTP_TIMEOUT_SECONDS = 10.0
+_PAYLOAD_SCHEMA_VERSION = 1
+
+# system_settings keys (all local; none contain PII).
+KEY_ENABLED = "telemetry_sharing_enabled"          # "true"/"false" — the consent
+KEY_CONSENT_AT = "telemetry_sharing_consent_at"
+KEY_BACKFILL_DAYS = "telemetry_sharing_backfill_days"
+KEY_LAST_SHARED_AT = "telemetry_sharing_last_shared_at"
+
+# The activation-funnel step events (mirrors the OSS emit allow-list). Kept local
+# so the payload never depends on the enterprise funnel module.
+_FUNNEL_STEPS = (
+    "setup_started",
+    "setup_step_create",
+    "setup_step_credential",
+    "setup_completed",
+    "setup_dismissed",
+)
+
+
+# ---------------------------------------------------------------------------
+# Consent state (local, reversible)
+# ---------------------------------------------------------------------------
+
+def is_consent_enabled() -> bool:
+    """Has the operator opted in? Default-off. Fail-safe (any read error → off)."""
+    try:
+        return db.get_setting_value(KEY_ENABLED, "false") == "true"
+    except Exception:  # pragma: no cover - never egress on a read failure
+        return False
+
+
+def is_hard_disabled() -> bool:
+    """Config/air-gap kill switch (``TELEMETRY_SHARING_ENABLED`` / ``DO_NOT_TRACK``)."""
+    return not TELEMETRY_SHARING_ENABLED
+
+
+def get_status() -> Dict:
+    """Operator-facing status for the Settings panel."""
+    try:
+        backfill = int(db.get_setting_value(KEY_BACKFILL_DAYS, str(TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS)))
+    except (TypeError, ValueError):
+        backfill = TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS
+    return {
+        "enabled": is_consent_enabled(),
+        "hard_disabled": is_hard_disabled(),
+        "consent_at": db.get_setting_value(KEY_CONSENT_AT, None),
+        "backfill_days": backfill,
+        "last_shared_at": db.get_setting_value(KEY_LAST_SHARED_AT, None),
+        "share_url": TELEMETRY_SHARING_URL,
+        "interval_hours": TELEMETRY_SHARING_INTERVAL_HOURS,
+    }
+
+
+def set_consent(enabled: bool, *, backfill_days: Optional[int] = None) -> Dict:
+    """Record (or revoke) the sharing consent. Does NOT itself egress — the caller
+    schedules an immediate backfill share on enable. Reversible: disabling stops
+    the next heartbeat's egress."""
+    db.set_setting(KEY_ENABLED, "true" if enabled else "false")
+    if enabled:
+        db.set_setting(KEY_CONSENT_AT, utc_now_iso())
+        if backfill_days is not None:
+            db.set_setting(KEY_BACKFILL_DAYS, str(max(int(backfill_days), 0)))
+    return get_status()
+
+
+# ---------------------------------------------------------------------------
+# Anonymized aggregate payload (inspectable before send)
+# ---------------------------------------------------------------------------
+
+def _edition_and_features() -> tuple[str, list]:
+    try:
+        from services.entitlement_service import entitlement_service
+        feats = entitlement_service.list_entitled_features()
+    except Exception:
+        feats = []
+    return ("enterprise" if feats else "community"), feats
+
+
+def build_aggregate_payload(window_days: Optional[int] = None, *, backfill: bool = False) -> Dict:
+    """Build the anonymized aggregate. Coarse counts + enums ONLY — no PII, no
+    content. ``window_days=None``/``0`` ⇒ all-time counts (used for backfill)."""
+    since = iso_cutoff(hours=window_days * 24) if (window_days and window_days > 0) else None
+    edition, features = _edition_and_features()
+
+    # Execution aggregates over the window (admin scope = all agents).
+    try:
+        hours = (window_days * 24) if (window_days and window_days > 0) else 0
+        exec_stats = db.get_fleet_execution_stats(None, hours=hours) or {}
+    except Exception:
+        exec_stats = {}
+
+    try:
+        funnel_raw = db.count_product_events_by_type(since=since) or {}
+    except Exception:
+        funnel_raw = {}
+    funnel = {step: int(funnel_raw.get(step, 0)) for step in _FUNNEL_STEPS}
+
+    try:
+        agent_count = int(db.count_non_system_agents())
+    except Exception:
+        agent_count = 0
+
+    return {
+        "installation_id": get_or_create_installation_id(),
+        "schema_version": _PAYLOAD_SCHEMA_VERSION,
+        "shared_at": utc_now_iso(),
+        "window_days": int(window_days or 0),
+        "backfill": bool(backfill),
+        "instance": {
+            "trinity_version": os.getenv("GIT_COMMIT_SHORT", "unknown"),
+            "edition": edition,
+            "platform": platform.system() or "unknown",
+            "python_version": platform.python_version(),
+        },
+        # Coarse capability list — already exposed via /api/version; no secrets.
+        "enterprise_features": features,
+        "counts": {
+            "agents": agent_count,
+            "executions_total": int(exec_stats.get("total", 0) or 0),
+            "executions_success": int(exec_stats.get("success_count", 0) or 0),
+            "executions_failed": int(exec_stats.get("failed_count", 0) or 0),
+        },
+        "activation_funnel": funnel,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Egress (gated, fail-open)
+# ---------------------------------------------------------------------------
+
+async def share_now(*, backfill: bool = False, window_days: Optional[int] = None) -> bool:
+    """POST one anonymized aggregate to the hosted intake, IF both gates allow.
+
+    Returns True only on a genuine 2xx. Never raises — best-effort. Both gates
+    (config hard-switch + stored consent) are re-checked here so a stale caller
+    can't force an egress.
+    """
+    try:
+        if is_hard_disabled():
+            logger.info("[telemetry-share] disabled (TELEMETRY_SHARING_ENABLED / DO_NOT_TRACK)")
+            return False
+        if not is_consent_enabled():
+            return False  # not opted in — nothing leaves the box
+
+        if window_days is None:
+            if backfill:
+                try:
+                    window_days = int(db.get_setting_value(KEY_BACKFILL_DAYS, str(TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS)))
+                except (TypeError, ValueError):
+                    window_days = TELEMETRY_SHARING_BACKFILL_DEFAULT_DAYS
+            else:
+                # A periodic heartbeat covers the interval since the last share.
+                window_days = max(TELEMETRY_SHARING_INTERVAL_HOURS // 24, 1)
+
+        payload = build_aggregate_payload(window_days, backfill=backfill)
+
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+            resp = await client.post(TELEMETRY_SHARING_URL, json=payload)
+
+        if 200 <= resp.status_code < 300:
+            db.set_setting(KEY_LAST_SHARED_AT, utc_now_iso())
+            logger.info(
+                "[telemetry-share] shared (install %s…, backfill=%s, window=%sd)",
+                payload["installation_id"][:8], backfill, window_days,
+            )
+            return True
+        logger.warning("[telemetry-share] POST returned HTTP %s", resp.status_code)
+        return False
+    except Exception as e:  # noqa: BLE001 — fire-and-forget, swallow everything
+        logger.info("[telemetry-share] skipped (ignored): %s", type(e).__name__)
+        return False
+
+
+class TelemetrySharingService:
+    """Background heartbeat that shares the aggregate on the configured cadence
+    when consent is on. Inert (a cheap consent read) when opted out."""
+
+    def __init__(self, interval_hours: int = TELEMETRY_SHARING_INTERVAL_HOURS):
+        self.interval_seconds = max(int(interval_hours), 1) * 3600
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+
+    def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info("[telemetry-share] heartbeat started (every %sh)", self.interval_seconds // 3600)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+
+    async def _loop(self) -> None:
+        while self._running:
+            # Sleep FIRST so boot isn't a share burst; jitter so replicas don't
+            # realign. If hard-disabled, idle (the operator can't opt in anyway).
+            jitter = random.uniform(0, min(600, self.interval_seconds * 0.1))
+            try:
+                await asyncio.sleep(self.interval_seconds + jitter)
+            except asyncio.CancelledError:
+                break
+            if not self._running:
+                break
+            if is_hard_disabled() or not is_consent_enabled():
+                continue
+            await share_now(backfill=False)
+
+
+telemetry_sharing_service = TelemetrySharingService()

--- a/src/frontend/src/components/OnboardingWizard.vue
+++ b/src/frontend/src/components/OnboardingWizard.vue
@@ -93,6 +93,34 @@
               <p class="mt-3 text-xs text-gray-400 dark:text-gray-500">No subscription? You can instead set a platform Anthropic API key in the same place.</p>
             </div>
 
+            <!-- ent#12 Tier-2 — value-framed, optional, default-off sharing ask.
+                 One line; never blocks finishing. Anonymized aggregates only. -->
+            <div
+              v-if="!shareHardDisabled"
+              class="mt-4 flex items-start gap-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 px-4 py-3"
+            >
+              <span class="text-lg leading-none">📊</span>
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-medium text-gray-900 dark:text-white">
+                  Share anonymous usage → see how your setup compares to the fleet
+                </p>
+                <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                  Coarse counts only — no content, prompts, emails, or agent names. Off by default, reversible in Settings.
+                </p>
+              </div>
+              <button
+                type="button"
+                :disabled="shareBusy || shareOptedIn"
+                @click="enableSharing"
+                class="flex-shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-60"
+                :class="shareOptedIn
+                  ? 'bg-status-success-100 dark:bg-status-success-900/30 text-status-success-700 dark:text-status-success-400'
+                  : 'bg-action-primary-600 text-white hover:bg-action-primary-700'"
+              >
+                {{ shareOptedIn ? '✓ Sharing on' : 'Share usage' }}
+              </button>
+            </div>
+
             <div class="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
               <button
                 @click="openChat"
@@ -151,10 +179,11 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import CreateAgentModal from './CreateAgentModal.vue'
 import { useProductTelemetryStore } from '../stores/productTelemetry'
+import { useTelemetrySharingStore } from '../stores/telemetrySharing'
 
 defineProps({
   // Whether platform Claude auth is configured (from feature-flags). Decides
@@ -168,6 +197,22 @@ const router = useRouter()
 // Local product-event funnel (ent#184). Fire-and-forget beacons; never awaited,
 // never blocks the wizard. Zero egress — recorded on this instance only.
 const telemetry = useProductTelemetryStore()
+
+// ent#12 Tier-2 — optional, value-framed sharing ask (default-off). Loaded lazily
+// so we know whether it's hard-disabled by config (then hide the ask entirely).
+const sharing = useTelemetrySharingStore()
+const shareBusy = ref(false)
+const shareOptedIn = computed(() => sharing.status.enabled)
+const shareHardDisabled = computed(() => sharing.status.hard_disabled)
+
+async function enableSharing() {
+  shareBusy.value = true
+  try {
+    await sharing.setConsent(true, 30)  // include 30d backfill so benchmarks are accurate
+  } finally {
+    shareBusy.value = false
+  }
+}
 
 // Intent → starter template. Each maps to a real local template shipped in
 // config/agent-templates. CreateAgentModal falls back to a blank agent if a
@@ -225,6 +270,8 @@ onMounted(() => {
   nextTick(() => focusable()[0]?.focus())
   // Funnel: the operator opened the first-run wizard (top of the funnel).
   telemetry.record('setup_started')
+  // ent#12: load sharing status so the (optional) consent ask reflects config.
+  sharing.load()
 })
 
 onUnmounted(() => {

--- a/src/frontend/src/components/OnboardingWizard.vue
+++ b/src/frontend/src/components/OnboardingWizard.vue
@@ -105,7 +105,7 @@
                   Share anonymous usage → see how your setup compares to the fleet
                 </p>
                 <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-                  Coarse counts only — no content, prompts, emails, or agent names. Off by default, reversible in Settings.
+                  Coarse counts only — no content, prompts, emails, or agent names. Includes the last 30 days of local counts. Off by default, reversible in Settings.
                 </p>
               </div>
               <button

--- a/src/frontend/src/components/settings/ActivationFunnelPanel.vue
+++ b/src/frontend/src/components/settings/ActivationFunnelPanel.vue
@@ -22,6 +22,19 @@
       </select>
     </div>
 
+    <!-- ent#12 Tier-2 — fleet benchmark reciprocity carrot (gated view). v1 is a
+         status surface until the hosted benchmark service lands. -->
+    <div
+      v-if="benchmark"
+      class="mx-6 mt-4 rounded-md border px-4 py-3 text-sm"
+      :class="benchmark.sharing_enabled
+        ? 'border-action-primary-200 dark:border-action-primary-800 bg-action-primary-50 dark:bg-action-primary-900/20'
+        : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40'"
+    >
+      <p class="font-medium text-gray-900 dark:text-gray-100">Fleet benchmarks</p>
+      <p class="mt-0.5 text-xs text-gray-600 dark:text-gray-400">{{ benchmark.message }}</p>
+    </div>
+
     <div class="p-6">
       <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading…</div>
 
@@ -113,6 +126,7 @@ const error = ref('')
 const funnelCounts = ref({})
 const firstValueCounts = ref({})
 const installationId = ref('')
+const benchmark = ref(null)  // ent#12 Tier-2 carrot status
 
 const funnel = computed(() =>
   FUNNEL_STEPS.map((s) => ({ ...s, count: funnelCounts.value[s.key] || 0 }))
@@ -152,6 +166,13 @@ async function load() {
     funnelCounts.value = r.data?.funnel || {}
     firstValueCounts.value = r.data?.first_value || {}
     installationId.value = r.data?.installation_id || ''
+    // ent#12: fetch the Tier-2 benchmark status (best-effort, non-blocking).
+    try {
+      const b = await api.get('/api/enterprise/telemetry/benchmark')
+      benchmark.value = b.data || null
+    } catch {
+      benchmark.value = null
+    }
   } catch (e) {
     error.value =
       e?.response?.data?.detail ||

--- a/src/frontend/src/components/settings/TelemetrySharingPanel.vue
+++ b/src/frontend/src/components/settings/TelemetrySharingPanel.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900 rounded-lg">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+      <h2 class="text-lg font-medium text-gray-900 dark:text-white">Usage sharing</h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Optionally share <span class="font-medium">anonymous, aggregate</span> usage
+        so you can see how your setup compares to the fleet. Off by default,
+        reversible any time — nothing is shared until you turn this on. (ent#12)
+      </p>
+    </div>
+
+    <div class="p-6 space-y-5">
+      <div v-if="store.error" class="text-sm text-status-danger-600 dark:text-status-danger-400">
+        {{ store.error }}
+      </div>
+
+      <!-- Hard-disabled by config -->
+      <div
+        v-if="store.status.hard_disabled"
+        class="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300"
+      >
+        Sharing is disabled by configuration
+        (<code class="text-xs">TELEMETRY_SHARING_ENABLED=false</code> or
+        <code class="text-xs">DO_NOT_TRACK</code>). The toggle stays off and nothing leaves the box.
+      </div>
+
+      <!-- Toggle -->
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <p class="text-sm font-medium text-gray-900 dark:text-gray-100">Share anonymous usage</p>
+          <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            <template v-if="store.status.enabled">
+              On since {{ fmt(store.status.consent_at) }}.
+              <template v-if="store.status.last_shared_at">Last shared {{ fmt(store.status.last_shared_at) }}.</template>
+            </template>
+            <template v-else>Currently off — no egress.</template>
+          </p>
+        </div>
+        <button
+          type="button"
+          :disabled="store.saving || store.status.hard_disabled"
+          @click="toggle"
+          :class="[
+            'relative inline-flex h-6 w-11 flex-shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-40',
+            store.status.enabled ? 'bg-action-primary-600' : 'bg-gray-300 dark:bg-gray-600',
+          ]"
+          role="switch"
+          :aria-checked="store.status.enabled"
+        >
+          <span
+            :class="['inline-block h-5 w-5 transform rounded-full bg-white transition-transform mt-0.5',
+                     store.status.enabled ? 'translate-x-5' : 'translate-x-0.5']"
+          ></span>
+        </button>
+      </div>
+
+      <!-- Backfill selection (only meaningful when turning on) -->
+      <div v-if="!store.status.enabled && !store.status.hard_disabled" class="flex items-center gap-2 text-sm">
+        <label class="text-gray-600 dark:text-gray-300">On consent, also share the last</label>
+        <select v-model.number="backfillDays" class="text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+          <option :value="7">7 days</option>
+          <option :value="30">30 days</option>
+          <option :value="90">90 days</option>
+          <option :value="0">no history</option>
+        </select>
+        <span class="text-gray-600 dark:text-gray-300">of local history, so your benchmarks are accurate.</span>
+      </div>
+
+      <!-- What's shared / inspectable preview -->
+      <details class="rounded-md border border-gray-200 dark:border-gray-700">
+        <summary class="cursor-pointer px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          Exactly what would be shared (inspect before you consent)
+        </summary>
+        <div class="px-4 pb-4 pt-1">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            Anonymized aggregates only — version, platform, edition, feature list,
+            agent &amp; execution <span class="font-medium">counts</span>, and
+            activation-funnel counts. <span class="font-medium">No PII, no content, no
+            prompts, no emails, no agent names.</span> Keyed by a random install id.
+          </p>
+          <pre class="overflow-x-auto rounded bg-gray-50 dark:bg-gray-900 p-3 text-xs text-gray-700 dark:text-gray-300"><code>{{ prettyPreview }}</code></pre>
+        </div>
+      </details>
+
+      <p class="text-xs text-gray-400 dark:text-gray-500">
+        Reversible: turn this off any time and egress stops immediately.
+        <a href="https://github.com/abilityai/trinity/blob/main/docs/PRODUCT_EVENTS.md" target="_blank" rel="noopener" class="underline">Payload schema &amp; details</a>.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useTelemetrySharingStore } from '../../stores/telemetrySharing'
+
+const store = useTelemetrySharingStore()
+const backfillDays = ref(30)
+
+const prettyPreview = computed(() =>
+  store.payloadPreview ? JSON.stringify(store.payloadPreview, null, 2) : '(load to preview)'
+)
+
+function fmt(iso) {
+  if (!iso) return '—'
+  try { return new Date(iso).toLocaleString() } catch { return iso }
+}
+
+async function toggle() {
+  const enabling = !store.status.enabled
+  const ok = await store.setConsent(enabling, enabling ? backfillDays.value : null)
+  if (ok) store.load(true)
+}
+
+onMounted(() => {
+  store.load()
+})
+</script>

--- a/src/frontend/src/stores/telemetrySharing.js
+++ b/src/frontend/src/stores/telemetrySharing.js
@@ -1,0 +1,64 @@
+import { defineStore } from 'pinia'
+import api from '../api'
+
+/**
+ * Tier-2 opt-in fleet telemetry sharing (ent#12).
+ *
+ * The consent + status for the anonymized-aggregate sharing channel. Default-off,
+ * reversible. All HTTP goes through the shared api.js client (Invariant #7).
+ *
+ * The `payload_preview` returned by GET is the EXACT anonymized aggregate that
+ * would be sent — surfaced in the Settings panel so the operator inspects what
+ * leaves the box before consenting. Coarse counts only; never any PII.
+ */
+export const useTelemetrySharingStore = defineStore('telemetrySharing', {
+  state: () => ({
+    loaded: false,
+    saving: false,
+    status: {
+      enabled: false,
+      hard_disabled: false,
+      consent_at: null,
+      backfill_days: 30,
+      last_shared_at: null,
+      share_url: '',
+      interval_hours: 24,
+    },
+    payloadPreview: null,
+    error: '',
+  }),
+
+  actions: {
+    async load(force = false) {
+      if (this.loaded && !force) return
+      this.error = ''
+      try {
+        const r = await api.get('/api/settings/telemetry-sharing')
+        const { payload_preview, ...status } = r.data || {}
+        this.status = { ...this.status, ...status }
+        this.payloadPreview = payload_preview || null
+      } catch (e) {
+        this.error = e?.response?.data?.detail || 'Failed to load sharing status.'
+      } finally {
+        this.loaded = true
+      }
+    },
+
+    async setConsent(enabled, backfillDays = null) {
+      this.saving = true
+      this.error = ''
+      try {
+        const body = { enabled }
+        if (backfillDays != null) body.backfill_days = backfillDays
+        const r = await api.put('/api/settings/telemetry-sharing', body)
+        this.status = { ...this.status, ...(r.data || {}) }
+        return true
+      } catch (e) {
+        this.error = e?.response?.data?.detail || 'Failed to update sharing.'
+        return false
+      } finally {
+        this.saving = false
+      }
+    },
+  },
+})

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -167,6 +167,12 @@
                The panel fetches the gated enterprise endpoint itself. -->
           <ActivationFunnelPanel v-if="activeTab === 'activation'" />
 
+          <!-- ent#12 — Tier-2 opt-in usage sharing. OSS-core, default-off,
+               reversible. Admin-only (General tab), visible in every edition. -->
+          <div v-if="activeTab === 'general'" class="mb-6">
+            <TelemetrySharingPanel />
+          </div>
+
           <!-- Platform Section -->
           <!-- Admin sign-in email (#82 Phase 1) — lets an existing admin bind a
                real email so they can sign in with email + password, matching
@@ -2312,6 +2318,7 @@ import AgentPermissionsMatrix from '../components/AgentPermissionsMatrix.vue'
 import TwoFactorPanel from '../components/settings/TwoFactorPanel.vue'
 import SsoPanel from '../components/settings/SsoPanel.vue'
 import ActivationFunnelPanel from '../components/settings/ActivationFunnelPanel.vue'
+import TelemetrySharingPanel from '../components/settings/TelemetrySharingPanel.vue'
 import ConfirmDialog from '../components/ConfirmDialog.vue'
 
 const router = useRouter()

--- a/tests/unit/test_ent12_telemetry_sharing.py
+++ b/tests/unit/test_ent12_telemetry_sharing.py
@@ -144,3 +144,41 @@ def test_set_consent_roundtrip(tss):
     st = mod.set_consent(False)
     assert st["enabled"] is False
     assert mod.is_consent_enabled() is False
+
+
+# --- review fixes (validation pass, 0.8.5) -----------------------------------
+
+def test_consent_audit_uses_a_real_audit_event_type():
+    """The consent handler audited with `AuditEventType.SETTINGS`, which does
+    not exist — the AttributeError was swallowed by the best-effort except, so
+    every consent flip of an egress channel went silently un-audited. Pin that
+    the member referenced by the telemetry handler actually exists."""
+    import re
+    from pathlib import Path
+    from services.platform_audit_service import AuditEventType
+
+    src = (Path(__file__).resolve().parents[2] / "src" / "backend" / "routers"
+           / "settings.py").read_text()
+    handler = src[src.index("telemetry_sharing_consent") - 2000:
+                  src.index("telemetry_sharing_consent") + 200]
+    members = re.findall(r"AuditEventType\.([A-Z_]+)", handler)
+    assert members, "consent handler must audit-log"
+    for m in members:
+        assert hasattr(AuditEventType, m), (
+            f"AuditEventType.{m} does not exist — the audit call would raise "
+            "AttributeError inside the best-effort except and never log"
+        )
+
+
+def test_generic_settings_put_blocks_telemetry_sharing_keys():
+    """Consent is human-only via the dedicated route (reject_agent_principal +
+    hard-disable 409 + audit). The generic PUT /api/settings/{key} must 422 the
+    telemetry_sharing_* family or an admin-owned agent-scoped key can flip
+    egress consent around all of that (trinity-ops-agent#232 class)."""
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2] / "src" / "backend" / "routers"
+           / "settings.py").read_text()
+    assert 'key.startswith("telemetry_sharing_")' in src, (
+        "generic settings PUT must block the telemetry_sharing_* key family"
+    )

--- a/tests/unit/test_ent12_telemetry_sharing.py
+++ b/tests/unit/test_ent12_telemetry_sharing.py
@@ -1,0 +1,146 @@
+"""Tier-2 opt-in fleet telemetry sharing (ent#12).
+
+Unit-level coverage of the egress gate + the anonymized-aggregate payload, with
+``db`` and ``httpx`` mocked (no real backend, no real egress). The end-to-end
+gating/delivery was also proven live against the Postgres stack.
+
+Locked behaviour (from the AC):
+  * NEVER egresses without BOTH gates: config switch AND stored consent.
+  * Payload is anonymized/coarse — no PII (no emails, agent names, content).
+  * Opt-out (consent off) stops egress immediately.
+  * Fail-open: a POST error never raises.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+@pytest.fixture
+def tss():
+    try:
+        import services.telemetry_sharing_service as mod
+    except ImportError:
+        pytest.skip("backend venv required")
+    # A db whose settings default to "off" and whose aggregates are coarse.
+    store = {}
+    mdb = MagicMock()
+    mdb.get_setting_value.side_effect = lambda k, d=None: store.get(k, d)
+    mdb.set_setting.side_effect = lambda k, v: store.update({k: v})
+    mdb.get_fleet_execution_stats.return_value = {
+        "total": 22, "success_count": 21, "failed_count": 1,
+    }
+    mdb.count_product_events_by_type.return_value = {"setup_started": 2}
+    mdb.count_non_system_agents.return_value = 3
+    with patch.object(mod, "db", mdb):
+        yield mod, store
+
+
+def _payload_blob(mod):
+    return json.dumps(mod.build_aggregate_payload(window_days=30, backfill=True)).lower()
+
+
+def test_payload_has_no_pii(tss):
+    mod, _ = tss
+    blob = _payload_blob(mod)
+    for banned in ("email", "agent_name", "message", "content", "prompt", "password", "token", "@"):
+        assert banned not in blob, f"payload leaked '{banned}'"
+
+
+def test_payload_is_coarse_and_keyed(tss):
+    mod, _ = tss
+    pl = mod.build_aggregate_payload(window_days=30, backfill=True)
+    assert pl["installation_id"]
+    assert pl["counts"]["agents"] == 3
+    assert pl["counts"]["executions_total"] == 22
+    assert "activation_funnel" in pl
+    assert set(pl["instance"]) == {"trinity_version", "edition", "platform", "python_version"}
+
+
+def test_no_egress_when_consent_off(tss):
+    mod, _store = tss
+    with patch.object(mod, "TELEMETRY_SHARING_ENABLED", True), \
+         patch.object(mod.httpx, "AsyncClient") as mclient:
+        result = asyncio.run(mod.share_now(backfill=True))
+    assert result is False
+    mclient.assert_not_called()  # never even constructed a client
+
+
+def test_no_egress_when_hard_disabled(tss):
+    mod, store = tss
+    store["telemetry_sharing_enabled"] = "true"  # consent ON...
+    with patch.object(mod, "TELEMETRY_SHARING_ENABLED", False), \
+         patch.object(mod.httpx, "AsyncClient") as mclient:
+        result = asyncio.run(mod.share_now(backfill=True))  # ...but config OFF
+    assert result is False
+    mclient.assert_not_called()
+
+
+def _fake_client(status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=ctx), client
+
+
+def test_egress_when_both_gates_on(tss):
+    mod, store = tss
+    store["telemetry_sharing_enabled"] = "true"
+    fake_ac, client = _fake_client(200)
+    with patch.object(mod, "TELEMETRY_SHARING_ENABLED", True), \
+         patch.object(mod.httpx, "AsyncClient", fake_ac):
+        result = asyncio.run(mod.share_now(backfill=True))
+    assert result is True
+    client.post.assert_awaited_once()
+    # last-shared stamped
+    assert store.get("telemetry_sharing_last_shared_at")
+    # the posted body is the anonymized payload
+    _, kwargs = client.post.call_args
+    body = json.dumps(kwargs["json"]).lower()
+    assert "@" not in body and "agent_name" not in body
+
+
+def test_fail_open_on_post_error(tss):
+    mod, store = tss
+    store["telemetry_sharing_enabled"] = "true"
+    fake_ac, client = _fake_client()
+    client.post = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(mod, "TELEMETRY_SHARING_ENABLED", True), \
+         patch.object(mod.httpx, "AsyncClient", fake_ac):
+        # must NOT raise
+        result = asyncio.run(mod.share_now(backfill=True))
+    assert result is False
+
+
+def test_non_2xx_not_marked_shared(tss):
+    mod, store = tss
+    store["telemetry_sharing_enabled"] = "true"
+    fake_ac, _client = _fake_client(404)
+    with patch.object(mod, "TELEMETRY_SHARING_ENABLED", True), \
+         patch.object(mod.httpx, "AsyncClient", fake_ac):
+        result = asyncio.run(mod.share_now(backfill=True))
+    assert result is False
+    assert "telemetry_sharing_last_shared_at" not in store
+
+
+def test_set_consent_roundtrip(tss):
+    mod, store = tss
+    st = mod.set_consent(True, backfill_days=7)
+    assert st["enabled"] is True and st["consent_at"] and st["backfill_days"] == 7
+    assert mod.is_consent_enabled() is True
+    st = mod.set_consent(False)
+    assert st["enabled"] is False
+    assert mod.is_consent_enabled() is False


### PR DESCRIPTION
## ent#12 — Tier-2 opt-in fleet sharing (OSS consent + egress + backfill)

The **opt-in egress** layer on top of Tier-1 (ent#184). **Default-OFF, reversible.** Gating shape confirmed: **OSS-core consent+egress+backfill**, enterprise-gated benchmark carrot.

> ⚠️ **Stacked on #1721** (ent#184). Base is the ent#184 branch so this diff shows only Tier-2 — retarget to `dev` when #1721 merges.

### Never egresses without consent — two independent gates
Both re-checked in `share_now`: the stored `telemetry_sharing_enabled` consent (default-off) **AND** the config switch `TELEMETRY_SHARING_ENABLED` (honors `DO_NOT_TRACK`). Either off ⇒ nothing leaves the box.

### What ships
- **`services/telemetry_sharing_service.py`** — consent state, `build_aggregate_payload` (**anonymized**: install id + version/edition/platform/python + coarse `enterprise_features` + agent/execution **counts** + Tier-1 funnel counts; **no PII, content, prompts, emails, agent names**), `share_now` (gated, fail-open, honest 2xx), and a sleeps-first jittered heartbeat (default 24h). Reuses the operator-intake #38 credential-free transport.
- **Retroactive backfill at consent** — on off→on, an immediate fire-and-forget backfill over a disclosed window (default 30d) from Tier-1 `product_events`.
- **API** — `GET /api/settings/telemetry-sharing` (status + **inspectable `payload_preview`** — see exactly what would be sent before consenting) + `PUT` (admin + human-only, audit-logged, 409 when hard-disabled). feature-flags exposes `telemetry_sharing_enabled`.
- **Frontend** — value-framed optional non-blocking wizard ask (hidden when hard-disabled) + reversible default-off Settings → General panel with payload preview + backfill picker; the gated funnel panel shows the benchmark status.
- **Docs** — `docs/PRODUCT_EVENTS.md` Tier-2 section (schema + reversibility + backfill) + requirements §45.1.

### AC coverage
- [x] Consent surface in wizard (value-framed) + Settings toggle (default-off, reversible), each stating what's shared
- [x] On consent: optional retroactive backfill, disclosed explicitly
- [x] Anonymized aggregate payload (documented schema, no PII) on a periodic heartbeat
- [x] Opt-out stops egress immediately; docs cover schema + reversibility
- [x] v1 carrot: participants view a benchmark status keyed by `installation_id` *(gated view lands with the enterprise PR; hosted percentile service is its own issue)*
- [x] Hosted aggregation intake scoped out (separate issue)

### Verification
`tests/unit/test_ent12_telemetry_sharing.py` (8): no-PII payload, both-gate egress, opt-out stops egress, fail-open, non-2xx not marked shared, consent round-trip. **Live on the Postgres stack**: gating + delivery to a **local sink** + no-PII + reversibility (21 checks) + router/preview end-to-end. **No real external egress in any test.**

Related to ent#12 · Tier-1 ent#184 · pairs with trinity-enterprise `feature/12-telemetry-benchmark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
