### PR TITLE
fix(ui): dark-mode contrast in the rooms surface (#1819)

### DIFF
--- a/src/frontend/src/components/rooms/NewRoomDialog.vue
+++ b/src/frontend/src/components/rooms/NewRoomDialog.vue
@@ -1,20 +1,24 @@
 <template>
   <div class="fixed inset-0 z-40 flex items-center justify-center p-4" @click.self="$emit('close')">
-    <div class="absolute inset-0 bg-black/40"></div>
+    <!-- #1819: 40% was translucent enough that the page behind (the empty-state
+         copy in particular) read as stray text floating beside the dialog. A
+         heavier scrim plus a blur separates the layers instead of hiding the
+         page, so the modal still reads as an overlay. -->
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
     <div class="relative w-full max-w-lg rounded-2xl bg-white dark:bg-gray-900 shadow-xl border border-gray-200 dark:border-gray-800 max-h-[90vh] flex flex-col">
       <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-800">
-        <h2 class="text-base font-semibold">New session</h2>
+        <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">New session</h2>
         <p class="text-xs text-gray-400 mt-0.5">Pick agents to work a topic together. You can @mention any of them once the room opens.</p>
       </div>
 
       <div class="px-5 py-4 space-y-4 overflow-y-auto">
         <div>
           <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Name</label>
-          <input v-model="name" type="text" placeholder="Design review" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-3 py-2 focus:ring-2 focus:ring-action-primary-500/40 focus:outline-none" />
+          <input v-model="name" type="text" placeholder="Design review" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm px-3 py-2 focus:ring-2 focus:ring-action-primary-500/40 focus:outline-none" />
         </div>
         <div>
           <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Topic <span class="text-gray-400">(optional)</span></label>
-          <input v-model="topic" type="text" placeholder="What should they work on?" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-3 py-2 focus:ring-2 focus:ring-action-primary-500/40 focus:outline-none" />
+          <input v-model="topic" type="text" placeholder="What should they work on?" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm px-3 py-2 focus:ring-2 focus:ring-action-primary-500/40 focus:outline-none" />
         </div>
 
         <div>
@@ -23,7 +27,7 @@
             <label v-for="a in roster" :key="a.name" class="flex items-center gap-2.5 px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50">
               <input type="checkbox" :value="a.name" v-model="selected" class="rounded text-action-primary-600 focus:ring-action-primary-500" />
               <PortalAvatar :name="a.name" :avatar-url="a.avatar_url" :size="22" />
-              <span class="text-sm truncate">{{ a.name }}</span>
+              <span class="text-sm truncate text-gray-900 dark:text-gray-100">{{ a.name }}</span>
             </label>
             <div v-if="!roster.length" class="px-3 py-4 text-center text-xs text-gray-400">No agents you can access.</div>
           </div>
@@ -32,21 +36,21 @@
         <div class="grid grid-cols-3 gap-3">
           <div>
             <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Max messages</label>
-            <input v-model.number="maxMessages" type="number" min="1" max="500" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-2.5 py-2 focus:outline-none" />
+            <input v-model.number="maxMessages" type="number" min="1" max="500" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 text-sm px-2.5 py-2 focus:outline-none" />
           </div>
           <div>
             <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Max cost $</label>
-            <input v-model.number="maxCost" type="number" min="0" step="0.5" placeholder="—" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-2.5 py-2 focus:outline-none" />
+            <input v-model.number="maxCost" type="number" min="0" step="0.5" placeholder="—" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm px-2.5 py-2 focus:outline-none" />
           </div>
           <div>
             <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">TTL hours</label>
-            <input v-model.number="ttlHours" type="number" min="0" max="168" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-2.5 py-2 focus:outline-none" />
+            <input v-model.number="ttlHours" type="number" min="0" max="168" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 text-sm px-2.5 py-2 focus:outline-none" />
           </div>
         </div>
 
         <div v-if="selected.length > 1">
           <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Scribe <span class="text-gray-400">(optional — records outcomes)</span></label>
-          <select v-model="scribe" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm px-3 py-2 focus:outline-none">
+          <select v-model="scribe" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 text-sm px-3 py-2 focus:outline-none">
             <option :value="null">None</option>
             <option v-for="n in selected" :key="n" :value="n">{{ n }}</option>
           </select>

--- a/src/frontend/src/components/rooms/ParticipantsRail.vue
+++ b/src/frontend/src/components/rooms/ParticipantsRail.vue
@@ -1,7 +1,7 @@
 <template>
   <aside class="hidden lg:flex flex-col h-full w-64 shrink-0 bg-gray-50 dark:bg-gray-950 border-l border-gray-200 dark:border-gray-800">
     <div class="shrink-0 px-4 h-14 flex items-center border-b border-gray-200 dark:border-gray-800">
-      <span class="text-sm font-semibold">Participants</span>
+      <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">Participants</span>
       <span class="ml-2 text-xs text-gray-400">{{ participants.length }}</span>
     </div>
 
@@ -18,7 +18,7 @@
         </div>
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-1.5">
-            <span class="text-sm truncate">{{ p.kind === 'user' ? p.identity : p.identity }}</span>
+            <span class="text-sm truncate text-gray-900 dark:text-gray-100">{{ p.kind === 'user' ? p.identity : p.identity }}</span>
             <span v-if="p.role !== 'member'" class="text-[10px] text-gray-400">{{ p.role }}</span>
           </div>
           <div class="text-[11px] text-gray-400">{{ p.kind === 'user' ? 'Human' : 'Agent' }}</div>

--- a/src/frontend/src/components/rooms/RoomComposer.vue
+++ b/src/frontend/src/components/rooms/RoomComposer.vue
@@ -29,7 +29,7 @@
         v-model="text"
         rows="1"
         placeholder="Message the room…  @mention an agent to wake it"
-        class="w-full resize-none rounded-xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm px-3 py-2.5 pr-12 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
+        class="w-full resize-none rounded-xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm px-3 py-2.5 pr-12 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
         @input="onInput"
         @keydown="onKeydown"
       ></textarea>

--- a/src/frontend/src/components/rooms/RoomsRail.vue
+++ b/src/frontend/src/components/rooms/RoomsRail.vue
@@ -40,7 +40,7 @@
             :class="r.status === 'open' ? 'bg-status-success-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"
             :title="r.status === 'open' ? 'Active' : `Closed — ${r.stop_reason || 'ended'}`"
           ></span>
-          <span class="text-sm font-medium truncate flex-1">{{ r.name }}</span>
+          <span class="text-sm font-medium truncate flex-1 text-gray-900 dark:text-gray-100">{{ r.name }}</span>
         </div>
         <div v-if="r.topic" class="ml-4 text-xs text-gray-400 truncate">{{ r.topic }}</div>
         <div class="ml-4 mt-1 flex items-center gap-3 text-[11px] text-gray-400">


### PR DESCRIPTION
The rooms half of #1819. The dev-based PR (#1848) cannot carry it: `RoomsRail.vue`, `NewRoomDialog.vue` and the rest of `components/rooms/` exist only on `feature/ent170-sessions-ui`, so this targets that branch instead.

## What was wrong

Four components inherit body colour instead of declaring their own. In dark mode that resolves to near-black text on a near-black surface.

| Component | Symptom |
|---|---|
| `RoomsRail.vue` | Session **name** invisible. Its subtitle and counts declare `text-gray-400`, so they stayed readable — the rail looked like blank rows with metadata under them. |
| `NewRoomDialog.vue` | "New session" heading, agent-picker names, and the Name / Topic / Max messages / Max cost / TTL fields. Typed values were the worst of it — you could not read what you had entered. |
| `ParticipantsRail.vue` | Heading + participant identities. **Not named in the issue.** |
| `RoomComposer.vue` | Textarea text + placeholder. **Not named in the issue.** |

The last two carry the same omission and sit one strip and one textarea from the dialog. Fixing the reported three and leaving these would have shipped the same bug in the same view, so they are in.

Second half of the report — the backdrop — moves from `bg-black/40` to `bg-black/60 backdrop-blur-sm`. At 40% the page behind stayed legible through the scrim and the transcript empty-state copy read as stray text floating beside the dialog (visible at the right edge of the before shot). The blur separates the layers without hiding the page, so the modal still reads as an overlay rather than a new screen.

## Fix

Every control declares text + placeholder colour for both themes rather than relying on inheritance. No structural, layout or logic change — `git diff` is class attributes plus one comment.

`Sessions.vue` is **not** touched: the backdrop lives inside the dialog, so the fix lands there. That also keeps this clear of in-flight work on that file.

## Verification

Live dark mode on local dev, admin/admin, `localStorage['trinity-theme']='dark'` + `prefers-color-scheme: dark`, 6 rooms seeded.

| | Path |
|---|---|
| Before | `/tmp/claude-1000/-home-oleksii-Desktop-abilityai-trinity/6e6de766-392c-4cd1-bece-cab147416521/scratchpad/rooms-before.png` |
| After (dialog) | `…/scratchpad/rooms-after.png` |
| After (rail, dialog closed) | `…/scratchpad/rooms-rail-after.png` |

Before shows all four defects at once: unreadable rail names, a barely-visible heading, dark-on-dark `60` / `—` / `24`, and the "session" fragment bleeding through the backdrop. After shows each readable. The rail needs its own shot because the heavier scrim correctly dims it while the dialog is open.

## Scope

Front-end only, `src/frontend/src/components/rooms/` (4 files, +17/-13). No backend, no schema, no API, no test change — this is a Tailwind class defect with no behaviour to assert on.

Related to #1819