### PR TITLE
docs(requirements): per-user GitHub PAT requirements entry (#1711)

### DIFF
--- a/docs/memory/requirements/github.md
+++ b/docs/memory/requirements/github.md
@@ -92,4 +92,64 @@
 - **Flow**: `docs/memory/feature-flows/git-sync-health.md`
 - **Related**: #1505 (general sweep-subtree seam — evidence cross-filed), #1501 (transient-pid seam), #1596 (threshold repack, superseded parameters)
 
+### 11.10 Per-User GitHub PAT (ent#162)
+- **Status**: ✅ Implemented (v0.8.5 payload) — OSS-core half of a private feature.
+- **Description**: A non-admin user can store **one personal GitHub token** in
+  their own settings, so agents they create are no longer confined to the admin's
+  global-PAT repo scope. It is a per-user, self-service credential — set/cleared
+  only by its owner — that feeds the agent-**creation** git identity. Storage:
+  a new credential-bearing column `users.github_pat_encrypted`.
+- **FR-1 — Who can set it (self-service, owner-only)**: three endpoints on the
+  caller's **own** account (`Depends(get_current_user)`; never another user's):
+  - `GET /api/users/me/github-pat` → `{configured: bool, has_global: bool}` —
+    **status only, the token is never returned** (see FR-5).
+  - `PUT /api/users/me/github-pat` → validates the token against GitHub before
+    storing (**honest validation**: GitHub-rejected → 400; GitHub-unreachable →
+    503 — never "your token is bad" when we never got an answer), then encrypts
+    at rest. Returns the resolved `github_username`, never the token.
+  - `DELETE /api/users/me/github-pat` → clears it; agents already created under
+    it keep their own persisted per-agent copy (#347) and are unaffected — only
+    **future** creations fall back to the global PAT.
+- **FR-2 — Three-tier resolution ladder (agent CREATE path)**:
+  `settings_service.resolve_github_pat(agent_name, owner_id) -> (pat, tier)`
+  resolves in strict order and returns the tier so the create path can key its
+  persist decision:
+  1. **`per_agent`** — the agent already has its own PAT (#347 explicit override).
+  2. **`per_user`** — the **agent owner's** personal PAT, read **live** by
+     `owner_id`. Resolution keys on **ownership only**, never on a calling/sharing
+     user, so a sharee can never inject their PAT as the agent's git identity.
+  3. **`global`** — the admin-set / env global PAT.
+  4. **`none`** — nothing configured (`pat == ""`).
+- **FR-3 — Persist carve-out (which tiers become the per-agent PAT)**: at
+  creation the resolved value is persisted as the agent's #347 per-agent PAT for
+  **`per_agent`/`per_user`** — **but NEVER for `global`**. A global-fallback agent
+  deliberately keeps `github_pat_encrypted` **NULL** so
+  `github_pat_propagation_service` continues to reach it when an admin rotates the
+  global PAT (ent#162 Decision 2). Persisting the global value there would sever
+  that propagation and freeze the agent on a stale token.
+- **FR-4 — Recreate/restart ladder is 2-tier, never re-derives per-user**: the
+  env-rebuild path on recreate/restart uses
+  `settings_service.get_github_pat_for_agent(agent_name)` = **per-agent → global
+  only**. It deliberately does **not** consult the per-user tier: re-deriving a
+  live per-user PAT there would make `check_github_pat_env_matches` reactive, so
+  **adding or rotating a personal token in Settings would force-recreate the
+  owner's running agents and kill in-flight work.** The per-user tier is a
+  **create-time input only**; adding a personal token never disturbs a running
+  agent.
+- **FR-5 — Never echoed on read (requirement, not just current behavior)**: no
+  read path returns the stored token. `GET /me/github-pat` returns a `configured`
+  flag; `PUT` returns the derived `github_username`. This is a standing
+  requirement — a future field/endpoint MUST NOT surface the plaintext PAT.
+- **FR-6 — Encryption at rest (Invariant #12)**: `users.github_pat_encrypted` is
+  an **AES-256-GCM JSON envelope** via `services/credential_encryption.py`;
+  plaintext persistence is forbidden. The column is listed among the tables under
+  Invariant #12 in `architecture.md` (channel/subscription/PAT credential tables).
+  Resolved live by the owner at agent creation; see §Security cross-reference in
+  `security.md` §20.9.
+- **Source of truth**: resolver `services/settings_service.py`
+  (`resolve_github_pat` create-path, `get_github_pat_for_agent` recreate-path);
+  column + envelope `db/schema.py` / `db/tables.py` /
+  `services/credential_encryption.py`; endpoints `routers/users.py`. Prose it
+  supersedes: the `users` table block in `architecture.md`.
+
 ---

--- a/docs/memory/requirements/security.md
+++ b/docs/memory/requirements/security.md
@@ -231,6 +231,22 @@
 - **Non-scanned zones**: `tests/**` (~192 intentionally-fake fixtures), `docs/memory/**` (the live engineering docs — architecture/requirements/feature-flows — carry API-usage examples: curl `Authorization: Bearer` commands, truncated JWTs, `KEY=`/`condition=` samples the default `curl-auth-header`/`generic-api-key` rules flag; 8 such FPs were verified during #1164), and `docs/archive|releases|security-reports/**` (historical records; the CSO reports hold secret-pattern examples) are blanket path allowlists — gitleaks pre-skips allowlisted paths before per-finding regex, so these are documented non-scanned zones rather than a narrowing that wouldn't hold. A real credential belongs in `.env`/injection, never a test/doc file; GUARD-002 runtime scanning + human review are the complementary layers. `.env.example` is deliberately **NOT** excluded (a real key pasted there fires). *(Scope note for review: only `docs/memory/**` is excluded, not all of `docs/**` — a broader `docs/**` exclusion is deferred to reviewer judgement; other doc trees stay scanned and rely on the inline `gitleaks:allow` escape hatch for any example FP.)*
 - **Honest limit**: the custom rule catches a **verbatim** `re_`-body key. It does **NOT** catch a re-split / XOR-obfuscated secret — verified: the settled #1158 leak's two base85 halves are undetectable by gitleaks under both `useDefault` and this config (neither half is a `re_` key nor keyword-adjacent, and generic entropy on base85 is unreliable in a codebase full of legitimate encoded data). Regex+entropy is defense-in-depth against a *re-land*; **credential rotation** (done in #1158) is the real defense against the original leak. Because the halves produce no finding, `.gitleaksignore` carries no #1158 fingerprint (documented there); it is a non-load-bearing baseline for any future known historical finding, and the range-scoped CI gate does not depend on it.
 
+### 20.9 Stored User Credential — Per-User GitHub PAT (ent#162)
+- **Status**: ✅ Implemented (v0.8.5 payload).
+- **Credential-storage summary (cross-reference)**: the per-user GitHub token is a
+  **stored user credential** — a new credential-bearing column
+  `users.github_pat_encrypted`, an **AES-256-GCM JSON envelope** under
+  **Invariant #12** (plaintext persistence forbidden; the column is listed among
+  the Invariant #12 tables in `architecture.md`). Set/cleared self-service by its
+  owner only; **the token is never echoed on read** (status/`configured` flag
+  only) — a standing requirement, not just current behavior. Resolution keys on
+  **agent ownership**, never a calling/sharing user, so a sharee cannot inject
+  their PAT as an agent's git identity.
+- **Full requirement (capability + resolution ladders + persist carve-out)**:
+  `docs/memory/requirements/github.md` §11.10 — this section is the
+  security-surface pointer; the resolution mechanics and the recreate-vs-create
+  ladder distinction live there.
+
 ---
 
 ## 26. Operator Queue & Operating Room (OPS-001)


### PR DESCRIPTION
## #1711 — per-user GitHub PAT requirements entry

Per-user GitHub credentials (ent#162, shipped in the v0.8.5 payload) were documented only as architecture prose. RoE §1 requires the relevant `requirements/` area file for a new capability — most of all a **stored user credential**. Docs-only.

### What's added — grounded in the code, not paraphrased
- **`requirements/github.md` §11.10** — the full capability:
  - **Who sets it:** self-service, owner-only (`GET`/`PUT`/`DELETE /api/users/me/github-pat`), honest validation (GitHub-rejected → 400, unreachable → 503).
  - **Three-tier CREATE ladder** (`resolve_github_pat`): per-agent → owner's **per-user (live)** → global, keyed on **ownership only** (a sharee can't inject their PAT).
  - **Persist carve-out:** `per_agent`/`per_user` persist as the #347 per-agent PAT; **`global` NEVER does** — a global-fallback agent keeps `github_pat_encrypted` **NULL** so PAT-propagation still reaches it on admin rotation (ent#162 Decision 2).
  - **Recreate/restart ladder** (`get_github_pat_for_agent`) stays **2-tier** (per-agent → global) and never re-derives per-user — so **adding a personal token can't force-recreate a running agent**.
  - **Never echoed on read** (standing requirement); **AES-256-GCM under Invariant #12**.
- **`requirements/security.md` §20.9** — the credential-storage-half cross-reference pointing at §11.10.

### AC coverage
All seven boxes: capability + who + storage guarantee ✅ · three-tier order ✅ · persist carve-out (NULL for global) ✅ · recreate ladder distinguished ✅ · Invariant #12 + column listed ✅ (already in architecture.md) · never-echoed as a requirement ✅ · security.md cross-reference ✅.

Docs-only — no code/test change, **safe to land during the v0.8.5 soak**.

Related to #1711 · ent#162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
