### PR TITLE
fix: clamp negative duration_ms at every execution writer

### DIFF
--- a/src/backend/db/schedules/executions.py
+++ b/src/backend/db/schedules/executions.py
@@ -366,7 +366,12 @@ class ScheduleExecutionsMixin:
 
             started_at = parse_iso_timestamp(row["started_at"])
             completed_at = parse_iso_timestamp(utc_now_iso())
-            duration_ms = int((completed_at - started_at).total_seconds() * 1000)
+            # started_at and completed_at are written by different processes
+            # (backend --workers 2, and the standalone scheduler container), so
+            # clock skew can make this subtraction negative. Clamp at the write
+            # rather than at every reader — get_agent_analytics consumes
+            # duration_ms unguarded (#1832).
+            duration_ms = max(0, int((completed_at - started_at).total_seconds() * 1000))
 
             values = {
                 "status": status,

--- a/src/scheduler/database.py
+++ b/src/scheduler/database.py
@@ -567,7 +567,10 @@ class SchedulerDatabase:
 
             started_at = parse_scheduler_ts(row["started_at"])
             completed_at = datetime.utcnow()
-            duration_ms = int((completed_at - started_at).total_seconds() * 1000)
+            # Clock skew between the writer of started_at and this process can
+            # make the subtraction negative; clamp so a poisoned duration never
+            # reaches the analytics chart (#1832).
+            duration_ms = max(0, int((completed_at - started_at).total_seconds() * 1000))
 
             cursor.execute("""
                 UPDATE schedule_executions
@@ -1217,7 +1220,10 @@ class SchedulerDatabase:
 
             started_at = parse_scheduler_ts(row["started_at"])
             completed_at = datetime.utcnow()
-            duration_ms = int((completed_at - started_at).total_seconds() * 1000)
+            # Clock skew between the writer of started_at and this process can
+            # make the subtraction negative; clamp so a poisoned duration never
+            # reaches the analytics chart (#1832).
+            duration_ms = max(0, int((completed_at - started_at).total_seconds() * 1000))
 
             cursor.execute("""
                 UPDATE process_schedule_executions

--- a/tests/unit/test_1771c_schedules_cas_edges.py
+++ b/tests/unit/test_1771c_schedules_cas_edges.py
@@ -328,29 +328,12 @@ def test_a5b_queued_at_is_unvalidated_at_this_layer(ops):
 # ===========================================================================
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "BUG: a `started_at` in the future relative to the finalizing process's "
-        "clock makes update_execution_status persist a NEGATIVE duration_ms "
-        "(unguarded `completed_at - started_at`), which then flows into "
-        "get_agent_analytics duration avg/p95. Producible because started_at and "
-        "completed_at are written by DIFFERENT processes (backend --workers 2 and "
-        "the standalone src/scheduler container, which repeats the same unguarded "
-        "subtraction at scheduler/database.py). Canary G-03 DETECTS the skew but "
-        "nothing prevents the poisoned metric. See /edge-cases report 2026-07-26 "
-        "(#1771 target 3) — follow-up issue not yet filed."
-    ),
-)
 def test_a6_clock_skew_must_not_persist_negative_duration(ops):
-    """A6 — ``duration_ms`` must never be negative. Currently it can be.
+    """A6 — ``duration_ms`` must never be negative.
 
-    Asserted as the *desired* contract (non-negative), marked ``xfail(strict)``
-    so the day a clamp or a validation lands, this test flips to XPASS and the
-    suite tells us instead of us having to remember.
-
-    Fixing is deliberately OUT of scope (#1771 AC#4: a real bug ships as a
-    strict xfail + a follow-up, never a silent product-code change).
+    Was a ``strict=True`` xfail pinning the unguarded subtraction. The clamp
+    landed in #1832, so the marker is gone and this now asserts the contract
+    directly, exactly as the xfail reason predicted it would.
     """
     future = _iso(datetime.now(timezone.utc) + timedelta(seconds=300))
     eid = insert_execution("a6-skew", status="running", started_at=future)
@@ -361,14 +344,18 @@ def test_a6_clock_skew_must_not_persist_negative_duration(ops):
     assert duration >= 0, f"negative duration_ms persisted: {duration}"
 
 
-def test_a6_current_behaviour_negative_duration_is_persisted(ops):
-    """A6 (companion) — pins what actually happens today, so the xfail above is
-    demonstrably about the *contract* and not about a flaky environment."""
+def test_a6_skewed_row_clamps_to_zero(ops):
+    """A6 (companion) — pins the post-clamp value, not just the sign.
+
+    Replaces the characterization test that asserted ``< 0``. A skewed row
+    lands on exactly ``0``, which is what makes it indistinguishable from a
+    genuine sub-millisecond execution — a deliberate trade recorded in #1832.
+    """
     future = _iso(datetime.now(timezone.utc) + timedelta(seconds=300))
     eid = insert_execution("a6-observed", status="running", started_at=future)
 
     assert ops.update_execution_status(eid, "success") is True
-    assert column_of(eid, "duration_ms") < 0
+    assert column_of(eid, "duration_ms") == 0
 
 
 # ===========================================================================

--- a/tests/unit/test_1832_duration_clamp.py
+++ b/tests/unit/test_1832_duration_clamp.py
@@ -1,0 +1,239 @@
+"""#1832 — a clock-skewed ``started_at`` must never persist a negative ``duration_ms``.
+
+``started_at`` and ``completed_at`` are written by **different processes** (the
+backend runs ``--workers 2``; the standalone ``src/scheduler`` container is a
+separate image), so an unguarded ``completed_at - started_at`` can go negative
+whenever the finalizing process's clock trails the one that opened the row. The
+value then flowed unguarded into ``get_agent_analytics`` and out to the Agent
+Detail Overview chart. Canary G-03 *detects* the skew at severity ``minor`` but
+prevents nothing.
+
+The fix clamps at the **write**, in all three writers, so no reader has to know:
+
+* ``src/backend/db/schedules/executions.py`` — ``update_execution_status``
+* ``src/scheduler/database.py`` — the ``schedule_executions`` finalizer
+* ``src/scheduler/database.py`` — the ``process_schedule_executions`` finalizer
+
+The issue named the first two; the third is the same unguarded subtraction on
+the process-execution table and is fixed here too, which is why this file guards
+the invariant at **source level** as well as behaviourally — the two scheduler
+writers live in a separate image that these unit tests cannot import, and a
+fourth call-site added later would otherwise reintroduce the bug silently.
+
+Trade-off recorded deliberately: a skewed row clamps to exactly ``0``, which
+makes it indistinguishable from a genuine sub-millisecond execution. Preserving
+the distinction would need a separate column or a sentinel, which is a schema
+change well beyond a p2 reliability fix.
+
+Companion coverage lives in ``test_1771c_schedules_cas_edges.py`` (A6), where the
+original ``strict=True`` xfail was retired by this fix.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: mirror test_1771c_schedules_cas_edges.py so `src/backend` imports
+# resolve and `tests/utils/` does not shadow `src/backend/utils/`.
+# ---------------------------------------------------------------------------
+_THIS = Path(__file__).resolve()
+_ROOT = _THIS.parent.parent.parent
+_BACKEND = _ROOT / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+for _shadow in ("utils", "utils.api_client", "utils.assertions", "utils.cleanup"):
+    sys.modules.pop(_shadow, None)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+from db_harness import db_backend, run as _hrun, scalar as _hscalar  # noqa: E402,F401
+
+_DB_MODULES = ("db.connection", "db.schedules", "db.activities", "database")
+_STUBBED_MODULE_NAMES = [
+    "utils",
+    "utils.api_client",
+    "utils.assertions",
+    "utils.cleanup",
+    *_DB_MODULES,
+]
+
+AGENT = "agent-1832"
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+@pytest.fixture
+def ops(db_backend):
+    """Composed ``ScheduleOperations`` bound to a fresh production schema."""
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+    from db.schedules import ScheduleOperations
+
+    yield ScheduleOperations(user_ops=MagicMock(), agent_ops=MagicMock())
+    for _m in _DB_MODULES:
+        sys.modules.pop(_m, None)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _insert(exec_id: str, *, started_at: str, status: str = "running") -> str:
+    cols = {
+        "id": exec_id,
+        "schedule_id": "sched-1832",
+        "agent_name": AGENT,
+        "status": status,
+        "started_at": started_at,
+        "message": "do the thing",
+        "triggered_by": "schedule",
+    }
+    names = ", ".join(cols)
+    binds = ", ".join(f":{k}" for k in cols)
+    _hrun(f"INSERT INTO schedule_executions ({names}) VALUES ({binds})", **cols)
+    return exec_id
+
+
+def _duration(exec_id: str):
+    return _hscalar(
+        "SELECT duration_ms FROM schedule_executions WHERE id = :i", i=exec_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour — the reported path
+# ---------------------------------------------------------------------------
+
+
+def test_1832_future_started_at_clamps_to_zero(ops):
+    """The reported reproduction: a row opened 300s in the future."""
+    future = _iso(datetime.now(timezone.utc) + timedelta(seconds=300))
+    eid = _insert("c1832-skew", started_at=future)
+
+    assert ops.update_execution_status(eid, "success", response="ok") is True
+
+    assert _duration(eid) == 0
+
+
+def test_1832_normal_duration_is_untouched(ops):
+    """The clamp must not flatten real durations — only negative ones."""
+    past = _iso(datetime.now(timezone.utc) - timedelta(seconds=5))
+    eid = _insert("c1832-normal", started_at=past)
+
+    assert ops.update_execution_status(eid, "success", response="ok") is True
+
+    duration = _duration(eid)
+    assert 4_000 <= duration <= 6_000, duration
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    ["success", "failed", "error"],
+    ids=["to-success", "to-failed", "to-error"],
+)
+def test_1832_clamp_applies_to_every_terminal_transition(ops, terminal_status):
+    """The subtraction is shared by all terminal writes, not just success."""
+    future = _iso(datetime.now(timezone.utc) + timedelta(seconds=300))
+    eid = _insert(f"c1832-{terminal_status}", started_at=future)
+
+    assert ops.update_execution_status(eid, terminal_status) is True
+
+    assert _duration(eid) == 0
+
+
+# ---------------------------------------------------------------------------
+# Behaviour — the consumption path the bug actually reached
+# ---------------------------------------------------------------------------
+
+
+def test_1832_analytics_never_reports_a_negative_duration(ops):
+    """A skewed row must not poison the Overview chart's avg/p95."""
+    future = _iso(datetime.now(timezone.utc) + timedelta(seconds=300))
+    eid = _insert("c1832-analytics", started_at=future)
+    assert ops.update_execution_status(eid, "success", response="ok") is True
+
+    out = ops.get_agent_analytics(AGENT, 168)
+
+    duration = out["duration_ms"]
+    assert duration["avg"] >= 0, duration
+    assert duration["p95"] >= 0, duration
+
+
+# ---------------------------------------------------------------------------
+# Source guard — every writer, including the two this suite cannot import
+# ---------------------------------------------------------------------------
+
+_WRITERS = (
+    _ROOT / "src" / "backend" / "db" / "schedules" / "executions.py",
+    _ROOT / "src" / "scheduler" / "database.py",
+)
+
+
+def _duration_assignments(path: Path):
+    """Yield (lineno, node) for every ``duration_ms = <expr>`` assignment."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "duration_ms":
+                yield node.lineno, node.value
+
+
+def _is_clamped(value: ast.AST) -> bool:
+    """True when the assigned expression is a literal 0 or wrapped in max()."""
+    if isinstance(value, ast.Constant) and value.value == 0:
+        return True  # the `skipped` rows write a literal 0
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Name)
+        and value.func.id == "max"
+    )
+
+
+@pytest.mark.parametrize("path", _WRITERS, ids=lambda p: p.name)
+def test_1832_every_duration_writer_is_clamped(path):
+    """No writer may assign an unguarded ``completed_at - started_at``.
+
+    The two ``src/scheduler`` writers ship in a separate image that these unit
+    tests cannot import, so the invariant is enforced against the source. This
+    also catches a fourth call-site added later, which is how the reported bug
+    survived being fixed in one place.
+    """
+    unclamped = [
+        lineno
+        for lineno, value in _duration_assignments(path)
+        if not _is_clamped(value)
+    ]
+
+    assert not unclamped, (
+        f"{path.relative_to(_ROOT)} assigns duration_ms unguarded at "
+        f"line(s) {unclamped} — wrap in max(0, ...) so clock skew cannot "
+        f"persist a negative duration (#1832)"
+    )
+
+
+def test_1832_source_guard_would_catch_a_regression():
+    """The guard must fail on an unclamped assignment, not vacuously pass."""
+    tree = ast.parse("duration_ms = int((completed_at - started_at).seconds)")
+    value = tree.body[0].value
+
+    assert _is_clamped(value) is False


### PR DESCRIPTION
Fixes #1832

## Problem

`started_at` and `completed_at` are written by **different processes** — the backend runs `--workers 2` and the standalone `src/scheduler` container is a separate image — so an unguarded `completed_at - started_at` goes negative whenever the finalizing process's clock trails the one that opened the row. The value flowed unguarded into `get_agent_analytics` and out to the Agent Detail Overview chart. Canary G-03 detects the skew at severity `minor` but prevents nothing.

## Fix

Clamps with `max(0, ...)` at the write, so no reader has to know.

The issue named two writers. There are **three** — the second scheduler site finalizes `process_schedule_executions` with the same unguarded subtraction, so fixing only the two named ones would have left the bug live on that path:

| Writer | |
|---|---|
| `src/backend/db/schedules/executions.py` | `update_execution_status` |
| `src/scheduler/database.py` | `schedule_executions` finalizer |
| `src/scheduler/database.py` | `process_schedule_executions` finalizer ← not named in the issue |

## The xfail, as promised

`test_1771c_schedules_cas_edges.py::test_a6_clock_skew_must_not_persist_negative_duration` is `strict=True`, so it flips to XPASS and fails the suite the moment a clamp lands — exactly as its reason predicted. The marker is removed and it now asserts the contract directly.

Its companion `test_a6_current_behaviour_negative_duration_is_persisted` pinned the **pre-fix** value (`< 0`) and would also have failed. It now pins the clamped value (`== 0`) and is renamed to say so.

## Tests

New `tests/unit/test_1832_duration_clamp.py`:

- the reported reproduction (row opened 300s in the future) clamps to `0`
- a real 5s duration is **not** flattened — the clamp only touches negatives
- every terminal transition (`success` / `failed` / `error`), since the subtraction is shared
- the consumption path: `get_agent_analytics` reports no negative `avg` / `p95`
- an **AST guard** asserting no writer assigns `duration_ms` unguarded

The AST guard covers the two `src/scheduler` writers, which ship in a separate image these unit tests cannot import, and it catches a fourth call-site added later — which is how this bug survived being fixed in one place. It accepts a literal `0` (the `skipped` rows) or a `max()` wrapper, and there is a test asserting the guard itself fails on unclamped source rather than passing vacuously.

```
52 passed
```

(9 new, plus the 43 existing in the CAS-edges file whose xfail this retires.)

## Trade-off

A skewed row clamps to exactly `0`, making it indistinguishable from a genuine sub-millisecond execution. The issue raises this. Preserving the distinction needs a separate column or a sentinel — a schema change, and with dual-track migrations that is well beyond a p2 reliability fix. Recorded in the test module docstring so the decision is discoverable rather than assumed.