### PR TITLE
feat(slack): per-channel proactive-messaging consent (ent#223)

### DIFF
--- a/docs/memory/feature-flows/proactive-messaging.md
+++ b/docs/memory/feature-flows/proactive-messaging.md
@@ -11,6 +11,18 @@ Enables agents to send proactive messages to specific users by verified email ac
 ## Key Features
 
 - **Explicit opt-in consent**: Users must enable `allow_proactive` flag on their sharing record
+- **Two consent units, by channel shape (ent#223)**: a **DM** to a person is consented
+  **per recipient** (`agent_sharing.allow_proactive`, keyed by verified email). A post to a
+  **Slack channel** is consented **per channel binding**
+  (`slack_channel_agents.allow_proactive`) — in an open Slack workspace users never
+  authenticate, so there is no verified-email recipient record to opt in, and the channel
+  is the only meaningful consent unit. Default posture: a **new** binding denies (binding
+  an agent is not itself consent); **existing** bindings were backfilled to allow, because
+  channel posts had no consent gate before ent#223 and must not silently break. Toggled in
+  the Slack channel panel, or via
+  `PUT /api/agents/{name}/slack/channels/{channel_id}/proactive`. Refusal is a named
+  `proactive_not_allowed` (403), kept distinct from *not bound* (404) and *rate capped*
+  (429) so the agent can relay **why**. Replying to a user's own message never needs it.
 - **Redis-based rate limiting**: 10 messages per recipient per hour (survives restarts)
 - **Mandatory audit logging**: All proactive sends logged via platform_audit_service
 - **Multi-channel delivery**: Auto-selection tries telegram → slack → web. WhatsApp is an explicit-only channel (`channel="whatsapp"`) and not part of `auto` — Twilio's 24-hour session window makes it unreliable for inactive recipients.

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -2272,6 +2272,11 @@ class DatabaseManager:
     def get_slack_channels_for_agent(self, agent_name):
         return self._slack_channel_ops.get_channels_for_agent(agent_name)
 
+    def set_slack_channel_allow_proactive(self, team_id, slack_channel_id, enabled):
+        """ent#223 — toggle per-channel proactive consent on a channel binding."""
+        return self._slack_channel_ops.set_channel_allow_proactive(
+            team_id, slack_channel_id, enabled)
+
     def unbind_slack_agent(self, team_id, agent_name):
         return self._slack_channel_ops.unbind_agent(team_id, agent_name)
 

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -3118,6 +3118,39 @@ def _migrate_product_events_table(cursor, conn):
     print("Created product_events table (ent#184)")
 
 
+def _migrate_slack_channel_allow_proactive(cursor, conn):
+    """ent#223 — per-channel proactive consent for Slack.
+
+    Adds ``allow_proactive INTEGER DEFAULT 0`` to ``slack_channel_agents``. In an
+    open Slack workspace users never authenticate, so the per-recipient consent
+    model (``agent_sharing.allow_proactive``, keyed by verified email) has nobody
+    to key on; for Slack the consent unit is the CHANNEL BINDING.
+
+    Default posture, and why it differs for existing vs new rows:
+      * NEW bindings default to 0 (deny) — binding an agent to a channel is not
+        by itself consent to unprompted posts; consent is explicit, matching the
+        DM path.
+      * EXISTING bindings are backfilled to 1 (allow) — channel posts had no
+        consent gate at all before this migration, so leaving them at 0 would
+        silently break every working integration. The AC is explicit that
+        existing behavior must not silently flip.
+
+    Mirrored by Alembic 0029_slack_channel_allow_proactive.
+    """
+    added = _safe_add_column(
+        cursor,
+        "slack_channel_agents",
+        "allow_proactive",
+        "ALTER TABLE slack_channel_agents ADD COLUMN allow_proactive INTEGER DEFAULT 0",
+    )
+    if added:
+        # Preserve today's behavior for bindings that already exist.
+        cursor.execute(
+            "UPDATE slack_channel_agents SET allow_proactive = 1 "
+            "WHERE allow_proactive IS NULL OR allow_proactive = 0"
+        )
+
+
 MIGRATIONS = [
     ("agent_sharing", _migrate_agent_sharing_table),
     ("schedule_executions_observability", _migrate_schedule_executions_observability),
@@ -3218,5 +3251,6 @@ MIGRATIONS = [
     ("operator_queue_request_id", _migrate_operator_queue_request_id),
     ("users_github_pat", _migrate_users_github_pat),
     ("agent_reminders_table", _migrate_agent_reminders_table),
+    ("slack_channel_allow_proactive", _migrate_slack_channel_allow_proactive),
     ("product_events_table", _migrate_product_events_table),
 ]

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -3135,7 +3135,7 @@ def _migrate_slack_channel_allow_proactive(cursor, conn):
         silently break every working integration. The AC is explicit that
         existing behavior must not silently flip.
 
-    Mirrored by Alembic 0029_slack_channel_allow_proactive.
+    Mirrored by Alembic 0030_slack_channel_allow_proactive.
     """
     added = _safe_add_column(
         cursor,

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -927,6 +927,12 @@ TABLES = {
             is_dm_default INTEGER DEFAULT 0,
             created_by TEXT,
             created_at TEXT NOT NULL,
+            -- ent#223: per-channel proactive consent. In an open Slack workspace
+            -- users never authenticate, so the per-recipient email consent
+            -- (agent_sharing.allow_proactive) has nobody to key on; for Slack the
+            -- consent unit is the CHANNEL BINDING. Deny by default: binding an
+            -- agent is not itself consent to unprompted posts.
+            allow_proactive INTEGER DEFAULT 0,
             UNIQUE(team_id, slack_channel_id),
             FOREIGN KEY (agent_name) REFERENCES agent_ownership(agent_name) ON DELETE CASCADE
         )

--- a/src/backend/db/slack_channels.py
+++ b/src/backend/db/slack_channels.py
@@ -211,6 +211,7 @@ class SlackChannelOperations:
             slack_channel_agents.c.is_dm_default,
             slack_channel_agents.c.created_by,
             slack_channel_agents.c.created_at,
+            slack_channel_agents.c.allow_proactive,
         ).where(
             and_(
                 slack_channel_agents.c.team_id == team_id,
@@ -301,6 +302,26 @@ class SlackChannelOperations:
             changed = result.rowcount > 0
         return changed
 
+    def set_channel_allow_proactive(self, team_id: str, slack_channel_id: str,
+                                    enabled: bool) -> bool:
+        """ent#223 — toggle per-channel proactive consent on a channel binding.
+
+        Returns True when a binding was updated, False when no such binding
+        exists (the caller turns that into a 404 rather than a silent success).
+        """
+        with get_engine().begin() as conn:
+            result = conn.execute(
+                update(slack_channel_agents)
+                .where(
+                    and_(
+                        slack_channel_agents.c.team_id == team_id,
+                        slack_channel_agents.c.slack_channel_id == slack_channel_id,
+                    )
+                )
+                .values(allow_proactive=1 if enabled else 0)
+            )
+        return (result.rowcount or 0) > 0
+
     def get_agents_for_workspace(self, team_id: str) -> List[dict]:
         """Get all agent-channel bindings for a workspace."""
         stmt = (
@@ -313,6 +334,7 @@ class SlackChannelOperations:
                 slack_channel_agents.c.is_dm_default,
                 slack_channel_agents.c.created_by,
                 slack_channel_agents.c.created_at,
+                slack_channel_agents.c.allow_proactive,
             )
             .where(slack_channel_agents.c.team_id == team_id)
             .order_by(slack_channel_agents.c.created_at.asc())
@@ -333,6 +355,7 @@ class SlackChannelOperations:
             slack_channel_agents.c.is_dm_default,
             slack_channel_agents.c.created_by,
             slack_channel_agents.c.created_at,
+            slack_channel_agents.c.allow_proactive,
         ).where(
             and_(
                 slack_channel_agents.c.team_id == team_id,
@@ -363,6 +386,7 @@ class SlackChannelOperations:
                 slack_channel_agents.c.is_dm_default,
                 slack_channel_agents.c.created_by,
                 slack_channel_agents.c.created_at,
+                slack_channel_agents.c.allow_proactive,
             )
             .where(slack_channel_agents.c.agent_name == agent_name)
             .order_by(slack_channel_agents.c.created_at.asc())
@@ -471,4 +495,7 @@ class SlackChannelOperations:
             "is_dm_default": bool(row[5]),
             "created_by": row[6],
             "created_at": row[7],
+            # ent#223: per-channel proactive consent. Older rows predate the
+            # column; treat a missing value as denied (safe default).
+            "allow_proactive": bool(row[8]) if len(row) > 8 else False,
         }

--- a/src/backend/db/tables.py
+++ b/src/backend/db/tables.py
@@ -810,6 +810,7 @@ slack_channel_agents = Table(
     Column("is_dm_default", Integer),
     Column("created_by", Text),
     Column("created_at", Text),
+    Column("allow_proactive", Integer),   # ent#223: per-channel proactive consent
 )
 
 slack_active_threads = Table(

--- a/src/backend/migrations/versions/0029_slack_channel_allow_proactive.py
+++ b/src/backend/migrations/versions/0029_slack_channel_allow_proactive.py
@@ -1,0 +1,51 @@
+"""per-channel proactive consent for Slack (ent#223)
+
+Adds ``allow_proactive`` to ``slack_channel_agents``. In an open Slack workspace
+users never authenticate, so the per-recipient consent model
+(``agent_sharing.allow_proactive``, keyed by verified email) has nobody to key
+on; for Slack the consent unit is the CHANNEL BINDING.
+
+Default posture (identical to the SQLite track in ``db/migrations.py``):
+  * NEW bindings default to 0 (deny) — binding an agent to a channel is not by
+    itself consent to unprompted posts.
+  * EXISTING bindings are backfilled to 1 (allow) — channel posts had no consent
+    gate before this migration, so leaving them at 0 would silently break every
+    working integration.
+
+Revision ID: 0029_slack_channel_allow_proactive
+Revises: 0028_agent_reminders
+Create Date: 2026-07-23
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0029_slack_channel_allow_proactive"
+down_revision = "0028_agent_reminders"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    return column in {c["name"] for c in sa.inspect(bind).get_columns(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _has_column(bind, "slack_channel_agents", "allow_proactive"):
+        return
+    op.add_column(
+        "slack_channel_agents",
+        sa.Column("allow_proactive", sa.Integer(), nullable=True, server_default="0"),
+    )
+    # Preserve today's behavior for bindings that already exist (no silent flip).
+    op.execute(
+        "UPDATE slack_channel_agents SET allow_proactive = 1 "
+        "WHERE allow_proactive IS NULL OR allow_proactive = 0"
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _has_column(bind, "slack_channel_agents", "allow_proactive"):
+        op.drop_column("slack_channel_agents", "allow_proactive")

--- a/src/backend/migrations/versions/0030_slack_channel_allow_proactive.py
+++ b/src/backend/migrations/versions/0030_slack_channel_allow_proactive.py
@@ -12,16 +12,16 @@ Default posture (identical to the SQLite track in ``db/migrations.py``):
     gate before this migration, so leaving them at 0 would silently break every
     working integration.
 
-Revision ID: 0029_slack_channel_allow_proactive
-Revises: 0028_agent_reminders
+Revision ID: 0030_slack_channel_allow_proactive
+Revises: 0029_product_events
 Create Date: 2026-07-23
 """
 from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision = "0029_slack_channel_allow_proactive"
-down_revision = "0028_agent_reminders"
+revision = "0030_slack_channel_allow_proactive"
+down_revision = "0029_product_events"
 branch_labels = None
 depends_on = None
 

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -2674,6 +2674,11 @@ class TelegramGroupMessageRequest(BaseModel):
     message: str
 
 
+class SlackChannelProactiveRequest(BaseModel):
+    """ent#223 — toggle per-channel proactive consent on a Slack channel binding."""
+    allow_proactive: bool
+
+
 class SlackChannelMessageRequest(BaseModel):
     """Request model for proactive Slack channel messaging (#350)."""
     message: str

--- a/src/backend/routers/slack.py
+++ b/src/backend/routers/slack.py
@@ -409,6 +409,9 @@ async def get_agent_slack_channel(
                 "workspace_team_id": ws["team_id"],
                 "workspace_name": ws["team_name"],
                 "is_dm_default": binding.get("is_dm_default", False),
+                # ent#223: per-channel proactive consent, so the UI can render
+                # (and toggle) the switch instead of it being API-only.
+                "allow_proactive": binding.get("allow_proactive", False),
                 "workspace_agent_count": len(workspace_agents),
                 "created_at": binding.get("created_at"),
             }

--- a/src/backend/routers/slack.py
+++ b/src/backend/routers/slack.py
@@ -20,7 +20,7 @@ from fastapi.responses import RedirectResponse
 
 from database import db
 from dependencies import get_current_user
-from models import SlackChannelMessageRequest, SlackEventResponse, User
+from models import SlackChannelMessageRequest, SlackChannelProactiveRequest, SlackEventResponse, User
 from services import channel_history, rate_limiter
 from services.slack_service import slack_service
 from db_models import SlackConnectionStatus, SlackOAuthInitResponse
@@ -648,6 +648,40 @@ async def list_agent_slack_channels(
     return {"channels": channels, "count": len(channels)}
 
 
+@auth_router.put("/api/agents/{name}/slack/channels/{channel_id}/proactive")
+async def set_slack_channel_proactive(
+    name: str,
+    channel_id: str,
+    request: SlackChannelProactiveRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """ent#223 — toggle proactive-messaging consent for one channel binding.
+
+    Owner-gated, mirroring the channel-message endpoint. This is what makes the
+    flag toggleable from the UI rather than API-only.
+    """
+    if not db.can_user_share_agent(current_user.username, name):  # noqa: inv8 — slack deferred (#1310)
+        raise HTTPException(status_code=403, detail="Only owners can change channel settings")
+
+    target = next(
+        (c for c in db.get_slack_channels_for_agent(name) if c["slack_channel_id"] == channel_id),
+        None,
+    )
+    if not target:
+        raise HTTPException(status_code=404, detail="Channel not found or not bound to this agent")
+
+    updated = db.set_slack_channel_allow_proactive(
+        target["team_id"], channel_id, request.allow_proactive)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Channel binding not found")
+
+    return {
+        "agent_name": name,
+        "slack_channel_id": channel_id,
+        "allow_proactive": request.allow_proactive,
+    }
+
+
 @auth_router.post("/api/agents/{name}/slack/channels/{channel_id}/messages")
 async def send_agent_slack_channel_message(
     name: str,
@@ -680,6 +714,24 @@ async def send_agent_slack_channel_message(
     )
     if not target:
         raise HTTPException(status_code=404, detail="Channel not found or not bound to this agent")
+
+    # ent#223: per-channel proactive consent. Open Slack workspaces have no
+    # verified-email recipient to key the DM-style consent on, so the consent unit
+    # is this channel binding. Refuse with a NAMED, actionable reason so the agent
+    # can relay *why* (consent) rather than a generic failure — and so it is
+    # distinguishable from "not bound" (404 above) and "rate capped" (429 below).
+    if not target.get("allow_proactive"):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "proactive_not_allowed",
+                "message": (
+                    f"Proactive messages are not enabled for channel {channel_id}. "
+                    "Enable 'Allow proactive messages' on this channel binding "
+                    "(agent → Channels → Slack) to let this agent post unprompted."
+                ),
+            },
+        )
 
     # Rate limit: per-channel then per-agent, caps sourced from settings (#1609;
     # 0 = unlimited → skip). Fail-open inside the limiter.

--- a/src/frontend/src/components/SlackChannelPanel.vue
+++ b/src/frontend/src/components/SlackChannelPanel.vue
@@ -63,6 +63,34 @@
         </div>
       </div>
 
+      <!-- Proactive consent (ent#223) — in an open Slack workspace nobody
+           authenticates, so consent is per-CHANNEL, not per-recipient. -->
+      <div class="mt-4 flex items-start justify-between gap-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+        <div class="min-w-0">
+          <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
+            Allow proactive messages
+          </div>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Lets this agent post to #{{ channel.channel_name }} without being asked first
+            (task updates, alerts). Replies to a user always work regardless.
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          :aria-checked="String(!!channel.allow_proactive)"
+          @click="toggleProactive"
+          :disabled="togglingProactive"
+          class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          :class="channel.allow_proactive ? 'bg-action-primary-600' : 'bg-gray-300 dark:bg-gray-600'"
+        >
+          <span
+            class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform"
+            :class="channel.allow_proactive ? 'translate-x-6' : 'translate-x-1'"
+          />
+        </button>
+      </div>
+
       <!-- Voice replies (epic #24 / #26) — shared agent-level TTS control -->
       <VoiceChannelToggle :agent-name="agentName" channel="slack" class="mt-4" />
     </div>
@@ -110,6 +138,7 @@ const unbinding = ref(false)
 const makingDefault = ref(false)
 const accessDenied = ref(false)
 const channel = ref({ bound: false })
+const togglingProactive = ref(false)
 const message = ref(null)
 
 const dmDefaultTooltip =
@@ -185,6 +214,34 @@ async function unbindChannel() {
     message.value = { type: 'error', text: detail }
   } finally {
     unbinding.value = false
+  }
+}
+
+async function toggleProactive() {
+  // ent#223: per-channel proactive consent. Optimistic-free — we re-read the
+  // binding so the switch always reflects what the backend actually stored.
+  togglingProactive.value = true
+  message.value = null
+  const next = !channel.value.allow_proactive
+  try {
+    await axios.put(
+      `/api/agents/${props.agentName}/slack/channels/${channel.value.channel_id}/proactive`,
+      { allow_proactive: next }
+    )
+    message.value = {
+      type: 'success',
+      text: next ? 'Proactive messages enabled for this channel' : 'Proactive messages disabled',
+    }
+    await loadChannel()
+    setTimeout(() => { message.value = null }, 3000)
+  } catch (e) {
+    const detail = e.response?.data?.detail
+    message.value = {
+      type: 'error',
+      text: (detail && (detail.message || detail)) || 'Failed to update proactive setting',
+    }
+  } finally {
+    togglingProactive.value = false
   }
 }
 

--- a/src/mcp-server/src/tools/channels.ts
+++ b/src/mcp-server/src/tools/channels.ts
@@ -254,7 +254,36 @@ export function createChannelTools(
             return JSON.stringify({
               success: false,
               error: "Rate limited. Please wait before sending more messages.",
+              reason: "rate_limited",
               rate_limited: true,
+            }, null, 2);
+          }
+
+          // ent#223: per-channel proactive consent refusal. Kept distinct from a
+          // rate cap (429) and from "not bound" (404) so the agent can relay WHY
+          // it could not post, instead of a generic failure the user can't act on.
+          if (
+            errorMessage.includes("proactive_not_allowed") ||
+            errorMessage.includes("Proactive messages are not enabled")
+          ) {
+            return JSON.stringify({
+              success: false,
+              error: errorMessage,
+              reason: "consent_required",
+              consent_required: true,
+              hint:
+                "Proactive posting is off for this channel. The agent owner can enable " +
+                "'Allow proactive messages' on the channel binding (agent → Channels → Slack). " +
+                "Replying to a user's message does not require this.",
+            }, null, 2);
+          }
+
+          if (errorMessage.includes("not bound") || errorMessage.includes("Channel not found")) {
+            return JSON.stringify({
+              success: false,
+              error: errorMessage,
+              reason: "not_bound",
+              hint: "This agent has no binding for that channel — bind it first.",
             }, null, 2);
           }
 

--- a/tests/unit/test_223_slack_channel_proactive_consent.py
+++ b/tests/unit/test_223_slack_channel_proactive_consent.py
@@ -1,0 +1,156 @@
+"""Per-channel proactive consent for Slack (ent#223).
+
+In an open Slack workspace users never authenticate, so the per-recipient consent
+model (``agent_sharing.allow_proactive``, keyed by verified email) has nobody to
+key on. For Slack the consent unit is the CHANNEL BINDING.
+
+The property that actually matters here is the DEFAULT POSTURE:
+  * a NEW binding denies proactive posts (consent is explicit), and
+  * an EXISTING binding is backfilled to allow, because channel posts had no
+    consent gate before this change — defaulting them to deny would silently
+    break every working integration.
+
+Module: src/backend/db/slack_channels.py, src/backend/db/migrations.py
+Issue:  https://github.com/Abilityai/trinity-enterprise/issues/223
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# IMPORTANT: set REDIS_URL BEFORE any backend import (Issue #589 hard-fail).
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+
+import pytest  # noqa: E402
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+from db_harness import db_backend  # noqa: E402,F401
+
+
+@pytest.fixture
+def ops(db_backend):
+    from db import slack_channels as sc_db
+    return sc_db.SlackChannelOperations()
+
+
+def _bind(ops, channel_id="C1", agent="analytics", team="T1"):
+    ops.bind_channel_to_agent(
+        team_id=team,
+        slack_channel_id=channel_id,
+        slack_channel_name="general",
+        agent_name=agent,
+        created_by="alice",
+    )
+    return ops.get_channel_agent(team, channel_id)
+
+
+class TestDefaultPosture:
+    def test_new_binding_denies_proactive_by_default(self, ops):
+        """Binding an agent to a channel is NOT itself consent to unprompted
+        posts — the flag starts off."""
+        binding = _bind(ops)
+        assert binding is not None
+        assert binding["allow_proactive"] is False
+
+    def test_read_exposes_the_flag_on_the_agent_channel_list(self, ops):
+        """The router gates on this field from get_channels_for_agent, so it has
+        to survive that read path too (not just get_channel_agent)."""
+        _bind(ops)
+        rows = ops.get_channels_for_agent("analytics")
+        assert rows and "allow_proactive" in rows[0]
+        assert rows[0]["allow_proactive"] is False
+
+
+class TestToggle:
+    def test_toggle_on_then_off(self, ops):
+        _bind(ops)
+        assert ops.set_channel_allow_proactive("T1", "C1", True) is True
+        assert ops.get_channel_agent("T1", "C1")["allow_proactive"] is True
+
+        assert ops.set_channel_allow_proactive("T1", "C1", False) is True
+        assert ops.get_channel_agent("T1", "C1")["allow_proactive"] is False
+
+    def test_toggle_unknown_binding_reports_miss(self, ops):
+        """Returns False so the caller raises 404 instead of silently 'succeeding'."""
+        assert ops.set_channel_allow_proactive("T1", "C-nope", True) is False
+
+    def test_toggle_is_scoped_to_one_channel(self, ops):
+        _bind(ops, channel_id="C1")
+        _bind(ops, channel_id="C2", agent="ads")
+        ops.set_channel_allow_proactive("T1", "C1", True)
+        assert ops.get_channel_agent("T1", "C1")["allow_proactive"] is True
+        assert ops.get_channel_agent("T1", "C2")["allow_proactive"] is False
+
+
+class TestMigrationBackfill:
+    """The no-silent-flip guarantee, tested against a REAL pre-migration table."""
+
+    def _legacy_db(self, tmp_path):
+        p = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(p))
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE slack_channel_agents (
+                id TEXT PRIMARY KEY,
+                team_id TEXT NOT NULL,
+                slack_channel_id TEXT NOT NULL,
+                slack_channel_name TEXT,
+                agent_name TEXT NOT NULL,
+                is_dm_default INTEGER DEFAULT 0,
+                created_by TEXT,
+                created_at TEXT NOT NULL,
+                UNIQUE(team_id, slack_channel_id)
+            )
+            """
+        )
+        cur.execute(
+            "INSERT INTO slack_channel_agents "
+            "(id, team_id, slack_channel_id, agent_name, created_at) "
+            "VALUES ('1','T1','C1','analytics','t')"
+        )
+        conn.commit()
+        return conn, cur
+
+    def test_existing_bindings_are_backfilled_to_allow(self, tmp_path):
+        """Existing integrations kept working before the gate existed; the
+        migration must not silently switch them off."""
+        from db.migrations import _migrate_slack_channel_allow_proactive
+        conn, cur = self._legacy_db(tmp_path)
+        _migrate_slack_channel_allow_proactive(cur, conn)
+        conn.commit()
+
+        cur.execute("SELECT allow_proactive FROM slack_channel_agents WHERE id='1'")
+        assert cur.fetchone()[0] == 1, "pre-existing binding must stay allowed"
+
+    def test_rows_created_after_migration_default_to_deny(self, tmp_path):
+        """New bindings get the safe default even on a migrated database."""
+        from db.migrations import _migrate_slack_channel_allow_proactive
+        conn, cur = self._legacy_db(tmp_path)
+        _migrate_slack_channel_allow_proactive(cur, conn)
+        cur.execute(
+            "INSERT INTO slack_channel_agents "
+            "(id, team_id, slack_channel_id, agent_name, created_at) "
+            "VALUES ('2','T1','C2','ads','t')"
+        )
+        conn.commit()
+        cur.execute("SELECT allow_proactive FROM slack_channel_agents WHERE id='2'")
+        assert cur.fetchone()[0] == 0, "a NEW binding must deny by default"
+
+    def test_migration_is_idempotent(self, tmp_path):
+        """Re-running must not re-backfill a binding an operator turned OFF."""
+        from db.migrations import _migrate_slack_channel_allow_proactive
+        conn, cur = self._legacy_db(tmp_path)
+        _migrate_slack_channel_allow_proactive(cur, conn)
+        cur.execute("UPDATE slack_channel_agents SET allow_proactive = 0 WHERE id='1'")
+        conn.commit()
+
+        _migrate_slack_channel_allow_proactive(cur, conn)   # second run
+        conn.commit()
+        cur.execute("SELECT allow_proactive FROM slack_channel_agents WHERE id='1'")
+        assert cur.fetchone()[0] == 0, "an operator's explicit OFF must survive re-runs"


### PR DESCRIPTION
Backend for **ent#223** — the partner fast-follow from the 2026-07-23 call. Built **OSS-core** (confirmed with the owner): the flag lives on `slack_channel_agents`, an OSS table, and **Invariant #3** forbids an enterprise migration from ALTERing an OSS table — so consent here is an edition-agnostic safety primitive (the `users.suspended_at` #995 pattern).

## Problem
Proactive consent was per-**recipient** (`agent_sharing.allow_proactive`, keyed by verified email). In an open Slack workspace nobody authenticates, so there's no recipient record to opt in — and channel posts had **no consent gate at all**, only the owner check + #1609 rate caps.

## What changed
- `slack_channel_agents.allow_proactive` — dual-track migration (SQLite `db/migrations.py` + Alembic `0029`), plus `schema.py` DDL and `tables.py` MetaData.
- **Default posture, deliberately split so nothing silently flips:**
  - **NEW** bindings → `0` (deny). Binding an agent to a channel isn't itself consent to unprompted posts.
  - **EXISTING** bindings → backfilled to `1` (allow), because channel posts worked with no gate before this. The AC is explicit that existing behavior must not silently flip.
  - The backfill runs only when *this* caller added the column, so an operator's later explicit **OFF survives re-runs** (tested).
- **Enforcement** in `send_agent_slack_channel_message`, placed between the **404** (not bound) and the **429** (rate capped) so all three refusal reasons stay distinguishable, returning a named actionable `proactive_not_allowed`. Rate caps still apply on top.
- **Toggle endpoint** `PUT /api/agents/{name}/slack/channels/{channel_id}/proactive` (owner-gated) so it isn't API-only.

## Tests
8 unit tests — default-deny for new bindings, flag on both read paths, toggle + scoping, unknown-binding miss, and the migration's no-silent-flip backfill, post-migration default, and idempotency. Green on SQLite (harness also runs PG when `TEST_POSTGRES_URL` is set).

## ⚠️ Alembic head collision to resolve at merge
This is `0029_...` off `0028_agent_reminders`. My open PR #1752 also adds a `0029_agent_evaluations` off the same parent — **two heads would break boot**. Whichever merges second needs a one-line `down_revision` rebase.

## Not in this PR (remaining ent#223 AC)
- The **channel-binding UI toggle** (`SlackChannelPanel.vue`) — the endpoint is here, the switch isn't yet.
- **MCP `send_group_message`** relaying the named reason to the agent.
- **Docs** (Slack proactive = per-channel consent; DM stays per-recipient).

Unblocks ent#224 (completion report-back is gated on this consent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)