### PR TITLE
docs: mark TRINITY_ONBOARD_PLUGIN.md historical — it specs a plugin that no longer exists

### DIFF
--- a/docs/requirements/TRINITY_ONBOARD_PLUGIN.md
+++ b/docs/requirements/TRINITY_ONBOARD_PLUGIN.md
@@ -3,9 +3,64 @@
 **Version**: 1.1
 **Created**: 2025-02-05
 **Updated**: 2026-02-09
-**Status**: Implemented
+**Status**: **Historical** — records the original spec, not current behaviour (marked 2026-08-07, #2055)
 
-> **System of Record**: All Trinity skills and onboarding are in the [abilityai/abilities](https://github.com/abilityai/abilities) repository.
+> ## ⚠️ This document is historical
+>
+> It captures the plugin as originally specified. The plugin has since been
+> restructured, and **several sections below describe things that no longer
+> exist**. Do not implement against it, and do not treat it as the onboarding
+> contract.
+>
+> **The live contract is the skill source itself:**
+> [`abilityai/abilities` → `plugins/trinity/`](https://github.com/abilityai/abilities/tree/main/plugins/trinity).
+> Each skill's `SKILL.md` carries its own version and changelog; read those.
+>
+> See [What changed since this spec](#what-changed-since-this-spec) for the
+> drifts verified when this banner was added.
+
+---
+
+## What changed since this spec
+
+Verified against `abilityai/abilities` → `plugins/trinity/` on 2026-08-07. This
+list is what was checked, not an exhaustive audit — assume anything below is
+stale unless the skill source confirms it.
+
+**`.mcp.json` is written by `/trinity:connect`, not by onboard** (#2055). This
+is the drift that prompted the banner. [Phase 7](#phase-7-configure-local-connection)
+below says onboard updates `.mcp.json`; onboard `v4.12` deleted that writer
+outright, along with the `.mcp.json.template` it produced. Its Step 4 now only
+*verifies* the connection, and the skill states the rule directly:
+
+> Authentication and MCP configuration are owned by **`/trinity:connect`** — the
+> single source of truth. onboard does **not** resolve credentials or write
+> `.mcp.json` itself (duplicating that is what drifted before).
+
+`onboard`, `sync` and `loop` all delegate to `connect`. A duplicated writer is
+exactly what drifted before and caused the refactor, so §3.2's `npx mcp-remote`
+config and every "creates `.mcp.json.template`" claim below are not just stale —
+re-implementing them would reintroduce the bug. Trinity connection credentials
+now live in `connect`'s `~/.trinity/config.json` + `.mcp.json`; the agent's
+`.env` is for the agent's *own* integration secrets only.
+
+**The skill set is different.** §4's table and §5's per-skill sections describe
+skills that are gone or renamed:
+
+| This doc describes | Actual `plugins/trinity/skills/` |
+|---|---|
+| `onboard`, `sync`, `connect` | still present (contents changed) |
+| `dashboard` | renamed `create-dashboard` |
+| `remote`, `schedules` | no longer exist as skills |
+| §5's `trinity-adopt`, `trinity-compatibility`, `trinity-remote`, `trinity-sync`, `trinity-schedules` | **none of these directories exist** |
+| — | new: `deploy-new-instance`, `loop`, `start-here` |
+
+**`plugins/trinity/templates/` does not exist.** §3 and §6 describe a templates
+directory (`template.yaml.example`, `gitignore.example`, `env.example`,
+`mcp-json.template.example`); the path returns 404.
+
+What has held up: the two-command install flow, `template.yaml` as the agent's
+manifest, and `abilityai/abilities` as the system of record.
 
 ---
 
@@ -139,6 +194,10 @@ plugins/trinity/
 
 ### 3.2 MCP Configuration
 
+> ⛔ **Superseded (#2055).** This `npx mcp-remote` shape is the writer onboard
+> deleted in `v4.12`. `/trinity:connect` owns `.mcp.json` now; do not
+> reimplement this from here.
+
 **File**: `.mcp.json`
 
 ```json
@@ -189,6 +248,13 @@ plugins/trinity/skills/
 ## 5. Skills Reference
 
 > **System of Record**: All skills are in `github.com/abilityai/abilities/plugins/trinity/skills/`
+>
+> ⛔ **Superseded (#2055).** **None of the five skill directories described in
+> this section still exist** (`trinity-adopt`, `trinity-compatibility`,
+> `trinity-remote`, `trinity-sync`, `trinity-schedules`). The actual set is
+> `connect`, `create-dashboard`, `deploy-new-instance`, `loop`, `onboard`,
+> `start-here`, `sync`. Read their `SKILL.md` files instead — every "required
+> files" list below, including the `.mcp.json.template` entries, is stale.
 
 ### 5.1 trinity-adopt
 
@@ -340,6 +406,10 @@ disable-model-invocation: false
 
 ## 6. Template Files
 
+> ⛔ **Superseded (#2055).** `plugins/trinity/templates/` **does not exist** —
+> the path 404s. §6.4's `mcp-json.template.example` is doubly gone: onboard
+> stopped emitting `.mcp.json.template` in `v4.12`.
+
 ### 6.1 template.yaml.example
 
 ```yaml
@@ -484,7 +554,14 @@ Or the onboard skill can copy from its own plugin directory.
 
 ### Phase 7: Configure Local Connection
 
-1. Update local `.mcp.json` to add Trinity server
+> ⛔ **Superseded (#2055).** Step 1 is wrong and must not be reimplemented:
+> onboard has no `.mcp.json` writer. `/trinity:connect` is the **single writer**
+> — onboard hands off to it, then only verifies (step 2 still holds). See
+> [What changed since this spec](#what-changed-since-this-spec).
+
+1. ~~Update local `.mcp.json` to add Trinity server~~ → run `/trinity:connect`,
+   which authenticates and writes `.mcp.json` (or refreshes it from a stored
+   profile)
 2. Verify connection: `mcp__trinity__list_agents()`
 
 ### Phase 8: Completion Report


### PR DESCRIPTION
## What

`docs/requirements/TRINITY_ONBOARD_PLUGIN.md` Phase 7 described `/trinity:onboard` updating `.mcp.json`. onboard **v4.12** deleted that writer outright, along with the `.mcp.json.template` it produced — `/trinity:connect` is the single writer, and `onboard`, `sync` and `loop` all delegate to it. The skill states the rule directly:

> Authentication and MCP configuration are owned by **`/trinity:connect`** — the single source of truth. onboard does **not** resolve credentials or write `.mcp.json` itself (duplicating that is what drifted before).

That duplicated writer is what caused the refactor, so a requirements doc still describing it actively invites reintroducing the bug — and it is the kind of doc an agent reads when reasoning about the onboarding contract.

## Why "mark historical" rather than "fix Phase 7"

Checking the fix against the marketplace showed the drift is **not confined to Phase 7**. Verified against `abilityai/abilities` → `plugins/trinity/` on 2026-08-07:

| This doc describes | Reality |
|---|---|
| §5's five skills: `trinity-adopt`, `trinity-compatibility`, `trinity-remote`, `trinity-sync`, `trinity-schedules` | **none of those directories exist** |
| §4 table: `remote`, `schedules`, `dashboard` | `remote`/`schedules` gone; `dashboard` → `create-dashboard`; new `deploy-new-instance`, `loop`, `start-here` |
| §3/§6 `plugins/trinity/templates/` | **404 — does not exist** |
| §3.2 `.mcp.json` via `npx mcp-remote` | that *is* the deleted writer |
| Phase 7 writes `.mcp.json` | Step 4 only verifies the connection |
| Header `Status: Implemented` | describes a plugin shape that no longer exists |

So editing Phase 7 alone would have been the worse outcome: one freshened paragraph under `Status: Implemented` implies the rest was checked. The issue offered marking it historical as its second option; that was chosen and recorded.

Current skill version is **v4.15** (v4.12 is the changelog entry that made the change).

## Changes

- **Header** → `Status: Historical`, dated, with a banner naming the skill source as the live contract. The doc already declared `abilityai/abilities` its system of record — this makes that deferral load-bearing rather than decorative.
- **New "What changed since this spec"** section recording the four verified drifts, leading with the `.mcp.json` delegation and quoting the skill's own composition rule. It says what was *checked* rather than claiming an exhaustive audit, and closes with what has held up, so the doc isn't read as uniformly wrong.
- **Four inline ⛔ markers** at the sections that would actually mislead someone landing mid-document (§3.2, §5, §6, Phase 7) — a top banner doesn't help a reader who arrived from a search hit.
- **Phase 7 step 1 struck through and replaced** with the delegation rather than deleted, so the record of what was originally specified survives next to the correction.

## Deliberately not done

A full re-spec against the current seven skills. That is reverse-engineering a different plugin and belongs in its own issue — well beyond a P3 / `complexity-low` docs ticket.

## Verification

Docs-only; no code paths touched. Internal anchors resolve (`#what-changed-since-this-spec`, `#phase-7-configure-local-connection`), and every factual claim above was checked against the live marketplace via the GitHub API rather than assumed.

Fixes #2055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

