### PR TITLE
feat(slack): report a finished task back to its originating channel/thread (ent#224)

### DIFF
--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -253,6 +253,11 @@ class ParallelTaskRequest(BaseModel):
     resume_session_id: Optional[str] = None  # Claude Code session ID to resume (EXEC-023)
     inject_result: Optional[bool] = False  # If true and self-task, inject result as message in originating chat session (SELF-EXEC-001)
     files: Optional[List[WebFileUpload]] = None  # File attachments (#364)
+    # ent#224: the CALLER's current execution id. When agent A delegates to B,
+    # B inherits A's originating channel/thread from this row, so B's completion
+    # can be reported back to the Slack thread the work actually came from.
+    # Optional and fail-open — absent means "no channel context to inherit".
+    parent_execution_id: Optional[str] = None
 
 
 # ============================================================================

--- a/src/backend/services/channel_completion_report.py
+++ b/src/backend/services/channel_completion_report.py
@@ -1,0 +1,175 @@
+"""Report a finished task back to the Slack channel/thread it came from (ent#224).
+
+The scenario this exists for: a user asks an agent in Slack, the agent kicks off
+(or delegates) a long-running job, the job finishes — and today nobody tells the
+user. The trigger side worked; the completion side died silently.
+
+Everything here is a JOIN of parts that already exist:
+  * task-completion terminals (#1578) give the chokepoint,
+  * ``schedule_executions.source_channel`` / ``_chat_id`` / ``_thread`` (ent#117)
+    give the destination,
+  * ``slack_service.send_message_detailed`` (#1649) gives the send + thread_ts,
+  * ``slack_channel_agents.allow_proactive`` (ent#223) gives consent,
+  * ``idempotency_service.effect_guard`` (#1084) gives at-most-once.
+
+**The no-double-post rule.** A direct channel turn is synchronous — the adapter
+already replies inline — and is recorded with ``triggered_by`` == the channel
+name. Reporting on those would duplicate every normal Slack reply. So we report
+ONLY when the execution *inherited* its channel context (a delegated or
+background terminal), i.e. ``triggered_by`` is NOT a channel trigger. That single
+condition is what keeps a customer workspace from being spammed.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Triggers whose executions ALREADY reply inline through the channel adapter.
+# An execution carrying one of these must never be reported again.
+INLINE_CHANNEL_TRIGGERS = frozenset({"slack", "telegram", "whatsapp"})
+
+# v1 covers Slack only — it is the channel the partner scenario needs and the one
+# with a per-channel consent unit (ent#223). Telegram/WhatsApp are group-shaped
+# differently and are a deliberate follow-up.
+SUPPORTED_CHANNELS = frozenset({"slack"})
+
+_MAX_REPORT_CHARS = 2800
+
+
+def _summarize(status: str, summary_or_error: Optional[str]) -> str:
+    """A short, honest completion line. Failures report too — a silent failure is
+    exactly the bug this closes."""
+    body = (summary_or_error or "").strip()
+    if len(body) > _MAX_REPORT_CHARS:
+        body = body[:_MAX_REPORT_CHARS].rstrip() + "…"
+    if status == "success":
+        head = "✅ Task finished"
+        return f"{head}\n\n{body}" if body else head
+    head = f"⚠️ Task ended with status `{status}`"
+    return f"{head}\n\n{body}" if body else head
+
+
+def _channel_allows_proactive(agent_name: str, channel_id: str) -> tuple[bool, Optional[str]]:
+    """ent#223 consent gate. Returns (allowed, team_id)."""
+    from database import db
+
+    binding = next(
+        (c for c in db.get_slack_channels_for_agent(agent_name)
+         if c.get("slack_channel_id") == channel_id),
+        None,
+    )
+    if not binding:
+        return False, None
+    return bool(binding.get("allow_proactive")), binding.get("team_id")
+
+
+async def report_completion(
+    *,
+    execution_id: str,
+    agent_name: str,
+    status: str,
+    summary_or_error: Optional[str],
+) -> bool:
+    """Post the terminal back to its originating channel/thread. Returns True if a
+    message was delivered. Never raises — a reporting failure must not disturb the
+    execution that already completed.
+
+    The destination + trigger are read from the execution row itself, so every
+    terminal chokepoint stays a one-liner and can't drift out of sync with what
+    was actually persisted.
+    """
+    try:
+        from database import db
+
+        row = db.get_execution(execution_id) if execution_id else None
+        if row is None:
+            return False
+        source_channel = getattr(row, "source_channel", None)
+        source_channel_chat_id = getattr(row, "source_channel_chat_id", None)
+        source_channel_thread = getattr(row, "source_channel_thread", None)
+        triggered_by = getattr(row, "triggered_by", None)
+
+        if not source_channel or not source_channel_chat_id:
+            return False                      # nothing to report back to
+        if source_channel not in SUPPORTED_CHANNELS:
+            return False
+        if (triggered_by or "") in INLINE_CHANNEL_TRIGGERS:
+            return False                      # the adapter already replied — no double-post
+
+        allowed, team_id = _channel_allows_proactive(agent_name, source_channel_chat_id)
+        if not allowed:
+            logger.info(
+                "[ent#224] completion report suppressed for %s: channel %s has no "
+                "proactive consent (or no binding)", agent_name, source_channel_chat_id)
+            return False
+
+        from database import db
+        from services.idempotency_service import EffectInProgressError, effect_guard
+        from services.slack_service import slack_service
+
+        bot_token = db.get_slack_workspace_bot_token(team_id) if team_id else None
+        if not bot_token:
+            logger.warning("[ent#224] no Slack bot token for team %s; cannot report", team_id)
+            return False
+
+        # At-most-once per (execution, destination) — a re-delivered or retried
+        # terminal must not post the same completion twice (#1084). Identity is
+        # the resolved destination only, never the generated body.
+        try:
+            async with effect_guard(
+                "channel_completion_report",
+                {
+                    "channel": source_channel,
+                    "chat_id": source_channel_chat_id,
+                    "thread": source_channel_thread or "",
+                },
+                execution_id=execution_id,
+                agent_name=agent_name,
+            ) as guard:
+                if guard.replay:
+                    return False              # already reported — do NOT re-post
+
+                ok, error, _ts = await slack_service.send_message_detailed(
+                    bot_token=bot_token,
+                    channel=source_channel_chat_id,
+                    text=_summarize(status, summary_or_error),
+                    username=agent_name,
+                    thread_ts=source_channel_thread,   # answer IN the originating thread
+                )
+                if not ok:
+                    logger.warning("[ent#224] Slack completion report failed for %s: %s",
+                                   execution_id, error)
+                    return False
+                guard.snapshot = {"reported": True, "channel": source_channel_chat_id}
+        except EffectInProgressError:
+            # A concurrent attempt holds the claim — never post a second copy.
+            return False
+
+        logger.info("[ent#224] reported %s terminal of %s back to %s",
+                    status, execution_id, source_channel_chat_id)
+        return True
+    except Exception as e:  # noqa: BLE001 — never disturb a completed execution
+        logger.warning("[ent#224] completion report raised for %s: %s", execution_id, e)
+        return False
+
+
+def spawn_completion_report(**kwargs) -> None:
+    """Fire-and-forget wrapper mirroring ``spawn_task_terminal_event`` (#1578).
+
+    Keeps a strong reference to the task (the #1083 GC footgun) and is a no-op
+    when there is no running loop.
+    """
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    task = loop.create_task(report_completion(**kwargs))
+    _inflight.add(task)
+    task.add_done_callback(_inflight.discard)
+
+
+_inflight: set = set()

--- a/src/backend/services/chat_execution_service.py
+++ b/src/backend/services/chat_execution_service.py
@@ -684,6 +684,34 @@ _TaskDerivation = namedtuple(
 )
 
 
+
+def _inherited_channel_context(request) -> tuple:
+    """ent#224: resolve the originating channel/thread from the CALLER's execution.
+
+    When agent A (answering in Slack) delegates to agent B, B's row would carry no
+    channel context and B's completion would have nowhere to go — that is exactly
+    the reported failure. If the caller passes its own ``parent_execution_id`` we
+    copy the destination down, so B's terminal can report into A's thread.
+
+    Fail-open: any miss returns (None, None, None) and behaviour is unchanged.
+    """
+    parent_id = getattr(request, "parent_execution_id", None)
+    if not parent_id:
+        return (None, None, None)
+    try:
+        from database import db
+        parent = db.get_execution(parent_id)
+        if parent is None:
+            return (None, None, None)
+        return (
+            getattr(parent, "source_channel", None),
+            getattr(parent, "source_channel_chat_id", None),
+            getattr(parent, "source_channel_thread", None),
+        )
+    except Exception:  # noqa: BLE001 — never fail a dispatch over provenance
+        return (None, None, None)
+
+
 async def run_async_task(
     agent_name: str,
     request: ParallelTaskRequest,
@@ -723,11 +751,15 @@ async def run_async_task(
     # signaled even if the post-task side effects below raise.
     result = None
     chat_session_id = None
+    _src_ch, _src_chat, _src_thread = _inherited_channel_context(request)
     try:
         result = await task_service.execute_task(
             agent_name=agent_name,
             message=request.message,
             triggered_by=triggered_by,
+            source_channel=_src_ch,
+            source_channel_chat_id=_src_chat,
+            source_channel_thread=_src_thread,
             source_user_id=user_id,
             source_user_email=user_email,
             source_agent_name=x_source_agent,

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -46,6 +46,7 @@ from services.capacity_manager import (
 )
 from services.dispatch_breaker import DispatchBreaker
 from services import event_dispatch_service
+from services import channel_completion_report
 from services.platform_audit_service import AuditEventType, platform_audit_service
 from services.settings_service import settings_service
 from utils.credential_sanitizer import sanitize_dict, sanitize_execution_log, sanitize_response, sanitize_text
@@ -840,6 +841,16 @@ async def _write_terminal_and_gate(
             terminal_status=status,
             summary_or_error=error,
             cost=cost,
+        )
+        # ent#224: tell the originating Slack channel/thread the job ended.
+        # Failure terminals report too — a silent failure is the bug this closes.
+        # No-ops unless the execution INHERITED channel context (never for an
+        # inline channel turn, which the adapter already answered).
+        channel_completion_report.spawn_completion_report(
+            execution_id=execution_id,
+            agent_name=agent_name,
+            status=str(getattr(status, "value", status)),
+            summary_or_error=error,
         )
     return won
 
@@ -1886,6 +1897,14 @@ class TaskExecutionService:
                 summary_or_error=sanitized_resp,
                 duration_ms=envelope.execution_time_ms,
                 cost=total_cost,
+            )
+            # ent#224: report the finished job back to its originating Slack
+            # channel/thread (no-op unless the context was inherited).
+            channel_completion_report.spawn_completion_report(
+                execution_id=eid,
+                agent_name=agent_name,
+                status="success",
+                summary_or_error=sanitized_resp,
             )
 
             return TaskExecutionResult(

--- a/src/mcp-server/src/tools/chat.ts
+++ b/src/mcp-server/src/tools/chat.ts
@@ -155,6 +155,9 @@ export interface RunAgentChatParams {
   async?: boolean;
   inject_result?: boolean;
   chat_session_id?: string;
+  /** ent#224: YOUR current execution_id, so the delegated task inherits the
+   *  Slack channel/thread this work came from and can report back on finish. */
+  execution_id?: string;
 }
 
 /**
@@ -181,6 +184,7 @@ export async function runAgentChat(
     model,
     allowed_tools,
     system_prompt,
+    execution_id,
     timeout_seconds,
     async: asyncMode,
     inject_result,
@@ -287,6 +291,9 @@ export async function runAgentChat(
         // SELF-EXEC-001: Pass inject_result and chat_session_id for self-tasks
         inject_result: isSelfTask ? inject_result : undefined,
         chat_session_id: isSelfTask ? chat_session_id : undefined,
+        // ent#224: carry the caller's execution so the child inherits the
+        // originating channel/thread and its completion can be reported back.
+        parent_execution_id: execution_id,
       },
       sourceAgent,
       mcpKeyInfo,
@@ -459,6 +466,14 @@ export function createChatTools(
           .describe(
             "Chat session ID to link this self-task to. Required for inject_result=true. " +
             "The result will be injected into this session when the task completes."
+          ),
+        execution_id: z
+          .string()
+          .optional()
+          .describe(
+            "Your CURRENT execution_id. Pass it when delegating long-running work so the " +
+            "delegated task inherits the channel/thread this request came from and its " +
+            "completion is reported back there (ent#224). Optional."
           ),
       }),
       execute: async (

--- a/tests/unit/test_224_channel_completion_report.py
+++ b/tests/unit/test_224_channel_completion_report.py
@@ -1,0 +1,179 @@
+"""Report a finished task back to its originating Slack channel/thread (ent#224).
+
+The property that matters most here is the **no-double-post rule**: a direct
+channel turn is synchronous and the adapter already replies inline, so reporting
+on it would duplicate every normal Slack reply in a customer workspace. Only an
+execution that INHERITED its channel context (a delegated/background terminal)
+may report.
+
+Module: src/backend/services/channel_completion_report.py
+Issue:  https://github.com/Abilityai/trinity-enterprise/issues/224
+"""
+
+import asyncio
+import os
+import sys
+import types
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+
+import pytest  # noqa: E402
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from services import channel_completion_report as ccr  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _execution(*, triggered_by="agent", channel="slack", chat_id="C123", thread="1.5"):
+    return types.SimpleNamespace(
+        source_channel=channel,
+        source_channel_chat_id=chat_id,
+        source_channel_thread=thread,
+        triggered_by=triggered_by,
+    )
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Wire every collaborator; return the list of sends that actually happened."""
+    sent = []
+
+    async def _send(**kwargs):
+        sent.append(kwargs)
+        return (True, None, "9999.0001")
+
+    fake_slack = types.SimpleNamespace(send_message_detailed=_send)
+    monkeypatch.setitem(sys.modules, "services.slack_service",
+                        types.SimpleNamespace(slack_service=fake_slack))
+
+    fake_db = types.SimpleNamespace(
+        get_execution=lambda eid: _execution(),
+        get_slack_channels_for_agent=lambda a: [
+            {"slack_channel_id": "C123", "team_id": "T1", "allow_proactive": True}],
+        get_slack_workspace_bot_token=lambda t: "xoxb-test",
+    )
+    monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(db=fake_db))
+
+    class _G:
+        replay = False
+        snapshot = None
+
+    @asynccontextmanager
+    async def _guard(*a, **k):
+        yield _G()
+
+    monkeypatch.setitem(
+        sys.modules, "services.idempotency_service",
+        types.SimpleNamespace(effect_guard=_guard,
+                              EffectInProgressError=type("E", (Exception,), {})))
+    return sent, fake_db
+
+
+def _report(**over):
+    kw = dict(execution_id="e1", agent_name="analytics",
+              status="success", summary_or_error="done")
+    kw.update(over)
+    return _run(ccr.report_completion(**kw))
+
+
+class TestNoDoublePost:
+    @pytest.mark.parametrize("trigger", ["slack", "telegram", "whatsapp"])
+    def test_inline_channel_turn_is_never_reported(self, wired, trigger):
+        """The adapter already answered this turn — reporting would duplicate
+        every normal Slack reply."""
+        sent, db = wired
+        db.get_execution = lambda eid: _execution(triggered_by=trigger)
+        assert _report() is False
+        assert sent == []
+
+    def test_delegated_terminal_is_reported(self, wired):
+        """A→B delegation: B inherited A's thread, so B's completion reports."""
+        sent, _ = wired
+        assert _report() is True
+        assert len(sent) == 1
+        assert sent[0]["channel"] == "C123"
+        assert sent[0]["thread_ts"] == "1.5"      # answers IN the originating thread
+
+
+class TestConsentGate:
+    def test_no_consent_means_no_post(self, wired):
+        """ent#223 consent is required for an unprompted post."""
+        sent, db = wired
+        db.get_slack_channels_for_agent = lambda a: [
+            {"slack_channel_id": "C123", "team_id": "T1", "allow_proactive": False}]
+        assert _report() is False
+        assert sent == []
+
+    def test_unbound_channel_means_no_post(self, wired):
+        sent, db = wired
+        db.get_slack_channels_for_agent = lambda a: []
+        assert _report() is False
+        assert sent == []
+
+
+class TestScope:
+    def test_no_channel_context_is_a_noop(self, wired):
+        sent, db = wired
+        db.get_execution = lambda eid: _execution(channel=None, chat_id=None)
+        assert _report() is False
+        assert sent == []
+
+    def test_non_slack_channel_is_out_of_scope_in_v1(self, wired):
+        sent, db = wired
+        db.get_execution = lambda eid: _execution(channel="telegram", triggered_by="agent")
+        assert _report() is False
+        assert sent == []
+
+    def test_failure_terminals_report_too(self, wired):
+        """Honest status — a silent failure is the bug this closes."""
+        sent, _ = wired
+        assert _report(status="failed", summary_or_error="boom") is True
+        assert "failed" in sent[0]["text"]
+
+    def test_missing_execution_row_is_a_noop(self, wired):
+        sent, db = wired
+        db.get_execution = lambda eid: None
+        assert _report() is False
+        assert sent == []
+
+
+class TestIdempotency:
+    def test_replay_does_not_repost(self, wired, monkeypatch):
+        """A re-delivered/retried terminal must not post the completion twice."""
+        sent, _ = wired
+
+        class _G:
+            replay = True
+            snapshot = {"reported": True}
+
+        @asynccontextmanager
+        async def _guard(*a, **k):
+            yield _G()
+
+        monkeypatch.setitem(
+            sys.modules, "services.idempotency_service",
+            types.SimpleNamespace(effect_guard=_guard,
+                                  EffectInProgressError=type("E", (Exception,), {})))
+        assert _report() is False
+        assert sent == []
+
+
+def test_reporter_never_raises(wired):
+    """A reporting failure must never disturb an execution that already finished."""
+    sent, db = wired
+
+    def _boom(_):
+        raise RuntimeError("db down")
+
+    db.get_execution = _boom
+    assert _report() is False        # swallowed, not raised


### PR DESCRIPTION
Closes the partner scenario from the 2026-07-23 call: *user asks in Slack → agent delegates a ~10-minute job → job succeeds → **nobody tells the user**.*

> **Stacked on #1761** (ent#223 consent) — it needs the per-channel consent gate. Base is the #1761 branch; retarget to `dev` once that merges.

## The issue called this "a join". It wasn't — two things were missing
1. **Channel context didn't survive delegation.** The A→B path never forwarded `source_channel*`, so B's row had **no destination**. `ParallelTaskRequest` gains `parent_execution_id`; `chat_execution_service` copies the parent's channel/chat/thread down (fail-open). MCP `chat_with_agent` gains an optional `execution_id`, mirroring the #1084 effect tools.
2. **Nothing reported at the terminal.** New `channel_completion_report` posts the outcome to the originating channel/thread, hooked at **both** CAS-won chokepoints beside `spawn_task_terminal_event` (#1578) — **success and failure**, since a silent failure is the bug.

## ⚠️ The load-bearing safety rule
A direct channel turn is **synchronous and already replies inline**, and those rows carry `triggered_by` == the channel name. Reporting them would **duplicate every normal Slack reply in a customer workspace**. So we report **only when the context was INHERITED** (`triggered_by` not in `{slack, telegram, whatsapp}`). That single condition is what keeps this from spamming the partner.

Also: ent#223 consent-gated · at-most-once via `effect_guard` (#1084) keyed on the **resolved destination**, never the generated body · Slack-only in v1 · fail-soft (a reporting failure never disturbs an execution that already completed and was billed).

## Tests — 12, green
Double-post guard across all three channel triggers · delegated reporting into the right thread · consent + unbound gates · no-context / non-Slack / missing-row no-ops · failure terminals report · replay doesn't re-post · never-raises.

## Honest limits
- **Not verified against live Slack** — the send path is mocked in tests. The posting primitive (`send_message_detailed`) is the same one #1649 already uses in production, but an end-to-end run needs a real workspace.
- **Opt-in by construction**: nothing reports until an agent passes `execution_id` when delegating *and* the channel has consent enabled.

Related to ent#224 · needs #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)