### PR TITLE
docs(release): 0.8.5 freeze plan + pre-freeze merge record

### DIFF
--- a/docs/releases/0.8.5-freeze-plan.md
+++ b/docs/releases/0.8.5-freeze-plan.md
@@ -32,10 +32,11 @@ commits pushed by the validator are noted.
 | 🔒 #214 | portal per-user memory injection (ent#212) | merged |
 | 🔒 #215 | eval strategy design doc (ent#206) | merged |
 | 🔒 #189 | telemetry fleet-benchmark surface (ent#12) | merged |
-| 🌐 #1734 | portal avatars on history rows (ent#186 half) | merged (flake rerun green; titles half still open) |
+| 🌐 #1734 | portal avatars on history rows (ent#186 half) | merged (flake rerun green; titles half closed by 🔒 #217 below) |
 | 🌐 #1751 | deploy-local .mcp.json validation (ent#213, security) | merged (CodeQL py/path-injection dismissed as false positive — dest_path sanitized at deploy.py:412 + :478-499) |
-| 🌐 #1723 | telemetry Tier-2 opt-in sharing (ent#12) | **pending CI** on review fixes: real audit enum (SETTINGS→CONFIGURATION), compose wiring for TELEMETRY_SHARING_* (dead kill switch), generic-PUT blocklist for the consent key family, wizard backfill disclosure — merge when green |
-| 🌐 #1753 | enterprise submodule pointer bump → 80b1bd7 (main TIP) | **open — needs non-author review**; merge after #1723 |
+| 🌐 #1723 | telemetry Tier-2 opt-in sharing (ent#12) | merged (2026-07-23 10:35, review fixes green) |
+| 🔒 #217 | portal thread titles on subscription OAuth (ent#216 — completes ent#186) | merged **at recheck** (2026-07-23): validated (security clean, resolver test green; 4 pre-existing env failures identical on main), append-append test conflict vs main resolved keeping both blocks |
+| 🌐 #1753 | enterprise submodule pointer bump → **594b0af** (main TIP) | **re-pointed at recheck**: original pin 80b1bd7 was stale — predated the ent#189 telemetry merge (would have shipped the OSS #1723 half without its enterprise module, the ent#185 class) — and now also carries ent#217. Approved (dolho); merge when checks green |
 
 ### Held out of 0.8.5 (confirmed deferrals)
 
@@ -64,8 +65,6 @@ commits pushed by the validator are noted.
 - **Telemetry Tier-2 sharing** is opt-in and default-OFF (double-gated, honors
   DO_NOT_TRACK). Fleet benchmarks show a pending status until the hosted
   benchmark service ships (trinity-enterprise#12 follow-up).
-- **Client-portal thread titles** (ent#186) shipped the avatar half only; LLM
-  thread titles pending.
 - **Executions `tool_calls` duplication** (#1741) is NOT fixed in this release —
   the fix regressed the #1083 apply_result contract and was held (PR #1742).
 - The dashboard **Sessions view had no visual e2e pass** at merge time; smoke it

--- a/docs/releases/0.8.5-freeze-plan.md
+++ b/docs/releases/0.8.5-freeze-plan.md
@@ -1,0 +1,85 @@
+# Release 0.8.5 — Freeze Plan & Pre-Freeze Merge Record
+
+> Produced by `/release-plan` + `/validate-pr` on 2026-07-23. Focused mode: payload census,
+> cross-repo pair coherence, PR-queue validation with per-PR verdicts, CI forensics.
+> The full seam fan-out (B1/B2/C/D/E over the whole payload) was NOT run — run
+> `/release-plan recheck` before the cut.
+
+## Scope
+
+- Last tag: v0.8.0 (2026-07-08, main)
+- Payload at review time (merge-base..origin/dev): 130 commits, 508 files, +87.6k/−13.5k
+- In-dev labels: ~75 public + 9 private issues
+
+## Pre-freeze merge record (executed 2026-07-23)
+
+Every PR was validated (/validate-pr methodology: issue link + closing keyword, security
+scan on the diff, packaging checks, test adequacy, invariants) before merge. Review-fix
+commits pushed by the validator are noted.
+
+| PR | What | Outcome |
+|----|------|---------|
+| 🌐 #1748 | delete agent whose container is gone (#1747) | merged (body: Related→Fixes) |
+| 🌐 #1746 | revoke agent MCP keys on delete (#1745, security) | merged (body: Related→Fixes) |
+| 🌐 #1744 | reconcile fleet totals with per-agent view (#1743) | merged (body: Related→Fixes) |
+| 🔒 #197 | enterprise module-registration isolation (ent#196) | merged |
+| 🌐 #1739 | honest enterprise ImportError + unregister_module (#1653) | merged (body: +Fixes #1653) |
+| 🔒 #195 | skill-runner module (ent#139) | merged **with review fixes**: single-slot pin (max_parallel_tasks=1 was claimed but never set), honest read-only docstring, ent#219 cascade residual annotated + regression test |
+| 🔒 #210 | shared-sessions rooms (ent#169) | merged **with review fix**: uniform-403 for unknown vs inaccessible agent (Invariant #8 enumeration oracle); design residuals filed as ent#220 |
+| 🌐 #1735 | skill-runner OSS half: library-read security fix + MCP tools + tile (ent#139) | merged (CI failure was the base-side hung-job flake; rerun green) |
+| 🌐 #1740 | rooms MCP tools + trigger allow-list fix (ent#169) | merged |
+| 🌐 #1750 | Sessions view UI, entitlement-dark (ent#170) | merged — **needs a visual smoke on an entitled instance before release notes claim it** |
+| 🔒 #214 | portal per-user memory injection (ent#212) | merged |
+| 🔒 #215 | eval strategy design doc (ent#206) | merged |
+| 🔒 #189 | telemetry fleet-benchmark surface (ent#12) | merged |
+| 🌐 #1734 | portal avatars on history rows (ent#186 half) | merged (flake rerun green; titles half still open) |
+| 🌐 #1751 | deploy-local .mcp.json validation (ent#213, security) | merged (CodeQL py/path-injection dismissed as false positive — dest_path sanitized at deploy.py:412 + :478-499) |
+| 🌐 #1723 | telemetry Tier-2 opt-in sharing (ent#12) | **pending CI** on review fixes: real audit enum (SETTINGS→CONFIGURATION), compose wiring for TELEMETRY_SHARING_* (dead kill switch), generic-PUT blocklist for the consent key family, wizard backfill disclosure — merge when green |
+| 🌐 #1753 | enterprise submodule pointer bump → 80b1bd7 (main TIP) | **open — needs non-author review**; merge after #1723 |
+
+### Held out of 0.8.5 (confirmed deferrals)
+
+| PR | Why |
+|----|-----|
+| 🌐 #1742 (#1741 tool_calls summary) | **Real regression** (not flake): `test_1083_apply_result.TestSuccessGolden::test_success_won_writes_full_row` fails under HEAD in all 3 seeds. Finding posted on the PR. |
+| 🌐 #1731 (pinia 3→4) | Major frontend bump days before a cut; frontend-e2e coverage thin (#1526). After the cut. |
+| 🌐 #1736/#1737/#1738 (dependabot, base=main) | Not in the dev payload; land after the cut. #1737 also has a failing auto-merge check. |
+| 🌐 #1619 (docker base images) | 3 checks failing. |
+| 🌐 #1752 (eval foundation, ent#206) | Conflicting; foundation only — design doc (ent#215) shipped. Next cycle. |
+| 🌐 #1718 (#728 drain-deadlock) | Conflicting; #1661 says the underlying fix is incomplete. Next cycle. |
+| 🌐 #1707 (#848 MCP inline email auth) | Conflicting; in progress. Next cycle. |
+| 🌐 #1628 + 🔒 #161 (A2A) | Changes requested + conflicts. Next cycle. |
+
+## Release-notes: Known limitations block
+
+```markdown
+### Known limitations
+- **Shared sessions (rooms)** ship entitlement-gated. Per-message cost is not yet
+  shown in the transcript; room roles (moderator/scribe) are recorded but not
+  enforced; turn chains run synchronously (long chains can outlive the HTTP
+  request). Tracked: trinity-enterprise#220.
+- **Skill runner** ships default-OFF behind its entitlement. Grants are not yet
+  revoked when an agent is deleted/renamed (recycled-name residual,
+  trinity-enterprise#219); the scratch-sweep runs on successful runs only.
+- **Telemetry Tier-2 sharing** is opt-in and default-OFF (double-gated, honors
+  DO_NOT_TRACK). Fleet benchmarks show a pending status until the hosted
+  benchmark service ships (trinity-enterprise#12 follow-up).
+- **Client-portal thread titles** (ent#186) shipped the avatar half only; LLM
+  thread titles pending.
+- **Executions `tool_calls` duplication** (#1741) is NOT fixed in this release —
+  the fix regressed the #1083 apply_result contract and was held (PR #1742).
+- The dashboard **Sessions view had no visual e2e pass** at merge time; smoke it
+  on an entitled instance.
+```
+
+## Soak risks / pre-cut checklist
+
+- [ ] `/release-plan recheck` (seam fan-out B1–E, census bucket reconciliation)
+- [ ] Sessions-view visual smoke on an entitled instance (create → mention → reply renders)
+- [ ] Unit-suite hang: one pytest matrix job intermittently hangs to the 25-min timeout
+      on random seed/side (seen on 3 PRs + once on base=dev). #1582 family or a new
+      hanging test — investigate before the cut.
+- [ ] Verify enterprise pointer at main TIP at cut time (#1753; ent#185 class)
+- [ ] Manual cross-tracker closes at release: ent#213 (via 🌐#1751), ent#139 halves,
+      ent#169/#170 (rooms shipped), ent#212 auto-closed at enterprise merge
+- [ ] Dependabot batch (#1731, #1736–#1738, #1619) queued for immediately after the cut


### PR DESCRIPTION
The /release-plan output for 0.8.5, persisted so /release can diff intent vs actual at cut time. Records the validated merge sequence executed 2026-07-23 (16 PRs across both trackers), the confirmed deferrals, the Known-limitations block for the release notes, and the pre-cut checklist (recheck, Sessions visual smoke, unit-suite hang investigation, pointer verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)