### PR TITLE
fix(agents): thread adopt_existing_workspace through create_agent_internal facade

### DIFF
--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -104,7 +104,8 @@ async def create_agent_internal(
     config: AgentConfig,
     current_user: User,
     request: Request,
-    skip_name_sanitization: bool = False
+    skip_name_sanitization: bool = False,
+    adopt_existing_workspace: bool = False
 ) -> AgentStatus:
     """
     Internal function to create an agent.
@@ -116,7 +117,8 @@ async def create_agent_internal(
         current_user=current_user,
         request=request,
         skip_name_sanitization=skip_name_sanitization,
-        ws_manager=manager
+        ws_manager=manager,
+        adopt_existing_workspace=adopt_existing_workspace
     )
 
 


### PR DESCRIPTION
Fixes #1768

## Summary

`POST /api/agents/deploy-local` (and the MCP `deploy_local_agent` tool) returned **500** on every call: `deploy.py` passes `adopt_existing_workspace=True` through `create_agent_fn`, but the router facade `create_agent_internal` in `routers/agents.py` never accepted that kwarg — #1667 added it only to the service-layer `crud.py` function. The call died with:

```
TypeError: create_agent_internal() got an unexpected keyword argument 'adopt_existing_workspace'
```

## Change

One facade signature fix in `src/backend/routers/agents.py`: accept `adopt_existing_workspace: bool = False` and forward it to the service-layer `_create_agent_internal(...)` call. Default `False` preserves every other caller's behavior (all callers checked — leading positionals + keywords only, so a trailing default kwarg is inert for them).

## Validation (live dev stack)

- **Red baseline reproduced** before the fix: the exact `TypeError` above returned as a 500 by the running backend.
- **All 7 failing tests from the issue pass** after the fix: `test_deploy_local.py` — `TestDeployLocalSuccessful` (×4), `TestDeployLocalResponse::test_response_structure`, `TestDeployLocalVersioning::test_redeploy_creates_version` — plus `test_agent_quota.py::TestAgentQuotaRedeploy::test_redeploy_existing_agent_bypasses_quota`. Real agent containers created/torn down (7 passed in 150s).
- **Full `test_deploy_local.py`: 16/16 passed** (98s) — auth, validation, security, limits classes included.
- Redeploy/versioning path confirms the #1667 adopt behavior is preserved (pre-populated workspace volume is mounted, not refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)