### PR TITLE
fix(rename): derive the rename cascade from AGENT_REFS, not a second hand list (#1819)

### DIFF
--- a/src/backend/db/agent_settings/metadata.py
+++ b/src/backend/db/agent_settings/metadata.py
@@ -13,23 +13,8 @@ from ..engine import get_engine
 from ..tables import (
     agent_ownership,
     agent_sharing,
-    agent_schedules,
-    schedule_executions,
-    chat_sessions,
-    chat_messages,
-    agent_activities,
     agent_permissions,
-    agent_shared_folder_config,
     agent_git_config,
-    agent_skills,
-    agent_tags,
-    agent_public_links,
-    mcp_api_keys,
-    agent_health_checks,
-    agent_dashboard_values,
-    monitoring_alert_cooldowns,
-    agent_shared_files,
-    agent_reports,
 )
 
 

--- a/src/backend/db/agent_settings/metadata.py
+++ b/src/backend/db/agent_settings/metadata.py
@@ -92,26 +92,16 @@ class MetadataMixin:
         """
         Rename an agent by updating all database references.
 
-        This updates agent_name in all tables that reference it:
-        - agent_ownership (primary)
-        - agent_sharing
-        - agent_schedules
-        - schedule_executions
-        - chat_sessions
-        - chat_messages
-        - agent_activities
-        - agent_permissions (source and target)
-        - agent_shared_folder_config
-        - agent_git_config
-        - agent_skills
-        - agent_tags
-        - agent_public_links
-        - mcp_api_keys
-        - agent_health_checks
-        - agent_dashboard_values
-        - monitoring_alert_cooldowns
-        - agent_shared_files
-        - agent_reports
+        Re-keys `agent_name` in `agent_ownership` (here) and in EVERY table
+        registered in `db.agent_cleanup.AGENT_REFS` (via `cascade_rename`),
+        plus any entitled-module table registered at runtime through
+        `register_agent_owned_table`.
+
+        Deliberately NOT a hand-maintained list of tables (#1819): the previous
+        docstring enumerated 19 and the code matched it, while the registry had
+        grown to 41 — so a rename silently stranded 23 tables' worth of the
+        agent's data, including its Session-tab history. The list is derived
+        now; adding a table to `AGENT_REFS` is all a new feature has to do.
 
         Args:
             old_name: Current agent name
@@ -210,136 +200,39 @@ class MetadataMixin:
                     )
                 )
 
-                # Sharing
-                conn.execute(
-                    update(agent_sharing)
-                    .where(agent_sharing.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
+                # Every other agent-keyed table, from the ONE registry
+                # (#1819). This used to be ~19 hand-written `update()` blocks,
+                # and the list had silently fallen 23 tables behind
+                # `AGENT_REFS`: a rename stranded the agent's Session-tab
+                # history (the reported symptom), and also its reminders,
+                # loops, notifications, operator-queue items, sync state,
+                # compatibility results, per-user memory, and its Telegram /
+                # WhatsApp / VoIP / Slack channel bindings.
+                #
+                # `cascade_rename` was written for exactly this and had ZERO
+                # callers — the delete path consumed the registry while rename
+                # kept its own copy, so every table added since only ever
+                # joined one of them. Two hand-maintained lists for one
+                # question is the defect; deriving both from `AGENT_REFS` is
+                # the fix, and `test_1819_rename_cascade_parity.py` fails CI if
+                # they diverge again.
+                #
+                # Safe by construction: every table the old sequence touched is
+                # already in the registry (verified — the hand list was a strict
+                # subset), `cascade_rename` skips absent tables, and it handles
+                # the multi-column refs (`agent_permissions.source_agent` /
+                # `.target_agent`, the event-subscription pair) the hand list
+                # spelled out twice.
+                from db.agent_cleanup import cascade_rename
 
-                # Schedules
-                conn.execute(
-                    update(agent_schedules)
-                    .where(agent_schedules.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Executions
-                conn.execute(
-                    update(schedule_executions)
-                    .where(schedule_executions.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Chat sessions
-                conn.execute(
-                    update(chat_sessions)
-                    .where(chat_sessions.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Chat messages
-                conn.execute(
-                    update(chat_messages)
-                    .where(chat_messages.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Activities
-                conn.execute(
-                    update(agent_activities)
-                    .where(agent_activities.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Permissions (both source and target)
-                conn.execute(
-                    update(agent_permissions)
-                    .where(agent_permissions.c.source_agent == old_name)
-                    .values(source_agent=new_name)
-                )
-                conn.execute(
-                    update(agent_permissions)
-                    .where(agent_permissions.c.target_agent == old_name)
-                    .values(target_agent=new_name)
-                )
-
-                # Shared folder config
-                conn.execute(
-                    update(agent_shared_folder_config)
-                    .where(agent_shared_folder_config.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Git config
-                conn.execute(
-                    update(agent_git_config)
-                    .where(agent_git_config.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Skills
-                conn.execute(
-                    update(agent_skills)
-                    .where(agent_skills.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Tags
-                conn.execute(
-                    update(agent_tags)
-                    .where(agent_tags.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Public links
-                conn.execute(
-                    update(agent_public_links)
-                    .where(agent_public_links.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # MCP API keys
-                conn.execute(
-                    update(mcp_api_keys)
-                    .where(mcp_api_keys.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Health checks
-                conn.execute(
-                    update(agent_health_checks)
-                    .where(agent_health_checks.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Dashboard values
-                conn.execute(
-                    update(agent_dashboard_values)
-                    .where(agent_dashboard_values.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Monitoring cooldowns
-                conn.execute(
-                    update(monitoring_alert_cooldowns)
-                    .where(monitoring_alert_cooldowns.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
-
-                # Shared files (outbound — amazing-file-outbound).
-                # FK has ON UPDATE CASCADE as belt-and-suspenders; this keeps
-                # the explicit cascade list complete for visibility.
-                conn.execute(
-                    update(agent_shared_files)
-                    .where(agent_shared_files.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
+                cascade_rename(conn, old_name, new_name)
 
                 # Entitled-module agent-scoped tables (ent#46) registered via
-                # db.agent_cleanup.register_agent_owned_table — e.g.
-                # enterprise_connectors. Table/column come from code (not user
-                # input); values are bound. Absent tables are skipped.
+                # db.agent_cleanup.register_agent_owned_table. Kept separate
+                # from the registry pass: these are runtime-registered by the
+                # private submodule, so they are not in `AGENT_REFS` at import
+                # time. Table/column come from code (not user input); values
+                # are bound. Absent tables are skipped.
                 from db.agent_cleanup import EXTRA_AGENT_REFS, _table_exists
                 for table, column in EXTRA_AGENT_REFS:
                     if not _table_exists(conn, table):
@@ -348,14 +241,6 @@ class MetadataMixin:
                         text(f"UPDATE {table} SET {column} = :new WHERE {column} = :old"),
                         {"new": new_name, "old": old_name},
                     )
-                # Reports (#918) — re-key so the renamed agent keeps its report
-                # history and the old name doesn't leave orphaned rows a reused
-                # name could inherit (cross-tenant disclosure).
-                conn.execute(
-                    update(agent_reports)
-                    .where(agent_reports.c.agent_name == old_name)
-                    .values(agent_name=new_name)
-                )
 
                 return True
 

--- a/tests/unit/test_1819_rename_cascade_parity.py
+++ b/tests/unit/test_1819_rename_cascade_parity.py
@@ -1,0 +1,310 @@
+"""Rename follows the SAME registry as delete (#1819).
+
+The reported symptom was that renaming an agent stranded its Session-tab
+history. The cause was structural: `cascade_delete` consumed
+`db.agent_cleanup.AGENT_REFS`, while `rename_agent` kept its own hand-written
+sequence of `update()` calls — two lists answering one question. Every table
+added since only ever joined one of them, so by the time this was filed the
+rename list had fallen **23 tables** behind the registry: sessions and session
+messages (reported), plus reminders, loops, notifications, events, operator
+queue, sync state, compatibility results, per-user memory, and the Telegram /
+WhatsApp / VoIP / Slack channel bindings.
+
+`test_agent_cleanup_parity.py` already guards schema ↔ registry. This guards
+registry ↔ **rename behaviour**, which is the half that was missing:
+
+  * behavioural — seed one row per registered table under the old name, rename,
+    and assert NOTHING is left behind. This fails on the pre-fix code.
+  * structural — `rename_agent` must not grow a private table list again.
+
+The behavioural test drives the real `rename_agent` against the real schema, so
+it cannot pass by agreeing with a mock about which tables exist.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+_TESTS = Path(__file__).resolve().parent.parent
+if str(_TESTS) not in sys.path:
+    sys.path.insert(0, str(_TESTS))
+
+OLD = "rename-probe-old"
+NEW = "rename-probe-new"
+
+
+@pytest.fixture
+def sqlite_db(tmp_path, monkeypatch):
+    """Real production schema on a throwaway SQLite file."""
+    try:
+        from db.engine import dispose_engines
+        from db_harness import bootstrap_schema
+    except ImportError:  # pragma: no cover - backend venv required
+        pytest.skip("backend venv required")
+    monkeypatch.setenv("TRINITY_DB_PATH", str(tmp_path / "trinity.db"))
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    dispose_engines()
+    bootstrap_schema()
+    yield
+    dispose_engines()
+
+
+def _columns(conn, table: str) -> dict:
+    from sqlalchemy import text
+
+    rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    # name -> (type, notnull, default, pk)
+    return {r[1]: (r[2] or "", r[3], r[4], r[5]) for r in rows}
+
+
+def _placeholder(coltype: str, name: str) -> object:
+    t = (coltype or "").upper()
+    if "INT" in t:
+        return 1
+    if "REAL" in t or "FLOA" in t or "DOUB" in t or "NUMERIC" in t:
+        return 1.0
+    # A timestamp-ish TEXT column with NOT NULL is common; any string works
+    # since nothing here parses it.
+    return f"seed-{name}"
+
+
+def _seed_row(conn, table: str, agent_column: str) -> bool:
+    """Insert one minimally-valid row for `table` keyed to OLD.
+
+    Returns False when the table cannot be seeded generically (e.g. a required
+    column this helper cannot synthesize); such tables are reported so the
+    coverage claim stays honest rather than silently shrinking.
+    """
+    from sqlalchemy import text
+
+    cols = _columns(conn, table)
+    if agent_column not in cols:
+        return False
+
+    values = {}
+    for name, (coltype, notnull, default, pk) in cols.items():
+        if name == agent_column:
+            values[name] = OLD
+        elif name == "scope":
+            # Some refs are scope-filtered (mcp_api_keys). A synthetic scope
+            # matches no filter, which would look like a strand when it is
+            # really this seeder's fault — see
+            # test_scope_filtered_keys_narrow_deliberately for the rows the
+            # filters intentionally leave alone.
+            values[name] = "agent"
+        elif pk and "INT" in (coltype or "").upper():
+            continue  # let AUTOINCREMENT assign
+        elif notnull and default is None:
+            values[name] = _placeholder(coltype, name)
+    collist = ", ".join(values)
+    binds = ", ".join(f":{c}" for c in values)
+    try:
+        conn.execute(text(f"INSERT INTO {table} ({collist}) VALUES ({binds})"), values)
+        return True
+    except Exception:
+        return False
+
+
+def test_rename_rekeys_every_registered_table(sqlite_db):
+    """Seed one row per AGENT_REFS entry, rename, assert none stay behind."""
+    from sqlalchemy import text
+
+    from db.agent_cleanup import AGENT_REFS
+    from db.engine import get_engine
+    from db.agent_settings.metadata import MetadataMixin
+
+    seeded: list[tuple[str, str]] = []
+    unseedable: list[str] = []
+    with get_engine().begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users (id, username, role, created_at, updated_at) "
+                "VALUES (1, 'admin', 'admin', 'now', 'now')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO agent_ownership (agent_name, owner_id, created_at) "
+                "VALUES (:n, 1, 'now')"
+            ),
+            {"n": OLD},
+        )
+        for ref in AGENT_REFS:
+            if _seed_row(conn, ref.table, ref.column):
+                seeded.append((ref.table, ref.column))
+            else:
+                unseedable.append(f"{ref.table}.{ref.column}")
+
+    # The guard is only as good as its coverage — say what it could not seed.
+    assert len(seeded) >= 25, (
+        f"only seeded {len(seeded)} registry tables; coverage too thin to trust. "
+        f"unseedable={unseedable}"
+    )
+
+    assert MetadataMixin().rename_agent(OLD, NEW) is True
+
+    stranded = []
+    with get_engine().begin() as conn:
+        for table, column in seeded:
+            left = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE {column} = :n"), {"n": OLD}
+            ).scalar()
+            moved = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE {column} = :n"), {"n": NEW}
+            ).scalar()
+            if left or not moved:
+                stranded.append(f"{table}.{column} (old={left}, new={moved})")
+
+    assert not stranded, (
+        "rename left rows behind — these tables are in AGENT_REFS but were not "
+        f"re-keyed:\n  " + "\n  ".join(stranded)
+    )
+
+
+def test_session_history_specifically_follows_the_rename(sqlite_db):
+    """The reported symptom, pinned on its own.
+
+    A generic sweep can drift (a table that stops being seedable quietly leaves
+    the assertion), so the two tables from the bug report get an explicit test
+    with realistic rows.
+    """
+    from sqlalchemy import text
+
+    from db.engine import get_engine
+    from db.agent_settings.metadata import MetadataMixin
+
+    with get_engine().begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users (id, username, role, created_at, updated_at) "
+                "VALUES (1, 'admin', 'admin', 'now', 'now')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO agent_ownership (agent_name, owner_id, created_at) "
+                "VALUES (:n, 1, 'now')"
+            ),
+            {"n": OLD},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO agent_sessions (id, agent_name, user_id, user_email, "
+                "started_at, last_message_at) VALUES ('s1', :n, 1, 'a@b.c', 'now', 'now')"
+            ),
+            {"n": OLD},
+        )
+        for i in range(4):
+            conn.execute(
+                text(
+                    "INSERT INTO agent_session_messages (id, session_id, agent_name, "
+                    "user_id, user_email, role, content, timestamp) "
+                    "VALUES (:i, 's1', :n, 1, 'a@b.c', 'user', 'hi', 'now')"
+                ),
+                {"i": f"m{i}", "n": OLD},
+            )
+
+    assert MetadataMixin().rename_agent(OLD, NEW) is True
+
+    with get_engine().begin() as conn:
+        assert conn.execute(
+            text("SELECT COUNT(*) FROM agent_sessions WHERE agent_name = :n"), {"n": NEW}
+        ).scalar() == 1
+        assert conn.execute(
+            text("SELECT COUNT(*) FROM agent_session_messages WHERE agent_name = :n"),
+            {"n": NEW},
+        ).scalar() == 4
+        assert conn.execute(
+            text("SELECT COUNT(*) FROM agent_sessions WHERE agent_name = :n"), {"n": OLD}
+        ).scalar() == 0
+
+
+def test_rename_does_not_maintain_its_own_table_list():
+    """Structural guard: the defect was two lists, so forbid the second one.
+
+    A future edit that re-adds `update(<some_table>)` inside `rename_agent`
+    recreates exactly the drift this issue is about — the behavioural test above
+    would still pass for the tables that edit happens to include.
+    """
+    source = (_BACKEND / "db" / "agent_settings" / "metadata.py").read_text()
+    start = source.index("def rename_agent")
+    end = source.index("\n    def ", start + 10)
+    body = source[start:end]
+
+    assert "cascade_rename(" in body, "rename_agent must derive its tables from AGENT_REFS"
+
+    # `agent_ownership` is legitimately updated here (the row being renamed, plus
+    # the #1664 volume_base_name pin); everything else belongs to the registry.
+    hand_written = {
+        t for t in re.findall(r"update\(([a-z_]+)\)", body) if t != "agent_ownership"
+    }
+    assert not hand_written, (
+        "rename_agent re-grew a private table list: "
+        f"{sorted(hand_written)} — add them to AGENT_REFS instead"
+    )
+
+
+def test_scope_filtered_keys_narrow_deliberately(sqlite_db):
+    """A behaviour change worth stating, not discovering later.
+
+    The old hand-written rename re-keyed EVERY `mcp_api_keys` row carrying the
+    agent's name. The registry declares two scope-filtered refs
+    (`scope='agent'`, `scope='connector'`), so those two follow the rename and a
+    row with any other scope does not.
+
+    That is deliberate: `cascade_delete` already used exactly these filters, so
+    honouring them in rename is what makes the two paths one rule. A user- or
+    system-scoped key is not per-agent — the column is provenance, not
+    ownership. Pinning it here so the narrowing stays a decision.
+    """
+    from sqlalchemy import text
+
+    from db.engine import get_engine
+    from db.agent_settings.metadata import MetadataMixin
+
+    with get_engine().begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users (id, username, role, created_at, updated_at) "
+                "VALUES (1, 'admin', 'admin', 'now', 'now')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO agent_ownership (agent_name, owner_id, created_at) "
+                "VALUES (:n, 1, 'now')"
+            ),
+            {"n": OLD},
+        )
+        for key_id, scope in (("k-agent", "agent"), ("k-conn", "connector"), ("k-user", "user")):
+            conn.execute(
+                text(
+                    "INSERT INTO mcp_api_keys (id, name, key_prefix, key_hash, "
+                    "created_at, user_id, agent_name, scope) "
+                    "VALUES (:i, :i, 'tk_', :i, 'now', 1, :n, :s)"
+                ),
+                {"i": key_id, "n": OLD, "s": scope},
+            )
+
+    assert MetadataMixin().rename_agent(OLD, NEW) is True
+
+    with get_engine().begin() as conn:
+        moved = {
+            row[0]
+            for row in conn.execute(
+                text("SELECT id FROM mcp_api_keys WHERE agent_name = :n"), {"n": NEW}
+            ).all()
+        }
+    assert moved == {"k-agent", "k-conn"}, (
+        "agent- and connector-scoped keys must follow the rename (a leaked "
+        "connector snippet must not reach a future same-name agent)"
+    )


### PR DESCRIPTION
## What

`rename_agent` now derives its table list from `db.agent_cleanup.AGENT_REFS` — the registry the delete path already used — instead of maintaining a second, hand-written one.

Related to #1819 (rename half; see "Not in this PR" below)

## The bug is bigger than the title

The issue reports two stranded tables. Measured against this schema, the rename list had fallen **23 tables** behind the registry:

```
registry (AGENT_REFS): 41 tables
rename (hand-written): 19 tables

not re-keyed by rename: agent_sessions, agent_session_messages, agent_reminders,
agent_loops, agent_notifications, agent_events, agent_event_subscriptions,
operator_queue, access_requests, agent_sync_state, agent_compatibility_results,
agent_dashboard_cache, public_user_memory, nevermined_agent_config,
nevermined_payment_log, subscription_rate_limit_events, slack_channel_agents,
slack_active_threads, telegram_bindings, whatsapp_bindings, voip_bindings,
voip_call_logs, enterprise_connectors
```

So renaming an agent also stranded its reminders, its operator-queue items, and its Telegram / WhatsApp / VoIP / Slack bindings — not just Session-tab history.

**`cascade_rename` already existed**, registry-driven and complete, with **zero callers**. It was written for exactly this and never wired in. That is the same dead-mechanism shape as `register_agent_owned_table` (noted in the issue thread).

## Why this is safe to switch

Checked before replacing anything: **every table the hand-written path touched is already in the registry** — the hand list was a strict subset, so nothing loses coverage. `cascade_rename` skips absent tables (`_table_exists`) and handles the multi-column refs (`agent_permissions.source_agent`/`.target_agent`, the event-subscription pair) that the old code spelled out twice.

`agent_ownership` stays hand-written here: it is the row being renamed, and it carries the #1664 `volume_base_name` pin that must move in the same statement.

## One deliberate behaviour change

The old code re-keyed **every** `mcp_api_keys` row carrying the agent's name. The registry declares two scope-filtered refs (`scope='agent'`, `scope='connector'`), so a user- or system-scoped row no longer follows a rename.

That is the point rather than a side effect — `cascade_delete` already used exactly those filters, and honouring them in rename is what makes the two paths one rule. Those scopes carry `agent_name` as provenance, not ownership. Pinned by `test_scope_filtered_keys_narrow_deliberately` so it stays a decision.

## Tests

`tests/unit/test_1819_rename_cascade_parity.py` — 4 cases, **all four fail against the pre-fix code**:

| test | guards |
|---|---|
| `test_rename_rekeys_every_registered_table` | seeds one row per registered table against the **real schema**, renames, asserts nothing is left behind. Reports what it could not seed, so coverage can't silently shrink |
| `test_session_history_specifically_follows_the_rename` | the reported symptom, with realistic session + 4 message rows |
| `test_scope_filtered_keys_narrow_deliberately` | the mcp_api_keys narrowing above |
| `test_rename_does_not_maintain_its_own_table_list` | structural — a future `update(<table>)` inside `rename_agent` fails CI. This is the drift that caused the bug; the behavioural test alone wouldn't catch a partial re-add |

```
pytest test_agent_cleanup_parity test_1664_renamed_agent_volume_safety \
       test_181_agent_display_label test_1819_rename_cascade_parity
65 passed
```

**Verified live** on a dev instance: an agent with 1 session and 10 reports renamed and back, with `agent_sessions`, `agent_session_messages`, `agent_reports`, `agent_events`, `agent_event_subscriptions`, `operator_queue` and `mcp_api_keys` all showing **0 rows under the old name** afterwards (before the fix, sessions stayed behind).

## Not in this PR

**The rooms dark-mode defects** added by the second comment (`NewRoomDialog.vue`, `RoomsRail.vue`, `Sessions.vue` backdrop). Those files exist only on `feature/ent170-sessions-ui` — the rooms components are not on `dev` — so they cannot land on this base. They need their own PR against that branch.

Also unaddressed, and worth its own issue: `EXTRA_AGENT_REFS` / `register_agent_owned_table` still has no callers, so entitled-module tables join neither cascade. This PR keeps the existing `EXTRA_AGENT_REFS` pass intact but cannot populate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
