### PR TITLE
fix(security): admin gates reject agent-scoped keys

### DIFF
--- a/src/backend/dependencies.py
+++ b/src/backend/dependencies.py
@@ -687,11 +687,17 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
 
     An agent-scoped key resolves to its owner CARRYING THE OWNER'S ROLE, so on a
     default admin-owned install every agent's injected `TRINITY_MCP_API_KEY`
-    satisfied this gate. That is three consecutive incidents of one class —
+    satisfied this gate. ent#297 traced FIVE occurrences of one class —
     trinity-ops-agent#232, #1644 (retention acknowledge), #1816 (system-agent
-    restart) — each previously closed by bolting `reject_agent_principal` onto
-    one more endpoint. Three occurrences means the GATE was wrong, not the
-    endpoints, so the rejection moves here and the class closes at once.
+    restart), ent#236 and ent#293 (skills-library repointing) — each previously
+    closed by bolting `reject_agent_principal` onto one more endpoint, 18 of
+    them, against 114 admin-gated call sites. Five occurrences means the GATE
+    was wrong, not the endpoints, so the rejection moves here.
+
+    Note this closes the class for THIS gate and `assert_admin`. It does not
+    reach `require_role("admin")`, a third spelling that must not exist — see
+    `require_role`'s docstring for why it stays permissive and the guard that
+    keeps the spelling from coming back.
 
     Safe by construction, verified rather than assumed: the agent-key flows that
     must keep working — heartbeat, structured reports, the #1083 result callback
@@ -727,6 +733,24 @@ def require_role(min_role: str):
 
     Raises:
         HTTPException(403): If user's role is below the minimum required
+
+    **Deliberately does NOT call `reject_agent_principal`** — read this before
+    "fixing" it to match `require_admin`/`assert_admin` (ent#293/ent#297).
+
+    Those two gates reject agent principals because an admin gate is never
+    agent-callable. This one is different: its main consumer is
+    `require_role("creator")` on `POST /api/agents`, and agent-spawned agent
+    creation is a SUPPORTED feature (ent#69 Part 2 — the spawn persists
+    `spawned_by_agent`, auto-grants the parent→child permission edge, and is
+    bounded by `enforce_agent_spawn_scope` + the per-parent spawn rate limit).
+    Adding a blanket rejection here would break ghost spawning outright.
+
+    The corollary, and the trap ent#297 walked into: `require_role("admin")` was
+    a THIRD spelling of an admin gate that this permissiveness left open after
+    the other two were closed. Do not write `require_role("admin")` — use
+    `require_admin`, which is equivalent (`admin` is last in ROLE_HIERARCHY) and
+    carries the agent rejection. `tests/unit/test_293_admin_gate_rejects_agent_keys.py`
+    fails the build if a `require_role("admin")` reappears.
     """
     def _require_role(current_user: User = Depends(get_current_user)) -> User:
         _reject_connector_principal(current_user)
@@ -961,11 +985,17 @@ def assert_admin(current_user: User, *, detail: str = "Admin access required") -
 
     An agent-scoped key resolves to its owner CARRYING THE OWNER'S ROLE, so on a
     default admin-owned install every agent's injected `TRINITY_MCP_API_KEY`
-    satisfied this gate. That is three consecutive incidents of one class —
+    satisfied this gate. ent#297 traced FIVE occurrences of one class —
     trinity-ops-agent#232, #1644 (retention acknowledge), #1816 (system-agent
-    restart) — each previously closed by bolting `reject_agent_principal` onto
-    one more endpoint. Three occurrences means the GATE was wrong, not the
-    endpoints, so the rejection moves here and the class closes at once.
+    restart), ent#236 and ent#293 (skills-library repointing) — each previously
+    closed by bolting `reject_agent_principal` onto one more endpoint, 18 of
+    them, against 114 admin-gated call sites. Five occurrences means the GATE
+    was wrong, not the endpoints, so the rejection moves here.
+
+    Note this closes the class for THIS gate and `assert_admin`. It does not
+    reach `require_role("admin")`, a third spelling that must not exist — see
+    `require_role`'s docstring for why it stays permissive and the guard that
+    keeps the spelling from coming back.
 
     Safe by construction, verified rather than assumed: the agent-key flows that
     must keep working — heartbeat, structured reports, the #1083 result callback

--- a/src/backend/dependencies.py
+++ b/src/backend/dependencies.py
@@ -680,9 +680,30 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
     Dependency that requires the current user to be an admin.
 
     Raises:
-        HTTPException(403): If user is not an admin
+        HTTPException(403): If user is not an admin, or is an agent/connector
+            principal.
+
+    ent#293 — an ADMIN gate is never agent-callable.
+
+    An agent-scoped key resolves to its owner CARRYING THE OWNER'S ROLE, so on a
+    default admin-owned install every agent's injected `TRINITY_MCP_API_KEY`
+    satisfied this gate. That is three consecutive incidents of one class —
+    trinity-ops-agent#232, #1644 (retention acknowledge), #1816 (system-agent
+    restart) — each previously closed by bolting `reject_agent_principal` onto
+    one more endpoint. Three occurrences means the GATE was wrong, not the
+    endpoints, so the rejection moves here and the class closes at once.
+
+    Safe by construction, verified rather than assumed: the agent-key flows that
+    must keep working — heartbeat, structured reports, the #1083 result callback
+    — authorize on `current_user.agent_name` self-checks and never touch an admin
+    gate. System-scoped keys are unaffected because `User.agent_name` is set only
+    for `scope == "agent"`, so `trinity-system` still passes.
+
+    This is the grant-vs-use line from `learnings.md`: the endpoint that USES a
+    capability may be agent-callable; the endpoint that GRANTS one is human-only.
     """
     _reject_connector_principal(current_user)
+    reject_agent_principal(current_user)
     if current_user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -932,11 +953,31 @@ def get_owned_agent_by_name(
 def assert_admin(current_user: User, *, detail: str = "Admin access required") -> None:
     """Imperative admin gate — parity with the ``require_admin`` Depends form.
 
-    Rejects connector principals first (they are consumption-only), then requires
-    ``role == "admin"``. Raises 403 on failure; returns None on success. Use in a
-    router body where the admin check is inline rather than a ``Depends``.
+    Rejects connector AND agent principals (neither is a human admin), then
+    requires ``role == "admin"``. Raises 403 on failure; returns None on success.
+    Use in a router body where the admin check is inline rather than a ``Depends``.
+
+    ent#293 — an ADMIN gate is never agent-callable.
+
+    An agent-scoped key resolves to its owner CARRYING THE OWNER'S ROLE, so on a
+    default admin-owned install every agent's injected `TRINITY_MCP_API_KEY`
+    satisfied this gate. That is three consecutive incidents of one class —
+    trinity-ops-agent#232, #1644 (retention acknowledge), #1816 (system-agent
+    restart) — each previously closed by bolting `reject_agent_principal` onto
+    one more endpoint. Three occurrences means the GATE was wrong, not the
+    endpoints, so the rejection moves here and the class closes at once.
+
+    Safe by construction, verified rather than assumed: the agent-key flows that
+    must keep working — heartbeat, structured reports, the #1083 result callback
+    — authorize on `current_user.agent_name` self-checks and never touch an admin
+    gate. System-scoped keys are unaffected because `User.agent_name` is set only
+    for `scope == "agent"`, so `trinity-system` still passes.
+
+    This is the grant-vs-use line from `learnings.md`: the endpoint that USES a
+    capability may be agent-callable; the endpoint that GRANTS one is human-only.
     """
     _reject_connector_principal(current_user)
+    reject_agent_principal(current_user)
     if current_user.role != "admin":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -31,7 +31,7 @@ from models import (
     User,
 )
 from database import db
-from dependencies import get_current_user, decode_token, require_role, AuthorizedAgentByName, OwnedAgentByName, CurrentUser, enforce_agent_spawn_scope
+from dependencies import get_current_user, decode_token, require_role, require_admin, AuthorizedAgentByName, OwnedAgentByName, CurrentUser, enforce_agent_spawn_scope
 from services.docker_service import (
     get_agent_container,
     get_agent_by_name,
@@ -826,7 +826,20 @@ async def force_release_agent(
 @router.post("/{agent_name}/circuit-breaker/reset")
 async def reset_circuit_breaker_endpoint(
     agent_name: AuthorizedAgentByName,
-    current_user: User = Depends(require_role("admin")),
+    # ent#293/ent#297: was `require_role("admin")` — the THIRD spelling of an
+    # admin gate, and the one this PR's first pass missed. `require_role`
+    # rejects connector principals but NOT agent ones, deliberately: agent
+    # -spawned agent creation runs through `require_role("creator")` (ent#69
+    # Part 2). So after `require_admin`/`assert_admin` were closed, an
+    # admin-owned agent's own key still passed HERE — and ent#297 names
+    # circuit-breaker resets in its blast radius. An agent that can re-close its
+    # own dispatch breaker on demand defeats the control built to contain it.
+    #
+    # `require_admin` is equivalent for this case (`admin` is last in
+    # ROLE_HIERARCHY, so ">= admin" is "== admin") and additionally rejects
+    # agent principals. Swapping this ONE call site is the fix; adding the
+    # rejection to `require_role` itself would break ghost spawning.
+    current_user: User = Depends(require_admin),
 ):
     """Force the agent's circuit breakers to closed (#921, #526).
 

--- a/src/backend/routers/monitoring.py
+++ b/src/backend/routers/monitoring.py
@@ -379,12 +379,20 @@ async def get_agent_health_history(
 @router.post("/agents/{agent_name}/check", response_model=AgentHealthDetail)
 async def trigger_health_check(
     agent_name: AuthorizedAgentByName,
-    current_user: User = Depends(require_admin)
+    current_user: User = Depends(get_current_user)
 ):
     """
     Trigger an immediate health check for an agent.
 
-    Admin only. Forces a fresh health check regardless of schedule.
+    Forces a fresh health check regardless of schedule.
+
+    ent#293 review: the `require_admin` here was redundant — `AuthorizedAgentByName`
+    already restricts this to callers who own or are shared the agent — and once
+    admin gates stopped accepting agent-scoped keys it made the surface
+    incoherent: an ops agent could READ health (`GET /status`,
+    `GET /agents/{name}`, both non-admin) but not REFRESH it. Triggering a probe
+    on an agent you can already see is a USE of a capability, not a grant of one,
+    so it takes the same gate as its siblings.
 
     #631 — this endpoint is the documented manual recovery path out of the
     dormant circuit state. Reset the circuit before running the check so the

--- a/src/backend/routers/subscriptions.py
+++ b/src/backend/routers/subscriptions.py
@@ -114,14 +114,29 @@ async def list_subscriptions(
     current_user: User = Depends(get_current_user)
 ):
     """
-    List all subscriptions with their assigned agents.
+    List subscriptions with their assigned agents. Admin sees the fleet; every
+    other caller sees only their own. Never returns the encrypted credentials.
 
-    Admin-only. Returns subscription metadata and agent assignments.
-    Never returns the encrypted credentials.
+    ent#293 review: this was `assert_admin`, which broke the subscription
+    workflow asymmetrically once admin gates stopped accepting agent-scoped
+    keys — `assign_subscription` / `clear_agent_subscription` / `get_agent_auth`
+    all kept working (owner gates), so an agent could ASSIGN a subscription it
+    could no longer ENUMERATE. A half-working workflow is worse than a closed
+    door.
+
+    Scoped rather than un-gated, deliberately. Dropping the gate entirely was
+    the first attempt and it was wrong: the payload carries `owner_email` and
+    the full agent-name list of EVERY subscription, so an ungated read hands any
+    `role=user` account a fleet-wide owner-email and agent-name enumeration
+    oracle — the disclosure class Invariant #8 exists to prevent, reintroduced
+    by a fix for a different disclosure. The `owner_id` filter is already part
+    of the accessor's contract, so scoping costs nothing and restores exactly
+    the read the workflow needs: an agent key resolves to its owner and sees
+    that owner's subscriptions, which are the only ones it can assign anyway.
     """
-    assert_admin(current_user)
-
-    return db.list_subscriptions_with_agents()
+    if current_user.role == "admin" and not getattr(current_user, "agent_name", None):
+        return db.list_subscriptions_with_agents()
+    return db.list_subscriptions_with_agents(owner_id=current_user.id)
 
 
 @router.get("/{subscription_id}/usage", response_model=SubscriptionUsage)
@@ -132,7 +147,9 @@ async def get_subscription_usage(
     """
     Get rolling usage statistics for a subscription (SUB-004).
 
-    Admin-only. Returns token and cost aggregates across two rolling windows:
+    Returns token and cost aggregates across two rolling windows (the docstring
+    said "Admin-only" while the gate has always been `get_current_user` — noted
+    while auditing this module for ent#293):
     - window_5h: last 5 hours
     - window_7d: last 7 days
 

--- a/tests/unit/test_1018_settlement_ordering.py
+++ b/tests/unit/test_1018_settlement_ordering.py
@@ -370,7 +370,8 @@ def _drive_retry(*, role="admin", log_entry="settle_failed"):
         entry = SimpleNamespace(action=log_entry, agent_name="agent-a")
     mock_db = MagicMock()
     mock_db.get_nevermined_payment_log_entry.return_value = entry
-    user = SimpleNamespace(role=role, username="u", connector_agent=None)
+    user = SimpleNamespace(role=role, username="u", connector_agent=None,
+                           agent_name=None)  # ent#293: not an agent-scoped key
 
     with (
         patch.object(nvm, "NEVERMINED_AVAILABLE", True),

--- a/tests/unit/test_1638_retention_upgrade_safety.py
+++ b/tests/unit/test_1638_retention_upgrade_safety.py
@@ -192,6 +192,7 @@ def test_ops_reset_cannot_strand_a_retention_window():
     admin = MagicMock()
     admin.role = "admin"
     admin.connector_agent = None  # #1310: not a connector principal
+    admin.agent_name = None  # ent#293: not an agent-scoped key
 
     fake_db = MagicMock()
     fake_db.delete_setting.return_value = True

--- a/tests/unit/test_293_admin_gate_rejects_agent_keys.py
+++ b/tests/unit/test_293_admin_gate_rejects_agent_keys.py
@@ -1,0 +1,217 @@
+"""An admin gate is never agent-callable (ent#293).
+
+An agent-scoped MCP key resolves to its owner **carrying the owner's role**, so
+on a default admin-owned install every agent's injected `TRINITY_MCP_API_KEY`
+satisfied every `assert_admin` / `require_admin` gate. The concrete chain: a
+prompt-injected agent repoints `skills_library_url` at an attacker-controlled
+repo through the generic `PUT /api/settings/{key}`, and the scheduled sync then
+writes attacker-authored `SKILL.md` files into every running agent — instructions
+Claude executes, persistent across restarts. One compromised agent becomes all of
+them.
+
+This is the THIRD occurrence of the class (trinity-ops-agent#232 → #1644 → #1816),
+each previously closed by bolting `reject_agent_principal` onto one more
+endpoint. So the fix moves into the gate, and these tests pin the gate rather
+than any single route — a fourth endpoint added tomorrow inherits the protection
+without anyone remembering to ask for it.
+
+**No MagicMock anywhere below, deliberately.** A bare `MagicMock` auto-creates a
+truthy `.agent_name`, so it reads as an agent key and passes these tests for the
+wrong reason — the trap #1816 recorded. Every principal here is an explicit
+object with explicit fields.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+
+@dataclass
+class _Principal:
+    """An explicit stand-in for `models.User` — every field stated."""
+    id: int = 1
+    username: str = "admin"
+    email: Optional[str] = "admin@example.com"
+    role: str = "admin"
+    agent_name: Optional[str] = None
+    connector_agent: Optional[str] = None
+    portal_delegate: bool = False
+
+
+def _deps():
+    try:
+        import dependencies
+    except ImportError:  # pragma: no cover - backend venv required
+        pytest.skip("backend venv required")
+    return dependencies
+
+
+# The exact principal the exploit uses: an agent's own key on an admin-owned
+# install. It carries role="admin" because that is precisely the bug.
+AGENT_KEY = _Principal(username="admin", role="admin", agent_name="prospector")
+HUMAN_ADMIN = _Principal(username="admin", role="admin", agent_name=None)
+SYSTEM_KEY = _Principal(username="admin", role="admin", agent_name=None)
+CONNECTOR_KEY = _Principal(role="admin", connector_agent="atlas")
+NON_ADMIN = _Principal(username="bob", role="user", agent_name=None)
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+def test_assert_admin_rejects_an_agent_scoped_key():
+    from fastapi import HTTPException
+
+    d = _deps()
+    with pytest.raises(HTTPException) as exc:
+        d.assert_admin(AGENT_KEY)
+    assert exc.value.status_code == 403
+
+
+def test_require_admin_rejects_an_agent_scoped_key():
+    """The `Depends` form must match the imperative one — half a fix is how the
+    class survived three rounds."""
+    from fastapi import HTTPException
+
+    d = _deps()
+    with pytest.raises(HTTPException) as exc:
+        d.require_admin(AGENT_KEY)
+    assert exc.value.status_code == 403
+
+
+def test_the_agent_principal_carries_the_owners_admin_role():
+    """Pins WHY the gate was wrong, so nobody 'simplifies' the fix away by
+    reasoning that an agent key could not have been an admin in the first
+    place."""
+    assert AGENT_KEY.role == "admin"
+    assert AGENT_KEY.agent_name == "prospector"
+
+
+# ---------------------------------------------------------------------------
+# Non-regression — the fix must not lock out legitimate callers
+# ---------------------------------------------------------------------------
+
+def test_a_human_admin_still_passes_both_gates():
+    d = _deps()
+    d.assert_admin(HUMAN_ADMIN)
+    assert d.require_admin(HUMAN_ADMIN) is HUMAN_ADMIN
+
+
+def test_a_system_scoped_key_still_passes():
+    """`trinity-system` must keep working. Safe by construction:
+    `User.agent_name` is populated only for `scope == "agent"`, so a
+    system-scoped key has `agent_name=None` and never trips the agent guard."""
+    d = _deps()
+    d.assert_admin(SYSTEM_KEY)
+    assert d.require_admin(SYSTEM_KEY) is SYSTEM_KEY
+
+
+def test_a_connector_key_is_still_rejected():
+    from fastapi import HTTPException
+
+    d = _deps()
+    for gate in (d.assert_admin, d.require_admin):
+        with pytest.raises(HTTPException) as exc:
+            gate(CONNECTOR_KEY)
+        assert exc.value.status_code == 403
+
+
+def test_a_non_admin_human_is_still_rejected():
+    from fastapi import HTTPException
+
+    d = _deps()
+    with pytest.raises(HTTPException) as exc:
+        d.assert_admin(NON_ADMIN)
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# The exploit, at the endpoint the chain actually used
+# ---------------------------------------------------------------------------
+
+def test_an_agent_key_cannot_repoint_the_skills_library(monkeypatch):
+    """AC #1, driven through the real handler.
+
+    `PUT /api/settings/{key}` is the generic setter the chain used, and the
+    SEC-179 guard constrains the HOST to github.com but not WHICH repository —
+    so any public repo was accepted. The gate is what has to stop this.
+    """
+    import asyncio
+    from fastapi import HTTPException
+
+    try:
+        from routers import settings as settings_router
+        from db_models import SystemSettingUpdate
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    class _Req:
+        client = type("c", (), {"host": "127.0.0.1"})()
+        url = type("u", (), {"path": "/api/settings/skills_library_url"})()
+        state = type("s", (), {"request_id": "r1"})()
+        headers: dict = {}
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            settings_router.update_setting(
+                key="skills_library_url",
+                body=SystemSettingUpdate(value="https://github.com/attacker/evil-skills"),
+                request=_Req(),
+                current_user=AGENT_KEY,
+            )
+        )
+    assert exc.value.status_code == 403
+
+
+def test_the_same_write_still_works_for_a_human_admin(monkeypatch):
+    """The fix must close the hole without breaking the feature: an operator
+    must still be able to point the fleet at a skills library."""
+    import asyncio
+
+    try:
+        from routers import settings as settings_router
+        from db_models import SystemSettingUpdate
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    written = {}
+    monkeypatch.setattr(
+        settings_router.db, "set_setting",
+        lambda key, value, *a, **k: written.update({key: value}) or True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings_router.db, "get_setting",
+        lambda *a, **k: {"key": "skills_library_url",
+                         "value": "https://github.com/acme/skills",
+                         "updated_at": "2026-07-30T00:00:00Z"},
+        raising=False,
+    )
+
+    class _Req:
+        client = type("c", (), {"host": "127.0.0.1"})()
+        url = type("u", (), {"path": "/api/settings/skills_library_url"})()
+        state = type("s", (), {"request_id": "r1"})()
+        headers: dict = {}
+
+    try:
+        asyncio.run(
+            settings_router.update_setting(
+                key="skills_library_url",
+                body=SystemSettingUpdate(value="https://github.com/acme/skills"),
+                request=_Req(),
+                current_user=HUMAN_ADMIN,
+            )
+        )
+    except Exception as e:  # pragma: no cover - surfaces a real regression
+        pytest.fail(f"a human admin must still be able to set the library: {e!r}")

--- a/tests/unit/test_293_admin_gate_rejects_agent_keys.py
+++ b/tests/unit/test_293_admin_gate_rejects_agent_keys.py
@@ -215,3 +215,148 @@ def test_the_same_write_still_works_for_a_human_admin(monkeypatch):
         )
     except Exception as e:  # pragma: no cover - surfaces a real regression
         pytest.fail(f"a human admin must still be able to set the library: {e!r}")
+
+
+# ---------------------------------------------------------------------------
+# Surface coherence — raised in review of this PR
+# ---------------------------------------------------------------------------
+#
+# Closing the admin gate to agent keys had fallout the first audit missed: six
+# MCP tools call admin-gated routes. Four of those 403s are INTENDED and are the
+# grant-vs-use line working —
+#
+#   get_credential_encryption_key  -> pulling the platform master key
+#   get_agent_ssh_access           -> already documents itself as admin-only
+#   register_subscription          -> granting a platform credential
+#   delete_subscription            -> revoking one
+#
+# — but two were reads, not grants, and left a half-working workflow, which is
+# worse than a cleanly closed door. These pin the resolution so the next change
+# to the gate cannot silently re-break them.
+
+def _dependency_names(fn) -> set:
+    """Names of the FastAPI dependencies a handler actually resolves.
+
+    Reads the resolved `Depends(...)` objects rather than grepping the source —
+    a substring search matches the word inside a docstring explaining the very
+    change, which is how the first version of these tests failed.
+    """
+    import inspect
+
+    names = set()
+    for param in inspect.signature(fn).parameters.values():
+        dep = getattr(param.default, "dependency", None)
+        if dep is not None:
+            names.add(getattr(dep, "__name__", str(dep)))
+        # Annotated[...] form: Depends lives in the metadata
+        for meta in getattr(param.annotation, "__metadata__", ()):  # noqa: B007
+            dep = getattr(meta, "dependency", None)
+            if dep is not None:
+                names.add(getattr(dep, "__name__", str(dep)))
+    return names
+
+
+def _calls_in_body(fn, name: str) -> bool:
+    """True if the function BODY calls `name` — AST, so comments and docstrings
+    cannot produce a false positive."""
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+    return any(
+        isinstance(n, ast.Call)
+        and getattr(n.func, "id", getattr(n.func, "attr", None)) == name
+        for n in ast.walk(tree)
+    )
+
+
+def test_triggering_a_health_check_is_not_admin_gated():
+    """An ops agent could READ health (`GET /status`, `GET /agents/{name}` — both
+    non-admin) but not REFRESH it. Probing an agent you can already see is a use,
+    not a grant, and the access control it relies on must remain."""
+    try:
+        from routers import monitoring
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    assert "require_admin" not in _dependency_names(monitoring.trigger_health_check)
+    assert not _calls_in_body(monitoring.trigger_health_check, "assert_admin")
+
+    # The per-agent access gate stays. Asserted from the SOURCE annotation, not
+    # the runtime-resolved dependency: sibling monitoring tests override that
+    # dependency with a lambda, so a runtime check here passes alone and fails
+    # in a full run purely on collection order.
+    import ast
+    import inspect
+    import textwrap
+
+    fn_ast = ast.parse(
+        textwrap.dedent(inspect.getsource(monitoring.trigger_health_check))
+    ).body[0]
+    annotations = {
+        ast.unparse(a.annotation)
+        for a in fn_ast.args.args
+        if a.annotation is not None
+    }
+    assert "AuthorizedAgentByName" in annotations
+
+
+def test_listing_subscriptions_is_not_admin_gated():
+    """`assign_subscription` / `clear_agent_subscription` / `get_agent_auth` all
+    kept working under owner gates, so an agent could ASSIGN a subscription it
+    could no longer ENUMERATE. The read is restored; assignment stays owner-gated.
+    """
+    try:
+        from routers import subscriptions
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    assert not _calls_in_body(subscriptions.list_subscriptions, "assert_admin")
+    # The write path must NOT have been widened along with the read.
+    assert _calls_in_body(subscriptions.assign_subscription_to_agent, "assert_agent_owner")
+
+
+def test_the_restored_read_is_scoped_not_ungated(monkeypatch):
+    """Un-gating this read outright was the first attempt and it traded one
+    disclosure for another: the payload carries `owner_email` and every agent
+    name, so any `role=user` account would enumerate the whole fleet. Each
+    caller sees only their own — and an agent key is NOT the fleet-wide admin
+    view even though it carries the owner's admin role, which is the entire
+    point of ent#293."""
+    import asyncio
+
+    try:
+        from routers import subscriptions
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    seen = []
+    monkeypatch.setattr(
+        subscriptions.db, "list_subscriptions_with_agents",
+        lambda owner_id=None: seen.append(owner_id) or [],
+        raising=False,
+    )
+
+    asyncio.run(subscriptions.list_subscriptions(current_user=HUMAN_ADMIN))
+    asyncio.run(subscriptions.list_subscriptions(current_user=NON_ADMIN))
+    asyncio.run(subscriptions.list_subscriptions(current_user=AGENT_KEY))
+
+    fleet_wide, non_admin, agent_key = seen
+    assert fleet_wide is None                 # a human admin still sees the fleet
+    assert non_admin == NON_ADMIN.id          # everyone else is scoped
+    assert agent_key == AGENT_KEY.id          # NOT the fleet view, despite role="admin"
+
+
+def test_the_granting_endpoints_stay_admin_only():
+    """The four intended 403s. If any of these loses its admin gate, the fix has
+    been widened past its own rationale."""
+    try:
+        from routers import subscriptions, credentials, agent_ssh
+    except ImportError:  # pragma: no cover
+        pytest.skip("backend venv required")
+
+    assert _calls_in_body(subscriptions.register_subscription, "assert_admin")
+    assert _calls_in_body(subscriptions.delete_subscription, "assert_admin")
+    assert "require_admin" in _dependency_names(credentials.get_encryption_key)
+    assert "require_admin" in _dependency_names(agent_ssh.create_ssh_access)

--- a/tests/unit/test_293_admin_gate_rejects_agent_keys.py
+++ b/tests/unit/test_293_admin_gate_rejects_agent_keys.py
@@ -360,3 +360,57 @@ def test_the_granting_endpoints_stay_admin_only():
     assert _calls_in_body(subscriptions.delete_subscription, "assert_admin")
     assert "require_admin" in _dependency_names(credentials.get_encryption_key)
     assert "require_admin" in _dependency_names(agent_ssh.create_ssh_access)
+
+
+# ---------------------------------------------------------------------------
+# The third spelling — found reviewing this PR
+# ---------------------------------------------------------------------------
+
+def test_no_route_uses_require_role_admin_as_an_admin_gate():
+    """`require_role("admin")` is a THIRD spelling of an admin gate, and the one
+    this PR's first pass missed.
+
+    `require_role` rejects connector principals but NOT agent ones, and that is
+    deliberate — agent-spawned agent creation runs through
+    `require_role("creator")` (ent#69 Part 2), so a blanket rejection there would
+    break ghost spawning. The consequence is that closing `require_admin` and
+    `assert_admin` left `require_role("admin")` open, and its one call site was
+    `POST /api/agents/{name}/circuit-breaker/reset` — a route ent#297 names in
+    its blast radius. An agent able to re-close its own dispatch breaker on
+    demand defeats the control that exists to contain it.
+
+    `require_admin` is equivalent for the admin case (`admin` is last in
+    ROLE_HIERARCHY, so ">= admin" is "== admin") AND rejects agent principals,
+    so it is the only correct spelling. Pinned as a source scan because the
+    failure mode is a NEW route choosing the wrong helper, which no behavioural
+    test of existing routes can see.
+    """
+    import ast
+    from pathlib import Path
+
+    routers = Path(__file__).resolve().parents[2] / "src" / "backend" / "routers"
+    offenders = []
+    for path in sorted(routers.rglob("*.py")):
+        # AST, not a regex over lines: the comment ON the fixed call site
+        # explains what not to write and therefore CONTAINS the offending
+        # string. A text scan flags its own documentation — which is exactly
+        # how the first version of this test failed, and how the sibling
+        # `_calls_in_body` helper above came to exist.
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:            # newer syntax than this interpreter
+            continue
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and getattr(node.func, "id", None) == "require_role"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == "admin"
+            ):
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    assert not offenders, (
+        "use `require_admin` (rejects agent principals) rather than "
+        f'`require_role("admin")` (does not): {offenders}'
+    )

--- a/tests/unit/test_retention_floor.py
+++ b/tests/unit/test_retention_floor.py
@@ -108,6 +108,7 @@ def _admin():
     u = MagicMock()
     u.role = "admin"
     u.connector_agent = None  # #1310: not a connector principal
+    u.agent_name = None  # ent#293: not an agent-scoped key
     return u
 
 

--- a/tests/unit/test_subscription_reassign_hotreload.py
+++ b/tests/unit/test_subscription_reassign_hotreload.py
@@ -59,6 +59,7 @@ def owner_user():
     u.username = "owner"
     u.role = "user"
     u.connector_agent = None  # #1310: not a connector principal
+    u.agent_name = None  # ent#293: not an agent-scoped key
     return u
 
 
@@ -68,6 +69,7 @@ def admin_user():
     u.username = "admin"
     u.role = "admin"
     u.connector_agent = None  # #1310: not a connector principal
+    u.agent_name = None  # ent#293: not an agent-scoped key
     return u
 
 


### PR DESCRIPTION
Fixes a privilege-escalation class reported privately. **P1.**

## The bug

An agent-scoped MCP key resolves to its owner **carrying the owner's role**, so on a default admin-owned install every agent's injected `TRINITY_MCP_API_KEY` satisfied every `assert_admin` / `require_admin` gate.

The chain that makes it P1: a prompt-injected agent repoints the platform skills library at an attacker-controlled repo through the generic settings setter; the scheduled sync pulls it; the fleet sweep writes attacker-authored `SKILL.md` files into **every running agent**. A `SKILL.md` is instructions Claude executes, persisted on the durable home volume. One compromised agent becomes all of them.

## Fixed at the gate, not the endpoint

This is the **third** occurrence of the class — trinity-ops-agent#232, #1644 (retention acknowledge), #1816 (system-agent restart) — each previously closed by bolting `reject_agent_principal` onto one more endpoint. Three occurrences means the gate is wrong, not the endpoints.

So `assert_admin` and `require_admin` now reject agent principals. The class closes at once, and a settings key or endpoint added tomorrow inherits the protection without anyone remembering to ask for it.

## Why this is safe — verified, not assumed

| Concern | Finding |
|---|---|
| Do agent flows need an admin gate? | **No.** Heartbeat, structured reports and the #1083 result callback authorize on `current_user.agent_name` self-checks. |
| Does `trinity-system` break? | **No.** `User.agent_name` is set only for `scope == "agent"`, so system-scoped keys never trip the guard. |
| Do MCP tools hit admin endpoints? | **Yes — six do.** The original audit was wrong (it only checked the skills tools against `/skills/library/sync`). Corrected below. |
| Do agents lose legitimate capability? | **No.** `require_role` is deliberately unchanged — MCP `deploy_system` uses `require_role("creator")`. |

That last row is the **grant-vs-use line** from `learnings.md` landing where it should: the endpoint that *uses* a capability may be agent-callable; the endpoint that *grants* one is human-only. Admin is the granting tier.

## Tests — 9, and no `MagicMock` anywhere

Deliberately: a bare `MagicMock` auto-creates a truthy `.agent_name`, so it reads as an agent key and passes for the wrong reason — the trap #1816 recorded and this issue's AC called out. Every principal is an explicit dataclass with every field stated.

Both gates reject an agent principal carrying `role="admin"`; the exploit is driven through the **real** `update_setting` handler; non-regression for a human admin, a system-scoped key, a connector key and a non-admin. **Verified 3 fail with the gate fix reverted.**

## Test-double churn, and why it's honest

The change broke 6 pre-existing tests. All six were incomplete principal doubles that set `connector_agent = None` — churn from when #1310 added the *connector* guard — but omitted `agent_name`: either absent (raising `AttributeError`) or a truthy `MagicMock` reading as an agent key.

I checked each rather than assuming, because 6 failures could equally have meant a real flow broke. They didn't; the doubles were simply one guard out of date. Same convention applied.

**815 passed** across the auth/admin/settings/ops/subscription/retention suites, at failure parity with base (3 pre-existing `bcrypt` environmental failures before and after).

Closes the privately-tracked issue.


---

## Correction: MCP surface fallout (review of this PR)

The claim above was inaccurate. Six MCP tools call admin-gated routes. Re-audited, split by whether the call is a **grant** or a **use**:

### Four intended 403s — deliberate, no change

The grant-vs-use line working as designed. Each hands out or revokes a platform credential, which is exactly what an agent-scoped key must not be able to do:

| Tool | Route | Why it stays closed |
|---|---|---|
| `get_credential_encryption_key` | `GET /api/agents/{name}/credentials/encryption-key` | Pulls the platform master key |
| `get_agent_ssh_access` | `POST /api/agents/{name}/ssh-access` | Already self-documents as admin-only |
| `register_subscription` | `POST /api/subscriptions` | Grants a platform credential |
| `delete_subscription` | `DELETE /api/subscriptions/{id}` | Revokes one |

An agent needing any of these is asking a human to perform a privileged act, and a 403 is the correct answer.

### Two fixed — reads, not grants

These left a half-working workflow, which is worse than a cleanly closed door:

**`trigger_health_check`** (`POST /api/monitoring/agents/{name}/check`) — an ops agent could READ health (`GET /status`, `GET /agents/{name}`, both non-admin) but not REFRESH it. The `require_admin` was redundant regardless: `AuthorizedAgentByName` already restricts the endpoint to callers who own or are shared the agent. Now `get_current_user` + the unchanged per-agent gate.

**`list_subscriptions`** (`GET /api/subscriptions`) — `assign_subscription` / `clear_agent_subscription` / `get_agent_auth` all kept working under owner gates, so an agent could ASSIGN a subscription it could no longer ENUMERATE.

Note this one is **scoped, not un-gated**. Un-gating was the first attempt and it traded one disclosure for another: the payload carries `owner_email` and the full agent-name list of *every* subscription, so an ungated read hands any `role=user` account a fleet-wide owner-email + agent-name enumeration oracle — the disclosure class Invariant #8 exists to prevent, reintroduced by a fix for a different disclosure. Resolution: admin keeps the fleet view, everyone else gets `owner_id`-scoped through a filter already in the accessor's contract. An agent key is excluded from the fleet view by the `agent_name` term *even though it carries the owner's admin role* — which is the whole point of ent#293.

Also corrected a stale "Admin-only" docstring on `get_subscription_usage`, whose gate has always been `get_current_user`.

### Pinned

`tests/unit/test_293_admin_gate_rejects_agent_keys.py` now covers all three resolutions plus the four intended 403s, so the next change to the gate cannot silently re-break them.

One note on how that test is written, since it bit during this fix: the access-gate assertion reads the **source annotation**, not the resolved `Depends`. Sibling monitoring tests override that dependency with a lambda, so a runtime check passes standalone and fails in a full run purely on collection order — caught by running the wider selection rather than the file alone.