### PR TITLE
feat(portal): agent avatar on chat-history rows (ent#186)

### DIFF
--- a/src/frontend/src/components/portal/PortalAvatar.vue
+++ b/src/frontend/src/components/portal/PortalAvatar.vue
@@ -1,11 +1,11 @@
 <template>
   <span
     class="inline-flex shrink-0 items-center justify-center rounded-full overflow-hidden text-white font-semibold select-none"
-    :style="{ width: size + 'px', height: size + 'px', background: imgOk ? 'transparent' : tint, fontSize: Math.round(size * 0.4) + 'px' }"
+    :style="{ width: size + 'px', height: size + 'px', background: showImage ? 'transparent' : tint, fontSize: Math.round(size * 0.4) + 'px' }"
     :title="name"
   >
     <img
-      v-if="avatarUrl && imgOk"
+      v-if="showImage"
       :src="avatarUrl"
       :alt="name"
       class="w-full h-full object-cover"
@@ -28,6 +28,11 @@ const props = defineProps({
 const imgOk = ref(true)
 watch(() => props.avatarUrl, () => { imgOk.value = true })
 
+// An <img> only renders when there IS a URL and it hasn't errored. The tint must
+// key off the SAME condition: `imgOk` alone starts true and only flips on an
+// @error that can never fire without an <img>, so an avatar-less agent rendered
+// white initials on a transparent background (ent#186).
+const showImage = computed(() => Boolean(props.avatarUrl) && imgOk.value)
 const initials = computed(() => toInitials(props.name))
 const tint = computed(() => agentColor(props.name))
 </script>

--- a/src/frontend/src/components/portal/PortalSidebar.vue
+++ b/src/frontend/src/components/portal/PortalSidebar.vue
@@ -41,10 +41,12 @@
           @click="$emit('open-thread', { session_id: r.session_id, agent_name: r.agent_name })"
         >
           <div class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full shrink-0" :style="{ background: agentColor(r.agent_name) }"></span>
-            <span class="text-sm truncate">{{ r.title || 'Chat' }}</span>
+            <PortalAvatar :name="r.agent_name" :avatar-url="avatarFor(r.agent_name)" :size="22" />
+            <span class="min-w-0 flex-1">
+              <span class="block text-sm truncate">{{ r.title || 'Chat' }}</span>
+              <span v-if="r.snippet" class="block text-xs text-gray-400 truncate">{{ r.snippet }}</span>
+            </span>
           </div>
-          <div v-if="r.snippet" class="ml-4 text-xs text-gray-400 truncate">{{ r.snippet }}</div>
         </button>
       </div>
 
@@ -75,7 +77,7 @@
             :class="t.id === currentSessionId ? 'bg-white dark:bg-gray-900 ring-1 ring-gray-200 dark:ring-gray-800' : ''"
             @click="$emit('open-thread', t)"
           >
-            <span class="w-2 h-2 rounded-full shrink-0" :style="{ background: agentColor(t.agent_name) }" :title="t.agent_name"></span>
+            <PortalAvatar :name="t.agent_name" :avatar-url="avatarFor(t.agent_name)" :size="22" />
             <span class="text-sm truncate flex-1">{{ threadTitle(t) }}</span>
           </button>
         </div>
@@ -106,7 +108,7 @@
 <script setup>
 import { computed } from 'vue'
 import PortalAvatar from './PortalAvatar.vue'
-import { agentColor, groupThreadsByDate, threadTitle } from './portalUtils'
+import { groupThreadsByDate, threadTitle } from './portalUtils'
 
 const props = defineProps({
   roster: { type: Array, default: () => [] },
@@ -121,4 +123,13 @@ defineEmits(['new-chat', 'new-chat-with-agent', 'open-thread', 'update:search', 
 
 const isSearching = computed(() => (props.search || '').trim().length >= 2)
 const grouped = computed(() => groupThreadsByDate(props.threads))
+
+// ent#186: history + search rows show the conversation's agent avatar instead of
+// a bare color dot. The URL is resolved from the roster already loaded at sign-in
+// (no per-row fetch); an unknown agent or one without a generated avatar falls
+// through to PortalAvatar's initials + tint.
+const avatarByAgent = computed(() =>
+  Object.fromEntries((props.roster || []).map((a) => [a.name, a.avatar_url])),
+)
+const avatarFor = (name) => avatarByAgent.value[name] || null
 </script>


### PR DESCRIPTION
Related to Abilityai/trinity-enterprise#186 (frontend half; the backend title-generation half is Abilityai/trinity-enterprise#194).

## What

Client-portal history rows and cross-chat search results identified their agent with a 2px color dot, while the Agents section directly above rendered full `PortalAvatar` components. A client with several agents had to hover for the tooltip to learn whose conversation a thread was.

## How

Both lists now render `PortalAvatar` at `size=22` — the same component (avatar-URL-with-initials-fallback) already used in four other portal places.

- The avatar URL is resolved **from the roster already loaded at sign-in** — an `avatarByAgent` computed map keyed by `agent_name`, built from the existing `roster` prop. **No additional request per row**, and no change to the sessions payload.
- An agent with no generated avatar falls through to `PortalAvatar`'s existing initials + deterministic tint — no new empty state.
- Search rows move the snippet into the title column so history and search share one layout (previously an `ml-4`-indented sibling that assumed the dot's width).
- `agentColor` is no longer imported directly by the sidebar (`PortalAvatar` still uses it internally for the tint).

## Acceptance criteria

- [x] History rows show the conversation's agent avatar instead of the color dot
- [x] Search-result rows use the same treatment
- [x] Initials + color fallback works when the agent has no avatar
- [x] Row height / truncation hold at the sidebar's narrow width, on mobile, in dark mode — `min-w-0` + `truncate` retained on both lines; `PortalAvatar` is `shrink-0`; no new colors (the avatar carries its own tint, dark-mode-agnostic)
- [x] No additional network request per row

## Verification

`@vue/compiler-sfc` parse + `compileScript` + `compileTemplate` on the changed SFC → compiles clean. (A full `npm run build` fails on this machine for an unrelated reason — `mermaid` is in `package.json` but missing from the local `node_modules`, breaking `AgentWorkspace.vue`; untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)