### PR TITLE
fix(canary): wire CANARY_ENABLED/_SLACK_WEBHOOK_URL into prod backend env

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -247,6 +247,19 @@ services:
       # packaging-gap class).
       - TELEMETRY_CONTAINER_STATS_TTL=${TELEMETRY_CONTAINER_STATS_TTL:-10}
       - TELEMETRY_DOCKER_POOL_SIZE=${TELEMETRY_DOCKER_POOL_SIZE:-16}
+      # Canary invariant harness (CANARY-001 / Issue #411). Mirrors
+      # docker-compose.yml; without these lines the .env knobs are inert in prod
+      # (the #1039 packaging-gap class). Load-bearing here specifically: the
+      # harness is documented as "CANARY_ENABLED=1 on staging/dev", and the dev
+      # instance deploys via THIS file (.github/workflows/deploy-dev.yml,
+      # scripts/deploy/gcp-deploy.sh) — so omitting them made the watcher
+      # un-enableable on the very instance it exists to watch.
+      # Default 0 — production users see no canary activity.
+      - CANARY_ENABLED=${CANARY_ENABLED:-0}
+      # Slack alert sink for canary green→red transitions. URL is the
+      # credential — leaking it lets anyone post to that one channel.
+      # Unset = canary cycles run silently (still persists violations).
+      - CANARY_SLACK_WEBHOOK_URL=${CANARY_SLACK_WEBHOOK_URL:-}
       # SSH access host override (read by services/ssh_service.py). Mirrors
       # docker-compose.yml; without this line the .env value is inert in prod (the
       # #1039 packaging-gap class) and SSH host detection falls back to localhost.

--- a/tests/unit/test_canary_env_prod_parity.py
+++ b/tests/unit/test_canary_env_prod_parity.py
@@ -1,0 +1,123 @@
+"""Regression guard: the canary env knobs must reach the backend in BOTH composes.
+
+Bug: `CANARY_ENABLED` / `CANARY_SLACK_WEBHOOK_URL` were wired into
+`docker-compose.yml` only. Every deploy path uses `docker-compose.prod.yml`
+(`.github/workflows/deploy-dev.yml`, `scripts/deploy/gcp-deploy.sh`), and prod
+compose launches **standalone** — no base-compose merge and no `env_file:` on any
+service — so the explicit `environment:` list is the only path into the
+container. A `CANARY_ENABLED=1` in the deployed `.env` was interpolated into
+nothing and silently dropped, leaving the CANARY-001 harness (#411)
+un-enableable on the very instance it exists to watch.
+
+This is the #1039/#1056 packaging-gap class: a documented `.env` lever that
+silently does nothing. It has now recurred five times (#1056 `VOIP_*`,
+trinity-enterprise#31 `LOG_*`, #1039, #1871 `AGENT_LOG_*`, and this), so the
+fix is pinned rather than trusted — deleting the compose lines must fail CI,
+not pass silently.
+
+Shape mirrors `test_1076_voice_model_config.py::test_compose_default_is_non_empty`,
+the existing precedent for guarding a compose injection against a silent revert.
+
+Lives under tests/unit/ so the CI unit job (`cd tests && pytest unit/`) collects
+it — a guard must run where the bug would regress.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# tests/unit/<this file> → parent=tests/unit, .parent=tests, .parent=repo root
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_COMPOSE_FILES = ["docker-compose.yml", "docker-compose.prod.yml"]
+
+# (var, the OFF default the injection must carry)
+_CANARY_VARS = [
+    ("CANARY_ENABLED", "0"),
+    ("CANARY_SLACK_WEBHOOK_URL", ""),
+]
+
+
+def _injection_lines(compose_file: str, var: str) -> list[str]:
+    """Uncommented `- VAR=${VAR:-…}` lines for `var` in `compose_file`."""
+    text = (_REPO_ROOT / compose_file).read_text(encoding="utf-8")
+    return [
+        ln
+        for ln in text.splitlines()
+        if f"{var}=${{{var}:-" in ln and not ln.strip().startswith("#")
+    ]
+
+
+@pytest.mark.parametrize("compose_file", _COMPOSE_FILES)
+@pytest.mark.parametrize("var,_default", _CANARY_VARS)
+def test_canary_var_is_injected(compose_file, var, _default):
+    """Both canary knobs must be injected in BOTH compose files.
+
+    The prod file is the load-bearing one: it is what every deploy path uses,
+    so an omission there makes the knob inert on every real instance while
+    still working on a developer's laptop — which is exactly how this shipped
+    unnoticed for ~2.5 months.
+    """
+    lines = _injection_lines(compose_file, var)
+    assert lines, (
+        f"{compose_file}: no `{var}=${{{var}:-…}}` injection under "
+        f"backend.environment. Without it the .env lever is INERT on any deploy "
+        f"using this file (the #1039/#1056 packaging-gap class)."
+    )
+
+
+@pytest.mark.parametrize("compose_file", _COMPOSE_FILES)
+@pytest.mark.parametrize("var,default", _CANARY_VARS)
+def test_canary_default_stays_off(compose_file, var, default):
+    """Presence must not mean enabled.
+
+    `.env.example` promises "Production stays 0": wiring the var in is what
+    makes the documented staging/dev workflow reachable, and the OFF default is
+    what keeps production quiet. A future edit that ships `:-1` would silently
+    start a 5-min watcher loop (and its synthetic fleet) on every install.
+    """
+    for ln in _injection_lines(compose_file, var):
+        assert f"${{{var}:-{default}}}" in ln, (
+            f"{compose_file}: `{var}` must default to {default!r} "
+            f"(found: {ln.strip()!r}). Presence is required; enabled-by-default "
+            f"is not — production must stay opt-in."
+        )
+
+
+def test_both_composes_agree():
+    """dev and prod must not drift — the drift IS the bug this file guards."""
+    for var, _ in _CANARY_VARS:
+        per_file = {f: len(_injection_lines(f, var)) for f in _COMPOSE_FILES}
+        assert len(set(per_file.values())) == 1 and 0 not in per_file.values(), (
+            f"{var} is wired inconsistently across compose files: {per_file}. "
+            f"A var present in dev but not prod is inert on every deploy."
+        )
+
+
+def test_guard_would_catch_a_revert():
+    """Meta-test: prove the matcher actually fails on the pre-fix content.
+
+    Without this, a matcher typo would make every assertion above vacuously
+    true and the guard would rot into a no-op.
+    """
+    pre_fix = "    environment:\n      - SECRET_KEY=${SECRET_KEY}\n"
+    assert not [
+        ln
+        for ln in pre_fix.splitlines()
+        if "CANARY_ENABLED=${CANARY_ENABLED:-" in ln and not ln.strip().startswith("#")
+    ], "matcher must find nothing in content that lacks the injection"
+
+    post_fix = "      - CANARY_ENABLED=${CANARY_ENABLED:-0}\n"
+    assert [
+        ln
+        for ln in post_fix.splitlines()
+        if "CANARY_ENABLED=${CANARY_ENABLED:-" in ln and not ln.strip().startswith("#")
+    ], "matcher must find the injection when present"
+
+    commented = "      # - CANARY_ENABLED=${CANARY_ENABLED:-0}\n"
+    assert not [
+        ln
+        for ln in commented.splitlines()
+        if "CANARY_ENABLED=${CANARY_ENABLED:-" in ln and not ln.strip().startswith("#")
+    ], "a commented-out injection must NOT count as wired"


### PR DESCRIPTION
Fixes #1878

## Summary

**The canary invariant harness could not be enabled on any deployed instance.**

`architecture.md` documents it as *"Disabled by default; `CANARY_ENABLED=1` on staging/dev"* — but every deploy path uses `docker-compose.prod.yml` (`.github/workflows/deploy-dev.yml`, `scripts/deploy/gcp-deploy.sh`), and that file never passed the two knobs into `backend.environment:`.

Prod compose launches **standalone** — no base-compose merge, and no `env_file:` on any service in either file — so the explicit `environment:` list is the only path in. A `CANARY_ENABLED=1` in the remote `.env` (which `gcp-deploy.sh` does write) was interpolated into nothing and silently dropped.

Net effect: **epic #411 was closed `COMPLETED` on 2026-07-28 at 53/53 sub-issues**, while the harness it delivered was un-turnable-on on the very instance it exists to watch — and its Slack alert sink was unconfigurable, so even a hand-enabled canary would have been a silent sink. `config/canary-fleet.yaml` targets a running instance's `/api/systems/deploy`, so this was never a laptop-only path.

## Change

Two lines in `docker-compose.prod.yml` `backend.environment:`, mirroring `docker-compose.yml` verbatim. No code change.

## Verification

Same test that proved the bug, with a positive control so the method itself is validated:

```
$ CANARY_ENABLED=1 CANARY_SLACK_WEBHOOK_URL=… VOIP_ENABLED=true \
    docker compose -f docker-compose.prod.yml config

before:  CANARY_ENABLED -> None    CANARY_SLACK_WEBHOOK_URL -> None    VOIP_ENABLED -> 'true'
after:   CANARY_ENABLED -> '1'     CANARY_SLACK_WEBHOOK_URL -> 'https://…'  VOIP_ENABLED -> 'true'
```

- [x] **Additive-safe** — unset resolves to `CANARY_ENABLED='0'` / `CANARY_SLACK_WEBHOOK_URL=''`, so existing installs see no behaviour change
- [x] `docker compose -f docker-compose.prod.yml config` validates
- [x] `docker compose -f docker-compose.prod.yml -f docker-compose.prod.enterprise.yml config` validates (the enterprise overlay layers on prod, so it inherits the fix)
- [x] dev/prod parity now complete for both vars — and these are the **only** two `CANARY_*` vars the backend reads
- [x] No other compose file needs it — `.gitea.yml` is an unrelated overlay; `.override*.yml` and `.sibling.yml` define no `backend` service

## Provenance

Found by an inert-lever audit posted on #1258, written while fixing the **same class** in #1871 (where `/validate-pr` §4.9 caught `AGENT_LOG_MAX_*` before merge). This is the #1039/#1056 packaging-gap class: a documented `.env` lever that silently does nothing.

That audit initially flagged 11 candidates; hand-verification retracted 2 as false positives (`TRINITY_GIT_*`, correctly handled by the `docker-compose.gitea.yml` overlay). **This is the only one that turned out to be a genuine, user-visible defect** — the remaining items are dev-compose parity and a docs deletion, both noted on #1258 rather than filed.

Deliberately no closing keyword: #1258 is an epic and #411 is already closed, so neither should be auto-closed by this PR.

## Not doing here

No CI guard. A naive "every `os.getenv` must be in compose" check fails on 56 pre-existing vars, most legitimately code-default-only. The tractable predicate — *read **and** uncommented in `.env.example` **and** not forwarded by any compose file **including overlays*** — is viable once #1258's short list is burned down; see the audit comment for why the overlay and comment-line cases must both be handled.

Refs #1258
Refs #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## "Was the omission deliberate?" — investigated, no

Fair challenge, since the originating commit's own wording sounds like intent. `.env.example` (added by the same commit `a4eec13`) says:

```
# CANARY INVARIANT HARNESS (Optional, staging/dev)
# Set to 1 on staging/dev to run the 5-min check loop. Production stays 0.
```

Four independent lines of evidence say the *omission from prod compose* was an oversight, not enforcement:

**1. The intent was unachievable from day one.** `.github/workflows/deploy-dev.yml` was created **2026-04-28** already using `docker-compose.prod.yml`. The canary landed **2026-05-10** — 12 days later. So "set to 1 on staging/dev" could never work on the deployed staging/dev instance; the deploy path did not change underneath it. Reading the omission as deliberate enforcement would mean the feature was dead on arrival everywhere, which is incoherent for an epic that also shipped a load-generator fleet manifest and a Slack alert sink.

**2. The same commit shipped another packaging gap.** #751 — *"backend Dockerfile missing COPY for canary/ package (a4eec13 breaks startup)"* — the very same commit omitted a required `COPY`, crashing the backend on boot. That PR demonstrably had packaging blind spots; two is unsurprising.

**3. "Production stays 0" is about the default, and the fix preserves it.** The variable being *present with an OFF default* is not the same as enabled. With both unset, the resolved prod config is still `CANARY_ENABLED='0'` and `CANARY_SLACK_WEBHOOK_URL=''` — verified above. Production users see no canary activity unless they deliberately opt in, exactly as written.

**4. Codebase convention is unambiguous.** `docker-compose.prod.yml` already carries **eight** default-OFF opt-in flags: `WORKSPACE_ENABLED`, `VOIP_ENABLED`, `MCP_AGENT_CHAT_PULL_ENABLED`, `REDELIVERY_GOVERNOR_ENABLED`, `OTEL_ENABLED`, `PUBLIC_ACCESS_REQUESTS_ENABLED`, `DO_NOT_TRACK`, `DISPATCH_ASYNC`. A default-OFF flag belongs in prod compose *with* its OFF default.

**And this exact question has already been adjudicated in this file.** The VOIP block, two lines above where the canary vars now sit:

```
# VoIP telephony (VOIP-001, #1056) — opt-in, default OFF. Default-OFF means
# the master switch MUST reach the container or voip_available stays false;
# omitting it here was the prod packaging gap (same class as #1039 LOG_*).
```

Identical situation, resolved as a packaging gap. This PR applies the same resolution.

---

## Added after `/validate-pr`

**Tracking (W2)** — filed **#1878** as a sub-issue of #1258 and switched to a closing keyword. Without it nothing transitioned `status-in-progress → status-in-dev`, so `/release` (which builds notes from in-dev issues) would have shipped a user-visible fix silently.

**Regression guard (W1)** — `tests/unit/test_canary_env_prod_parity.py`. The fix is two compose lines that nothing asserted: delete them and every test still passed, which is precisely how the original omission survived ~2.5 months and an epic close-out. The guard pins, for **both** compose files and **both** knobs:

- the injection line exists (absence ⇒ the lever is inert on every deploy)
- it defaults to **OFF** (presence must not mean enabled — a future `:-1` would start a 5-min watcher loop *and its synthetic agent fleet* on every install)
- dev and prod agree (the drift **is** the bug)
- plus a meta-test proving the matcher fails on pre-fix content, so a typo can't make the assertions vacuously true

Verified it actually bites: with the fix reverted in-memory, the matcher drops from 1 injection line to 0 and the guard fails. Shape mirrors `test_1076_voice_model_config.py`, the existing precedent for guarding a compose injection against a silent revert.