### PR TITLE
docs: correct the first-run setup instructions (#1791)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Prerequisites: Docker + Docker Compose v2; an Anthropic API key (Claude agents) 
 curl -fsSL https://raw.githubusercontent.com/abilityai/trinity/main/install.sh | bash
 ```
 
-Then open `http://localhost` → setup wizard → set the admin password → **Settings → API Keys** to add the model API key.
+Then open `http://localhost` → setup wizard → set the admin email + password (12+ chars, mixed case + digit + symbol) → **Settings → Integrations → API Keys** to add the model API key.
 
 **Verify:**
 
@@ -101,7 +101,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/agents
 
 ## Operate a Trinity instance over MCP
 
-Get an MCP API key (Settings → API Keys in the UI; `/trinity:connect` and `trinity init` auto-provision one), then configure:
+Get an MCP API key (Settings → MCP Keys in the UI; `/trinity:connect` and `trinity init` auto-provision one), then configure:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ cp .env.example .env
 **First-time setup**
 
 1. Open http://localhost — you'll be redirected to the setup wizard
-2. Set your **admin password** (minimum 8 characters)
-3. Log in with username `admin` and your new password
-4. Go to **Settings** → **API Keys** to configure your Anthropic API key
+2. Enter your **admin email** — this becomes your sign-in identity — and an **admin password** (minimum 12 characters, with upper- and lowercase, a digit, and a special character)
+3. Log in with that email (or the username `admin`) and your password
+4. Go to **Settings** → **Integrations** → **API Keys** to configure your Anthropic API key
 
 **Access**
 
@@ -628,7 +628,7 @@ Trinity Connect enables real-time coordination between local Claude Code instanc
 # Install listener dependencies
 brew install websocat jq
 
-# Set your MCP API key (from Settings → API Keys)
+# Set your MCP API key (from Settings → MCP Keys)
 export TRINITY_API_KEY="trinity_mcp_xxx"
 
 # Listen for events from a specific agent

--- a/docs/onboarding/01-getting-started.md
+++ b/docs/onboarding/01-getting-started.md
@@ -95,20 +95,23 @@ You should see:
 Open your browser and navigate to:
 
 ```
-http://localhost:3000
+http://localhost
 ```
+
+(or `http://localhost:<FRONTEND_PORT>` if you changed it in `.env`)
 
 You'll be redirected to the **Setup Wizard** on first launch.
 
 ### Step 2: Create Admin Account
 
-1. **Set Admin Password**
-   - Enter a strong password (minimum 8 characters)
+1. **Create the Admin Account**
+   - Enter your **admin email** — this becomes your sign-in identity
+   - Enter a strong password (minimum 12 characters, including upper- and lowercase, a digit, and a special character)
    - Confirm the password
    - Click **Create Account**
 
 2. **Login**
-   - Username: `admin`
+   - Email: the admin email you just entered (the username `admin` also works)
    - Password: (the password you just created)
    - Click **Sign In**
 


### PR DESCRIPTION
## What

Corrects the documented first-run flow, which was stale at every step against v0.8.5. Docs only.

## Each claim, checked against the code

| Doc said | Reality | Source |
|---|---|---|
| password "minimum 8 characters" | **12**, plus complexity (upper, lower, digit, special, not a common password) | `utils/password_validation.py` — `MIN_LENGTH = 12`, `PASSWORD_REQUIREMENTS_MESSAGE` |
| no mention of an admin email | **required** — it is the sign-in identity | `SetupPassword.vue` ("Admin email *", "You'll sign in with this email"), `routers/setup.py` (400 on blank/invalid) |
| "Log in with username `admin`" | the admin **email** works too (#82) | verified live: both return a token |
| "Settings → **API Keys**" | no such tab. Model key is under **Settings → Integrations → API Keys** | `Settings.vue:587` opens the `integrations` block; the Anthropic field is inside it at :597 |
| `http://localhost:3000` (onboarding) | `http://localhost` — 3000 is a Vite dev port | `FRONTEND_PORT=80` in `.env.example` |

The complexity requirement matters on its own: a user who reads "minimum 12 characters" and picks a 12-character all-lowercase password still gets rejected, so the docs now state the full rule.

## The two "API Keys" are different things

Worth calling out for review — the old wording conflated them:

- **Model** API key (Anthropic/Google) → **Settings → Integrations → API Keys**
- **MCP** API key → the separate **MCP Keys** tab

Two references that clearly meant *MCP* keys (`AGENTS.md:104`, `README.md:631`) pointed at "Settings → API Keys" and now say **MCP Keys**.

## Files

- `README.md` — first-time-setup steps; MCP-key pointer
- `AGENTS.md` — setup one-liner; MCP-key pointer
- `docs/onboarding/01-getting-started.md` — Web UI URL, admin-account steps, login step

## Relationship to #1788 / #1797

The fourth item in #1791 — the README naming `SECRET_KEY` as the required `.env` edit when `ADMIN_PASSWORD` is what actually blocks the install — is already fixed on the #1788 branch (PR #1797), which rewrote that block. This PR deliberately leaves it alone.

Both branches touch `README.md` and `AGENTS.md` but in different sections (install block vs first-run steps), so they should merge cleanly in either order. Worth a glance if they land far apart.

## Verification

- Live 0.8.5 instance: `POST /api/token` succeeds with **both** the admin email and `admin`.
- Setup wizard rejects a short password and requires the email field (exercised during the fresh-install test that produced #1791).
- 22 doc/claims guard tests pass; no test covers the edited prose.

Fixes #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)