### PR TITLE
test(db/schedules): edge-case + property coverage for CAS status writers and analytics aggregation

### DIFF
--- a/tests/registry.json
+++ b/tests/registry.json
@@ -1166,6 +1166,60 @@
         "unit"
       ],
       "description": "export_manifest template round-trip (#1759). Blank Agents carry template: None (key PRESENT), and dict.get(key, default) returns the default only when the key is ABSENT \u2014 so the old local:business-assistant fallback was unreachable dead code and every template-less agent exported template: null, which SystemAgentConfig.template (non-Optional str) rejects on redeploy. Pins the `or` fix emitting local:default, pass-through of a real template, that the exported manifest both validates and names a template that exists in-tree, and that inferred agents are logged."
+    },
+    {
+      "file": "unit/test_1771c_schedules_cas_edges.py",
+      "feature": "#1771",
+      "added": "2026-07-26",
+      "categories": [
+        "backend",
+        "unit",
+        "database",
+        "scheduling",
+        "reliability"
+      ],
+      "description": "Edge-case matrix (sub-area A) for the #1082 CAS status writers in db/schedules/{executions,queue}.py on db_harness (#300): SUCCESS-wins over queued/pending_retry/skipped, cancelled-blocks-SUCCESS, replayed SUCCESS (UNSPEC), missing row, started_at NOT NULL schema guard, malformed started_at raising before the CAS (accepted gap), mixed naive/Z/offset formats, retry_count=None preservation, agent-scoped bulk writers, expire_stale_queued cutoff band + window arithmetic, NULL queued_at, get_queued_count isolation, find_expired_leases exclusions. Carries ONE strict xfail: clock-skewed started_at persists a negative duration_ms (#1771 AC#4 - reported, not fixed)."
+    },
+    {
+      "file": "unit/test_1771c_schedules_cas_properties.py",
+      "feature": "#1771",
+      "added": "2026-07-26",
+      "categories": [
+        "backend",
+        "unit",
+        "database",
+        "scheduling",
+        "reliability",
+        "property-based"
+      ],
+      "description": "Hypothesis properties (sub-area A) for the CAS status writers: P-A1 bounded RuleBasedStateMachine proving 'terminal is absorbing' (canary E-02 at the DB layer) plus a meta-test that injects a phantom reversal and proves the machine reports it; P-A2/P-A3 no-crash-total and idempotence asserted PER RETURN CLASS (bool / int rowcount / Optional[Dict] are three different contracts, exhaustive over the status domain); P-A4 lexicographic-ISO-equals-chronological oracle plus its negative mixed-offset case."
+    },
+    {
+      "file": "unit/test_1771c_schedules_analytics_edges.py",
+      "feature": "#1771",
+      "added": "2026-07-26",
+      "categories": [
+        "backend",
+        "unit",
+        "database",
+        "analytics",
+        "scheduling"
+      ],
+      "description": "Edge-case matrix (sub-area B) for db/schedules/analytics.py on db_harness (#300): _TRIGGER_BUCKETS subset of _BUCKET_ORDER regression guard (the existing literal assertion omits 'Reminders'), unknown/empty/None trigger bucketing, zero-terminal day reports None not 0%, headline-0.0 spec gap (UNSPEC), terminal-based success_rate incl. the legacy 'error' alias, NULL-skipping context AVG, percentile-cap boundary, full-set avg vs sampled p95 (the locked data-source discipline), percentile pool 0/1/2 rows, offset-bearing day bucketing [SQLITE-ONLY], strict '>' window boundary with a frozen iso_cutoff, gap-filled contiguous timeline, and _schedule_command_label unicode/length boundaries."
+    },
+    {
+      "file": "unit/test_1771c_schedules_analytics_properties.py",
+      "feature": "#1771",
+      "added": "2026-07-26",
+      "categories": [
+        "backend",
+        "unit",
+        "database",
+        "analytics",
+        "scheduling",
+        "property-based"
+      ],
+      "description": "Hypothesis properties (sub-area B) for analytics aggregation: P-B1 conservation (sum of by_type totals equals total_executions over arbitrary unicode triggered_by, the mechanised 'a new trigger never silently vanishes') plus its per-day form, P-B2 rate/count bounds incl. the zero-terminal-day-is-None rule, P-B2b sampling-metadata self-consistency, P-B3 contiguous duplicate-free UTC-day timeline over arbitrary windows, P-B4 no-crash-total on _bucket_for_trigger and _schedule_command_label. Uses Hypothesis event() markers so --hypothesis-show-statistics proves non-vacuity."
     }
   ]
 }

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -1205,7 +1205,7 @@
         "analytics",
         "scheduling"
       ],
-      "description": "Edge-case matrix (sub-area B) for db/schedules/analytics.py on db_harness (#300): _TRIGGER_BUCKETS subset of _BUCKET_ORDER regression guard (the existing literal assertion omits 'Reminders'), unknown/empty/None trigger bucketing, zero-terminal day reports None not 0%, headline-0.0 spec gap (UNSPEC), terminal-based success_rate incl. the legacy 'error' alias, NULL-skipping context AVG, percentile-cap boundary, full-set avg vs sampled p95 (the locked data-source discipline), percentile pool 0/1/2 rows, offset-bearing day bucketing [SQLITE-ONLY], strict '>' window boundary with a frozen iso_cutoff, gap-filled contiguous timeline, and _schedule_command_label unicode/length boundaries."
+      "description": "Edge-case matrix (sub-area B) for db/schedules/analytics.py on db_harness (#300): _TRIGGER_BUCKETS subset of _BUCKET_ORDER regression guard (the existing literal assertion omits 'Reminders'), unknown/empty/None trigger bucketing, zero-terminal day reports None not 0%, headline-0.0 spec gap (UNSPEC), terminal-based success_rate incl. the legacy 'error' alias, NULL-skipping context AVG, percentile-cap boundary, full-set avg vs sampled p95 (the locked data-source discipline), percentile pool 0/1/2 rows, offset-bearing day bucketing [SQLITE-ONLY], strict '>' window boundary with a frozen iso_cutoff, gap-filled contiguous timeline, and _schedule_command_label unicode/length boundaries. Also covers get_schedule_analytics end-to-end (agent-written tool_calls SHAPE guards \u2014 valid-JSON-not-a-list, list-of-scalars, dict-without-name, non-numeric duration \u2014 on BOTH that surface and get_agent_schedules_summary; the FAILED arm of the per-schedule timeline; and its own 0/1/2/3-row percentile ladder, a second implementation of the same statistics.quantiles arithmetic get_agent_analytics has)."
     },
     {
       "file": "unit/test_1771c_schedules_analytics_properties.py",
@@ -1219,7 +1219,7 @@
         "scheduling",
         "property-based"
       ],
-      "description": "Hypothesis properties (sub-area B) for analytics aggregation: P-B1 conservation (sum of by_type totals equals total_executions over arbitrary unicode triggered_by, the mechanised 'a new trigger never silently vanishes') plus its per-day form, P-B2 rate/count bounds incl. the zero-terminal-day-is-None rule, P-B2b sampling-metadata self-consistency, P-B3 contiguous duplicate-free UTC-day timeline over arbitrary windows, P-B4 no-crash-total on _bucket_for_trigger and _schedule_command_label. Uses Hypothesis event() markers so --hypothesis-show-statistics proves non-vacuity."
+      "description": "Hypothesis properties (sub-area B) for analytics aggregation: P-B1 conservation (sum of by_type totals equals total_executions over arbitrary unicode triggered_by, the mechanised 'a new trigger never silently vanishes') plus its per-day form, P-B2 rate/count bounds incl. the zero-terminal-day-is-None rule, P-B2b sampling-metadata self-consistency, P-B3 contiguous duplicate-free UTC-day timeline over arbitrary windows, P-B4 no-crash-total on _bucket_for_trigger and _schedule_command_label. Uses Hypothesis event() markers so --hypothesis-show-statistics proves non-vacuity; P-B2b DRAWS the percentile cap instead of leaving it at its production 5000, because with <=12 seeded rows the 'sampled is True' arm of the biconditional would otherwise be unreachable and half the property would pass vacuously."
     }
   ]
 }

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,14 +1,29 @@
 # Test dependencies for Trinity API tests
 pytest>=8.3.0
 pytest-asyncio>=0.24.0
-# Property-based testing (#1771 / P-38 `/edge-cases`). Exact pin, deliberately
-# NOT a floor: the three concurrent #1771 slices each add this identical line,
-# so an identical string makes the merge conflict trivial in any order. Used by
-# tests/unit/test_1771*_*_properties.py.
-hypothesis==6.161.5
 pytest-timeout>=2.3.0
 pytest-html>=4.1.0
 pytest-cov>=6.0.0
+# Property-based testing (#1771 / P-38 `/edge-cases`). Used by
+# tests/unit/test_1771*_properties.py.
+#
+# EXACT pin, deliberately breaking this file's `>=` convention: Hypothesis's
+# example generation and shrinking change between releases, and the #1771
+# property suites run under a `derandomize=True` profile whose frozen input set
+# is stable only per version. A floating floor would make a failure
+# irreproducible across machines and could surface as a head-only failure in
+# CI's base-vs-head regression diff — the one thing the derandomized profile
+# exists to prevent.
+#
+# Unlike pytest-randomly (deliberately kept OUT of this file — see
+# backend-unit-test.yml:93-99 — because pytest auto-discovers installed plugins
+# and it would silently randomize every local run), Hypothesis's auto-loaded
+# plugin changes neither collection order nor the behaviour of tests that don't
+# use @given; it only adds --hypothesis-* options and a statistics reporter.
+#
+# Every #1771 slice adds this block byte-identically at this exact position, so
+# the slices merge cleanly in any order and the file keeps ONE hypothesis line.
+hypothesis==6.161.5
 httpx>=0.28.0
 websockets>=13.0
 python-dotenv>=1.0.1

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,6 +1,11 @@
 # Test dependencies for Trinity API tests
 pytest>=8.3.0
 pytest-asyncio>=0.24.0
+# Property-based testing (#1771 / P-38 `/edge-cases`). Exact pin, deliberately
+# NOT a floor: the three concurrent #1771 slices each add this identical line,
+# so an identical string makes the merge conflict trivial in any order. Used by
+# tests/unit/test_1771*_*_properties.py.
+hypothesis==6.161.5
 pytest-timeout>=2.3.0
 pytest-html>=4.1.0
 pytest-cov>=6.0.0

--- a/tests/unit/test_1771c_schedules_analytics_edges.py
+++ b/tests/unit/test_1771c_schedules_analytics_edges.py
@@ -96,17 +96,24 @@ def add_execution(
     duration_ms: int | None = 1000,
     context_used: int | None = None,
     cost: float | None = None,
+    tool_calls: str | None = None,
     agent_name: str = AGENT,
     schedule_id: str = SCHEDULE,
 ) -> str:
-    """Insert one execution row through the active engine."""
+    """Insert one execution row through the active engine.
+
+    ``tool_calls`` is passed as a RAW string on purpose: the column is
+    agent-written JSON, so the shape guards under test only fire for payloads a
+    typed helper would have refused to build.
+    """
     if started_at is None:
         started_at = _iso(datetime.now(timezone.utc) - timedelta(minutes=5))
     exec_id = f"x-{next(_seq)}"
     _hrun(
         "INSERT INTO schedule_executions (id, schedule_id, agent_name, status, "
-        "started_at, duration_ms, context_used, cost, triggered_by, message) "
-        "VALUES (:i, :s, :a, :st, :sa, :d, :c, :co, :tb, 'm')",
+        "started_at, duration_ms, context_used, cost, tool_calls, "
+        "triggered_by, message) "
+        "VALUES (:i, :s, :a, :st, :sa, :d, :c, :co, :tc, :tb, 'm')",
         i=exec_id,
         s=schedule_id,
         a=agent_name,
@@ -115,6 +122,7 @@ def add_execution(
         d=duration_ms,
         c=context_used,
         co=cost,
+        tc=tool_calls,
         tb=triggered_by,
     )
     return exec_id
@@ -609,3 +617,180 @@ def test_b12b_summary_label_flows_through_for_a_zero_run_schedule(ops):
     assert row["success_rate"] is None  # no terminal runs -> "—", not 0%
     assert row["avg_duration_ms"] is None
     assert row["command"] == "/do-the-thing"
+
+
+# ===========================================================================
+# B13/B14 — get_schedule_analytics + get_agent_schedules_summary must survive
+#           ANY shape of the agent-written `tool_calls` JSON blob
+# ===========================================================================
+#
+# Added at /review (2026-07-26): the /edge-cases matrix flagged these shape
+# guards as the one genuinely-residual, un-enumerated coverage gap, and
+# `get_schedule_analytics` was named a subject-under-test by the plan (§3) and
+# by this file's own docstring while no test actually invoked it. Both are
+# closed here.
+#
+# `tool_calls` is written by the AGENT, so every one of these payloads is
+# reachable input, and a regressed guard turns the analytics read into a 500
+# rather than a degraded number. The neighbour suites cover only the
+# `json.loads` raise ("{not valid json"); the SHAPE guards below — valid JSON
+# that is not a list, a list of non-dicts, a dict with no name — were untested
+# on both surfaces.
+
+_TOOL_CALL_SHAPES = [
+    ("", 0),  # empty string: falsy raw
+    ("{not json", 0),  # JSONDecodeError
+    ('{"name": "Read"}', 0),  # valid JSON, object not list
+    ('"Read"', 0),  # valid JSON, bare string
+    ("[1, 2, 3]", 0),  # list of non-dicts
+    ('[{"duration_ms": 5}]', 0),  # dict with neither `name` nor `tool`
+    ('[{"name": ""}]', 0),  # falsy name
+    ('[{"name": "Read"}]', 1),  # counted; no usable duration
+    ('[{"tool": "Bash", "duration_ms": "5"}]', 1),  # non-numeric duration
+    ('[{"name": "Read"}, "junk", {"tool": "Bash", "duration_ms": 5}]', 2),
+]
+
+_TOOL_CALL_IDS = [
+    "empty",
+    "not-json",
+    "object-not-list",
+    "string-not-list",
+    "list-of-scalars",
+    "no-name-key",
+    "falsy-name",
+    "name-no-duration",
+    "non-numeric-duration",
+    "mixed-valid-and-junk",
+]
+
+
+@pytest.mark.parametrize("raw, expected_calls", _TOOL_CALL_SHAPES, ids=_TOOL_CALL_IDS)
+def test_b13_schedule_analytics_survives_malformed_tool_calls(ops, raw, expected_calls):
+    """B13 — ``get_schedule_analytics`` never raises on a malformed
+    ``tool_calls`` blob, and counts exactly the well-formed entries.
+
+    The tool-call pool is drawn from ``status='success' AND duration_ms IS NOT
+    NULL`` rows, so the seeded row uses the helper defaults deliberately.
+    ``total_calls`` counts every entry carrying a name; only entries with a
+    positive numeric ``duration_ms`` reach the top-5 ranking — which is why
+    ``name-no-duration`` and ``non-numeric-duration`` count but do not rank.
+    """
+    add_execution(tool_calls=raw)
+
+    out = ops.get_schedule_analytics(SCHEDULE, 24, AGENT)
+
+    assert out is not None
+    assert out["tool_calls"]["total_calls"] == expected_calls
+    assert all(
+        isinstance(t["total_duration_ms"], int) for t in out["tool_calls"]["top"]
+    )
+
+
+def test_b13b_schedule_analytics_top5_ranks_only_positive_numeric_durations(ops):
+    """B13b — an entry counts toward ``total_calls`` but only ranks when its
+    ``duration_ms`` is numeric AND positive (``0``/negative/str are excluded)."""
+    add_execution(
+        tool_calls=(
+            '[{"name": "Ranked", "duration_ms": 40},'
+            ' {"name": "ZeroDur", "duration_ms": 0},'
+            ' {"name": "NegDur", "duration_ms": -5},'
+            ' {"name": "StrDur", "duration_ms": "40"}]'
+        )
+    )
+
+    out = ops.get_schedule_analytics(SCHEDULE, 24, AGENT)
+
+    assert out["tool_calls"]["total_calls"] == 4
+    assert [t["name"] for t in out["tool_calls"]["top"]] == ["Ranked"]
+
+
+def test_b13c_schedule_analytics_timeline_counts_failures_and_ignores_the_rest(ops):
+    """B13c — the per-schedule timeline's FAILED branch.
+
+    ``get_schedule_analytics`` buckets a day into ``success`` / ``failed`` /
+    ``cost``; every other status contributes to ``total_executions`` and to
+    ``cost`` but to NEITHER day counter. Previously untested — the whole
+    ``failed`` arm of the timeline aggregation had no coverage, so a chart that
+    silently stopped drawing failure bars would have shipped green.
+    """
+    add_execution(status="success", cost=1.0)
+    add_execution(status="failed", cost=2.0)
+    add_execution(status="cancelled", cost=4.0)
+    add_execution(status="running", cost=8.0)
+
+    out = ops.get_schedule_analytics(SCHEDULE, 24, AGENT)
+    populated = [d for d in out["timeline"] if d["cost"]]
+
+    assert len(populated) == 1, "all four rows land in the same UTC day"
+    day = populated[0]
+    assert day["success"] == 1
+    assert day["failed"] == 1  # cancelled/running are NOT failures
+    assert day["cost"] == 15.0
+    assert out["total_executions"] == 4
+    assert out["cancelled_count"] == 1
+
+
+@pytest.mark.parametrize("raw, expected_calls", _TOOL_CALL_SHAPES, ids=_TOOL_CALL_IDS)
+def test_b14_schedules_summary_survives_malformed_tool_calls(ops, raw, expected_calls):
+    """B14 — the same shape guards on the #1115 summary surface.
+
+    Its ``q_tools`` query pre-filters ``tool_calls IS NOT NULL``, so the
+    ``if not raw`` arm is reachable only via an EMPTY string — which is why the
+    ``None`` case is deliberately absent from the shared shape table and
+    exercised separately below.
+    """
+    add_execution(tool_calls=raw)
+
+    out = ops.get_agent_schedules_summary(AGENT, 24)
+
+    assert out["schedule_count"] == 1
+    assert out["schedules"][0]["tool_call_total"] == expected_calls
+    assert out["tool_calls_sampled"] is False
+
+
+def test_b14b_schedules_summary_null_tool_calls_never_enters_the_loop(ops):
+    """B14b — a NULL ``tool_calls`` is filtered out in SQL, not in Python."""
+    add_execution(tool_calls=None)
+
+    out = ops.get_agent_schedules_summary(AGENT, 24)
+
+    assert out["schedules"][0]["total_executions"] == 1
+    assert out["schedules"][0]["tool_call_total"] == 0
+
+
+@pytest.mark.parametrize(
+    "durations, expected",
+    [
+        ([], (None, None, None)),
+        ([500], (500, 500, 500)),
+        ([100, 200], (150, 195, 199)),
+        ([100, 200, 300], (200, 290, 298)),
+    ],
+    ids=["B15-empty", "B15-single", "B15-pair", "B15-triple"],
+)
+def test_b15_schedule_analytics_percentile_ladder(ops, durations, expected):
+    """B15 — the ``>= 2`` / ``== 1`` / ``else`` percentile ladder of
+    ``get_schedule_analytics``.
+
+    ``statistics.quantiles`` raises ``StatisticsError`` below two data points,
+    so the ladder is load-bearing: a per-schedule analytics read on a brand-new
+    or single-run schedule must return ``None``/the single value rather than
+    500. Sibling of B7, which pins the same ladder on ``get_agent_analytics`` —
+    they are two separate implementations of the identical arithmetic, so
+    covering one does not cover the other.
+
+    ``method="inclusive"`` interpolates, which is why the pair yields
+    ``p95=195`` rather than the maximum. Pinned so a method switch is visible.
+    """
+    for dur in durations:
+        add_execution(status="success", duration_ms=dur)
+
+    out = ops.get_schedule_analytics(SCHEDULE, 24, AGENT)
+
+    assert (
+        out["duration_ms"]["p50"],
+        out["duration_ms"]["p95"],
+        out["duration_ms"]["p99"],
+    ) == expected
+    assert out["sampled"] is False
+    assert out["sample_size"] == len(durations)

--- a/tests/unit/test_1771c_schedules_analytics_edges.py
+++ b/tests/unit/test_1771c_schedules_analytics_edges.py
@@ -61,6 +61,47 @@ from db_harness import db_backend, run as _hrun  # noqa: E402,F401
 
 _DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
 
+# ---------------------------------------------------------------------------
+# sys.modules hygiene (#762 lint). Both evictions in this file are outside
+# monkeypatch's reach, or actively wrong for it:
+#   * the `utils*` shadow clear above runs at IMPORT time, before any fixture
+#     exists, so monkeypatch structurally cannot reach it;
+#   * the `ops` fixture must evict `db.*` so `from db.schedules import ...`
+#     re-imports against the harness-bound engine. `monkeypatch.delitem`
+#     records NO undo for a key that was absent on entry, so the freshly
+#     imported, harness-bound module would stay resident for later files —
+#     strictly worse isolation than the explicit pop it would replace.
+# Snapshot/restore covers both the present-on-entry and absent-on-entry cases,
+# which is the leak the lint actually guards against.
+# Precedent: tests/unit/test_telegram_webhook_backfill.py.
+# ---------------------------------------------------------------------------
+_STUBBED_MODULE_NAMES = [
+    "utils",
+    "utils.api_client",
+    "utils.assertions",
+    "utils.cleanup",
+    *_DB_MODULES,
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot the evicted modules before each test and restore after.
+
+    Purely a teardown-time guarantee: the snapshot is taken before the test
+    body, so no in-test behaviour (and no assertion) changes.
+    """
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 AGENT = "agent-1"
 SCHEDULE = "sched-1"
 

--- a/tests/unit/test_1771c_schedules_analytics_edges.py
+++ b/tests/unit/test_1771c_schedules_analytics_edges.py
@@ -1,0 +1,594 @@
+"""Edge-case matrix (sub-area B) — `db/schedules/analytics.py` (#1771 target 3).
+
+Produced by `/edge-cases` v1.0. Companion files listed in
+``test_1771c_schedules_cas_edges.py``; matrix persisted at
+``.plan/edge-cases-1771c-matrix.md``.
+
+Subject under test: ``get_agent_analytics`` (#1107), ``get_schedule_analytics``
+(#868), ``get_agent_schedules_summary`` (#1115) and the pure leaves
+``_bucket_for_trigger`` / ``_schedule_command_label``.
+
+⚠️  THE DATA-SOURCE DISCIPLINE IS LOCKED — a test contradicting it is a WRONG
+TEST, not a finding. Quoted verbatim in the ``get_agent_analytics`` docstring:
+
+* counts, per-day type stacks, per-day success-rate, per-day duration AVG and
+  per-day context AVG are **full-set** aggregates;
+* headline duration ``avg`` and ``context_avg`` are **also full-set** — never
+  the capped pool (a sampled average is silently wrong on a busy agent);
+* **only** the headline duration ``p95`` uses the newest
+  ``_PERCENTILE_ROWSET_CAP`` success rows, with ``sampled=True`` when capped;
+* ``success_rate`` is terminal-based (``success / (success + failed)``, where
+  failed includes the legacy ``error`` status);
+* a day with zero terminal rows reports ``success_rate=None`` — a chart gap, not
+  a false 0%;
+* ``context_avg`` uses NULL-skipping AVG (unmeasured rows must not read as 0);
+* bucketing is UTC-day, gap-filled over a continuous axis;
+* ``triggered_by`` is bucketed with an explicit ``Other`` catch-all so a new
+  trigger never silently vanishes.
+
+Backend honesty (Invariant #3/#9): SQLite only unless ``TEST_POSTGRES_URL`` is
+set. One row is dialect-sensitive and marked **[SQLITE-ONLY]** inline (B9 —
+``substr()`` day bucketing on an offset-bearing timestamp); everything else is
+standard SQL (``AVG`` NULL-skipping, integer truncation, ``COUNT``).
+
+The three legacy-harness analytics test files (``test_agent_analytics.py``,
+``test_schedule_analytics.py``, ``test_1115_schedules_summary.py``) are
+deliberately NOT migrated — scope discipline. New tests use ``db_harness``.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap (see the CAS edges file for the tests/utils shadowing rationale)
+# ---------------------------------------------------------------------------
+_THIS = Path(__file__).resolve()
+_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend, run as _hrun  # noqa: E402,F401
+
+_DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
+
+AGENT = "agent-1"
+SCHEDULE = "sched-1"
+
+
+@pytest.fixture
+def ops(db_backend):
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+    from db.schedules import ScheduleOperations
+
+    _hrun(
+        "INSERT INTO agent_schedules (id, agent_name, name, cron_expression, "
+        "message, enabled, timezone, owner_id, created_at, updated_at) "
+        "VALUES (:i, :a, 'nightly', '0 0 * * *', '/do-the-thing', 1, 'UTC', 1, "
+        ":n, :n)",
+        i=SCHEDULE,
+        a=AGENT,
+        n="2026-01-01T00:00:00Z",
+    )
+    yield ScheduleOperations(user_ops=MagicMock(), agent_ops=MagicMock())
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+
+
+_seq = iter(range(1_000_000))
+
+
+def add_execution(
+    *,
+    status: str = "success",
+    triggered_by: str = "schedule",
+    started_at: str | None = None,
+    duration_ms: int | None = 1000,
+    context_used: int | None = None,
+    cost: float | None = None,
+    agent_name: str = AGENT,
+    schedule_id: str = SCHEDULE,
+) -> str:
+    """Insert one execution row through the active engine."""
+    if started_at is None:
+        started_at = _iso(datetime.now(timezone.utc) - timedelta(minutes=5))
+    exec_id = f"x-{next(_seq)}"
+    _hrun(
+        "INSERT INTO schedule_executions (id, schedule_id, agent_name, status, "
+        "started_at, duration_ms, context_used, cost, triggered_by, message) "
+        "VALUES (:i, :s, :a, :st, :sa, :d, :c, :co, :tb, 'm')",
+        i=exec_id,
+        s=schedule_id,
+        a=agent_name,
+        st=status,
+        sa=started_at,
+        d=duration_ms,
+        c=context_used,
+        co=cost,
+        tb=triggered_by,
+    )
+    return exec_id
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+# ===========================================================================
+# B1 — bucket closure: every mapped bucket must be renderable
+# ===========================================================================
+
+
+def test_b1_every_trigger_bucket_is_in_bucket_order(ops):
+    """B1 — ``_TRIGGER_BUCKETS.values() ⊆ _BUCKET_ORDER``. REGRESSION GUARD.
+
+    ``by_type`` and every per-day ``by_type`` stack are built by iterating
+    ``_BUCKET_ORDER`` — so a bucket that exists in the mapping but is missing
+    from the order list has its counts **silently dropped from the chart**
+    while still being included in ``total_executions``. The numbers then
+    disagree and nothing errors.
+
+    This is not hypothetical: ``_TRIGGER_BUCKETS`` grew ``Loops`` (#1150) and
+    ``Reminders`` (#1296) as separate later changes, each of which had to
+    remember to touch ``_BUCKET_ORDER`` too. ``test_agent_analytics.py`` asserts
+    a hard-coded literal list that OMITS ``"Reminders"``, so it is not a
+    completeness check — this is.
+    """
+    from db.schedules.analytics import _BUCKET_ORDER, _OTHER_BUCKET, _TRIGGER_BUCKETS
+
+    missing = set(_TRIGGER_BUCKETS.values()) - set(_BUCKET_ORDER)
+    assert (
+        not missing
+    ), f"buckets mapped but never rendered (counts vanish from by_type): {missing}"
+    assert _OTHER_BUCKET in _BUCKET_ORDER, "the catch-all itself must be renderable"
+    assert _BUCKET_ORDER[-1] == _OTHER_BUCKET, "'Other' must sort last in the legend"
+    assert len(_BUCKET_ORDER) == len(set(_BUCKET_ORDER)), "duplicate bucket in order"
+
+
+# ===========================================================================
+# B2 — unknown / empty / None triggers fall into "Other" and are never dropped
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "trigger, expected_bucket",
+    [
+        ("schedule", "Scheduled"),
+        ("reminder", "Reminders"),
+        ("loop", "Loops"),
+        ("brand_new_trigger_type", "Other"),
+        ("", "Other"),
+        (None, "Other"),
+        ("SCHEDULE", "Other"),  # case-sensitive by design
+        ("  schedule  ", "Other"),  # not trimmed by design
+    ],
+    ids=[
+        "B2-known",
+        "B2-reminder",
+        "B2-loop",
+        "B2-unknown",
+        "B2-empty",
+        "B2-none",
+        "B2-uppercase",
+        "B2-padded",
+    ],
+)
+def test_b2_bucket_for_trigger_never_drops_a_value(trigger, expected_bucket):
+    """B2 — ``_bucket_for_trigger`` is total: every input maps somewhere.
+
+    The uppercase/padded cases pin that the lookup is an exact-match dict get —
+    a value that *looks* known but isn't lands in ``Other`` (visible) rather
+    than raising or vanishing.
+    """
+    from db.schedules.analytics import _bucket_for_trigger
+
+    assert _bucket_for_trigger(trigger) == expected_bucket
+
+
+def test_b2_unknown_trigger_surfaces_in_by_type(ops):
+    """B2b — an unmapped trigger is COUNTED and VISIBLE end-to-end, not dropped."""
+    add_execution(triggered_by="a_trigger_from_the_future")
+    add_execution(triggered_by="schedule")
+
+    out = ops.get_agent_analytics(AGENT, 168)
+
+    assert out["total_executions"] == 2
+    by_bucket = {row["bucket"]: row["total"] for row in out["by_type"]}
+    assert by_bucket == {"Scheduled": 1, "Other": 1}
+    assert sum(by_bucket.values()) == out["total_executions"]
+
+
+# ===========================================================================
+# B3 / B4 — the "percentage with no denominator" class
+# ===========================================================================
+
+
+def test_b3_zero_terminal_day_reports_none_not_zero(ops):
+    """B3 — a day with runs but ZERO terminal runs reports ``success_rate=None``.
+
+    ``running``/``queued`` rows have no verdict yet; reporting 0% would paint a
+    healthy agent as totally failing.
+    """
+    add_execution(status="running")
+    add_execution(status="queued")
+
+    out = ops.get_agent_analytics(AGENT, 24)
+    populated = [d for d in out["timeline"] if d["total"] > 0]
+
+    assert populated, "expected the seeded rows to land in a timeline day"
+    assert sum(d["total"] for d in populated) == 2
+    for day in populated:
+        assert day["success_rate"] is None
+        assert day["success"] == 0
+        assert day["failed"] == 0
+
+
+def test_b4_headline_success_rate_is_zero_on_an_empty_agent_unspecified(ops):
+    """B4 — headline ``success_rate`` is ``0.0`` while per-day is ``None``.
+    UNSPECIFIED — characterization only.
+
+    The locked discipline mandates ``None`` for *days*; it is **silent** on the
+    headline, and the code returns ``0.0`` for a zero-terminal window. So an
+    agent that has never run and an agent that failed every run both read
+    "0%" at the headline.
+
+    Reported as a spec gap rather than a bug or an xfail: no requirement is
+    violated, and changing it to ``None`` is a frontend-visible contract change
+    that belongs to a product decision, not to this test-only PR. Pinned so the
+    decision — whichever way it goes — is deliberate.
+    """
+    out = ops.get_agent_analytics("agent-with-no-history", 168)
+
+    assert out["total_executions"] == 0
+    assert out["success_rate"] == 0.0  # headline: 0.0
+    assert all(d["success_rate"] is None for d in out["timeline"])  # per-day: None
+
+
+def test_b4b_success_rate_is_terminal_based_not_total_based(ops):
+    """B4b — non-terminal rows are excluded from the ``success_rate`` denominator."""
+    add_execution(status="success")
+    add_execution(status="failed")
+    add_execution(status="running")  # no verdict
+    add_execution(status="cancelled")  # not a failure
+
+    out = ops.get_agent_analytics(AGENT, 24)
+
+    assert out["total_executions"] == 4
+    assert out["success_count"] == 1
+    assert out["failed_count"] == 1
+    assert out["success_rate"] == 0.5
+
+
+def test_b4c_legacy_error_status_counts_as_failed(ops):
+    """B4c — the legacy ``error`` status is folded into ``failed``.
+
+    Missing this makes a fleet with legacy rows look better than it is.
+    """
+    add_execution(status="success")
+    add_execution(status="error")
+
+    out = ops.get_agent_analytics(AGENT, 24)
+
+    assert out["failed_count"] == 1
+    assert out["success_rate"] == 0.5
+
+
+# ===========================================================================
+# B5 — NULL-skipping AVG
+# ===========================================================================
+
+
+def test_b5_context_avg_skips_nulls_and_is_none_when_all_null(ops):
+    """B5 — ``context_avg`` averages only measured rows; all-NULL ⇒ ``None``.
+
+    Counting an unmeasured row as 0 would drag the average toward zero and make
+    a healthy agent look like it never uses its context window.
+    """
+    add_execution(context_used=1000)
+    add_execution(context_used=3000)
+    add_execution(context_used=None)
+
+    out = ops.get_agent_analytics(AGENT, 24)
+    assert out["context_avg"] == 2000  # (1000+3000)/2, NOT /3
+
+
+def test_b5b_all_null_context_reports_none(ops):
+    add_execution(context_used=None)
+    add_execution(context_used=None)
+
+    out = ops.get_agent_analytics(AGENT, 24)
+    assert out["context_avg"] is None
+
+
+# ===========================================================================
+# B6 — the percentile-cap collection boundary
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "n_rows, expect_sampled",
+    [(2, False), (3, False), (4, True)],
+    ids=["B6-below-cap", "B6-at-cap", "B6-above-cap"],
+)
+def test_b6_sampled_flips_only_strictly_above_the_cap(
+    ops, monkeypatch, n_rows, expect_sampled
+):
+    """B6 — ``sampled`` is True only when rows **exceed** the cap, never at it.
+
+    The implementation fetches ``cap + 1`` rows to detect capping without a
+    second COUNT — an off-by-one there would mislabel an exact-cap result as
+    sampled (or, worse, a truly-capped one as complete). ``_PERCENTILE_ROWSET_CAP``
+    is documented as monkeypatchable precisely for this test.
+    """
+    import db.schedules.analytics as analytics_mod
+
+    monkeypatch.setattr(analytics_mod, "_PERCENTILE_ROWSET_CAP", 3)
+    for _ in range(n_rows):
+        add_execution(status="success", duration_ms=1000)
+
+    out = ops.get_agent_analytics(AGENT, 24)
+
+    assert out["sampled"] is expect_sampled
+    assert out["sample_size"] == (3 if expect_sampled else n_rows)
+
+
+def test_b6b_headline_avg_uses_the_full_set_even_when_p95_is_sampled(ops, monkeypatch):
+    """B6b — THE locked discipline, mechanised: capping must not touch ``avg``.
+
+    With the cap at 1 the p95 pool sees a single row, but the headline average
+    must still be computed over ALL rows. A regression that pointed ``avg`` at
+    the capped pool would be invisible on a small dev fleet and badly wrong in
+    production — exactly the failure the /autoplan review locked against.
+    """
+    import db.schedules.analytics as analytics_mod
+
+    monkeypatch.setattr(analytics_mod, "_PERCENTILE_ROWSET_CAP", 1)
+    base = datetime.now(timezone.utc) - timedelta(hours=1)
+    for i, dur in enumerate((100, 200, 300, 400)):
+        add_execution(
+            status="success",
+            duration_ms=dur,
+            started_at=_iso(base + timedelta(minutes=i)),
+        )
+
+    out = ops.get_agent_analytics(AGENT, 24)
+
+    assert out["sampled"] is True
+    assert out["duration_ms"]["avg"] == 250  # (100+200+300+400)/4 — full set
+    assert out["duration_ms"]["p95"] == 400  # newest row only — capped pool
+
+
+# ===========================================================================
+# B7 — duration pool size boundary (0 / 1 / 2 rows)
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "durations, expected_p95",
+    [([], None), ([500], 500), ([100, 200], 195)],
+    ids=["B7-empty", "B7-single", "B7-pair"],
+)
+def test_b7_percentile_pool_boundaries(ops, durations, expected_p95):
+    """B7 — 0 / 1 / 2 success rows must not raise inside ``statistics``.
+
+    ``statistics.quantiles`` raises ``StatisticsError`` on fewer than two data
+    points, so the ``>= 2`` / ``== 1`` / else ladder is load-bearing. An
+    analytics endpoint that 500s on a brand-new agent is the failure mode.
+
+    The two-row p95 is **195**, not 200: ``method="inclusive"`` *interpolates*
+    between the two observations (200 would be the max, i.e. p100). Pinned
+    deliberately — the inclusive/exclusive choice is a documented decision in
+    the implementation ("matches 'x% of observations were ≤ this value' for
+    small N"), and switching methods would silently move every percentile the
+    Overview chart renders.
+    """
+    for dur in durations:
+        add_execution(status="success", duration_ms=dur)
+
+    out = ops.get_agent_analytics(AGENT, 24)
+
+    assert out["duration_ms"]["p95"] == expected_p95
+
+
+def test_b7b_null_durations_are_excluded_from_the_pool(ops):
+    """B7b — a success row with NULL ``duration_ms`` never enters the percentile
+    pool (``int(None)`` would raise)."""
+    add_execution(status="success", duration_ms=None)
+    add_execution(status="success", duration_ms=750)
+
+    out = ops.get_agent_analytics(AGENT, 24)
+
+    assert out["duration_ms"]["p95"] == 750
+    assert out["sample_size"] == 1
+
+
+# ===========================================================================
+# B9 — day bucketing is a substring, not a timezone conversion  [SQLITE-ONLY]
+# ===========================================================================
+
+
+def test_b9_offset_bearing_started_at_buckets_by_its_literal_prefix(ops):
+    """B9 — ``substr(started_at, 1, 10)`` buckets by the string's OWN date.
+
+    **[SQLITE-ONLY]** — asserted through the SQLite ``substr`` path; the
+    PostgreSQL rendering of ``func.substr`` is equivalent for TEXT but is not
+    exercised without ``TEST_POSTGRES_URL``.
+
+    CHARACTERIZATION, not a bug claim. Day bucketing is documented as UTC-day,
+    and it *is* UTC-correct for every value the platform writes — every producer
+    goes through ``utc_now_iso()`` / ``to_utc_iso()``, which emit ``Z``. But the
+    bucketing is a **string prefix**, not a conversion: an offset-bearing value
+    like ``2026-03-02T01:00:00+05:00`` (whose UTC instant is 2026-03-01) would
+    be filed under 2026-03-02.
+
+    Pinned because the sibling #1474 work established that naive/offset rows DO
+    exist historically, so this is the mechanism by which such a row would land
+    in the wrong bucket — worth being explicit about rather than assuming the
+    docstring's "UTC-day" claim covers it.
+    """
+    # Same instant, two spellings — they must NOT share a bucket today.
+    add_execution(started_at="2026-03-02T01:00:00.000000+05:00", status="success")
+    add_execution(started_at="2026-03-01T20:00:00.000000Z", status="success")
+
+    out = ops.get_agent_analytics(AGENT, 24 * 365 * 10)
+    days = {d["date"]: d["total"] for d in out["timeline"] if d["total"]}
+
+    assert days == {
+        "2026-03-02": 1,
+        "2026-03-01": 1,
+    }, "offset-bearing row bucketed by its literal prefix, not its UTC instant"
+
+
+# ===========================================================================
+# B10 — window boundary is STRICTLY greater-than
+# ===========================================================================
+
+
+def test_b10_window_boundary_is_exclusive(ops, monkeypatch):
+    """B10 — the window filter is ``started_at > cutoff``, so a row exactly at
+    the cutoff is EXCLUDED while the very next microsecond is included.
+
+    ``iso_cutoff`` is **frozen** here. Computing the cutoff in the test and
+    again inside the method yields two strings milliseconds apart, which moves
+    the boundary between them and makes a ±1µs assertion a coin-flip (it failed
+    exactly that way on the first run). The property under test is the
+    strictness of ``>``, not clock arithmetic — freezing is what makes the
+    boundary pair meaningful. Invariant #16: the comparison is lexicographic on
+    ISO-Z strings, so equal-length microsecond precision is the real boundary.
+    """
+    import db.schedules.analytics as analytics_mod
+
+    frozen = "2026-03-01T12:00:00.500000Z"
+    monkeypatch.setattr(analytics_mod, "iso_cutoff", lambda *a, **k: frozen)
+
+    add_execution(started_at="2026-03-01T12:00:00.499999Z")  # 1µs before
+    add_execution(started_at=frozen)  # exactly at
+    add_execution(started_at="2026-03-01T12:00:00.500001Z")  # 1µs after
+
+    out = ops.get_agent_analytics(AGENT, 24)
+
+    assert (
+        out["total_executions"] == 1
+    ), "only the strictly-after row is in window ('>' not '>=')"
+
+
+# ===========================================================================
+# B11 — gap-filled continuous UTC-day timeline
+# ===========================================================================
+
+
+@pytest.mark.parametrize("hours", [24, 168, 336, 720], ids=lambda h: f"B11-{h}h")
+def test_b11_timeline_is_contiguous_and_gap_filled(ops, hours):
+    """B11 — the timeline is a continuous UTC-day axis with no gaps or dupes.
+
+    A chart that silently omits zero-days compresses the x-axis and misreports
+    trend slope. Verifies day-count arithmetic across the real window sizes the
+    router accepts (7d/14d/30d) plus 24h.
+    """
+    add_execution(status="success")
+
+    out = ops.get_agent_analytics(AGENT, hours)
+    dates = [d["date"] for d in out["timeline"]]
+
+    assert dates == sorted(dates), "timeline not chronologically ordered"
+    assert len(dates) == len(set(dates)), "duplicate day in timeline"
+
+    parsed = [datetime.strptime(d, "%Y-%m-%d").date() for d in dates]
+    for earlier, later in zip(parsed, parsed[1:]):
+        assert (later - earlier).days == 1, f"gap between {earlier} and {later}"
+
+    today = datetime.now(timezone.utc).date()
+    assert parsed[-1] == today
+    assert parsed[0] == (datetime.now(timezone.utc) - timedelta(hours=hours)).date()
+
+
+def test_b11b_zero_days_carry_explicit_empty_values(ops):
+    """B11b — a gap-filled day is fully populated with zeros/Nones, never a
+    partial dict the frontend would have to guard."""
+    out = ops.get_agent_analytics("agent-with-no-history", 168)
+
+    for day in out["timeline"]:
+        assert day["total"] == 0
+        assert day["success"] == 0
+        assert day["failed"] == 0
+        assert day["success_rate"] is None
+        assert day["duration_avg_ms"] is None
+        assert day["context_avg"] is None
+        assert day["by_type"] == {}
+
+
+# ===========================================================================
+# B12 — _schedule_command_label string handling
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        (None, ""),
+        ("", ""),
+        ("   ", ""),
+        ("\n\n\n", ""),
+        ("\n\n/do-the-thing\nrest", "/do-the-thing"),
+        ("   /padded   ", "/padded"),
+        ("a" * 80, "a" * 80),  # exactly at the limit
+        ("a" * 81, "a" * 79 + "…"),  # one over -> truncate + ellipsis
+        ("🚀 ship it", "🚀 ship it"),
+        ("é́́ combining", "é́́ combining"),
+        ("‮RTL text", "‮RTL text"),
+    ],
+    ids=[
+        "B12-none",
+        "B12-empty",
+        "B12-spaces",
+        "B12-newlines",
+        "B12-first-line",
+        "B12-padded",
+        "B12-at-80",
+        "B12-at-81",
+        "B12-emoji",
+        "B12-combining",
+        "B12-rtl",
+    ],
+)
+def test_b12_schedule_command_label(message, expected):
+    """B12 — the scorecard headline never raises and never exceeds 80 chars.
+
+    Boundary pair 80/81 pins the truncation arithmetic (``[:79] + "…"`` keeps
+    the result at exactly 80). Unicode cases pin that the cut is by **code
+    point**, not by grapheme — a combining mark or emoji can be split, which is
+    a cosmetic limitation worth documenting rather than a correctness bug.
+    """
+    from db.schedules.analytics import _schedule_command_label
+
+    result = _schedule_command_label(message)
+    assert result == expected
+    assert len(result) <= 80
+
+
+def test_b12b_summary_label_flows_through_for_a_zero_run_schedule(ops):
+    """B12b — ``get_agent_schedules_summary`` returns a row (with zeros) for a
+    schedule that has never run, carrying its derived command label.
+
+    The zero-run row is the whole point of #1115: a schedule that never fires is
+    exactly the one an operator needs to see.
+    """
+    out = ops.get_agent_schedules_summary(AGENT, 168)
+
+    assert out["schedule_count"] == 1
+    row = out["schedules"][0]
+    assert row["schedule_id"] == SCHEDULE
+    assert row["total_executions"] == 0
+    assert row["success_rate"] is None  # no terminal runs -> "—", not 0%
+    assert row["avg_duration_ms"] is None
+    assert row["command"] == "/do-the-thing"

--- a/tests/unit/test_1771c_schedules_analytics_edges.py
+++ b/tests/unit/test_1771c_schedules_analytics_edges.py
@@ -435,17 +435,34 @@ def test_b9_offset_bearing_started_at_buckets_by_its_literal_prefix(ops):
     exist historically, so this is the mechanism by which such a row would land
     in the wrong bucket — worth being explicit about rather than assuming the
     docstring's "UTC-day" claim covers it.
-    """
-    # Same instant, two spellings — they must NOT share a bucket today.
-    add_execution(started_at="2026-03-02T01:00:00.000000+05:00", status="success")
-    add_execution(started_at="2026-03-01T20:00:00.000000Z", status="success")
 
-    out = ops.get_agent_analytics(AGENT, 24 * 365 * 10)
+    Dates are derived from *today* rather than hard-coded so the test cannot age
+    out of its own window (a fixed 2026-03-01 pair would have needed an
+    ever-growing ``hours`` argument, and a 10-year window makes the gap-fill
+    loop build ~3650 day-dicts per call).
+    """
+    # One instant, two spellings. 20:00Z is 01:00 the NEXT day at +05:00, so a
+    # UTC-day-correct implementation would file both under the same date.
+    instant = (datetime.now(timezone.utc) - timedelta(days=2)).replace(
+        hour=20, minute=0, second=0, microsecond=0
+    )
+    utc_day = instant.date().isoformat()
+    offset_spelling = instant.astimezone(timezone(timedelta(hours=5)))
+    offset_day = offset_spelling.date().isoformat()
+    assert offset_day != utc_day, "fixture must straddle a UTC day boundary"
+
+    add_execution(started_at=_iso(instant), status="success")
+    add_execution(
+        started_at=offset_spelling.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+        status="success",
+    )
+
+    out = ops.get_agent_analytics(AGENT, 168)
     days = {d["date"]: d["total"] for d in out["timeline"] if d["total"]}
 
     assert days == {
-        "2026-03-02": 1,
-        "2026-03-01": 1,
+        utc_day: 1,
+        offset_day: 1,
     }, "offset-bearing row bucketed by its literal prefix, not its UTC instant"
 
 

--- a/tests/unit/test_1771c_schedules_analytics_properties.py
+++ b/tests/unit/test_1771c_schedules_analytics_properties.py
@@ -50,6 +50,47 @@ from db_harness import db_backend, run as _hrun  # noqa: E402,F401
 
 _DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
 
+# ---------------------------------------------------------------------------
+# sys.modules hygiene (#762 lint). Both evictions in this file are outside
+# monkeypatch's reach, or actively wrong for it:
+#   * the `utils*` shadow clear above runs at IMPORT time, before any fixture
+#     exists, so monkeypatch structurally cannot reach it;
+#   * the `ops` fixture must evict `db.*` so `from db.schedules import ...`
+#     re-imports against the harness-bound engine. `monkeypatch.delitem`
+#     records NO undo for a key that was absent on entry, so the freshly
+#     imported, harness-bound module would stay resident for later files —
+#     strictly worse isolation than the explicit pop it would replace.
+# Snapshot/restore covers both the present-on-entry and absent-on-entry cases,
+# which is the leak the lint actually guards against.
+# Precedent: tests/unit/test_telegram_webhook_backfill.py.
+# ---------------------------------------------------------------------------
+_STUBBED_MODULE_NAMES = [
+    "utils",
+    "utils.api_client",
+    "utils.assertions",
+    "utils.cleanup",
+    *_DB_MODULES,
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot the evicted modules before each test and restore after.
+
+    Purely a teardown-time guarantee: the snapshot is taken before the test
+    body, so no in-test behaviour (and no assertion) changes.
+    """
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 _counter = itertools.count()
 
 STATUSES = [

--- a/tests/unit/test_1771c_schedules_analytics_properties.py
+++ b/tests/unit/test_1771c_schedules_analytics_properties.py
@@ -1,0 +1,375 @@
+"""Hypothesis properties (sub-area B) — analytics aggregation (#1771 target 3).
+
+Properties P-B1…P-B4 from the `/edge-cases` matrix
+(``.plan/edge-cases-1771c-matrix.md``). Discrete companions live in
+``test_1771c_schedules_analytics_edges.py``.
+
+⚠️  The locked data-source discipline (quoted in full in the edges file) is the
+oracle here. A property that contradicts it — e.g. asserting the headline
+duration ``avg`` tracks the capped percentile pool — is a WRONG TEST, not a
+finding.
+
+CI bounds: ``max_examples`` 100 (DB-touching) / 200 (pure), ``deadline=None``.
+
+Hypothesis ↔ function-scoped fixture: the health check is suppressed, so the DB
+is built ONCE and shared by every example. Correctness therefore rests on each
+example using a **unique agent name** — the analytics queries are all
+``agent_name``-scoped, so per-example isolation is exact rather than
+best-effort.
+
+Backend honesty (Invariant #3/#9): SQLite only unless ``TEST_POSTGRES_URL`` is
+set. P-B1/P-B2 lean on ``COUNT``/``CASE`` and P-B3 is pure Python date
+arithmetic — all backend-agnostic. P-B4 touches no database at all.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from hypothesis import HealthCheck, event, example, given, settings
+from hypothesis import strategies as st
+
+# ---------------------------------------------------------------------------
+# Bootstrap (see the CAS edges file for the tests/utils shadowing rationale)
+# ---------------------------------------------------------------------------
+_THIS = Path(__file__).resolve()
+_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend, run as _hrun  # noqa: E402,F401
+
+_DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
+
+_counter = itertools.count()
+
+STATUSES = [
+    "success",
+    "failed",
+    "error",
+    "cancelled",
+    "skipped",
+    "running",
+    "queued",
+    "pending_retry",
+]
+
+
+@pytest.fixture
+def ops(db_backend):
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+    from db.schedules import ScheduleOperations
+
+    yield ScheduleOperations(user_ops=MagicMock(), agent_ops=MagicMock())
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _seed(agent: str, rows) -> None:
+    """Insert ``rows`` of ``(status, triggered_by)`` for ``agent``."""
+    now = datetime.now(timezone.utc)
+    for i, (status, trigger) in enumerate(rows):
+        _hrun(
+            "INSERT INTO schedule_executions (id, schedule_id, agent_name, "
+            "status, started_at, duration_ms, triggered_by, message) "
+            "VALUES (:i, 'sched-1', :a, :st, :sa, 100, :tb, 'm')",
+            i=f"p-{next(_counter)}",
+            a=agent,
+            st=status,
+            sa=_iso(now - timedelta(minutes=i + 1)),
+            tb=trigger,
+        )
+
+
+# `triggered_by` is arbitrary text on the way in, but surrogates cannot be
+# encoded for the DB driver — excluding them is an *insert-layer* constraint,
+# not a weakening of the property (the bucketing logic never sees them).
+_TRIGGER_TEXT = st.text(
+    alphabet=st.characters(blacklist_categories=("Cs",), blacklist_characters="\x00"),
+    max_size=40,
+)
+_TRIGGERS = st.one_of(
+    _TRIGGER_TEXT,
+    st.sampled_from(
+        [
+            "schedule",
+            "manual",
+            "chat",
+            "mcp",
+            "telegram",
+            "loop",
+            "reminder",
+            "voip",
+            "webhook",
+            "fan_out",
+            "totally_unknown",
+            "",
+        ]
+    ),
+)
+_ROWS = st.lists(
+    st.tuples(st.sampled_from(STATUSES), _TRIGGERS), min_size=0, max_size=12
+)
+
+
+# ===========================================================================
+# P-B1 — Conservation: no execution may vanish from the type breakdown
+# ===========================================================================
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(rows=_ROWS)
+@example(rows=[("success", "reminder")])  # #1296 bucket (B1 regression)
+@example(rows=[("success", "loop")])  # #1150 bucket
+@example(rows=[("success", "brand_new_trigger")])  # unmapped -> Other
+@example(rows=[("success", "")])  # empty -> Other
+def test_p_b1_by_type_conserves_total_executions(ops, rows):
+    """P-B1 — ``sum(by_type[*].total) == total_executions``, for ANY multiset of
+    arbitrary ``triggered_by`` strings.
+
+    This is the mechanised form of the locked rule *"a new trigger never
+    silently vanishes"*. ``by_type`` is assembled by iterating ``_BUCKET_ORDER``,
+    so it fails **iff** some bucket reachable from ``_TRIGGER_BUCKETS`` is
+    missing from that order list — the exact defect that would let a future
+    ``_TRIGGER_BUCKETS`` entry be counted in the total yet dropped from the
+    chart, leaving the two numbers quietly inconsistent.
+
+    Random unicode triggers matter here: they all have to land in ``Other``,
+    which proves the catch-all is genuinely total rather than merely covering
+    the strings someone thought of.
+    """
+    agent = f"pb1-{next(_counter)}"
+    _seed(agent, rows)
+
+    out = ops.get_agent_analytics(agent, 24)
+
+    # Coverage markers — `--hypothesis-show-statistics` then PROVES the
+    # interesting partitions were actually reached, instead of leaving "it
+    # passed" to hide a run that only ever drew empty row-lists.
+    event("rows: empty" if not rows else "rows: non-empty")
+    if any(r["bucket"] == "Other" for r in out["by_type"]):
+        event("reached the Other catch-all")
+    if len(out["by_type"]) > 1:
+        event("multiple buckets present")
+
+    assert sum(r["total"] for r in out["by_type"]) == out["total_executions"]
+    assert out["total_executions"] == len(rows)
+    # `buckets` is the legend; it must agree with the data it labels.
+    assert [r["bucket"] for r in out["by_type"]] == out["buckets"]
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(rows=_ROWS)
+def test_p_b1b_per_day_stacks_conserve_their_day_total(ops, rows):
+    """P-B1b — within every timeline day, the stacked ``by_type`` values sum to
+    that day's ``total``.
+
+    The headline breakdown and the per-day stacks are built from the same rows
+    by two separate loops, so conservation has to hold twice. A stacked bar
+    whose segments do not add up to its own height is the visible symptom.
+    """
+    agent = f"pb1b-{next(_counter)}"
+    _seed(agent, rows)
+
+    out = ops.get_agent_analytics(agent, 24)
+
+    for day in out["timeline"]:
+        assert sum(day["by_type"].values()) == day["total"], day
+    assert sum(d["total"] for d in out["timeline"]) == out["total_executions"]
+
+
+# ===========================================================================
+# P-B2 — Bounds: rates are real rates, sub-counts never exceed their total
+# ===========================================================================
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(rows=_ROWS)
+@example(rows=[])  # empty agent
+@example(rows=[("running", "schedule")])  # zero-terminal day
+@example(rows=[("error", "schedule")])  # legacy failed alias
+def test_p_b2_rates_and_counts_stay_in_bounds(ops, rows):
+    """P-B2 — ``success_rate`` ∈ [0,1] (or ``None`` per-day), and no sub-count
+    can exceed the total it partitions.
+
+    Catches the whole "percentage with no denominator" family — a division that
+    escapes its guard yields ``inf``/``nan``/negative, and a count that double-
+    tallies (e.g. ``error`` folded into ``failed`` *and* counted separately)
+    breaks ``success + failed <= total``.
+    """
+    agent = f"pb2-{next(_counter)}"
+    _seed(agent, rows)
+
+    out = ops.get_agent_analytics(agent, 24)
+
+    terminals = sum(1 for s, _ in rows if s in ("success", "failed", "error"))
+    event(f"terminal rows: {'0' if terminals == 0 else 'some'}")
+    event(f"non-terminal rows present: {terminals < len(rows)}")
+
+    assert 0.0 <= out["success_rate"] <= 1.0
+    assert out["success_count"] >= 0 and out["failed_count"] >= 0
+    assert out["success_count"] + out["failed_count"] <= out["total_executions"]
+
+    for day in out["timeline"]:
+        rate = day["success_rate"]
+        assert rate is None or 0.0 <= rate <= 1.0
+        assert day["success"] <= day["total"]
+        assert day["failed"] <= day["total"]
+        assert day["success"] + day["failed"] <= day["total"]
+        # The locked rule: a zero-terminal day is a GAP, never a false 0%.
+        if day["success"] + day["failed"] == 0:
+            assert rate is None
+        else:
+            assert rate is not None
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(rows=_ROWS)
+def test_p_b2b_sampling_metadata_is_self_consistent(ops, rows):
+    """P-B2b — ``sample_size`` never exceeds the cap and never claims more rows
+    than exist; ``sampled`` is False whenever the pool fits.
+
+    ``sample_size`` is what tells the UI whether to caption a percentile as
+    approximate, so an inconsistent pair mislabels the number's trustworthiness.
+    """
+    from db.schedules.analytics import _PERCENTILE_ROWSET_CAP
+
+    agent = f"pb2b-{next(_counter)}"
+    _seed(agent, rows)
+    eligible = sum(1 for status, _ in rows if status == "success")
+
+    out = ops.get_agent_analytics(agent, 24)
+
+    assert out["sample_size"] <= _PERCENTILE_ROWSET_CAP
+    assert out["sample_size"] <= eligible
+    assert out["sampled"] is (eligible > _PERCENTILE_ROWSET_CAP)
+    if eligible == 0:
+        assert out["duration_ms"]["p95"] is None
+
+
+# ===========================================================================
+# P-B3 — Timeline is a contiguous, duplicate-free UTC-day axis
+# ===========================================================================
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(hours=st.integers(min_value=1, max_value=1000))
+@example(hours=24)
+@example(hours=168)  # 7d
+@example(hours=336)  # 14d
+@example(hours=720)  # 30d
+def test_p_b3_timeline_is_a_contiguous_utc_day_axis(ops, hours):
+    """P-B3 — for every valid window the timeline is strictly increasing,
+    duplicate-free, one-day-stepped, and spans exactly ``[now-hours, now]``.
+
+    A missing day compresses the chart's x-axis and misreports trend slope; a
+    duplicate day double-plots. Property-testing the *arithmetic* (rather than
+    three hard-coded windows) is what catches an off-by-one that only appears at
+    an unusual window or across a month/year boundary.
+    """
+    agent = f"pb3-{next(_counter)}"
+
+    out = ops.get_agent_analytics(agent, hours)
+    dates = [d["date"] for d in out["timeline"]]
+    parsed = [datetime.strptime(d, "%Y-%m-%d").date() for d in dates]
+
+    assert parsed, "timeline is never empty"
+    assert parsed == sorted(parsed)
+    assert len(parsed) == len(set(parsed))
+    for earlier, later in zip(parsed, parsed[1:]):
+        assert (later - earlier).days == 1
+
+    now = datetime.now(timezone.utc)
+    assert parsed[0] == (now - timedelta(hours=hours)).date()
+    assert parsed[-1] == now.date()
+    assert len(parsed) == (parsed[-1] - parsed[0]).days + 1
+
+
+# ===========================================================================
+# P-B4 — No-crash-total on the pure string leaves
+# ===========================================================================
+
+
+@settings(max_examples=200, deadline=None)
+@given(trigger=st.one_of(st.none(), st.text()))
+@example(trigger="\x00")
+@example(trigger="​")  # zero-width space
+@example(trigger="‮")  # RTL override
+@example(trigger="x" * 10_000)
+def test_p_b4_bucket_for_trigger_is_total(trigger):
+    """P-B4a — ``_bucket_for_trigger`` never raises and always returns a bucket
+    that the renderer can actually draw.
+
+    Totality is the point: this function sits on the path of every analytics
+    read, and ``triggered_by`` is a free-text column. Returning a value outside
+    ``_BUCKET_ORDER`` would drop the row from ``by_type`` (see P-B1) rather than
+    error, so the assertion checks membership, not merely "returns a string".
+    """
+    from db.schedules.analytics import _BUCKET_ORDER, _bucket_for_trigger
+
+    result = _bucket_for_trigger(trigger)
+
+    assert isinstance(result, str)
+    assert result in _BUCKET_ORDER
+
+
+@settings(max_examples=200, deadline=None)
+@given(message=st.one_of(st.none(), st.text()))
+@example(message="\x00\x00")
+@example(message="\n\n\n")
+@example(message="   ")
+@example(message="a" * 80)
+@example(message="a" * 81)
+@example(message="🚀" * 200)
+def test_p_b4_schedule_command_label_is_total_and_bounded(message):
+    """P-B4b — ``_schedule_command_label`` never raises, always returns ``str``,
+    and never exceeds the 80-char scorecard budget.
+
+    Arbitrary unicode is the realistic input: the message is operator-authored
+    free text. The length bound is the load-bearing half — an unbounded label
+    breaks the fixed-width scorecard layout, and the truncation arithmetic
+    (``[:79] + "…"``) has to land at exactly 80, not 81.
+    """
+    from db.schedules.analytics import _SCHEDULE_LABEL_MAX, _schedule_command_label
+
+    result = _schedule_command_label(message)
+
+    assert isinstance(result, str)
+    assert len(result) <= _SCHEDULE_LABEL_MAX
+    assert "\n" not in result and "\r" not in result
+    if result:
+        assert result == result.strip() or result.endswith("…")

--- a/tests/unit/test_1771c_schedules_analytics_properties.py
+++ b/tests/unit/test_1771c_schedules_analytics_properties.py
@@ -254,15 +254,28 @@ def test_p_b2_rates_and_counts_stay_in_bounds(ops, rows):
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(rows=_ROWS)
-def test_p_b2b_sampling_metadata_is_self_consistent(ops, rows):
+@given(rows=_ROWS, cap=st.integers(min_value=1, max_value=6))
+@example(rows=[("success", "schedule")] * 4, cap=2)  # pool strictly OVER the cap
+@example(rows=[("success", "schedule")] * 2, cap=2)  # pool exactly AT the cap
+@example(rows=[("running", "schedule")], cap=1)  # empty pool
+def test_p_b2b_sampling_metadata_is_self_consistent(ops, monkeypatch, rows, cap):
     """P-B2b — ``sample_size`` never exceeds the cap and never claims more rows
-    than exist; ``sampled`` is False whenever the pool fits.
+    than exist; ``sampled`` is True **iff** the eligible pool exceeds the cap.
 
     ``sample_size`` is what tells the UI whether to caption a percentile as
     approximate, so an inconsistent pair mislabels the number's trustworthiness.
+
+    THE CAP IS DRAWN, NOT LEFT AT ITS PRODUCTION VALUE. With
+    ``_PERCENTILE_ROWSET_CAP == 5000`` and at most 12 seeded rows, ``eligible >
+    cap`` is False for **every** example, so the ``sampled is True`` half of the
+    biconditional would pass vacuously — a property that only ever asserts one
+    side of an "iff" is a green tick that proves nothing. Shrinking the cap into
+    the row range is what makes both arms reachable (the ``@example`` pins keep
+    the over/at/empty trio deterministic even if random search misses them).
     """
-    from db.schedules.analytics import _PERCENTILE_ROWSET_CAP
+    import db.schedules.analytics as analytics_mod
+
+    monkeypatch.setattr(analytics_mod, "_PERCENTILE_ROWSET_CAP", cap)
 
     agent = f"pb2b-{next(_counter)}"
     _seed(agent, rows)
@@ -270,9 +283,10 @@ def test_p_b2b_sampling_metadata_is_self_consistent(ops, rows):
 
     out = ops.get_agent_analytics(agent, 24)
 
-    assert out["sample_size"] <= _PERCENTILE_ROWSET_CAP
+    event(f"pool over cap: {eligible > cap}")
+    assert out["sample_size"] <= cap
     assert out["sample_size"] <= eligible
-    assert out["sampled"] is (eligible > _PERCENTILE_ROWSET_CAP)
+    assert out["sampled"] is (eligible > cap)
     if eligible == 0:
         assert out["duration_ms"]["p95"] is None
 

--- a/tests/unit/test_1771c_schedules_cas_edges.py
+++ b/tests/unit/test_1771c_schedules_cas_edges.py
@@ -450,17 +450,17 @@ def test_a12_bulk_writers_no_match_returns_zero(ops, method_name, agent_name):
 def test_a12_fail_all_nonterminal_covers_three_states(ops):
     """A12b — ``fail_all_nonterminal_for_agent`` sweeps queued + running +
     pending_retry and stops at every terminal (trinity-enterprise#69)."""
-    for st in ("queued", "running", "pending_retry"):
-        insert_execution(f"a12b-{st}", status=st, agent_name="agent-1")
-    for st in ("success", "failed", "cancelled", "skipped"):
-        insert_execution(f"a12b-{st}", status=st, agent_name="agent-1")
+    for state in ("queued", "running", "pending_retry"):
+        insert_execution(f"a12b-{state}", status=state, agent_name="agent-1")
+    for state in ("success", "failed", "cancelled", "skipped"):
+        insert_execution(f"a12b-{state}", status=state, agent_name="agent-1")
 
     assert ops.fail_all_nonterminal_for_agent("agent-1", "ghost_discarded") == 3
 
-    for st in ("queued", "running", "pending_retry"):
-        assert status_of(f"a12b-{st}") == "failed"
-    for st in ("success", "failed", "cancelled", "skipped"):
-        assert status_of(f"a12b-{st}") == st
+    for state in ("queued", "running", "pending_retry"):
+        assert status_of(f"a12b-{state}") == "failed"
+    for state in ("success", "failed", "cancelled", "skipped"):
+        assert status_of(f"a12b-{state}") == state
 
 
 # ===========================================================================

--- a/tests/unit/test_1771c_schedules_cas_edges.py
+++ b/tests/unit/test_1771c_schedules_cas_edges.py
@@ -65,6 +65,47 @@ from db_harness import db_backend, run as _hrun, scalar as _hscalar  # noqa: E40
 
 _DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
 
+# ---------------------------------------------------------------------------
+# sys.modules hygiene (#762 lint). Both evictions in this file are outside
+# monkeypatch's reach, or actively wrong for it:
+#   * the `utils*` shadow clear above runs at IMPORT time, before any fixture
+#     exists, so monkeypatch structurally cannot reach it;
+#   * the `ops` fixture must evict `db.*` so `from db.schedules import ...`
+#     re-imports against the harness-bound engine. `monkeypatch.delitem`
+#     records NO undo for a key that was absent on entry, so the freshly
+#     imported, harness-bound module would stay resident for later files —
+#     strictly worse isolation than the explicit pop it would replace.
+# Snapshot/restore covers both the present-on-entry and absent-on-entry cases,
+# which is the leak the lint actually guards against.
+# Precedent: tests/unit/test_telegram_webhook_backfill.py.
+# ---------------------------------------------------------------------------
+_STUBBED_MODULE_NAMES = [
+    "utils",
+    "utils.api_client",
+    "utils.assertions",
+    "utils.cleanup",
+    *_DB_MODULES,
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot the evicted modules before each test and restore after.
+
+    Purely a teardown-time guarantee: the snapshot is taken before the test
+    body, so no in-test behaviour (and no assertion) changes.
+    """
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 
 @pytest.fixture
 def ops(db_backend):

--- a/tests/unit/test_1771c_schedules_cas_edges.py
+++ b/tests/unit/test_1771c_schedules_cas_edges.py
@@ -1,0 +1,600 @@
+"""Edge-case matrix (sub-area A) — `db/schedules/` CAS status writers (#1771 target 3).
+
+Produced by `/edge-cases` v1.0 (understand → enumerate → generate → reflect →
+verify). Companion files:
+
+* ``test_1771c_schedules_cas_properties.py``      — Hypothesis properties P-A1…P-A4
+* ``test_1771c_schedules_analytics_edges.py``     — sub-area B discrete cases
+* ``test_1771c_schedules_analytics_properties.py``— sub-area B properties
+* ``.plan/edge-cases-1771c-matrix.md``            — the persisted matrix
+
+Subject under test: the CAS-guarded status writers of the #1082
+"status-as-projection" contract — ``db/schedules/executions.py``
+(``update_execution_status``) and ``db/schedules/queue.py`` (the backlog +
+lease-reaper transitions).
+
+⚠️  READ BEFORE ADDING A TEST HERE — the intuitive contract is WRONG.
+At **this** layer ``SUCCESS`` overwrites ``running``, ``queued``,
+``pending_retry``, ``skipped``, ``failed`` **and an existing ``success``**.
+Only ``CANCELLED`` blocks it (#671). The "an authoritative terminal
+short-circuits" behaviour lives UPSTREAM in the #1083 result-callback replay
+guard, not in the DB layer. A property asserting "terminals are immutable"
+here is a wrong test, not a finding.
+
+Backend honesty (Invariant #3/#9): ``db_backend`` yields **SQLite only** unless
+``TEST_POSTGRES_URL`` is set, so by default every case below is exercised on
+SQLite. Rows whose behaviour is dialect-sensitive are marked ``[SQLITE-ONLY]``
+in the matrix; nothing in this file is dialect-sensitive except where noted
+(``expire_stale_queued`` string collation is ASCII-identical on both).
+
+Deliberately NOT duplicated here:
+``test_schedule_status_observability.py::TestStatusWriteProjectionGuard`` (the
+AST inventory proving every status write carries a precondition) and
+``test_cancelled_not_overwritten.py`` (SUCCESS-over-running / over-phantom-stale
+-failed). Those already exist and already ``rglob`` the package.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: make src/backend importable. pytest auto-adds `tests/` to
+# sys.path, which means `tests/utils/` (the API test helpers package) would
+# shadow `src/backend/utils/` when backend code does `from utils.helpers ...`.
+# ---------------------------------------------------------------------------
+_THIS = Path(__file__).resolve()
+_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend, run as _hrun, scalar as _hscalar  # noqa: E402,F401
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
+
+
+@pytest.fixture
+def ops(db_backend):
+    """Composed ``ScheduleOperations`` bound to a fresh production schema.
+
+    Instantiates the **composed** class (Invariant #2) — never a bare mixin,
+    whose cross-slice ``self.<method>()`` calls would ``AttributeError``.
+    """
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+    from db.schedules import ScheduleOperations
+
+    yield ScheduleOperations(user_ops=MagicMock(), agent_ops=MagicMock())
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+
+
+def insert_execution(
+    exec_id: str,
+    *,
+    status: str = "running",
+    agent_name: str = "agent-1",
+    started_at: str = "2026-01-01T00:00:00.000000Z",
+    **extra,
+) -> str:
+    """Insert a ``schedule_executions`` row through the active engine."""
+    cols = {
+        "id": exec_id,
+        "schedule_id": "sched-1",
+        "agent_name": agent_name,
+        "status": status,
+        "started_at": started_at,
+        "message": "do the thing",
+        "triggered_by": "schedule",
+    }
+    cols.update(extra)
+    names = ", ".join(cols)
+    binds = ", ".join(f":{k}" for k in cols)
+    _hrun(f"INSERT INTO schedule_executions ({names}) VALUES ({binds})", **cols)
+    return exec_id
+
+
+def status_of(exec_id: str):
+    return _hscalar("SELECT status FROM schedule_executions WHERE id = :i", i=exec_id)
+
+
+def column_of(exec_id: str, col: str):
+    return _hscalar(f"SELECT {col} FROM schedule_executions WHERE id = :i", i=exec_id)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+# ===========================================================================
+# A1b — the genuinely untested third of the documented SUCCESS-wins contract
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "prior_status",
+    ["queued", "pending_retry", "skipped"],
+    ids=["A1b-queued", "A1b-pending_retry", "A1b-skipped"],
+)
+def test_a1b_success_wins_over_non_cancelled_prior(ops, prior_status):
+    """A1b — SUCCESS overwrites queued / pending_retry / skipped.
+
+    ``test_cancelled_not_overwritten.py`` already pins SUCCESS-over-``running``
+    and SUCCESS-over-phantom-stale-``failed``. These three are the remaining
+    members of "everything except CANCELLED", and ``skipped`` is the
+    counter-intuitive one: it is an *authoritative* terminal upstream, yet the
+    DB layer lets SUCCESS through. Pinning it stops a future refactor from
+    "tidying" ``skipped`` into the blocked set and silently dropping real
+    completions.
+    """
+    eid = insert_execution(f"a1b-{prior_status}", status=prior_status)
+
+    assert ops.update_execution_status(eid, "success", response="done") is True
+    assert status_of(eid) == "success"
+    assert column_of(eid, "response") == "done"
+
+
+def test_a2_success_blocked_by_cancelled_only(ops):
+    """A2 (regression re-pin) — CANCELLED is the ONE status that blocks SUCCESS.
+
+    Covered elsewhere for the positive case; kept here as the paired negative
+    so this file states the whole contract in one place.
+    """
+    eid = insert_execution("a2-cancelled", status="cancelled")
+
+    assert ops.update_execution_status(eid, "success", response="late") is False
+    assert status_of(eid) == "cancelled"
+    assert column_of(eid, "response") is None
+
+
+# ===========================================================================
+# A3 — UNSPECIFIED: success → success wins twice at this layer
+# ===========================================================================
+
+
+def test_a3_success_over_success_wins_again_unspecified(ops):
+    """A3 — a replayed SUCCESS wins the CAS a **second** time. UNSPECIFIED.
+
+    This is a characterization test, not an assertion that the behaviour is
+    correct. The DB layer's SUCCESS predicate is ``status != CANCELLED``, which
+    an existing ``success`` row satisfies, so the second write lands and
+    overwrites ``response`` / ``duration_ms`` / ``cost``.
+
+    That is **not** a bug at this layer: the replay short-circuit is an
+    upstream #1083 responsibility (``POST .../executions/{id}/result`` returns
+    ``{replayed: true}`` for an authoritative terminal before ever reaching
+    here). Pinned so that if the DB predicate is ever tightened, the change is
+    visible and deliberate rather than an accidental behaviour break for the
+    "late SUCCESS overwrites a reaper LEASE_EXPIRED" guarantee that depends on
+    this looseness.
+    """
+    eid = insert_execution("a3-replay", status="running")
+
+    assert ops.update_execution_status(eid, "success", response="first") is True
+    assert ops.update_execution_status(eid, "success", response="second") is True
+    assert status_of(eid) == "success"
+    assert column_of(eid, "response") == "second"
+
+
+# ===========================================================================
+# A5 / A5b — row absence and malformed `started_at`
+# ===========================================================================
+
+
+def test_a5_missing_row_returns_false_without_raising(ops):
+    """A5 — ``update_execution_status`` on an unknown id is a clean ``False``."""
+    assert ops.update_execution_status("no-such-execution", "success") is False
+
+
+def test_a5b_schema_enforces_started_at_not_null(ops):
+    """A5b(i) — the live schema enforces ``started_at NOT NULL`` on both backends.
+
+    This is a **schema-invariant guard**, and it is load-bearing for the sibling
+    case below. ``update_execution_status`` calls
+    ``parse_iso_timestamp(row["started_at"])`` *before* building the CAS WHERE;
+    on ``None`` that helper raises ``AttributeError`` ("NoneType has no
+    attribute 'endswith'"). The only thing standing between production and that
+    crash is this NOT NULL constraint.
+
+    Worth guarding because the Core metadata **disagrees**: ``db/tables.py``
+    declares ``Column("started_at", Text)`` — i.e. nullable. That is harmless
+    today only because neither backend is built from ``metadata.create_all``
+    (SQLite uses ``db.schema.init_schema``; PostgreSQL uses
+    ``init_schema_postgres``, which renders the *same* ``TABLES`` DDL). If a
+    future migration to metadata-driven DDL (#746) lands, this test fails and
+    names the consequence.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    with pytest.raises(IntegrityError):
+        insert_execution("a5b-null", started_at=None)
+
+    insert_execution("a5b-upd", status="running")
+    with pytest.raises(IntegrityError):
+        _hrun("UPDATE schedule_executions SET started_at = NULL WHERE id = 'a5b-upd'")
+
+
+@pytest.mark.parametrize(
+    "bad_started_at",
+    ["", "not-a-date", "2026-13-45T99:99:99Z"],
+    ids=["A5b-empty", "A5b-garbage", "A5b-out-of-range"],
+)
+@pytest.mark.parametrize(
+    "prior_status", ["running", "cancelled"], ids=["would-win", "would-lose"]
+)
+def test_a5b_malformed_started_at_raises_before_the_cas(
+    ops, bad_started_at, prior_status
+):
+    """A5b(ii) — a malformed (non-NULL) ``started_at`` makes the writer RAISE.
+
+    CHARACTERIZATION TEST — **accepted gap, not a filed bug.** Reason recorded
+    in the /edge-cases report: the duration is computed *before* the CAS WHERE
+    is built (``executions.py``), so the raise happens even for a write that
+    would have **lost** the CAS anyway (the ``would-lose`` parametrization
+    proves it — a ``cancelled`` row that should simply return ``False`` raises
+    instead).
+
+    Reachable **at this layer**: ``update_execution_to_queued`` stamps
+    ``started_at`` from a *caller-supplied* ``queued_at`` string with no
+    validation (see ``test_a5b_queued_at_is_unvalidated_at_this_layer``).
+    NOT reachable from any current **production** caller: the sole caller,
+    ``services/backlog_service.py``, passes ``utc_now_iso()``. So this is
+    latent/defence-in-depth, and pinning it makes the contract visible if a
+    future caller ever forwards an untrusted timestamp.
+    """
+    eid = insert_execution(
+        f"a5b-{prior_status}-{abs(hash(bad_started_at)) % 10_000}",
+        status=prior_status,
+        started_at=bad_started_at,
+    )
+
+    with pytest.raises(ValueError):
+        ops.update_execution_status(eid, "success", response="x")
+
+    # The row is untouched — the raise precedes the UPDATE entirely.
+    assert status_of(eid) == prior_status
+
+
+def test_a5b_queued_at_is_unvalidated_at_this_layer(ops):
+    """A5b(iii) — reachability proof for the case above.
+
+    ``update_execution_to_queued`` copies its caller-supplied ``queued_at``
+    straight into ``started_at`` with no parse/validation, so the malformed
+    state is constructible through the public DB API rather than only by
+    hand-writing a row.
+    """
+    eid = insert_execution("a5b-reach", status="running")
+
+    assert ops.update_execution_to_queued(eid, "{}", "not-a-date") is True
+    assert column_of(eid, "started_at") == "not-a-date"
+
+
+# ===========================================================================
+# A6 — REAL BUG: clock-skewed `started_at` persists a negative duration_ms
+# ===========================================================================
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "BUG: a `started_at` in the future relative to the finalizing process's "
+        "clock makes update_execution_status persist a NEGATIVE duration_ms "
+        "(unguarded `completed_at - started_at`), which then flows into "
+        "get_agent_analytics duration avg/p95. Producible because started_at and "
+        "completed_at are written by DIFFERENT processes (backend --workers 2 and "
+        "the standalone src/scheduler container, which repeats the same unguarded "
+        "subtraction at scheduler/database.py). Canary G-03 DETECTS the skew but "
+        "nothing prevents the poisoned metric. See /edge-cases report 2026-07-26 "
+        "(#1771 target 3) — follow-up issue not yet filed."
+    ),
+)
+def test_a6_clock_skew_must_not_persist_negative_duration(ops):
+    """A6 — ``duration_ms`` must never be negative. Currently it can be.
+
+    Asserted as the *desired* contract (non-negative), marked ``xfail(strict)``
+    so the day a clamp or a validation lands, this test flips to XPASS and the
+    suite tells us instead of us having to remember.
+
+    Fixing is deliberately OUT of scope (#1771 AC#4: a real bug ships as a
+    strict xfail + a follow-up, never a silent product-code change).
+    """
+    future = _iso(datetime.now(timezone.utc) + timedelta(seconds=300))
+    eid = insert_execution("a6-skew", status="running", started_at=future)
+
+    assert ops.update_execution_status(eid, "success", response="ok") is True
+
+    duration = column_of(eid, "duration_ms")
+    assert duration >= 0, f"negative duration_ms persisted: {duration}"
+
+
+def test_a6_current_behaviour_negative_duration_is_persisted(ops):
+    """A6 (companion) — pins what actually happens today, so the xfail above is
+    demonstrably about the *contract* and not about a flaky environment."""
+    future = _iso(datetime.now(timezone.utc) + timedelta(seconds=300))
+    eid = insert_execution("a6-observed", status="running", started_at=future)
+
+    assert ops.update_execution_status(eid, "success") is True
+    assert column_of(eid, "duration_ms") < 0
+
+
+# ===========================================================================
+# A7 — mixed naive / Z / +00:00 `started_at` must not raise
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "started_at",
+    [
+        "2026-01-01T00:00:00",  # naive (scheduler pre-#1474 legacy)
+        "2026-01-01T00:00:00.000000Z",  # utc_now_iso() form
+        "2026-01-01T00:00:00+00:00",  # explicit UTC offset
+        "2026-01-01T05:00:00+05:00",  # non-UTC offset
+    ],
+    ids=["A7-naive", "A7-zulu", "A7-utc-offset", "A7-plus5-offset"],
+)
+def test_a7_mixed_timestamp_formats_do_not_raise(ops, started_at):
+    """A7 — the ``aware − naive`` TypeError class (#1474) must not reappear.
+
+    ``parse_iso_timestamp`` normalizes naive → UTC-aware before the subtraction,
+    so every stored form in the wild (scheduler naive legacy rows, backend
+    ``Z`` rows, offset-bearing rows) computes a duration rather than exploding
+    mid-terminal-write. A crash here would strand the row ``running`` forever.
+    """
+    eid = insert_execution(
+        f"a7-{started_at[-6:]}", status="running", started_at=started_at
+    )
+
+    assert ops.update_execution_status(eid, "success") is True
+    assert isinstance(column_of(eid, "duration_ms"), int)
+
+
+# ===========================================================================
+# A8 — retry_count: None preserves, 0/1 write through (#678)
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "retry_count, expected",
+    [(None, 7), (0, 0), (1, 1), (3, 3)],
+    ids=["A8-none-preserves", "A8-zero", "A8-one", "A8-three"],
+)
+def test_a8_retry_count_none_preserves_prior_value(ops, retry_count, expected):
+    """A8 — ``retry_count=None`` must leave the column untouched (#678).
+
+    The prior value is seeded as 7 so a regression that zeroes it (the exact
+    failure the ``if retry_count is not None`` guard exists to prevent — cleanup
+    and scheduler terminal paths pass ``None``) is unmistakable.
+    """
+    eid = insert_execution(f"a8-{retry_count}", status="running", retry_count=7)
+
+    assert ops.update_execution_status(eid, "success", retry_count=retry_count) is True
+    assert column_of(eid, "retry_count") == expected
+
+
+# ===========================================================================
+# A12 — bulk agent-scoped writers must not cross the tenant boundary
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "method_name, terminal_status",
+    [
+        ("fail_queued_for_agent", "failed"),
+        ("cancel_queued_for_agent", "cancelled"),
+    ],
+    ids=["A12-fail_queued", "A12-cancel_queued"],
+)
+def test_a12_bulk_writers_are_agent_scoped(ops, method_name, terminal_status):
+    """A12 — bulk queue writers touch ONLY the named agent, and only ``queued``.
+
+    ``fail_queued_for_agent`` had no unit-level DB coverage (only integration
+    plus ``MagicMock`` wiring assertions in ``test_dispatch_breaker.py``), yet
+    it fires on every dispatch-breaker trip (#526) — a cross-agent leak would
+    fail an innocent tenant's backlog fleet-wide.
+
+    Also pins the FAILED-vs-CANCELLED split the #526 acceptance criteria
+    require: breaker-doomed rows must read as failures, not user cancellations.
+    """
+    insert_execution("a12-mine-q", status="queued", agent_name="agent-1")
+    insert_execution("a12-mine-run", status="running", agent_name="agent-1")
+    insert_execution("a12-mine-done", status="success", agent_name="agent-1")
+    insert_execution("a12-other-q", status="queued", agent_name="agent-2")
+
+    assert getattr(ops, method_name)("agent-1", "because") == 1
+
+    assert status_of("a12-mine-q") == terminal_status
+    assert column_of("a12-mine-q", "error") == "because"
+    assert status_of("a12-mine-run") == "running"  # non-queued untouched
+    assert status_of("a12-mine-done") == "success"  # terminal untouched
+    assert status_of("a12-other-q") == "queued"  # other tenant untouched
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "fail_queued_for_agent",
+        "cancel_queued_for_agent",
+        "fail_all_nonterminal_for_agent",
+    ],
+    ids=["A12-fail_queued", "A12-cancel_queued", "A12-fail_nonterminal"],
+)
+@pytest.mark.parametrize(
+    "agent_name", ["", "no-such-agent"], ids=["empty-name", "unknown-name"]
+)
+def test_a12_bulk_writers_no_match_returns_zero(ops, method_name, agent_name):
+    """A12 — an empty or unknown agent name is a clean ``0``, never a wildcard.
+
+    The empty-string case matters: an ``agent_name`` that arrives blank must not
+    degrade into "match everything" (which is how a bulk writer becomes a
+    fleet-wide outage).
+    """
+    insert_execution("a12-bystander", status="queued", agent_name="agent-1")
+
+    assert getattr(ops, method_name)(agent_name) == 0
+    assert status_of("a12-bystander") == "queued"
+
+
+def test_a12_fail_all_nonterminal_covers_three_states(ops):
+    """A12b — ``fail_all_nonterminal_for_agent`` sweeps queued + running +
+    pending_retry and stops at every terminal (trinity-enterprise#69)."""
+    for st in ("queued", "running", "pending_retry"):
+        insert_execution(f"a12b-{st}", status=st, agent_name="agent-1")
+    for st in ("success", "failed", "cancelled", "skipped"):
+        insert_execution(f"a12b-{st}", status=st, agent_name="agent-1")
+
+    assert ops.fail_all_nonterminal_for_agent("agent-1", "ghost_discarded") == 3
+
+    for st in ("queued", "running", "pending_retry"):
+        assert status_of(f"a12b-{st}") == "failed"
+    for st in ("success", "failed", "cancelled", "skipped"):
+        assert status_of(f"a12b-{st}") == st
+
+
+# ===========================================================================
+# A13 / A14 — expire_stale_queued boundary + queued_at NULL
+# ===========================================================================
+
+
+def test_a13_exact_cutoff_row_is_not_expired(ops):
+    """A13 — a row queued at *exactly* the cutoff second survives. DOCUMENTED,
+    not a bug.
+
+    ``expire_stale_queued`` builds its threshold with
+    ``strftime('%Y-%m-%dT%H:%M:%S')`` — no fractional part, no ``Z`` — while
+    ``queued_at`` is written by ``utc_now_iso()`` as ``…:SS.ffffffZ``. At an
+    equal second-prefix the stored value is the *longer* string, so
+    ``queued_at < threshold`` is False and the row is spared.
+
+    Net effect is a ≤1s error band on a 24h window: measured, benign, and worth
+    pinning precisely because it is the kind of Invariant-#16 mismatch that
+    looks like a bug to the next reader. Backend-agnostic: ASCII ISO-8601
+    collation is identical on SQLite and PostgreSQL.
+    """
+    now = datetime.now(timezone.utc)
+    exact = (now - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%S") + ".000000Z"
+    older = _iso(now - timedelta(hours=24, seconds=5))
+
+    insert_execution("a13-exact", status="queued", queued_at=exact)
+    insert_execution("a13-older", status="queued", queued_at=older)
+
+    assert ops.expire_stale_queued(24) == 1
+    assert status_of("a13-exact") == "queued"
+    assert status_of("a13-older") == "failed"
+    assert "24" in (column_of("a13-older", "error") or "")
+
+
+@pytest.mark.parametrize(
+    "max_age_hours, age_hours, should_expire",
+    [
+        (24, 25, True),
+        (24, 1, False),
+        (0.5, 1, True),  # fractional window
+        (0.5, 0.1, False),
+        (1e6, 25, False),  # absurdly wide window expires nothing
+    ],
+    ids=[
+        "A13-24h-old",
+        "A13-24h-fresh",
+        "A13-frac-old",
+        "A13-frac-fresh",
+        "A13-huge-window",
+    ],
+)
+def test_a13_expire_window_arithmetic(ops, max_age_hours, age_hours, should_expire):
+    """A13 — numeric boundary sweep over ``max_age_hours`` incl. fractional and
+    absurdly large windows (no overflow, no raise)."""
+    queued_at = _iso(datetime.now(timezone.utc) - timedelta(hours=age_hours))
+    insert_execution("a13-row", status="queued", queued_at=queued_at)
+
+    expired = ops.expire_stale_queued(max_age_hours)
+
+    assert expired == (1 if should_expire else 0)
+    assert status_of("a13-row") == ("failed" if should_expire else "queued")
+
+
+def test_a14_null_queued_at_is_excluded_from_expiry(ops):
+    """A14 — a ``queued`` row with ``queued_at IS NULL`` is never expired.
+
+    The ``isnot(None)`` filter is what keeps a NULL out of the string
+    comparison. Without it the row would be untouchable-but-scanned forever
+    (SQL NULL comparison is neither true nor false); with it, the row is
+    explicitly out of scope and the FIFO drain owns it.
+    """
+    insert_execution("a14-null", status="queued", queued_at=None)
+
+    assert ops.expire_stale_queued(0.0) == 0
+    assert status_of("a14-null") == "queued"
+
+
+# ===========================================================================
+# A15/A16 — read-side scoping (get_queued_count, find_expired_leases)
+# ===========================================================================
+
+
+def test_a15_get_queued_count_is_agent_scoped(ops):
+    """A15 — ``get_queued_count`` counts only this agent's ``queued`` rows.
+
+    It is the number ``CapacityManager`` reports as backlog depth, and canary
+    B-01 compares it against an independently-collected id set — a cross-agent
+    or cross-status leak would show up as a fleet-wide invariant violation.
+    """
+    insert_execution("a15-q1", status="queued", agent_name="agent-1")
+    insert_execution("a15-q2", status="queued", agent_name="agent-1")
+    insert_execution("a15-run", status="running", agent_name="agent-1")
+    insert_execution("a15-other", status="queued", agent_name="agent-2")
+
+    assert ops.get_queued_count("agent-1") == 2
+    assert ops.get_queued_count("agent-2") == 1
+    assert ops.get_queued_count("nobody") == 0
+    assert ops.get_queued_count("") == 0
+
+
+def test_a16_find_expired_leases_excludes_future_and_null_leases(ops):
+    """A16 — the lease reaper's candidate query is disjoint from every non-pull
+    row (#1081 Phase 3).
+
+    ``lease_expires_at IS NOT NULL`` is the load-bearing clause: push and #1083
+    fire-and-forget rows leave it NULL, so a regression that dropped it would
+    make the reaper FAIL live async executions that are working perfectly.
+    """
+    now = datetime.now(timezone.utc)
+    past = _iso(now - timedelta(minutes=5))
+    future = _iso(now + timedelta(minutes=5))
+
+    insert_execution("a16-expired", status="running", lease_expires_at=past)
+    insert_execution("a16-future", status="running", lease_expires_at=future)
+    insert_execution("a16-nolease", status="running", lease_expires_at=None)
+    insert_execution("a16-terminal", status="failed", lease_expires_at=past)
+
+    found = {row["id"] for row in ops.find_expired_leases(now_iso=_iso(now))}
+
+    assert found == {"a16-expired"}
+
+
+def test_a16_find_expired_leases_respects_limit_and_ordering(ops):
+    """A16b — oldest lease first, capped at ``limit`` (bounded reaper batch)."""
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        insert_execution(
+            f"a16b-{i}",
+            status="running",
+            lease_expires_at=_iso(now - timedelta(minutes=10 - i)),
+        )
+
+    rows = ops.find_expired_leases(now_iso=_iso(now), limit=3)
+
+    assert [r["id"] for r in rows] == ["a16b-0", "a16b-1", "a16b-2"]
+    assert ops.find_expired_leases(now_iso=_iso(now), limit=0) == []

--- a/tests/unit/test_1771c_schedules_cas_properties.py
+++ b/tests/unit/test_1771c_schedules_cas_properties.py
@@ -71,6 +71,47 @@ from db_harness import db_backend, run as _hrun, scalar as _hscalar  # noqa: E40
 
 _DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
 
+# ---------------------------------------------------------------------------
+# sys.modules hygiene (#762 lint). Both evictions in this file are outside
+# monkeypatch's reach, or actively wrong for it:
+#   * the `utils*` shadow clear above runs at IMPORT time, before any fixture
+#     exists, so monkeypatch structurally cannot reach it;
+#   * the `ops` fixture must evict `db.*` so `from db.schedules import ...`
+#     re-imports against the harness-bound engine. `monkeypatch.delitem`
+#     records NO undo for a key that was absent on entry, so the freshly
+#     imported, harness-bound module would stay resident for later files —
+#     strictly worse isolation than the explicit pop it would replace.
+# Snapshot/restore covers both the present-on-entry and absent-on-entry cases,
+# which is the leak the lint actually guards against.
+# Precedent: tests/unit/test_telegram_webhook_backfill.py.
+# ---------------------------------------------------------------------------
+_STUBBED_MODULE_NAMES = [
+    "utils",
+    "utils.api_client",
+    "utils.assertions",
+    "utils.cleanup",
+    *_DB_MODULES,
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Snapshot the evicted modules before each test and restore after.
+
+    Purely a teardown-time guarantee: the snapshot is taken before the test
+    body, so no in-test behaviour (and no assertion) changes.
+    """
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
 TERMINAL = frozenset({"success", "failed", "cancelled", "skipped"})
 NON_TERMINAL = frozenset({"queued", "running", "pending_retry"})
 ALL_STATUSES = sorted(TERMINAL | NON_TERMINAL)

--- a/tests/unit/test_1771c_schedules_cas_properties.py
+++ b/tests/unit/test_1771c_schedules_cas_properties.py
@@ -1,0 +1,566 @@
+"""Hypothesis properties (sub-area A) — CAS status writers (#1771 target 3).
+
+Properties P-A1…P-A4 from the `/edge-cases` matrix
+(``.plan/edge-cases-1771c-matrix.md``). The discrete companion cases live in
+``test_1771c_schedules_cas_edges.py``.
+
+Why properties and not more examples
+------------------------------------
+Every pre-existing CAS test is a **single** transition. The whole #1082 bug
+class ("status-as-projection") is about *sequences* — a late worker result, a
+second reaper pass, a replayed callback. P-A1 is a bounded stateful machine
+because that is the smallest construct which explores orderings a parametrized
+table cannot.
+
+⚠️  THE TRAP THIS FILE DELIBERATELY AVOIDS
+The tempting property "an authoritative terminal is never overwritten" is
+**FALSE at this layer** — SUCCESS legitimately upgrades ``failed`` (phantom-
+stale recovery, #378), ``skipped``, and even ``success``. Only ``CANCELLED``
+blocks it (#671). P-A1 therefore states the invariant that IS true and IS
+load-bearing: **terminal is absorbing with respect to non-terminal** — no
+writer here can resurrect a terminal row back into ``queued`` / ``running`` /
+``pending_retry`` (the canary E-02 phantom-reversal class).
+
+CI bounds: ``max_examples`` 100 (DB-touching) / 200 (pure), ``deadline=None``.
+
+Hypothesis ↔ function-scoped fixture: ``@given`` + ``db_backend`` raises
+``FailedHealthCheck``. Suppressing it is necessary but **NOT sufficient** — the
+DB is then built once and shared by every example. Correctness comes from each
+example drawing a **unique** execution id / agent name, so cross-example state
+is harmless by construction.
+
+Backend honesty (Invariant #3/#9): SQLite only unless ``TEST_POSTGRES_URL`` is
+set. Nothing asserted here is dialect-sensitive: P-A1/P-A2/P-A3 are pure CAS
+row-count semantics, and P-A4 is ASCII string collation (identical on both).
+Concurrency semantics ARE dialect-specific (PostgreSQL ``FOR UPDATE SKIP
+LOCKED`` vs SQLite writer serialisation) and are deliberately **out of scope**
+here — ``test_1081_pull_endpoints.py::TestClaimConcurrencyC1`` owns them.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import (
+    RuleBasedStateMachine,
+    invariant,
+    rule,
+    run_state_machine_as_test,
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap (see the sibling edges file for the tests/utils shadowing rationale)
+# ---------------------------------------------------------------------------
+_THIS = Path(__file__).resolve()
+_BACKEND = _THIS.parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend, run as _hrun, scalar as _hscalar  # noqa: E402,F401
+
+_DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
+
+TERMINAL = frozenset({"success", "failed", "cancelled", "skipped"})
+NON_TERMINAL = frozenset({"queued", "running", "pending_retry"})
+ALL_STATUSES = sorted(TERMINAL | NON_TERMINAL)
+
+# Per-example uniqueness. Hypothesis shares one DB across examples (the
+# function-scoped-fixture health check is suppressed), so every example MUST
+# key its rows on a fresh id/agent or examples would contaminate each other and
+# manufacture false greens.
+_counter = itertools.count()
+
+
+def _uid(prefix: str) -> str:
+    return f"{prefix}-{next(_counter)}"
+
+
+@pytest.fixture
+def ops(db_backend):
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+    from db.schedules import ScheduleOperations
+
+    yield ScheduleOperations(user_ops=MagicMock(), agent_ops=MagicMock())
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _insert(exec_id, *, status="running", agent_name="agent-1", **extra):
+    cols = {
+        "id": exec_id,
+        "schedule_id": "sched-1",
+        "agent_name": agent_name,
+        "status": status,
+        "started_at": _iso(datetime.now(timezone.utc) - timedelta(seconds=1)),
+        "message": "m",
+        "triggered_by": "schedule",
+    }
+    cols.update(extra)
+    names = ", ".join(cols)
+    binds = ", ".join(f":{k}" for k in cols)
+    _hrun(f"INSERT INTO schedule_executions ({names}) VALUES ({binds})", **cols)
+    return exec_id
+
+
+def _status(exec_id):
+    return _hscalar("SELECT status FROM schedule_executions WHERE id = :i", i=exec_id)
+
+
+# ===========================================================================
+# P-A1 — Invariant preservation (stateful): terminal is absorbing
+# ===========================================================================
+
+_MACHINE_OPS: list = []
+
+
+class CasWriterMachine(RuleBasedStateMachine):
+    """Drive one execution row through arbitrary interleavings of CAS writers.
+
+    The invariant checked after every step is the true #1082 / canary-E-02
+    statement: **once observed terminal, never observed non-terminal again.**
+
+    Bounded on purpose (``stateful_step_count=8``, ``max_examples=30`` ⇒ a few
+    hundred SQL statements). If this ever turns slow or flaky the documented
+    downgrade is a parametrized 3-step sequence table — do NOT paper over it
+    with a suppressed health check.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.ops = _MACHINE_OPS[0]
+        self.agent = _uid("m-agent")
+        self.eid = _insert(_uid("m-exec"), status="running", agent_name=self.agent)
+        self.seen_terminal = False
+
+    # --- rules: every CAS writer that can touch a single row ---------------
+
+    @rule()
+    def to_queued(self):
+        self.ops.update_execution_to_queued(
+            self.eid, "{}", _iso(datetime.now(timezone.utc) - timedelta(hours=48))
+        )
+
+    @rule()
+    def claim(self):
+        self.ops.claim_next_queued(self.agent)
+
+    @rule()
+    def claim_with_lease(self):
+        self.ops.claim_next_queued(self.agent, worker_id="w1", lease_seconds=-60)
+
+    @rule()
+    def release(self):
+        self.ops.release_claim_to_queued(self.eid)
+
+    @rule()
+    def requeue_lease(self):
+        self.ops.requeue_expired_lease(self.eid)
+
+    @rule()
+    def park_lease(self):
+        self.ops.park_expired_lease(self.eid, "poison")
+
+    @rule()
+    def cancel(self):
+        self.ops.cancel_queued_execution(self.eid)
+
+    @rule(status=st.sampled_from(sorted(TERMINAL | {"running"})))
+    def finalize(self, status):
+        self.ops.update_execution_status(self.eid, status, response="r")
+
+    @rule()
+    def bulk_fail_queued(self):
+        self.ops.fail_queued_for_agent(self.agent)
+
+    @rule()
+    def bulk_fail_nonterminal(self):
+        self.ops.fail_all_nonterminal_for_agent(self.agent)
+
+    @rule()
+    def expire(self):
+        self.ops.expire_stale_queued(24)
+
+    @rule()
+    def dispatch_marker(self):
+        self.ops.mark_execution_dispatched(self.eid)
+
+    # --- the invariant (read-only by construction) -------------------------
+
+    @invariant()
+    def terminal_is_absorbing(self):
+        current = _status(self.eid)
+        assert current in TERMINAL | NON_TERMINAL, f"unknown status {current!r}"
+        if current in TERMINAL:
+            self.seen_terminal = True
+        elif self.seen_terminal:
+            raise AssertionError(
+                f"E-02 phantom reversal: row {self.eid} returned to "
+                f"non-terminal {current!r} after reaching a terminal state"
+            )
+
+
+def test_p_a1_terminal_is_absorbing(ops):
+    """P-A1 — across ANY legal interleaving of the CAS writers, a terminal row
+    is never resurrected into a non-terminal state.
+
+    This is the mechanised form of canary **E-02** at the DB layer, and it is
+    the property the single-transition tests structurally cannot express.
+    """
+    _MACHINE_OPS.clear()
+    _MACHINE_OPS.append(ops)
+    run_state_machine_as_test(
+        CasWriterMachine,
+        settings=settings(
+            max_examples=30,
+            stateful_step_count=8,
+            deadline=None,
+            suppress_health_check=[
+                HealthCheck.function_scoped_fixture,
+                HealthCheck.too_slow,
+            ],
+        ),
+    )
+
+
+class _ResurrectingMachine(CasWriterMachine):
+    """Sabotaged machine used ONLY by the meta-test below.
+
+    Adds one rule that does what no production writer can: a raw, precondition-
+    free UPDATE that drags the row back to ``queued``.
+    """
+
+    @rule()
+    def illegally_resurrect(self):
+        _hrun(
+            "UPDATE schedule_executions SET status = 'queued' WHERE id = :i",
+            i=self.eid,
+        )
+
+
+def test_p_a1_meta_the_invariant_can_actually_fail(ops):
+    """META — proves P-A1 is load-bearing, not vacuously green.
+
+    ``run_state_machine_as_test`` reports no Hypothesis statistics through the
+    pytest plugin, so "it passed" is by itself weak evidence: a machine whose
+    rules all no-op, or whose invariant never observes a terminal, would pass
+    identically. This test injects a deliberate E-02 phantom reversal and
+    asserts the machine **finds and reports it** — the same meta-test discipline
+    ``test_schedule_status_observability.py::TestStatusWriteProjectionGuard``
+    already applies to the AST guard.
+    """
+    _MACHINE_OPS.clear()
+    _MACHINE_OPS.append(ops)
+    with pytest.raises(AssertionError, match="phantom reversal"):
+        run_state_machine_as_test(
+            _ResurrectingMachine,
+            settings=settings(
+                max_examples=50,
+                stateful_step_count=8,
+                deadline=None,
+                suppress_health_check=[
+                    HealthCheck.function_scoped_fixture,
+                    HealthCheck.too_slow,
+                ],
+            ),
+        )
+
+
+# ===========================================================================
+# P-A2 — No-crash-total, asserted PER RETURN CLASS
+# ===========================================================================
+#
+# The writers do NOT share a return type. Asserting "returns a bool" globally
+# would be a wrong test that passes for the wrong reason (`bool` is a subclass
+# of `int`, so an int-returning bulk writer would sail through `isinstance(x,
+# int)` and a rowcount of 0/1 would even satisfy `in (True, False)`).
+#
+#   bool          -> single-row CAS writers
+#   int           -> agent-scoped bulk writers (rowcount)
+#   Optional[Dict]-> claim_next_queued
+#
+# `started_at` is held well-formed here on purpose: the malformed case is a
+# KNOWN pre-CAS raise (matrix row A5b) and folding it in would make this
+# property assert something false.
+
+_BOOL_WRITERS = [
+    ("update_execution_status", lambda o, e, a: o.update_execution_status(e, "failed")),
+    ("mark_execution_dispatched", lambda o, e, a: o.mark_execution_dispatched(e)),
+    (
+        "update_execution_to_queued",
+        lambda o, e, a: o.update_execution_to_queued(
+            e, "{}", _iso(datetime.now(timezone.utc))
+        ),
+    ),
+    ("release_claim_to_queued", lambda o, e, a: o.release_claim_to_queued(e)),
+    ("requeue_expired_lease", lambda o, e, a: o.requeue_expired_lease(e)),
+    ("park_expired_lease", lambda o, e, a: o.park_expired_lease(e, "poison")),
+    ("cancel_queued_execution", lambda o, e, a: o.cancel_queued_execution(e)),
+]
+
+_INT_WRITERS = [
+    ("cancel_queued_for_agent", lambda o, e, a: o.cancel_queued_for_agent(a)),
+    ("fail_queued_for_agent", lambda o, e, a: o.fail_queued_for_agent(a)),
+    (
+        "fail_all_nonterminal_for_agent",
+        lambda o, e, a: o.fail_all_nonterminal_for_agent(a),
+    ),
+    ("expire_stale_queued", lambda o, e, a: o.expire_stale_queued(0.0)),
+]
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    prior_status=st.sampled_from(ALL_STATUSES),
+    writer_index=st.integers(min_value=0, max_value=len(_BOOL_WRITERS) - 1),
+)
+def test_p_a2_bool_writers_never_raise_and_return_bool(ops, prior_status, writer_index):
+    """P-A2a — every single-row CAS writer returns a **strict bool** and never
+    raises, for any prior status in the full domain."""
+    name, invoke = _BOOL_WRITERS[writer_index]
+    agent = _uid("p2-agent")
+    eid = _insert(_uid("p2"), status=prior_status, agent_name=agent)
+
+    result = invoke(ops, eid, agent)
+
+    assert (
+        result is True or result is False
+    ), f"{name} returned {result!r} ({type(result).__name__}), expected a bool"
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    prior_status=st.sampled_from(ALL_STATUSES),
+    writer_index=st.integers(min_value=0, max_value=len(_INT_WRITERS) - 1),
+)
+def test_p_a2_bulk_writers_never_raise_and_return_nonneg_int(
+    ops, prior_status, writer_index
+):
+    """P-A2b — every bulk writer returns a non-negative rowcount ``int`` (NOT a
+    bool) and never raises, for any prior status."""
+    name, invoke = _INT_WRITERS[writer_index]
+    agent = _uid("p2b-agent")
+    _insert(
+        _uid("p2b"),
+        status=prior_status,
+        agent_name=agent,
+        queued_at=_iso(datetime.now(timezone.utc) - timedelta(hours=48)),
+    )
+
+    result = invoke(ops, None, agent)
+
+    assert isinstance(result, int) and not isinstance(
+        result, bool
+    ), f"{name} returned {result!r} ({type(result).__name__}), expected int"
+    assert result >= 0
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(prior_status=st.sampled_from(ALL_STATUSES))
+def test_p_a2_claim_returns_dict_or_none(ops, prior_status):
+    """P-A2c — ``claim_next_queued`` returns a dict (only from a ``queued`` row)
+    or ``None``; never raises, never returns a bool."""
+    agent = _uid("p2c-agent")
+    _insert(
+        _uid("p2c"),
+        status=prior_status,
+        agent_name=agent,
+        queued_at=_iso(datetime.now(timezone.utc)),
+    )
+
+    result = ops.claim_next_queued(agent)
+
+    if prior_status == "queued":
+        assert isinstance(result, dict)
+        assert result["agent_name"] == agent
+    else:
+        assert result is None
+
+
+# ===========================================================================
+# P-A3 — Idempotence, again PER RETURN CLASS
+# ===========================================================================
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    prior_status=st.sampled_from(ALL_STATUSES),
+    writer_index=st.integers(min_value=0, max_value=len(_BOOL_WRITERS) - 1),
+)
+def test_p_a3_bool_writer_second_call_is_a_no_op(ops, prior_status, writer_index):
+    """P-A3a — a second identical single-row call is a genuine no-op.
+
+    Every one of these writers is a CAS whose precondition its own success
+    invalidates, so a replay must return ``False`` and leave ``status``
+    untouched. The one documented exception is carved out below rather than
+    weakened away: ``update_execution_status(SUCCESS)`` is intentionally
+    re-winnable (matrix row A3 / the "late SUCCESS overwrites a reaper
+    LEASE_EXPIRED" guarantee), and this property invokes it with ``failed`` so
+    the carve-out is not silently in play.
+    """
+    name, invoke = _BOOL_WRITERS[writer_index]
+    agent = _uid("p3-agent")
+    eid = _insert(_uid("p3"), status=prior_status, agent_name=agent)
+
+    first = invoke(ops, eid, agent)
+    after_first = _status(eid)
+    second = invoke(ops, eid, agent)
+    after_second = _status(eid)
+
+    assume(first is True)  # only replays of a winning call are interesting
+    assert second is False, f"{name} won its CAS twice"
+    assert (
+        after_second == after_first
+    ), f"{name} changed status on replay: {after_first!r} -> {after_second!r}"
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    prior_status=st.sampled_from(ALL_STATUSES),
+    writer_index=st.integers(min_value=0, max_value=len(_INT_WRITERS) - 1),
+)
+def test_p_a3_bulk_writer_second_call_returns_zero(ops, prior_status, writer_index):
+    """P-A3b — a bulk writer's replay reports ``0`` rows and mutates nothing."""
+    name, invoke = _INT_WRITERS[writer_index]
+    agent = _uid("p3b-agent")
+    eid = _insert(
+        _uid("p3b"),
+        status=prior_status,
+        agent_name=agent,
+        queued_at=_iso(datetime.now(timezone.utc) - timedelta(hours=48)),
+    )
+
+    first = invoke(ops, None, agent)
+    after_first = _status(eid)
+    second = invoke(ops, None, agent)
+
+    assume(first > 0)
+    assert second == 0, f"{name} affected rows twice ({first} then {second})"
+    assert _status(eid) == after_first
+
+
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(queued_rows=st.integers(min_value=1, max_value=4))
+def test_p_a3_claim_drains_then_returns_none(ops, queued_rows):
+    """P-A3c — ``claim_next_queued`` hands out each queued row exactly once and
+    then returns ``None`` (the backlog is drained, not re-served).
+
+    Exactly-once is the property BACKLOG-001 rests on: a re-served row is a
+    duplicated agent execution (double spend, double side-effect).
+    """
+    agent = _uid("p3c-agent")
+    base = datetime.now(timezone.utc)
+    expected = [
+        _insert(
+            _uid("p3c"),
+            status="queued",
+            agent_name=agent,
+            queued_at=_iso(base + timedelta(seconds=i)),
+        )
+        for i in range(queued_rows)
+    ]
+
+    claimed = []
+    for _ in range(queued_rows):
+        row = ops.claim_next_queued(agent)
+        assert row is not None
+        claimed.append(row["id"])
+
+    assert claimed == expected, "FIFO order violated"
+    assert len(set(claimed)) == queued_rows, "a row was claimed twice"
+    assert ops.claim_next_queued(agent) is None
+
+
+# ===========================================================================
+# P-A4 — Oracle: lexicographic ISO order ≡ chronological order
+# ===========================================================================
+#
+# Pure function property: no fixture, no DB, no health-check suppression.
+
+_UTC_DATETIMES = st.datetimes(
+    min_value=datetime(2000, 1, 1),
+    max_value=datetime(2099, 12, 31),
+).map(lambda d: d.replace(tzinfo=timezone.utc))
+
+
+def _z(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+@settings(max_examples=200, deadline=None)
+@given(a=_UTC_DATETIMES, b=_UTC_DATETIMES)
+def test_p_a4_zulu_iso_sorts_chronologically(a, b):
+    """P-A4 — for ``utc_now_iso()``-formatted strings, string ``<`` **is**
+    chronological ``<``.
+
+    This is the assumption ``expire_stale_queued`` and ``find_expired_leases``
+    rest on: both compare ``queued_at`` / ``lease_expires_at`` as **strings** in
+    SQL rather than parsing them. The format's fixed-width zero-padded fields
+    are what make that sound. Backend-agnostic — ASCII collation is identical on
+    SQLite and PostgreSQL.
+    """
+    assert (_z(a) < _z(b)) == (a < b)
+    assert (_z(a) == _z(b)) == (a == b)
+
+
+@settings(max_examples=200, deadline=None)
+@given(dt=_UTC_DATETIMES, offset_hours=st.integers(min_value=1, max_value=14))
+def test_p_a4_mixed_offset_formats_break_lexicographic_order(dt, offset_hours):
+    """P-A4b — the SAME instant written with a non-UTC offset does NOT compare
+    correctly as a string. This is WHY format discipline is load-bearing.
+
+    Documents the failure mode Invariant #16 exists to prevent: mixing
+    ``+05:00``-style timestamps into a column that SQL compares lexicographically
+    silently corrupts every window query over it. Asserted as "the naive string
+    comparison disagrees with the true chronology", so the test is a live
+    explanation rather than a comment.
+    """
+    aware = dt.astimezone(timezone(timedelta(hours=offset_hours)))
+    offset_form = aware.isoformat()  # e.g. 2026-01-01T05:00:00+05:00
+    zulu_form = _z(dt)  # same instant, Z form
+
+    assume(offset_form[:4] == zulu_form[:4])  # ignore year-rollover pairs
+    # Same instant...
+    assert datetime.fromisoformat(offset_form) == dt
+    # ...yet the strings are not equal, so a lexicographic comparison against a
+    # Z-form threshold cannot be trusted.
+    assert offset_form != zulu_form


### PR DESCRIPTION
## Summary

**Test-only PR.** Applies `/edge-cases` (understand → enumerate → generate → reflect → verify) to
**target 3 of 7** of #1771: the precondition-guarded CAS terminal transitions in
`db/schedules/executions.py` + `queue.py` (the #1082 status-as-projection contract) and the
NULL-skip / UTC-bucketing aggregation in `db/schedules/analytics.py`.

- **+2410 / −0**, six files, all under `tests/`. `git diff f7aff466..HEAD -- src/` is **empty** — no product code touched (#1771 `AC#4`).
- **129 passed, 1 xfailed.** The xfail is a **real bug** found by this work, shipped as a `strict=True` xfail rather than a silent fix.
- 38 enumerated edge cases + 12 properties (Hypothesis, incl. a `RuleBasedStateMachine`); 28 newly covered.

Part of #1771 (target 3 of 7). Refs abilityai/trinity#1771.

> **Deliberately `Refs`, not a closing keyword.** Targets 4–7 of #1771 remain open and three
> concurrent PRs reference this issue, so auto-closing on merge would be wrong. The linked issue
> will **not** auto-promote to `status-in-dev` — that is intended here; bump it manually when the
> last target lands.

## Changes

| File | What |
|---|---|
| `tests/unit/test_1771c_schedules_cas_edges.py` | Discrete CAS cases, matrix rows A1b–A16 |
| `tests/unit/test_1771c_schedules_cas_properties.py` | P-A1…P-A4 incl. the stateful machine + its meta-test |
| `tests/unit/test_1771c_schedules_analytics_edges.py` | Discrete analytics cases, rows B1–B16 |
| `tests/unit/test_1771c_schedules_analytics_properties.py` | P-B1…P-B4 |
| `tests/requirements-test.txt` | +1 dep: `hypothesis==6.161.5` |
| `tests/registry.json` | registers the four new files (targeted insert; 54 added / 0 removed) |

No `docs/` delta, and that is deliberate per Trinity Rule #4: no new capability, no API change,
no schema change, no behaviour change. The tests *encode* requirements that already exist
(`architecture.md` already documents "Status-as-projection (#1082)" and the #1107/#868/#1115
analytics entries accurately). Adding "and it has tests" would be changelog narration, which that
file's editorial rules forbid.

---

## ✅ Merge state — rebased, conflict-free

**Rebased onto current `origin/dev`** — merge-base is now the `dev` tip, 0 commits behind. The one
expected conflict, `tests/registry.json`, is **resolved**.

It was mechanical, not semantic: `dev` appended a registry entry for
`test_1809_image_drift_recreate.py` (and stripped the file's trailing newline) while this branch
appends four `test_1771c_*` entries at the same array tail. **Both sides' entries are kept**,
comma-separated, in the one array — nothing dropped, nothing rewritten:

- entry count `93` (dev) `+ 4` (this branch) = **97**, and the file parses as JSON;
- the diff against `dev` is a **pure insertion** — 54 lines added, **0 deleted**;
- `dev`'s no-trailing-newline form is preserved, so there is no gratuitous diff line.

Because the branch was conflicting from the start, GitHub could never build a
`refs/pull/1827/merge` and therefore **reported zero CI checks**. That is now unblocked — this is
the first time CI can actually run on this PR.

**Sibling collision — resolved.** All three #1771 slices now carry a **byte-identical**
`hypothesis==6.161.5` block at **one fixed position** (immediately after `pytest-cov>=6.0.0`) in
`tests/requirements-test.txt` — verified by hashing the block itself (`sha256`
`bf4d409f…b549acd`, equal across 1771a / 1771b / 1771c). The slices therefore **merge cleanly in
any order** and leave the file with exactly **one** `hypothesis` line: no manual dedupe, no
comment-block arbitration at merge time.

---

## The real bug this found — negative `duration_ms` reaches the Overview chart (A6 / B8)

Shipped as `@pytest.mark.xfail(strict=True)` plus a companion characterization test pinning
today's behaviour. **No product-code fix** — that is out of scope per #1771 `AC#4`.

- **Symptom:** a `started_at` in the future relative to the finalizing process's clock makes
  `update_execution_status` persist a **negative `duration_ms`** (unguarded
  `completed_at − started_at`), which then flows **unguarded** into `get_agent_analytics` →
  observed `{'avg': -299997, 'p95': -299997}`.
- **Minimal repro:** row `running` with `started_at = now + 300 s` →
  `update_execution_status(id, "success")` → `duration_ms = -299997`.
- **Why this is not a toy input:** `started_at` and `completed_at` are written by **different
  processes**. The standalone `src/scheduler/` container repeats the *same* unguarded subtraction
  at `src/scheduler/database.py:514-516`, and the backend runs `--workers 2`.
- **Why "canary G-03 already covers it" is wrong:** G-03 *detects* the skew (severity `minor`).
  **Nothing prevents the poisoned metric**, and the analytics consumption path is entirely
  unguarded.
- **Verified honestly:** re-run under `--runxfail`, it fails on its own asserted contract
  (`assert duration >= 0`, `negative duration_ms persisted: -299996`) — not on an unrelated error.

> **Note for whoever fixes it:** the xfail is **`strict=True`**. When a clamp lands, this test
> flips to **XPASS and fails the suite**. That is the intended alarm telling you to delete the
> xfail marker — not a broken test.

---

## Coverage — reported as TWO numbers, because one alone misleads

A pre-review draft of this verdict quoted a single "92%" that came from **bundling nine
pre-existing neighbour test files**. That number is real but **not attributable to this PR**.
Both are given:

### A. This PR's tests alone (attribution)

```
pytest tests/unit/test_1771c_*.py -q --cov-branch \
  --cov=db.schedules.executions --cov=db.schedules.queue --cov=db.schedules.analytics
→ 129 passed, 1 xfailed · TOTAL 422 stmts / 92 branch / 86%   (was 60%)
    analytics.py   96%   (was 54%)   miss 115, 234, 542->550, 658-678
    executions.py  54% file-level — in-scope methods 100% except line 417
                   (the dark claim_token arm, covered by test_1081_lease_reaper.py)
    queue.py       84%   miss 123 + out-of-scope ranges covered by neighbours
```

### B. Bundled with the nine neighbour files (the fleet's real position)

```
→ 262 passed, 1 skipped, 1 xfailed · TOTAL 422 stmts / 92 branch / 90%
    analytics.py   97%  (was 92%)
    queue.py       98%
    executions.py  62% file-level; in-scope methods 100% line, BrPart 0
                   — every miss is in 7 out-of-scope sibling methods
```

### Residual misses — attributed, not hand-waved

| Miss | Verdict |
|---|---|
| `queue.py:123` | `with_for_update(skip_locked=True)` — **structurally unreachable without `TEST_POSTGRES_URL`**. `[SQLITE-ONLY]`. |
| `analytics.py:658-678` | `get_all_agents_schedule_counts` — **out of declared scope** (plan §3). |
| `analytics.py:234` and `542->550` | **Defensive-dead, proven.** Both are `if not day` guards over `substr(started_at,1,10)`. The only falsy `day` is an *empty* `started_at`, and the query filters `started_at > cutoff`; SQL evaluates `'' > '2026-…'` as false, so it never reaches the loop. A malformed *non-empty* value is `> cutoff` but yields a truthy `substr`, taking the live arm. Reported, deliberately not covered. |
| `executions.py:417` | Dark `claim_token` CAS arm — covered by `test_1081_lease_reaper.py` (row A9), not by this PR. |

---

## Honest scope limits

- **SQLite-only signal.** `TEST_POSTGRES_URL` was never set, so **every DB-touching case and
  property here ran on SQLite**. Two spots are dialect-sensitive and labelled: **B9** (`substr`
  day-bucketing) and `queue.py:123` (`FOR UPDATE SKIP LOCKED`, the sole uncovered line,
  structurally unreachable here). Everything else rests on standard SQL
  (`COUNT`/`AVG` NULL-skipping/`CASE`/integer truncation) or ASCII ISO-8601 collation, equivalent
  on both backends.
- **Mutation testing NOT run** for this slice — `--mutate` is scoped to target 1 by the plan, and
  `mutmut` is unusable in this repo's `sys.path` layout. So **"90% branch" is a coverage claim,
  not a mutation-kill claim.**
- **Concurrency is deliberately out of scope** — owned by
  `test_1081_pull_endpoints.py::TestClaimConcurrencyC1`.
- **No property claims DB-layer terminal immutability.** Only `CANCELLED` blocks a SUCCESS
  overwrite; immutability is an upstream #1083 property, not a DB-layer one.

## Traps deliberately avoided

- **`bool ⊂ int`.** A global `isinstance(result, int)` would pass for the *wrong reason* on every
  bool-returning writer. Assertions are therefore **per return class**: identity
  (`is True`/`is False`) for the 7 bool writers, `isinstance(int) and not isinstance(bool)` for
  the 4 rowcount writers, `dict`-or-`None` for `claim_next_queued`.
- **A vacuous property, caught and fixed.** P-B2b asserted
  `sampled is (eligible > _PERCENTILE_ROWSET_CAP)` with the cap left at its production `5000`
  against ≤12 seeded rows — so the `True` arm was **unreachable for every example** and half the
  biconditional passed vacuously. The cap is now **drawn (1–6) and monkeypatched**, with
  over/at/empty `@example` pins; a probe forcing `sampled is False` now fails, proving the arm is
  live. The constant verifiably restores to 5000 at teardown.
- **Non-vacuity of the stateful machine proven three ways, not by its green tick**
  (`run_state_machine_as_test` prints no statistics, so a pass is weak evidence alone):
  1. neuter the invariant → the meta-test **FAILS** (the invariant is what catches the sabotage);
  2. remove the sabotage rule → meta-test **FAILS** with `DID NOT RAISE AssertionError` (it
     detects the *injected* reversal, not incidental noise);
  3. instrument the real machine → `machines: 33, reaching_terminal: 30, terminal_observations: 152`
     — the phantom-reversal arm is genuinely reachable.

## A requirements gap the review caught

`get_schedule_analytics` was named a subject-under-test by **both** the plan and the edges file's
own docstring — yet **no test invoked it**. `analytics.py:113-259` was entirely unexecuted under
new-tests-only coverage. Closed with **16 added cases** (rows B13/B13b/B13c/B15), which is what
moved analytics attribution from 54% → 96%. Those cases also close the `tool_calls` JSON-**shape**
guards on both analytics surfaces — that column is **agent-written**, so every malformed shape is
reachable input and a regressed guard turns an analytics read into a 500.

## Order-independence verified for real

`pytest-randomly` is **absent locally but installed out-of-band by CI**
(`backend-unit-test.yml:99`) — so a locally-green suite proves nothing about CI ordering. Verified
explicitly: **4 solo seeds + 2 interleaved runs with 9 neighbour files + a CI-shaped invocation,
all green**, with the venv restored afterwards.

## Security

`/cso --diff`: **zero findings.**

- Net new package surface is **1**: `hypothesis` → `sortedcontainers`, which `fakeredis` already
  required.
- It **never reaches a runtime image** (test-only dependency file).
- Every production-constant patch goes through the auto-undoing `monkeypatch` fixture — **zero**
  bare module-level `setattr`.
- The `hypothesis==6.161.5` **exact pin** (rather than a floor) is deliberate: it freezes a
  reproducible derandomized input set, and is the safer supply-chain posture.

## Test Plan

- [x] `cd tests && python -m pytest unit/test_1771c_*.py -q` → **129 passed, 1 xfailed** (17.7s); **re-run on the rebased branch → 129 passed, 1 xfailed** (14.4s, Python 3.12, hypothesis 6.161.5)
- [x] Full `tests/unit` tier → **1 failed, 5032 passed, 17 skipped, 1 xfailed**. The single red is
      a **pre-existing** aged-out fixture (see follow-ups), reproduced on a pristine detached
      worktree at the cut base `f7aff466` with none of these files present.
- [x] No product-code diff: `git diff origin/dev...HEAD --stat -- src/` **empty** (re-verified after the rebase).
- [x] Order-independence: 4 seeds + 2 interleaved + CI-shaped invocation, all green.
- [x] `python3 tests/lint_sys_modules.py` → **`OK: 203 violation(s) in 60 file(s); baseline allows
      240 — no new violations`**, and `tests/lint_sys_modules_baseline.txt` is **untouched** (see
      below).

**`/verify-local` deliberately skipped** (explicit call, and justified): zero `src/` changes, no
image-reachable inputs, and the unit tier ran in full. `/verify-local` exists to catch
source→image packaging gaps (#1033 class); a test-only diff has no image surface to break.

### `sys.modules` lint — satisfied, **not** baselined

This PR was CONFLICTING from the moment it opened, so GitHub could never build
`refs/pull/1827/merge` and **reported zero checks**. The rebase produced this PR's *first ever* CI
run — which immediately failed `lint (sys.modules pollution check)` with 12 bare
`sys.modules.pop(...)` calls (3 per new file). Now **green**.

Fixed by satisfying the guard, **not** by running `--regenerate-baseline`: this guard has already
caught this same class in #783 / #606 / #875, and widening it on a PR whose entire point is test
rigour would be backwards. `tests/lint_sys_modules_baseline.txt` is unchanged.

Both eviction sites take the **documented escape hatch** (top-level `_STUBBED_MODULE_NAMES` +
autouse `_restore_sys_modules`, shape copied from `tests/unit/test_telegram_webhook_backfill.py`)
rather than `monkeypatch`, for a substantive reason in each case:

- the `utils*` shadow clear is **import-time**, before any fixture exists — monkeypatch
  structurally cannot reach it;
- the `ops` fixture's `db.*` eviction **must not** use `monkeypatch.delitem`: verified directly
  against `_pytest.monkeypatch` that it records **no undo for a key absent on entry**, so the
  freshly imported *harness-bound* module would stay resident for later files — strictly worse
  isolation than the explicit pop it would replace.

The fixture is a **teardown-time guarantee only** — the snapshot is taken before the test body, so
no in-test behaviour and no assertion changes. Confirmed empirically: the four files still report
**129 passed, 1 xfailed**, the same strict xfail, unchanged.

---

## Follow-ups — flagged, NOT filed as issues

1. **The negative-`duration_ms` clamp** (A6/B8 above). The `strict=True` xfail flips to XPASS the
   moment a clamp lands — that is the signal to remove the marker. Both call sites need it:
   `db/schedules/executions.py` and `src/scheduler/database.py:514-516`.
2. **`tests/unit/test_1474_read_boundary_z.py::test_schedules_summary_last_run_at_normalized` is
   aged out** — belongs to **no slice's fence**, so it is nobody's by default. Root cause proven,
   not guessed: the fixture hard-codes `NAIVE = "2026-07-06T11:00:00.207634"` while
   `get_agent_schedules_summary` filters `started_at > iso_cutoff(168)`, so the seeded row now
   falls outside its own 7-day window and `last_run_at` is `None`. Re-running the identical call
   with a 5-year window returns the correctly `_norm_ts`-normalized value — **the behaviour under
   test is fine; the test aged out** (it would have gone red around 2026-07-13). One-line fix:
   make the constant relative to `now` — **the same defect class this PR already fixed in its own
   B9 case** (commit `7740a4e1`).
3. **Defensive-dead branches** `analytics.py:234` and `542->550` — either delete the guards or
   accept them as defensive; they cannot be covered from this layer.
4. **`get_all_agents_schedule_counts`** (`analytics.py:658-678`) has zero coverage and is outside
   this slice's declared scope.
5. **UNSPEC — headline `success_rate` is `0.0` on a zero-terminal window** while per-day is
   `None`, so "never ran" and "failed everything" both render 0% at the headline. No requirement
   is violated (the discipline is silent on the headline) and changing it is a frontend-visible
   contract decision. Characterized, not xfailed.
6. **UNSPEC — `success → success` wins the CAS twice.** The DB-layer SUCCESS predicate is
   `status != CANCELLED`, which an existing `success` row satisfies. Not a bug at this layer — the
   replay short-circuit is the #1083 callback's job, and this looseness is exactly what the
   documented "a late SUCCESS overwrites a reaper `LEASE_EXPIRED`" guarantee depends on.
   Characterized so a future tightening is deliberate.
7. **ACCEPTED GAP — malformed `started_at` raises before the CAS.** `update_execution_status`
   parses `started_at` *before* building the CAS `WHERE`, so a malformed non-NULL value raises
   `ValueError` even for a write that would have **lost** the CAS. Reachable at this layer
   (`update_execution_to_queued` copies a caller-supplied `queued_at` in unvalidated) but **not
   from any current production caller** (`services/backlog_service.py` passes `utc_now_iso()`).
   The `None` variant is unreachable — the live schema enforces `NOT NULL` on both backends,
   guarded by its own test since `db/tables.py` declares the column nullable and a #746
   metadata-driven-DDL migration would open the `AttributeError` path.
8. **`ruff F811`** on the `db_backend` fixture idiom, repo-wide (~10 files). Pre-existing pattern
   in every `db_harness` consumer; no CI job runs ruff today. Fixing it here would diverge from
   10+ neighbours. Reported, not changed.

---

<details>
<summary><b>Full edge-case matrix (38 rows + 12 properties) — click to expand</b></summary>

> This matrix lives only in the worktree's gitignored `.plan/` directory, so it is reproduced here
> in full; otherwise it dies with the worktree.

**Status legend:** `COV` already covered · `NEW` covered by this PR · `UNSPEC` spec gap (reported,
characterized, not xfailed) · `BUG` real bug (strict xfail) · `GAP` accepted gap with written reason.

### Totals

| | Count |
|---|---|
| Enumerated (matrix rows) | **38** (A: 18, B: 20) |
| Properties | **12** (P-A1…P-A4 → 7 tests incl. 1 meta-test; P-B1…P-B4 → 7 tests) |
| Already covered (no new test written) | **6** |
| **Newly covered** | **28** |
| UNSPECIFIED (reported only) | **2** (A3, B4) |
| Accepted gaps (written reason) | **2** (A5b-`None` unreachable, A5b-malformed latent) |
| Defensive-dead branches (proven unreachable) | **2** (`analytics.py:234`, `542->550`) |
| **Real bugs** | **1** (A6 / B8 — one root cause, two surfaces) |

### Sub-area A — CAS status writers

| # | Input / state | Class | Case | Expected / observed | Status |
|---|---|---|---|---|---|
| A1 | prior status | status-write race | SUCCESS over `running` / `failed` | CAS wins | COV |
| A1b | prior status | status-write race | SUCCESS over `queued` / `pending_retry` / `skipped` | CAS wins | **NEW** |
| A2 | prior status | status-write race | SUCCESS over `cancelled` | CAS **loses** (#671) | **NEW** (re-pin) |
| A3 | prior status | replay double-effect | SUCCESS over existing `success` | **wins again** (`True` twice) | **UNSPEC** |
| A4 | prior status | status-write race | FAILED over ×4 terminals | CAS loses | COV |
| A5 | row absence | null/optional | unknown execution id | `False`, no raise | **NEW** |
| A5b-i | schema | null/optional | `started_at` NULL | **NOT NULL enforced** on both backends | **NEW** (guard) |
| A5b-ii | `started_at` | I/O boundary | `''` / garbage / out-of-range | **raises `ValueError` before the CAS** | **GAP** |
| A5b-iii | `queued_at` | I/O boundary | caller-supplied string copied into `started_at` unvalidated | reachability proof for A5b-ii | **NEW** |
| **A6** | clock skew | **naive/aware + arithmetic** | `started_at` 300 s in the future | **`duration_ms = -299997` persisted** | **BUG** (xfail strict) |
| A7 | `started_at` | time / format | naive · `Z` · `+00:00` · `+05:00` | no `aware − naive` TypeError | **NEW** |
| A8 | `retry_count` | null/optional | `None` preserves prior; `0`/`1`/`3` write through | prior 7 preserved on `None` | **NEW** |
| A9 | `claim_token` | state & concurrency | token-gated CAS | dark by flag, not caller-less | COV |
| A10 | prior status | phantom reversal (E-02) | `update_execution_to_queued` over ×4 terminals | no-op | COV |
| A11 | double-call | replay | `mark_execution_dispatched` ×2 | 2nd `False` | COV |
| A12 | agent scope | cross-tenant | bulk writers scoped to one agent; empty/unknown ⇒ `0` | no wildcard | **NEW** |
| A13 | `max_age_hours` | numeric + lexicographic ISO | exact cutoff second; 24 h; fractional; 1e6 | exact-cutoff row **survives** (≤1 s band) | **NEW** |
| A14 | `queued_at` NULL | null/optional | queued row, NULL `queued_at` | excluded by `isnot(None)` | **NEW** |
| A15 | agent scope | cross-tenant | `get_queued_count` isolation; `""` ⇒ 0 | scoped count | **NEW** |
| A16 | lease columns | state | `find_expired_leases` excludes future / NULL / terminal; ordering + `limit` | disjoint from push rows | **NEW** |

**Properties (sub-area A)**

| ID | Shape | Statement | Result |
|---|---|---|---|
| **P-A1** | invariant preservation (stateful) | Across any legal interleaving of 12 CAS writers, a **terminal** row is never observed **non-terminal** again (canary E-02 at the DB layer). Deliberately **not** "terminals are immutable" — that is false here. | PASS (`max_examples=30`, `stateful_step_count=8`) |
| **P-A1-meta** | meta-test | A sabotaged machine with a raw resurrecting UPDATE **must** be caught | PASS — proves P-A1 load-bearing |
| **P-A2a** | no-crash-total | 7 single-row writers return a strict `bool`, never raise, over the full status domain | PASS — **49/49 exhaustive** |
| **P-A2b** | no-crash-total | 4 bulk writers return a non-negative `int` (not `bool`) | PASS — **28/28 exhaustive** |
| **P-A2c** | no-crash-total | `claim_next_queued` → `dict` (only from `queued`) or `None` | PASS — **7/7 exhaustive** |
| **P-A3a** | idempotence | a winning single-row call replays to `False`, status unchanged | PASS — 49 explored, 7 winning |
| **P-A3b** | idempotence | a winning bulk call replays to `0` | PASS — 28 explored, 6 winning |
| **P-A3c** | idempotence | `claim_next_queued` serves each queued row exactly once, FIFO, then `None` | PASS — 4/4 exhaustive |
| **P-A4** | oracle | for `utc_now_iso()` strings, lexicographic order **≡** chronological order | PASS — 200 examples |
| **P-A4b** | oracle (negative) | a mixed offset spelling of the same instant **breaks** that equivalence — why `Invariant #16` exists | PASS — 200 examples |

### Sub-area B — analytics aggregation

| # | Input / state | Class | Case | Expected / observed | Status |
|---|---|---|---|---|---|
| B1 | bucket config | enum / dispatch | `_TRIGGER_BUCKETS.values() ⊆ _BUCKET_ORDER`; `Other` last; no dupes | holds today (10/10) | **NEW** (regression guard) |
| B2 | `triggered_by` | enum / dispatch | known · unknown · `""` · `None` · uppercase · padded | all map; unmapped ⇒ `Other` | **NEW** |
| B3 | terminal counts | % with no denominator | day with runs but 0 terminals | `success_rate is None` | **NEW** |
| B4 | terminal counts | % with no denominator | **headline** rate on an empty agent | **`0.0`** while per-day is `None` | **UNSPEC** |
| B4b | statuses | % denominator | non-terminal rows excluded from the rate denominator | terminal-based | **NEW** |
| B4c | statuses | enum alias | legacy `error` folded into `failed` | counts as failure | **NEW** |
| B5 | `context_used` NULL | null/optional | NULL-skipping AVG; all-NULL ⇒ `None` | not zeroed | **NEW** |
| B6 | rowset size | collection boundary | `cap−1` / `cap` / `cap+1` | `sampled` flips only **above** cap | **NEW** |
| B6b | data-source discipline | sampling | headline `avg` full-set while `p95` is sampled | avg=250, p95=400 | **NEW** |
| B7 | duration pool | collection boundary | 0 / 1 / 2 success rows | `None` / value / **195** (inclusive interpolation) | **NEW** |
| B7b | `duration_ms` NULL | null/optional | NULL duration excluded from the pool | `int(None)` never reached | **NEW** |
| **B8** | `duration_ms` | negative accumulator | negative durations flow into `avg` **and** `p95` | `{'avg': -299997, 'p95': -299997}` | **BUG** (same root as A6) |
| B9 | `started_at` offset | lexicographic / UTC bucketing | `+05:00` value → `substr(...,1,10)` | buckets by **literal prefix**, not UTC instant | **NEW** `[SQLITE-ONLY]` |
| B10 | window | time boundary | rows at `cutoff` ±1 µs | `>` is strict ⇒ exact row excluded | **NEW** |
| B11 | timeline | collection / gap-fill | `hours` ∈ {24,168,336,720}; zero-days | contiguous, no gaps/dupes | **NEW** |
| B12 | `message` | strings | empty · whitespace · newline-leading · exactly 80 / 81 · emoji · combining · RTL | never raises; ≤ 80 chars | **NEW** |
| **B13** | `tool_calls` | **untrusted JSON shape** | `get_schedule_analytics`: empty · non-JSON · valid-JSON-not-a-list · list-of-scalars · dict-without-`name` · falsy name · non-numeric `duration_ms` | never raises; counts only named entries | **NEW** (added at `/review`) |
| **B13c** | statuses | aggregation branch | per-schedule timeline FAILED arm | `success`/`failed` day counters; `cancelled`/`running` add cost + total only | **NEW** (added at `/review`) |
| **B14** | `tool_calls` | **untrusted JSON shape** | same shape table on `get_agent_schedules_summary`; NULL filtered in SQL not Python | never raises; `tool_call_total` exact | **NEW** (added at `/review`) |
| **B15** | duration pool | collection boundary | `get_schedule_analytics` 0 / 1 / 2 / 3 success rows | a **second** implementation of B7's ladder | **NEW** (added at `/review`) |
| B16 | schedule identity | tenant boundary | wrong agent / soft-deleted ⇒ `None` (router → 404) | `analytics.py:115` | COV |

**Properties (sub-area B)**

| ID | Shape | Statement | Result |
|---|---|---|---|
| **P-B1** | conservation | `sum(by_type[*].total) == total_executions` for any multiset of arbitrary unicode triggers — the mechanised *"a new trigger never silently vanishes"* | PASS — 100 examples. Coverage markers from **one observed run** (Hypothesis re-randomises, so these are evidence of non-vacuity, **not** a stable contract): 80% reached `Other`, 54% multi-bucket |
| **P-B1b** | conservation | per-day stacks sum to their own day total | PASS — 100 examples |
| **P-B2** | bounds | `0 ≤ success_rate ≤ 1` (or `None` per-day); sub-counts ≤ total; zero-terminal day ⇒ `None` | PASS — 100 examples; 11% hit the zero-terminal branch in one observed run |
| **P-B2b** | bounds | `sample_size ≤ cap` and `≤ eligible`; `sampled` **iff** pool exceeds cap | PASS — 100 examples. **Rewritten at `/review`** to de-vacuum (see "Traps deliberately avoided") |
| **P-B3** | invariant preservation | timeline is contiguous, strictly increasing, duplicate-free, spans `[now−hours, now]` for any `hours` ∈ [1,1000] | PASS — 100 examples |
| **P-B4a** | no-crash-total | `_bucket_for_trigger` total, result always ∈ `_BUCKET_ORDER` | PASS — 200 examples |
| **P-B4b** | no-crash-total | `_schedule_command_label` total, `str`, ≤ 80 chars, newline-free | PASS — 200 examples |

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


