### PR TITLE
fix(git-sync): stop the base image's container-only .claude/settings.json leaking into agent repos (#2036)

### DIFF
--- a/config/agent-templates/dd-bizmodel/.gitignore
+++ b/config/agent-templates/dd-bizmodel/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-captable/.gitignore
+++ b/config/agent-templates/dd-captable/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-competitor/.gitignore
+++ b/config/agent-templates/dd-competitor/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-compliance/.gitignore
+++ b/config/agent-templates/dd-compliance/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-founder/.gitignore
+++ b/config/agent-templates/dd-founder/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-intake/.gitignore
+++ b/config/agent-templates/dd-intake/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-lead/.gitignore
+++ b/config/agent-templates/dd-lead/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-legal/.gitignore
+++ b/config/agent-templates/dd-legal/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-market/.gitignore
+++ b/config/agent-templates/dd-market/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-tech/.gitignore
+++ b/config/agent-templates/dd-tech/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/dd-traction/.gitignore
+++ b/config/agent-templates/dd-traction/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/sage/.gitignore
+++ b/config/agent-templates/sage/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/scout/.gitignore
+++ b/config/agent-templates/scout/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/config/agent-templates/scribe/.gitignore
+++ b/config/agent-templates/scribe/.gitignore
@@ -67,7 +67,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
+++ b/docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md
@@ -192,7 +192,16 @@ __pycache__/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/plugins/
-# Keep: .claude/commands/, .claude/skills/, .claude/agents/, settings.local.json
+# settings.json is baked by the Trinity base image with container-only hook
+# paths (/opt/trinity/hooks/*.py). Committing it bricks any clone made outside
+# the container: the missing hook script exits 2, which Claude Code reads as
+# "block this tool call", so every Bash/Edit/Write fails there. (#2036)
+.claude/settings.json
+.claude/remote-settings.json
+.claude/policy-limits.json
+.claude/backups/
+.claude/.last-cleanup
+# Keep: .claude/commands/, .claude/skills/, .claude/agents/
 
 # Temporary files
 *.log

--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -1325,6 +1325,29 @@ _GITIGNORE_PATTERNS: Tuple[str, ...] = (
     # the 15-min sync loop commits it (and every plugin update commits another
     # copy) — repo bloat, same class as #1596. Re-installable, so never in git.
     ".claude/plugins/",
+    # #2036: container-only Claude Code config. The base image bakes
+    # `~/.claude/settings.json` (docker/base-image/hooks/claude-settings.json)
+    # registering the platform guardrail hooks by ABSOLUTE container path
+    # (`/opt/trinity/hooks/*.py`). HOME == the repo root, so `git add -A` swept
+    # it into the agent's GitHub repo — and any clone made outside the container
+    # is then hard-bricked: a PreToolUse hook whose script is missing exits 2,
+    # which is precisely Claude Code's "block this tool call" signal, so every
+    # Bash/Edit/Write fails on a machine that has no `/opt/trinity`. Worse blast
+    # radius than #462/#1596/#1702 — the leak breaks foreign clones rather than
+    # merely bloating them. The rest are runtime state observed leaking in the
+    # same commit (`backups/` alone was ~3,000 lines).
+    #
+    # Trade-off, stated: `.claude/settings.json` doubles as Claude Code's
+    # PROJECT-level settings file, so a template can no longer commit one. That
+    # is the right default — the baked file always exists and would collide —
+    # and an agent that genuinely needs it keeps the #1596 escape hatch: negate
+    # in its own `.gitignore` (`!.claude/settings.json`). `settings.local.json`
+    # is already covered by the `*.local.json` rule below.
+    ".claude/settings.json",
+    ".claude/remote-settings.json",
+    ".claude/policy-limits.json",
+    ".claude/backups/",
+    ".claude/.last-cleanup",
     # Temporary files
     "*.log",
     "*.tmp",

--- a/tests/unit/test_2036_claude_settings_leak.py
+++ b/tests/unit/test_2036_claude_settings_leak.py
@@ -1,0 +1,318 @@
+"""Regression tests for #2036 — the base image's `~/.claude/settings.json`
+must never reach the agent's GitHub repo.
+
+## The defect
+
+`docker/base-image/Dockerfile` bakes `hooks/claude-settings.json` into
+`/home/developer/.claude/settings.json`, registering the platform guardrail
+hooks by ABSOLUTE container path (`/opt/trinity/hooks/*.py`). Agent HOME is
+also the git repo root and the in-container auto-sync commits with
+`git add -A`, so the file was swept into the repo on the next sync.
+
+The damage lands somewhere else entirely: a clone of that repo made outside
+the container has no `/opt/trinity`, so each registered PreToolUse hook exits
+**2** — which is exactly Claude Code's "block this tool call" signal. Every
+Bash/Edit/Write is refused. Same leak class as #462 / #1596 / #1702, but those
+only bloated the repo; this one bricks it.
+
+## What is asserted here
+
+Two properties, deliberately at different levels:
+
+1. **Behavioural, against real `git` and real `bash`** — the shipped
+   `_build_gitignore_merge_command` / `_build_rm_cached_ignored_command` are
+   executed against a temp repo. A pattern list assertion alone would pass
+   against a rule git does not actually apply (`.claude/.last-cleanup` is a
+   dotfile inside a dotdir; `.claude/backups/` is a dir rule), so the test
+   drives the real thing.
+2. **The premise** — that the baked settings file really does carry absolute
+   container paths. That is the entire reason the ignore rule must exist; if a
+   future change makes the hook paths relative (or moves registration out of
+   the synced tree, the issue's suggested longer-term fix), this test fails and
+   the reviewer gets to re-decide the rule rather than inherit it.
+
+Both halves matter for the *already-bricked* repos: the fix only helps them if
+the migration untracks the committed copy, which is the `rm --cached` case
+below.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+_project_root = Path(__file__).resolve().parents[2]
+backend_path = str(_project_root / "src" / "backend")
+if backend_path not in sys.path:
+    sys.path.insert(0, backend_path)
+
+
+# The runtime artifacts observed leaking in a single real sync commit on an
+# affected agent. `settings.json` is the one that bricks; the rest are state.
+LEAKING_PATHS = (
+    ".claude/settings.json",
+    ".claude/remote-settings.json",
+    ".claude/policy-limits.json",
+    ".claude/backups/session-2026-08-01.json",
+    ".claude/.last-cleanup",
+)
+
+# Must stay committable — these are the agent's actual source, and a rule that
+# swallowed them would silently strip an agent's skills on the next push (the
+# `.trinity/setup.sh` trap documented in `_build_rm_cached_ignored_command`).
+KEEP_PATHS = (
+    ".claude/commands/deploy.md",
+    ".claude/skills/research/SKILL.md",
+    ".claude/agents/reviewer.md",
+    "CLAUDE.md",
+)
+
+
+def _load_git_service():
+    """Import git_service with heavy dependencies mocked out (mirrors
+    `test_github_init_gitignore.py` so both files stub the same surface)."""
+    mock_modules = {}
+    for mod in [
+        "docker", "docker.errors", "docker.types",
+        "redis", "redis.asyncio",
+        "database",
+        "services.docker_service",
+    ]:
+        mock_modules[mod] = Mock()
+    mock_modules["database"].db = Mock()
+    mock_modules["database"].AgentGitConfig = Mock
+    mock_modules["database"].GitSyncResult = Mock
+
+    with patch.dict("sys.modules", mock_modules):
+        for key in list(sys.modules.keys()):
+            if key.startswith("services.git_service"):
+                del sys.modules[key]
+        import services.git_service as gs
+    return gs
+
+
+def _git(repo: Path):
+    def run(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=10,
+        )
+    return run
+
+
+def _init_repo(repo: Path):
+    git = _git(repo)
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("config", "commit.gpgsign", "false")
+    return git
+
+
+def _write(repo: Path, rel: str, content: str = "x"):
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def _run_shell(command: str, repo: Path):
+    result = subprocess.run(
+        command, shell=True, capture_output=True, text=True, timeout=15
+    )
+    assert result.returncode == 0, (
+        f"command failed in {repo}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 1. The premise: the baked file is container-only by construction
+# ---------------------------------------------------------------------------
+
+def test_baked_settings_registers_absolute_container_paths():
+    """The reason `.claude/settings.json` may never be committed.
+
+    If this fails because the hooks became relative or moved out of the synced
+    tree, the ignore rule below is no longer load-bearing and should be
+    re-argued — not silently kept.
+    """
+    baked = _project_root / "docker" / "base-image" / "hooks" / "claude-settings.json"
+    assert baked.is_file(), f"baked hook settings missing at {baked}"
+
+    settings = json.loads(baked.read_text())
+    commands = [
+        hook["command"]
+        for event_hooks in settings.get("hooks", {}).values()
+        for matcher in event_hooks
+        for hook in matcher.get("hooks", [])
+        if hook.get("type") == "command"
+    ]
+    assert commands, "baked settings registers no command hooks — premise changed"
+    assert any("/opt/trinity/hooks/" in c for c in commands), (
+        "baked settings no longer references absolute /opt/trinity paths; the "
+        "#2036 ignore rule exists because those paths cannot resolve outside "
+        "the container — re-evaluate it."
+    )
+
+
+def test_dockerfile_still_bakes_settings_into_the_repo_root():
+    """HOME == repo root is what puts the baked file inside the working tree.
+
+    Pinned so a move (e.g. registering hooks outside `/home/developer`) is a
+    conscious change that revisits this fix rather than leaving a dead rule.
+    """
+    dockerfile = (
+        _project_root / "docker" / "base-image" / "Dockerfile"
+    ).read_text()
+    assert "/home/developer/.claude/settings.json" in dockerfile
+
+
+# ---------------------------------------------------------------------------
+# 2. The pattern list
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        ".claude/settings.json",
+        ".claude/remote-settings.json",
+        ".claude/policy-limits.json",
+        ".claude/backups/",
+        ".claude/.last-cleanup",
+    ],
+)
+def test_pattern_is_canonical(pattern):
+    gs = _load_git_service()
+    assert pattern in gs._GITIGNORE_PATTERNS, (
+        f"{pattern} missing from _GITIGNORE_PATTERNS (#2036)"
+    )
+
+
+def test_project_scoped_claude_source_is_not_swallowed():
+    """No rule may exclude `.claude/` wholesale — commands/skills/agents are
+    the agent's source and must keep syncing (G-001 in the validation spec)."""
+    gs = _load_git_service()
+    for bad in (".claude", ".claude/", ".claude/*"):
+        assert bad not in gs._GITIGNORE_PATTERNS
+
+
+# ---------------------------------------------------------------------------
+# 3. Behaviour: a fresh agent never stages the leaking files
+# ---------------------------------------------------------------------------
+
+def test_add_all_does_not_stage_leaking_runtime_files(tmp_path):
+    """The in-container auto-sync runs `git add -A`. After the canonical
+    `.gitignore` merge, none of the leaking artifacts may be staged — while
+    every legitimate `.claude/` source file still is."""
+    gs = _load_git_service()
+    git = _init_repo(tmp_path)
+
+    for rel in LEAKING_PATHS + KEEP_PATHS:
+        _write(tmp_path, rel)
+
+    _run_shell(gs._build_gitignore_merge_command(str(tmp_path)), tmp_path)
+
+    # Exactly what `_run_auto_sync_once` does in the agent container.
+    git("add", "-A")
+    staged = set(git("diff", "--cached", "--name-only").stdout.splitlines())
+
+    leaked = [p for p in LEAKING_PATHS if p in staged]
+    assert not leaked, f"runtime artifacts still staged by `git add -A`: {leaked}"
+
+    missing = [p for p in KEEP_PATHS if p not in staged]
+    assert not missing, f"legitimate agent source no longer staged: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Behaviour: an already-bricked repo heals on the next Push
+# ---------------------------------------------------------------------------
+
+def test_existing_committed_settings_is_untracked_but_kept_on_disk(tmp_path):
+    """The repos that are already broken are the point of the fix.
+
+    `_migrate_workspace_gitignore` must untrack the committed copy so the next
+    push deletes it from the remote (unbricking future clones), while leaving
+    the working-tree file alone so the RUNNING agent keeps its guardrail hooks.
+    """
+    gs = _load_git_service()
+    git = _init_repo(tmp_path)
+
+    for rel in LEAKING_PATHS + KEEP_PATHS:
+        _write(tmp_path, rel)
+    # `-f`: simulate an agent that committed these before the rule existed.
+    git("add", "-f", *(LEAKING_PATHS + KEEP_PATHS))
+    git("commit", "-q", "-m", "seed leaked runtime state")
+
+    tracked_before = set(git("ls-files").stdout.splitlines())
+    for rel in LEAKING_PATHS:
+        assert rel in tracked_before, f"fixture did not track {rel}"
+
+    for build in (
+        gs._build_gitignore_merge_command,
+        gs._build_rm_cached_ignored_command,
+    ):
+        _run_shell(build(str(tmp_path)), tmp_path)
+
+    tracked_after = set(git("ls-files").stdout.splitlines())
+
+    still_tracked = [p for p in LEAKING_PATHS if p in tracked_after]
+    assert not still_tracked, (
+        f"still in the index after migration — external clones stay bricked: "
+        f"{still_tracked}"
+    )
+
+    # The running agent must NOT lose its hooks: index-only removal.
+    assert (tmp_path / ".claude" / "settings.json").is_file(), (
+        "working-tree settings.json was deleted — the live agent would lose "
+        "its guardrail hook registration"
+    )
+
+    dropped = [p for p in KEEP_PATHS if p not in tracked_after]
+    assert not dropped, f"migration untracked legitimate agent source: {dropped}"
+
+
+def test_migration_is_idempotent(tmp_path):
+    """A second Push must be a no-op — `.gitignore` gains no duplicate lines
+    and `rm --cached` finds nothing (it runs on every push, #462)."""
+    gs = _load_git_service()
+    _init_repo(tmp_path)
+    _write(tmp_path, ".claude/settings.json")
+
+    _run_shell(gs._build_gitignore_merge_command(str(tmp_path)), tmp_path)
+    first = (tmp_path / ".gitignore").read_text()
+    _run_shell(gs._build_gitignore_merge_command(str(tmp_path)), tmp_path)
+    second = (tmp_path / ".gitignore").read_text()
+
+    assert first == second
+    lines = [ln for ln in second.splitlines() if ln.strip()]
+    assert len(lines) == len(set(lines)), "duplicate .gitignore entries appended"
+
+
+def test_agent_can_override_with_a_negation(tmp_path):
+    """The #1596 escape hatch still works: an agent that genuinely needs to
+    commit project settings negates the rule in its own `.gitignore`.
+
+    Asserted because the fix removes a file Claude Code also uses for
+    PROJECT-level settings — the trade-off is only acceptable if the opt-out
+    is real."""
+    gs = _load_git_service()
+    git = _init_repo(tmp_path)
+    _write(tmp_path, ".claude/settings.json")
+
+    _run_shell(gs._build_gitignore_merge_command(str(tmp_path)), tmp_path)
+    with (tmp_path / ".gitignore").open("a") as fh:
+        fh.write("!.claude/settings.json\n")
+
+    git("add", "-A")
+    staged = set(git("diff", "--cached", "--name-only").stdout.splitlines())
+    assert ".claude/settings.json" in staged

--- a/tests/unit/test_2036_claude_settings_leak.py
+++ b/tests/unit/test_2036_claude_settings_leak.py
@@ -40,7 +40,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -72,26 +72,35 @@ KEEP_PATHS = (
 )
 
 
-def _load_git_service():
-    """Import git_service with heavy dependencies mocked out (mirrors
-    `test_github_init_gitignore.py` so both files stub the same surface)."""
-    mock_modules = {}
-    for mod in [
-        "docker", "docker.errors", "docker.types",
-        "redis", "redis.asyncio",
-        "database",
-        "services.docker_service",
-    ]:
-        mock_modules[mod] = Mock()
-    mock_modules["database"].db = Mock()
-    mock_modules["database"].AgentGitConfig = Mock
-    mock_modules["database"].GitSyncResult = Mock
+_STUBBED_MODULE_NAMES = (
+    "docker", "docker.errors", "docker.types",
+    "redis", "redis.asyncio",
+    "database",
+    "services.docker_service",
+)
 
-    with patch.dict("sys.modules", mock_modules):
-        for key in list(sys.modules.keys()):
-            if key.startswith("services.git_service"):
-                del sys.modules[key]
-        import services.git_service as gs
+
+def _load_git_service(monkeypatch):
+    """Import git_service with heavy dependencies stubbed out.
+
+    Stubs the same surface as `test_github_init_gitignore.py`, but through
+    `monkeypatch.setitem`/`delitem` rather than a bare `del sys.modules[...]`
+    — teardown then restores the real modules automatically, so this file
+    cannot leak a stubbed `database`/`docker` into a later test in the same
+    worker (`tests/lint_sys_modules.py` enforces this).
+    """
+    for name in _STUBBED_MODULE_NAMES:
+        monkeypatch.setitem(sys.modules, name, Mock())
+    sys.modules["database"].db = Mock()
+    sys.modules["database"].AgentGitConfig = Mock
+    sys.modules["database"].GitSyncResult = Mock
+
+    # Force a fresh import so the stubs above are the ones it binds to.
+    for key in list(sys.modules):
+        if key.startswith("services.git_service"):
+            monkeypatch.delitem(sys.modules, key, raising=False)
+
+    import services.git_service as gs
     return gs
 
 
@@ -191,17 +200,17 @@ def test_dockerfile_still_bakes_settings_into_the_repo_root():
         ".claude/.last-cleanup",
     ],
 )
-def test_pattern_is_canonical(pattern):
-    gs = _load_git_service()
+def test_pattern_is_canonical(pattern, monkeypatch):
+    gs = _load_git_service(monkeypatch)
     assert pattern in gs._GITIGNORE_PATTERNS, (
         f"{pattern} missing from _GITIGNORE_PATTERNS (#2036)"
     )
 
 
-def test_project_scoped_claude_source_is_not_swallowed():
+def test_project_scoped_claude_source_is_not_swallowed(monkeypatch):
     """No rule may exclude `.claude/` wholesale — commands/skills/agents are
     the agent's source and must keep syncing (G-001 in the validation spec)."""
-    gs = _load_git_service()
+    gs = _load_git_service(monkeypatch)
     for bad in (".claude", ".claude/", ".claude/*"):
         assert bad not in gs._GITIGNORE_PATTERNS
 
@@ -210,11 +219,11 @@ def test_project_scoped_claude_source_is_not_swallowed():
 # 3. Behaviour: a fresh agent never stages the leaking files
 # ---------------------------------------------------------------------------
 
-def test_add_all_does_not_stage_leaking_runtime_files(tmp_path):
+def test_add_all_does_not_stage_leaking_runtime_files(tmp_path, monkeypatch):
     """The in-container auto-sync runs `git add -A`. After the canonical
     `.gitignore` merge, none of the leaking artifacts may be staged — while
     every legitimate `.claude/` source file still is."""
-    gs = _load_git_service()
+    gs = _load_git_service(monkeypatch)
     git = _init_repo(tmp_path)
 
     for rel in LEAKING_PATHS + KEEP_PATHS:
@@ -237,14 +246,14 @@ def test_add_all_does_not_stage_leaking_runtime_files(tmp_path):
 # 4. Behaviour: an already-bricked repo heals on the next Push
 # ---------------------------------------------------------------------------
 
-def test_existing_committed_settings_is_untracked_but_kept_on_disk(tmp_path):
+def test_existing_committed_settings_is_untracked_but_kept_on_disk(tmp_path, monkeypatch):
     """The repos that are already broken are the point of the fix.
 
     `_migrate_workspace_gitignore` must untrack the committed copy so the next
     push deletes it from the remote (unbricking future clones), while leaving
     the working-tree file alone so the RUNNING agent keeps its guardrail hooks.
     """
-    gs = _load_git_service()
+    gs = _load_git_service(monkeypatch)
     git = _init_repo(tmp_path)
 
     for rel in LEAKING_PATHS + KEEP_PATHS:
@@ -281,10 +290,10 @@ def test_existing_committed_settings_is_untracked_but_kept_on_disk(tmp_path):
     assert not dropped, f"migration untracked legitimate agent source: {dropped}"
 
 
-def test_migration_is_idempotent(tmp_path):
+def test_migration_is_idempotent(tmp_path, monkeypatch):
     """A second Push must be a no-op — `.gitignore` gains no duplicate lines
     and `rm --cached` finds nothing (it runs on every push, #462)."""
-    gs = _load_git_service()
+    gs = _load_git_service(monkeypatch)
     _init_repo(tmp_path)
     _write(tmp_path, ".claude/settings.json")
 
@@ -298,14 +307,14 @@ def test_migration_is_idempotent(tmp_path):
     assert len(lines) == len(set(lines)), "duplicate .gitignore entries appended"
 
 
-def test_agent_can_override_with_a_negation(tmp_path):
+def test_agent_can_override_with_a_negation(tmp_path, monkeypatch):
     """The #1596 escape hatch still works: an agent that genuinely needs to
     commit project settings negates the rule in its own `.gitignore`.
 
     Asserted because the fix removes a file Claude Code also uses for
     PROJECT-level settings — the trade-off is only acceptable if the opt-out
     is real."""
-    gs = _load_git_service()
+    gs = _load_git_service(monkeypatch)
     git = _init_repo(tmp_path)
     _write(tmp_path, ".claude/settings.json")
 


### PR DESCRIPTION
Fixes #2036

## What

The agent base image bakes `~/.claude/settings.json` registering the platform guardrail hooks by **absolute container path** (`/opt/trinity/hooks/*.py`). Agent HOME is also the git repo root and the in-container auto-sync commits with `git add -A`, so the file was swept into the agent's GitHub repo on the next sync.

A clone of that repo made anywhere without `/opt/trinity` is then hard-bricked. The mechanism is deterministic, not incidental: a PreToolUse hook whose script is missing exits **2**, and exit 2 is exactly Claude Code's "block this tool call" signal — so every Bash/Edit/Write fails, on a machine with no obvious connection to the agent that leaked it.

Adds `.claude/settings.json` plus the four other runtime artifacts observed in the same sync commit (`remote-settings.json`, `policy-limits.json`, `backups/`, `.last-cleanup`) to the canonical `_GITIGNORE_PATTERNS`.

Same leak class as #462 / #1596 / #1702 — the next missing entry in that list, with a worse blast radius, since this one *breaks* foreign clones rather than merely bloating them.

## How the already-broken repos heal

The fix is only worth anything if it reaches agents that have already pushed. It does, through the existing `_migrate_workspace_gitignore` machinery (#462): every Push merges the canonical list into the workspace `.gitignore` and then `git rm --cached`s anything that now matches. That is **index-only** — the working-tree file stays, so the *running* agent keeps its guardrail hook registration while the next push deletes the poisoned copy from the remote. Asserted in `test_existing_committed_settings_is_untracked_but_kept_on_disk`.

Second distribution path, for free: `compatibility/static_checks.py` computes its missing-pattern set dynamically from `_GITIGNORE_PATTERNS`, and `compatibility/fixes.py` appends them — so affected agents surface in the Overview compatibility panel and can be auto-fixed there without waiting for a Push.

## Trade-off, stated rather than buried

`.claude/settings.json` is also Claude Code's **project-level** settings file, so after this a template can no longer commit one. That is the right default — the base image always writes that path, so a template-supplied copy was already colliding with a container-only file — and the #1596 escape hatch still works: an agent that genuinely needs it negates the rule in its own `.gitignore` (`!.claude/settings.json`). There is a test for the escape hatch, because a trade-off is only acceptable if the opt-out is real.

## Changes

| File | What |
|---|---|
| `src/backend/services/git_service.py` | the five patterns + the rationale |
| `docs/TRINITY_COMPATIBLE_AGENT_GUIDE.md` | canonical block — **required**, `test_doc_and_constant_in_sync` pins `constant ⊆ doc` |
| `config/agent-templates/*/.gitignore` (14) | regenerated via the #1908 regenerator, not hand-edited |
| `tests/unit/test_2036_claude_settings_leak.py` | **new** — 12 tests |

One line touched outside the strict scope: the doc block's `# Keep: … settings.local.json` clause was already wrong (`*.local.json` ignores it) and sits directly beside the new rule, where it would have read as a contradiction. Dropped the clause; the rest of the comment stands.

## Tests

`tests/unit/test_2036_claude_settings_leak.py` asserts at two levels deliberately.

**Behavioural, against real `git` and real `bash`** — the shipped `_build_gitignore_merge_command` / `_build_rm_cached_ignored_command` run against a temp repo. A pattern-list assertion alone would pass against a rule git does not actually apply (`.claude/.last-cleanup` is a dotfile inside a dotdir, `.claude/backups/` is a directory rule), so the test drives the real thing and reproduces the auto-sync's own `git add -A`.

**The premise** — that the baked settings file really does carry absolute `/opt/trinity` paths, and that the Dockerfile still writes it inside the repo root. Those two facts are the entire reason the rule must exist. If a later change makes the hook paths relative, or moves registration out of the synced tree (the issue's suggested longer-term fix), these fail and a reviewer gets to re-decide the rule rather than inherit a dead one.

Every check also pins that legitimate `.claude/` source (`commands/`, `skills/`, `agents/`) keeps syncing — the `.trinity/setup.sh` trap already documented in `_build_rm_cached_ignored_command`, where an over-broad ignore silently untracks an agent's own files and pushes the deletion.

```
tests/unit/test_2036_claude_settings_leak.py            12 passed
tests/unit/test_github_init_gitignore.py
  + test_1908_bundled_template_gitignore.py
  + test_1596_git_sync_observability.py
  + test_data_paths_gitignore.py
  + test_953_startup_sh_no_gitignore_writes.py         111 passed
full tests/unit/                            7667 passed, 17 skipped
```

**Mutation check.** Reverting only `git_service.py` and rerunning fails **7 of 12** — including both behavioural tests. A guard never shown to fire is decorative.

The 4 failures in the full run (`test_1472_schedule_validation.py::test_accepts_valid[Europe/Kiev]`, 3 in `test_admin_email_login.py`) reproduce identically on a clean `dev` with this branch stashed — pre-existing, unrelated.

## Not fixed here

- **The `.gitignore` merge only runs on a backend-mediated Push/init.** The in-container 15-min auto-sync never updates `.gitignore` — deliberately, per #953, which removed startup.sh's shell-level append because it produced permanent `M .gitignore` drift. So an agent whose operator never Pushes keeps leaking until the compatibility auto-fix is applied. Pre-existing and identical for #1596/#1702; worth its own issue rather than reopening #953 inside a P1 bug fix.
- **The longer-term fix the issue suggests** — registering the platform hooks outside the synced tree entirely — is not attempted. The obvious lever (`CLAUDE_CONFIG_DIR`) relocates *all* of `~/.claude`, including `projects/<uuid>.jsonl`, which the Session tab reaper and `jsonl_recovery` both address by fixed path. That is a real change with real blast radius, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)