### PR TITLE
fix(ui): show a not-found state instead of a blank page for an unknown agent (#1914)

### DIFF
--- a/src/frontend/e2e/agent-not-found.spec.js
+++ b/src/frontend/e2e/agent-not-found.spec.js
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Agent Detail not-found state (#1914).
+ *
+ * Regression guard for a BLANK PAGE: navigating to /agents/<unknown> rendered
+ * nothing at all. `stores/agents.js::fetchAgent` caught the 404, logged it to
+ * the console, and returned `undefined`, so `AgentDetail.vue::loadAgent`'s catch
+ * never ran — `error` stayed '' and `agent` stayed null, making BOTH the error
+ * banner (`v-if="error && !agent"`) and the agent body (`v-if="agent"`) false.
+ * The only evidence was a console line the user never sees.
+ *
+ * @smoke, deliberately: the whole point is that the agent does NOT exist, so
+ * unlike the other AgentDetail specs this needs no fixture agent, no running
+ * container, and no Claude dispatch. It is fast and deterministic.
+ *
+ * The name below must never resolve to a real agent. `sanitize_agent_name`
+ * strips a leading underscore (see the `_retention-guard` sentinel in
+ * architecture.md), so a name in this shape cannot be created through the API.
+ */
+
+const MISSING_AGENT = '_e2e-agent-1914-does-not-exist'
+
+test.describe('agent detail — not found', () => {
+  test('@smoke unknown agent renders a not-found state, not a blank page', async ({ page }) => {
+    await page.goto(`/agents/${MISSING_AGENT}`)
+
+    const panel = page.getByTestId('agent-not-found')
+    await expect(panel).toBeVisible({ timeout: 10000 })
+    await expect(panel).toContainText(/agent not found/i)
+
+    // No dead empty state — there is a way out (Product Quality Bar). The exit
+    // is the Dashboard, not the Agents list: the agent you asked for isn't
+    // there either, so the list is a second dead end for the same question.
+    const back = panel.getByRole('link', { name: /back to dashboard/i })
+    await expect(back).toBeVisible()
+    await back.click()
+    await expect(page).toHaveURL(/\/$/)
+  })
+
+  test('@smoke not-found copy does not disclose whether the agent exists', async ({ page }) => {
+    // The backend returns a UNIFORM 404 for "no such agent" and "you can't see
+    // this agent" on purpose — the differential is an enumeration oracle
+    // (Invariant #8 / #186). The UI must not reintroduce it by claiming which
+    // case this is. This asserts the copy covers BOTH, and pins the absence of
+    // an existence claim so a future copy edit can't quietly leak it.
+    await page.goto(`/agents/${MISSING_AGENT}`)
+
+    const panel = page.getByTestId('agent-not-found')
+    await expect(panel).toBeVisible({ timeout: 10000 })
+    await expect(panel).toContainText(/doesn't exist, or you don't have access/i)
+    await expect(panel).not.toContainText(/no such agent|does not exist on this instance|was deleted/i)
+  })
+
+  test('@smoke a non-404 failure shows a retryable load error, not the not-found state', async ({ page }) => {
+    // Retrying a 404 is pointless; retrying a 500/network blip is not. The two
+    // failures must stay visually and behaviourally distinct.
+    await page.route('**/api/agents/*', (route) => {
+      const url = route.request().url()
+      // Only the single-agent GET — leave /api/agents, /sync-health, etc. alone.
+      if (/\/api\/agents\/[^/?]+(\?|$)/.test(url)) {
+        return route.fulfill({ status: 500, contentType: 'application/json', body: '{"detail":"boom"}' })
+      }
+      return route.continue()
+    })
+
+    await page.goto('/agents/anything')
+
+    await expect(page.getByTestId('agent-load-error')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByTestId('agent-not-found')).toHaveCount(0)
+    await expect(page.getByTestId('agent-load-retry')).toBeVisible()
+  })
+})

--- a/src/frontend/src/stores/agents.js
+++ b/src/frontend/src/stores/agents.js
@@ -154,8 +154,15 @@ export const useAgentsStore = defineStore('agents', {
         }
         return this.selectedAgent
       } catch (error) {
+        // #1914: re-throw. Swallowing here returned `undefined` to the caller,
+        // which is indistinguishable from a successful empty fetch — that is
+        // how a 404 rendered AgentDetail as a blank page (neither the error
+        // banner nor the agent body had a truthy condition). Callers that
+        // genuinely tolerate a failure (the post-stop status poll in
+        // AgentDetail) already wrap this in their own try/catch.
         this.error = error.message
         console.error('Failed to fetch agent:', error)
+        throw error
       } finally {
         this.loading = false
       }

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -22,8 +22,35 @@
           {{ notification.message }}
         </div>
 
-        <div v-if="error && !agent" class="bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300 px-4 py-3 rounded mb-4">
-          {{ error }}
+        <!-- #1914: agent 404'd. Deliberately does NOT say whether the agent
+             exists — the backend's 404 is uniform for missing vs. inaccessible
+             (Invariant #8 / #186) and this copy must not undo that. -->
+        <div v-if="notFound && !loading" data-testid="agent-not-found" class="max-w-lg mx-auto text-center py-16">
+          <svg class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h2 class="mt-4 text-lg font-semibold text-gray-900 dark:text-gray-100">Agent not found</h2>
+          <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            <span class="font-mono text-gray-800 dark:text-gray-200">{{ route.params.name }}</span>
+            doesn't exist, or you don't have access to it.
+          </p>
+          <router-link
+            to="/"
+            class="mt-6 inline-block px-4 py-2 rounded-lg bg-action-primary-600 hover:bg-action-primary-700 text-white text-sm font-medium transition-colors"
+          >
+            Back to Dashboard
+          </router-link>
+        </div>
+
+        <div v-if="error && !agent" data-testid="agent-load-error" class="bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300 px-4 py-3 rounded mb-4 flex items-center justify-between gap-4">
+          <span>{{ error }}</span>
+          <button
+            @click="loadAgent"
+            data-testid="agent-load-retry"
+            class="shrink-0 px-3 py-1 rounded border border-status-danger-400 dark:border-status-danger-700 text-sm font-medium hover:bg-status-danger-200 dark:hover:bg-status-danger-900 transition-colors"
+          >
+            Retry
+          </button>
         </div>
 
         <div v-if="agent" :class="['ml-16', isFullscreenTab ? 'flex-1 flex flex-col min-h-0' : '']">
@@ -370,6 +397,7 @@ const sessionsStore = useSessionsStore()  // SESSION_TAB_2026-04 Phase 3
 const agent = ref(null)
 const loading = ref(true)
 const error = ref('')
+const notFound = ref(false)  // #1914: the agent 404'd (missing OR inaccessible — uniform by design)
 const activeTab = ref('overview')  // #1107: Overview is the default landing tab
 // Tabs reachable via ?tab= deep-link (Timeline / EXEC-023 navigation).
 // Single source — referenced in onMounted + onActivated (#1107: dedupe + overview).
@@ -855,13 +883,29 @@ const visibleTabs = computed(() => {
 })
 
 // Load agent
+//
+// #1914: a failure here has to reach the template, or the page renders blank —
+// `v-if="agent"` and the error banner are both false when `agent` is null and
+// `error` is ''. Two distinct failure states:
+//   404      -> not-found panel. The backend returns a UNIFORM 404 for both a
+//               non-existent agent and one this caller cannot access (an
+//               enumeration oracle otherwise — Invariant #8 / #186), so the
+//               copy must not claim which of the two it is.
+//   anything -> generic "couldn't load" banner with a retry (network blip,
+//   else      500, expired token). Retrying a 404 is pointless, so only this
+//               branch offers it.
 async function loadAgent() {
   loading.value = true
   error.value = ''
+  notFound.value = false
   try {
     agent.value = await agentsStore.fetchAgent(route.params.name)
   } catch (err) {
-    error.value = 'Failed to load agent details'
+    if (err.response?.status === 404) {
+      notFound.value = true
+    } else {
+      error.value = 'Failed to load agent details'
+    }
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
Closes #1914

## The bug

Navigating to `/agents/<unknown>` rendered a **completely blank page** — no error, no way back. `AgentDetail.vue` already **had** an error banner (`v-if="error && !agent"`). It just never fired.

## Root cause — the store, not the view

`stores/agents.js::fetchAgent` caught the 404, logged it to the console, and returned `undefined`:

```js
} catch (error) {
  this.error = error.message
  console.error('Failed to fetch agent:', error)   // <-- swallowed, returns undefined
}
```

So `AgentDetail::loadAgent`'s `catch` never ran: `error` stayed `''` and `agent` stayed `null`, which made **both** `v-if="error && !agent"` and `v-if="agent"` false. Nothing rendered. The only evidence was a console line the user never sees.

Returning `undefined` on failure is indistinguishable from a successful empty fetch — that ambiguity is the whole bug.

## The fix

- **`fetchAgent` re-throws.** The one caller that genuinely tolerates a failure — the post-stop status poll in `AgentDetail` (`waitForAgentStatus`, ~L739) — already wraps it in its own `try/catch`, so it keeps polling through transient errors exactly as before. Verified: only two callers of `agentsStore.fetchAgent` exist, both in this file. (`AgentWorkspace.vue` / `AgentBrainOrb.vue` have their own local `fetchAgent` that hits axios directly and deliberately degrades — untouched.)
- **`loadAgent` splits 404 from everything else.** 404 → a not-found panel. Anything else (network blip, 500, expired token) → the generic banner, now with a **Retry**. Retrying a 404 is pointless, so only the retryable branch offers one.
- **The exit is the Dashboard, not the Agents list** — the agent you asked for isn't in that list either, so the list is a second dead end for the same question.

## The copy is deliberately vague, and a test pins that

The backend returns a **uniform 404** for "no such agent" and "you can't see this agent" on purpose — the differential is an enumeration oracle (Invariant #8 / #186). So the panel says:

> `skills-fixture` doesn't exist, or you don't have access to it.

…covering both without claiming which. One of the specs asserts the *absence* of an existence claim (`not.toContainText(/no such agent|does not exist on this instance|was deleted/i)`) so a well-meaning future copy edit can't quietly leak it back.

## Tests

`src/frontend/e2e/agent-not-found.spec.js` — 3 specs, tagged **`@smoke`** so they run in CI on `ui`-labelled PRs. They're `@smoke`-eligible precisely because the agent deliberately does *not* exist: unlike every other AgentDetail spec, they need no fixture agent, no running container, and no Claude dispatch. ~2s, deterministic.

1. unknown agent renders the not-found state (not a blank page) + "Back to Dashboard" navigates
2. the copy doesn't disclose whether the agent exists
3. a non-404 (mocked 500) shows the *retryable* load error, not the not-found state

**Verified failing on the pre-fix code** — stashed the two source files, re-ran, 3/3 failed; restored, 3/3 pass. Existing `smoke.spec.js` still green. Happy path (real agent loads) confirmed unaffected by the re-throw.

## Verification

Run against a live stack via a Vite dev server on the branch, proxying to the local backend:

| State | Result |
|---|---|
| `/agents/skills-fixture` | "Agent not found" panel + Back to Dashboard |
| Click Back to Dashboard | lands on `/` |
| `/agents/acme-scout` | normal agent page, unchanged |
| mocked 500 | red banner + Retry |
| dark + light | both styled |

## Scope note

`stores/agents.js` has the same swallow-and-return-`undefined` shape in other actions (`fetchAgents`, etc.). Left alone here — none of them produce a blank page, and widening this would turn a targeted bug fix into a store-wide refactor. Worth a follow-up.
