### PR TITLE
fix(helper-mcp): rename to unscoped trinity-docs-mcp (npm scope unavailable)

### DIFF
--- a/.github/workflows/publish-helper-mcp.yml
+++ b/.github/workflows/publish-helper-mcp.yml
@@ -1,11 +1,11 @@
 name: Publish Helper MCP to npm
 
-# Publishes @abilityai/trinity-docs-mcp (src/helper-mcp/) with npm provenance.
+# Publishes trinity-docs-mcp (src/helper-mcp/) with npm provenance.
 #
 # BOOTSTRAP (one-time, manual): npm cannot pre-register a trusted publisher
 # for a package that does not exist yet (unlike PyPI pending publishers).
 # The FIRST publish must be done by a maintainer:
-#   1. create the @abilityai npm org (if absent)
+#   1. (unscoped package — no npm org needed; the abilityai npm name is held by an inaccessible legacy account)
 #   2. cd src/helper-mcp && npm publish --access public   (with a real login)
 #   3. on npmjs.com → package → Settings → add this workflow as a
 #      Trusted Publisher, then revoke the token used in step 2.
@@ -65,7 +65,7 @@ jobs:
         id: check
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if npm view "@abilityai/trinity-docs-mcp@${VERSION}" version > /dev/null 2>&1; then
+          if npm view "trinity-docs-mcp@${VERSION}" version > /dev/null 2>&1; then
             echo "Version $VERSION already exists on npm — skipping publish."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ Trinity includes an MCP server for external orchestration of agents:
 ### Ask Trinity from any MCP client — no instance required
 
 Evaluating Trinity, or want its docs assistant inside your editor? The standalone
-[`@abilityai/trinity-docs-mcp`](src/helper-mcp/) server answers questions about
+[`trinity-docs-mcp`](src/helper-mcp/) server answers questions about
 Trinity, grounded in this documentation — no Trinity instance, no API key:
 
 ```json
@@ -543,7 +543,7 @@ Trinity, grounded in this documentation — no Trinity instance, no API key:
   "mcpServers": {
     "trinity-docs": {
       "command": "npx",
-      "args": ["-y", "@abilityai/trinity-docs-mcp"]
+      "args": ["-y", "trinity-docs-mcp"]
     }
   }
 }

--- a/docs/memory/feature-flows/trinity-docs-qa.md
+++ b/docs/memory/feature-flows/trinity-docs-qa.md
@@ -43,7 +43,7 @@ Public conversational Q&A system for Trinity documentation, powered by Vertex AI
 
 Consumers: `scripts/ask-trinity.sh`, raw REST, the docs-site assistant, the
 in-app Help widget (#391), and the standalone `trinity-docs-mcp` MCP server
-(#1459 — see [MCP Distribution](#mcp-distribution--abilityaitrinity-docs-mcp-1459)).
+(#1459 — see [MCP Distribution](#mcp-distribution--trinity-docs-mcp-1459)).
 
 ## Components
 

--- a/docs/memory/feature-flows/trinity-docs-qa.md
+++ b/docs/memory/feature-flows/trinity-docs-qa.md
@@ -68,7 +68,7 @@ in-app Help widget (#391), and the standalone `trinity-docs-mcp` MCP server
 | `docs/onboarding/*.md` | Source documentation (onboarding) |
 | `docs/user-docs/**/*.md` | Source documentation (user docs incl. the 264-Q&A FAQ) |
 | `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md` | Source documentation (agent guide, #1459) |
-| `src/helper-mcp/` | Standalone MCP server exposing the endpoint (`@abilityai/trinity-docs-mcp`, #1459) |
+| `src/helper-mcp/` | Standalone MCP server exposing the endpoint (`trinity-docs-mcp`, #1459) |
 
 ## Data Flow
 
@@ -238,7 +238,7 @@ User clicks help button → Panel opens → Types question → Enter to send
 - Conversation history shown in-panel during session
 - "New conversation" clears local messages and session ID
 
-## MCP Distribution — `@abilityai/trinity-docs-mcp` (#1459)
+## MCP Distribution — `trinity-docs-mcp` (#1459)
 
 A standalone, dependency-light MCP server (`src/helper-mcp/`) exposes this
 endpoint to any MCP client (Claude Code, Claude Desktop, Cursor) — **no Trinity

--- a/docs/memory/requirements/mcp.md
+++ b/docs/memory/requirements/mcp.md
@@ -124,7 +124,7 @@ servers (each replica polls + reconciles independently).
 ## Trinity Helper MCP Server (#1459)
 
 **Description**: A standalone, dependency-light MCP server (`src/helper-mcp/`, npm
-`@abilityai/trinity-docs-mcp`) that exposes the public Trinity Docs Q&A service
+`trinity-docs-mcp`) that exposes the public Trinity Docs Q&A service
 (DOCS-QA-001, `docs/memory/feature-flows/trinity-docs-qa.md`) as MCP tools, so anyone can
 add a grounded "ask Trinity anything" assistant to Claude Code / Claude Desktop / any MCP
 client **without running a Trinity instance**. Pure protocol adapter over the existing

--- a/docs/user-docs/getting-started/help.md
+++ b/docs/user-docs/getting-started/help.md
@@ -13,7 +13,7 @@ MCP client — no Trinity instance or API key required:
 
 ```bash
 # Claude Code
-claude mcp add trinity-docs -- npx -y @abilityai/trinity-docs-mcp
+claude mcp add trinity-docs -- npx -y trinity-docs-mcp
 ```
 
 ```json
@@ -21,7 +21,7 @@ claude mcp add trinity-docs -- npx -y @abilityai/trinity-docs-mcp
   "mcpServers": {
     "trinity-docs": {
       "command": "npx",
-      "args": ["-y", "@abilityai/trinity-docs-mcp"]
+      "args": ["-y", "trinity-docs-mcp"]
     }
   }
 }

--- a/src/helper-mcp/README.md
+++ b/src/helper-mcp/README.md
@@ -1,4 +1,4 @@
-# Trinity Docs MCP (`@abilityai/trinity-docs-mcp`)
+# Trinity Docs MCP (`trinity-docs-mcp`)
 
 Ask Trinity anything, from any MCP client. A standalone [Model Context
 Protocol](https://modelcontextprotocol.io) server that exposes the
@@ -15,7 +15,7 @@ be inaccurate; treat them as guidance.
 ### Claude Code
 
 ```bash
-claude mcp add trinity-docs -- npx -y @abilityai/trinity-docs-mcp
+claude mcp add trinity-docs -- npx -y trinity-docs-mcp
 ```
 
 ### Claude Desktop / Cursor / any MCP client
@@ -25,7 +25,7 @@ claude mcp add trinity-docs -- npx -y @abilityai/trinity-docs-mcp
   "mcpServers": {
     "trinity-docs": {
       "command": "npx",
-      "args": ["-y", "@abilityai/trinity-docs-mcp"]
+      "args": ["-y", "trinity-docs-mcp"]
     }
   }
 }
@@ -51,7 +51,7 @@ Requires Node.js ≥ 18 (`npx` ships with it).
 - **"server disconnected" immediately** — check Node version: `node --version`
   must be ≥ 18. The launcher prints a clear message to the client's MCP logs.
 - **Stale version after an update** — `npx` caches packages; clear with
-  `npx clear-npx-cache` or pin a version: `npx -y @abilityai/trinity-docs-mcp@latest`.
+  `npx clear-npx-cache` or pin a version: `npx -y trinity-docs-mcp@latest`.
 - **Slow first call** — the answer API generates responses with an LLM; expect
   seconds. The server waits up to 50s before reporting a timeout.
 

--- a/src/helper-mcp/package-lock.json
+++ b/src/helper-mcp/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@abilityai/trinity-docs-mcp",
+  "name": "trinity-docs-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@abilityai/trinity-docs-mcp",
+      "name": "trinity-docs-mcp",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/helper-mcp/package.json
+++ b/src/helper-mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@abilityai/trinity-docs-mcp",
+  "name": "trinity-docs-mcp",
   "version": "0.1.0",
   "description": "Ask Trinity anything — standalone MCP server exposing the Trinity docs Q&A assistant (Vertex AI Search + Gemini, grounded on the Trinity documentation). No Trinity instance or API key required.",
   "type": "module",


### PR DESCRIPTION
The `@abilityai` npm scope is held by a legacy account we can't access (website login/recovery dead-ends — support recovery is being pursued out-of-band), so the v0.8.5 `Publish Helper MCP to npm` workflow could never bootstrap. Resolution: publish **unscoped** as `trinity-docs-mcp`.

- `trinity-docs-mcp@0.1.0` is **already live** on npm (manual first publish done today; Trusted Publisher being pointed at `publish-helper-mcp.yml` so future publishes are OIDC/tokenless)
- Renames the package in `package.json` + lockfile, README install snippets, the publish workflow (incl. its version-exists guard + bootstrap comment), and the three docs pages that referenced the scoped name
- The workflow's red X on main self-resolves once this reaches main at the next cut — the version-exists guard makes re-runs idempotent

Closes Abilityai/trinity-enterprise#330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
