### PR TITLE
feat(agents): set display label at creation + harden the label contract (#1640)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -803,8 +803,9 @@ Full flow: [cornelius-default-agent.md](feature-flows/cornelius-default-agent.md
 | GET | `/api/agents/context-stats` | Context & activity state for all agents |
 | GET | `/api/agents/autonomy-status` | Autonomy status for all accessible agents |
 | GET | `/api/agents/sync-health` | Per-agent git sync health for dashboard dots (#389) |
-| POST | `/api/agents` | Create agent |
+| POST | `/api/agents` | Create agent. Accepts an optional `display_label` (ent#1640) — the human-facing name set at creation (normalized + named-error validated like `PUT /label`); omit/blank → renders under the slug |
 | GET | `/api/agents/{name}` | Get agent details |
+| GET/PUT | `/api/agents/{name}/label` | Get / set-or-clear the agent's human-facing **display label** (ent#181/#1640). Owner-only (`OwnedAgentByName`); `label` nullable — blank/None clears to the slug fallback; presentation-only (the slug never moves, unlike `PUT /rename`); trims + rejects control chars/line-breaks with a **named** error, **not** unique (the slug guarantees uniqueness), audit-logged, broadcasts `agent_label_changed` |
 | DELETE | `/api/agents/{name}` | Soft-delete agent (see [Soft Delete](#soft-delete-retention--recovery-834-772)) |
 | POST | `/api/agents/{name}/start` | Start agent |
 | POST | `/api/agents/{name}/stop` | Stop agent |

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -3,6 +3,7 @@ Pydantic models for the Trinity backend API.
 """
 import os
 import re
+import unicodedata
 
 from pydantic import BaseModel, EmailStr, Field, SecretStr, field_validator, model_validator
 from typing import Dict, List, Literal, Optional
@@ -86,7 +87,11 @@ class EphemeralConfig(BaseModel):
 
 class AgentConfig(BaseModel):
     """Configuration for creating a new agent."""
-    name: str
+    name: str  # the immutable slug — every route/container/volume/key keys on it
+    # ent#1640: optional human-facing display label set AT creation. Presentation
+    # only; None → the agent renders under its slug (exactly today's behavior).
+    # Same normalization + named validation as the post-creation PUT /label.
+    display_label: Optional[str] = None
     type: Optional[str] = "business-assistant"
     base_image: str = "trinity-agent-base:latest"
     resources: Optional[dict] = {"cpu": "2", "memory": "4g"}
@@ -113,6 +118,42 @@ class AgentConfig(BaseModel):
     # hard-discarded at budget. Entitlement-gated at the creation path.
     ephemeral: Optional[EphemeralConfig] = None
 
+    @field_validator("display_label")
+    @classmethod
+    def _normalize_display_label(cls, v: Optional[str]) -> Optional[str]:
+        return normalize_display_label(v)
+
+
+# ent#181/#1640 — the human-facing display label. Shared normalization + a
+# NAMED validation error (not a generic 422 blob), used everywhere a label is
+# accepted (set-after-creation AND at creation), so the policy lives in one place.
+DISPLAY_LABEL_MAX_LEN = 120
+
+
+def normalize_display_label(value: Optional[str]) -> Optional[str]:
+    """Trim, empty→None (clear), reject control chars / line breaks, cap length.
+
+    Uniqueness is deliberately NOT enforced — the slug (`agent_name`) already
+    guarantees uniqueness; a display label is a presentation string that may
+    legitimately repeat across agents (#1640). Raises ``ValueError`` with a
+    specific message on bad input so callers surface a named error.
+    """
+    if value is None:
+        return None
+    # Normalize to NFC so visually-identical labels compare/store consistently.
+    value = unicodedata.normalize("NFC", value).strip()
+    if not value:
+        return None  # blank clears the label → render under the slug again
+    if len(value) > DISPLAY_LABEL_MAX_LEN:
+        raise ValueError(
+            f"display label must be at most {DISPLAY_LABEL_MAX_LEN} characters"
+        )
+    # A display name is a single line: reject control chars (category Cc, incl.
+    # \n\t\r) and the Unicode line/paragraph separators.
+    if any(unicodedata.category(ch) == "Cc" or ch in (" ", " ") for ch in value):
+        raise ValueError("display label must not contain control characters or line breaks")
+    return value
+
 
 class AgentLabelUpdate(BaseModel):
     """PUT body — set or clear an agent's human-facing label (ent#181).
@@ -121,7 +162,12 @@ class AgentLabelUpdate(BaseModel):
     again. Presentation only: the slug never moves, which is the entire point —
     a slug rename re-keys ~20 tables and strands the agent's volumes (#1664).
     """
-    label: Optional[str] = Field(default=None, max_length=120)
+    label: Optional[str] = None
+
+    @field_validator("label")
+    @classmethod
+    def _normalize_label(cls, v: Optional[str]) -> Optional[str]:
+        return normalize_display_label(v)
 
 
 class AgentStatus(BaseModel):

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -886,6 +886,22 @@ async def set_agent_label_endpoint(
         raise HTTPException(status_code=404, detail="Agent not found")
 
     label = db.get_display_label(agent_name)
+
+    # ent#1640: audit the label change (set vs clear). Best-effort — never blocks
+    # the (already-committed) write. `label` is the resolved stored value.
+    try:
+        await platform_audit_service.log(
+            event_type=AuditEventType.AGENT_LIFECYCLE,
+            event_action="set_display_label" if label else "clear_display_label",
+            source="api",
+            actor_user=current_user,
+            target_type="agent",
+            target_id=agent_name,
+            details={"display_label": label},
+        )
+    except Exception:
+        logger.debug("[#1640] display-label audit log failed", exc_info=True)
+
     if manager:
         await manager.broadcast(json.dumps({
             # `event` is the field the frontend WS client switches on; `type`

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -1327,6 +1327,16 @@ def _register_agent(
         max_parallel_tasks=(1 if config.ephemeral else None),
     )
 
+    # ent#1640: persist the optional display label set at creation. Reuses the
+    # same setter as PUT /label (trim + blank→NULL), on the row just created.
+    # Best-effort: a label write must never fail a successful agent creation —
+    # the agent is fully functional under its slug without it.
+    if config.display_label:
+        try:
+            db.set_display_label(config.name, config.display_label)
+        except Exception as e:
+            logger.warning(f"Could not set display label for {config.name}: {e}")
+
     # trinity-enterprise#69 Part 2: auto-grant the parent→child
     # permission edge so the spawning agent can immediately
     # chat/list/info its child (the MCP layer gates on

--- a/src/frontend/src/components/CreateAgentModal.vue
+++ b/src/frontend/src/components/CreateAgentModal.vue
@@ -12,7 +12,7 @@
 
             <div class="space-y-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Agent Name</label>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Slug / Identifier</label>
                 <input
                   v-model="form.name"
                   type="text"
@@ -20,6 +20,28 @@
                   class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                   placeholder="my-agent"
                 />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  The permanent identifier used in URLs, containers, and API keys.
+                  Lowercase, no spaces — it can't be changed casually later.
+                </p>
+              </div>
+
+              <!-- ent#1640: optional human-facing display name, set at creation. -->
+              <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Display name <span class="font-normal text-gray-400">(optional)</span>
+                </label>
+                <input
+                  v-model="form.display_label"
+                  type="text"
+                  maxlength="120"
+                  class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 focus:ring-action-primary-500 focus:border-action-primary-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                  placeholder="e.g. Marketing Assistant"
+                />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  A friendly name shown in the UI. Leave blank to display the slug.
+                  You can change this any time.
+                </p>
               </div>
 
               <div>
@@ -319,6 +341,7 @@ const authStore = useAuthStore()
 
 const form = reactive({
   name: '',
+  display_label: '',   // ent#1640: optional human-facing display name
   template: props.initialTemplate || ''
 })
 
@@ -441,6 +464,10 @@ const createAgent = async () => {
     const payload = {
       name: form.name
     }
+    // ent#1640: optional display name (trimmed); omit when blank so the agent
+    // falls back to its slug, exactly as before.
+    const label = (form.display_label || '').trim()
+    if (label) payload.display_label = label
 
     if (form.template === 'github-custom') {
       const repo = parseGithubRepo(githubRepoUrl.value)

--- a/tests/unit/test_1640_display_label_at_creation.py
+++ b/tests/unit/test_1640_display_label_at_creation.py
@@ -1,0 +1,106 @@
+"""Display label at creation + hardened validation (#1640, ent#181 follow-up 2/5).
+
+#1676 shipped the column, the db setter, `PUT /{name}/label`, the resolver, and
+rendering. #1640 adds: set-at-creation (`AgentConfig.display_label`), a shared
+normalization + **named** validation (not a generic 422 blob), and confirms the
+policy — optional, presentation-only, NOT unique, blank clears to the slug.
+
+Pure/deterministic model-level coverage (no DB, no container).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+@pytest.fixture
+def M():
+    try:
+        import models as M
+    except ImportError:
+        pytest.skip("backend venv required")
+    return M
+
+
+# ---------------------------------------------------------------------------
+# normalize_display_label — the single shared policy
+# ---------------------------------------------------------------------------
+
+def test_trim_and_blank_clears(M):
+    assert M.normalize_display_label("  My Bot  ") == "My Bot"
+    assert M.normalize_display_label("   ") is None   # blank → clear to slug
+    assert M.normalize_display_label("") is None
+    assert M.normalize_display_label(None) is None
+
+
+def test_unicode_preserved(M):
+    assert M.normalize_display_label("Café ☕ 日本語") == "Café ☕ 日本語"
+
+
+def test_overlength_named_error(M):
+    with pytest.raises(ValueError, match="at most 120 characters"):
+        M.normalize_display_label("x" * 121)
+
+
+@pytest.mark.parametrize("bad", ["line\nbreak", "tab\there", "car\rriage", "null\x00byte", "sep here"])
+def test_control_chars_rejected_named(M, bad):
+    with pytest.raises(ValueError, match="control characters or line breaks"):
+        M.normalize_display_label(bad)
+
+
+def test_exactly_max_len_ok(M):
+    label = "a" * 120
+    assert M.normalize_display_label(label) == label
+
+
+# ---------------------------------------------------------------------------
+# AgentConfig — set at creation
+# ---------------------------------------------------------------------------
+
+def test_agentconfig_normalizes_display_label(M):
+    c = M.AgentConfig(name="my-agent", display_label="  Marketing Bot  ")
+    assert c.display_label == "Marketing Bot"
+
+
+def test_agentconfig_display_label_optional_default_none(M):
+    c = M.AgentConfig(name="my-agent")
+    assert c.display_label is None   # absent → renders under the slug (unchanged)
+
+
+def test_agentconfig_rejects_bad_label(M):
+    with pytest.raises(Exception):
+        M.AgentConfig(name="my-agent", display_label="x" * 200)
+    with pytest.raises(Exception):
+        M.AgentConfig(name="my-agent", display_label="bad\nname")
+
+
+def test_agentconfig_blank_label_clears(M):
+    c = M.AgentConfig(name="my-agent", display_label="   ")
+    assert c.display_label is None
+
+
+# ---------------------------------------------------------------------------
+# AgentLabelUpdate — same policy on the post-creation PUT
+# ---------------------------------------------------------------------------
+
+def test_label_update_shares_policy(M):
+    assert M.AgentLabelUpdate(label="  Hi  ").label == "Hi"
+    assert M.AgentLabelUpdate(label="").label is None       # clear
+    assert M.AgentLabelUpdate().label is None
+    with pytest.raises(Exception):
+        M.AgentLabelUpdate(label="bad\ttab")
+
+
+def test_not_unique_policy(M):
+    # Two agents may carry the SAME display label — the slug guarantees
+    # uniqueness, the label is presentation only. Nothing here enforces
+    # uniqueness, by design (#1640).
+    a = M.AgentConfig(name="agent-one", display_label="Support")
+    b = M.AgentConfig(name="agent-two", display_label="Support")
+    assert a.display_label == b.display_label == "Support"


### PR DESCRIPTION
## #1640 — set an agent's display label at creation (residual of ent#181 / #964 2/5)

#1676 already shipped the column, db setter, `GET/PUT /{name}/label`, resolver, rendering (#1642/#1643), and AgentHeader already edits **both** the display label (pencil) and slug (Advanced rename) clearly. This fills the two genuine gaps + records the decisions.

### What's added
- **Set at creation** (the headline): `AgentConfig.display_label` → the create endpoint accepts it; `crud.py` persists it right after `register_agent_owner` via the same tested setter (best-effort — never fails a creation). `CreateAgentModal.vue` gains an optional **Display name** field; the old "Agent Name" input is relabelled **Slug / Identifier** with helper text (the exact #964 confusion).
- **One shared hardened policy** — `models.normalize_display_label`: trim, blank→None (clear to slug), NFC-normalize, reject control chars + line breaks, cap 120, **named** ValueError (not a generic 422 blob). Field-validators on **both** `AgentConfig.display_label` and `AgentLabelUpdate.label` so the surfaces can't drift.
- **Audit** — `PUT /label` now logs `set_display_label`/`clear_display_label` (was unlogged).
- **Docs** — architecture.md API table: `/label` GET/PUT rows + `display_label` note on `POST /api/agents`.

### AC coverage
| AC | Status |
|----|--------|
| Owner-only PUT, nullable, clears to fallback | ✅ existing `PUT /{name}/label` (`OwnedAgentByName`) — **not** duplicated as `/display-name` |
| Named validation error on over-length | ✅ + control-char/line-break rejection, one shared policy |
| Unicode/trim/control policy enforced | ✅ NFC + trim + `Cc`/`  ` reject |
| Uniqueness decided + documented | ✅ **not unique** (slug guarantees it) — recorded on issue + docs |
| Audit-logged | ✅ |
| CreateAgentModal display-name field + name→"Slug" | ✅ |
| AgentHeader edits both fields, clearly | ✅ already (ent#181) |
| Optional everywhere, graceful fallback | ✅ |
| MCP tool or explicit decision | ✅ **UI/REST-only**, recorded on issue |
| architecture.md updated | ✅ |

### Verification
Unit `test_1640_display_label_at_creation.py` (15) + models-guard. **Live** (Postgres): bad label → 422 named error, good label trimmed+persisted+**audited**, restore — no residue.

> ⚠️ **Feature — hold out of `dev` until after the v0.8.5 cut** (freeze).

Related to #1640 · #964 · ent#181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
