### PR TITLE
docs: stop advertising install paths that fail on a fresh machine (#1788)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@ Trinity is an autonomous agent orchestration platform: every agent runs in its o
 Prerequisites: Docker + Docker Compose v2; an Anthropic API key (Claude agents) or Google API key (Gemini agents).
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/abilityai/trinity/main/install.sh | bash
+git clone https://github.com/abilityai/trinity.git
+cd trinity
+./scripts/deploy/start.sh --unattended
 ```
 
 Then open `http://localhost` → setup wizard → set the admin password → **Settings → API Keys** to add the model API key.

--- a/README.md
+++ b/README.md
@@ -127,15 +127,7 @@ The runbook ([`docs/AGENT_INSTALL_GUIDE.md`](docs/AGENT_INSTALL_GUIDE.md)) is a
 deterministic verify → install → confirm → report-next-steps loop that any
 capable agent can execute and explain to you as it goes.
 
-**One-line install (run it yourself)**
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/abilityai/trinity/main/install.sh | bash
-```
-
-This clones the repository, configures the environment, builds the base image, and starts all services. For a fully non-interactive bring-up (no admin-password prompt — one is generated and printed), run `./scripts/deploy/start.sh --unattended`.
-
-**Manual installation**
+**Install it yourself**
 
 ```bash
 # 1. Clone the repository
@@ -144,8 +136,9 @@ cd trinity
 
 # 2. Configure environment
 cp .env.example .env
-# Edit .env - at minimum set:
-#   SECRET_KEY (generate with: openssl rand -hex 32)
+# Edit .env and set ADMIN_PASSWORD (12+ characters) — the only required edit.
+# start.sh generates SECRET_KEY, the encryption keys and the Redis
+# passwords for you on first run.
 
 # 3. Build the base agent image
 ./scripts/deploy/build-base-image.sh
@@ -154,7 +147,7 @@ cp .env.example .env
 ./scripts/deploy/start.sh
 ```
 
-> Prefer a guided setup? `./quickstart.sh` walks you through it interactively (or `./quickstart.sh --defaults` for non-interactive bring-up with auto-generated secrets).
+For a fully non-interactive bring-up, run `./scripts/deploy/start.sh --unattended` (or set `TRINITY_UNATTENDED=1`) and skip the `.env` edit entirely — an admin password is generated and printed in the final summary.
 
 > **Note**: the repo's git submodules are private and optional — cloning (even with `--recurse-submodules`) needs no credentials; they're skipped automatically. See [docs/ENTERPRISE.md](docs/ENTERPRISE.md).
 

--- a/config/agent-templates/cornelius/CLAUDE.md
+++ b/config/agent-templates/cornelius/CLAUDE.md
@@ -267,8 +267,10 @@ resources/
 
 **Option 2: Self-host Trinity**
 ```bash
-# One-line install
-curl -fsSL https://raw.githubusercontent.com/abilityai/trinity/main/install.sh | bash
+# Install Trinity
+git clone https://github.com/abilityai/trinity.git
+cd trinity
+./scripts/deploy/start.sh --unattended
 
 # Access at localhost (UI) and localhost:8000/docs (API)
 ```

--- a/docs/AGENT_INSTALL_GUIDE.md
+++ b/docs/AGENT_INSTALL_GUIDE.md
@@ -6,7 +6,7 @@
 > **Stable URL** (fetch this mid‑install if you have web access):
 > `https://raw.githubusercontent.com/abilityai/trinity/main/docs/AGENT_INSTALL_GUIDE.md`
 >
-> This guide is versioned with the installer (`install.sh` / `scripts/deploy/start.sh`) — it describes what those scripts actually do, so it never drifts. Scope: the local **"install on my computer"** path (macOS Docker Desktop or Linux). Remote/cloud provisioning is a different flow (`trinity:deploy-new-instance`).
+> This guide is versioned with the installer (`scripts/deploy/start.sh`) — it describes what that script actually does, so it never drifts. Scope: the local **"install on my computer"** path (macOS Docker Desktop or Linux). Remote/cloud provisioning is a different flow (`trinity:deploy-new-instance`).
 
 ---
 
@@ -48,7 +48,9 @@ docker compose version >/dev/null 2>&1 && echo "compose: ok" || echo "compose: M
 **Fresh machine (no clone yet):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/abilityai/trinity/main/install.sh | bash
+git clone https://github.com/abilityai/trinity.git
+cd trinity
+./scripts/deploy/start.sh --unattended
 ```
 
 **Already have the repo (or you cloned it):**
@@ -131,4 +133,4 @@ Safe to re‑run `./scripts/deploy/start.sh` any time:
 
 ---
 
-*Keep this guide in sync with `scripts/deploy/start.sh` and `install.sh`. If you change the installer's behavior or the ports/flags, update this file in the same PR — it is the single source of truth agents fetch.*
+*Keep this guide in sync with `scripts/deploy/start.sh`. If you change the installer's behavior or the ports/flags, update this file in the same PR — it is the single source of truth agents fetch.*

--- a/docs/onboarding/01-getting-started.md
+++ b/docs/onboarding/01-getting-started.md
@@ -29,15 +29,17 @@ Before you begin, make sure you have:
 
 ### Option 1: Quick Install (Recommended)
 
-Run the one-line installer:
+Clone the repo and run the start script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/abilityai/trinity/main/install.sh | bash
+git clone https://github.com/abilityai/trinity.git
+cd trinity
+./scripts/deploy/start.sh --unattended
 ```
 
-This will:
-1. Clone the Trinity repository
-2. Create `.env` file from template
+`start.sh` will:
+1. Create the `.env` file from the template
+2. Generate the required secrets (secret key, encryption keys, Redis passwords) and an admin password
 3. Build the base agent image
 4. Start all services
 

--- a/tests/unit/test_1646_cornelius_template_claims.py
+++ b/tests/unit/test_1646_cornelius_template_claims.py
@@ -178,9 +178,11 @@ def test_claude_md_does_not_reference_unshipped_slash_commands(claude_md):
     `/namespace:command` form. `_EXTERNAL` covers the rest: `plugin` is a Claude
     Code builtin, and the others are POSIX path segments that suppress false
     positives from prose paths like `open /path/to/folder` (CLAUDE.md:30) — not
-    builtins. Extend it when CLAUDE.md gains a new prose path.
+    builtins. Extend it when CLAUDE.md gains a new prose path (`scripts`
+    entered with the `./scripts/deploy/start.sh` install command, #1788).
     """
-    _EXTERNAL = {"plugin", "home", "api", "data", "path", "opt", "usr", "var", "tmp", "mcp", "docs"}
+    _EXTERNAL = {"plugin", "home", "api", "data", "path", "opt", "usr", "var", "tmp", "mcp", "docs",
+                     "scripts"}
     # (?!:) skips plugin-namespaced commands like /trinity:onboard
     referenced = set(re.findall(r"(?<![\w/])/([a-z][a-z0-9-]{2,})\b(?!:)", claude_md))
     referenced -= _EXTERNAL


### PR DESCRIPTION
## What

Docs-only fix for #1788. The shell scripts are **not** touched — they are simply no longer advertised.

## Why

`install.sh` and `quickstart.sh` both bypass `scripts/deploy/start.sh` and call `docker compose up -d` directly. `start.sh` is the only thing that generates `REDIS_PASSWORD`, `REDIS_BACKEND_PASSWORD`, `CREDENTIAL_ENCRYPTION_KEY`, `INTERNAL_API_SECRET` and `AGENT_AUTH_SECRET`; `.env.example` ships all of them blank. Compose guards the Redis pair with `${VAR:?…}`, so on a fresh machine both paths die before starting anything:

```
[OK] Base image built
[INFO] Starting Trinity services...
error while interpolating services.redis.environment.[]: required variable REDIS_PASSWORD is missing a value
```

`install.sh` runs with `set -e`, so it exits there — after a full base-image build, with no error guidance and **zero containers created**.

Both were verified on v0.8.5 (`b8cf94ca`): `install.sh` by running the advertised one-liner end to end, `quickstart.sh` by feeding its exact end-state `.env` to `docker compose config`.

## Changes

| File | Change |
|---|---|
| `README.md` | One-line install block → clone + `start.sh`. Names `ADMIN_PASSWORD` as the required `.env` edit (`SECRET_KEY` is auto-generated; `ADMIN_PASSWORD` is what actually blocks the install). Drops the `quickstart.sh` recommendation. |
| `AGENTS.md` | Same replacement. |
| `docs/AGENT_INSTALL_GUIDE.md` | Same replacement; drops the two now-stale `install.sh` self-references. The rest of this guide was already correct — its body used `start.sh --unattended` and the right port throughout. |
| `docs/onboarding/01-getting-started.md` | Same replacement; corrects the step list (`start.sh` does not clone the repo). |
| `config/agent-templates/cornelius/CLAUDE.md` | Same replacement. This one mattered most — a shipped agent template was handing users the broken command. |

Every entry point now documents:

```bash
git clone https://github.com/abilityai/trinity.git
cd trinity
./scripts/deploy/start.sh --unattended
```

## Verification

- The clone + `./scripts/deploy/start.sh` path is **runtime-verified** on a clean host: stack came up healthy, wizard completed, starter fleet seeded, agent chat returned a normal response.
- `--unattended` is verified by code inspection only (`start.sh` generates `ADMIN_PASSWORD` when blank and surfaces it in the summary); I did not get a second clean host to run that exact flag end to end.
- No remaining `install.sh | bash` or `quickstart.sh` references in live docs (`docs/archive`, `docs/releases`, `docs/security-reports` intentionally untouched — historical records).

## Out of scope

- **The scripts themselves remain in the repo and remain broken.** `curl …/install.sh | bash` will keep failing for anyone with an existing link, cached page, blog post or older newsletter — docs changes cannot reach them. Deleting the two scripts would close that hole without editing script logic; flagged in #1788 for a separate decision.
- The README first-run-setup wording (password minimum, admin-email step, nonexistent "Settings → API Keys" tab) is tracked separately in #1791. `AGENTS.md:46` carries the same "Settings → API Keys" claim and is left for that issue.

Fixes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)