### PR TITLE
fix(reminders): surface the autonomy hold instead of failing silently (#1806)

### DIFF
--- a/docs/user-docs/automation/agent-reminders.md
+++ b/docs/user-docs/automation/agent-reminders.md
@@ -11,6 +11,7 @@ There is no web UI for reminders. They are a backend and MCP primitive that agen
 - **Reminder** — A one-shot, durable, self-scheduled task. An agent sets a reminder on **itself** with a message and a fire time. At that time, Trinity runs a normal execution of the agent with that message.
 - **Self-only** — An agent can set, list, and cancel only *its own* reminders. A reminder against a sibling agent is rejected (`403`).
 - **Durable** — Reminders survive a restart. The fire time is stored, not held in memory, and re-armed on boot. A reminder due during a restart fires when the service comes back rather than being lost.
+- **Autonomy-gated** — Reminders only fire while the agent's **autonomy mode** is on, the same master switch that governs [schedules](scheduling.md). Autonomy is **off by default on a newly created agent**.
 
 ### Reminder vs. Loop vs. Schedule
 
@@ -36,6 +37,19 @@ Optional per-reminder overrides — `model`, `timeout_seconds`, and `allowed_too
 **Listing** returns pending reminders by default (soonest fire first); pass a status filter of `all` to see fired, cancelled, and failed reminders too.
 
 **Cancelling** a still-pending reminder stops it from firing. Cancelling an already-cancelled reminder is a no-op success; a reminder that has already fired, is mid-fire, or has failed cannot be cancelled (`409`). An unknown reminder id returns `404`.
+
+### Autonomy must be on
+
+A reminder set on an agent whose autonomy mode is **off** is accepted and **held**: it stays `pending`, is never armed, and does not fire — even once its fire time passes. Turn autonomy on and it fires past-due within about a minute. Nothing is lost, but nothing happens either.
+
+Because autonomy defaults to off on a new agent, this is the usual reason a first reminder "never fires".
+
+How to tell:
+
+- The create response and `list_reminders` set **`autonomy_hold: true`** on any reminder in this state, and the `set_reminder` tool result adds an explicit `warning`. An agent should relay that to the user rather than reporting the reminder as scheduled.
+- The scheduler logs a count each reconcile pass, e.g. `2 reminder(s) held: their agent's autonomy is disabled.`
+
+Chat is *not* autonomy-gated, so an agent can be mid-conversation, accept "remind me in an hour", and still be unable to fire it. Check autonomy when a user asks for a reminder.
 
 **Where fired reminders appear** — a fired reminder is a normal execution row (with `triggered_by: "reminder"`), so it appears on the Executions page, in per-execution detail, and as its own **Reminders** category in the agent's analytics timeline — never folded into Scheduled.
 

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -2165,6 +2165,11 @@ class ReminderSummary(BaseModel):
     created_at: str
     fired_at: Optional[str] = None
     cancelled_at: Optional[str] = None
+    # #1806: derived at read time (NOT a column) — true when this reminder is
+    # still live but its agent has autonomy off, so the scheduler will not arm
+    # it. Without this a held reminder is indistinguishable from a healthy one:
+    # `pending` with a fire_at that quietly slides into the past.
+    autonomy_hold: bool = False
 
     class Config:
         from_attributes = True

--- a/src/backend/routers/reminders.py
+++ b/src/backend/routers/reminders.py
@@ -59,9 +59,36 @@ def _self_gate(current_user: User, name: str) -> None:
         )
 
 
+# #1806: statuses the autonomy gate can still act on. A terminal reminder is
+# never "held" — it already fired, was cancelled, or gave up.
+_LIVE_STATUSES = ("pending", "firing")
+
+
+def _autonomy_hold(name: str, row_status: str, autonomy_enabled: Optional[bool] = None) -> bool:
+    """Is this reminder live but un-armable because the agent's autonomy is off?
+
+    #1806: the scheduler's ``get_active_reminders`` filters on
+    ``ao.autonomy_enabled = 1``, so a reminder on a paused agent is never armed
+    — no job, therefore no skip to log. Derived at read time (one cheap lookup,
+    no column, no migration). Fail-open to "not held": a settings-read failure
+    must never invent a warning on a healthy reminder.
+    """
+    if row_status not in _LIVE_STATUSES:
+        return False
+    try:
+        if autonomy_enabled is None:
+            autonomy_enabled = db.get_autonomy_enabled(name)
+    except Exception:  # pragma: no cover - defensive
+        logger.warning("Could not resolve autonomy for %s; reporting no hold", name)
+        return False
+    return not autonomy_enabled
+
+
 def _reminder_response(row: dict) -> dict:
     """Reminder-model-shaped JSON dict (drops the non-response provenance cols)."""
-    return Reminder(**row).model_dump()
+    return Reminder(
+        **row, autonomy_hold=_autonomy_hold(row["agent_name"], row["status"])
+    ).model_dump()
 
 
 @router.post("/agents/{name}/reminders", response_model=Reminder, status_code=201)
@@ -143,7 +170,10 @@ async def create_reminder_endpoint(
     else:
         idempotency_service.complete(idem, reminder["id"], snapshot)
 
-    return Reminder(**reminder)
+    return Reminder(
+        **reminder,
+        autonomy_hold=_autonomy_hold(name, reminder["status"]),
+    )
 
 
 @router.get("/agents/{name}/reminders", response_model=List[ReminderSummary])
@@ -160,7 +190,15 @@ async def list_reminders_endpoint(
     _self_gate(current_user, name)
     effective = None if status_filter in (None, "", "all") else status_filter
     rows = db.list_reminders(name, status=effective)
-    return [ReminderSummary(**r) for r in rows]
+    # #1806: one autonomy lookup for the whole page — every row belongs to the
+    # same agent, so a per-row resolve would be a pointless N+1.
+    autonomy = db.get_autonomy_enabled(name) if rows else True
+    return [
+        ReminderSummary(
+            **r, autonomy_hold=_autonomy_hold(name, r["status"], autonomy)
+        )
+        for r in rows
+    ]
 
 
 @router.post("/agents/{name}/reminders/{reminder_id}/cancel", response_model=Reminder)
@@ -190,4 +228,6 @@ async def cancel_reminder_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Reminder not found"
         )
-    return Reminder(**row)
+    return Reminder(
+        **row, autonomy_hold=_autonomy_hold(name, row["status"])
+    )

--- a/src/mcp-server/src/tools/reminders.ts
+++ b/src/mcp-server/src/tools/reminders.ts
@@ -69,7 +69,11 @@ export function createReminderTools(
         "`delay_seconds` (relative) or `fire_at` (absolute ISO-8601). The fire " +
         "must be at least 60s and at most 30 days out. Durable — survives a " +
         "backend/scheduler restart. Use `list_reminders`/`cancel_reminder` to " +
-        "manage pending ones.",
+        "manage pending ones. NOTE: reminders only fire while the agent's " +
+        "autonomy mode is ON. If autonomy is off the reminder is accepted and " +
+        "HELD (the response sets `autonomy_hold`), then fires past-due once " +
+        "autonomy is re-enabled — tell the user this rather than promising a " +
+        "reminder that cannot arrive.",
       parameters: z.object({
         agent_name: z
           .string()
@@ -148,7 +152,20 @@ export function createReminderTools(
             timeout_seconds: params.timeout_seconds,
             allowed_tools: params.allowed_tools,
           });
-          return JSON.stringify({ success: true, ...(result as object) }, null, 2);
+          const reminder = result as { autonomy_hold?: boolean };
+          // #1806: the reminder is accepted but the scheduler will not arm it
+          // while autonomy is off. Surface an explicit sentence, not just the
+          // boolean — the caller is an LLM about to tell a user "done".
+          const warning = reminder?.autonomy_hold
+            ? "HELD: this agent's autonomy mode is off, so this reminder will " +
+              "NOT fire until autonomy is re-enabled (it will then fire past-due). " +
+              "Do not tell the user the reminder is scheduled without saying this."
+            : undefined;
+          return JSON.stringify(
+            { success: true, ...(result as object), ...(warning ? { warning } : {}) },
+            null,
+            2
+          );
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           console.error(`[set_reminder] error: ${msg}`);

--- a/src/scheduler/database.py
+++ b/src/scheduler/database.py
@@ -708,6 +708,27 @@ class SchedulerDatabase:
             """)
             return [self._row_to_reminder(row) for row in cursor.fetchall()]
 
+    def count_held_reminders(self) -> int:
+        """Live reminders excluded from arming solely because autonomy is off (#1806).
+
+        The complement of ``get_active_reminders``'s autonomy predicate, with the
+        same live-status and not-deleted conditions. Exists purely for
+        observability: a held reminder is never armed, so there is no job and
+        therefore no skip for the scheduler to log. Without this count an
+        operator debugging "my reminder never fired" has nothing to go on.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT COUNT(*) FROM agent_reminders r
+                JOIN agent_ownership ao ON ao.agent_name = r.agent_name
+                WHERE r.status IN ('pending', 'firing')
+                  AND ao.deleted_at IS NULL
+                  AND ao.autonomy_enabled = 0
+            """)
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+
     def get_reminder_by_id(self, reminder_id: str) -> Optional[Reminder]:
         """Fetch a single reminder by id (to re-read fire_attempts after a CAS)."""
         with self.get_connection() as conn:

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -1783,6 +1783,22 @@ class SchedulerService:
             )
             return
 
+        # #1806: reminders on autonomy-disabled agents are filtered out of
+        # get_active_reminders, so they are never armed and produce no job and
+        # no skip line — the reconcile is the only place that can say they
+        # exist. Log a COUNT (not a row per reminder) once per pass, and only
+        # when non-zero, so a paused fleet doesn't spam the log. Best-effort:
+        # observability must never break the reconcile.
+        try:
+            held = self.db.count_held_reminders()
+            if held:
+                logger.info(
+                    f"{held} reminder(s) held: their agent's autonomy is disabled. "
+                    f"They will fire past-due when autonomy is re-enabled."
+                )
+        except Exception as e:
+            logger.debug(f"Held-reminder count unavailable: {e}")
+
         now = datetime.utcnow()
         # A firing row older than this (with no live job) is a crash-mid-fire
         # orphan: the dispatch window + poll buffer + a margin.

--- a/tests/unit/test_1806_reminder_autonomy_hold.py
+++ b/tests/unit/test_1806_reminder_autonomy_hold.py
@@ -1,0 +1,105 @@
+"""
+Regression for #1806 — a reminder held by the autonomy gate must say so.
+
+The scheduler's `get_active_reminders` filters `ao.autonomy_enabled = 1`, so a
+reminder on a paused agent is never armed: no job, therefore no skip line, and
+the API reported a bare `pending` next to a `fire_at` that quietly slid into the
+past. These tests pin the derived `autonomy_hold` flag that makes the state
+legible.
+
+The gate itself is deliberate (a paused agent must not wake itself) and is NOT
+changed here — only its visibility.
+
+`routers.reminders` is imported lazily inside each test, matching the
+convention in `tests/unit/test_deploy_writable_templates.py`: importing the
+router chain at collection time trips the documented
+tests/utils-shadows-backend-utils sys.modules race. Monkeypatching module
+attributes (never `sys.modules[...] =`) keeps `tests/lint_sys_modules.py` green.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _row(status: str = "pending", agent: str = "a1") -> dict:
+    return {
+        "id": "rem_x",
+        "agent_name": agent,
+        "message": "check the PR",
+        "fire_at": "2026-07-27T10:43:51Z",
+        "status": status,
+        "created_at": "2026-07-27T10:42:51Z",
+    }
+
+
+@pytest.mark.parametrize("status", ["pending", "firing"])
+def test_live_reminder_on_paused_agent_is_flagged(monkeypatch, status):
+    """The whole point: live reminder + autonomy off ⇒ autonomy_hold True."""
+    from routers import reminders
+
+    monkeypatch.setattr(reminders.db, "get_autonomy_enabled", lambda name: False)
+    assert reminders._autonomy_hold("a1", status) is True
+
+
+@pytest.mark.parametrize("status", ["pending", "firing"])
+def test_live_reminder_on_active_agent_is_not_flagged(monkeypatch, status):
+    from routers import reminders
+
+    monkeypatch.setattr(reminders.db, "get_autonomy_enabled", lambda name: True)
+    assert reminders._autonomy_hold("a1", status) is False
+
+
+@pytest.mark.parametrize("status", ["fired", "cancelled", "failed"])
+def test_terminal_reminder_is_never_flagged(monkeypatch, status):
+    """A terminal reminder is not waiting on anything — flagging it would be a lie.
+
+    Also asserts the autonomy lookup is skipped entirely for terminal rows.
+    """
+    from routers import reminders
+
+    def _boom(name):  # pragma: no cover - must not be reached
+        raise AssertionError("autonomy must not be resolved for a terminal reminder")
+
+    monkeypatch.setattr(reminders.db, "get_autonomy_enabled", _boom)
+    assert reminders._autonomy_hold("a1", status) is False
+
+
+def test_autonomy_read_failure_fails_open(monkeypatch):
+    """A settings-read failure must not invent a warning on a healthy reminder."""
+    from routers import reminders
+
+    def _boom(name):
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(reminders.db, "get_autonomy_enabled", _boom)
+    assert reminders._autonomy_hold("a1", "pending") is False
+
+
+def test_precomputed_autonomy_is_used_without_a_lookup(monkeypatch):
+    """The list path resolves autonomy once per page, not once per row."""
+    from routers import reminders
+
+    def _boom(name):  # pragma: no cover - must not be reached
+        raise AssertionError("precomputed autonomy should short-circuit the lookup")
+
+    monkeypatch.setattr(reminders.db, "get_autonomy_enabled", _boom)
+    assert reminders._autonomy_hold("a1", "pending", autonomy_enabled=False) is True
+    assert reminders._autonomy_hold("a1", "pending", autonomy_enabled=True) is False
+
+
+def test_response_model_carries_the_flag(monkeypatch):
+    """_reminder_response is the shared JSON shaper — it must include the flag."""
+    from routers import reminders
+
+    monkeypatch.setattr(reminders.db, "get_autonomy_enabled", lambda name: False)
+    payload = reminders._reminder_response(_row())
+    assert payload["autonomy_hold"] is True
+
+
+def test_model_defaults_to_not_held():
+    """Any construction path that omits the flag must default to the safe value."""
+    from models import Reminder, ReminderSummary
+
+    assert ReminderSummary(**_row()).autonomy_hold is False
+    assert Reminder(**_row()).autonomy_hold is False


### PR DESCRIPTION
## What

Makes the autonomy hold on self-reminders visible. **The gate is not changed** — a paused agent still must not wake itself. Only the silence is fixed.

## Why

`get_active_reminders` filters `ao.autonomy_enabled = 1`, so a reminder on a paused agent is never armed. No job is created, so there is no skip to log — and the API reported a healthy-looking row:

```
status: pending | fire_at: 2026-07-27T10:43:51.215559Z | attempts: None | error: None
```

Clean A/B on a fresh 0.8.5 instance, two agents, identical 60s reminder set in the same second, only `autonomy_enabled` differing:

```
10:43:53Z  scout(autonomy ON)=fired    corbin(autonomy OFF)=pending
10:44:08Z  scout(autonomy ON)=fired    corbin(autonomy OFF)=pending
```

Worse than the sibling schedules case (#1796) on every observability axis: schedules at least log `skipped: … autonomy is disabled`, and `scheduling.md` documents the dependency. Reminders had neither.

## Why not reject at create

Considered and rejected. Chat is **not** autonomy-gated, so an agent can be mid-conversation with a user who says "remind me in an hour". A 409 would fail a legitimate request, and queue-until-unpaused is genuinely useful — the reminder does fire past-due once autonomy returns (verified: held reminder fired ~1 reconcile cycle after enabling). The problem was never the holding; it was not saying so.

## Changes

| Layer | Change |
|---|---|
| `models.py` | `autonomy_hold` on `ReminderSummary` (inherited by `Reminder`), **derived at read time** — no column, no dual-track migration. Defaults `False`. |
| `routers/reminders.py` | `_autonomy_hold()` applied to create, list, cancel. Terminal reminders never flagged and skip the lookup. List resolves autonomy **once per page** (all rows share one agent — a per-row resolve would be a pointless N+1). Fail-open on a read error. |
| `src/scheduler` | log a **count** of held reminders per reconcile pass, only when non-zero, best-effort. The only place that can report them, since they never enter the job store. |
| MCP `set_reminder` | explicit `warning` sentence when held — not just the boolean, since the caller is an LLM about to tell a user "done" — plus the dependency in the tool description (Invariant #13). |
| `docs/user-docs/automation/agent-reminders.md` | documents the dependency, mirroring `scheduling.md`. |

## Verification

**Unit** — `tests/unit/test_1806_reminder_autonomy_hold.py`, 11 cases, all passing: held for `pending`/`firing`, not held when autonomy is on, never flagged for `fired`/`cancelled`/`failed` (asserting the lookup is *not even attempted*), fail-open on a read error, precomputed autonomy short-circuits the per-row lookup, the shared response shaper carries the flag, and both models default to `False`.

**Live**, patched into a running 0.8.5 instance (its backend source is bind-mounted):

```
CREATE on paused agent   → status: pending | autonomy_hold: True
CREATE on active agent   → status: pending | autonomy_hold: False
LIST on paused agent     → fired   | autonomy_hold: False      # terminal, correctly not flagged
                           pending | autonomy_hold: True
```

Then toggling autonomy on, without touching the row:

```
pending | autonomy_hold: False   <- flipped, proving it is derived live, not frozen at create
```

The instance was restored to stock afterwards and verified clean.

**MCP server** compiles (`tsc` via the image build, exit 0).

## Not verified

The scheduler log line is unit-and-inspection level only — the scheduler image is not bind-mounted on my test stack, so I did not rebuild it to watch the line appear. The query is the exact complement of `get_active_reminders`' predicate and is wrapped best-effort.

## Follow-up worth its own issue

A reminder held for days fires **immediately** on unpause, and several would fire at once. "Remind me in an hour" arriving three days late may be worse than never arriving. Deliberately out of scope here — flagging it rather than widening this fix before the release.

Related to #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1806
