### PR TITLE
hotfix(compose): restore Vector log writes and unbreak prod compose validation (#1799)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -131,6 +131,9 @@ services:
       # merge), so an operator-set LOG_RETENTION_DAYS never reached the
       # container and retention silently fell back to the code default. Default
       # is the 5-day community floor; enterprise `retention` unlocks longer.
+      # LOG_ARCHIVE_PATH is intentionally omitted: the code default
+      # (/data/archives) already lands in the TRINITY_DATA_PATH bind mount
+      # (/data), so no new volume is needed.
       - LOG_RETENTION_DAYS=${LOG_RETENTION_DAYS:-5}
       - LOG_ARCHIVE_ENABLED=${LOG_ARCHIVE_ENABLED:-true}
       - LOG_CLEANUP_HOUR=${LOG_CLEANUP_HOUR:-3}
@@ -248,14 +251,19 @@ services:
       # docker-compose.yml; without this line the .env value is inert in prod (the
       # #1039 packaging-gap class) and SSH host detection falls back to localhost.
       - SSH_HOST=${SSH_HOST:-}
-      # Log retention & archival (services/log_archive_service.py). Mirrors
-      # docker-compose.yml; without these lines the .env knobs are inert in prod
-      # (the #1039 packaging-gap class). LOG_ARCHIVE_PATH is intentionally omitted:
-      # the code default (/data/archives) already lands in the TRINITY_DATA_PATH
-      # bind mount (/data), so no new volume is needed.
-      - LOG_ARCHIVE_ENABLED=${LOG_ARCHIVE_ENABLED:-true}
-      - LOG_RETENTION_DAYS=${LOG_RETENTION_DAYS:-90}
-      - LOG_CLEANUP_HOUR=${LOG_CLEANUP_HOUR:-3}
+      # NOTE (#1799): a duplicate LOG_ARCHIVE_ENABLED / LOG_RETENTION_DAYS /
+      # LOG_CLEANUP_HOUR trio lived here. Two separate #1039-class "mirror
+      # docker-compose.yml" fixes each appended the same three vars, which broke
+      # this file two different ways:
+      #   * LOG_ARCHIVE_ENABLED and LOG_CLEANUP_HOUR were byte-identical in both
+      #     blocks, and Compose requires array items to be unique — so
+      #     `docker compose -f docker-compose.prod.yml config` failed outright.
+      #   * LOG_RETENTION_DAYS was duplicated with a DIFFERENT value (5 vs 90).
+      #     Differing strings are not caught by the uniqueness check, and Docker
+      #     resolves a repeated env key by last-wins — so prod would silently run
+      #     90 while this file's own block above, docker-compose.yml, and
+      #     config.py (COMMUNITY_RETENTION_FLOOR_DAYS = 5) all say 5.
+      # Resolved in favour of the block above; keep the LOG_* trio defined ONCE.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/agent-templates:/agent-configs/templates:ro
@@ -517,6 +525,21 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # #1799: #1478 chowns /data/logs to 1000:1000 (chmod 775) so the UID-1000
+    # backend's retention sweep can delete archived originals. Vector runs as
+    # root, but cap_drop: ALL strips CAP_DAC_OVERRIDE — the capability that lets
+    # root ignore file permissions — so root is neither owner nor group and
+    # falls through to "other" (r-x) on that 775 dir. EVERY sink write then
+    # fails with "Permission denied", silently: a file-sink error does not fail
+    # the :8686 healthcheck, so Vector reports healthy while writing nothing.
+    #
+    # Joining GID 1000 uses the dir's existing group-write bit instead of
+    # restoring a capability, so the cap_drop posture is preserved. Vector must
+    # stay ROOT for the uid: raw container logs under /var/lib/docker/containers
+    # are 0640 root:root, so user: "1000:1000" would swap a write failure for a
+    # read failure.
+    group_add:
+      - "1000"
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:8686/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -537,6 +537,21 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # #1799: #1478 chowns /data/logs to 1000:1000 (chmod 775) so the UID-1000
+    # backend's retention sweep can delete archived originals. Vector runs as
+    # root, but cap_drop: ALL strips CAP_DAC_OVERRIDE — the capability that lets
+    # root ignore file permissions — so root is neither owner nor group and
+    # falls through to "other" (r-x) on that 775 dir. EVERY sink write then
+    # fails with "Permission denied", silently: a file-sink error does not fail
+    # the :8686 healthcheck, so Vector reports healthy while writing nothing.
+    #
+    # Joining GID 1000 uses the dir's existing group-write bit instead of
+    # restoring a capability, so the cap_drop posture is preserved. Vector must
+    # stay ROOT for the uid: raw container logs under /var/lib/docker/containers
+    # are 0640 root:root, so user: "1000:1000" would swap a write failure for a
+    # read failure.
+    group_add:
+      - "1000"
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:8686/health"]
       interval: 30s


### PR DESCRIPTION
**Hotfix to `main`** (P-07 fast-track) of the fix already up for `dev` in #1800.

Cherry-pick of `f137fd0d` onto `origin/main` (v0.8.5) — applied with **no conflicts**. `docker-compose.yml` and `docker-compose.prod.yml` are byte-identical between `main` and `dev`, so this branch carries exactly the change under review in #1800, no adaptation.

Closes #1799

---

## Why this warrants going straight to `main`

Two silent defects, both live in v0.8.5 today:

**1. Vector has discarded ALL log output since #1478 (v0.8.0)** — affects both compose files.

`logs-init` chowns `/data/logs` to `1000:1000` / `775` so the UID-1000 backend's retention sweep can delete archived originals. But `vector` runs as **root** with `cap_drop: ALL`, which strips `CAP_DAC_OVERRIDE` — the capability that lets root bypass file permission checks. Root is neither the owner (1000) nor in the group (1000), so it falls through to *other* on a `775` dir: `r-x`, **no write bit**. Every sink write fails:

```
ERROR sink{component_id=local_logs component_type=file}: vector::internal_events::file:
  Unable to open the file. path=b"/data/logs/local-2026-07-27.json"
  error=Permission denied (os error 13) error_code=failed_opening_file
```

This is invisible because a file-sink error does not fail Vector's healthcheck, which only probes the `:8686` API — the container reports `healthy` while writing nothing. On the instance where this surfaced, `/data/logs` had **no new files between 2026-07-09 and 2026-07-27**. Every production install on v0.8.0+ is currently losing all platform and agent logs, and the loss is unrecoverable — which is the case for not waiting on the release train.

Fixed with `group_add: ["1000"]` — uses the directory's existing group-write bit rather than restoring a capability, so the `cap_drop: ALL` posture is preserved. Vector must stay **root** for the uid: raw container logs under `/var/lib/docker/containers/*/*-json.log` are `0640 root:root`, so `user: "1000:1000"` would trade a write failure for a read failure.

**2. `docker-compose.prod.yml` fails schema validation**, and hides a conflicting retention default.

Two separate "#1039 packaging gap" fixes each appended the same `LOG_*` trio to the `backend.environment` **list**:

- `LOG_ARCHIVE_ENABLED` and `LOG_CLEANUP_HOUR` ended up byte-identical in both blocks. Compose requires array items to be unique, so the prod file **does not parse**:
  ```
  validating docker-compose.prod.yml: services.backend.environment array items[67,112] must be unique
  ```
- `LOG_RETENTION_DAYS` is *also* duplicated, but `5` vs `90`. Differing strings are **not** caught by the uniqueness check, so deduping only the identical pair would fix the parse error and silently leave this. Docker resolves a repeated env key by last-wins → prod runs `90` while its own earlier block, `docker-compose.yml`, and `config.py` (`COMMUNITY_RETENTION_FLOOR_DAYS = 5`) all say 5.

Direction is "keeps 18× more", so this is **disk growth**, not data loss (unlike #1638). Still material: `log_archive_service` only deletes originals older than the window, making it a large contributor to the unbounded growth that filled the disk and wedged the Docker daemon in the originating incident.

Fix removes the later duplicate block, keeping the one that matches `docker-compose.yml` and the code default.

---

## Verification (on this branch, against `main`)

```
docker compose -f docker-compose.yml      config  -> VALID
docker compose -f docker-compose.prod.yml config  -> VALID   (before: parse error)

vector.group_add = ['1000'],  cap_drop = ['ALL'],  user = root
backend LOG_RETENTION_DAYS = 5               (prod before: silently 90)
```

Live on the affected instance:

```
before: 0 output files since 2026-07-09, repeated "Permission denied" per cycle
after : -rw-r--r-- 1 root root 2636479 /data/logs/local-2026-07-27.json
        0 permission errors
```

## Blast radius

Compose-only: no schema change, no migration, no code change, no new config surface. Deployments pick the Vector fix up on the next `docker compose up -d` — its service config changed, so Vector is recreated automatically.

## Follow-up (not in this PR)

The same investigation found that **no** compose service or SDK-created agent container sets `logging:` / `log_config`, so container logs grow unbounded — the root cause of the full disk. Deliberately excluded to keep this hotfix minimal; to be filed separately.

Per P-07 this needs a `v0.8.6` tag after squash-merge, plus a `main → dev` back-merge. #1800 can then be closed as superseded, or left to merge normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
