### PR TITLE
hotfix(ui): stop the nav controls overlapping the Enterprise link (#1789)

### DIFF
--- a/src/frontend/e2e/navbar-overflow.spec.js
+++ b/src/frontend/e2e/navbar-overflow.spec.js
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Top nav overflow (#1789).
+ *
+ * NavBar.vue is one `flex justify-between` row with two children: the logo +
+ * router-link row on the left, the controls (connection dot, version chip,
+ * docs, theme toggle, user menu) on the right. Neither child used to set
+ * `min-w-0`, and a flex item defaults to `min-width: auto` — so once the two
+ * clusters' natural widths exceeded the `max-w-7xl` cap they stopped
+ * compressing and overflowed INTO each other, which `justify-between` parked
+ * in the middle of the bar. On an entitled build (7 links, `Sessions` +
+ * `Enterprise` both present) that put the connection indicator on top of the
+ * `Enterprise PRO` link at EVERY viewport width, and below ~1180px it pushed
+ * the theme toggle and the user menu — the only route to Sign out — past the
+ * viewport edge with no horizontal scroll to recover them.
+ *
+ * These tests pin the three properties the fix guarantees, none of which
+ * depend on how many links the build renders:
+ *   1. no link ever visually collides with a control,
+ *   2. the controls stay fully on-screen and hit-testable,
+ *   3. links that don't fit stay reachable via a scroll container rather than
+ *      being clipped dead or overlapping.
+ *
+ * Widths ≥1280 are the entitled-build regression (the container is capped at
+ * `max-w-7xl`, so "just use a wider monitor" never fixed it); the narrow
+ * widths keep the spec meaningful on an OSS build too, where 5 links only
+ * exhaust the bar once the viewport is small.
+ */
+
+// Viewports: the two laptop widths where the bug was worst, the cap boundary,
+// and down to the `sm` breakpoint where the link row first appears.
+const WIDTHS = [1920, 1600, 1440, 1366, 1280, 1180, 1024, 900, 768, 640]
+
+// Geometry of the nav, measured the way a user perceives it: link boxes are
+// clipped to the scroll row's visible box first, because a link scrolled past
+// the boundary still reports full un-clipped `getBoundingClientRect()`
+// geometry while being invisible on screen.
+async function navGeometry(page) {
+  return page.evaluate(() => {
+    const row = document.querySelector('nav .flex.justify-between')
+    const [left, right] = row.children
+    const linkRow = left.children[1]
+    const clip = linkRow.getBoundingClientRect()
+
+    const controls = [...right.children].map((c) => c.getBoundingClientRect())
+    let worstCollision = 0
+    for (const raw of left.querySelectorAll('a')) {
+      const b = raw.getBoundingClientRect()
+      const l = Math.max(b.left, clip.left)
+      const r = Math.min(b.right, clip.right)
+      if (r <= l) continue // fully scrolled out of view
+      for (const c of controls) {
+        worstCollision = Math.max(worstCollision, Math.min(r, c.right) - Math.max(l, c.left))
+      }
+    }
+
+    const menu = right.lastElementChild
+    const menuBox = menu.getBoundingClientRect()
+    const hit = document.elementFromPoint(
+      menuBox.left + menuBox.width / 2,
+      menuBox.top + menuBox.height / 2
+    )
+
+    return {
+      worstCollision: Math.max(0, worstCollision),
+      controlsRightEdge: Math.max(...controls.map((c) => c.right)),
+      controlsLeftEdge: Math.min(...controls.map((c) => c.left)),
+      userMenuHitTestable: !!(hit && menu.contains(hit)),
+      navHeight: row.getBoundingClientRect().height,
+      linkRowOverflowX: getComputedStyle(linkRow).overflowX,
+      linkRowScrollWidth: linkRow.scrollWidth,
+      linkRowClientWidth: linkRow.clientWidth,
+      linkCount: left.querySelectorAll('a').length,
+    }
+  })
+}
+
+test.describe('NavBar overflow (#1789)', () => {
+  test('@smoke nav links never collide with the right-hand controls', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible({
+      timeout: 15000,
+    })
+
+    for (const width of WIDTHS) {
+      await page.setViewportSize({ width, height: 900 })
+      const g = await navGeometry(page)
+
+      // The regression itself: a visible link box overlapping a control box.
+      expect(g.worstCollision, `link/control overlap at ${width}px`).toBe(0)
+
+      // The bar must not grow a second line — the pre-fix symptom was the
+      // `PRO` badge and version chip wrapping inside a fixed 64px bar.
+      expect(g.navHeight, `nav height at ${width}px`).toBe(64)
+    }
+  })
+
+  test('@smoke controls stay on-screen and clickable at every width', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible({
+      timeout: 15000,
+    })
+
+    for (const width of WIDTHS) {
+      await page.setViewportSize({ width, height: 900 })
+      const g = await navGeometry(page)
+
+      // Pre-fix the cluster ran to x≈1170 regardless of viewport, and
+      // documentElement.scrollWidth stayed at the viewport width — so the
+      // overhang was unreachable rather than merely off to the side.
+      expect(g.controlsRightEdge, `controls right edge at ${width}px`).toBeLessThanOrEqual(width)
+      expect(g.controlsLeftEdge, `controls left edge at ${width}px`).toBeGreaterThanOrEqual(0)
+
+      // The user menu owns Sign out. `elementFromPoint` at its centre is the
+      // honest check — a box inside the viewport that something else covers
+      // is still not clickable.
+      expect(g.userMenuHitTestable, `user menu hit-testable at ${width}px`).toBe(true)
+    }
+
+    // And it genuinely opens at the width where it used to be unreachable.
+    await page.setViewportSize({ width: 900, height: 900 })
+    await page.locator('nav .flex.justify-between > div:last-child > div:last-child button').click()
+    await expect(page.getByRole('button', { name: /sign out/i })).toBeVisible({ timeout: 5000 })
+  })
+
+  test('@smoke overflowing links stay reachable via the scroll row', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible({
+      timeout: 15000,
+    })
+
+    // The mechanism that replaces overlap: the link row is a scroll container,
+    // so a link set too wide for the bar scrolls instead of spilling over the
+    // controls. Guards against a future refactor dropping `overflow-x-auto`.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const wide = await navGeometry(page)
+    expect(wide.linkRowOverflowX).toBe('auto')
+
+    // Squeeze until the row must overflow, then prove the last link can be
+    // brought into view — clipped-but-scrollable, not clipped-dead.
+    await page.setViewportSize({ width: 640, height: 900 })
+    const narrow = await navGeometry(page)
+    expect(narrow.linkRowScrollWidth).toBeGreaterThan(narrow.linkRowClientWidth)
+
+    const lastLink = page.locator('nav .flex.justify-between > div:first-child > div:last-child a').last()
+    await lastLink.scrollIntoViewIfNeeded()
+    await expect(lastLink).toBeInViewport()
+  })
+})

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -1,31 +1,45 @@
 <template>
   <nav class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-900">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between h-16">
-        <div class="flex">
+      <!-- #1789 — `gap-4` guarantees breathing room between the two clusters at
+           the width where they finally meet, so a link clipped by the scroll
+           boundary never butts up against the connection dot. -->
+      <div class="flex justify-between h-16 gap-4">
+        <!-- #1789 — `min-w-0` is load-bearing. A flex item defaults to
+             `min-width: auto`, so without it this cluster cannot shrink below
+             its min-content width: once logo + links + the right-hand controls
+             exceed the `max-w-7xl` cap the two clusters stop compressing and
+             overflow INTO each other, which `justify-between` parks in the
+             middle of the bar (Connected landing on top of Enterprise PRO). -->
+        <div class="flex min-w-0">
           <router-link to="/" class="flex-shrink-0 flex items-center hover:opacity-80 transition-opacity">
             <img src="../assets/trinity-logo.svg" alt="Trinity Logo" class="h-8 w-8 mr-2 dark:hidden" />
             <img src="../assets/trinity-logo-white.svg" alt="Trinity Logo" class="h-8 w-8 mr-2 hidden dark:block" />
             <h1 class="text-xl font-bold text-gray-900 dark:text-white">Trinity</h1>
           </router-link>
-          <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
+          <!-- #1789 — the link row is the elastic side: it scrolls when the
+               full set can't fit, so every link stays reachable instead of
+               being clipped or overlapping the controls. Gaps tighten below
+               `xl` to buy the ~150px that keeps a 7-link entitled build
+               scroll-free at the capped container width. -->
+          <div class="hidden sm:ml-6 sm:flex sm:space-x-3 xl:space-x-6 min-w-0 overflow-x-auto nav-links-scroll">
             <router-link
               to="/"
-              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex flex-shrink-0 whitespace-nowrap items-center px-1 pt-1 border-b-2 text-sm font-medium"
               :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': $route.path === '/' }"
             >
               Dashboard
             </router-link>
             <router-link
               to="/agents"
-              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex flex-shrink-0 whitespace-nowrap items-center px-1 pt-1 border-b-2 text-sm font-medium"
               :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': isAgentSection }"
             >
               Agents
             </router-link>
             <router-link
               to="/templates"
-              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex flex-shrink-0 whitespace-nowrap items-center px-1 pt-1 border-b-2 text-sm font-medium"
               :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': $route.path === '/templates' }"
             >
               Templates
@@ -36,7 +50,7 @@
                  running-execution count lives inside the Executions tab. -->
             <router-link
               to="/operations"
-              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium relative"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex flex-shrink-0 whitespace-nowrap items-center px-1 pt-1 border-b-2 text-sm font-medium relative"
               :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': $route.path === '/operations' }"
             >
               Operations
@@ -57,7 +71,7 @@
             -->
             <router-link
               to="/settings"
-              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex flex-shrink-0 whitespace-nowrap items-center px-1 pt-1 border-b-2 text-sm font-medium"
               :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': $route.path === '/settings' }"
             >
               Settings
@@ -77,7 +91,7 @@
             <router-link
               v-if="enterpriseStore.isEntitled('shared_sessions')"
               to="/sessions"
-              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex flex-shrink-0 whitespace-nowrap items-center px-1 pt-1 border-b-2 text-sm font-medium"
               :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': $route.path.startsWith('/sessions') }"
             >
               Sessions
@@ -85,7 +99,7 @@
             <router-link
               v-if="enterpriseStore.hasAnyEnterprise"
               to="/enterprise"
-              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+              class="border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200 inline-flex flex-shrink-0 whitespace-nowrap items-center px-1 pt-1 border-b-2 text-sm font-medium"
               :class="{ 'border-blue-500 dark:border-blue-400 text-gray-900 dark:text-white': $route.path.startsWith('/enterprise') }"
             >
               Enterprise
@@ -93,18 +107,34 @@
             </router-link>
           </div>
         </div>
-        <div class="flex items-center space-x-4">
-          <!-- WebSocket Status -->
-          <span class="text-sm text-gray-500 dark:text-gray-400">
-            <span class="inline-block h-2 w-2 rounded-full mr-1" :class="isConnected ? 'bg-status-success-400' : 'bg-gray-400 dark:bg-gray-600'"></span>
-            {{ isConnected ? 'Connected' : 'Disconnected' }}
+        <!-- #1789 — `flex-shrink-0`: these are the bar's controls (docs, theme,
+             and the user menu that owns Sign out). They must never be
+             compressed or pushed past the viewport edge, so the link row above
+             absorbs all the width pressure instead. -->
+        <div class="flex flex-shrink-0 items-center space-x-4">
+          <!-- WebSocket Status — dot only (#1789). The word cost ~80px of a
+               budget the bar does not have at the `max-w-7xl` cap; the state is
+               conveyed by colour, a tooltip, and the sr-only label, and a lost
+               connection additionally pulses. -->
+          <span
+            class="flex items-center text-sm text-gray-500 dark:text-gray-400"
+            :title="isConnected ? 'Connected' : 'Disconnected'"
+          >
+            <span
+              class="inline-block h-2 w-2 rounded-full"
+              :class="isConnected ? 'bg-status-success-400' : 'bg-status-warning-500 animate-pulse'"
+            ></span>
+            <span class="sr-only">{{ isConnected ? 'Connected' : 'Disconnected' }}</span>
           </span>
 
-          <!-- Build Info Chip (#926) — small muted version label; click opens detail modal -->
+          <!-- Build Info Chip (#926) — small muted version label; click opens detail modal.
+               Hidden below `xl` (#1789) — it is the widest non-interactive item in
+               the bar and the same data is one click away in the Build Info modal
+               and on Settings. -->
           <button
             v-if="buildInfo.info.value"
             @click="showBuildInfoModal = true"
-            class="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 font-mono"
+            class="hidden xl:block text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 font-mono whitespace-nowrap"
             :title="`Click for build info — commit ${buildInfo.info.value.git_commit_short}`"
           >
             v{{ buildInfo.displayVersion.value }}<span
@@ -432,3 +462,23 @@ const handleLogout = () => {
   router.push('/login')
 }
 </script>
+
+<style scoped>
+/*
+ * #1789 — the nav link row is an `overflow-x-auto` container so an
+ * over-wide link set scrolls instead of overlapping the controls. A
+ * classic scrollbar inside a 64px bar would eat vertical space and sit
+ * under the active-link underline, so the gutter is suppressed. The row
+ * remains scrollable by wheel, trackpad, touch, and keyboard focus
+ * (focusing an off-screen link scrolls it into view) — the affordance is
+ * hidden, not the capability.
+ */
+.nav-links-scroll {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* legacy Edge */
+}
+
+.nav-links-scroll::-webkit-scrollbar {
+  display: none; /* Chromium, WebKit */
+}
+</style>


### PR DESCRIPTION
**Hotfix to `main`** (P-07 fast-track) of the fix already up for `dev` in #1794.

Cherry-pick of `3a3d5d65` onto `origin/main` (v0.8.5) — applied with **no conflicts**. `src/frontend/src/components/NavBar.vue` is byte-identical between `main` and `dev`, and the diff on this branch was verified byte-identical to #1794's, so this carries exactly the change under review there with no adaptation.

Closes #1789

---

## Why this warrants going straight to `main`

`NavBar.vue` is one `flex justify-between` row with two children — logo + link row on the left, controls (connection dot, version chip, docs, theme, user menu) on the right. Neither set `min-w-0`, and a flex item defaults to `min-width: auto`, so once the two clusters exceeded the `max-w-7xl` cap they stopped compressing and **overflowed into each other** — which `justify-between` parks in the middle of the bar.

Because the container is capped at 1280px, **a wider monitor never helped**: 28px of overlap was measured at every width from 1280 to 1920.

**Not merely cosmetic.** Below ~1180px the controls ran to x≈1170 while `documentElement.scrollWidth` stayed at the viewport width, so there was no scroll to recover them. At 1024px and narrower the theme toggle and the **user menu — the only route to Sign out — were unreachable** (`elementFromPoint` at the avatar centre returned `null`). That is a users-cannot-log-out bug on any entitled build at a common laptop width, which is the case for not waiting on the release train.

Trigger is link count: entitled builds render `Sessions` and `Enterprise` on top of the five OSS links, pushing the row past the cap — so **v0.8.5 enterprise installs are affected today**.

## The fix

- `min-w-0` on the link cluster so it can actually shrink, plus `overflow-x-auto` so an over-wide link set **scrolls instead of spilling over the controls**. Links get `flex-shrink-0 whitespace-nowrap` so they keep natural width and the `PRO` badge can't wrap.
- `flex-shrink-0` on the control cluster — never compressed or pushed off-screen; the link row absorbs all width pressure.
- Reclaims ~150px to keep a 7-link entitled build scroll-free at the capped width: tighter link gaps below `xl`, version chip hidden below `xl`, connection status becomes dot-only with tooltip + `sr-only` label.
- `gap-4` between clusters so a link clipped at the scroll boundary never butts against the status dot.

### Deliberate visual changes

Both needed to fit the budget — the widest layout must fit 1216px (`max-w-7xl` minus `lg:px-8`), a ceiling that does not move on a bigger screen:

1. **`Connected`/`Disconnected` text → dot only** (~80px). State still conveyed by colour, a `title` tooltip, and an `sr-only` label; a lost connection now also **pulses**, so the failure state is more visible than before.
2. **Version chip hidden below `xl`.** Same data stays one click away in the Build Info modal and on Settings, and it still shows at ≥1280px.

## Verification

Measured against a live stack at ten widths, before and after:

```
 ok  w=1920  collide=  0px rightEdge= 1568(<=1920) userMenuHitTestable=true navH=64 linkRowScrolls=false
 ok  w=1600  collide=  0px rightEdge= 1408(<=1600) userMenuHitTestable=true navH=64 linkRowScrolls=false
 ok  w=1440  collide=  0px rightEdge= 1328(<=1440) userMenuHitTestable=true navH=64 linkRowScrolls=false
 ok  w=1366  collide=  0px rightEdge= 1291(<=1366) userMenuHitTestable=true navH=64 linkRowScrolls=false
 ok  w=1280  collide=  0px rightEdge= 1248(<=1280) userMenuHitTestable=true navH=64 linkRowScrolls=false
 ok  w=1180  collide=  0px rightEdge= 1148(<=1180) userMenuHitTestable=true navH=64 linkRowScrolls=false
 ok  w=1024  collide=  0px rightEdge=  992(<=1024) userMenuHitTestable=true navH=64 linkRowScrolls=false
 ok  w= 900  collide=  0px rightEdge=  876(<= 900) userMenuHitTestable=true navH=64 linkRowScrolls=true by 96px
 ok  w= 768  collide=  0px rightEdge=  744(<= 768) userMenuHitTestable=true navH=64 linkRowScrolls=true by 228px
 ok  w= 640  collide=  0px rightEdge=  616(<= 640) userMenuHitTestable=true navH=64 linkRowScrolls=true by 356px
```

Carries the regression test `src/frontend/e2e/navbar-overflow.spec.js` (+150). `src/frontend/e2e/` already exists on `main`, so the suite lands intact.

## Blast radius

Frontend-only: one component plus a new e2e spec. No backend change, no schema change, no migration, no API surface.

Per P-07 this needs a `v0.8.6` tag after squash-merge, plus a `main → dev` back-merge. #1794 can then be closed as superseded, or left to merge normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
