### PR TITLE
Fix dashboard header overlap at narrow desktop widths

### DIFF
--- a/src/frontend/src/components/HostTelemetry.vue
+++ b/src/frontend/src/components/HostTelemetry.vue
@@ -149,14 +149,17 @@ onUnmounted(() => {
 .host-telemetry {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   font-size: 12px;
+  min-width: 0;
 }
 
 .stat-item {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
 }
 
 .stat-label {
@@ -199,5 +202,19 @@ onUnmounted(() => {
 /* Dark mode adjustments */
 .dark .disk-bar {
   background: rgba(55, 65, 81, 0.5);
+}
+
+@media (max-width: 1100px) {
+  .host-telemetry {
+    gap: 8px;
+  }
+
+  .host-telemetry :deep(.sparkline-chart) {
+    display: none;
+  }
+
+  .disk-bar {
+    width: 36px;
+  }
 }
 </style>

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -12,10 +12,10 @@
       <div class="flex flex-col flex-1 overflow-hidden">
         <!-- Compact Header -->
         <div class="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-2">
-          <div class="flex items-center justify-between">
+          <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
             <!-- Left: Stats -->
-            <div class="flex items-center min-w-0 overflow-hidden">
-              <div class="flex items-center space-x-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+            <div class="flex min-w-0 flex-1 basis-80 items-center overflow-hidden">
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
                 <span class="flex items-center space-x-1">
                   <span class="w-1.5 h-1.5 rounded-full bg-status-success-500"></span>
                   <span class="font-medium text-status-success-600 dark:text-status-success-400">{{ runningCount }}/{{ agents.length }}</span>
@@ -39,7 +39,7 @@
             </div>
 
             <!-- Right: Controls -->
-            <div class="flex items-center space-x-2 flex-shrink-0">
+            <div class="flex min-w-0 flex-shrink flex-wrap items-center justify-end gap-2">
               <!-- Quick Tag Filter Dropdown -->
               <div v-if="availableTags.length > 0" class="relative">
                 <button


### PR DESCRIPTION
## Summary

- allow the dashboard header stats and controls to wrap cleanly
- make host telemetry compact below 1100px by hiding sparklines and shrinking the disk bar
- keep the fix scoped to dashboard/header layout

## Root cause

The compact dashboard header forced the status/telemetry row and controls into one horizontal line. At narrow desktop widths, fixed-width telemetry elements competed with the filter/view controls and caused crowding/overlap.

## Validation

- `npm run check:tokens`
- `npm run build`

Note: Docker was unavailable in this session, so the final production build was run locally after installing frontend dependencies from the lockfile.
