### PR TITLE
feat(mcp): room tools for shared multi-agent sessions (ent#169)

### DIFF
--- a/src/backend/routers/executions.py
+++ b/src/backend/routers/executions.py
@@ -21,7 +21,11 @@ from services.agent_service.helpers import accessible_agent_names, narrow_to_age
 router = APIRouter(prefix="/api/executions", tags=["executions"])
 
 _VALID_STATUSES = {"running", "queued", "success", "failed", "error", "cancelled", "skipped"}
-_VALID_TRIGGERS = {"schedule", "manual", "agent", "mcp", "chat", "session", "public", "webhook", "fan_out", "loop", "reminder"}
+# NOTE: this is a filter ALLOW-LIST, not a DB enum — `triggered_by` is a plain
+# TEXT column. An unknown value here degrades to "no filter" (see below), which
+# silently returns EVERY execution instead of none, so a trigger that reaches
+# this endpoint must be listed or its filter lies. `room` is ent#169.
+_VALID_TRIGGERS = {"schedule", "manual", "agent", "mcp", "chat", "session", "public", "webhook", "fan_out", "loop", "reminder", "room"}
 _VALID_HOURS = {0, 1, 6, 24, 168, 720}  # 0 = all-time
 
 

--- a/src/mcp-server/src/client.ts
+++ b/src/mcp-server/src/client.ts
@@ -241,6 +241,44 @@ export class TrinityClient {
   /**
    * Public request method for custom API calls
    */
+  // --- Shared sessions / rooms (ent#169) ------------------------------------
+  // A room is a shared persistent RECORD; membership is the grant, so an
+  // agent-scoped key reaches exactly the rooms its agent belongs to and the
+  // backend answers a uniform 404 otherwise.
+
+  async createRoom(body: {
+    name: string;
+    agents: string[];
+    topic?: string;
+    max_messages?: number;
+    max_cost_usd?: number;
+    ttl_hours?: number;
+    scribe?: string;
+  }): Promise<any> {
+    return this.request("POST", "/api/rooms", body);
+  }
+
+  async listRooms(): Promise<{ rooms: any[] }> {
+    return this.request("GET", "/api/rooms");
+  }
+
+  async readRoom(roomId: string, since = 0): Promise<any> {
+    return this.request(
+      "GET",
+      `/api/rooms/${encodeURIComponent(roomId)}?since=${encodeURIComponent(String(since))}`
+    );
+  }
+
+  async postToRoom(roomId: string, content: string): Promise<any> {
+    return this.request("POST", `/api/rooms/${encodeURIComponent(roomId)}/messages`, {
+      content,
+    });
+  }
+
+  async closeRoom(roomId: string, reason?: string): Promise<any> {
+    return this.request("POST", `/api/rooms/${encodeURIComponent(roomId)}/close`, { reason });
+  }
+
   async request<T>(
     method: string,
     path: string,

--- a/src/mcp-server/src/server.ts
+++ b/src/mcp-server/src/server.ts
@@ -12,6 +12,7 @@ import { createChatTools } from "./tools/chat.js";
 import { createSystemTools } from "./tools/systems.js";
 import { createDocsTools } from "./tools/docs.js";
 import { createSkillsTools } from "./tools/skills.js";
+import { createRoomTools } from "./tools/rooms.js";  // ent#169 shared sessions
 import { createScheduleTools } from "./tools/schedules.js";
 import { createTagTools } from "./tools/tags.js";
 import { createNotificationTools } from "./tools/notifications.js";
@@ -270,6 +271,7 @@ export async function createServer(config: ServerConfig = {}) {
     createVoipTools(client, requireApiKey),       // VoIP telephony — call_user (VOIP-001, #1056)
     createOperatorQueueTools(client, requireApiKey), // Operator queue read + respond (OPS-001, #1101/#1104)
     createGitTools(client, requireApiKey),           // Direct git status/sync/log/pull/sync-state/reset (#905)
+    createRoomTools(client, requireApiKey),          // Shared sessions / rooms (ent#169)
   ];
   // Operator tools: hidden from connector-scoped keys.
   for (const group of toolGroups) {

--- a/src/mcp-server/src/tools/rooms.ts
+++ b/src/mcp-server/src/tools/rooms.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared sessions / rooms (ent#169).
+ *
+ * A room is a shared persistent RECORD, never a shared CONTEXT: every agent
+ * keeps its own isolated session and is handed only the transcript it has not
+ * seen. Turn-taking is mechanical — you are woken iff you were @mentioned — so
+ * nothing here has to decide who speaks next.
+ *
+ * These tools are a thin proxy. All authorization lives server-side: membership
+ * is the grant, and a non-member gets a uniform 404 (never a 403 that would
+ * confirm the room exists). The acting identity comes from the API key, so an
+ * agent-scoped key always acts as its own agent and cannot post as anyone else.
+ *
+ * On an OSS build (or an unentitled instance) the backend routes are absent and
+ * these tools return a structured "not enabled" result rather than throwing a
+ * transport error at the agent.
+ */
+import { z } from "zod";
+import { TrinityClient } from "../client.js";
+import type { McpAuthContext } from "../types.js";
+
+const NOT_ENABLED = {
+  error: "shared_sessions_not_enabled",
+  message: "Shared sessions are not enabled on this Trinity instance.",
+};
+
+function unavailable(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return msg.includes("404") || msg.includes("403");
+}
+
+export function createRoomTools(client: TrinityClient, requireApiKey: boolean) {
+  const getClient = (authContext?: McpAuthContext): TrinityClient => {
+    if (requireApiKey) {
+      if (!authContext?.mcpApiKey) {
+        throw new Error(
+          "MCP API key authentication required but no API key found in request context"
+        );
+      }
+      const userClient = new TrinityClient(client.getBaseUrl());
+      userClient.setToken(authContext.mcpApiKey);
+      return userClient;
+    }
+    return client;
+  };
+
+  const guard = async (fn: () => Promise<unknown>): Promise<string> => {
+    try {
+      return JSON.stringify(await fn(), null, 2);
+    } catch (e) {
+      if (unavailable(e)) return JSON.stringify(NOT_ENABLED, null, 2);
+      return JSON.stringify(
+        { error: "room_request_failed", message: e instanceof Error ? e.message : String(e) },
+        null,
+        2
+      );
+    }
+  };
+
+  return {
+    createRoom: {
+      name: "create_room",
+      description:
+        "Open a shared session (room) with one or more agents so you can work a " +
+        "topic together across many turns. You must have access to every agent " +
+        "you add. Rooms are bounded: they close when they hit their message, " +
+        "cost, or time budget.",
+      parameters: z.object({
+        name: z.string().describe("Short room name"),
+        agents: z.array(z.string()).min(1).describe("Agent names to add as participants"),
+        topic: z.string().optional().describe("What the room is for"),
+        max_messages: z.number().int().positive().optional().describe("Message budget (default 60)"),
+        max_cost_usd: z.number().positive().optional().describe("Cost budget in USD"),
+        ttl_hours: z.number().int().min(0).optional().describe("Auto-close after N hours (default 24; 0 = never)"),
+        scribe: z.string().optional().describe("Participant designated to record outcomes"),
+      }),
+      execute: async (args: any, context?: { session?: McpAuthContext }) =>
+        guard(() => getClient(context?.session).createRoom(args)),
+    },
+
+    listRooms: {
+      name: "list_rooms",
+      description:
+        "List the shared sessions (rooms) you are a participant in, with their " +
+        "status, message count and participant count.",
+      parameters: z.object({}),
+      execute: async (_a: unknown, context?: { session?: McpAuthContext }) =>
+        guard(() => getClient(context?.session).listRooms()),
+    },
+
+    readRoom: {
+      name: "read_room",
+      description:
+        "Read a room's transcript and participants. Pass `since` (a message seq) " +
+        "to fetch only what is new — the cheap way to catch up on a long room.",
+      parameters: z.object({
+        room_id: z.string(),
+        since: z.number().int().min(0).optional().describe("Return only messages after this seq"),
+      }),
+      execute: async (
+        { room_id, since }: { room_id: string; since?: number },
+        context?: { session?: McpAuthContext }
+      ) => guard(() => getClient(context?.session).readRoom(room_id, since ?? 0)),
+    },
+
+    postToRoom: {
+      name: "post_to_room",
+      description:
+        "Post a message to a room. @mention a participant by name to wake them — " +
+        "a message with no mention joins the transcript without waking anyone. " +
+        "You post as yourself; you cannot post as another participant.",
+      parameters: z.object({
+        room_id: z.string(),
+        content: z.string().describe("Message text; @mention participants to wake them"),
+      }),
+      execute: async (
+        { room_id, content }: { room_id: string; content: string },
+        context?: { session?: McpAuthContext }
+      ) => guard(() => getClient(context?.session).postToRoom(room_id, content)),
+    },
+
+    closeRoom: {
+      name: "close_room",
+      description:
+        "Close a room. The transcript stays readable; no further messages can be " +
+        "posted. Idempotent.",
+      parameters: z.object({
+        room_id: z.string(),
+        reason: z.string().optional(),
+      }),
+      execute: async (
+        { room_id, reason }: { room_id: string; reason?: string },
+        context?: { session?: McpAuthContext }
+      ) => guard(() => getClient(context?.session).closeRoom(room_id, reason)),
+    },
+  };
+}

--- a/tests/unit/test_ent169_room_trigger_filter.py
+++ b/tests/unit/test_ent169_room_trigger_filter.py
@@ -1,0 +1,33 @@
+"""`triggered_by=room` must actually filter (ent#169).
+
+`routers/executions.py` treats `_VALID_TRIGGERS` as an allow-list and degrades an
+unrecognised value to `None` — i.e. NO filter — so an unlisted trigger silently
+returns EVERY execution rather than none. Verified live before the fix:
+
+    triggered_by=room          -> 14 rows, kinds=['agent','public','room']
+    triggered_by=bogus-trigger -> 14 rows, kinds=['agent','public','room']
+
+Identical to a garbage value: the filter lied. ent#169 introduces `room` as a
+runtime `triggered_by`, so it has to be listed or the Sessions UI (ent#170)
+cannot filter room executions and users get silently wrong data.
+"""
+from __future__ import annotations
+
+
+def test_room_is_an_accepted_trigger_filter():
+    from routers.executions import _VALID_TRIGGERS
+
+    assert "room" in _VALID_TRIGGERS, (
+        "an unlisted trigger degrades to NO filter, so `triggered_by=room` "
+        "would return every execution instead of the room's"
+    )
+
+
+def test_every_known_trigger_is_filterable():
+    """Any value written to `triggered_by` that a user can filter on must be
+    listed; otherwise its filter silently returns everything."""
+    from routers.executions import _VALID_TRIGGERS
+
+    for trigger in ("schedule", "manual", "agent", "mcp", "chat", "session",
+                    "public", "webhook", "fan_out", "loop", "reminder", "room"):
+        assert trigger in _VALID_TRIGGERS


### PR DESCRIPTION
OSS half of Abilityai/trinity-enterprise#169 (enterprise module: Abilityai/trinity-enterprise#210).

Five MCP tools — `create_room`, `list_rooms`, `read_room`, `post_to_room`, `close_room` — proxying the enterprise rooms API. Tool code ships in the public server even though the feature is gated (Invariant #13).

## Thin by design

All authorization is server-side and nothing here decides access:

- **Membership is the grant** — a non-member gets a uniform 404 from the backend.
- **The acting identity comes from the API key**, so an agent-scoped key always posts as its own agent and cannot post as another participant. There is no `sender` parameter to spoof.
- The tools' only local logic is turning an absent/forbidden route into a structured result instead of a transport error.

## Graceful fallback, verified

On an OSS build (or unentitled instance) the routes are absent, so the tools return:

```json
{ "error": "shared_sessions_not_enabled",
  "message": "Shared sessions are not enabled on this Trinity instance." }
```

Verified live in both directions: with the module unregistered → the fallback above; with it registered → real data.

## Live verification

Real MCP JSON-RPC with an agent's own `TRINITY_MCP_API_KEY` (tool count 100 → **105**):

- `list_rooms` → the agent's rooms with status, `stop_reason`, message and participant counts
- `read_room` with `since` → transcript tail + participants
- `post_to_room` → landed as `#15 agent/portal-demo`, i.e. recorded as the **agent**, resolved from auth context

## Known gap

`TrinityClient.request()` takes no headers argument, so `post_to_room` cannot send an `Idempotency-Key`. The endpoint accepts one — Invariant #18 is satisfied at the boundary — but wiring it through the MCP client needs a client-signature change I didn't want to make unasked. Left as a follow-up.

**Note for reviewers:** the MCP server is a baked image, so `docker compose build mcp-server` is needed to pick these up; `npm run build` on the host is not enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)