### PR TITLE
fix(recovery): stop recreate_missing_container rebuilding a divergent agent (#1811)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -561,6 +561,10 @@ class DatabaseManager:
     def delete_agent_ownership(self, agent_name: str):
         return self._agent_ops.delete_agent_ownership(agent_name)
 
+    def deactivate_agent_mcp_keys(self, agent_name: str) -> int:
+        """Deactivate an agent's agent/connector-scoped MCP keys (#1811)."""
+        return self._agent_ops.deactivate_agent_mcp_keys(agent_name)
+
     def purge_agent_ownership(self, agent_name: str):
         return self._agent_ops.purge_agent_ownership(agent_name)
 

--- a/src/backend/db/agents.py
+++ b/src/backend/db/agents.py
@@ -395,6 +395,18 @@ class AgentOperations(
             .values(is_active=1 if active else 0)
         ).rowcount or 0
 
+    def deactivate_agent_mcp_keys(self, agent_name: str) -> int:
+        """Deactivate this agent's agent- and connector-scoped MCP keys (#1811).
+
+        Standalone-transaction wrapper over `_deactivate_agent_keys_in_txn`, for
+        callers outside a delete/recover transaction — specifically the recovery
+        recreate, which mints a fresh key on every invocation (the old key's
+        plaintext is unrecoverable) and previously left every superseded row
+        active. Returns the number of rows flipped.
+        """
+        with get_engine().begin() as conn:
+            return self._deactivate_agent_keys_in_txn(conn, agent_name, active=False)
+
     def delete_agent_ownership(self, agent_name: str) -> bool:
         """Soft-delete the agent ownership row (Issue #834 Phase 1a).
 

--- a/src/backend/services/agent_service/crud.py
+++ b/src/backend/services/agent_service/crud.py
@@ -1272,10 +1272,19 @@ async def _build_volume_mounts(
     # /home/developer lives on the container writable layer (overlayfs),
     # auto-reclaimed by container removal. Volumes exist to survive
     # recreate, and ghosts never recreate.
+    # #1811: the `encrypted-data:/data` mount was removed rather than copied
+    # into the recovery path. It was dead AND unsafe:
+    #   * nothing in the agent image ever touched /data — the Dockerfile only
+    #     `mkdir`s it, and no code in docker/base-image references it;
+    #   * the volume name was a LITERAL, so a single volume was mounted rw into
+    #     every agent at once — a cross-agent read/write surface in a product
+    #     whose premise is per-agent isolation. Unused today is not a guarantee.
+    # Removing it here (instead of adding it to recreate_missing_container)
+    # makes both paths agree and closes the surface. The volume itself is not
+    # deleted, so anything historically written to it remains on the host.
     volumes = {
         str(config_path): {'bind': '/config/agent-config.yaml', 'mode': 'ro'},
         str(credentials_path): {'bind': '/config/credentials.json', 'mode': 'ro'},
-        'encrypted-data': {'bind': '/data', 'mode': 'rw'},
     }
     if not config.ephemeral:
         await _workspace_volume_mount(config, volumes)

--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -775,6 +775,28 @@ def _workspace_volume_name(agent_name: str) -> str:
         return f"agent-{agent_name}-workspace"
 
 
+def _reconstruct_template_id(agent_name: str, tmpl: dict) -> str:
+    """Best-effort rebuild of an agent's template id after its container is gone (#1811).
+
+    Returns "" when nothing identifying survives — the honest answer, and the
+    same value the caller had before, so this can only improve the result.
+    """
+    try:
+        git_cfg = db.get_git_config(agent_name)
+    except Exception:  # noqa: BLE001 — never block recovery on this
+        git_cfg = None
+
+    repo = getattr(git_cfg, "github_repo", None) if git_cfg else None
+    if repo:
+        branch = getattr(git_cfg, "working_branch", None) or getattr(
+            git_cfg, "source_branch", None
+        )
+        return f"github:{repo}@{branch}" if branch else f"github:{repo}"
+
+    name = (tmpl.get("name") or "").strip()
+    return f"local:{name}" if name else ""
+
+
 async def _read_template_yaml_from_volume(agent_name: str) -> dict:
     """Read the agent's `template.yaml` off its persisted workspace volume
     without a running container (#1559).
@@ -843,7 +865,18 @@ async def recreate_missing_container(agent_name: str):
     else:
         runtime = "claude-code"
         runtime_model = ""
-    template_name = tmpl.get("_template") or ""  # display-only; label field
+    # #1811: the original template id (`local:scout`, `github:Org/repo@main`)
+    # lived ONLY in the destroyed container's TEMPLATE_NAME env and
+    # `trinity.template` label — the workspace `template.yaml` carries `name:`
+    # and `type:`, never `_template`, so this was always empty in practice and
+    # both the label and (once restored) the env var came back blank.
+    # Reconstruct from what actually survives:
+    #   * a GitHub-native agent → its persisted git config (repo + branch);
+    #   * otherwise → `local:{name}` from the volume's template.yaml.
+    # This is a reconstruction, not the original string: an agent created from
+    # a github: URL with no branch suffix gets one back. Persisting the id at
+    # creation is the authoritative fix and needs a schema change.
+    template_name = tmpl.get("_template") or _reconstruct_template_id(agent_name, tmpl)
 
     # --- Resource limits: per-agent DB override → system defaults ---
     system_defaults = get_agent_default_resources()
@@ -864,6 +897,13 @@ async def recreate_missing_container(agent_name: str):
         "AGENT_RUNTIME": runtime,
         "AGENT_RUNTIME_MODEL": runtime_model,
         "TMPDIR": AGENT_DEFAULT_TMPDIR,
+        # #1811: creation sets this (crud.py) and two consumers read it —
+        # startup.sh gates local-template init on it, and the agent-server
+        # /info route reports it. Recovery read the value off template.yaml but
+        # used it only for the `trinity.template` LABEL, so a recovered agent
+        # reported an empty template_name and skipped the local-template
+        # branch. Same empty-string-when-absent shape as creation.
+        "TEMPLATE_NAME": template_name,
     }
 
     # OpenTelemetry (default on) — same wiring as create.
@@ -882,6 +922,21 @@ async def recreate_missing_container(agent_name: str):
     owner_username = owner.get("owner_username") or owner.get("username")
     try:
         if owner_username:
+            # #1811: recovery is not idempotent — every call mints a key, and a
+            # repeatedly-recovered agent accumulated active rows (50 observed on
+            # one instance). Deactivate the superseded ones FIRST, so the key we
+            # are about to mint stays active; the same hygiene #1745 gave delete.
+            # Best-effort: never block recovery on credential bookkeeping.
+            try:
+                superseded = db.deactivate_agent_mcp_keys(agent_name)
+                if superseded:
+                    logger.info(
+                        "Deactivated %d superseded MCP key(s) for %s before recovery mint (#1811)",
+                        superseded, agent_name,
+                    )
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Could not deactivate prior MCP keys for %s: %s", agent_name, e)
+
             agent_mcp_key = db.create_agent_mcp_api_key(
                 agent_name, owner_username, description="recovery-recreate"
             )

--- a/tests/unit/test_1811_recovery_container_parity.py
+++ b/tests/unit/test_1811_recovery_container_parity.py
@@ -1,0 +1,134 @@
+"""
+Regression + drift guard for #1811 — the recovery recreate must build the same
+kind of container as creation.
+
+`recreate_missing_container` (#1559) rebuilds an agent's container spec from
+scratch instead of from the creation path, and drifted: `TEMPLATE_NAME` was
+never restored (so a recovered agent reported an empty `template_name` from
+`/info` and skipped the local-template branch in `startup.sh:341`), and a
+literal shared `encrypted-data:/data` mount existed only on the creation side.
+
+The two builders live ~400 lines apart in different modules and share no spec,
+so nothing stopped them diverging. This asserts the parity directly, by
+reading the env keys each one assigns.
+
+Deliberately source-level (AST) rather than behavioural: driving both builders
+end-to-end needs the full docker/db mock harness, and the failure mode here is
+"someone adds an env var to one path and not the other" — which is visible in
+the source and cheap to check on every run. It is a drift guard, not a
+substitute for the create-path characterization suite (#1484).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+_CRUD = _BACKEND / "services" / "agent_service" / "crud.py"
+_LIFECYCLE = _BACKEND / "services" / "agent_service" / "lifecycle.py"
+
+# Keys creation sets inline that recovery supplies through helpers instead of a
+# literal — parity holds at runtime, not in the source text.
+# Verified against `_apply_persisted_auth_env` (lifecycle.py), which the
+# recovery path calls — these reach a recovered container at runtime even
+# though they are not literals inside `recreate_missing_container`.
+_SUPPLIED_BY_HELPERS = {
+    "ANTHROPIC_API_KEY",          # auth env, resolved from the persisted mode
+    "AGENT_GUARDRAILS",           # lifecycle.py:491 (GUARD-001)
+    "AGENT_TOOL_STALL_LIMIT_S",   # lifecycle.py:501
+}
+
+
+def _env_keys_assigned_in(path: Path, func_name: str) -> set[str]:
+    """Every string-literal key assigned into a dict inside `func_name`.
+
+    Catches both `env_vars["X"] = ...` and `{"X": ...}` literal forms, which is
+    how the two builders express their env sets.
+    """
+    tree = ast.parse(path.read_text())
+    target = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            target = node
+            break
+    assert target is not None, f"{func_name} not found in {path.name}"
+
+    keys: set[str] = set()
+    for node in ast.walk(target):
+        # {"KEY": value}
+        if isinstance(node, ast.Dict):
+            for k in node.keys:
+                if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                    keys.add(k.value)
+        # env_vars["KEY"] = value
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if (
+                    isinstance(tgt, ast.Subscript)
+                    and isinstance(tgt.slice, ast.Constant)
+                    and isinstance(tgt.slice.value, str)
+                ):
+                    keys.add(tgt.slice.value)
+    return keys
+
+
+def _looks_like_env_var(key: str) -> bool:
+    """Env vars are SHOUTY_SNAKE; dict literals in these functions also carry
+    label keys ('trinity.platform'), mount specs ('bind') and JSON fields."""
+    return key.isupper() and key.replace("_", "").isalnum()
+
+
+def test_template_name_is_restored_on_recovery():
+    """The concrete #1811 regression: recovery must set TEMPLATE_NAME."""
+    recovery = _env_keys_assigned_in(_LIFECYCLE, "recreate_missing_container")
+    assert "TEMPLATE_NAME" in recovery, (
+        "recreate_missing_container must set TEMPLATE_NAME — startup.sh:341 gates "
+        "local-template init on it and agent-server /info reports it (#1811)."
+    )
+
+
+def test_recovery_env_covers_creation_env():
+    """Drift guard: an env var added to creation must reach recovery too."""
+    created = {k for k in _env_keys_assigned_in(_CRUD, "_build_base_env") if _looks_like_env_var(k)}
+    recovered = {k for k in _env_keys_assigned_in(_LIFECYCLE, "recreate_missing_container") if _looks_like_env_var(k)}
+
+    missing = created - recovered - _SUPPLIED_BY_HELPERS
+    assert not missing, (
+        "These env vars are set when an agent is CREATED but not when one is "
+        f"RECOVERED, so a recovered agent comes back different: {sorted(missing)}. "
+        "Add them to recreate_missing_container, or to _SUPPLIED_BY_HELPERS if a "
+        "helper provides them at runtime (#1811)."
+    )
+
+
+def test_no_shared_encrypted_data_mount_anywhere():
+    """The mount was a literal name shared rw by every agent — isolation hole.
+
+    Removed from creation rather than copied into recovery, so this asserts it
+    stays gone from BOTH paths.
+    """
+    for path in (_CRUD, _LIFECYCLE):
+        assert "'encrypted-data'" not in path.read_text(), (
+            f"{path.name} mounts the shared `encrypted-data` volume. It is a literal "
+            "name, so one volume would be mounted rw into every agent at once (#1811)."
+        )
+
+
+def test_recovery_deactivates_superseded_keys_before_minting():
+    """Order matters: deactivating AFTER the mint would kill the new key too."""
+    src = _LIFECYCLE.read_text()
+    func_start = src.index("async def recreate_missing_container")
+    body = src[func_start:]
+    deactivate_at = body.find("deactivate_agent_mcp_keys")
+    mint_at = body.find("create_agent_mcp_api_key")
+
+    assert deactivate_at != -1, "recovery must deactivate superseded MCP keys (#1811)"
+    assert mint_at != -1
+    assert deactivate_at < mint_at, (
+        "deactivate_agent_mcp_keys must run BEFORE create_agent_mcp_api_key — "
+        "it flips every agent-scoped key for the agent, so running it after the "
+        "mint would deactivate the key just issued (#1811)."
+    )


### PR DESCRIPTION
## What

All four acceptance criteria from #1811, verified live by reproducing the reporter's exact trigger (remove a stopped agent's container, `POST /api/agents/{name}/start`).

Two of the three fixes are **not** what the issue proposed, for reasons below.

## 1. `encrypted-data:/data` — removed from creation, not added to recovery

The issue asked: *"Worth confirming whether the mount is still wanted at all; if it is dead, the honest fix may be deleting it from `crud.py` rather than adding it here."*

It is dead, and it is worse than dead:

- Nothing under `docker/base-image/` references `/data` — the Dockerfile only `mkdir`s it. The reporter's own observation (empty in both agents) matches.
- The volume name is a **literal**, not per-agent. So a single volume was mounted **rw into every agent simultaneously** — a cross-agent read/write surface in a product whose premise is per-agent container isolation. Nothing writes there *today*; that is not a guarantee.

Removed at the source. Both paths now agree, and the surface is gone. The volume itself isn't deleted, so anything historically written to it remains on the host.

## 2. `TEMPLATE_NAME` — the suggested fix alone doesn't work

The issue proposed re-setting it "from the value already read off `template.yaml`". I did that first and verified it live: **still empty**.

`_read_template_yaml_from_volume` returns the workspace `template.yaml`, which carries `name:` and `type:` — never `_template`. So `tmpl.get("_template")` is empty in practice, which is also why `trinity.template` came back blank. The original id (`local:scout`, `github:Org/repo@main`) existed **only** in the destroyed container's env and label.

`_reconstruct_template_id` rebuilds it from what survives:

- GitHub-native agent → persisted `agent_git_config` (`github:{repo}@{working_branch}`)
- otherwise → `local:{name}` from the volume's `template.yaml`
- nothing identifying → `""`, the honest answer and no worse than before

Being explicit: this is a **reconstruction, not the original string**. A github agent created without a branch suffix gets one back. The authoritative fix is persisting the template id at creation, which needs a schema change — happy to file that as a follow-up.

## 3. MCP keys — deactivate *before* mint

Order is load-bearing: `_deactivate_agent_keys_in_txn` flips **every** agent/connector-scoped key for the agent, so running it after the mint would deactivate the key just issued. Reuses #1745's in-txn primitive via a new standalone-transaction accessor (`deactivate_agent_mcp_keys`), best-effort so credential bookkeeping can never block a recovery. There's a test pinning the ordering.

## 4. Parity guard

`tests/unit/test_1811_recovery_container_parity.py` — the "cheap regression guard" the issue asked for. Source-level (AST) rather than behavioural: driving both builders end-to-end needs the full docker/db mock harness, while the actual failure mode ("someone adds an env var to one path and not the other") is visible in the source and cheap to check every run. It asserts creation's env keys are covered by recovery, `TEMPLATE_NAME` among them, neither path mounts the shared volume, and the deactivate-then-mint order.

It earned its keep immediately: it flagged `AGENT_GUARDRAILS` and `AGENT_TOOL_STALL_LIMIT_S` as divergent. Both turned out to be genuinely supplied at runtime by `_apply_persisted_auth_env` (lifecycle.py:491, 501) — I had guessed at those names in the allowlist instead of reading them, and the test caught my error, not the code's. Now recorded with verified names and line references.

## Verification

**Unit** — 44 passed: the 4 new parity cases plus the full #1484 create-agent characterization suite (unaffected by the mount removal). `tests/lint_sys_modules.py` reports no new violations.

**Live**, reproducing the reporter's trigger on a real instance:

```
before recovery:  TEMPLATE_NAME=local:scout   active agent keys: 1

after recovery (fixed):
  TEMPLATE_NAME = local:scout
  trinity.template = 'local:scout'
  mounts: agent-up-beta-workspace -> /home/developer     (no encrypted-data)
  active agent keys: 1        ← was 1, would have been 2
  log: "Deactivated 1 superseded MCP key(s) for up-beta before recovery mint (#1811)"
```

A **second** recovery left the key count at 1, confirming the operation is now idempotent. The instance was reverted to stock afterwards and verified clean.

## Not done

The issue's structural suggestion — one shared container-spec builder across `create_agent_internal` and both recreate paths — is the real cure and is out of scope here; #1028 already tracks the `crud.py` split that would enable it. This PR fixes the three concrete divergences and adds the guard that makes the next one fail loudly instead of silently.

Fixes #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)