### PR TITLE
feat(prompt): model-conditional prompt tiers — mechanism only, provable no-op (ent#243)

### DIFF
--- a/docs/memory/requirements/runtimes.md
+++ b/docs/memory/requirements/runtimes.md
@@ -267,3 +267,90 @@ endpoint. See the [Harness Authoring Guide](harness-authoring-guide.md) for addi
 a fourth runtime.
 
 ---
+
+## 41. Model-Conditional Prompt Tiers (ent#243)
+
+### 41.1 Tier Resolution — the axis is the MODEL, not the runtime
+
+Anthropic's Claude 5-generation context-engineering guidance (rules → judgment,
+examples → interface design) applies to *frontier coding-post-trained models*,
+and is **actively harmful** on smaller/older ones — Sonnet 4.5 and Haiku 4.5 need
+the explicit structure it removes. Three vendors reached the same conclusion
+independently (OpenAI on GPT-5-Codex over-prompting, Google on Gemini 3
+over-analyzing verbose prompt engineering), so the fault line is model class, not
+vendor and not harness.
+
+This is why the tier is **not** keyed on `AGENT_RUNTIME`. MODEL-001 lets a
+schedule, loop, or chat turn pin any model string — including free-text — so a
+`claude-code` agent routinely runs Haiku 4.5. Gating on the runtime label would
+silently degrade the majority of the selectable surface (7 of 9 `PRESET_MODELS`
+entries sit in the tier where the guidance does not apply). Runtime already has
+its own orthogonal job in this module: `_adapt_instructions_for_runtime` rewrites
+MCP tool naming for Codex (#1187 F-MCP). The two axes stay separate.
+
+**Functional requirements:**
+- **FR-1 — Classifier:** `services/prompt_tier.py::resolve_prompt_tier(model)`
+  returns `PromptTier.MINIMAL | PromptTier.VERBOSE`. Total function, never raises,
+  pure-stdlib. Mirrors the `services/model_context.py` shape: family-prefix rules,
+  first-match-wins, most-specific-first.
+- **FR-2 — Unknown fails toward VERBOSE.** An unrecognized, empty, or `None` model
+  resolves to `VERBOSE` — today's prompt. Over-instructing a Claude 5 model costs
+  tokens; under-instructing a 4.5 model silently degrades it, and free-text model
+  passthrough makes an unknown id routine rather than exceptional. This mirrors
+  `model_context.py`'s "fail toward the conservative value" invariant and is the
+  property that bounds this feature's blast radius to *status quo*.
+- **FR-3 — Section-level gating, never two prompt strings.** `PLATFORM_INSTRUCTIONS`
+  stays a single authored literal; sections are derived from it by splitting on
+  its `###` headings and filtered by tier at render time. Maintaining two full
+  prompts guarantees drift — a security instruction added to one variant and not
+  the other is the failure mode this forbids by construction.
+- **FR-4 — A section with no explicit tier renders always.** An unmapped or renamed
+  heading falls back to always-render, and the heading set is CI-pinned so a rename
+  fails loudly instead of silently changing what agents are told.
+- **FR-5 — Safety and privacy sections are un-gateable.** Operator Communication
+  (the #1402 fire-and-park contract, itself sentinel-locked and synced to
+  `config/trinity-meta-prompt/prompt.md`) and the per-user memory-leak warning
+  render at every tier. They are not tool-usage guidance and have no tool
+  description to live in.
+
+**Non-functional:**
+- **Provable no-op on landing.** The MINIMAL prefix set ships **empty**, so every
+  model resolves VERBOSE and the rendered prompt is byte-identical to the previous
+  release. Enabling a family is a separate, evidence-gated change (ent#243 PR 2),
+  which is what keeps a fleet-wide prompt change out of the same PR as its mechanism.
+- **Prompt caching is unaffected.** The cache is keyed per model, so a cache entry
+  is never shared across models; varying the prefix by model adds no fragmentation.
+- Not vendored to the agent server (unlike `model_context.py`, Invariant #5): the
+  backend composes the prompt and ships it in the turn payload, so the agent server
+  never resolves a tier.
+
+### 41.2 Model Availability at Compose Time
+
+The prompt is composed **per turn** and is never baked into the container:
+`get_platform_system_prompt()` is uncached and re-reads the operator's
+`trinity_prompt` setting on every call, and the result travels in the request
+payload. A model changed in the UI therefore takes effect on the next turn with no
+container recreate, restart, or cache invalidation.
+
+Composition paths and whether the model is known:
+
+| Path | Model at compose time |
+|---|---|
+| `task_execution_service` (schedules, loops, webhooks, public/paid/channel via `execute_task`) | resolved to a concrete string before compose |
+| `chat_execution_service` | `request.model`, **nullable** — no default-resolution step on this path |
+| `pull_coordination_service` | **absent** — not passed into `ExecutionContext` at all (fixed here) |
+
+- **FR-6 — The pull path threads its model.** `pull_coordination_service` populates
+  `ExecutionContext.model`, so a pull-claimed turn is classified like any other.
+- **FR-7 — An unpinned chat turn resolves VERBOSE, by design.** When the caller
+  sends no model the *agent container* selects one (`claude_code.py` →
+  `claude-sonnet-4-6`) **after** the prompt was composed — the decision does not
+  exist backend-side at compose time and cannot be threaded. `claude-sonnet-4-6` is
+  a 4.x model that wants the verbose prompt, so FR-2's default is already correct
+  for this case. Resolving the platform default backend-side instead would trade a
+  known-safe gap for a hidden one, since the backend default and the agent's
+  `get_default_model()` can diverge silently. Making that second decision point
+  explicit is a tracked follow-up, not a prerequisite (the same split underlies
+  #1521's context-window "safe floor").
+
+---

--- a/src/backend/services/chat_execution_service.py
+++ b/src/backend/services/chat_execution_service.py
@@ -294,7 +294,11 @@ def build_chat_payload(
         )
     except Exception as e:
         logger.warning(f"[Chat] execution context build failed, falling back: {e}")
-        payload["system_prompt"] = get_platform_system_prompt(runtime=agent_runtime)
+        # ent#243: pass the model here too — a context-build failure must not
+        # silently swap the prompt tier as well as the context block.
+        payload["system_prompt"] = get_platform_system_prompt(
+            runtime=agent_runtime, model=request.model
+        )
     # Pass execution ID so agent registers process under the same ID (enables termination)
     if task_execution_id:
         payload["execution_id"] = task_execution_id

--- a/src/backend/services/platform_prompt_service.py
+++ b/src/backend/services/platform_prompt_service.py
@@ -14,6 +14,7 @@ import httpx
 
 from database import db
 from models import REPORT_PAYLOAD_MAX_BYTES
+from services.prompt_tier import PromptTier, resolve_prompt_tier
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +196,92 @@ PLATFORM_INSTRUCTIONS = PLATFORM_INSTRUCTIONS.replace(
     "__REPORT_PAYLOAD_MAX__", f"{REPORT_PAYLOAD_MAX_BYTES // (1024 * 1024)} MB"
 )
 
+
+# ---------------------------------------------------------------------------
+# Model-conditional prompt tiers (ent#243)
+# ---------------------------------------------------------------------------
+#
+# The prompt stays ONE authored literal above. Sections are *derived* from it by
+# splitting on its top-level ``###`` headings, never re-typed into a parallel
+# list — maintaining two full prompt strings guarantees drift, and the drift that
+# matters is a security instruction added to one variant and not the other.
+#
+# The delimiter is ``\n\n###`` + space, which cannot match the ``####``
+# subsections inside Operator Communication (they carry a fourth ``#`` where this
+# pattern requires a space). ``split``/``join`` on the same delimiter round-trips
+# byte-exactly, which is what makes the VERBOSE render provably identical to the
+# pre-ent#243 constant.
+
+_SECTION_DELIMITER = "\n\n### "
+
+# Sections DROPPED at PromptTier.MINIMAL. Each is tool-usage guidance whose
+# real home is the corresponding MCP tool description — the "single source of
+# truth" rule. Dropping them is inert until _MINIMAL_PREFIXES is non-empty.
+_MINIMAL_DROP_SECTIONS = frozenset({
+    "Agent Collaboration",              # → list_agents / chat_with_agent descriptions
+    "Sharing Files with Users",         # → share_file description
+    "Publishing Reports",               # → report description (+ #1535 display_hint enum)
+})
+
+# Every top-level section, CI-pinned (tests/unit/test_ent243_prompt_tier.py).
+# A renamed heading must fail loudly: an unmapped section falls back to
+# always-render (see _iter_sections), which is safe but silent, and "silent" is
+# how a section intended to be dropped quietly stops being dropped — or worse,
+# how a rename makes a drop-list entry dead without anyone noticing.
+_KNOWN_SECTION_HEADINGS = frozenset({
+    "Agent Collaboration",
+    "Sharing Files with Users",
+    "Publishing Reports",
+    "Operator Communication",
+    "Package Persistence",
+    "Remembering Things About Users (Public & Channel Sessions)",
+})
+
+# Sections that render at EVERY tier, stated positively for the reader. These are
+# NOT tool-usage guidance and have no tool description to live in:
+#   * Operator Communication — the #1402 fire-and-park contract. Sentinel-locked
+#     by tests/unit/test_1402_prompt_contract.py and synced to
+#     config/trinity-meta-prompt/prompt.md; it documents a FILE protocol
+#     (~/.trinity/operator-queue.json), not an MCP tool.
+#   * Remembering Things About Users — carries the shared-memory-directory leak
+#     warning. A privacy guard, un-gateable by construction.
+#   * Package Persistence — a Trinity environment gotcha (~/.trinity/setup.sh)
+#     that no model can infer from tool signatures.
+# Derived, not hand-listed, so it cannot disagree with the drop set.
+_ALWAYS_SECTIONS = _KNOWN_SECTION_HEADINGS - _MINIMAL_DROP_SECTIONS
+
+
+def _iter_sections(text: str) -> list[tuple[str, str]]:
+    """Split the platform instructions into ``(heading, chunk)`` pairs.
+
+    The first chunk is the preamble (everything before the first ``###``); it
+    carries the empty heading ``""`` and always renders. Each subsequent chunk is
+    the raw split fragment — heading line included, WITHOUT the delimiter — so
+    that ``_SECTION_DELIMITER.join(chunk for _, chunk in ...)`` reconstructs the
+    input byte-for-byte.
+    """
+    chunks = text.split(_SECTION_DELIMITER)
+    sections: list[tuple[str, str]] = [("", chunks[0])]
+    for chunk in chunks[1:]:
+        sections.append((chunk.split("\n", 1)[0].strip(), chunk))
+    return sections
+
+
+def render_platform_instructions(tier: PromptTier = PromptTier.VERBOSE) -> str:
+    """Render PLATFORM_INSTRUCTIONS for a prompt tier (ent#243).
+
+    ``VERBOSE`` returns the constant unchanged — byte-identical, not merely
+    equivalent. An unknown/renamed heading renders (fail toward more instruction,
+    matching prompt_tier's own unknown→VERBOSE invariant).
+    """
+    if tier is not PromptTier.MINIMAL:
+        return PLATFORM_INSTRUCTIONS
+    kept = [
+        chunk
+        for heading, chunk in _iter_sections(PLATFORM_INSTRUCTIONS)
+        if heading not in _MINIMAL_DROP_SECTIONS
+    ]
+    return _SECTION_DELIMITER.join(kept)
 
 
 # ---------------------------------------------------------------------------
@@ -379,7 +466,9 @@ async def summarize_user_memory_background(
         )
 
 
-def get_platform_system_prompt(runtime: str = "claude-code") -> str:
+def get_platform_system_prompt(
+    runtime: str = "claude-code", model: Optional[str] = None
+) -> str:
     """
     Build the full platform system prompt.
 
@@ -391,11 +480,17 @@ def get_platform_system_prompt(runtime: str = "claude-code") -> str:
             Codex gets MCP-tool references without the Claude-only
             ``mcp__trinity__`` prefix; Claude/Gemini/unknown keep the canonical
             naming (#1187 F-MCP).
+        model: the model this turn will run on, when the caller knows it. Selects
+            the prompt tier (ent#243) — a frontier coding model gets the MINIMAL
+            render, everything else (including ``None``) gets VERBOSE. Orthogonal
+            to ``runtime``: that decides tool *naming*, this decides how much
+            prose. Inert until ``prompt_tier._MINIMAL_PREFIXES`` is non-empty.
 
     Returns:
         Combined system prompt string
     """
-    parts = [_adapt_instructions_for_runtime(PLATFORM_INSTRUCTIONS, runtime)]
+    instructions = render_platform_instructions(resolve_prompt_tier(model))
+    parts = [_adapt_instructions_for_runtime(instructions, runtime)]
 
     # Append custom prompt from database setting (operator-configurable)
     custom_prompt = db.get_setting_value("trinity_prompt", default=None)
@@ -648,8 +743,19 @@ def compose_system_prompt(
 
     ``runtime`` is threaded to :func:`get_platform_system_prompt` so the MCP-tool
     naming matches the agent's harness (Codex vs. Claude/Gemini, #1187 F-MCP).
+
+    ``execution_context.model`` selects the prompt tier (ent#243). It was already
+    carried on the context for *rendering* (the Execution Context block); this
+    also reads it for *selection*. A caller that does not know the model — the
+    chat path, where the container picks one after composition — leaves it
+    ``None`` and gets VERBOSE, which is the pre-ent#243 prompt.
     """
-    parts: List[str] = [get_platform_system_prompt(runtime=runtime)]
+    parts: List[str] = [
+        get_platform_system_prompt(
+            runtime=runtime,
+            model=execution_context.model if execution_context is not None else None,
+        )
+    ]
 
     if include_execution_context and execution_context is not None:
         # Auto-fill collaborators and platform URL without mutating the caller's

--- a/src/backend/services/prompt_tier.py
+++ b/src/backend/services/prompt_tier.py
@@ -1,0 +1,115 @@
+"""Model → platform-prompt tier — single source of truth (ent#243).
+
+Answers one question: "how much explicit instruction does model X want in the
+platform system prompt?" Anthropic's Claude 5-generation context-engineering
+guidance (rules → judgment, examples → interface design) removed 80%+ of Claude
+Code's own system prompt with no measured loss — but that guidance is scoped to
+frontier *coding-post-trained* models and is ACTIVELY HARMFUL below that line.
+Sonnet 4.5 and Haiku 4.5 need the structure it deletes.
+
+THE AXIS IS THE MODEL, NOT THE RUNTIME
+--------------------------------------
+Deliberately NOT keyed on ``AGENT_RUNTIME``. MODEL-001 lets a schedule, loop, or
+chat turn pin any model string — including free text — so a ``claude-code``
+agent routinely runs Haiku 4.5. Gating on the runtime label would silently
+degrade the majority of the selectable surface (most ``PRESET_MODELS`` entries
+sit in the tier where the guidance does not apply). ``runtime`` already has an
+orthogonal job over in ``platform_prompt_service``: it rewrites MCP tool naming
+for Codex (#1187 F-MCP). Keep the two axes apart — a tier is about how much prose
+a model wants, tool naming is about what the harness can parse.
+
+Three vendors reached this conclusion independently (OpenAI on GPT-5-Codex
+over-prompting, Google on Gemini 3 over-analyzing verbose prompt engineering), so
+the fault line is model class — not vendor, and not harness.
+
+DESIGN INVARIANT — unknown fails toward VERBOSE (ent#243)
+---------------------------------------------------------
+An unrecognized, empty, or ``None`` model resolves to ``VERBOSE``: exactly the
+prompt shipped before this module existed. The asymmetry is the whole point.
+Over-instructing a Claude 5 model costs tokens; under-instructing a 4.5 model
+silently degrades it, with no error and no signal. Free-text model passthrough
+makes an unknown id routine rather than exceptional, so this default is load
+bearing rather than defensive. It mirrors ``model_context.py``'s "fail toward the
+conservative value" rule, and it is the property that bounds this feature's blast
+radius to *status quo*.
+
+Do NOT "modernize" this by defaulting an unknown id to MINIMAL because "most new
+models are frontier". The failure is silent in that direction, which is precisely
+why it must not be the default.
+
+SHIPS AS A PROVABLE NO-OP (ent#243 PR 1)
+----------------------------------------
+``_MINIMAL_PREFIXES`` is EMPTY on purpose. Every model resolves ``VERBOSE``, so
+the rendered prompt is byte-identical to the previous release
+(``tests/unit/test_ent243_prompt_tier.py`` proves it over the live preset list).
+Enabling a family is a separate, evidence-gated change — a fleet-wide prompt
+change does not belong in the same PR as the mechanism that makes it possible.
+
+NOT VENDORED (contrast: Invariant #5)
+-------------------------------------
+Unlike ``model_context.py``, this module is NOT copied into the agent server. The
+backend composes the system prompt and ships it in the turn payload; the agent
+server never resolves a tier. If that ever changes, vendor it byte-identically
+and add a parity test — do not import across the image boundary.
+"""
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class PromptTier(str, Enum):
+    """How much explicit instruction the target model wants.
+
+    ``str`` mixin so a tier is log- and JSON-friendly without a ``.value`` dance.
+    """
+
+    #: Frontier coding-post-trained models: judgment over rules, interface over
+    #: examples. Tool-usage sections are dropped in favour of tool descriptions.
+    MINIMAL = "minimal"
+
+    #: Everything else, and the SAFE DEFAULT for anything unrecognized. This is
+    #: the prompt Trinity shipped before ent#243.
+    VERBOSE = "verbose"
+
+
+#: Model-id prefixes that want the MINIMAL prompt (first match wins, most
+#: specific first — the ``model_context.py`` shape).
+#:
+#: INTENTIONALLY EMPTY (ent#243 PR 1). Populating this tuple is the behaviour
+#: change; it lands separately behind per-(runtime, model-tier) evidence, since a
+#: spot-check cannot catch a regression that only manifests on Haiku-pinned
+#: schedules. Candidates when that evidence exists: ``claude-fable-5``,
+#: ``claude-sonnet-5``, ``gpt-5.1-codex``, ``gemini-3``.
+_MINIMAL_PREFIXES: tuple[str, ...] = ()
+
+
+def resolve_prompt_tier(model: str | None) -> PromptTier:
+    """Best-effort prompt tier for a model string.
+
+    Total function: any input returns a ``PromptTier`` and never raises.
+
+    Resolution order:
+      1. Empty / ``None`` → ``VERBOSE`` (the caller does not know the model; on
+         the chat path the container picks one *after* composition, so this is a
+         real and expected case, not an error — see requirements §41.2 FR-7).
+      2. A known MINIMAL family prefix → ``MINIMAL``.
+      3. Anything else → ``VERBOSE``.
+
+    Deliberately silent. ``model_context.py`` warns on an unrecognized id because
+    there the fallback is a *guess* at a numeric window; here the fallback is the
+    exact prompt the platform already shipped, so an unknown id is a non-event.
+    Warning would fire on every turn of every agent while ``_MINIMAL_PREFIXES``
+    is empty.
+    """
+    if not model:
+        return PromptTier.VERBOSE
+    m = model.strip().lower()
+    if not m:
+        return PromptTier.VERBOSE
+    for prefix in _MINIMAL_PREFIXES:
+        if m.startswith(prefix):
+            return PromptTier.MINIMAL
+    return PromptTier.VERBOSE

--- a/src/backend/services/pull_coordination_service.py
+++ b/src/backend/services/pull_coordination_service.py
@@ -73,11 +73,17 @@ def _compose_pull_system_prompt(
     caller_prompt: Optional[str],
     *,
     execution_id: Optional[str],
+    model: Optional[str] = None,
 ) -> Optional[str]:
     """Compose platform prompt + execution context + caller override for a
     pull-claimed turn (#1629). Fail-open: on ANY composition error the turn runs
     with the caller prompt only (parity with the pre-#1629 pull path) + a WARN —
-    a prompt failure never blocks dispatch."""
+    a prompt failure never blocks dispatch.
+
+    ``model`` (ent#243) selects the prompt tier. It is passed explicitly rather
+    than left to default because this context previously omitted the field
+    entirely — not ``None``-valued, absent — so every pull-claimed turn would
+    have resolved VERBOSE forever with nothing to indicate why."""
     runtime = _resolve_agent_runtime(agent_name)
     try:
         exec_ctx = ExecutionContext(
@@ -85,6 +91,7 @@ def _compose_pull_system_prompt(
             mode=ExecutionContext.derive_mode(triggered_by),
             triggered_by=triggered_by,
             execution_id=execution_id,
+            model=model,
         )
         return compose_system_prompt(
             execution_context=exec_ctx,
@@ -215,11 +222,14 @@ def _build_claim_response(row: Dict[str, Any]) -> Dict[str, Any]:
     # worker reads (`execute_headless(system_prompt=overrides.get("system_prompt"))`).
     # Fold in any caller override; fail-open leaves the caller prompt (or None).
     overrides: Dict[str, Any] = dict(meta.get("task_overrides") or {})
+    # ent#243: a caller override is what the worker will actually run, so it wins
+    # over the row's recorded model_used; either may be absent → VERBOSE.
     overrides["system_prompt"] = _compose_pull_system_prompt(
         row.get("agent_name"),
         row.get("triggered_by"),
         overrides.get("system_prompt"),
         execution_id=row["id"],
+        model=overrides.get("model") or row.get("model_used"),
     )
     payload["task_overrides"] = overrides
 

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -1246,7 +1246,11 @@ class TaskExecutionService:
                 logger.warning(
                     f"[TaskExecService] execution context build failed, falling back: {e}"
                 )
-                platform_prompt = get_platform_system_prompt(runtime=agent_runtime)
+                # ent#243: pass the model here too — a context-build failure must
+                # not silently swap the prompt tier as well as the context block.
+                platform_prompt = get_platform_system_prompt(
+                    runtime=agent_runtime, model=model
+                )
                 effective_system_prompt = (
                     platform_prompt + "\n\n" + system_prompt if system_prompt else platform_prompt
                 )

--- a/tests/unit/test_ent243_prompt_tier.py
+++ b/tests/unit/test_ent243_prompt_tier.py
@@ -1,0 +1,170 @@
+"""ent#243 — model-conditional prompt tiers: no-op proof + mechanism contract.
+
+PR 1 ships the tier *mechanism* with an EMPTY ``_MINIMAL_PREFIXES``, so the
+rendered prompt must be byte-identical to the pre-ent#243 release for every model
+anyone can actually select. "Provable no-op" is only a claim until a test proves
+it; that is what ``TestNoOp`` is for, and it reads the live picker list off
+``ModelSelector.vue`` so a newly-added preset is covered without anyone
+remembering to update this file.
+
+The remaining classes test the mechanism directly (by constructing a MINIMAL
+render) so that PR 2 — which populates the prefix tuple — inherits a suite that
+already pins what MINIMAL is allowed to drop.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from services.platform_prompt_service import (
+    _ALWAYS_SECTIONS,
+    _KNOWN_SECTION_HEADINGS,
+    _MINIMAL_DROP_SECTIONS,
+    _SECTION_DELIMITER,
+    _iter_sections,
+    PLATFORM_INSTRUCTIONS,
+    render_platform_instructions,
+)
+from services.prompt_tier import (
+    _MINIMAL_PREFIXES,
+    PromptTier,
+    resolve_prompt_tier,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODEL_SELECTOR = REPO_ROOT / "src" / "frontend" / "src" / "components" / "ModelSelector.vue"
+
+
+def _preset_models() -> list[str]:
+    """Every model id the picker offers, read from the live Vue source.
+
+    Deliberately parsed rather than duplicated: a hardcoded copy would silently
+    stop covering a preset added later, which is exactly the model most likely to
+    be a new frontier one.
+    """
+    source = MODEL_SELECTOR.read_text(encoding="utf-8")
+    block = source.split("const PRESET_MODELS = [", 1)[1].split("]", 1)[0]
+    return re.findall(r"value:\s*'([^']+)'", block)
+
+
+class TestNoOp:
+    """PR 1 changes no agent's prompt. Byte-identity, not equivalence."""
+
+    def test_preset_list_parsed(self):
+        # Guard the guard: a refactor of ModelSelector.vue that breaks the parse
+        # would otherwise make every test below vacuously pass.
+        presets = _preset_models()
+        assert len(presets) >= 5
+        assert "claude-fable-5" in presets
+        assert "claude-haiku-4-5-20251001" in presets
+
+    @pytest.mark.parametrize("model", _preset_models())
+    def test_every_preset_renders_the_unchanged_prompt(self, model):
+        assert render_platform_instructions(resolve_prompt_tier(model)) == PLATFORM_INSTRUCTIONS
+
+    @pytest.mark.parametrize(
+        "model",
+        [None, "", "   ", "claude-fable-5[1m]", "gpt-5.1-codex", "gemini-3-flash",
+         "some-unreleased-model", "Claude-Sonnet-5", "🙂"],
+    )
+    def test_edge_and_freetext_models_render_the_unchanged_prompt(self, model):
+        assert render_platform_instructions(resolve_prompt_tier(model)) == PLATFORM_INSTRUCTIONS
+
+    def test_minimal_prefix_set_is_empty(self):
+        # The no-op contract itself. PR 2 populating this MUST consciously edit
+        # this test — that is the point, not an inconvenience.
+        assert _MINIMAL_PREFIXES == ()
+
+
+class TestTierResolution:
+    def test_unknown_fails_toward_verbose(self):
+        for model in (None, "", "  ", "not-a-real-model", "gpt-4", "llama-3"):
+            assert resolve_prompt_tier(model) is PromptTier.VERBOSE
+
+    def test_total_function_never_raises(self):
+        for model in (None, "", "x" * 10_000, "\n\t", "💥", "claude-" * 500):
+            assert isinstance(resolve_prompt_tier(model), PromptTier)
+
+    def test_tier_is_not_keyed_on_runtime(self):
+        # The signature is the contract: runtime decides MCP tool *naming*
+        # (#1187), model decides prose volume. Merging them is the regression
+        # this asserts against (requirements §41.1).
+        import inspect
+
+        params = inspect.signature(resolve_prompt_tier).parameters
+        assert list(params) == ["model"]
+
+
+class TestSectionSplit:
+    def test_split_round_trips_byte_exactly(self):
+        rebuilt = _SECTION_DELIMITER.join(chunk for _, chunk in _iter_sections(PLATFORM_INSTRUCTIONS))
+        assert rebuilt == PLATFORM_INSTRUCTIONS
+
+    def test_heading_set_is_pinned(self):
+        found = {heading for heading, _ in _iter_sections(PLATFORM_INSTRUCTIONS) if heading}
+        assert found == _KNOWN_SECTION_HEADINGS, (
+            "A '###' section was added or renamed. An unmapped section renders at "
+            "every tier (safe), but a renamed one silently orphans its drop-list "
+            "entry — update _KNOWN_SECTION_HEADINGS and _MINIMAL_DROP_SECTIONS."
+        )
+
+    def test_drop_set_is_a_subset_of_known_headings(self):
+        # A typo'd drop entry is dead code that looks like configuration.
+        assert _MINIMAL_DROP_SECTIONS <= _KNOWN_SECTION_HEADINGS
+
+    def test_subsections_stay_with_their_parent(self):
+        # Operator Communication owns four '####' subsections; the delimiter must
+        # not split on them or the contract section would fragment.
+        sections = dict((h, c) for h, c in _iter_sections(PLATFORM_INSTRUCTIONS))
+        operator = sections["Operator Communication"]
+        assert "#### The contract: fire-and-park, never block-and-wait" in operator
+        assert "#### Ask before irreversible actions" in operator
+
+    def test_preamble_is_first_and_headingless(self):
+        first_heading, first_chunk = _iter_sections(PLATFORM_INSTRUCTIONS)[0]
+        assert first_heading == ""
+        assert first_chunk.startswith("# Trinity Platform Instructions")
+
+
+class TestMinimalRender:
+    """Exercises the mechanism PR 2 will switch on. Inert in production today."""
+
+    @pytest.fixture
+    def minimal(self) -> str:
+        return render_platform_instructions(PromptTier.MINIMAL)
+
+    def test_minimal_is_shorter(self, minimal):
+        assert len(minimal) < len(PLATFORM_INSTRUCTIONS)
+
+    def test_minimal_drops_exactly_the_drop_set(self, minimal):
+        headings = {h for h, _ in _iter_sections(minimal) if h}
+        assert headings == _KNOWN_SECTION_HEADINGS - _MINIMAL_DROP_SECTIONS
+
+    def test_minimal_keeps_the_operator_contract_verbatim(self, minimal):
+        # #1402's sentinels are load-bearing and sentinel-locked elsewhere; a tier
+        # must never be able to remove the async human-gate contract.
+        assert "fire-and-park, never block-and-wait" in minimal
+        assert "#### Ask before irreversible actions" in minimal
+        assert "~/.trinity/operator-queue.json" in minimal
+
+    def test_minimal_keeps_the_user_memory_leak_warning(self, minimal):
+        # The shared-memory-directory warning is a privacy guard, not tool docs.
+        assert "~/.claude/projects/memory/" in minimal
+        assert "shared across all users" in minimal
+
+    def test_minimal_keeps_package_persistence(self, minimal):
+        assert "~/.trinity/setup.sh" in minimal
+
+    def test_always_sections_all_present(self, minimal):
+        for heading in _ALWAYS_SECTIONS:
+            assert f"### {heading}" in minimal
+
+    def test_minimal_still_starts_with_the_preamble(self, minimal):
+        assert minimal.startswith("# Trinity Platform Instructions")
+
+    def test_minimal_has_no_dangling_delimiters(self, minimal):
+        assert "\n\n\n\n" not in minimal
+        assert not minimal.endswith(_SECTION_DELIMITER)


### PR DESCRIPTION
## What

Lands the **mechanism** for model-conditional platform prompts, and nothing else.
`_MINIMAL_PREFIXES` ships **empty**, so every model resolves `VERBOSE` and the
rendered prompt is byte-identical to `dev`. Enabling a family is PR 2, behind
evaluation evidence.

Implements ent#243 PR 1 (ACs on that issue were revised today to match the
research pass in its comment thread — the original ACs described a
runtime-scoped version this supersedes).

## Why the model, not the runtime

The Claude 5 context-engineering guidance (rules → judgment, examples →
interface design) applies to frontier coding-post-trained models and is
**actively harmful** below that line — Sonnet 4.5 and Haiku 4.5 need the
structure it deletes. OpenAI (Codex over-prompting) and Google (Gemini 3
over-analyzing verbose prompts) reached the same conclusion independently, so
the fault line is model class, not vendor and not harness.

MODEL-001 lets any turn pin any model string, including free text, so a
`claude-code` agent routinely runs Haiku 4.5. Gating on `AGENT_RUNTIME` would
silently degrade most of the selectable surface. `runtime` keeps its orthogonal
job — Codex MCP tool naming (#1187 F-MCP) — and a test pins the signature so the
two axes can't quietly merge.

## Design

- **`services/prompt_tier.py`** — family-prefix classifier mirroring
  `services/model_context.py`. Total, pure-stdlib, never raises.
  Unknown/empty/`None` → `VERBOSE`. That asymmetry is load-bearing:
  over-instructing a Claude 5 model costs tokens, under-instructing a 4.5 model
  degrades it *silently*. Not vendored to the agent server — the backend composes
  the prompt and ships it in the turn payload.
- **Section derivation, not a second prompt.** `PLATFORM_INSTRUCTIONS` stays one
  authored literal; sections are derived by splitting on its top-level `###`
  headings. Two full prompt strings guarantee drift, and the drift that matters
  is a security instruction added to one variant and not the other. The delimiter
  cannot match the `####` subsections, and `split`/`join` round-trips byte-exactly.
- **Un-gateable sections:** Operator Communication (#1402 fire-and-park contract,
  sentinel-locked and synced to `config/trinity-meta-prompt/prompt.md`), the
  shared-memory-dir leak warning, and Package Persistence. None is tool-usage
  guidance; none has a tool description to live in.
- **Fail-loud on rename.** An unmapped heading renders at every tier (safe), so
  the heading set is CI-pinned — otherwise a rename silently orphans its
  drop-list entry.

## Model-threading gaps closed

`pull_coordination_service` omitted `model` from its `ExecutionContext`
**entirely** — absent, not `None` — so every pull-claimed turn would have
resolved `VERBOSE` forever with nothing to indicate why. Both degraded fallback
paths now pass the model too, so a context-build failure cannot silently swap the
prompt tier as well as the context block.

An **unpinned chat turn stays `VERBOSE` by design**: the container picks the model
(`claude_code.py` → `claude-sonnet-4-6`) *after* composition, so the decision does
not exist backend-side and cannot be threaded. That default is already correct for
a 4.x model. Resolving the platform default backend-side would trade a known-safe
gap for a hidden one, since it can diverge from the agent's own
`get_default_model()`. Tracked as a follow-up; the same split underlies #1521's
context-window safe floor.

## Verification

- **Byte-identity proven directly against `origin/dev`** — `PLATFORM_INSTRUCTIONS`
  hashes `sha256 4cabe4557f2580580d154476406ace31525bdde4354a9ef77d6884affba2158e`,
  9207 bytes, on both sides. Identical, not merely equivalent.
- **36 new tests** (`tests/unit/test_ent243_prompt_tier.py`), including a
  parametrized no-op proof over the **live** `PRESET_MODELS` list parsed from
  `ModelSelector.vue` — a preset added later is covered without anyone updating
  the test — plus a guard against that parse silently breaking.
- Existing prompt contracts unaffected: `test_1402_prompt_contract.py`,
  `test_1535_report_prompt_guidance.py`, `test_platform_prompt_runtime.py`,
  `test_public_channel_prompt.py` all green. 351 passed across the
  prompt/chat/pull/task-execution selection.
- `tests/lint_sys_modules.py`: 194 violations vs baseline 240 — no new.

### Pre-existing failure, not from this PR

The full local unit suite fails
`test_1081_physical_meter.py::TestPerAgentMeter::test_available_floors_at_zero_over_ceiling[sqlite]`.
**Clean `origin/dev` @ `47f8843b` fails the identical test with the identical
command**, so this branch inherits it rather than causing it. It is an
order-dependent `sys.modules` leak surfaced by `pytest-randomly`; the file passes
14/14 in isolation. Filed separately.

## Requirements

`docs/memory/requirements/runtimes.md` §41 (written before implementation per
RoE #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
