### PR TITLE
fix(git): resolve the agent repo root with git rev-parse, not a content probe (#2075)

### DIFF
--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -1413,14 +1413,82 @@ def _build_rm_cached_ignored_command(git_dir: str) -> str:
     return f"bash -c {shlex.quote(script)}"
 
 
+# Probe git itself for the repo root. `--show-toplevel` walks UP from the cwd,
+# so starting inside `workspace/` finds a workspace-rooted legacy repo first and
+# falls through to the home-rooted repo otherwise: nearest-enclosing repo wins,
+# which is the legacy/standard split the old content heuristic was approximating.
+#
+# GIT_DISCOVERY_ACROSS_FILESYSTEM=1 because `workspace/` is a plausible mount
+# point and git's default is to stop discovery at a filesystem boundary — which
+# would silently reintroduce the very misclassification this fixes. Letting
+# discovery cross the boundary is safe here only because `_parse_git_root`
+# refuses any answer outside `/home/developer`.
+_GIT_ROOT_PROBE = (
+    "cd /home/developer/workspace 2>/dev/null || cd /home/developer || exit 1; "
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM=1 git rev-parse --show-toplevel 2>/dev/null"
+)
+
+
+def _parse_git_root(output: str) -> Optional[str]:
+    """The repo root from ``git rev-parse --show-toplevel`` output, or None.
+
+    Deliberately defensive: the container exec channel returns stdout and
+    stderr merged, so the payload can arrive with noise around it. Only a line
+    that is exactly ``/home/developer`` or lives beneath it is accepted — ``/``,
+    ``/home`` (an accidental repo above the agent) and look-alikes such as
+    ``/home/developer2`` are rejected rather than acted on.
+    """
+    for line in (output or "").splitlines():
+        candidate = line.strip()
+        if candidate == "/home/developer" or candidate.startswith("/home/developer/"):
+            return candidate
+    return None
+
+
 async def _detect_git_dir(container_name: str) -> str:
     """Pick the directory git operations should run in for an agent container.
 
-    Standard path is ``/home/developer``. Returns ``/home/developer/workspace``
-    only for legacy agents (created before 2026-02) that have content under
-    that subdirectory. Mirrors the detection ``initialize_git_in_container``
-    has always used so init and the post-init migration agree.
+    Asks git, not the filesystem. ``git rev-parse --show-toplevel``, run from
+    ``/home/developer/workspace`` when that exists and from ``/home/developer``
+    otherwise, returns the root of the *nearest enclosing* repository — so a
+    legacy agent (created before 2026-02) whose repo really is rooted at
+    ``workspace/`` still gets ``workspace/``, while a standard agent gets
+    ``/home/developer`` even when ``workspace/`` holds unrelated data.
+
+    The previous implementation inferred the root from whether ``workspace/``
+    had any content, which tests *content* rather than *legacy-ness*: an agent
+    that keeps a populated non-git data directory there was reported as
+    workspace-rooted, and every path-based consumer (the compatibility
+    collector, the `.gitignore` migration and its `.git` guard, the fix
+    endpoint) then read and wrote a subdirectory's files as if they were the
+    repo root's.
+
+    The content heuristic is retained VERBATIM as the no-repository fallback:
+    ``initialize_git_in_container`` uses this result to CHOOSE where to run
+    ``git init``, so placement on a fresh agent must stay exactly what it has
+    always been.
     """
+    probe = await execute_command_in_container(
+        container_name=container_name,
+        command=f"bash -c {shlex.quote(_GIT_ROOT_PROBE)}",
+        timeout=5,
+    )
+    if probe.get("exit_code") == 0:
+        git_root = _parse_git_root(probe.get("output", ""))
+        if git_root:
+            return git_root
+
+    # No repository yet (or an unreadable probe) — fall back to the historical
+    # content heuristic, unchanged, so a fresh agent's `git init` lands where it
+    # always has. `git rev-parse` output carries no credentials, so the probe
+    # result is safe to log verbatim (truncated for volume, not for secrecy).
+    logger.warning(
+        "_detect_git_dir: no repository resolved for %s (exit=%s, output=%r); "
+        "falling back to the workspace-content heuristic",
+        container_name,
+        probe.get("exit_code"),
+        (probe.get("output") or "")[:200],
+    )
     check_workspace = await execute_command_in_container(
         container_name=container_name,
         command=(

--- a/tests/unit/test_2075_git_root_detection.py
+++ b/tests/unit/test_2075_git_root_detection.py
@@ -1,0 +1,362 @@
+"""
+Tests for agent repo-root detection in `_detect_git_dir`.
+
+`_detect_git_dir` decided an agent's repository root by probing whether
+`/home/developer/workspace` had any content, which tests *content* rather than
+*legacy-ness*: an agent whose repository is rooted at `/home/developer` but that
+also keeps a populated, non-git data directory under `workspace/` was reported
+as workspace-rooted. Every consumer that treats the result as a filesystem path
+— the compatibility collector, the `.gitignore` migration and its `.git` guard,
+and the compatibility fix endpoint — then read and wrote a subdirectory's files
+as if they were the repository root's.
+
+The fix asks git instead: `git rev-parse --show-toplevel` walks UP from the
+starting directory, so the nearest enclosing repository wins and a genuinely
+workspace-rooted legacy repository still resolves to `workspace/`. The old
+content heuristic is retained verbatim as the no-repository fallback, because
+`initialize_git_in_container` uses this value to choose where to CREATE a
+repository and fresh-agent placement must stay byte-compatible.
+
+Module: src/backend/services/git_service.py
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+_project_root = Path(__file__).resolve().parents[2]
+backend_path = str(_project_root / "src" / "backend")
+if backend_path not in sys.path:
+    sys.path.insert(0, backend_path)
+
+
+def _load_git_service():
+    """Import git_service with heavy dependencies mocked out."""
+    mock_modules = {}
+    for mod in [
+        "docker",
+        "docker.errors",
+        "docker.types",
+        "redis",
+        "redis.asyncio",
+        "database",
+        "services.docker_service",
+    ]:
+        mock_modules[mod] = Mock()
+
+    # `database` exposes `db`, `AgentGitConfig`, `GitSyncResult` at import time
+    mock_modules["database"].db = Mock()
+    mock_modules["database"].AgentGitConfig = Mock
+    mock_modules["database"].GitSyncResult = Mock
+
+    with patch.dict("sys.modules", mock_modules):
+        # Force reimport
+        for key in list(sys.modules.keys()):
+            if key.startswith("services.git_service"):
+                del sys.modules[key]
+        import services.git_service as gs
+    return gs
+
+
+class _FakeExec:
+    """Async stand-in for `execute_command_in_container`, keyed on the command.
+
+    Exactly two probes reach it:
+      * the git-root probe  — contains `git rev-parse --show-toplevel`
+      * the content probe   — contains `find /home/developer/workspace`
+    Anything else is a bug in the test, not the code, so it raises.
+    """
+
+    def __init__(
+        self,
+        *,
+        toplevel=None,
+        workspace_populated=False,
+        probe_output=None,
+        probe_exit=None,
+        raises=False,
+    ):
+        self.toplevel = toplevel  # str | None (None = no repo)
+        self.workspace_populated = workspace_populated
+        self.probe_output = probe_output  # raw override, wins over `toplevel`
+        self.probe_exit = probe_exit  # raw override
+        self.raises = raises
+        self.calls: list[str] = []
+
+    async def __call__(self, container_name: str, command: str, timeout: int = 60):
+        self.calls.append(command)
+        if self.raises:
+            raise RuntimeError("container is not running")
+        if "git rev-parse --show-toplevel" in command:
+            if self.probe_output is not None or self.probe_exit is not None:
+                return {
+                    "exit_code": self.probe_exit or 0,
+                    "output": self.probe_output or "",
+                }
+            if self.toplevel is None:
+                return {
+                    "exit_code": 128,
+                    "output": "",
+                }  # rev-parse's stderr is /dev/null'd
+            return {"exit_code": 0, "output": self.toplevel + "\n"}
+        if "find /home/developer/workspace" in command:
+            return (
+                {"exit_code": 0, "output": "1\n"}
+                if self.workspace_populated
+                else {"exit_code": 1, "output": ""}
+            )
+        raise AssertionError(f"unexpected command: {command!r}")
+
+
+class _FakeMigrateExec(_FakeExec):
+    """`_FakeExec` plus the branches `_migrate_workspace_gitignore` needs.
+
+    Models an agent whose real repository is rooted at `/home/developer`: the
+    `[ -d <dir>/.git ]` guard succeeds only for that path and fails for
+    `workspace/`. The merge and rm-cached commands are accepted and recorded.
+
+    The catch-all deliberately returns success rather than raising: the caller
+    wraps its body in `except Exception`, which would swallow an `AssertionError`
+    into a log line instead of failing the test.
+    """
+
+    TRUE_ROOT_GUARD = "[ -d /home/developer/.git ]"
+    WORKSPACE_GUARD = "[ -d /home/developer/workspace/.git ]"
+
+    async def __call__(self, container_name: str, command: str, timeout: int = 60):
+        if (
+            "git rev-parse --show-toplevel" in command
+            or "find /home/developer/workspace" in command
+        ):
+            return await super().__call__(container_name, command, timeout)
+        self.calls.append(command)
+        if self.WORKSPACE_GUARD in command:
+            return {"exit_code": 1, "output": ""}
+        if self.TRUE_ROOT_GUARD in command:
+            return {"exit_code": 0, "output": ""}
+        # `.gitignore` merge / `git rm --cached` sweep.
+        return {"exit_code": 0, "output": ""}
+
+
+# --------------------------------------------------------------------------
+# Case 1 — the defect itself.
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_populated_workspace_with_home_rooted_repo_returns_home():
+    """A home-rooted repo + a populated non-git `workspace/` resolves to home.
+
+    This is the bug: the content heuristic classifies any non-empty
+    `workspace/` as a legacy repo root, so every path-based consumer is
+    pointed at a data directory instead of the repository.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(toplevel="/home/developer", workspace_populated=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs._detect_git_dir("agent-test")
+
+    assert result == "/home/developer", (
+        "git reports the repo root as /home/developer, but _detect_git_dir "
+        f"returned {result!r} — the populated workspace/ data directory was "
+        "mistaken for a legacy repo root"
+    )
+
+
+# --------------------------------------------------------------------------
+# Case 2 — the legacy layout must keep working.
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_legacy_workspace_rooted_repo_returns_workspace():
+    """A genuinely workspace-rooted repo still resolves to `workspace/`."""
+    gs = _load_git_service()
+    fake = _FakeExec(toplevel="/home/developer/workspace", workspace_populated=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs._detect_git_dir("agent-test")
+
+    assert result == "/home/developer/workspace", (
+        "a repo actually rooted at workspace/ must keep resolving there; "
+        f"got {result!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Cases 3 & 4 — the no-repository fallback (init placement guarantee).
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_no_repo_populated_workspace_falls_back_to_workspace():
+    """No repo anywhere + populated workspace/ keeps the historical answer.
+
+    `initialize_git_in_container` uses this value to choose where to run
+    `git init`, so fresh-agent placement must remain byte-compatible.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(toplevel=None, workspace_populated=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs._detect_git_dir("agent-test")
+
+    assert result == "/home/developer/workspace", (
+        "with no repository present the retained content heuristic must give "
+        f"the historical answer; got {result!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_repo_empty_workspace_falls_back_to_home():
+    """No repo anywhere + empty workspace/ keeps the historical answer."""
+    gs = _load_git_service()
+    fake = _FakeExec(toplevel=None, workspace_populated=False)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs._detect_git_dir("agent-test")
+
+    assert result == "/home/developer", (
+        "with no repository and an empty workspace/ the historical answer is "
+        f"/home/developer; got {result!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Cases 5a/5b/5c — probe robustness.
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_garbage_probe_output_falls_back_to_heuristic():
+    """A zero-exit probe with unusable output is rejected, not acted on.
+
+    `workspace_populated=True` makes this discriminating: the fallback answers
+    `workspace/`, so the assertion cannot be satisfied by the probe value.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(
+        probe_exit=0,
+        probe_output="bash: git: command not found\n",
+        workspace_populated=True,
+    )
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs._detect_git_dir("agent-test")
+
+    assert result == "/home/developer/workspace", (
+        "unparseable probe output must fall through to the content heuristic; "
+        f"got {result!r}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("toplevel", ["/home/developer2/repo", "/", "/home"])
+async def test_lookalike_root_is_rejected(toplevel):
+    """Roots outside `/home/developer` are refused, including look-alikes.
+
+    Guards the prefix test: a naive `startswith` or a blind accept would
+    return the probe value instead of falling back.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(toplevel=toplevel, workspace_populated=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs._detect_git_dir("agent-test")
+
+    assert result == "/home/developer/workspace", (
+        f"probe root {toplevel!r} is outside /home/developer and must be "
+        f"rejected in favour of the fallback; got {result!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exec_failure_propagates():
+    """A genuine raise still propagates to the caller.
+
+    Callers depend on this: the push path reports a `detect`-stage failure and
+    the inspection path must never claim agreement on an unknown state.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(raises=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        with pytest.raises(RuntimeError):
+            await gs._detect_git_dir("agent-test")
+
+
+# --------------------------------------------------------------------------
+# Case 6 — noisy but valid probe output.
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_noisy_probe_output_is_parsed():
+    """A valid root is found even when the exec channel adds noise.
+
+    `workspace_populated=True` keeps this non-vacuous: without it the fallback
+    would also answer `/home/developer`.
+    """
+    gs = _load_git_service()
+    fake = _FakeExec(
+        probe_exit=0,
+        probe_output="warning: something\n/home/developer\n",
+        workspace_populated=True,
+    )
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        result = await gs._detect_git_dir("agent-test")
+
+    assert result == "/home/developer", (
+        "the valid root line must be picked out of noisy probe output; "
+        f"got {result!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Case 7 — the content probe is not issued when git answers.
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_content_probe_skipped_when_repo_found():
+    """When git resolves the root, the content heuristic is never consulted."""
+    gs = _load_git_service()
+    fake = _FakeExec(toplevel="/home/developer")
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        await gs._detect_git_dir("agent-test")
+
+    assert not any("find /home/developer/workspace" in c for c in fake.calls), (
+        "the content heuristic must not run once git has resolved the repo "
+        f"root; commands issued: {fake.calls}"
+    )
+    assert (
+        len(fake.calls) == 1
+    ), f"expected exactly one exec (the git-root probe); got {fake.calls}"
+
+
+# --------------------------------------------------------------------------
+# Case 8 — the downstream consumer that motivated the fix.
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_migrate_gitignore_targets_the_real_repo_root():
+    """The `.gitignore` migration runs at the real root, not at `workspace/`.
+
+    On an affected agent the `[ -d <dir>/.git ]` guard is issued against
+    `workspace/`, fails, and the whole migration silently no-ops — which is why
+    fleet-wide ignore patterns never reached these agents.
+
+    Asserted on the presence of `cd /home/developer &&` because the migration's
+    command builders emit a RELATIVE `.gitignore` path, so an absolute-path
+    assertion would be unfalsifiable. The trailing `&&` matters on both sides:
+    the root probe itself starts `cd /home/developer/workspace 2>/dev/null ||`
+    and is recorded unconditionally, so a bare `cd /home/developer/workspace`
+    negative assertion would match the probe before AND after the fix.
+    """
+    gs = _load_git_service()
+    fake = _FakeMigrateExec(toplevel="/home/developer", workspace_populated=True)
+
+    with patch.object(gs, "execute_command_in_container", fake):
+        await gs._migrate_workspace_gitignore("someagent")
+
+    assert any("cd /home/developer &&" in c for c in fake.calls), (
+        "the migration never ran at the real repo root — the .git guard was "
+        f"issued against the wrong directory and the migration no-opped; "
+        f"commands issued: {fake.calls}"
+    )
+    assert not any("cd /home/developer/workspace &&" in c for c in fake.calls), (
+        "no migration command may target the workspace/ subdirectory; "
+        f"commands issued: {fake.calls}"
+    )


### PR DESCRIPTION

Closes #<N>

## Symptom

`_detect_git_dir` decided an agent's repository root by probing whether
`/home/developer/workspace` had any content. That tests **content, not
legacy-ness**: an agent whose repository is rooted at `/home/developer` but which
also keeps a populated, non-git `workspace/` data directory was classified as
workspace-rooted. Every consumer that treats the result as a filesystem path then
read and wrote a subdirectory's files as if they were the repository root's — the
compatibility collector snapshotted the wrong root (producing a false
`F-001 template.yaml exists`, which cascades into 24 `no_template` skips), the
per-Push `.gitignore` migration's `[ -d <dir>/.git ]` guard failed and the whole
migration silently no-opped, and `POST /{agent}/compatibility/fix` wrote its
correction into a `.gitignore` that governs only that subdirectory — then verified
its own write and reported success. A security-relevant check could therefore pass
on the strength of a rule that does not apply to the files it names.

## Fix

Ask git. `git rev-parse --show-toplevel`, run from `/home/developer/workspace`
when it exists and from `/home/developer` otherwise, returns the root of the
**nearest enclosing** repository — `--show-toplevel` walks *up*, so a genuinely
workspace-rooted legacy agent still resolves to `workspace/` while a standard
agent resolves to `/home/developer` even with a populated `workspace/`.

`GIT_DISCOVERY_ACROSS_FILESYSTEM=1` is set because `workspace/` is a plausible
mount point and git otherwise stops discovery at a filesystem boundary, which
would silently reintroduce the exact misclassification this fixes. That is safe
only because `_parse_git_root` accepts an answer **only** when it is
`/home/developer` or below — `/`, `/home` and look-alikes such as
`/home/developer2` are rejected, each covered by a test.

## Caller audit (all 7)

Git discovers the enclosing repo by walking up from the cwd, so a caller that
merely `cd`s into the returned directory and runs a plain git command was already
operating on the right repository. Only callers that treat the result as a
**path** were broken.

| # | Caller | Uses result as | Before | After |
|---|---|---|---|---|
| 1 | `update_remote_pat:211` | cwd | accidentally correct via upward discovery | same repo, directly |
| 2 | `rebind_origin_and_push:325` | cwd | correct via upward discovery | unchanged; `stage="detect"` path preserved |
| 3 | `inspect_container_git:453` | cwd | correct via upward discovery | unchanged |
| 4 | `_migrate_workspace_gitignore:1453` | **path** | `.git` guard fails → **silent no-op** | migration finally runs on the real `.gitignore` |
| 5 | `initialize_git_in_container:1533` | **path** | chooses where `git init` lands | **byte-compatible for fresh agents** (see below) |
| 6 | `compatibility/collector.py:176` | **path** | snapshots a data directory | snapshots the real repo root |
| 7 | `compatibility/fixes.py:172` | **path** | writes a subdirectory `.gitignore` | writes the root `.gitignore` |

## Why not just reuse `check_git_initialized`?

Worth preempting, because `check_git_initialized:1698-1727` already resolves
affected agents **correctly** (`[ -d workspace/.git ]` then
`[ -d /home/developer/.git ]`). The honest framing is that this change makes the
two helpers **agree** rather than adding a third opinion — the file previously
held three different answers to one question (`_detect_git_dir`'s heuristic,
`check_git_initialized`, and `_append_agent_gitignore:709`'s hardcoded
`/home/developer`). This matters beyond tidiness: `check_git_initialized` gates
the `409 Git sync already configured` at `routers/git.py:388-397`, so the two
helpers disagreeing was caller-visible.

It is not reused directly because it answers a **different question** — *is there
a `.git` here?*, returning `Optional[str]` with `None` when absent — whereas
callers of `_detect_git_dir` need a directory **even when no repository exists
yet**: `initialize_git_in_container` uses it to choose where to *create* one.
Collapsing them would either break init placement or force every caller to handle
`None`. Consolidating the two is a reasonable follow-up, out of scope here.

## The no-repo fallback is retained verbatim

The old content heuristic is kept **byte-identical** as the no-repository
fallback, including its `"1" in output` substring test. This is deliberate and is
the safety argument for caller #5: `initialize_git_in_container` uses this value
to choose where `git init` runs, so fresh-agent placement must not move. The
`"1" in output` looseness is not where the bug lives — the bug is using a content
probe to answer a repo-topology question — and tightening it would be an
unrequested behaviour change on the exact path whose byte-compatibility is the
safety argument. Two tests pin this (populated → `workspace/`, empty → home).

Cost: 1 exec in the common repo-present case, 2 in the no-repo case (previously
always 1), plus one `warning` log line when no repository resolves.

Exceptions are **not** swallowed. `execute_command_in_container` already converts
a dead container into a non-zero exit rather than a raise, so a genuine raise is
a real fault — swallowing it would destroy caller #2's `stage="detect"` message
and caller #3's unknown-never-agreement invariant (ent#109 AC #5). A test pins
propagation.

## Operator notes — behaviour changes on already-affected agents

1. **The next Push contains deletions.** Once the migration stops no-op'ing, the
   next Push appends the fleet-wide `_GITIGNORE_PATTERNS` to the real root
   `.gitignore` and `git rm --cached`s every tracked file that now matches a
   rule. Working-tree files are untouched and history is **not** rewritten —
   anything already pushed stays in history, so any credential rotation is
   separate ops follow-up, not part of this PR.
2. **Re-init has a larger scope.** A post-fix `initialize_git_in_container` on an
   affected agent runs at `/home/developer` rather than `workspace/`, so the
   `.gitignore` merge, `git init`, `git add .` and (on the empty-remote path)
   `git push -u origin main --force` cover the whole home directory — a much
   larger add surface. **The ordering is safe by construction:** the ignore merge
   (`:1545-1549`) happens *before* `git init` (`:1566`) and `git add .`, so the
   fleet-wide rules are in force at the real root before anything is staged.
   Relatedly, `git init` at `/home/developer` where a repo already exists is a
   harmless re-init, whereas the pre-fix behaviour could create a **nested** repo
   inside `workspace/`.

## Known limitation — agents this does not repair

An agent already **re-initialised while misdetected** now has a real
`workspace/.git`, i.e. a genuine nested repository, and is **indistinguishable
from a legitimate legacy agent** by any probe — git's own answer for it *is*
`workspace/`. This fix keeps resolving it to `workspace/`: correct by the new
rule, still wrong by intent. Repairing those needs a per-agent operator decision,
not an algorithm.

Exposure is bounded: `routers/git.py:388-397` refuses re-initialisation with a
`409` whenever a git-config row exists **and** `check_git_initialized` finds a
`.git` — and that is one of the correct helpers. Only an agent with an
**orphaned** config row (row present, no `.git`) reaches the re-init path.

Read-only ops detection, per agent:
```bash
docker exec agent-<name> bash -c \
  '[ -d /home/developer/.git ] && echo home-repo; \
   [ -d /home/developer/workspace/.git ] && echo workspace-repo; \
   git -C /home/developer rev-parse --show-toplevel 2>/dev/null'
```
Both markers present ⇒ nested repo ⇒ needs a human decision.

## Follow-up filed separately (not widened into this diff)

`_detect_git_dir` and `check_git_initialized` can still diverge when `.git` is a
**file** rather than a directory — the pointer form used by `git worktree` and by
submodule checkouts. `git rev-parse` resolves it; `[ -d …/.git ]` does not. The
result would be `_detect_git_dir` reporting a root while `check_git_initialized`
reports `None` (so the re-init `409` fails to fire), and
`_migrate_workspace_gitignore`'s own `[ -d <dir>/.git ]` guard still bailing at a
root the probe just resolved. Pre-existing in kind and not triggered by any
current agent layout.

## Tests

TDD, two commits: the failing test first, then the minimal fix.

**RED** — new test file against unfixed code:

```
$ cd tests && pytest unit/test_<N>_git_root_detection.py -q -p no:randomly -p no:cacheprovider
4 failed, 8 passed, 15 warnings in 0.17s
FAILED ...::test_populated_workspace_with_home_rooted_repo_returns_home
FAILED ...::test_noisy_probe_output_is_parsed
FAILED ...::test_content_probe_skipped_when_repo_found
FAILED ...::test_migrate_gitignore_targets_the_real_repo_root
```

The migration case shows the defect directly — the guard is issued against the
wrong directory and no further command is ever sent:

```
E  AssertionError: the migration never ran at the real repo root — the .git guard was issued
   against the wrong directory and the migration no-opped; commands issued:
   ['bash -c "[ -d /home/developer/workspace ] && find /home/developer/workspace -mindepth 1
   -maxdepth 1 | head -1 | wc -l"', 'bash -c "[ -d /home/developer/workspace/.git ]"']
```

The 8 that passed pre-fix are the invariants that must **not** move: the legacy
workspace-rooted layout, both no-repository fallback branches, look-alike root
rejection, and exception propagation.

**GREEN** — after the fix:

```
$ cd tests && pytest unit/test_<N>_git_root_detection.py -q -p no:randomly -p no:cacheprovider
12 passed, 15 warnings in 0.15s
```

**Neighbours** (post-fix):

```
$ pytest unit/test_github_init_gitignore.py unit/test_github_init_push.py \
    unit/test_compatibility_checks.py unit/test_2036_claude_settings_leak.py \
    unit/test_ent123_tokenless_clone.py unit/test_1264_per_agent_pat_propagation.py -q -p no:randomly
142 passed, 17 warnings in 4.03s
```

**Full unit suite**, identical pinned flags before and after
(`-m "not slow" -p no:randomly -p no:cacheprovider`; `pytest-randomly` is pinned
off so the two runs are comparable):

| Run | passed | failed | skipped |
|---|---|---|---|
| Before (branch point) | 8912 | 1 | 18 |
| **After** | **8924** | **1** | **18** |

**Delta: +12 passed, +0 failed.** The +12 is exactly the new test file.

The single failure is pre-existing and unrelated — it reproduces on untouched
`dev` before any change in this PR, and is not addressed here:

```
FAILED unit/test_1898_sys_modules_isolation.py::TestTheOutcome::test_a_victim_passes_when_collected_after_the_offender[test_ent125_resilient_system_deploy.py]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
