### PR TITLE
fix(create): reject an unresolvable local: template instead of creating an empty agent (#1793)

### DIFF
--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -672,7 +672,11 @@ async def _reserve_git_instance(
 def _resolve_local_template(config: AgentConfig) -> tuple[dict, Optional[dict]]:
     """Load a `local:`-prefixed template's `template.yaml` (curated catalog then
     deploy-local store, #950). Mutates `config` runtime/type/resources/tools/
-    mcp_servers fields. Returns `(template_data, template_shared_folders)`."""
+    mcp_servers fields. Returns `(template_data, template_shared_folders)`.
+
+    Raises `HTTPException(404, UNKNOWN_LOCAL_TEMPLATE)` when the name resolves
+    to no `template.yaml` under either root (#1793) — this previously returned
+    an empty dict and the caller provisioned a templateless container."""
     template_data: dict = {}
     template_shared_folders = None
     # Local template - strip "local:" prefix. Look in curated catalog
@@ -691,33 +695,51 @@ def _resolve_local_template(config: AgentConfig) -> tuple[dict, Optional[dict]]:
 
     template_yaml = template_path / "template.yaml"
 
-    if template_yaml.exists():
-        try:
-            with open(template_yaml) as f:
-                template_data = yaml.safe_load(f)
-                config.type = template_data.get("type", config.type)
-                config.resources = template_data.get("resources", config.resources)
-                config.tools = template_data.get("tools", config.tools)
-                creds = template_data.get("credentials", {})
-                mcp_servers = list(creds.get("mcp_servers", {}).keys())
-                if mcp_servers:
-                    config.mcp_servers = mcp_servers
-                # Multi-runtime support - extract runtime config from template
-                runtime_config = template_data.get("runtime", {})
-                if isinstance(runtime_config, dict):
-                    config.runtime = runtime_config.get("type", config.runtime)
-                    config.runtime_model = runtime_config.get("model", config.runtime_model)
-                elif isinstance(runtime_config, str):
-                    config.runtime = runtime_config
-                # Phase 9.11: Extract shared folder config from template
-                shared_folders_config = template_data.get("shared_folders", {})
-                if shared_folders_config:
-                    template_shared_folders = {
-                        "expose": shared_folders_config.get("expose", False),
-                        "consume": shared_folders_config.get("consume", False)
-                    }
-        except Exception as e:
-            logger.warning(f"Error loading template config: {e}")
+    # #1793: an unresolvable `local:` template must fail here, before any side
+    # effect. Falling through with an empty `template_data` used to provision a
+    # running container with no CLAUDE.md, no template.yaml and no skills — an
+    # empty shell reported to the caller as a normal 200 creation. The `github:`
+    # path already fails fast on an unknown repo; this makes `local:` match.
+    if not template_yaml.exists():
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": (
+                    f"Local template {raw_name!r} was not found. Check the id "
+                    f"against GET /api/templates — templates marked hidden are "
+                    f"not deployable. To create an agent with no template at "
+                    f"all, omit the 'template' field."
+                ),
+                "code": "UNKNOWN_LOCAL_TEMPLATE",
+            },
+        )
+
+    try:
+        with open(template_yaml) as f:
+            template_data = yaml.safe_load(f)
+            config.type = template_data.get("type", config.type)
+            config.resources = template_data.get("resources", config.resources)
+            config.tools = template_data.get("tools", config.tools)
+            creds = template_data.get("credentials", {})
+            mcp_servers = list(creds.get("mcp_servers", {}).keys())
+            if mcp_servers:
+                config.mcp_servers = mcp_servers
+            # Multi-runtime support - extract runtime config from template
+            runtime_config = template_data.get("runtime", {})
+            if isinstance(runtime_config, dict):
+                config.runtime = runtime_config.get("type", config.runtime)
+                config.runtime_model = runtime_config.get("model", config.runtime_model)
+            elif isinstance(runtime_config, str):
+                config.runtime = runtime_config
+            # Phase 9.11: Extract shared folder config from template
+            shared_folders_config = template_data.get("shared_folders", {})
+            if shared_folders_config:
+                template_shared_folders = {
+                    "expose": shared_folders_config.get("expose", False),
+                    "consume": shared_folders_config.get("consume", False)
+                }
+    except Exception as e:
+        logger.warning(f"Error loading template config: {e}")
     return template_data, template_shared_folders
 
 

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -695,12 +695,39 @@ def _resolve_local_template(config: AgentConfig) -> tuple[dict, Optional[dict]]:
 
     template_yaml = template_path / "template.yaml"
 
-    # #1793: an unresolvable `local:` template must fail here, before any side
-    # effect. Falling through with an empty `template_data` used to provision a
-    # running container with no CLAUDE.md, no template.yaml and no skills — an
-    # empty shell reported to the caller as a normal 200 creation. The `github:`
-    # path already fails fast on an unknown repo; this makes `local:` match.
-    if not template_yaml.exists():
+    if template_yaml.exists():
+        try:
+            with open(template_yaml) as f:
+                template_data = yaml.safe_load(f)
+                config.type = template_data.get("type", config.type)
+                config.resources = template_data.get("resources", config.resources)
+                config.tools = template_data.get("tools", config.tools)
+                creds = template_data.get("credentials", {})
+                mcp_servers = list(creds.get("mcp_servers", {}).keys())
+                if mcp_servers:
+                    config.mcp_servers = mcp_servers
+                # Multi-runtime support - extract runtime config from template
+                runtime_config = template_data.get("runtime", {})
+                if isinstance(runtime_config, dict):
+                    config.runtime = runtime_config.get("type", config.runtime)
+                    config.runtime_model = runtime_config.get("model", config.runtime_model)
+                elif isinstance(runtime_config, str):
+                    config.runtime = runtime_config
+                # Phase 9.11: Extract shared folder config from template
+                shared_folders_config = template_data.get("shared_folders", {})
+                if shared_folders_config:
+                    template_shared_folders = {
+                        "expose": shared_folders_config.get("expose", False),
+                        "consume": shared_folders_config.get("consume", False)
+                    }
+        except Exception as e:
+            logger.warning(f"Error loading template config: {e}")
+    else:
+        # #1793: an unresolvable `local:` template must fail before any side
+        # effect. Falling through with an empty `template_data` provisioned a
+        # running container with no CLAUDE.md, no template.yaml and no skills —
+        # an empty shell reported to the caller as a normal 200 creation. The
+        # `github:` path already fails fast on an unknown repo; this matches it.
         raise HTTPException(
             status_code=404,
             detail={
@@ -713,33 +740,6 @@ def _resolve_local_template(config: AgentConfig) -> tuple[dict, Optional[dict]]:
                 "code": "UNKNOWN_LOCAL_TEMPLATE",
             },
         )
-
-    try:
-        with open(template_yaml) as f:
-            template_data = yaml.safe_load(f)
-            config.type = template_data.get("type", config.type)
-            config.resources = template_data.get("resources", config.resources)
-            config.tools = template_data.get("tools", config.tools)
-            creds = template_data.get("credentials", {})
-            mcp_servers = list(creds.get("mcp_servers", {}).keys())
-            if mcp_servers:
-                config.mcp_servers = mcp_servers
-            # Multi-runtime support - extract runtime config from template
-            runtime_config = template_data.get("runtime", {})
-            if isinstance(runtime_config, dict):
-                config.runtime = runtime_config.get("type", config.runtime)
-                config.runtime_model = runtime_config.get("model", config.runtime_model)
-            elif isinstance(runtime_config, str):
-                config.runtime = runtime_config
-            # Phase 9.11: Extract shared folder config from template
-            shared_folders_config = template_data.get("shared_folders", {})
-            if shared_folders_config:
-                template_shared_folders = {
-                    "expose": shared_folders_config.get("expose", False),
-                    "consume": shared_folders_config.get("consume", False)
-                }
-    except Exception as e:
-        logger.warning(f"Error loading template config: {e}")
     return template_data, template_shared_folders
 
 

--- a/tests/unit/test_1484_create_agent_characterization.py
+++ b/tests/unit/test_1484_create_agent_characterization.py
@@ -246,6 +246,24 @@ def _load_crud(monkeypatch, docker_available=True):
         if (key == "services" or key.startswith("services.")) and key not in mocks:
             monkeypatch.delitem(sys.modules, key, raising=False)
     import services.agent_service.crud as crud
+
+    # #1793: an unresolvable `local:` template is now a 404 instead of a
+    # silent templateless creation. These cases exercise the local-template
+    # HAPPY path with `local:scout`, and passed previously only because the
+    # unit env has no template roots on disk — the missing template.yaml was
+    # tolerated. Point the roots at a tmp dir carrying a minimal `scout` so
+    # the fixture supplies the template the cases always assumed. Deliberately
+    # minimal (no `resources`, no `avatar_prompt`) so the pinned container
+    # kwargs — mem_limit 4g / nano_cpus 2 — are unchanged, and so
+    # set_default_avatar stays unreached for every case but the one that
+    # builds its own root. Cases that monkeypatch `_LOCAL_TEMPLATE_ROOTS`
+    # themselves still win: their setattr runs after this.
+    _tpl_root = Path(tempfile.mkdtemp(prefix="trinity_1484_templates_"))
+    _scout = _tpl_root / "scout"
+    _scout.mkdir()
+    (_scout / "template.yaml").write_text("type: business-assistant\n")
+    monkeypatch.setattr(crud, "_LOCAL_TEMPLATE_ROOTS", (_tpl_root, _tpl_root))
+
     return crud, {
         "patcher": patcher,
         "db": db,

--- a/tests/unit/test_1793_unknown_local_template.py
+++ b/tests/unit/test_1793_unknown_local_template.py
@@ -1,0 +1,130 @@
+"""
+Regression for #1793 — an unresolvable `local:` template must fail, not
+silently produce a templateless agent.
+
+Before this fix, `_resolve_local_template` returned an empty `template_data`
+when the name matched no `template.yaml` under either root. The caller carried
+on and provisioned a running container with no CLAUDE.md, no template.yaml and
+no skills, and `POST /api/agents` reported a normal 200 creation. The
+`github:` path already failed fast on an unknown repo; these tests pin the
+`local:` path to the same contract.
+
+`services.agent_service.crud` is imported lazily inside each test body rather
+than at module level — same rationale as `tests/unit/test_deploy_writable_templates.py`
+and `tests/unit/test_local_templates_listing.py` (importing the crud chain at
+collection time trips the documented tests/utils-shadows-backend-utils
+sys.modules race). Roots are monkeypatched via the module attribute, so no
+`sys.modules[...] =` assignment is introduced (keeps `tests/lint_sys_modules.py`
+green).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+TEMPLATE_YAML = """\
+name: fixture-template
+type: research-agent
+runtime:
+  type: claude-code
+resources:
+  cpu: "2"
+  memory: "4g"
+"""
+
+
+def _config(template: str):
+    from models import AgentConfig
+
+    return AgentConfig(name="t1793", template=template)
+
+
+def _patch_roots(monkeypatch, curated: Path, deployed: Path) -> None:
+    from services.agent_service import crud
+
+    monkeypatch.setattr(
+        crud, "_LOCAL_TEMPLATE_ROOTS", (curated.resolve(), deployed.resolve())
+    )
+
+
+def test_unknown_local_template_raises_404(monkeypatch, tmp_path):
+    """A name present under neither root is rejected before any side effect."""
+    from services.agent_service import crud
+
+    curated = tmp_path / "curated"
+    deployed = tmp_path / "deployed"
+    curated.mkdir()
+    deployed.mkdir()
+    _patch_roots(monkeypatch, curated, deployed)
+
+    with pytest.raises(HTTPException) as exc:
+        crud._resolve_local_template(_config("local:does-not-exist"))
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail["code"] == "UNKNOWN_LOCAL_TEMPLATE"
+    # The message must name the template so the caller can spot a typo.
+    assert "does-not-exist" in exc.value.detail["error"]
+
+
+def test_directory_without_template_yaml_raises_404(monkeypatch, tmp_path):
+    """A directory that exists but carries no template.yaml is still unusable.
+
+    This is the shape that produced the empty agent: the path resolved, so the
+    old code proceeded with an empty template_data.
+    """
+    from services.agent_service import crud
+
+    curated = tmp_path / "curated"
+    deployed = tmp_path / "deployed"
+    (curated / "hollow").mkdir(parents=True)
+    deployed.mkdir()
+    _patch_roots(monkeypatch, curated, deployed)
+
+    with pytest.raises(HTTPException) as exc:
+        crud._resolve_local_template(_config("local:hollow"))
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail["code"] == "UNKNOWN_LOCAL_TEMPLATE"
+
+
+@pytest.mark.parametrize("root_index", [0, 1])
+def test_resolvable_template_still_loads(monkeypatch, tmp_path, root_index):
+    """The happy path is unchanged under both roots (curated and deploy-local)."""
+    from services.agent_service import crud
+
+    roots = [tmp_path / "curated", tmp_path / "deployed"]
+    for r in roots:
+        r.mkdir()
+    target = roots[root_index] / "fixture-template"
+    target.mkdir()
+    (target / "template.yaml").write_text(TEMPLATE_YAML)
+    _patch_roots(monkeypatch, roots[0], roots[1])
+
+    config = _config("local:fixture-template")
+    template_data, shared_folders = crud._resolve_local_template(config)
+
+    assert template_data["name"] == "fixture-template"
+    # Template fields are still projected onto the config.
+    assert config.type == "research-agent"
+    assert config.runtime == "claude-code"
+    assert shared_folders is None
+
+
+def test_invalid_name_still_400_not_404(monkeypatch, tmp_path):
+    """Traversal-ish names keep their existing 400 — #1793 must not mask it."""
+    from services.agent_service import crud
+
+    curated = tmp_path / "curated"
+    deployed = tmp_path / "deployed"
+    curated.mkdir()
+    deployed.mkdir()
+    _patch_roots(monkeypatch, curated, deployed)
+
+    with pytest.raises(HTTPException) as exc:
+        crud._resolve_local_template(_config("local:../etc"))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "INVALID_LOCAL_TEMPLATE_NAME"


### PR DESCRIPTION
## What

`POST /api/agents` with a `local:` template that doesn't resolve now returns **404 `UNKNOWN_LOCAL_TEMPLATE`** instead of creating a templateless agent and reporting 200.

## Why

`_resolve_local_template` looked for `template.yaml` under the curated root then the deploy-local root, and when neither had it, simply returned an empty `template_data`. Creation continued and provisioned a **running container with no CLAUDE.md, no template.yaml and no skills**:

```
$ curl -X POST … -d '{"name":"p1-nope","template":"local:does-not-exist"}'
200 {"name":"p1-nope","type":"business-assistant","status":"stopped", …}

$ curl …/api/agents/p1-nope/info
{"has_template":false,"message":"No template.yaml found - this agent was created without a template","status":"running"}

$ docker exec agent-p1-nope ls /home/developer
.bashrc  .cache  .claude  .config  .mcp.json  .ssh  .trinity  content  mcp-servers    # no CLAUDE.md
```

`type: business-assistant` there is a fabricated default — nothing in the response indicated the requested template was never found. The agent shows `running` in the fleet list and answers chat as a generic assistant with no idea what it is for, having already consumed a container and a data volume.

The `github:` path already handled this correctly (`400`, "Repository … was not found or is private"), so the two source types disagreed.

The most exposed caller is the MCP `create_agent` tool, which takes a free-text template id — precisely the surface used by the "Claude Code writes the agent, Trinity runs it" workflow, and where a stale or hallucinated id shows up. A renamed or newly-`hidden` template silently downgraded any saved script the same way.

## Change

One guard clause in `_resolve_local_template`, raising before any side effect. It sits in the template-resolution phase, so a rejected create leaves **no container, volume, MCP key or ownership row**.

The diff looks larger than it is: the load block is dedented one level now that the existence check is a guard clause. No logic inside it changed.

## Behavior preserved

- **Templateless creation still works** by omitting `template` — the fallback is now opt-in rather than the silent result of an unresolvable name.
- **Invalid/traversal names keep their existing 400** `INVALID_LOCAL_TEMPLATE_NAME` (covered by a test, so #1793 can't mask it).
- **deploy-local (#950) unaffected** — `deploy_local_agent_logic` already validates the uploaded archive contains a `template.yaml` before writing it to the deploy-local root, so a deployed template always resolves.

## Verification

`tests/unit/test_1793_unknown_local_template.py` — 5 cases, all passing:

```
5 passed, 15 warnings in 0.18s
```

- unknown name → 404 `UNKNOWN_LOCAL_TEMPLATE`, message names the template
- directory exists but has no `template.yaml` → 404 (this is the shape that produced the empty agent)
- resolvable template still loads and still projects `type`/`runtime` onto the config — parametrized over **both** roots
- traversal name still 400, not 404

Live check against a running 0.8.5 instance (patch applied to the running backend, which bind-mounts its source):

```
POST {"name":"p1793-bogus","template":"local:does-not-exist"}  → HTTP 404
  {"detail":{"error":"Local template 'does-not-exist' was not found.","code":"UNKNOWN_LOCAL_TEMPLATE"}}
containers matching agent-p1793-bogus: 0

POST {"name":"p1793-ok","template":"local:scribe"}             → HTTP 200
```

The instance was restored to stock afterwards.

Related to #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1793
