### PR TITLE
feat(skills): skill-runner execution surface + close the raw library read (ent#139)

### DIFF
--- a/src/backend/routers/skills.py
+++ b/src/backend/routers/skills.py
@@ -15,7 +15,13 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 
 from models import User
-from dependencies import get_current_user, require_admin, get_authorized_agent_by_name, get_owned_agent_by_name
+from dependencies import (
+    get_current_user,
+    require_admin,
+    reject_agent_principal,
+    get_authorized_agent_by_name,
+    get_owned_agent_by_name,
+)
 from database import db
 from db_models import AgentSkill, SkillInfo, AgentSkillsUpdate
 from services.skill_service import skill_service, SkillInjectionBusy
@@ -72,7 +78,20 @@ async def get_skill(
 ):
     """
     Get details for a specific skill including full content.
+
+    **Human/operator surface only** (ent#139). This returns the skill's full
+    content — SKILL.md plus any bundled `scripts/` — so it is executable
+    material, not metadata. An agent-scoped key resolves to its owner user, so
+    before this gate any agent could pull arbitrary executable content out of
+    the library and run it locally: self-acquisition, which is exactly the
+    supply-chain risk the skill runner exists to avoid.
+
+    Agents get skills two supported ways instead: assigned/injected by an
+    operator, or executed on the dedicated runner under a per-skill allow-list.
+    Neither needs raw content over REST. Listing (name + description) stays open
+    so an agent can still *discover* what exists.
     """
+    reject_agent_principal(current_user)
     skill = skill_service.get_skill(skill_name)
     if not skill:
         raise HTTPException(status_code=404, detail=f"Skill '{skill_name}' not found")

--- a/src/frontend/src/components/AgentTile.vue
+++ b/src/frontend/src/components/AgentTile.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="gtile" :class="{ system: isSystemAgent }">
+  <div class="gtile" :class="{ system: isSystemAgent, runner: isSkillRunner }">
     <!-- Avatar half-out on the left edge -->
     <div class="gtile-avatar">
       <div
         class="rounded-full border-2 shadow-md overflow-hidden"
-        :class="isSystemAgent ? 'border-accent-purple-400 dark:border-accent-purple-500' : 'border-action-primary-400 dark:border-action-primary-500'"
+        :class="avatarRingClass"
       >
         <AgentAvatar :name="agent.name" :avatar-url="agent.avatar_url" size="lg" />
       </div>
@@ -25,6 +25,13 @@
             class="sys-badge"
             title="System Agent - Platform Orchestrator"
           >SYSTEM</span>
+          <!-- ent#139: agent-class variant. The runner is not a persona, it is
+               an execution surface, so it gets its own identity chip. -->
+          <span
+            v-else-if="isSkillRunner"
+            class="runner-badge"
+            :title="runnerTooltip"
+          >SKILL RUNNER</span>
         </div>
         <div class="t-repo" :class="{ local: !githubRepoShort }">
           <svg v-if="githubRepoShort" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" clip-rule="evenodd" /></svg>
@@ -181,6 +188,27 @@ const gridStore = useFleetGridStore()
 
 const name = computed(() => props.agent.name)
 const isSystemAgent = computed(() => props.agent.is_system === true)
+
+// ent#139 — agent-class variant. Keyed off the agent's TYPE (the trinity.agent-type
+// label the runner is created with), so the tile needs no extra per-agent field
+// and degrades to the standard tile the moment the feature is absent: with the
+// module unmounted no agent carries this type, and `runnerStatus` stays null.
+const isSkillRunner = computed(() => props.agent.type === 'skill-runner')
+const runnerStatus = computed(() => (isSkillRunner.value ? gridStore.skillRunnerStatus : null))
+const avatarRingClass = computed(() => {
+  if (isSystemAgent.value) return 'border-accent-purple-400 dark:border-accent-purple-500'
+  // Runner ring rides the tile's own CSS-var palette (like .sys-badge) rather
+  // than a Tailwind color token — there is no teal token in tailwind.config.js,
+  // and an invented class name silently renders no border at all.
+  if (isSkillRunner.value) return 'ring-runner'
+  return 'border-action-primary-400 dark:border-action-primary-500'
+})
+const runnerTooltip = computed(() => {
+  const s = runnerStatus.value
+  if (!s) return 'Skill runner — executes library skills for permitted agents'
+  if (!s.enabled) return 'Skill runner — skill execution is currently disabled'
+  return `Skill runner — ${s.exposed_skill_count} skill(s) exposed to ${s.grant_count} grant(s)`
+})
 const isRunning = computed(() => props.agent.status === 'running')
 
 // --- Zone 1: identity ---
@@ -266,6 +294,19 @@ const chips = computed(() => {
   const sh = gridStore.syncHealth[name.value]
   if (sh && sh.last_sync_status === 'failed' && sh.consecutive_failures > 0) {
     out.push({ kind: 'warn', icon: '⟳', text: `sync failing ×${sh.consecutive_failures}`, title: sh.last_error_summary || 'Git sync failing' })
+  }
+  // ent#139: the runner's defining fact is how much it exposes. Reported by the
+  // status the store already holds — no per-tile request.
+  if (isSkillRunner.value && runnerStatus.value) {
+    out.push({
+      kind: runnerStatus.value.enabled ? 'calm' : 'warn',
+      text: runnerStatus.value.enabled
+        ? `${runnerStatus.value.exposed_skill_count} skills exposed`
+        : 'skill running disabled',
+      title: runnerStatus.value.enabled
+        ? `${runnerStatus.value.grant_count} grant(s) across ${runnerStatus.value.exposed_skill_count} skill(s)`
+        : 'The skill runner exists but skill execution is turned off',
+    })
   }
   // Calm facts after problems. The system agent gets these too — an empty
   // chip row leaves a visual void on the tile.
@@ -503,6 +544,22 @@ watch(
   padding: 1px 5px;
   background: var(--gv-badge-sys-bg);
   color: var(--gv-badge-sys-tx);
+}
+/* ent#139 — skill-runner agent class. Same shape as .sys-badge so the two
+   variants read as one family; own palette vars (defined per theme in
+   FleetGrid.vue) so it is distinguishable in light AND dark. */
+.runner-badge {
+  flex: none;
+  font-size: 9px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 1px 5px;
+  letter-spacing: 0.02em;
+  background: var(--gv-badge-runner-bg);
+  color: var(--gv-badge-runner-tx);
+}
+.ring-runner {
+  border-color: var(--gv-ring-runner);
 }
 .t-repo {
   display: flex;

--- a/src/frontend/src/components/AgentTile.vue
+++ b/src/frontend/src/components/AgentTile.vue
@@ -301,7 +301,7 @@ const chips = computed(() => {
     out.push({
       kind: runnerStatus.value.enabled ? 'calm' : 'warn',
       text: runnerStatus.value.enabled
-        ? `${runnerStatus.value.exposed_skill_count} skills exposed`
+        ? `${runnerStatus.value.exposed_skill_count} skill${runnerStatus.value.exposed_skill_count === 1 ? '' : 's'} exposed`
         : 'skill running disabled',
       title: runnerStatus.value.enabled
         ? `${runnerStatus.value.grant_count} grant(s) across ${runnerStatus.value.exposed_skill_count} skill(s)`

--- a/src/frontend/src/components/FleetGrid.vue
+++ b/src/frontend/src/components/FleetGrid.vue
@@ -559,6 +559,10 @@ onBeforeUnmount(() => {
   --gv-badge-warn-tx: #a16207;
   --gv-badge-sys-bg: #f3e8ff;
   --gv-badge-sys-tx: #7e22ce;
+  /* ent#139 skill-runner class: teal, distinct from system purple */
+  --gv-badge-runner-bg: #ccfbf1;
+  --gv-badge-runner-tx: #0f766e;
+  --gv-ring-runner: #2dd4bf;
   --gv-sys-tile: rgba(250, 245, 255, 0.9);
   --gv-sys-border: #e9d5ff;
   --gv-sys-btn-bg: #faf5ff;
@@ -620,6 +624,9 @@ onBeforeUnmount(() => {
   --gv-badge-warn-tx: #fde047;
   --gv-badge-sys-bg: rgba(88, 28, 135, 0.5);
   --gv-badge-sys-tx: #d8b4fe;
+  --gv-badge-runner-bg: rgba(19, 78, 74, 0.55);
+  --gv-badge-runner-tx: #5eead4;
+  --gv-ring-runner: #0d9488;
   --gv-sys-tile: rgba(88, 28, 135, 0.3);
   --gv-sys-border: rgba(126, 34, 206, 0.5);
   --gv-sys-btn-bg: rgba(88, 28, 135, 0.3);

--- a/src/frontend/src/stores/fleetGrid.js
+++ b/src/frontend/src/stores/fleetGrid.js
@@ -227,10 +227,32 @@ export const useFleetGridStore = defineStore('fleetGrid', () => {
     }
   }
 
+  // ent#139 — skill-runner status for the runner's tile variant. Rides the
+  // existing visibility-aware batch refresh (no new polling loop), and the
+  // endpoint is admin-only, so a non-admin simply keeps `null` and the tile
+  // falls back to its standard rendering. Never surfaces an error: absent
+  // status is a legitimate state (OSS build, unentitled, non-admin viewer).
+  const skillRunnerStatus = ref(null)
+
+  async function fetchSkillRunnerStatus() {
+    try {
+      const res = await axios.get('/api/enterprise/skill-runner/status', {
+        headers: authStore.authHeader,
+      })
+      skillRunnerStatus.value = res.data
+    } catch {
+      skillRunnerStatus.value = null
+    }
+  }
+
   let _pollTimer = null
 
   function refreshBatchData() {
-    return Promise.allSettled([fetchSyncHealth(), fetchOpQueuePending()])
+    return Promise.allSettled([
+      fetchSyncHealth(),
+      fetchOpQueuePending(),
+      fetchSkillRunnerStatus(),
+    ])
   }
 
   /** Visibility-aware slow poll; active only while the Grid view is mounted. */
@@ -268,6 +290,7 @@ export const useFleetGridStore = defineStore('fleetGrid', () => {
     hydrate,
     syncHealth,
     opQueuePending,
+    skillRunnerStatus,
     refreshBatchData,
     startPolling,
     stopPolling,

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -329,6 +329,35 @@ export class TrinityClient {
   }
 
   /**
+   * Skills the calling agent is permitted to execute on the skill runner
+   * (ent#139). The acting agent is resolved server-side from the API key, so
+   * an agent-scoped key can never ask on another agent's behalf.
+   * Returns `enabled: false` with an empty list when the feature is off.
+   */
+  async getRunnableSkills(): Promise<{
+    caller_agent: string;
+    enabled: boolean;
+    skills: Array<{ name: string; description?: string; version?: string }>;
+  }> {
+    return this.request("GET", "/api/enterprise/skill-runner/available");
+  }
+
+  /**
+   * Execute one library skill on the skill runner (ent#139). Server-side the
+   * per-skill allow-list is re-checked at dispatch — this client never decides
+   * what is runnable.
+   */
+  async runSkill(
+    skillName: string,
+    input?: string
+  ): Promise<{ skill: string; result: string; cost?: number; execution_id?: string }> {
+    return this.request("POST", "/api/enterprise/skill-runner/run", {
+      skill_name: skillName,
+      input,
+    });
+  }
+
+  /**
    * Get the agent compatibility report (#668).
    * STATIC checks recompute live; pass includeAi=true to force a fresh AI
    * evaluation (otherwise the last persisted AI verdicts are returned).

--- a/src/mcp-server/src/tools/skills.ts
+++ b/src/mcp-server/src/tools/skills.ts
@@ -342,5 +342,104 @@ export function createSkillsTools(
         }, null, 2);
       },
     },
+
+    // ========================================================================
+    // run_skill - Execute a library skill on the dedicated skill runner
+    // ========================================================================
+    runSkill: {
+      name: "run_skill",
+      description:
+        "Execute a library skill on the platform's skill runner and return its result. " +
+        "Use list_runnable_skills first to see which skills you are permitted to run. " +
+        "The runner is a separate agent with its own workspace — it cannot see your " +
+        "files, so this is for self-contained skills (call an API, generate an " +
+        "artifact, process the input you pass). Skills that must operate on YOUR " +
+        "workspace have to be assigned to you by an operator instead.",
+      parameters: z.object({
+        skill_name: z.string().describe("Skill to run, exactly as returned by list_runnable_skills"),
+        input: z.string().optional().describe("Input / arguments for the skill"),
+      }),
+      execute: async (
+        { skill_name, input }: { skill_name: string; input?: string },
+        context?: { session?: McpAuthContext }
+      ) => {
+        const apiClient = getClient(context?.session);
+
+        // Server-side enforcement is authoritative — the backend re-checks the
+        // per-skill allow-list at dispatch. This pre-check exists only to turn a
+        // predictable refusal into a helpful message listing what IS available
+        // (the run_playbook shape), never to decide access.
+        let available: string[] = [];
+        try {
+          const runnable = await apiClient.getRunnableSkills();
+          if (!runnable.enabled) {
+            return JSON.stringify({
+              error: "skill_runner_disabled",
+              message: "Skill execution is not enabled on this platform.",
+            }, null, 2);
+          }
+          available = runnable.skills.map((s) => s.name);
+          if (!available.includes(skill_name)) {
+            return JSON.stringify({
+              error: "skill_not_permitted",
+              message: `You are not permitted to run "${skill_name}".`,
+              available,
+            }, null, 2);
+          }
+        } catch {
+          // Availability lookup failed (feature absent in an OSS build, network
+          // hiccup). Fall through and let the backend be the single authority —
+          // never fail open into "assume permitted" locally, and never block a
+          // legitimate run on a flaky pre-check.
+        }
+
+        try {
+          const result = await apiClient.runSkill(skill_name, input);
+          return JSON.stringify(result, null, 2);
+        } catch (e) {
+          return JSON.stringify({
+            error: "skill_run_failed",
+            message: e instanceof Error ? e.message : String(e),
+            ...(available.length ? { available } : {}),
+          }, null, 2);
+        }
+      },
+    },
+
+    // ========================================================================
+    // list_runnable_skills - What THIS agent may execute on the runner
+    // ========================================================================
+    listRunnableSkills: {
+      name: "list_runnable_skills",
+      description:
+        "List the skills you are permitted to execute via run_skill. This is your " +
+        "own permitted set, not the whole library — an operator decides which " +
+        "skills each agent may run.",
+      parameters: z.object({}),
+      execute: async (_params: unknown, context?: { session?: McpAuthContext }) => {
+        const apiClient = getClient(context?.session);
+        try {
+          const runnable = await apiClient.getRunnableSkills();
+          return JSON.stringify({
+            enabled: runnable.enabled,
+            count: runnable.skills.length,
+            skills: runnable.skills,
+            ...(runnable.enabled
+              ? {}
+              : { message: "Skill execution is not enabled on this platform." }),
+          }, null, 2);
+        } catch (e) {
+          // Honest, distinct status — an OSS build has no runner at all, which
+          // is different from "you have no grants".
+          return JSON.stringify({
+            enabled: false,
+            count: 0,
+            skills: [],
+            message: "Skill execution is not available on this platform.",
+            detail: e instanceof Error ? e.message : String(e),
+          }, null, 2);
+        }
+      },
+    },
   };
 }


### PR DESCRIPTION
Related to Abilityai/trinity-enterprise#139 (OSS half; the gated module is Abilityai/trinity-enterprise#195).

## 1. Security fix — close the unrestricted library read

`GET /api/skills/library/{name}` returns a skill's **full content** — SKILL.md plus any bundled `scripts/`, i.e. executable material — behind a bare `get_current_user`. An agent-scoped key resolves to its owner, so **any agent could pull arbitrary executable content out of the library and run it locally**: self-acquisition with no chokepoint.

Now calls `reject_agent_principal`. This is edition-agnostic and stands on its own, which is why it lives in OSS rather than behind the entitlement. **Listing stays open** (name + description) so agents can still discover what exists — only the content fetch is closed.

⚠️ **Behavior change:** an agent-scoped MCP key calling `get_skill` now gets 403. Agents get skills two supported ways instead — assigned/injected by an operator, or executed on the runner under a per-skill allow-list. Neither needs raw content over REST.

## 2. MCP tools

`run_skill(skill_name, input)` and `list_runnable_skills` — structurally `run_playbook` (`tools/connector.ts`) pointed at the library. Both auto-register from the existing tool group; no `server.ts` change.

The tool-side allow-list check is **not authorization** — it exists only to turn a predictable refusal into a message listing what IS available. The backend re-checks the ACL at dispatch, and a failed pre-check falls through to the backend rather than failing open into "assume permitted". On an OSS build (no module mounted) both tools return an honest `enabled: false` / "not available on this platform" instead of throwing a stack trace at the agent.

## 3. Grid tile — first agent-class variant

`AgentTile.vue` keyed off `agent.type === 'skill-runner'` (the `trinity.agent-type` label), so:

- no new per-agent field on the agents payload;
- it **degrades to the standard tile automatically** — with the module unmounted no agent carries that type.

Adds a `SKILL RUNNER` identity chip (same shape as `.sys-badge`), a teal avatar ring, and an exposed-skill chip (or a warn chip when the runner exists but execution is off).

The ring uses a CSS var (`--gv-ring-runner`, defined per-theme in `FleetGrid.vue`) rather than a Tailwind class — **there is no teal token in `tailwind.config.js`, and an invented class name renders no border at all, silently**. Light and dark values both defined.

Status rides the Grid's **existing** visibility-aware `refreshBatchData` — no new polling loop — and the endpoint is admin-only, so a non-admin viewer keeps `null` and gets the standard tile.

Deliberately scoped as an in-tile variant rather than a new component, so it does not pre-empt epic Abilityai/trinity-enterprise#94's tile-variant architecture.

## Verification

- `npx tsc --noEmit` on the MCP server → clean.
- `@vue/compiler-sfc` parse + `compileScript` + `compileTemplate` on `AgentTile.vue` and `FleetGrid.vue` → clean. (A full `npm run build` fails on this machine for an unrelated pre-existing reason: `mermaid` is in `package.json` but missing from the local `node_modules`, breaking `AgentWorkspace.vue`.)
- `pytest tests/unit -k "skill or models_centralized or auth_wiring or enumeration"` → **138 passed, 3 skipped**.
- Live: `GET /api/skills/library` still 200 for an admin JWT.

## Not done

The Grid tile has **not been seen rendered** — no skill-runner agent exists on this stack (the module refuses to provision without a configured skills library), so the variant is verified by compilation and code inspection only, not visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)