### PR TITLE
fix(skills): reap directories the package prune empties (#1842)

### DIFF
--- a/src/backend/services/skill_service.py
+++ b/src/backend/services/skill_service.py
@@ -640,24 +640,35 @@ print(json.dumps({{
         return result
 
     async def _finalize_injected_dirs(
-        self, agent_name: str, skill_names: List[str], exec_paths: List[str]
+        self,
+        agent_name: str,
+        skill_names: List[str],
+        exec_paths: List[str],
+        pruned_paths: Optional[List[str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """Post-restore finalization in ONE exec: chmod +x (git modes are
-        dropped by restore's write_bytes), per-skill .gitignore lines, and
-        untracking already-committed matches.
+        dropped by restore's write_bytes), per-skill .gitignore lines,
+        untracking already-committed matches, and reaping directories the prune
+        just emptied (#1842).
 
         The gitignore step is load-bearing (strategy review F1): the 15-min git
         auto-sync deliberately COMMITS .claude/, so without per-name ignore
         lines every injected package lands in the agent's GitHub repo — the
         #1595/#1596 fleet bloat class. Only platform-injected names are
         ignored; agent-authored Playbooks keep committing.
+
+        The empty-dir reap rides here rather than next to the per-file DELETEs
+        because it needs to ASK the filesystem whether a directory is now empty
+        — one in-agent exec answers that for every pruned path at once, where
+        the remote file API would need a round trip per directory.
         """
         script = f"""
 import json, os, stat, subprocess
 names = {json.dumps(sorted(set(skill_names)))}
 exec_paths = {json.dumps(sorted(set(exec_paths)))}
+pruned_paths = {json.dumps(sorted(set(pruned_paths or [])))}
 home = os.path.expanduser("~")
-out = {{"chmod": 0, "gitignore": False, "untracked": False, "errors": []}}
+out = {{"chmod": 0, "gitignore": False, "untracked": False, "rmdir": 0, "errors": []}}
 for rel in exec_paths:
     p = os.path.join(home, rel)
     try:
@@ -665,6 +676,27 @@ for rel in exec_paths:
         out["chmod"] += 1
     except Exception:
         out["errors"].append("chmod:" + rel)
+# #1842: compute_prune diffs MANIFESTS, and a manifest holds files, so dropping
+# a package subdirectory deleted its files and left the directory standing. Climb
+# from each pruned file toward the skill root, removing only what is already
+# empty. `os.rmdir` IS the safety property: it refuses a directory holding
+# anything, so runtime artifacts a skill's own scripts wrote (__pycache__,
+# downloaded models) and agent-authored files keep the directory alive — the same
+# "only remove what the platform wrote" guarantee compute_prune states. It also
+# refuses a symlink (NotADirectoryError), so a doctored tree cannot redirect it.
+for rel in pruned_paths:
+    parts = rel.split("/")
+    if len(parts) < 4 or parts[0] != ".claude" or parts[1] != "skills":
+        continue  # prefix confinement, mirroring compute_prune's own guard
+    root = "/".join(parts[:3])
+    d = os.path.dirname(rel)
+    while d.startswith(root + "/"):
+        try:
+            os.rmdir(os.path.join(home, d))
+            out["rmdir"] += 1
+        except OSError:
+            break  # non-empty, already gone, or not a directory — stop climbing
+        d = os.path.dirname(d)
 lines = [".claude/skills/%s/" % n for n in names]
 gi = os.path.join(home, ".gitignore")
 try:
@@ -763,6 +795,9 @@ print(json.dumps(out))
         running_total = 0
         exec_paths: List[str] = []
         injected_names: List[str] = []
+        # #1842: paths the prune deleted, so finalize can reap any directory
+        # they leave empty.
+        pruned_paths: List[str] = []
         contracts: Dict[str, Dict[str, Any]] = {}
 
         for skill_name in skill_names:
@@ -872,14 +907,16 @@ print(json.dumps(out))
                             warnings.append("prune_truncated")
                         for path in stale:
                             deleted = await self._delete_agent_file(client, path)
-                            if not deleted:
+                            if deleted:
+                                pruned_paths.append(path)
+                            else:
                                 warnings.append(f"stale_delete_failed:{path}")
             results[skill_name] = outcome
 
         # Post-restore finalization: chmod + gitignore + untrack, one exec.
         if injected_names:
             finalize = await self._finalize_injected_dirs(
-                agent_name, injected_names, exec_paths
+                agent_name, injected_names, exec_paths, pruned_paths
             )
             if not isinstance(finalize, dict):
                 for name in injected_names:

--- a/src/backend/services/skill_service.py
+++ b/src/backend/services/skill_service.py
@@ -688,6 +688,12 @@ for rel in pruned_paths:
     parts = rel.split("/")
     if len(parts) < 4 or parts[0] != ".claude" or parts[1] != "skills":
         continue  # prefix confinement, mirroring compute_prune's own guard
+    if ".." in parts:
+        # compute_prune already drops these, but the startswith() confinement
+        # below is satisfied by `.claude/skills/x/../../..` — so without this the
+        # LAST line of defense would be a prefix check that a traversal segment
+        # walks straight through. Reject rather than rely on the caller.
+        continue
     root = "/".join(parts[:3])
     d = os.path.dirname(rel)
     while d.startswith(root + "/"):

--- a/tests/unit/test_ent183_skill_packages.py
+++ b/tests/unit/test_ent183_skill_packages.py
@@ -1105,3 +1105,20 @@ class TestPrunedEmptyDirReap:
         assert out["rmdir"] == 0
         assert target.is_dir()
         assert (skill / "reference").is_symlink()
+
+    def test_traversal_segment_is_rejected_by_the_reap(self, service, tmp_path, monkeypatch):
+        """#1842 review: the script's own prefix check is satisfied by
+        `.claude/skills/pkg/../../..`, so a `..` segment would climb out of the
+        skill root. compute_prune filters these upstream — this pins the reap's
+        last line of defense rather than trusting the caller."""
+        skill = self._skill(tmp_path)
+        (skill / "reference").mkdir()
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        out = self._run_finalize(
+            service, tmp_path, monkeypatch,
+            [".claude/skills/pkg/../../victim/x.txt", ".claude/skills/pkg/reference/notes.md"],
+        )
+        assert victim.is_dir()          # never touched
+        assert out["rmdir"] == 1        # only the legitimate one was reaped
+        assert not (skill / "reference").exists()

--- a/tests/unit/test_ent183_skill_packages.py
+++ b/tests/unit/test_ent183_skill_packages.py
@@ -713,9 +713,12 @@ class TestInjectOrchestration:
         with patch.object(skill_service_module, "get_agent_client", return_value=client):
             _run(service.inject_skills("agent-x", ["multi"], force=True))
         service._finalize_injected_dirs.assert_awaited_once()
-        _agent, names, exec_paths = service._finalize_injected_dirs.await_args.args
+        # #1842 added a 4th arg: the paths the prune deleted, so finalize can
+        # reap the directories they emptied.
+        _agent, names, exec_paths, pruned = service._finalize_injected_dirs.await_args.args
         assert names == ["multi"]
         assert exec_paths == []
+        assert pruned == []   # fallback wrote only SKILL.md; nothing was pruned
 
     def test_total_cap_skips_overflow_skill(self, service, monkeypatch):
         monkeypatch.setenv("SKILLS_TOTAL_MAX_BYTES", "150")
@@ -999,3 +1002,106 @@ class TestListAndGetSurface:
         paths = {f["path"] for f in skill["files"]}
         assert paths == {"SKILL.md", "ref/a.txt"}
         assert skill["content"].startswith("# d")
+
+
+class TestPrunedEmptyDirReap:
+    """#1842: `compute_prune` diffs MANIFESTS and a manifest holds files, so a
+    package that drops a subdirectory had its files deleted and the directory
+    left standing. Reproduced live: after `reference/notes.md` was pruned,
+    `~/.claude/skills/pkg-probe/reference/` remained as an empty directory that
+    no later injection ever removed.
+
+    These execute the real finalize script against a tmp home — a mocked
+    assertion on the arg list would not catch a bad rmdir climb."""
+
+    def _run_finalize(self, service, tmp_path, monkeypatch, pruned):
+        captured = []
+
+        async def grab(agent_name, script):
+            captured.append(script)
+            return None
+
+        service._run_agent_python = grab
+        _run(service._finalize_injected_dirs("agent-x", ["pkg"], [], pruned))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        proc = subprocess.run(
+            [sys.executable, "-"], input=captured[0], text=True,
+            capture_output=True, timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(proc.stdout)
+
+    def _skill(self, tmp_path):
+        d = tmp_path / ".claude" / "skills" / "pkg"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("# pkg\n")
+        return d
+
+    def test_directory_emptied_by_the_prune_is_removed(self, service, tmp_path, monkeypatch):
+        skill = self._skill(tmp_path)
+        (skill / "reference").mkdir()          # its only file was just pruned
+        out = self._run_finalize(
+            service, tmp_path, monkeypatch,
+            [".claude/skills/pkg/reference/notes.md"],
+        )
+        assert out["rmdir"] == 1
+        assert not (skill / "reference").exists()
+        assert (skill / "SKILL.md").exists()   # the package itself is untouched
+
+    def test_directory_still_holding_files_is_kept(self, service, tmp_path, monkeypatch):
+        """`os.rmdir` IS the safety property: runtime artifacts a skill's own
+        scripts wrote (__pycache__, downloaded models) keep the dir alive."""
+        skill = self._skill(tmp_path)
+        (skill / "scripts").mkdir()
+        (skill / "scripts" / "run.sh").write_text("#!/bin/sh\n")
+        (skill / "scripts" / "__pycache__").mkdir()
+        (skill / "scripts" / "__pycache__" / "x.pyc").write_bytes(b"\x00")
+        out = self._run_finalize(
+            service, tmp_path, monkeypatch,
+            [".claude/skills/pkg/scripts/old.py"],
+        )
+        assert out["rmdir"] == 0
+        assert (skill / "scripts" / "run.sh").exists()
+        assert (skill / "scripts" / "__pycache__" / "x.pyc").exists()
+
+    def test_climb_stops_at_the_skill_root(self, service, tmp_path, monkeypatch):
+        """Even with every level empty, the skill root and `.claude/skills`
+        above it must survive — the package is still installed."""
+        skill = self._skill(tmp_path)
+        (skill / "a" / "b").mkdir(parents=True)
+        out = self._run_finalize(
+            service, tmp_path, monkeypatch, [".claude/skills/pkg/a/b/gone.txt"],
+        )
+        assert out["rmdir"] == 2                    # b/, then a/
+        assert not (skill / "a").exists()
+        assert skill.exists() and (skill / "SKILL.md").exists()
+        assert (tmp_path / ".claude" / "skills").is_dir()
+
+    def test_paths_outside_the_skills_prefix_are_ignored(self, service, tmp_path, monkeypatch):
+        """Prefix confinement mirrors compute_prune's own guard: a doctored
+        manifest must never steer an rmdir elsewhere in the agent home."""
+        self._skill(tmp_path)
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / ".claude" / "loose").mkdir()
+        out = self._run_finalize(
+            service, tmp_path, monkeypatch,
+            ["workspace/data.csv", ".claude/loose/x.txt", "../../etc/passwd"],
+        )
+        assert out["rmdir"] == 0
+        assert (tmp_path / "workspace").is_dir()
+        assert (tmp_path / ".claude" / "loose").is_dir()
+
+    def test_symlinked_directory_is_not_followed(self, service, tmp_path, monkeypatch):
+        """A symlink where a package dir used to be must not be unlinked —
+        os.rmdir refuses it (NotADirectoryError), so the target is safe."""
+        skill = self._skill(tmp_path)
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        (skill / "reference").symlink_to(target, target_is_directory=True)
+        out = self._run_finalize(
+            service, tmp_path, monkeypatch,
+            [".claude/skills/pkg/reference/notes.md"],
+        )
+        assert out["rmdir"] == 0
+        assert target.is_dir()
+        assert (skill / "reference").is_symlink()


### PR DESCRIPTION
## What

The package prune now removes directories it empties, instead of leaving them behind.

Related to #1842

## Live before / after

Same package, `reference/` dropped between v1 and v2:

```
before                                    after
.../pkg-probe/.trinity-skill.json         .../pkg-probe/.trinity-skill.json
.../pkg-probe/SKILL.md                    .../pkg-probe/SKILL.md
.../pkg-probe/reference        ← empty
```

## Why bother, at P3

The failure it produces is the confusing kind. A stale agent running a skill that says *"read `reference/notes.md`"* hits an **empty directory** rather than a clean `No such file or directory` — `ls` succeeds and shows nothing. And nothing ever cleans them up, including a full re-inject, so they accumulate with every reorganisation.

## Approach

Climb from each pruned file toward the skill root, removing only what is already empty.

**`os.rmdir` is the safety property, not an implementation detail.** It refuses a directory holding anything, so runtime artifacts a skill's own scripts wrote (`__pycache__`, downloaded models) and agent-authored files keep their directory alive — preserving exactly the guarantee `compute_prune` documents, that the platform only ever deletes what it wrote. It also refuses a symlink (`NotADirectoryError`), so a doctored tree can't redirect it at something else, and the path prefix stays confined to `.claude/skills/<name>/` the same way `compute_prune` confines its own candidates. The climb stops at the skill root, which stays installed.

**Placement:** it rides in `_finalize_injected_dirs` rather than next to the per-file DELETEs, because "is this directory now empty?" has to be asked of the filesystem — one in-agent exec answers it for every pruned path at once, where the remote file API would cost a round trip per directory. Only paths whose DELETE actually succeeded are passed, so a failed prune never triggers a climb.

## Verification

```
pytest tests/unit/test_ent183_skill_packages.py tests/unit/test_183_skill_packages_backward_compat.py
64 passed
```

5 new cases that **execute** the rendered script against a tmp home — a mocked assertion on the argument list would not catch a bad climb:

- directory emptied by the prune is removed
- directory still holding `run.sh` + `__pycache__/x.pyc` is kept (`rmdir == 0`)
- multi-level climb removes `b/` then `a/` and stops at the skill root
- out-of-prefix paths (`workspace/data.csv`, `../../etc/passwd`) are ignored
- a symlink where the package dir used to be is not followed, target survives

Removed the reap with the tests in place → **2 failed**.

Also updated `test_fallback_skills_queue_no_chmod_paths`, which unpacked the old 3-arg `_finalize_injected_dirs` signature. Caught it in the run rather than in review — same trap that blocked #1822.

Verified live end to end on a running instance: v1 injected with `reference/notes.md`, v2 dropping the directory re-injected, `reference/` gone where it previously survived.

## Not in scope

`unmanaged_dir_overwritten` (a skill directory with no `.trinity-skill.json`) still prunes nothing at all, by design — the platform can't tell which files it wrote. Unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1842