### PR TITLE
fix(ui): prevent dashboard chrome overlap at narrow viewports

### DIFF
--- a/src/frontend/e2e/dashboard-responsive.spec.js
+++ b/src/frontend/e2e/dashboard-responsive.spec.js
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Dashboard responsive chrome regression (#1754).
+ *
+ * The global navigation and Replay Timeline toolbar are independent flex
+ * surfaces, but both previously exposed their full desktop content around
+ * 700px. Keep geometry assertions here so future labels, badges, or build
+ * metadata cannot silently reintroduce page-level overflow.
+ */
+
+const VIEWPORT_WIDTHS = [375, 639, 640, 700, 714, 768, 1024, 1100, 1101, 1279, 1280, 1440]
+
+async function selectTimeline(page) {
+  const timelineButton = page.getByRole('button', { name: 'timeline', exact: true })
+  await expect(timelineButton).toBeVisible({ timeout: 15000 })
+  await timelineButton.click()
+  await expect(page.getByTestId('replay-timeline')).toBeVisible()
+}
+
+async function responsiveGeometry(page) {
+  return page.evaluate(() => {
+    const isVisible = (element) => {
+      if (!element) return false
+      const rect = element.getBoundingClientRect()
+      return getComputedStyle(element).display !== 'none' && rect.width > 0 && rect.height > 0
+    }
+
+    const overlaps = (first, second) => {
+      if (!isVisible(first) || !isVisible(second)) return false
+      const a = first.getBoundingClientRect()
+      const b = second.getBoundingClientRect()
+      return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
+    }
+
+    const nav = document.querySelector('[data-testid="global-navigation"]')
+    const desktopNav = document.querySelector('[data-testid="desktop-navigation"]')
+    const desktopStatus = document.querySelector('[data-testid="desktop-connection-status"]')
+    const compactTrigger = document.querySelector('[data-testid="compact-navigation-trigger"]')
+    const settings = desktopNav?.querySelector('a[href="/settings"]')
+    const toolbar = document.querySelector('[data-testid="replay-timeline-toolbar"]')
+    const legend = document.querySelector('[data-testid="replay-timeline-legend"]')
+    const activeOnly = Array.from(toolbar?.querySelectorAll('label') || [])
+      .find((element) => element.textContent?.includes('Active only'))
+    const agentTriggered = Array.from(legend?.querySelectorAll('span') || [])
+      .find((element) => element.textContent?.trim() === 'Agent-Triggered')
+    const timelineScroll = document.querySelector('.timeline-scroll-container')
+
+    return {
+      documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      headerBorderWidth: parseFloat(getComputedStyle(nav).borderBottomWidth),
+      desktopNavVisible: isVisible(desktopNav),
+      compactTriggerVisible: isVisible(compactTrigger),
+      settingsStatusOverlap: overlaps(settings, desktopStatus),
+      toolbarOverflow: toolbar.scrollWidth - toolbar.clientWidth,
+      activeOnlyHeight: activeOnly?.getBoundingClientRect().height || 0,
+      legendVisible: isVisible(legend),
+      agentTriggeredHeight: agentTriggered?.getBoundingClientRect().height || 0,
+      timelineHasInternalOverflow: timelineScroll.scrollWidth > timelineScroll.clientWidth,
+    }
+  })
+}
+
+test.describe('Dashboard responsive chrome (#1754)', () => {
+  test('@smoke reflows without overlap across breakpoint boundaries', async ({ page }) => {
+    await page.setViewportSize({ width: 714, height: 900 })
+    await page.goto('/')
+    await selectTimeline(page)
+
+    for (const width of VIEWPORT_WIDTHS) {
+      await page.setViewportSize({ width, height: 900 })
+      const geometry = await responsiveGeometry(page)
+
+      expect(geometry.documentOverflow, `document overflow at ${width}px`).toBeLessThanOrEqual(1)
+      expect(geometry.headerBorderWidth, `header divider at ${width}px`).toBeGreaterThan(0)
+      expect(geometry.settingsStatusOverlap, `Settings/status overlap at ${width}px`).toBe(false)
+      expect(geometry.toolbarOverflow, `timeline toolbar overflow at ${width}px`).toBeLessThanOrEqual(1)
+      expect(geometry.activeOnlyHeight, `Active only wraps at ${width}px`).toBeLessThanOrEqual(20)
+      expect(geometry.timelineHasInternalOverflow, `timeline canvas overflow at ${width}px`).toBe(true)
+
+      if (width < 1280) {
+        expect(geometry.compactTriggerVisible, `compact navigation at ${width}px`).toBe(true)
+        expect(geometry.desktopNavVisible, `desktop navigation at ${width}px`).toBe(false)
+      } else {
+        expect(geometry.compactTriggerVisible, `compact navigation at ${width}px`).toBe(false)
+        expect(geometry.desktopNavVisible, `desktop navigation at ${width}px`).toBe(true)
+      }
+
+      if (geometry.legendVisible) {
+        expect(geometry.agentTriggeredHeight, `Agent-Triggered wraps at ${width}px`).toBeLessThanOrEqual(20)
+      }
+    }
+  })
+
+  test('@smoke compact navigation keeps routes and runtime state reachable', async ({ page }) => {
+    await page.setViewportSize({ width: 714, height: 900 })
+    await page.goto('/')
+
+    const trigger = page.getByTestId('compact-navigation-trigger')
+    await expect(trigger).toBeVisible({ timeout: 15000 })
+    await trigger.click()
+
+    const panel = page.getByTestId('compact-navigation-panel')
+    await expect(panel).toBeVisible()
+    await expect(panel.locator('a[href="/"]')).toBeVisible()
+    await expect(panel.locator('a[href="/agents"]')).toBeVisible()
+    await expect(panel.locator('a[href="/templates"]')).toBeVisible()
+    await expect(panel.locator('a[href="/operations"]')).toBeVisible()
+
+    const settings = panel.locator('a[href="/settings"]')
+    await expect(settings).toBeVisible()
+    await expect(panel.locator('[role="status"]')).toContainText(/Connected|Disconnected/)
+
+    const noDocumentOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1
+    )
+    expect(noDocumentOverflow).toBe(true)
+
+    await settings.focus()
+    await page.keyboard.press('Escape')
+    await expect(panel).toHaveCount(0)
+    await expect(trigger).toBeFocused()
+  })
+
+  test('@smoke resize preserves Timeline mode and internal scrolling', async ({ page }) => {
+    await page.setViewportSize({ width: 700, height: 900 })
+    await page.goto('/')
+    await selectTimeline(page)
+
+    const timelineButton = page.getByRole('button', { name: 'timeline', exact: true })
+    for (const width of [1280, 700]) {
+      await page.setViewportSize({ width, height: 900 })
+      await expect(timelineButton).toHaveClass(/bg-blue-600/)
+      await expect(page.getByTestId('replay-timeline')).toBeVisible()
+    }
+  })
+})

--- a/src/frontend/src/components/HostTelemetry.vue
+++ b/src/frontend/src/components/HostTelemetry.vue
@@ -149,14 +149,17 @@ onUnmounted(() => {
 .host-telemetry {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   font-size: 12px;
+  min-width: 0;
 }
 
 .stat-item {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
 }
 
 .stat-label {
@@ -199,5 +202,19 @@ onUnmounted(() => {
 /* Dark mode adjustments */
 .dark .disk-bar {
   background: rgba(55, 65, 81, 0.5);
+}
+
+@media (max-width: 1100px) {
+  .host-telemetry {
+    gap: 8px;
+  }
+
+  .host-telemetry :deep(.sparkline-chart) {
+    display: none;
+  }
+
+  .disk-bar {
+    width: 36px;
+  }
 }
 </style>

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -1,14 +1,14 @@
 <template>
-  <nav class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900">
+  <nav ref="navRef" data-testid="global-navigation" class="border-b border-gray-200 bg-white shadow dark:border-gray-700 dark:bg-gray-800 dark:shadow-gray-900">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between h-16">
-        <div class="flex">
+      <div class="flex h-16 items-stretch justify-between gap-2">
+        <div class="flex min-w-0">
           <router-link to="/" class="flex-shrink-0 flex items-center hover:opacity-80 transition-opacity">
             <img src="../assets/trinity-logo.svg" alt="Trinity Logo" class="h-8 w-8 mr-2 dark:hidden" />
             <img src="../assets/trinity-logo-white.svg" alt="Trinity Logo" class="h-8 w-8 mr-2 hidden dark:block" />
             <h1 class="text-xl font-bold text-gray-900 dark:text-white">Trinity</h1>
           </router-link>
-          <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
+          <div data-testid="desktop-navigation" class="hidden min-w-0 xl:ml-6 xl:flex xl:space-x-6 2xl:space-x-8">
             <router-link
               to="/"
               class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
@@ -82,18 +82,29 @@
             </router-link>
           </div>
         </div>
-        <div class="flex items-center space-x-4">
+        <div class="flex flex-shrink-0 items-center space-x-2 lg:space-x-3 xl:space-x-4">
           <!-- WebSocket Status -->
-          <span class="text-sm text-gray-500 dark:text-gray-400">
-            <span class="inline-block h-2 w-2 rounded-full mr-1" :class="isConnected ? 'bg-status-success-400' : 'bg-gray-400 dark:bg-gray-600'"></span>
-            {{ isConnected ? 'Connected' : 'Disconnected' }}
+          <span
+            class="hidden flex-shrink-0 items-center whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 xl:inline-flex"
+            data-testid="desktop-connection-status"
+            role="status"
+            aria-live="polite"
+            :aria-label="isConnected ? 'Connected' : 'Disconnected'"
+            :title="isConnected ? 'Connected' : 'Disconnected'"
+          >
+            <span
+              class="mr-1 inline-block h-2 w-2 rounded-full"
+              :class="isConnected ? 'bg-status-success-400' : 'bg-gray-400 dark:bg-gray-600'"
+              aria-hidden="true"
+            ></span>
+            <span>{{ isConnected ? 'Connected' : 'Disconnected' }}</span>
           </span>
 
           <!-- Build Info Chip (#926) — small muted version label; click opens detail modal -->
           <button
             v-if="buildInfo.info.value"
             @click="showBuildInfoModal = true"
-            class="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 font-mono"
+            class="hidden font-mono text-xs text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 xl:inline-flex"
             :title="`Click for build info — commit ${buildInfo.info.value.git_commit_short}`"
           >
             v{{ buildInfo.displayVersion.value }}<span
@@ -108,7 +119,7 @@
             href="https://docs.ability.ai"
             target="_blank"
             rel="noopener noreferrer"
-            class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="hidden p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 lg:inline-flex"
             title="Documentation (opens docs.ability.ai)"
             aria-label="Documentation"
           >
@@ -121,7 +132,7 @@
           <!-- Theme Toggle Button -->
           <button
             @click="cycleTheme"
-            class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="hidden p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 lg:inline-flex"
             :title="themeTitle"
           >
             <!-- Sun icon for light mode -->
@@ -135,6 +146,26 @@
             <!-- Computer/System icon for system mode -->
             <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </button>
+
+          <!-- Compact navigation trigger: the full route strip cannot fit safely
+               alongside connection and account utilities below xl. -->
+          <button
+            ref="compactNavButtonRef"
+            data-testid="compact-navigation-trigger"
+            @click="toggleCompactNav"
+            class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 xl:hidden"
+            type="button"
+            :aria-label="showCompactNav ? 'Close navigation' : 'Open navigation'"
+            aria-controls="trinity-compact-navigation"
+            :aria-expanded="showCompactNav"
+          >
+            <svg v-if="!showCompactNav" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            <svg v-else class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
 
@@ -235,6 +266,67 @@
           </div>
         </div>
       </div>
+
+      <!-- Compact primary navigation. Route links and runtime state get their
+           own rows so async badges and build metadata cannot collide. -->
+      <div
+        v-if="showCompactNav"
+        id="trinity-compact-navigation"
+        data-testid="compact-navigation-panel"
+        role="navigation"
+        aria-label="Primary navigation"
+        class="border-t border-gray-200 py-3 dark:border-gray-700 xl:hidden"
+      >
+        <div class="grid gap-1 sm:grid-cols-2">
+          <router-link
+            v-for="item in compactNavItems"
+            :key="item.key"
+            :to="item.to"
+            class="flex min-h-11 items-center justify-between rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white"
+            :class="item.active ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' : ''"
+            @click="showCompactNav = false"
+          >
+            <span>{{ item.label }}</span>
+            <span
+              v-if="item.key === 'operations' && combinedOpsCount > 0"
+              class="inline-flex items-center justify-center rounded-full px-1.5 py-0.5 text-xs font-bold leading-none text-white"
+              :class="hasCriticalOpsItem ? 'bg-status-danger-500 animate-pulse' : 'bg-status-urgent-500'"
+            >
+              {{ combinedOpsCount > 99 ? '99+' : combinedOpsCount }}
+            </span>
+            <span
+              v-else-if="item.key === 'enterprise'"
+              class="rounded bg-purple-100 px-1.5 py-0.5 text-[10px] font-bold leading-none text-purple-700 dark:bg-purple-900 dark:text-purple-200"
+            >PRO</span>
+          </router-link>
+        </div>
+
+        <div class="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-gray-200 px-3 pt-3 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+          <span
+            class="inline-flex items-center whitespace-nowrap"
+            role="status"
+            aria-live="polite"
+          >
+            <span
+              class="mr-1.5 inline-block h-2 w-2 rounded-full"
+              :class="isConnected ? 'bg-status-success-400' : 'bg-gray-400 dark:bg-gray-600'"
+              aria-hidden="true"
+            ></span>
+            {{ isConnected ? 'Connected' : 'Disconnected' }}
+          </span>
+          <button
+            v-if="buildInfo.info.value"
+            @click="showBuildInfoModal = true; showCompactNav = false"
+            class="font-mono text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+            :title="`Click for build info — commit ${buildInfo.info.value.git_commit_short}`"
+          >
+            v{{ buildInfo.displayVersion.value }}<span
+              v-if="buildInfo.info.value.git_commit_short && buildInfo.info.value.git_commit_short !== 'unknown'"
+              class="ml-1 opacity-70"
+            >· {{ buildInfo.info.value.git_commit_short }}</span>
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Build Info Modal (#926) — click-out to dismiss -->
@@ -301,7 +393,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { useThemeStore } from '../stores/theme'
@@ -346,6 +438,27 @@ const hasCriticalOpsItem = computed(() =>
   operatorQueueStore.criticalCount > 0 || notificationsStore.hasUrgentPending
 )
 
+const compactNavItems = computed(() => {
+  const items = [
+    { key: 'dashboard', label: 'Dashboard', to: '/', active: route.value.path === '/' },
+    { key: 'agents', label: 'Agents', to: '/agents', active: isAgentSection.value },
+    { key: 'templates', label: 'Templates', to: '/templates', active: route.value.path === '/templates' },
+    { key: 'operations', label: 'Operations', to: '/operations', active: route.value.path === '/operations' },
+    { key: 'settings', label: 'Settings', to: '/settings', active: route.value.path === '/settings' }
+  ]
+
+  if (enterpriseStore.hasAnyEnterprise) {
+    items.push({
+      key: 'enterprise',
+      label: 'Enterprise',
+      to: '/enterprise',
+      active: route.value.path.startsWith('/enterprise')
+    })
+  }
+
+  return items
+})
+
 // Theme management
 const themeTitle = computed(() => {
   const titles = {
@@ -366,12 +479,20 @@ const setTheme = (theme) => {
 
 // User menu state
 const showUserMenu = ref(false)
+const showCompactNav = ref(false)
+const navRef = ref(null)
+const compactNavButtonRef = ref(null)
 const userMenuRef = ref(null)
 const avatarError = ref(false)
+
+watch(() => route.value.fullPath, () => {
+  showCompactNav.value = false
+})
 
 onMounted(async () => {
   // Add click outside listener
   document.addEventListener('click', handleClickOutside)
+  document.addEventListener('keydown', handleKeydown)
 
   // Start polling for notifications
   notificationsStore.startPolling(60000)
@@ -398,16 +519,38 @@ onMounted(async () => {
 
 onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
+  document.removeEventListener('keydown', handleKeydown)
   notificationsStore.stopPolling()
 })
 
 const toggleUserMenu = () => {
+  showCompactNav.value = false
   showUserMenu.value = !showUserMenu.value
+}
+
+const toggleCompactNav = () => {
+  showUserMenu.value = false
+  showCompactNav.value = !showCompactNav.value
 }
 
 const handleClickOutside = (event) => {
   if (userMenuRef.value && !userMenuRef.value.contains(event.target)) {
     showUserMenu.value = false
+  }
+  if (navRef.value && !navRef.value.contains(event.target)) {
+    showCompactNav.value = false
+  }
+}
+
+const handleKeydown = async (event) => {
+  if (event.key === 'Escape') {
+    const compactNavWasOpen = showCompactNav.value
+    showCompactNav.value = false
+    showUserMenu.value = false
+    if (compactNavWasOpen) {
+      await nextTick()
+      compactNavButtonRef.value?.focus()
+    }
   }
 }
 

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -150,11 +150,16 @@
           </button>
 
           <!-- Compact navigation trigger: the full route strip cannot fit safely
-               alongside connection and account utilities below xl. -->
+               alongside connection and account utilities below xl.
+               @click.stop is required: the icon-swap (v-if/v-else) detaches the
+               clicked <path> from the DOM before the document click-outside
+               handler runs, so navRef.contains(target) is false and the panel
+               would close the instant it opened. Stopping propagation keeps the
+               open click from ever reaching handleClickOutside. -->
           <button
             ref="compactNavButtonRef"
             data-testid="compact-navigation-trigger"
-            @click="toggleCompactNav"
+            @click.stop="toggleCompactNav"
             class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 xl:hidden"
             type="button"
             :aria-label="showCompactNav ? 'Close navigation' : 'Open navigation'"

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="replay-timeline flex flex-col h-full bg-gray-50 dark:bg-gray-900">
+  <div data-testid="replay-timeline" class="replay-timeline flex min-h-0 min-w-0 flex-col h-full bg-gray-50 dark:bg-gray-900">
     <!-- Header with controls -->
-    <div class="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex-shrink-0">
+    <div data-testid="replay-timeline-toolbar" class="flex flex-col items-stretch gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex-shrink-0 lg:flex-row lg:items-center lg:justify-between">
       <!-- Left: Controls -->
-      <div class="flex items-center space-x-3">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
         <!-- Zoom Controls -->
-        <div class="flex items-center space-x-1">
+        <div class="flex flex-shrink-0 items-center space-x-1">
           <button
             @click="zoomOut"
             class="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
@@ -22,7 +22,7 @@
             min="0.5"
             max="20"
             step="0.5"
-            class="w-20 h-1 accent-blue-500"
+            class="h-1 w-16 accent-blue-500 sm:w-20"
             title="Zoom level"
           />
           <button
@@ -34,12 +34,12 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
             </svg>
           </button>
-          <span class="text-xs text-gray-400 dark:text-gray-500 ml-1 w-8">{{ Math.round(zoomLevel * 100) }}%</span>
+          <span class="ml-1 w-10 whitespace-nowrap text-right text-xs tabular-nums text-gray-400 dark:text-gray-500">{{ Math.round(zoomLevel * 100) }}%</span>
         </div>
 
         <!-- Hide inactive toggle -->
-        <div class="flex items-center space-x-1 border-l border-gray-300 dark:border-gray-600 pl-3">
-          <label class="flex items-center space-x-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
+        <div class="flex flex-shrink-0 items-center space-x-1 border-l border-gray-300 dark:border-gray-600 pl-3">
+          <label class="flex items-center space-x-1.5 whitespace-nowrap text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
             <input
               type="checkbox"
               v-model="hideInactiveAgents"
@@ -53,7 +53,7 @@
         <button
           v-if="isLiveMode && !autoScrollEnabled"
           @click="jumpToNow"
-          class="flex items-center space-x-1 px-2 py-1 text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 rounded hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors"
+          class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap px-2 py-1 text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 rounded hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors"
         >
           <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd" />
@@ -63,43 +63,45 @@
       </div>
 
       <!-- Right: Legend and Stats -->
-      <div class="flex items-center space-x-4 text-xs text-gray-500 dark:text-gray-400">
+      <div class="flex min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-gray-500 dark:text-gray-400 lg:flex-nowrap lg:justify-end">
         <!-- Activity type legend -->
-        <div class="hidden sm:flex items-center space-x-3 border-r border-gray-300 dark:border-gray-600 pr-3">
-          <span class="flex items-center space-x-1" title="Manual task executions">
+        <div data-testid="replay-timeline-legend" class="hidden min-w-0 flex-wrap items-center gap-x-3 gap-y-1 border-r border-gray-300 pr-3 dark:border-gray-600 sm:flex lg:flex-nowrap">
+          <span class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap" title="Manual task executions">
             <span class="w-2 h-2 rounded" style="background-color: #22c55e"></span>
             <span>Manual</span>
           </span>
-          <span class="flex items-center space-x-1" title="MCP executions (via Claude Code)">
+          <span class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap" title="MCP executions (via Claude Code)">
             <span class="w-2 h-2 rounded" style="background-color: #ec4899"></span>
             <span>MCP</span>
           </span>
-          <span class="flex items-center space-x-1" title="Scheduled task executions">
+          <span class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap" title="Scheduled task executions">
             <span class="w-2 h-2 rounded" style="background-color: #8b5cf6"></span>
             <span>Scheduled</span>
           </span>
-          <span class="flex items-center space-x-1" title="Agent-triggered executions (called by another agent)">
+          <span class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap" title="Agent-triggered executions (called by another agent)">
             <span class="w-2 h-2 rounded" style="background-color: #06b6d4"></span>
             <span>Agent-Triggered</span>
           </span>
-          <span class="flex items-center space-x-1" title="Paid executions (via Nevermined payment)">
+          <span class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap" title="Paid executions (via Nevermined payment)">
             <span class="w-2 h-2 rounded" style="background-color: #eab308"></span>
             <span>Paid</span>
           </span>
-          <span class="flex items-center space-x-1" title="Public link executions">
+          <span class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap" title="Public link executions">
             <span class="w-2 h-2 rounded" style="background-color: #0d9488"></span>
             <span>Public</span>
           </span>
-          <span class="flex items-center space-x-1" title="Schedule marker (shows next scheduled run time)">
+          <span class="flex flex-shrink-0 items-center space-x-1 whitespace-nowrap" title="Schedule marker (shows next scheduled run time)">
             <span class="text-accent-purple-500 text-xs font-bold">▼</span>
             <span>Next Run</span>
           </span>
         </div>
-        <span v-if="isLiveMode" class="flex items-center space-x-1">
-          <span class="w-1.5 h-1.5 rounded-full bg-status-success-500 animate-pulse"></span>
-          <span>Live</span>
-        </span>
-        <span>{{ totalEvents }} events</span>
+        <div class="flex flex-shrink-0 items-center gap-4 whitespace-nowrap">
+          <span v-if="isLiveMode" class="flex items-center space-x-1">
+            <span class="w-1.5 h-1.5 rounded-full bg-status-success-500 animate-pulse"></span>
+            <span>Live</span>
+          </span>
+          <span>{{ totalEvents }} events</span>
+        </div>
       </div>
     </div>
 

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -9,13 +9,13 @@
         @edit="openEditModal"
       />
 
-      <div class="flex flex-col flex-1 overflow-hidden">
+      <div data-testid="dashboard-content" class="flex min-w-0 flex-1 flex-col overflow-hidden">
         <!-- Compact Header -->
         <div class="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-2">
-          <div class="flex items-center justify-between">
+          <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
             <!-- Left: Stats -->
-            <div class="flex items-center min-w-0 overflow-hidden">
-              <div class="flex items-center space-x-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+            <div class="flex min-w-0 flex-1 basis-80 items-center overflow-hidden">
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
                 <span class="flex items-center space-x-1">
                   <span class="w-1.5 h-1.5 rounded-full bg-status-success-500"></span>
                   <span class="font-medium text-status-success-600 dark:text-status-success-400">{{ runningCount }}/{{ agents.length }}</span>
@@ -39,7 +39,7 @@
             </div>
 
             <!-- Right: Controls -->
-            <div class="flex items-center space-x-2 flex-shrink-0">
+            <div class="flex min-w-0 flex-shrink flex-wrap items-center justify-end gap-2">
               <!-- Quick Tag Filter Dropdown -->
               <div v-if="availableTags.length > 0" class="relative">
                 <button


### PR DESCRIPTION
## Description

> Maintainer action: please apply the `ui` label to trigger the frontend Playwright workflow. The contributor account cannot assign repository labels.

Fix the narrow-desktop responsive layout across Trinity's shared navigation, Dashboard summary/control bar, and Replay Timeline.

The change:

- replaces the overfull route strip below 1280px with an accessible compact menu;
- keeps every primary route, connection text, Operations badge, and build information reachable;
- adds a clear global-header divider in light and dark themes;
- keeps Dashboard statistics, telemetry, and controls grouped while wrapping;
- makes Replay Timeline controls and legend chips wrap as atomic units; and
- preserves the Timeline canvas as the only horizontal scrolling surface.

## Related issue

Fixes #1754

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Reproduced untouched current `dev` at `714 × 863`: Settings/status intersected, toolbar overflowed by 140px, and header border was 0px.
- [x] Verified fixed current `dev` at 375, 639, 640, 700, 714, 768, 1024, 1100, 1101, 1279, 1280, and 1440px.
- [x] At every width: document overflow 0px, Replay toolbar overflow 0px, no Settings/status intersection, 1px header divider, and internal Timeline scrolling preserved.
- [x] Verified compact menu routes, text connection state, `99+` badge, outside-click closure, Escape closure, and focus return.
- [x] Verified light and dark header dividers at 714px.
- [x] Added `e2e/dashboard-responsive.spec.js` to the `@smoke` CI set.
- [x] `npm run check:tokens`
- [x] `npm run build`
- [x] Playwright discovery with `--grep @smoke --list`
- [ ] `npm run test:e2e:smoke` locally (admin credential was intentionally not exposed; CI will execute it)

## Checklist

- [x] Code follows the project's style and design-token conventions.
- [x] No sensitive data or backend/API changes are included.
- [x] Maintainer edits are allowed.
- [x] Intentional Timeline canvas scrolling remains internal.
