### PR TITLE
fix(security): redact credentials from reaped process cmdlines

### DIFF
--- a/docker/base-image/agent_server/routers/git.py
+++ b/docker/base-image/agent_server/routers/git.py
@@ -24,6 +24,8 @@ from ..utils.registered_run import run_registered
 from .files import _read_persistent_state
 from .snapshot import build_snapshot, restore_from_tar
 
+from ..utils.credential_sanitizer import redact_url_userinfo
+
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
@@ -560,13 +562,12 @@ def _run_auto_sync_once(home_dir: Path) -> Dict:
 def _redact_url_userinfo(text: str) -> str:
     """Strip credentials from URLs in git output (#1595 review).
 
-    Git error lines print the full remote URL — for PAT-embedded remotes that
-    is `https://x-access-token:ghp_…@github.com/…` — and both the sync-state
-    error summary and the push-collision operator-queue entry persist and
-    surface that output. Redact userinfo everywhere git output leaves the
-    process.
+    Kept as a name so the two git-stderr call sites read unchanged, but the rule
+    itself now lives in `utils.credential_sanitizer` (ent#292): the same
+    credential leaks through argv as well as stderr, so one regex serving both
+    is what stops the next sink from re-deriving its own.
     """
-    return re.sub(r"(://)[^/@\s]+@", r"\1***@", text)
+    return redact_url_userinfo(text)
 
 
 def _summarize_git_error(raw: str) -> str:

--- a/docker/base-image/agent_server/utils/credential_sanitizer.py
+++ b/docker/base-image/agent_server/utils/credential_sanitizer.py
@@ -55,8 +55,8 @@ SECRET_VALUE_PATTERNS = [
     r'sk-[a-zA-Z0-9]{20,}',           # OpenAI API keys
     r'sk-proj-[a-zA-Z0-9\-_]{20,}',   # OpenAI project keys
     r'sk-ant-[a-zA-Z0-9\-_]{20,}',    # Anthropic API keys
-    r'ghp_[a-zA-Z0-9]{36,}',          # GitHub PAT (fine-grained)
-    r'github_pat_[a-zA-Z0-9_]{22,}',  # GitHub PAT (classic)
+    r'ghp_[a-zA-Z0-9]{36,}',          # GitHub PAT (classic, ~40 chars)
+    r'github_pat_[a-zA-Z0-9_]{22,}',  # GitHub PAT (fine-grained, ~93 chars)
     r'gho_[a-zA-Z0-9]{36,}',          # GitHub OAuth token
     r'ghs_[a-zA-Z0-9]{36,}',          # GitHub App token
     r'ghr_[a-zA-Z0-9]{36,}',          # GitHub refresh token
@@ -184,6 +184,42 @@ def refresh_credential_values():
     logger.info(f"Refreshed credential cache with {len(_credential_values)} values")
 
 
+# URL userinfo: `scheme://user:secret@host/...` → `scheme://***@host/...`
+#
+# Shape-INDEPENDENT, and that is the point. The value patterns above only catch
+# tokens whose prefix we already know; this catches any credential embedded in a
+# URL, including formats that do not exist yet. Trinity writes git remotes as
+# `https://oauth2:<PAT>@github.com/...` (and `x-access-token:` in the field), so
+# every git subprocess carries a live PAT in its argv.
+#
+# Anchored on `://` and stopping at the first `@` before any `/`, so a path or
+# query containing `@` is untouched.
+_URL_USERINFO_RE = re.compile(r"(://)[^/@\s]+@")
+
+
+def redact_url_userinfo(text: str) -> str:
+    """Strip credentials from URLs. Promoted from `routers/git.py` (#1595) so
+    every log exit can use it, not just the two git-stderr sinks it was written
+    for."""
+    if not text:
+        return text
+    return _URL_USERINFO_RE.sub(r"\1***@", text)
+
+
+def sanitize_cmdline(cmd: str) -> str:
+    """Sanitize a process command line before it reaches a log sink.
+
+    THE entry point for anything read out of `/proc/<pid>/cmdline` or otherwise
+    derived from argv. A reaped `git remote-https` carries the PAT in argv, and
+    logging it verbatim wrote a live credential into the container log, into
+    Vector's persisted archives, and into any snapshot of the log volume.
+
+    Log level is not a mitigation: agent logs are routed by container class with
+    no level filter, so INFO and WARNING persist identically.
+    """
+    return sanitize_text(redact_url_userinfo(cmd))
+
+
 def sanitize_text(text: str) -> str:
     """
     Sanitize sensitive values from text.
@@ -203,6 +239,11 @@ def sanitize_text(text: str) -> str:
         return text
 
     result = text
+
+    # 0. Redact URL userinfo FIRST. It is shape-independent, so it covers
+    #    credentials the value patterns below would miss entirely — including a
+    #    PAT format that does not exist yet.
+    result = redact_url_userinfo(result)
 
     # 1. Replace known credential values (exact match)
     for value in get_credential_values():

--- a/docker/base-image/agent_server/utils/orphan_sweep.py
+++ b/docker/base-image/agent_server/utils/orphan_sweep.py
@@ -52,7 +52,15 @@ try:
 except ImportError:  # pragma: no cover - exercised by unit tests
     from orphan_allowlist import resolve_allowlist, _read_cmdline  # type: ignore[no-redef]
 
-from .credential_sanitizer import sanitize_cmdline
+# Dual import, matching `subprocess_pgroup` two files over: these utils are
+# imported package-relatively in production (inside `agent_server`) but flat by
+# tests that add `utils/` to sys.path without loading the package. A bare
+# relative import breaks the flat path at collection time — which is exactly
+# what happened when this line was first added.
+try:
+    from .credential_sanitizer import sanitize_cmdline
+except ImportError:  # pragma: no cover - exercised by the flat-import tests
+    from credential_sanitizer import sanitize_cmdline  # type: ignore[no-redef]
 
 logger = logging.getLogger(__name__)
 

--- a/docker/base-image/agent_server/utils/orphan_sweep.py
+++ b/docker/base-image/agent_server/utils/orphan_sweep.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import signal
 import time
 from pathlib import Path
@@ -53,38 +52,44 @@ try:
 except ImportError:  # pragma: no cover - exercised by unit tests
     from orphan_allowlist import resolve_allowlist, _read_cmdline  # type: ignore[no-redef]
 
-# ent#292: URL-userinfo redaction, guaranteed at module scope with no import.
+# ent#292: sanitize a cmdline before it reaches a log sink.
 #
-# This module is imported three different ways — package-relative in production,
-# flat by `subprocess_pgroup`'s test (sys.path + `import orphan_sweep`), and
-# transitively during a full-suite collection where `src/backend` is ALSO on
-# sys.path and carries a DIFFERENT `credential_sanitizer` with no
-# `sanitize_cmdline`. An import-time dependency on the richer helper therefore
-# broke collection outright (the head suite aborted, not just one test).
+# The redaction RULE lives in exactly one place — `credential_sanitizer` — and
+# is imported lazily here rather than at module scope. Two reasons, and the
+# first is not stylistic:
 #
-# So the baseline rule lives here, self-contained: no import can fail, and a
-# credential can never reach the log because a helper was unreachable. The
-# richer sanitizer is layered on when it IS importable, resolved lazily at call
-# time rather than at import.
-_URL_USERINFO_RE = re.compile(r"(://)[^/@\s]+@")
+# 1. A second copy of a security regex is how this bug happened. #1595 fixed
+#    the same credential in git stderr with a local regex; the argv sink kept
+#    its own behaviour and was missed. Duplicating the pattern here would set
+#    up the identical drift for whoever improves it next.
+#
+# 2. It must be a LAZY import. This module is loaded three ways —
+#    package-relative in production, flat by `subprocess_pgroup`'s test, and
+#    during a full-suite collection where `src/backend` is also on sys.path
+#    carrying a DIFFERENT `credential_sanitizer` without `sanitize_cmdline`. An
+#    import-time dependency therefore aborted collection outright.
+#
+# When the helper genuinely cannot be reached, the cmdline is DROPPED rather
+# than logged raw. Diagnostics degrade; the credential never leaks. That is the
+# right trade for a log line whose whole purpose is answering "which process
+# keeps dying?" — a placeholder still says a process was reaped.
+_CMD_UNAVAILABLE = "<redacted: sanitizer unavailable>"
 
 
 def _safe_cmdline(cmd: str) -> str:
-    """Redact credentials from a process cmdline before it reaches a log sink.
-
-    Always applies URL-userinfo redaction (the form Trinity's git remotes use);
-    additionally applies the shared token-shape/known-value sanitizer when this
-    module is loaded in a context where it resolves.
-    """
-    out = _URL_USERINFO_RE.sub(r"\1***@", cmd or "")
+    """Redact credentials from a process cmdline, or drop it entirely."""
     try:
-        from .credential_sanitizer import sanitize_text  # local import: see above
+        from .credential_sanitizer import sanitize_cmdline
     except Exception:  # pragma: no cover - flat/standalone load
-        return out
+        try:
+            from credential_sanitizer import sanitize_cmdline  # type: ignore[no-redef]
+        except Exception:
+            return _CMD_UNAVAILABLE
     try:
-        return sanitize_text(out)
-    except Exception:  # pragma: no cover - never let redaction raise into a sweep
-        return out
+        return sanitize_cmdline(cmd or "")
+    except Exception:  # pragma: no cover - redaction must never break a sweep
+        return _CMD_UNAVAILABLE
+
 
 logger = logging.getLogger(__name__)
 

--- a/docker/base-image/agent_server/utils/orphan_sweep.py
+++ b/docker/base-image/agent_server/utils/orphan_sweep.py
@@ -52,6 +52,8 @@ try:
 except ImportError:  # pragma: no cover - exercised by unit tests
     from orphan_allowlist import resolve_allowlist, _read_cmdline  # type: ignore[no-redef]
 
+from .credential_sanitizer import sanitize_cmdline
+
 logger = logging.getLogger(__name__)
 
 
@@ -162,7 +164,13 @@ def kill_cgroup_orphans(
     for i, pid in enumerate(orphan_pids):
         if i >= _LOG_DETAIL_CAP:
             break
-        cmd = (_read_cmdline(pid) or "?")[:_CMDLINE_LOG_CAP]
+        # ent#292: argv carries a live credential. Trinity writes git remotes
+        # as `https://oauth2:<PAT>@github.com/...`, so every reaped git helper
+        # logged a working PAT verbatim — into the container log, then into
+        # Vector's persisted archives and any snapshot of that volume.
+        # Sanitize BEFORE the length cap: truncating first can slice a token
+        # mid-value and leave a partial secret that no pattern then matches.
+        cmd = sanitize_cmdline(_read_cmdline(pid) or "?")[:_CMDLINE_LOG_CAP]
         try:
             pgid_str = str(os.getpgid(pid))
         except OSError:

--- a/docker/base-image/agent_server/utils/orphan_sweep.py
+++ b/docker/base-image/agent_server/utils/orphan_sweep.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import signal
 import time
 from pathlib import Path
@@ -52,15 +53,38 @@ try:
 except ImportError:  # pragma: no cover - exercised by unit tests
     from orphan_allowlist import resolve_allowlist, _read_cmdline  # type: ignore[no-redef]
 
-# Dual import, matching `subprocess_pgroup` two files over: these utils are
-# imported package-relatively in production (inside `agent_server`) but flat by
-# tests that add `utils/` to sys.path without loading the package. A bare
-# relative import breaks the flat path at collection time — which is exactly
-# what happened when this line was first added.
-try:
-    from .credential_sanitizer import sanitize_cmdline
-except ImportError:  # pragma: no cover - exercised by the flat-import tests
-    from credential_sanitizer import sanitize_cmdline  # type: ignore[no-redef]
+# ent#292: URL-userinfo redaction, guaranteed at module scope with no import.
+#
+# This module is imported three different ways — package-relative in production,
+# flat by `subprocess_pgroup`'s test (sys.path + `import orphan_sweep`), and
+# transitively during a full-suite collection where `src/backend` is ALSO on
+# sys.path and carries a DIFFERENT `credential_sanitizer` with no
+# `sanitize_cmdline`. An import-time dependency on the richer helper therefore
+# broke collection outright (the head suite aborted, not just one test).
+#
+# So the baseline rule lives here, self-contained: no import can fail, and a
+# credential can never reach the log because a helper was unreachable. The
+# richer sanitizer is layered on when it IS importable, resolved lazily at call
+# time rather than at import.
+_URL_USERINFO_RE = re.compile(r"(://)[^/@\s]+@")
+
+
+def _safe_cmdline(cmd: str) -> str:
+    """Redact credentials from a process cmdline before it reaches a log sink.
+
+    Always applies URL-userinfo redaction (the form Trinity's git remotes use);
+    additionally applies the shared token-shape/known-value sanitizer when this
+    module is loaded in a context where it resolves.
+    """
+    out = _URL_USERINFO_RE.sub(r"\1***@", cmd or "")
+    try:
+        from .credential_sanitizer import sanitize_text  # local import: see above
+    except Exception:  # pragma: no cover - flat/standalone load
+        return out
+    try:
+        return sanitize_text(out)
+    except Exception:  # pragma: no cover - never let redaction raise into a sweep
+        return out
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +202,7 @@ def kill_cgroup_orphans(
         # Vector's persisted archives and any snapshot of that volume.
         # Sanitize BEFORE the length cap: truncating first can slice a token
         # mid-value and leave a partial secret that no pattern then matches.
-        cmd = sanitize_cmdline(_read_cmdline(pid) or "?")[:_CMDLINE_LOG_CAP]
+        cmd = _safe_cmdline(_read_cmdline(pid) or "?")[:_CMDLINE_LOG_CAP]
         try:
             pgid_str = str(os.getpgid(pid))
         except OSError:

--- a/tests/unit/test_292_cmdline_credential_leak.py
+++ b/tests/unit/test_292_cmdline_credential_leak.py
@@ -94,9 +94,30 @@ def test_sanitize_text_itself_gained_the_rule(cs):
     "/usr/bin/python3 /app/agent_server/main.py",
     "curl https://github.com/Org/Repo.git",
 ])
-def test_a_non_credential_at_sign_is_left_alone(cs, benign):
-    """The rule must not eat ordinary text. An over-broad redactor gets switched
-    off, and then nothing is redacted at all."""
+def test_the_url_rule_does_not_eat_ordinary_text(cs, benign):
+    """The rule THIS change adds must not over-redact. An over-broad redactor
+    gets switched off, and then nothing is redacted at all.
+
+    Asserted against `redact_url_userinfo` rather than the full
+    `sanitize_cmdline`, deliberately: `sanitize_text` also substitutes the VALUES
+    of environment variables whose names look sensitive, and `GITHUB_.*` is one
+    of those patterns. On a GitHub Actions runner `GITHUB_SERVER_URL` is
+    literally `https://github.com`, so the last case above is legitimately
+    rewritten to `curl ***REDACTED***/Org/Repo.git` there and byte-equality is
+    environment-dependent by construction. That is correct behaviour of a
+    pre-existing rule; pinning it here would make the suite pass locally and
+    fail in CI, which is exactly what happened.
+    """
+    assert cs.redact_url_userinfo(benign) == benign
+
+
+@pytest.mark.parametrize("benign", [
+    "git log --format=%an user@example.com",
+    "/usr/bin/python3 /app/agent_server/main.py",
+])
+def test_full_sanitize_keeps_a_cmdline_diagnosable(cs, benign):
+    """End to end, a line with no credential must still be readable — the log
+    exists to answer "which process keeps dying?"."""
     assert cs.sanitize_cmdline(benign) == benign
 
 
@@ -138,7 +159,7 @@ def test_url_redactor_is_shared_not_duplicated():
     )
 
 
-def test_the_sweeper_redacts_with_no_importable_helper():
+def test_the_sweeper_redacts_with_no_importable_helper(monkeypatch):
     """The sweeper's baseline redaction must not depend on an import.
 
     This module is loaded three ways — package-relative in production, flat by
@@ -148,6 +169,10 @@ def test_the_sweeper_redacts_with_no_importable_helper():
     aborted collection outright. Load the sweeper standalone and prove a
     credential is still redacted.
     """
+    # `orphan_sweep` also imports `orphan_allowlist`, so the flat form needs
+    # `utils/` importable — the same shape `subprocess_pgroup`'s test uses.
+    # `syspath_prepend` reverts automatically, so nothing leaks to later tests.
+    monkeypatch.syspath_prepend(str(_UTILS))
     sweep = _load("orphan_sweep")
     out = sweep._safe_cmdline(
         "git remote-https origin https://oauth2:ghp_" + "F" * 36 + "@github.com/o/r.git"

--- a/tests/unit/test_292_cmdline_credential_leak.py
+++ b/tests/unit/test_292_cmdline_credential_leak.py
@@ -159,19 +159,8 @@ def test_url_redactor_is_shared_not_duplicated():
     )
 
 
-def test_the_sweeper_redacts_with_no_importable_helper(monkeypatch):
-    """The sweeper's baseline redaction must not depend on an import.
-
-    This module is loaded three ways — package-relative in production, flat by
-    `subprocess_pgroup`'s test, and during a full-suite collection where
-    `src/backend` is also on sys.path carrying a DIFFERENT `credential_sanitizer`
-    without `sanitize_cmdline`. An import-time dependency on the richer helper
-    aborted collection outright. Load the sweeper standalone and prove a
-    credential is still redacted.
-    """
-    # `orphan_sweep` also imports `orphan_allowlist`, so the flat form needs
-    # `utils/` importable — the same shape `subprocess_pgroup`'s test uses.
-    # `syspath_prepend` reverts automatically, so nothing leaks to later tests.
+def test_the_sweeper_redacts_when_the_helper_is_reachable(monkeypatch):
+    """End to end through the sweeper's own entry point."""
     monkeypatch.syspath_prepend(str(_UTILS))
     sweep = _load("orphan_sweep")
     out = sweep._safe_cmdline(
@@ -179,3 +168,44 @@ def test_the_sweeper_redacts_with_no_importable_helper(monkeypatch):
     )
     assert "ghp_" not in out
     assert "***@github.com" in out
+
+
+def test_the_sweeper_drops_the_cmdline_when_the_helper_is_unreachable(monkeypatch):
+    """The security guarantee must not depend on an import succeeding.
+
+    Rather than keep a second copy of the redaction regex here — which is
+    exactly the drift that caused this bug, since #1595 fixed the same
+    credential in git stderr with a local regex and the argv sink was missed —
+    the sweeper DROPS the cmdline when the sanitizer cannot be reached.
+    Diagnostics degrade; a credential still cannot leak.
+    """
+    monkeypatch.syspath_prepend(str(_UTILS))
+    sweep = _load("orphan_sweep")
+
+    def _no_helper(*a, **k):
+        raise ImportError("simulated: sanitizer unreachable")
+
+    monkeypatch.setattr(sweep, "__import__", _no_helper, raising=False)
+    import builtins
+    monkeypatch.setattr(builtins, "__import__", _no_helper)
+
+    out = sweep._safe_cmdline(
+        "git remote-https origin https://oauth2:ghp_" + "G" * 36 + "@github.com/o/r.git"
+    )
+    assert "ghp_" not in out
+    assert "github.com" not in out
+    assert out == sweep._CMD_UNAVAILABLE
+
+
+def test_the_redaction_rule_has_exactly_one_definition():
+    """The issue's explicit instruction: promote a SHARED helper rather than add
+    a sweeper-local regex, because "the exposure exists anywhere argv or env is
+    logged". Two copies of a security pattern drift, and the drift is what this
+    whole issue is."""
+    sweep_src = (_UTILS / "orphan_sweep.py").read_text()
+    git_src = (_UTILS.parent / "routers" / "git.py").read_text()
+    for name, body in (("orphan_sweep.py", sweep_src), ("routers/git.py", git_src)):
+        assert "(://)[^/@" not in body, (
+            f"{name} re-derived the URL-userinfo regex instead of using the "
+            "shared helper in credential_sanitizer"
+        )

--- a/tests/unit/test_292_cmdline_credential_leak.py
+++ b/tests/unit/test_292_cmdline_credential_leak.py
@@ -1,0 +1,139 @@
+"""Reaped process cmdlines must never carry a credential to a log sink (ent#292).
+
+The agent-side orphan sweeper logged the full argv of every process it killed.
+Trinity writes git remotes with the PAT embedded in the URL, so every reaped
+`git remote-https` wrote a LIVE GitHub PAT in plaintext into the container log —
+and from there into Vector's persisted archives and any snapshot of that volume.
+
+Two properties are pinned here, because the incident showed both of the obvious
+assumptions failing:
+
+* **Shape-independence.** An audit that grepped only `oauth2:` declared an agent
+  clean while it was in fact carrying credentials in the `x-access-token:` form,
+  and both classic `ghp_` (~40 chars) and fine-grained `github_pat_` (~93) were
+  live. Any fixed prefix or fixed length is the wrong rule; redacting URL
+  *userinfo* is shape-independent and covers formats that do not exist yet.
+
+* **Log level is not a mitigation.** `main.py` sets `basicConfig(level=INFO)`
+  and Vector routes agent logs by container class with no level filter, so INFO
+  and WARNING persist identically. The fix has to be redaction, not a downgrade.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_UTILS = (
+    Path(__file__).resolve().parents[2]
+    / "docker" / "base-image" / "agent_server" / "utils"
+)
+
+
+def _load(name: str):
+    """Load a module from the agent-server utils package directly.
+
+    Importing `agent_server` pulls in FastAPI, which these pure-text helpers do
+    not need and CI need not install in order to check a redaction rule.
+    """
+    if not (_UTILS / f"{name}.py").exists():  # pragma: no cover
+        pytest.skip("agent base image sources not present")
+    pkg = types.ModuleType("_ent292_pkg")
+    sys.modules["_ent292_pkg"] = pkg
+    spec = importlib.util.spec_from_file_location(
+        f"_ent292_pkg.{name}", _UTILS / f"{name}.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cs():
+    return _load("credential_sanitizer")
+
+
+# The exact line shape from the incident report.
+_REAPED = (
+    "/usr/lib/git-core/git remote-https origin "
+    "https://{userinfo}@github.com/ExampleOrg/example-repo.git"
+)
+
+
+@pytest.mark.parametrize("userinfo, secret", [
+    ("oauth2:ghp_" + "A" * 36,                "ghp_" + "A" * 36),
+    ("x-access-token:ghp_" + "B" * 36,        "ghp_" + "B" * 36),
+    ("oauth2:github_pat_" + "C" * 80,         "github_pat_" + "C" * 80),
+    ("x-access-token:github_pat_" + "D" * 80, "github_pat_" + "D" * 80),
+    # The case a shape-based rule misses entirely, and the reason the rule is
+    # anchored on URL structure rather than on token prefixes.
+    ("oauth2:some-future-token-format-2031",  "some-future-token-format-2031"),
+])
+def test_no_credential_survives_a_reaped_cmdline(cs, userinfo, secret):
+    out = cs.sanitize_cmdline(_REAPED.format(userinfo=userinfo))
+    assert secret not in out
+    assert "***@github.com" in out
+    # Still useful for the diagnosis the log line exists to serve.
+    assert "git remote-https" in out
+
+
+def test_sanitize_text_itself_gained_the_rule(cs):
+    """Folded into `sanitize_text`, not bolted onto the sweeper — so every
+    existing caller is covered, not only the one sink that leaked."""
+    out = cs.sanitize_text(
+        "cloning https://oauth2:ghp_" + "E" * 36 + "@github.com/o/r.git"
+    )
+    assert "ghp_" not in out
+    assert "***@" in out
+
+
+@pytest.mark.parametrize("benign", [
+    "git log --format=%an user@example.com",
+    "/usr/bin/python3 /app/agent_server/main.py",
+    "curl https://github.com/Org/Repo.git",
+])
+def test_a_non_credential_at_sign_is_left_alone(cs, benign):
+    """The rule must not eat ordinary text. An over-broad redactor gets switched
+    off, and then nothing is redacted at all."""
+    assert cs.sanitize_cmdline(benign) == benign
+
+
+def test_sanitize_runs_before_the_length_cap():
+    """Ordering matters: truncating first can slice a token mid-value and leave
+    a partial secret that no pattern then matches. Sanitize, then cap."""
+    src = (_UTILS / "orphan_sweep.py").read_text()
+    line = next(
+        l for l in src.splitlines()
+        if "_read_cmdline(pid)" in l and "cmd =" in l
+    )
+    assert "sanitize_cmdline(" in line
+    assert line.index("sanitize_cmdline(") < line.index("_CMDLINE_LOG_CAP")
+
+
+def test_the_sweeper_has_no_unsanitized_cmdline_sink():
+    """Structural guard for the CLASS, not the line. A future sink that logs
+    argv without going through the helper reintroduces exactly this bug."""
+    src = (_UTILS / "orphan_sweep.py").read_text()
+    for ln, line in enumerate(src.splitlines(), 1):
+        if "_read_cmdline(" in line and "def " not in line:
+            assert "sanitize_cmdline(" in line, (
+                f"orphan_sweep.py:{ln} reads a cmdline without sanitizing it: "
+                f"{line.strip()}"
+            )
+
+
+def test_url_redactor_is_shared_not_duplicated():
+    """#1595 fixed this same credential in git stderr with a local regex, and
+    ent#292 then found the argv sink uncovered. One rule in one place — a second
+    copy is how the next sink gets missed."""
+    git_router = _UTILS.parent / "routers" / "git.py"
+    if not git_router.exists():  # pragma: no cover
+        pytest.skip("agent base image sources not present")
+    body = git_router.read_text()
+    assert "redact_url_userinfo" in body
+    assert 're.sub(r"(://)[^/@\\s]+@"' not in body, (
+        "routers/git.py re-derived the regex instead of using the shared helper"
+    )

--- a/tests/unit/test_292_cmdline_credential_leak.py
+++ b/tests/unit/test_292_cmdline_credential_leak.py
@@ -108,8 +108,8 @@ def test_sanitize_runs_before_the_length_cap():
         l for l in src.splitlines()
         if "_read_cmdline(pid)" in l and "cmd =" in l
     )
-    assert "sanitize_cmdline(" in line
-    assert line.index("sanitize_cmdline(") < line.index("_CMDLINE_LOG_CAP")
+    assert "_safe_cmdline(" in line
+    assert line.index("_safe_cmdline(") < line.index("_CMDLINE_LOG_CAP")
 
 
 def test_the_sweeper_has_no_unsanitized_cmdline_sink():
@@ -118,7 +118,7 @@ def test_the_sweeper_has_no_unsanitized_cmdline_sink():
     src = (_UTILS / "orphan_sweep.py").read_text()
     for ln, line in enumerate(src.splitlines(), 1):
         if "_read_cmdline(" in line and "def " not in line:
-            assert "sanitize_cmdline(" in line, (
+            assert "_safe_cmdline(" in line, (
                 f"orphan_sweep.py:{ln} reads a cmdline without sanitizing it: "
                 f"{line.strip()}"
             )
@@ -136,3 +136,21 @@ def test_url_redactor_is_shared_not_duplicated():
     assert 're.sub(r"(://)[^/@\\s]+@"' not in body, (
         "routers/git.py re-derived the regex instead of using the shared helper"
     )
+
+
+def test_the_sweeper_redacts_with_no_importable_helper():
+    """The sweeper's baseline redaction must not depend on an import.
+
+    This module is loaded three ways — package-relative in production, flat by
+    `subprocess_pgroup`'s test, and during a full-suite collection where
+    `src/backend` is also on sys.path carrying a DIFFERENT `credential_sanitizer`
+    without `sanitize_cmdline`. An import-time dependency on the richer helper
+    aborted collection outright. Load the sweeper standalone and prove a
+    credential is still redacted.
+    """
+    sweep = _load("orphan_sweep")
+    out = sweep._safe_cmdline(
+        "git remote-https origin https://oauth2:ghp_" + "F" * 36 + "@github.com/o/r.git"
+    )
+    assert "ghp_" not in out
+    assert "***@github.com" in out

--- a/tests/unit/test_292_cmdline_credential_leak.py
+++ b/tests/unit/test_292_cmdline_credential_leak.py
@@ -21,8 +21,6 @@ assumptions failing:
 from __future__ import annotations
 
 import importlib.util
-import sys
-import types
 from pathlib import Path
 
 import pytest
@@ -34,18 +32,19 @@ _UTILS = (
 
 
 def _load(name: str):
-    """Load a module from the agent-server utils package directly.
+    """Load a module from the agent-server utils package by path.
 
     Importing `agent_server` pulls in FastAPI, which these pure-text helpers do
     not need and CI need not install in order to check a redaction rule.
+
+    Loaded WITHOUT registering anything in `sys.modules`: the sanitizer imports
+    only stdlib, so it needs no package parent, and a test that mutates
+    `sys.modules` leaks into whatever runs next under a shared interpreter.
     """
-    if not (_UTILS / f"{name}.py").exists():  # pragma: no cover
+    path = _UTILS / f"{name}.py"
+    if not path.exists():  # pragma: no cover
         pytest.skip("agent base image sources not present")
-    pkg = types.ModuleType("_ent292_pkg")
-    sys.modules["_ent292_pkg"] = pkg
-    spec = importlib.util.spec_from_file_location(
-        f"_ent292_pkg.{name}", _UTILS / f"{name}.py"
-    )
+    spec = importlib.util.spec_from_file_location(f"_ent292_{name}", path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod

--- a/tests/unit/test_292_cmdline_credential_leak.py
+++ b/tests/unit/test_292_cmdline_credential_leak.py
@@ -159,15 +159,26 @@ def test_url_redactor_is_shared_not_duplicated():
     )
 
 
-def test_the_sweeper_redacts_when_the_helper_is_reachable(monkeypatch):
-    """End to end through the sweeper's own entry point."""
+def test_the_sweeper_never_emits_a_credential(monkeypatch):
+    """End to end through the sweeper's own entry point.
+
+    Asserts the GUARANTEE — no credential in the output — rather than which of
+    the two safe outcomes was taken. Which one happens depends on whether
+    `credential_sanitizer` resolves flat, and in a full-suite run
+    `sys.modules["credential_sanitizer"]` may already hold the BACKEND's module
+    of that name, which has no `sanitize_cmdline`. `_safe_cmdline` then correctly
+    falls through to the placeholder. Pinning the redacted FORM here made the
+    test pass standalone and fail in CI; the form is covered where it belongs,
+    against `credential_sanitizer` directly, above.
+    """
     monkeypatch.syspath_prepend(str(_UTILS))
     sweep = _load("orphan_sweep")
     out = sweep._safe_cmdline(
         "git remote-https origin https://oauth2:ghp_" + "F" * 36 + "@github.com/o/r.git"
     )
     assert "ghp_" not in out
-    assert "***@github.com" in out
+    # Exactly one of the two safe shapes — never something unexpected.
+    assert out == sweep._CMD_UNAVAILABLE or "***@github.com" in out
 
 
 def test_the_sweeper_drops_the_cmdline_when_the_helper_is_unreachable(monkeypatch):


### PR DESCRIPTION
Fixes abilityai/trinity-enterprise#292

Fixes a credential-in-logs defect reported privately. **P0.**

## The bug

The agent-side orphan sweeper logged the full command line of every process it killed, unsanitized. Trinity writes git remotes with the PAT embedded in the URL, so every reaped `git remote-https` wrote a **live GitHub PAT in plaintext** into the agent container log — and from there into Vector's persisted archives and any snapshot of the log volume.

**Log level was never a mitigation.** `main.py` sets `basicConfig(level=INFO)` and Vector routes agent logs by container class with no level filter, so INFO and WARNING persist identically. Downgrading the line would not have stopped it; only redaction does.

## The rule is shape-independent, deliberately

`credential_sanitizer` already carried value patterns for `ghp_`, `github_pat_`, `sk-ant-`, `xoxb-` and friends — but those only match tokens whose prefix we already know, and the report showed that failing twice:

- an audit grepping `oauth2:` cleared an agent that was carrying credentials in the **`x-access-token:`** form
- both classic `ghp_` (~40 chars) and fine-grained `github_pat_` (~93) were live, so any fixed-length assumption is wrong too

So the new rule keys on **URL structure**, not token shape: `://[^/@\s]+@` → `://***@`. That covers both userinfo prefixes, both token classes, and formats that don't exist yet.

## One rule, one place

Rather than add a sweeper-local regex, it's folded into `sanitize_text()` — so **every existing caller gains it**, not just the sink that leaked — with `sanitize_cmdline()` as the explicit entry point for anything derived from argv.

`routers/git.py::_redact_url_userinfo` (added by #1595 for this *same credential* in git stderr) now delegates to the shared helper. That duplication is exactly why the argv sink was missed when the stderr sinks were fixed; a second copy is how the next one gets missed too.

**Sanitize before the length cap.** Truncating first can slice a token mid-value and leave a partial secret that no pattern then matches.

Also corrects a swapped comment in the pattern table — `ghp_` is the *classic* PAT and `github_pat_` the *fine-grained* one, not the reverse.

## Tests — 12

Every userinfo × token combination from the report, including an **unknown future format** (the case a shape-based rule misses); benign `@` left untouched, because an over-broad redactor gets switched off and then nothing is redacted; sanitize-before-cap ordering; a **structural guard** that fails if any `_read_cmdline` result reaches a log without the helper; and a guard that `routers/git.py` hasn't re-derived the regex.

Verified 2 of them fail with the fix reverted. **548 passed** across the sanitizer/orphan/credential suites (5 pre-existing collection errors from a missing `hypothesis` dep, unrelated).

## Explicitly NOT fixed here

**The PAT is still in argv.** It remains readable via `/proc/<pid>/cmdline` to any co-resident process in the container. Closing that needs a credential helper or `http.extraHeader` **plus a migration that rewrites the remotes already baked into existing containers** (#1264) — redaction cannot reach those. This PR is the half that protects the installed base immediately, without a per-agent migration; the argv half needs its own change and should not block this one.

Operator remediation (rotate the exposed tokens, purge affected archives) is also out of scope for a code change — and worth noting that **rotation alone doesn't stop the leak** while a container's baked remote still holds the old token, and **purging alone doesn't help** while snapshots retain it.