### PR TITLE
chore(docs): land July announcements, latest video, and the .claude bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ temp/
 # Local deployment configuration (contains sensitive data)
 CLAUDE.local.md
 .trinity-sync.yaml
+.trinity-remote.yaml
 
 # API logs
 api.log

--- a/docs/user-docs/dev-announcements/2026-07-14-144624.md
+++ b/docs/user-docs/dev-announcements/2026-07-14-144624.md
@@ -1,0 +1,58 @@
+---
+date: 2026-07-14T14:46:24
+channels:
+  - discord:updates
+  - slack:updates
+  - telegram:updates
+  - twitter:trinity
+  - twitter:default
+  - github:announcements
+links:
+  video: https://youtu.be/_BFKrp9GnNQ
+  paper: https://github.com/Abilityai/trinity/tree/main/research/closed-loop-forecasting
+  dashboard: https://brierhq.ai
+  twitter_trinity: https://x.com/i/status/2077026693944938802
+  twitter_default: https://x.com/i/status/2077026726840795367
+  github_discussion: https://github.com/Abilityai/trinity/discussions/1613
+---
+
+📄 New research is out — "A Measurably Self-Improving Multi-Agent Forecasting System: Five Feedback Loops, No Retraining"
+
+🎥 Video walkthrough: https://youtu.be/_BFKrp9GnNQ
+📖 Paper + data: https://github.com/Abilityai/trinity/tree/main/research/closed-loop-forecasting
+
+A multi-agent forecasting system that has been running on Trinity since February 2026 and improves while it runs — no retraining, no fine-tuning. Seven specialized forecasting agents (the oracle fleet), a meta-analyst (Cleon) that measures quality and routes corrections, and a knowledge-base agent (Cornelius) that turns surprising failures into insights served back before future predictions.
+
+The record so far:
+• 96,161 logged predictions, 73,552 resolved outcomes
+• Brier 0.194 vs 0.250 always-0.5 and 0.217 base-rate baselines; skill score +0.105
+• 93.5–99.7% of prediction error is noise, not bias — calibration alone can't fix that
+• 56,347 scored hidden-state hypotheses, with a monotone win-rate gradient across lifecycle tiers (strong 75.0%, emerging 68.2%, fading 59.0%)
+• Three of five compared agents improved both Brier score and surprise rate; two moved against their feedback — a limitation reported, not hidden
+
+The five feedback loops:
+1. Noise-adaptive calibration — routes to process-consistency guidance when noise dominates
+2. Surprise-driven insight extraction — confident misses become knowledge
+3. Knowledge retrieval before prediction
+4. Hidden-state hypothesis injection — theses about unobserved world state, scored by the predictions that use them
+5. A generative loop that decides what is worth forecasting — abducing theses from cross-domain anomalies and commissioning falsifiable predictions
+
+Live dashboard: https://brierhq.ai — predictions, resolutions, and Brier scores published as they land.
+
+Built and running entirely on Trinity — free and open source (Apache 2.0).
+
+---
+
+## Twitter variants (280-char)
+
+**trinity account:**
+New research: a forecasting system on Trinity that improves as it runs — 5 feedback loops, zero retraining. 96,161 predictions, 73,552 resolved, Brier 0.194.
+
+📄 https://github.com/Abilityai/trinity/tree/main/research/closed-loop-forecasting
+🎥 https://youtu.be/_BFKrp9GnNQ
+
+**default account:**
+Six months ago I switched on a forecasting system that keeps score on itself. 96,161 predictions later: Brier 0.194, five feedback loops, zero retraining.
+
+📄 https://github.com/Abilityai/trinity/tree/main/research/closed-loop-forecasting
+🎥 https://youtu.be/_BFKrp9GnNQ

--- a/docs/user-docs/dev-announcements/2026-07-16-144445.md
+++ b/docs/user-docs/dev-announcements/2026-07-16-144445.md
@@ -1,0 +1,42 @@
+---
+date: 2026-07-16T14:44:45
+channel: discord:updates, slack:updates, telegram:updates, twitter:trinity, twitter:default, github:announcements
+---
+
+📺 New video: Trinity architecture explained (4:44)
+https://youtu.be/XDLOq1crF9w
+
+An animated walkthrough of how Trinity works — follows one scheduled task end to end: the agent container, the admission gate, delegation between agents, human approval, the audit ledger, circuit breakers, capacity queues, channel adapters (Slack/Telegram/WhatsApp), and the network security model.
+
+---
+
+**Twitter (trinity)** — https://x.com/i/status/2077751166432104541
+
+> New video: Trinity architecture explained in 4:44 — one scheduled task followed end to end: agent container, admission gate, delegation, human approval, audit ledger, circuit breakers, channels.
+>
+> https://youtu.be/XDLOq1crF9w
+
+**Twitter (default)** — https://x.com/i/status/2077751204776382559
+
+> Made a 4:44 animated video explaining Trinity's architecture — one scheduled task followed end to end through the container, gate, delegation, approval, audit, and breaker machinery.
+>
+> https://youtu.be/XDLOq1crF9w
+
+**GitHub Discussion** — https://github.com/Abilityai/trinity/discussions/1657
+
+Title: *Video: Trinity architecture explained (4:44)*
+
+> https://youtu.be/XDLOq1crF9w
+>
+> An animated walkthrough of Trinity's architecture. It follows one scheduled task end to end and covers:
+>
+> - Agent containers — git-repo templates, encrypted credential injection, git-backed memory
+> - The two-network split and MCP-only agent access
+> - The admission gate and idempotent retries
+> - Agent-to-agent delegation
+> - Human approval via the operator queue
+> - The append-only, hash-chained audit ledger
+> - Circuit breakers and capacity queues
+> - Channel adapters: Slack, Telegram, WhatsApp
+> - The VPN perimeter, roles, and sharing model
+> - Fleet verbs: delegate, fan out, loop

--- a/docs/user-docs/dev-announcements/2026-07-22-183918.md
+++ b/docs/user-docs/dev-announcements/2026-07-22-183918.md
@@ -1,0 +1,44 @@
+---
+date: 2026-07-22T18:39:18
+channel: discord:updates, slack:updates, telegram:updates, twitter:trinity, twitter:default, github:announcements
+---
+
+# Agent Builder Workshop — Jul 23 session (all channels)
+
+**Discord / Slack / Telegram (per-platform formatting of the same message):**
+
+**Agent Builder Workshop — tomorrow, Thu Jul 23 · 12 PM ET / 9 AM PT**
+Live on Zoom, free. This week: building a company knowledge base with Cornelius on Trinity — from empty session to a deployed agent, built live. Bring your own setup and build along.
+Hosted by Eugene Vyborov, creator of Trinity.
+Meet Cornelius: https://youtu.be/aEEOElFpsEo
+Register: https://www.ability.ai/workshops/agent-builder-workshop-july
+Can't make it? Recordings go to newsletter subscribers. Next week (Jul 30): making home-grown Claude Code agents run autonomously on Trinity.
+
+**twitter:trinity** (https://x.com/i/status/2079969281643528430):
+
+Tomorrow, 12 PM ET / 9 AM PT — live Agent Builder Workshop: building a company knowledge base with Cornelius on Trinity. Free, on Zoom, build along live.
+
+Meet Cornelius: https://youtu.be/aEEOElFpsEo
+Register: https://www.ability.ai/workshops/agent-builder-workshop-july
+
+**twitter:default** (https://x.com/i/status/2079969373440127154):
+
+Free live workshop tomorrow (Thu, 12 PM ET): build a company knowledge base agent with Cornelius on Trinity — zero to deployed, live on Zoom.
+
+Cornelius in action: https://youtu.be/aEEOElFpsEo
+Join: https://www.ability.ai/workshops/agent-builder-workshop-july
+
+**github:announcements** (https://github.com/Abilityai/trinity/discussions/1749):
+
+Title: Workshop tomorrow (Jul 23): Building a company knowledge base with Cornelius on Trinity
+
+The next **Agent Builder Workshop** is tomorrow — **Thursday, July 23, 12 PM ET / 9 AM PT**, live on Zoom, free.
+
+This week's build: **a company knowledge base with Cornelius on Trinity** — starting from an empty session and ending with a deployed agent, live. Bring your own setup and build along.
+
+Hosted by Eugene Vyborov, creator of Trinity.
+
+- **Meet Cornelius:** https://youtu.be/aEEOElFpsEo
+- **Register:** https://www.ability.ai/workshops/agent-builder-workshop-july
+- **Can't make it?** Recordings go out to newsletter subscribers.
+- **Next session (Jul 30):** Making home-grown Claude Code agents run autonomously on Trinity.

--- a/docs/user-docs/dev-announcements/2026-07-28-164135.md
+++ b/docs/user-docs/dev-announcements/2026-07-28-164135.md
@@ -1,0 +1,25 @@
+---
+date: 2026-07-28T16:41:35
+channel: discord:updates, slack:updates, telegram:updates, twitter:trinity, twitter:default, github:announcements
+---
+
+**Trinity v0.8.5 is out** 🚀
+
+773 commits, ~95 issues. The theme: agents that coordinate — with each other, and with time.
+
+📣 **Task-completion events** — agents subscribe to each other's task terminals and get woken with the outcome the moment work finishes. Orchestrators stop polling; long-running handoffs just work.
+⏰ **Agent self-reminders** — a running agent can schedule a future re-invocation of itself ("check this again in 2 hours"). Durable, survives restarts, visible in the execution timeline.
+🧑‍🤝‍🧑 **Shared rooms** — multi-agent sessions: several agents in one conversation with a mention-wake turn engine, budgets, and a live Sessions view on the dashboard (enterprise).
+📦 **Skills are full packages now** — a skill is a directory (scripts, templates, resources), versioned and safely synced; plus a stateless skill-runner that executes library skills over MCP (enterprise).
+🏷️ **Display names** — rename the label, never the slug: friendly agent names across the whole UI without breaking URLs, automations, or integrations.
+👻 **Ghost agents** — disposable, budgeted agents for burst work that hard-discard themselves at their execution/TTL budget (enterprise).
+🔑 **Bring your own GitHub token** — per-user PATs (each user's own repo scope), and public `github:` templates now clone with no token at all.
+
+Plus voice replies v2 (voice is now a per-message agent choice), local-first telemetry (default-on, never leaves the box), a big fleet-hygiene pass (git bloat root-caused, Docker volume reclaim), and a blast-radius guard on data retention.
+
+📝 What's new: https://docs.ability.ai/whats-new/v0.8.5
+🔍 Full notes: https://github.com/abilityai/trinity/releases/tag/v0.8.5
+
+---
+
+*Per-channel variants: Slack mrkdwn, Telegram HTML, two X posts (trinity: https://x.com/i/status/2082129245963276661 · default: https://x.com/i/status/2082129286987690310, varied wording), GitHub Discussion with full sectioned body incl. upgrade notes (https://github.com/Abilityai/trinity/discussions/1858).*

--- a/docs/user-docs/dev-announcements/2026-07-28-180637.md
+++ b/docs/user-docs/dev-announcements/2026-07-28-180637.md
@@ -1,0 +1,43 @@
+---
+date: 2026-07-28T18:06:37
+channel: discord:updates, slack:updates, telegram:updates, twitter:trinity, twitter:default, github:announcements
+---
+
+📺 New video: How to Build a Second Brain for Your AI Agents
+https://youtu.be/fia2qa4YcLg
+
+Your agents are only as smart as the data you feed them — stale or inconsistent knowledge doesn't just cause bad answers, it causes catastrophic actions. This workshop covers the 5 core rules for managing agent knowledge and a production-ready pattern that separates canonical truth from operational data:
+• The 3-part framework: **Decisions** (canon), **Facts** (operational data), **Judgment** (insights)
+• Knowledge as Code — Git repositories as the single source of truth
+• A central "mind center" agent separating direct data access from agent-based judgment
+• Why human endorsement is non-negotiable for updating the canon
+
+---
+
+**Twitter (trinity)** — https://x.com/i/status/2082150679481577647
+
+> New video: How to Build a Second Brain for Your AI Agents — the 5 rules for managing agent knowledge, the Decisions/Facts/Judgment framework, Knowledge as Code with Git, and why human endorsement gates the canon.
+>
+> https://youtu.be/fia2qa4YcLg
+
+**Twitter (default)** — https://x.com/i/status/2082150702260932713
+
+> Stale knowledge doesn't give agents bad answers — it gives them catastrophic actions. New workshop: building a second brain for your AI fleet. Decisions vs Facts vs Judgment, knowledge as code, human-endorsed canon.
+>
+> https://youtu.be/fia2qa4YcLg
+
+**GitHub Discussion** — https://github.com/Abilityai/trinity/discussions/1859
+
+Title: *Video: How to Build a Second Brain for Your AI Agents*
+
+> https://youtu.be/fia2qa4YcLg
+>
+> Your AI agents are only as smart as the data you feed them — stale, inconsistent, or incorrect knowledge doesn't just cause bad answers, it causes catastrophic actions. This workshop covers the 5 core rules for managing agent knowledge and a production-ready architectural pattern that separates canonical truth from operational data.
+>
+> Covered in the video:
+>
+> - Why stale data is far more dangerous for autonomous agents than for humans
+> - The 3-part framework for organizing company knowledge: **Decisions** (canon), **Facts** (operational data), and **Judgment** (insights)
+> - Implementing "Knowledge as Code" — Git repositories as the single source of truth
+> - The architectural pattern that separates direct data access from agent-based judgment via a central "mind center" agent
+> - Why human endorsement is non-negotiable for updating the canonical knowledge base

--- a/docs/user-docs/dev-announcements/2026-07-30-150300.md
+++ b/docs/user-docs/dev-announcements/2026-07-30-150300.md
@@ -1,0 +1,39 @@
+---
+date: 2026-07-30T15:03:00
+channel: discord:updates, slack:updates, telegram:updates, twitter:trinity, twitter:default, github:announcements
+---
+
+# Agent Builder Workshop — Jul 30 session, day-of announcement (all channels)
+
+**Discord / Slack / Telegram (per-platform formatting of the same message):**
+
+**Agent Builder Workshop — today, Thu Jul 30 · 12 PM ET / 9 AM PT**
+Live on Zoom, free. This week: converting an entire fleet of existing agents — built with Claude Code, n8n, LangChain, or any other stack — into a validated, Trinity-compatible agent fleet, step by step.
+Hosted by Eugene Vyborov, creator of Trinity.
+Register: https://www.ability.ai/workshops/agent-builder-workshop-july
+Can't make it? Recordings go to newsletter subscribers.
+
+**twitter:trinity** (https://x.com/i/status/2082829113576837391):
+
+Today, 12 PM ET / 9 AM PT — live Agent Builder Workshop: converting a fleet of existing agents (Claude Code, n8n, LangChain, anything) into a validated Trinity-compatible fleet, step by step. Free, on Zoom.
+
+Register: https://www.ability.ai/workshops/agent-builder-workshop-july
+
+**twitter:default** (https://x.com/i/status/2082829142278471768):
+
+Got a pile of agents built with Claude Code, n8n, or LangChain? Free live workshop today (12 PM ET / 9 AM PT): turning them into a validated, Trinity-compatible agent fleet — step by step, live on Zoom.
+
+Join: https://www.ability.ai/workshops/agent-builder-workshop-july
+
+**github:announcements** (https://github.com/Abilityai/trinity/discussions/1892):
+
+Title: Workshop today (Jul 30): Converting your existing agent fleet into a validated Trinity-compatible fleet
+
+The next **Agent Builder Workshop** is **today — Thursday, July 30, 12 PM ET / 9 AM PT**, live on Zoom, free.
+
+This week's session: **converting an entire fleet of existing agents into a validated, Trinity-compatible agent fleet** — step by step. It doesn't matter what the agents were built with: Claude Code, n8n, plain LangChain, or any other stack.
+
+Hosted by Eugene Vyborov, creator of Trinity.
+
+- **Register:** https://www.ability.ai/workshops/agent-builder-workshop-july
+- **Can't make it?** Recordings go out to newsletter subscribers.

--- a/docs/user-docs/videos.md
+++ b/docs/user-docs/videos.md
@@ -47,6 +47,7 @@ Workshops, demos, and deep-dives on building and running autonomous agents with 
 
 ## Use Cases & Case Studies
 
+- [Measurably Self-Improving Multi-Agent System Without Retraining](https://youtu.be/_BFKrp9GnNQ) — *Jul 2026* · Brier HQ: a forecasting fleet with five feedback loops — paper at [research/closed-loop-forecasting](https://github.com/Abilityai/trinity/tree/main/research/closed-loop-forecasting)
 - [How I Built an Agent That Makes Movies While I Sleep](https://youtu.be/CblJsMI9ekU) — *Feb 2026* · long-running creative production + heartbeat
 - [Investigative Analysis of Epstein Files Using an AI Agent](https://youtu.be/8a9p60kOWgU) — *Jan 2026* · knowledge graph over a messy corpus
 - [Control My DGX Spark From Anywhere](https://youtu.be/epDBrEtg4nE) — *Jan 2026* · Trinity on local/edge hardware over Tailscale


### PR DESCRIPTION
## What

Four small housekeeping items that had accumulated uncommitted in the working tree.

| Change | Detail |
|---|---|
| **6 dev-announcements** | `2026-07-14` → `2026-07-30`, joining the 25 already tracked |
| **1 video entry** | Brier HQ talk in `docs/user-docs/videos.md` |
| **1 gitignore line** | `.trinity-remote.yaml` |
| **1 submodule bump** | `.claude` `de7fc71` → `ba23cf5` |

## Detail

**Announcements** — the durable record of what `/announce` broadcast. They were generated at send time but never committed, leaving a two-week gap in the tracked series.

**Video** — *Measurably Self-Improving Multi-Agent System Without Retraining*: a forecasting fleet with five feedback loops, paired with the existing `research/closed-loop-forecasting` paper.

**gitignore** — `.trinity-remote.yaml` holds per-clone remote-instance config and should never be committed. Sibling of the already-ignored `.trinity-sync.yaml`, listed directly beneath it.

**Submodule** — picks up `/edge-cases`, the release Step 8 refactor, orchestrate hygiene, and a fix closing a cross-repo issue-status leak. That last one matters: the release status automation is same-repo only, so private `trinity-enterprise` issues delivered by public-repo PRs never reach `status-in-dev` and fall out of both the release payload and the close sweep — six issues shipped in v0.8.5 that way and stayed open until a manual reconciliation on 2026-08-03.

## Risk

Docs and config only — no code, no schema. The `.claude` submodule is private and marked `update = none`, so OSS clones are unaffected by the bump. Staged text was swept for emails, tokens, and internal hosts before commit; clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)