### PR TITLE
fix(version): report the code that is running, not the image it was built in (#1810, #1814)

### DIFF
--- a/docs/releases/0.8.5.md
+++ b/docs/releases/0.8.5.md
@@ -188,6 +188,32 @@ the change is additive, and Phases 2-3 of the skill epic (#139 placement/skill-
 runner, #178 unified exposable-skills config) build on this contract, so a flag
 would have a deliberately short life._
 
+### Upgrading in place: rebuild the platform images (#1814)
+
+`./scripts/deploy/start.sh` runs `docker compose up -d` — it does **not** rebuild
+platform images. Checking out a new release and re-running `start.sh` therefore
+does not, on its own, put the new platform code into service:
+
+- On **`docker-compose.prod.yml`** there is no `src/backend` bind mount, so the
+  containers keep running the code baked into the previous build. `start.sh`
+  still reports the stack ready and health still passes.
+- On the **default compose** the backend source *is* bind-mounted, so the new
+  code does run — but the image is still the old one, so anything derived from
+  the image build (the `git_*` provenance fields on `GET /api/version`) keeps
+  describing the previous release.
+
+Rebuild the platform images as part of the upgrade:
+
+```bash
+git checkout v0.8.5
+docker compose build            # or: docker compose build backend frontend mcp-server scheduler
+./scripts/deploy/start.sh
+```
+
+Verify with `GET /api/version`: `version` reports the code in service, and
+`image_version` reports the build it is running inside. **If those two differ,
+the image is stale** — rebuild before continuing.
+
 ### Base-image rebuild + agent recreate required for several v0.8.5 features
 
 Ten files under `docker/base-image/` changed this release. A running fleet on an

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1279,24 +1279,56 @@ def _build_version_payload(
     import os
     from pathlib import Path
 
-    # Version resolution order (#993):
-    #   1. VERSION env var — build-stamped from git (e.g. "0.9.0+g4c640b6e"),
-    #      wired through docker-compose backend.build.args + start.sh.
-    #   2. VERSION file — curated semver, mounted in dev / copied in image.
-    #   3. "unknown" — neither present.
-    # Env-first means dev (bind-mount) and prod (build-arg) agree for the
-    # same commit instead of diverging on the file-mount being absent.
-    version = os.getenv("VERSION") or None
-    if not version:
-        version_paths = [
-            Path("/app/VERSION"),  # In container (mounted)
-            Path(__file__).parent.parent.parent / "VERSION",  # Development
-        ]
-        for version_file in version_paths:
+    # Version resolution (#993, corrected by #1810 + #1814).
+    #
+    #   env VERSION  — build-stamped from git ("0.9.0+g4c640b6e"), wired through
+    #                  docker-compose backend.build.args + start.sh. Describes
+    #                  the IMAGE.
+    #   VERSION file — curated semver. Bind-mounted live in dev
+    #                  (docker-compose.yml `./VERSION:/app/VERSION:ro`), COPY'd
+    #                  into the image in prod. In dev it describes the CODE.
+    #
+    # #1810: `ARG VERSION=unknown` + an unconditional `ENV` means the env var is
+    # always set — to the literal string "unknown" when no build arg was passed.
+    # That sentinel is truthy, so the old `or None` never fired and the file tier
+    # was unreachable for exactly the operator it was written for. Treat the
+    # sentinel as absence.
+    #
+    # #1814: `start.sh` never rebuilds platform images, so after an in-place
+    # upgrade the baked env still names the PREVIOUS build while the
+    # bind-mounted source runs the new code. The two then disagree, and the
+    # file — being live in dev — is the one describing what is actually
+    # executing. Prefer it, and keep the baked value as `image_version` so the
+    # drift is visible rather than silently smoothed over. In prod both are
+    # baked from the same build, so they agree and this branch never fires.
+    _SENTINEL = "unknown"
+
+    env_version = (os.getenv("VERSION") or "").strip()
+    if env_version == _SENTINEL:
+        env_version = ""
+
+    file_version = ""
+    version_paths = [
+        Path("/app/VERSION"),  # In container (mounted in dev, COPY'd in prod)
+        Path(__file__).parent.parent.parent / "VERSION",  # Development
+    ]
+    for version_file in version_paths:
+        try:
             if version_file.exists():
-                version = version_file.read_text().strip()
+                file_version = version_file.read_text().strip()
                 break
-    version = version or "unknown"
+        except OSError:
+            # An unreadable VERSION file must never 500 this endpoint — it is
+            # the endpoint operators reach for when something is already wrong.
+            continue
+
+    # Compare on the semver base: the env value carries a `+g<sha>` suffix the
+    # curated file does not.
+    image_version = env_version or None
+    if env_version and file_version and file_version != env_version.split("+")[0]:
+        version = file_version
+    else:
+        version = env_version or file_version or _SENTINEL
 
     git_commit = os.getenv("GIT_COMMIT", "unknown")
     git_commit_short = git_commit[:8] if git_commit != "unknown" else "unknown"
@@ -1317,6 +1349,12 @@ def _build_version_payload(
             "base_image": f"trinity-agent-base:{version}"
         },
         "runtimes": ["claude-code", "gemini-cli", "codex"],
+        # #1814: the version baked into the running image. Equal to `version`
+        # on a normally-built stack; DIFFERENT means the image is stale
+        # relative to the code being executed (an in-place upgrade without
+        # `docker compose build`), and the git_* fields below describe that
+        # older image, not `version`. None when the image carries no stamp.
+        "image_version": image_version,
         "build_date": os.getenv("BUILD_DATE", "unknown"),
         "git_commit": git_commit,
         "git_commit_short": git_commit_short,

--- a/tests/unit/test_1810_1814_version_truth.py
+++ b/tests/unit/test_1810_1814_version_truth.py
@@ -1,0 +1,108 @@
+"""
+Regression for #1810 + #1814 — `/api/version` must never name a version that
+isn't running.
+
+Two distinct ways the old resolver got it wrong, both observed on a real
+v0.8.0 → v0.8.5 upgrade:
+
+  #1810  `ARG VERSION=unknown` + an unconditional `ENV` means the env var is
+         ALWAYS set — to the literal string "unknown" when no build arg was
+         passed. That sentinel is truthy, so `os.getenv("VERSION") or None`
+         never fell through and the VERSION-file tier was unreachable for
+         exactly the operator it was added for (#993).
+
+  #1814  `start.sh` never rebuilds platform images, so after an in-place
+         upgrade the baked env still names the PREVIOUS build while the
+         bind-mounted source runs the new code. Observed: `version` reported
+         0.8.0+gb3b7078b while migrations 83 → 99 had applied and 0.8.5-only
+         routes answered 200.
+
+The resolver is exercised through the module-level payload builder rather than
+the route so no app/auth wiring is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _payload(monkeypatch, tmp_path, *, env_version, file_version):
+    """Build the version payload with a controlled env var and VERSION file."""
+    import main
+
+    if env_version is None:
+        monkeypatch.delenv("VERSION", raising=False)
+    else:
+        monkeypatch.setenv("VERSION", env_version)
+
+    # Point the first candidate path at a temp file (or nowhere).
+    version_file = tmp_path / "VERSION"
+    if file_version is not None:
+        version_file.write_text(file_version + "\n")
+
+    real_exists = Path.exists
+    real_read = Path.read_text
+
+    def fake_exists(self):
+        # NB: must call the CAPTURED original on the temp file — calling
+        # `version_file.exists()` here would re-enter this patch forever.
+        if self.name == "VERSION":
+            return real_exists(version_file)
+        return real_exists(self)
+
+    def fake_read_text(self, *a, **kw):
+        if self.name == "VERSION":
+            return real_read(version_file, *a, **kw)
+        return real_read(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    return main._build_version_payload(edition="oss", enterprise_features=[], voice_enabled=False)
+
+
+def test_1810_unknown_sentinel_falls_through_to_the_file(monkeypatch, tmp_path):
+    """The bug: a sentinel env var hid a perfectly good baked VERSION file."""
+    out = _payload(monkeypatch, tmp_path, env_version="unknown", file_version="0.8.5")
+    assert out["version"] == "0.8.5"
+    assert out["components"]["backend"] == "0.8.5"
+
+
+def test_1810_absent_env_uses_the_file(monkeypatch, tmp_path):
+    out = _payload(monkeypatch, tmp_path, env_version=None, file_version="0.8.5")
+    assert out["version"] == "0.8.5"
+
+
+def test_1814_stale_image_reports_the_running_code(monkeypatch, tmp_path):
+    """In-place upgrade: file (live bind mount) wins over the stale baked env."""
+    out = _payload(
+        monkeypatch, tmp_path, env_version="0.8.0+gb3b7078b", file_version="0.8.5"
+    )
+    assert out["version"] == "0.8.5", "must report the code that is running"
+    assert out["image_version"] == "0.8.0+gb3b7078b", "drift must stay visible"
+
+
+def test_matching_build_keeps_the_git_suffix(monkeypatch, tmp_path):
+    """A normally-built stack must keep the richer git-stamped value."""
+    out = _payload(
+        monkeypatch, tmp_path, env_version="0.8.5+gb8cf94ca", file_version="0.8.5"
+    )
+    assert out["version"] == "0.8.5+gb8cf94ca"
+    assert out["image_version"] == "0.8.5+gb8cf94ca"
+
+
+def test_no_stamp_and_no_file_is_still_unknown(monkeypatch, tmp_path):
+    """The honest fallback survives — this must not become a crash or a lie."""
+    out = _payload(monkeypatch, tmp_path, env_version="unknown", file_version=None)
+    assert out["version"] == "unknown"
+    assert out["image_version"] is None
+
+
+def test_env_only_still_works(monkeypatch, tmp_path):
+    """Prod-style: env stamped, no readable file — unchanged behaviour."""
+    out = _payload(
+        monkeypatch, tmp_path, env_version="0.8.5+gb8cf94ca", file_version=None
+    )
+    assert out["version"] == "0.8.5+gb8cf94ca"

--- a/tests/unit/test_1810_1814_version_truth.py
+++ b/tests/unit/test_1810_1814_version_truth.py
@@ -27,10 +27,38 @@ from pathlib import Path
 
 import pytest
 
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+
+
+def _load_builder():
+    """Slice `_build_version_payload` out of main.py source and exec it —
+    the same loader as test_926_version_endpoint.py, for the same reason:
+    `import main` executes main.py's full import graph (opentelemetry,
+    slack_sdk, twilio, …), which the unit-test venv deliberately lacks.
+    The builder is stdlib-only by contract (its docstring), so the exec'd
+    snippet is self-sufficient.
+    """
+    src_path = _BACKEND / "main.py"
+    if not src_path.exists():
+        pytest.skip("backend source not present")
+    text = src_path.read_text()
+    marker = "def _build_version_payload"
+    start = text.find(marker)
+    if start == -1:
+        pytest.fail(f"_build_version_payload not found in {src_path}")
+    rest = text[start:]
+    end = rest.find("\n\n\n")  # function ends before the two blank lines
+    snippet = rest[: end if end != -1 else len(rest)]
+    ns: dict = {"__file__": str(src_path)}
+    exec(snippet, ns)
+    return ns["_build_version_payload"]
+
 
 def _payload(monkeypatch, tmp_path, *, env_version, file_version):
     """Build the version payload with a controlled env var and VERSION file."""
-    import main
+    # Load BEFORE the Path patches below — the loader reads main.py via
+    # Path.read_text, which is about to be monkeypatched.
+    build = _load_builder()
 
     if env_version is None:
         monkeypatch.delenv("VERSION", raising=False)
@@ -60,7 +88,7 @@ def _payload(monkeypatch, tmp_path, *, env_version, file_version):
     monkeypatch.setattr(Path, "exists", fake_exists)
     monkeypatch.setattr(Path, "read_text", fake_read_text)
 
-    return main._build_version_payload(edition="oss", enterprise_features=[], voice_enabled=False)
+    return build(edition="oss", enterprise_features=[], voice_enabled=False)
 
 
 def test_1810_unknown_sentinel_falls_through_to_the_file(monkeypatch, tmp_path):

--- a/tests/unit/test_926_version_endpoint.py
+++ b/tests/unit/test_926_version_endpoint.py
@@ -92,19 +92,27 @@ def test_version_payload_falls_back_to_unknown_when_env_missing(monkeypatch):
     assert payload["build_date"] == "unknown"
 
 
-def test_version_payload_prefers_version_env(monkeypatch):
-    """#993 — the build-stamped VERSION env var (e.g. `0.9.0+g4c640b6e`)
-    takes precedence over the VERSION file so dev (bind-mount) and prod
-    (build-arg) agree for the same commit."""
-    monkeypatch.setenv("VERSION", "0.9.0+gdeadbeef")
+def test_version_payload_file_wins_when_env_disagrees(monkeypatch):
+    """#1810/#1814 — when the build-stamped env and the live VERSION file
+    disagree, the FILE (describing the code that is running) wins and the
+    baked value surfaces as `image_version` so the drift stays visible.
+    Supersedes the pre-#1814 env-first contract (#993) this test used to
+    pin: env-first reported a stale image's version after an in-place
+    upgrade."""
+    # The repo VERSION file is read via the injected __file__ path; derive a
+    # guaranteed-disagreeing env stamp from whatever it currently holds.
+    repo_version = (_BACKEND.parent.parent / "VERSION").read_text().strip()
+    stale_env = f"{repo_version}-stale+gdeadbeef"
+    monkeypatch.setenv("VERSION", stale_env)
 
     build = _load_builder()
     payload = build(voice_enabled=False, edition="oss", enterprise_features=[])
 
-    assert payload["version"] == "0.9.0+gdeadbeef"
+    assert payload["version"] == repo_version
+    assert payload["image_version"] == stale_env
     # Version flows into the component descriptors too.
-    assert payload["components"]["backend"] == "0.9.0+gdeadbeef"
-    assert payload["components"]["base_image"] == "trinity-agent-base:0.9.0+gdeadbeef"
+    assert payload["components"]["backend"] == repo_version
+    assert payload["components"]["base_image"] == f"trinity-agent-base:{repo_version}"
 
 
 def test_version_payload_empty_version_env_falls_back_to_file(monkeypatch):


### PR DESCRIPTION
## What

Closes two ways `GET /api/version` reported a version that wasn't running. Both were observed on the same real v0.8.0 → v0.8.5 in-place upgrade, and they're opposite failures of the same resolver, so they're fixed together.

| | #1810 | #1814 |
|---|---|---|
| `VERSION` env holds | the literal sentinel `"unknown"` | a real, correct-for-that-image value (`0.8.0+gb3b7078b`) |
| Cause | `ARG VERSION=unknown` + unconditional `ENV`; truthy sentinel makes the file tier unreachable | image never rebuilt, so the baked value describes the previous build |
| Reported | `"unknown"` | `0.8.0` while 0.8.5 was executing |

Worth being explicit: **#1810's own suggested patch does not fix #1814.** Filtering the sentinel leaves `_version_env = "0.8.0+gb3b7078b"` — truthy and not the sentinel — so tier 1 still wins and the answer is still wrong. That's why this needed a rethink of the precedence rather than a one-line guard.

## The rethink

The two sources describe **different things**, and the old comment ("Env-first means dev and prod agree") assumed they describe the same thing:

- **env `VERSION`** — stamped at image build. Describes the **image**.
- **`VERSION` file** — bind-mounted live in dev (`docker-compose.yml:262` → `./VERSION:/app/VERSION:ro`), `COPY`'d into the image in prod (`docker/backend/Dockerfile:114`). In dev it describes the **code**.

So:

- `"unknown"` is treated as absence, not a value → #1810's operator gets the curated semver that was already sitting in the image.
- When the file and env **disagree**, the file wins (it's the live one) and the baked value is surfaced as a new **`image_version`** field, so drift is visible rather than smoothed over.
- When they **agree**, the env value wins so the richer `+g<sha>` provenance is preserved. Comparison is on the semver base, since only the env value carries the suffix.
- In prod both come from the same build, so they agree by construction and this branch never fires.
- An unreadable `VERSION` file can no longer 500 the endpoint operators reach for when something is already wrong.

`image_version` is additive and nullable. The `git_*` fields still describe the image — now labelled as such in a comment, since when `version != image_version` they are *not* describing `version`.

## Docs (#1814's other half)

`docs/releases/0.8.5.md` never mentioned `docker compose build`; its only operator actions were "rebuild the base image" and "recreate agents" (and per #1809 the second is a no-op too). Added an upgrade section covering:

- prod compose has **no** `src/backend` bind mount → an in-place checkout leaves the old code running, while `start.sh` reports ready and health passes;
- the default compose runs the new code but keeps stale image metadata;
- the rebuild command, and how to verify via `version` vs `image_version`.

**`start.sh` is deliberately unchanged** — the shell scripts stay as they are, per the same call made on #1788.

## Verification

**Unit** — `tests/unit/test_1810_1814_version_truth.py`, 6 cases, all passing: sentinel falls through to the file, absent env falls through, stale image reports the running code *and* keeps the drift visible, a matching build keeps the git suffix, no-stamp-no-file is still honestly `"unknown"`, and env-only (prod-style) is unchanged.

**Live** — applied to the actual upgraded instance that produced #1814, i.e. 0.8.5 code running inside a 0.8.0 image:

```
before:  version: 0.8.0+gb3b7078b     (no way to tell it was wrong)

after:   version      : 0.8.5              ← code actually running
         image_version: 0.8.0+gb3b7078b    ← stale image, now visible
         backend      : 0.8.5
         git_commit   : b3b7078b           (describes the image)
```

The instance was reverted to stock afterwards and verified clean. That the code really was 0.8.5 is independently established: migrations 83 → 99, `agent_reminders` created, and the 0.8.5-only `/reminders`, `/label` and `/settings/retention` routes all answering 200.

## Not covered

`start.sh` still doesn't rebuild, so the underlying staleness remains possible — this makes it *visible and documented* rather than preventing it. The `scripts/deploy/upgrade.sh` promised in `DEPLOYMENT.md` (backup + rebuild + start + verify) is the real fix; #1814 can stay open for it if you'd rather track it that way.

Related to #1810
Related to #1814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1810
Fixes #1814
