### PR TITLE
fix(ui): move the Agent Detail toast off the header controls (#1953)

### DIFF
--- a/src/frontend/src/components/FilesPanel.vue
+++ b/src/frontend/src/components/FilesPanel.vue
@@ -295,10 +295,12 @@
       </div>
     </div>
 
-    <!-- Notification Toast -->
+    <!-- Notification Toast. #1953: same anchor as the AgentDetail toast — this
+         panel renders inside Agent Detail, so `top-20 right-4` collided with the
+         same header controls. See views/AgentDetail.vue for the full rationale. -->
     <div v-if="notification"
       :class="[
-        'fixed top-20 right-4 z-50 px-4 py-3 rounded-lg shadow-lg transition-all duration-300',
+        'fixed bottom-24 right-6 z-50 px-4 py-3 rounded-lg shadow-lg transition-all duration-300',
         notification.type === 'success' ? 'bg-status-success-100 dark:bg-status-success-900/50 border border-status-success-400 dark:border-status-success-700 text-status-success-700 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300'
       ]"
     >

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -12,10 +12,15 @@
           <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-action-primary-500 mx-auto"></div>
         </div>
 
-        <!-- Notification Toast -->
+        <!-- Notification Toast.
+             #1953: anchored bottom-right, NOT `top-20 right-4`. `top-20` is exactly
+             where AgentHeader's row-1 right cluster starts (NavBar h-16 + main py-2 +
+             inner py-2 = 80px), so the toast covered the Running toggle and Delete.
+             `bottom-24` clears the global HelpChatWidget FAB (bottom-6 + h-14 = 80px),
+             which is why this is not the `bottom-4 right-4` used elsewhere. -->
         <div v-if="notification"
           :class="[
-            'fixed top-20 right-4 z-50 px-4 py-3 rounded-lg shadow-lg transition-all duration-300',
+            'fixed bottom-24 right-6 z-50 px-4 py-3 rounded-lg shadow-lg transition-all duration-300',
             notification.type === 'success' ? 'bg-status-success-100 dark:bg-status-success-900/50 border border-status-success-400 dark:border-status-success-700 text-status-success-700 dark:text-status-success-300' : 'bg-status-danger-100 dark:bg-status-danger-900/50 border border-status-danger-400 dark:border-status-danger-700 text-status-danger-700 dark:text-status-danger-300'
           ]"
         >


### PR DESCRIPTION
Closes #1953

## The bug

Saving anything on Agent Detail popped a toast directly on top of the header's top-right control cluster — the **Running** toggle and the **Delete** button — until it faded.

Not guardrails-specific: every `notify()` on the view (rename, autonomy, read-only, subscription change, tag edits) hit it.

## Why

Both elements resolve to the same coordinates; the toast wins on `z-index`.

- Toast: `fixed top-20 right-4 z-50` → **80px** from the viewport top, flush right.
- Header row-1 right cluster also starts at **80px**: `NavBar` `h-16` (64) + `<main>` `py-2` (8) + inner `py-2` (8), with `AgentHeader` immediately after.

`top-20` *is* the header's first row. Not width-dependent — it collided at every viewport size.

## The fix

Anchor the toast bottom-right: `fixed bottom-24 right-6 z-50`.

Deliberately **not** `bottom-4 right-4` (the other convention in this codebase, `PlaybooksPanel.vue:162` / `PublicLinksPanel.vue:350`) — `HelpChatWidget` is a **global** 56px FAB at `bottom-6 right-6 z-50` (`App.vue:12`), so that would trade one overlap for another. `bottom-24` puts the toast in the FAB's own right gutter with a 16px gap above it, which is the only region on this view with no fixed/absolute competition.

`FilesPanel.vue` carries a byte-identical toast and renders **inside** Agent Detail, so it had the same collision and moves with it.

## Left alone, deliberately

- `Agents.vue:10` and `AgentListPanel.vue:17` use the same `top-20 right-4`, but those views have no header controls there — no collision.
- `PlaybooksPanel` / `PublicLinksPanel` at `bottom-4 right-4` overlap the Help FAB. Pre-existing, unreported, separate fix.
- Extracting a shared `<Toast>` component is the real cure for five hand-rolled copies drifting apart — a refactor, not this bug.

## Verification

```
$ npm run build
✓ built in 2.43s

$ grep -ho "\.bottom-24{[^}]*}\|\.right-6{[^}]*}" dist/assets/*.css | sort -u
.bottom-24{bottom:6rem}
.right-6{right:1.5rem}
```

Tailwind emits both utilities into the bundle (they're literal strings in the `:class` array, so JIT picks them up). Geometry: toast bottom edge at 96px, FAB top edge at 24 + 56 = 80px → 16px clearance.

Frontend-only, two class strings plus comments. No backend, no schema, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
