### PR TITLE
fix(seam): scope the enterprise ImportError arm to the top-level import (#1653)

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1014,22 +1014,19 @@ def _report_enterprise_failure(exc: BaseException) -> None:
 
 try:
     from enterprise.backend import register_enterprise  # type: ignore[import-not-found]
-    register_enterprise(app)
-    # `print(..., flush=True)`: this import block runs at module init,
-    # which is BEFORE `lifespan` calls `setup_logging()`. The default
-    # Python logger drops INFO-level records, so `logger.info` here
-    # would be silently swallowed. Print to stdout instead — docker
-    # logs captures it for ops + the CI workflow greps for it.
-    print("Trinity Enterprise modules registered", flush=True)
 except ModuleNotFoundError as e:
-    # "Not present" is ONLY true when the enterprise package itself is missing.
-    # A bare `except ImportError` here also swallowed a *failed* import inside a
-    # mounted submodule — e.g. a module importing a name that doesn't exist yet
-    # — and reported it as the reassuring line below. An operator then saw
-    # "this is normal" while a feature they paid for was silently absent, and
-    # diagnosing it needed a hand-run `register_enterprise()` to see the real
-    # traceback. Narrow the benign case to its actual signature; everything
-    # else falls through to the loud handler.
+    # SCOPE: this arm covers ONLY the top-level import. It used to wrap
+    # `register_enterprise(app)` too, so a ModuleNotFoundError raised deep inside
+    # a module's `register()` — enterprise modules lazily import OSS seams there
+    # — was reported as the calm line below. On a MOUNTED install that message is
+    # actively false, the diagnostic traceback never printed, and the failing
+    # module's routes could stay mounted-but-unentitled, 403-ing forever with
+    # nothing in the logs connecting the two (#1653, spotted by @vybe).
+    #
+    # Even here "not present" is only true when the missing module IS the
+    # enterprise package. If `enterprise.backend` imports some third-party
+    # package that isn't installed, that is a real failure wearing the same
+    # exception type — so check which module went missing.
     if (e.name or "").split(".")[0] == "enterprise":
         print(
             "Trinity Enterprise submodule not present — OSS-only build "
@@ -1038,8 +1035,23 @@ except ModuleNotFoundError as e:
         )
     else:
         _report_enterprise_failure(e)
-except Exception as e:
+except ImportError as e:
+    # A non-ModuleNotFoundError ImportError from the top-level import (e.g. the
+    # package exists but imports a name that doesn't) is a real bug, not an
+    # absent submodule.
     _report_enterprise_failure(e)
+else:
+    try:
+        register_enterprise(app)
+        # `print(..., flush=True)`: this block runs at module init, BEFORE
+        # `lifespan` calls `setup_logging()`. The default Python logger drops
+        # INFO records, so `logger.info` here would be silently swallowed. Print
+        # to stdout — docker logs captures it and CI greps for this exact string.
+        print("Trinity Enterprise modules registered", flush=True)
+    except Exception as e:
+        # ANY failure inside registration is a bug and gets the diagnostic —
+        # including ModuleNotFoundError, which is why this is a separate try.
+        _report_enterprise_failure(e)
 
 
 # WebSocket endpoint

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -997,6 +997,21 @@ app.include_router(ws_tickets_router)  # WebSocket auth tickets (#550)
 # repo is restructured into `backend/` and `frontend/` subdirs so the
 # same repo can be dual-mounted (`src/backend/enterprise/` for Python,
 # `src/frontend/src/enterprise/` for Vite).
+def _report_enterprise_failure(exc: BaseException) -> None:
+    """Surface a real enterprise-registration failure loudly.
+
+    A BUG in registration (schema init, migration, router mount, a bad import)
+    must NOT take down the core platform — degrade and report instead of
+    crashing boot. Modules that registered before the failure stay active.
+    """
+    import traceback
+    print(
+        f"Trinity Enterprise registration FAILED — continuing OSS-only: {exc!r}",
+        flush=True,
+    )
+    traceback.print_exc()
+
+
 try:
     from enterprise.backend import register_enterprise  # type: ignore[import-not-found]
     register_enterprise(app)
@@ -1006,24 +1021,25 @@ try:
     # would be silently swallowed. Print to stdout instead — docker
     # logs captures it for ops + the CI workflow greps for it.
     print("Trinity Enterprise modules registered", flush=True)
-except ImportError:
-    print(
-        "Trinity Enterprise submodule not present — OSS-only build "
-        "(this is normal; enterprise modules are an optional private submodule)",
-        flush=True,
-    )
+except ModuleNotFoundError as e:
+    # "Not present" is ONLY true when the enterprise package itself is missing.
+    # A bare `except ImportError` here also swallowed a *failed* import inside a
+    # mounted submodule — e.g. a module importing a name that doesn't exist yet
+    # — and reported it as the reassuring line below. An operator then saw
+    # "this is normal" while a feature they paid for was silently absent, and
+    # diagnosing it needed a hand-run `register_enterprise()` to see the real
+    # traceback. Narrow the benign case to its actual signature; everything
+    # else falls through to the loud handler.
+    if (e.name or "").split(".")[0] == "enterprise":
+        print(
+            "Trinity Enterprise submodule not present — OSS-only build "
+            "(this is normal; enterprise modules are an optional private submodule)",
+            flush=True,
+        )
+    else:
+        _report_enterprise_failure(e)
 except Exception as e:
-    # A BUG in enterprise registration (schema init, migration, router
-    # mount, pusher start) must NOT take down the core platform. Degrade
-    # to OSS-only and surface loudly instead of crashing boot. Any modules
-    # that registered before the failure stay active; the rest are absent
-    # (their entitlement simply won't appear in feature-flags). (#995/#997)
-    import traceback
-    print(
-        f"Trinity Enterprise registration FAILED — continuing OSS-only: {e!r}",
-        flush=True,
-    )
-    traceback.print_exc()
+    _report_enterprise_failure(e)
 
 
 # WebSocket endpoint

--- a/src/backend/services/entitlement_service.py
+++ b/src/backend/services/entitlement_service.py
@@ -97,6 +97,29 @@ class EntitlementService:
             f"(total: {len(self._registered_modules)})"
         )
 
+    def unregister_module(self, feature_id: str) -> bool:
+        """Withdraw a previously-registered feature_id. Returns True if it was
+        registered.
+
+        The registration seam is a *claim* that a feature is present and served.
+        A module that claims its id and then fails partway through mounting
+        leaves that claim standing with nothing behind it — the feature is
+        advertised by ``GET /api/settings/feature-flags``, the OSS bundle shows
+        its UI, and every request 404s. This lets the registering side roll its
+        own claim back so a half-registered module is simply absent, which is
+        the honest state.
+
+        Idempotent — withdrawing an unregistered id is a no-op.
+        """
+        if feature_id not in self._registered_modules:
+            return False
+        self._registered_modules.discard(feature_id)
+        logger.warning(
+            f"[EntitlementService] withdrew enterprise module: {feature_id!r} "
+            f"(total: {len(self._registered_modules)})"
+        )
+        return True
+
     def is_entitled(self, feature_id: str) -> bool:
         """Return True if the named feature is licensed AND registered.
 

--- a/tests/unit/test_1653_enterprise_load_reporting.py
+++ b/tests/unit/test_1653_enterprise_load_reporting.py
@@ -1,0 +1,163 @@
+"""The enterprise-load block must not call a real failure "normal" (#1653 / ent#196).
+
+`main.py` used to wrap the enterprise import AND `register_enterprise(app)` in a
+single `try` whose first arm was `except ImportError`. `ModuleNotFoundError`
+subclasses `ImportError`, so a real bug raised *inside* module registration —
+enterprise modules lazily import OSS seams in their `register()` — printed:
+
+    Trinity Enterprise submodule not present — OSS-only build
+    (this is normal; enterprise modules are an optional private submodule)
+
+On a mounted install that is actively false. The diagnostic traceback never ran,
+boot did not crash, and the failing module's routes could stay mounted while its
+entitlement was never registered — 403-ing forever, with nothing in the logs
+connecting the two.
+
+The fix has two parts and BOTH are needed:
+
+1. **Structural** — the `ImportError` arms now cover only the top-level import;
+   anything raised by `register_enterprise(app)` reaches the diagnostic. This is
+   what catches a module lazily importing a missing *sibling*, whose
+   `ModuleNotFoundError.name` starts with `enterprise` and would look benign to a
+   name check.
+2. **Name check** — even on the top-level import, "not present" is only true when
+   the missing module IS the enterprise package. A missing third-party dependency
+   wears the same exception type and is a real failure.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MAIN_PY = Path(__file__).resolve().parents[2] / "src" / "backend" / "main.py"
+
+
+def _classify_top_level(exc: BaseException) -> str:
+    """The predicate main.py applies to a failure of the TOP-LEVEL import."""
+    if isinstance(exc, ModuleNotFoundError):
+        return "benign" if (exc.name or "").split(".")[0] == "enterprise" else "loud"
+    return "loud"
+
+
+# --- the top-level import arm ------------------------------------------------
+
+def test_absent_submodule_is_still_reported_as_normal():
+    """An OSS clone has no `enterprise` package — that must stay calm."""
+    assert _classify_top_level(
+        ModuleNotFoundError("No module named 'enterprise'", name="enterprise")
+    ) == "benign"
+    assert _classify_top_level(
+        ModuleNotFoundError("No module named 'enterprise.backend'", name="enterprise.backend")
+    ) == "benign"
+
+
+def test_missing_third_party_dependency_is_loud():
+    """The package is present but needs something that isn't installed — a real
+    failure wearing the same exception type as an absent submodule."""
+    assert _classify_top_level(
+        ModuleNotFoundError("No module named 'pyotp'", name="pyotp")
+    ) == "loud"
+
+
+def test_missing_name_in_the_top_level_import_is_loud():
+    """A plain ImportError (package exists, NAME doesn't) is a bug."""
+    exc = ImportError("cannot import name 'register_enterprise'")
+    assert not isinstance(exc, ModuleNotFoundError)
+    assert _classify_top_level(exc) == "loud"
+
+
+# --- the structural guarantee (what a name check cannot provide) -------------
+
+def test_registration_call_is_outside_the_importerror_arms():
+    """`register_enterprise(app)` must sit in the `else` arm, so EVERY exception
+    it raises reaches the diagnostic rather than an ImportError handler.
+
+    This is the case a name check gets wrong: a module doing
+    `from .some_missing_sibling import x` inside `register()` raises
+    `ModuleNotFoundError(name='enterprise.backend.some_missing_sibling')`, whose
+    first segment IS `enterprise` — indistinguishable from an absent submodule by
+    name alone.
+
+    Parsed with `ast`, not string search: the surrounding comments mention
+    `register_enterprise(app)` in prose, and a substring check matches those.
+    """
+    import ast
+
+    tree = ast.parse(MAIN_PY.read_text())
+
+    def calls_register(nodes) -> bool:
+        return any(
+            isinstance(n, ast.Call) and getattr(n.func, "id", None) == "register_enterprise"
+            for node in nodes
+            for n in ast.walk(node)
+        )
+
+    guarded = [
+        t for t in ast.walk(tree)
+        if isinstance(t, ast.Try) and calls_register(t.orelse)
+    ]
+    assert guarded, (
+        "register_enterprise(app) must be called from the `else` arm of the "
+        "try/except that guards the top-level import (#1653)"
+    )
+
+    for t in guarded:
+        # It must NOT also be reachable from the try body those handlers guard.
+        assert not calls_register(t.body), (
+            "register_enterprise(app) still shares the try that catches "
+            "ImportError — a ModuleNotFoundError from inside register() would be "
+            "reported as 'submodule not present'"
+        )
+        # The else arm must itself catch broadly and report.
+        inner = [n for n in ast.walk(ast.Module(body=t.orelse, type_ignores=[]))
+                 if isinstance(n, ast.Try)]
+        assert inner, "the registration call needs its own try/except"
+        handlers = [h for tr in inner for h in tr.handlers]
+        assert any(getattr(h.type, "id", None) == "Exception" for h in handlers), (
+            "registration must be guarded by `except Exception` so a "
+            "ModuleNotFoundError from register() reaches the diagnostic"
+        )
+
+
+def test_a_missing_sibling_from_register_is_treated_as_a_bug():
+    """Behavioural proof, with the real exception shape a lazy sibling import
+    produces — the case that motivated the structural change."""
+    missing_sibling = ModuleNotFoundError(
+        "No module named 'enterprise.backend.gone'", name="enterprise.backend.gone")
+
+    # A name check alone calls this benign — precisely the trap.
+    assert _classify_top_level(missing_sibling) == "benign"
+
+    # Raised from register_enterprise(app), which no longer sits under the
+    # ImportError arms, it is handled as a bug. Mirror that placement:
+    handled = None
+    try:                                  # the top-level import
+        pass
+    except ModuleNotFoundError:           # pragma: no cover — not taken
+        handled = "benign"
+    else:
+        try:
+            raise missing_sibling
+        except Exception:
+            handled = "loud"
+    assert handled == "loud"
+
+
+def test_benign_message_is_gated_on_the_enterprise_package():
+    src = MAIN_PY.read_text()
+    start = src.index("from enterprise.backend import register_enterprise")
+    block = src[start:start + 3000]
+    assert 'split(".")[0] == "enterprise"' in block, (
+        "the benign branch must verify the missing module IS the enterprise package"
+    )
+
+
+# --- CI string contract ------------------------------------------------------
+
+def test_ci_grepped_strings_are_unchanged():
+    """`.github/workflows/*` greps stdout for these exact strings — the
+    `backend boots without enterprise submodule` job asserts the OSS-only one, so
+    a reworded message would break CI silently."""
+    src = MAIN_PY.read_text()
+    assert '"Trinity Enterprise modules registered"' in src
+    assert "Trinity Enterprise submodule not present — OSS-only build " in src

--- a/tests/unit/test_847_entitlement_seam.py
+++ b/tests/unit/test_847_entitlement_seam.py
@@ -264,10 +264,19 @@ def test_submodule_registers_audit_and_sso():
     # SSO-OIDC (#32) landed in the submodule via #1303. It self-registers the
     # `sso` feature_id inside `.sso.register` (mirroring the other real modules),
     # so `register_module("sso")` is NOT called here in __init__.py — the pin is
-    # on the import + registration call instead.
-    assert "from .sso import register as register_sso" in src, (
-        "SSO-OIDC (#32) is implemented — __init__.py must import the .sso package"
-    )
-    assert "register_sso(app)" in src, (
-        "SSO-OIDC must be registered on the enterprise app via register_sso(app)"
+    # on the registration call instead.
+    #
+    # ent#196 changed the MECHANISM, not the fact: each module is now registered
+    # through an isolating helper (`_register_module(app, "<name>")`) so one
+    # module's failure can't abort every later module. The old literal
+    # `from .sso import register as register_sso` + `register_sso(app)` pair no
+    # longer appears. Pin the intent — "the submodule registers sso" — not the
+    # import style, so this cross-repo static check doesn't break on a
+    # refactor that preserves behavior.
+    assert '_register_module(app, "sso")' in src or (
+        "from .sso import register as register_sso" in src and "register_sso(app)" in src
+    ), (
+        "SSO-OIDC (#32) is implemented — __init__.py must register the .sso "
+        "package (via _register_module(app, \"sso\") since ent#196, or the "
+        "pre-ent#196 direct import + call)"
     )

--- a/tests/unit/test_847_entitlement_seam.py
+++ b/tests/unit/test_847_entitlement_seam.py
@@ -280,3 +280,42 @@ def test_submodule_registers_audit_and_sso():
         "package (via _register_module(app, \"sso\") since ent#196, or the "
         "pre-ent#196 direct import + call)"
     )
+
+
+# --- unregister_module (ent#196) ---------------------------------------------
+
+def test_unregister_module_withdraws_a_claim():
+    """The registration seam is a CLAIM that a feature is present and served.
+    A module that claims its id then fails partway leaves that claim standing
+    with nothing behind it — advertised in feature-flags, UI shown, every call
+    404s. The registering side needs a way to roll its own claim back.
+    """
+    from services.entitlement_service import EntitlementService
+
+    svc = EntitlementService()
+    svc.register_module("thing")
+    assert svc.is_entitled("thing") is True
+
+    assert svc.unregister_module("thing") is True
+    assert svc.is_entitled("thing") is False
+    assert "thing" not in svc.list_entitled_features()
+
+
+def test_unregister_module_is_idempotent():
+    from services.entitlement_service import EntitlementService
+
+    svc = EntitlementService()
+    assert svc.unregister_module("never-registered") is False   # no-op, no raise
+    svc.register_module("thing")
+    assert svc.unregister_module("thing") is True
+    assert svc.unregister_module("thing") is False
+
+
+def test_unregister_module_leaves_other_claims_alone():
+    from services.entitlement_service import EntitlementService
+
+    svc = EntitlementService()
+    svc.register_module("keep")
+    svc.register_module("drop")
+    svc.unregister_module("drop")
+    assert svc.list_entitled_features() == ["keep"]

--- a/tests/unit/test_ent196_enterprise_load_reporting.py
+++ b/tests/unit/test_ent196_enterprise_load_reporting.py
@@ -1,0 +1,85 @@
+"""The enterprise-load block must not call a real failure "normal" (ent#196).
+
+`main.py` wraps the enterprise import + registration in one try. It used to
+catch bare `ImportError` and print:
+
+    Trinity Enterprise submodule not present — OSS-only build
+    (this is normal; enterprise modules are an optional private submodule)
+
+That line is correct for an OSS clone. But `ImportError` also covers a *mounted*
+submodule whose module failed to import — e.g. importing a name from an OSS
+table that hasn't landed yet. Observed live: the submodule was present and
+correctly mounted, a module failed, and the operator was told "this is normal"
+while a paid feature was silently absent. Diagnosing it required hand-running
+`register_enterprise()` to see the real traceback.
+
+The benign case is now narrowed to its actual signature — a `ModuleNotFoundError`
+naming the `enterprise` package itself. These tests pin the classification so a
+future edit can't widen it back.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+MAIN_PY = Path(__file__).resolve().parents[2] / "src" / "backend" / "main.py"
+
+
+def _classify(exc: BaseException) -> str:
+    """The exact predicate main.py uses, applied to an exception."""
+    if isinstance(exc, ModuleNotFoundError):
+        return "benign" if (exc.name or "").split(".")[0] == "enterprise" else "loud"
+    return "loud"
+
+
+def test_absent_submodule_is_still_reported_as_normal():
+    """An OSS clone has no `enterprise` package — that must stay quiet."""
+    try:
+        import enterprise.backend  # noqa: F401
+        pytest.skip("enterprise submodule is mounted in this checkout")
+    except ModuleNotFoundError as e:
+        assert _classify(e) == "benign"
+
+
+def test_missing_name_inside_a_mounted_module_is_loud():
+    """The ent#196 case: the package is present, a module imports a name that
+    doesn't exist. Python raises a plain ImportError (NOT ModuleNotFoundError),
+    so it must never take the benign branch."""
+    exc = ImportError("cannot import name 'product_events' from 'db.tables'")
+    assert not isinstance(exc, ModuleNotFoundError)
+    assert _classify(exc) == "loud"
+
+
+def test_missing_third_party_dependency_is_loud():
+    """A module needing an uninstalled package is a real failure, not an
+    absent submodule."""
+    assert _classify(ModuleNotFoundError("No module named 'pyotp'", name="pyotp")) == "loud"
+
+
+def test_nested_enterprise_module_absence_is_benign():
+    """`enterprise.backend` missing is the same OSS-clone signature as
+    `enterprise` missing."""
+    assert _classify(
+        ModuleNotFoundError("No module named 'enterprise.backend'", name="enterprise.backend")
+    ) == "benign"
+
+
+def test_main_py_does_not_catch_bare_importerror_for_the_benign_message():
+    """Static guard: the reassuring message must sit behind the narrowed
+    `ModuleNotFoundError` + name check, never a bare `except ImportError`."""
+    src = MAIN_PY.read_text()
+    block_start = src.index("from enterprise.backend import register_enterprise")
+    block = src[block_start:block_start + 2500]
+
+    assert "except ModuleNotFoundError" in block, (
+        "the benign branch must key off ModuleNotFoundError"
+    )
+    assert re.search(r"except ImportError\s*:", block) is None, (
+        "a bare `except ImportError` here re-buries a real module failure under "
+        '"submodule not present — this is normal" (ent#196)'
+    )
+    assert 'split(".")[0] == "enterprise"' in block, (
+        "the benign branch must verify the missing module IS the enterprise package"
+    )


### PR DESCRIPTION
Fixes #1653.

Related to Abilityai/trinity-enterprise#196 (OSS half; the enterprise half — per-module registration isolation — is Abilityai/trinity-enterprise#197).

## The bug

The enterprise load block caught bare `ImportError` and printed:

```
Trinity Enterprise submodule not present — OSS-only build
(this is normal; enterprise modules are an optional private submodule)
```

Correct for an OSS clone. But `ImportError` also covers a **mounted** submodule whose module failed to import — e.g. importing a name from an OSS table that hasn't landed yet.

Observed live: the submodule was present and correctly mounted, a module failed, and the operator was told **"this is normal"** while a paid feature was silently absent. Diagnosing it required hand-running `register_enterprise()` in the container to see the real traceback.

## The fix

Narrow the benign branch to its actual signature — a `ModuleNotFoundError` whose missing module **is** the `enterprise` package:

| Situation | Exception | Branch |
|---|---|---|
| OSS clone, no submodule | `ModuleNotFoundError(name="enterprise.backend")` | benign ✓ |
| Module imports a missing **name** | plain `ImportError` (not a `ModuleNotFoundError`) | **loud** ✓ |
| Module needs an uninstalled package | `ModuleNotFoundError(name="pyotp")` | **loud** ✓ |
| Anything else (schema, migration, mount) | `Exception` | **loud** ✓ (unchanged) |

The loud handler was already correct and is only factored into `_report_enterprise_failure()` so both paths share it. No behavior change for a genuine OSS build.

## Test-pin update

`tests/unit/test_847_entitlement_seam.py` statically pinned the literal `from .sso import register as register_sso` + `register_sso(app)` in the **enterprise** `__init__.py`. The paired enterprise PR registers each module through an isolating helper, so that exact pair no longer exists.

The pin moves to the **intent** — "the submodule registers `sso`" — and still accepts the pre-ent#196 form, so this cross-repo static check doesn't break on a behavior-preserving refactor in the other repo.

## Verification

New `tests/unit/test_ent196_enterprise_load_reporting.py` (4 passed, 1 skipped — the skip is the "no submodule" case, which can't be exercised in a checkout that has one). Includes a static guard that fails if a bare `except ImportError` ever comes back in front of the benign message.

Full OSS unit suite: **4667 passed, 16 skipped, 5 failed**. All 5 failures reproduce on a clean `origin/dev` worktree and are unrelated:
- 3× `test_admin_email_login` — `AttributeError: module 'bcrypt' has no attribute '__about__'` (local bcrypt/passlib version mismatch)
- `test_1474_read_boundary_z::test_schedules_summary_last_run_at_normalized`
- `test_1472_schedule_validation::test_accepts_valid[0 4 * * *-Europe/Kiev]`

Enterprise-docs guard run locally against `docs/`, `CLAUDE.md`, `main.py`, `entitlement_service.py` — clean (the new comment describes the generic seam and names no module).

Verified live: with the enterprise submodule mounted and one module genuinely broken, the log now reads `Trinity Enterprise registration completed with 1 FAILED module(s): …` instead of the reassuring line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
