### PR TITLE
fix(skills): scrub the whole credential run from a double-@ URL (ent#347)

### DIFF
--- a/src/backend/services/skill_service.py
+++ b/src/backend/services/skill_service.py
@@ -42,6 +42,7 @@ from services.skill_source_clone import (
     QUARANTINE_SUFFIX,
     SOURCE_ID_RE,
     SkillSourceClone,
+    redact,
 )
 from urllib.parse import urlparse, urlunparse
 
@@ -112,9 +113,21 @@ _SYNC_LOCK_TTL_SECONDS = 300
 
 
 def _scrub_pat(text: str) -> str:
-    """Replace credentials in any `https://<creds>@host` URL. Never raises."""
+    """Replace credentials in any `https://<creds>@host` URL. Never raises.
+
+    Delegates to `skill_source_clone.redact` (ent#347). These were two separate
+    hand-written patterns that had drifted apart and were each wrong in a
+    different way — the one duplication that matters, since the value it guards
+    lands in DURABLE admin-rendered state (`skills_library_last_error`) and in
+    an HTTP `detail`. One pattern, one place; see `_CREDENTIAL_URL_RE`.
+
+    The try/except stays: this wrapper's own contract is "never raises", and it
+    is called on a `str(e)` from an arbitrary exception whose `__str__` can
+    itself blow up. `redact` is total for `str`/`None`, so this is belt to its
+    suspenders rather than a live branch.
+    """
     try:
-        return re.sub(r"https://[^@\s]+@", "https://***@", text)
+        return redact(text)
     except Exception:  # noqa: BLE001
         return ""
 

--- a/src/backend/services/skill_source_clone.py
+++ b/src/backend/services/skill_source_clone.py
@@ -122,9 +122,44 @@ def validate_declared_root(value: Any) -> Optional[str]:
     return root
 
 
+# ent#347: THE credential pattern for free-text (git stderr / exception) scrubs.
+# One definition on purpose — the bug this fixes was two scrubbers carrying two
+# hand-written patterns that had drifted apart and were each wrong differently.
+#
+# `[^\s/?#]+` is greedy and cannot cross a path separator, a query/fragment
+# delimiter, or whitespace, which is what makes it correct on all four shapes:
+#
+#   * `https://PAT@LEGACY@github.com/o/r` — `_authenticated_url` splices the
+#     platform PAT in FRONT of userinfo the stored URL already carried, so a
+#     double-`@` authority is the normal shape here, not a curiosity. The class
+#     spans `PAT@LEGACY@github.com`, then backtracks to the LAST `@` before the
+#     path, so the whole credential run is replaced. The previous `[^@...]+`
+#     classes stopped dead at the FIRST `@` and left the second token verbatim.
+#   * `https://github.com/o/r?ref=a@b` — the class stops at `/`, so no `@`
+#     follows and the URL is untouched. An `@` in a path or query is not a
+#     credential.
+#   * `https://github.com?x=a@b` — stops at `?` for the same reason. This is why
+#     `?#` are excluded on top of `/`: neither is legal unencoded in userinfo
+#     (RFC 3986), so excluding them can only ever prevent a false positive.
+#   * a plain URL followed later in the same stderr by a credentialed one —
+#     `\s` in the class stops the match at the first whitespace/newline, so the
+#     two cannot be bridged. `redact`'s old `[^@]+` could cross `/` AND newlines
+#     and would swallow everything between them, mangling the message while
+#     hiding the token by accident.
+#
+# This is text-oriented by necessity: git stderr carries several URLs plus
+# prose, so the single-URL parser in `utils/url_validation.py` cannot drop in.
+# It must nonetheless AGREE with that parser on where the authority ends.
+_CREDENTIAL_URL_RE = re.compile(r"https://[^\s/?#]+@")
+
+
 def redact(text: str) -> str:
-    """Strip any embedded PAT from git output before it is logged or returned."""
-    return re.sub(r"https://[^@]+@", "https://***@", text or "")
+    """Strip any embedded PAT from git output before it is logged or returned.
+
+    Handles the double-`@` shape `_authenticated_url` produces (ent#347); see
+    `_CREDENTIAL_URL_RE`. Never raises.
+    """
+    return _CREDENTIAL_URL_RE.sub("https://***@", text or "")
 
 
 def canonical_remote(url: str) -> str:

--- a/tests/unit/test_ent347_pat_scrubber_double_at.py
+++ b/tests/unit/test_ent347_pat_scrubber_double_at.py
@@ -1,0 +1,196 @@
+"""ent#347 — both free-text PAT scrubbers under-matched a double-`@` URL.
+
+`skill_service._authenticated_url` splices the platform PAT in FRONT of
+whatever userinfo the stored URL already carries:
+
+    stored:   https://LEGACYTOK@github.com/org/private-skills
+    spliced:  https://PLATFORMPAT@LEGACYTOK@github.com/org/private-skills
+
+Both scrubbers used a character class that stops at the FIRST `@`
+(`[^@\\s]+@` and `[^@]+@`), so the second credential survived verbatim into
+
+  * `system_settings['skills_library_last_error']` — durable, and rendered on
+    the admin Settings panel, and
+  * an HTTP `detail` body.
+
+Not a theoretical path: git resolves the username as `PLATFORMPAT@LEGACYTOK`
+and auth is REJECTED, so the error branch — the one that persists the scrubbed
+string — is the guaranteed branch, not the rare one. A stored URL can carry
+userinfo today because `_adopt_legacy_clone` writes with no validation and
+`validate_skills_library_url` ignores userinfo by design.
+
+These tests drive the REAL `redact` / `_scrub_pat`, and the end-to-end case
+builds its input with the REAL `_authenticated_url` rather than a hand-typed
+double-`@` string — otherwise the suite would still pass if the splice changed
+shape and the scrubbers silently stopped covering it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.skill_source_clone import redact
+
+
+# ---------------------------------------------------------------------------
+# The defect
+# ---------------------------------------------------------------------------
+
+
+def test_double_at_url_is_fully_scrubbed():
+    """The bug, directly: everything before the LAST `@` of the authority goes."""
+    assert redact("https://a@b@github.com/o/r") == "https://***@github.com/o/r"
+
+
+def test_no_credential_material_survives_a_real_looking_double_at():
+    """Stated as an absence, not an equality — the property that matters is
+    'the token is not in the output', and an equality assertion can be
+    satisfied by a pattern that happens to produce the right string on one
+    input while leaking on a neighbouring one."""
+    out = redact("https://ghp_PLATFORM@ghp_LEGACY@github.com/org/private-skills")
+    assert "ghp_PLATFORM" not in out
+    assert "ghp_LEGACY" not in out
+    assert out == "https://***@github.com/org/private-skills"
+
+
+def test_single_credential_still_scrubbed():
+    """The case that already worked must keep working."""
+    assert redact("https://ghp_TOK@github.com/o/r") == "https://***@github.com/o/r"
+
+
+def test_triple_at_is_also_covered():
+    """Nothing in the splice caps the userinfo at two segments — a stored URL
+    that already carried a double-`@` yields three. The rule is 'the last `@`
+    before the path wins', not 'handle two'."""
+    assert redact("https://x@y@z@github.com/o/r") == "https://***@github.com/o/r"
+
+
+# ---------------------------------------------------------------------------
+# What must NOT be touched
+# ---------------------------------------------------------------------------
+
+
+def test_at_in_query_is_not_a_credential():
+    """An `@` after the path separator is data. Scrubbing it would corrupt the
+    error message an operator is trying to read."""
+    url = "https://github.com/o/r?ref=a@b"
+    assert redact(url) == url
+
+
+def test_at_in_a_path_segment_is_not_a_credential():
+    url = "https://github.com/o/r/refs/heads/user@example"
+    assert redact(url) == url
+
+
+def test_at_in_a_query_with_no_path_is_not_a_credential():
+    """`?` and `#` are excluded from the class on top of `/`: neither is legal
+    unencoded in userinfo (RFC 3986), so excluding them can only prevent a
+    false positive. The issue's suggested `[^\\s/]+@` would mangle this one."""
+    url = "https://github.com?x=a@b"
+    assert redact(url) == url
+
+
+def test_plain_url_followed_by_a_credentialed_one():
+    """`redact`'s old `[^@]+@` could cross `/` AND newlines, so an earlier plain
+    URL matched all the way into a later credentialed one — mangling the
+    message while hiding the token only by accident."""
+    text = "remote: https://github.com/o/r\nfatal: https://ghp_TOK@github.com/o/p denied"
+    out = redact(text)
+    assert "ghp_TOK" not in out
+    assert out == (
+        "remote: https://github.com/o/r\nfatal: https://***@github.com/o/p denied"
+    )
+
+
+def test_multiline_stderr_scrubs_every_occurrence():
+    """git stderr carries several URLs plus prose — this is why the scrubbers
+    stay text-oriented rather than using the single-URL parser."""
+    text = (
+        "Cloning into '/data/skills-library'...\n"
+        "remote: https://a@b@github.com/o/one\n"
+        "fatal: could not read Username for https://c@d@github.com/o/two\n"
+    )
+    out = redact(text)
+    for token in ("a@b", "c@d"):
+        assert token not in out
+    assert out.count("https://***@github.com/o/") == 2
+
+
+# ---------------------------------------------------------------------------
+# Totality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", None, "no urls here at all", "https://", "@@@"])
+def test_redact_never_raises(value):
+    redact(value)
+
+
+def test_scrub_pat_never_raises_on_a_hostile_exception_string():
+    """`_scrub_pat` is called on `str(e)` for an arbitrary exception, whose
+    `__str__` can itself raise. Its contract is 'never raises' and the caller
+    is a persistence path — a throw there would replace a scrubbed error with
+    an unhandled one."""
+    from services.skill_service import _scrub_pat
+
+    class _Hostile:
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        str(_Hostile())  # the input itself is what explodes
+
+    assert _scrub_pat("https://a@b@github.com/o/r") == "https://***@github.com/o/r"
+
+
+# ---------------------------------------------------------------------------
+# The two scrubbers must not drift apart again
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://a@b@github.com/o/r",
+        "https://ghp_TOK@github.com/o/r",
+        "https://github.com/o/r?ref=a@b",
+        "https://github.com?x=a@b",
+        "remote: https://github.com/o/r\nfatal: https://t@github.com/o/p",
+        "",
+    ],
+)
+def test_both_scrubbers_agree(text):
+    """The root cause was TWO hand-written patterns that had drifted apart and
+    were each wrong differently. Pinned as an equality across both entry points
+    so a future edit to one is caught here rather than by a leaked token."""
+    from services.skill_service import _scrub_pat
+
+    assert _scrub_pat(text) == redact(text)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the shape the splice actually produces
+# ---------------------------------------------------------------------------
+
+
+def test_scrubber_covers_what_authenticated_url_actually_builds():
+    """Input built by the REAL splice, not typed by hand.
+
+    This is the assertion that ties the fix to the reported path: if
+    `_authenticated_url` ever changes how it composes the authority, this fails
+    instead of the scrubbers quietly ceasing to cover it.
+    """
+    from services.skill_service import SkillService
+
+    stored = "https://ghp_LEGACY@github.com/org/private-skills"
+    spliced = SkillService._authenticated_url(stored, "ghp_PLATFORM")
+
+    # Precondition: the splice really does produce a double-`@` authority.
+    assert spliced.count("@") >= 2, f"splice no longer double-@: {spliced!r}"
+    assert "ghp_PLATFORM" in spliced and "ghp_LEGACY" in spliced
+
+    # The durable-state path: an error string carrying that URL.
+    persisted = redact(f"fatal: could not read Username for '{spliced}'")
+    assert "ghp_PLATFORM" not in persisted
+    assert "ghp_LEGACY" not in persisted
+    assert "https://***@github.com/org/private-skills" in persisted


### PR DESCRIPTION
Related to abilityai/trinity-enterprise#347

## What

Both free-text PAT scrubbers used a character class that stops at the **first** `@`, so neither stripped a credential from a double-`@` URL — and that is the shape the skills clone path constructs.

`_authenticated_url` splices the platform PAT in front of whatever userinfo the stored URL already carries (verified at the source: `netloc = f"{github_pat}@{parsed.netloc}"`):

```
stored:   https://LEGACYTOK@github.com/org/private-skills
spliced:  https://PLATFORMPAT@LEGACYTOK@github.com/org/private-skills
```

| scrubber | old pattern | old result |
|---|---|---|
| `skill_service._scrub_pat` | `https://[^@\s]+@` | `https://***@LEGACYTOK@github.com/...` |
| `skill_source_clone.redact` | `https://[^@]+@` | `https://***@LEGACYTOK@github.com/...` |

The surviving token reached `system_settings['skills_library_last_error']` — durable, and rendered on the admin Settings panel — and an HTTP `detail` body.

This is the **guaranteed** branch, not a rare one: git resolves the username as `PLATFORMPAT@LEGACYTOK`, auth is rejected, and the error path is the one that persists the scrubbed string. A stored URL can carry userinfo today because `_adopt_legacy_clone` writes with no validation and `validate_skills_library_url` ignores userinfo by design.

## The fix

One pattern, `https://[^\s/?#]+@`, defined once as `_CREDENTIAL_URL_RE` in `skill_source_clone`; `_scrub_pat` delegates to `redact` and keeps only its never-raises wrapper.

**The single definition is part of the fix, not tidying.** The root cause was two hand-written patterns that had drifted apart and were each wrong in a different way. Leaving two copies leaves the mechanism that produced the bug.

Greedy and unable to cross `/`, `?`, `#` or whitespace, so the **last `@` before the path** wins:

| input | output |
|---|---|
| `https://a@b@github.com/o/r` | `https://***@github.com/o/r` |
| `https://github.com/o/r?ref=a@b` | untouched |
| `https://github.com?x=a@b` | untouched |
| plain URL, then a credentialed one | only the credential goes |

### One deviation from the issue's suggested pattern

The issue proposes `https://[^\s/]+@`. I also excluded `?` and `#`. Neither is legal unencoded in userinfo (RFC 3986), so excluding them can only ever *prevent* a false positive — and the issue's pattern mangles `https://github.com?x=a@b` (no path, so nothing stops the class before the `@`) into `https://***@b`. All five acceptance criteria still hold; this covers one more.

The issue's second observation is fixed by the same change: `redact`'s old `[^@]+` could cross `/` **and** newlines, so an earlier plain URL matched all the way into a later credentialed one — mangling the message while hiding the token only by accident. `\s` in the class stops that.

These stay text-oriented, as the issue specifies: git stderr carries several URLs plus prose, so the single-URL parser cannot drop in. The comment on `_CREDENTIAL_URL_RE` records that it must nonetheless *agree* with that parser on where the authority ends.

## Coordination note

The issue describes `strip_url_credentials` in `utils/url_validation.py` as already present from ent#334. **It is not on `dev`** — ent#334 is still `status-in-progress` with no PR. So this fix deliberately takes no dependency on it. When ent#334 lands, its parser and `_CREDENTIAL_URL_RE` need to agree on the authority boundary; a cross-check test between them belongs on whichever lands second.

## Tests

`tests/unit/test_ent347_pat_scrubber_double_at.py` — 22 tests driving the **real** `redact` / `_scrub_pat`:

- all five acceptance criteria, plus triple-`@` (nothing caps userinfo at two segments) and multiline stderr
- `@` in a path segment and in a query are left alone — scrubbing them corrupts the message an operator is reading
- the leak assertions are phrased as an **absence** (`"ghp_LEGACY" not in out`), not only an equality: an equality can be satisfied by a pattern that is right on one input and leaks on its neighbour
- **both scrubbers agree**, parametrized across six inputs, so they cannot drift apart again
- totality: neither raises on `""`, `None`, `"https://"`, `"@@@"`

And the end-to-end case, which is the one tying the fix to the reported path: its input is built by the **real `_authenticated_url`**, not a hand-typed double-`@` string, and it asserts the splice really is double-`@` before scrubbing. If the splice ever changes shape, that test fails rather than the scrubbers quietly ceasing to cover it.

```
tests/unit/test_ent347_pat_scrubber_double_at.py     22 passed
+ ent237 / ent332 / user_agent / ssrf / ent183 ×2    265 passed
lint_sys_modules.py                                  no new violations
```

**Mutation check.** Reverting both service files fails **11 of 22**.

**Pre-existing, not mine:** running `test_ent183_skill_packages.py` before `test_ent236_skills_lifecycle.py` collection-errors with `ImportError: cannot import name 'get_skills_auto_sync_interval'` — a `sys.modules` stubbing artifact. Reproduced identically on clean `dev` with this branch stashed; `test_ent236` passes standalone (64).

## Scope

Two functions, one shared pattern, one new test file. No schema change, no migration, no endpoint, no config. Filed on the enterprise tracker but the code is OSS-core, so it lands here per the tracker≠repo rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
