### PR TITLE
test(retention): edge-case + property coverage for the retention blast-radius guard (#1771)

### DIFF
--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -4,6 +4,19 @@ pytest-asyncio>=0.24.0
 pytest-timeout>=2.3.0
 pytest-html>=4.1.0
 pytest-cov>=6.0.0
+# Property-based testing (#1771 / P-38 /edge-cases). EXACT pin, not a `>=` floor,
+# deliberately breaking this file's convention: Hypothesis's example generation and
+# shrinking change between releases, so a floating floor makes a derandomized-seed
+# failure non-reproducible across machines and CI runs. Three concurrent #1771
+# slices add this identical line — keeping it byte-identical keeps the merge
+# trivial in any order.
+#
+# Unlike pytest-randomly (deliberately kept OUT of this file, backend-unit-test.yml:93-99,
+# because pytest auto-discovers installed plugins and it would silently randomize
+# every local run), Hypothesis's auto-loaded plugin does not alter collection order
+# or the behaviour of tests that don't use @given — it only adds --hypothesis-*
+# options and a statistics reporter.
+hypothesis==6.161.5
 httpx>=0.28.0
 websockets>=13.0
 python-dotenv>=1.0.1

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -4,18 +4,25 @@ pytest-asyncio>=0.24.0
 pytest-timeout>=2.3.0
 pytest-html>=4.1.0
 pytest-cov>=6.0.0
-# Property-based testing (#1771 / P-38 /edge-cases). EXACT pin, not a `>=` floor,
-# deliberately breaking this file's convention: Hypothesis's example generation and
-# shrinking change between releases, so a floating floor makes a derandomized-seed
-# failure non-reproducible across machines and CI runs. Three concurrent #1771
-# slices add this identical line — keeping it byte-identical keeps the merge
-# trivial in any order.
+# Property-based testing (#1771 / P-38 `/edge-cases`). Used by
+# tests/unit/test_1771*_properties.py.
 #
-# Unlike pytest-randomly (deliberately kept OUT of this file, backend-unit-test.yml:93-99,
-# because pytest auto-discovers installed plugins and it would silently randomize
-# every local run), Hypothesis's auto-loaded plugin does not alter collection order
-# or the behaviour of tests that don't use @given — it only adds --hypothesis-*
-# options and a statistics reporter.
+# EXACT pin, deliberately breaking this file's `>=` convention: Hypothesis's
+# example generation and shrinking change between releases, and the #1771
+# property suites run under a `derandomize=True` profile whose frozen input set
+# is stable only per version. A floating floor would make a failure
+# irreproducible across machines and could surface as a head-only failure in
+# CI's base-vs-head regression diff — the one thing the derandomized profile
+# exists to prevent.
+#
+# Unlike pytest-randomly (deliberately kept OUT of this file — see
+# backend-unit-test.yml:93-99 — because pytest auto-discovers installed plugins
+# and it would silently randomize every local run), Hypothesis's auto-loaded
+# plugin changes neither collection order nor the behaviour of tests that don't
+# use @given; it only adds --hypothesis-* options and a statistics reporter.
+#
+# Every #1771 slice adds this block byte-identically at this exact position, so
+# the slices merge cleanly in any order and the file keeps ONE hypothesis line.
 hypothesis==6.161.5
 httpx>=0.28.0
 websockets>=13.0

--- a/tests/unit/test_1771a_retention_edges.py
+++ b/tests/unit/test_1771a_retention_edges.py
@@ -421,12 +421,82 @@ class TestRefusalAlarm:
     def test_alarm_id_is_the_natural_key_and_expiry_is_null(self, guard_db):
         """C9 + C10. `expires_at` must stay None: `mark_operator_queue_expired`
         flips any pending row past `expires_at` to `expired` fleet-wide every 5s,
-        which would silently retire the alarm."""
+        which would silently retire the alarm.
+
+        The id is compared against a LITERAL format, not against `_alarm_id()`
+        itself. Asserting `item["id"] == _alarm_id(...)` is a tautology — both
+        sides move together, so it survives any change to the id's shape. The
+        mutation gate caught exactly that: mutating the `"retention-guard-"`
+        prefix left the original assertion green. The format is load-bearing:
+        `create_item` is INSERT ... ON CONFLICT DO NOTHING on `id`, so the natural
+        key is what makes re-emission idempotent (one alarm per setting+window).
+        """
         _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
         _agent, item = guard_db.queue_items[0]
 
-        assert item["id"] == _RG._alarm_id("execution_row_retention_days", 5)
+        assert item["id"] == "retention-guard-execution_row_retention_days-5"
         assert item["expires_at"] is None
+
+    def test_alarm_is_raised_as_a_critical_alert(self, guard_db):
+        """The alarm's ROUTING and VISIBILITY fields, not just its key set.
+
+        `priority` decides how loudly a refused mass-deletion surfaces to an
+        operator; downgrading it to `low` is a silent re-run of the #1638
+        failure mode (the signal exists but nobody sees it). `type` decides
+        which queue surface renders it, and `alert_type` is the discriminator
+        consumers filter on. The C8 payload test pins the key SET; these are the
+        VALUES, which the mutation gate showed were unasserted.
+        """
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        _agent, item = guard_db.queue_items[0]
+
+        assert item["type"] == "alert"
+        assert item["priority"] == "critical"
+        assert item["context"]["alert_type"] == "retention_blast_radius"
+        assert item["context"]["setting_key"] == "execution_row_retention_days"
+        assert item["context"]["window_days"] == 5
+
+    def test_window_source_distinguishes_a_db_row_from_a_code_default(self, guard_db):
+        """The provenance field whose ABSENCE made #1638 invisible.
+
+        A `code-default` window is one a future edit to `OPS_SETTINGS_DEFAULTS`
+        can move under the operator's feet; a `db-row` window is one they chose.
+        Reporting the wrong one on a refusal alarm points the investigation at
+        the wrong cause. Both branches asserted — the mutation gate showed only
+        the `db-row` side was covered.
+        """
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        _agent, item = guard_db.queue_items[0]
+        assert (
+            item["context"]["window_source"] == "code-default"
+        ), "no setting row exists, so the window came from the code default"
+
+        guard_db.settings["health_check_retention_days"] = "7"
+        _RG.announce_refusal("health_check_retention_days", "health", 7, _verdict())
+        _agent, item = guard_db.queue_items[1]
+        assert item["context"]["window_source"] == "db-row"
+
+
+class TestVerdictImmutability:
+
+    def test_guard_verdict_cannot_be_mutated_after_the_decision(self):
+        """`GuardVerdict` is a FROZEN dataclass, and that is a safety property.
+
+        The verdict is handed to `announce_refusal` and returned through
+        `_guard_allows` to the sweep that is about to delete rows. If it were
+        mutable, any of those hops — or a future one — could flip `allowed` from
+        False to True after the decision was made, turning a refusal into a
+        prune with no re-evaluation. `test_1644:170` asserts `v.allowed is False`
+        after a failed alarm, which only proves anything BECAUSE the object is
+        frozen; the mutation gate showed `frozen=True` -> `frozen=False` survived
+        the whole suite.
+        """
+        import dataclasses
+
+        v = _RG.GuardVerdict(False, 5000, 1000, "over_threshold")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            v.allowed = True
+        assert v.allowed is False
 
     def test_alarm_hosts_on_the_uncreatable_sentinel_agent(self, guard_db):
         _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())

--- a/tests/unit/test_1771a_retention_edges.py
+++ b/tests/unit/test_1771a_retention_edges.py
@@ -599,6 +599,41 @@ class TestRetentionSettingsCoercion:
         )
         assert _CS._read_retention_settings() == (11, 22, 33, 44)
 
+    def test_a_missing_row_falls_back_to_that_keys_code_default(
+        self, cleanup_db, monkeypatch
+    ):
+        """The un-configured install — the DEFAULT state, and #1638's blast radius.
+
+        Every other test in this class overrides `get_setting_value` to IGNORE the
+        `default` it is handed, so nothing asserted where that default comes from.
+        The reader passes `OPS_SETTINGS_DEFAULTS.get(key, "0")`
+        (cleanup_service.py:174); replacing that lookup with a literal, or reading
+        it under the wrong key, hands every install-with-no-row a window nobody
+        chose — the #1638 mechanism one layer above the constant it moved.
+
+        The expectation is READ from `OPS_SETTINGS_DEFAULTS` at runtime, never
+        transcribed: pinning the numbers here would BE the anti-pattern this file
+        exists to avoid (learnings.md:101-103). The DIRECTION those defaults may
+        move is pinned by `test_1638_retention_upgrade_safety.py`, which is where
+        that belongs. This test pins only the WIRING.
+        """
+        from services.settings_service import OPS_SETTINGS_DEFAULTS
+
+        # Returning the handed-in `default` is exactly "there is no system_settings
+        # row for this key" — `db.get_setting_value` is a get-or-default accessor.
+        monkeypatch.setattr(
+            cleanup_db, "get_setting_value", lambda key, default=None: default
+        )
+        assert _CS._read_retention_settings() == tuple(
+            int(OPS_SETTINGS_DEFAULTS[key])
+            for key in (
+                "execution_log_retention_days",
+                "execution_row_retention_days",
+                "health_check_retention_days",
+                "agent_reports_retention_days",
+            )
+        )
+
     def test_unicode_digits_are_accepted_by_int(self, cleanup_db, monkeypatch):
         """D5 — OBSERVED, NOT ENDORSED. `int()` accepts non-ASCII decimal digits,
         so an Arabic-Indic '١٢' resolves to a real 12-day window. Harmless (the
@@ -681,22 +716,26 @@ class TestGuardAdapters:
 
     def test_refused_verdict_announces_and_blocks_the_prune(self, monkeypatch):
         """H2. Returning True here is the unrecoverable failure — it is the
-        difference between 'refused' and '95.7% of the table is gone'."""
+        difference between 'refused' and '95.7% of the table is gone'.
+
+        The WHOLE forwarded argument tuple is asserted, not just the setting key.
+        `announce_refusal(setting_key, label, window_days, verdict)` is positional,
+        so transposing `label` and `window_days` would key the transition memo on a
+        label string and stamp the alarm's `context.window_days` with prose — a
+        wrong blast-radius report on the one row an operator reads to decide.
+        """
         calls = []
-        monkeypatch.setattr(
-            _RG,
-            "evaluate",
-            lambda *a, **k: _RG.GuardVerdict(False, 9999, 1000, "over_threshold"),
-        )
+        refused = _RG.GuardVerdict(False, 9999, 1000, "over_threshold")
+        monkeypatch.setattr(_RG, "evaluate", lambda *a, **k: refused)
         monkeypatch.setattr(
             _RG, "note_allowed", lambda key: calls.append(("allow", key))
         )
         monkeypatch.setattr(
-            _RG, "announce_refusal", lambda *a: calls.append(("refuse", a[0]))
+            _RG, "announce_refusal", lambda *a: calls.append(("refuse", a))
         )
 
         assert _CS._guard_allows("k", "label", 5, lambda limit: 9999) is False
-        assert calls == [("refuse", "k")]
+        assert calls == [("refuse", ("k", "label", 5, refused))]
 
     def test_floor_is_forwarded_to_evaluate(self, monkeypatch):
         """A dropped `floor` would silently promote the agent sweep (floor 0, every
@@ -808,22 +847,36 @@ class TestPredicateEdges:
         call time (retention.py:134), so a row seeded 'at the cutoff' at T0 is
         compared against a cutoff computed at T1 > T0 and is strictly older by the
         elapsed microseconds — written naively this test fails on CORRECT code.
+
+        The neighbouring row is seeded ONE TICK older, and its removal is asserted:
+        `counted == pruned` alone is satisfied by `0 == 0`, so without a positive
+        control a predicate that matched NOTHING would pass this test. `iso_cutoff`
+        always returns `...ffffffZ`, so swapping the trailing `Z` (0x5A) for `0`
+        (0x30) yields a same-length string that sorts strictly BEFORE the cutoff —
+        the tightest possible input for `<` versus `<=`.
         """
         import db.schedules.retention as _RET
 
         frozen = _days_ago_iso(90)
+        assert frozen.endswith("Z"), f"iso_cutoff format changed: {frozen!r}"
         monkeypatch.setattr(_RET, "iso_cutoff", lambda **kwargs: frozen)
 
         _seed("at-cutoff", frozen)
-        _seed("one-tick-older", frozen[:-1] + "0" if frozen[-1] != "0" else frozen)
+        _seed("one-tick-older", frozen[:-1] + "0")
 
         counted = sched.count_execution_row_candidates(90, limit=1000)
         pruned = sched.prune_execution_rows(90, chunk_size=1000)
-        assert counted == pruned
+        assert counted == pruned == 1, "exactly the strictly-older row is a candidate"
         assert (
             _hscalar("SELECT COUNT(*) FROM schedule_executions WHERE id = 'at-cutoff'")
             == 1
         ), "a row exactly at the cutoff is not yet past it"
+        assert (
+            _hscalar(
+                "SELECT COUNT(*) FROM schedule_executions WHERE id = 'one-tick-older'"
+            )
+            == 0
+        ), "one tick past the cutoff IS past it"
 
     def test_prune_execution_rows_drains_fully_with_a_small_chunk_size(self, sched):
         """F11: `chunk_size` bounds each TRANSACTION, not the call — the loop

--- a/tests/unit/test_1771a_retention_edges.py
+++ b/tests/unit/test_1771a_retention_edges.py
@@ -1,0 +1,910 @@
+"""#1771 target 1 — edge cases for the retention blast-radius guard (/edge-cases, P-38).
+
+Companion to `test_1644_retention_guard.py`, which pins the guard's headline
+properties (predicate parity, fail-closed). This file works the BOUNDARIES and the
+surfaces #1644's suite executes but never asserts:
+
+* exactly-at-threshold decisions (`<=` at `retention_guard.py:183`) — the existing
+  suite only probes 12-vs-1000 and 1001-vs-1000, so the one comparison that decides
+  whether a prune runs is never tested at its own boundary;
+* the `_last_refused` transition memo, the alarm's log LEVEL, its COUNT, and its
+  PAYLOAD — `announce_refusal`/`note_allowed`/`_alarm_id` all run today
+  (`test_1644:177`, `test_cleanup_inner_sweeps:105`) but nothing asserts what they
+  did, which is precisely the state in which a mutant survives;
+* `_read_retention_settings`, whose body never executes anywhere in the suite —
+  all 8 references are `patch.object(_CS, "_read_retention_settings", ...)`;
+* the per-sweep floors, which `MAX_ROWS_PER_SWEEP`'s direction test does NOT cover
+  (`retention_guard.py:170` is `MAX_ROWS_PER_SWEEP if floor is None else floor` —
+  there is no `min()`, so a floor OVERRIDES the global rather than being bounded by
+  it, and raising `FLOOR_SCHEDULES` would disarm that sweep with every test green).
+
+HOUSE RULE THIS FILE OBEYS (docs/memory/learnings.md:101-103)
+------------------------------------------------------------
+#1638 shipped green because a test asserted the DESTRUCTIVE VALUE as the
+requirement (`assert OPS_SETTINGS_DEFAULTS[key] == "5"`). Nothing here pins a
+retention value or a threshold value. Assertions pin DIRECTIONS
+(`FLOOR_SCHEDULES <= MAX_ROWS_PER_SWEEP`) and STRUCTURAL INVARIANTS (every
+`RETENTION_OPS_KEYS` window has a `_guard_allows` call site) — never a number that
+is safe today and catastrophic tomorrow.
+
+Invocation: `cd tests && python -m pytest unit/test_1771a_retention_edges.py`.
+`tests/unit/pytest.ini` wins ini-discovery, so rootdir is `tests/unit` and the root
+`pyproject.toml` `pythonpath`/`markers` do NOT apply; `tests/` reaches `sys.path`
+only via the `cd tests` + `python -m pytest` form.
+"""
+
+import ast
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from db_harness import db_backend, run as _hrun, scalar as _hscalar  # noqa: E402,F401
+
+import services.retention_guard as _RG  # noqa: E402
+from services import cleanup_service as _CS  # noqa: E402
+from utils.helpers import iso_cutoff  # noqa: E402
+
+_SRC_CLEANUP = _BACKEND / "services" / "cleanup_service.py"
+
+
+def _days_ago_iso(days: int) -> str:
+    return iso_cutoff(hours=days * 24)
+
+
+# ---------------------------------------------------------------------------
+# Doubles + isolation
+# ---------------------------------------------------------------------------
+
+
+class _DbDouble:
+    """In-memory stand-in for the four `db` methods this subsystem touches.
+
+    Verified signatures: `get_setting_value(key, default=None)`, `set_setting(key,
+    value)`, `delete_setting(key)` (database.py:1705-1711) and
+    `create_operator_queue_item(agent_name, item)` (database.py:2513).
+
+    A dict double rather than a real DB because these tests assert the exact alarm
+    PAYLOAD and the exact alarm COUNT, which a real queue table would only let us
+    observe indirectly.
+    """
+
+    def __init__(self, settings=None):
+        self.settings = dict(settings or {})
+        self.queue_items = []
+        self.raise_on_get = False
+        self.raise_on_create = False
+
+    def get_setting_value(self, key, default=None):
+        if self.raise_on_get:
+            raise RuntimeError("settings read exploded")
+        return self.settings.get(key, default)
+
+    def set_setting(self, key, value):
+        self.settings[key] = value
+
+    def delete_setting(self, key):
+        self.settings.pop(key, None)
+
+    def create_operator_queue_item(self, agent_name, item):
+        if self.raise_on_create:
+            raise RuntimeError("operator queue is down")
+        self.queue_items.append((agent_name, item))
+
+
+@pytest.fixture(autouse=True)
+def _reset_transition_memo(monkeypatch):
+    """`retention_guard._last_refused` is module state that outlives every test.
+
+    `test_1644:177` already writes `_last_refused["execution_row_retention_days"]`
+    and `test_cleanup_inner_sweeps` pops keys via `note_allowed`. CI runs
+    `pytest-randomly` under three seeds (backend-unit-test.yml:99,117), so without
+    this reset a "first refusal fires ERROR + exactly one alarm" assertion silently
+    degrades into the repeat-refusal case whenever another file ran first — a test
+    that passes for the wrong reason.
+    """
+    monkeypatch.setattr(_RG, "_last_refused", {})
+
+
+@pytest.fixture
+def guard_db(monkeypatch):
+    """Patch `db` BY OBJECT on the guard module.
+
+    `retention_guard.py:56` does `from database import db`, binding its own
+    module-global — patching `database.db` is inert here (learnings.md:99, and the
+    same note at test_cleanup_inner_sweeps.py:32-35).
+    """
+    double = _DbDouble()
+    monkeypatch.setattr(_RG, "db", double)
+    return double
+
+
+@pytest.fixture
+def cleanup_db(monkeypatch):
+    """Same, for `cleanup_service`'s own `db` binding."""
+    double = _DbDouble()
+    monkeypatch.setattr(_CS, "db", double)
+    return double
+
+
+# ---------------------------------------------------------------------------
+# A — evaluate() decision boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateBoundaries:
+    """The `candidates <= threshold` comparison decides whether data dies."""
+
+    @pytest.mark.parametrize(
+        "row,floor,available,expect_allowed,expect_reason",
+        [
+            # A3/A5: exactly AT the threshold passes — `<=`, not `<`.
+            (
+                "A5-rows-at-threshold",
+                None,
+                _RG.MAX_ROWS_PER_SWEEP,
+                True,
+                "under_threshold",
+            ),
+            (
+                "A3-schedules-at-floor",
+                _RG.FLOOR_SCHEDULES,
+                _RG.FLOOR_SCHEDULES,
+                True,
+                "under_threshold",
+            ),
+            # A6: one below / one above, both floors.
+            (
+                "A6-rows-below",
+                None,
+                _RG.MAX_ROWS_PER_SWEEP - 1,
+                True,
+                "under_threshold",
+            ),
+            (
+                "A4-rows-above",
+                None,
+                _RG.MAX_ROWS_PER_SWEEP + 1,
+                False,
+                "over_threshold",
+            ),
+            (
+                "A6-schedules-below",
+                _RG.FLOOR_SCHEDULES,
+                _RG.FLOOR_SCHEDULES - 1,
+                True,
+                "under_threshold",
+            ),
+            (
+                "A4-schedules-above",
+                _RG.FLOOR_SCHEDULES,
+                _RG.FLOOR_SCHEDULES + 1,
+                False,
+                "over_threshold",
+            ),
+            # A2: floor=0 must NOT fall back to MAX_ROWS_PER_SWEEP (`is None`, not falsy).
+            ("A2-agents-at-zero", _RG.FLOOR_AGENTS, 0, True, "under_threshold"),
+            ("A2-agents-one-candidate", _RG.FLOOR_AGENTS, 1, False, "over_threshold"),
+        ],
+    )
+    def test_threshold_boundary(
+        self, row, floor, available, expect_allowed, expect_reason, guard_db
+    ):
+        """`available` is what a real bounded count would see; count_fn is
+        limit-honouring (`min`), exactly like `_bounded_count`."""
+        v = _RG.evaluate(
+            "execution_row_retention_days",
+            90,
+            lambda limit: min(available, limit),
+            floor=floor,
+        )
+        assert (v.allowed, v.reason) == (expect_allowed, expect_reason), row
+
+    def test_count_fn_receives_exactly_threshold_plus_one(self, guard_db):
+        """A14: the bound must be `threshold + 1` — with `threshold`, a candidate
+        set of exactly `threshold + 1` would count as `threshold` and slip through
+        the `<=` as 'under threshold'."""
+        seen = []
+
+        def counting(limit):
+            seen.append(limit)
+            return 0
+
+        _RG.evaluate("execution_row_retention_days", 90, counting, floor=7)
+        assert seen == [8]
+
+    def test_negative_candidate_count_is_allowed_through(self, guard_db):
+        """A11: a negative return is `<= threshold`, so it proceeds. Documented so
+        the fail-safe direction is deliberate: `-1` is also the sentinel
+        `count_failed` uses, and only the REASON distinguishes them."""
+        v = _RG.evaluate("execution_row_retention_days", 90, lambda limit: -5)
+        assert (v.allowed, v.reason) == (True, "under_threshold")
+
+    def test_nan_count_without_ack_refuses(self, guard_db):
+        """A10: `nan <= threshold` is False, so a NaN count falls through to the
+        ack path and refuses — the safe direction, but by accident of IEEE-754
+        rather than by an explicit check."""
+        v = _RG.evaluate("execution_row_retention_days", 90, lambda limit: float("nan"))
+        assert (v.allowed, v.reason) == (False, "over_threshold")
+
+    def test_nan_count_with_ack_is_allowed(self, guard_db):
+        """A10b: the NaN fail-safe is NOT unconditional. With an ack on file the
+        same NaN yields allowed=True. Pinned so nobody reads the test above as
+        'NaN always refuses'."""
+        _RG.record_acknowledgement("execution_row_retention_days", 90)
+        v = _RG.evaluate("execution_row_retention_days", 90, lambda limit: float("nan"))
+        assert v.allowed is True
+        assert v.reason == "acknowledged"
+
+    def test_negative_floor_refuses_regardless_of_data(self, guard_db):
+        """A17: no caller passes a negative floor; pin the fail-safe direction in
+        case one ever does. threshold=-1 makes the bound 0, the accessors
+        short-circuit on `limit <= 0` and return 0, and `0 <= -1` is False — so it
+        refuses on an EMPTY table. Refusing too much is the correct direction."""
+        v = _RG.evaluate(
+            "execution_row_retention_days",
+            90,
+            lambda limit: 0 if limit <= 0 else 1,
+            floor=-1,
+        )
+        assert v.allowed is False
+
+    def test_zero_candidates_never_trips_any_floor(self, guard_db):
+        """A7: an empty candidate set must pass at every floor — otherwise a
+        healthy install refuses forever and the alarm becomes noise."""
+        for floor in (None, _RG.FLOOR_AGENTS, _RG.FLOOR_SCHEDULES):
+            v = _RG.evaluate(
+                "execution_row_retention_days", 90, lambda limit: 0, floor=floor
+            )
+            assert v.allowed is True, f"floor={floor}"
+
+
+class TestEvaluateRaisesContract:
+    """`evaluate`'s docstring says 'NEVER raises. Fails CLOSED.' — one case
+    contradicts it. Recorded as OBSERVED behaviour, not endorsed as correct."""
+
+    def test_non_numeric_count_raises_out_of_evaluate(self, guard_db):
+        """A9 — OBSERVED, NOT CONTRACTUAL. `candidates <= threshold`
+        (retention_guard.py:183) sits OUTSIDE the try that wraps `count_fn`, so a
+        `count_fn` returning a non-number raises `TypeError` straight out of
+        `evaluate`, contradicting the ':153' docstring and the
+        `cleanup_service.py:219-221` comment that leans on it.
+
+        Production-unreachable: all 8 `count_fn`s are `db.count_*` accessors that
+        return `int(...)`. Safety today therefore comes from each sweep's OUTER
+        try/except, not from the documented contract — which is exactly what
+        `test_cleanup_inner_sweeps.py:81-85` records ('a bare MagicMock ...
+        correctly fails closed'). Pinned here so any change to it is a deliberate,
+        visible edit; the docstring correction is a flagged follow-up (#1771).
+        """
+        with pytest.raises(TypeError):
+            _RG.evaluate("execution_row_retention_days", 90, lambda limit: None)
+
+    def test_numeric_returns_never_raise(self, guard_db):
+        """The half of the contract that IS true, pinned as the real guarantee."""
+        for value in (0, 1, -1, 10**12, 0.5, float("inf"), float("nan")):
+            _RG.evaluate("execution_row_retention_days", 90, lambda limit: value)
+
+
+# ---------------------------------------------------------------------------
+# B — ack lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAckLifecycle:
+
+    def test_consume_without_an_ack_is_a_no_op(self, guard_db):
+        """B5: the common path. Every under-threshold sweep calls this."""
+        _RG.consume_acknowledgement("execution_row_retention_days")
+        assert guard_db.settings == {}
+
+    def test_stored_value_is_stripped_before_comparison(self, guard_db):
+        """B6: `is_acknowledged` does `str(raw).strip()`, so a value written with
+        stray whitespace still matches."""
+        guard_db.settings["retention_ack_execution_row_retention_days"] = "  30  "
+        assert _RG.is_acknowledged("execution_row_retention_days", 30) is True
+
+    @pytest.mark.parametrize("stored", ["030", "+30", "30.0", "3 0", "", "thirty"])
+    def test_non_canonical_stored_values_do_not_acknowledge(self, stored, guard_db):
+        """B7: the comparison is on the STRING, so only the canonical `str(int)`
+        form authorizes. Fail-safe: an unparseable ack must never approve a mass
+        delete."""
+        guard_db.settings["retention_ack_execution_row_retention_days"] = stored
+        assert _RG.is_acknowledged("execution_row_retention_days", 30) is False
+
+    def test_ack_key_is_namespaced_under_the_blocklisted_prefix(self, guard_db):
+        """The prefix is what `PUT /api/settings/{key}` blocklists; an ack written
+        outside it would be self-writable through the catch-all."""
+        _RG.record_acknowledgement("execution_row_retention_days", 5)
+        assert list(guard_db.settings) == [
+            f"{_RG.ACK_KEY_PREFIX}execution_row_retention_days"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# C — announce_refusal / _last_refused / note_allowed / _alarm_id
+# ---------------------------------------------------------------------------
+
+
+def _verdict(candidates=5000, threshold=1000, reason="over_threshold"):
+    return _RG.GuardVerdict(False, candidates, threshold, reason)
+
+
+class TestRefusalAlarm:
+    """These functions execute today; nothing asserts what they DID."""
+
+    def test_first_refusal_logs_error_and_raises_exactly_one_alarm(
+        self, guard_db, caplog
+    ):
+        """C1. 'Exactly one' is the point: `create_item` is INSERT ... ON CONFLICT
+        DO NOTHING, so a duplicate is silent — only a count proves the transition
+        gate works."""
+        with caplog.at_level(logging.INFO, logger=_RG.logger.name):
+            _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+
+        assert len(guard_db.queue_items) == 1
+        levels = [r.levelno for r in caplog.records]
+        assert logging.ERROR in levels
+
+    def test_repeat_refusal_drops_to_info_and_raises_no_second_alarm(
+        self, guard_db, caplog
+    ):
+        """C2. 288 identical ERRORs a day is how an alert gets muted — and a muted
+        alert is the #1638 failure mode repeated."""
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=_RG.logger.name):
+            _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+
+        assert len(guard_db.queue_items) == 1, "the repeat must not re-alarm"
+        assert [r.levelno for r in caplog.records] == [logging.INFO]
+
+    def test_a_narrowed_window_is_a_fresh_transition(self, guard_db, caplog):
+        """C3. The memo is keyed by (setting, window). A window narrowing 30 -> 5
+        is a NEW blast radius and must re-alarm even though the key is unchanged —
+        that narrowing IS the #1638 event."""
+        _RG.announce_refusal("execution_row_retention_days", "rows", 30, _verdict())
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=_RG.logger.name):
+            _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+
+        assert len(guard_db.queue_items) == 2
+        assert logging.ERROR in [r.levelno for r in caplog.records]
+
+    def test_note_allowed_rearms_the_error_level(self, guard_db, caplog):
+        """C4. A sweep that recovers and then degrades again must shout again."""
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        _RG.note_allowed("execution_row_retention_days")
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=_RG.logger.name):
+            _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+
+        assert len(guard_db.queue_items) == 2
+        assert logging.ERROR in [r.levelno for r in caplog.records]
+
+    def test_note_allowed_only_clears_its_own_key(self, guard_db, caplog):
+        """A recovering sweep must not re-arm an unrelated sweep's alarm."""
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        _RG.announce_refusal("health_check_retention_days", "health", 5, _verdict())
+        _RG.note_allowed("execution_row_retention_days")
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=_RG.logger.name):
+            _RG.announce_refusal("health_check_retention_days", "health", 5, _verdict())
+
+        assert (
+            len(guard_db.queue_items) == 2
+        ), "health was still refusing — no new alarm"
+
+    def test_settings_read_failure_degrades_source_and_never_propagates(self, guard_db):
+        """C7: `announce_refusal` is decorative and must never raise into a caller
+        that has already refused."""
+        guard_db.raise_on_get = True
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+
+        _agent, item = guard_db.queue_items[0]
+        assert item["context"]["window_source"] == "unknown"
+
+    def test_alarm_failure_does_not_propagate(self, guard_db):
+        """C5, restated at the alarm surface (test_1644:170 asserts only that the
+        verdict object is unchanged, which it trivially is — it is frozen)."""
+        guard_db.raise_on_create = True
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+
+    def test_alarm_id_is_the_natural_key_and_expiry_is_null(self, guard_db):
+        """C9 + C10. `expires_at` must stay None: `mark_operator_queue_expired`
+        flips any pending row past `expires_at` to `expired` fleet-wide every 5s,
+        which would silently retire the alarm."""
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        _agent, item = guard_db.queue_items[0]
+
+        assert item["id"] == _RG._alarm_id("execution_row_retention_days", 5)
+        assert item["expires_at"] is None
+
+    def test_alarm_hosts_on_the_uncreatable_sentinel_agent(self, guard_db):
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        agent, _item = guard_db.queue_items[0]
+        assert agent == _RG.ALARM_AGENT_NAME
+
+    def test_alarm_payload_carries_counts_and_identifiers_only(self, guard_db):
+        """C8 — SECURITY. The queue row is durable and operator-visible, and
+        `schedule_executions.message`/`response`/`error`/`backlog_metadata` hold
+        user content and credential-bearing agent output (canary G-04 exists
+        because that blob leaked secrets into exactly this kind of state).
+
+        Allowlists the WHOLE item, not just `context`: `question` embeds the
+        free-text message built at `retention_guard.py:255-260`, so a
+        context-only assertion would false-green on a leak through the prose.
+        Any future `"sample_rows"` / `"examples"` key fails this test.
+        """
+        guard_db.settings["execution_row_retention_days"] = "SENTINEL-WINDOW-VALUE"
+        _RG.announce_refusal("execution_row_retention_days", "rows", 5, _verdict())
+        _agent, item = guard_db.queue_items[0]
+
+        assert set(item) == {
+            "id",
+            "type",
+            "priority",
+            "title",
+            "question",
+            "context",
+            "expires_at",
+        }
+        assert set(item["context"]) == {
+            "alert_type",
+            "setting_key",
+            "window_days",
+            "window_source",
+            "candidate_count",
+            "threshold",
+            "reason",
+        }
+        # No nested containers anywhere in `context` — a row payload could only
+        # arrive as a list/dict of rows.
+        for key, value in item["context"].items():
+            assert isinstance(value, (str, int, type(None))), key
+
+        # The setting's stored VALUE must never be echoed; only its provenance
+        # ("db-row" / "code-default") may be. A mutant that reported the raw value
+        # instead of the derived source leaks operator config into a durable row.
+        flat = repr(item)
+        assert "SENTINEL-WINDOW-VALUE" not in flat
+        assert item["context"]["window_source"] == "db-row"
+
+
+# ---------------------------------------------------------------------------
+# D — _read_retention_settings coercion (body never executes elsewhere)
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionSettingsCoercion:
+
+    @pytest.mark.parametrize(
+        "row,raw,expected",
+        [
+            ("D1-plain-int-string", "30", 30),
+            ("D1-zero", "0", 0),
+            ("D6-surrounding-space", " 7 ", 7),
+            ("D2-alpha", "abc", 0),
+            ("D2-empty", "", 0),
+            ("D2-blank", "   ", 0),
+            ("D2-float-string", "1.5", 0),
+            ("D2-scientific", "1e5", 0),
+            ("D2-hex", "0x10", 0),
+            ("D3-none", None, 0),
+            ("D4-negative", "-5", 0),
+            ("D4-negative-large", "-999999", 0),
+        ],
+    )
+    def test_raw_value_coercion(self, row, raw, expected, cleanup_db, monkeypatch):
+        """Invalid or negative -> 0 (sweep disabled). The failure direction is
+        'keep everything', which is the correct one: a malformed setting must
+        never enable an unbounded prune."""
+        monkeypatch.setattr(
+            cleanup_db, "get_setting_value", lambda key, default=None: raw
+        )
+        assert _CS._read_retention_settings() == (expected,) * 4, row
+
+    def test_returns_the_four_windows_in_a_fixed_order(self, cleanup_db, monkeypatch):
+        """The caller unpacks positionally
+        (`log_days, row_days, hc_days, reports_days`) — a reordering would swap
+        two retention windows silently."""
+        values = {
+            "execution_log_retention_days": "11",
+            "execution_row_retention_days": "22",
+            "health_check_retention_days": "33",
+            "agent_reports_retention_days": "44",
+        }
+        monkeypatch.setattr(
+            cleanup_db,
+            "get_setting_value",
+            lambda key, default=None: values.get(key, default),
+        )
+        assert _CS._read_retention_settings() == (11, 22, 33, 44)
+
+    def test_unicode_digits_are_accepted_by_int(self, cleanup_db, monkeypatch):
+        """D5 — OBSERVED, NOT ENDORSED. `int()` accepts non-ASCII decimal digits,
+        so an Arabic-Indic '١٢' resolves to a real 12-day window. Harmless (the
+        result is still a bounded positive int that the guard then gates), but
+        recorded so the behaviour is known rather than discovered."""
+        monkeypatch.setattr(
+            cleanup_db, "get_setting_value", lambda key, default=None: "١٢"
+        )
+        assert _CS._read_retention_settings() == (12,) * 4
+
+    def test_absurdly_large_window_stays_an_int_and_disables_nothing(
+        self, cleanup_db, monkeypatch
+    ):
+        """D7: a huge window is not coerced to 0 — it is a legitimately enormous
+        int. It reaches `iso_cutoff(hours=days*24)`, whose overflow is slice b's
+        target; the fail-closed chain is that the COUNT raises and the guard
+        refuses. Asserted here only as 'the reader does not silently disable'."""
+        monkeypatch.setattr(
+            cleanup_db, "get_setting_value", lambda key, default=None: "9" * 40
+        )
+        result = _CS._read_retention_settings()
+        assert all(isinstance(v, int) and v > 0 for v in result)
+
+
+# ---------------------------------------------------------------------------
+# E — _log_prune level rule
+# ---------------------------------------------------------------------------
+
+
+class TestLogPruneLevels:
+    """Chunking splits one catastrophic delete into a sequence of unremarkable
+    lines; the level rule is the only thing that makes a big prune visible."""
+
+    @pytest.mark.parametrize(
+        "row,pruned,expected_level",
+        [
+            ("E3-zero", 0, logging.INFO),
+            ("E2-trickle", 3, logging.INFO),
+            ("E2-just-under-cap", _CS.RETENTION_CHUNK_SIZE_PER_CYCLE - 1, logging.INFO),
+            ("E1-exactly-cap", _CS.RETENTION_CHUNK_SIZE_PER_CYCLE, logging.WARNING),
+            ("E1-over-cap", _CS.RETENTION_CHUNK_SIZE_PER_CYCLE + 1, logging.WARNING),
+        ],
+    )
+    def test_level_escalates_at_the_chunk_boundary(
+        self, row, pruned, expected_level, caplog
+    ):
+        with caplog.at_level(logging.INFO, logger=_CS.logger.name):
+            _CS._log_prune(pruned, "prune happened")
+        assert [r.levelno for r in caplog.records] == [expected_level], row
+
+
+# ---------------------------------------------------------------------------
+# H — the cleanup_service guard adapters
+# ---------------------------------------------------------------------------
+
+
+class TestGuardAdapters:
+    """`_guard_allows` and `_after_guarded_prune` are the only things standing
+    between a verdict and a DELETE."""
+
+    def test_allowed_verdict_clears_the_memo_and_permits_the_prune(self, monkeypatch):
+        """H1."""
+        calls = []
+        monkeypatch.setattr(
+            _RG,
+            "evaluate",
+            lambda *a, **k: _RG.GuardVerdict(True, 1, 1000, "under_threshold"),
+        )
+        monkeypatch.setattr(
+            _RG, "note_allowed", lambda key: calls.append(("allow", key))
+        )
+        monkeypatch.setattr(
+            _RG,
+            "announce_refusal",
+            lambda *a: calls.append(("refuse", a[0])),
+        )
+
+        assert _CS._guard_allows("k", "label", 5, lambda limit: 1) is True
+        assert calls == [("allow", "k")]
+
+    def test_refused_verdict_announces_and_blocks_the_prune(self, monkeypatch):
+        """H2. Returning True here is the unrecoverable failure — it is the
+        difference between 'refused' and '95.7% of the table is gone'."""
+        calls = []
+        monkeypatch.setattr(
+            _RG,
+            "evaluate",
+            lambda *a, **k: _RG.GuardVerdict(False, 9999, 1000, "over_threshold"),
+        )
+        monkeypatch.setattr(
+            _RG, "note_allowed", lambda key: calls.append(("allow", key))
+        )
+        monkeypatch.setattr(
+            _RG, "announce_refusal", lambda *a: calls.append(("refuse", a[0]))
+        )
+
+        assert _CS._guard_allows("k", "label", 5, lambda limit: 9999) is False
+        assert calls == [("refuse", "k")]
+
+    def test_floor_is_forwarded_to_evaluate(self, monkeypatch):
+        """A dropped `floor` would silently promote the agent sweep (floor 0, every
+        candidate destroys Docker volumes) to the 1000-row default."""
+        seen = {}
+
+        def fake_evaluate(setting_key, window_days, count_fn, floor=None):
+            seen["floor"] = floor
+            return _RG.GuardVerdict(True, 0, 0, "under_threshold")
+
+        monkeypatch.setattr(_RG, "evaluate", fake_evaluate)
+        monkeypatch.setattr(_RG, "note_allowed", lambda key: None)
+        _CS._guard_allows("k", "label", 5, lambda limit: 0, floor=_RG.FLOOR_AGENTS)
+        assert seen["floor"] == _RG.FLOOR_AGENTS
+
+    def test_after_guarded_prune_is_a_no_op_without_an_ack(self, guard_db):
+        """H3: the common, under-threshold path."""
+        _CS._after_guarded_prune("execution_row_retention_days")
+        assert guard_db.settings == {}
+
+    def test_after_guarded_prune_consumes_a_present_ack(self, guard_db):
+        """Single-use: one approval buys one complete drain, then the guard re-arms."""
+        _RG.record_acknowledgement("execution_row_retention_days", 5)
+        _CS._after_guarded_prune("execution_row_retention_days")
+        assert _RG.is_acknowledged("execution_row_retention_days", 5) is False
+
+    def test_after_guarded_prune_never_raises_into_a_completed_sweep(
+        self, monkeypatch, caplog
+    ):
+        """H4. This runs AFTER rows were deleted. A raise here would abort the
+        sweep's remaining bookkeeping over a stale-ack problem, which is a (small)
+        safety hole, not a data-loss one."""
+        monkeypatch.setattr(
+            _RG,
+            "consume_acknowledgement",
+            lambda key: (_ for _ in ()).throw(RuntimeError("settings write failed")),
+        )
+        with caplog.at_level(logging.ERROR, logger=_CS.logger.name):
+            _CS._after_guarded_prune("execution_row_retention_days")
+        assert [r.levelno for r in caplog.records] == [logging.ERROR]
+
+
+# ---------------------------------------------------------------------------
+# F — predicate edges (real DB)
+# ---------------------------------------------------------------------------
+
+
+def _seed(eid, completed_at, status="success", log="x"):
+    _hrun(
+        "INSERT INTO schedule_executions "
+        "(id, schedule_id, agent_name, status, started_at, completed_at, message, "
+        " triggered_by, execution_log) "
+        "VALUES (:id, 's1', 'a1', :st, :ts, :done, 'm', 'schedule', :log)",
+        id=eid,
+        st=status,
+        ts=_days_ago_iso(200),
+        done=completed_at,
+        log=log,
+    )
+
+
+@pytest.fixture
+def sched(db_backend, monkeypatch):
+    for mod in ("db.connection", "db.schedules"):
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+    from db.schedules import ScheduleOperations
+
+    return ScheduleOperations(None, None)
+
+
+class TestPredicateEdges:
+
+    def test_all_four_terminal_states_are_counted_and_pruned_together(self, sched):
+        """F4: `test_execution_retention_prune` covers all four for the PRUNE, and
+        `test_1644` covers parity for `success` only — so parity across the full
+        terminal set was never proven. A state counted but not pruned (or vice
+        versa) is exactly the drift the shared predicate exists to prevent."""
+        for i, status in enumerate(("success", "failed", "cancelled", "skipped")):
+            _seed(f"term{i}", _days_ago_iso(100), status=status)
+        _seed("running", _days_ago_iso(100), status="running")
+        _seed("queued", _days_ago_iso(100), status="queued")
+
+        counted = sched.count_execution_row_candidates(90, limit=1000)
+        pruned = sched.prune_execution_rows(90, chunk_size=1000)
+        assert counted == pruned == 4
+        assert _hscalar("SELECT COUNT(*) FROM schedule_executions") == 2
+
+    def test_terminal_row_with_null_completed_at_is_excluded_by_both_sides(self, sched):
+        """F5: the predicate's `completed_at IS NOT NULL` term, untested on either
+        side. A terminal row that never recorded a completion has no age, so it
+        must not be aged out."""
+        _seed("no-completion", None)
+        _seed("old", _days_ago_iso(100))
+
+        counted = sched.count_execution_row_candidates(90, limit=1000)
+        pruned = sched.prune_execution_rows(90, chunk_size=1000)
+        assert counted == pruned == 1
+        assert (
+            _hscalar(
+                "SELECT COUNT(*) FROM schedule_executions WHERE id = 'no-completion'"
+            )
+            == 1
+        )
+
+    def test_a_row_exactly_at_the_cutoff_survives(self, sched, monkeypatch):
+        """F6: the predicate is a strict `<`, so `completed_at == cutoff` is kept.
+
+        The cutoff MUST be frozen. `iso_cutoff` is evaluated INSIDE the accessor at
+        call time (retention.py:134), so a row seeded 'at the cutoff' at T0 is
+        compared against a cutoff computed at T1 > T0 and is strictly older by the
+        elapsed microseconds — written naively this test fails on CORRECT code.
+        """
+        import db.schedules.retention as _RET
+
+        frozen = _days_ago_iso(90)
+        monkeypatch.setattr(_RET, "iso_cutoff", lambda **kwargs: frozen)
+
+        _seed("at-cutoff", frozen)
+        _seed("one-tick-older", frozen[:-1] + "0" if frozen[-1] != "0" else frozen)
+
+        counted = sched.count_execution_row_candidates(90, limit=1000)
+        pruned = sched.prune_execution_rows(90, chunk_size=1000)
+        assert counted == pruned
+        assert (
+            _hscalar("SELECT COUNT(*) FROM schedule_executions WHERE id = 'at-cutoff'")
+            == 1
+        ), "a row exactly at the cutoff is not yet past it"
+
+    def test_prune_execution_rows_drains_fully_with_a_small_chunk_size(self, sched):
+        """F11: `chunk_size` bounds each TRANSACTION, not the call — the loop
+        drains the entire candidate set (`cleanup_service.py:84-96`, 'READ THIS,
+        THE NAME LIES'). This accessor is the one #1638 accessor lacking a drain
+        proof; #1638 destroyed 5352 rows in one sweep, which a real per-call cap
+        could not have produced. A regression to a single-chunk return would make
+        that comment a lie and understate every reported blast radius."""
+        for i in range(23):
+            _seed(f"old{i}", _days_ago_iso(100))
+
+        assert sched.prune_execution_rows(90, chunk_size=5) == 23
+        assert _hscalar("SELECT COUNT(*) FROM schedule_executions") == 0
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_non_positive_chunk_size_prunes_nothing(self, bad, sched):
+        """A `chunk_size <= 0` must be a no-op, never an unbounded delete."""
+        _seed("old", _days_ago_iso(100))
+        assert sched.prune_execution_rows(90, chunk_size=bad) == 0
+        assert _hscalar("SELECT COUNT(*) FROM schedule_executions") == 1
+
+
+# ---------------------------------------------------------------------------
+# G — structural invariants
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralInvariants:
+
+    def test_every_retention_window_has_a_guard_call_site(self):
+        """G3. Read the SOURCE, don't import it (learnings.md:111): importing
+        `cleanup_service` for a structural check drags in `settings_service` ->
+        `database` -> `init_database()` at module-import time.
+
+        Strict SET EQUALITY in both directions, and deliberately NO hardcoded
+        count — `architecture.md` still says '7 window-driven destructive prunes'
+        while there are 8 since #1296, and hardcoding a count is the #1638
+        'pin the value' trap in miniature. Set equality also catches the inverse
+        bug: a guarded sweep whose key is not a registered retention window.
+        """
+        from services.settings_service import RETENTION_OPS_KEYS
+
+        tree = ast.parse(_SRC_CLEANUP.read_text())
+        guarded = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "_guard_allows"
+            ):
+                first = node.args[0] if node.args else None
+                assert isinstance(first, ast.Constant), (
+                    "a _guard_allows call site whose setting_key is not a literal "
+                    "cannot be audited statically"
+                )
+                guarded.append(first.value)
+
+        assert len(guarded) == len(
+            set(guarded)
+        ), f"a retention window is guarded twice: {guarded}"
+        assert set(guarded) == set(RETENTION_OPS_KEYS), (
+            "every registered retention window must have exactly one "
+            "_guard_allows call site, and every guarded sweep must be a "
+            "registered window.\n"
+            f"  unguarded windows: {set(RETENTION_OPS_KEYS) - set(guarded)}\n"
+            f"  guarded non-windows: {set(guarded) - set(RETENTION_OPS_KEYS)}"
+        )
+
+    def test_ack_prefix_is_blocklisted_from_the_generic_settings_endpoint(self):
+        """G6 — SECURITY. `retention_guard.py:61-63` claims the ack prefix is
+        blocklisted from the generic `PUT /api/settings/{key}`; nothing asserted
+        it. Without that blocklist, anything reaching the catch-all could write
+        its own approval and disarm the guard — the ack IS the gate, so this is
+        the one setting whose writability is a security property.
+
+        Read the SOURCE, don't import it (learnings.md:111): `routers/settings.py`
+        pulls `routers/__init__.py`, which imports every router in the app.
+
+        Deliberately matched on the SYMBOL, not the literal string: the router
+        does `from services.retention_guard import ACK_KEY_PREFIX` rather than
+        duplicating `"retention_ack_"`, which is the correct choice (no mirror to
+        drift). An earlier draft of this test grepped for the literal and failed
+        on correct code.
+        """
+        tree = ast.parse((_BACKEND / "routers" / "settings.py").read_text())
+
+        handler = next(
+            (
+                n
+                for n in ast.walk(tree)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and n.name == "update_setting"
+            ),
+            None,
+        )
+        assert handler is not None, (
+            "the generic PUT /api/settings/{key} handler was renamed — re-point "
+            "this test, do not delete it (#1644)"
+        )
+
+        guards = [
+            node
+            for node in ast.walk(handler)
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Call)
+            and isinstance(node.test.func, ast.Attribute)
+            and node.test.func.attr == "startswith"
+            and any(
+                isinstance(a, ast.Name) and a.id == "ACK_KEY_PREFIX"
+                for a in node.test.args
+            )
+            and any(isinstance(stmt, ast.Raise) for stmt in ast.walk(node))
+        ]
+        assert guards, (
+            "PUT /api/settings/{key} no longer refuses keys starting with "
+            "ACK_KEY_PREFIX. An ack written through this unvalidated endpoint "
+            "pre-approves a mass deletion — the blast-radius guard is disarmed by "
+            "the same route that causes the bug it exists to catch (#1644)."
+        )
+
+    def test_per_sweep_floors_are_pinned_by_direction_not_by_value(self):
+        """G7. `test_1644:285` pins only `MAX_ROWS_PER_SWEEP`. But
+        `retention_guard.py:170` is `MAX_ROWS_PER_SWEEP if floor is None else
+        floor` — there is no `min()`, so a floor OVERRIDES the global rather than
+        being bounded by it. Raising `FLOOR_SCHEDULES` 100 -> 100000 disarms that
+        sweep entirely while every existing test stays green: exactly the failure
+        the threshold-direction test exists to prevent, one level down.
+
+        Lowering a floor is always safe; raising one weakens every install."""
+        from services.retention_guard import FLOOR_AGENTS, FLOOR_SCHEDULES
+
+        PREVIOUS_AGENTS = 0
+        PREVIOUS_SCHEDULES = 100
+        assert FLOOR_AGENTS <= PREVIOUS_AGENTS, (
+            "FLOOR_AGENTS is 0 because every agent purge destroys Docker volumes "
+            "(#1581). Raising it lets volume destruction through unacknowledged."
+        )
+        assert FLOOR_SCHEDULES <= PREVIOUS_SCHEDULES, (
+            "Raising a per-sweep floor disarms that sweep's guard. If intentional, "
+            "it needs a reviewer and a docs/migrations/ note, not a one-line diff."
+        )
+
+    def test_no_per_sweep_floor_exceeds_the_global_ceiling(self):
+        """G8. The floors are meant to be STRICTER than the global threshold (they
+        encode how unrecoverable each sweep's loss is). A floor above
+        MAX_ROWS_PER_SWEEP would be a per-sweep RELAXATION wearing the word
+        'floor' — and `evaluate` would honour it, because there is no `min()`."""
+        from services.retention_guard import (
+            FLOOR_AGENTS,
+            FLOOR_SCHEDULES,
+            MAX_ROWS_PER_SWEEP,
+        )
+
+        assert max(FLOOR_AGENTS, FLOOR_SCHEDULES) <= MAX_ROWS_PER_SWEEP

--- a/tests/unit/test_1771a_retention_edges.py
+++ b/tests/unit/test_1771a_retention_edges.py
@@ -846,6 +846,160 @@ class TestPredicateEdges:
         assert _hscalar("SELECT COUNT(*) FROM schedule_executions") == 1
 
 
+class TestDisabledSweepGuards:
+    """`retention_days <= 0 or limit <= 0` on every accessor.
+
+    `0` means DISABLED. If that guard weakens, `iso_cutoff(hours=0)` is *now* and
+    the predicate `completed_at < now` matches the entire terminal table — the
+    #1638 blast radius reached directly, bypassing the window entirely. The
+    mutation gate showed these guards almost completely unasserted: only
+    `count_execution_row_candidates(0, ...)` had a test, and nothing covered
+    `limit == 0`, `chunk_size == 0`, or the `or`.
+
+    `limit == 0` is genuinely reachable, not theoretical: the guard calls
+    `count_fn(threshold + 1)`, so a floor of −1 (matrix row A17) makes the bound
+    exactly 0.
+    """
+
+    @pytest.mark.parametrize(
+        "days,limit", [(0, 10), (10, 0), (0, 0), (-1, 10), (10, -1)]
+    )
+    @pytest.mark.parametrize(
+        "accessor",
+        [
+            "count_execution_log_candidates",
+            "count_execution_row_candidates",
+            "count_soft_deleted_schedules_past_retention",
+        ],
+    )
+    def test_non_positive_window_or_limit_counts_nothing(
+        self, accessor, days, limit, sched
+    ):
+        _seed("old", _days_ago_iso(100))
+        assert getattr(sched, accessor)(days, limit=limit) == 0
+
+    @pytest.mark.parametrize(
+        "days,limit", [(0, 10), (10, 0), (0, 0), (-1, 10), (10, -1)]
+    )
+    def test_non_positive_window_or_limit_finds_no_schedules(self, days, limit, sched):
+        assert sched.find_soft_deleted_schedules_past_retention(days, limit=limit) == []
+
+    @pytest.mark.parametrize(
+        "days,chunk", [(0, 10), (10, 0), (0, 0), (-1, 10), (10, -1)]
+    )
+    @pytest.mark.parametrize("pruner", ["prune_execution_logs", "prune_execution_rows"])
+    def test_non_positive_window_or_chunk_prunes_nothing(
+        self, pruner, days, chunk, sched
+    ):
+        _seed("old", _days_ago_iso(100))
+        assert getattr(sched, pruner)(days, chunk_size=chunk) == 0
+        assert _hscalar("SELECT COUNT(*) FROM schedule_executions") == 1
+
+    @pytest.mark.parametrize("chunk", [0, -1])
+    def test_non_positive_chunk_scrubs_nothing(self, chunk, sched):
+        """`scrub_terminal_backlog_metadata` is not age-gated (it is a security
+        invariant, not a retention window), so `chunk_size` is its only guard."""
+        assert sched.scrub_terminal_backlog_metadata(chunk_size=chunk) == 0
+
+
+class TestCutoffStrictness:
+    """`completed_at < cutoff` is STRICT on all three predicates.
+
+    F6 covers the row predicate. The mutation gate showed the sibling log
+    predicate (`retention.py:36`) and the soft-deleted-schedules predicate
+    (`:58`) had no exactly-at-cutoff test, so `<` -> `<=` survived on both. An
+    inclusive comparison prunes one window-boundary cohort early on every cycle.
+    """
+
+    def test_log_predicate_keeps_a_row_exactly_at_the_cutoff(self, sched, monkeypatch):
+        import db.schedules.retention as _RET
+
+        frozen = _days_ago_iso(90)
+        monkeypatch.setattr(_RET, "iso_cutoff", lambda **kw: frozen)
+
+        _seed("at-cutoff", frozen, log="transcript")
+        counted = sched.count_execution_log_candidates(90, limit=100)
+        pruned = sched.prune_execution_logs(90, chunk_size=100)
+
+        assert counted == pruned == 0, "a row exactly at the cutoff is not past it"
+        assert (
+            _hscalar(
+                "SELECT COUNT(*) FROM schedule_executions WHERE execution_log IS NOT NULL"
+            )
+            == 1
+        )
+
+    def test_soft_deleted_schedule_exactly_at_the_cutoff_survives(
+        self, sched, monkeypatch
+    ):
+        """Also the only coverage of `find_soft_deleted_schedules_past_retention`'s
+        row extraction — it binds its own `iso_cutoff` via a function-local import,
+        so both bindings are patched."""
+        import db.schedules.retention as _RET
+        import utils.helpers as _H
+
+        frozen = _days_ago_iso(30)
+        monkeypatch.setattr(_RET, "iso_cutoff", lambda **kw: frozen)
+        monkeypatch.setattr(_H, "iso_cutoff", lambda **kw: frozen)
+
+        for sid, deleted in (("at-cutoff", frozen), ("older", _days_ago_iso(60))):
+            _hrun(
+                "INSERT INTO agent_schedules "
+                "(id, agent_name, name, cron_expression, message, owner_id, "
+                " created_at, updated_at, deleted_at) "
+                "VALUES (:id, 'a1', 'n', '* * * * *', 'm', 1, :t, :t, :d)",
+                id=sid,
+                t=_days_ago_iso(100),
+                d=deleted,
+            )
+
+        found = sched.find_soft_deleted_schedules_past_retention(30, limit=100)
+        counted = sched.count_soft_deleted_schedules_past_retention(30, limit=100)
+
+        assert found == ["older"], "only the strictly-older schedule is past retention"
+        assert counted == 1
+
+
+class TestWindowArithmetic:
+    """`iso_cutoff(hours=retention_days * 24)` — the days->hours conversion.
+
+    A wrong multiplier silently rescales EVERY retention window (24->25 makes a
+    90-day window prune at ~86 days). Row-seeded tests cannot see a 4% shift, so
+    the mutation gate found all six call sites unasserted. Asserting the call
+    itself is the only way to pin arithmetic that no realistic fixture reveals.
+    """
+
+    @pytest.mark.parametrize("days", [1, 7, 90, 365])
+    @pytest.mark.parametrize(
+        "call",
+        [
+            ("count_execution_log_candidates", {"limit": 10}),
+            ("count_execution_row_candidates", {"limit": 10}),
+            ("count_soft_deleted_schedules_past_retention", {"limit": 10}),
+            ("prune_execution_logs", {"chunk_size": 10}),
+            ("prune_execution_rows", {"chunk_size": 10}),
+        ],
+    )
+    def test_window_is_converted_to_hours_by_exactly_24(
+        self, call, days, sched, monkeypatch
+    ):
+        import db.schedules.retention as _RET
+
+        seen = []
+
+        def spy(**kwargs):
+            seen.append(kwargs)
+            return _days_ago_iso(3650)
+
+        monkeypatch.setattr(_RET, "iso_cutoff", spy)
+        name, kwargs = call
+        getattr(sched, name)(days, **kwargs)
+
+        assert seen and seen[0] == {
+            "hours": days * 24
+        }, f"{name} must convert its window with exactly 24 hours/day; got {seen}"
+
+
 # ---------------------------------------------------------------------------
 # G — structural invariants
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_1771a_retention_edges.py
+++ b/tests/unit/test_1771a_retention_edges.py
@@ -1123,6 +1123,34 @@ class TestStructuralInvariants:
             f"  guarded non-windows: {set(guarded) - set(RETENTION_OPS_KEYS)}"
         )
 
+    def test_the_prune_terminal_set_matches_the_platform_terminal_set(self):
+        """A new terminal status must not fall silently out of BOTH the prune and
+        its coverage.
+
+        `db/schedules/retention.py:_RETENTION_TERMINAL` is a hand-mirrored copy of
+        the platform's terminal set (`cleanup_service._TERMINAL_EXECUTION_STATUSES`,
+        itself mirroring `models.TaskExecutionStatus`). Two failure directions, and
+        this pins both because it is an EQUALITY, not a subset:
+          * a status added to the platform set but not here -> those rows are
+            terminal forever and never age out (an unbounded table, no signal);
+          * a status added here but not there -> the prune deletes rows the rest of
+            the platform still considers live.
+
+        It is also the coverage tripwire: `test_1771a_retention_properties.py`'s
+        `_TERMINAL` / `_row` strategy samples this set literally, so widening the
+        product set without widening the strategy would leave the new status
+        UNGENERATED and untested. Compared as SETS against another module's
+        constant, so nothing here is a hardcoded literal.
+        """
+        from db.schedules.retention import _RETENTION_TERMINAL
+
+        assert set(_RETENTION_TERMINAL) == set(_CS._TERMINAL_EXECUTION_STATUSES), (
+            "the retention predicate's terminal set drifted from the platform's. "
+            "Update both, plus `_TERMINAL` in test_1771a_retention_properties.py "
+            "(its `_row` strategy generates from that tuple) and the four-state "
+            "parity test above."
+        )
+
     def test_ack_prefix_is_blocklisted_from_the_generic_settings_endpoint(self):
         """G6 — SECURITY. `retention_guard.py:61-63` claims the ack prefix is
         blocklisted from the generic `PUT /api/settings/{key}`; nothing asserted

--- a/tests/unit/test_1771a_retention_edges.py
+++ b/tests/unit/test_1771a_retention_edges.py
@@ -999,6 +999,30 @@ class TestWindowArithmetic:
             "hours": days * 24
         }, f"{name} must convert its window with exactly 24 hours/day; got {seen}"
 
+    @pytest.mark.parametrize("days", [1, 7, 90, 365])
+    def test_soft_delete_finder_also_converts_by_exactly_24(
+        self, days, sched, monkeypatch
+    ):
+        """`find_soft_deleted_schedules_past_retention` re-imports `iso_cutoff`
+        INSIDE the function body (retention.py:99), so it binds
+        `utils.helpers.iso_cutoff` rather than the module-level `_RET.iso_cutoff`
+        every other accessor uses. The module-level spy above cannot see it — the
+        mutation gate caught that this one call site was still unasserted."""
+        import utils.helpers as _H
+
+        seen = []
+
+        def spy(**kwargs):
+            seen.append(kwargs)
+            return _days_ago_iso(3650)
+
+        monkeypatch.setattr(_H, "iso_cutoff", spy)
+        sched.find_soft_deleted_schedules_past_retention(days, limit=10)
+
+        assert seen and seen[0] == {
+            "hours": days * 24
+        }, f"the soft-delete finder must convert by 24 hours/day; got {seen}"
+
 
 # ---------------------------------------------------------------------------
 # G — structural invariants

--- a/tests/unit/test_1771a_retention_properties.py
+++ b/tests/unit/test_1771a_retention_properties.py
@@ -1,0 +1,856 @@
+"""#1771 target 1 — property tests for the retention blast-radius guard (P-38).
+
+Companion to `test_1771a_retention_edges.py` (parametrized examples). Where that
+file pins named boundaries, this one asserts the invariants that must hold across
+the whole input space.
+
+TWO TIERS, because the fixture cost differs by two orders of magnitude:
+
+* **Tier 1 — pure** (`max_examples=200`). No DB. `evaluate` is near-100% branching
+  over an injected `count_fn` plus four thin `db` calls, so its whole decision
+  table is exercisable in-memory.
+* **Tier 2 — real DB** (`max_examples=30`). Predicate parity and full drain, which
+  need actual SQL because the property under test IS the SQL predicate.
+
+THE ORACLE, NOT A MEMBERSHIP CHECK
+----------------------------------
+`test_decision_table_matches_an_independent_oracle` recomputes the expected
+`(allowed, candidates, threshold, reason)` from the spec and asserts EQUALITY.
+It deliberately does not assert "the result is one of the five legal verdicts":
+`evaluate` has exactly five `return` statements, so a membership check is a
+tautology that survives `<=` -> `<`, `if acked` -> `if not acked`, and
+`count_fn(threshold + 1)` -> `count_fn(threshold)` — the three mutants that matter
+most. All three are verified to break this oracle (see its docstring).
+
+TWO TRAPS THIS FILE HANDLES EXPLICITLY (both produce silent FALSE GREENS)
+------------------------------------------------------------------------
+1. **A fixture is NOT reset between Hypothesis examples.** A function-scoped
+   fixture is built once per test FUNCTION, and `@given` runs many examples inside
+   it. Hypothesis raises `FailedHealthCheck` to say so. Rather than suppress that,
+   Tier 1 uses a per-example CONTEXT MANAGER (`isolated_guard`) — the fix
+   Hypothesis itself recommends — and Tier 2 keeps its engine module-scoped and
+   TRUNCATES at the top of every example. Suppressing the health check here would
+   have shipped two real bugs: an alarm-count property that accumulates across
+   examples, and row sets that leak from one example into the next.
+2. **`TRINITY_DB_PATH` alone is not isolation.** `db/engine.py:34-41`
+   `resolve_database_url()` reads **`DATABASE_URL` first**. With that exported —
+   routine in this repo — a per-example `DELETE FROM schedule_executions` and a
+   real `prune_execution_rows` would run against THAT database. In a task about
+   destructive-path safety that is the one unacceptable failure mode, so the
+   fixture unsets both env vars and ASSERTS the resolved URL points at its own
+   temp file before any test issues a DELETE.
+
+Invocation: `cd tests && python -m pytest unit/test_1771a_retention_properties.py`.
+"""
+
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from hypothesis import assume, example, given, settings
+from hypothesis import strategies as st
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import services.retention_guard as _RG  # noqa: E402
+from services import cleanup_service as _CS  # noqa: E402
+
+# CI-bounded (AC#2): pure properties are cheap, DB properties are not.
+PURE_EXAMPLES = 200
+DB_EXAMPLES = 30
+
+
+# ---------------------------------------------------------------------------
+# Doubles + per-example isolation
+# ---------------------------------------------------------------------------
+
+
+class _DbDouble:
+    """In-memory stand-in for the four `db` methods this subsystem touches.
+
+    Verified signatures: `get_setting_value(key, default=None)`,
+    `set_setting(key, value)`, `delete_setting(key)` (database.py:1705-1711),
+    `create_operator_queue_item(agent_name, item)` (database.py:2513).
+    """
+
+    def __init__(self):
+        self.settings = {}
+        self.queue_items = []
+        self.writes = 0
+
+    def get_setting_value(self, key, default=None):
+        return self.settings.get(key, default)
+
+    def set_setting(self, key, value):
+        self.writes += 1
+        self.settings[key] = value
+
+    def delete_setting(self, key):
+        self.writes += 1
+        self.settings.pop(key, None)
+
+    def create_operator_queue_item(self, agent_name, item):
+        self.writes += 1
+        self.queue_items.append((agent_name, item))
+
+
+@contextmanager
+def _null_patch():
+    """A do-nothing `with` target, so the error-path branch of the oracle property
+    stays a single code path instead of forking into two near-identical bodies."""
+    yield
+
+
+@contextmanager
+def isolated_guard():
+    """Fresh `db` double + empty transition memo, scoped to ONE Hypothesis example.
+
+    Deliberately a context manager rather than a pytest fixture. A function-scoped
+    fixture is built once per test FUNCTION and is NOT reset between the inputs
+    `@given` generates; Hypothesis raises `FailedHealthCheck` to say exactly that,
+    and this is the fix it recommends. Suppressing the health check instead would
+    have left real shared state in place:
+
+      * `_RG.db` — the double accumulates `queue_items` across examples, so
+        "exactly one alarm" silently becomes "one alarm, eventually";
+      * `_RG._last_refused` — module state that outlives the whole session
+        (`test_1644:177` already writes to it, and CI shuffles order under
+        `pytest-randomly`), so a "first refusal" example degrades into a "repeat
+        refusal" one depending on what ran before.
+
+    Both patches are BY OBJECT: `retention_guard.py:56` does
+    `from database import db`, binding its own module-global, so patching
+    `database.db` would be inert (learnings.md:99).
+    """
+    double = _DbDouble()
+    with patch.object(_RG, "db", double), patch.object(_RG, "_last_refused", {}):
+        yield double
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Floors bounded well below MAX_ROWS_PER_SWEEP so BOTH sides of every threshold
+# are reachable by random search, not just the "far under" case.
+_floors = st.one_of(st.none(), st.integers(min_value=-2, max_value=200))
+_available = st.integers(min_value=0, max_value=400)
+_windows = st.integers(min_value=0, max_value=3650)
+_keys = st.sampled_from(
+    [
+        "execution_log_retention_days",
+        "execution_row_retention_days",
+        "health_check_retention_days",
+        "agent_soft_delete_retention_days",
+        "schedule_soft_delete_retention_days",
+        "agent_reports_retention_days",
+        "operator_queue_retention_days",
+        "agent_reminders_retention_days",
+    ]
+)
+
+
+def _expected_verdict(available, floor, acked, count_raises=False, ack_raises=False):
+    """Independent reimplementation of `evaluate`'s decision table.
+
+    Written from the SPEC (the ':153' docstring + the module design notes), not by
+    copying the implementation, so it is a real oracle. `min(available, limit)`
+    mirrors what `_bounded_count` actually does — which is what makes this
+    property sensitive to the `threshold + 1` bound.
+
+    The two error branches are modelled here rather than left to the example
+    tests, so this one property covers the FAIL-CLOSED guarantee too. That matters:
+    a hand-applied mutation check showed that flipping `count_failed`'s verdict
+    from False to True — inverting the whole fail-closed design (module docstring
+    note 3: "a guard that fails open is worse than no guard, because it
+    manufactures confidence") — was caught only by `test_1644`, not by this file.
+    A property file that cannot detect the single most dangerous mutation in its
+    own subject is not carrying its weight.
+    """
+    threshold = _RG.MAX_ROWS_PER_SWEEP if floor is None else floor
+    if count_raises:
+        return False, -1, threshold, "count_failed"
+    candidates = min(available, threshold + 1)
+    if candidates <= threshold:
+        return True, candidates, threshold, "under_threshold"
+    if ack_raises:
+        return False, candidates, threshold, "ack_lookup_failed"
+    if acked:
+        return True, candidates, threshold, "acknowledged"
+    return False, candidates, threshold, "over_threshold"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — pure properties
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionTable:
+
+    @given(
+        available=_available,
+        floor=_floors,
+        acked=st.booleans(),
+        window=_windows,
+        key=_keys,
+        count_raises=st.booleans(),
+        ack_raises=st.booleans(),
+    )
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    # A5 — exactly at the global threshold.
+    @example(
+        available=_RG.MAX_ROWS_PER_SWEEP,
+        floor=None,
+        acked=False,
+        window=90,
+        key="execution_row_retention_days",
+        count_raises=False,
+        ack_raises=False,
+    )
+    # A4 — one over the global threshold, unacknowledged (the #1638 shape).
+    @example(
+        available=_RG.MAX_ROWS_PER_SWEEP + 1,
+        floor=None,
+        acked=False,
+        window=5,
+        key="execution_row_retention_days",
+        count_raises=False,
+        ack_raises=False,
+    )
+    # A13 — the same, acknowledged.
+    @example(
+        available=_RG.MAX_ROWS_PER_SWEEP + 1,
+        floor=None,
+        acked=True,
+        window=5,
+        key="execution_row_retention_days",
+        count_raises=False,
+        ack_raises=False,
+    )
+    # A2 — floor=0 must NOT fall back to the global default (`is None`, not falsy).
+    @example(
+        available=1,
+        floor=0,
+        acked=False,
+        window=180,
+        key="agent_soft_delete_retention_days",
+        count_raises=False,
+        ack_raises=False,
+    )
+    @example(
+        available=0,
+        floor=0,
+        acked=False,
+        window=180,
+        key="agent_soft_delete_retention_days",
+        count_raises=False,
+        ack_raises=False,
+    )
+    # A3 — exactly at the schedules floor.
+    @example(
+        available=100,
+        floor=100,
+        acked=False,
+        window=30,
+        key="schedule_soft_delete_retention_days",
+        count_raises=False,
+        ack_raises=False,
+    )
+    # A17 — a negative floor refuses even on an empty table.
+    @example(
+        available=0,
+        floor=-1,
+        acked=False,
+        window=90,
+        key="execution_row_retention_days",
+        count_raises=False,
+        ack_raises=False,
+    )
+    def test_decision_table_matches_an_independent_oracle(
+        self, available, floor, acked, window, key, count_raises, ack_raises
+    ):
+        """A16 + A14. Equality on the whole verdict, against a spec-derived oracle.
+
+        Covers all FIVE exits, including both fail-closed error branches, so the
+        whole decision table is one property.
+
+        Anti-tautology — why this is an oracle and not a shape check. `evaluate`
+        has exactly five `return` statements, so "the verdict is one of the five
+        legal pairs" would be trivially true. Each of these mutants survives that
+        check and is killed by this one (all verified by hand-applying them to
+        `retention_guard.py` and re-running this file):
+          * `<=` -> `<` (:183) flips `available == threshold` to refused while the
+            oracle still says allowed;
+          * `if acked` -> `if not acked` (:195) inverts every over-threshold row;
+          * `count_fn(threshold + 1)` -> `count_fn(threshold)` (:175) makes an
+            over-threshold set count as exactly `threshold`, which the mutant then
+            reads as `under_threshold`, while the oracle still computes
+            `min(available, threshold + 1) > threshold`;
+          * dropping `floor` (:170) silently promotes the agent sweep's floor of 0
+            to the 1000-row default;
+          * `GuardVerdict(False, ...)` -> `GuardVerdict(True, ...)` on either error
+            branch — the fail-OPEN inversion, and the most dangerous single edit
+            possible in this file.
+        """
+        with isolated_guard():
+            if acked:
+                _RG.record_acknowledgement(key, window)
+
+            seen_limits = []
+
+            def count_fn(limit):
+                seen_limits.append(limit)
+                if count_raises:
+                    raise RuntimeError("db is down")
+                return min(available, limit)
+
+            expected = _expected_verdict(
+                available, floor, acked, count_raises, ack_raises
+            )
+
+            # `is_acknowledged` is only consulted on the over-threshold path, so an
+            # ack-lookup failure can only be observed there.
+            ack_patch = (
+                patch.object(
+                    _RG,
+                    "is_acknowledged",
+                    side_effect=RuntimeError("ack lookup exploded"),
+                )
+                if ack_raises
+                else _null_patch()
+            )
+            with ack_patch:
+                verdict = _RG.evaluate(key, window, count_fn, floor=floor)
+
+            assert (
+                verdict.allowed,
+                verdict.candidates,
+                verdict.threshold,
+                verdict.reason,
+            ) == expected, (
+                f"available={available} floor={floor} acked={acked} "
+                f"window={window} key={key} count_raises={count_raises} "
+                f"ack_raises={ack_raises}"
+            )
+            # A14: the bound must be `threshold + 1`. With `threshold`, a
+            # candidate set of exactly `threshold + 1` counts as `threshold` and
+            # slips through the `<=` as "under threshold".
+            assert seen_limits == [expected[2] + 1], (
+                f"count_fn must be called exactly once with threshold+1; got "
+                f"{seen_limits} for floor={floor}"
+            )
+
+    @given(
+        available=_available,
+        floor=_floors,
+        acked=st.booleans(),
+        window=_windows,
+        key=_keys,
+    )
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    def test_evaluate_never_writes_to_the_database(
+        self, available, floor, acked, window, key
+    ):
+        """A15. `evaluate` is a DECISION, not an action: it must never record an
+        ack, clear one, or raise an alarm.
+
+        Scoped to `evaluate`'s own DIRECT writes — "never mutates anything" is
+        unprovable for an arbitrary generated `count_fn`, which may itself write,
+        so the `count_fn` here is pure.
+        """
+        with isolated_guard() as db:
+            if acked:
+                _RG.record_acknowledgement(key, window)
+            baseline = db.writes
+
+            _RG.evaluate(key, window, lambda limit: min(available, limit), floor=floor)
+
+            assert db.writes == baseline
+            assert db.queue_items == []
+
+    @given(
+        value=st.one_of(
+            st.integers(min_value=-(10**18), max_value=10**18),
+            st.floats(allow_nan=True, allow_infinity=True),
+        ),
+        floor=_floors,
+    )
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    def test_never_raises_for_any_numeric_count(self, value, floor):
+        """The half of the ':153' "NEVER raises" contract that is actually true.
+
+        The docstring is false for a non-NUMERIC return, because
+        `candidates <= threshold` (:183) sits outside the try that wraps
+        `count_fn`. That case is production-unreachable (all 8 `count_fn`s are
+        `db.count_*` accessors returning `int(...)`) and is pinned as OBSERVED
+        behaviour in `test_1771a_retention_edges.py`; the docstring correction is
+        a flagged follow-up. This property asserts the guarantee that does hold.
+        """
+        with isolated_guard():
+            _RG.evaluate(
+                "execution_row_retention_days", 90, lambda limit: value, floor=floor
+            )
+
+
+class TestAckRoundTrip:
+
+    @given(window=st.integers(), key=_keys)
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    @example(window=0, key="execution_row_retention_days")
+    @example(window=-1, key="execution_row_retention_days")
+    @example(window=5, key="execution_row_retention_days")
+    @example(window=30, key="execution_row_retention_days")
+    def test_ack_round_trips_at_any_window(self, window, key):
+        """B1. Existing coverage is only w in {5, 30}, both hardcoded."""
+        with isolated_guard():
+            assert _RG.is_acknowledged(key, window) is False
+            _RG.record_acknowledgement(key, window)
+            assert _RG.is_acknowledged(key, window) is True
+            _RG.consume_acknowledgement(key)
+            assert _RG.is_acknowledged(key, window) is False
+
+    @given(recorded=st.integers(), probed=st.integers(), key=_keys)
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    @example(recorded=30, probed=5, key="execution_row_retention_days")
+    def test_an_ack_authorizes_exactly_one_window(self, recorded, probed, key):
+        """B9. Narrowing the window invalidates the old approval: approving "prune
+        at 30 days" is not approving "prune at 1 day" — and that narrowing IS the
+        #1638 event, so the ack must not survive it."""
+        assume(recorded != probed)
+        with isolated_guard():
+            _RG.record_acknowledgement(key, recorded)
+            assert _RG.is_acknowledged(key, probed) is False
+            assert _RG.is_acknowledged(key, recorded) is True
+
+    @given(recorded_key=_keys, probed_key=_keys, window=st.integers())
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    def test_an_ack_authorizes_exactly_one_setting(
+        self, recorded_key, probed_key, window
+    ):
+        """B3, generalized: an ack for one sweep must never license another."""
+        assume(recorded_key != probed_key)
+        with isolated_guard():
+            _RG.record_acknowledgement(recorded_key, window)
+            assert _RG.is_acknowledged(probed_key, window) is False
+
+
+class TestAlarmTransitions:
+
+    @given(
+        ops=st.lists(
+            st.tuples(
+                st.sampled_from(["refuse", "allow"]),
+                st.integers(min_value=1, max_value=4),
+            ),
+            min_size=1,
+            max_size=12,
+        )
+    )
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    @example(ops=[("refuse", 1)])  # C1
+    @example(ops=[("refuse", 1), ("refuse", 1)])  # C2 repeat
+    @example(ops=[("refuse", 1), ("refuse", 2)])  # C3 window change
+    @example(ops=[("refuse", 1), ("allow", 1), ("refuse", 1)])  # C4 re-arm
+    def test_alarm_count_equals_the_number_of_transitions(self, ops):
+        """C1-C4 as a state machine.
+
+        The alarm must fire on the green->red TRANSITION, not per cycle: 288
+        identical ERRORs a day is how an alert gets muted, and a muted alert is
+        the #1638 failure mode repeated. It must equally not UNDER-fire — a
+        narrowed window is a new blast radius and has to re-alarm.
+
+        The expected count is recomputed from the memo's contract (fresh iff
+        `_last_refused[key] != window`), never read back from the implementation's
+        own bookkeeping.
+        """
+        key = "execution_row_retention_days"
+        with isolated_guard() as db:
+            memo = {}
+            expected = 0
+            for op, window in ops:
+                if op == "allow":
+                    memo.pop(key, None)
+                    _RG.note_allowed(key)
+                    continue
+                if memo.get(key) != window:
+                    expected += 1
+                memo[key] = window
+                _RG.announce_refusal(
+                    key,
+                    "rows",
+                    window,
+                    _RG.GuardVerdict(False, 5000, 1000, "over_threshold"),
+                )
+
+            assert len(db.queue_items) == expected, (
+                f"ops={ops} produced {len(db.queue_items)} alarms, expected "
+                f"{expected} transitions"
+            )
+
+    @given(
+        window=st.integers(min_value=0, max_value=3650),
+        key=_keys,
+        candidates=st.integers(min_value=0, max_value=10**7),
+        threshold=st.integers(min_value=0, max_value=10**4),
+    )
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    def test_alarm_payload_never_grows_new_fields(
+        self, window, key, candidates, threshold
+    ):
+        """C8 — SECURITY, as an invariant over the whole input space.
+
+        The queue row is durable and operator-visible. `schedule_executions`
+        `message`/`response`/`error`/`backlog_metadata` carry user content and
+        credential-bearing agent output; canary G-04 exists because that blob
+        leaked secrets into exactly this kind of durable state. The "show the
+        operator what would be deleted" instinct is the bug.
+
+        Pins the key set of the WHOLE item (any future `sample_rows`/`examples`
+        fails) and that no `context` value is a container — a row payload could
+        only arrive as a list or dict of rows.
+        """
+        with isolated_guard() as db:
+            _RG.announce_refusal(
+                key,
+                "label",
+                window,
+                _RG.GuardVerdict(False, candidates, threshold, "over_threshold"),
+            )
+            _agent, item = db.queue_items[0]
+
+            assert set(item) == {
+                "id",
+                "type",
+                "priority",
+                "title",
+                "question",
+                "context",
+                "expires_at",
+            }
+            assert set(item["context"]) == {
+                "alert_type",
+                "setting_key",
+                "window_days",
+                "window_source",
+                "candidate_count",
+                "threshold",
+                "reason",
+            }
+            for name, value in item["context"].items():
+                assert isinstance(value, (str, int, type(None))), name
+            # `expires_at` must stay NULL: `mark_operator_queue_expired` flips any
+            # pending row past it to `expired` fleet-wide every 5s.
+            assert item["expires_at"] is None
+            assert item["id"] == _RG._alarm_id(key, window)
+
+
+class TestRetentionSettingsTotality:
+
+    @given(
+        raw=st.one_of(
+            st.none(),
+            st.text(max_size=40),
+            st.integers(min_value=-(10**9), max_value=10**9),
+            st.sampled_from(["0", "30", " 7 ", "-5", "abc", "", "1e5", "0x10", "1.5"]),
+        )
+    )
+    @settings(max_examples=PURE_EXAMPLES, deadline=None)
+    @example(raw=None)
+    @example(raw="")
+    @example(raw="-5")
+    @example(raw="abc")
+    def test_reader_is_total_and_never_negative(self, raw):
+        """D8. `_read_retention_settings` must be TOTAL: any stored value, however
+        malformed, yields four non-negative ints and never raises.
+
+        The failure DIRECTION is the point — an unreadable setting coerces to 0
+        ("sweep disabled", keep everything), never to a small positive number,
+        which is the catastrophic input for a destructive window (#1638).
+        """
+
+        class _Raw:
+            def get_setting_value(self, key, default=None):
+                return raw
+
+        with patch.object(_CS, "db", _Raw()):
+            result = _CS._read_retention_settings()
+
+        assert isinstance(result, tuple) and len(result) == 4
+        assert all(isinstance(v, int) and v >= 0 for v in result), f"raw={raw!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — real DB (predicate parity + full drain)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def retention_db(tmp_path_factory):
+    """A throwaway SQLite file with ONLY `schedule_executions`.
+
+    MODULE-scoped on purpose. A function-scoped fixture is built once per test
+    FUNCTION and `@given` runs many examples inside it, so per-example isolation
+    cannot come from the fixture either way — it comes from the explicit
+    `truncate()` each example calls first. Making it module-scoped additionally
+    keeps Hypothesis's `function_scoped_fixture` health check meaningful for this
+    file instead of blanket-suppressed.
+
+    Building the full `db_harness` schema (67 tables + 149 indexes) and letting it
+    auto-parametrize onto PostgreSQL when `TEST_POSTGRES_URL` is set buys nothing
+    here: `db/tables.py` declares zero ForeignKey/UniqueConstraint, so the single
+    table builds standalone.
+
+    SAFETY (the reason for the assert): `resolve_database_url()` reads
+    `DATABASE_URL` FIRST and only then falls back to `TRINITY_DB_PATH`. If
+    `DATABASE_URL` is exported in the shell, every DELETE below would run against
+    THAT database. Both env vars are unset here, and the resolved URL is asserted
+    to be this fixture's own temp file before any test deletes anything.
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()  # `monkeypatch` itself is function-scoped
+    db_file = tmp_path_factory.mktemp("retention-props") / "trinity.db"
+
+    mp.delenv("DATABASE_URL", raising=False)
+    mp.delenv("TEST_POSTGRES_URL", raising=False)
+    mp.setenv("TRINITY_DB_PATH", str(db_file))
+
+    import db.connection as conn_mod
+
+    mp.setattr(conn_mod, "DB_PATH", str(db_file))
+
+    from db.engine import get_engine, resolve_database_url
+
+    resolved = resolve_database_url()
+    assert resolved == f"sqlite:///{db_file}", (
+        "REFUSING to run destructive property tests: the engine resolves to "
+        f"{resolved!r}, not this test's temp database. Something re-set "
+        "DATABASE_URL / TRINITY_DB_PATH — these tests DELETE rows."
+    )
+
+    from db.tables import metadata, schedule_executions
+
+    engine = get_engine()
+    metadata.create_all(engine, tables=[schedule_executions])
+
+    from db.schedules import ScheduleOperations
+    from sqlalchemy import delete as sa_delete
+
+    def truncate():
+        """Per-EXAMPLE isolation. Without this, rows accumulate across the
+        examples `@given` generates and every property passes on the wrong data —
+        the single most likely way to ship a false green here."""
+        with engine.begin() as conn:
+            conn.execute(sa_delete(schedule_executions))
+
+    try:
+        yield ScheduleOperations(None, None), engine, schedule_executions, truncate
+    finally:
+        mp.undo()
+
+
+_TERMINAL = ("success", "failed", "cancelled", "skipped")
+_NON_TERMINAL = ("running", "queued")
+
+# (status, age_in_days | None -> completed_at IS NULL, has_execution_log)
+_row = st.tuples(
+    st.sampled_from(_TERMINAL + _NON_TERMINAL),
+    st.one_of(st.none(), st.integers(min_value=0, max_value=400)),
+    st.booleans(),
+)
+
+
+def _seed(conn, table, rows, cutoff):
+    """Insert generated rows; return the ids a correct row-prune must remove.
+
+    The expectation is computed in PYTHON from the generated data, never by
+    re-running the accessor — otherwise the parity assertion is a tautology.
+    """
+    from sqlalchemy import insert
+    from utils.helpers import iso_cutoff
+
+    expected_rows, expected_logs = [], []
+    for i, (status, age_days, has_log) in enumerate(rows):
+        completed = None if age_days is None else iso_cutoff(hours=age_days * 24)
+        conn.execute(
+            insert(table).values(
+                id=f"r{i}",
+                schedule_id="s1",
+                agent_name="a1",
+                status=status,
+                started_at=cutoff,
+                completed_at=completed,
+                message="m",
+                triggered_by="schedule",
+                execution_log="transcript" if has_log else None,
+            )
+        )
+        if status in _TERMINAL and completed is not None and completed < cutoff:
+            expected_rows.append(f"r{i}")
+            if has_log:
+                expected_logs.append(f"r{i}")
+    return expected_rows, expected_logs
+
+
+@contextmanager
+def _frozen_cutoff(cutoff):
+    """Freeze `iso_cutoff` for BOTH the count and the prune.
+
+    `iso_cutoff` is evaluated INSIDE each accessor at call time
+    (retention.py:121,134), so the count and the prune each compute their own
+    "now". Without freezing, a row seeded exactly at the cutoff is strictly older
+    by the elapsed microseconds by the time the second call runs — the property
+    would fail on CORRECT code.
+    """
+    import db.schedules.retention as _RET
+
+    with patch.object(_RET, "iso_cutoff", lambda **kwargs: cutoff):
+        yield
+
+
+class TestPredicateParityProperty:
+
+    @given(
+        rows=st.lists(_row, max_size=25),
+        window=st.integers(min_value=1, max_value=300),
+        chunk=st.integers(min_value=1, max_value=8),
+    )
+    @settings(max_examples=DB_EXAMPLES, deadline=None)
+    @example(rows=[], window=90, chunk=5)
+    # F4: every terminal state, jointly counted and pruned.
+    @example(rows=[(s, 100, True) for s in _TERMINAL], window=90, chunk=5)
+    # F5: a terminal row with no completion has no age.
+    @example(rows=[("success", None, True), ("success", 100, True)], window=90, chunk=5)
+    # F7: non-terminal rows are never touched.
+    @example(rows=[(s, 100, True) for s in _NON_TERMINAL], window=90, chunk=5)
+    # F11: full drain when the candidate set far exceeds chunk_size.
+    @example(rows=[("success", 100, True)] * 25, window=90, chunk=1)
+    def test_row_count_equals_what_the_prune_deletes(
+        self, rows, window, chunk, retention_db
+    ):
+        """F3 + F11 — the headline property, over arbitrary generated row sets.
+
+        Two invariants at once:
+          * PARITY — the guard's count and the prune's DELETE describe the same
+            set. They share `_execution_row_prune_predicate` by construction; this
+            asserts that construction actually holds. A guard that counts a
+            different set than the prune deletes reports a blast radius that is
+            not the one about to happen.
+          * FULL DRAIN — `chunk_size` bounds each TRANSACTION, not the call
+            (`cleanup_service.py:84-96`, "READ THIS, THE NAME LIES"). #1638
+            destroyed 5352 rows in one sweep, which a real per-call cap could not
+            have produced. `chunk` is drawn 1-8 against up to 25 rows, so
+            multi-chunk drains are the common case here, not an edge one.
+
+        Also asserts the SET of survivors, not just the counts — equal counts over
+        different row sets would still be a broken predicate.
+        """
+        from sqlalchemy import select
+        from utils.helpers import iso_cutoff
+
+        sched, engine, table, truncate = retention_db
+        truncate()  # per-example isolation — see the fixture docstring
+
+        cutoff = iso_cutoff(hours=window * 24)
+        with engine.begin() as conn:
+            expected_ids, _ = _seed(conn, table, rows, cutoff)
+
+        with _frozen_cutoff(cutoff):
+            counted = sched.count_execution_row_candidates(window, limit=len(rows) + 10)
+            pruned = sched.prune_execution_rows(window, chunk_size=chunk)
+
+        # `hide_parameters=True` (db/engine.py:67) keeps bound values out of
+        # SQLAlchemy errors, so the shrunk input has to be in the message.
+        detail = f"rows={rows} window={window} chunk={chunk}"
+        assert counted == len(expected_ids), f"count drifted: {detail}"
+        assert pruned == len(expected_ids), f"prune drifted (drain?): {detail}"
+
+        with engine.connect() as conn:
+            remaining = {r[0] for r in conn.execute(select(table.c.id))}
+        assert remaining == {f"r{i}" for i in range(len(rows))} - set(
+            expected_ids
+        ), f"the prune deleted a different set than it counted: {detail}"
+
+    @given(
+        rows=st.lists(_row, max_size=25),
+        window=st.integers(min_value=1, max_value=300),
+        chunk=st.integers(min_value=1, max_value=8),
+    )
+    @settings(max_examples=DB_EXAMPLES, deadline=None)
+    @example(rows=[("success", 100, False), ("success", 100, True)], window=90, chunk=5)
+    def test_log_count_equals_what_the_log_prune_nulls(
+        self, rows, window, chunk, retention_db
+    ):
+        """F3 for the sibling `execution_log` sweep, whose predicate adds
+        `execution_log IS NOT NULL` — the term that makes this predicate falsify
+        its own denominator, and precisely why the guard uses absolute counts with
+        no percentage (`retention_guard.py:27-35`)."""
+        from sqlalchemy import select
+        from utils.helpers import iso_cutoff
+
+        sched, engine, table, truncate = retention_db
+        truncate()
+
+        cutoff = iso_cutoff(hours=window * 24)
+        with engine.begin() as conn:
+            _, expected_logs = _seed(conn, table, rows, cutoff)
+
+        with _frozen_cutoff(cutoff):
+            counted = sched.count_execution_log_candidates(window, limit=len(rows) + 10)
+            pruned = sched.prune_execution_logs(window, chunk_size=chunk)
+
+        detail = f"rows={rows} window={window} chunk={chunk}"
+        assert counted == len(expected_logs) == pruned, f"log parity broken: {detail}"
+
+        # The null-out PRESERVES the row — that is the whole point of the #772 log
+        # sweep versus the row sweep (~150-190 KB/row reclaimed, metadata kept).
+        with engine.connect() as conn:
+            assert len(list(conn.execute(select(table.c.id)))) == len(rows), detail
+
+    @given(
+        available=st.integers(min_value=0, max_value=30),
+        limit=st.integers(min_value=1, max_value=40),
+    )
+    @settings(max_examples=DB_EXAMPLES, deadline=None)
+    @example(available=20, limit=6)
+    def test_bounded_count_returns_min_of_candidates_and_limit(
+        self, available, limit, retention_db
+    ):
+        """F9 as a property. The count answers "is this more than N?", not "how
+        many?" — `_bounded_count`'s LIMIT subquery is what makes the guard
+        O(limit) rather than O(candidates) on a loop that runs every 5 minutes. A
+        regression to an unbounded COUNT would be invisible to a correctness test
+        while putting a full-table scan on the cleanup path."""
+        from sqlalchemy import insert
+        from utils.helpers import iso_cutoff
+
+        sched, engine, table, truncate = retention_db
+        truncate()
+
+        old = iso_cutoff(hours=200 * 24)
+        with engine.begin() as conn:
+            for i in range(available):
+                conn.execute(
+                    insert(table).values(
+                        id=f"r{i}",
+                        schedule_id="s1",
+                        agent_name="a1",
+                        status="success",
+                        started_at=old,
+                        completed_at=old,
+                        message="m",
+                        triggered_by="schedule",
+                        execution_log="x",
+                    )
+                )
+
+        counted = sched.count_execution_row_candidates(90, limit=limit)
+        assert counted == min(available, limit), f"available={available} limit={limit}"

--- a/tests/unit/test_1771a_retention_properties.py
+++ b/tests/unit/test_1771a_retention_properties.py
@@ -821,6 +821,12 @@ class TestPredicateParityProperty:
     )
     @settings(max_examples=DB_EXAMPLES, deadline=None)
     @example(available=20, limit=6)
+    # `limit=1` is the boundary of the LIMIT subquery and the only input that
+    # separates `limit <= 0` from `limit <= 1` in the accessor's disabled-sweep
+    # guard. Random search usually finds it (the strategy's min_value is 1), but
+    # "usually" is not a gate: pinned so that mutant is killed deterministically
+    # rather than whenever Hypothesis happens to draw the boundary.
+    @example(available=5, limit=1)
     def test_bounded_count_returns_min_of_candidates_and_limit(
         self, available, limit, retention_db
     ):


### PR DESCRIPTION
**Part of #1771 (target 1 of 7).** Refs abilityai/trinity#1771 — deliberately **not** a
closing keyword: targets 2–7 remain outstanding and other slices reference the same issue.

Test-only edge-case + property coverage (P-38 `/edge-cases`) for the **destructive retention
prunes** — the #1638/#1644 data-loss class, where a wrong window silently hard-DELETEs an
un-configured install's history and ships green because a test asserted the destructive default.

**Targets:** `src/backend/services/retention_guard.py` (all of it) ·
`src/backend/db/schedules/retention.py` (prune predicates, bounded counts, the three drain
accessors) · exactly 4 functions of `cleanup_service.py` (`_read_retention_settings`,
`_log_prune`, `_guard_allows`, `_after_guarded_prune`).

**AC#4 holds — zero product-code change.** `git diff origin/dev...HEAD --stat -- src/` is
**empty** — re-verified against current `dev` after the §4 dependency harmonization.
No real product bug was found, and none was manufactured. Two defects that *are* real
(a false docstring and an observability gap) are **pinned as observed behaviour or enumerated**,
never silently fixed — fixing them is product code, which AC#4 forbids.

---

## 1. AC#1 deliverable — completed edge-case matrix

Legend: **C** = already covered on `dev` · **N** = newly covered here · **U** = UNSPECIFIED
(reported, deliberately not tested). Files: `E` = `test_1771a_retention_edges.py`,
`P` = `test_1771a_retention_properties.py`.

### A — `evaluate()` decision logic

| # | Case | Status | Covered by |
|---|---|---|---|
| A2 | `floor=0` does not default to 1000 | **N** (was partial C) | `E::TestEvaluateBoundaries::test_threshold_boundary[A2-*]`, `P::test_decision_table_matches_an_independent_oracle` `@example(floor=0)` |
| A3 | floor=100 with exactly 100 candidates | **N** | `E::...[A3-schedules-at-floor]`, `P` `@example(available=100, floor=100)` |
| A4 | one over threshold, no ack | **N** | `E::...[A4-*]`, `P` `@example(MAX+1, acked=False)` |
| A5 | candidates == threshold exactly | **N** | `E::...[A5-rows-at-threshold]`, `P` `@example(MAX)` |
| A6 | threshold−1 / threshold+1 | **N** | `E::...[A6-*]` |
| A7 | 0 candidates at every floor | **N** (was C for one floor) | `E::test_zero_candidates_never_trips_any_floor` |
| A8 | `count_fn` raises → refuse, `-1`, `count_failed` | C + **N** | `test_1644::test_count_error_refuses`; now also `P::...oracle` (`count_raises=True`) |
| A9 | non-numeric `count_fn` return raises `TypeError` | **N** (observed, not endorsed) | `E::TestEvaluateRaisesContract::test_non_numeric_count_raises_out_of_evaluate` → **Finding 2** |
| A10 | NaN count, no ack → refuse | **N** | `E::test_nan_count_without_ack_refuses` |
| A10b | NaN count, ack present → **allowed** | **N** | `E::test_nan_count_with_ack_is_allowed` |
| A11 | negative count is allowed through | **N** | `E::test_negative_candidate_count_is_allowed_through` |
| A12 | ack lookup raises → refuse | C + **N** | `test_1644::test_ack_lookup_error_refuses`; now also `P::...oracle` (`ack_raises=True`) |
| A13 | acked while over threshold | C + **N** | `test_1644::test_acknowledged_proceeds`; `P` `@example(acked=True)` |
| A14 | `count_fn` receives exactly `threshold + 1` | **N** | `E::test_count_fn_receives_exactly_threshold_plus_one`, `P::...oracle` (asserts `seen_limits`) |
| A15 | `evaluate` performs no direct DB write | **N** | `P::test_evaluate_never_writes_to_the_database` |
| A16 | full decision table == independent oracle | **N** | `P::test_decision_table_matches_an_independent_oracle` (all 5 exits) |
| A17 | negative floor refuses regardless of data | **N** | `E::test_negative_floor_refuses_regardless_of_data`, `P` `@example(floor=-1)` |

### B — ack lifecycle

| # | Case | Status | Covered by |
|---|---|---|---|
| B1 | round-trip at arbitrary window | **N** (C only for w∈{5,30}) | `P::test_ack_round_trips_at_any_window` |
| B2/B3/B4 | wrong window / wrong key / single-use | C + **N** | `test_1644::TestAcknowledgement::*`; generalized in `P::test_an_ack_authorizes_exactly_one_{window,setting}` |
| B5 | consume with no ack present | **N** | `E::test_consume_without_an_ack_is_a_no_op` |
| B6 | stored value with whitespace | **N** | `E::test_stored_value_is_stripped_before_comparison` |
| B7 | `"030"`/`"+30"`/`"30.0"`/`""`/`"thirty"` | **N** | `E::test_non_canonical_stored_values_do_not_acknowledge` |
| B8 | `w=True` vs `w=1` | **U** | unreachable from the router (Pydantic coerces to int); fail-safe direction |
| B9 | window binding over arbitrary pairs | **N** | `P::test_an_ack_authorizes_exactly_one_window` |
| — | ack key lives under the blocklisted prefix | **N** | `E::test_ack_key_is_namespaced_under_the_blocklisted_prefix` |

### C — `announce_refusal` / `_last_refused` / `note_allowed` / `_alarm_id`

| # | Case | Status | Covered by |
|---|---|---|---|
| C1 | first refusal → ERROR + exactly one alarm | **N** | `E::test_first_refusal_logs_error_and_raises_exactly_one_alarm`, `P::test_alarm_count_equals_the_number_of_transitions` |
| C2 | repeat → INFO, no second alarm | **N** | `E::test_repeat_refusal_drops_to_info_and_raises_no_second_alarm`, `P` `@example` |
| C3 | same key, narrowed window → fresh | **N** | `E::test_a_narrowed_window_is_a_fresh_transition`, `P` `@example` |
| C4 | `note_allowed` re-arms ERROR | **N** | `E::test_note_allowed_rearms_the_error_level`, `P` `@example` |
| C5 | alarm raises → refusal unchanged | C + **N** | `test_1644::test_alarm_failure_never_flips_the_refusal`; `E::test_alarm_failure_does_not_propagate` |
| C6 | memo written BEFORE the alarm try → a failed alarm never retries | **U** | **Finding 3** — observability gap; the fix is product code, forbidden by AC#4 |
| C7 | settings read raises → `source == "unknown"` | **N** | `E::test_settings_read_failure_degrades_source_and_never_propagates` |
| C8 | **SECURITY** whole-item allowlist + no value echo | **N** | `E::test_alarm_payload_carries_counts_and_identifiers_only`, `P::test_alarm_payload_never_grows_new_fields` |
| C9 | `_alarm_id` natural key | **N** | `E::test_alarm_id_is_the_natural_key_and_expiry_is_null` |
| C10 | `expires_at is None` | **N** | same as C9, and `P::test_alarm_payload_never_grows_new_fields` |
| — | `note_allowed` clears only its own key | **N** | `E::test_note_allowed_only_clears_its_own_key` |
| — | alarm hosts on the uncreatable sentinel | **N** | `E::test_alarm_hosts_on_the_uncreatable_sentinel_agent` |

### D — `_read_retention_settings` (body executed nowhere on `dev`)

| # | Case | Status | Covered by |
|---|---|---|---|
| D1–D4, D6 | valid / invalid / None / negative / spaced | **N** | `E::TestRetentionSettingsCoercion::test_raw_value_coercion` (12 params) |
| D5 | unicode digits accepted by `int()` | **N** (observed) | `E::test_unicode_digits_are_accepted_by_int` |
| D7 | absurdly large window stays a positive int | **N** | `E::test_absurdly_large_window_stays_an_int_and_disables_nothing` |
| D8 | totality: 4 non-negative ints, never raises | **N** | `P::test_reader_is_total_and_never_negative` |
| — | the 4 windows are returned in a fixed ORDER | **N** | `E::test_returns_the_four_windows_in_a_fixed_order` |

### E — `_log_prune` level rule

| # | Case | Status | Covered by |
|---|---|---|---|
| E1–E3 | 0 / trickle / cap−1 / cap / cap+1 | **N** | `E::TestLogPruneLevels::test_level_escalates_at_the_chunk_boundary` (5 params) |

### F — predicate parity + drain semantics

| # | Case | Status | Covered by |
|---|---|---|---|
| F1/F2 | count == prune, fixed example | C | `test_1644::TestPredicateParity::*` |
| F3 | **property**: parity over arbitrary row sets | **N** | `P::test_row_count_equals_what_the_prune_deletes`, `P::test_log_count_equals_what_the_log_prune_nulls` |
| F4 | all four terminal states counted AND pruned jointly | **N** | `E::test_all_four_terminal_states_are_counted_and_pruned_together`, `P` `@example` |
| F5 | terminal row with `completed_at IS NULL` | **N** | `E::test_terminal_row_with_null_completed_at_is_excluded_by_both_sides`, `P` `@example` |
| F6 | `completed_at` exactly == cutoff (strict `<`) | **N** | `E::test_a_row_exactly_at_the_cutoff_survives` (frozen cutoff — see §5) |
| F7 | non-terminal never touched | C + **N** | `test_1644`; `P` `@example(_NON_TERMINAL)` |
| F8 | `execution_log IS NULL` excluded | C | `test_1644::test_execution_log_count_matches_prune` |
| F9 | `_bounded_count` == `min(candidates, limit)` | C + **N** | `test_1644::test_count_is_bounded_by_limit`; `P::test_bounded_count_returns_min_of_candidates_and_limit` |
| F10 | `retention_days <= 0` / `limit <= 0` → 0 | C + **N** | `test_1644`; `E::test_non_positive_chunk_size_prunes_nothing` |
| F11 | full drain at small `chunk_size` | **N** | `E::test_prune_execution_rows_drains_fully_with_a_small_chunk_size`, `P` `@example(chunk=1, 25 rows)` |
| F12 | naive vs `Z`-suffixed `completed_at` | **U** | boundary with slice **b** (`iso_cutoff` is b's target) — enumerated, not tested here |

### G — structural invariants

| # | Case | Status | Covered by |
|---|---|---|---|
| G1/G2 | threshold direction + not settings-backed | C | `test_1644::TestGuardIsNotItselfA1638::*` |
| G3 | every `RETENTION_OPS_KEYS` window has exactly one `_guard_allows` site | **N** | `E::test_every_retention_window_has_a_guard_call_site` (AST, strict set-equality both directions, **no hardcoded count**) |
| G4/G5 | sentinel uncreatable + windows ⊆ keys | C | `test_1644::TestCrossModuleInvariants::*` |
| G6 | **SECURITY** ack prefix blocklisted from generic `PUT /api/settings/{key}` | **N** | `E::test_ack_prefix_is_blocklisted_from_the_generic_settings_endpoint` |
| G7 | per-sweep floors pinned by DIRECTION | **N** | `E::test_per_sweep_floors_are_pinned_by_direction_not_by_value` |
| G8 | no floor exceeds the global ceiling | **N** | `E::test_no_per_sweep_floor_exceeds_the_global_ceiling` |

### H — `cleanup_service` guard adapters

| # | Case | Status | Covered by |
|---|---|---|---|
| H1 | allowed → `note_allowed`, True, no announce | **N** | `E::test_allowed_verdict_clears_the_memo_and_permits_the_prune` |
| H2 | refused → announce, False, no `note_allowed` | **N** | `E::test_refused_verdict_announces_and_blocks_the_prune` |
| H3 | `_after_guarded_prune` with no ack | **N** | `E::test_after_guarded_prune_is_a_no_op_without_an_ack` |
| H4 | consume raises → ERROR, never re-raised | **N** | `E::test_after_guarded_prune_never_raises_into_a_completed_sweep` |
| — | `floor` is forwarded to `evaluate` | **N** | `E::test_floor_is_forwarded_to_evaluate` |
| — | ack consumed when present | **N** | `E::test_after_guarded_prune_consumes_a_present_ack` |

### Totals

| | count |
|---|---|
| Enumerated | **62** |
| Already covered on `dev` (C, incl. C+N) | **18** |
| Newly covered by this slice (N) | **41** |
| UNSPECIFIED — reported, not tested (U) | **3** (B8, C6, F12) |

**146 tests** across the two files (71 example tests incl. parametrization + 12 Hypothesis
properties: 9 × 200 examples, 3 × 30 examples).

---

## 2. AC#3 — mutation gate

### `mutmut` is structurally unusable in this repo (reusable finding)

`mutmut==3.6.0` was installed and driven through four configurations. It generates mutants
correctly but **cannot resolve this repo's module paths**: it derives the module name from the
file path (`src/backend/services/retention_guard.py` → `backend.services.retention_guard`)
while `tests/unit/conftest.py` puts `src/backend` **directly** on `sys.path`, so the tests
import `services.retention_guard`. mutmut detects the mismatch itself and stops:

> `Stopping early, because tests recorded trampoline hits but none match any mutant key.`
> `Recorded keys: ['services.retention_guard.x_evaluate']`
> `Expected keys: ['backend.services.retention_guard.x_evaluate']`

This is structural, not a config error, and affects **any** future mutmut use here — flagged as
a follow-up, since P-38 mandates `--mutate` on subsequent targets.

The plan's sanctioned fallback (a hand-applied mutant list) was used, but made **complete**
rather than cherry-picked: a small AST mutator enumerates every mutation point with a standard
operator set (comparison swaps, boolean-operator flips, `not`-removal, numeric/string/boolean
constant mutation), applies exactly one per variant, and runs the scoped suite.

**Two harness controls run before every gate**, because a broken harness reports false kills:
(1) the pristine source must pass; (2) an **unmutated `ast.unparse` round-trip** must also pass
— **without this second control every mutant falsely reads as "killed"**, and the gate would be
meaningless. Both PASS for both targets. `__pycache__` is cleared around every apply/restore
(the same-byte-length hazard), and `git status` is clean after each run.

### Recorded run

| Target | Mutants | Killed | Survived | Coverage of run |
|---|---|---|---|---|
| `services/retention_guard.py` | 59 | **48** | 11 | complete (every mutant executed) |
| `db/schedules/retention.py` | 73 | **52** | 21 | complete (every mutant executed) |

Both improved by looping back to implementation: guard **41→48**, predicates **38→52**.
Thirteen killing tests were added as a direct result of the gate.

### Survivor dispositions — **two rows corrected since the recorded run**

The recorded survivor table was wrong in two rows. Both are corrected here; the recorded
`killed` counts above therefore **understate** the true kill count on this HEAD. I am not
restating a revised total, because the gate was not re-run end-to-end after the corrections —
the two rows were verified individually.

| Group | Count | Target | Disposition |
|---|---|---|---|
| Log/alarm **prose** string literals (message fragments, `logger` format strings, alarm `title`) | 11 | guard | **Accepted survivor.** Wording is not a behavioural contract. The log **level** (E1–E3), the alarm **count** (C1–C4), the routing **values** (`type`/`priority`/`alert_type`) and the payload **key set** (C8) are each asserted independently. Pinning prose breaks on any wording improvement and catches no bug. |
| `limit <= 0` / `chunk_size <= 0` → `< 0`, and the sibling `or`→`and` | — | predicates | **Equivalent mutants.** With `limit == 0` the early return is bypassed but the query becomes `LIMIT 0`, which returns no rows — and the chunked pruners then `break` on an empty id list. Observable behaviour is identical, so no test can distinguish them. |
| Default **argument values** (`chunk_size=500` ×3, `limit=5000` ×1) | 4 | predicates | **Accepted survivor.** Every production call site passes an explicit value (`RETENTION_CHUNK_SIZE_PER_CYCLE`), and the F3/F11 properties prove *any* positive chunk drains the full candidate set. Pinning `500` would be pinning a destructive default — **exactly the #1638 anti-pattern this slice exists to prevent** (a test asserting a destructive default is what let #1638 ship green). |
| ~~`limit <= 0` → `<= 1`~~ | — | predicates | **CORRECTION — now a deterministic KILL, removed from the survivor list.** An added `@example(available=5, limit=1)` on the bounded-count property (`test_1771a_retention_properties.py:829`) kills it at seeds **0 and 777**. |
| ~~`retention_days <= 0` → `<= 1`~~ | — | predicates | **CORRECTION — mislabelled; already killed** by `E::test_window_is_converted_to_hours_by_exactly_24[days=1]` (`test_1771a_retention_edges.py:1036`). |

---

## 3. Verification evidence

```
cd tests && ../.venv-1771a/bin/python -m pytest \
    unit/test_1771a_retention_edges.py unit/test_1771a_retention_properties.py \
    -q -p no:randomly -p no:warnings
→ 146 passed in 11.55s
```

**Branch coverage** (`--cov=services.retention_guard --cov=db.schedules.retention --cov-branch`,
run with the 3 pre-existing neighbours): `191 passed`.

| Module | Stmts | Miss | Branch | BrPart | Cover |
|---|---|---|---|---|---|
| `services/retention_guard.py` | 66 | 0 | 10 | 0 | **100%** |
| `db/schedules/retention.py` | 90 | 0 | 26 | 0 | **100%** |
| TOTAL | 156 | 0 | 36 | 0 | **100%** |

Zero partial branches — no conditional in either target has an uncovered edge.

**Full unit suite on HEAD:** `1 failed, 5049 passed, 17 skipped`. The single failure —
`test_1474_read_boundary_z.py::test_schedules_summary_last_run_at_normalized` (`assert None is
not None`) — was **reconfirmed on a pristine `f7aff466` worktree**, so it is pre-existing and
unrelated to this branch (see follow-ups).

**Order-independence:** `pytest-randomly` is deliberately absent from `requirements-test.txt`,
so it was installed **locally only** to reproduce CI's 3-seed shuffle. The retention
neighbourhood passes at seeds `1`, `12345`, `99999` — **237 passed** each. This confirms the
`_last_refused` module-global isolation holds under shuffling.

`python3 tests/lint_sys_modules.py` → `OK: 203 violation(s) in 60 file(s); baseline allows 240 —
no new violations.`

### Destructive-test isolation — proven in **both** directions

The highest-consequence risk in this slice is a property's per-example `DELETE` running against
a **real** database (`db/engine.py`'s `resolve_database_url()` prefers `DATABASE_URL`) — a
destructive accident inside a task about destructive-path safety. The fixture `delenv`s
`DATABASE_URL` + `TEST_POSTGRES_URL` and asserts the resolved URL is the tmp file **before** any
DELETE. Verified both ways:

- **Positive:** with a decoy DB of 7 marked rows and hostile `DATABASE_URL` / `TEST_POSTGRES_URL`
  exported into the shell, the suite ran **12 passed with all 7 decoy rows intact**.
- **Negative:** with the fixture's `delenv` deliberately neutered, the suite **refused at setup**
  — `AssertionError: REFUSING to run destructive property tests: the engine resolves to …, not
  this test's temp database.` — rather than proceeding.

---

## 4. `hypothesis==6.161.5` — an exact pin, harmonized across the three slices

`hypothesis` was absent from every requirements file, and all three concurrent #1771 slices
need it. **All three now carry one byte-identical comment block + pin at one fixed position**
in `tests/requirements-test.txt` — immediately after `pytest-cov>=6.0.0`. Block
sha256 `bf4d409f804f6ba414dc94a8334bd40bc2817daa2b42e24f6704debe9b549acd`, verified equal in
each slice. Consequence: the three PRs **merge cleanly into `dev` in any order**, and the file
keeps exactly **one** `hypothesis` line whichever lands first — the second and third slices
contribute an identical hunk, not a competing one.

This harmonization was applied deliberately, after the earlier per-slice variants were found to
conflict **with each other** (never with `dev`): each slice had written its own comment wording,
and the insertion positions differed. Both positions fell **inside git's 3-line context window**,
so the hunks overlapped and any second slice to merge would have hit a conflict — and a careless
resolution could have left the file with two `hypothesis` lines. Collapsing to a single canonical
block at a single anchor removes that failure mode by construction rather than by merge-time care.

The pin itself is unchanged from the original slice proposals, and this harmonization touches
**only** the comment text and anchor — no test file, and no `src/` file.

It is the **only `==` among 34 `>=` floors** — a conscious deviation from the file's convention.
Rationale: Hypothesis's example generation and shrinking change between releases, and the #1771
property suites run under a `derandomize=True` profile whose frozen input set is stable only per
version. A floating floor makes a failure non-reproducible across machines and could surface as a
head-only failure in CI's base-vs-head regression diff — the one thing the derandomized profile
exists to prevent. A floor would also auto-adopt unreviewed releases of a package with an
entry-point/plugin surface.

**Honest caveat:** 6.161.5 was uploaded **2026-07-25**, so it had ~1 day of soak when pinned —
effectively zero. Mitigating facts: 0 OSV advisories for `hypothesis` 6.161.5 or its
`sortedcontainers` dependency, and it is a **test-only** dependency that never reaches a runtime
image (`tests/requirements-test.txt` is referenced by no Dockerfile and no compose service).
A reviewer who wants a longer-soaked version should say so — bumping the pin is a one-line change
(that would need re-applying to all three slices to keep them byte-identical).

**Also worth stating for a reviewer who knows the precedent** (and recorded in the in-file comment
so it survives beyond this PR): `pytest-randomly` is deliberately kept **out** of this file
(`backend-unit-test.yml:93-99`) because pytest auto-discovers installed plugins and it would
silently randomize every local run. Hypothesis also ships an auto-loaded plugin, but unlike
`pytest-randomly` it does **not** alter collection order or the behaviour of tests that don't use
`@given` — it only adds `--hypothesis-*` options and a statistics reporter.

---

## 5. Known risk this work **increased** — PostgreSQL collation

`E::test_a_row_exactly_at_the_cutoff_survives` builds its one-tick-older control row as
`frozen[:-1] + "0"` — swapping the trailing `Z` (0x5A) for `"0"` (0x30) to get a same-length
string that sorts strictly before the frozen cutoff. This relies on `'0' < 'Z'`.

The construction is **pre-existing**, but strengthening the assertion to `counted == pruned == 1`
(a positive control, so a predicate matching *nothing* can no longer pass via `0 == 0`) made it
**load-bearing** where it was previously decorative. It is correct under SQLite's byte ordering
and **unverified under a non-C PostgreSQL collation**.

Collation-robust fix, for whoever touches this next: subtract one microsecond from the *parsed*
timestamp and re-emit a valid ISO-Z string, instead of byte-poking the suffix. Not done here —
it is a behavioural change to a passing test, and PostgreSQL is not exercised by any workflow
(`TEST_POSTGRES_URL` is unset everywhere; test ids show `[sqlite]`).

---

## 6. CI note — `schema-parity` will run in full

This PR triggers the **required** `schema-parity` check purely via its
`tests/requirements-test.txt` path entry (`schema-parity.yml:44,90`) **despite touching no DDL**.
Expect it to execute the full parity check rather than self-skip; it should be green.

---

## 7. Follow-ups — **flagged, not filed** (agents don't open issues here)

1. **`architecture.md` says "7 window-driven destructive prunes" / "`RETENTION_OPS_KEYS` carries
   all 7 windows" — there are 8** since #1296 (`f3559506`). Not fixed here: `architecture.md` is a
   3-way conflict magnet across the concurrent #1771 slices. **Mitigated structurally instead** by
   matrix row G3, which pins set-equality via AST and hardcodes neither 7 nor 8.
2. **`retention_guard.evaluate`'s "NEVER raises" docstring (`:153`) is false** for a non-numeric
   `count_fn` return — `candidates <= threshold` (`:183`) sits **outside** the try that wraps
   `count_fn`. Production-unreachable (all 8 `count_fn`s confirmed to return `int(...)`); safety
   today comes from each sweep's outer try/except, not from the contract. The
   `cleanup_service.py:219-221` comment leans on the same false claim. Pinned as observed
   behaviour, not xfail'd (AC#4 forbids the fix).
3. **★ `db/agents.py::count_soft_deleted_agents_past_retention` is the ONE guarded count invoked
   at `limit == 1` in production.** `FLOOR_AGENTS = 0` and `evaluate` calls `count_fn(threshold + 1)`.
   A `limit <= 1`-shaped regression there returns `0` → `0 <= 0` → **allowed** → **unacknowledged
   Docker-volume destruction (#1581)** — the **fail-OPEN** direction. This slice's survivor
   disposition for the `limit`-guard mutants is sound for `db/schedules/retention.py` (its smallest
   production limit is 101) but **does not generalise** to the agents accessor, which is out of
   this slice's scope. Worth its own coverage.
4. **A failed alarm permanently suppresses its own retry.** `announce_refusal` writes
   `_last_refused[key]` at `:247`, **before** the `create_operator_queue_item` try at `:268` — so
   if the alarm write fails, the memo already says "seen" and no later cycle retries it. The
   refusal is still logged at ERROR that cycle, so it is not silent, but the durable
   operator-visible alarm is lost until a restart or a window change. The fix (move the memo write
   after a successful alarm) is product code.
5. **`mutmut` is unusable in this repo** as-is (§2). Worth a shared fix — a `conftest`-level module
   alias, or a documented `also_copy` + `sys.path` recipe — since P-38 mandates `--mutate` on
   future targets.
6. **`feature-flows/cleanup-service.md` Related Files table** (lines 571-576) indexes test files
   for this flow and would conventionally gain the two new files. Not added: the plan's
   docs-delta decision was "none", reaffirmed at orchestration.
7. **Module-import-time `init_database()` runs migrations against whatever `DATABASE_URL` is
   exported, for ANY unit test file** — reproduced with `test_1644`, which predates this branch.
   So "the tests are isolated" is true of the **DML, not the DDL**: §3's isolation proof covers
   the destructive row operations, not schema creation. Pre-existing and repo-wide.
8. **The aged-out `test_1474` fixture** (the one pre-existing full-suite red, §3) belongs to no
   #1771 slice's fence and needs an owner.

---

## 8. Stated plainly — what was **not** verified by execution

- An independent adversarial **tautology-audit subagent was dispatched and never returned**
  (API limit). **Its findings are NOT reflected here** — every property-vs-tautology judgement in
  this PR is the author's own audit. A reviewer should treat property-test tautology as
  un-second-voiced. (The *plan* did receive two independent adversarial reviews — Codex `gpt-5.5`
  and a Claude subagent, 15 findings, all dispositioned — but that was the plan, not the tests.)
- **PostgreSQL was never exercised** (`TEST_POSTGRES_URL` unset in every workflow; test ids show
  `[sqlite]`). See §5.
- **`/verify-local` was deliberately not run** — Andrii's explicit call, justified by: zero `src/`
  changes (mechanically proven); `tests/requirements-test.txt` is referenced by **no Dockerfile and
  no compose service** (verified by two independent `/cso` passes), so the images rebuild
  byte-identical; and the load-bearing unit tier ran in full (§3).
- **gitleaks is not installed locally** — only a pattern grep of the diff was run (clean). CI
  `secret-scan.yml` is the authority.

## 9. Docs delta — none, deliberately

RETENTION-GUARD-001 (`requirements/lifecycle-observability.md:51-71`) already specifies this
behaviour; the slice adds **no capability**, so Trinity's tiered rule puts a test-only PR at
"descriptive commit message only". The one tempting `architecture.md` edit is follow-up 1 above,
mitigated structurally by G3 rather than by a doc edit that would 3-way-conflict with the
concurrent slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

