### PR TITLE
fix(deps): pin mcp-server's fast-uri override to ^3.1.5, not an unbounded range (#2050)

### DIFF
--- a/src/mcp-server/package-lock.json
+++ b/src/mcp-server/package-lock.json
@@ -1188,9 +1188,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/src/mcp-server/package.json
+++ b/src/mcp-server/package.json
@@ -33,7 +33,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": ">=4.12.31",
     "axios": ">=1.15.2",
-    "fast-uri": ">=3.1.2",
+    "fast-uri": "^3.1.5",
     "@hono/node-server": ">=1.19.13",
     "ip-address": ">=10.2.0",
     "qs": ">=6.15.2",


### PR DESCRIPTION
Fixes #2050

## What

`src/mcp-server/package.json` declared its `fast-uri` override as `">=3.1.2"` — unbounded, so it admits 4.x. The root `package.json` beside it uses a caret (`"^3.1.4"`) and is correctly pinned to 3.x. That inconsistency is the entire bug.

Because of it, Dependabot security PR #2034 proposes **fast-uri 3.1.2 → 4.1.2** — a major jump — while `ajv`, the only consumer in the tree, declares `fast-uri: ^3.0.1`. Even the latest published ajv (8.20.0) still declares `^3.0.1`; **no released ajv accepts v4**. The override forces it there anyway, because that is what overrides do.

## Why 3.1.5 is the right target, not 4.1.2

All three advisories are fixed on the 3.x line:

| Advisory | Severity | 3.x fixed in |
|---|---|---|
| GHSA-4c8g-83qw-93j6 — host confusion via failed IDN canonicalization | high | 3.1.3 |
| GHSA-v2hh-gcrm-f6hx — host confusion via literal backslash authority delimiter | high | 3.1.4 |
| GHSA-7p8r-x3mc-p8w7 — host confusion via backslash authority introducer | high | 3.1.5 |

**3.1.5 closes every one of them** without leaving ajv's supported range. The major bump buys no additional security and spends compatibility for it.

This is also what root already does: #2032 took root's fast-uri to 3.1.5 and stayed in 3.x, precisely because its override is a caret.

## Why CI would not have caught the alternative

The failure mode of forcing ajv onto fast-uri v4 is at **runtime**, in ajv's `$ref` URI resolution — not at build time. The mcp-server PRs carry no `build` or `e2e` check (`e2e` is CANCELLED/SKIPPED on them), so a break would have shipped green. v4.0.0 also carries a real type-surface change ("chore: removed types deprecated") and an escape-handling fix, so it is not a no-op.

## Verification

```
fast-uri resolves to  3.1.5   (was 3.1.2)
ajv 8.18.0            ^3.0.1  satisfied
npm run build (tsc)   clean
npm test              170 passed, 0 failed
npm audit             fast-uri no longer listed
```

Diff is four lines: the override, and fast-uri's `version`/`resolved`/`integrity` in the lockfile. Nothing else moved.

## Scope / follow-up

Targets `dev` per the SDLC, since this is a code change to the override rather than a Dependabot-generated lockfile bump.

Note the residual: `main` still carries mcp-server fast-uri **3.1.2**, vulnerable to all three, until this releases. #2034 is left open rather than closed (closing makes Dependabot recreate it) and should be superseded by this. If the exposure warrants expediting, this is the commit to cherry-pick to `main` — not #2034.

The remaining `npm audit` findings on this tree (hono, ip-address, undici, @hono/node-server) are fixed by #2001 / #1972 / #1986 / #2000, which merged to `main` as Dependabot security PRs and reach `dev` on the next release back-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)