### PR TITLE
fix(ui): widen the Settings panel to fit its own tab strip (#1862)

### DIFF
--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -2,7 +2,14 @@
   <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
     <NavBar />
 
-    <main class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+    <!-- #1862: `max-w-4xl` (896px) was too narrow for this view's own tab
+         strip — the ten tabs measure ~925px, so `main` overflowed by ~61px
+         and scrolled horizontally at any desktop width. Settings was also
+         the ONLY top-level view on 4xl; Agents, Operations, Templates and
+         ExecutionDetail all use 7xl. Matching them fixes the overflow and
+         removes the odd one out rather than inventing a bespoke width.
+         `max-w-*` is a ceiling, so narrow viewports are unaffected. -->
+    <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
       <div class="px-4 py-6 sm:px-0">
         <div class="mb-8">
           <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Settings</h1>
@@ -1670,8 +1677,10 @@ Example:
               </div>
 
               <!-- Users Table — padding trimmed + compact actions so the
-                   entitlement-gated Management column fits the max-w-4xl
-                   card without a horizontal scrollbar (#995). -->
+                   entitlement-gated Management column fits without a horizontal
+                   scrollbar (#995). That trimming was sized against the old
+                   max-w-4xl container; the view is max-w-7xl since #1862, so
+                   there is now headroom here rather than a tight fit. -->
               <div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
                 <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                   <thead class="bg-gray-50 dark:bg-gray-700">


### PR DESCRIPTION
Closes #1862.

## Diagnosis (the issue asked for this)

The issue left a placeholder: *"Fill in when picking up: which specific components overflow on the default panel."* Measured at a 1440px viewport:

```
main             = 896px   (max-w-4xl)
main.scrollWidth = 957px   -> 61px of horizontal overflow
overflowing child: nav.-mb-px.flex.space-x-6   (925px inside an 832px box)
```

**The overflowing component is the view's own tab strip.** Ten tabs (General … Activation) need ~925px, so the tab row rendered past the right edge of the content card beneath it. That is the only offender — no input, select, table or form overflows its parent.

## Root cause

Settings was the **only** top-level view constrained to `max-w-4xl` (896px):

| View | max-width |
|---|---|
| Agents, Operations, Templates, ExecutionDetail | `max-w-7xl` |
| **Settings** | **`max-w-4xl`** |

So the fix matches the house convention rather than inventing a bespoke width. `max-w-*` is a ceiling, so nothing changes below it.

## Verified across viewports — before vs after

| width | before | after | |
|---|---|---|---|
| 1440px | 4 horizontal scrollers, main 896px | **0 scrollers**, main 1280px | fixed |
| 1024px | doc scroll 1014 | doc scroll 1009 | slightly better |
| 768px | doc scroll 949 | doc scroll 949 | **identical — no regression** |

Measured by re-running the same probe against `max-w-4xl` and `max-w-7xl` on a live instance, not inferred.

## Honest scope note

**768px still overflows, before and after.** Ten tabs cannot fit a 768px viewport at any container width — that needs the strip to wrap or scroll deliberately, which is the class of #1754 and explicitly not addressed here. This issue is the panel being narrower than the viewport allows; that one is the strip being wider than a small viewport.

## Also

Corrected a comment on the users table justifying trimmed padding as fitting *"the max-w-4xl card"* (#995). That constraint is gone; left as-is the comment would push the next person to preserve a workaround for a limit that no longer exists.

## Screenshots

Before / after at 1440px are attached to the issue thread. The visible difference: the tab strip previously ran past the right edge of the content card; it now sits inside it, and the cards use the full width.