### PR TITLE
feat(grid): widget chassis — InfoTile, GRID_WIDGETS registry, layout v2, Tiles menu (ent#325)

### DIFF
--- a/src/frontend/e2e/dashboard-type-filter.spec.js
+++ b/src/frontend/e2e/dashboard-type-filter.spec.js
@@ -66,7 +66,13 @@ test.describe('dashboard type-to-filter (trinity-enterprise#261)', () => {
     // and the grid canvas stays MOUNTED (transient zero-match while typing
     // must never unmount the pane — plan eng F1 pin).
     await pillInput(page).fill('zzz')
-    await expect(page.locator('.gv-tile')).toHaveCount(0)
+    // Agent tiles only. ent#325 puts info tiles on the same `.gv-tile` chassis
+    // (deliberately — drag/keyboard/culling/snap all reuse one code path), and
+    // they are NOT agents: the filter is an agent filter, `placedWidgets` never
+    // consults it, and the zero-match card says "No agents match", which stays
+    // true with a fleet-summary tile on the canvas. A bare `.gv-tile` count
+    // asserts something this spec never meant to claim.
+    await expect(page.locator('.gv-tile:not(.gv-tile-widget)')).toHaveCount(0)
     await expect(queryEmpty(page)).toBeVisible()
     await expect(queryEmpty(page)).toContainText('No agents match "zzz"')
     await expect(page.getByRole('button', { name: 'Get started' })).toHaveCount(0)

--- a/src/frontend/src/components/FleetGrid.vue
+++ b/src/frontend/src/components/FleetGrid.vue
@@ -965,6 +965,15 @@ onBeforeUnmount(() => {
   --gv-bk-man: #14b8a6;
   --gv-bk-ext: #ec4899;
   --gv-dots: rgba(17, 24, 39, 0.12);
+  /* ent#325 info-tile chassis. Defined in BOTH blocks: a token defined in one
+     theme only is the same bug the tiles shipped with — a live fallback that
+     never flips. --gv-radius matches .gv-tile's 12px so the inner surface and
+     the chassis share a corner. */
+  --gv-radius: 12px;
+  --gv-peg-bg: #111827;
+  --gv-peg-fg: #f9fafb;
+  --gv-danger-border: rgba(220, 38, 38, 0.35);
+  --gv-skel: rgba(17, 24, 39, 0.07);
   /* Layered depth: top-edge highlight (glass lip) + tight contact shadow +
      mid key shadow + soft ambient falloff. */
   --gv-tile-sheen: linear-gradient(180deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0) 55%);
@@ -1038,6 +1047,14 @@ onBeforeUnmount(() => {
   --gv-bk-man: #2dd4bf;
   --gv-bk-ext: #f472b6;
   --gv-dots: rgba(249, 250, 251, 0.08);
+  /* ent#325 info-tile chassis — dark half. The peg inverts (light chip on the
+     dark card) so it reads as a raised marker in both themes rather than
+     disappearing into the tile. */
+  --gv-radius: 12px;
+  --gv-peg-bg: #f9fafb;
+  --gv-peg-fg: #111827;
+  --gv-danger-border: rgba(248, 113, 113, 0.45);
+  --gv-skel: rgba(249, 250, 251, 0.10);
   --gv-drag-shadow: 0 28px 56px -12px rgba(0, 0, 0, 0.75);
   --gv-tile-sheen: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0) 55%);
   --gv-tile-shadow:

--- a/src/frontend/src/components/FleetGrid.vue
+++ b/src/frontend/src/components/FleetGrid.vue
@@ -156,6 +156,35 @@
             @pointerdown.stop.prevent="startConnect(agent.name, $event)"
           ></span>
         </div>
+
+        <!-- Info tiles (ent#325). Same `.gv-tile` chassis and the same
+             `data-agent` hook, so drag / swap-with-preview / keyboard /
+             culling / the snap socket all apply with no second code path.
+             Deliberately NO connect handle: an info tile is not an org node
+             and can never be a reporting-line endpoint. -->
+        <div
+          v-for="w in placedWidgets"
+          :key="w.key"
+          class="gv-tile gv-tile-widget"
+          :class="{
+            dragging: draggingName === w.key,
+            snapping: snappingName === w.key,
+            locked: lockedName === w.key,
+          }"
+          :style="tileStyle(w.key)"
+          :data-agent="w.key"
+          role="listitem"
+          tabindex="0"
+          :aria-label="w.entry.title + ' info tile — drag to any cell, or use arrow keys'"
+          @transitionend="onTileTransitionEnd(w.key, $event)"
+        >
+          <component
+            :is="w.entry.component"
+            v-if="visibleNames.has(w.key)"
+            :agents="agents"
+          />
+          <div v-else class="gv-tile-far">{{ w.entry.title }}</div>
+        </div>
       </div>
     </div>
 
@@ -172,6 +201,35 @@
       </button>
     </div>
     <span class="gv-zoomlvl">{{ Math.round(vz * 100) }}%</span>
+
+    <!-- Tiles menu (ent#325). Placed in the existing bottom control cluster
+         rather than as a fifth top-level header button: the grid header
+         already carries Tidy up / Reset layout and gained Zones / Lines /
+         Group by dept / New dept from #305, and the issue's scope note asks
+         that the responsive ladder not be widened unconditionally. -->
+    <div class="gv-tilesctl">
+      <button
+        type="button"
+        class="act"
+        :class="{ on: tilesMenuOpen }"
+        aria-haspopup="true"
+        :aria-expanded="tilesMenuOpen"
+        title="Show or hide fleet info tiles"
+        @click="tilesMenuOpen = !tilesMenuOpen"
+      >Tiles ▾</button>
+      <div v-if="tilesMenuOpen" class="gv-tilesmenu" @pointerdown.stop>
+        <p v-if="!widgetCatalog.length" class="empty">No info tiles available.</p>
+        <label v-for="w in widgetCatalog" :key="w.id">
+          <input
+            type="checkbox"
+            :checked="isWidgetOn(w)"
+            @change="gridStore.setWidgetEnabled(w.id, $event.target.checked)"
+          />
+          <span>{{ w.title }}</span>
+        </label>
+        <button type="button" class="reset" @click="resetTiles">Reset to defaults</button>
+      </div>
+    </div>
 
     <!-- PROTOTYPE org overlay controls -->
     <div class="gv-orgctl">
@@ -249,6 +307,8 @@
 <script setup>
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import AgentTile from './AgentTile.vue'
+// Side-effect import: registers the info-tile catalog into GRID_WIDGETS.
+import './tiles/catalog'
 import { useFleetGridStore } from '@/stores/fleetGrid'
 import {
   CELL_W,
@@ -263,6 +323,13 @@ import {
   layoutBBox,
   occupantAt,
 } from '@/utils/gridLayout'
+import {
+  catalogFor,
+  isWidgetEnabled,
+  widgetById,
+  widgetIdFromKey,
+} from '@/utils/gridWidgets'
+import { zoneAt } from '@/utils/gridOrg'
 import { useOrgOverlay } from '@/composables/useOrgOverlay'
 
 /**
@@ -350,11 +417,46 @@ const placedAgents = computed(() =>
   props.agents.filter((a) => layout.value[a.name])
 )
 
+// --- info tiles (ent#325) ---
+const tilesMenuOpen = ref(false)
+const widgetCatalog = computed(() => catalogFor(gridStore.isAdmin))
+function isWidgetOn(entry) {
+  return isWidgetEnabled(entry, gridStore.widgetPrefs)
+}
+function resetTiles() {
+  gridStore.resetWidgets()
+  tilesMenuOpen.value = false
+}
+
+/** Enabled tiles that have a position — the widget analogue of placedAgents. */
+const placedWidgets = computed(() =>
+  gridStore.activeWidgetKeys
+    .filter((key) => layout.value[key])
+    .map((key) => ({ key, entry: widgetById(widgetIdFromKey(key)) }))
+    .filter((w) => w.entry && w.entry.component)
+)
+
+/**
+ * Veto cells that fall inside a department frame when seeding a new tile
+ * (#305 interlock D). Rows -3..-1 are empty of TILES, but a department whose
+ * members were dragged upward has a hull that reaches there, and a tile
+ * seeded inside that frame would read as one of its members.
+ */
+function isCellBlocked(c, r) {
+  if (!zones.value || zones.value.length === 0) return false
+  const [x, y] = cellXY(c, r)
+  return !!zoneAt(zones.value, x + CELL_W / 2, y + CELL_H / 2)
+}
+
 function syncLayoutFromAgents() {
   const names = props.agents.map((a) => a.name)
   const systemNames = new Set(props.agents.filter((a) => a.is_system).map((a) => a.name))
-  gridStore.syncLayout(names, systemNames, newcomerOriginFor)
+  gridStore.syncLayout(names, systemNames, newcomerOriginFor, isCellBlocked)
 }
+
+// Toggling a tile on/off re-runs the reconcile so it is seeded (or dropped)
+// immediately rather than on the next roster change.
+watch(() => gridStore.activeWidgetKeys.join('\n'), () => syncLayoutFromAgents())
 
 
 // --- viewport culling (#47: render/hydrate only tiles near the viewport) ---
@@ -365,15 +467,25 @@ const visibleNames = computed(() => {
   if (!vw || !vh) return set
   const x0 = -vtx.value / vz.value
   const y0 = -vty.value / vz.value
-  const w = vw / vz.value
+  const w2 = vw / vz.value
   const h = vh / vz.value
-  const mx = w * 0.6
+  const mx = w2 * 0.6
   const my = h * 0.6
   for (const agent of placedAgents.value) {
     const p = layout.value[agent.name]
     const [x, y] = cellXY(p.c, p.r)
-    if (x + CELL_W >= x0 - mx && x <= x0 + w + mx && y + CELL_H >= y0 - my && y <= y0 + h + my) {
+    if (x + CELL_W >= x0 - mx && x <= x0 + w2 + mx && y + CELL_H >= y0 - my && y <= y0 + h + my) {
       set.add(agent.name)
+    }
+  }
+  // Info tiles cull on the same rule (ent#325) — a far-away tile renders a
+  // light placeholder and fetches nothing, exactly like an agent tile.
+  for (const w of placedWidgets.value) {
+    const p = layout.value[w.key]
+    if (!p) continue
+    const [x, y] = cellXY(p.c, p.r)
+    if (x + CELL_W >= x0 - mx && x <= x0 + w2 + mx && y + CELL_H >= y0 - my && y <= y0 + h + my) {
+      set.add(w.key)
     }
   }
   if (draggingName.value) set.add(draggingName.value)
@@ -757,6 +869,11 @@ function resetToDefault() {
   const names = props.agents.map((a) => a.name)
   const systemNames = new Set(props.agents.filter((a) => a.is_system).map((a) => a.name))
   gridStore.resetLayout(names, systemNames)
+  // `resetLayout` rebuilds the AGENT default layout only, so re-run the
+  // reconcile to seed enabled tiles back into the band above it (ent#325) —
+  // otherwise "Reset layout" silently removes every info tile until the next
+  // roster change happens to trigger a sync.
+  syncLayoutFromAgents()
   nextTick(fitView)
 }
 
@@ -1312,6 +1429,88 @@ onBeforeUnmount(() => {
 .gv-tile.linktarget {
   border-color: color-mix(in srgb, var(--gv-blue) 70%, var(--gv-border));
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--gv-blue) 20%, transparent), var(--gv-tile-shadow);
+}
+
+/* --- info tiles: Tiles menu + widget chassis (ent#325) --- */
+/* Sits directly under the org cluster, sharing its chrome, so the header
+   ladder gains no fifth top-level button. */
+.gv-tilesctl {
+  position: absolute;
+  top: 58px;
+  right: 16px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+.gv-tilesctl > button {
+  border: 0;
+  background: var(--gv-panel);
+  border: 1px solid var(--gv-border);
+  color: var(--gv-muted);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: var(--gv-tile-shadow, 0 1px 2px rgba(0, 0, 0, 0.08));
+}
+.gv-tilesctl > button:hover,
+.gv-tilesctl > button.on {
+  background: var(--gv-btn-bg-hover);
+  color: var(--gv-fg);
+}
+.gv-tilesmenu {
+  min-width: 190px;
+  padding: 8px;
+  border-radius: 10px;
+  background: var(--gv-panel);
+  border: 1px solid var(--gv-border);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.gv-tilesmenu label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 6px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--gv-fg);
+  cursor: pointer;
+}
+.gv-tilesmenu label:hover {
+  background: var(--gv-btn-bg-hover);
+}
+.gv-tilesmenu .empty {
+  margin: 0;
+  padding: 6px;
+  font-size: 12px;
+  color: var(--gv-muted);
+}
+.gv-tilesmenu .reset {
+  margin-top: 4px;
+  border: 0;
+  border-top: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.08));
+  background: transparent;
+  color: var(--gv-muted);
+  font: inherit;
+  font-size: 11px;
+  padding: 7px 6px 3px;
+  text-align: left;
+  cursor: pointer;
+}
+.gv-tilesmenu .reset:hover {
+  color: var(--gv-fg);
+}
+/* The widget chassis reuses .gv-tile wholesale (drag physics, snap, focus
+   ring). Only the drop shadow differs, so an info tile reads as board
+   furniture rather than as a fleet member. */
+.gv-tile-widget {
+  --gv-tile-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .gv-orgctl {

--- a/src/frontend/src/components/InfoTile.vue
+++ b/src/frontend/src/components/InfoTile.vue
@@ -1,0 +1,237 @@
+<template>
+  <article class="it" :class="{ 'is-error': state === 'error' }">
+    <!-- Half-inset SQUARE peg. AgentTile's peg is a round avatar; the shape
+         is the at-a-glance "this is not an agent" signal, so it must stay
+         square even if the icon changes. Kept inside the GAP_X budget (40px)
+         so it can never collide with an adjacent department frame's chrome
+         (#305 ZONE_CHROME contract, ent#325 interlock C). -->
+    <div class="it-peg" aria-hidden="true">
+      <slot name="icon">
+        <svg viewBox="0 0 24 24" width="18" height="18"><rect x="3" y="3" width="18" height="18" rx="3"></rect></svg>
+      </slot>
+    </div>
+
+    <header class="it-head">
+      <div class="it-titles">
+        <span class="it-scope">{{ scope }} ·</span>
+        <h3 class="it-title">{{ title }}</h3>
+      </div>
+      <span v-if="stamp" class="it-stamp" :title="stampTitle || undefined">{{ stamp }}</span>
+    </header>
+
+    <div class="it-body">
+      <!-- Loading is an honest skeleton, never a spinner over stale numbers:
+           a tile that looks live while showing last week's figures is worse
+           than one that admits it is loading (ent#325 AC). -->
+      <div v-if="state === 'loading'" class="it-skel" role="status" aria-label="Loading">
+        <span class="l l1"></span><span class="l l2"></span><span class="l l3"></span>
+      </div>
+
+      <!-- Per-tile failure degrades THIS tile only — the grid and every
+           sibling stay live (#47 hydration contract, ent#325 AC). -->
+      <div v-else-if="state === 'error'" class="it-msg">
+        <b>Couldn't load</b>
+        <span>{{ errorText || 'This tile only — the rest of the board is unaffected.' }}</span>
+        <button v-if="onRetry" type="button" class="nodrag" @click.stop="onRetry">Retry</button>
+      </div>
+
+      <!-- An empty state names the next action rather than showing a void
+           (ent#325 AC: "non-dead empty state"). -->
+      <div v-else-if="state === 'empty'" class="it-msg">
+        <b>{{ emptyTitle || 'Nothing yet' }}</b>
+        <span>{{ emptyHint }}</span>
+      </div>
+
+      <slot v-else></slot>
+    </div>
+
+    <footer v-if="linkTo" class="it-foot">
+      <RouterLink class="nodrag" :to="linkTo" @pointerdown.stop>{{ linkLabel }}</RouterLink>
+    </footer>
+  </article>
+</template>
+
+<script setup>
+/**
+ * InfoTile (trinity-enterprise#325) — the shell every fleet info tile renders
+ * inside. The chassis half of epic #94's widget architecture.
+ *
+ * Deliberately NOT an agent tile:
+ *   - no Run / Autonomy toggles. Info tiles summarize; they do not operate.
+ *     Giving a fleet-scope tile an operating control would make the blast
+ *     radius of a misclick the whole fleet.
+ *   - no org-overlay affordances. `AgentTile` gained a bottom-center connect
+ *     port for reporting lines (#305); an info tile is not an org node, so it
+ *     has no port, cannot be a reporting-line endpoint, and is not a `dept-*`
+ *     drop target. Enforced by omission here and by key namespace upstream.
+ *
+ * Interactive children carry `.nodrag`, which `FleetGrid.onTilePointerDown`
+ * checks before starting a drag — otherwise clicking a tile's own link would
+ * begin a tile drag instead.
+ */
+defineProps({
+  /** Scope prefix rendered before the title: "Fleet", "Host", … */
+  scope: { type: String, default: 'Fleet' },
+  title: { type: String, required: true },
+  /** Freshness / window stamp, e.g. "24h" or "updated 2m ago". */
+  stamp: { type: String, default: '' },
+  stampTitle: { type: String, default: '' },
+  /** 'ready' | 'loading' | 'error' | 'empty' */
+  state: { type: String, default: 'ready' },
+  errorText: { type: String, default: '' },
+  emptyTitle: { type: String, default: '' },
+  emptyHint: { type: String, default: '' },
+  /** vue-router target for the footer deep-link into the owning surface. */
+  linkTo: { type: [String, Object], default: null },
+  linkLabel: { type: String, default: 'Open' },
+  onRetry: { type: Function, default: null },
+})
+</script>
+
+<style scoped>
+/* Tokens come from the --gv-* cascade FleetGrid establishes, so an info tile
+   and an agent tile can never drift apart on colour. */
+.it {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  padding: 14px 16px 10px 30px;
+  border-radius: var(--gv-radius, 14px);
+  background: var(--gv-tile-bg, #fff);
+  border: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.08));
+  box-shadow: var(--gv-tile-shadow, 0 1px 2px rgba(0, 0, 0, 0.06));
+  overflow: hidden;
+}
+.it.is-error {
+  border-color: var(--gv-danger-border, rgba(220, 38, 38, 0.35));
+}
+
+/* Half-inset square peg: 32px wide, 16px of it outside the tile's left edge.
+   16 < GAP_X (40), so it stays inside the inter-column gap budget. */
+.it-peg {
+  position: absolute;
+  left: -16px;
+  top: 16px;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  background: var(--gv-peg-bg, #111827);
+  color: var(--gv-peg-fg, #fff);
+  border: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.08));
+}
+.it-peg :deep(svg) {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.it-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 20px;
+}
+.it-titles {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+}
+.it-scope {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--gv-muted, #6b7280);
+  flex: none;
+}
+.it-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--gv-fg, #111827);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.it-stamp {
+  font-size: 11px;
+  color: var(--gv-muted, #6b7280);
+  flex: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.it-body {
+  flex: 1;
+  min-height: 0;
+  margin-top: 10px;
+  overflow: hidden;
+}
+
+.it-skel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 4px;
+}
+.it-skel .l {
+  height: 12px;
+  border-radius: 6px;
+  background: var(--gv-skel, rgba(0, 0, 0, 0.07));
+  animation: it-pulse 1.4s ease-in-out infinite;
+}
+.it-skel .l1 { width: 62%; }
+.it-skel .l2 { width: 88%; animation-delay: 0.15s; }
+.it-skel .l3 { width: 44%; animation-delay: 0.3s; }
+@keyframes it-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .it-skel .l { animation: none; }
+}
+
+.it-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+  font-size: 12px;
+  color: var(--gv-muted, #6b7280);
+}
+.it-msg b {
+  font-size: 13px;
+  color: var(--gv-fg, #111827);
+}
+.it-msg button {
+  margin-top: 6px;
+  font: inherit;
+  padding: 3px 10px;
+  border-radius: 7px;
+  cursor: pointer;
+  border: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.12));
+  background: transparent;
+  color: inherit;
+}
+
+.it-foot {
+  margin-top: auto;
+  padding-top: 8px;
+  font-size: 11px;
+}
+.it-foot a {
+  color: var(--gv-muted, #6b7280);
+  text-decoration: none;
+}
+.it-foot a:hover {
+  color: var(--gv-fg, #111827);
+  text-decoration: underline;
+}
+</style>

--- a/src/frontend/src/components/InfoTile.vue
+++ b/src/frontend/src/components/InfoTile.vue
@@ -100,8 +100,8 @@ defineProps({
   box-sizing: border-box;
   padding: 14px 16px 10px 30px;
   border-radius: var(--gv-radius, 14px);
-  background: var(--gv-tile-bg, #fff);
-  border: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.08));
+  background: var(--gv-tile, rgba(255, 255, 255, 0.9));
+  border: 1px solid var(--gv-border, #e5e7eb);
   box-shadow: var(--gv-tile-shadow, 0 1px 2px rgba(0, 0, 0, 0.06));
   overflow: hidden;
 }
@@ -122,7 +122,7 @@ defineProps({
   border-radius: 8px;
   background: var(--gv-peg-bg, #111827);
   color: var(--gv-peg-fg, #fff);
-  border: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.08));
+  border: 1px solid var(--gv-border, #e5e7eb);
 }
 .it-peg :deep(svg) {
   fill: none;
@@ -156,7 +156,7 @@ defineProps({
   margin: 0;
   font-size: 13px;
   font-weight: 650;
-  color: var(--gv-fg, #111827);
+  color: var(--gv-text, #111827);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -208,7 +208,7 @@ defineProps({
 }
 .it-msg b {
   font-size: 13px;
-  color: var(--gv-fg, #111827);
+  color: var(--gv-text, #111827);
 }
 .it-msg button {
   margin-top: 6px;
@@ -216,7 +216,7 @@ defineProps({
   padding: 3px 10px;
   border-radius: 7px;
   cursor: pointer;
-  border: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.12));
+  border: 1px solid var(--gv-border, #e5e7eb);
   background: transparent;
   color: inherit;
 }
@@ -231,7 +231,7 @@ defineProps({
   text-decoration: none;
 }
 .it-foot a:hover {
-  color: var(--gv-fg, #111827);
+  color: var(--gv-text, #111827);
   text-decoration: underline;
 }
 </style>

--- a/src/frontend/src/components/tiles/FleetSummaryTile.vue
+++ b/src/frontend/src/components/tiles/FleetSummaryTile.vue
@@ -1,0 +1,90 @@
+<template>
+  <InfoTile
+    scope="Fleet"
+    title="Fleet summary"
+    :stamp="`${agents.length} agent${agents.length === 1 ? '' : 's'}`"
+    :state="agents.length ? 'ready' : 'empty'"
+    empty-title="No agents yet"
+    empty-hint="Create an agent and it appears on this board."
+    :link-to="{ name: 'Agents' }"
+    link-label="Open the fleet →"
+  >
+    <template #icon>
+      <svg viewBox="0 0 24 24" width="18" height="18">
+        <rect x="3" y="3" width="7" height="7" rx="1.5"></rect>
+        <rect x="14" y="3" width="7" height="7" rx="1.5"></rect>
+        <rect x="3" y="14" width="7" height="7" rx="1.5"></rect>
+        <rect x="14" y="14" width="7" height="7" rx="1.5"></rect>
+      </svg>
+    </template>
+
+    <dl class="fs">
+      <div v-for="s in stats" :key="s.label" class="fs-item">
+        <dt>{{ s.label }}</dt>
+        <dd :class="s.tone">{{ s.value }}</dd>
+      </div>
+    </dl>
+  </InfoTile>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import InfoTile from '../InfoTile.vue'
+
+/**
+ * Fleet summary — the chassis's REFERENCE tile (trinity-enterprise#325).
+ *
+ * Its job is to prove the chassis, not to be the interesting tile: it reads
+ * the `agents` array `FleetGrid` already holds and issues no request, so the
+ * widget foundation carries no data dependency of its own and could not be
+ * blocked behind the sibling `GET /api/executions/timeline` work (ent#326).
+ *
+ * The real catalog arrives one sub-issue at a time (#95 host resources, #96
+ * executions, #97 Cornelius mind, #98 cost, #99 next schedules, #100 recent
+ * failures, #101 tokens, #259 subscription pressure).
+ */
+const props = defineProps({
+  agents: { type: Array, default: () => [] },
+})
+
+const stats = computed(() => {
+  const total = props.agents.length
+  const running = props.agents.filter((a) => a.status === 'running').length
+  const autonomous = props.agents.filter((a) => a.autonomy_enabled).length
+  return [
+    { label: 'Running', value: `${running}/${total}`, tone: running ? 'ok' : 'muted' },
+    { label: 'Autonomous', value: String(autonomous), tone: 'muted' },
+    { label: 'Stopped', value: String(total - running), tone: total - running ? 'warn' : 'muted' },
+  ]
+})
+</script>
+
+<style scoped>
+.fs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin: 0;
+}
+.fs-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.fs-item dt {
+  font-size: 11px;
+  color: var(--gv-muted, #6b7280);
+  white-space: nowrap;
+}
+.fs-item dd {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--gv-fg, #111827);
+}
+.fs-item dd.ok { color: var(--gv-ok, #059669); }
+.fs-item dd.warn { color: var(--gv-warn, #b45309); }
+.fs-item dd.muted { color: var(--gv-fg, #111827); }
+</style>

--- a/src/frontend/src/components/tiles/FleetSummaryTile.vue
+++ b/src/frontend/src/components/tiles/FleetSummaryTile.vue
@@ -82,9 +82,9 @@ const stats = computed(() => {
   font-size: 22px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  color: var(--gv-fg, #111827);
+  color: var(--gv-text, #111827);
 }
-.fs-item dd.ok { color: var(--gv-ok, #059669); }
-.fs-item dd.warn { color: var(--gv-warn, #b45309); }
-.fs-item dd.muted { color: var(--gv-fg, #111827); }
+.fs-item dd.ok { color: var(--gv-green-text, #16a34a); }
+.fs-item dd.warn { color: var(--gv-yellow-text, #a16207); }
+.fs-item dd.muted { color: var(--gv-text, #111827); }
 </style>

--- a/src/frontend/src/components/tiles/FleetSummaryTile.vue
+++ b/src/frontend/src/components/tiles/FleetSummaryTile.vue
@@ -6,7 +6,7 @@
     :state="agents.length ? 'ready' : 'empty'"
     empty-title="No agents yet"
     empty-hint="Create an agent and it appears on this board."
-    :link-to="{ name: 'Agents' }"
+    :link-to="{ name: 'Dashboard', query: { view: 'list' } }"
     link-label="Open the fleet →"
   >
     <template #icon>

--- a/src/frontend/src/components/tiles/catalog.js
+++ b/src/frontend/src/components/tiles/catalog.js
@@ -1,0 +1,25 @@
+/**
+ * Grid info-tile catalog (trinity-enterprise#325).
+ *
+ * Imported for its SIDE EFFECT by `FleetGrid.vue`: each entry registers into
+ * the `GRID_WIDGETS` registry in `utils/gridWidgets.js`. That module stays
+ * free of `.vue` imports so it remains unit-testable under vitest's node
+ * environment — this file is where the component references live instead.
+ *
+ * Adding a tile (epic #94 sub-issues #95-#101, #259) is one block here plus
+ * the component. Components are imported eagerly, not lazily: a tile that
+ * fails to resolve should break the build rather than render as a silent
+ * blank cell on an operator's dashboard.
+ */
+import { registerWidget } from '@/utils/gridWidgets'
+import FleetSummaryTile from './FleetSummaryTile.vue'
+
+registerWidget({
+  id: 'fleet-summary',
+  title: 'Fleet summary',
+  scope: 'Fleet',
+  component: FleetSummaryTile,
+  adminOnly: false,
+  defaultOn: true,
+  cells: { w: 1, h: 1 },
+})

--- a/src/frontend/src/stores/fleetGrid.js
+++ b/src/frontend/src/stores/fleetGrid.js
@@ -10,6 +10,11 @@ import {
   tidyLayout,
   occupantAt,
 } from '@/utils/gridLayout'
+import {
+  isWidgetKey,
+  enabledWidgetKeys,
+  seedWidgetCells,
+} from '@/utils/gridWidgets'
 
 /**
  * Fleet Grid store (trinity-enterprise#47) — owns the Dashboard Grid view's
@@ -27,7 +32,17 @@ import {
  *     while the Grid is mounted.
  */
 
-const LAYOUT_KEY = 'trinity-grid-layout-v1'
+// ent#325: layout v2 admits `widget:*` keys alongside agents. The key is
+// bumped rather than reused so a v1 client and a v2 client on the same browser
+// cannot fight over one blob — and the migration is a one-time COPY, leaving
+// v1 in place, so downgrading is not a data-loss event.
+const LAYOUT_KEY_V1 = 'trinity-grid-layout-v1'
+const LAYOUT_KEY = 'trinity-grid-layout-v2'
+// Sparse `{ widgetId: boolean }` OVERRIDE map — see gridWidgets.isWidgetEnabled.
+// Its own key: the org overlay (#305) persists Zones/Lines under keys of its
+// own and the tile prefs must not be entangled with either, so that "Reset
+// tiles" cannot clobber an overlay toggle (ent#325 scope note).
+const WIDGET_PREFS_KEY = 'trinity-grid-widgets-v1'
 const ANALYTICS_WINDOW = '14d' // one fetch feeds Activity·14d + Context·7d (last 7 entries)
 const ANALYTICS_STALE_MS = 5 * 60 * 1000
 const HYDRATE_CONCURRENCY = 4
@@ -52,12 +67,65 @@ export const useFleetGridStore = defineStore('fleetGrid', () => {
     try {
       const raw = localStorage.getItem(LAYOUT_KEY)
       const parsed = raw ? JSON.parse(raw) : null
-      _savedRaw = parsed && typeof parsed === 'object' ? parsed : {}
+      if (parsed && typeof parsed === 'object') {
+        _savedRaw = parsed
+        return _savedRaw
+      }
+      // One-time v1 -> v2 migration. v1 holds agent keys only, so the copy is
+      // straight; widgets are seeded afterwards by `syncLayout` into the band
+      // above the fleet, which is why an existing constellation does not move.
+      const legacy = localStorage.getItem(LAYOUT_KEY_V1)
+      const legacyParsed = legacy ? JSON.parse(legacy) : null
+      _savedRaw =
+        legacyParsed && typeof legacyParsed === 'object' ? { ...legacyParsed } : {}
+      if (Object.keys(_savedRaw).length) {
+        try {
+          localStorage.setItem(LAYOUT_KEY, JSON.stringify(_savedRaw))
+        } catch {
+          /* private mode */
+        }
+      }
     } catch {
       _savedRaw = {}
     }
     return _savedRaw
   }
+
+  // --- info-tile show/hide preferences (ent#325) ---
+  const widgetPrefs = ref({})
+  try {
+    const raw = localStorage.getItem(WIDGET_PREFS_KEY)
+    const parsed = raw ? JSON.parse(raw) : null
+    if (parsed && typeof parsed === 'object') widgetPrefs.value = parsed
+  } catch {
+    /* defaults */
+  }
+
+  function _persistWidgetPrefs() {
+    try {
+      localStorage.setItem(WIDGET_PREFS_KEY, JSON.stringify(widgetPrefs.value))
+    } catch {
+      /* private mode — session-local */
+    }
+  }
+
+  function setWidgetEnabled(id, enabled) {
+    widgetPrefs.value = { ...widgetPrefs.value, [id]: !!enabled }
+    _persistWidgetPrefs()
+  }
+
+  /** Back to catalog defaults (an empty override map IS "defaults"). */
+  function resetWidgets() {
+    widgetPrefs.value = {}
+    _persistWidgetPrefs()
+  }
+
+  const isAdmin = computed(() => authStore.user?.role === 'admin')
+
+  /** Layout keys of the tiles that should be on the board for this viewer. */
+  const activeWidgetKeys = computed(() =>
+    enabledWidgetKeys(isAdmin.value, widgetPrefs.value)
+  )
 
   function _persist() {
     _savedRaw = { ..._loadSavedRaw(), ...layout.value }
@@ -75,16 +143,34 @@ export const useFleetGridStore = defineStore('fleetGrid', () => {
    * nearest free cell. Falls back to the deterministic default layout when
    * nothing usable is saved.
    */
-  function syncLayout(agentNames, systemNames = new Set(), originFor = null) {
-    const saved = { ..._loadSavedRaw(), ...layout.value }
+  function syncLayout(
+    agentNames,
+    systemNames = new Set(),
+    originFor = null,
+    isCellBlocked = null
+  ) {
+    const widgetKeys = activeWidgetKeys.value
+    let saved = { ..._loadSavedRaw(), ...layout.value }
     if (Object.keys(saved).length === 0) {
-      layout.value = defaultLayout(agentNames, systemNames)
-      _persist()
-      return
+      saved = defaultLayout(agentNames, systemNames)
     }
-    const { layout: healed, changed } = normalizeLayout(saved, agentNames, originFor)
+    // Seed any enabled tile that has never been placed into the band ABOVE the
+    // fleet, consulting the caller's veto for cells inside a department frame
+    // (#305 interlock D). Seeding BEFORE normalize means the tile arrives with
+    // a real position rather than being treated as a homeless newcomer and
+    // dropped at the board origin, on top of the agents.
+    const unplaced = widgetKeys.filter((k) => !saved[k])
+    if (unplaced.length) {
+      saved = { ...saved, ...seedWidgetCells(saved, unplaced, isCellBlocked) }
+    }
+    const { layout: healed, changed } = normalizeLayout(
+      saved,
+      agentNames,
+      originFor,
+      widgetKeys
+    )
     layout.value = healed
-    if (changed) _persist()
+    if (changed || unplaced.length) _persist()
   }
 
   /** Drop a tile on `(c, r)`; an occupied target swaps with the dragged tile. */
@@ -106,6 +192,9 @@ export const useFleetGridStore = defineStore('fleetGrid', () => {
   function resetLayout(agentNames, systemNames = new Set()) {
     try {
       localStorage.removeItem(LAYOUT_KEY)
+      // v1 too, or the next _loadSavedRaw migrates the stale blob straight
+      // back in and "Reset layout" appears not to have worked (ent#325).
+      localStorage.removeItem(LAYOUT_KEY_V1)
     } catch {
       /* ignore */
     }
@@ -121,9 +210,21 @@ export const useFleetGridStore = defineStore('fleetGrid', () => {
     _persist()
   }
 
-  /** Replace the whole layout (org-overlay "Group by department" arrange). */
+  /**
+   * Replace the layout (org-overlay "Group by department" / zone tidy).
+   *
+   * Belt to `gridOrg`'s braces (ent#325 interlock A): those helpers now carry
+   * `widget:*` keys through themselves, but this was a blind wholesale replace
+   * and a single caller forgetting to pass the current layout would silently
+   * delete every info tile. Two independent guards, because one of them being
+   * the only guard is exactly how the bug existed in the first place.
+   */
   function applyLayout(map) {
-    layout.value = { ...map }
+    const carried = {}
+    for (const [k, p] of Object.entries(layout.value)) {
+      if (isWidgetKey(k) && !(k in map)) carried[k] = p
+    }
+    layout.value = { ...carried, ...map }
     _persist()
   }
 
@@ -298,6 +399,11 @@ export const useFleetGridStore = defineStore('fleetGrid', () => {
 
   return {
     layout,
+    widgetPrefs,
+    activeWidgetKeys,
+    isAdmin,
+    setWidgetEnabled,
+    resetWidgets,
     syncLayout,
     moveTile,
     tidy,

--- a/src/frontend/src/utils/gridLayout.js
+++ b/src/frontend/src/utils/gridLayout.js
@@ -110,14 +110,23 @@ export function defaultLayout(agentNames, systemNames = new Set()) {
  *   - an invalid or colliding saved position resolves to the nearest free cell
  * Returns `{ layout, changed }` — `changed` signals the caller to re-persist.
  */
-export function normalizeLayout(saved, agentNames, originFor = null) {
+export function normalizeLayout(saved, agentNames, originFor = null, widgetKeys = []) {
   const layout = {}
   let changed = false
-  const names = [...agentNames]
+  // Agents FIRST, then widgets (ent#325). Order matters: on a collision the
+  // first pass keeps whoever it reaches first, and an agent's saved position
+  // is the one a user is more likely to have arranged deliberately — an info
+  // tile evicted to a neighbouring cell is a smaller surprise than a fleet
+  // constellation shifting under them.
+  const names = [...agentNames, ...widgetKeys]
   const source = saved && typeof saved === 'object' ? saved : {}
+  const live = new Set(names)
 
-  // Drop entries for agents that no longer exist (gap remains free).
-  if (Object.keys(source).some((n) => !agentNames.includes(n))) changed = true
+  // Drop entries for occupants that no longer exist (gap remains free).
+  // `live` covers widgets too — checking against `agentNames` alone would
+  // report `changed` on every pass for any board carrying a widget, which
+  // re-persists localStorage once per reconcile forever.
+  if (Object.keys(source).some((n) => !live.has(n))) changed = true
 
   // First pass: keep valid, non-colliding saved positions.
   const pending = []
@@ -132,8 +141,14 @@ export function normalizeLayout(saved, agentNames, originFor = null) {
   }
 
   // Second pass: place newcomers / evicted entries near their origin.
+  // `originFor` is agent-only by contract (a widget has no department, so the
+  // org overlay has no zone to seed it beside) — widgets fall through to the
+  // board origin here, and their DEFAULT placement is owned by
+  // `gridWidgets.seedWidgetCells`, which knows about the band above the fleet.
   for (const name of pending) {
-    const origin = (originFor && originFor(name, layout)) || { c: 0, r: 0 }
+    const origin =
+      (originFor && !name.startsWith('widget:') && originFor(name, layout)) ||
+      { c: 0, r: 0 }
     const o = isValidPos(origin) ? origin : { c: 0, r: 0 }
     layout[name] = nearestFreeCell(layout, o.c, o.r)
     changed = true

--- a/src/frontend/src/utils/gridOrg.js
+++ b/src/frontend/src/utils/gridOrg.js
@@ -21,6 +21,27 @@
  */
 
 import { CELL_W, CELL_H, GAP_X, GAP_Y, cellXY, nearestFreeCell } from './gridLayout'
+import { isWidgetKey } from './gridWidgets'
+
+/**
+ * Layout entries that are NOT agents — today, info tiles (ent#325).
+ *
+ * Both arrange helpers below rebuild a FRESH map keyed from the `agents`
+ * array, and `fleetGrid.applyLayout` replaces the layout wholesale, so
+ * without this every `widget:*` position was destroyed by a single "Tidy up"
+ * or "Group by dept" the moment the org overlay was on. Seeding the output
+ * with these keys first both preserves them and makes them obstacles the
+ * agent placement flows around, since both helpers place through
+ * `nearestFreeCell`.
+ */
+function nonAgentEntries(layout, agents) {
+  const agentNames = new Set((agents || []).map((a) => a.name))
+  const out = {}
+  for (const [k, p] of Object.entries(layout || {})) {
+    if (!agentNames.has(k) && isWidgetKey(k)) out[k] = { c: p.c, r: p.r }
+  }
+  return out
+}
 
 export const DEPT_PREFIX = 'dept-'
 export const REPORTS_PREFIX = 'reports-to-'
@@ -254,7 +275,7 @@ function blockCols(n) {
  * blocks pack densely and the grid stays uniform. Output is a normal layout
  * map — fully hand-editable afterwards, exactly like Tidy.
  */
-export function arrangeByDept(agents, meta) {
+export function arrangeByDept(agents, meta, layout = null) {
   const m = meta || orgMeta(agents)
   const groups = new Map()
   for (const a of agents) {
@@ -269,7 +290,12 @@ export function arrangeByDept(agents, meta) {
     return y[1].length - x[1].length || x[0].localeCompare(y[0])
   })
   const MAX_COLS = 8
-  const layout = {}
+  // Seed with the info tiles so their positions survive the arrange and the
+  // department blocks flow around them (ent#325 AC). With no widgets on the
+  // board `nearestFreeCell` returns every requested cell unchanged, so the
+  // department layout is byte-identical to the pre-ent#325 behaviour — pinned
+  // by a test, because that equivalence is the whole reason this is safe.
+  const out = nonAgentEntries(layout, agents)
   let blockC = 0
   let blockR = 0
   let bandRows = 0
@@ -282,12 +308,12 @@ export function arrangeByDept(agents, meta) {
       bandRows = 0
     }
     names.forEach((n, i) => {
-      layout[n] = { c: blockC + (i % cols), r: blockR + Math.floor(i / cols) }
+      out[n] = nearestFreeCell(out, blockC + (i % cols), blockR + Math.floor(i / cols))
     })
     blockC += cols
     bandRows = Math.max(bandRows, rows)
   }
-  return layout
+  return out
 }
 
 /**
@@ -321,7 +347,9 @@ export function tidyByDept(layout, agents, meta) {
     return { dept, names: ordered, minC, minR }
   })
   entries.sort((a, b) => a.minR - b.minR || a.minC - b.minC)
-  const out = {}
+  // Seed with the info tiles (ent#325): preserved, and treated as obstacles
+  // by the `nearestFreeCell` placement below.
+  const out = nonAgentEntries(layout, agents)
   for (const g of entries) {
     const cols = blockCols(g.names.length)
     g.names.forEach((n, i) => {

--- a/src/frontend/src/utils/gridWidgets.js
+++ b/src/frontend/src/utils/gridWidgets.js
@@ -1,0 +1,185 @@
+/**
+ * Grid widget registry (trinity-enterprise#325, foundation for epic #94).
+ *
+ * Info tiles are just another occupant of the same magnetic lattice agent
+ * tiles live on: same 384x216 chassis, same `--gv-*` tokens, same drag/swap/
+ * tidy/keyboard physics. The ONLY thing that distinguishes them in the layout
+ * map is the key namespace.
+ *
+ * ## Why a `widget:` key prefix rather than a second map
+ *
+ * The drag machinery in `FleetGrid.vue` is keyed entirely off `layout[name]`
+ * and a `data-agent` attribute. Putting widgets in the SAME map means drag,
+ * swap-with-preview, keyboard reorder, viewport culling and the snap socket
+ * all work for widgets with no second code path — which is also the only way
+ * "full parity with agent tiles" stays true as those behaviours evolve.
+ *
+ * `:` is safe as the separator because it cannot appear in an agent name:
+ * `utils/helpers.sanitize_agent_name` strips everything outside
+ * `[A-Za-z0-9_-]`, so a `widget:*` key can never collide with a real agent,
+ * and `isWidgetKey` is an exact answer rather than a heuristic.
+ *
+ * ## Registry shape
+ *
+ * `{ id, title, icon, component, adminOnly, defaultOn, cells }`
+ *
+ * `cells` is declared now and deliberately ignored by v1 rendering: every
+ * tile occupies one cell. Multi-cell occupancy is epic #94's stated v2, and
+ * declaring the field now means the catalog entries do not have to be rewritten
+ * when `gridLayout.js` learns occupancy — the registry is the thing a future
+ * "add custom tile" feature appends to, so its shape wants to be stable.
+ */
+
+import { COORD_LIMIT } from './gridLayout'
+
+export const WIDGET_PREFIX = 'widget:'
+
+/** True for a layout key that belongs to an info tile rather than an agent. */
+export function isWidgetKey(key) {
+  return typeof key === 'string' && key.startsWith(WIDGET_PREFIX)
+}
+
+/** `widget:fleet-summary` -> `fleet-summary`. */
+export function widgetIdFromKey(key) {
+  return isWidgetKey(key) ? key.slice(WIDGET_PREFIX.length) : null
+}
+
+/** `fleet-summary` -> `widget:fleet-summary`. */
+export function widgetKey(id) {
+  return `${WIDGET_PREFIX}${id}`
+}
+
+/**
+ * The tile catalog.
+ *
+ * v1 ships ONE tile — the chassis needs a real occupant for "default-on tiles
+ * render above the constellation" to be a testable claim rather than an
+ * assertion about an empty list, and epic #94's own acceptance criteria
+ * require it. It is deliberately the cheapest possible tile: it reads the
+ * agent array the grid already holds and issues no request, so the chassis
+ * carries no data dependency of its own and cannot be blocked by the sibling
+ * `GET /api/executions/timeline` work.
+ *
+ * The real catalog (#95 host resources, #96 executions, #97 Cornelius mind,
+ * #98 cost, #99 next schedules, #100 recent failures, #101 tokens, #259
+ * subscription pressure) appends here, one entry per sub-issue.
+ *
+ * `component` is a resolved component, not a name string: an unknown name
+ * fails at render as a blank tile, whereas an unresolved import fails at build.
+ */
+export const GRID_WIDGETS = []
+
+/** Register a tile. Exported so sub-issues add catalog entries in one line. */
+export function registerWidget(entry) {
+  const existing = GRID_WIDGETS.findIndex((w) => w.id === entry.id)
+  const normalized = {
+    adminOnly: false,
+    defaultOn: false,
+    cells: { w: 1, h: 1 },
+    ...entry,
+  }
+  if (existing >= 0) GRID_WIDGETS[existing] = normalized
+  else GRID_WIDGETS.push(normalized)
+  return normalized
+}
+
+/** Catalog entry by id, or null. */
+export function widgetById(id) {
+  return GRID_WIDGETS.find((w) => w.id === id) || null
+}
+
+/**
+ * The tiles this viewer may see: catalog minus `adminOnly` for non-admins.
+ *
+ * Visibility is a SEPARATE question from access. This only decides what is
+ * offered in the "Tiles" menu and rendered; every tile's data still comes
+ * from an access-scoped endpoint, so hiding is a UI courtesy and never the
+ * control (epic #94 AC: "all tile data inherits endpoint access scoping").
+ */
+export function catalogFor(isAdmin) {
+  return GRID_WIDGETS.filter((w) => !w.adminOnly || isAdmin)
+}
+
+/**
+ * Is this tile on, given the user's stored preferences?
+ *
+ * `prefs` is a sparse `{ id: boolean }` OVERRIDE map, not a list of enabled
+ * ids. Absent means "follow the catalog's `defaultOn`", which is what makes a
+ * tile added in a later release appear for existing users instead of staying
+ * invisible behind a stale allow-list — and equally lets a user keep a
+ * default-on tile switched off. "Reset" is therefore just `prefs = {}`.
+ */
+export function isWidgetEnabled(entry, prefs = {}) {
+  if (!entry) return false
+  const override = prefs[entry.id]
+  return typeof override === 'boolean' ? override : !!entry.defaultOn
+}
+
+/** Keys of the tiles that should currently be on the board, in catalog order. */
+export function enabledWidgetKeys(isAdmin, prefs = {}) {
+  return catalogFor(isAdmin)
+    .filter((w) => isWidgetEnabled(w, prefs))
+    .map((w) => widgetKey(w.id))
+}
+
+/**
+ * Default placement band for info tiles: the rows directly ABOVE the agent
+ * block, filled left-to-right.
+ *
+ * Seeding above rather than into the agent area is what makes epic #94's
+ * "default-on tiles appear without moving any saved agent position" true by
+ * construction — `defaultLayout` starts agents at r=0 and grows downward, so
+ * negative rows are unclaimed on every existing install.
+ *
+ * `isBlocked(c, r)` lets the caller veto a cell. The org overlay (#305) is the
+ * reason it exists: rows -3..-1 are empty of TILES, but a department whose
+ * members were dragged upward has a zone hull that reaches into them, and a
+ * widget seeded inside that frame would read as a member of a department it
+ * has nothing to do with. Optional — without it the band is used as-is.
+ */
+export function seedWidgetCells(layout, keys, isBlocked = null, band = [-3, -1]) {
+  const out = {}
+  if (!keys || keys.length === 0) return out
+  const occupied = new Set()
+  for (const p of Object.values(layout || {})) {
+    if (p && Number.isInteger(p.c) && Number.isInteger(p.r)) occupied.add(`${p.c},${p.r}`)
+  }
+  const [rTop, rBottom] = band
+  let c = 0
+  let r = rTop
+  for (const key of keys) {
+    // Walk the band left-to-right, row by row, skipping taken/vetoed cells.
+    let guard = 0
+    while (guard++ < COORD_LIMIT * 4) {
+      const taken = occupied.has(`${c},${r}`)
+      const vetoed = isBlocked ? isBlocked(c, r) : false
+      if (!taken && !vetoed) break
+      c++
+      if (c > COORD_LIMIT) {
+        c = 0
+        r = r < rBottom ? r + 1 : rTop - 1 // spill upward, never into the agents
+      }
+    }
+    out[key] = { c, r }
+    occupied.add(`${c},${r}`)
+    c++
+    if (c > COORD_LIMIT) {
+      c = 0
+      r = r < rBottom ? r + 1 : rTop - 1
+    }
+  }
+  return out
+}
+
+// --- catalog registration lives ELSEWHERE, on purpose --------------------
+//
+// This module stays PURE (no `.vue` imports) so `vitest.config.js`'s node
+// environment can import it directly — the registry, the key namespace and
+// the seeding band are exactly the logic that needs unit tests, and they
+// would be untestable here if importing this file dragged in an SFC.
+// `gridOrg.js` also imports `isWidgetKey` from here, so a component import
+// would break the existing `gridOrg.spec.js` too.
+//
+// Catalog entries therefore live in `components/tiles/catalog.js`, which
+// `FleetGrid.vue` imports for its side effect. Sub-issues add their tile
+// there, in one `registerWidget({...})` block.

--- a/src/frontend/tests/unit/gridTileLinks.spec.js
+++ b/src/frontend/tests/unit/gridTileLinks.spec.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Every info-tile link must name a route that EXISTS (trinity-enterprise#325).
+ *
+ * `FleetSummaryTile` shipped `:link-to="{ name: 'Agents' }"`. There is no route
+ * named `Agents` — the standalone Agents page was folded into the Dashboard
+ * (#1109-era), leaving `/agents` as an UNNAMED redirect to `/?view=list`. So
+ * the name resolved to nothing and `InfoTile`'s `<RouterLink :to>` threw during
+ * render.
+ *
+ * The cost was wildly out of proportion to the typo, which is why this is
+ * guarded rather than just fixed. A throw inside render aborts Vue's update for
+ * the whole tree, so the DASHBOARD FROZE: the type-to-filter e2e failed with
+ * the pill's input visibly holding "trinity" while the match-count never
+ * appeared and no tile ever filtered — the DOM kept the typed characters and
+ * Vue simply stopped re-rendering. Nothing in that symptom points at a link in
+ * a tile, and the tile itself renders as an empty box rather than an error.
+ *
+ * Static on purpose: `vitest.config.js` pins `environment: 'node'` (pure
+ * modules only, no DOM), so a mount test is not available here, and the e2e
+ * that DID catch it is `ui`-label-gated — it does not run on most PRs. Reading
+ * the source costs nothing and runs everywhere.
+ *
+ * This matters more as the catalog grows (epic #94: #95-#101, #259). Each new
+ * tile is "one block plus the component" per catalog.js, and every one of them
+ * can carry a link.
+ */
+
+const _dir = dirname(fileURLToPath(import.meta.url))
+const SRC = resolve(_dir, '../../src')
+const TILES = resolve(SRC, 'components/tiles')
+
+/** Route names declared in the real router. */
+function routeNames() {
+  const src = readFileSync(resolve(SRC, 'router/index.js'), 'utf8')
+  return new Set([...src.matchAll(/name:\s*['"]([A-Za-z][\w-]*)['"]/g)].map((m) => m[1]))
+}
+
+/** `{ name: 'X' }` targets bound to a `link-to` on any tile component. */
+function tileLinkTargets() {
+  const out = []
+  for (const file of readdirSync(TILES).filter((f) => f.endsWith('.vue'))) {
+    const src = readFileSync(resolve(TILES, file), 'utf8')
+    for (const m of src.matchAll(/link-to\s*=\s*"\s*\{([^}]*)\}/g)) {
+      const named = /name:\s*['"]([^'"]+)['"]/.exec(m[1])
+      if (named) out.push({ file, name: named[1] })
+    }
+  }
+  return out
+}
+
+describe('grid info-tile links (ent#325)', () => {
+  it('the router exposes named routes to check against', () => {
+    const names = routeNames()
+    // Sanity: a guard that reads nothing certifies nothing.
+    expect(names.size).toBeGreaterThan(5)
+    expect(names.has('Dashboard')).toBe(true)
+  })
+
+  it('finds the link targets it is meant to police', () => {
+    // Same reason: if the scan silently matched zero tiles it would pass
+    // forever, including on the exact regression it exists to catch.
+    expect(tileLinkTargets().length).toBeGreaterThan(0)
+  })
+
+  it('every tile link names an existing route', () => {
+    const names = routeNames()
+    const bad = tileLinkTargets().filter((t) => !names.has(t.name))
+    expect(
+      bad.map((b) => `${b.file} -> { name: '${b.name}' }`),
+      'a RouterLink to an unknown route name THROWS during render, which aborts '
+        + "Vue's update for the whole tree and freezes the dashboard — the tile "
+        + 'renders as an empty box and gives no hint where the fault is',
+    ).toEqual([])
+  })
+
+  it("'Agents' specifically is not a route — it folded into the Dashboard", () => {
+    // Pins the trap itself. `/agents` still exists as an unnamed redirect to
+    // `/?view=list`, so the path works and only the NAME is gone; that is what
+    // made the original mistake so easy to make and so hard to spot.
+    expect(routeNames().has('Agents')).toBe(false)
+  })
+})

--- a/src/frontend/tests/unit/gridTokens.spec.js
+++ b/src/frontend/tests/unit/gridTokens.spec.js
@@ -1,0 +1,144 @@
+/**
+ * Every `--gv-*` a grid tile consumes must be DEFINED in the cascade, in BOTH
+ * themes (ent#325 review).
+ *
+ * InfoTile's style block opens by asserting the invariant — "tokens come from
+ * the --gv-* cascade FleetGrid establishes, so an info tile and an agent tile
+ * can never drift apart on colour" — and nothing enforced it. 10 of the 12
+ * tokens the two tile components consumed were defined nowhere, so every
+ * fallback was permanently live and the tile could not respond to the theme at
+ * all. It shipped past a 28-test suite because a comment is not a test.
+ *
+ * The two tokens that DID resolve are what made it a contrast failure rather
+ * than a cosmetic one: `--gv-muted` correctly flips to #9ca3af in dark, and
+ * landed on a background hardcoded to #fff — gray-400 on white is ~2.4:1,
+ * under the 4.5:1 WCAG AA floor, on a white card sitting among dark AgentTiles.
+ *
+ * This is a static check by design. The unit suite is node-environment ("pure
+ * modules only, no DOM"), and a jsdom test could not catch this anyway: jsdom
+ * does not do cascade resolution, so `getComputedStyle` returns the fallback
+ * and the broken state looks identical to the fixed one. Parsing the source is
+ * what actually distinguishes them.
+ *
+ * It pays off repeatedly rather than once: ent#94 adds tiles one sub-issue at a
+ * time (#95–#101, #259), and each new tile is a fresh chance to consume a token
+ * nobody defined — failing silently in exactly one theme.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src')
+
+/** Components that render inside the grid lattice and inherit its cascade. */
+const TILE_COMPONENTS = [
+  'components/InfoTile.vue',
+  'components/tiles/FleetSummaryTile.vue',
+]
+
+/** The two blocks in FleetGrid.vue that establish the cascade. */
+const LIGHT_SELECTOR = '.fleet-canvas {'
+const DARK_SELECTOR = ':root.dark .fleet-canvas {'
+
+function walk(dir) {
+  return readdirSync(dir).flatMap((name) => {
+    const full = join(dir, name)
+    return statSync(full).isDirectory() ? walk(full) : [full]
+  })
+}
+
+/** `--gv-x` names declared anywhere under src/ (any .vue file). */
+function definedTokens() {
+  const found = new Set()
+  for (const file of walk(SRC).filter((f) => f.endsWith('.vue'))) {
+    for (const m of readFileSync(file, 'utf8').matchAll(/^\s*(--gv-[a-z0-9-]+)\s*:/gm)) {
+      found.add(m[1])
+    }
+  }
+  return found
+}
+
+/** `--gv-x` names read via var() in one file. */
+function consumedTokens(relPath) {
+  const text = readFileSync(join(SRC, relPath), 'utf8')
+  return [...text.matchAll(/var\((--gv-[a-z0-9-]+)/g)].map((m) => m[1])
+}
+
+/** Token names declared inside one `{ … }` block of FleetGrid.vue. */
+function tokensInBlock(selector) {
+  const text = readFileSync(join(SRC, 'components/FleetGrid.vue'), 'utf8')
+  const start = text.indexOf(`\n${selector}`)
+  expect(start, `cascade block "${selector}" not found in FleetGrid.vue`).toBeGreaterThan(-1)
+  const end = text.indexOf('\n}', start)
+  return new Set(
+    [...text.slice(start, end).matchAll(/^\s*(--gv-[a-z0-9-]+)\s*:/gm)].map((m) => m[1]),
+  )
+}
+
+describe('grid tile design tokens (ent#325)', () => {
+  it.each(TILE_COMPONENTS)('%s consumes only tokens that exist', (relPath) => {
+    const defined = definedTokens()
+    const undefinedTokens = [...new Set(consumedTokens(relPath))]
+      .filter((t) => !defined.has(t))
+      .sort()
+
+    expect(
+      undefinedTokens,
+      `${relPath} reads ${undefinedTokens.length} token(s) defined nowhere in src/, so their ` +
+        'var() fallbacks are permanently live and the component cannot respond to the theme',
+    ).toEqual([])
+  })
+
+  it('defines every tile token in BOTH the light and dark cascade blocks', () => {
+    // A token present in one block only is the same class of bug: it resolves
+    // in one theme and silently falls back in the other, which is precisely how
+    // a white card ended up on the dark canvas.
+    const light = tokensInBlock(LIGHT_SELECTOR)
+    const dark = tokensInBlock(DARK_SELECTOR)
+
+    const consumed = new Set(TILE_COMPONENTS.flatMap(consumedTokens))
+    const oneThemeOnly = [...consumed]
+      .filter((t) => light.has(t) !== dark.has(t))
+      .map((t) => `${t} (${light.has(t) ? 'light only' : 'dark only'})`)
+      .sort()
+
+    expect(
+      oneThemeOnly,
+      'these tokens are defined in one theme block only — they resolve in that ' +
+        'theme and fall back in the other',
+    ).toEqual([])
+  })
+
+  it('the light and dark blocks declare the same token set', () => {
+    // Broader than the tiles: keeps the two blocks in step as a whole, so a
+    // token added for a future tile cannot land in one block by itself.
+    const light = tokensInBlock(LIGHT_SELECTOR)
+    const dark = tokensInBlock(DARK_SELECTOR)
+    expect([...light].filter((t) => !dark.has(t)).sort()).toEqual([])
+    expect([...dark].filter((t) => !light.has(t)).sort()).toEqual([])
+  })
+
+  it('no tile hardcodes a raw colour where a token exists', () => {
+    // The original failure was not only missing tokens — the fallbacks were raw
+    // literals (#fff, #111827) chosen to look right in light mode, which is what
+    // made the broken state invisible to anyone reading the file in light mode.
+    // A bare colour OUTSIDE a var() fallback cannot be themed at all.
+    const offenders = []
+    for (const relPath of TILE_COMPONENTS) {
+      const text = readFileSync(join(SRC, relPath), 'utf8')
+      const style = text.slice(text.indexOf('<style'))
+      for (const line of style.split('\n')) {
+        if (!/^\s*(background|color|border|border-color|box-shadow)\b/.test(line)) continue
+        const withoutVars = line.replace(/var\([^;]*\)/g, '')
+        if (/#[0-9a-fA-F]{3,8}\b|\brgba?\(/.test(withoutVars)) {
+          offenders.push(`${relPath}: ${line.trim()}`)
+        }
+      }
+    }
+    expect(
+      offenders,
+      'raw colour outside a var() fallback — it cannot flip with the theme',
+    ).toEqual([])
+  })
+})

--- a/src/frontend/tests/unit/gridWidgets.spec.js
+++ b/src/frontend/tests/unit/gridWidgets.spec.js
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  WIDGET_PREFIX,
+  GRID_WIDGETS,
+  isWidgetKey,
+  widgetKey,
+  widgetIdFromKey,
+  registerWidget,
+  widgetById,
+  catalogFor,
+  isWidgetEnabled,
+  enabledWidgetKeys,
+  seedWidgetCells,
+} from '@/utils/gridWidgets'
+import { normalizeLayout, CELL_W, CELL_H } from '@/utils/gridLayout'
+import { tidyByDept, arrangeByDept, computeZones, orgMeta } from '@/utils/gridOrg'
+
+/**
+ * ent#325 — the widget chassis's pure half.
+ *
+ * `utils/gridWidgets.js` is deliberately free of `.vue` imports so it can be
+ * tested here under vitest's node environment; the catalog entries (which do
+ * import components) live in `components/tiles/catalog.js` instead. That
+ * split is what makes the registry testable at all, so the first test pins it.
+ */
+
+function resetCatalog() {
+  GRID_WIDGETS.length = 0
+}
+
+const AGENTS = [
+  { name: 'alpha', tags: ['dept-eng'] },
+  { name: 'beta', tags: ['dept-eng'] },
+  { name: 'gamma', tags: ['dept-sales'] },
+]
+
+describe('widget key namespace', () => {
+  it('round-trips id <-> key', () => {
+    expect(widgetKey('fleet-summary')).toBe('widget:fleet-summary')
+    expect(widgetIdFromKey('widget:fleet-summary')).toBe('fleet-summary')
+  })
+
+  it('never mistakes an agent name for a widget', () => {
+    // `sanitize_agent_name` strips everything outside [A-Za-z0-9_-], so a real
+    // agent name can never contain `:` — this is exact, not a heuristic.
+    for (const name of ['widget', 'widget-summary', 'my_agent', 'a-b-c', '']) {
+      expect(isWidgetKey(name)).toBe(false)
+    }
+    expect(isWidgetKey(`${WIDGET_PREFIX}x`)).toBe(true)
+  })
+
+  it('widgetIdFromKey returns null for a non-widget key', () => {
+    expect(widgetIdFromKey('alpha')).toBeNull()
+  })
+})
+
+describe('registry', () => {
+  beforeEach(resetCatalog)
+
+  it('registers with defaults and looks up by id', () => {
+    const e = registerWidget({ id: 'x', title: 'X', component: {} })
+    expect(e.adminOnly).toBe(false)
+    expect(e.defaultOn).toBe(false)
+    expect(e.cells).toEqual({ w: 1, h: 1 })
+    expect(widgetById('x')).toBe(e)
+    expect(widgetById('nope')).toBeNull()
+  })
+
+  it('re-registering the same id replaces rather than duplicates', () => {
+    registerWidget({ id: 'x', title: 'first', component: {} })
+    registerWidget({ id: 'x', title: 'second', component: {} })
+    expect(GRID_WIDGETS.filter((w) => w.id === 'x')).toHaveLength(1)
+    expect(widgetById('x').title).toBe('second')
+  })
+
+  it('hides adminOnly tiles from non-admins', () => {
+    registerWidget({ id: 'open', title: 'Open', component: {} })
+    registerWidget({ id: 'secret', title: 'Secret', component: {}, adminOnly: true })
+    expect(catalogFor(true).map((w) => w.id)).toEqual(['open', 'secret'])
+    expect(catalogFor(false).map((w) => w.id)).toEqual(['open'])
+  })
+
+  it('an adminOnly tile is never enabled for a non-admin, even if prefs say on', () => {
+    // Prefs are per-user and survive a role change; the catalog filter, not
+    // the preference, has to be what decides.
+    registerWidget({ id: 'secret', title: 'S', component: {}, adminOnly: true, defaultOn: true })
+    expect(enabledWidgetKeys(false, { secret: true })).toEqual([])
+    expect(enabledWidgetKeys(true, {})).toEqual(['widget:secret'])
+  })
+})
+
+describe('enablement prefs are a sparse override map', () => {
+  beforeEach(() => {
+    resetCatalog()
+    registerWidget({ id: 'on', title: 'On', component: {}, defaultOn: true })
+    registerWidget({ id: 'off', title: 'Off', component: {}, defaultOn: false })
+  })
+
+  it('absent pref follows the catalog default', () => {
+    expect(enabledWidgetKeys(true, {})).toEqual(['widget:on'])
+  })
+
+  it('a user can turn a default-on tile off and a default-off tile on', () => {
+    expect(enabledWidgetKeys(true, { on: false, off: true })).toEqual(['widget:off'])
+  })
+
+  it('reset (empty prefs) restores defaults', () => {
+    expect(enabledWidgetKeys(true, {})).toEqual(['widget:on'])
+  })
+
+  it('a NEW default-on tile appears for a user with existing prefs', () => {
+    // The reason prefs store overrides rather than an allow-list: a stale
+    // allow-list would keep every future tile invisible forever.
+    const prefs = { on: false }
+    registerWidget({ id: 'brandnew', title: 'New', component: {}, defaultOn: true })
+    expect(enabledWidgetKeys(true, prefs)).toContain('widget:brandnew')
+  })
+
+  it('isWidgetEnabled is false for a missing entry', () => {
+    expect(isWidgetEnabled(null, {})).toBe(false)
+  })
+})
+
+describe('seedWidgetCells — the band above the fleet', () => {
+  it('seeds into negative rows so no saved agent position moves', () => {
+    const agents = { a: { c: 0, r: 0 }, b: { c: 1, r: 0 }, c: { c: 2, r: 1 } }
+    const seeded = seedWidgetCells(agents, ['widget:one', 'widget:two'])
+    for (const p of Object.values(seeded)) expect(p.r).toBeLessThan(0)
+    // and it did not touch the agents
+    expect(agents).toEqual({ a: { c: 0, r: 0 }, b: { c: 1, r: 0 }, c: { c: 2, r: 1 } })
+  })
+
+  it('never collides with an existing occupant or with a sibling widget', () => {
+    const layout = { a: { c: 0, r: -3 } }
+    const seeded = seedWidgetCells(layout, ['widget:one', 'widget:two', 'widget:three'])
+    const cells = Object.values(seeded).map((p) => `${p.c},${p.r}`)
+    expect(new Set(cells).size).toBe(cells.length)
+    expect(cells).not.toContain('0,-3')
+  })
+
+  it('honours the isBlocked veto (a department frame reaching into the band)', () => {
+    const blocked = (c, r) => r === -3 && c < 2
+    const seeded = seedWidgetCells({}, ['widget:one'], blocked)
+    expect(blocked(seeded['widget:one'].c, seeded['widget:one'].r)).toBe(false)
+  })
+
+  it('returns an empty map for no keys', () => {
+    expect(seedWidgetCells({}, [])).toEqual({})
+    expect(seedWidgetCells({}, null)).toEqual({})
+  })
+})
+
+describe('normalizeLayout round-trips widget keys', () => {
+  it('DROPS widget keys when not declared — the pre-ent#325 behaviour', () => {
+    // Pinned so the regression is visible: this is exactly why a saved
+    // layout lost its tiles on the next reconcile.
+    const saved = { a: { c: 0, r: 0 }, 'widget:x': { c: 0, r: -1 } }
+    const { layout } = normalizeLayout(saved, ['a'])
+    expect(layout['widget:x']).toBeUndefined()
+  })
+
+  it('keeps widget positions when declared', () => {
+    const saved = { a: { c: 0, r: 0 }, 'widget:x': { c: 3, r: -2 } }
+    const { layout } = normalizeLayout(saved, ['a'], null, ['widget:x'])
+    expect(layout['widget:x']).toEqual({ c: 3, r: -2 })
+    expect(layout.a).toEqual({ c: 0, r: 0 })
+  })
+
+  it('does not report `changed` on a steady-state board carrying a widget', () => {
+    // A false `changed` re-persists localStorage on every reconcile forever.
+    const saved = { a: { c: 0, r: 0 }, 'widget:x': { c: 3, r: -2 } }
+    const { changed } = normalizeLayout(saved, ['a'], null, ['widget:x'])
+    expect(changed).toBe(false)
+  })
+
+  it('an agent wins a collision; the widget is re-placed', () => {
+    const saved = { a: { c: 1, r: 1 }, 'widget:x': { c: 1, r: 1 } }
+    const { layout } = normalizeLayout(saved, ['a'], null, ['widget:x'])
+    expect(layout.a).toEqual({ c: 1, r: 1 })
+    expect(layout['widget:x']).not.toEqual({ c: 1, r: 1 })
+  })
+
+  it('originFor is never consulted for a widget', () => {
+    // originFor is the org overlay's zone-aware seeding hook and is agent-only
+    // by contract — a widget has no department.
+    const seen = []
+    normalizeLayout({}, ['a'], (n) => { seen.push(n); return { c: 4, r: 4 } }, ['widget:x'])
+    expect(seen).toEqual(['a'])
+  })
+})
+
+describe('org overlay preserves widget positions (ent#325 interlock A)', () => {
+  const meta = orgMeta(AGENTS)
+
+  it('tidyByDept carries widget keys through', () => {
+    const layout = {
+      alpha: { c: 0, r: 0 },
+      beta: { c: 1, r: 0 },
+      gamma: { c: 0, r: 2 },
+      'widget:x': { c: 0, r: -2 },
+    }
+    const out = tidyByDept(layout, AGENTS, meta)
+    expect(out['widget:x']).toEqual({ c: 0, r: -2 })
+  })
+
+  it('arrangeByDept carries widget keys through', () => {
+    const layout = { alpha: { c: 0, r: 0 }, 'widget:x': { c: 5, r: -1 } }
+    const out = arrangeByDept(AGENTS, meta, layout)
+    expect(out['widget:x']).toEqual({ c: 5, r: -1 })
+  })
+
+  it('arrangeByDept is byte-identical to the old behaviour with no widgets', () => {
+    // The safety argument for adding nearestFreeCell to arrangeByDept: with
+    // no widgets every requested cell is free, so placement cannot change.
+    const withNothing = arrangeByDept(AGENTS, meta)
+    const withEmptyLayout = arrangeByDept(AGENTS, meta, {})
+    expect(withEmptyLayout).toEqual(withNothing)
+    // three agents, two departments, packed from the origin
+    expect(Object.keys(withNothing).sort()).toEqual(['alpha', 'beta', 'gamma'])
+    for (const p of Object.values(withNothing)) {
+      expect(p.r).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('a widget sitting in the agent area displaces the department block, not itself', () => {
+    const layout = { 'widget:x': { c: 0, r: 0 } }
+    const out = arrangeByDept(AGENTS, meta, layout)
+    expect(out['widget:x']).toEqual({ c: 0, r: 0 })
+    for (const name of ['alpha', 'beta', 'gamma']) {
+      expect(out[name]).not.toEqual({ c: 0, r: 0 })
+    }
+  })
+
+  it('non-widget stray keys are NOT carried (only widgets are)', () => {
+    // Guard against turning the carry-through into "preserve anything unknown",
+    // which would resurrect a deleted agent's position forever.
+    const layout = { alpha: { c: 0, r: 0 }, 'ghost-agent': { c: 9, r: 9 } }
+    const out = arrangeByDept(AGENTS, meta, layout)
+    expect(out['ghost-agent']).toBeUndefined()
+  })
+})
+
+describe('widgets stay out of department zone hulls (interlock B)', () => {
+  it('a widget parked beside a department does not stretch its frame', () => {
+    const withoutWidget = computeZones(
+      { alpha: { c: 0, r: 0 }, beta: { c: 1, r: 0 }, gamma: { c: 0, r: 3 } },
+      AGENTS,
+      orgMeta(AGENTS)
+    )
+    const withWidget = computeZones(
+      {
+        alpha: { c: 0, r: 0 },
+        beta: { c: 1, r: 0 },
+        gamma: { c: 0, r: 3 },
+        'widget:x': { c: 8, r: 0 },
+      },
+      AGENTS,
+      orgMeta(AGENTS)
+    )
+    expect(withWidget).toEqual(withoutWidget)
+  })
+
+  it('sanity: the hull does cover its own members', () => {
+    const zones = computeZones(
+      { alpha: { c: 0, r: 0 }, beta: { c: 1, r: 0 } },
+      AGENTS,
+      orgMeta(AGENTS)
+    )
+    const eng = zones.find((z) => z.dept === 'eng')
+    expect(eng).toBeTruthy()
+    expect(eng.w).toBeGreaterThan(CELL_W)
+    expect(eng.h).toBeGreaterThanOrEqual(CELL_H)
+  })
+})


### PR DESCRIPTION
Fixes abilityai/trinity-enterprise#325 · foundation for epic ent#94

> **Rebased onto `dev` and retargeted** (was stacked on #1918 / `feature/305-grid-org-overlay`, which squash-merged so its tip never became a `dev` ancestor). `git rebase --onto origin/dev origin/feature/305-grid-org-overlay` applied cleanly with zero conflicts; the diff below is this issue's work only, and the required checks now run against it.

## What

The widget chassis every tile sub-issue on ent#94 (#95–#101, #259) is blocked on. Until now none of them was claimable, because whoever picked one first had to build the whole chassis off-issue.

- `InfoTile.vue` — the tile shell
- `GRID_WIDGETS` registry + `widget:*` key namespace
- layout v2 with a one-time v1 migration
- the "Tiles ▾" show/hide menu
- one reference tile, so the chassis is demonstrable

## Info tiles are occupants of the same lattice, not a parallel system

Widgets join the **same** layout map under `widget:*` keys. `:` cannot appear in an agent name (`sanitize_agent_name` strips everything outside `[A-Za-z0-9_-]`), so collision is impossible and `isWidgetKey` is exact rather than a heuristic.

The payoff is that drag, swap-with-preview, keyboard reorder, viewport culling and the snap socket all work for tiles through the existing `data-agent` path — no second code path to keep in sync as those behaviours evolve. Keyboard came free: `@keydown` is on the world container and resolves through `layout[name]`.

Deliberately **absent** from `InfoTile`: Run/Autonomy toggles (info tiles summarize, they don't operate — a fleet-scope operating control makes a misclick fleet-wide), and any org affordance. No connect port, so a tile cannot be a reporting-line endpoint; that is enforced by omitting the hover handlers `AgentTile` uses, not by a runtime check.

## Org-overlay interlock — the load-bearing part

**A. Tidy and Group-by-dept would have silently deleted every tile position.** Both `tidyByDept` and `arrangeByDept` build a fresh map keyed only from `agents`, and `applyLayout` replaced the layout wholesale. Fixed at **both** ends as the issue asks: the helpers carry `widget:*` keys through (seeded first, so department blocks flow around them via `nearestFreeCell`), **and** `applyLayout` merges instead of blind-replacing. Either alone is a single point of failure, and one-guard-only is how this bug existed in the first place.

Adding `nearestFreeCell` to `arrangeByDept` is behaviour-preserving when no widgets are present — every requested cell is free, so placement is unchanged. There is a test pinning that equivalence, because it is the entire safety argument for touching that function.

**B. Widgets stay out of zone hulls — left alone deliberately.** `computeZones` iterates `agents`, so a `widget:*` key is excluded by construction. Not "fixed" by iterating the layout map; pinned by a test asserting a tile parked beside a department does not stretch its frame.

**C. Gap budget.** The peg overhangs 16px, inside `GAP_X` (40), so it cannot collide with `ZONE_CHROME`.

**D. Seeding consults `zoneAt`** and skips cells inside a department frame — rows −3…−1 are empty of *tiles* but not necessarily of *hulls*.

## Layout v2

`trinity-grid-layout-v2`, migrated by a one-time **copy** from v1 — v1 is left in place, so downgrading is not a data-loss event.

`normalizeLayout` gains a `widgetKeys` argument. Without it every `widget:*` entry was dropped on the next reconcile; that is pinned as a test so the regression stays visible rather than becoming folklore. Agents reconcile **first**, so a collision evicts the tile — an info tile moving one cell is a smaller surprise than a constellation the user arranged shifting under them. The `changed` check now covers widgets too, or every reconcile would re-persist localStorage forever.

Default placement is the band **above** the fleet, which is what makes "default-on tiles appear without moving any saved agent position" true by construction: `defaultLayout` starts agents at `r=0` and grows downward, so negative rows are unclaimed on every existing install.

## Tiles menu

Per-user, persisted under its own key so it can never clobber the overlay's Zones/Lines prefs. Preferences are a **sparse override map**, not an allow-list — so a tile added in a later release appears for existing users instead of staying invisible behind a stale list, a user can keep a default-on tile off, and "Reset" is just an empty map. Placed in the bottom control cluster rather than as a fifth top-level header button, per the issue's responsive-ladder note.

## Registry, and why the catalog lives elsewhere

`utils/gridWidgets.js` stays free of `.vue` imports so vitest's node environment can test it — and because `gridOrg.js` now imports `isWidgetKey` from it, a component import there would have broken #1918's existing `gridOrg.spec.js`. Catalog entries live in `components/tiles/catalog.js`, imported by `FleetGrid` for its side effect. Adding a tile is one `registerWidget({...})` block plus the component.

`cells` is declared and ignored: v1 renders single-cell only, multi-cell occupancy is #94's stated v2. Declaring it now means catalog entries don't need rewriting when `gridLayout.js` learns occupancy.

**One reference tile ships** (Fleet summary): it reads the `agents` array the grid already holds and issues no request, so the chassis carries no data dependency of its own and could not be blocked behind the sibling ent#326 endpoint. This is not scope creep — the epic's ACs require a default-on tile to render, so an empty catalog would leave half of them unverifiable. Real tiles arrive one sub-issue at a time.

## Tests

`tests/unit/gridWidgets.spec.js` — 28 tests: key namespace (incl. that no agent-shaped name reads as a widget), registry, **an `adminOnly` tile never enabled for a non-admin even when prefs say on** (prefs survive a role change; the catalog filter has to be what decides), override-map semantics incl. a newly-registered default-on tile reaching a user with existing prefs, seeding band + veto, normalize round-trip in **both** directions, the tidy/arrange preservation rule, and zone-hull exclusion. One guard asserts stray non-widget keys are *not* carried, so the carry-through can't drift into "preserve anything unknown" and resurrect a deleted agent forever.

```
tests/unit/gridWidgets.spec.js   28 passed   (new)
tests/unit/gridOrg.spec.js       21 passed   (#1918, unbroken)
tests/unit/gridLayout.spec.js     6 passed   (#1918, unbroken)
                                 55 passed
```

## Verification note, stated honestly

`npm run build` and `npm run test:unit` cannot run against this machine's `node_modules` — it predates #1918 (no `vitest`) and is missing `mermaid`/`qrcode`. Both were run out-of-band instead: vitest standalone with an equivalent inline config (the 55 above), and a production `vite build` with the stale deps externalized, which transformed **638 modules clean** — covering every file in this PR. CI runs both properly.

## Not in scope

Multi-cell tiles (#94 v2), agent-declared custom tiles (#94 v2, unfiled), and the actual data tiles (#95–#101, #259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

