### PR TITLE
fix(ui): elastic Dashboard stats bar — degrade telemetry instead of clipping it (#1830)

### DIFF
--- a/src/frontend/e2e/dashboard-stats-overflow.spec.js
+++ b/src/frontend/e2e/dashboard-stats-overflow.spec.js
@@ -1,0 +1,154 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Dashboard stats-bar overflow (#1830).
+ *
+ * The Dashboard header row is [elastic stats cluster | fixed controls cluster].
+ * It used to be inelastic: the stats cluster was only ever CLIPPED by
+ * `overflow-hidden`, so below ~1170 CSS px of effective width the host
+ * telemetry meters were cut mid-element and their boxes ran under the Tags /
+ * owner / Grid-Timeline / time-range controls (29 px measured overlap at 900 px
+ * on an entitled build). Same defect class as the NavBar row in #1789.
+ *
+ * The fix makes the stats cluster a size container (`container-type:
+ * inline-size` on `.stats-cluster`) and degrades its contents in a defined
+ * order as the leftover width shrinks: sparklines → Disk → Mem → telemetry →
+ * "messages" → "working now", with the agent count always surviving. Keying on
+ * the CONTAINER (not the viewport) is what makes it hold when the controls
+ * cluster grows — grid mode adds Tidy up / Reset, and the Tags chip and owner
+ * filter only appear on some fleets.
+ *
+ * This suite pins the two properties that must never regress:
+ *   1. no box of the controls cluster intersects any box of the stats cluster
+ *   2. nothing in the stats cluster is clipped mid-element by the cluster edge
+ * plus no page-level horizontal overflow, across both dashboard modes.
+ */
+
+const WIDTHS = [640, 768, 900, 1024, 1170, 1366, 1600]
+const MODES = ['timeline', 'grid']
+const ROW = 'main .border-b .flex.items-center.justify-between'
+
+// Geometry probe. Compares every leaf box of the left (stats) cluster against
+// every leaf box of the right (controls) cluster, and separately reports any
+// stats leaf that straddles the cluster's own right edge (the clip that the
+// old markup produced instead of degrading).
+const PROBE = () => {
+  const row = document.querySelector(
+    'main .border-b .flex.items-center.justify-between'
+  )
+  if (!row) return { error: 'header row not found' }
+  const [left, right] = row.children
+  const leaves = (root) =>
+    [...root.querySelectorAll('*')].filter(
+      (e) => e.children.length === 0 && e.getBoundingClientRect().width > 0
+    )
+  const describe = (e) =>
+    `${e.tagName.toLowerCase()}.${String(e.className).slice(0, 40)} "${(
+      e.textContent || ''
+    )
+      .trim()
+      .slice(0, 16)}"`
+
+  let worst = { px: 0 }
+  for (const l of leaves(left)) {
+    const lr = l.getBoundingClientRect()
+    for (const r of leaves(right)) {
+      const rr = r.getBoundingClientRect()
+      const ox = Math.min(lr.right, rr.right) - Math.max(lr.left, rr.left)
+      const oy = Math.min(lr.bottom, rr.bottom) - Math.max(lr.top, rr.top)
+      if (ox > 0 && oy > 0 && ox > worst.px) {
+        worst = { px: Math.round(ox), left: describe(l), right: describe(r) }
+      }
+    }
+  }
+
+  const lbox = left.getBoundingClientRect()
+  const clipped = leaves(left)
+    .filter((e) => {
+      const r = e.getBoundingClientRect()
+      // Starts inside the cluster but runs past its right edge (0.5px slack for
+      // sub-pixel layout).
+      return r.left < lbox.right && r.right > lbox.right + 0.5
+    })
+    .map(describe)
+
+  return {
+    overlapPx: worst.px,
+    overlapPair: worst.px ? `${worst.left} ⨯ ${worst.right}` : null,
+    clipped,
+    scrollWidth: document.documentElement.scrollWidth,
+    innerWidth: window.innerWidth,
+  }
+}
+
+async function gotoDashboard(page, mode) {
+  // The store reads the persisted mode on init (stores/network.js), so seeding
+  // it is more deterministic than clicking the toggle and racing the re-render.
+  await page.addInitScript((m) => {
+    localStorage.setItem('trinity-dashboard-view', m)
+  }, mode)
+  await page.goto('/')
+  await page.waitForSelector(ROW, { timeout: 15000 })
+  // Host telemetry paints on its first 5s poll; give the meters a beat to land
+  // so the sweep measures the widest state, not the pre-fetch one.
+  await page.waitForTimeout(1500)
+}
+
+test.describe('Dashboard stats bar overflow (#1830)', () => {
+  for (const mode of MODES) {
+    test(`@interactive ${mode} mode: controls never overlap the stats cluster`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: WIDTHS.at(-1), height: 800 })
+      await gotoDashboard(page, mode)
+
+      for (const width of WIDTHS) {
+        await page.setViewportSize({ width, height: 800 })
+        await page.waitForTimeout(250) // container query re-layout
+        const r = await page.evaluate(PROBE)
+
+        expect(r.error, `probe failed at ${width}px`).toBeUndefined()
+        expect(
+          r.overlapPx,
+          `${mode} @ ${width}px — controls overlap stats by ${r.overlapPx}px (${r.overlapPair})`
+        ).toBe(0)
+        expect(
+          r.clipped,
+          `${mode} @ ${width}px — stats content clipped mid-element instead of degrading`
+        ).toEqual([])
+        expect(
+          r.scrollWidth,
+          `${mode} @ ${width}px — page overflows horizontally`
+        ).toBeLessThanOrEqual(r.innerWidth)
+      }
+    })
+  }
+
+  // The ladder must degrade, not amputate: at a comfortable width every meter is
+  // still there. Guards an over-eager threshold that would hide telemetry on a
+  // normal laptop.
+  test('@interactive wide viewport keeps CPU, Mem and Disk meters', async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 800 })
+    await gotoDashboard(page, 'timeline')
+
+    for (const metric of ['cpu', 'mem', 'disk']) {
+      await expect(page.locator(`[data-metric="${metric}"]`)).toBeVisible()
+    }
+  })
+
+  // ...and at a narrow width the meters are REMOVED (display:none), not merely
+  // scrolled out of a clipping box — which is what the old markup did.
+  test('@interactive narrow viewport hides the meters rather than clipping them', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1600, height: 800 })
+    await gotoDashboard(page, 'grid')
+    await expect(page.locator('[data-metric="disk"]')).toBeVisible()
+
+    await page.setViewportSize({ width: 700, height: 800 })
+    await page.waitForTimeout(250)
+    await expect(page.locator('[data-metric="disk"]')).toBeHidden()
+    // The agent count is the one thing that always survives.
+    await expect(page.locator('.stats-cluster')).toContainText('agents')
+  })
+})

--- a/src/frontend/src/components/HostTelemetry.vue
+++ b/src/frontend/src/components/HostTelemetry.vue
@@ -96,40 +96,52 @@ onUnmounted(() => {
 <template>
   <div class="host-telemetry">
     <template v-if="!loading">
+      <!-- Leading separator lives here (not in Dashboard.vue) so it disappears
+           together with the meters when the ladder hides them (#1830). -->
+      <span class="text-gray-300 dark:text-gray-600">·</span>
+
       <!-- CPU -->
-      <span class="stat-item">
+      <span class="stat-item" data-metric="cpu" :title="`CPU ${formatPercent(hostStats?.cpu?.percent)}%`">
         <span class="dot bg-blue-500"></span>
         <span class="stat-label">CPU</span>
-        <SparklineChart
-          :data="cpuHistory"
-          color="#3b82f6"
-          :y-max="100"
-          :width="60"
-          :height="20"
-        />
+        <span class="spark">
+          <SparklineChart
+            :data="cpuHistory"
+            color="#3b82f6"
+            :y-max="100"
+            :width="60"
+            :height="20"
+          />
+        </span>
         <span class="stat-value" :class="getColorClass(hostStats?.cpu?.percent)">{{ formatPercent(hostStats?.cpu?.percent) }}%</span>
       </span>
 
-      <span class="text-gray-300 dark:text-gray-600">·</span>
+      <span class="text-gray-300 dark:text-gray-600" data-sep="mem">·</span>
 
       <!-- Memory -->
-      <span class="stat-item">
+      <span
+        class="stat-item"
+        data-metric="mem"
+        :title="`Memory ${formatMemory(hostStats?.memory?.used_gb, hostStats?.memory?.total_gb)}`"
+      >
         <span class="dot bg-accent-purple-500"></span>
         <span class="stat-label">Mem</span>
-        <SparklineChart
-          :data="memHistory"
-          color="#a855f7"
-          :y-max="100"
-          :width="60"
-          :height="20"
-        />
+        <span class="spark">
+          <SparklineChart
+            :data="memHistory"
+            color="#a855f7"
+            :y-max="100"
+            :width="60"
+            :height="20"
+          />
+        </span>
         <span class="stat-value" :class="getColorClass(hostStats?.memory?.percent)">{{ formatMemory(hostStats?.memory?.used_gb, hostStats?.memory?.total_gb) }}</span>
       </span>
 
-      <span class="text-gray-300 dark:text-gray-600">·</span>
+      <span class="text-gray-300 dark:text-gray-600" data-sep="disk">·</span>
 
       <!-- Disk -->
-      <span class="stat-item">
+      <span class="stat-item" data-metric="disk" :title="`Disk ${formatPercent(hostStats?.disk?.percent)}%`">
         <span class="dot bg-status-success-500"></span>
         <span class="stat-label">Disk</span>
         <span class="disk-bar">
@@ -199,5 +211,42 @@ onUnmounted(() => {
 /* Dark mode adjustments */
 .dark .disk-bar {
   background: rgba(55, 65, 81, 0.5);
+}
+
+/*
+ * Progressive degrade (#1830) — the meters shed detail, then whole metrics,
+ * as the stats cluster loses width, instead of being clipped mid-element by
+ * the cluster's `overflow-hidden`. Queried against the `statsbar` size
+ * container declared on `.stats-cluster` in Dashboard.vue (the only mount
+ * point); without that ancestor these rules simply never match, so the
+ * component stays safe to reuse elsewhere.
+ *
+ * Order: sparklines → Disk → Mem → everything (see the ladder comment in
+ * Dashboard.vue, which owns the two count groups below this).
+ */
+@container statsbar (max-width: 820px) {
+  .spark {
+    display: none;
+  }
+}
+
+@container statsbar (max-width: 700px) {
+  [data-metric='disk'],
+  [data-sep='disk'] {
+    display: none;
+  }
+}
+
+@container statsbar (max-width: 560px) {
+  [data-metric='mem'],
+  [data-sep='mem'] {
+    display: none;
+  }
+}
+
+@container statsbar (max-width: 420px) {
+  .host-telemetry {
+    display: none;
+  }
 }
 </style>

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -13,8 +13,11 @@
         <!-- Compact Header -->
         <div class="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-2">
           <div class="flex items-center justify-between">
-            <!-- Left: Stats -->
-            <div class="flex items-center min-w-0 overflow-hidden">
+            <!-- Left: Stats — elastic (#1830). `flex-1 min-w-0` makes this the
+                 only cluster that gives ground, and `container-type: inline-size`
+                 (see .stats-cluster below) turns its leftover width into the
+                 query axis the progressive-hide ladder degrades against. -->
+            <div class="stats-cluster flex items-center min-w-0 flex-1 overflow-hidden">
               <div class="flex items-center space-x-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
                 <span class="flex items-center space-x-1">
                   <span class="w-1.5 h-1.5 rounded-full bg-status-success-500"></span>
@@ -22,18 +25,18 @@
                   <span>agents</span>
                 </span>
                 <!-- Working-now count (trinity-enterprise#47) -->
-                <span class="text-gray-300 dark:text-gray-600">·</span>
-                <span class="flex items-center space-x-1">
+                <span class="text-gray-300 dark:text-gray-600" data-sep="working">·</span>
+                <span class="flex items-center space-x-1" data-stat="working">
                   <span class="font-medium text-status-info-600 dark:text-status-info-400">{{ workingNowCount }}</span>
                   <span>working now</span>
                 </span>
-                <span class="text-gray-300 dark:text-gray-600">·</span>
-                <span class="flex items-center space-x-1">
+                <span class="text-gray-300 dark:text-gray-600" data-sep="messages">·</span>
+                <span class="flex items-center space-x-1" data-stat="messages">
                   <span class="font-medium text-status-info-600 dark:text-status-info-400">{{ totalCollaborationCount }}</span>
                   <span>messages ({{ timeRangeHours }}h)</span>
                 </span>
-                <!-- Host Telemetry (inline) -->
-                <span class="text-gray-300 dark:text-gray-600">·</span>
+                <!-- Host Telemetry (inline) — owns its own leading separator and
+                     its own container-query hide ladder (HostTelemetry.vue). -->
                 <HostTelemetry />
               </div>
             </div>
@@ -670,6 +673,55 @@ function handleClickOutside(event) {
 </script>
 
 <style scoped>
+
+/*
+ * Stats bar progressive degrade (#1830).
+ *
+ * The header row is [elastic stats cluster | fixed controls cluster]. Before
+ * this, the stats cluster only ever got CLIPPED by `overflow-hidden` — the
+ * telemetry meters were cut mid-element (and their boxes still ran under the
+ * controls) with no visual affordance. Making the cluster a size container
+ * lets the content drop out in a defined order as space runs out, keyed to the
+ * width actually left over — so it adapts to a wider controls cluster (grid
+ * mode, tags chip, owner filter) instead of a guessed viewport breakpoint.
+ *
+ * Ladder (widest → narrowest), split by ownership:
+ *   ≤ 820px  sparklines drop        (HostTelemetry.vue)
+ *   ≤ 700px  Disk meter drops       (HostTelemetry.vue)
+ *   ≤ 560px  Mem meter drops        (HostTelemetry.vue)
+ *   ≤ 420px  telemetry drops whole  (HostTelemetry.vue)
+ *   ≤ 330px  "messages (Nh)" drops  (here)
+ *   ≤ 200px  "working now" drops    (here)
+ * The agent count always survives.
+ *
+ * Each threshold sits ~25-30px ABOVE the measured intrinsic width of the level
+ * it gates (full 791 → no-sparks 663 → no-disk 522 → no-mem 394 → no-telemetry
+ * 308 → no-messages 182 → agents-only 71), so every level still fits its own
+ * band with headroom for wider live values (three-digit fleets, 100.0/128G).
+ * Thresholds set below those widths reintroduce the clip this fixes — re-measure
+ * before moving one.
+ *
+ * The container NAME is the contract HostTelemetry.vue queries against — keep
+ * `statsbar` in sync with the @container rules there if it ever changes.
+ */
+.stats-cluster {
+  container-type: inline-size;
+  container-name: statsbar;
+}
+
+@container statsbar (max-width: 330px) {
+  [data-stat='messages'],
+  [data-sep='messages'] {
+    display: none;
+  }
+}
+
+@container statsbar (max-width: 200px) {
+  [data-stat='working'],
+  [data-sep='working'] {
+    display: none;
+  }
+}
 
 /* Replay Mode Styles */
 .mode-toggle {


### PR DESCRIPTION
## What

Makes the Dashboard header row elastic. The stats cluster becomes a size container and its contents degrade in a defined order as the leftover width shrinks, instead of being clipped mid-element under the controls cluster.

Related to #1830

## The bug

Row is `[stats cluster | controls cluster]`: the left side was `min-w-0 overflow-hidden` (clip-only, no `flex-1`), the right side `flex-shrink-0`. Once the content stopped fitting, nothing gave — the telemetry meters were cut mid-element and their boxes ran under Tags / owner / Grid-Timeline / time-range.

Measured on a live stack (Playwright, timeline mode, 1-agent fleet — the collision threshold moves up on fleets with the owner filter and more tags, which is the ~1170px reported in the issue):

| width | overlap | clipped mid-element |
|---|---|---|
| 900px | **22px** (`Disk 33%` ⨯ `Timeline` button) | `stat-label` (the "Disk" word, rendered as "D") |
| 1024px+ | 0 | – |

## The fix

- `.stats-cluster` gets `flex-1 min-w-0` + `container-type: inline-size` (name `statsbar`) — it is now the only cluster that gives ground, and its leftover width is the query axis.
- Ladder, widest → narrowest: sparklines → Disk → Mem → whole telemetry → `messages (Nh)` → `working now`. The agent count always survives.
- Keyed on the **container**, not the viewport — the controls cluster is not a constant (grid mode adds Tidy up / Reset; Tags chip and owner filter only render on some fleets), so a viewport breakpoint would be right on one fleet and wrong on the next.
- Thresholds sit ~25–30px above the **measured** intrinsic width of the level each one gates (full 791 → no-sparks 663 → no-disk 522 → no-mem 394 → no-telemetry 308 → no-messages 182 → agents-only 71), leaving headroom for wider live values (three-digit fleets, `100.0/128G`). Setting one below its level reintroduces the clip — noted in the code comment.
- `HostTelemetry` owns its leading `·` separator now (so it leaves with the meters) and each metric carries a `title`, so the value stays reachable once its meter is hidden.

No JS, no ResizeObserver, no new dependency — `@container` is plain CSS through Vite (Chrome 105+ / Safari 16+ / Firefox 110+).

## Acceptance criteria

- [x] No controls/stats element overlap at any swept width from 640px up — verified 640/700/768/860/900/960/1024/1100/1170/1280/1366/1600, both modes
- [x] Telemetry degrades progressively (sparklines → Disk → Mem → all) instead of clipping mid-meter
- [x] No page-level horizontal overflow (`document.scrollWidth <= innerWidth` at every swept width)
- [x] Playwright width sweep spec (`src/frontend/e2e/dashboard-stats-overflow.spec.js`), same shape as the #1789 nav spec
- [x] Both Grid and Timeline modes covered

## Verification

```
$ npx playwright test dashboard-stats-overflow --reporter=list
  ✓ [setup] authenticate as admin
  ✓ @interactive timeline mode: controls never overlap the stats cluster
  ✓ @interactive grid mode: controls never overlap the stats cluster
  ✓ @interactive wide viewport keeps CPU, Mem and Disk meters
  ✓ @interactive narrow viewport hides the meters rather than clipping them
  5 passed (6.7s)
```

Same spec against the pre-fix markup (fix stashed) — **4 failed, 1 passed**:

```
Error: timeline @ 640px — controls overlap stats by 22px (span.stat-value "78%" ⨯ button "timeline")
Error: grid @ 640px — controls overlap stats by 65px (span "messages (24h)" ⨯ button "timeline")
```

Screenshots at 900px, timeline mode — before: "Disk" cut to "D", meter and value gone under the Grid/Timeline toggle. After: sparklines and Disk dropped, CPU/Mem kept as compact values, clean gap before the controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1830