### PR TITLE
fix(ui): render failed fetches as failed, not as empty or nothing (#1926)

### DIFF
--- a/docs/memory/design-system-contract.md
+++ b/docs/memory/design-system-contract.md
@@ -19,7 +19,7 @@ Load this before writing any code under `src/frontend/`. It is the condensed, bi
 
 ## Primitives first
 
-- Compose `BaseButton`, `BaseInput`, `BaseSelect`, `BaseToggle`, `BaseTextarea`, `BaseBadge`, `BaseCard`, the modal shell (`ConfirmDialog`), `OverflowTabs`, and the bounded data table. Never hand-roll a lookalike — identical pixels from a class string is still a defect.
+- Compose `BaseButton`, `BaseInput`, `BaseSelect`, `BaseToggle`, `BaseTextarea`, `BaseBadge`, `BaseCard`, the modal shell (`ConfirmDialog`), `OverflowTabs`, the bounded data table, and the failed-state pair `LoadFailed` (failed fetch) / `InlineError` (failed verb). Never hand-roll a lookalike — identical pixels from a class string is still a defect.
 - BaseButton: 4 variants (primary/secondary/danger/ghost) × 2 sizes (md 13.5 pad 7×14 · sm 12.5 pad 4×10), radius 6px. Disabled = opacity .45. In-flight = 16px spinner + progressive label. Focus ring on all variants.
 - BaseInput/BaseSelect: field bg, border-strong, radius 6px, pad 8×11; focus = accent border + 3px ring; errors name the problem, the fix, and an example — never a bare red border.
 - BaseTextarea: min-height 84px, `resize: vertical` only, mono variant for prompts/config, same focus/error as inputs.
@@ -69,10 +69,10 @@ Data loading:
 14. Loading = "no data yet"; cache hits skip animation; reduced motion honored.
 
 Honest state:
-15. Loading ≠ empty ≠ failed ≠ partial — visually distinct, never optimistic success.
+15. Loading ≠ empty ≠ failed ≠ partial — visually distinct, never optimistic success. An empty state requires a fetch that **succeeded and returned zero** (`store.hasLoaded`), never `list.length === 0`; a failed fetch renders `LoadFailed`, never the empty copy (#1926).
 16. No dead ends: empty states name the purpose and the next action.
 17. Validation errors are named, actionable, with an example; pre-validate client-side where known.
-18. Verbs acknowledge in ~100ms and confirm completion; toasts for completed verbs, never errors.
+18. Verbs acknowledge in ~100ms and confirm completion; toasts for completed verbs, never errors. A failed verb surfaces an `InlineError` next to its control and persists until dismissed — never `console.error` alone, never `alert()` (#1926).
 19. Destructive actions: named verb, restated consequence, safe action focused first.
 22. Times are honest: relative for recency, absolute + timezone on hover/detail.
 23. Keyboard baseline: visible focus, Esc closes overlays, modal focus trap, tab order = visual order.
@@ -94,7 +94,8 @@ Before requesting review, verify:
 - [ ] Every button/input/select/toggle/textarea/badge/card/modal/tab/table is a Base* primitive, not hand-rolled
 - [ ] Verified in light AND dark; dark meta text is gray-300/400, never gray-500
 - [ ] Spacing on the 4px grid; radii 6px controls / 8–10px surfaces; type within the six-size scale
-- [ ] Loading/empty/failed states all exist, visually distinct, sharing one footprint — no layout shift on arrival
+- [ ] Loading/empty/failed states all exist, visually distinct, sharing one footprint — no layout shift on arrival; the empty branch gates on a succeeded fetch (`hasLoaded`), not on list length
+- [ ] Every action failure has a user-visible home (`InlineError` near the control); no `console.error`-only catch, no `alert()`, and `Promise.allSettled` bulk helpers report their rejected count
 - [ ] Data loading uses the scanline primitive keyed off store state; background refresh is invisible (no re-flash, no scroll reset)
 - [ ] `prefers-reduced-motion` handled on any animation touched
 - [ ] Empty states name purpose + one next action; errors name problem + fix + example

--- a/docs/memory/design-system.md
+++ b/docs/memory/design-system.md
@@ -227,10 +227,39 @@ The existing `OverflowTabs` component (#1114, `docs/memory/feature-flows/agent-d
 - **Do:** "No schedules yet — Schedules run this agent automatically on a cron cadence. [New schedule]"
 - **Don't:** a blank region, or "No data" with no next action (principle 16).
 
+### Failed states — the third member of the triad (#1926)
+
+**Recipe:** the two shipped primitives are `components/LoadFailed.vue` (a failed
+*fetch* — owns the surface where the list would be) and `components/InlineError.vue`
+(a failed *verb* — sits next to the control that was pressed). Both name what
+happened in user vocabulary, offer the next action, and keep the raw error
+(status code, server message) behind a "Technical detail" disclosure
+(principle 25). `LoadFailed` shares the centered footprint of the sibling
+loading/empty blocks so nothing shifts when the state resolves (principle 4).
+
+**The rule the audit found broken across ten surfaces:** an empty state may only
+render once a fetch has **succeeded and returned zero**. `list.length === 0` is
+not that condition — before the first response it means *loading*, and after a
+rejection it means *failed*. Stores therefore expose a `hasLoaded` flag that
+flips only on success (`stores/operatorQueue.js`, `stores/notifications.js`),
+and components gate on `hasLoaded` + `error`, never on length alone. Failed must
+never borrow the empty state's copy: "No templates found" on a network error
+sends the user to create a template when the fix is to retry.
+
+**Verb failures are never console-only.** A `console.error` is invisible — the
+row snaps back to its server value and the verb looks like it simply did
+nothing. Neither is `alert()` acceptable: it blocks the page and leaves no
+record once dismissed. Use `InlineError`, and say what did NOT happen ("Nothing
+was changed — try again").
+
+**Watch `Promise.allSettled`:** a bulk helper built on it *resolves* even when
+every item failed, so a `try/catch` around it reports success on a total
+failure. Inspect the settlement and report the count that did not apply.
+
 ### Alerts & toasts
 
 **Alert recipe:** tinted ground per token family (light token-100 bg + token-700 text; dark token-500/16% + token-300), radius 8, padding 12×14, 13.5, 16px stroke icon, bold lead sentence, plain-language body. Errors say what went wrong **and how to fix it** ("Execution failed — exit 137 (out of memory). Raise the agent's memory limit in Settings → Resources."). Warnings carry their action inline.
-**Toast recipe:** surface bg + border-strong + shadow-lg, radius 8, padding 10×16. Toasts confirm **completed verbs** and include the fact you'd check next ("Schedule created — next run Mon 09:00 UTC"); auto-dismiss ~5s; **never used for errors** (principle 18) — errors persist until acknowledged.
+**Toast recipe:** surface bg + border-strong + shadow-lg, radius 8, padding 10×16. Toasts confirm **completed verbs** and include the fact you'd check next ("Schedule created — next run Mon 09:00 UTC"); auto-dismiss ~5s; **never used for errors** (principle 18) — errors persist until acknowledged. Enforced in `composables/useNotification.js` (#1926): a `type: 'error'` notification does not start the dismiss timer and stays until the user closes it, so every toast host renders a dismiss control for it. A failure that belongs next to a control should not be a toast at all — use `InlineError`/`LoadFailed` above.
 
 ## 6. Motion — the data-loading standard
 

--- a/src/frontend/e2e/honest-failed-states.spec.js
+++ b/src/frontend/e2e/honest-failed-states.spec.js
@@ -1,0 +1,128 @@
+import { test, expect, request } from '@playwright/test'
+
+/**
+ * Honest loading / empty / failed states (#1926, design-system p15 + p25).
+ *
+ * The defect these guard: a failed fetch was rendered with the EMPTY state's
+ * copy ("No tasks yet", "All caught up", "No templates found"), which points
+ * the user at the wrong remedy — create something, or relax — when the real
+ * remedy is retry. A first-load window rendered as empty for the same reason.
+ *
+ * Each test forces the failure at the network boundary with `page.route`,
+ * which is the only way to reach the failed branch deterministically against a
+ * healthy stack. The assertions are two-sided on purpose: the failed state must
+ * appear AND the empty-state copy must not — asserting only the former would
+ * still pass if both rendered.
+ */
+
+const TEST_AGENT = process.env.TEST_AGENT || 'trinity-system'
+
+/** Fail every matching request as a transport error (the audit's scenario). */
+async function failRoute(page, pattern) {
+  await page.route(pattern, (route) => route.abort('failed'))
+}
+
+test.describe('operator queue — failed fetch is not "All caught up" (#1926)', () => {
+  test('@smoke renders the failed state and never the all-clear copy', async ({ page }) => {
+    await failRoute(page, '**/api/operator-queue?**')
+    await failRoute(page, '**/api/operator-queue')
+
+    await page.goto('/operations?tab=needs-response')
+
+    const failed = page.getByTestId('load-failed')
+    await expect(failed).toBeVisible({ timeout: 15000 })
+    await expect(failed).toContainText(/couldn't load the queue/i)
+    // The lie the issue is about: claiming the operator has nothing to answer
+    // when we simply could not ask.
+    await expect(page.getByText('All caught up')).toHaveCount(0)
+    // Principle 25 — a retry, not a dead end.
+    await expect(failed.getByRole('button', { name: /try again/i })).toBeVisible()
+  })
+
+  test('retry re-issues the request and recovers into the real state', async ({ page }) => {
+    let attempts = 0
+    await page.route('**/api/operator-queue**', async (route) => {
+      attempts += 1
+      if (attempts === 1) return route.abort('failed')
+      return route.fulfill({ json: { items: [] } })
+    })
+
+    await page.goto('/operations?tab=needs-response')
+    await expect(page.getByTestId('load-failed')).toBeVisible({ timeout: 15000 })
+
+    await page.getByTestId('load-failed').getByRole('button', { name: /try again/i }).click()
+
+    // Now — and only now, after a SUCCEEDED fetch that returned zero — the
+    // empty state is the honest answer.
+    await expect(page.getByText('All caught up')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId('load-failed')).toHaveCount(0)
+  })
+})
+
+test.describe('notifications — failed fetch is not "No events yet" (#1926)', () => {
+  test('renders the failed state instead of a blank body or the empty copy', async ({ page }) => {
+    await failRoute(page, '**/api/notifications?**')
+
+    await page.goto('/operations?tab=notifications')
+
+    const failed = page.getByTestId('load-failed')
+    await expect(failed).toBeVisible({ timeout: 15000 })
+    await expect(failed).toContainText(/couldn't load notifications/i)
+    await expect(page.getByText('No events yet')).toHaveCount(0)
+  })
+})
+
+test.describe('task history — failed fetch is not "No tasks yet" (#1926)', () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    const api = await request.newContext({ baseURL })
+    const ok = await api
+      .get(`/api/agents/${TEST_AGENT}`)
+      .then((r) => r.ok())
+      .catch(() => false)
+    await api.dispose()
+    test.skip(!ok, `TEST_AGENT '${TEST_AGENT}' not found on this stack`)
+  })
+
+  test('renders the failed state and keeps the card footprint', async ({ page }) => {
+    await failRoute(page, `**/api/agents/${TEST_AGENT}/executions**`)
+
+    await page.goto(`/agents/${TEST_AGENT}?tab=tasks`)
+
+    const card = page.getByTestId('task-history-card')
+    await expect(card).toBeVisible({ timeout: 15000 })
+    await expect(card.getByTestId('load-failed')).toBeVisible()
+    await expect(card.getByTestId('load-failed')).toContainText(/couldn't load task history/i)
+    await expect(page.getByText('No tasks yet')).toHaveCount(0)
+  })
+})
+
+test.describe('schedule toggle — a failed verb is visible, not console-only (#1926)', () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    const api = await request.newContext({ baseURL })
+    const schedules = await api
+      .get(`/api/agents/${TEST_AGENT}/schedules`)
+      .then((r) => (r.ok() ? r.json() : []))
+      .catch(() => [])
+    await api.dispose()
+    test.skip(
+      !Array.isArray(schedules) || schedules.length === 0,
+      `TEST_AGENT '${TEST_AGENT}' has no schedules to toggle`
+    )
+  })
+
+  test('a rejected enable/disable surfaces a persistent inline error', async ({ page }) => {
+    await page.route(`**/api/agents/${TEST_AGENT}/schedules/*/enable`, (route) => route.abort('failed'))
+    await page.route(`**/api/agents/${TEST_AGENT}/schedules/*/disable`, (route) => route.abort('failed'))
+
+    await page.goto(`/agents/${TEST_AGENT}?tab=schedules`)
+    await page.getByTitle(/enable|disable/i).first().click()
+
+    const err = page.getByTestId('inline-error')
+    await expect(err).toBeVisible({ timeout: 15000 })
+    await expect(err).toContainText(/couldn't/i)
+
+    // Principle 18: this is not a toast — it must still be here later.
+    await page.waitForTimeout(4000)
+    await expect(err).toBeVisible()
+  })
+})

--- a/src/frontend/src/components/AgentListPanel.vue
+++ b/src/frontend/src/components/AgentListPanel.vue
@@ -18,7 +18,14 @@
         notification.type === 'success' ? 'bg-status-success-100 dark:bg-status-success-900/50 border border-status-success-400 dark:border-status-success-700 text-status-success-700 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300'
       ]"
     >
-      {{ notification.message }}
+      <span>{{ notification.message }}</span>
+      <button
+        v-if="notification.type === 'error'"
+        type="button"
+        class="ml-3 font-medium opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-status-danger-500/40 rounded"
+        aria-label="Dismiss notification"
+        @click="dismissNotification"
+      >✕</button>
     </div>
 
     <!-- Filter toolbar (name / status / sort — tag + owner filters live in the
@@ -680,6 +687,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { formatCostCompact } from '../composables/useFormatters'
+import { useNotification } from '../composables/useNotification'
 import { useAgentsStore } from '../stores/agents'
 import { useNetworkStore } from '../stores/network'
 import { agentDisplayName, agentNameTooltip } from '../utils/agentName'
@@ -722,7 +730,6 @@ const emit = defineEmits(['tags-changed', 'clear-chassis-filters'])
 const agentsStore = useAgentsStore()
 const networkStore = useNetworkStore()
 
-const notification = ref(null)
 const autonomyLoading = ref(null)
 const readOnlyLoading = ref(null)
 
@@ -821,12 +828,11 @@ const commonTagsInSelection = computed(() => {
   return Array.from(allTags).sort()
 })
 
-const showNotification = (message, type = 'success') => {
-  notification.value = { message, type }
-  setTimeout(() => {
-    notification.value = null
-  }, 3000)
-}
+// #1926: was a local copy of the toast helper with a hardcoded 3s
+// auto-dismiss, so an error toast vanished before it could be read or acted
+// on. Now the shared composable, which keeps errors up until dismissed
+// (principle 18).
+const { notification, showNotification, dismissNotification } = useNotification()
 
 // #389 sync-health: mount fetch + 60s visibility-aware refresh while the List
 // mode is active (mirrors the grid's chip-poll discipline — a parked List tab

--- a/src/frontend/src/components/ExecutionsPanel.vue
+++ b/src/frontend/src/components/ExecutionsPanel.vue
@@ -30,6 +30,20 @@
       </button>
     </div>
 
+    <!-- Stop failure (#1926) — a failed stop used to navigate the user to the
+         detail page with no message, so a stop that never happened looked like
+         a deliberate hand-off. -->
+    <InlineError
+      v-if="stopError"
+      class="mb-4"
+      :message="stopError"
+      :detail="stopErrorDetail"
+      retryable
+      retry-label="Open the execution"
+      @retry="openFailedStopTarget"
+      @dismiss="clearStopError"
+    />
+
     <!-- Stat cards -->
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
       <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
@@ -312,11 +326,18 @@ import { useAuthStore } from '../stores/auth'
 import { useAgentsStore } from '../stores/agents'
 import { agentNameTooltip, agentOptionLabel } from '../utils/agentName'
 import { useWebSocket } from '../utils/websocket'
+import InlineError from './InlineError.vue'
+import { apiErrorMessage } from '../utils/apiError'
 
 const router = useRouter()
 const store = useExecutionsStore()
 const authStore = useAuthStore()
 const agentsStore = useAgentsStore()
+
+// #1926: a failed stop is reported here instead of silently redirecting.
+const stopError = ref('')
+const stopErrorDetail = ref('')
+const stopTarget = ref(null)
 const { isConnected } = useWebSocket()
 
 const agentNames = computed(() =>
@@ -417,8 +438,9 @@ function goToDetail(row) {
   router.push(`/agents/${row.agent_name}/executions/${row.id}`)
 }
 
-// --- stop execution (navigates to agent detail where stop is handled) ---
+// --- stop execution ---
 async function stopExecution(row) {
+  clearStopError()
   try {
     await axios.post(
       `/api/agents/${row.agent_name}/schedules/stop-execution/${row.id}`,
@@ -426,10 +448,26 @@ async function stopExecution(row) {
       { headers: authStore.authHeader }
     )
     store.refresh()
-  } catch {
-    // stop endpoint may not exist; fall back to opening detail page
-    goToDetail(row)
+  } catch (err) {
+    // #1926: the old handler swallowed the error and silently routed to the
+    // detail page — the execution kept running while the UI implied the stop
+    // had been handed off. Say it failed, keep the user where they are, and
+    // offer the detail page as an explicit next step rather than a redirect.
+    console.error('Failed to stop execution:', err)
+    stopTarget.value = row
+    stopError.value = `Couldn't stop ${row.agent_name}'s execution — it is still running. Try again, or open it for more detail.`
+    stopErrorDetail.value = apiErrorMessage(err, 'Request failed')
   }
+}
+
+function clearStopError() {
+  stopError.value = ''
+  stopErrorDetail.value = ''
+  stopTarget.value = null
+}
+
+function openFailedStopTarget() {
+  if (stopTarget.value) goToDetail(stopTarget.value)
 }
 
 // --- search debounce ---

--- a/src/frontend/src/components/FilesPanel.vue
+++ b/src/frontend/src/components/FilesPanel.vue
@@ -302,7 +302,14 @@
         notification.type === 'success' ? 'bg-status-success-100 dark:bg-status-success-900/50 border border-status-success-400 dark:border-status-success-700 text-status-success-700 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300'
       ]"
     >
-      {{ notification.message }}
+      <span>{{ notification.message }}</span>
+      <button
+        v-if="notification.type === 'error'"
+        type="button"
+        class="ml-3 font-medium opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-status-danger-500/40 rounded"
+        aria-label="Dismiss notification"
+        @click="dismissNotification"
+      >✕</button>
     </div>
   </div>
 </template>
@@ -310,6 +317,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useAgentsStore } from '../stores/agents'
+import { useNotification } from '../composables/useNotification'
 import FileTreeNode from './file-manager/FileTreeNode.vue'
 import FilePreview from './file-manager/FilePreview.vue'
 
@@ -326,14 +334,11 @@ const props = defineProps({
 
 const agentsStore = useAgentsStore()
 
-// Notification system
-const notification = ref(null)
-const showNotification = (message, type = 'success') => {
-  notification.value = { message, type }
-  setTimeout(() => {
-    notification.value = null
-  }, 4000)
-}
+// #1926: was a local copy of the toast helper with a hardcoded 4s
+// auto-dismiss, so an error toast vanished before it could be read or acted
+// on. Now the shared composable, which keeps errors up until dismissed
+// (principle 18).
+const { notification, showNotification, dismissNotification } = useNotification()
 
 // State
 const fileTree = ref([])

--- a/src/frontend/src/components/InfoPanel.vue
+++ b/src/frontend/src/components/InfoPanel.vue
@@ -5,7 +5,21 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500"></div>
     </div>
 
-    <!-- No Template State -->
+    <!-- Failed State (#1926) — a failed /info fetch used to be dressed up as
+         has_template:false, i.e. "This agent was created without a template",
+         which is a claim about the agent rather than about the request. -->
+    <LoadFailed
+      v-else-if="loadError"
+      title="Couldn't load template info"
+      :message="agentStatus === 'running'
+        ? 'The agent did not return its template information. Try again.'
+        : 'The agent is not running, so its template information is unavailable. Start the agent and try again.'"
+      :detail="loadError"
+      :retrying="loading"
+      @retry="loadTemplateInfo"
+    />
+
+    <!-- No Template State — the agent answered, and has no template -->
     <div v-else-if="!templateInfo?.has_template" class="text-center py-8">
       <div class="mx-auto w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mb-4">
         <svg class="w-8 h-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -294,6 +308,8 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents'
+import LoadFailed from './LoadFailed.vue'
+import { apiErrorMessage } from '../utils/apiError'
 
 const props = defineProps({
   agentName: {
@@ -311,6 +327,9 @@ const emit = defineEmits(['item-click'])
 const agentsStore = useAgentsStore()
 const templateInfo = ref(null)
 const loading = ref(true)
+// #1926: "the request failed" is a different state from "the agent has no
+// template" — the old code collapsed the first into the second.
+const loadError = ref('')
 
 // #1107: whether any technical-metadata section has content (gates the
 // collapsible "Technical details" disclosure).
@@ -331,15 +350,17 @@ const hasTechnicalDetails = computed(() => {
 
 const loadTemplateInfo = async () => {
   loading.value = true
+  loadError.value = ''
   try {
     const response = await agentsStore.getAgentInfo(props.agentName)
     templateInfo.value = response
+    loadError.value = ''
   } catch (error) {
     console.error('Failed to load template info:', error)
-    templateInfo.value = {
-      has_template: false,
-      message: 'Failed to load template information'
-    }
+    // Do NOT synthesize a has_template:false payload here — that renders the
+    // failure as the empty state (#1926). Keep the last good value (if any)
+    // and let the failed state own the surface.
+    loadError.value = apiErrorMessage(error, 'Request failed')
   } finally {
     loading.value = false
   }

--- a/src/frontend/src/components/InlineError.vue
+++ b/src/frontend/src/components/InlineError.vue
@@ -25,10 +25,8 @@
 
     <div class="min-w-0 flex-1">
       <p class="break-words">{{ message }}</p>
-      <details v-if="detail" class="mt-1">
-        <summary class="text-xs opacity-80 cursor-pointer select-none">Technical detail</summary>
-        <p class="mt-1 text-xs font-mono break-words opacity-90">{{ detail }}</p>
-      </details>
+      <!-- Action before disclosure: the next step the user should take must
+           come before the optional trace, not after it. -->
       <button
         v-if="retryable"
         type="button"
@@ -37,6 +35,10 @@
       >
         {{ retryLabel }}
       </button>
+      <details v-if="detail" class="mt-1">
+        <summary class="text-xs opacity-80 cursor-pointer select-none">Technical detail</summary>
+        <p class="mt-1 text-xs font-mono break-words opacity-90">{{ detail }}</p>
+      </details>
     </div>
 
     <button

--- a/src/frontend/src/components/InlineError.vue
+++ b/src/frontend/src/components/InlineError.vue
@@ -1,0 +1,77 @@
+<template>
+  <!--
+    #1926 — the failure surface for a VERB (toggle, acknowledge, respond, stop),
+    as opposed to a failed list fetch (see LoadFailed.vue).
+
+    Design-system principle 18: toasts announce completed verbs, so a failed
+    verb may not be a toast — it must persist next to the control the user just
+    pressed, until they dismiss it or retry. Principle 25: name what happened
+    and what to do; keep the raw error behind a disclosure.
+  -->
+  <div
+    v-if="message"
+    class="flex items-start gap-2 rounded-md border border-status-danger-200 dark:border-status-danger-500/30 bg-status-danger-50 dark:bg-status-danger-500/10 px-3 py-2 text-sm text-status-danger-700 dark:text-status-danger-300"
+    role="alert"
+    data-testid="inline-error"
+  >
+    <svg class="w-4 h-4 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+
+    <div class="min-w-0 flex-1">
+      <p class="break-words">{{ message }}</p>
+      <details v-if="detail" class="mt-1">
+        <summary class="text-xs opacity-80 cursor-pointer select-none">Technical detail</summary>
+        <p class="mt-1 text-xs font-mono break-words opacity-90">{{ detail }}</p>
+      </details>
+      <button
+        v-if="retryable"
+        type="button"
+        class="mt-1 text-xs font-medium underline hover:no-underline focus:outline-none focus:ring-2 focus:ring-status-danger-500/40 rounded"
+        @click="$emit('retry')"
+      >
+        {{ retryLabel }}
+      </button>
+    </div>
+
+    <button
+      type="button"
+      class="flex-shrink-0 opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-status-danger-500/40 rounded"
+      :aria-label="`Dismiss error: ${message}`"
+      @click="$emit('dismiss')"
+    >
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  // What happened + what to do. Empty string renders nothing.
+  message: {
+    type: String,
+    default: ''
+  },
+  detail: {
+    type: String,
+    default: ''
+  },
+  retryable: {
+    type: Boolean,
+    default: false
+  },
+  retryLabel: {
+    type: String,
+    default: 'Try again'
+  }
+})
+
+defineEmits(['dismiss', 'retry'])
+</script>

--- a/src/frontend/src/components/LoadFailed.vue
+++ b/src/frontend/src/components/LoadFailed.vue
@@ -1,0 +1,101 @@
+<template>
+  <!--
+    #1926 — the "failed" member of the loading / empty / failed triad
+    (design-system principles 15 + 25).
+
+    A failed fetch must never borrow the empty state's copy: "No templates
+    found" on a network error points the user at the wrong remedy (create one)
+    instead of the right one (retry). This block names what happened, offers
+    the retry, and keeps the raw technical detail behind a disclosure so the
+    headline stays in user vocabulary.
+
+    Shares the footprint of the sibling loading/empty blocks (same centered
+    `py-12` column) so nothing shifts when the state resolves (principle 4).
+  -->
+  <div
+    class="text-center px-4"
+    :class="dense ? 'py-6' : 'py-12'"
+    role="alert"
+    data-testid="load-failed"
+  >
+    <svg
+      class="mx-auto text-status-danger-500 dark:text-status-danger-400"
+      :class="dense ? 'w-8 h-8 mb-2' : 'w-12 h-12 mb-4'"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+
+    <p class="font-medium text-gray-900 dark:text-gray-100">{{ title }}</p>
+    <p class="text-sm mt-1 text-gray-600 dark:text-gray-400">{{ message }}</p>
+
+    <button
+      v-if="onRetry !== false"
+      type="button"
+      class="mt-4 text-sm font-medium text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300 focus:outline-none focus:ring-2 focus:ring-action-primary-500/40 rounded px-2 py-1 disabled:opacity-45 disabled:cursor-wait"
+      :disabled="retrying"
+      @click="$emit('retry')"
+    >
+      {{ retrying ? 'Retrying…' : retryLabel }}
+    </button>
+
+    <!-- Principle 25: codes and traces live behind a disclosure, not in the headline. -->
+    <details v-if="detail" class="mt-3 text-left max-w-md mx-auto">
+      <summary class="text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none">
+        Technical detail
+      </summary>
+      <p class="mt-1 text-xs font-mono break-words text-gray-600 dark:text-gray-400">
+        {{ detail }}
+      </p>
+    </details>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  // Headline: what happened, in user vocabulary.
+  title: {
+    type: String,
+    default: "Couldn't load"
+  },
+  // What it means / what to do next.
+  message: {
+    type: String,
+    default: 'The request failed. Check your connection and try again.'
+  },
+  // Raw error text (status code, server message) — disclosed, never the headline.
+  detail: {
+    type: String,
+    default: ''
+  },
+  retryLabel: {
+    type: String,
+    default: 'Try again'
+  },
+  // True while the retry is in flight, so the control can't be double-fired.
+  retrying: {
+    type: Boolean,
+    default: false
+  },
+  // Pass `:on-retry="false"` for the rare surface with nothing to retry.
+  onRetry: {
+    type: [Boolean, String],
+    default: true
+  },
+  // Compact variant for small panels and rows.
+  dense: {
+    type: Boolean,
+    default: false
+  }
+})
+
+defineEmits(['retry'])
+</script>

--- a/src/frontend/src/components/LoadFailed.vue
+++ b/src/frontend/src/components/LoadFailed.vue
@@ -38,7 +38,7 @@
     <p class="text-sm mt-1 text-gray-600 dark:text-gray-400">{{ message }}</p>
 
     <button
-      v-if="onRetry !== false"
+      v-if="showRetry"
       type="button"
       class="mt-4 text-sm font-medium text-action-primary-600 dark:text-action-primary-400 hover:text-action-primary-800 dark:hover:text-action-primary-300 focus:outline-none focus:ring-2 focus:ring-action-primary-500/40 rounded px-2 py-1 disabled:opacity-45 disabled:cursor-wait"
       :disabled="retrying"
@@ -85,9 +85,11 @@ defineProps({
     type: Boolean,
     default: false
   },
-  // Pass `:on-retry="false"` for the rare surface with nothing to retry.
-  onRetry: {
-    type: [Boolean, String],
+  // `:show-retry="false"` for the rare surface with nothing to retry.
+  // NOT named `onRetry`: Vue compiles the parent's `@retry` into an `onRetry`
+  // prop, so a prop of that name collides with this component's own emit.
+  showRetry: {
+    type: Boolean,
     default: true
   },
   // Compact variant for small panels and rows.

--- a/src/frontend/src/components/SchedulesPanel.vue
+++ b/src/frontend/src/components/SchedulesPanel.vue
@@ -268,11 +268,33 @@
       </div>
     </div>
 
+    <!-- Action failure (#1926) — enable/disable used to fail to console only
+         (the row silently snapped back), and delete/trigger used a native
+         alert(). Both now surface here and persist until dismissed. -->
+    <InlineError
+      v-if="actionError"
+      class="mb-4"
+      :message="actionError"
+      :detail="actionErrorDetail"
+      @dismiss="clearActionError"
+    />
+
     <!-- Schedules List -->
     <div v-if="loading" class="text-center py-8">
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary-500 mx-auto"></div>
       <p class="text-sm text-gray-500 dark:text-gray-400 mt-2">Loading schedules...</p>
     </div>
+
+    <!-- Failed list fetch (#1926) — "No schedules configured" on a failed fetch
+         invites the user to create a duplicate schedule. -->
+    <LoadFailed
+      v-else-if="loadError"
+      title="Couldn't load schedules"
+      message="The schedule list didn't load, so what you see may be incomplete. Try again."
+      :detail="loadError"
+      :retrying="loading"
+      @retry="loadSchedules"
+    />
 
     <div v-else-if="schedules.length === 0" class="text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg">
       <svg class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -803,6 +825,9 @@ import { parseUTC } from '@/utils/timestamps'
 import ConfirmDialog from './ConfirmDialog.vue'
 import ModelSelector from './ModelSelector.vue'
 import ScheduleAnalyticsCard from './ScheduleAnalyticsCard.vue'
+import LoadFailed from './LoadFailed.vue'
+import InlineError from './InlineError.vue'
+import { apiErrorMessage } from '../utils/apiError'
 import { useAuthStore } from '../stores/auth'
 import { useExecutionsStore } from '../stores/executions'
 
@@ -852,6 +877,11 @@ const formLoading = ref(false)
 const formError = ref('')
 const triggerLoading = ref(null)
 const toggleLoading = ref(null)
+// #1926: a failed list fetch is not an empty list; a failed verb is not a
+// silent no-op. Both get their own state instead of console.error/alert().
+const loadError = ref('')
+const actionError = ref('')
+const actionErrorDetail = ref('')
 const deleteLoading = ref(null)
 const expandedSchedule = ref(null)
 const executions = ref({})
@@ -1120,13 +1150,16 @@ function toggleAllTools() {
 // Load schedules
 async function loadSchedules() {
   loading.value = true
+  loadError.value = ''
   try {
     const response = await axios.get(`/api/agents/${props.agentName}/schedules`, {
       headers: authStore.authHeader
     })
     schedules.value = response.data
+    loadError.value = ''
   } catch (error) {
     console.error('Failed to load schedules:', error)
+    loadError.value = apiErrorMessage(error, 'Request failed')
   } finally {
     loading.value = false
   }
@@ -1249,8 +1282,9 @@ function deleteSchedule(schedule) {
       })
       await loadSchedules()
     } catch (error) {
-      console.error('Failed to delete schedule:', error)
-      alert(error.response?.data?.detail || 'Failed to delete schedule')
+      // alert() blocks the page and dies on OK, leaving no record of what
+      // failed; an inline error persists next to the row (#1926).
+      reportActionFailure(error, `delete the schedule "${schedule.name}"`)
     } finally {
       deleteLoading.value = null
     }
@@ -1258,17 +1292,32 @@ function deleteSchedule(schedule) {
   confirmDialog.visible = true
 }
 
+function clearActionError() {
+  actionError.value = ''
+  actionErrorDetail.value = ''
+}
+
+// #1926 — one place that turns a failed verb into a persistent, named error.
+function reportActionFailure(error, what) {
+  console.error(`Failed to ${what}:`, error)
+  actionError.value = `Couldn't ${what}. Nothing was changed — try again.`
+  actionErrorDetail.value = apiErrorMessage(error, 'Request failed')
+}
+
 // Toggle schedule enabled/disabled
 async function toggleSchedule(schedule) {
   toggleLoading.value = schedule.id
+  clearActionError()
+  const wanted = schedule.enabled ? 'disable' : 'enable'
   try {
-    const endpoint = schedule.enabled ? 'disable' : 'enable'
-    await axios.post(`/api/agents/${props.agentName}/schedules/${schedule.id}/${endpoint}`, {}, {
+    await axios.post(`/api/agents/${props.agentName}/schedules/${schedule.id}/${wanted}`, {}, {
       headers: authStore.authHeader
     })
     await loadSchedules()
   } catch (error) {
-    console.error('Failed to toggle schedule:', error)
+    // The row reverts to its server state on reload, so without this the user
+    // sees the toggle snap back with no explanation (#1926).
+    reportActionFailure(error, `${wanted} the schedule "${schedule.name}"`)
   } finally {
     toggleLoading.value = null
   }
@@ -1286,8 +1335,7 @@ async function triggerSchedule(schedule) {
       await loadExecutions(schedule.id)
     }
   } catch (error) {
-    console.error('Failed to trigger schedule:', error)
-    alert(error.response?.data?.detail || 'Failed to trigger schedule')
+    reportActionFailure(error, `run the schedule "${schedule.name}" now`)
   } finally {
     triggerLoading.value = null
   }

--- a/src/frontend/src/components/SchedulesPanel.vue
+++ b/src/frontend/src/components/SchedulesPanel.vue
@@ -1276,6 +1276,7 @@ function deleteSchedule(schedule) {
   confirmDialog.variant = 'danger'
   confirmDialog.onConfirm = async () => {
     deleteLoading.value = schedule.id
+    clearActionError()
     try {
       await axios.delete(`/api/agents/${props.agentName}/schedules/${schedule.id}`, {
         headers: authStore.authHeader
@@ -1326,6 +1327,7 @@ async function toggleSchedule(schedule) {
 // Trigger schedule manually
 async function triggerSchedule(schedule) {
   triggerLoading.value = schedule.id
+  clearActionError()
   try {
     await axios.post(`/api/agents/${props.agentName}/schedules/${schedule.id}/trigger`, {}, {
       headers: authStore.authHeader

--- a/src/frontend/src/components/SystemViewEditor.vue
+++ b/src/frontend/src/components/SystemViewEditor.vue
@@ -121,8 +121,25 @@
               </button>
             </div>
 
+            <!-- Tag-suggestion fetch failed (#1926) — the "Available:" row used
+                 to vanish silently, which reads as "this agent fleet has no
+                 tags" rather than "we couldn't fetch them". Typing a tag by
+                 hand still works, so this is a note plus a retry, not a block. -->
+            <div
+              v-if="tagsError"
+              class="flex items-center gap-2 text-xs text-status-danger-600 dark:text-status-danger-400"
+              role="status"
+            >
+              <span>Couldn't load existing tags — you can still type one above.</span>
+              <button
+                type="button"
+                class="font-medium underline hover:no-underline"
+                @click="fetchAvailableTags"
+              >Try again</button>
+            </div>
+
             <!-- Available Tags -->
-            <div v-if="availableTags.length > 0" class="text-xs text-gray-500 dark:text-gray-400">
+            <div v-else-if="availableTags.length > 0" class="text-xs text-gray-500 dark:text-gray-400">
               Available:
               <button
                 v-for="tag in availableTags"
@@ -251,6 +268,8 @@ const form = reactive({
 
 const tagInput = ref('')
 const availableTags = ref([])
+// #1926: distinguishes "no tags exist" from "the tag fetch failed".
+const tagsError = ref(false)
 const isSubmitting = ref(false)
 const error = ref(null)
 
@@ -289,11 +308,13 @@ watch(() => props.isOpen, async (open) => {
 })
 
 async function fetchAvailableTags() {
+  tagsError.value = false
   try {
     const response = await axios.get('/api/tags')
     availableTags.value = response.data.tags || []
   } catch (err) {
     console.error('Failed to fetch tags:', err)
+    tagsError.value = true
   }
 }
 

--- a/src/frontend/src/components/TasksPanel.vue
+++ b/src/frontend/src/components/TasksPanel.vue
@@ -149,7 +149,19 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-2">Loading tasks...</p>
       </div>
 
-      <!-- Empty State -->
+      <!-- Failed State (#1926) — "No tasks yet" on a failed fetch is a lie that
+           tells the user to run a task when the real fix is to retry. -->
+      <div v-else-if="loadError && allTasks.length === 0" class="flex-1 flex flex-col justify-center">
+        <LoadFailed
+          title="Couldn't load task history"
+          message="The execution list didn't load. Check your connection and try again."
+          :detail="loadError"
+          :retrying="loading"
+          @retry="loadAllData"
+        />
+      </div>
+
+      <!-- Empty State — fetch succeeded and returned zero -->
       <div v-else-if="allTasks.length === 0" class="text-center py-12 flex-1 flex flex-col justify-center">
         <svg class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
@@ -534,6 +546,8 @@ import { parseUTC } from '@/utils/timestamps'
 import { useAuthStore } from '../stores/auth'
 import { formatCost, formatCostCompact } from '../composables/useFormatters'
 import ModelSelector from './ModelSelector.vue'
+import LoadFailed from './LoadFailed.vue'
+import { apiErrorMessage } from '../utils/apiError'
 
 // Template ref for highlighted task element
 const highlightedTaskRef = ref(null)
@@ -566,6 +580,8 @@ const executions = ref([])
 const pendingTasks = ref([]) // Local tasks we've submitted
 const queueStatus = ref(null)
 const loading = ref(true)
+// #1926: a failed executions fetch renders as failed, not as "No tasks yet".
+const loadError = ref('')
 const newTaskMessage = ref('')
 const taskLoading = ref(false)
 const releaseLoading = ref(false)
@@ -675,6 +691,7 @@ async function loadAllData() {
 
 // Load executions from server
 async function loadExecutions() {
+  loadError.value = ''
   try {
     const response = await axios.get(`/api/agents/${props.agentName}/executions?limit=100`, {
       headers: authStore.authHeader
@@ -687,6 +704,7 @@ async function loadExecutions() {
     }
   } catch (error) {
     console.error('Failed to load executions:', error)
+    loadError.value = apiErrorMessage(error, 'Request failed')
   }
 }
 

--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -165,6 +165,20 @@
         />
       </div>
 
+      <!-- Failed REFRESH (#1926) — the first load succeeded, so the list below
+           is real but stale (it may even be the previous filter's rows).
+           Say so rather than presenting stale data as fresh; the list stays
+           put, since blanking it would lose data we do have. -->
+      <div v-if="refreshFailed" class="px-6 pt-4">
+        <InlineError
+          message="Couldn't refresh notifications — showing the last results that loaded."
+          :detail="notificationsStore.error"
+          retryable
+          @retry="fetchNotifications"
+          @dismiss="notificationsStore.error = null"
+        />
+      </div>
+
       <!-- Loading state (#1926) — the body used to render blank during the
            first fetch: neither list, nor empty state, nor spinner. -->
       <div v-if="firstLoad" class="px-6 py-12 text-center" aria-busy="true">
@@ -414,6 +428,9 @@ onMounted(() => {
 // failed first fetch reads as failed — not as "No events yet".
 const firstLoad = computed(() => !notificationsStore.hasLoaded && !notificationsStore.error)
 const loadFailed = computed(() => !notificationsStore.hasLoaded && !!notificationsStore.error)
+// Distinct from loadFailed: we HAVE data, but the newest attempt to update it
+// failed, so what's rendered is stale (possibly for a different filter).
+const refreshFailed = computed(() => notificationsStore.hasLoaded && !!notificationsStore.error)
 
 function clearActionError() {
   actionError.value = ''

--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -153,7 +153,39 @@
         </div>
       </div>
 
-      <div class="divide-y divide-gray-200 dark:divide-gray-700">
+      <!-- Action failure (#1926) — acknowledge / dismiss / bulk failures used to
+           go to console only, so the row stayed put and the verb looked like it
+           had simply done nothing. Errors persist here until dismissed
+           (principle 18: toasts are for completed verbs). -->
+      <div v-if="actionError" class="px-6 pt-4">
+        <InlineError
+          :message="actionError"
+          :detail="actionErrorDetail"
+          @dismiss="clearActionError"
+        />
+      </div>
+
+      <!-- Loading state (#1926) — the body used to render blank during the
+           first fetch: neither list, nor empty state, nor spinner. -->
+      <div v-if="firstLoad" class="px-6 py-12 text-center" aria-busy="true">
+        <svg class="w-8 h-8 mx-auto mb-4 animate-spin text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Loading notifications…</p>
+      </div>
+
+      <!-- Failed state (#1926) — previously there was none at all. -->
+      <LoadFailed
+        v-else-if="loadFailed"
+        title="Couldn't load notifications"
+        message="We can't show what your agents have sent. Check your connection and try again."
+        :detail="notificationsStore.error"
+        :retrying="loading"
+        @retry="fetchNotifications"
+      />
+
+      <div v-else class="divide-y divide-gray-200 dark:divide-gray-700">
         <div
           v-for="notification in displayedNotifications"
           :key="notification.id"
@@ -264,8 +296,8 @@
           </div>
         </div>
 
-        <!-- Empty State -->
-        <div v-if="displayedNotifications.length === 0 && !loading" class="px-6 py-12 text-center">
+        <!-- Empty State — only once a fetch has SUCCEEDED and returned zero -->
+        <div v-if="displayedNotifications.length === 0" class="px-6 py-12 text-center">
           <InboxIcon class="w-12 h-12 mx-auto mb-4 text-gray-300 dark:text-gray-600" />
           <p class="text-lg font-medium text-gray-900 dark:text-white">
             {{ hasActiveFilters ? 'No matching events' : 'No events yet' }}
@@ -302,6 +334,9 @@ import { ref, computed, onMounted } from 'vue'
 import { useNotificationsStore } from '../../stores/notifications'
 import { useAgentsStore } from '../../stores/agents'
 import { agentNameTooltip, agentOptionLabel } from '../../utils/agentName'
+import LoadFailed from '../LoadFailed.vue'
+import InlineError from '../InlineError.vue'
+import { apiErrorMessage } from '../../utils/apiError'
 import {
   XMarkIcon,
   CheckIcon,
@@ -319,6 +354,10 @@ const agentsStore = useAgentsStore()
 
 // State
 const loading = ref(false)
+// #1926: failures of the row verbs (acknowledge / dismiss / bulk) surface here,
+// next to the controls, and persist until dismissed.
+const actionError = ref('')
+const actionErrorDetail = ref('')
 const statusFilter = ref('pending')
 const priorityFilter = ref('')
 const agentFilter = ref('')
@@ -370,6 +409,36 @@ onMounted(() => {
 })
 
 // Methods
+// #1926 loading / failed / empty triad. `hasLoaded` flips only on a succeeded
+// fetch, so an empty list before the first response reads as loading, and a
+// failed first fetch reads as failed — not as "No events yet".
+const firstLoad = computed(() => !notificationsStore.hasLoaded && !notificationsStore.error)
+const loadFailed = computed(() => !notificationsStore.hasLoaded && !!notificationsStore.error)
+
+function clearActionError() {
+  actionError.value = ''
+  actionErrorDetail.value = ''
+}
+
+// The store's bulk helpers use Promise.allSettled, so they RESOLVE even when
+// every item failed — a try/catch alone would report success on a total
+// failure (#1926). Inspect the settlement and say how many did not apply.
+function reportSettled(results, attempted, verb, past) {
+  const rejected = (results || []).filter(r => r.status === 'rejected')
+  if (!rejected.length) return
+  const failed = rejected.length
+  actionError.value = failed === attempted
+    ? `Couldn't ${verb} the ${attempted} selected notification(s) — none were changed. Try again.`
+    : `${failed} of ${attempted} notification(s) couldn't be ${past} and are unchanged. Try again.`
+  actionErrorDetail.value = apiErrorMessage(rejected[0].reason, 'Request failed')
+}
+
+function reportActionFailure(err, what) {
+  console.error(`Failed to ${what}:`, err)
+  actionError.value = `Couldn't ${what}. Nothing was changed — try again.`
+  actionErrorDetail.value = apiErrorMessage(err, 'Request failed')
+}
+
 async function fetchNotifications() {
   loading.value = true
   try {
@@ -405,34 +474,50 @@ function clearFilters() {
 }
 
 async function acknowledge(notificationId) {
+  clearActionError()
   try {
     await notificationsStore.acknowledgeNotification(notificationId)
   } catch (err) {
-    console.error('Failed to acknowledge notification:', err)
+    reportActionFailure(err, 'acknowledge this notification')
   }
 }
 
 async function dismiss(notificationId) {
+  clearActionError()
   try {
     await notificationsStore.dismissNotification(notificationId)
   } catch (err) {
-    console.error('Failed to dismiss notification:', err)
+    reportActionFailure(err, 'dismiss this notification')
   }
 }
 
 async function bulkAcknowledge() {
+  clearActionError()
+  const count = notificationsStore.selectedIds.length
   try {
-    await notificationsStore.bulkAcknowledge(notificationsStore.selectedIds)
+    reportSettled(
+      await notificationsStore.bulkAcknowledge(notificationsStore.selectedIds),
+      count,
+      'acknowledge',
+      'acknowledged'
+    )
   } catch (err) {
-    console.error('Failed to bulk acknowledge:', err)
+    reportActionFailure(err, 'acknowledge the selected notifications')
   }
 }
 
 async function bulkDismiss() {
+  clearActionError()
+  const count = notificationsStore.selectedIds.length
   try {
-    await notificationsStore.bulkDismiss(notificationsStore.selectedIds)
+    reportSettled(
+      await notificationsStore.bulkDismiss(notificationsStore.selectedIds),
+      count,
+      'dismiss',
+      'dismissed'
+    )
   } catch (err) {
-    console.error('Failed to bulk dismiss:', err)
+    reportActionFailure(err, 'dismiss the selected notifications')
   }
 }
 

--- a/src/frontend/src/components/process/TemplateSelector.vue
+++ b/src/frontend/src/components/process/TemplateSelector.vue
@@ -25,7 +25,18 @@
       </svg>
     </div>
 
-    <!-- Empty state -->
+    <!-- Failed state (#1926) — a failed fetch is NOT "no templates found":
+         that copy sends the user to create a template when the fix is retry. -->
+    <LoadFailed
+      v-else-if="loadError"
+      title="Couldn't load templates"
+      message="The template list didn't load. Check your connection and try again."
+      :detail="loadError"
+      :retrying="loading"
+      @retry="fetchTemplates"
+    />
+
+    <!-- Empty state — only after a fetch SUCCEEDED and returned zero -->
     <div
       v-else-if="filteredTemplates.length === 0"
       class="text-center py-12 text-gray-500 dark:text-gray-400"
@@ -185,6 +196,8 @@ import {
   DocumentPlusIcon,
   ArrowsRightLeftIcon,
 } from '@heroicons/vue/24/outline'
+import LoadFailed from '../LoadFailed.vue'
+import { apiErrorMessage } from '../../utils/apiError'
 
 const props = defineProps({
   selectedId: {
@@ -200,6 +213,9 @@ const templates = ref([])
 const categories = ref([])
 const selectedCategory = ref('')
 const loading = ref(false)
+// #1926: distinct from `templates.length === 0` — a failed fetch must render as
+// failed, not as the empty state.
+const loadError = ref('')
 const previewTemplate = ref(null)
 
 // Computed
@@ -226,6 +242,7 @@ watch(selectedCategory, () => {
 // Methods
 async function fetchTemplates() {
   loading.value = true
+  loadError.value = ''
   try {
     const token = localStorage.getItem('token')
     const response = await axios.get('/api/process-templates', {
@@ -234,6 +251,7 @@ async function fetchTemplates() {
     templates.value = response.data.templates || []
   } catch (err) {
     console.error('Failed to fetch templates:', err)
+    loadError.value = apiErrorMessage(err, 'Request failed')
   } finally {
     loading.value = false
   }

--- a/src/frontend/src/composables/useNotification.js
+++ b/src/frontend/src/composables/useNotification.js
@@ -1,21 +1,51 @@
 import { ref } from 'vue'
 
 /**
- * Composable for toast notification management
- * Provides a simple notification system with auto-dismiss
+ * Toast notifications.
+ *
+ * #1926 (design-system principle 18): **toasts announce completed verbs, not
+ * failures.** A 3-second auto-dismissing error is a failure the user is likely
+ * to miss entirely — and if they do catch it, it is gone before they can read
+ * the detail or act on it. So an `error` notification now persists until it is
+ * dismissed; success/info keep the timed behaviour.
+ *
+ * A failure that belongs *next to a control* should not use this composable at
+ * all — use `components/InlineError.vue` (verb failures) or
+ * `components/LoadFailed.vue` (failed fetches), which stay anchored to the
+ * thing that failed.
  */
 export function useNotification() {
   const notification = ref(null)
+  let timer = null
 
-  const showNotification = (message, type = 'success') => {
+  const clearTimer = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  const dismissNotification = () => {
+    clearTimer()
+    notification.value = null
+  }
+
+  const showNotification = (message, type = 'success', { timeout = 3000 } = {}) => {
+    // Clearing the pending timer matters even on the success path: without it a
+    // second toast inherited the first one's countdown and could vanish almost
+    // immediately.
+    clearTimer()
     notification.value = { message, type }
-    setTimeout(() => {
+    if (type === 'error') return // persists until dismissed (principle 18)
+    timer = setTimeout(() => {
       notification.value = null
-    }, 3000)
+      timer = null
+    }, timeout)
   }
 
   return {
     notification,
-    showNotification
+    showNotification,
+    dismissNotification
   }
 }

--- a/src/frontend/src/stores/notifications.js
+++ b/src/frontend/src/stores/notifications.js
@@ -16,6 +16,9 @@ export const useNotificationsStore = defineStore('notifications', () => {
   const pendingCount = ref(0)
   const loading = ref(false)
   const error = ref(null)
+  // #1926: only a SUCCEEDED fetch licenses the empty state. Before this flips,
+  // an empty `notifications` means "loading" or "failed", never "no events".
+  const hasLoaded = ref(false)
   const totalCount = ref(0)
   const hasMore = ref(true)
 
@@ -108,6 +111,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
 
       // Update pending count from filtered results
       updatePendingCount()
+      hasLoaded.value = true
     } catch (err) {
       console.error('Failed to fetch notifications:', err)
       error.value = err.response?.data?.detail || 'Failed to load notifications'
@@ -304,6 +308,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     pendingCount,
     loading,
     error,
+    hasLoaded,
     totalCount,
     hasMore,
     filters,

--- a/src/frontend/src/stores/operatorQueue.js
+++ b/src/frontend/src/stores/operatorQueue.js
@@ -10,6 +10,7 @@ import { ref, computed } from 'vue'
 import axios from 'axios'
 import api from '../api'
 import { useAuthStore } from './auth'
+import { apiErrorMessage } from '../utils/apiError'
 
 // Agent display helpers
 const AGENT_COLORS = [
@@ -34,6 +35,10 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
   const expandedItemId = ref(null)
   const loading = ref(false)
   const error = ref(null)
+  // #1926: "the list is empty" is only true once a fetch has SUCCEEDED and
+  // returned zero. Before the first success, `items.length === 0` means
+  // "loading" or "failed" — consumers must gate their empty state on this.
+  const hasLoaded = ref(false)
   const activeTab = ref('open') // 'open' or 'resolved'
   let _pollTimer = null
 
@@ -93,8 +98,9 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
         headers: authStore.authHeader
       })
       items.value = response.data.items || []
+      hasLoaded.value = true
     } catch (err) {
-      error.value = err.response?.data?.detail || err.message
+      error.value = apiErrorMessage(err, 'Request failed')
       // Don't clear items on error — keep stale data visible
     } finally {
       loading.value = false
@@ -132,7 +138,7 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
         error.value = 'This item was cancelled or answered by another operator — your response was not recorded.'
         fetchItems()
       } else {
-        error.value = err.response?.data?.detail || err.message
+        error.value = apiErrorMessage(err, 'Request failed')
       }
     }
   }
@@ -146,7 +152,7 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
       await fetchItems()
       return response.data
     } catch (err) {
-      error.value = err.response?.data?.detail || err.message
+      error.value = apiErrorMessage(err, 'Request failed')
       throw err
     }
   }
@@ -160,7 +166,7 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
       await fetchItems()
       return response.data
     } catch (err) {
-      error.value = err.response?.data?.detail || err.message
+      error.value = apiErrorMessage(err, 'Request failed')
       throw err
     }
   }
@@ -218,6 +224,7 @@ export const useOperatorQueueStore = defineStore('operatorQueue', () => {
     expandedItemId,
     loading,
     error,
+    hasLoaded,
     activeTab,
     openItems,
     resolvedItems,

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -19,7 +19,14 @@
             notification.type === 'success' ? 'bg-status-success-100 dark:bg-status-success-900/50 border border-status-success-400 dark:border-status-success-700 text-status-success-700 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300'
           ]"
         >
-          {{ notification.message }}
+          <span>{{ notification.message }}</span>
+          <button
+            v-if="notification.type === 'error'"
+            type="button"
+            class="ml-3 font-medium opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-status-danger-500/40 rounded"
+            aria-label="Dismiss notification"
+            @click="dismissNotification"
+          >✕</button>
         </div>
 
         <div v-if="error && !agent" class="bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300 px-4 py-3 rounded mb-4">
@@ -470,7 +477,7 @@ function toggleChatMode() {
 }
 
 // Initialize composables
-const { notification, showNotification } = useNotification()
+const { notification, showNotification, dismissNotification } = useNotification()
 
 // Agent lifecycle composable
 const {

--- a/src/frontend/src/views/FileManager.vue
+++ b/src/frontend/src/views/FileManager.vue
@@ -10,7 +10,14 @@
         class="px-4 py-3 rounded-md text-sm"
         :class="notification.type === 'success' ? 'bg-status-success-100 dark:bg-status-success-900/50 border border-status-success-400 dark:border-status-success-700 text-status-success-700 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300'"
       >
-        {{ notification.message }}
+        <span>{{ notification.message }}</span>
+        <button
+          v-if="notification.type === 'error'"
+          type="button"
+          class="ml-3 font-medium opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-status-danger-500/40 rounded"
+          aria-label="Dismiss notification"
+          @click="dismissNotification"
+        >✕</button>
       </div>
     </div>
 
@@ -282,6 +289,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useAgentsStore } from '@/stores/agents'
+import { useNotification } from '@/composables/useNotification'
 import { agentOptionLabel } from '@/utils/agentName'
 import NavBar from '@/components/NavBar.vue'
 import FileTreeNode from '@/components/file-manager/FileTreeNode.vue'
@@ -289,14 +297,11 @@ import FilePreview from '@/components/file-manager/FilePreview.vue'
 
 const agentsStore = useAgentsStore()
 
-// Notification system
-const notification = ref(null)
-const showNotification = (message, type = 'success') => {
-  notification.value = { message, type }
-  setTimeout(() => {
-    notification.value = null
-  }, 4000)
-}
+// #1926: was a local copy of the toast helper with a hardcoded 4s
+// auto-dismiss, so an error toast vanished before it could be read or acted
+// on. Now the shared composable, which keeps errors up until dismissed
+// (principle 18).
+const { notification, showNotification, dismissNotification } = useNotification()
 
 // State
 const selectedAgentName = ref(localStorage.getItem('fileManager.selectedAgent') || '')

--- a/src/frontend/src/views/MobileAdmin.vue
+++ b/src/frontend/src/views/MobileAdmin.vue
@@ -60,6 +60,18 @@
           </svg>
         </div>
 
+        <!-- Action failure banner (#1926) — start/stop, autonomy, queue respond
+             and acknowledge used to fail to console only, so on a phone the
+             verb simply appeared to do nothing. Persists until dismissed
+             (principle 18: toasts are for completed verbs, not errors). -->
+        <div v-if="actionError" class="action-error result-error" role="alert">
+          <div class="action-error-body">
+            <p>{{ actionError }}</p>
+            <p v-if="actionErrorDetail" class="action-error-detail">{{ actionErrorDetail }}</p>
+          </div>
+          <button class="action-error-dismiss" aria-label="Dismiss error" @click="clearActionError">✕</button>
+        </div>
+
         <!-- AGENTS TAB -->
         <div v-if="activeTab === 'agents'" class="tab-panel">
           <!-- Search -->
@@ -442,6 +454,7 @@ import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 import { useAgentsStore } from '../stores/agents'
 import { agentNameTooltip } from '../utils/agentName'
+import { apiErrorMessage } from '../utils/apiError'
 
 const route = useRoute()
 const authStore = useAuthStore()
@@ -493,6 +506,10 @@ const executionStats = ref({})
 const confirmDialog = ref(null)
 const actionLoading = ref(false)
 const actionResult = ref(null)
+// #1926: failed verbs (start/stop, autonomy, queue respond, acknowledge) land
+// here instead of console.error, and stay until the operator dismisses them.
+const actionError = ref('')
+const actionErrorDetail = ref('')
 
 // Loading states
 const loading = reactive({
@@ -650,6 +667,20 @@ function toggleAgentExpand(name) {
   expandedAgent.value = expandedAgent.value === name ? null : name
 }
 
+// #1926 — one persistent, dismissible surface for every failed verb on this
+// screen. console.error alone is invisible on a phone, where there is no
+// devtools pane to open.
+function clearActionError() {
+  actionError.value = ''
+  actionErrorDetail.value = ''
+}
+
+function reportActionFailure(e, what) {
+  console.error(`Failed to ${what}:`, e)
+  actionError.value = `Couldn't ${what}. Nothing was changed — try again.`
+  actionErrorDetail.value = apiErrorMessage(e, 'Request failed')
+}
+
 async function toggleAgent(name, currentStatus) {
   togglingAgents[name] = true
   try {
@@ -660,7 +691,7 @@ async function toggleAgent(name, currentStatus) {
     }
     await fetchAgents()
   } catch (e) {
-    console.error(`Failed to toggle ${name}:`, e)
+    reportActionFailure(e, `${currentStatus === 'running' ? 'stop' : 'start'} ${name}`)
   } finally {
     togglingAgents[name] = false
   }
@@ -673,7 +704,9 @@ async function toggleAutonomy(agent) {
     await axios.put(`/api/agents/${agent.name}/autonomy`, { enabled: newState })
     agent.autonomy_enabled = newState
   } catch (e) {
-    console.error(`Failed to toggle autonomy for ${agent.name}:`, e)
+    // The toggle reverts to the server value, so without this the switch just
+    // springs back with no reason given (#1926).
+    reportActionFailure(e, `change autonomy for ${agent.name}`)
   } finally {
     togglingAutonomy[agent.name] = false
   }
@@ -858,7 +891,8 @@ async function respondToQueueItem(id, response) {
     responseTexts[id] = ''
     await fetchQueue()
   } catch (e) {
-    console.error('Failed to respond:', e)
+    // Critical: the operator believes they answered the agent. They did not.
+    reportActionFailure(e, 'send your response — the agent is still waiting')
   } finally {
     respondingItems[id] = false
   }
@@ -869,7 +903,7 @@ async function acknowledgeNotification(id) {
     await axios.post(`/api/notifications/${id}/acknowledge`)
     await fetchNotifications()
   } catch (e) {
-    console.error('Failed to acknowledge:', e)
+    reportActionFailure(e, 'acknowledge that notification')
   }
 }
 
@@ -1728,6 +1762,45 @@ watch(() => authStore.isAuthenticated, (isAuth) => {
 .result-error {
   background: #7f1d1d;
   color: #fca5a5;
+}
+
+/* #1926: persistent failed-verb banner (see the template note). Layout only —
+   it composes `.result-error` for the palette, so failure reads the same
+   everywhere on this screen and no new hardcoded color enters the ratchet. */
+.action-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 0 12px;
+  padding: 12px;
+  border-radius: 10px;
+  font-size: 14px;
+  text-align: left;
+}
+
+.action-error-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.action-error-detail {
+  margin-top: 4px;
+  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  opacity: 0.85;
+  overflow-wrap: anywhere;
+}
+
+.action-error-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 4px;
+  min-width: 32px;
+  min-height: 32px;
 }
 
 /* ─── Confirm Dialog ────────────────────────────────────────────────────── */

--- a/src/frontend/src/views/Operations.vue
+++ b/src/frontend/src/views/Operations.vue
@@ -134,8 +134,32 @@
 
       <!-- Needs Response Tab (narrow card feed) -->
       <div v-if="activeTab === 'needs-response'" class="max-w-3xl mx-auto">
-        <!-- Empty state -->
-        <div v-if="operatorQueueStore.openItems.length === 0" class="text-center py-16">
+        <!-- Loading state (#1926) — before the first poll returns we do NOT
+             know the queue is empty; claiming "All caught up" is optimistic
+             success (principle 15). -->
+        <div v-if="queueFirstLoad" class="text-center py-16" aria-busy="true">
+          <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-800 mb-4">
+            <svg class="w-8 h-8 animate-spin text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+            </svg>
+          </div>
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white">Checking the queue…</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Loading items that need your response.</p>
+        </div>
+
+        <!-- Failed state (#1926) -->
+        <LoadFailed
+          v-else-if="queueLoadFailed"
+          title="Couldn't load the queue"
+          message="We can't tell whether your agents need you. Check your connection and try again."
+          :detail="operatorQueueStore.error"
+          :retrying="operatorQueueStore.loading"
+          @retry="operatorQueueStore.fetchItems"
+        />
+
+        <!-- Empty state — a fetch succeeded and returned zero -->
+        <div v-else-if="operatorQueueStore.openItems.length === 0" class="text-center py-16">
           <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-status-success-100 dark:bg-status-success-900/20 mb-4">
             <svg class="w-8 h-8 text-status-success-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
@@ -177,7 +201,20 @@
 
       <!-- Resolved Items Tab (narrow card feed) -->
       <div v-if="activeTab === 'resolved'" class="max-w-3xl mx-auto">
-        <div v-if="operatorQueueStore.resolvedItems.length === 0" class="text-center py-16">
+        <div v-if="queueFirstLoad" class="text-center py-16" aria-busy="true">
+          <p class="text-sm text-gray-500 dark:text-gray-400">Loading resolved items…</p>
+        </div>
+
+        <LoadFailed
+          v-else-if="queueLoadFailed"
+          title="Couldn't load resolved items"
+          message="The queue didn't load. Check your connection and try again."
+          :detail="operatorQueueStore.error"
+          :retrying="operatorQueueStore.loading"
+          @retry="operatorQueueStore.fetchItems"
+        />
+
+        <div v-else-if="operatorQueueStore.resolvedItems.length === 0" class="text-center py-16">
           <p class="text-sm text-gray-500 dark:text-gray-400">No resolved items yet</p>
         </div>
 
@@ -216,6 +253,7 @@ import NotificationsPanel from '../components/operator/NotificationsPanel.vue'
 import MonitoringPanel from '../components/MonitoringPanel.vue'
 import ExecutionsPanel from '../components/ExecutionsPanel.vue'
 import ReportsPanelFleet from '../components/ReportsPanelFleet.vue'
+import LoadFailed from '../components/LoadFailed.vue'
 import { useOperatorQueueStore } from '../stores/operatorQueue'
 import { useNotificationsStore } from '../stores/notifications'
 import { useAgentsStore } from '../stores/agents'
@@ -229,6 +267,19 @@ const agentsStore = useAgentsStore()
 const authStore = useAuthStore()
 
 const isAdmin = computed(() => authStore.role === 'admin')
+
+// #1926 — the loading / failed / empty triad for the operator-queue tabs.
+// `hasLoaded` flips only on a SUCCEEDED fetch, so an empty list before the
+// first poll returns reads as loading, and a failed first poll reads as failed
+// (it used to read as "All caught up" — optimistic success).
+// A background poll failing after a good load keeps the stale list visible
+// rather than blanking the surface (principle 13: refresh is invisible).
+const queueFirstLoad = computed(
+  () => !operatorQueueStore.hasLoaded && !operatorQueueStore.error
+)
+const queueLoadFailed = computed(
+  () => !operatorQueueStore.hasLoaded && !!operatorQueueStore.error
+)
 
 // Health is admin-only; non-admins must not reach it even via deep link.
 const VALID_TABS = ['needs-response', 'notifications', 'health', 'executions', 'reports', 'resolved']

--- a/src/frontend/src/views/Operations.vue
+++ b/src/frontend/src/views/Operations.vue
@@ -134,6 +134,19 @@
 
       <!-- Needs Response Tab (narrow card feed) -->
       <div v-if="activeTab === 'needs-response'" class="max-w-3xl mx-auto">
+        <!-- Failed REFRESH (#1926) — the 5s poll stopped landing. The cards
+             below are real but stale, and an operator reading a queue must
+             know that; blanking them would be worse. -->
+        <InlineError
+          v-if="queueRefreshFailed"
+          class="mb-3"
+          message="Couldn't refresh the queue — showing the last items that loaded."
+          :detail="operatorQueueStore.error"
+          retryable
+          @retry="operatorQueueStore.fetchItems"
+          @dismiss="operatorQueueStore.error = null"
+        />
+
         <!-- Loading state (#1926) — before the first poll returns we do NOT
              know the queue is empty; claiming "All caught up" is optimistic
              success (principle 15). -->
@@ -254,6 +267,7 @@ import MonitoringPanel from '../components/MonitoringPanel.vue'
 import ExecutionsPanel from '../components/ExecutionsPanel.vue'
 import ReportsPanelFleet from '../components/ReportsPanelFleet.vue'
 import LoadFailed from '../components/LoadFailed.vue'
+import InlineError from '../components/InlineError.vue'
 import { useOperatorQueueStore } from '../stores/operatorQueue'
 import { useNotificationsStore } from '../stores/notifications'
 import { useAgentsStore } from '../stores/agents'
@@ -279,6 +293,10 @@ const queueFirstLoad = computed(
 )
 const queueLoadFailed = computed(
   () => !operatorQueueStore.hasLoaded && !!operatorQueueStore.error
+)
+// We have items, but the newest poll failed — the feed is stale, not wrong.
+const queueRefreshFailed = computed(
+  () => operatorQueueStore.hasLoaded && !!operatorQueueStore.error
 )
 
 // Health is admin-only; non-admins must not reach it even via deep link.


### PR DESCRIPTION
## Problem

Across the ten audited surfaces, a failed fetch was rendered with the **empty** state's copy, and failed actions were swallowed to `console.error`. Failed-shown-as-empty is actively misleading — it points the user at the wrong remedy:

- "No templates found" on a network error → create a template, when the fix is retry
- "All caught up" before the first poll returns → nobody needs you, when we haven't asked yet
- `InfoPanel` synthesized a `has_template: false` payload in its `catch`, turning *"the request failed"* into a claim about the agent

Swallowed action failures are worse — the verb appears to succeed. The row snaps back to its server value with no explanation, and on `MobileAdmin` there is no console to open.

## Two primitives

| Component | For | Behaviour |
|---|---|---|
| `LoadFailed.vue` | a failed **fetch** | owns the surface where the list would be, shares the loading/empty footprint (principle 4), names the problem, offers the retry |
| `InlineError.vue` | a failed **verb** | sits next to the control that was pressed, persists until dismissed (principle 18), optional retry |

Both are token-only and keep the raw error (status code, server message) behind a "Technical detail" disclosure — headline in user vocabulary, trace on demand (principle 25). Both reuse the existing `utils/apiError.js::apiErrorMessage`, so a FastAPI 422 renders as a sentence rather than a stringified Pydantic array.

## The structural fix: `hasLoaded`

`list.length === 0` cannot express "the fetch succeeded and returned zero" — before the first response it means *loading*, after a rejection it means *failed*. That single overload is what produced both the "loading rendered as empty" and "failed rendered as empty" families. So `stores/operatorQueue.js` and `stores/notifications.js` now expose a `hasLoaded` flag that flips **only on success**, and the consuming components gate their empty branch on it. A background refresh failing *after* a good load deliberately keeps the stale list rather than blanking the surface (principle 13).

## Per-surface

**Failed → distinct:** `process/TemplateSelector.vue`, `TasksPanel.vue`, `InfoPanel.vue`.

**Loading → distinct:** `views/Operations.vue` (both queue tabs), `operator/NotificationsPanel.vue` (which had *no* failed state and rendered a blank body during its first fetch).

**Swallowed verbs → visible:** `views/MobileAdmin.vue` (start/stop, autonomy, queue respond, acknowledge), `operator/NotificationsPanel.vue` (acknowledge/dismiss/bulk), `components/SchedulesPanel.vue` (toggle, plus the two blocking `alert()`s on delete/trigger), `components/ExecutionsPanel.vue`, `components/SystemViewEditor.vue`.

Two of these deserve calling out:

- **`ExecutionsPanel` stop** silently redirected to the detail page on failure. An execution that kept running looked like a deliberate hand-off. It now says the execution is still running, keeps the user in place, and offers the detail page as an explicit next step.
- **The bulk helpers use `Promise.allSettled`**, so they *resolve* even when every item failed — a `try/catch` around them reported success on a total failure. The panel now inspects the settlement and names the count that did not apply ("3 of 5 notification(s) couldn't be dismissed and are unchanged").

## Toasts (principle 18)

The listed instance (`views/Agents.vue:8`) is gone, but the behaviour had moved into the shared `composables/useNotification.js`, which auto-dismissed **every** notification after 3s — errors included. An `error` notification now persists until dismissed, and all four toast hosts render a dismiss control (a persistent toast with no close button would be a dead end). The three files carrying hand-rolled copies of the helper now use the composable. The pending timer is also cleared on a new toast — a second notification used to inherit the first one's countdown and could vanish almost immediately.

## Scope note — two listed spots no longer exist

`views/Agents.vue:673` and `views/Agents.vue:8` were audited on 2026-07-31; ent#260 has since retired that page. Its successor `Dashboard.vue` already ships the loading/failed/empty triad (#1266), and `AgentListPanel.vue`'s filtered-empty card correctly gates on `agents.length > 0`. Nothing to fix there; flagged rather than silently dropped.

## Verification

```
$ npm run build
✓ built in 2.58s          # no errors

$ npm run check:tokens
Design-token check OK: 11 tokens equivalent to source palettes; all references resolve

# raw-color ratchet, measured as before-vs-after on exactly the touched files
BEFORE: {raw_nongray: 216, raw_gray: 1349, hardcoded_colors: 134, semantic_tokens: 705}
AFTER : {raw_nongray: 216, raw_gray: 1370, hardcoded_colors: 134, semantic_tokens: 726}
```

`raw_nongray +0` and `hardcoded_colors +0`: the new components are semantic-token-only, and the MobileAdmin banner composes the existing `.result-error` palette instead of introducing two new hexes (it did, in an earlier pass — the scan caught it). `raw_gray` grows because gray is the contract's non-semantic default.

`e2e/honest-failed-states.spec.js` forces each failure with `page.route(...).abort()` and asserts **two-sided** — the failed state appears AND the empty-state copy does not; asserting only the former would still pass if both rendered. It also covers retry-recovers-into-the-real-state and the "still there after 4s" toast/inline-error persistence check.

**Not run locally:** the e2e needs a live stack and this machine's `trinity-backend` / `trinity-frontend` containers are stopped, so the spec is unexecuted — it needs the `ui` label for `frontend-e2e` in CI. Everything else above was run.

## Docs

`docs/memory/design-system.md` gains a "Failed states" recipe section (the primitives, the `hasLoaded` rule, the no-console-only/no-`alert()` rule, and the `allSettled` trap); `design-system-contract.md` updates principles 15 and 18, the primitives list, and adds two PR self-check boxes.

Related to #1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)