### PR TITLE
docs(release)+test: ent#187 skill-package decision (accept risk) + backward-compat regression

### DIFF
--- a/docs/releases/0.8.5.md
+++ b/docs/releases/0.8.5.md
@@ -1,0 +1,40 @@
+# v0.8.5
+
+**Released**: _pending cut_
+**Tag**: `v0.8.5` &nbsp;·&nbsp; **Diff**: [v0.8.0...v0.8.5](https://github.com/abilityai/trinity/compare/v0.8.0...v0.8.5)
+
+> **PRE-CUT SEED.** This file seeds the **behavior-change / upgrade notes** that
+> must appear in the generated v0.8.5 notes. The full feature/bug lists are
+> produced at the dev→main cut; fold this section in rather than overwriting it.
+
+## ⚠️ Behavior changes / upgrade notes
+
+### Skill loading changed for every agent (#183, ent#182)
+
+v0.8.5 replaces single-file skill injection with **full-directory skill
+packages** (`.claude/skills/<name>/` — `SKILL.md` plus `scripts/`, `templates/`,
+`resources/`), a hardened frontmatter contract, tree-SHA versioning, and
+manifest-based pruning. This changes `sync_agent_skills` / `list_skills` /
+`get_skill` for **all agents** — there is no feature flag.
+
+**This is a deliberate unflagged change (decision: ent#187 — accept the risk).**
+It is safe because it is **strictly additive and backward-compatible**, verified
+by `tests/unit/test_183_skill_packages_backward_compat.py`:
+
+- **A skill with no frontmatter** still lists, loads, and stays user-invocable —
+  a missing frontmatter block parses to an empty contract (no deps, no warnings),
+  with the description falling back to the first paragraph exactly as before.
+- **An agent whose skills were synced under the old format** (no injection
+  manifest) is **re-injected in full and never destructively pruned** — the
+  platform only ever deletes files a *prior package injection* wrote, so an
+  un-managed skill directory is overwritten, not lost. Agents self-heal to the
+  new package format on their next sync.
+
+No operator action is required. If a skill directory carries a malformed
+frontmatter block it is reported as `frontmatter_invalid` and skipped for that
+skill only (the rest sync normally).
+
+_Rationale for shipping without a kill-switch, in full, is recorded on ent#187:
+the change is additive, and Phases 2-3 of the skill epic (#139 placement/skill-
+runner, #178 unified exposable-skills config) build on this contract, so a flag
+would have a deliberately short life._

--- a/tests/unit/test_183_skill_packages_backward_compat.py
+++ b/tests/unit/test_183_skill_packages_backward_compat.py
@@ -1,0 +1,111 @@
+"""#183 full-directory skill packages — backward-compatibility regression (ent#187).
+
+ent#187 decision: **accept the risk, no kill-switch** — #183 is strictly additive
+and backward-compatible, so a flag is unwarranted (and would have a limited life:
+Phases 2-3, #139/#178, build on this contract). This test is the AC-required proof
+that a **legacy-format skill (no frontmatter)** and a **legacy-synced agent
+(no prior injection manifest)** both survive the new sync/list/get path.
+
+The two backward-compat questions ent#187 asks, each pinned here:
+
+1. **A skill directory with NO frontmatter** — parses cleanly to an empty
+   contract, stays `user_invocable=True`, gets a first-paragraph description
+   fallback, and raises no contract warnings. It lists and loads exactly as
+   before #183 (no regression on the universal skill-load path).
+
+2. **An agent whose skills were synced under the OLD format** (no
+   `.trinity-skill.json` manifest) — `compute_prune` deletes **nothing** without a
+   prior manifest ("no-meta → full inject, no prune — safe direction"), so the
+   platform never destroys files it did not write. The agent self-heals to the
+   new package format on the next sync.
+
+Pure/deterministic — packaging functions + `_parse_skill_info` over a temp file;
+no container, no git, no network.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+@pytest.fixture
+def pkg():
+    try:
+        import services.skill_packaging as pkg
+    except ImportError:
+        pytest.skip("backend venv required")
+    return pkg
+
+
+# ---------------------------------------------------------------------------
+# Q1 — a skill with no frontmatter is strictly additive
+# ---------------------------------------------------------------------------
+
+def test_missing_frontmatter_parses_clean(pkg):
+    """No `---` block → (None, None): missing frontmatter is NOT an error."""
+    fm, warning = pkg.parse_frontmatter("# My Skill\n\nDoes a useful thing.\n")
+    assert fm is None
+    assert warning is None  # never flagged frontmatter_invalid
+
+
+def test_empty_contract_defaults_are_backward_compatible(pkg):
+    """extract_contract(None) → the pre-#183 defaults: invocable, no deps."""
+    contract, warnings = pkg.extract_contract(None)
+    assert contract["user_invocable"] is True          # legacy skills stay invocable
+    assert contract["description"] is None
+    assert contract["automation"] is None
+    assert contract["allowed_tools"] is None
+    assert contract["requires"] == {"packages": [], "binaries": [], "env": []}
+    assert warnings == []                               # no dep/contract warnings
+
+
+def test_legacy_skill_md_lists_and_loads(pkg, tmp_path, monkeypatch):
+    """A legacy no-frontmatter SKILL.md is parsed into a valid, invocable entry
+    with a first-paragraph description — the list/get surface is unchanged."""
+    from services.skill_service import SkillService
+
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("# Legacy Skill\n\nRuns the legacy thing.\n")
+
+    svc = SkillService()
+    # _parse_skill_info only calls _skill_files for file_count/size — stub it so
+    # this stays a pure parse test (no library dir needed).
+    monkeypatch.setattr(svc, "_skill_files", lambda name: [])
+
+    info = svc._parse_skill_info("legacy-skill", skill_md)
+    assert info["name"] == "legacy-skill"
+    assert info["user_invocable"] is True
+    assert info["description"] == "Runs the legacy thing."   # first-paragraph fallback
+    assert info["contract_warnings"] == []
+    assert info["requires"] == {"packages": [], "binaries": [], "env": []}
+
+
+# ---------------------------------------------------------------------------
+# Q2 — a legacy-synced agent (no prior manifest) is never destructively pruned
+# ---------------------------------------------------------------------------
+
+def test_no_prior_manifest_prunes_nothing(pkg):
+    """The 'safe direction': without a previous injection manifest, compute_prune
+    deletes nothing — a legacy-synced (or unmanaged) agent dir is re-injected,
+    never destroyed."""
+    stale, truncated = pkg.compute_prune(None, [".claude/skills/s/SKILL.md"], "s")
+    assert stale == []
+    assert truncated is False
+    # A non-list junk value is treated the same (untrusted agent-side state).
+    assert pkg.compute_prune("not-a-list", [".claude/skills/s/a"], "s") == ([], False)
+
+
+def test_prune_only_removes_previously_written_files(pkg):
+    """When a prior #183 manifest DOES exist, prune removes only what changed —
+    proving the new-format path is well-behaved (the counterpart to Q2)."""
+    prev = [".claude/skills/s/old.md", ".claude/skills/s/keep.md"]
+    new = [".claude/skills/s/keep.md"]
+    stale, truncated = pkg.compute_prune(prev, new, "s")
+    assert stale == [".claude/skills/s/old.md"]
+    assert truncated is False


### PR DESCRIPTION
## ent#187 — decision: accept the risk (no kill-switch)

Records the decision + delivers the AC items for the unflagged #183 skill-package change. **Test + docs only — no behavior change; freeze-safe** (this is the "skill packages" targeted regression the v0.8.5 plan calls for during soak).

### Why accept-risk (verified in code, not asserted)
The #183 change is **strictly additive and backward-compatible** on both questions ent#187 asks:

| Case | Behavior | Proof |
|------|----------|-------|
| Skill with **no frontmatter** | Still lists/loads, `user_invocable=True`, first-paragraph description fallback, no warnings | `parse_frontmatter`→`(None,None)`; `extract_contract(None)`→defaults |
| Agent synced under the **old format** (no manifest) | Full re-inject, **zero** destructive prune ("no-meta → no prune, safe direction") | `compute_prune(None,…)`→`([],False)`; prune only removes files a *prior* injection wrote |

A kill-switch would also be short-lived — Phases 2-3 (#139/#178) build on this contract. The two same-day hotfixes were hardening (path sanitization, `REDIS_URL` via config), not compat fixes.

### Deliverables (AC)
- [x] Decision recorded with rationale (this PR + ent#187 comment)
- [x] Backward-compat argument written down (both cases above)
- [x] Release notes state skill loading changed for all agents — `docs/releases/0.8.5.md` pre-cut seed
- [x] Regression test: legacy no-frontmatter skill survives sync — `tests/unit/test_183_skill_packages_backward_compat.py` (5, passing)

Related to trinity-enterprise#187 · #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
