### PR TITLE
fix(ui): paint the page canvas so overscroll isn't white (#1888)

### DIFF
--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -7,6 +7,24 @@
    don't shift horizontally. Issue #954. */
 html {
   scrollbar-gutter: stable;
+
+  /* Paint the page canvas. The app background lives on the #app wrapper, so it
+     stops at that element's box — anything the browser draws outside it (macOS
+     elastic overscroll past the top/bottom, and the gap a short page leaves)
+     falls back to the default white canvas, which flashes bright against the
+     dark UI. The canvas takes its color from <html>, which Tailwind's preflight
+     leaves transparent; setting it here is the only place that covers it. */
+  background-color: theme('colors.gray.100');
+
+  /* Tell the browser which scheme its own chrome should use: native scrollbars
+     (Firefox ignores the ::-webkit-scrollbar rules below), form-control
+     defaults, and the fallback canvas. */
+  color-scheme: light;
+}
+
+html.dark {
+  background-color: theme('colors.gray.900');
+  color-scheme: dark;
 }
 
 /* Theme transition for smooth dark mode switching */


### PR DESCRIPTION
Closes #1888

## What

Two rules in `src/frontend/src/style.css`. That's the whole diff.

```css
html {
  background-color: theme('colors.gray.100');
  color-scheme: light;
}

html.dark {
  background-color: theme('colors.gray.900');
  color-scheme: dark;
}
```

## Why here and not somewhere else

The app background is on the `#app` wrapper (`App.vue`: `min-h-screen bg-gray-100
dark:bg-gray-900`), so it stops at that element's box. Elastic overscroll reveals the
**browser canvas**, which takes its color from `<html>` — and Tailwind's preflight
leaves `<html>` and `<body>` transparent. Nothing in the tree paints it, so the browser
falls back to white.

`<html>` is the only element that can fix this. Widening the `#app` background can't:
the canvas is outside the document's box by definition.

`.dark` is applied to `document.documentElement` (`stores/theme.js`), so `html.dark`
is the right selector.

## The `color-scheme` half

This file styles scrollbars only via `.dark ::-webkit-scrollbar*`. **Firefox ignores
those rules**, so the scrollbar has always rendered light against the dark UI.
`color-scheme` is the standard way to tell a browser which scheme its own chrome should
use — it covers native scrollbars, form-control defaults, and the browser's fallback
canvas. Same defect class as the white band (browser-owned chrome not told about the
theme), one line, so it rides along.

Trade-off worth stating: `color-scheme: dark` also changes the rendering of *unstyled*
native controls. Trinity's inputs carry explicit Tailwind backgrounds, so the visible
effect is native `<select>` popups and scrollbars adopting the dark theme — which is
the intent. Flagging it because it's a wider blast radius than the background rule.

## Verification

Measured against a running instance, `getComputedStyle(document.documentElement)`:

```
BEFORE  light  html-bg=rgba(0, 0, 0, 0)    color-scheme=normal
BEFORE  dark   html-bg=rgba(0, 0, 0, 0)    color-scheme=normal
AFTER   light  html-bg=rgb(243, 244, 246)  color-scheme=light
AFTER   dark   html-bg=rgb(17, 24, 39)     color-scheme=dark
```

`rgb(17, 24, 39)` is `gray-900` and `rgb(243, 244, 246)` is `gray-100` — exact matches
with the app shell, so the canvas is indistinguishable from the page rather than a
near-miss shade.

Also confirmed by eye on a dev server built from this branch: overscroll past the top
and bottom in both themes, and theme toggling (the existing `* { transition:
background-color }` rule carries `<html>` across, so there's no white frame mid-toggle).

## Scope

CSS only. No JS, no component, no build-config change. Every full-page view in
`views/` already uses `gray-50`/`gray-100` light and `gray-900` dark, so one canvas
color is correct for all of them.
