### PR TITLE
refactor(ui): raise dark meta text off the gray-500 floor (#1922)

### DIFF
--- a/docs/memory/design-system.md
+++ b/docs/memory/design-system.md
@@ -67,6 +67,8 @@ The app ships `darkMode: 'class'`. Every primitive and pattern is specced, built
 
 - **Do (dark):** `dark:text-gray-300` for "Last run 12 min ago".
 - **Don't:** `dark:text-gray-500` on anything a user is expected to read.
+- **Also don't:** ship a light-theme `text-gray-500` with *no* `dark:` override. It is not neutral — the light tertiary is reused verbatim in dark, where it lands exactly on the floor. This is the quieter half of the breach and the harder half to catch in review (#1922).
+- **Enforced, per file:** `npm run check:tokens` holds the ladder over the files a sweep has already cleaned (`INK_LADDER_SWEPT` in `scripts/check-design-tokens.mjs`) — nothing below the floor, no missing `dark:` override, and a per-file cap on floor-level ink that may be lowered but never raised. It also reads FleetGrid's `--gv-*` ink, which states its ladder as hex custom properties that no class scanner can see. Fleet-wide enforcement waits on the raw-color ratchet (#1430); each sweep adds its files to the set and they can never regress.
 
 ### Interactive accent (`action-primary`) per theme
 

--- a/src/frontend/scripts/check-design-tokens.mjs
+++ b/src/frontend/scripts/check-design-tokens.mjs
@@ -7,6 +7,8 @@
  *      `dark:*-status-*` reference in the migrated source files uses one of
  *      the defined token names (catches typos that Tailwind would silently
  *      drop).
+ *   3. The dark ink ladder holds in every SWEPT file (#1922) — see
+ *      `checkDarkInkLadder` below.
  *
  * Run via `npm run check:tokens` or directly: `node scripts/check-design-tokens.mjs`.
  */
@@ -91,9 +93,145 @@ function checkTokenReferences() {
   return failures
 }
 
+// ---------------------------------------------------------------------------
+// Dark ink ladder (#1922)
+//
+// design-system.md: in dark theme, primary is gray-100, secondary gray-300,
+// tertiary gray-400. **gray-500 is the floor** — disabled states and pure
+// decoration only, never readable meta text (keeps ≥4.5:1 AA on gray-800).
+//
+// Enforcing that fleet-wide today would fail on hundreds of pre-existing hits,
+// so this is a RATCHET BY MEMBERSHIP: it runs only over files a sweep has
+// already cleaned. A later sweep adds its files here and they can never regress.
+// Membership is the whole mechanism — there is no allowlist of individual
+// lines to drift out of date.
+//
+// Three rules, in descending order of how mechanical they are:
+//
+//   R1  No `dark:text-gray-{600..900}` at all. Below the floor is wrong even
+//       for decoration, so this needs no judgement and no exceptions.
+//   R2  No template `text-gray-{500..900}` in a class attribute that has no
+//       `dark:text-*` companion. This is the quieter breach and the one the
+//       audit found in Audit.vue: with no dark override the light-theme
+//       tertiary is simply reused in dark, where it sits at or below the floor.
+//   R3  `dark:text-gray-500` is legal (it IS the floor) but capped per file at
+//       the count left after the sweep, which is only disabled states, svg
+//       glyphs and separator characters. The cap can be lowered, never raised
+//       — raising it means new floor-level ink shipped, which is the thing the
+//       sweep just removed.
+//
+// R3's numbers are deliberately literal rather than regenerated: a cap that
+// rewrites itself from the current source is not a ratchet, it is a rubber stamp.
+const INK_LADDER_SWEPT = {
+  'components/FleetGrid.vue': 0,
+  // Not in the #1922 audit list, but it renders INTO the Dashboard stats
+  // bar: its separators sat next to Dashboard's own. Sweeping one and not
+  // the other leaves two inks in a single row.
+  'components/HostTelemetry.vue': 3,          // 3 separator glyphs
+  'components/NavBar.vue': 0,
+  'components/ReplayTimeline.vue': 2,          // 2 separator glyphs
+  'components/SystemViewsSidebar.vue': 0,
+  'components/TasksPanel.vue': 1,              // empty-state svg
+  'components/operator/NotificationsPanel.vue': 2, // spinner svg + inbox svg
+  'components/operator/QueueCard.vue': 4,      // separator, dismiss glyph, 2 disabled buttons
+  'components/operator/QueueItemDetail.vue': 0,
+  'views/Dashboard.vue': 5,                    // 3 separators, search svg, clear glyph
+  'views/Login.vue': 0,
+  'views/enterprise/Audit.vue': 0,
+}
+
+const BELOW_FLOOR_RE = /\bdark:text-gray-(?:600|700|800|900)\b/g
+const AT_FLOOR_RE = /\bdark:text-gray-500\b/g
+// `(?<!:)` keeps `dark:text-gray-500` / `hover:text-gray-500` out of R2 — those
+// carry their own variant prefix and are judged by R1/R3 instead.
+const BARE_DARK_UNSAFE_RE = /(?<!:)\btext-gray-(?:500|600|700|800|900)\b/
+
+/** Blank out <script>/<style> blocks, preserving offsets AND line numbers. */
+function templateOnly(source) {
+  return source.replace(/<(script|style)\b[\s\S]*?<\/\1>/g, (block) =>
+    block.replace(/[^\n]/g, ' ')
+  )
+}
+
+function checkDarkInkLadder() {
+  const failures = []
+  for (const [rel, floorCap] of Object.entries(INK_LADDER_SWEPT)) {
+    const full = join(FRONTEND_ROOT, 'src', rel)
+    let content
+    try {
+      content = readFileSync(full, 'utf8')
+    } catch {
+      // A swept file that moved or vanished must fail loudly: silently dropping
+      // it would retire the guard for that file without anyone deciding to.
+      failures.push(`${rel}: listed as swept for the dark ink ladder but not readable — update INK_LADDER_SWEPT`)
+      continue
+    }
+
+    const lineOf = (index) => content.slice(0, index).split('\n').length
+
+    for (const m of content.matchAll(BELOW_FLOOR_RE)) {
+      failures.push(`src/${rel}:${lineOf(m.index)}: "${m[0]}" is BELOW the dark ink floor (gray-500). Dark meta text is gray-400 or lighter; decoration stops at gray-500.`)
+    }
+
+    const template = templateOnly(content)
+    for (const m of template.matchAll(/class="([^"]*)"/g)) {
+      const cls = m[1]
+      if (BARE_DARK_UNSAFE_RE.test(cls) && !cls.includes('dark:text-')) {
+        failures.push(`src/${rel}:${lineOf(m.index)}: light-theme gray with no dark: override — it is reused verbatim in dark, at or below the floor. Add dark:text-gray-400. ("${cls.trim().slice(0, 70)}")`)
+      }
+    }
+
+    const atFloor = (content.match(AT_FLOOR_RE) || []).length
+    if (atFloor > floorCap) {
+      failures.push(`src/${rel}: ${atFloor} uses of dark:text-gray-500, cap is ${floorCap}. The floor is for disabled states and pure decoration only — if this is meta text use gray-400; if it is genuinely decoration, raise the cap in INK_LADDER_SWEPT and say why.`)
+    }
+  }
+  failures.push(...checkFleetGridInkVars())
+  return failures
+}
+
+// FleetGrid states its ink as CSS custom properties rather than classes, so the
+// three rules above cannot see it — its whole dark ladder is four hex literals.
+// The vars below all resolve to TEXT (`--gv-ghost` reaches the repo label and
+// the dimmed half of a stat line in AgentTile), so none may sit at or below the
+// gray-500 floor.
+const DARK_UNSAFE_INK_HEXES = new Set([
+  '#6b7280', // gray-500 — the floor: decoration only, never text
+  '#4b5563', // gray-600
+  '#374151', // gray-700
+  '#1f2937', // gray-800
+  '#111827', // gray-900
+])
+const FLEETGRID_INK_VARS = ['--gv-text', '--gv-muted', '--gv-faint', '--gv-ghost']
+
+function checkFleetGridInkVars() {
+  const rel = 'components/FleetGrid.vue'
+  let content
+  try {
+    content = readFileSync(join(FRONTEND_ROOT, 'src', rel), 'utf8')
+  } catch {
+    return [`${rel}: not readable — the FleetGrid dark ink check cannot run`]
+  }
+  const darkBlock = content.match(/:root\.dark\s+\.fleet-canvas\s*\{([\s\S]*?)\}/)
+  if (!darkBlock) {
+    return [`src/${rel}: the ":root.dark .fleet-canvas" block is gone — the dark ink check silently covers nothing, so update it deliberately`]
+  }
+  const failures = []
+  for (const varName of FLEETGRID_INK_VARS) {
+    const m = darkBlock[1].match(new RegExp(`${varName}\\s*:\\s*(#[0-9a-fA-F]{3,8})`))
+    if (!m) continue
+    const hex = m[1].toLowerCase()
+    if (DARK_UNSAFE_INK_HEXES.has(hex)) {
+      failures.push(`src/${rel}: dark ${varName} is ${hex}, at or below the gray-500 floor. Every --gv-* ink var here renders text; use #9ca3af (gray-400) or lighter.`)
+    }
+  }
+  return failures
+}
+
 const paletteFailures = checkPaletteEquivalence()
 const referenceFailures = checkTokenReferences()
-const allFailures = [...paletteFailures, ...referenceFailures]
+const inkLadderFailures = checkDarkInkLadder()
+const allFailures = [...paletteFailures, ...referenceFailures, ...inkLadderFailures]
 
 if (allFailures.length > 0) {
   console.error('Design-token check FAILED:')
@@ -102,4 +240,5 @@ if (allFailures.length > 0) {
 }
 
 const tokenCount = Object.keys(EXPECTED_ALIASES).length
-console.log(`Design-token check OK: ${tokenCount} tokens equivalent to source palettes; all references resolve`)
+const sweptCount = Object.keys(INK_LADDER_SWEPT).length
+console.log(`Design-token check OK: ${tokenCount} tokens equivalent to source palettes; all references resolve; dark ink ladder holds in ${sweptCount} swept files`)

--- a/src/frontend/src/components/FleetGrid.vue
+++ b/src/frontend/src/components/FleetGrid.vue
@@ -600,8 +600,17 @@ onBeforeUnmount(() => {
 :root.dark .fleet-canvas {
   --gv-text: #f9fafb;
   --gv-muted: #9ca3af;
-  --gv-faint: #6b7280;
-  --gv-ghost: #4b5563;
+  /* #1922: dark ink ladder — gray-500 is the floor (disabled/decoration only).
+     Both of these carry READABLE text (--gv-faint: the zoom readout, the
+     far-tile placeholder and the empty stat line; --gv-ghost: the repo label
+     and the dimmed half of a stat), so neither may sit below tertiary.
+     They collapse onto gray-400 with --gv-muted because the dark ladder has
+     exactly ONE legal step for tertiary text — there is no darker ink left to
+     spend. Re-separating them needs weight or size, not a darker gray; that is
+     a design call for #1430, not a color sweep. The light block keeps all three
+     distinct (it has headroom below tertiary). */
+  --gv-faint: #9ca3af;
+  --gv-ghost: #9ca3af;
   --gv-border: #374151;
   --gv-border-soft: rgba(55, 65, 81, 0.5);
   --gv-panel: #1f2937;

--- a/src/frontend/src/components/HostTelemetry.vue
+++ b/src/frontend/src/components/HostTelemetry.vue
@@ -98,7 +98,7 @@ onUnmounted(() => {
     <template v-if="!loading">
       <!-- Leading separator lives here (not in Dashboard.vue) so it disappears
            together with the meters when the ladder hides them (#1830). -->
-      <span class="text-gray-300 dark:text-gray-600">·</span>
+      <span class="text-gray-300 dark:text-gray-500">·</span>
 
       <!-- CPU -->
       <span class="stat-item" data-metric="cpu" :title="`CPU ${formatPercent(hostStats?.cpu?.percent)}%`">
@@ -116,7 +116,7 @@ onUnmounted(() => {
         <span class="stat-value" :class="getColorClass(hostStats?.cpu?.percent)">{{ formatPercent(hostStats?.cpu?.percent) }}%</span>
       </span>
 
-      <span class="text-gray-300 dark:text-gray-600" data-sep="mem">·</span>
+      <span class="text-gray-300 dark:text-gray-500" data-sep="mem">·</span>
 
       <!-- Memory -->
       <span
@@ -138,7 +138,7 @@ onUnmounted(() => {
         <span class="stat-value" :class="getColorClass(hostStats?.memory?.percent)">{{ formatMemory(hostStats?.memory?.used_gb, hostStats?.memory?.total_gb) }}</span>
       </span>
 
-      <span class="text-gray-300 dark:text-gray-600" data-sep="disk">·</span>
+      <span class="text-gray-300 dark:text-gray-500" data-sep="disk">·</span>
 
       <!-- Disk -->
       <span class="stat-item" data-metric="disk" :title="`Disk ${formatPercent(hostStats?.disk?.percent)}%`">

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -130,7 +130,7 @@
           <button
             v-if="buildInfo.info.value"
             @click="showBuildInfoModal = true"
-            class="hidden xl:block text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 font-mono whitespace-nowrap"
+            class="hidden xl:block text-xs text-gray-400 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 font-mono whitespace-nowrap"
             :title="`Click for build info — commit ${buildInfo.info.value.git_commit_short}`"
           >
             v{{ buildInfo.displayVersion.value }}<span

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -34,7 +34,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
             </svg>
           </button>
-          <span class="text-xs text-gray-400 dark:text-gray-500 ml-1 w-8">{{ Math.round(zoomLevel * 100) }}%</span>
+          <span class="text-xs text-gray-400 dark:text-gray-400 ml-1 w-8">{{ Math.round(zoomLevel * 100) }}%</span>
         </div>
 
         <!-- Hide inactive toggle -->
@@ -172,7 +172,7 @@
                     </span>
                     <span
                       v-if="hasDistinctLabel({ name: row.name, display_label: row.displayLabel })"
-                      class="text-[10px] text-gray-400 dark:text-gray-500 truncate leading-none"
+                      class="text-[10px] text-gray-400 dark:text-gray-400 truncate leading-none"
                     >{{ row.name }}</span>
                   </div>
                   <span
@@ -207,7 +207,7 @@
                   class="text-[10px] font-medium w-7 text-right"
                   :class="getSuccessBarClass(getRowSuccessPercent(row)).replace('bg-', 'text-')"
                 >{{ getRowSuccessPercent(row) }}%</span>
-                <span v-else class="text-[10px] text-gray-400 dark:text-gray-500 w-7 text-right">&mdash;</span>
+                <span v-else class="text-[10px] text-gray-400 dark:text-gray-400 w-7 text-right">&mdash;</span>
               </div>
 
               <!-- Row 3: Stats (compact) -->
@@ -215,15 +215,15 @@
                 <template v-if="row.executionStats && row.executionStats.taskCount > 0">
                   <span class="font-medium text-gray-700 dark:text-gray-300">{{ row.executionStats.taskCount }}</span>
                   <span>tasks</span>
-                  <span class="text-gray-300 dark:text-gray-600">·</span>
+                  <span class="text-gray-300 dark:text-gray-500">·</span>
                   <span :class="getSuccessRateClass(row.executionStats.successRate)" class="font-medium">{{ Math.round(row.executionStats.successRate || 0) }}%</span>
                   <template v-if="row.executionStats.totalCost > 0">
-                    <span class="text-gray-300 dark:text-gray-600">·</span>
+                    <span class="text-gray-300 dark:text-gray-500">·</span>
                     <span class="font-medium">{{ formatCostCompact(row.executionStats.totalCost) }}</span>
                   </template>
                 </template>
                 <template v-else>
-                  <span class="text-gray-400 dark:text-gray-500">No tasks</span>
+                  <span class="text-gray-400 dark:text-gray-400">No tasks</span>
                 </template>
                 <span class="flex-1"></span>
                 <span class="text-gray-400">{{ row.memoryLimit || '4g' }}</span>

--- a/src/frontend/src/components/SystemViewsSidebar.vue
+++ b/src/frontend/src/components/SystemViewsSidebar.vue
@@ -72,7 +72,7 @@
 
         <template v-if="!isCollapsed">
           <span class="truncate flex-1 text-left">{{ view.name }}</span>
-          <span class="ml-2 text-xs text-gray-400 dark:text-gray-500">{{ view.agent_count }}</span>
+          <span class="ml-2 text-xs text-gray-400 dark:text-gray-400">{{ view.agent_count }}</span>
 
           <!-- Edit/Delete on hover -->
           <div class="hidden group-hover:flex items-center ml-1 space-x-1">

--- a/src/frontend/src/components/TasksPanel.vue
+++ b/src/frontend/src/components/TasksPanel.vue
@@ -167,7 +167,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
         <p class="mt-2 text-gray-500 dark:text-gray-400">No tasks yet</p>
-        <p class="text-sm text-gray-400 dark:text-gray-500">Run a task above or configure schedules</p>
+        <p class="text-sm text-gray-400 dark:text-gray-400">Run a task above or configure schedules</p>
       </div>
 
       <!-- Task List with vertical scroll (#1500: fills the card, no fixed cap) -->
@@ -449,7 +449,7 @@
                       <span>•</span>
                       <span>{{ entry.toolCount }} tools</span>
                     </div>
-                    <div v-if="entry.mcpServers.length" class="text-gray-400 dark:text-gray-500">
+                    <div v-if="entry.mcpServers.length" class="text-gray-400 dark:text-gray-400">
                       MCP: {{ entry.mcpServers.join(', ') }}
                     </div>
                   </div>
@@ -523,7 +523,7 @@
         v-if="queueStatus?.current_execution"
         @click="forceReleaseQueue"
         :disabled="releaseLoading"
-        class="text-xs text-gray-500 hover:text-status-danger-600 dark:hover:text-status-danger-400 mr-4"
+        class="text-xs text-gray-500 dark:text-gray-400 hover:text-status-danger-600 dark:hover:text-status-danger-400 mr-4"
       >
         {{ releaseLoading ? 'Releasing...' : 'Force Release Queue' }}
       </button>
@@ -531,7 +531,7 @@
         v-if="queueStatus?.queue_length > 0"
         @click="clearQueue"
         :disabled="clearLoading"
-        class="text-xs text-gray-500 hover:text-status-danger-600 dark:hover:text-status-danger-400"
+        class="text-xs text-gray-500 dark:text-gray-400 hover:text-status-danger-600 dark:hover:text-status-danger-400"
       >
         {{ clearLoading ? 'Clearing...' : 'Clear Queued' }}
       </button>

--- a/src/frontend/src/components/operator/NotificationsPanel.vue
+++ b/src/frontend/src/components/operator/NotificationsPanel.vue
@@ -269,7 +269,7 @@
                   <CheckIcon class="w-3 h-3" />
                   Acknowledged
                 </span>
-                <span v-if="notification.status === 'dismissed'" class="text-gray-400 dark:text-gray-500">
+                <span v-if="notification.status === 'dismissed'" class="text-gray-400 dark:text-gray-400">
                   Dismissed
                 </span>
               </div>
@@ -312,7 +312,7 @@
 
         <!-- Empty State — only once a fetch has SUCCEEDED and returned zero -->
         <div v-if="displayedNotifications.length === 0" class="px-6 py-12 text-center">
-          <InboxIcon class="w-12 h-12 mx-auto mb-4 text-gray-300 dark:text-gray-600" />
+          <InboxIcon class="w-12 h-12 mx-auto mb-4 text-gray-300 dark:text-gray-500" />
           <p class="text-lg font-medium text-gray-900 dark:text-white">
             {{ hasActiveFilters ? 'No matching events' : 'No events yet' }}
           </p>

--- a/src/frontend/src/components/operator/QueueCard.vue
+++ b/src/frontend/src/components/operator/QueueCard.vue
@@ -21,7 +21,7 @@
               :title="agentNameTooltip(agentsStore.agentRefForSlug(item.agent_name))"
             >{{ item.agent_name }}</span>
             <span class="text-xs text-gray-400 dark:text-gray-500">&middot;</span>
-            <span class="text-xs text-gray-400 dark:text-gray-500">{{ timeAgo(item.created_at) }}</span>
+            <span class="text-xs text-gray-400 dark:text-gray-400">{{ timeAgo(item.created_at) }}</span>
           </div>
 
           <!-- Title -->
@@ -68,7 +68,7 @@
       <div v-if="item.context && Object.keys(item.context).length > 0" class="px-4 pb-4">
         <button
           @click.stop="showContext = !showContext"
-          class="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 flex items-center gap-1"
+          class="text-xs text-gray-400 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 flex items-center gap-1"
         >
           <svg class="w-3.5 h-3.5 transition-transform" :class="showContext ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -77,7 +77,7 @@
         </button>
         <div v-if="showContext" class="mt-2 bg-gray-50 dark:bg-gray-900/50 rounded-lg p-3">
           <div v-for="(value, key) in item.context" :key="key" class="flex gap-3 text-xs py-0.5">
-            <span class="text-gray-400 dark:text-gray-500 font-mono min-w-[100px]">{{ key }}</span>
+            <span class="text-gray-400 dark:text-gray-400 font-mono min-w-[100px]">{{ key }}</span>
             <a
               v-if="isUrl(String(value))"
               :href="String(value)"

--- a/src/frontend/src/components/operator/QueueItemDetail.vue
+++ b/src/frontend/src/components/operator/QueueItemDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-full flex flex-col">
     <!-- Empty state -->
-    <div v-if="!item" class="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-500">
+    <div v-if="!item" class="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-400">
       <div class="text-center">
         <svg class="mx-auto h-12 w-12 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
@@ -63,7 +63,7 @@
             </svg>
             Expires {{ formatDate(item.expires_at) }}
           </span>
-          <span class="text-gray-400 dark:text-gray-600">{{ item.request_id || item.id }}</span>
+          <span class="text-gray-400 dark:text-gray-400">{{ item.request_id || item.id }}</span>
         </div>
       </div>
 

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -28,12 +28,12 @@
                   <span>agents</span>
                 </span>
                 <!-- Working-now count (trinity-enterprise#47) -->
-                <span class="text-gray-300 dark:text-gray-600" data-sep="working">·</span>
+                <span class="text-gray-300 dark:text-gray-500" data-sep="working">·</span>
                 <span class="flex items-center space-x-1" data-stat="working">
                   <span class="font-medium text-status-info-600 dark:text-status-info-400">{{ workingNowCount }}</span>
                   <span>working now</span>
                 </span>
-                <span class="text-gray-300 dark:text-gray-600" data-sep="messages">·</span>
+                <span class="text-gray-300 dark:text-gray-500" data-sep="messages">·</span>
                 <span class="flex items-center space-x-1" data-stat="messages">
                   <span class="font-medium text-status-info-600 dark:text-status-info-400">{{ totalCollaborationCount }}</span>
                   <span>messages ({{ timeRangeHours }}h)</span>
@@ -105,7 +105,7 @@
                     ]"
                   >
                     <span>#{{ tagInfo.tag }}</span>
-                    <span class="text-gray-400 dark:text-gray-500 text-[10px]">{{ tagInfo.count }}</span>
+                    <span class="text-gray-400 dark:text-gray-400 text-[10px]">{{ tagInfo.count }}</span>
                   </button>
                 </div>
               </div>
@@ -123,7 +123,7 @@
                 </option>
               </select>
 
-              <span v-if="availableTags.length > 0 || availableOwners.length > 1" class="text-gray-300 dark:text-gray-600">|</span>
+              <span v-if="availableTags.length > 0 || availableOwners.length > 1" class="text-gray-300 dark:text-gray-500">|</span>
 
               <!-- Type-to-filter hint (ent#261) — mouse/touch parity for the
                    `/` hotkey. TOGGLES: opens the pill when closed,

--- a/src/frontend/src/views/Login.vue
+++ b/src/frontend/src/views/Login.vue
@@ -135,7 +135,7 @@
               <p class="text-sm text-gray-600 dark:text-gray-400">
                 📧 We sent a 6-digit code to <strong class="text-gray-900 dark:text-white">{{ emailInput }}</strong>
               </p>
-              <p v-if="countdown > 0" class="text-xs text-gray-500 dark:text-gray-500 mt-1">
+              <p v-if="countdown > 0" class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 Code expires in {{ formatTime(countdown) }}
               </p>
             </div>

--- a/src/frontend/src/views/enterprise/Audit.vue
+++ b/src/frontend/src/views/enterprise/Audit.vue
@@ -607,12 +607,12 @@ const detailsJson = computed(() => {
         <div v-show="heatmapsOpen" class="px-4 pb-4">
           <!-- Weekly (dow × hour) -->
           <div v-show="heatmapTab === 'weekly'" role="tabpanel" aria-label="Weekly pattern">
-            <div v-if="store.heatmapLoading" class="text-xs text-gray-500 py-4 text-center">
+            <div v-if="store.heatmapLoading" class="text-xs text-gray-500 dark:text-gray-400 py-4 text-center">
               Loading heatmap…
             </div>
             <div
               v-else-if="(store.heatmap?.total || 0) === 0"
-              class="text-xs text-gray-500 py-4 text-center"
+              class="text-xs text-gray-500 dark:text-gray-400 py-4 text-center"
             >
               No events in this window.
             </div>
@@ -655,12 +655,12 @@ const detailsJson = computed(() => {
 
           <!-- Calendar (per-day, GitHub-style) -->
           <div v-show="heatmapTab === 'calendar'" role="tabpanel" aria-label="Calendar">
-            <div v-if="store.calendarLoading" class="text-xs text-gray-500 py-4 text-center">
+            <div v-if="store.calendarLoading" class="text-xs text-gray-500 dark:text-gray-400 py-4 text-center">
               Loading calendar…
             </div>
             <div
               v-else-if="(store.calendar?.total || 0) === 0"
-              class="text-xs text-gray-500 py-4 text-center"
+              class="text-xs text-gray-500 dark:text-gray-400 py-4 text-center"
             >
               No events in this window.
             </div>
@@ -839,12 +839,12 @@ const detailsJson = computed(() => {
           class="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden"
           :class="store.selectedEntry ? 'lg:max-w-3xl' : ''"
         >
-          <div v-if="store.loading" class="p-6 text-sm text-gray-500 text-center">
+          <div v-if="store.loading" class="p-6 text-sm text-gray-500 dark:text-gray-400 text-center">
             Loading…
           </div>
           <div
             v-else-if="!store.entries.length"
-            class="p-6 text-sm text-gray-500 text-center"
+            class="p-6 text-sm text-gray-500 dark:text-gray-400 text-center"
           >
             {{
               store.total === 0


### PR DESCRIPTION
The dark ink ladder puts primary at gray-100, secondary at gray-300, tertiary at gray-400, with **gray-500 as the floor** — disabled states and pure decoration only. Twelve files rendered readable meta text at or below it: timestamps, counts, empty-state helpers, the build-info chip, the resend countdown, request ids, repo labels. Under 4.5:1 on a gray-800 surface.

## The audit found the loud half; there is a quiet half

`dark:text-gray-500` is greppable. The other breach is a light-theme `text-gray-500` with **no `dark:` override at all** — Audit.vue's loading and empty text (the issue's :610/:658/:842/:847). It reads as neutral in review, but Tailwind reuses the light tertiary verbatim in dark, landing exactly on the floor. Six of those, and a grep for `dark:text-gray-5` cannot see any of them.

## What moved, and what deliberately did not

| | Change | Why |
|---|---|---|
| Readable text | → gray-400 | Tertiary — the dimmest step the ladder allows for text |
| Decoration **below** the floor (separator glyphs, empty-state inbox icon) | gray-600 → gray-500 | Up to the floor, not to gray-400: ornaments should recede |
| Disabled buttons, svg glyphs, icon-only affordances | **unchanged** | Already at the floor, which is exactly where the ladder puts them |

Leaving the last row alone keeps the diff to what the issue describes. Raising icon-only buttons is a judgement call about affordance weight, not an ink-ladder breach.

**HostTelemetry.vue was not on the list.** It is here because its separators render *into* the Dashboard stats bar, beside Dashboard's own — sweeping one and not the other leaves two different inks in one row. I found it by measuring rendered colors, not by reading files: the probe came back with two values where the fix should have left one.

**FleetGrid states its ladder as CSS custom properties**, so no class-level fix reaches it. Dark `--gv-faint` (#6b7280) and `--gv-ghost` (#4b5563) both carry text — the zoom readout, the far-tile placeholder, the empty stat line, and (via AgentTile) the repo label and the dimmed half of a stat line. Both go to gray-400, and therefore **collapse onto `--gv-muted`**. That is the honest consequence of the ladder having exactly one legal step for tertiary text: there is no darker ink left to spend. The light block keeps all three distinct because it has headroom *below* tertiary. Re-separating them in dark needs weight or size, not a darker gray — a design call for #1430, not a color sweep. Flagging it rather than burying it, since the AC read as "gray-400/gray-300" and gray-300 would have made a var named `ghost` render *brighter* than `faint`.

## Enforcement — a ratchet, not a spot-check

AC 3 asks for a spot-check "once the raw-color scanner is wired into CI". `npm run check:tokens` is already wired, so the check goes there as a **ratchet by membership** over the twelve swept files — fleet-wide today would fail on hundreds of pre-existing hits, which is #1430's job:

- **R1** nothing at `dark:text-gray-600`+ — below the floor needs no judgement and has no exceptions
- **R2** no template gray-500+ in a class attribute with no `dark:text-*` companion (the quiet half above)
- **R3** a per-file cap on floor-level ink — lowerable, never raisable
- **R4** FleetGrid's `--gv-*` hex ink, which no class scanner can see

Caps are literals on purpose: a cap regenerated from current source is not a ratchet, it is a rubber stamp. A swept file that moves or vanishes **fails** the check rather than being silently skipped — otherwise the guard retires itself for that file with nobody deciding to. A later sweep adds its files and they can never regress; membership is the whole mechanism, so there is no per-line allowlist to drift.

**Proven both directions.** Against pre-fix source it reports **24 findings**, including all six Audit.vue no-override sites and both FleetGrid vars. Against this branch: clean.

## Visual evidence (AC 4)

Before/after captured on a live stack in dark theme — Dashboard, FleetGrid, operator queue, notifications, agent Tasks, Audit, login countdown. Both passes ran against the **same tree**, differing only by this diff (the sweep stashed for the "before" pass), so nothing else can account for the delta.

Colors were **probed via `getComputedStyle`, not eyeballed**:

| Element | Before | After |
|---|---|---|
| Dashboard stats separators | `rgb(75, 85, 99)` gray-600 | `rgb(107, 114, 128)` gray-500 |
| NavBar build-info chip | `rgb(107, 114, 128)` gray-500 | `rgb(156, 163, 175)` gray-400 |
| FleetGrid `--gv-faint` | `#6b7280` | `#9ca3af` |
| FleetGrid `--gv-ghost` | `#4b5563` | `#9ca3af` |

The separator row is the useful one: **before it returned one value across four elements, after the HostTelemetry fix it returns one again** — the intermediate run returned two, which is what surfaced the twelfth file.

## What I did not verify

The capture harness was a throwaway spec run against a local stack; it is not committed, so these surfaces have no *automated* visual regression. The static guard covers the ink, not the rendering. Light theme is untouched by construction (every edit is either a `dark:`-prefixed class or inside `:root.dark`), and I did not re-shoot light theme to confirm.

Fixes #1922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
