### PR TITLE
fix(agents): delete an agent whose container is gone (#1747)

### DIFF
--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -508,8 +508,21 @@ async def delete_agent_endpoint(agent_name: str, request: Request, current_user:
             )
         }
 
+    # #1747: an agent's identity lives in `agent_ownership`, not in Docker.
+    # This used to 404 whenever the container was missing, which left an agent
+    # with a live row simultaneously invisible (the listing is Docker-as-truth),
+    # undeletable, and still holding its own name — escapable only by calling
+    # `/start` on an agent you cannot see. Agents reach that state routinely:
+    # the #834 Phase 1c recovery flow leaves them there BY DESIGN (metadata-only,
+    # "operator runs POST /start"), as does any docker prune / daemon reset or a
+    # crash between the row write and container creation.
+    #
+    # Decide existence from the ROW and treat the container as best-effort
+    # cleanup — exactly what the ephemeral branch above already does for the same
+    # "live row, no container" residue. An already-soft-deleted agent still 404s:
+    # it is deleted, and `is_agent_live` is False for it.
     container = get_agent_container(agent_name)
-    if not container:
+    if not container and not db.is_agent_live(agent_name):
         raise HTTPException(status_code=404, detail="Agent not found")
 
     # Issue #834 Phase 1a: agent delete is now a SOFT-delete. We stop +
@@ -522,11 +535,20 @@ async def delete_agent_endpoint(agent_name: str, request: Request, current_user:
     # (default 180). At that point the #816 cascade_delete primitive
     # tears down all the child rows and on-disk artifacts in one shot.
 
-    try:
-        await container_stop(container)
-        await container_remove(container)
-    except Exception as e:
-        logger.warning(f"Error stopping/removing container: {e}")
+    if container:
+        try:
+            await container_stop(container)
+            await container_remove(container)
+        except Exception as e:
+            logger.warning(f"Error stopping/removing container: {e}")
+    else:
+        # Nothing to tear down. Everything below — soft-delete, queue cancel,
+        # Redis keyspace clearing, name reservation — keys off the agent NAME,
+        # so the delete completes normally without a container (#1747).
+        logger.info(
+            f"Deleting {agent_name} with no container present (#1747) — "
+            "proceeding with the ownership-row delete"
+        )
 
     # BACKLOG-001: in-flight queued tasks can't be recovered (the
     # container is gone), so cancel them now rather than waiting for

--- a/tests/unit/test_1747_delete_without_container.py
+++ b/tests/unit/test_1747_delete_without_container.py
@@ -1,0 +1,139 @@
+"""An agent with no container is still deletable (#1747).
+
+`DELETE /api/agents/{name}` looked up the Docker container first and treated its
+absence as "agent not found". But identity lives in `agent_ownership`, not
+Docker, so an agent with a live row and no container was simultaneously:
+
+* **invisible** — `GET /api/agents` is Docker-as-truth (Invariant #11);
+* **undeletable** — 404 "Agent not found";
+* **holding its own name** — re-creating returned "Agent already exists";
+
+escapable only by calling `POST /start` on an agent you cannot see.
+
+Agents reach that state routinely: the #834 Phase 1c recovery flow leaves them
+there *by design* (metadata-only, "operator runs POST /start"), as does any
+`docker prune` / daemon reset, or a crash between the row write and container
+creation.
+
+The ephemeral branch directly above the guard already handled the same "live row,
+no container" residue — its comment says a half-discarded ghost "must be
+force-discardable, never 404". Ordinary agents simply never got that treatment.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+AGENTS_ROUTER = Path(__file__).resolve().parents[2] / "src" / "backend" / "routers" / "agents.py"
+
+
+def _delete_endpoint_source() -> str:
+    """Source of the delete endpoint only — the same 3-line container guard
+    appears in four endpoints in this module, so a file-wide string search would
+    silently pass on the wrong one."""
+    tree = ast.parse(AGENTS_ROUTER.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "delete_agent_endpoint":
+            return ast.get_source_segment(AGENTS_ROUTER.read_text(), node)
+    raise AssertionError("delete_agent_endpoint not found")
+
+
+def test_existence_is_decided_by_the_ownership_row_not_docker():
+    src = _delete_endpoint_source()
+    assert "not db.is_agent_live(agent_name)" in src, (
+        "delete must decide existence from agent_ownership — gating on the "
+        "container alone traps any agent whose container is missing (#1747)"
+    )
+    # The bare form is the bug.
+    assert "if not container:\n        raise HTTPException(status_code=404" not in src
+
+
+def test_container_teardown_is_conditional():
+    """`container_stop(None)` would raise into the generic except and log a
+    misleading error; the delete must simply skip teardown when there is nothing
+    to tear down."""
+    src = _delete_endpoint_source()
+    stop_at = src.index("await container_stop(")
+    preceding = src[:stop_at]
+    assert "if container:" in preceding, (
+        "container stop/remove must be guarded by `if container:`"
+    )
+
+
+def test_unknown_agent_still_404s():
+    """The guard must not turn a genuinely unknown name into a 200 — that would
+    trade one bug for a worse one."""
+    src = _delete_endpoint_source()
+    assert 'raise HTTPException(status_code=404, detail="Agent not found")' in src
+    # 404 requires BOTH: no container AND no live row.
+    assert "if not container and not db.is_agent_live(agent_name):" in src
+
+
+def test_ephemeral_branch_still_precedes_the_container_lookup():
+    """#69 relies on the ephemeral discard running BEFORE the container lookup so
+    a half-discarded ghost is force-discardable. The #1747 change must not have
+    reordered that."""
+    src = _delete_endpoint_source()
+    assert src.index("discard_ephemeral_agent") < src.index("get_agent_container("), (
+        "the ephemeral discard branch must stay above the container lookup (#69)"
+    )
+
+
+# --- the primitive the guard relies on ---------------------------------------
+
+@pytest.fixture()
+def live_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "trinity-1747.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+    from db.engine import get_engine
+    # mcp_api_keys is not needed by this branch's delete_agent_ownership, but
+    # #1745 makes it deactivate the agent's keys in the same transaction — create
+    # it so this fixture holds before and after that lands.
+    from db.tables import metadata as m, agent_ownership, users, mcp_api_keys
+    m.create_all(get_engine(), tables=[agent_ownership, users, mcp_api_keys])
+    from sqlalchemy import insert
+    with get_engine().begin() as conn:
+        conn.execute(insert(users).values(id=1, username="alice", role="admin",
+                                          created_at="t", updated_at="t"))
+    yield str(db_file)
+
+
+def test_is_agent_live_distinguishes_the_three_states(live_db):
+    """The guard's whole correctness rests on this predicate: a live agent is
+    deletable, an already-deleted one and an unknown one both 404."""
+    from database import db
+    from sqlalchemy import insert, text
+    from db.engine import get_engine
+    from db.tables import agent_ownership
+
+    with get_engine().begin() as conn:
+        conn.execute(insert(agent_ownership).values(
+            agent_name="alive", owner_id=1, created_at="t"))
+        conn.execute(insert(agent_ownership).values(
+            agent_name="already-deleted", owner_id=1, created_at="t", deleted_at="t"))
+
+    assert db.is_agent_live("alive") is True             # deletable without a container
+    assert db.is_agent_live("already-deleted") is False  # 404 — it IS deleted
+    assert db.is_agent_live("never-existed") is False    # 404 — unknown
+
+
+def test_delete_of_a_containerless_agent_soft_deletes_the_row(live_db):
+    """The soft-delete itself never needed a container — it keys off the name."""
+    from database import db
+    from sqlalchemy import insert
+    from db.engine import get_engine
+    from db.tables import agent_ownership
+
+    with get_engine().begin() as conn:
+        conn.execute(insert(agent_ownership).values(
+            agent_name="containerless", owner_id=1, created_at="t"))
+
+    assert db.delete_agent_ownership("containerless") is True
+    assert db.is_agent_live("containerless") is False
+    # The name stays reserved — that is the normal soft-delete policy for EVERY
+    # delete (#834), not something this fix changes.
+    assert db.is_agent_name_reserved("containerless") is True


### PR DESCRIPTION
Fixes #1747.

## The bug

`DELETE /api/agents/{name}` decided existence from Docker:

```python
container = get_agent_container(agent_name)
if not container:
    raise HTTPException(status_code=404, detail="Agent not found")
```

Identity lives in `agent_ownership`, so an agent with a live row and no container was **invisible** (the listing is Docker-as-truth, Invariant #11), **undeletable**, and **still holding its own name** — escapable only by calling `POST /start` on an agent you cannot see.

## The fix

404 now requires **both** no container and no live row; container teardown becomes conditional.

```python
container = get_agent_container(agent_name)
if not container and not db.is_agent_live(agent_name):
    raise HTTPException(status_code=404, detail="Agent not found")
```

Everything downstream — soft-delete, queue cancel, Redis keyspace clearing, name reservation — keys off the agent **name** and never needed a container. Teardown is guarded because `container_stop(None)` would otherwise raise into the generic `except` and log a misleading error.

This is the same reasoning the **ephemeral branch directly above already applies**: it sits before the container lookup precisely so a half-discarded ghost ("live row, no container") is force-discardable, *"never 404"*. Ordinary agents just never got it. A test pins that ordering so this change didn't disturb #69.

## Verified live

```
create agent -> docker rm -f agent-stuck-probe   (live row, no container)
DELETE  -> HTTP 200,  deleted_at set             (was 404 forever)

unknown agent         -> 404   (still)
already soft-deleted  -> 404   (still)
```

## Two corrections to the issue as I filed it

1. **"the name is reusable" was wrong.** After this delete the name stays reserved — that is the normal #834 soft-delete policy for *every* delete (180 days, `is_agent_name_reserved` sees soft-deleted rows), not something this fix should change. The AC is corrected in the commit message; recreating under the same name still returns 409, correctly.
2. **Scope.** The same three-line guard appears in four endpoints in this module — `delete`, `stop`, `logs`, `activities`. My first patch attempt used a blanket string replace and would have changed all four; the assertion caught it. Only `delete` traps the agent, so only `delete` is changed. (`activities` 404ing on a missing container is arguably odd for a DB-backed read, but that is a separate question.)

## Tests

`tests/unit/test_1747_delete_without_container.py` — 6 passed. The static checks parse the module with **`ast`** and assert against the delete endpoint's source specifically, because that same guard exists in four functions and a file-wide string search would happily pass on the wrong one. Plus behavioural coverage of `is_agent_live` across all three states (live / already-deleted / unknown) and the containerless soft-delete.

Related suites: 858 passed, 3 skipped.
