### PR TITLE
feat(ui): Sessions view — rooms rail, transcript, participants, human participation (ent#170)

### DIFF
--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -71,6 +71,17 @@
                  is hidden entirely. The store's `featureFlagsLoaded`
                  guard means the link doesn't flicker on first paint
                  (loadFeatureFlags fires in onMounted below). -->
+            <!-- Shared sessions (ent#170) — visible only when the rooms
+                 backend is entitled (shared_sessions). Hidden entirely in
+                 OSS/unentitled builds, like every enterprise surface. -->
+            <router-link
+              v-if="enterpriseStore.isEntitled('shared_sessions')"
+              to="/sessions"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+              :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': $route.path.startsWith('/sessions') }"
+            >
+              Sessions
+            </router-link>
             <router-link
               v-if="enterpriseStore.hasAnyEnterprise"
               to="/enterprise"

--- a/src/frontend/src/components/rooms/NewRoomDialog.vue
+++ b/src/frontend/src/components/rooms/NewRoomDialog.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="fixed inset-0 z-40 flex items-center justify-center p-4" @click.self="$emit('close')">
+    <div class="absolute inset-0 bg-black/40"></div>
+    <div class="relative w-full max-w-lg rounded-2xl bg-white dark:bg-gray-900 shadow-xl border border-gray-200 dark:border-gray-800 max-h-[90vh] flex flex-col">
+      <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-800">
+        <h2 class="text-base font-semibold">New session</h2>
+        <p class="text-xs text-gray-400 mt-0.5">Pick agents to work a topic together. You can @mention any of them once the room opens.</p>
+      </div>
+
+      <div class="px-5 py-4 space-y-4 overflow-y-auto">
+        <div>
+          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Name</label>
+          <input v-model="name" type="text" placeholder="Design review" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-3 py-2 focus:ring-2 focus:ring-action-primary-500/40 focus:outline-none" />
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Topic <span class="text-gray-400">(optional)</span></label>
+          <input v-model="topic" type="text" placeholder="What should they work on?" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-3 py-2 focus:ring-2 focus:ring-action-primary-500/40 focus:outline-none" />
+        </div>
+
+        <div>
+          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Agents <span class="text-gray-400">({{ selected.length }} selected)</span></label>
+          <div class="max-h-44 overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800">
+            <label v-for="a in roster" :key="a.name" class="flex items-center gap-2.5 px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50">
+              <input type="checkbox" :value="a.name" v-model="selected" class="rounded text-action-primary-600 focus:ring-action-primary-500" />
+              <PortalAvatar :name="a.name" :avatar-url="a.avatar_url" :size="22" />
+              <span class="text-sm truncate">{{ a.name }}</span>
+            </label>
+            <div v-if="!roster.length" class="px-3 py-4 text-center text-xs text-gray-400">No agents you can access.</div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-3 gap-3">
+          <div>
+            <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Max messages</label>
+            <input v-model.number="maxMessages" type="number" min="1" max="500" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-2.5 py-2 focus:outline-none" />
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Max cost $</label>
+            <input v-model.number="maxCost" type="number" min="0" step="0.5" placeholder="—" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-2.5 py-2 focus:outline-none" />
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">TTL hours</label>
+            <input v-model.number="ttlHours" type="number" min="0" max="168" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-2.5 py-2 focus:outline-none" />
+          </div>
+        </div>
+
+        <div v-if="selected.length > 1">
+          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Scribe <span class="text-gray-400">(optional — records outcomes)</span></label>
+          <select v-model="scribe" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-3 py-2 focus:outline-none">
+            <option :value="null">None</option>
+            <option v-for="n in selected" :key="n" :value="n">{{ n }}</option>
+          </select>
+        </div>
+
+        <p v-if="err" class="text-xs text-status-danger-600 dark:text-status-danger-400">{{ err }}</p>
+      </div>
+
+      <div class="px-5 py-4 border-t border-gray-200 dark:border-gray-800 flex justify-end gap-2">
+        <button class="px-4 py-2 text-sm rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800" @click="$emit('close')">Cancel</button>
+        <button
+          class="px-4 py-2 text-sm rounded-lg bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-40 disabled:cursor-not-allowed"
+          :disabled="!canCreate || creating"
+          @click="create"
+        >{{ creating ? 'Creating…' : 'Create session' }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import PortalAvatar from '../portal/PortalAvatar.vue'
+
+const props = defineProps({
+  roster: { type: Array, default: () => [] },
+})
+const emit = defineEmits(['close', 'created'])
+
+const name = ref('')
+const topic = ref('')
+const selected = ref([])
+const maxMessages = ref(60)
+const maxCost = ref(null)
+const ttlHours = ref(24)
+const scribe = ref(null)
+const creating = ref(false)
+const err = ref(null)
+
+const canCreate = computed(() => name.value.trim() && selected.value.length > 0)
+
+async function create() {
+  if (!canCreate.value) return
+  creating.value = true
+  err.value = null
+  const payload = {
+    name: name.value.trim(),
+    agents: selected.value,
+    topic: topic.value.trim() || undefined,
+    max_messages: maxMessages.value || undefined,
+    max_cost_usd: maxCost.value || undefined,
+    ttl_hours: ttlHours.value ?? undefined,
+    scribe: scribe.value || undefined,
+  }
+  try {
+    emit('created', payload, (e) => { err.value = e; creating.value = false })
+  } catch {
+    creating.value = false
+  }
+}
+</script>

--- a/src/frontend/src/components/rooms/ParticipantsRail.vue
+++ b/src/frontend/src/components/rooms/ParticipantsRail.vue
@@ -1,0 +1,89 @@
+<template>
+  <aside class="hidden lg:flex flex-col h-full w-64 shrink-0 bg-gray-50 dark:bg-gray-950 border-l border-gray-200 dark:border-gray-800">
+    <div class="shrink-0 px-4 h-14 flex items-center border-b border-gray-200 dark:border-gray-800">
+      <span class="text-sm font-semibold">Participants</span>
+      <span class="ml-2 text-xs text-gray-400">{{ participants.length }}</span>
+    </div>
+
+    <div class="flex-1 min-h-0 overflow-y-auto p-3 space-y-2">
+      <div v-for="p in participants" :key="p.kind + ':' + p.identity" class="flex items-center gap-2.5">
+        <div class="relative">
+          <PortalAvatar :name="p.identity" :avatar-url="p.kind === 'agent' ? (avatarByName[p.identity] || null) : null" :size="30" />
+          <span
+            v-if="p.kind === 'agent'"
+            class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ring-2 ring-gray-50 dark:ring-gray-950"
+            :class="workingState[p.identity] === 'working' ? 'bg-status-success-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'"
+            :title="workingState[p.identity] === 'working' ? 'Working…' : 'Idle'"
+          ></span>
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-1.5">
+            <span class="text-sm truncate">{{ p.kind === 'user' ? p.identity : p.identity }}</span>
+            <span v-if="p.role !== 'member'" class="text-[10px] text-gray-400">{{ p.role }}</span>
+          </div>
+          <div class="text-[11px] text-gray-400">{{ p.kind === 'user' ? 'Human' : 'Agent' }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- budgets -->
+    <div class="shrink-0 border-t border-gray-200 dark:border-gray-800 p-3 space-y-3">
+      <div>
+        <div class="flex items-center justify-between text-[11px] text-gray-500 dark:text-gray-400 mb-1">
+          <span>Messages</span>
+          <span :class="msgNearLimit ? 'text-status-warning-600 dark:text-status-warning-400 font-medium' : ''">{{ messageCount }} / {{ maxMessages }}</span>
+        </div>
+        <div class="h-1.5 rounded-full bg-gray-200 dark:bg-gray-800 overflow-hidden">
+          <div class="h-full rounded-full transition-all" :class="msgNearLimit ? 'bg-status-warning-500' : 'bg-action-primary-500'" :style="{ width: msgPct + '%' }"></div>
+        </div>
+      </div>
+
+      <div v-if="maxCost">
+        <div class="flex items-center justify-between text-[11px] text-gray-500 dark:text-gray-400 mb-1">
+          <span>Cost</span>
+          <span :class="costNearLimit ? 'text-status-warning-600 dark:text-status-warning-400 font-medium' : ''">${{ cost.toFixed(3) }} / ${{ maxCost.toFixed(2) }}</span>
+        </div>
+        <div class="h-1.5 rounded-full bg-gray-200 dark:bg-gray-800 overflow-hidden">
+          <div class="h-full rounded-full transition-all" :class="costNearLimit ? 'bg-status-warning-500' : 'bg-action-primary-500'" :style="{ width: costPct + '%' }"></div>
+        </div>
+      </div>
+      <div v-else class="flex items-center justify-between text-[11px] text-gray-400">
+        <span>Cost</span><span>${{ cost.toFixed(3) }} · no cap</span>
+      </div>
+
+      <div v-if="expiresAt" class="flex items-center justify-between text-[11px] text-gray-400">
+        <span>Expires</span><span>{{ expiresLabel }}</span>
+      </div>
+    </div>
+  </aside>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import PortalAvatar from '../portal/PortalAvatar.vue'
+
+const props = defineProps({
+  participants: { type: Array, default: () => [] },
+  workingState: { type: Object, default: () => ({}) },
+  avatarByName: { type: Object, default: () => ({}) },
+  messageCount: { type: Number, default: 0 },
+  maxMessages: { type: Number, default: 60 },
+  cost: { type: Number, default: 0 },
+  maxCost: { type: Number, default: null },
+  expiresAt: { type: String, default: null },
+})
+
+const msgPct = computed(() => Math.min(100, Math.round((props.messageCount / (props.maxMessages || 1)) * 100)))
+const msgNearLimit = computed(() => msgPct.value >= 80)
+const costPct = computed(() => (props.maxCost ? Math.min(100, Math.round((props.cost / props.maxCost) * 100)) : 0))
+const costNearLimit = computed(() => props.maxCost && costPct.value >= 80)
+
+const expiresLabel = computed(() => {
+  if (!props.expiresAt) return ''
+  const ms = new Date(props.expiresAt).getTime() - Date.now()
+  if (ms <= 0) return 'now'
+  const h = Math.floor(ms / 3600000)
+  if (h >= 1) return `in ${h}h`
+  return `in ${Math.max(1, Math.floor(ms / 60000))}m`
+})
+</script>

--- a/src/frontend/src/components/rooms/RoomComposer.vue
+++ b/src/frontend/src/components/rooms/RoomComposer.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="shrink-0 border-t border-gray-200 dark:border-gray-800 p-3">
+    <!-- closed room: read-only with the reason -->
+    <div v-if="closed" class="text-center text-xs text-gray-400 py-3">
+      This session is closed<span v-if="stopReason"> — {{ closeReasonLabel }}</span>. The transcript stays readable.
+    </div>
+
+    <div v-else class="relative">
+      <!-- @mention autocomplete -->
+      <div
+        v-if="mentionOpen && mentionMatches.length"
+        class="absolute bottom-full mb-1 left-0 w-56 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg overflow-hidden z-10"
+      >
+        <button
+          v-for="(p, i) in mentionMatches"
+          :key="p.identity"
+          class="w-full flex items-center gap-2 px-3 py-1.5 text-left text-sm"
+          :class="i === mentionIndex ? 'bg-action-primary-50 dark:bg-action-primary-900/30' : 'hover:bg-gray-50 dark:hover:bg-gray-800'"
+          @mousedown.prevent="applyMention(p)"
+        >
+          <PortalAvatar :name="p.identity" :avatar-url="avatarByName[p.identity] || null" :size="20" />
+          <span class="truncate">{{ p.identity }}</span>
+          <span v-if="p.role !== 'member'" class="ml-auto text-[10px] text-gray-400">{{ p.role }}</span>
+        </button>
+      </div>
+
+      <textarea
+        ref="ta"
+        v-model="text"
+        rows="1"
+        placeholder="Message the room…  @mention an agent to wake it"
+        class="w-full resize-none rounded-xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm px-3 py-2.5 pr-12 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
+        @input="onInput"
+        @keydown="onKeydown"
+      ></textarea>
+      <button
+        class="absolute right-2 bottom-2 p-1.5 rounded-lg text-white bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition"
+        :disabled="!text.trim() || posting"
+        @click="send"
+        title="Send (Enter)"
+      >
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M12 5l7 7-7 7" /></svg>
+      </button>
+    </div>
+    <p v-if="!closed" class="mt-1.5 px-1 text-[11px] text-gray-400">
+      <span class="font-mono">@mention</span> wakes an agent — plain messages just join the transcript.
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import PortalAvatar from '../portal/PortalAvatar.vue'
+
+const props = defineProps({
+  participants: { type: Array, default: () => [] },
+  avatarByName: { type: Object, default: () => ({}) },
+  posting: { type: Boolean, default: false },
+  closed: { type: Boolean, default: false },
+  stopReason: { type: String, default: null },
+})
+const emit = defineEmits(['send'])
+
+const ta = ref(null)
+const text = ref('')
+const mentionOpen = ref(false)
+const mentionQuery = ref('')
+const mentionIndex = ref(0)
+const mentionStart = ref(-1)
+
+const _REASONS = {
+  user_closed: 'closed by an operator',
+  max_messages: 'reached its message budget',
+  max_cost: 'reached its cost budget',
+  expired: 'expired',
+}
+const closeReasonLabel = computed(() => _REASONS[props.stopReason] || 'ended')
+
+const agentParticipants = computed(() =>
+  props.participants.filter((p) => p.kind === 'agent' && !p.left_at)
+)
+const mentionMatches = computed(() => {
+  const q = mentionQuery.value.toLowerCase()
+  return agentParticipants.value.filter((p) => p.identity.toLowerCase().startsWith(q)).slice(0, 6)
+})
+
+function onInput(e) {
+  autosize(e.target)
+  const caret = e.target.selectionStart
+  const upto = text.value.slice(0, caret)
+  const m = upto.match(/@([A-Za-z0-9_-]*)$/)
+  if (m) {
+    mentionOpen.value = true
+    mentionQuery.value = m[1]
+    mentionStart.value = caret - m[0].length
+    mentionIndex.value = 0
+  } else {
+    mentionOpen.value = false
+  }
+}
+
+function applyMention(p) {
+  const before = text.value.slice(0, mentionStart.value)
+  const after = text.value.slice(mentionStart.value).replace(/@([A-Za-z0-9_-]*)/, '')
+  text.value = `${before}@${p.identity} ${after}`.replace(/\s+$/, ' ')
+  mentionOpen.value = false
+  ta.value?.focus()
+}
+
+function onKeydown(e) {
+  if (mentionOpen.value && mentionMatches.value.length) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); mentionIndex.value = (mentionIndex.value + 1) % mentionMatches.value.length; return }
+    if (e.key === 'ArrowUp') { e.preventDefault(); mentionIndex.value = (mentionIndex.value - 1 + mentionMatches.value.length) % mentionMatches.value.length; return }
+    if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); applyMention(mentionMatches.value[mentionIndex.value]); return }
+    if (e.key === 'Escape') { mentionOpen.value = false; return }
+  }
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() }
+}
+
+function send() {
+  const v = text.value.trim()
+  if (!v || props.posting) return
+  emit('send', v)
+  text.value = ''
+  if (ta.value) ta.value.style.height = 'auto'
+}
+
+function autosize(el) {
+  el.style.height = 'auto'
+  el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+}
+</script>

--- a/src/frontend/src/components/rooms/RoomTranscript.vue
+++ b/src/frontend/src/components/rooms/RoomTranscript.vue
@@ -1,0 +1,118 @@
+<template>
+  <div ref="scrollEl" class="flex-1 min-h-0 overflow-y-auto px-4 py-4 space-y-4">
+    <div v-if="!messages.length" class="h-full flex items-center justify-center text-sm text-gray-400">
+      No messages yet — say something, and <span class="font-mono mx-1">@mention</span> an agent to wake it.
+    </div>
+
+    <template v-for="m in messages" :key="m.id">
+      <!-- system event line -->
+      <div v-if="m.kind === 'system'" class="flex justify-center">
+        <span class="text-[11px] text-gray-400 bg-gray-100 dark:bg-gray-800/60 rounded-full px-3 py-1">
+          {{ m.content }}
+        </span>
+      </div>
+
+      <!-- a message -->
+      <div v-else class="flex gap-3" :class="{ 'opacity-60': m._optimistic }">
+        <PortalAvatar :name="senderLabel(m)" :avatar-url="avatarFor(m)" :size="30" class="mt-0.5" />
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2 mb-0.5">
+            <span class="text-sm font-medium text-gray-800 dark:text-gray-100">{{ senderLabel(m) }}</span>
+            <span
+              class="text-[10px] font-semibold px-1.5 py-0.5 rounded"
+              :class="m.sender_kind === 'agent'
+                ? 'bg-action-primary-100 text-action-primary-700 dark:bg-action-primary-900 dark:text-action-primary-200'
+                : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300'"
+            >{{ m.sender_kind === 'agent' ? 'Agent' : 'You' }}</span>
+            <span class="text-[11px] text-gray-400">{{ time(m.created_at) }}</span>
+          </div>
+
+          <!-- bubble -->
+          <div
+            class="inline-block max-w-full rounded-2xl px-3.5 py-2 text-sm leading-relaxed break-words"
+            :class="m.sender_kind === 'agent'
+              ? 'bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-100'
+              : 'bg-action-primary-600 text-white'"
+            v-html="renderWithMentions(m)"
+          ></div>
+
+          <!-- per-agent metadata line -->
+          <div v-if="m.execution_id" class="mt-1 flex items-center gap-3 text-[11px] text-gray-400">
+            <span v-if="cost(m) != null">${{ cost(m).toFixed(4) }}</span>
+            <span class="font-mono opacity-70">exec {{ m.execution_id.slice(0, 8) }}</span>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- working indicator (typing dots) -->
+    <div v-for="ident in workingAgents" :key="'working-' + ident" class="flex gap-3">
+      <PortalAvatar :name="ident" :avatar-url="avatarByName[ident] || null" :size="30" class="mt-0.5" />
+      <div>
+        <div class="text-sm font-medium text-gray-800 dark:text-gray-100 mb-0.5">{{ ident }}</div>
+        <div class="inline-flex items-center gap-1 rounded-2xl bg-gray-100 dark:bg-gray-800 px-4 py-3">
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay:0ms"></span>
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay:150ms"></span>
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay:300ms"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import PortalAvatar from '../portal/PortalAvatar.vue'
+import { renderMarkdown } from '../../utils/markdown'
+
+const props = defineProps({
+  messages: { type: Array, default: () => [] },
+  participants: { type: Array, default: () => [] },
+  workingState: { type: Object, default: () => ({}) },
+  executionCosts: { type: Object, default: () => ({}) }, // execution_id -> cost (optional)
+  avatarByName: { type: Object, default: () => ({}) },   // agent name -> avatar_url
+})
+
+const scrollEl = ref(null)
+
+const workingAgents = computed(() =>
+  Object.entries(props.workingState).filter(([, s]) => s === 'working').map(([n]) => n)
+)
+
+function senderLabel(m) {
+  if (m.sender_kind === 'user') return m.sender_identity === 'You' ? 'You' : m.sender_identity
+  return m.sender_identity || 'Agent'
+}
+function avatarFor(m) {
+  return m.sender_kind === 'agent' ? (props.avatarByName[m.sender_identity] || null) : null
+}
+function cost(m) {
+  return props.executionCosts[m.execution_id] ?? null
+}
+function time(iso) {
+  try { return new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }) }
+  catch { return '' }
+}
+
+// Highlight @mentions of real participants; everything else is DOMPurify'd markdown.
+const agentNames = computed(() =>
+  new Set(props.participants.filter((p) => p.kind === 'agent').map((p) => p.identity))
+)
+function renderWithMentions(m) {
+  const html = renderMarkdown(m.content || '')
+  // wrap @name tokens that match a participant — applied to the already-sanitized
+  // markdown output; the replacement injects only a span with static classes.
+  return html.replace(/@([A-Za-z0-9][A-Za-z0-9_-]{0,99})/g, (full, name) =>
+    agentNames.value.has(name)
+      ? `<span class="font-semibold ${m.sender_kind === 'user' ? 'text-white underline' : 'text-action-primary-600 dark:text-action-primary-400'}">${full}</span>`
+      : full
+  )
+}
+
+function scrollToBottom() {
+  nextTick(() => { if (scrollEl.value) scrollEl.value.scrollTop = scrollEl.value.scrollHeight })
+}
+onMounted(scrollToBottom)
+watch(() => props.messages.length, scrollToBottom)
+watch(() => workingAgents.value.length, scrollToBottom)
+</script>

--- a/src/frontend/src/components/rooms/RoomsRail.vue
+++ b/src/frontend/src/components/rooms/RoomsRail.vue
@@ -1,0 +1,63 @@
+<template>
+  <aside class="flex flex-col h-full w-72 shrink-0 bg-gray-50 dark:bg-gray-950 border-r border-gray-200 dark:border-gray-800">
+    <div class="shrink-0 p-3 border-b border-gray-200 dark:border-gray-800">
+      <button
+        class="w-full flex items-center justify-center gap-2 rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white px-3 py-2 text-sm font-medium transition"
+        @click="$emit('new-session')"
+      >
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
+        New session
+      </button>
+    </div>
+
+    <div class="flex-1 min-h-0 overflow-y-auto p-2 space-y-1">
+      <div v-if="loading && !rooms.length" class="px-2 py-8 text-center text-xs text-gray-400">Loading…</div>
+
+      <!-- empty state: explainer + CTA -->
+      <div v-else-if="!rooms.length" class="px-3 py-10 text-center">
+        <div class="mx-auto w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-800 flex items-center justify-center mb-3">
+          <svg class="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a2 2 0 01-2-2m10-8V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l4-4h2" /></svg>
+        </div>
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">No sessions yet</p>
+        <p class="mt-1 text-xs text-gray-400 leading-relaxed">
+          Start a shared session to work a topic with several agents at once. Mention an agent to bring it in.
+        </p>
+        <button class="mt-3 text-xs font-medium text-action-primary-600 hover:underline" @click="$emit('new-session')">
+          Start your first session →
+        </button>
+      </div>
+
+      <button
+        v-for="r in rooms"
+        :key="r.id"
+        class="w-full text-left rounded-lg px-2.5 py-2 transition"
+        :class="r.id === activeRoomId ? 'bg-white dark:bg-gray-900 ring-1 ring-gray-200 dark:ring-gray-800' : 'hover:bg-white dark:hover:bg-gray-900'"
+        @click="$emit('open', r.id)"
+      >
+        <div class="flex items-center gap-2">
+          <span
+            class="w-2 h-2 rounded-full shrink-0"
+            :class="r.status === 'open' ? 'bg-status-success-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"
+            :title="r.status === 'open' ? 'Active' : `Closed — ${r.stop_reason || 'ended'}`"
+          ></span>
+          <span class="text-sm font-medium truncate flex-1">{{ r.name }}</span>
+        </div>
+        <div v-if="r.topic" class="ml-4 text-xs text-gray-400 truncate">{{ r.topic }}</div>
+        <div class="ml-4 mt-1 flex items-center gap-3 text-[11px] text-gray-400">
+          <span>{{ r.participant_count }} participant<span v-if="r.participant_count !== 1">s</span></span>
+          <span>·</span>
+          <span>{{ r.message_count }} message<span v-if="r.message_count !== 1">s</span></span>
+        </div>
+      </button>
+    </div>
+  </aside>
+</template>
+
+<script setup>
+defineProps({
+  rooms: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  activeRoomId: { type: String, default: null },
+})
+defineEmits(['new-session', 'open'])
+</script>

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -189,6 +189,17 @@ const routes = [
     meta: { requiresAuth: true, requiresEntitlement: 'audit', title: 'Audit Log' }
   },
   {
+    // Shared sessions / rooms (ent#170, backend ent#169). Top-level view — a
+    // room spans multiple agents, so it is NOT an Agent Detail tab. Gated Vue in
+    // the OSS bundle (portal precedent): the route + NavBar entry only appear
+    // when `shared_sessions` is in enterprise_features; the guard below catches a
+    // direct URL. `:roomId?` makes a session deep-linkable / refresh-safe.
+    path: '/sessions/:roomId?',
+    name: 'Sessions',
+    component: () => import('../views/enterprise/Sessions.vue'),
+    meta: { requiresAuth: true, requiresEntitlement: 'shared_sessions', title: 'Sessions' }
+  },
+  {
     // Public client-facing portal — a client signs in with a verified email
     // (no platform account) and sees the agents shared with them. Standalone
     // (no NavBar / platform chrome), no requiresAuth. Backend 404s in

--- a/src/frontend/src/stores/rooms.js
+++ b/src/frontend/src/stores/rooms.js
@@ -33,6 +33,8 @@ export const useRoomsStore = defineStore('rooms', () => {
 
   let _pollTimer = null
   let _seqSeen = 0                   // highest seq applied to activeRoom
+  let _appendInFlight = false        // serialize refetches (chain events arrive back-to-back)
+  let _appendAgain = false           // an event landed mid-refetch → run once more
 
   // --- getters ---
   const anyWorking = computed(() =>
@@ -66,6 +68,8 @@ export const useRoomsStore = defineStore('rooms', () => {
     roomLoading.value = true
     workingState.value = {}
     _seqSeen = 0
+    _appendInFlight = false
+    _appendAgain = false
     try {
       await _refreshActiveRoom()
     } finally {
@@ -85,24 +89,44 @@ export const useRoomsStore = defineStore('rooms', () => {
 
   // Append only the messages after what we've applied, so a WS-triggered refetch
   // doesn't rebuild the whole transcript (and lose scroll).
+  //
+  // Two guards make this dedup-safe. Room chains fire several `room_message`
+  // events back-to-back, so overlapping refetches would otherwise BOTH read the
+  // same `_seqSeen`, fetch the same rows, and append them twice (observed: the
+  // same message + execution_id rendered twice).
+  //  1. In-flight lock — only one refetch runs; an event mid-flight sets a rerun
+  //     flag so nothing is missed.
+  //  2. Dedup by seq — append only rows whose seq isn't already present, so even
+  //     an overlapping `since=` window (or the backstop poll) can't duplicate.
   async function _appendSince() {
     if (!activeRoomId.value || !activeRoom.value) return
-    const { data } = await api.get(
-      `/api/rooms/${encodeURIComponent(activeRoomId.value)}?since=${_seqSeen}`
-    )
-    const fresh = data.messages || []
-    if (fresh.length) {
-      // drop any optimistic placeholders now confirmed by a real row
-      activeRoom.value.messages = activeRoom.value.messages.filter((m) => !m._optimistic)
-      activeRoom.value.messages.push(...fresh)
-      _seqSeen = fresh[fresh.length - 1].seq
+    if (_appendInFlight) { _appendAgain = true; return }
+    _appendInFlight = true
+    try {
+      const { data } = await api.get(
+        `/api/rooms/${encodeURIComponent(activeRoomId.value)}?since=${_seqSeen}`
+      )
+      if (!activeRoom.value) return
+      const known = new Set(
+        activeRoom.value.messages.filter((m) => !m._optimistic).map((m) => m.seq)
+      )
+      const fresh = (data.messages || []).filter((m) => !known.has(m.seq))
+      if (fresh.length) {
+        // drop optimistic placeholders now confirmed by real rows
+        activeRoom.value.messages = activeRoom.value.messages.filter((m) => !m._optimistic)
+        activeRoom.value.messages.push(...fresh)
+        _seqSeen = Math.max(_seqSeen, ...fresh.map((m) => m.seq))
+      }
+      activeRoom.value.status = data.status
+      activeRoom.value.stop_reason = data.stop_reason
+      activeRoom.value.message_count = data.message_count
+      activeRoom.value.cost = data.cost
+      activeRoom.value.participants = data.participants
+      _syncRailRow(data)
+    } finally {
+      _appendInFlight = false
+      if (_appendAgain) { _appendAgain = false; _appendSince() }
     }
-    activeRoom.value.status = data.status
-    activeRoom.value.stop_reason = data.stop_reason
-    activeRoom.value.message_count = data.message_count
-    activeRoom.value.cost = data.cost
-    activeRoom.value.participants = data.participants
-    _syncRailRow(data)
   }
 
   function _syncRailRow(data) {
@@ -201,6 +225,8 @@ export const useRoomsStore = defineStore('rooms', () => {
     activeRoom.value = null
     workingState.value = {}
     _seqSeen = 0
+    _appendInFlight = false
+    _appendAgain = false
   }
 
   return {

--- a/src/frontend/src/stores/rooms.js
+++ b/src/frontend/src/stores/rooms.js
@@ -1,0 +1,212 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import api from '../api'
+
+/**
+ * Shared sessions / rooms store (ent#170, backend ent#169).
+ *
+ * A room is a shared persistent RECORD: agents + humans in one transcript,
+ * mention-wake turn-taking, hard budgets. The backend WS payloads are thin
+ * (ids only, the #918 pattern) — a `room_message` carries `{room_id, seq}`, so
+ * the store refetches over the access-controlled REST rather than trusting a
+ * broadcast to carry transcript content. Working/idle presence rides
+ * `room_participant_state`; a close rides `room_closed`.
+ *
+ * All HTTP goes through the shared api.js client (Invariant #7). The live
+ * updates follow the loops store shape (#1106): react to fleet-wide events for
+ * the room on screen, plus a backstop poll while anything is working so a
+ * dropped event can't leave the transcript stale.
+ */
+const POLL_INTERVAL_MS = 12000
+
+export const useRoomsStore = defineStore('rooms', () => {
+  // --- state ---
+  const rooms = ref([])              // list rail: RoomSummary[]
+  const roomsLoading = ref(false)
+  const activeRoomId = ref(null)
+  const activeRoom = ref(null)       // { …room, participants, messages, message_count, cost }
+  const roomLoading = ref(false)
+  const posting = ref(false)
+  const error = ref(null)
+  // identity -> 'working' | 'idle', driven by room_participant_state
+  const workingState = ref({})
+
+  let _pollTimer = null
+  let _seqSeen = 0                   // highest seq applied to activeRoom
+
+  // --- getters ---
+  const anyWorking = computed(() =>
+    Object.values(workingState.value).some((s) => s === 'working')
+  )
+  const activeParticipants = computed(() =>
+    (activeRoom.value?.participants || []).filter((p) => !p.left_at)
+  )
+  const agentParticipants = computed(() =>
+    activeParticipants.value.filter((p) => p.kind === 'agent')
+  )
+  const isClosed = computed(() => activeRoom.value?.status === 'closed')
+
+  // --- list ---
+  async function fetchRooms() {
+    roomsLoading.value = true
+    try {
+      const { data } = await api.get('/api/rooms')
+      rooms.value = data.rooms || []
+    } catch (e) {
+      error.value = e?.response?.data?.detail?.message || 'Failed to load rooms'
+    } finally {
+      roomsLoading.value = false
+    }
+  }
+
+  // --- one room ---
+  async function openRoom(roomId) {
+    if (!roomId) return
+    activeRoomId.value = roomId
+    roomLoading.value = true
+    workingState.value = {}
+    _seqSeen = 0
+    try {
+      await _refreshActiveRoom()
+    } finally {
+      roomLoading.value = false
+    }
+    _ensurePolling()
+  }
+
+  async function _refreshActiveRoom() {
+    if (!activeRoomId.value) return
+    const { data } = await api.get(`/api/rooms/${encodeURIComponent(activeRoomId.value)}`)
+    activeRoom.value = data
+    _seqSeen = data.messages?.length ? data.messages[data.messages.length - 1].seq : 0
+    // keep the rail row in sync (count / status / cost)
+    _syncRailRow(data)
+  }
+
+  // Append only the messages after what we've applied, so a WS-triggered refetch
+  // doesn't rebuild the whole transcript (and lose scroll).
+  async function _appendSince() {
+    if (!activeRoomId.value || !activeRoom.value) return
+    const { data } = await api.get(
+      `/api/rooms/${encodeURIComponent(activeRoomId.value)}?since=${_seqSeen}`
+    )
+    const fresh = data.messages || []
+    if (fresh.length) {
+      // drop any optimistic placeholders now confirmed by a real row
+      activeRoom.value.messages = activeRoom.value.messages.filter((m) => !m._optimistic)
+      activeRoom.value.messages.push(...fresh)
+      _seqSeen = fresh[fresh.length - 1].seq
+    }
+    activeRoom.value.status = data.status
+    activeRoom.value.stop_reason = data.stop_reason
+    activeRoom.value.message_count = data.message_count
+    activeRoom.value.cost = data.cost
+    activeRoom.value.participants = data.participants
+    _syncRailRow(data)
+  }
+
+  function _syncRailRow(data) {
+    const idx = rooms.value.findIndex((r) => r.id === data.id)
+    if (idx !== -1) {
+      rooms.value[idx] = {
+        ...rooms.value[idx],
+        status: data.status,
+        stop_reason: data.stop_reason,
+        message_count: data.message_count ?? rooms.value[idx].message_count,
+        participant_count: (data.participants || []).length || rooms.value[idx].participant_count,
+      }
+    }
+  }
+
+  // --- create / post / close ---
+  async function createRoom(payload) {
+    const { data } = await api.post('/api/rooms', payload)
+    await fetchRooms()
+    return data
+  }
+
+  async function postMessage(content) {
+    if (!activeRoomId.value || !content.trim()) return
+    posting.value = true
+    // optimistic append (rolled back on failure)
+    const optimistic = {
+      id: `opt-${Date.now()}`,
+      seq: _seqSeen + 0.5,
+      sender_kind: 'user',
+      sender_identity: 'You',
+      kind: 'message',
+      mentions: [],
+      content,
+      created_at: new Date().toISOString(),
+      _optimistic: true,
+    }
+    activeRoom.value?.messages.push(optimistic)
+    try {
+      // Idempotency-Key so a retried send creates one message (Invariant #18).
+      await api.post(
+        `/api/rooms/${encodeURIComponent(activeRoomId.value)}/messages`,
+        { content },
+        { headers: { 'Idempotency-Key': `${activeRoomId.value}:${optimistic.id}` } }
+      )
+      await _appendSince()
+    } catch (e) {
+      // rollback the optimistic row and surface the reason
+      if (activeRoom.value) {
+        activeRoom.value.messages = activeRoom.value.messages.filter((m) => m.id !== optimistic.id)
+      }
+      const d = e?.response?.data?.detail
+      error.value = (d && (d.message || d)) || 'Failed to send'
+      throw e
+    } finally {
+      posting.value = false
+      _ensurePolling()
+    }
+  }
+
+  async function closeRoom(roomId) {
+    await api.post(`/api/rooms/${encodeURIComponent(roomId)}/close`)
+    if (roomId === activeRoomId.value) await _refreshActiveRoom()
+    else await fetchRooms()
+  }
+
+  // --- live updates (fleet-wide events; act only on the room on screen) ---
+  function handleWebSocketEvent(data) {
+    if (!data || data.room_id !== activeRoomId.value) return
+    if (data.type === 'room_message') {
+      _appendSince().catch(() => {})
+    } else if (data.type === 'room_participant_state') {
+      workingState.value = { ...workingState.value, [data.identity]: data.state }
+    } else if (data.type === 'room_closed') {
+      _refreshActiveRoom().catch(() => {})
+      workingState.value = {}
+    }
+    _ensurePolling()
+  }
+
+  function _ensurePolling() {
+    if (anyWorking.value && activeRoomId.value) {
+      if (!_pollTimer) _pollTimer = setInterval(() => _appendSince().catch(() => {}), POLL_INTERVAL_MS)
+    } else {
+      stopPolling()
+    }
+  }
+
+  function stopPolling() {
+    if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null }
+  }
+
+  function clear() {
+    stopPolling()
+    activeRoomId.value = null
+    activeRoom.value = null
+    workingState.value = {}
+    _seqSeen = 0
+  }
+
+  return {
+    rooms, roomsLoading, activeRoomId, activeRoom, roomLoading, posting, error,
+    workingState, anyWorking, activeParticipants, agentParticipants, isClosed,
+    fetchRooms, openRoom, createRoom, postMessage, closeRoom,
+    handleWebSocketEvent, stopPolling, clear,
+  }
+})

--- a/src/frontend/src/utils/websocket.js
+++ b/src/frontend/src/utils/websocket.js
@@ -6,6 +6,7 @@ import { useOperatorQueueStore } from '../stores/operatorQueue'
 import { useExecutionsStore } from '../stores/executions'
 import { useLoopsStore } from '../stores/loops'
 import { useReportsStore, useFleetReportsStore } from '../stores/reports'
+import { useRoomsStore } from '../stores/rooms'
 
 const ws = ref(null)
 const isConnected = ref(false)
@@ -25,6 +26,7 @@ export function useWebSocket() {
   const notificationsStore = useNotificationsStore()
   const operatorQueueStore = useOperatorQueueStore()
   const executionsStore = useExecutionsStore()
+  const roomsStore = useRoomsStore()
   const loopsStore = useLoopsStore()
   const reportsStore = useReportsStore()
   const fleetReportsStore = useFleetReportsStore()
@@ -176,6 +178,12 @@ export function useWebSocket() {
         if (data.type === 'agent_report') {
           reportsStore.handleWebSocketEvent(data)
           fleetReportsStore.handleWebSocketEvent(data)
+        }
+        // ent#170: shared-session (room) events. Thin payloads (room_id + seq /
+        // state / stop_reason); the store filters to the room on screen and
+        // refetches over REST (#918 pattern). No-op when Sessions isn't mounted.
+        if (data.type === 'room_message' || data.type === 'room_participant_state' || data.type === 'room_closed') {
+          roomsStore.handleWebSocketEvent(data)
         }
         break
     }

--- a/src/frontend/src/views/enterprise/Sessions.vue
+++ b/src/frontend/src/views/enterprise/Sessions.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="h-[calc(100vh-4rem)] flex bg-white dark:bg-gray-900">
+    <RoomsRail
+      :rooms="store.rooms"
+      :loading="store.roomsLoading"
+      :active-room-id="store.activeRoomId"
+      @new-session="showDialog = true"
+      @open="openRoom"
+    />
+
+    <!-- center: transcript + composer -->
+    <div class="flex-1 min-w-0 flex flex-col">
+      <template v-if="store.activeRoom">
+        <!-- header -->
+        <div class="shrink-0 h-14 px-4 flex items-center gap-3 border-b border-gray-200 dark:border-gray-800">
+          <div class="flex -space-x-2">
+            <PortalAvatar
+              v-for="p in store.agentParticipants.slice(0, 4)"
+              :key="p.identity"
+              :name="p.identity"
+              :avatar-url="avatarByName[p.identity] || null"
+              :size="26"
+              class="ring-2 ring-white dark:ring-gray-900"
+            />
+          </div>
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="text-sm font-semibold truncate">{{ store.activeRoom.name }}</span>
+              <span
+                class="text-[10px] font-semibold px-1.5 py-0.5 rounded"
+                :class="store.isClosed
+                  ? 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+                  : 'bg-status-success-100 text-status-success-700 dark:bg-status-success-900 dark:text-status-success-200'"
+              >{{ store.isClosed ? 'Closed' : 'Active' }}</span>
+            </div>
+            <div v-if="store.activeRoom.topic" class="text-xs text-gray-400 truncate">{{ store.activeRoom.topic }}</div>
+          </div>
+          <div class="ml-auto flex items-center gap-3">
+            <span class="text-[11px] text-gray-400">{{ store.activeRoom.message_count }}/{{ store.activeRoom.max_messages }} msgs</span>
+            <span class="text-[11px] text-gray-400">${{ (store.activeRoom.cost || 0).toFixed(3) }}</span>
+            <button
+              v-if="!store.isClosed"
+              class="text-xs px-2.5 py-1 rounded-lg border border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+              @click="closeRoom"
+            >Close</button>
+          </div>
+        </div>
+
+        <RoomTranscript
+          :messages="store.activeRoom.messages || []"
+          :participants="store.activeRoom.participants || []"
+          :working-state="store.workingState"
+          :execution-costs="{}"
+          :avatar-by-name="avatarByName"
+        />
+
+        <p v-if="store.error" class="px-4 py-1 text-xs text-status-danger-600 dark:text-status-danger-400">{{ store.error }}</p>
+
+        <RoomComposer
+          :participants="store.activeRoom.participants || []"
+          :avatar-by-name="avatarByName"
+          :posting="store.posting"
+          :closed="store.isClosed"
+          :stop-reason="store.activeRoom.stop_reason"
+          @send="send"
+        />
+      </template>
+
+      <!-- no room selected -->
+      <div v-else class="flex-1 flex items-center justify-center text-center px-6">
+        <div>
+          <div class="mx-auto w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a2 2 0 01-2-2m10-8V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l4-4h2" /></svg>
+          </div>
+          <p class="text-sm font-medium text-gray-700 dark:text-gray-200">Shared sessions</p>
+          <p class="mt-1 text-xs text-gray-400 max-w-xs">Work a topic with several agents at once. Pick a session on the left, or start a new one.</p>
+        </div>
+      </div>
+    </div>
+
+    <ParticipantsRail
+      v-if="store.activeRoom"
+      :participants="store.activeParticipants"
+      :working-state="store.workingState"
+      :avatar-by-name="avatarByName"
+      :message-count="store.activeRoom.message_count || 0"
+      :max-messages="store.activeRoom.max_messages || 60"
+      :cost="store.activeRoom.cost || 0"
+      :max-cost="store.activeRoom.max_cost_usd"
+      :expires-at="store.activeRoom.expires_at"
+    />
+
+    <NewRoomDialog v-if="showDialog" :roster="roster" @close="showDialog = false" @created="onCreate" />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { useRoomsStore } from '../../stores/rooms'
+import { useAgentsStore } from '../../stores/agents'
+import PortalAvatar from '../../components/portal/PortalAvatar.vue'
+import RoomsRail from '../../components/rooms/RoomsRail.vue'
+import RoomTranscript from '../../components/rooms/RoomTranscript.vue'
+import RoomComposer from '../../components/rooms/RoomComposer.vue'
+import ParticipantsRail from '../../components/rooms/ParticipantsRail.vue'
+import NewRoomDialog from '../../components/rooms/NewRoomDialog.vue'
+
+const store = useRoomsStore()
+const agentsStore = useAgentsStore()
+const router = useRouter()
+const route = useRoute()
+const showDialog = ref(false)
+
+// avatar URL by agent name — from the fleet roster already loaded, so no
+// per-message fetch (the #1734 idiom).
+const roster = computed(() => agentsStore.agents || [])
+const avatarByName = computed(() =>
+  Object.fromEntries(roster.value.map((a) => [a.name, a.avatar_url]))
+)
+
+async function openRoom(id) {
+  await store.openRoom(id)
+  if (route.params.roomId !== id) router.replace({ name: 'Sessions', params: { roomId: id } })
+}
+async function send(content) {
+  try { await store.postMessage(content) } catch { /* store surfaces error */ }
+}
+async function closeRoom() {
+  if (store.activeRoomId) await store.closeRoom(store.activeRoomId)
+}
+async function onCreate(payload, onErr) {
+  try {
+    const room = await store.createRoom(payload)
+    showDialog.value = false
+    await openRoom(room.id)
+  } catch (e) {
+    const d = e?.response?.data?.detail
+    onErr?.((d && (d.message || d)) || 'Failed to create session')
+  }
+}
+
+onMounted(async () => {
+  if (!agentsStore.agents?.length) { try { await agentsStore.fetchAgents() } catch { /* non-fatal */ } }
+  await store.fetchRooms()
+  if (route.params.roomId) await openRoom(route.params.roomId)
+})
+onUnmounted(() => store.clear())
+</script>


### PR DESCRIPTION
The operator UI for shared multi-agent sessions. Builds on the ent#169 backend (Abilityai/trinity-enterprise#210 + Abilityai/trinity#1740).

**This was blocked until now** — when I picked up #170 the rooms backend didn't exist. It does now and runs on the dev instance, so the UI is built against a live, verified contract rather than invented from the epic.

## What it is

A top-level `/sessions` view — a human and several agents working one topic in a persistent transcript. Three panes:

- **Rooms rail** — active/closed list (live dot, participant + message counts) and a New-session dialog: pick agents from the accessible roster, set message/cost/TTL budgets, optional scribe.
- **Transcript** — sender row per message with an Agent/You badge + tinted-initials avatar (`PortalAvatar`), portal bubble styling, `@mentions` highlighted, system event lines, per-agent metadata (execution link), and a typing-dots "working" indicator.
- **Participants rail** — presence dots, budget meters that warn near exhaustion, expiry countdown.
- **Composer** — `@mention` autocomplete over participants, the "mention wakes an agent" hint, optimistic append rolled back on failure, `Idempotency-Key` on send.

## Gating (portal precedent)

Gated Vue in the OSS bundle: the route + NavBar entry appear only when `shared_sessions` is in `enterprise_features`, and the router guard catches a direct URL. **Ships dark in OSS/unentitled builds** and lights up only once the ent#169 backend is entitled — no coupling to the submodule being present. Invariants followed: single `api.js` client (#7), domain store (#6), WS-through-the-bus (#10), DOMPurify markdown (H-005).

## Live updates

Follows the loops pattern (#1106): the store reacts to fleet-wide `room_message` / `room_participant_state` / `room_closed` events for the room on screen and refetches over REST (thin WS payloads, the #918 pattern), plus a 12s backstop poll while any agent is working.

## Verification — and its honest limit

- **All 6 SFCs + the 3 edited files compile** (`@vue/compiler-sfc`), store is valid JS, HMR applied with no errors.
- **Contract verified against the running ent#169 backend**: every field the components read — room (`status`/`stop_reason`/`cost`/`max_messages`/`expires_at`/…), each message (`seq`/`sender_kind`/`sender_identity`/`kind`/`mentions`/`execution_id`), each participant (`kind`/`identity`/`role`/`left_at`) — is present in the live `/api/rooms` and `/api/rooms/{id}` responses. There is a real room on the instance (a 3-way agent conversation) for the panes to render.
- **I could not visually confirm the render** — no browser tooling in this session. The above is contract- and compile-level verification, not a screenshot. The e2e-smoke AC (create → mention → response renders with identity + working lifecycle) needs a human or Playwright pass. Flagging plainly rather than claiming it works on screen.

## Known gaps (deliberate, stated)

- **Per-message cost/duration not shown.** The room-detail response returns an `execution_id` per message and a room total, but not per-message cost — so the metadata line links the execution without its cost. A small ent#169 backend addition (join `schedule_executions`) would fill it.
- **No artifact/report card** for messages referencing a shared file or report — the backend doesn't surface that linkage on a message yet.

Both are backend-surface gaps, not UI shortcuts; noted for the follow-up rather than faked in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)