### PR TITLE
fix(tests): scope test_ent183_skill_packages' sys.modules stubs to one import (#1898)

### DIFF
--- a/tests/registry.json
+++ b/tests/registry.json
@@ -1575,6 +1575,18 @@
         "security"
       ],
       "description": "Per-source skills-library root (ent#332): catalog.yaml skills_root: declaration -> evidence-gated skills/ probe -> .claude/skills/ fallback, resolved per SkillSourceClone; packaging rewrites tar arcnames to the canonical agent-side .claude/skills/ destination at filter_skill_archive so manifests, prune confinement and the ent#236 removal machinery stay destination-canonical with zero migration. Covers: resolution order + zero-config back-compat; dual-layout (evidence under BOTH roots, no catalog) keeps .claude/skills/ and flags layout_conflict instead of silently flipping which executable content ent#236 auto-injects; segment-wise skills_root validation ('.', './skills', 'skills//x' all rejected -- a whole-string charset regex admits each and breaks archive-prefix math into per-skill empty-package failures); every bad catalog shape (unparseable, alias-bearing HardenedYamlError, non-mapping, unknown schema_version, oversized, symlinked) falls back to probe and never raises through list_skills; symlinked probe/declared roots fall to the next tier rather than blanking the source, and an escaping final tier empty/None-propagates without a TypeError; tree-SHA version parity across layouts (repo restructure with unchanged content keeps versions stable -- no spurious fleet re-inject); arcname rewrite identity for legacy layout, destination-canonical executable_paths, fail-visible layout-mismatch, unsafe source_root ValueError; cross-layout prune continuity; _legacy_fallback SKILL.md lookup with rewritten members; end-to-end mixed-layout merge through the real service with per-source skills_root in library status."
+    },
+    {
+      "file": "unit/test_1898_sys_modules_isolation.py",
+      "feature": "#1898",
+      "added": "2026-08-05",
+      "categories": [
+        "backend",
+        "unit",
+        "test-isolation",
+        "reliability"
+      ],
+      "description": "test_ent183_skill_packages wrote fake modules straight into sys.modules at IMPORT time and left them there. That is collection-time code and pytest imports every test module before running a single test, so every file collected afterwards resolved services.settings_service (plus database, services.agent_client, utils.url_validation) to a four-function fake, captured names from it at module scope, and kept those bindings for the session. Its own autouse sys.modules-restore fixture could not help: the damage is a BINDING in another module's namespace, which restoring the module table does not reach. Two symptom shapes, both looking like unrelated bugs - ImportError 'cannot import name X from services.settings_service (unknown location)' at collection (#1855), and silent wrong behaviour when the stub happens to define the name (7 failures in test_1081_physical_meter). Fixed by installing the stubs inside a mock.patch.dict context scoped to the single import that needs them, so nothing survives the with-block while the imported module keeps its stub bindings. Guards the mechanism statically (no module-scope sys.modules assignment - the AST walk deliberately allows assignments inside a with, since banning all of them would ban the fix; and the stubs must sit in a patch.dict) and the outcome behaviourally (a subprocess runs the cheapest known victim after the offender in one process). A first version of the fix also evicted cached services.skill* modules to force a fresh import; that broke 10 sibling tests by producing a second module object, and was reverted - caught by comparing the same selection with and without the change (435 passed without, 10 failed with)."
     }
   ]
 }

--- a/tests/unit/test_1898_sys_modules_isolation.py
+++ b/tests/unit/test_1898_sys_modules_isolation.py
@@ -1,0 +1,138 @@
+"""#1898 — a test module must not leave `sys.modules` stubs behind.
+
+`test_ent183_skill_packages.py` wrote fake modules straight into `sys.modules`
+at import time and left them there. That is collection-time code, and pytest
+imports every test module before running a single test — so every file
+collected afterwards resolved `services.settings_service` (and three siblings)
+to a four-function fake, captured names from it at module scope, and kept those
+bindings for the rest of the session.
+
+Its own autouse `sys.modules` restore fixture could not help: by the time a
+fixture first runs, the damage is a *binding* in another module's namespace,
+which restoring the module table does not reach.
+
+Two shapes of symptom, both looking like unrelated bugs:
+
+  * `ImportError: cannot import name X from 'services.settings_service'
+    (unknown location)` at COLLECTION, for anything importing a real name the
+    stub does not define (#1855);
+  * silent wrong behaviour, when the stub happens to define the name — 7
+    failures in `test_1081_physical_meter.py` (#1898's own reproduction).
+
+The fix scopes the stubs to the single import that needs them. This file guards
+both halves of that: the mechanism (statically, so a rewrite cannot quietly
+reintroduce a bare assignment) and the outcome (by actually running a victim
+after the offender in one process).
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_TESTS = _REPO / "tests"
+_OFFENDER = _TESTS / "unit" / "test_ent183_skill_packages.py"
+
+pytestmark = pytest.mark.unit
+
+
+def _module_level_sys_modules_writes(path: Path) -> list:
+    """Module-level `sys.modules[...] = ...`, ignoring anything inside a
+    function, a class, or a `with` block.
+
+    The `with` exclusion is the point: installing stubs for the duration of one
+    import is the fix, and a guard that banned every assignment would ban the
+    fix along with the bug.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found = []
+
+    def walk(nodes, *, inside_with=False):
+        for node in nodes:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue  # runtime code, restored by the autouse fixture
+            if isinstance(node, ast.With):
+                walk(node.body, inside_with=True)
+                continue
+            if isinstance(node, (ast.For, ast.If, ast.Try)):
+                walk(node.body, inside_with=inside_with)
+                walk(getattr(node, "orelse", []), inside_with=inside_with)
+                walk(getattr(node, "finalbody", []), inside_with=inside_with)
+                continue
+            if inside_with:
+                continue
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Subscript)
+                        and isinstance(target.value, ast.Attribute)
+                        and target.value.attr == "modules"
+                    ):
+                        found.append(node.lineno)
+
+    walk(tree.body)
+    return found
+
+
+class TestTheMechanism:
+
+    def test_no_stub_is_installed_at_module_scope(self):
+        """The bug in one assertion: a bare `sys.modules[x] = fake` at module
+        scope runs during collection and outlives the file."""
+        leaks = _module_level_sys_modules_writes(_OFFENDER)
+        assert not leaks, (
+            f"{_OFFENDER.name} writes sys.modules at module scope "
+            f"(line(s) {leaks}) — that runs during COLLECTION and poisons "
+            "every file imported after it (#1898)"
+        )
+
+    def test_the_stubs_are_scoped_to_a_patch_context(self):
+        """Guards the fix's shape, not just the bug's absence: the stubs must
+        be installed by something that restores them, and `patch.dict` is what
+        makes the `with` meaningful."""
+        tree = ast.parse(_OFFENDER.read_text(encoding="utf-8"))
+        withs = [n for n in ast.walk(tree) if isinstance(n, ast.With)]
+        patch_dicts = [
+            w for w in withs
+            if any(
+                isinstance(item.context_expr, ast.Call)
+                and "patch" in ast.dump(item.context_expr)
+                and "dict" in ast.dump(item.context_expr)
+                for item in w.items
+            )
+        ]
+        assert patch_dicts, (
+            "the stubs are no longer installed inside a patch.dict context — "
+            "whatever replaced it must restore sys.modules on exit (#1898)"
+        )
+
+
+class TestTheOutcome:
+    """Statically-correct is not the claim; the claim is that a victim runs
+    clean after the offender in one process."""
+
+    @pytest.mark.parametrize("victim", [
+        # Fails at COLLECTION pre-fix: imports a real `settings_service` name
+        # the stub does not define (#1855's reported pair). Chosen because it
+        # is the cheapest reproduction — ~2s.
+        "test_ent125_resilient_system_deploy.py",
+    ])
+    def test_a_victim_passes_when_collected_after_the_offender(self, victim):
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest",
+             f"unit/{_OFFENDER.name}", f"unit/{victim}",
+             "-q", "-p", "no:randomly", "-p", "no:warnings", "--timeout=120"],
+            cwd=_TESTS,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        assert result.returncode == 0, (
+            f"{victim} does not survive being collected after "
+            f"{_OFFENDER.name} (#1898)\n{result.stdout[-3000:]}"
+        )

--- a/tests/unit/test_ent183_skill_packages.py
+++ b/tests/unit/test_ent183_skill_packages.py
@@ -364,7 +364,8 @@ class TestRestoreRoundTrip:
 
 # Stub heavy backend deps ONLY if a real module isn't already loaded (combined
 # runs where the full backend imported first must keep their real modules).
-import types as _types  # noqa: E402
+import types as _types
+import unittest.mock as _mock  # noqa: E402
 
 _STUBBED_MODULE_NAMES = [
     "database",
@@ -376,11 +377,17 @@ _STUBBED_MODULE_NAMES = [
 
 @pytest.fixture(autouse=True)
 def _restore_sys_modules():
-    """Snapshot sys.modules before each test and restore after.
+    """Per-test safety net. NOT the mechanism any more — see the import below.
 
-    The stubs below are installed at import time (skill_service reaches them
-    at module scope, before any fixture could run), so without this they would
-    leak into other files in the same pytest session — the #762 class.
+    This fixture used to be the only defence, and it could not work: the stubs
+    were installed at IMPORT time, i.e. during collection, and pytest imports
+    every test module before running any test. So by the time a fixture first
+    ran, later modules had already been collected against the stubs and had
+    captured names from them — bindings no amount of `sys.modules` restoration
+    can reach (#1898).
+
+    Kept because it is nearly free and it does catch a test that stubs at RUN
+    time, which is a different and still-live hazard.
     """
     saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
     try:
@@ -420,16 +427,51 @@ _STUBS = {
         "ALLOWED_SKILLS_LIBRARY_HOSTS": {"github.com", "www.github.com"},
     },
 }
+# #1898: the stubs live ONLY for the duration of the import below.
+#
+# They used to be written straight into `sys.modules` and left there. That is
+# import-time code, so it runs during COLLECTION — and pytest imports every
+# test module before running a single test. Every file collected after this one
+# therefore resolved `services.settings_service` (and the other three) to a
+# four-function fake, captured names from it at its own module scope, and kept
+# those bindings for the rest of the session. Restoring `sys.modules` later
+# cannot reach a name another module has already bound.
+#
+# The symptoms were order-dependent and looked like unrelated bugs: 7 failures
+# in `test_1081_physical_meter.py` when it happened to be collected after this
+# file, and `ImportError: cannot import name ... from 'services.settings_service'
+# (unknown location)` at collection for anything importing a real name the stub
+# does not define (#1855).
+#
+# `patch.dict` restores the whole mapping on exit, so nothing survives the
+# `with`. The module objects bound below keep referencing the stubs, which is
+# exactly what these tests want — the stubbing was never meant to outlive this
+# import.
+_stub_modules = {}
 for _name, _attrs in _STUBS.items():
-    if _name not in sys.modules:
-        _mod = _types.ModuleType(_name)
-        for _k, _v in _attrs.items():
-            setattr(_mod, _k, _v)
-        sys.modules[_name] = _mod
+    _mod = _types.ModuleType(_name)
+    for _k, _v in _attrs.items():
+        setattr(_mod, _k, _v)
+    _stub_modules[_name] = _mod
 
-import services.skill_service as skill_service_module  # noqa: E402
-from services.skill_service import SkillService, SkillInjectionBusy  # noqa: E402
-from services.skill_source_clone import SkillSourceClone  # noqa: E402
+with _mock.patch.dict(sys.modules, _stub_modules):
+    # Deliberately NOT evicting a cached `services.skill*` here.
+    #
+    # A first version of this fix did, to force a fresh import against the
+    # stubs regardless of collection order. It broke 10 sibling tests
+    # (`test_ent236_skills_lifecycle`, `test_ent237_skill_sources`): evicting
+    # and re-importing produces a SECOND module object, so this file's
+    # `skill_service_module` and the one those files patch stop being the same
+    # object, and their monkeypatching lands on a module the code under test is
+    # not using.
+    #
+    # The pre-existing behaviour — take whatever `import` returns — is kept. It
+    # means the stubs are ignored when something imported `skill_service`
+    # first, which is a separate wart and not what #1898 is about. Scope creep
+    # in a test-isolation fix is how a test-isolation fix breaks tests.
+    import services.skill_service as skill_service_module  # noqa: E402
+    from services.skill_service import SkillService, SkillInjectionBusy  # noqa: E402
+    from services.skill_source_clone import SkillSourceClone  # noqa: E402
 
 
 def _run(coro):


### PR DESCRIPTION
## Summary

`test_ent183_skill_packages.py` wrote fake modules straight into `sys.modules` at **import** time and left them there. That is collection-time code, and pytest imports every test module before running a single test — so every file collected afterwards resolved `services.settings_service` (plus `database`, `services.agent_client`, `utils.url_validation`) to a four-function fake, captured names from it at module scope, and kept those bindings for the rest of the session.

Its own autouse `sys.modules`-restore fixture never had a chance. By the time a fixture first runs, the damage is a **binding in another module's namespace**, and restoring the module table doesn't reach it.

Two symptom shapes, both of which read as unrelated bugs:

```
ImportError: cannot import name 'resolve_github_pat' from
'services.settings_service' (unknown location)          # at COLLECTION (#1855)
```

…and silent wrong behaviour when the stub happens to define the name — the 7 failures in `test_1081_physical_meter.py` this issue reproduces.

## Fix

The stubs now live inside a `mock.patch.dict` scoped to the single import that needs them. Nothing survives the `with`; the imported module keeps its stub bindings, which is all the stubbing was ever for.

## A false start worth reading

My first version *also* evicted cached `services.skill*` modules, to force a fresh import against the stubs regardless of collection order. It broke **10 sibling tests** in `test_ent236_skills_lifecycle` and `test_ent237_skill_sources`: evicting and re-importing produces a **second module object**, so their monkeypatching lands on a module the code under test isn't using.

I caught it by running the same selection with and without my change — 435 passed without, 10 failed with — not by reading the diff. Reverted, with the reasoning left in the file: the order-dependence it addressed is a real wart, but it isn't what #1898 is about, and *scope creep in a test-isolation fix is how a test-isolation fix breaks tests*.

## Verification

| Case | Before | After |
|---|---|---|
| The issue's reproduction (`+ test_1081_physical_meter`) | 7 failed | **74 passed** |
| #1855's pair (`+ test_ent125_resilient_system_deploy`) | collection error | **79 passed** |
| `+ test_ent236_skills_lifecycle` | error | **124 passed** |
| The selection my false start regressed | 435 passed | **436 passed, 0 failed** |

3 guard tests, mutation-verified — reintroducing the bare module-scope assignment fails all three. The static guard's AST walk deliberately **allows** `sys.modules` assignment inside a `with`: a rule banning every assignment would ban the fix along with the bug.

## One correction

When I triaged this I said it explained a `test_subscription_auto_switch_pingpong` flake I'd seen on #2025. **I can't substantiate that.** The error signature matched #1855's family, but the pairing doesn't reproduce pre-fix, and neither does a broader selection. `test_ent236_skills_lifecycle` *is* a confirmed victim (error → 124 passed); the pingpong one stays unexplained.

## Related

**#1855 is the same root cause with a different victim** and should close as a duplicate once this lands.

Closes #1898
