### PR TITLE
fix(templates): v0.8.5 default-manifest audit — ship starter-trio slash commands + audit pins (trinity-enterprise#239)

### DIFF
--- a/config/agent-templates/sage/.claude/commands/analyze.md
+++ b/config/agent-templates/sage/.claude/commands/analyze.md
@@ -1,0 +1,13 @@
+---
+description: Conduct strategic analysis of a question or situation
+argument-hint: [question or situation]
+---
+Conduct strategic analysis of: $ARGUMENTS
+
+If no question or situation was provided, ask what to analyze and stop.
+
+1. Frame the problem or question
+2. Gather relevant research (check Scout's findings under /home/developer/shared-in/)
+3. Apply analytical frameworks
+4. Develop insights and implications
+5. Save the analysis to /home/developer/shared-out/strategy/analyses/

--- a/config/agent-templates/sage/.claude/commands/briefing.md
+++ b/config/agent-templates/sage/.claude/commands/briefing.md
@@ -1,0 +1,13 @@
+---
+description: Generate an executive briefing on a topic
+argument-hint: [topic]
+---
+Generate an executive briefing on: $ARGUMENTS
+
+If no topic was provided, ask for one and stop.
+
+1. Gather the latest research from Scout (/home/developer/shared-in/)
+2. Synthesize key findings
+3. Add strategic implications
+4. Format for executive consumption
+5. Save the briefing to /home/developer/shared-out/strategy/briefings/

--- a/config/agent-templates/sage/.claude/commands/framework.md
+++ b/config/agent-templates/sage/.claude/commands/framework.md
@@ -1,0 +1,9 @@
+---
+description: Apply a strategic framework (SWOT, Porter's Five Forces, Value Chain, BCG Matrix, Ansoff Matrix)
+argument-hint: [framework-name] [subject]
+---
+Apply a strategic framework to a subject: $ARGUMENTS
+
+The first word is the framework, the rest is the subject. Supported frameworks (see CLAUDE.md): SWOT, Porter's Five Forces, Value Chain, BCG Matrix, Ansoff Matrix. If the framework or subject is missing, ask for them and stop.
+
+Apply the framework rigorously and save the result to /home/developer/shared-out/strategy/frameworks/

--- a/config/agent-templates/sage/.claude/commands/recommend.md
+++ b/config/agent-templates/sage/.claude/commands/recommend.md
@@ -1,0 +1,13 @@
+---
+description: Provide strategic recommendations for a decision
+argument-hint: [decision context]
+---
+Provide strategic recommendations for: $ARGUMENTS
+
+If no decision context was provided, ask for it and stop.
+
+1. Understand the decision context
+2. Identify options and alternatives
+3. Evaluate trade-offs
+4. Recommend with rationale
+5. Save the document to /home/developer/shared-out/strategy/recommendations/

--- a/config/agent-templates/sage/.claude/commands/request-research.md
+++ b/config/agent-templates/sage/.claude/commands/request-research.md
@@ -1,0 +1,9 @@
+---
+description: Request Scout to conduct research on a topic
+argument-hint: [topic]
+---
+Request research from Scout on: $ARGUMENTS
+
+If no topic was provided, ask for one and stop.
+
+Use the Trinity MCP server: find the Scout agent via mcp__trinity__list_agents() (named acme-scout when deployed as the acme system, scout when deployed individually), then send it the request with mcp__trinity__chat_with_agent(agent_name=..., message="/research $ARGUMENTS"). Report back what Scout returned.

--- a/config/agent-templates/scout/.claude/commands/competitors.md
+++ b/config/agent-templates/scout/.claude/commands/competitors.md
@@ -1,0 +1,12 @@
+---
+description: Analyze competitors in a market segment
+argument-hint: [industry or company]
+---
+Analyze competitors for: $ARGUMENTS
+
+If no industry or company was provided, ask which to analyze and stop.
+
+1. Identify the key players
+2. Analyze their strengths and weaknesses
+3. Map competitive positioning
+4. Save the profile to /home/developer/shared-out/research/competitors/

--- a/config/agent-templates/scout/.claude/commands/opportunities.md
+++ b/config/agent-templates/scout/.claude/commands/opportunities.md
@@ -1,0 +1,12 @@
+---
+description: Find market opportunities
+argument-hint: [market]
+---
+Find market opportunities in: $ARGUMENTS
+
+If no market was provided, ask which market to analyze and stop.
+
+1. Analyze market gaps
+2. Evaluate potential
+3. Prioritize by feasibility
+4. Save the brief to /home/developer/shared-out/research/opportunities/

--- a/config/agent-templates/scout/.claude/commands/research.md
+++ b/config/agent-templates/scout/.claude/commands/research.md
@@ -1,0 +1,12 @@
+---
+description: Research a specific topic or market
+argument-hint: [topic]
+---
+Conduct comprehensive market research on: $ARGUMENTS
+
+If no topic was provided, ask what to research and stop.
+
+1. Define the scope and key questions
+2. Gather information from multiple sources
+3. Analyze and synthesize findings
+4. Save the report to /home/developer/shared-out/research/ using the file-naming convention in CLAUDE.md ({date}-{topic}-{type}.md)

--- a/config/agent-templates/scout/.claude/commands/status.md
+++ b/config/agent-templates/scout/.claude/commands/status.md
@@ -1,0 +1,4 @@
+---
+description: Check recent research activity
+---
+Report on recent research activity and pending tasks: list what has been saved under /home/developer/shared-out/research/ (if anything), and any requests from Sage or Scribe you have not completed yet. If nothing has been produced, say so honestly and suggest what to research first.

--- a/config/agent-templates/scout/.claude/commands/trends.md
+++ b/config/agent-templates/scout/.claude/commands/trends.md
@@ -1,0 +1,12 @@
+---
+description: Identify current trends in a domain
+argument-hint: [domain]
+---
+Identify trends in: $ARGUMENTS
+
+If no domain was provided, ask which domain to scan and stop.
+
+1. Scan for emerging patterns
+2. Categorize by impact and timeline
+3. Assess implications
+4. Save the report to /home/developer/shared-out/research/trends/

--- a/config/agent-templates/scribe/.claude/commands/deliverable.md
+++ b/config/agent-templates/scribe/.claude/commands/deliverable.md
@@ -1,0 +1,13 @@
+---
+description: Package a complete client deliverable
+argument-hint: [project-name]
+---
+Package a complete client deliverable for: $ARGUMENTS
+
+If no project name was provided, ask for one and stop.
+
+1. Collect all relevant research and strategy from the shared folders
+2. Create a cohesive narrative
+3. Format professionally per the writing standards in CLAUDE.md
+4. Include appendices as needed
+5. Save it to /home/developer/shared-out/deliverables/

--- a/config/agent-templates/scribe/.claude/commands/proposal.md
+++ b/config/agent-templates/scribe/.claude/commands/proposal.md
@@ -1,0 +1,13 @@
+---
+description: Draft a client proposal
+argument-hint: [client] [engagement-type]
+---
+Draft a client proposal for: $ARGUMENTS
+
+If the client or engagement type is missing, ask for them and stop.
+
+1. Understand client context and needs
+2. Define engagement scope and approach
+3. Outline deliverables and timeline
+4. Include investment and terms
+5. Save it to /home/developer/shared-out/deliverables/proposals/

--- a/config/agent-templates/scribe/.claude/commands/report.md
+++ b/config/agent-templates/scribe/.claude/commands/report.md
@@ -1,0 +1,12 @@
+---
+description: Create a professional report (brief, full, or executive)
+argument-hint: [topic] [brief|full|executive]
+---
+Create a professional report on: $ARGUMENTS
+
+The last word may be a format: brief (1-2 pages), full (5-10 pages), or executive (2-3 pages, C-suite focused); default to brief. If no topic was provided, ask for one and stop.
+
+1. Gather research from Scout's findings (/home/developer/shared-in/)
+2. Incorporate Sage's strategic analysis
+3. Structure and write the report per the writing standards in CLAUDE.md
+4. Save it to /home/developer/shared-out/deliverables/reports/

--- a/config/agent-templates/scribe/.claude/commands/status.md
+++ b/config/agent-templates/scribe/.claude/commands/status.md
@@ -1,0 +1,4 @@
+---
+description: Check recent content production
+---
+Report on recent content production and pending work: list what has been saved under /home/developer/shared-out/deliverables/ (if anything), and any requests from the team you have not completed yet. If nothing has been produced, say so honestly and suggest what to create first.

--- a/config/agent-templates/scribe/.claude/commands/summary.md
+++ b/config/agent-templates/scribe/.claude/commands/summary.md
@@ -1,0 +1,12 @@
+---
+description: Create an executive summary of a document or topic
+argument-hint: [source]
+---
+Create an executive summary of: $ARGUMENTS
+
+If no source document or topic was provided, ask for one and stop.
+
+1. Read the source document or research the topic in the shared folders
+2. Extract key points and insights
+3. Write a concise summary (1 page max)
+4. Save it to /home/developer/shared-out/deliverables/summaries/

--- a/tests/unit/test_ent124_default_system_seed.py
+++ b/tests/unit/test_ent124_default_system_seed.py
@@ -162,6 +162,12 @@ def test_bundled_manifest_local_templates_exist_in_tree():
             f"{short}: bundled manifest references '{cfg.template}' but "
             f"{template_dir}/template.yaml does not exist — this would seed a blank agent"
         )
+        # ent#239: template.yaml alone still deploys "successfully" but seeds an
+        # agent with no instructions — CLAUDE.md is the zero-cred usefulness bar.
+        assert (template_dir / "CLAUDE.md").is_file(), (
+            f"{short}: '{cfg.template}' ships no CLAUDE.md — the agent would "
+            f"deploy but have no instructions (fails the zero-cred useful bar)"
+        )
 
 
 # --- gating --------------------------------------------------------------------

--- a/tests/unit/test_ent124_default_system_seed.py
+++ b/tests/unit/test_ent124_default_system_seed.py
@@ -170,6 +170,32 @@ def test_bundled_manifest_local_templates_exist_in_tree():
         )
 
 
+def test_bundled_manifest_templates_ship_declared_commands():
+    """ent#239 live finding: Claude Code intercepts any leading-`/` message
+    before the model sees it, so a command that is only *documented* (in
+    template.yaml / CLAUDE.md prose) fails as typed — `/research` returned
+    "Unknown command: /research" and `/status` hit the built-in. Every command
+    a seeded template declares must ship a real `.claude/commands/<name>.md`
+    (the pattern trinity-system / demo-* templates already follow); a shipped
+    file also shadows same-named built-ins (verified live for /status)."""
+    import yaml
+
+    manifest = system_service.parse_manifest(REAL_MANIFEST.read_text(encoding="utf-8"))
+    for short, cfg in manifest.agents.items():
+        template_dir = REPO_ROOT / "config" / "agent-templates" / cfg.template.split(":", 1)[1]
+        declared = [
+            c["name"]
+            for c in (yaml.safe_load((template_dir / "template.yaml").read_text()) or {}).get("commands", [])
+        ]
+        for cmd in declared:
+            cmd_file = template_dir / ".claude" / "commands" / f"{cmd}.md"
+            assert cmd_file.is_file(), (
+                f"{short}: template.yaml declares command '{cmd}' but ships no "
+                f"{cmd_file.relative_to(REPO_ROOT)} — as typed, /{cmd} is "
+                f"intercepted by the CLI and fails ('Unknown command')"
+            )
+
+
 # --- gating --------------------------------------------------------------------
 
 def test_seeds_on_fresh_install(env):


### PR DESCRIPTION
Pre-release audit of the bundled default-system manifest for v0.8.5 (Abilityai/trinity-enterprise#239). **Verdict: manifest passes — nothing trimmed or replaced.** The audit surfaced one real first-run defect in the starter templates (fixed here) plus one test hardening.

## Audit evidence (per AC)

- **Public / anonymously clonable**: satisfied by construction — the manifest is `local:`-only (scout/sage/scribe), zero network and zero PAT at seed time. `test_bundled_manifest_local_templates_exist_in_tree` pins the `local:`-only invariant and tree existence.
- **Agents create and start (live)**: bundled manifest deployed verbatim through the executor's own path (`POST /api/systems/deploy`, `strict=false` — the exact seed semantics): `status=deployed`, 3/3 agents created and healthy (`clone_status: ok`), full-mesh = 6 permission edges, shared-folder mounts exactly as the templates document (sage sees `shared-in/acme-scout`, scribe sees both), agent MCP keys + `.mcp.json` present zero-cred. Torn down after verification.
- **Zero-cred useful (live first chat)**: scout/sage answered a cold "what can you do?" with useful, accurate onboarding; scribe/scout `/status` produced an honest zero-state report after the fix below. No credentials demanded, no crash, no dead agent.
- **Manifest hygiene (#122 caution)**: clean system name `acme`; no `schedules:`; no `prompt:` override; `full-mesh` + shared folders are deliberate and documented in-manifest (the trio's CLAUDE.md assumes the team shape). Pinned by `test_bundled_manifest_parses_and_validates`.
- **#125 interaction**: resilient deploy IS in the cut. Partial-failure behavior covered by the ent#125 suite + ent#124 seed tests (partial → flag latches + one operator alert; failed → retry next boot).
- **Repo-side findings for #137**: no external repos referenced. Cornelius defects (trinity#1646/#1656) are adjacent but out of manifest scope (separate seeder; declares no commands, so it does not share the defect below). A catalog-wide scan confirmed scout/sage/scribe were the only templates declaring commands without shipping them.

## Finding + fix: documented slash commands failed as typed

Live first-chat exercise caught what the static pass could not: **every documented command in all three templates was broken as typed**. Claude Code intercepts any leading-`/` message before the model sees it — `/research` returned `Unknown command: /research`, `/status` hit the disabled built-in — while the agents' own onboarding replies teach exactly that syntax (first-run paper cut, same class as trinity#1646).

Fix: ship real `.claude/commands/<name>.md` files for all 15 declared commands (the pattern `trinity-system`/`demo-*` templates already follow). Verified live on a fresh agent created from the updated template: `/research` engages per its command file, and a shipped `status.md` **shadows the built-in** `/status`. The startup template copy (`find /template -mindepth 1`) carries dot-dirs, so the files land on first boot.

## Changes

- `config/agent-templates/{scout,sage,scribe}/.claude/commands/*.md` — 15 command files, bodies faithful to each template's CLAUDE.md process docs, graceful no-argument handling
- `tests/unit/test_ent124_default_system_seed.py` — `test_bundled_manifest_templates_ship_declared_commands` (declared↔shipped parity for every manifest-referenced template) + the earlier CLAUDE.md-existence pin

## Verification

```
tests/unit $ python3 -m pytest test_ent124_default_system_seed.py -q
31 passed
```

Live (dev instance, current dev code): manifest dry-run `valid` → deploy `deployed` 3/3 → containers healthy → zero-cred chats useful → command files verified end-to-end (template → create → start → `/research`, `/status`) → all test agents deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)