### PR TITLE
docs: document /trinity:start-here, the guided first journey

### DIFF
--- a/docs/user-docs/abilities/overview.md
+++ b/docs/user-docs/abilities/overview.md
@@ -6,6 +6,16 @@ The official agent development toolkit for Claude Code. Curated plugins covering
 
 ## Quick Start
 
+**New to Trinity?** Install the `trinity` plugin and run `/trinity:start-here` — a guided, resumable journey from "what is Trinity?" to your first agent running on your own instance. It sequences everything below, so you don't have to pick a starting point:
+
+```bash
+/plugin marketplace add abilityai/abilities
+/plugin install trinity@abilityai
+/trinity:start-here
+```
+
+Prefer to drive yourself?
+
 ```bash
 # Add the abilities marketplace (one-time)
 /plugin marketplace add abilityai/abilities
@@ -32,7 +42,7 @@ claude plugin install create-agent@abilityai
 |--------|--------|---------|------------|
 | [create-agent](create-agent-plugin.md) | 14 | Agent creation wizards | `/create-agent:prospector`, `/create-agent:custom` |
 | [agent-dev](agent-dev-plugin.md) | 20 | Extend existing agents | `/agent-dev:create-playbook`, `/agent-dev:add-memory`, `/agent-dev:add-orchestrator`, `/agent-dev:work-loop` |
-| [trinity](trinity-plugin.md) | 6 | Deploy to and operate on Trinity | `/trinity:connect`, `/trinity:onboard`, `/trinity:loop` |
+| [trinity](trinity-plugin.md) | 7 | Deploy to and operate on Trinity | `/trinity:start-here`, `/trinity:connect`, `/trinity:onboard`, `/trinity:loop` |
 | [dev-methodology](dev-methodology-plugin.md) | 24 | Development workflow | `/dev-methodology:implement`, `/dev-methodology:validate-pr` |
 | [utilities](utilities-plugin.md) | 7 | Ops and productivity | `/utilities:safe-deploy`, `/utilities:docker-ops` |
 

--- a/docs/user-docs/abilities/trinity-plugin.md
+++ b/docs/user-docs/abilities/trinity-plugin.md
@@ -1,6 +1,8 @@
 # trinity Plugin
 
-Connect, deploy, operate, and sync agents on the Trinity platform. Six skills covering the complete lifecycle — from first connection to running remote loops and provisioning new instances.
+Connect, deploy, operate, and sync agents on the Trinity platform. Seven skills covering the complete lifecycle — from a guided first journey through connection, deployment, remote loops, and instance provisioning.
+
+> 🧭 **New to Trinity? Start with `/trinity:start-here`** — a guided, resumable walkthrough that takes you from "what is Trinity?" to your first agent running on your own instance. [Jump to the section](#the-guided-journey-trinitystart-here).
 
 > 📺 **Watch:** [Build Autonomous Loops for Your AI Agents](https://youtu.be/q3YvFYtuhec) *(Jun 2026)* · [all videos](../videos.md)
 
@@ -14,12 +16,39 @@ Connect, deploy, operate, and sync agents on the Trinity platform. Six skills co
 
 | Skill | Description |
 |-------|-------------|
+| `/trinity:start-here` | **New here?** Guided, resumable journey: what Trinity is → get an instance → connect → first agent alive |
 | `/trinity:connect` | One-time: authenticate and configure the MCP connection |
 | `/trinity:onboard` | Per-agent: compatibility check, file creation, deploy |
 | `/trinity:sync` | Ongoing: sync changes between local and the running remote agent |
 | `/trinity:loop` | Run a remote agent task in a sequential, bounded loop — fire once, disconnect, check back |
 | `/trinity:create-dashboard` | Generate an agent-specific `/update-dashboard` skill that keeps `dashboard.yaml` current |
 | `/trinity:deploy-new-instance` | Deploy a Trinity instance on any server and scaffold an ops agent to manage it |
+
+## The Guided Journey: `/trinity:start-here`
+
+```bash
+/plugin marketplace add abilityai/abilities
+/plugin install trinity@abilityai
+/trinity:start-here
+```
+
+One command that concierges a newcomer through the whole path — it sequences the skills below rather than replacing them, so you never have to know which one comes next:
+
+| Stage | What happens |
+|-------|--------------|
+| **Orient** | What Trinity is, in plain terms, plus the current release |
+| **Choose your door** | Just looking · build my first agent · I already have agents · set up my instance |
+| **Get an instance** | Hands off to `/trinity:deploy-new-instance` (cloud, your server, or local Docker) — or takes the URL you already have |
+| **Connect + verify** | Hands off to `/trinity:connect`, then runs a live smoke test: fleet visible, instance healthy, docs assistant online |
+| **First agent alive** | Deploys via `/trinity:onboard` (or picks an existing agent) and exchanges a real message with it |
+
+Three things worth knowing:
+
+- **Nothing is deployed until you choose it.** The "just looking" door asks for no credentials and creates nothing.
+- **It resumes.** Progress is saved in `~/.trinity/start-here.json`, so quitting — or the Claude Code restart needed to load the MCP server — picks up exactly where you stopped. Run `/trinity:start-here reset` to start over.
+- **Answers come from live documentation, not a script.** Questions are answered from these docs at run time — through the public [Trinity Docs Q&A](../getting-started/help.md) before you have an instance, and through your instance's own `ask_trinity` tool afterward.
+
+Already know what you want? The individual skills below work standalone, in any order.
 
 ## How It Works
 


### PR DESCRIPTION
## What

Documents the trinity plugin's new seventh skill, `/trinity:start-here` — a guided, resumable journey that takes a newcomer from "what is Trinity?" to a first agent running on their own instance. Shipped in the marketplace as [abilities `629aabb`](https://github.com/Abilityai/abilities/commit/629aabb) (trinity plugin 2.6.1).

**Docs-only.** No code, no behavior change.

## Why now

`docs/user-docs/abilities/trinity-plugin.md` says "Six skills" and lists six; `overview.md` gives newcomers a bare install list with no suggested entry point. Both are now stale, and both are upstream of the two surfaces people actually read:

- the docs site, regenerated by the `trinity-docs` agent's `/sync-docs` from `docs/user-docs/`
- the **Trinity Docs Q&A** Vertex index, re-synced by `.github/workflows/sync-docs-to-vertex.yml` on every push to `main`

So until this lands, neither the site nor the docs assistant can tell anyone the skill exists.

## Changes

| File | Change |
|---|---|
| `abilities/trinity-plugin.md` | Skills-table row; new **Guided Journey** section (stage table, zero-commitment tour, resume/`reset`, live-docs grounding); intro banner linking to it; "Six" → "Seven" |
| `abilities/overview.md` | Quick Start leads with the guided path before the manual install list; plugin table 6 → 7 skills |

## Notes for review

- The skill routes to existing skills (`connect`, `deploy-new-instance`, `onboard`, the create-agent wizards) rather than reimplementing them — the docs describe it that way deliberately.
- It answers platform questions from live docs at run time (public Docs Q&A endpoint pre-connect, the instance's `ask_trinity` after), so this page is describing behavior that stays current on its own.
- Cross-link target `../getting-started/help.md` verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)