### PR TITLE
security: revoke an agent's MCP keys when the agent is deleted (#1745)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -1024,6 +1024,14 @@ class DatabaseManager:
     def get_agent_mcp_api_key(self, agent_name: str):
         return self._mcp_key_ops.get_agent_mcp_api_key(agent_name)
 
+    def set_agent_keys_active(self, agent_name: str, active: bool) -> int:
+        """#1745: activate/deactivate an agent's per-agent MCP keys."""
+        return self._mcp_key_ops.set_agent_keys_active(agent_name, active)
+
+    def deactivate_orphaned_agent_keys(self) -> int:
+        """#1745: deactivate per-agent keys whose agent is no longer live."""
+        return self._mcp_key_ops.deactivate_orphaned_agent_keys()
+
     def delete_agent_mcp_api_key(self, agent_name: str):
         return self._mcp_key_ops.delete_agent_mcp_api_key(agent_name)
 

--- a/src/backend/db/agents.py
+++ b/src/backend/db/agents.py
@@ -375,6 +375,26 @@ class AgentOperations(
         with get_engine().connect() as conn:
             return int(conn.execute(stmt).scalar() or 0)
 
+    @staticmethod
+    def _deactivate_agent_keys_in_txn(conn, agent_name: str, *, active: bool) -> int:
+        """Flip per-agent key activity on an EXISTING connection (#1745).
+
+        Runs inside the caller's transaction so the credential state can never
+        diverge from the ownership state — a key left active after a committed
+        delete is the whole bug.
+        """
+        from .tables import mcp_api_keys
+
+        return conn.execute(
+            update(mcp_api_keys)
+            .where(
+                mcp_api_keys.c.agent_name == agent_name,
+                mcp_api_keys.c.scope.in_(("agent", "connector")),
+                mcp_api_keys.c.is_active == (0 if active else 1),
+            )
+            .values(is_active=1 if active else 0)
+        ).rowcount or 0
+
     def delete_agent_ownership(self, agent_name: str) -> bool:
         """Soft-delete the agent ownership row (Issue #834 Phase 1a).
 
@@ -400,6 +420,16 @@ class AgentOperations(
                 .values(deleted_at=utc_now_iso())
             )
             if result.rowcount > 0:
+                # #1745: revoke the agent's credentials in the SAME transaction.
+                # `mcp_api_keys` is CASCADE in AGENT_REFS precisely because "an
+                # orphaned key must not survive its agent", but that cascade only
+                # runs at the hard purge — i.e. after the whole soft-delete
+                # window (default 180 days), during which the key kept
+                # authenticating, enumerating the fleet, and able to mint a fresh
+                # key of its own. Deactivate (not delete) so recovery can restore
+                # them; `validate_mcp_api_key` requires is_active=1, so this
+                # closes both the REST and MCP paths.
+                self._deactivate_agent_keys_in_txn(conn, agent_name, active=False)
                 return True
             # rowcount==0 — either already soft-deleted or doesn't exist
             row = conn.execute(
@@ -480,6 +510,11 @@ class AgentOperations(
                 )
                 .values(deleted_at=None)
             )
+            if result.rowcount > 0:
+                # #1745: recovery is the inverse of delete — restore the same
+                # credentials so a recovered agent keeps working without
+                # re-issuing keys into a running container.
+                self._deactivate_agent_keys_in_txn(conn, agent_name, active=True)
             return result.rowcount > 0
 
     def list_soft_deleted_agents(self, limit: int = 200) -> List[Dict]:

--- a/src/backend/db/mcp_keys.py
+++ b/src/backend/db/mcp_keys.py
@@ -19,7 +19,7 @@ from typing import Optional, List, Dict
 from sqlalchemy import select, insert, update, delete
 
 from .engine import get_engine
-from .tables import mcp_api_keys, users
+from .tables import mcp_api_keys, users, agent_ownership
 from db_models import McpApiKey, McpApiKeyCreate, McpApiKeyWithSecret
 from utils.helpers import utc_now_iso
 
@@ -213,6 +213,67 @@ class McpKeyOperations:
         with get_engine().begin() as conn:
             result = conn.execute(stmt)
             return result.rowcount > 0
+
+    def set_agent_keys_active(self, agent_name: str, active: bool) -> int:
+        """Activate/deactivate every per-agent key for `agent_name` (#1745).
+
+        Soft-deleting an agent used to leave its keys `is_active = 1`, so the
+        credential kept authenticating for the whole soft-delete window (default
+        180 days) — enumerating the fleet, reading other agents, and able to mint
+        a fresh key of its own, which made revoking it afterwards pointless.
+        `mcp_api_keys` is registered CASCADE in `AGENT_REFS` for exactly this
+        reason ("an orphaned key must not survive its agent"), but that cascade
+        only runs at the hard purge at the END of that window.
+
+        Deactivation rather than deletion because soft-delete is *recoverable*:
+        recovering the agent flips the same keys back on, so a recovered agent
+        keeps working without re-issuing credentials to a running container.
+        `validate_mcp_api_key` already requires `is_active = 1`, so this is
+        sufficient on both the REST and MCP paths.
+
+        Covers scope='agent' AND scope='connector' — both are per-agent
+        credentials and both are CASCADE entries.
+
+        Returns: number of key rows changed.
+        """
+        stmt = (
+            update(mcp_api_keys)
+            .where(
+                mcp_api_keys.c.agent_name == agent_name,
+                mcp_api_keys.c.scope.in_(("agent", "connector")),
+                mcp_api_keys.c.is_active == (0 if active else 1),
+            )
+            .values(is_active=1 if active else 0)
+        )
+        with get_engine().begin() as conn:
+            return conn.execute(stmt).rowcount or 0
+
+    def deactivate_orphaned_agent_keys(self) -> int:
+        """Deactivate per-agent keys whose agent is not live (#1745 backfill).
+
+        "Not live" = no `agent_ownership` row at all, or one carrying
+        `deleted_at`. Idempotent — only flips rows that are still active, so it
+        finds nothing once an instance is clean.
+
+        This is not hypothetical: on the instance where the bug was found, 12 of
+        17 active agent-scoped keys were already orphaned, 10 of them from
+        ephemeral test agents.
+        """
+        live = select(agent_ownership.c.agent_name).where(
+            agent_ownership.c.deleted_at.is_(None)
+        )
+        stmt = (
+            update(mcp_api_keys)
+            .where(
+                mcp_api_keys.c.agent_name.isnot(None),
+                mcp_api_keys.c.scope.in_(("agent", "connector")),
+                mcp_api_keys.c.is_active == 1,
+                mcp_api_keys.c.agent_name.notin_(live),
+            )
+            .values(is_active=0)
+        )
+        with get_engine().begin() as conn:
+            return conn.execute(stmt).rowcount or 0
 
     def validate_mcp_api_key(
         self, api_key: str, *, track_usage: bool = True

--- a/src/backend/services/cleanup_service.py
+++ b/src/backend/services/cleanup_service.py
@@ -314,6 +314,7 @@ class CleanupReport:
     health_checks_pruned: int = 0
     # Issue #1449: backlog_metadata PII scrubbed on authoritative-terminal rows
     backlog_metadata_scrubbed: int = 0
+    orphaned_agent_keys_revoked: int = 0  # #1745
     # Issue #834 Phase 1a: soft-deleted agents purged past their retention window
     soft_deleted_agents_purged: int = 0
     # Issue #834 Phase 1b: soft-deleted schedules purged past their retention window
@@ -371,6 +372,7 @@ class CleanupReport:
             "execution_logs_pruned": self.execution_logs_pruned,
             "execution_rows_pruned": self.execution_rows_pruned,
             "backlog_metadata_scrubbed": self.backlog_metadata_scrubbed,
+            "orphaned_agent_keys_revoked": self.orphaned_agent_keys_revoked,
             "health_checks_pruned": self.health_checks_pruned,
             "soft_deleted_agents_purged": self.soft_deleted_agents_purged,
             "soft_deleted_schedules_purged": self.soft_deleted_schedules_purged,
@@ -843,6 +845,24 @@ class CleanupService:
                 )
         except Exception as e:
             logger.error(f"[Cleanup] Error scrubbing backlog_metadata: {e}")
+
+        # #1745: deactivate per-agent MCP keys whose agent is no longer live.
+        # The delete/recover paths keep this in sync going forward; this catches
+        # keys orphaned BEFORE the fix, and any that slip through a path that
+        # removes an agent without going through delete_agent_ownership. Not
+        # age-gated — an orphaned credential is a security invariant, not a
+        # retention window (the #1449 reasoning).
+        try:
+            revoked = db.deactivate_orphaned_agent_keys()
+            report.orphaned_agent_keys_revoked = revoked
+            if revoked > 0:
+                _log_prune(
+                    revoked,
+                    f"[Cleanup] Deactivated {revoked} MCP key(s) belonging to "
+                    f"agents that are no longer live (#1745)",
+                )
+        except Exception as e:
+            logger.error(f"[Cleanup] Error deactivating orphaned agent keys: {e}")
 
     def _sweep_operator_queue_retention(self, report: CleanupReport) -> None:
         """4c-quinquies. Issue #1142: delete terminal operator_queue rows past

--- a/tests/unit/test_1745_agent_key_revocation.py
+++ b/tests/unit/test_1745_agent_key_revocation.py
@@ -1,0 +1,212 @@
+"""Deleting an agent revokes its credentials (#1745).
+
+Soft-deleting an agent used to leave its agent-scoped MCP key `is_active = 1`.
+The credential kept authenticating against both the REST API and the MCP server,
+inherited its owner's role (so on an admin-owned install it reached
+`/api/audit-log`), enumerated the whole fleet — and could **mint a fresh key of
+its own**, which made revoking it afterwards pointless.
+
+`mcp_api_keys` is registered CASCADE in `AGENT_REFS` for exactly this reason
+("an orphaned key must not survive its agent"), but `cascade_delete()` only runs
+at the *hard purge* — after the entire soft-delete window (default 180 days).
+
+Fix: deactivate on soft-delete, reactivate on recover (soft-delete is
+recoverable, so the credential state has to be reversible too), plus a sweep for
+keys orphaned before the fix. On the instance where this was found, 12 of 17
+active agent-scoped keys were already orphaned.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def keys_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "trinity-keys.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+
+    from db.engine import get_engine
+    from db.tables import metadata as m, agent_ownership, users, mcp_api_keys
+    m.create_all(get_engine(), tables=[agent_ownership, users, mcp_api_keys])
+
+    from sqlalchemy import insert
+    with get_engine().begin() as conn:
+        conn.execute(insert(users).values(id=1, username="alice", role="admin",
+                                          created_at="t", updated_at="t"))
+    yield str(db_file)
+
+
+def _mk_agent(name: str):
+    from sqlalchemy import insert
+    from db.engine import get_engine
+    from db.tables import agent_ownership
+    with get_engine().begin() as conn:
+        conn.execute(insert(agent_ownership).values(
+            agent_name=name, owner_id=1, created_at="t"))
+
+
+def _mk_key(name: str, agent: str, scope: str = "agent", active: int = 1):
+    from sqlalchemy import insert
+    from db.engine import get_engine
+    from db.tables import mcp_api_keys
+    with get_engine().begin() as conn:
+        conn.execute(insert(mcp_api_keys).values(
+            id=name, name=name, key_prefix="trinity_mcp_x", key_hash=f"h-{name}",
+            created_at="t", is_active=active, user_id=1,
+            agent_name=agent, scope=scope))
+
+
+def _active(key_id: str) -> int:
+    from sqlalchemy import text
+    from db.engine import get_engine
+    with get_engine().connect() as conn:
+        return conn.execute(
+            text("SELECT is_active FROM mcp_api_keys WHERE id = :i"), {"i": key_id}
+        ).scalar()
+
+
+# --- delete revokes ----------------------------------------------------------
+
+def test_soft_delete_deactivates_the_agents_key(keys_db):
+    from database import db
+
+    _mk_agent("doomed")
+    _mk_key("k-doomed", "doomed")
+    assert _active("k-doomed") == 1
+
+    assert db.delete_agent_ownership("doomed") is True
+    assert _active("k-doomed") == 0, (
+        "an agent's credential must not outlive the agent — it could otherwise "
+        "keep authenticating for the whole 180-day soft-delete window"
+    )
+
+
+def test_connector_scoped_keys_are_revoked_too(keys_db):
+    """Both scopes are per-agent credentials and both are CASCADE entries."""
+    from database import db
+
+    _mk_agent("doomed")
+    _mk_key("k-agent", "doomed", scope="agent")
+    _mk_key("k-conn", "doomed", scope="connector")
+    db.delete_agent_ownership("doomed")
+    assert _active("k-agent") == 0 and _active("k-conn") == 0
+
+
+def test_other_agents_keys_are_untouched(keys_db):
+    from database import db
+
+    _mk_agent("doomed"); _mk_agent("survivor")
+    _mk_key("k-doomed", "doomed"); _mk_key("k-survivor", "survivor")
+    db.delete_agent_ownership("doomed")
+    assert _active("k-doomed") == 0
+    assert _active("k-survivor") == 1
+
+
+def test_user_scoped_keys_are_untouched(keys_db):
+    """A user-scoped key is not a per-agent credential — deleting an agent must
+    not revoke the owner's own key."""
+    from database import db
+
+    _mk_agent("doomed")
+    _mk_key("k-user", None, scope="user")
+    _mk_key("k-doomed", "doomed")
+    db.delete_agent_ownership("doomed")
+    assert _active("k-user") == 1
+
+
+# --- recover restores --------------------------------------------------------
+
+def test_recover_reactivates_the_key(keys_db):
+    """Soft-delete is recoverable, so the credential state must be reversible —
+    otherwise a recovered agent silently cannot talk to the platform."""
+    from database import db
+
+    _mk_agent("comeback")
+    _mk_key("k-comeback", "comeback")
+    db.delete_agent_ownership("comeback")
+    assert _active("k-comeback") == 0
+
+    assert db.recover_agent_ownership("comeback") is True
+    assert _active("k-comeback") == 1
+
+
+def test_delete_recover_delete_round_trip(keys_db):
+    from database import db
+
+    _mk_agent("yoyo")
+    _mk_key("k-yoyo", "yoyo")
+    db.delete_agent_ownership("yoyo");      assert _active("k-yoyo") == 0
+    db.recover_agent_ownership("yoyo");     assert _active("k-yoyo") == 1
+    db.delete_agent_ownership("yoyo");      assert _active("k-yoyo") == 0
+
+
+def test_recover_does_not_resurrect_a_manually_revoked_key(keys_db):
+    """A key an operator revoked by hand stays revoked... and one the delete
+    turned off comes back. Both flip together today because the delete path
+    cannot distinguish them — documented here so the behaviour is a decision
+    rather than a surprise."""
+    from database import db
+
+    _mk_agent("mixed")
+    _mk_key("k-live", "mixed", active=1)
+    _mk_key("k-revoked", "mixed", active=0)   # revoked by an operator earlier
+    db.delete_agent_ownership("mixed")
+    db.recover_agent_ownership("mixed")
+    assert _active("k-live") == 1
+    # KNOWN: the manually-revoked key is also reactivated. Recording the current
+    # behaviour; distinguishing the two needs a "revoked_by" column.
+    assert _active("k-revoked") == 1
+
+
+# --- backfill ----------------------------------------------------------------
+
+def test_backfill_deactivates_keys_of_soft_deleted_and_missing_agents(keys_db):
+    from database import db
+    from sqlalchemy import text
+    from db.engine import get_engine
+
+    _mk_agent("live-one")
+    _mk_key("k-live", "live-one")
+    _mk_key("k-ghost", "never-existed")            # no ownership row at all
+    _mk_agent("soft"); _mk_key("k-soft", "soft")
+    with get_engine().begin() as conn:             # soft-delete WITHOUT the fix
+        conn.execute(text("UPDATE agent_ownership SET deleted_at='t' WHERE agent_name='soft'"))
+
+    assert db.deactivate_orphaned_agent_keys() == 2
+    assert _active("k-ghost") == 0 and _active("k-soft") == 0
+    assert _active("k-live") == 1
+
+
+def test_backfill_is_idempotent(keys_db):
+    from database import db
+
+    _mk_key("k-ghost", "never-existed")
+    assert db.deactivate_orphaned_agent_keys() == 1
+    assert db.deactivate_orphaned_agent_keys() == 0
+
+
+def test_backfill_leaves_user_scoped_keys_alone(keys_db):
+    from database import db
+
+    _mk_key("k-user", None, scope="user")
+    assert db.deactivate_orphaned_agent_keys() == 0
+    assert _active("k-user") == 1
+
+
+# --- the validation gate this relies on --------------------------------------
+
+def test_validation_requires_an_active_key(keys_db):
+    """Deactivation is only sufficient because every auth path requires
+    `is_active = 1`. Pin that, or the fix becomes cosmetic."""
+    import inspect
+    from db import mcp_keys
+
+    src = inspect.getsource(mcp_keys.McpKeyOperations.validate_mcp_api_key)
+    assert "is_active" in src, (
+        "validate_mcp_api_key must gate on is_active — the #1745 fix deactivates "
+        "rather than deletes, so an auth path ignoring the flag would keep the "
+        "orphaned credential working"
+    )


### PR DESCRIPTION
Fixes #1745.

## The bug

Soft-deleting an agent left its agent-scoped MCP key `is_active = 1`. `mcp_api_keys` is *already* registered CASCADE in `AGENT_REFS` with the rationale **"an orphaned key must not survive its agent"** — but `cascade_delete()` only runs at the **hard purge**, after the whole soft-delete window (default 180 days). The intent was recorded; the window was wide open.

## The fix

Deactivate (not delete) **in the same transaction as the ownership write**, and reactivate on recover.

Deactivation rather than deletion because soft-delete is *recoverable* — the credential state has to be reversible too, or a recovered agent silently cannot talk to the platform. `validate_mcp_api_key` already requires `is_active = 1`, so this closes the REST and MCP paths together; a test pins that dependency, because the fix is cosmetic without it. Covers `scope='agent'` **and** `scope='connector'` — both are per-agent credentials and both are CASCADE entries.

A cleanup sweep handles keys orphaned before the fix, and any that slip through a path bypassing `delete_agent_ownership`. Not age-gated — an orphaned credential is a security invariant, not a retention window (the #1449 reasoning).

## Verified by replaying the original attack

```
BEFORE delete:  /api/agents          200

DELETE /api/agents/keytest2

AFTER delete:   /api/users/me        401
                /api/agents          401
                /api/audit-log       401
                POST /api/mcp/keys   401   ← the persistence path, closed
                MCP initialize       401
```

Recover/re-delete round trip flips the key back on, then off:

```
recovered+started -> key 200
DELETE            -> key 401,  deleted_at set,  is_active 0
```

Backfill on the real instance:

```
[Cleanup] Deactivated 12 MCP key(s) belonging to agents that are no longer live (#1745)
per-agent keys for non-live agents: 15 total, 0 still active
```

## Things a reviewer should weigh

- **Deactivate vs delete.** I chose reversible. The trade-off is that the *same* key value comes back on recovery — if the credential was already leaked, recovery restores a compromised key. Deleting and re-minting on recover would be stronger but breaks a running container's env. Worth a call.
- **A manually-revoked key is reactivated by recovery.** The delete path cannot distinguish "operator revoked this" from "delete revoked this" without a `revoked_by` column. Current behaviour is recorded in a test named for it rather than left to be discovered.
- **Only `delete_agent_ownership` is covered.** Any future path that removes an agent another way is caught by the sweep within 5 minutes, not instantly.

## Unrelated bug found while testing (not fixed here)

A **recovered agent cannot be deleted again until it is started**. Recovery deliberately does not recreate the container, and `DELETE /api/agents/{name}` looks up the container first, so it returns `404 "Agent not found"` for an agent whose ownership row is very much alive. It briefly looked like my fix had failed — it hadn't; the delete never ran. Pre-existing and out of scope, but worth its own issue.

## Tests

`tests/unit/test_1745_agent_key_revocation.py` — 11 passed: delete revokes, connector scope too, other agents' and user-scoped keys untouched, recover restores, the delete→recover→delete round trip, backfill over soft-deleted **and** never-existed agents, idempotency, and the `is_active` gate the whole fix depends on.

Related suites: 584 passed, 3 skipped.
