### PR TITLE
fix(executions): reconcile fleet totals with the per-agent view (#1743)

### DIFF
--- a/src/backend/db/schedules/stats.py
+++ b/src/backend/db/schedules/stats.py
@@ -385,13 +385,15 @@ class ScheduleStatsMixin:
                 "total": 0, "success_count": 0, "failed_count": 0,
                 "total_cost": 0.0, "success_rate": 0.0,
                 "running_count": 0, "queued_count": 0, "hours": hours,
+                "deleted_agent_count": 0, "deleted_agent_cost": 0.0,
             }
 
         bind: Dict = {}
         agent_where = ""
         if agent_names is not None:
             keys = [f"an{i}" for i in range(len(agent_names))]
-            agent_where = "WHERE agent_name IN (%s)" % ",".join(f":{k}" for k in keys)
+            # Qualified: the #1743 LEFT JOIN puts agent_name in both tables.
+            agent_where = "WHERE se.agent_name IN (%s)" % ",".join(f":{k}" for k in keys)
             bind.update(dict(zip(keys, agent_names)))
 
         # Single-pass query: windowed totals via conditional aggregation +
@@ -401,7 +403,7 @@ class ScheduleStatsMixin:
         # integer raises; SQLite tolerated it. #300.) The named :cutoff bind is
         # reused across all four CASE expressions.
         if hours:
-            time_cond = "started_at > :cutoff"
+            time_cond = "se.started_at > :cutoff"
             bind["cutoff"] = iso_cutoff(hours)
         else:
             time_cond = "1=1"
@@ -410,12 +412,26 @@ class ScheduleStatsMixin:
             row = conn.execute(text(f"""
                 SELECT
                     SUM(CASE WHEN {time_cond} THEN 1 ELSE 0 END) AS total,
-                    SUM(CASE WHEN {time_cond} AND status = 'success' THEN 1 ELSE 0 END) AS success_count,
-                    SUM(CASE WHEN {time_cond} AND status IN ('failed', 'error') THEN 1 ELSE 0 END) AS failed_count,
-                    SUM(CASE WHEN {time_cond} THEN COALESCE(cost, 0) ELSE 0 END) AS total_cost,
-                    SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running_count,
-                    SUM(CASE WHEN status = 'queued' THEN 1 ELSE 0 END) AS queued_count
-                FROM schedule_executions
+                    SUM(CASE WHEN {time_cond} AND se.status = 'success' THEN 1 ELSE 0 END) AS success_count,
+                    SUM(CASE WHEN {time_cond} AND se.status IN ('failed', 'error') THEN 1 ELSE 0 END) AS failed_count,
+                    SUM(CASE WHEN {time_cond} THEN COALESCE(se.cost, 0) ELSE 0 END) AS total_cost,
+                    SUM(CASE WHEN se.status = 'running' THEN 1 ELSE 0 END) AS running_count,
+                    SUM(CASE WHEN se.status = 'queued' THEN 1 ELSE 0 END) AS queued_count,
+                    -- #1743: the slice of the window that belongs to no LIVE agent.
+                    -- Execution rows outlive their agent on purpose (cost is
+                    -- billing truth, and a soft-deleted agent is recoverable), but
+                    -- the per-agent surfaces only render live agents — so without
+                    -- this the fleet total and the sum of the tiles differ by an
+                    -- amount nothing explains. Reported, never silently dropped.
+                    SUM(CASE WHEN {time_cond} AND ao.agent_name IS NULL THEN 1 ELSE 0 END)
+                        AS deleted_agent_count,
+                    SUM(CASE WHEN {time_cond} AND ao.agent_name IS NULL
+                             THEN COALESCE(se.cost, 0) ELSE 0 END) AS deleted_agent_cost
+                FROM schedule_executions se
+                -- Joins only LIVE agents, so both a soft-deleted row (deleted_at
+                -- set) and a hard-purged one (no row at all) fall to NULL.
+                LEFT JOIN agent_ownership ao
+                       ON ao.agent_name = se.agent_name AND ao.deleted_at IS NULL
                 {agent_where}
             """), bind).mappings().first()
             total = row["total"] or 0
@@ -434,4 +450,6 @@ class ScheduleStatsMixin:
                 "running_count": row["running_count"] or 0,
                 "queued_count": row["queued_count"] or 0,
                 "hours": hours,
+                "deleted_agent_count": row["deleted_agent_count"] or 0,
+                "deleted_agent_cost": round(row["deleted_agent_cost"] or 0.0, 4),
             }

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -871,6 +871,14 @@ class FleetExecutionStats(BaseModel):
     total_cost: float
     success_rate: float
     hours: int  # 0 = all-time
+    # #1743: the slice of the above that belongs to a DELETED agent (soft-deleted
+    # or purged). Execution rows outlive their agent deliberately — cost is
+    # billing truth and a soft-deleted agent is recoverable — but the per-agent
+    # surfaces render only live agents, so these totals would otherwise exceed
+    # the sum of the tiles by an amount nothing on screen explains. Defaults keep
+    # the field additive for any client that predates it.
+    deleted_agent_count: int = 0
+    deleted_agent_cost: float = 0.0
 
 
 class CircuitBreakerConfigUpdate(BaseModel):

--- a/src/frontend/src/components/ExecutionsPanel.vue
+++ b/src/frontend/src/components/ExecutionsPanel.vue
@@ -56,6 +56,24 @@
       </div>
     </div>
 
+    <!--
+      #1743: these totals include executions whose agent has since been deleted.
+      The rows are kept on purpose — cost is billing truth and a soft-deleted
+      agent is recoverable — but no per-agent surface renders a deleted agent, so
+      without this line the fleet totals exceed the sum of the Dashboard tiles by
+      an amount nothing explains. Shown only when there is something to explain.
+    -->
+    <p
+      v-if="store.stats?.deleted_agent_count > 0"
+      class="-mt-2 mb-4 text-xs text-gray-500 dark:text-gray-400"
+    >
+      Includes
+      <span class="font-medium text-gray-700 dark:text-gray-300">{{ store.stats.deleted_agent_count }}</span>
+      execution<span v-if="store.stats.deleted_agent_count !== 1">s</span>
+      ({{ formatCostCompact(store.stats.deleted_agent_cost) }})
+      from deleted agents, which have no tile on the dashboard.
+    </p>
+
     <!-- Filter bar -->
     <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-4">
       <div class="flex flex-wrap items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700">

--- a/tests/unit/test_1743_deleted_agent_spend.py
+++ b/tests/unit/test_1743_deleted_agent_spend.py
@@ -1,0 +1,148 @@
+"""Fleet totals stay reconcilable with the per-agent surfaces (#1743).
+
+`GET /api/executions/stats` counts every accessible execution row. Those rows
+deliberately outlive their agent — cost is billing truth and a soft-deleted agent
+is recoverable — but `GET /api/agents/execution-stats` (the Dashboard tiles)
+renders only live agents. So the fleet cards and the sum of the tiles differed by
+the deleted agents' share, with nothing on either surface explaining the gap.
+
+Measured on a dev instance before the fix (24h window): fleet 16 executions /
+$0.8933 versus 12 / $0.6291 across the tiles — 4 executions and $0.2642, 30% of
+the window's spend, attributable to nothing.
+
+The fix reports the difference rather than hiding it: `deleted_agent_count` /
+`deleted_agent_cost` are the slice belonging to no live agent, so
+`total - deleted_agent_count` reconciles with the tiles by subtraction and the
+spend stays visible.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def stats_db(tmp_path, monkeypatch):
+    """Sqlite with schedule_executions + agent_ownership, seeded with a live
+    agent, a soft-deleted one, and a hard-purged one."""
+    db_file = tmp_path / "trinity-stats.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+
+    from db.engine import get_engine
+    from db.tables import metadata as m, schedule_executions, agent_ownership, users
+    m.create_all(get_engine(), tables=[schedule_executions, agent_ownership, users])
+
+    from sqlalchemy import insert
+    from utils.helpers import utc_now_iso
+
+    now = utc_now_iso()
+    with get_engine().begin() as conn:
+        conn.execute(insert(users).values(id=1, username="alice", role="admin",
+                                          created_at="t", updated_at="t"))
+        # live agent, soft-deleted agent — and "ghost" gets NO ownership row at
+        # all, standing in for a hard-purged one.
+        conn.execute(insert(agent_ownership).values(
+            agent_name="live-agent", owner_id=1, created_at="t"))
+        conn.execute(insert(agent_ownership).values(
+            agent_name="gone-agent", owner_id=1, created_at="t", deleted_at=now))
+
+        def _exec(eid, agent, status, cost):
+            conn.execute(insert(schedule_executions).values(
+                id=eid, schedule_id="__manual__", agent_name=agent, status=status,
+                started_at=now, completed_at=now, message="m",
+                triggered_by="manual", cost=cost, duration_ms=100))
+
+        _exec("e1", "live-agent", "success", 1.0)
+        _exec("e2", "live-agent", "failed", 0.5)
+        _exec("e3", "gone-agent", "success", 2.0)      # soft-deleted
+        _exec("e4", "ghost", "success", 4.0)           # no ownership row at all
+    yield str(db_file)
+
+
+def _stats(agent_names=None, hours=0):
+    from database import db
+    return db.get_fleet_execution_stats(agent_names, hours=hours)
+
+
+def test_deleted_agent_slice_is_reported(stats_db):
+    s = _stats()
+    assert s["total"] == 4
+    assert s["total_cost"] == pytest.approx(7.5)
+    # e3 (soft-deleted) + e4 (purged)
+    assert s["deleted_agent_count"] == 2
+    assert s["deleted_agent_cost"] == pytest.approx(6.0)
+
+
+def test_totals_reconcile_with_the_live_agent_view(stats_db):
+    """THE invariant: fleet total minus the deleted slice is what the per-agent
+    surfaces can actually account for."""
+    s = _stats()
+    assert s["total"] - s["deleted_agent_count"] == 2          # e1 + e2
+    assert s["total_cost"] - s["deleted_agent_cost"] == pytest.approx(1.5)
+
+
+def test_soft_deleted_and_purged_are_both_counted(stats_db):
+    """A soft-deleted agent (row with deleted_at) and a purged one (no row) are
+    equally invisible to the tiles, so both belong in the slice — the LEFT JOIN
+    is on `deleted_at IS NULL` precisely so they collapse together."""
+    from sqlalchemy import text
+    from db.engine import get_engine
+
+    with get_engine().begin() as conn:
+        conn.execute(text("DELETE FROM schedule_executions WHERE id = 'e4'"))
+    soft_only = _stats()
+    assert soft_only["deleted_agent_count"] == 1               # the soft-deleted one
+    assert soft_only["deleted_agent_cost"] == pytest.approx(2.0)
+
+
+def test_no_deleted_agents_reports_zero(stats_db):
+    """A clean fleet reports 0/0 so the UI line stays hidden — the explanation
+    only appears when there is something to explain."""
+    from sqlalchemy import text
+    from db.engine import get_engine
+
+    with get_engine().begin() as conn:
+        conn.execute(text("DELETE FROM schedule_executions WHERE agent_name IN ('gone-agent','ghost')"))
+    s = _stats()
+    assert s["deleted_agent_count"] == 0 and s["deleted_agent_cost"] == 0.0
+    assert s["total"] == 2
+
+
+def test_agent_filtered_stats_still_split(stats_db):
+    """A non-admin caller passes an explicit agent list; the split must still be
+    computed over exactly that set (the JOIN must not bypass the filter)."""
+    s = _stats(agent_names=["live-agent"])
+    assert s["total"] == 2 and s["deleted_agent_count"] == 0
+    s2 = _stats(agent_names=["gone-agent"])
+    assert s2["total"] == 1 and s2["deleted_agent_count"] == 1
+
+
+def test_empty_accessible_set_short_circuits_with_the_new_fields(stats_db):
+    """The early-return path for a caller with no accessible agents must still
+    carry the fields, or the response model loses them for that caller."""
+    s = _stats(agent_names=[])
+    assert s["deleted_agent_count"] == 0 and s["deleted_agent_cost"] == 0.0
+
+
+def test_windowed_query_splits_correctly(stats_db):
+    """The split rides the same time window as the totals it explains."""
+    s = _stats(hours=24)
+    assert s["total"] == 4 and s["deleted_agent_count"] == 2
+    assert s["total_cost"] - s["deleted_agent_cost"] == pytest.approx(1.5)
+
+
+def test_response_model_exposes_the_fields():
+    """Additive with defaults, so a client predating the field still validates."""
+    from models import FleetExecutionStats
+
+    m = FleetExecutionStats(total=0, success_count=0, failed_count=0,
+                            running_count=0, queued_count=0, total_cost=0.0,
+                            success_rate=0.0, hours=24)
+    assert m.deleted_agent_count == 0 and m.deleted_agent_cost == 0.0
+    full = FleetExecutionStats(total=4, success_count=3, failed_count=1,
+                               running_count=0, queued_count=0, total_cost=7.5,
+                               success_rate=75.0, hours=24,
+                               deleted_agent_count=2, deleted_agent_cost=6.0)
+    assert full.deleted_agent_cost == 6.0


### PR DESCRIPTION
Fixes #1743.

## The problem

`GET /api/executions/stats` (Operations stat cards) counts every accessible execution row. `GET /api/agents/execution-stats` (Dashboard tiles) renders only **live** agents. Execution rows outlive their agent on purpose — cost is billing truth, and a soft-deleted agent is recoverable — so the two surfaces differed by the deleted agents' share, with nothing explaining the gap.

Measured on a dev instance, 24h window:

| surface | executions | cost |
|---|---|---|
| fleet stats | 16 | $0.8933 |
| sum of tiles | 12 | $0.6291 |
| **gap** | **4** | **$0.2642** (30% of the window's spend) |

## The fix

Neither endpoint was wrong on its own, so **neither changes its totals**. The difference is *reported* instead:

```json
{ "total": 16, "total_cost": 0.8933,
  "deleted_agent_count": 4, "deleted_agent_cost": 0.2642 }
```

`total − deleted_agent_count` now reconciles with the tiles by subtraction, and the spend stays attributable rather than being silently dropped from either side.

Computed in the **same single pass** via a LEFT JOIN matching only live ownership rows, so a soft-deleted agent (`deleted_at` set) and a hard-purged one (no row at all) collapse together — both are equally invisible to the tiles, so both belong in the slice.

The Executions panel shows one line, and only when the count is non-zero:

> Includes **4** executions ($0.26) from deleted agents, which have no tile on the dashboard.

## Things worth a reviewer's eye

- **The join made columns ambiguous.** `agent_name`, `status`, `started_at` and `cost` all exist on both sides; PostgreSQL rejects the ambiguous form outright (SQLite would have tolerated some of it). Every column in that query is now qualified.
- **The empty-accessible-set early return** short-circuits before the query, so it needed the new keys too — otherwise a caller with no accessible agents loses the fields.
- **Fields are additive with defaults**, so a client predating them still validates.
- The `?agent=` / non-admin filtered path is covered: the split is computed over exactly the filtered set, not the whole table.

## Verification

Live, after the change:

```
fleet stats        : total=16  cost=0.8933
deleted-agent slice: count=4   cost=0.2642
fleet minus slice  : total=12  cost=0.6291
sum of tiles       : total=12  cost=0.6291
RECONCILES: True
```

`tests/unit/test_1743_deleted_agent_spend.py` — 8 passed: the slice itself, the reconciliation invariant, soft-deleted **and** purged both counted, zero-when-clean (so the UI line stays hidden), the agent-filtered path, the empty-set early return, the windowed path, and the model defaults.

Related suites: 212 passed, 3 skipped.

## Found by

A cross-surface consistency audit — checking every reported metric against the DB across all surfaces. Everything else agreed exactly (counts, cost, success_rate, duration, context); this was the one disagreement.

## Not addressed here

`success_rate` is 0–1 from the analytics endpoints and 0–100 from `execution-stats`. Every current consumer handles its own source correctly, so there's no live defect — noted in #1743's body rather than fixed here, since changing either scale would silently break whichever consumer wasn't updated in the same breath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
