### PR TITLE
fix(tests): test_1474 time-bomb fixture — seed relative to now (#1783)

### DIFF
--- a/tests/unit/test_1474_read_boundary_z.py
+++ b/tests/unit/test_1474_read_boundary_z.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import sqlite3
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -48,8 +48,11 @@ def _restore_sys_modules():
 
 
 # A naive scheduler-written timestamp (no 'Z') and its aware equivalent.
-NAIVE = "2026-07-06T11:00:00.207634"
-INSTANT = datetime(2026, 7, 6, 11, 0, 0, 207634, tzinfo=timezone.utc)
+# Derived from now − 1h, NOT a fixed literal: the schedules-summary read is
+# 168h-windowed, so a literal date rots out of the window and the test becomes
+# a time bomb (#1783 — fired first on the v0.8.5 release PR).
+INSTANT = datetime.now(timezone.utc).replace(microsecond=207634) - timedelta(hours=1)
+NAIVE = INSTANT.replace(tzinfo=None).isoformat()
 
 
 def _assert_utc_normalized(value: str):


### PR DESCRIPTION
Fixes #1783

Test-only, one file. The fixed `2026-07-06` fixture literal rotted out of the 168h schedules-summary window on 2026-07-13; the failure was invisible on dev (matrix runs PR-only; intra-dev PRs fail it on both diff sides) and first fired on the v0.8.5 release PR (#1781) as a head-only failure in all 3 seeds. Seeding `now − 1h` keeps the row in-window forever while preserving the naive no-`Z` string shape the test exists to pin.

Unblocks the v0.8.5 cut — once this lands, #1781 re-runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)