### PR TITLE
docs(releases): v0.8.5 post-release addendum (#1783 shipped, #1782 CI nit)

### DIFF
--- a/docs/releases/0.8.5.md
+++ b/docs/releases/0.8.5.md
@@ -245,6 +245,19 @@ abort-on-first-failure behavior. Automation that treated any HTTP 200 as
 - The dashboard **Sessions view had no visual e2e pass** at merge time; smoke it
   on an entitled instance.
 
+## Commit-reconciled addendum (post-release)
+
+- **#1783** (fix, shipped in the payload): `test_1474_read_boundary_z`'s schedules-summary
+  test was a time bomb — its fixed `2026-07-06` fixture rotted out of the 168h
+  window on 2026-07-13 and had been silently failing on dev since (matrix runs
+  are PR-only; intra-dev PRs fail it on both diff sides). Surfaced by the
+  release PR's first base=main full-suite run; the fixture now seeds relative
+  to now.
+- **#1782** (known CI nit, NOT fixed in this release): the frontend-e2e
+  `changes` path-filter job calls `gh pr diff`, which GitHub refuses for PRs
+  over 300 files — so release-sized PRs show a spurious red X and the e2e
+  suite is skipped, not run.
+
 ---
 
 **Full diff**: [v0.8.0...v0.8.5](https://github.com/abilityai/trinity/compare/v0.8.0...v0.8.5)


### PR DESCRIPTION
Step 10b-2 commit reconciliation for v0.8.5: adds the addendum section to `docs/releases/0.8.5.md` — #1783 (test time-bomb fix that shipped in the payload after the notes were written) and #1782 (the frontend-e2e `changes`-job >300-file red X, not fixed). No other deltas: zero no-issue feat/fix commits in the exact payload range, both trackers fully closed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)