### PR TITLE
fix(systems): resolve templates in the deploy dry run (#1841)

### DIFF
--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -622,7 +622,8 @@ class SystemDeployFailure(BaseModel):
 class SystemDeployResponse(BaseModel):
     """Response from system deployment."""
     # "deployed" (all created) | "partial" (some failed) | "failed" (none created)
-    # | "valid" (dry_run) — trinity-enterprise#125
+    # | "valid" (dry_run, will deploy) | "invalid" (dry_run, blockers in `failed`,
+    # #1841) — trinity-enterprise#125
     status: str
     system_name: str
     agents_created: List[str]  # Final agent names created

--- a/src/backend/services/system_service.py
+++ b/src/backend/services/system_service.py
@@ -781,6 +781,51 @@ def _default_create_agent_fn():
     return create_agent_internal
 
 
+def _preflight_template(
+    final_name: str, short_name: str, template: Optional[str]
+) -> Optional[SystemDeployFailure]:
+    """Can this agent's template resolve? Returns a failure, or None if it can.
+
+    Reuses the CREATE path's own resolver rather than re-deriving "does this
+    template exist", so the preview cannot drift from the deploy: the reason
+    string and status code a caller sees here are produced by the same code that
+    will produce them for real (#1841).
+
+    Scope, deliberately:
+      * ``local:`` — resolved (a filesystem read, no side effects). This is
+        where the cheap typo lives, and where #1793/#1759 made an unresolvable
+        id a hard 404 instead of a silent blank agent.
+      * ``github:`` — NOT probed. Validating it means a network call to GitHub
+        with the platform PAT on a preview endpoint; slow, rate-limited, and a
+        new outbound call on a path that had none. A dry run therefore still
+        cannot promise a github-template manifest deploys.
+      * no template — valid by construction (creates a bare agent by design).
+    """
+    if not template or not template.startswith("local:"):
+        return None
+
+    # Lazy import: crud imports service-layer modules, so a module-level import
+    # here would close a cycle (same reason `_default_create_agent_fn` is lazy).
+    from models import AgentConfig
+    from services.agent_service.crud import _resolve_local_template
+
+    try:
+        # A throwaway config: `_resolve_local_template` mutates the object it is
+        # given (type/resources/tools/runtime from template.yaml), which is why
+        # the manifest's own config is never handed to it.
+        _resolve_local_template(AgentConfig(name=final_name, template=template))
+    except Exception as e:  # noqa: BLE001 — mirrors the create loop's catch
+        reason, status_code = _failure_reason(e)
+        return SystemDeployFailure(
+            name=final_name,
+            short_name=short_name,
+            template=template,
+            reason=reason,
+            status_code=status_code,
+        )
+    return None
+
+
 def _failure_reason(exc: Exception) -> Tuple[str, Optional[int]]:
     """Normalize an agent-create exception into a (reason, status_code) pair.
 
@@ -863,13 +908,34 @@ async def deploy_manifest(
                 for short_name, final_name in agent_names.items()
             ]
 
+            # #1841: a preview that only checks manifest SHAPE clears manifests
+            # the real deploy then 404s on — a typo'd or renamed template id is
+            # the cheapest mistake to make and precisely what a preview is for.
+            # It matters more than it sounds: a partial deploy is expensive to
+            # undo, because re-running the same manifest creates suffixed
+            # duplicates of whatever already succeeded, so recovery is manual
+            # and per-agent.
+            preview_failed = [
+                failure for failure in (
+                    _preflight_template(
+                        final_name, short_name, manifest.agents[short_name].template
+                    )
+                    for short_name, final_name in agent_names.items()
+                ) if failure is not None
+            ]
+
             return SystemDeployResponse(
-                status="valid",
+                # "valid" keeps its meaning — a manifest that will deploy. A
+                # preview that found blockers reports `invalid`, matching the
+                # deploy path's own vocabulary (`partial` / `failed`) instead of
+                # claiming success next to a populated failure list.
+                status="invalid" if preview_failed else "valid",
                 system_name=manifest.name,
                 agents_created=[],
                 agents_to_create=agents_to_create,
                 prompt_updated=bool(manifest.prompt),
-                warnings=all_warnings
+                warnings=all_warnings,
+                failed=preview_failed,
             )
 
         # 5. Create all agents — best-effort by default (trinity-enterprise#125):

--- a/src/mcp-server/src/tools/systems.ts
+++ b/src/mcp-server/src/tools/systems.ts
@@ -46,7 +46,8 @@ export function createSystemTools(
       description:
         "Deploy a multi-agent system from a YAML manifest. " +
         "The manifest defines the system name, agents, permissions, schedules, and shared folders. " +
-        "Supports dry_run mode for validation without deployment. " +
+        "Supports dry_run mode for validation without deployment — a dry run resolves each `local:` template, "
+        + "so `status: 'invalid'` with a populated `failed[]` means the manifest would not deploy cleanly. " +
         "Agents are created with naming pattern '{system}-{agent}' (e.g., 'content-production-orchestrator'). " +
         "Supports permission presets: 'full-mesh', 'orchestrator-workers', 'none', or explicit rules. " +
         "Deploy is best-effort: check `status` ('deployed' | 'partial' | 'failed') and `failed[]` " +
@@ -93,7 +94,7 @@ export function createSystemTools(
 
         // Call backend deploy endpoint
         const response = await apiClient.request<{
-          status: string; // "deployed" | "partial" | "failed" | "valid" (dry_run)
+          status: string; // "deployed" | "partial" | "failed" | "valid" (dry_run) | "invalid" (dry_run, #1841)
           system_name: string;
           agents_created: string[];
           agents_to_create?: Array<{ name: string; short_name: string; template: string }>;

--- a/tests/unit/test_ent125_resilient_system_deploy.py
+++ b/tests/unit/test_ent125_resilient_system_deploy.py
@@ -27,6 +27,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 import routers.systems as systems
+import services.agent_service.crud as crud
 import services.system_service as system_service
 from dependencies import get_current_user
 
@@ -89,6 +90,12 @@ def env(monkeypatch):
     monkeypatch.setattr(system_service, "create_system_view", mocks.create_system_view)
     monkeypatch.setattr(system_service, "start_all_agents", mocks.start_all_agents)
     monkeypatch.setattr(system_service, "db", mocks.db)
+    # #1841: the dry-run preflight resolves `local:` templates through the
+    # create path's own resolver. The catalog root (/agent-configs/templates)
+    # does not exist under pytest, so stub the seam to "resolves fine" here
+    # and let the preflight tests below override it. Patched on the crud
+    # MODULE because the preflight lazy-imports it at call time (cycle).
+    monkeypatch.setattr(crud, "_resolve_local_template", lambda config: ({}, None))
     # Hermetic name resolution — no shared-SQLite reads.
     monkeypatch.setattr(
         system_service,
@@ -374,3 +381,114 @@ def test_orchestrator_failure_warns_headless_fleet(env):
     assert env.m.configure_permissions.call_args.kwargs["agent_names"] == {
         "worker": "test-orch-worker"
     }
+
+
+# --- dry-run template preflight (#1841) ---------------------------------------
+
+MIXED_MANIFEST = """
+name: mixed
+agents:
+  good:
+    template: local:default
+  bad:
+    template: local:this-template-does-not-exist
+"""
+
+GITHUB_MANIFEST = """
+name: gh
+agents:
+  remote:
+    template: github:Abilityai/some-template
+"""
+
+
+def _unresolvable(*bad_ids):
+    """Resolver stub: raises the create path's real 404 for the named ids."""
+    def _resolve(config):
+        raw = config.template[len("local:"):]
+        if raw in bad_ids:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": f"Local template {raw!r} was not found.",
+                    "code": "UNKNOWN_LOCAL_TEMPLATE",
+                },
+            )
+        return ({}, None)
+    return _resolve
+
+
+def test_dry_run_flags_an_unresolvable_template(env, monkeypatch):
+    """#1841: the preview must not clear a manifest the deploy would 404 on.
+
+    Recovery from a partial deploy is manual (re-running the manifest creates
+    suffixed duplicates of whatever already succeeded), so a preview that says
+    'valid' here costs real cleanup later.
+    """
+    monkeypatch.setattr(
+        crud, "_resolve_local_template", _unresolvable("this-template-does-not-exist")
+    )
+
+    resp = _deploy(env, MIXED_MANIFEST, dry_run=True)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "invalid"
+    assert [f["short_name"] for f in data["failed"]] == ["bad"]
+    failure = data["failed"][0]
+    assert failure["name"] == "mixed-bad"
+    assert failure["status_code"] == 404
+    assert "was not found" in failure["reason"]
+    # Still a preview: the full plan is reported and nothing is created.
+    assert len(data["agents_to_create"]) == 2
+    env.m.create_agent.assert_not_awaited()
+
+
+def test_dry_run_stays_valid_when_every_template_resolves(env):
+    resp = _deploy(env, TWO_AGENT_MANIFEST, dry_run=True)
+
+    data = resp.json()
+    assert data["status"] == "valid"
+    assert data["failed"] == []
+    env.m.create_agent.assert_not_awaited()
+
+
+def test_dry_run_does_not_probe_github_templates(env, monkeypatch):
+    """Validating a `github:` id means a network call with the platform PAT on a
+    preview endpoint. Out of scope by decision — the preflight must skip it, not
+    fail it."""
+    calls = []
+    monkeypatch.setattr(
+        crud, "_resolve_local_template", lambda config: calls.append(config.template) or ({}, None)
+    )
+
+    resp = _deploy(env, GITHUB_MANIFEST, dry_run=True)
+
+    data = resp.json()
+    assert data["status"] == "valid"
+    assert data["failed"] == []
+    assert calls == [], "github: templates must not reach the local resolver"
+
+
+def test_preflight_reason_matches_what_the_real_deploy_reports(env, monkeypatch):
+    """The preview reuses the create path's resolver, so an operator comparing a
+    dry run against the deploy that follows sees the same reason and code."""
+    monkeypatch.setattr(
+        crud, "_resolve_local_template", _unresolvable("this-template-does-not-exist")
+    )
+    preview = _deploy(env, MIXED_MANIFEST, dry_run=True).json()["failed"][0]
+
+    # Same manifest, real deploy: the create seam raises the same error.
+    env.m.create_agent.side_effect = lambda **kw: (_ for _ in ()).throw(
+        HTTPException(
+            status_code=404,
+            detail={"error": "Local template 'this-template-does-not-exist' was not found.",
+                    "code": "UNKNOWN_LOCAL_TEMPLATE"},
+        )
+    ) if kw["config"].template.endswith("this-template-does-not-exist") else {"status": "created"}
+
+    real = _deploy(env, MIXED_MANIFEST).json()["failed"][0]
+
+    assert preview["reason"] == real["reason"]
+    assert preview["status_code"] == real["status_code"]
+    assert preview["template"] == real["template"]


### PR DESCRIPTION
## What

The deploy dry run now resolves each `local:` template, so a manifest that cannot deploy stops reporting `valid`.

Related to #1841

## Before / after, same manifest

```yaml
name: sysprobe
agents:
  good: {template: local:dd-intake}
  bad:  {template: local:this-template-does-not-exist}
```

**Before** — `status: "valid"`, `warnings: []`, `failed: []`. **After**, on a live instance:

```json
{
  "status": "invalid",
  "failed": [{
    "name": "sysprobe2-bad",
    "short_name": "bad",
    "template": "local:this-template-does-not-exist",
    "reason": "Local template 'this-template-does-not-exist' was not found. Check the id against GET /api/templates — ...",
    "status_code": 404
  }],
  "agents_to_create": ["sysprobe2-good", "sysprobe2-bad"]
}
```

## Why this and not a doc note

Recovery from a partial deploy is manual. The deploy path's own warning spells it out — re-running the manifest creates **suffixed duplicates** of the agents that already succeeded — so the fix is per-agent by hand. The preview is the control that avoids paying that, and the failure it was blind to (typo'd or renamed template id) is the cheapest mistake available. #1793/#1759 had just made an unresolvable `local:` template a hard 404 at create time; validation-time resolution is the matching half of that change.

## Approach

The preflight calls the **create path's own** `_resolve_local_template` on a throwaway `AgentConfig`, instead of re-deriving "does this template exist". Two consequences worth reviewing:

- The preview cannot drift from the deploy. The reason string and status code an operator sees in a dry run are produced by the same code that will produce them for real — `test_preflight_reason_matches_what_the_real_deploy_reports` asserts that equality directly rather than hard-coding an expected message.
- The throwaway config matters: that resolver **mutates** the object it is handed (type/resources/tools/runtime from `template.yaml`), so the manifest's own config is never passed to it.

The import is lazy, matching the existing `_default_create_agent_fn` seam — a module-level import would close a cycle.

**`github:` is deliberately not probed.** Validating it means a network call to GitHub with the platform PAT on a preview endpoint: slow, rate-limited, and a new outbound call on a path that had none. So a dry run still cannot promise a github-template manifest deploys, and a test pins that the local resolver is never reached for one. Worth a second opinion during review — the alternative is an opt-in `?probe_remote=true`.

**`status` gains `invalid`** for a preview with blockers, matching the deploy path's own `partial` / `failed` vocabulary rather than claiming success beside a populated `failed[]`. `agents_to_create` still lists the full plan, so the preview shows what was asked for and what blocks it. The response-model comment and the MCP `deploy_system` tool description are updated (Invariant #13).

## Verification

```
pytest tests/unit/test_ent125_resilient_system_deploy.py
19 passed
```

4 new cases; reverted the preflight with the tests in place → **2 failed** (the flagged-failure case and the preview/deploy equality case).

One fixture change to flag: the ent125 `env` fixture now stubs the resolver seam. The preflight reads the real catalog root (`/agent-configs/templates`), which does not exist under pytest, so without the stub every pre-existing dry-run test would have started failing — the same "new contract, old test" trap that blocked #1822.

Full unit suite posted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1841