### PR TITLE
fix(systems): harden manifest YAML against expansion bombs and duplicate keys (#1884)

### DIFF
--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -627,6 +627,10 @@ class SystemManifest(BaseModel):
 
 class SystemDeployRequest(BaseModel):
     """Request to deploy a system from YAML manifest."""
+    # #1884: the raw YAML is parsed by `system_service.parse_manifest`, which
+    # applies the size / expansion-cost / duplicate-key guards mirroring the MCP
+    # pipeline reader (#919). Not validated here — a Pydantic field cannot see
+    # YAML structure.
     manifest: str  # Raw YAML string
     dry_run: bool = False
     # trinity-enterprise#125: abort on the first agent-create failure (legacy

--- a/src/backend/services/system_service.py
+++ b/src/backend/services/system_service.py
@@ -32,17 +32,140 @@ logger = logging.getLogger(__name__)
 _REASON_MAX_LEN = 500
 
 
+# --- Manifest YAML hardening (#1884) -------------------------------------
+#
+# `yaml.safe_load` blocks arbitrary object construction but not two other
+# things, and the MCP pipeline reader (#919) already set the house standard for
+# this class — "size cap + duplicate-key guard + alias guard". This mirrors that
+# rather than inventing a second approach; PyYAML simply has no equivalent of
+# the JS `yaml` library's `uniqueKeys` / `maxAliasCount` options, so both are
+# implemented here.
+
+# Bounds the INPUT. Deliberately not sufficient on its own: alias expansion is
+# bounded by the budget below, because a few hundred bytes can expand to
+# gigabytes ("billion laughs") while sitting comfortably under any size cap.
+MANIFEST_MAX_BYTES = 256 * 1024
+
+# Bounds the EXPANSION COST, not the alias count.
+#
+# A naive `maxAliasCount` is the wrong shape for a bomb: the classic
+# billion-laughs uses ~45 aliases across a few levels and would sail under any
+# count-based budget, because the blow-up is MULTIPLICATIVE per level, not
+# linear in aliases. So this budget is the total number of logical nodes the
+# document would have if every alias were written out — which is exactly the
+# quantity that explodes.
+#
+# Measured, not assumed: PyYAML itself does NOT expand aliases into copies (it
+# memoises constructed objects per node, so a bomb yields a shared-reference
+# DAG at ~20 KB, not gigabytes). The DoS the issue describes is therefore not
+# reachable through `safe_load` alone. The guard stays because the DAG re-expands
+# the moment anything walks or serialises it — `json.dumps`, a deep copy, or an
+# echo of the manifest back to a client — and a parser that gains this guard is
+# cheaper than auditing every future consumer.
+MANIFEST_MAX_EXPANDED_NODES = 100_000
+
+
+class ManifestError(ValueError):
+    """A manifest the platform refuses to parse.
+
+    A distinct type so the router can answer a NAMED 400 instead of letting a
+    bomb surface as a request timeout or an unnamed 500 — which is the
+    difference between "your manifest is malformed" and "Trinity is broken".
+    """
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        super().__init__(message)
+
+
+class _HardenedManifestLoader(yaml.SafeLoader):
+    """SafeLoader + an expansion-cost budget + duplicate-key rejection."""
+
+    def __init__(self, stream):
+        super().__init__(stream)
+        self._expanded_nodes = 0
+        self._anchor_cost: dict = {}
+
+    def compose_node(self, parent, index):
+        # An alias contributes the FULL logical size of what it points at, so a
+        # pyramid of anchors costs what it would cost written out.
+        if self.check_event(yaml.events.AliasEvent):
+            anchor = self.peek_event().anchor
+            cost = self._anchor_cost.get(anchor, 1)
+            self._expanded_nodes += cost
+            if self._expanded_nodes > MANIFEST_MAX_EXPANDED_NODES:
+                raise ManifestError(
+                    "manifest_alias_budget_exceeded",
+                    f"Manifest expands to more than {MANIFEST_MAX_EXPANDED_NODES:,} "
+                    "nodes once its YAML aliases are resolved. This is the shape of "
+                    "an expansion bomb; if the manifest is genuine, write the "
+                    "repeated block out instead of anchoring it.",
+                )
+            return super().compose_node(parent, index)
+
+        before = self._expanded_nodes
+        self._expanded_nodes += 1
+        event = self.peek_event()
+        anchor = getattr(event, "anchor", None)
+        node = super().compose_node(parent, index)
+        if anchor:
+            # Cost of this subtree = everything composed while inside it.
+            self._anchor_cost[anchor] = self._expanded_nodes - before
+        return node
+
+    def construct_mapping(self, node, deep=False):
+        # `safe_load` silently keeps the LAST duplicate, so a manifest with two
+        # `agents:` blocks deploys only the second one with no signal at all —
+        # the real footgun now that the manifest is hand-editable in a textarea.
+        # Applied at EVERY mapping depth, so a duplicate inside one agent's
+        # config is caught too, not just the two levels the issue names.
+        seen = set()
+        for key_node, _ in node.value:
+            try:
+                key = self.construct_object(key_node, deep=deep)
+            except yaml.constructor.ConstructorError:
+                continue
+            try:
+                if key in seen:
+                    raise ManifestError(
+                        "manifest_duplicate_key",
+                        f"Duplicate key {key!r} at line {key_node.start_mark.line + 1}. "
+                        "YAML would silently keep only the last one.",
+                    )
+                seen.add(key)
+            except TypeError:
+                # Unhashable key — malformed, but not this guard's business.
+                continue
+        return super().construct_mapping(node, deep=deep)
+
+
+def _load_manifest_yaml(yaml_str: str):
+    """Parse manifest YAML with the three guards applied."""
+    if len(yaml_str.encode("utf-8")) > MANIFEST_MAX_BYTES:
+        raise ManifestError(
+            "manifest_too_large",
+            f"Manifest exceeds the {MANIFEST_MAX_BYTES}-byte parse cap.",
+        )
+    try:
+        return yaml.load(yaml_str, Loader=_HardenedManifestLoader)
+    except ManifestError:
+        raise
+    except yaml.YAMLError as e:
+        raise ManifestError("manifest_yaml_invalid", f"YAML parse error: {e}")
+
+
 def parse_manifest(yaml_str: str) -> SystemManifest:
     """
     Parse YAML string into SystemManifest.
 
     Raises:
-        ValueError: If YAML is invalid or missing required fields
+        ManifestError: If the manifest is oversized, uses more aliases than the
+            expansion budget allows, or carries a duplicate key (#1884). A
+            subclass of ValueError, so existing callers catching ValueError are
+            unaffected.
+        ValueError: If required fields are missing.
     """
-    try:
-        data = yaml.safe_load(yaml_str)
-    except yaml.YAMLError as e:
-        raise ValueError(f"YAML parse error: {str(e)}")
+    data = _load_manifest_yaml(yaml_str)
 
     if not data:
         raise ValueError("Empty manifest")
@@ -881,6 +1004,11 @@ async def deploy_manifest(
         # 1. Parse YAML
         try:
             manifest = parse_manifest(manifest_yaml)
+        except ManifestError as e:
+            # #1884: a NAMED 400. The refusal must be distinguishable from a
+            # generic parse error — "manifest_alias_budget_exceeded" tells an
+            # operator what to change; a bare stack trace or a timeout does not.
+            raise HTTPException(status_code=400, detail=f"{e.code}: {e}")
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 

--- a/tests/unit/test_1884_manifest_yaml_hardening.py
+++ b/tests/unit/test_1884_manifest_yaml_hardening.py
@@ -1,0 +1,188 @@
+"""System-manifest YAML hardening — size, expansion, duplicate keys (#1884).
+
+`yaml.safe_load` blocks arbitrary object construction but not two other things,
+and the MCP pipeline reader (#919) already set the house standard for this class:
+size cap + duplicate-key guard + alias guard. PyYAML has no equivalent of the JS
+`yaml` library's `uniqueKeys` / `maxAliasCount`, so both are implemented in
+`system_service` and pinned here.
+
+**A measured correction to the issue's premise, recorded so the next reader does
+not re-derive it.** The issue describes a few-hundred-byte manifest expanding to
+gigabytes and pinning a worker. That does not reproduce on PyYAML: it memoises
+constructed objects per node, so a billion-laughs document yields a
+shared-reference DAG (~20 KB peak, milliseconds), not an exponential tree. The
+expansion guard is kept anyway — the DAG re-expands the instant anything walks or
+serialises it (`json.dumps`, a deep copy, echoing the manifest back) — but the
+duplicate-key half is the one with immediate, user-visible impact.
+
+That correction is also why the budget counts **expansion cost, not aliases**: a
+classic bomb uses only ~45 aliases and would sail under any count-based limit,
+because the blow-up is multiplicative per level.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+def _svc():
+    try:
+        from services import system_service
+    except ImportError:  # pragma: no cover - backend venv required
+        pytest.skip("backend venv required")
+    return system_service
+
+
+def _bomb(levels: int, fan: int = 9) -> str:
+    """A classic billion-laughs pyramid: each level references the one below
+    `fan` times, so the logical size is fan**levels."""
+    lines = ["name: bomb", 'a0: &a0 ["x","x","x","x","x","x","x","x","x"]']
+    for i in range(1, levels):
+        refs = ",".join([f"*a{i - 1}"] * fan)
+        lines.append(f"a{i}: &a{i} [{refs}]")
+    lines.append(f"top: [{','.join([f'*a{levels - 1}'] * fan)}]")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Expansion budget
+# ---------------------------------------------------------------------------
+
+def test_billion_laughs_is_refused_by_name():
+    """AC: a named 400-able error, not a timeout and not an unnamed 500."""
+    svc = _svc()
+    doc = _bomb(levels=8)
+    assert len(doc) < 1000, "the point of a bomb is that the source is tiny"
+
+    with pytest.raises(svc.ManifestError) as exc:
+        svc.parse_manifest(doc)
+    assert exc.value.code == "manifest_alias_budget_exceeded"
+
+
+def test_the_budget_counts_expansion_not_alias_count():
+    """The reason a `maxAliasCount`-style limit is the wrong shape here.
+
+    This bomb uses far FEWER than 100 alias references, so a count-based budget
+    would pass it — while its expanded size is in the millions.
+    """
+    svc = _svc()
+    doc = _bomb(levels=8)
+    assert doc.count("*a") < 100, "otherwise this test proves nothing"
+
+    with pytest.raises(svc.ManifestError):
+        svc.parse_manifest(doc)
+
+
+def test_legitimate_anchor_reuse_still_parses():
+    """The guard must not break the feature. Merge keys are the normal, useful
+    way to share defaults across agents in a manifest — an over-tight budget
+    would make anchors unusable and get the guard removed."""
+    svc = _svc()
+    manifest = svc.parse_manifest(
+        "name: sys\n"
+        "defaults: &d\n"
+        "  template: 'local:default'\n"
+        "agents:\n"
+        "  a: {<<: *d}\n"
+        "  b: {<<: *d}\n"
+        "  c: {<<: *d}\n"
+    )
+    assert sorted(manifest.agents) == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Duplicate keys — the half with immediate user-visible impact
+# ---------------------------------------------------------------------------
+
+def test_duplicate_agents_block_is_refused():
+    """`safe_load` silently keeps the LAST duplicate, so this manifest would
+    have deployed only `b` with no signal — the real footgun now that the
+    manifest is hand-editable in a textarea."""
+    svc = _svc()
+    with pytest.raises(svc.ManifestError) as exc:
+        svc.parse_manifest(
+            "name: sys\n"
+            "agents:\n"
+            "  a: {template: 'local:x'}\n"
+            "agents:\n"
+            "  b: {template: 'local:y'}\n"
+        )
+    assert exc.value.code == "manifest_duplicate_key"
+    assert "agents" in str(exc.value)
+
+
+def test_duplicate_key_inside_one_agent_is_also_refused():
+    """Applied at every mapping depth, not only the two levels the issue names —
+    a duplicated `template:` is the same silent-last-wins bug one level down."""
+    svc = _svc()
+    with pytest.raises(svc.ManifestError) as exc:
+        svc.parse_manifest(
+            "name: sys\n"
+            "agents:\n"
+            "  a:\n"
+            "    template: 'local:x'\n"
+            "    template: 'local:y'\n"
+        )
+    assert exc.value.code == "manifest_duplicate_key"
+
+
+def test_the_error_names_the_line():
+    """A refusal an operator can act on. 'Duplicate key' without a location in a
+    200-line manifest is a worse experience than the silent bug."""
+    svc = _svc()
+    with pytest.raises(svc.ManifestError) as exc:
+        svc.parse_manifest(
+            "name: sys\n"
+            "agents:\n"
+            "  a: {template: 'local:x'}\n"
+            "agents:\n"
+            "  b: {template: 'local:y'}\n"
+        )
+    assert "line 4" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Size cap, and the contract the callers rely on
+# ---------------------------------------------------------------------------
+
+def test_oversized_manifest_is_refused():
+    svc = _svc()
+    with pytest.raises(svc.ManifestError) as exc:
+        svc.parse_manifest("name: x\n" + "#" * svc.MANIFEST_MAX_BYTES)
+    assert exc.value.code == "manifest_too_large"
+
+
+def test_manifest_error_is_a_valueerror():
+    """Both call sites (`deploy_manifest`, `system_seed_service`) catch
+    ValueError. Subclassing keeps them working unchanged — the named code is
+    additive, not a breaking change."""
+    svc = _svc()
+    assert issubclass(svc.ManifestError, ValueError)
+
+
+def test_a_normal_manifest_is_unaffected():
+    svc = _svc()
+    manifest = svc.parse_manifest(
+        "name: sys\n"
+        "description: a normal system\n"
+        "agents:\n"
+        "  worker: {template: 'local:default'}\n"
+    )
+    assert manifest.name == "sys"
+    assert list(manifest.agents) == ["worker"]
+
+
+def test_invalid_yaml_still_reports_as_a_parse_error():
+    """Malformed YAML must not be mislabelled as a bomb or a duplicate key."""
+    svc = _svc()
+    with pytest.raises(svc.ManifestError) as exc:
+        svc.parse_manifest("name: [unclosed\n")
+    assert exc.value.code == "manifest_yaml_invalid"

--- a/tests/unit/test_1884_manifest_yaml_hardening.py
+++ b/tests/unit/test_1884_manifest_yaml_hardening.py
@@ -186,3 +186,46 @@ def test_invalid_yaml_still_reports_as_a_parse_error():
     with pytest.raises(svc.ManifestError) as exc:
         svc.parse_manifest("name: [unclosed\n")
     assert exc.value.code == "manifest_yaml_invalid"
+
+
+# ---------------------------------------------------------------------------
+# Gaps found reviewing this change, not writing it
+# ---------------------------------------------------------------------------
+
+def test_a_wide_shallow_bomb_is_also_refused():
+    """The tests above are all DEEP pyramids. A bomb can equally be wide and
+    shallow — two levels with a huge fan — which a level-based intuition misses
+    entirely. The budget is shape-agnostic because it counts expanded nodes, and
+    this pins that rather than leaving it to luck."""
+    svc = _svc()
+    fan = 400
+    doc = (
+        "name: b\n"
+        'a: &a ["' + '","'.join(["x"] * fan) + '"]\n'
+        f"b: [{','.join(['*a'] * fan)}]\n"
+    )
+    assert len(doc) < 4000
+    with pytest.raises(svc.ManifestError) as exc:
+        svc.parse_manifest(doc)
+    assert exc.value.code == "manifest_alias_budget_exceeded"
+
+
+def test_every_shipped_manifest_still_parses():
+    """The guard must not brick first-run seeding.
+
+    `config/manifests/default-system.yaml` is deployed automatically on a fresh
+    install (`system_seed_service`), so a false positive here would not be a
+    rejected request — it would be a broken installation. Parse everything the
+    repo ships.
+    """
+    import glob
+
+    svc = _svc()
+    root = Path(__file__).resolve().parents[2]
+    manifests = sorted(glob.glob(str(root / "config" / "manifests" / "*.yaml")))
+    assert manifests, "expected bundled manifests to exist"
+
+    for path in manifests:
+        with open(path) as fh:
+            manifest = svc.parse_manifest(fh.read())
+        assert manifest.agents, f"{path} parsed to zero agents"

--- a/tests/unit/test_1884_manifest_yaml_hardening.py
+++ b/tests/unit/test_1884_manifest_yaml_hardening.py
@@ -229,3 +229,40 @@ def test_every_shipped_manifest_still_parses():
         with open(path) as fh:
             manifest = svc.parse_manifest(fh.read())
         assert manifest.agents, f"{path} parsed to zero agents"
+
+
+# ---------------------------------------------------------------------------
+# The loader is still SAFE — raised by CodeQL review of this PR
+# ---------------------------------------------------------------------------
+
+def test_the_hardened_loader_is_a_safeloader_not_a_full_loader():
+    """CodeQL flags `yaml.load(..., Loader=...)` as unsafe deserialization by
+    call shape, without resolving the subclass.
+
+    It is a false positive here — but "trust me, it subclasses SafeLoader" is an
+    assertion, and this change is the reason the call moved off `safe_load` in
+    the first place. So the safety property is pinned rather than argued: if
+    anyone ever re-parents this loader to `FullLoader` or `yaml.Loader`, the
+    build fails instead of a reviewer having to notice.
+    """
+    import yaml
+
+    svc = _svc()
+    mro = svc._HardenedManifestLoader.__mro__
+    assert yaml.SafeLoader in mro
+    unsafe = {"FullLoader", "UnsafeLoader", "Loader", "CLoader", "CFullLoader"}
+    assert not {c.__name__ for c in mro} & unsafe
+
+
+@pytest.mark.parametrize("payload", [
+    '!!python/object/apply:os.system ["echo pwned"]',
+    'name: !!python/object/apply:subprocess.check_output [["id"]]',
+    "!!python/name:os.system {}",
+    "!!python/object/new:type [x, !!python/tuple [], {}]",
+])
+def test_python_object_tags_are_refused(payload):
+    """The behavioural half: arbitrary object construction must be impossible,
+    which is the actual property CodeQL's rule exists to protect."""
+    svc = _svc()
+    with pytest.raises(svc.ManifestError):
+        svc.parse_manifest(payload)


### PR DESCRIPTION
Closes #1884.

`parse_manifest` used bare `yaml.safe_load`. Mirrors the house standard set by the MCP pipeline reader (#919) — **size cap + duplicate-key guard + alias guard** — rather than inventing a second approach. PyYAML has no equivalent of the JS `yaml` library's `uniqueKeys` / `maxAliasCount`, so both are implemented in a `SafeLoader` subclass.

## A measured correction to the issue's premise

The issue describes a few-hundred-byte manifest expanding to gigabytes and pinning a worker. **That does not reproduce on PyYAML.** It memoises constructed objects per node, so a billion-laughs document yields a shared-reference DAG:

```
levels=4  src=237B  parse=0.002s  peak=19KB  aliases-shared=True
levels=6  src=329B  parse=0.003s  peak=18KB  aliases-shared=True
levels=8  src=421B  parse=0.013s  peak=20KB  aliases-shared=True
```

The stated DoS isn't reachable through `safe_load` alone. The guard ships anyway — the DAG re-expands the instant anything walks or serialises it (`json.dumps`, a deep copy, echoing the manifest back), and guarding the parser is cheaper than auditing every future consumer — but **the duplicate-key half is the one with immediate user-visible impact**, and that ordering is now written down rather than left implied.

## …which changed the guard's shape

A `maxAliasCount`-style budget is the wrong rule here. The classic bomb uses **~45 aliases** across a few levels and would sail under any count-based limit, because the blow-up is *multiplicative per level*, not linear in aliases.

So the budget counts **expansion cost** — the number of logical nodes the document would have with every alias resolved — accumulated at compose time, so it's spent before the document is materialised. Verified behaviour:

| input | result |
|---|---|
| bomb, 3–4 levels | parses (small structure, no DoS) |
| bomb, 5–8 levels | **refused** `manifest_alias_budget_exceeded` |
| `<<: *defaults` reuse across 3 agents | **parses** — the guard must not break the feature |

## Duplicate keys

Rejected at **every mapping depth**, not just the two levels the issue names — a duplicated `template:` inside one agent is the same silent last-wins bug one level down. The error names the offending line, because "duplicate key" without a location in a 200-line manifest is worse than the silent bug.

## Two assumptions in the issue that don't hold on `dev`

Neither the *"tracked as a follow-up"* comment in `models.py` nor `MANIFEST_MAX_BYTES` exists here — trinity-enterprise#126 hasn't landed in the public repo. So the size cap is **introduced** by this change (completing the three-part mirror), and the `models.py` pointer is **added** rather than updated. Flagging rather than silently reinterpreting the AC.

## Compatibility

`ManifestError` subclasses `ValueError`, so both call sites (`deploy_manifest`, `system_seed_service`) keep working unchanged. The deploy path additionally surfaces the code, giving the **named 400** the AC asks for instead of a timeout or an unnamed 500.

## Tests — 10

Billion-laughs refused by name; a bomb with <100 aliases still refused (pinning *why* the budget isn't count-based); legitimate anchor reuse still parses; duplicate `agents:` and duplicate `template:` both refused; the error names the line; oversize refused; `ManifestError` is a `ValueError`; a normal manifest unaffected; malformed YAML still reported as a parse error rather than mislabelled as a bomb.

**Verified 7 fail with the guards bypassed.** 204 passed across the system/manifest suites; CI-style collection clean at 5617 tests (the 4 errors are `hypothesis`-dependent files, absent locally, installed in CI).