### PR TITLE
fix(label): reject a mistyped label body instead of silently clearing (#1821)

### DIFF
--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -5,7 +5,7 @@ import os
 import re
 import unicodedata
 
-from pydantic import BaseModel, EmailStr, Field, SecretStr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, SecretStr, field_validator, model_validator
 from typing import Any, Dict, List, Literal, Optional, Union
 from datetime import datetime
 from enum import Enum
@@ -262,8 +262,18 @@ class AgentLabelUpdate(BaseModel):
     `label=None` (or blank) clears it, and the agent renders under its slug
     again. Presentation only: the slug never moves, which is the entire point —
     a slug rename re-keys ~20 tables and strands the agent's volumes (#1664).
+
+    #1821: `label` is REQUIRED-but-nullable, and unknown fields are rejected.
+    Clearing is a legitimate operation expressed as an explicit null, but with
+    an ignored-extras model and a `None` default it was also what you got from
+    any body the server did not recognise — so `{"display_label": "..."}` (an
+    easy mistake: `display_label` is the DB column and `display_name` the
+    response field) returned 200 and silently wiped the label. Both an unknown
+    field and an empty `{}` now 422 instead of destroying data.
     """
-    label: Optional[str] = None
+    model_config = ConfigDict(extra="forbid")
+
+    label: Optional[str]
 
     @field_validator("label")
     @classmethod

--- a/tests/unit/test_1640_display_label_at_creation.py
+++ b/tests/unit/test_1640_display_label_at_creation.py
@@ -92,9 +92,23 @@ def test_agentconfig_blank_label_clears(M):
 def test_label_update_shares_policy(M):
     assert M.AgentLabelUpdate(label="  Hi  ").label == "Hi"
     assert M.AgentLabelUpdate(label="").label is None       # clear
-    assert M.AgentLabelUpdate().label is None
+    assert M.AgentLabelUpdate(label=None).label is None     # clear, said explicitly
     with pytest.raises(Exception):
         M.AgentLabelUpdate(label="bad\ttab")
+
+
+def test_label_update_requires_the_label_field(M):
+    """#1821: an omitted or misnamed `label` no longer means "clear".
+
+    It used to, which made a typo'd field name — `display_label`, the DB column,
+    right next to the `display_name` response field — indistinguishable from a
+    deliberate clear: the unknown key was dropped, `label` defaulted to None, and
+    the PUT wiped the label while answering 200. Clearing is still supported and
+    unchanged in meaning (see the two cases above); it just has to be stated."""
+    with pytest.raises(Exception):
+        M.AgentLabelUpdate()                              # empty body
+    with pytest.raises(Exception):
+        M.AgentLabelUpdate(display_label="Typo Name")     # the actual #1821 trigger
 
 
 def test_not_unique_policy(M):

--- a/tests/unit/test_1821_label_update_strictness.py
+++ b/tests/unit/test_1821_label_update_strictness.py
@@ -1,0 +1,65 @@
+"""
+Regression for #1821 — a mistyped label body must not silently clear the label.
+
+`AgentLabelUpdate` ignored unknown fields and defaulted `label` to None, and
+None *means* "clear". So a body the server did not recognise was
+indistinguishable from a deliberate clear:
+
+    PUT {"display_label": "Typo Name"}  ->  200, label wiped
+
+That mistake is easy to make: the DB column is `display_label`, the response
+field is `display_name`, and only `label` is accepted.
+
+Clearing stays supported — it just has to be said explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+
+def _model():
+    from models import AgentLabelUpdate
+
+    return AgentLabelUpdate
+
+
+def test_unknown_field_is_rejected_not_treated_as_a_clear():
+    """The exact bug: the field name from the DB column must not wipe the label."""
+    with pytest.raises(ValidationError):
+        _model()(display_label="Typo Name")
+
+
+def test_empty_body_is_rejected():
+    """`{}` was also a silent clear — ambiguous with a malformed request."""
+    with pytest.raises(ValidationError):
+        _model()()
+
+
+def test_explicit_null_still_clears():
+    """Clearing is legitimate — it just has to be explicit."""
+    assert _model()(label=None).label is None
+
+
+def test_blank_string_still_clears():
+    """Documented clear-by-blank behaviour is unchanged (normalizer maps to None)."""
+    assert _model()(label="   ").label is None
+
+
+def test_setting_a_label_still_works():
+    assert _model()(label="Alpha (Research Lead)").label == "Alpha (Research Lead)"
+
+
+def test_label_is_still_normalized():
+    """The ent#181 normalizer must still run — strictness must not bypass it.
+
+    It trims and NFC-normalizes; it does NOT collapse internal whitespace.
+    """
+    assert _model()(label="  Alpha Lead  ").label == "Alpha Lead"
+
+
+def test_control_characters_are_still_rejected():
+    """The normalizer's own guard must survive the stricter model config."""
+    with pytest.raises(ValidationError):
+        _model()(label="bad\nlabel")


### PR DESCRIPTION
## What

`PUT /api/agents/{name}/label` no longer returns 200 and silently wipes the label when the body uses a field name it doesn't recognise.

## Why

`label=None` means "clear", and the model ignored unknown fields with `label` defaulting to `None` — so a malformed body and a deliberate clear were the same request. I hit this by accident while testing the feature, sending `display_label` (the DB column name):

```
label before                        : Alpha (Research Lead)
PUT {"display_label":"Typo Name"} → HTTP 200
label after                         : None
```

The naming makes it easy: the column is `display_label`, the response field is `display_name`, only `label` is accepted.

## Change

- `model_config = ConfigDict(extra="forbid")` — an unknown field 422s.
- `label` becomes **required-but-nullable** — `{}` also 422s, since it carried the same ambiguity and was never a documented way to clear.

Clearing is unchanged in meaning and still supported; it just has to be explicit.

## Compatibility

- The frontend already sends `{ label }` on every call (`stores/agents.js:393`), including when clearing.
- No MCP tool sets labels.
- Behaviour change worth naming: `PUT {}` now 422s where it used to clear. That path was indistinguishable from a typo, which is the bug.

## Verification

**Unit** — `tests/unit/test_1821_label_update_strictness.py`, 7 cases: unknown field rejected, empty body rejected, explicit null still clears, blank string still clears, setting works, the ent#181 normalizer still runs, and control characters are still rejected (strictness must not bypass the existing validator).

One test of mine was wrong on the first pass — I asserted the normalizer collapses internal whitespace; it only trims and NFC-normalizes. Corrected to the real behaviour rather than changing the code to match my assumption.

**Live**, reproducing the issue exactly:

```
PUT {"display_label":"Typo"}   -> 422   (was 200 + silent wipe)
PUT {}                         -> 422
label survived                 : Alpha (Research Lead)
PUT {"label":null}             -> 200
label now                      : None
```

Instance reverted to stock afterwards.

Fixes #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
