### PR TITLE
test: reconcile ent#89 tests with ent#128's compatibility contract

### DIFF
--- a/tests/unit/test_compatibility_checks.py
+++ b/tests/unit/test_compatibility_checks.py
@@ -674,8 +674,11 @@ class TestReportDirectionOnAFailingValidator:
 
     def test_persisted_check_error_does_not_replay_as_clean(self):
         """`_report_from_persisted` recomputes counts from `checks_json`, so a
-        swallowed raise persisted once is replayed as a clean bill of health on
-        every stopped-agent read. This pins the shape of that recompute."""
+        swallowed raise persisted once used to be replayed as a clean bill of
+        health on every stopped-agent read. ent#128 closed that at the sink:
+        `_did_not_pass` counts a `skipped` row carrying `check_error` as a
+        finding, so a row persisted by an OLDER build — before the swallow
+        started returning `fail` — still cannot replay as clean."""
         import services.compatibility as svc
 
         swallowed = {"checks": [{
@@ -687,7 +690,7 @@ class TestReportDirectionOnAFailingValidator:
             "skip_reason": None,
         }]}
 
-        assert svc._counts(swallowed["checks"])["soft_count"] == 0
+        assert svc._counts(swallowed["checks"])["soft_count"] == 1
         assert svc._counts(failed["checks"])["soft_count"] == 1
 
         degraded = svc._report_from_persisted(
@@ -699,7 +702,8 @@ class TestRunStaticLogsItsSwallow:
     def test_a_raising_check_is_logged(self, monkeypatch, caplog):
         """Before ent#89 this swallow left no trace anywhere, for all ~100
         checks — a broken validator reported "healthy" and the logs were
-        silent."""
+        silent. Both halves are now closed: ent#128 makes the result a FAIL so
+        `_counts` sees it, and ent#89 logs it so it is diagnosable."""
         import logging
 
         monkeypatch.setitem(
@@ -708,6 +712,10 @@ class TestRunStaticLogsItsSwallow:
         with caplog.at_level(logging.ERROR):
             out = run_static(good_snapshot(), ["T-001"])
 
-        assert (out["T-001"][2] or {}).get("skip_reason") == "check_error"
+        status, _msg, detail = out["T-001"]
+        # FAIL, not a skip: a check that could not evaluate is not a check that
+        # passed, and only a counted status reaches `hard_count`/`soft_count`.
+        assert status == "fail"
+        assert (detail or {}).get("check_error") == "kaboom"
         assert any("T-001" in r.message or "T-001" in str(r.args)
                    for r in caplog.records)

--- a/tests/unit/test_ent89_template_schedules.py
+++ b/tests/unit/test_ent89_template_schedules.py
@@ -342,7 +342,9 @@ class TestCatalogSurface:
             "name: demo\ndescription: d\n"
             "schedules:\n  - name: daily\n    cron: '0 9 * * *'\n    message: /m\n"
         )
-        entry = self._ts()._build_local_template(tmp_path)
+        # `is_bundled` is keyword-only and required (ent#128): it selects the
+        # credential-metadata trust label, which is orthogonal to `schedules:`.
+        entry = self._ts()._build_local_template(tmp_path, is_bundled=True)
         assert [s["name"] for s in entry["schedules"]] == ["daily"]
         assert entry["schedule_errors"] == []
 
@@ -354,7 +356,8 @@ class TestCatalogSurface:
         ts = self._ts()
         assert ts._build_template("owner/repo", {"schedules": 5})["schedules"] == []
         (tmp_path / "template.yaml").write_text("name: d\nschedules: 5\n")
-        assert ts._build_local_template(tmp_path)["schedules"] == []
+        assert ts._build_local_template(
+            tmp_path, is_bundled=True)["schedules"] == []
 
     def test_malformed_block_logs_exactly_one_warning_naming_the_template(
             self, caplog):


### PR DESCRIPTION
## What

Four unit tests are failing on `dev` right now. This fixes them.

They are not a defect in either PR that produced them: **#1899 (ent#128) and #1946 (ent#89) were each green in isolation**, and the failures only exist in their combination. Nothing in the production code is wrong — the four assertions describe a contract that #1899 deliberately changed, and #1946 was written before that landed.

## Why it reached `dev`

`dev`'s required checks are `Analyze (python)`, `Analyze (javascript-typescript)`, `schema-parity` and `verify-non-root`. **None of them runs a unit test.** The `regression diff` job does, but it reports after the required set goes green — so auto-merge had already landed #1946 by the time the failures were visible.

`regression diff` on the merge commit reported exactly these four, against a base with zero failures:

```
## ❌ New failures introduced by HEAD (4)
- [F] test_compatibility_checks.TestReportDirectionOnAFailingValidator::test_persisted_check_error_does_not_replay_as_clean
- [F] test_compatibility_checks.TestRunStaticLogsItsSwallow::test_a_raising_check_is_logged
- [F] test_ent89_template_schedules.TestCatalogSurface::test_a_malformed_block_does_not_raise_out_of_either_builder
- [F] test_ent89_template_schedules.TestCatalogSurface::test_local_builder_surfaces_normalized_schedules
```

All six `pytest` jobs (base and head × 3 seeds) themselves passed — they emit JUnit XML and let `regression diff` be the gate.

## The four

### 1. `test_a_raising_check_is_logged`

`run_static`'s per-check swallow used to record `_skip(..., "check_error")`. #1899 changed it to `_fail(..., {"check_error": ...})` so that a crashed check is actually counted by `_counts` — without that, a raise inside a HARD check dropped `hard_count` and flipped `overall_status` to `compatible` on a broken agent.

The test still read `detail["skip_reason"]`, which no longer exists. It now asserts the FAIL shape, which *is* the fix — only a counted status reaches `hard_count`/`soft_count`.

Worth noting the file was already internally inconsistent: a sibling test in the same class asserts `t018["status"] == "fail"` and was passing.

### 2. `test_persisted_check_error_does_not_replay_as_clean`

This asserted `_counts(...)["soft_count"] == 0` for a persisted `skipped` + `check_error` row — i.e. **it pinned the bug as expected behaviour**. #1899's `_did_not_pass` counts exactly that row as a finding, on purpose.

Expectation flipped to `1`, and the docstring rewritten so the test keeps real teeth: a row persisted by an *older* build, before the swallow started returning `fail`, still must not replay as a clean bill of health on a stopped-agent read.

### 3 & 4. `_build_local_template(...)`

#1899 gave it a required keyword-only `is_bundled` parameter (it selects the credential-metadata trust label, so an operator-uploaded template does not inherit the bundled catalog's label). Both ent#89 call sites now pass it. Orthogonal to the `schedules:` block under test.

## Verification

```
$ pytest tests/unit/test_compatibility_checks.py \
         tests/unit/test_ent89_template_schedules.py \
         tests/unit/test_ent128b1_compat_gates.py -q
225 passed, 1 skipped in 0.48s
```

Full backend unit suite on this branch:

```
6698 passed, 19 skipped
```

Two unrelated files (`test_1081_physical_meter.py`, `test_subscription_auto_switch_pingpong.py`) reported failures/errors in that local whole-suite run **but pass on a pristine `origin/dev` worktree and pass in CI on both base and head** — local suite-ordering artifacts on this host, not touched by this change (the diff is two test files). The four `test_1771*` hypothesis property files were excluded: the dependency is absent from this host.

## Scope

Two test files, 18 insertions / 7 deletions. No production code.
