### PR TITLE
fix(ui): stop the MCP key metadata row wrapping mid-timestamp (#1848)

### DIFF
--- a/src/frontend/scripts/check-design-tokens.mjs
+++ b/src/frontend/scripts/check-design-tokens.mjs
@@ -135,6 +135,9 @@ const INK_LADDER_SWEPT = {
   'components/operator/NotificationsPanel.vue': 2, // spinner svg + inbox svg
   'components/operator/QueueCard.vue': 4,      // separator, dismiss glyph, 2 disabled buttons
   'components/operator/QueueItemDetail.vue': 0,
+  // #1848 swept the key-list metadata row, whose inverted ink pair
+  // (text-gray-400 dark:text-gray-500) failed AA in BOTH themes at rest.
+  'components/settings/McpKeysTab.vue': 1,     // empty-state svg glyph
   'views/Dashboard.vue': 5,                    // 3 separators, search svg, clear glyph
   'views/Login.vue': 0,
   'views/enterprise/Audit.vue': 0,

--- a/src/frontend/src/components/settings/McpKeysTab.vue
+++ b/src/frontend/src/components/settings/McpKeysTab.vue
@@ -62,7 +62,12 @@
       </div>
 
       <ul v-else class="divide-y divide-gray-200 dark:divide-gray-700">
-        <li v-for="key in displayedKeys" :key="key.id" class="p-6 hover:bg-gray-50 dark:hover:bg-gray-700">
+        <!-- #1848: the dark hover surface is the chrome shade gray-750, not
+             gray-700 (which is border-strong). On gray-700 the row's tertiary
+             meta ink sits at 4.06:1 — below AA — whenever the cursor is on the
+             row, and the gray-700 prefix chip below becomes invisible (1.00:1).
+             On gray-750 they read 5.21:1 and 1.28:1. -->
+        <li v-for="key in displayedKeys" :key="key.id" class="p-6 hover:bg-gray-50 dark:hover:bg-gray-750">
           <div class="flex items-center justify-between">
             <div class="flex items-center flex-1">
               <div class="flex-shrink-0">
@@ -96,19 +101,30 @@
                   </span>
                 </div>
                 <p v-if="key.description" class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ key.description }}</p>
-                <div class="mt-1 flex items-center text-xs text-gray-400 dark:text-gray-500 space-x-4">
+                <!-- #1848: uniform inline flow. `space-x-4` is margin-left on every
+                     item after the first, which indents continuation lines the moment
+                     the row wraps — so a wrapping row needs `gap`, not `space-x`. Each
+                     label+value atom is nowrap so a timestamp can never orphan its
+                     AM/PM; the email instead gets min-w-0 + break-all, because an
+                     address has no spaces and so would otherwise be an unbreakable
+                     token that overflows the row. The Last-used slot always renders so
+                     every row has the same item set — that, not nowrap alone, is what
+                     stops rows breaking at different points. Ink is the tertiary ladder
+                     rung (gray-500/gray-400), which was inverted and failed AA in both
+                     themes at rest. -->
+                <div class="mt-1 flex items-center flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
                   <span>
                     <code class="bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded font-mono">{{ key.key_prefix }}...</code>
                   </span>
-                  <span v-if="key.user_email" class="flex items-center">
-                    <svg class="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <span v-if="key.user_email" class="flex items-center min-w-0 break-all">
+                    <svg class="h-3 w-3 mr-1 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                     </svg>
                     {{ key.user_email }}
                   </span>
-                  <span>Created {{ formatDate(key.created_at) }}</span>
-                  <span v-if="key.last_used_at">Last used {{ formatDate(key.last_used_at) }}</span>
-                  <span class="flex items-center">
+                  <span class="whitespace-nowrap tabular-nums">Created {{ formatDate(key.created_at) }}</span>
+                  <span class="whitespace-nowrap tabular-nums">Last used {{ key.last_used_at ? formatDate(key.last_used_at) : 'never' }}</span>
+                  <span class="flex items-center whitespace-nowrap tabular-nums">
                     <svg class="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                     </svg>

--- a/src/frontend/src/components/settings/McpKeysTab.vue
+++ b/src/frontend/src/components/settings/McpKeysTab.vue
@@ -111,13 +111,20 @@
                      every row has the same item set — that, not nowrap alone, is what
                      stops rows breaking at different points. Ink is the tertiary ladder
                      rung (gray-500/gray-400), which was inverted and failed AA in both
-                     themes at rest. -->
+                     themes at rest.
+
+                     The owner span is the one item that can now go multi-line (break-all
+                     is what made that reachable), so its icon is items-start + mt-0.5
+                     rather than items-center — it must sit on the FIRST line, not float
+                     to the vertical centre of two. text-xs is a 16px line box and the
+                     glyph is 12px, so mt-0.5 (2px) is exactly the offset items-center
+                     was already producing: single-line rows are pixel-identical. -->
                 <div class="mt-1 flex items-center flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
                   <span>
                     <code class="bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded font-mono">{{ key.key_prefix }}...</code>
                   </span>
-                  <span v-if="key.user_email" class="flex items-center min-w-0 break-all">
-                    <svg class="h-3 w-3 mr-1 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <span v-if="key.user_email" class="flex items-start min-w-0 break-all">
+                    <svg class="h-3 w-3 mr-1 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                     </svg>
                     {{ key.user_email }}


### PR DESCRIPTION
Fixes #1848

The per-key metadata line under **Settings → MCP Keys** was a single non-wrapping flex row. Three things combined to break it, and the reported symptom was the third-order effect of the second:

* `flex` with **no** `flex-wrap`, so an overflowing row could not move an item to a new line and the browser **shrank items instead**. A span's automatic minimum size is its min-content width, so `Created 7/28/2026 11:53:50 AM` (`toLocaleTimeString` includes seconds) wrapped *internally* at a space and orphaned the `AM`.
* The **item set differed per row**: `v-if="key.last_used_at"` meant a used key rendered 5 items and a never-used key 4, so rows carried different shrink pressure and broke at different points. That asymmetry — not the wrap alone — is why rows stopped lining up with each other.
* `space-x-4` is `margin-left` on every item after the first, which is correct only while the row never wraps. Adding `flex-wrap` *without* replacing it would indent every continuation line — a new misalignment wearing the old one's clothes.

**Fix:** a uniform inline flow — `flex-wrap gap-x-4 gap-y-1` (4px grid), `whitespace-nowrap tabular-nums` on the three label+value atoms, and a Last-used slot that **always renders** with a `never` placeholder, matching `AgentMcpKeyPanel.vue` (#1854) which already states the same field the same way. The `v-if` was redundant regardless: `formatDate` has returned `'Never'` for a falsy input since it was written.

2 files, +33/−7. Confined to `McpKeysTab.vue` L70 + L122–140 and one additive entry in `check-design-tokens.mjs`.

---

## ⚠️ Reviewer: one question, and it is the load-bearing one

**Please confirm or reject this reading of AC #3 before approving — it is an interpretation, not a proof, and it is the single biggest interpretive risk in this PR.**

> This implements AC #2's *uniform inline flow* option; **it does not column-align.** Confirm that reading of AC #3, or say so — in which case the escalation spec in the plan (§6.2) applies.

The three reasons the reading is believed correct:

1. **Structural** — AC #2 explicitly offers *"either true column alignment or a uniform inline flow — pick one"*. Reading AC #3 as demanding cross-row column alignment would invalidate a branch of AC #2's own menu one line later.
2. **The reporter's own remedy** — the issue's Technical Notes propose `flex-wrap gap-x-4 …` + `whitespace-nowrap` (i.e. uniform inline flow) as the **first** likely fix. Judging the shipped change an AC #3 failure would be judging the reporter's own proposed remedy a failure.
3. **Causal** — AC #3's stated subject is *"long timestamps"*. Post-fix, `whitespace-nowrap` plus an always-rendered Last-used slot mean a long timestamp can no longer be the *mechanism* that displaces `N requests`.

**Honest residual, stated not buried:** cross-row `x` **still varies** with owner-email length (and with unpadded `toLocaleDateString()`, ≤2 glyphs). Uniform inline flow does not column-align, by definition.

**And note what escalating would not buy you:** the §6.2 escalation (always-render the email slot, then `grid grid-cols-[auto_minmax(0,1fr)_auto_auto_auto]` on the metadata row) delivers *intra-row* structure and per-row determinism but **still not cross-row alignment** — because `user_email` is `v-if`-gated over a **nullable** `users.email` column, so an owner-less key shifts every subsequent track. True columns need a `<table>`-shaped rewrite of the row, which should be its own `complexity-medium` issue rather than a rider here — especially on a file #1923/#1924/#1926 are already queued against.

---

## No doc update — bug-fix tier

Per CLAUDE.md Rule of Engagement #4, a bug fix requires a descriptive commit message only. **This was decided, not forgotten.** Four specific negatives, each checked rather than assumed:

- [x] **`docs/memory/architecture.md`** — `grep -n "McpKeysTab\|MCP Keys"` → 2 hits, both incidental (L825 *"keys already list in Settings → MCP Keys"*; L2189 the **agent** MCP-key subsystem heading). Nothing this change makes stale.
- [x] **`docs/memory/design-system.md` / `design-system-contract.md`** — no edit needed: this change **conforms to** the existing ink ladder, chrome-surface tokens, spacing scale and both-theme rules. It introduces no new pattern and changes no rule. (`grep McpKeysTab` → 0 hits in both.)
- [x] **`docs/memory/requirements/`** — `grep -rn McpKeysTab` → 0 hits. No requirement text describes this row.
- [x] **No new engineering paradigm is introduced.** This was the one real threat to the bug-fix tier: a first-of-its-kind frontend source-shape test would have changed the repo's testing standards and dragged doc obligations with it. **That test was deliberately dropped** (see *Scope* below). What remains outside the component is one entry in an existing data map (`INK_LADDER_SWEPT`) whose mechanism and rationale are already documented in place at `check-design-tokens.mjs:97–124` — enrolling a file is the documented way to **use** it, not a new mechanism.

Related: `docs/memory/feature-flows/agent-mcp-key.md:25` claims #1854 touched *"zero lines of `McpKeysTab.vue`"* — verified **still true**; that sentence describes what #1854 did, and this PR does not retro-falsify it.

---

## Evidence — and what it does *not* cover

### ⛔ None of this is pixel evidence

**There is no automated visual verification in this run.** No browser was driven, no screenshot taken, no DOM rendered. The vitest specs are **pure-logic** modules (`scanlinePhase`, `gridOrg`, `gridLayout`) — they prove only that *nothing else broke*; they are not evidence for this fix.

**AC #1, AC #2 and AC #3 therefore have NO automated coverage.** Only AC #4's *ink* half is mechanised (by `check:tokens`). The rest rests on the human visual checklist below. There is no component-testing capability in this repo to do better: `vitest.config.js` is `environment: 'node'` with the explicit comment *"Unit tests cover pure modules (utils/) only"*, and `@vue/test-utils`, `jsdom` and `happy-dom` are all absent from `package.json`.

### What *was* run (all observed, all on this branch at `94c0a558`)

| Check | Command | Result |
|---|---|---|
| Design tokens | `npm run check:tokens` | **EXIT 0** — *"dark ink ladder holds in **13** swept files"* (was 12; this PR enrols the 13th) |
| Unit specs | `npm run test:unit` | **EXIT 0** — **3 files, 43 tests passed**, 239ms |
| Build | `npm run build` | **EXIT 0** — **2737 modules transformed**, built in 1.64s |
| Raw-color ratchet | `node src/frontend/scripts/scan-raw-colors.mjs src/frontend --json` | `McpKeysTab.vue` = **`{raw_nongray: 0, raw_gray: 97, hardcoded_colors: 0}`** |

**Raw-color three-way equality** (not merely "no growth") — measured by putting `origin/dev`'s file back, re-scanning, then restoring:

```
BEFORE (origin/dev file) : {raw_nongray: 0, raw_gray: 97, hardcoded_colors: 0}
AFTER  (this branch)     : {raw_nongray: 0, raw_gray: 97, hardcoded_colors: 0}
BASELINE (2026-07-31)    : {raw_nongray: 0, raw_gray: 97, hardcoded_colors: 0}
```

Every swap is gray-to-gray and every added class is colorless, so the file's counts are **identical** on all three sides.

### 🔬 Ratchet probe — proof the new guard actually bites

Enrolling a file in `INK_LADDER_SWEPT` is only worth anything if the guard fails without the fix. Verified by reverting **only** the metadata row's ink pair and re-running:

```
$ sed -i '' 's/text-gray-500 dark:text-gray-400/text-gray-400 dark:text-gray-500/' McpKeysTab.vue
$ npm run check:tokens
  src/components/settings/McpKeysTab.vue: 2 uses of dark:text-gray-500, cap is 1.
  The floor is for disabled states and pure decoration only — if this is meta text
  use gray-400; if it is genuinely decoration, raise the cap in INK_LADDER_SWEPT
  and say why.
EXIT=1

$ # restore
$ npm run check:tokens
  Design-token check OK: ... dark ink ladder holds in 13 swept files
EXIT=0
```

So the enrolment is **not vacuous**: the ink half of this fix is now CI-enforced and cannot silently regress. (R1 = 0, R2 = 0, R3 = 1 — the remaining hit is the empty-state svg glyph at L57 — against a cap of 1. Note `checkDarkInkLadder` counts over the **whole file**, not just the template, so any new `dark:text-gray-500` anywhere in this file will turn CI red.)

### Contrast — four ratios, recomputed independently

Measured with the WCAG relative-luminance formula against `tailwindcss/colors` + `tailwind.config.js` (`gray-750 = rgb(42, 48, 60)`). Row surface is `bg-white dark:bg-gray-800` (L50). 12px text ⇒ the AA threshold is **4.5:1**.

| State | Before | After |
|---|---|---|
| Light, at rest (ink on white) | **2.54** ❌ | **4.83** ✅ |
| Dark, at rest (ink on `gray-800`) | **3.04** ❌ | **5.78** ✅ |
| Dark, cursor **on the row** (ink on hover surface) | **4.06** ❌ | **5.21** ✅ |
| Prefix chip boundary (`gray-700` chip on the hover surface) | **1.00** (invisible) | **1.28** |

---

## Scope — three deliberate extensions, declared so none reads as stealth

This PR is titled as an alignment fix. Three changes go beyond pure alignment. Each is called out here rather than left for a reviewer to find:

1. **The ink pair was swapped** (L122): `text-gray-400 dark:text-gray-500` → `text-gray-500 dark:text-gray-400`. The pair was **inverted** and failed AA in **both** themes at rest (2.54 and 3.04). In scope because AC #4 makes both-theme correctness an acceptance criterion, and ticking AC #4 with a 2.54:1 rest state would have been a false tick.
2. **The dark hover surface was re-tokenised** (L70): `dark:hover:bg-gray-700` → `dark:hover:bg-gray-750`. `gray-750` is the design contract's named dark **chrome** shade; `gray-700` is **border-strong**. Fixing only the ink would still have left the row at 4.06:1 whenever the cursor was on it, and left the `gray-700` prefix chip at **1.00:1** — literally invisible. One-token swap, raw-color-neutral.
3. **`items-start` + `mt-0.5` + `flex-shrink-0` on the owner-email `<span>`/svg** (L126, commit `94c0a558`). Adding `min-w-0 break-all` in `c7b02667` made the owner span the **one** item in the row that can render on two lines — a state that did not exist before, because an email has no whitespace and so simply overflowed. With `items-center` the 12px person glyph would then float to the vertical centre of the wrapped block instead of sitting beside the first line. **Provably neutral where it does not apply:** from the built CSS, `.text-xs{line-height:1rem}` (16px box) and `.h-3{height:.75rem}` (12px glyph), so `items-center` was *already* producing a (16−12)/2 = **2px** top offset, and `.mt-0\.5` is **exactly 2px** — single-line rows (effectively every row) are pixel-identical. `grep line-height` over `src/**/*.css` confirms nothing overrides it. `items-start` + `mt-0.5` on an icon is the established house pattern for multi-line-capable rows (`ImportValidationStep.vue:66`, `CompatibilityPanel.vue:188`).

**Deliberately NOT done** (kept out to preserve the bug-fix tier and avoid collision): a frontend source-shape guard test. Asserting that a template contains the literal string `flex-wrap` proves nothing about the rendered DOM, and being the repo's first frontend source-shape test it would have changed the repo's testing standards. Dropped on review.

**Merge hygiene:** #1923 / #1924 / #1926 are queued against this same file. The diff is confined to L70 and L122–140. Verified by count, not assertion: the two modal copy-buttons still carry `dark:hover:bg-gray-700` (now L297/L310 — **#1923's** territory, untouched), 6 `console.error`, 4 `alert()`, both hand-rolled modals unchanged. **Zero line-level overlap.**

---

## ⚠️ `dark:hover:bg-gray-750` is human-verified ONLY

`check:tokens` inspects **text** classes, and its family regex is `status|state|brand|accent|action` — so a `gray` **surface** class is invisible to it. **There is no CI guard on the hover-surface change.** A future revert to `dark:hover:bg-gray-700` would silently reintroduce the 4.06:1 AA failure and the 1.00:1 invisible chip, and nothing would go red.

That is why the measured ratios live in an in-template comment beside the class rather than only in this PR description — moving them into a PR body deletes the only guard there is.

---

## Human visual checklist — REQUIRED

No automated substitute exists (see above). Confirm on a running stack at `/settings?tab=mcp-keys`, with at least one used key and one never-used key present:

- [ ] **light @1440px** — no orphaned `AM`/`PM`; every row shows a `Last used` item
- [ ] **dark @1440px** — same, and the meta ink is legible at rest
- [ ] 🔍 **dark, cursor ON a row** — **no CI check can cover this step.** Meta ink still legible, and the `prefix` chip still has a visible boundary against the row. This is the un-guarded `gray-750` landing; if it looks wrong, the hover token is the thing to look at.
- [ ] **@1280px** (AC #1's stated floor) — the row wraps at item boundaries only, never mid-value
- [ ] 🔍 **@~900px with a long owner email** — **no CI check can cover this step.** The email must break **mid-string** rather than overflowing; **no page-level horizontal scroll**; the owner svg icon sits on the **FIRST line** (not floated to the vertical centre) and is **not squashed**.
- [ ] a never-used row and a used row read as the same flow — same item count, same order

---

## Follow-ups — flagged, NOT filed

1. **The raw-color ratchet runs in NO workflow.** CLAUDE.md Rule #10 calls it binding (*"per-file counts may only shrink"*), but `scan-raw-colors.mjs` appears in **zero** `.github/workflows/` files and is **not even an npm script** (only `check:tokens` is) — so it must be run and pasted by hand, as it was here. Measured drift past the 2026-07-31 baseline (`commit 5b289996`): totals `raw_nongray 753→772`, `raw_gray 7446→8268`, `hardcoded 383→410`, with **16 files above their baseline** plus **16 files carrying raw colors that never entered the baseline at all**. Largest movers: `views/Dashboard.vue` raw_gray 77→126, `components/ReportsPanel.vue` 25→46, `components/FleetGrid.vue` hardcoded 102→126, `ConnectorChannelPanel.vue` 41→55. **The ratchet is documentation, not a ratchet.** Fix = wire it into `frontend-build.yml` and regenerate the baseline. *(Same "inert by obscurity" class as #1958.)* **This PR does not touch that debt** — `McpKeysTab.vue` matches its baseline exactly.
2. **Fleet-wide dark chrome-token audit.** `dark:hover:bg-gray-700` is used as a **surface** across many components (2 more in this file alone, L297/L310) where the contract names `gray-750`. Every such site puts tertiary ink at ~4.06:1 and camouflages any `dark:bg-gray-700` chip on it.
3. **Extract a `MetaRow.vue` primitive.** The wrapped-meta-row idiom (`flex items-center flex-wrap gap-x-N gap-y-1 … text-xs <tertiary ink>`) now exists in **4** places — and they have already drifted: `SchedulesPanel.vue:353` and this file use `gap-x-4`, while `SchedulesPanel.vue:427` and `views/Settings.vue:1753` use `gap-x-3` (verified). That inconsistency is itself the argument for the primitive. It would discharge *"primitives over lookalikes"* properly and is the natural home for the nowrap/tabular/break-all rules.
4. **The second row-shape variance survives.** `v-if="key.user_email"` is still present and `users.email` is **nullable** (`db/schema.py` `email TEXT`, no NOT NULL — a password-only `admin` can have none). Benign under inline flow (a missing email simply shortens the row), but **fatal to any future grid template** — it is precisely what breaks a fixed `grid-cols-[…]`.
5. **Principle-22 time rendering on this row.** `toLocaleTimeString()` prints seconds, which is why the string was long enough to wrap at all. Contract principle 22 (*"times are honest: relative for recency, absolute + timezone on hover/detail"*) suggests a larger rethink. Changing displayed data was out of scope here.
6. **Add frontend component-testing capability** (`@vue/test-utils` + `jsdom`, `environment` split in `vitest.config.js`). This is the **structural** reason this — and every future frontend bug — ships without rendering evidence. Worth its own `type-refactor` issue.
7. **`docs/memory/feature-flows/api-keys-page.md` is already stale, independently of this change.** It documents a standalone `/api-keys` page and a NavBar "Keys" link that #302/#700 removed — `src/frontend/src/views/ApiKeys.vue` **does not exist** (verified), yet the doc cites it at `router/index.js:132-136`. It also quotes pre-token raw palette classes and line refs that no longer resolve. Deliberately not fixed here (584 lines, well outside bug-fix scope).

---

## Merge note

**This PR touches no documentation files**, so it has **no `architecture.md` collision** with the sibling PRs in this batch. It can merge in any order relative to them.

Branch is 2 commits on `origin/dev` @ `ef3b0ebf`, **0 behind** (re-checked at push time — no rebase needed).
