### PR TITLE
fix(agents): default base image to UTC + ISO-Z file timestamps (#1795)

### DIFF
--- a/docker/base-image/Dockerfile
+++ b/docker/base-image/Dockerfile
@@ -9,7 +9,12 @@ ARG VERSION=latest
 LABEL trinity.base-image-version="${VERSION}"
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/New_York
+# Default to UTC so container-local time == UTC and matches /etc/localtime
+# (Etc/UTC). Agents, the backend, and the scheduler all reason in UTC
+# (Invariant #16); a non-UTC default made agents run hours off and file
+# timestamps surface as naive local time (#1795). Override at deploy time
+# with `docker run -e TZ=...` if a specific zone is required.
+ENV TZ=Etc/UTC
 ENV TRINITY_BASE_VERSION="${VERSION}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/base-image/agent_server/routers/credentials.py
+++ b/docker/base-image/agent_server/routers/credentials.py
@@ -5,7 +5,6 @@ import os
 import base64
 import binascii
 import logging
-from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -25,6 +24,7 @@ from ..models import (
 from ..state import agent_state
 from ..services.trinity_mcp import inject_trinity_mcp_if_configured
 from ..utils.credential_sanitizer import refresh_credential_values
+from ..utils.helpers import iso_z_from_mtime
 # Second-layer credential-path policy (Invariant #5) — byte-identical vendored
 # copy of src/backend/services/credential_paths.py (#11).
 from ..credential_paths import is_allowed_credential_path
@@ -242,7 +242,7 @@ async def get_credentials_status():
             files_status[filename] = {
                 "exists": True,
                 "size": stat.st_size,
-                "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+                "modified": iso_z_from_mtime(stat.st_mtime)
             }
         else:
             files_status[filename] = {"exists": False}

--- a/docker/base-image/agent_server/routers/dashboard.py
+++ b/docker/base-image/agent_server/routers/dashboard.py
@@ -6,10 +6,11 @@ Reads and serves dashboard configuration from dashboard.yaml file.
 import logging
 from pathlib import Path
 from typing import Optional, Dict, Any, List
-from datetime import datetime
 
 from fastapi import APIRouter
 import yaml
+
+from ..utils.helpers import iso_z_from_mtime
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -227,7 +228,7 @@ async def get_dashboard():
 
         # Get file modification time
         stat = dashboard_path.stat()
-        last_modified = datetime.fromtimestamp(stat.st_mtime).isoformat()
+        last_modified = iso_z_from_mtime(stat.st_mtime)
 
         # Ensure defaults
         if 'refresh' not in config:

--- a/docker/base-image/agent_server/routers/files.py
+++ b/docker/base-image/agent_server/routers/files.py
@@ -4,12 +4,13 @@ File browser endpoints.
 import logging
 import mimetypes
 import shutil
-from datetime import datetime
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import PlainTextResponse, FileResponse
 from pydantic import BaseModel
+
+from ..utils.helpers import iso_z_from_mtime
 
 
 class FileUpdateRequest(BaseModel):
@@ -70,7 +71,7 @@ async def list_files(path: str = "/home/developer", show_hidden: bool = False):
                             "type": "directory",
                             "children": subtree["children"],
                             "file_count": subtree["file_count"],
-                            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+                            "modified": iso_z_from_mtime(stat.st_mtime)
                         })
                         total_files += subtree["file_count"]
                     else:
@@ -80,7 +81,7 @@ async def list_files(path: str = "/home/developer", show_hidden: bool = False):
                             "path": str(relative_path),
                             "type": "file",
                             "size": stat.st_size,
-                            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+                            "modified": iso_z_from_mtime(stat.st_mtime)
                         })
                         total_files += 1
 
@@ -421,7 +422,7 @@ async def update_file(path: str, request: FileUpdateRequest, platform: bool = Fa
             "success": True,
             "path": path,
             "size": stat.st_size,
-            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+            "modified": iso_z_from_mtime(stat.st_mtime)
         }
 
     except Exception as e:
@@ -489,7 +490,7 @@ async def create_folder(path: str):
             "success": True,
             "path": path,
             "type": "directory",
-            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+            "modified": iso_z_from_mtime(stat.st_mtime)
         }
 
     except HTTPException:

--- a/docker/base-image/agent_server/routers/files.py
+++ b/docker/base-image/agent_server/routers/files.py
@@ -4,13 +4,12 @@ File browser endpoints.
 import logging
 import mimetypes
 import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import PlainTextResponse, FileResponse
 from pydantic import BaseModel
-
-from ..utils.helpers import iso_z_from_mtime
 
 
 class FileUpdateRequest(BaseModel):
@@ -19,6 +18,17 @@ class FileUpdateRequest(BaseModel):
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _iso_z_from_mtime(mtime: float) -> str:
+    """Format an mtime (epoch seconds) as canonical ISO-Z UTC.
+
+    Defined locally rather than imported from ``..utils.helpers`` so this router
+    stays standalone-importable: tests/unit/test_ent183_skill_packages.py loads
+    this file by path (no package context) to verify its protected-path logic,
+    and a relative import would break that load (#1795).
+    """
+    return datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 @router.get("/api/files")
@@ -71,7 +81,7 @@ async def list_files(path: str = "/home/developer", show_hidden: bool = False):
                             "type": "directory",
                             "children": subtree["children"],
                             "file_count": subtree["file_count"],
-                            "modified": iso_z_from_mtime(stat.st_mtime)
+                            "modified": _iso_z_from_mtime(stat.st_mtime)
                         })
                         total_files += subtree["file_count"]
                     else:
@@ -81,7 +91,7 @@ async def list_files(path: str = "/home/developer", show_hidden: bool = False):
                             "path": str(relative_path),
                             "type": "file",
                             "size": stat.st_size,
-                            "modified": iso_z_from_mtime(stat.st_mtime)
+                            "modified": _iso_z_from_mtime(stat.st_mtime)
                         })
                         total_files += 1
 
@@ -422,7 +432,7 @@ async def update_file(path: str, request: FileUpdateRequest, platform: bool = Fa
             "success": True,
             "path": path,
             "size": stat.st_size,
-            "modified": iso_z_from_mtime(stat.st_mtime)
+            "modified": _iso_z_from_mtime(stat.st_mtime)
         }
 
     except Exception as e:
@@ -490,7 +500,7 @@ async def create_folder(path: str):
             "success": True,
             "path": path,
             "type": "directory",
-            "modified": iso_z_from_mtime(stat.st_mtime)
+            "modified": _iso_z_from_mtime(stat.st_mtime)
         }
 
     except HTTPException:

--- a/docker/base-image/agent_server/utils/helpers.py
+++ b/docker/base-image/agent_server/utils/helpers.py
@@ -1,7 +1,20 @@
 """
 Helper utility functions for the agent server.
 """
+from datetime import datetime, timezone
 from typing import Dict, Any
+
+
+def iso_z_from_mtime(mtime: float) -> str:
+    """Format a filesystem mtime (epoch seconds) as a canonical ISO-Z UTC string.
+
+    Uses an explicit UTC timezone so the result is independent of the container's
+    local TZ (Invariant #16: platform timestamps are ISO-Z UTC). A naive
+    ``datetime.fromtimestamp(mtime).isoformat()`` renders in local time with no
+    zone marker, which downstream consumers (that treat naive ISO as UTC) then
+    display hours off. Returns e.g. ``"2026-07-27T08:06:58.549706Z"``.
+    """
+    return datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def shorten_path(path: str) -> str:

--- a/docs/memory/feature-flows/skills-on-agent-start.md
+++ b/docs/memory/feature-flows/skills-on-agent-start.md
@@ -579,7 +579,7 @@ async def update_file(path: str, request: FileUpdateRequest):
             "success": True,
             "path": path,
             "size": stat.st_size,
-            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+            "modified": iso_z_from_mtime(stat.st_mtime)  # ISO-Z UTC, TZ-independent (#1795)
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update file: {str(e)}")

--- a/docs/memory/feature-flows/skills-on-agent-start.md
+++ b/docs/memory/feature-flows/skills-on-agent-start.md
@@ -579,7 +579,7 @@ async def update_file(path: str, request: FileUpdateRequest):
             "success": True,
             "path": path,
             "size": stat.st_size,
-            "modified": iso_z_from_mtime(stat.st_mtime)  # ISO-Z UTC, TZ-independent (#1795)
+            "modified": _iso_z_from_mtime(stat.st_mtime)  # ISO-Z UTC, TZ-independent (#1795)
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update file: {str(e)}")

--- a/tests/unit/test_1795_agent_timestamp_utc.py
+++ b/tests/unit/test_1795_agent_timestamp_utc.py
@@ -1,0 +1,82 @@
+"""Regression tests for #1795 — agent timezone / naive-timestamp bug.
+
+Two guards:
+
+* Part B — ``iso_z_from_mtime`` emits a canonical ISO-Z UTC string that is
+  *independent of the container's local TZ*, so agent file/credential/dashboard
+  ``modified`` fields can never again surface as naive local time (the bug the
+  frontend rendered "4 hours ago" for a just-written file).
+* Part A — the base image defaults ``TZ`` to ``Etc/UTC`` (static content guard
+  so a future edit can't silently re-introduce ``America/New_York``).
+
+``conftest.py`` registers ``docker/base-image/agent_server`` as a namespace
+package, so ``from agent_server.utils.helpers import ...`` resolves directly.
+"""
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from agent_server.utils.helpers import iso_z_from_mtime
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCKERFILE = _REPO_ROOT / "docker" / "base-image" / "Dockerfile"
+
+
+def test_iso_z_from_mtime_zero_epoch_is_canonical_z():
+    # Deterministic anchor: epoch 0 is the Unix epoch in UTC.
+    assert iso_z_from_mtime(0.0) == "1970-01-01T00:00:00Z"
+
+
+def test_iso_z_from_mtime_marks_zone_and_preserves_instant():
+    mtime = 1753603618.549706  # a real fractional mtime
+    out = iso_z_from_mtime(mtime)
+
+    # Canonical ISO-Z: zone-marked with a trailing Z, never a bare naive string
+    # and never the "+00:00" form (Invariant #16 uses Z).
+    assert out.endswith("Z")
+    assert "+00:00" not in out
+    assert out[10] == "T"  # date/time separator
+
+    # Same instant as the source mtime, interpreted as UTC.
+    parsed = datetime.fromisoformat(out.replace("Z", "+00:00"))
+    assert parsed == datetime.fromtimestamp(mtime, tz=timezone.utc)
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="time.tzset() is Unix-only")
+def test_iso_z_from_mtime_is_independent_of_container_tz():
+    """The crux of #1795: output must not shift with the process TZ.
+
+    ``datetime.fromtimestamp(mtime, tz=utc)`` ignores the local zone, so the
+    formatted string is identical whether the container is UTC or US/Eastern —
+    which is exactly why Part B is robust to any future TZ change.
+    """
+    mtime = 1753603618.549706
+    original_tz = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = "UTC"
+        time.tzset()
+        as_utc = iso_z_from_mtime(mtime)
+
+        os.environ["TZ"] = "America/New_York"  # the value #1795 removed
+        time.tzset()
+        as_eastern = iso_z_from_mtime(mtime)
+
+        assert as_utc == as_eastern
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
+
+
+def test_base_image_defaults_to_utc():
+    """Part A static guard: the base image must default TZ to UTC."""
+    content = _DOCKERFILE.read_text(encoding="utf-8")
+    assert "ENV TZ=Etc/UTC" in content
+    assert "America/New_York" not in content

--- a/tests/unit/test_1795_agent_timestamp_utc.py
+++ b/tests/unit/test_1795_agent_timestamp_utc.py
@@ -14,6 +14,7 @@ package, so ``from agent_server.utils.helpers import ...`` resolves directly.
 """
 from __future__ import annotations
 
+import importlib.util
 import os
 import time
 from datetime import datetime, timezone
@@ -80,3 +81,22 @@ def test_base_image_defaults_to_utc():
     content = _DOCKERFILE.read_text(encoding="utf-8")
     assert "ENV TZ=Etc/UTC" in content
     assert "America/New_York" not in content
+
+
+def test_files_router_stays_standalone_importable():
+    """#1795 regression: files.py must load by path with no package context.
+
+    tests/unit/test_ent183_skill_packages.py loads files.py via
+    spec_from_file_location to check its protected-path logic; a relative import
+    (``from ..utils.helpers``) breaks that standalone load. Guard both the load
+    and that the router's local ``_iso_z_from_mtime`` matches the shared helper.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_test1795_agent_files",
+        str(_REPO_ROOT / "docker/base-image/agent_server/routers/files.py"),
+    )
+    files_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(files_mod)  # must not raise (a relative import would)
+
+    for mtime in (0.0, 1753603618.549706):
+        assert files_mod._iso_z_from_mtime(mtime) == iso_z_from_mtime(mtime)


### PR DESCRIPTION
## Summary
- The agent base image baked `ENV TZ=America/New_York`, so **every agent container ran on US Eastern** regardless of operator location — disagreeing with its own `/etc/localtime` (`Etc/UTC`), the backend, and the scheduler.
- Agent-server file/credential/dashboard `modified` fields were emitted as **naive local** strings; consumers treating naive ISO as UTC (Invariant #16) rendered a just-written file "hours ago" (e.g. 4h for a UTC viewer, 7h for UTC+3).

## Changes
- **A** — `docker/base-image/Dockerfile`: `ENV TZ=Etc/UTC` (local == UTC; overridable at deploy via `-e TZ=...`).
- **B** — `agent_server/utils/helpers.py`: new `iso_z_from_mtime()` → canonical **ISO-Z UTC**, independent of the container TZ.
  - Applied at all 6 file-metadata sites: `routers/files.py` (×4), `routers/credentials.py`, `routers/dashboard.py`; dropped the now-dead `datetime` imports.
- `tests/unit/test_1795_agent_timestamp_utc.py`: helper correctness + **TZ-independence** + Dockerfile static guard.
- Doc-sync: `docs/memory/feature-flows/skills-on-agent-start.md` snippet updated to match.

## Test Plan
- [x] Unit assertions pass (helper output, TZ-independence, Dockerfile guard) — verified standalone (stdlib helper runs on 3.9).
- [x] `/verify-local` Docker stages green: base image builds, `import agent_server` succeeds **inside the built image**, and a real agent **boots healthy** from the rebuilt image.
- [x] `/cso --diff` clean (no new surface/auth/injection; Invariant #5 parity intact).
- [ ] CI full unit + integration suite (local run was `incomplete` — no Python ≥3.10 on the dev box; environmental, not a defect).

## Notes
- Base-image change: existing agents adopt UTC on **recreate**, not restart (`ENV` is baked at build).
- Frontend consumers (`new Date()`/`parseUTC`) render the zone-marked value correctly; backend proxies `modified` verbatim (no change needed).

Fixes #1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)