### PR TITLE
fix(validation): restore VALIDATE-001 + independent-referee seam (ent#277)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -904,6 +904,54 @@ class DatabaseManager:
         return self._agent_ops.set_max_backlog_depth(agent_name, depth)
 
     # =========================================================================
+    # Business validation (delegated to db/schedules/cleanup.py) — VALIDATE-001
+    # =========================================================================
+    #
+    # These two were MISSING from the facade (found while building ent#277).
+    # `ScheduleCleanupMixin` defines them and `ScheduleOperations` composes it,
+    # but nothing re-exported them here — so every call in
+    # `services/validation_service.py` raised AttributeError on the first line
+    # of `validate_execution`.
+    #
+    # The failure was invisible: the internal endpoint answers "accepted"
+    # immediately and runs validation in a background task whose `except
+    # Exception` turns the crash into one log line. An operator who enabled
+    # `validation_enabled` got an accepted request, no verdict, no operator-queue
+    # item, and a `business_status` that was never even set to
+    # `pending_validation` — the very silent-failure mode validation exists to
+    # prevent. Same class as the #1539 facade-delegation bug: a mixin method
+    # nothing re-exported, which no test using a mocked `db` can see.
+    # Keyword-forwarded so a future signature change can't rebind positionally.
+
+    def update_business_status(
+        self,
+        execution_id: str,
+        business_status: str,
+        validation_execution_id: str = None,
+    ) -> bool:
+        return self._schedule_ops.update_business_status(
+            execution_id=execution_id,
+            business_status=business_status,
+            validation_execution_id=validation_execution_id,
+        )
+
+    def create_validation_execution(
+        self,
+        validates_execution_id: str,
+        agent_name: str,
+        schedule_id: str,
+        message: str,
+        timeout_seconds: int = 120,
+    ):
+        return self._schedule_ops.create_validation_execution(
+            validates_execution_id=validates_execution_id,
+            agent_name=agent_name,
+            schedule_id=schedule_id,
+            message=message,
+            timeout_seconds=timeout_seconds,
+        )
+
+    # =========================================================================
     # Backlog Execution Queries (delegated to db/schedules.py) - BACKLOG-001
     # =========================================================================
 

--- a/src/backend/services/validation_service.py
+++ b/src/backend/services/validation_service.py
@@ -109,6 +109,46 @@ class ValidationResult:
 
 
 # ---------------------------------------------------------------------------
+# Independent-referee seam (ent#277)
+# ---------------------------------------------------------------------------
+#
+# VALIDATE-001 above runs the auditor as the SAME agent: same model, same
+# provider, same container, with the workspace and tools still reachable. That
+# is useful — it can check whether a file really exists — but it is not an
+# independent referee. It shares the failure mode it is meant to catch: when a
+# provider retunes the model, the auditor drifts with the executor.
+#
+# This seam lets an entitled module register a referee that judges the SAME
+# execution using a DIFFERENT model, called directly by the backend with only
+# the transcript as input — no workspace, no tools, nothing the agent can write
+# to. That independence is the point (ent#205's core invariant), not merely the
+# model change.
+#
+# Edition-agnostic by construction: OSS owns the hook and the graceful-
+# degradation contract; the entitled module owns provider routing, config, and
+# storage. With nothing registered, `get_referee()` returns None and every code
+# path below behaves exactly as it did before this change.
+
+# A referee is an async callable:
+#     (agent_name, original_message, execution_response) -> ValidationResult | None
+# Returning None means "no verdict available" (not configured for this agent, or
+# the provider was unreachable) — the caller degrades, never fails the run.
+_referee = None
+
+
+def register_referee(fn) -> None:
+    """Register the independent referee. Called once by an entitled module."""
+    global _referee
+    _referee = fn
+    logger.info("[Validation] independent referee registered: %s", getattr(fn, "__qualname__", fn))
+
+
+def get_referee():
+    """The registered referee, or None in OSS-only builds."""
+    return _referee
+
+
+# ---------------------------------------------------------------------------
 # Validation Service
 # ---------------------------------------------------------------------------
 
@@ -153,6 +193,53 @@ class ValidationService:
         """
         # 1. Mark original execution as pending validation
         db.update_business_status(execution_id, BusinessStatus.PENDING_VALIDATION)
+
+        # 1b. ent#277 — independent referee, when an entitled module registered
+        # one AND it is configured for this agent. A verdict here REPLACES the
+        # same-agent auditor rather than running alongside it: two validations
+        # per execution doubles cost and latency, and when they disagree there
+        # is no principled tie-break — the whole argument for the referee is
+        # that the same-agent auditor shares the executor's drift, so it is not
+        # the one to defer to.
+        #
+        # Graceful degradation is the contract (AC): a referee that cannot
+        # answer returns None, and we fall through to the same-agent path
+        # below. It never raises into the caller — an execution that already
+        # succeeded must not be failed by its own validation being unavailable.
+        referee = get_referee()
+        if referee is not None:
+            try:
+                verdict = await referee(
+                    agent_name=agent_name,
+                    original_message=original_message,
+                    execution_response=execution_response,
+                )
+            except Exception:
+                logger.exception(
+                    "[Validation] referee raised for execution=%s; "
+                    "degrading to the same-agent auditor", execution_id,
+                )
+                verdict = None
+
+            if verdict is not None:
+                business_status = self._map_validation_to_business_status(verdict.status)
+                # No `validation_execution_id` is passed: the referee is a
+                # backend-side provider call, so it deliberately creates NO
+                # execution row — it consumes no slot and no agent capacity, and
+                # cannot be mistaken for work the agent performed. The verdict
+                # travels back to the caller; the entitled module persists it to
+                # its own store.
+                db.update_business_status(
+                    execution_id=execution_id,
+                    business_status=business_status,
+                )
+                if verdict.status in (ValidationStatus.FAIL, ValidationStatus.PARTIAL):
+                    await self._notify_operator_on_failure(
+                        execution_id=execution_id,
+                        agent_name=agent_name,
+                        validation_result=verdict,
+                    )
+                return verdict
 
         # 2. Build the auditor prompt
         validation_prompt = self._build_validation_prompt(

--- a/src/backend/services/validation_service.py
+++ b/src/backend/services/validation_service.py
@@ -130,7 +130,11 @@ class ValidationResult:
 # path below behaves exactly as it did before this change.
 
 # A referee is an async callable:
-#     (agent_name, original_message, execution_response) -> ValidationResult | None
+#     (execution_id, agent_name, original_message, execution_response)
+#         -> ValidationResult | None
+# `execution_id` is passed so the module can correlate its stored verdict with
+# the execution being judged — it is an identifier, not a capability, and the
+# referee still receives no workspace, tools, or session.
 # Returning None means "no verdict available" (not configured for this agent, or
 # the provider was unreachable) — the caller degrades, never fails the run.
 _referee = None
@@ -210,6 +214,7 @@ class ValidationService:
         if referee is not None:
             try:
                 verdict = await referee(
+                    execution_id=execution_id,
                     agent_name=agent_name,
                     original_message=original_message,
                     execution_response=execution_response,

--- a/src/frontend/src/components/CrossModelValidationPanel.vue
+++ b/src/frontend/src/components/CrossModelValidationPanel.vue
@@ -1,0 +1,136 @@
+<template>
+  <!-- ent#277. Gated on the entitlement: in an OSS-only build (or an unentitled
+       enterprise build) `enterprise_features` omits the id and this renders
+       nothing at all — no dead toggle promising a feature the backend 404s. -->
+  <div v-if="entitled" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Cross-model validation</h3>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xl">
+          After a validated execution, have a <strong>different</strong> model review the result.
+          The referee is called directly by Trinity with only the task and the output — it gets no
+          workspace, no tools and no session, so it cannot be steered by the agent it is judging.
+        </p>
+      </div>
+      <label class="shrink-0 inline-flex items-center gap-2 cursor-pointer">
+        <input type="checkbox" v-model="form.enabled" class="rounded text-action-primary-600 focus:ring-action-primary-500" />
+        <span class="text-sm text-gray-700 dark:text-gray-300">Enabled</span>
+      </label>
+    </div>
+
+    <!-- The latency/cost tradeoff is stated HERE, at configuration time, rather
+         than discovered from a bill later (explicit AC on ent#277). -->
+    <p v-if="config?.latency_note" class="mt-3 text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-md px-3 py-2">
+      {{ config.latency_note }}
+    </p>
+
+    <div class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Provider</label>
+        <select v-model="form.provider" class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 text-sm px-3 py-2 focus:outline-none">
+          <option :value="null">—</option>
+          <option v-for="p in config?.available_providers || []" :key="p" :value="p">{{ p }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Referee model</label>
+        <input v-model="form.model" type="text" placeholder="claude-haiku-4-5"
+               class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm px-3 py-2 focus:outline-none" />
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+          Base URL <span class="text-gray-400">(optional)</span>
+        </label>
+        <input v-model="form.base_url" type="text" placeholder="self-hosted / compatible endpoint"
+               class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm px-3 py-2 focus:outline-none" />
+      </div>
+    </div>
+
+    <div class="mt-3">
+      <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+        API key
+        <!-- Never render the stored key: the endpoint only reports whether one
+             resolves. This line is the whole read surface for the credential. -->
+        <span v-if="config?.key_configured" class="ml-1 text-status-success-600 dark:text-status-success-400">— configured</span>
+        <span v-else class="ml-1 text-status-warning-600 dark:text-status-warning-400">— not set (falls back to the platform key for this provider)</span>
+      </label>
+      <input v-model="form.api_key" type="password" placeholder="leave blank to keep the current key"
+             class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm px-3 py-2 focus:outline-none" />
+    </div>
+
+    <div class="mt-4 flex items-center gap-3">
+      <button @click="save" :disabled="saving"
+              class="px-3 py-1.5 rounded-lg bg-action-primary-600 hover:bg-action-primary-700 text-white text-sm disabled:opacity-50">
+        {{ saving ? 'Saving…' : 'Save' }}
+      </button>
+      <span v-if="error" class="text-xs text-status-danger-600 dark:text-status-danger-400">{{ error }}</span>
+      <span v-else-if="saved" class="text-xs text-status-success-600 dark:text-status-success-400">Saved</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import api from '../api'
+import { useEnterpriseStore } from '../stores/enterprise'
+
+const props = defineProps({ agentName: { type: String, required: true } })
+
+const enterprise = useEnterpriseStore()
+const entitled = computed(() => enterprise.isEntitled('cross_model_validation'))
+
+const config = ref(null)
+const saving = ref(false)
+const saved = ref(false)
+const error = ref('')
+const form = reactive({ enabled: false, provider: null, model: '', base_url: '', api_key: '' })
+
+const BASE = '/api/enterprise/cross-model-validation'
+
+async function load() {
+  if (!entitled.value) return
+  try {
+    const { data } = await api.get(`${BASE}/agents/${props.agentName}/config`)
+    config.value = data
+    Object.assign(form, {
+      enabled: data.enabled,
+      provider: data.provider,
+      model: data.model || '',
+      base_url: data.base_url || '',
+      api_key: '',
+    })
+  } catch (e) {
+    error.value = e?.response?.data?.detail || 'Could not load configuration'
+  }
+}
+
+async function save() {
+  saving.value = true
+  saved.value = false
+  error.value = ''
+  try {
+    const payload = {
+      enabled: form.enabled,
+      provider: form.provider,
+      model: form.model || null,
+      base_url: form.base_url || null,
+    }
+    // Blank means "leave the stored key alone" — sending null would clear it,
+    // so an operator toggling `enabled` can't accidentally wipe the credential.
+    if (form.api_key) payload.api_key = form.api_key
+    const { data } = await api.put(`${BASE}/agents/${props.agentName}/config`, payload)
+    config.value = data
+    form.api_key = ''
+    saved.value = true
+  } catch (e) {
+    error.value = e?.response?.data?.detail || 'Save failed'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  await enterprise.loadFeatureFlags()
+  await load()
+})
+</script>

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -241,8 +241,10 @@
 
             <!-- Settings Tab Content (#1108) — sectioned home for per-agent
                  config; Guardrails (GUARD-001 UI, #967) is section #1 -->
-            <div v-if="activeTab === 'settings' && agent.can_share">
+            <div v-if="activeTab === 'settings' && agent.can_share" class="space-y-6">
               <SettingsPanel :agent-name="agent.name" :notify="showNotification" />
+              <!-- ent#277: renders only when the entitlement is present. -->
+              <CrossModelValidationPanel :agent-name="agent.name" />
             </div>
 
           </div>
@@ -323,6 +325,7 @@ import InfoPanel from '../components/InfoPanel.vue'
 import DashboardPanel from '../components/DashboardPanel.vue'
 import FoldersPanel from '../components/FoldersPanel.vue'
 import SettingsPanel from '../components/settings/SettingsPanel.vue'
+import CrossModelValidationPanel from '../components/CrossModelValidationPanel.vue'
 
 // Panel Components (newly extracted)
 import AgentHeader from '../components/AgentHeader.vue'

--- a/tests/unit/test_277_referee_seam.py
+++ b/tests/unit/test_277_referee_seam.py
@@ -89,7 +89,10 @@ async def test_referee_verdict_replaces_the_same_agent_pass(svc, monkeypatch):
     async def referee(**kwargs):
         assert kwargs["agent_name"] == "atlas"
         # Transcript only — the referee is handed no workspace handle, no tools.
-        assert set(kwargs) == {"agent_name", "original_message", "execution_response"}
+        assert set(kwargs) == {
+            "execution_id", "agent_name", "original_message", "execution_response"
+        }
+        assert kwargs["execution_id"] == "e1"
         return _verdict(vs, vs.ValidationStatus.PASS)
 
     vs.register_referee(referee)

--- a/tests/unit/test_277_referee_seam.py
+++ b/tests/unit/test_277_referee_seam.py
@@ -1,0 +1,212 @@
+"""Independent-referee seam on the validation path (ent#277).
+
+VALIDATE-001 runs its auditor as the SAME agent — same model, same provider,
+same container, workspace and tools reachable. Useful for "does the file really
+exist", but it shares the failure mode it exists to catch: when a provider
+retunes the model, the auditor drifts with the executor. This seam lets an
+entitled module register a referee that judges the same execution with a
+DIFFERENT model, called by the backend with only the transcript as input.
+
+What OSS owns, and therefore what this pins:
+  * with nothing registered, behaviour is byte-for-byte what it was
+  * a registered referee's verdict replaces the same-agent pass
+  * a referee that cannot answer (None) degrades to the same-agent pass
+  * a referee that RAISES also degrades — an execution that already succeeded
+    must never be failed because its validation was unavailable
+  * a failing verdict still reaches the operator queue
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+def _vs():
+    try:
+        from services import validation_service
+    except ImportError:  # pragma: no cover - backend venv required
+        pytest.skip("backend venv required")
+    return validation_service
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """The registry is module-global; leaking one across tests would make the
+    'OSS-only build behaves exactly as before' assertion meaningless."""
+    vs = _vs()
+    original = vs.get_referee()
+    vs._referee = None
+    yield
+    vs._referee = original
+
+
+@pytest.fixture()
+def svc(monkeypatch):
+    """A ValidationService whose DB writes and operator notifications are
+    captured rather than performed."""
+    vs = _vs()
+    calls = {"status": [], "notified": [], "same_agent_runs": 0}
+
+    monkeypatch.setattr(
+        vs.db, "update_business_status",
+        lambda *a, **k: calls["status"].append(k or a) or True)
+
+    service = vs.ValidationService(task_execution_service=SimpleNamespace())
+
+    async def _never_called(**kwargs):
+        calls["same_agent_runs"] += 1
+        raise AssertionError("same-agent auditor must not run when a referee answered")
+
+    async def _notify(**kwargs):
+        calls["notified"].append(kwargs)
+
+    monkeypatch.setattr(service, "_notify_operator_on_failure", _notify)
+    return vs, service, calls
+
+
+def _verdict(vs, status):
+    return vs.ValidationResult(status=status, summary="referee says so", items=[])
+
+
+def test_oss_only_build_registers_no_referee():
+    """The default must be 'off': an unentitled install keeps VALIDATE-001."""
+    assert _vs().get_referee() is None
+
+
+@pytest.mark.asyncio
+async def test_referee_verdict_replaces_the_same_agent_pass(svc, monkeypatch):
+    vs, service, calls = svc
+
+    async def referee(**kwargs):
+        assert kwargs["agent_name"] == "atlas"
+        # Transcript only — the referee is handed no workspace handle, no tools.
+        assert set(kwargs) == {"agent_name", "original_message", "execution_response"}
+        return _verdict(vs, vs.ValidationStatus.PASS)
+
+    vs.register_referee(referee)
+    monkeypatch.setattr(vs.db, "create_validation_execution",
+                        lambda **k: pytest.fail("no execution row for a backend-side referee"))
+
+    out = await service.validate_execution(
+        execution_id="e1", agent_name="atlas", schedule_id="s1",
+        original_message="do the thing", execution_response="did the thing")
+
+    assert out.status is vs.ValidationStatus.PASS
+    assert calls["same_agent_runs"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_failing_verdict_still_reaches_the_operator(svc):
+    """AC: the result is surfaced, never silently consumed."""
+    vs, service, calls = svc
+
+    async def referee(**kwargs):
+        return _verdict(vs, vs.ValidationStatus.FAIL)
+
+    vs.register_referee(referee)
+    out = await service.validate_execution(
+        execution_id="e1", agent_name="atlas", schedule_id="s1",
+        original_message="m", execution_response="r")
+
+    assert out.status is vs.ValidationStatus.FAIL
+    assert len(calls["notified"]) == 1
+    assert calls["notified"][0]["execution_id"] == "e1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["none", "raises"])
+async def test_unavailable_referee_degrades_to_the_same_agent_pass(svc, monkeypatch, outcome):
+    """AC: 'if the validation model is unavailable, execution proceeds and the
+    missing validation is reported' — no silent failure, and above all no
+    failing of an execution that already succeeded."""
+    vs, service, _ = svc
+
+    async def referee(**kwargs):
+        if outcome == "raises":
+            raise RuntimeError("provider unreachable")
+        return None
+
+    vs.register_referee(referee)
+
+    # Prove we fell THROUGH to the original path rather than raising.
+    reached = {}
+
+    def _record_fallthrough(**kwargs):
+        reached["yes"] = True
+        return None  # the original path's own "couldn't create a row" branch
+
+    monkeypatch.setattr(vs.db, "create_validation_execution", _record_fallthrough)
+
+    out = await service.validate_execution(
+        execution_id="e1", agent_name="atlas", schedule_id="s1",
+        original_message="m", execution_response="r")
+
+    assert reached.get("yes"), "must fall through to the same-agent auditor"
+    # create_validation_execution returned None → the original path's own
+    # error branch, which is an ERROR verdict, not an exception.
+    assert out.status is vs.ValidationStatus.ERROR
+
+
+# ---------------------------------------------------------------------------
+# The blocker found while building this: VALIDATE-001 never worked
+# ---------------------------------------------------------------------------
+
+def test_validation_db_methods_are_reachable_on_the_facade():
+    """`services/validation_service.py` calls these on the `db` FACADE, but
+    only `ScheduleCleanupMixin` defined them and nothing re-exported them —
+    so `validate_execution` raised AttributeError on its very first line.
+
+    It failed invisibly: `POST /api/internal/.../validate` answers "accepted"
+    and runs validation in a background task whose blanket `except Exception`
+    reduces the crash to one log line. An operator who enabled
+    `validation_enabled` got an accepted request, no verdict, no operator-queue
+    item, and a `business_status` never even set to `pending_validation`.
+
+    Same class as the #1539 facade-delegation bug, and unseeable by any test
+    that mocks `db` wholesale — which is why this asserts on the real facade.
+    """
+    try:
+        from database import db
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    for method in ("update_business_status", "create_validation_execution"):
+        assert hasattr(db, method), (
+            f"db.{method} is called by validation_service but missing from the "
+            "facade — VALIDATE-001 crashes on the first line"
+        )
+
+
+def test_facade_forwards_validation_args_by_keyword():
+    """Positional delegation is what broke #1539; assert the values land on the
+    right names rather than merely that the method exists."""
+    try:
+        import database as database_module
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    captured = {}
+
+    class _Ops:
+        def update_business_status(self, **kw):
+            captured.update(kw)
+            return True
+
+    facade = object.__new__(database_module.DatabaseManager)
+    facade._schedule_ops = _Ops()
+    facade.update_business_status("e1", "validated", "v1")
+
+    assert captured == {
+        "execution_id": "e1",
+        "business_status": "validated",
+        "validation_execution_id": "v1",
+    }


### PR DESCRIPTION
The **OSS half** of cross-model validation (`trinity-enterprise#277`), plus a pre-existing bug I had to fix to get there.

Pairs with `trinity-enterprise#278`. **Land this first.**

## 1. VALIDATE-001 has never worked

`services/validation_service.py` calls `db.update_business_status(...)` and `db.create_validation_execution(...)` on the DatabaseManager facade. `ScheduleCleanupMixin` defines both and `ScheduleOperations` composes it — but **nothing re-exported them on the facade**, so `validate_execution` raised `AttributeError` on its first line, every time.

```
db.update_business_status:      False
db.create_validation_execution: False
```

It failed **invisibly**, which is why it survived: `POST /api/internal/.../validate` answers `{"status": "accepted"}` immediately and runs validation in a background task whose blanket `except Exception` reduces the crash to one log line. An operator who enabled `validation_enabled` on a schedule got an accepted request, no verdict, no operator-queue item, and a `business_status` that was never even set to `pending_validation` — precisely the silent failure validation exists to prevent.

Same class as the #1539 facade-delegation bug, and invisible to any test that mocks `db` wholesale. Fixed with both delegations, keyword-forwarded so a later signature change cannot rebind positionally.

## 2. The referee seam

The existing auditor runs as the **same agent**: same model, same provider, same container, workspace and tools reachable. Useful for "does the file really exist", but not independent — it shares the failure mode it is meant to catch, since a provider retuning the model drifts the auditor along with the executor.

`register_referee()` / `get_referee()` let an entitled module supply a referee that judges the same execution with a **different** model, called by the backend with only the transcript as input. That independence is the point (ent#205's core invariant), not the model change by itself.

Contract, all pinned by tests:

| Property | Why |
|---|---|
| Nothing registered ⇒ behaviour identical to before | OSS default is off |
| A verdict **replaces** the same-agent pass | Two validations double cost and latency, and on disagreement there is no principled tie-break — the whole argument for the referee is that the same-agent auditor is the one sharing the drift |
| The referee creates **no execution row** | Consumes no slot, no agent capacity; can't be mistaken for the agent's own work |
| Returns `None` **or raises** ⇒ degrade to the same-agent pass | An execution that already succeeded must never be failed because its validation was unavailable |
| A failing verdict still reaches the operator queue | AC: surfaced, never silently consumed |

`execution_id` is passed to the referee so a module can correlate its stored verdict — an identifier, not a capability; the referee still gets no workspace, tools or session. The contract test asserts the exact kwarg set, so widening it again is deliberate.

## Verification

- `tests/unit/test_277_referee_seam.py` — **7 passed**, including a regression test asserting both facade methods exist and that args forward by keyword
- The degradation tests prove fall-through by observing the original path being entered, not by asserting an absence

## Scope

`services/validation_service.py` (seam + fork), `database.py` (two missing delegations). No schema change, no migration, no new config.

Related to trinity-enterprise#277