### PR TITLE
docs(release): 0.8.5 upgrade notes + known limitations + recheck record

### DIFF
--- a/docs/releases/0.8.5-freeze-plan.md
+++ b/docs/releases/0.8.5-freeze-plan.md
@@ -82,3 +82,55 @@ commits pushed by the validator are noted.
 - [ ] Manual cross-tracker closes at release: ent#213 (via 🌐#1751), ent#139 halves,
       ent#169/#170 (rooms shipped), ent#212 auto-closed at enterprise merge
 - [ ] Dependabot batch (#1731, #1736–#1738, #1619) queued for immediately after the cut
+
+---
+
+## Recheck addendum — 2026-07-26 (`/release-plan recheck`)
+
+Full seam fan-out (B1/B2/C/D/E) run over v0.8.0..origin/dev (755 commits, 585 files),
+as the 2026-07-23 plan required. Cut decision: **NO-GO until the 4 MUST-LAND items merge**
+(all opened same day); GO after.
+
+### Prior checklist status
+
+| Item | Status |
+|------|--------|
+| Seam fan-out B1–E + census | ✅ DONE (findings below) |
+| Unit-suite hang | ✅ CLEARED — no recurrence in recent dev CI |
+| Enterprise pointer at TIP | ❌ RE-FIRED — pin 6f073c73 missed e898cef8 (**ent#220 rooms security fix**); fixed by PR #1776 / #1777 |
+| Sessions-view visual smoke | ⚠️ carried forward (Known-limitations line stands) |
+| Cross-tracker closes | ◐ ent#212/#206 closed; ~10 shipped ent issues still status-in-progress → post-cut /groom |
+| Dependabot batch | ⚠️ 3 bumps landed straight on main → main→dev reconcile PR #1777 (merge-commit) |
+| #1742 tool_calls fix | STILL OPEN (now conflicting) — limitations line stands |
+
+### Seam results
+
+- **C (migrations, semantic)**: CLEAN — 16↔16 SQLite↔Alembic pairs column-identical,
+  single chain 0015→0030, 3-way schema parity, enterprise migrations touch zero OSS
+  tables. Cosmetic: stale docstring IDs in 0017/0018.
+- **B2 (vendored twins)**: CLEAN — 0 drift across 12 pairs. 10 base-image files changed
+  → "rebuild base image + recreate agents" upgrade note added to 0.8.5.md.
+- **B1/D (reachability)**: 3 findings — skill-runner admin/ACL surface (6 endpoints,
+  ent#139) UNREACHABLE (**FENCE**: API-only activation documented, admin-surface issue
+  filed); room participant add/remove (ent#169/#170) UNREACHABLE (**FENCE**: fixed-roster
+  limitation documented, tracked under ent#220); dead `GET /label` read twin (trivial).
+- **E (dark flags)**: eval-code leak check CLEAR (PR #1752 held; only the ent#206 design
+  doc shipped). 12 intended-dark features + 8 carried-over dark flags; 3 features ship
+  lit (ent#123 always-on, ent#124 fresh-install-only, **ent#125 default flip** — upgrade
+  note added). Two defects: enterprise `backend/__init__.py` registers skill_runner twice
+  and three modules bypass the ent#196 `_register_module` isolation wrapper (latent,
+  verified at pin AND tip — filed upstream, next cycle); rooms + skill-runner MCP tools
+  register unconditionally on unentitled instances (**DEFER** — limitations line).
+
+### MUST-LAND record (opened 2026-07-26)
+
+| # | PR | What |
+|---|----|------|
+| 1 | #1776 | enterprise pointer → e898cef8 (ent#220 security fix) |
+| 2 | #1777 | main→dev reconcile (13 commits; merge-commit, NOT squash) |
+| 3 | (this PR) | 0.8.5.md upgrade notes (base-image rebuild, ent#125 flip) + Known-limitations block |
+| 4 | #1765 | user-docs reconcile (pre-existing, needs review) |
+
+Deferred with eyes open: N4 `__init__.py` fix (latent; upstream issue filed), Deploy-to-Dev
+infra flake (stale container name on the dev box — soak instance only), label drift
+(post-cut /groom), dependabot queue #1731/#1737/#1619 (post-cut).

--- a/docs/releases/0.8.5.md
+++ b/docs/releases/0.8.5.md
@@ -38,3 +38,60 @@ _Rationale for shipping without a kill-switch, in full, is recorded on ent#187:
 the change is additive, and Phases 2-3 of the skill epic (#139 placement/skill-
 runner, #178 unified exposable-skills config) build on this contract, so a flag
 would have a deliberately short life._
+
+### Base-image rebuild + agent recreate required for several v0.8.5 features
+
+Ten files under `docker/base-image/` changed this release. A running fleet on an
+old base image **degrades safely but silently lacks**:
+
+- **PAT-free clone of public `github:` templates** (trinity-enterprise#123) — an
+  old image skips the tokenless clone path entirely, so a credential-less agent
+  created from a public template comes up empty.
+- **Git maintenance ownership** (#1595/#1596) — auto-gc disable + the auto-sync
+  repack/gc cycle that prevents multi-GB `.git` bloat only exist in the new
+  image.
+- **`gh` CLI preinstalled + `GH_TOKEN`/`GITHUB_TOKEN` wiring** (#1574) — agents
+  on old images still need a manual `gh` install.
+- Pull-worker scaffolding (dark, `PULL_MODE_PILOT_AGENTS`-gated) and hardened
+  credential sanitization.
+
+**Operator action**: run `./scripts/deploy/build-base-image.sh`, then recreate
+agents (a config-drift recreate or stop/start-with-recreate picks up the new
+image). Create-before-rebuild ordering matters for ent#123: build the image
+**before** creating tokenless-template agents.
+
+### System-manifest deploy default changed: continue-on-error (trinity-enterprise#125)
+
+`deploy_system` / `POST /api/systems/deploy` now **continues past per-agent
+failures** and reports partial success (HTTP 200 with `status: "partial"` and a
+per-agent result list) instead of aborting on the first failure. Pass
+`strict: true` in the request body to restore the previous
+abort-on-first-failure behavior. Automation that treated any HTTP 200 as
+"everything deployed" must check the `status` field.
+
+## Known limitations
+
+- **Shared sessions (rooms)** ship entitlement-gated. The participant roster is
+  fixed at room creation — the add/remove-participant endpoints exist but have
+  no UI or MCP surface yet; per-message cost is not yet shown in the transcript;
+  turn chains run synchronously (long chains can outlive the HTTP request).
+  Moderator-only lifecycle mutations and the participant cap **are** enforced
+  (ent#220 fix included). Remaining residuals: trinity-enterprise#220.
+- **Skill runner** ships default-OFF behind its entitlement. Activation —
+  enable, provision, library sync, and per-agent access grants — is currently
+  **API-only** (no UI or MCP admin tools). Grants are not revoked when an agent
+  is deleted/renamed (trinity-enterprise#219); the scratch-sweep runs on
+  successful runs only.
+- **Rooms and skill-runner MCP tools are advertised to all MCP clients**, even
+  on instances without the corresponding entitlement; calls fail with a clear
+  error instead of the tools being hidden.
+- **Telemetry Tier-2 sharing** is opt-in and default-OFF (double-gated, honors
+  `DO_NOT_TRACK`). Fleet benchmarks show a pending status until the hosted
+  benchmark service ships (trinity-enterprise#12 follow-up).
+- **Executions `tool_calls` duplication** (#1741) is NOT fixed in this release —
+  the fix regressed the #1083 `apply_result` contract and was held (PR #1742).
+- **Default system seed** (trinity-enterprise#124) fires on **fresh installs
+  only** — existing instances will not see the starter fleet. An absent
+  `local:` template currently creates a blank agent silently (#1759).
+- The dashboard **Sessions view had no visual e2e pass** at merge time; smoke it
+  on an entitled instance.


### PR DESCRIPTION
## What

Completes the v0.8.5 pre-cut seed per the 2026-07-26 `/release-plan recheck`:

- **Two missing behavior-change notes**: base-image rebuild + agent recreate requirement (10 `docker/base-image/` files changed — ent#123 tokenless clone, #1595 git maintenance, #1574 gh CLI wiring silently absent on old images), and the ent#125 system-deploy **default flip** (continue-on-error + `status: "partial"`; `strict: true` restores).
- **Known-limitations block** for the generated notes: rooms fixed-roster + ent#220 residuals, skill-runner API-only activation, unentitled-visible MCP tools, telemetry Tier-2 default-OFF, #1741 not fixed, ent#124 fresh-install-only + #1759, Sessions-view smoke caveat.
- **Recheck addendum** appended to `0.8.5-freeze-plan.md`: seam-scan results (migrations CLEAN 16↔16, twins CLEAN 0-drift, 3 reachability findings fenced, eval-leak CLEAR), prior-checklist status, MUST-LAND record (#1776, #1777, this PR, #1765).

Docs-only; part of the MUST-LAND set for cutting v0.8.5 today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)