### PR TITLE
fix(security): CSO 2026-08-09 — terminal-tier HIGH + access-control + supply-chain hardening

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [dev]
 
+# CSO L5: least-privilege token — deploy runs over SSH/Tailscale secrets, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -11,6 +11,10 @@ on:
       - 'src/frontend/**'
       - '.github/workflows/frontend-build.yml'
 
+# CSO M9: least-privilege token — this workflow only reads the checkout.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -101,8 +101,8 @@ RUN pip install --no-cache-dir \
     reportlab==4.2.5 \
     google-genai==1.63.0 \
     "slack_sdk[socket-mode]==3.41.0" \
-    aiohttp \
-    slackify-markdown \
+    aiohttp==3.14.3 \
+    slackify-markdown==0.2.4 \
     tenacity==9.0.0 \
     opentelemetry-api==1.29.0 \
     opentelemetry-sdk==1.29.0 \

--- a/docker/frontend/Dockerfile.prod
+++ b/docker/frontend/Dockerfile.prod
@@ -6,11 +6,12 @@ FROM node:24-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package.json package-lock.json* ./
+# Copy package files (lockfile is tracked — require it)
+COPY package.json package-lock.json ./
 
-# Install dependencies (use npm install since package-lock.json might not exist)
-RUN npm install
+# Install from the tracked lockfile (CSO M4: npm ci is lockfile-exact and fails
+# on drift; the prior npm install floated semver ranges in the shipped bundle).
+RUN npm ci
 
 # Copy source code
 COPY . .

--- a/docs/security-reports/cso-2026-08-09.json
+++ b/docs/security-reports/cso-2026-08-09.json
@@ -1,0 +1,235 @@
+{
+  "version": "1.1",
+  "date": "2026-08-09",
+  "mode": "daily",
+  "confidence_gate": 8,
+  "scope": "full codebase",
+  "branch": "dev",
+  "baseline_report": "cso-2026-07-13",
+  "phases_run": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],
+  "method": "4 parallel phase scanners (secrets/supply-chain, ci-cd+infra, webhook+ai, owasp) over 321 commits since last full audit + fresh-context adversarial refutation of the two disputed findings",
+  "attack_surface": {
+    "backend_routers": 72,
+    "http_routes": 473,
+    "websocket_endpoints": 7,
+    "ci_workflows": 21,
+    "prod_dockerfiles": 5,
+    "docker_networks": 2,
+    "node_projects": 4,
+    "backend_python_deps": 36
+  },
+  "totals": { "critical": 0, "high": 1, "medium": 9, "low": 7, "info": 6 },
+  "findings": [
+    {
+      "id": "H1", "severity": "high", "confidence": 9, "status": "verified",
+      "verification": "double refuted-confirmed (fresh-context)",
+      "category": "access-control-tier",
+      "phase": 9, "persistent": true, "prior_id": "F1 (terminal half, re-rated MED->HIGH)",
+      "file": "src/backend/services/agent_service/terminal.py", "line": 124,
+      "title": "Terminal WS at accessor tier grants chat-shared user a /bin/bash container shell",
+      "description": "handle_terminal_session gates on can_user_access_agent (owner OR shared OR admin), not the owner-only can_user_share_agent. mode=bash (a client ?mode= param the frontend defaults to) resolves to cmd=['/bin/bash'] at terminal.py:203 with no further gate. Prod-reachable via nginx WS-upgrade proxy (no auth_request); raw JWT in first WS message (no ownership-rechecking ticket).",
+      "exploit": "Owner shares agent for chat -> collaborator email auto-whitelisted -> OTP login -> connect wss://host/api/agents/{name}/terminal?mode=bash against a running agent -> exec runs /bin/bash as developer, inherits container Config.Env so printenv dumps CLAUDE_CODE_OAUTH_TOKEN + TRINITY_MCP_API_KEY; .env/.credentials.enc readable; RCE as agent + lateral movement via leaked MCP key.",
+      "recommendation": "Gate the terminal WS (esp. mode=bash) at owner/admin tier (can_user_share_agent / delete-tier), matching the deliberately admin-only SSH-access endpoint.",
+      "caveat": "Terminal tab commented out in owner UI (AgentDetail.vue:883) reduces discoverability, not exploitability; route registered unconditionally."
+    },
+    {
+      "id": "M1", "severity": "medium", "confidence": 9, "status": "verified",
+      "category": "access-control-tier", "phase": 9, "persistent": true, "prior_id": "F1 (schedule half)",
+      "file": "src/backend/routers/schedules.py", "line": 405,
+      "title": "Schedule enable/disable/trigger at accessor tier while update/delete require owner",
+      "description": "enable/disable/trigger (schedules.py:405,424,443) use AuthorizedAgent; DB setter takes no owner check. update_schedule/delete_schedule pass current_user.username and 403 on non-owner. Inconsistent boundary.",
+      "exploit": "Shared user flips owner-intent schedule state (re-enable paused work, disable automation) and fires executions (LLM spend), but cannot edit/delete.",
+      "recommendation": "Move the three control routes to OwnedAgentByName."
+    },
+    {
+      "id": "M2", "severity": "medium", "confidence": 9, "status": "verified",
+      "category": "data-at-rest-plaintext", "phase": 2, "persistent": true, "prior_id": "F4 (narrowed by #1449)",
+      "file": "src/backend/db/schedules/queue.py", "line": 127,
+      "title": "backlog_metadata caller content not nulled at drain; persists on running + FAILED rows",
+      "description": "enqueue json.dumps message/system_prompt/user_message/user_email into backlog_metadata (backlog_service.py:78). #1449 scrub_terminal_backlog_metadata (retention.py:331) NULLs authoritative-terminal rows unconditionally (improvement) but FAILED is excluded and drain-claim (queue.py:127) never nulls. Residual: plaintext on running rows + up to 90 days on FAILED rows; canary G-04 scans queued-only.",
+      "exploit": "A secret embedded by a caller in a task body persists plaintext at rest (DB/backup), unscanned by G-04 once drained.",
+      "recommendation": "Null backlog_metadata at drain-claim (RETURNING already captures it); scrub FAILED rows past the late-CAS resurrection window; widen G-04."
+    },
+    {
+      "id": "M3", "severity": "medium", "confidence": 8, "status": "verified",
+      "category": "supply-chain-cve", "phase": 3, "persistent": false,
+      "file": "src/mcp-server/package.json", "line": 0,
+      "title": "HIGH advisories (ip-address SSRF, undici desync) transitive in mcp-server + helper-mcp prod trees",
+      "description": "npm audit: mcp-server 7 vulns (3 high), helper-mcp 5 (2 high). ip-address <=10.3.0 HIGH (SSRF/trust-boundary) via express-rate-limit; undici 7.0.0-7.28.0 HIGH (desync/CRLF/cache-poison). mcp-server override pins ip-address >=10.2.0, a floor INSIDE the vulnerable range. Transitive -> reachability unproven -> MEDIUM.",
+      "exploit": "The component fronting every agent MCP key ships known-HIGH-CVSS deps; a reachable path would enable SSRF or HTTP desync.",
+      "recommendation": "npm audit fix; raise the ip-address override above 10.3.0. Bump frontend dompurify (H-005 boundary) despite unreachable advisory."
+    },
+    {
+      "id": "M4", "severity": "medium", "confidence": 9, "status": "verified",
+      "category": "supply-chain-process", "phase": 3, "persistent": true, "prior_id": "F2",
+      "file": "src/mcp-server/Dockerfile", "line": 11,
+      "title": "Prod images build via npm install (not npm ci); dev frontend deletes the lockfile",
+      "description": "mcp-server/Dockerfile:11 and frontend/Dockerfile.prod:12 use npm install (floating semver); frontend/Dockerfile:9 (dev) rm -f package-lock.json. Lockfiles exist and are tracked; gap is build-time enforcement.",
+      "exploit": "A poisoned point-release of any ^-ranged dep lands in the next image with no lockfile diff to catch it.",
+      "recommendation": "npm ci in the prod Dockerfiles; stop deleting the dev lockfile."
+    },
+    {
+      "id": "M5", "severity": "medium", "confidence": 9, "status": "verified",
+      "category": "supply-chain-pinning", "phase": 3, "persistent": true, "prior_id": "F5 (+ new backend strays)",
+      "file": "docker/base-image/Dockerfile", "line": 111,
+      "title": "Unpinned deps: base-image pips, base CLIs, backend aiohttp/slackify-markdown, unverified fetches",
+      "description": "base-image Dockerfile:111 installs agent-server pips with zero pins; base CLIs @latest (:78) / unversioned (:81); backend Dockerfile floats aiohttp + slackify-markdown amid an exact-pinned set; base curl|bash (:38) + Go tarball (:42) have no integrity check.",
+      "exploit": "A compromised CLI/pip release executes inside every agent container (holds .env + MCP key) on the next rebuild.",
+      "recommendation": "Pin the pips and the two backend strays; add SHA256 to the Go fetch."
+    },
+    {
+      "id": "M6", "severity": "medium", "confidence": 9, "status": "verified",
+      "category": "secrets-history", "phase": 2, "persistent": false,
+      "file": "src/cli/trinity_cli/_notify.py", "line": 0,
+      "title": "Revoked Resend API key recoverable from git history",
+      "description": "_notify.py (added 3986c50b, removed 3f906af4, refs #1158) shipped an obfuscated Resend key (XOR-split base85). Removal commit documents the key was revoked; file absent from dev. Public indexed history keeps it recoverable via git show.",
+      "exploit": "git show 3986c50b:src/cli/trinity_cli/_notify.py + XOR of the two halves yields the (dead) key.",
+      "recommendation": "Complete the standing git-history-scrub follow-up (filter-repo/BFG + coordinated force-push). Key already revoked."
+    },
+    {
+      "id": "M7", "severity": "medium", "confidence": 6, "status": "verified",
+      "category": "oauth-scope", "phase": 6, "persistent": false,
+      "file": "src/backend/routers/credentials.py", "line": 209,
+      "title": "Google OAuth requests full .../auth/drive scope",
+      "description": "credentials.py:209 requests full Drive read/write/delete (a Google restricted scope) for a credential-injection helper where .../auth/drive.file would suffice. Conditional on operator having configured Google OAuth. No tokens/auth-codes logged.",
+      "exploit": "A compromised/prompt-injected agent holding the injected Google token can exfiltrate/destroy the user's entire Drive.",
+      "recommendation": "Narrow to drive.file unless full Drive is a documented product requirement."
+    },
+    {
+      "id": "M8", "severity": "medium", "confidence": 9, "status": "verified",
+      "category": "ci-cd-hardening", "phase": 4, "persistent": true,
+      "file": ".github/workflows", "line": 0,
+      "title": "First-party actions on floating major tags, not SHA-pinned",
+      "description": "All actions/* and github/codeql-action/* use floating major tags across ~15 workflows. Third-party actions ARE SHA-pinned.",
+      "exploit": "A compromise/retag of a first-party action tag runs attacker code in CI with that workflow's token/secret scope.",
+      "recommendation": "SHA-pin first-party actions (MEDIUM per first-party guidance)."
+    },
+    {
+      "id": "M9", "severity": "medium", "confidence": 8, "status": "verified",
+      "category": "ci-cd-hardening", "phase": 4, "persistent": true, "prior_id": "A9 (permissions half)",
+      "file": ".github/workflows/frontend-build.yml", "line": 0,
+      "title": "frontend-build.yml has no permissions block (fork-reachable pull_request)",
+      "description": "No top-level or job-level permissions:; triggered on pull_request. Default GITHUB_TOKEN scope granted though unused.",
+      "exploit": "A compromised build/test step inherits a broader-than-needed token.",
+      "recommendation": "Add permissions: contents: read."
+    },
+    {
+      "id": "L1", "severity": "low", "confidence": 8, "status": "verified",
+      "verification": "refuted-confirmed (severity tempered)",
+      "category": "access-control-idor", "phase": 9, "persistent": false,
+      "file": "src/backend/routers/event_subscriptions.py", "line": 229,
+      "title": "GET /event-subscriptions/{id} has no owner check (asymmetric with PUT/DELETE)",
+      "description": "get_event_subscription authenticates but performs no tenant/ownership check; PUT/DELETE call assert_agent_owner. Returns subscriber_agent/source_agent/target_message/created_by cross-tenant. Bounded by ~96-bit esub_ id with no cross-tenant harvest surface.",
+      "exploit": "An authenticated user with a leaked subscription id reads another tenant's subscription config; not enumerable.",
+      "recommendation": "Add assert_agent_owner(current_user, sub.subscriber_agent) after the lookup, matching PUT/DELETE."
+    },
+    {
+      "id": "L2", "severity": "low", "confidence": 6, "status": "verified",
+      "category": "auth-timing", "phase": 6, "persistent": true, "prior_id": "A6",
+      "file": "src/backend/adapters/transports/telegram_webhook.py", "line": 54,
+      "title": "Telegram secret token compared with != not constant-time",
+      "description": "actual_token != expected_token; gated behind the URL-path webhook secret lookup first, so timing attack is impractical.",
+      "exploit": "Theoretical byte-by-byte timing recovery of the per-bot secret token.",
+      "recommendation": "hmac.compare_digest(actual_token, expected_token)."
+    },
+    {
+      "id": "L3", "severity": "low", "confidence": 6, "status": "mitigated-csp",
+      "category": "stored-html-injection", "phase": 7, "persistent": true, "prior_id": "A1",
+      "file": "src/frontend/public/brain-orb/orb.js", "line": 441,
+      "title": "Brain-orb raw innerHTML of agent data.json strings",
+      "description": "Raw el.innerHTML sinks with agent-derived strings; markdown note body IS DOMPurified. Prod CSP script-src 'self' with no unsafe-inline blocks execution.",
+      "exploit": "In dev CSP only (unsafe-inline) an onerror= vector is self-XSS; prod blocked.",
+      "recommendation": "Escape via the existing _escHtml; CSP is the single mitigating control."
+    },
+    {
+      "id": "L4", "severity": "low", "confidence": 6, "status": "verified",
+      "category": "ci-cd-injection", "phase": 4, "persistent": true, "prior_id": "A8",
+      "file": ".github/workflows/publish-cli.yml", "line": 73,
+      "title": "publish-cli.yml interpolates git-tag value into run: sed",
+      "description": "steps.version.outputs.version (from the pushed tag) re-embedded via ${{ }} into a sed command. Source requires repo write access (trusted actor).",
+      "exploit": "A crafted tag could break out of the sed expression -> command injection (trusted-actor only).",
+      "recommendation": "Pass the value via env: and reference \"$VERSION\" inside run:."
+    },
+    {
+      "id": "L5", "severity": "low", "confidence": 7, "status": "verified",
+      "category": "ci-cd-hardening", "phase": 4, "persistent": false,
+      "file": ".github/workflows/deploy-dev.yml", "line": 0,
+      "title": "deploy-dev.yml has no permissions block",
+      "description": "No permissions: anywhere. Fires on push to dev (trusted) and uses SSH secrets not GITHUB_TOKEN; least-privilege hygiene.",
+      "exploit": "None concrete; hardening.",
+      "recommendation": "Add permissions: {} / contents: read."
+    },
+    {
+      "id": "L6", "severity": "low", "confidence": 6, "status": "verified",
+      "category": "crypto-config", "phase": 9, "persistent": true, "prior_id": "A5",
+      "file": "src/backend/config.py", "line": 74,
+      "title": "Placeholder SECRET_KEY printed, not raised",
+      "description": "A literal 'your-secret-key-change-in-production' prints CRITICAL and continues, unlike REDIS_URL which hard-raises. Placeholder ships nowhere; empty -> random per-session key.",
+      "exploit": "An operator who pastes the exact placeholder runs with a publicly-known JWT signing key (forgeable admin JWTs). Low likelihood.",
+      "recommendation": "raise RuntimeError on the placeholder, mirroring the REDIS_URL check."
+    },
+    {
+      "id": "L7", "severity": "low", "confidence": 7, "status": "verified",
+      "category": "business-confidentiality", "phase": 2, "persistent": true, "prior_id": "F6",
+      "file": "docs/memory/architecture.md", "line": 0,
+      "title": "Paid-module ids named in live public docs outside the enterprise-docs-guard pattern",
+      "description": "architecture.md + feature-flow docs name entitlement-gated module ids the guard's grep pattern does not cover. Also visible in the OSS bundle's enterprise_features surface (guard's documented allowance), so may be accepted; standing rule says public docs carry no paid-feature catalog.",
+      "exploit": "Business-confidentiality disclosure (names only, no schema/design).",
+      "recommendation": "Policy decision: bless vs genericize + extend the guard token list."
+    }
+  ],
+  "accepted_risk_info": [
+    {"id": "A4", "title": "Dependabot review-bypassing auto-merge PAT", "status": "accepted-risk-unchanged"},
+    {"title": "pipenet dormant public-exposure lib in mcp-server prod tree", "status": "info"},
+    {"title": "python-multipart==0.0.20 — known advisories fixed in <=0.0.20 (likely prior miscalibration)", "status": "info-verify"},
+    {"title": "Dead POST /api/internal/decrypt-and-inject reference (startup.sh:541, models.py:975) — fails closed 404", "status": "housekeeping"},
+    {"title": "ops.py fleet-stop/pause + logs.py retention PUT lack reject_agent_principal (DoS-class, consistency gap)", "status": "info-consistency"},
+    {"title": "CODEOWNERS covers workflows; require_code_owner_reviews enforcement is a live-GitHub check (prior F3)", "status": "live-github-check"}
+  ],
+  "resolved_since_baseline": [
+    "A7 Slack download_file SSRF -> two-tier host-gated + follow_redirects=False (#1951/#1932)",
+    "A10 /user-memory -> execution-ownership check + server-resolved email",
+    "A9 exfil half -> fork PRs receive no secrets + empty-case handled (permissions-block half persists as M9)",
+    "F7 python-multipart -> advisories fixed in <=0.0.20 (likely prior miscalibration)"
+  ],
+  "verified_clean_negatives": [
+    "#589 two-network Redis isolation (hard-coded at all 3 create sites)",
+    "Redis ACL model -@dangerous + fail-closed mandatory dual passwords + config raises on credential-less REDIS_URL",
+    "base_image allowlist enforced on create + both recreate paths",
+    "all 5 agent-scoped self-boundaries reject sibling keys via authorize_heartbeat",
+    "backend->agent X-Trinity-Agent-Token derived + fail-closed; middleware exempts only /health+OPTIONS incl WS",
+    "vendored parity byte-identical: credential_paths.py, model_context.py, safe_yaml.py",
+    "db/ layer parameterized; execute_command_in_container exec-form; skill_sources github.com-only + credential rejection on write AND clone",
+    "channel media SSRF two-tier + follow_redirects=False; template-registry https-only + private-IP-blocked + admin-only",
+    "JWT HS256 + jti blacklist revocation on logout (#187); SSH admin+public-key-only",
+    "auth rate-limiting per-account + per-IP Redis-backed; inline-auth account-scoped (#591)",
+    "CORS explicit allowlist; 422 strips input+ctx; hide_parameters=True",
+    "every v-html via DOMPurify; MCP dedicated-tool descriptions name-only (#846); voice-token config-locked, ephemeral_token field",
+    "webhook context framed + capped (currently a no-op end-to-end)",
+    "no pull_request_target; no github.event shell interpolation; third-party actions SHA-pinned; fork PRs receive no secrets",
+    "no tracked .env (never committed); history secret hits are synthetic fixtures; CLAUDE.local.md untracked"
+  ],
+  "supply_chain_summary": {
+    "python_backend": "exact-pinned except aiohttp + slackify-markdown (M5); python-multipart==0.0.20 (verify)",
+    "python_agent_server": "fully unpinned in base-image Dockerfile (M5)",
+    "node_lockfiles": "present + tracked for all 4 projects; build-time bypass via npm install (M4)",
+    "node_audit_high": "ip-address <=10.3.0 (SSRF) + undici 7.0.0-7.28.0 (desync) transitive in mcp-server/helper-mcp prod (M3)",
+    "install_scripts_prod": "only tldjs@2.3.2 (via pipenet) — benign, env-gated postinstall, no install-time network"
+  },
+  "filter_stats": {
+    "adversarial_refutations_run": 2,
+    "confirmed": 2,
+    "severity_elevated": 1,
+    "severity_tempered": 1
+  },
+  "trend": {
+    "baseline": "cso-2026-07-13",
+    "ceiling_prev": "medium",
+    "ceiling_now": "high",
+    "resolved": 4,
+    "improved": 1,
+    "persistent": 9,
+    "new": 7,
+    "note": "Ceiling rose from MEDIUM to HIGH via a severity re-rating (not a new defect) — last cycle's bundled F1 terminal half, now double-refuted-confirmed as prod-reachable container-shell + credential-exfil."
+  }
+}

--- a/docs/security-reports/cso-2026-08-09.md
+++ b/docs/security-reports/cso-2026-08-09.md
@@ -1,0 +1,165 @@
+# CSO Audit — 2026-08-09 (full codebase)
+
+**Mode**: daily (8/10 confidence gate) · **Branch**: `dev` · **Scope**: all phases 0–14
+**Baseline for trend**: `cso-2026-07-13` (full — 7 MEDIUM + several LOW, ceiling MEDIUM)
+**Method**: 4 parallel phase scanners (secrets/supply-chain, CI/CD+infra, webhook+AI, OWASP) over 321 commits since the last full audit, then fresh-context adversarial refutation of the two disputed findings.
+
+## Bottom line
+
+**One HIGH, verified by double refutation; the rest is MEDIUM and below.** The single HIGH is a *persistent* access-control tier gap (last cycle's F1) that a fresh-context skeptic confirmed end-to-end: a **chat-only shared collaborator can open an interactive `/bin/bash` in the agent container** and dump the agent's OAuth token + Trinity MCP key. It is re-rated MEDIUM→HIGH on the confirmed credential-exfiltration + RCE consequence and proven prod-reachability. Everything memory-corrupting / remote-unauthenticated is clean.
+
+The CRITICAL-class platform invariants are all intact and independently re-verified: the #589 two-network Redis isolation, the Redis ACL model with fail-closed mandatory dual passwords, the `base_image` allowlist, setup hard-lock, non-root prod images, and all three byte-identical vendored-parity pairs. No `pull_request_target`, no `github.event` shell injection, injection/SSRF surfaces parameterized and host-fixed, agent-identity self-boundaries reject sibling keys, MCP tool descriptions name-only, voice-token config-locked. Two prior LOWs are **resolved** (Slack `download_file` SSRF now two-tier gated; `/user-memory` now execution-ownership gated); one prior MEDIUM (`python-multipart`) appears to have been a miscalibration.
+
+**Attack surface:** 72 backend routers / 473 HTTP routes / 7 WebSocket endpoints, 21 CI workflows, 5 prod Dockerfiles, two Docker networks, 4 Node projects + ~36 backend Python deps.
+
+## Remediation applied in-branch (`fix/cso-2026-08-09-terminal-tier-and-hardening`)
+
+Fixed and verified this session (disposition: H1 "fix now", mechanical bundle "do all now"):
+
+| Finding | Fix | Verification |
+|---|---|---|
+| **H1** | Terminal WS gate `can_user_access_agent` → `can_user_share_agent` (owner/admin) | `py_compile` ✓ |
+| **M1** | Schedule enable/disable/trigger `AuthorizedAgent` → `OwnedAgentByName` | `py_compile` ✓; `test_186` 36 passed |
+| **L1** | `GET /event-subscriptions/{id}` gains `assert_agent_access` (accessor-tier, matches list/PUT/DELETE) | `test_subscription_bola` ✓ |
+| **M3** | `npm audit fix` on mcp-server + helper-mcp + frontend; `ip-address` override floor → `>=10.5.0` | **0 vulnerabilities** in all three; mcp-server `tsc` ✓, frontend `vite build` ✓ |
+| **M4** | mcp-server `Dockerfile` + frontend `Dockerfile.prod`: `npm install` → `npm ci` | `npm ci` exit 0 locally (lock in sync) |
+| **M5 (partial)** | Backend `Dockerfile`: pin `aiohttp==3.14.3`, `slackify-markdown==0.2.4` (versions read from the live backend) | pinned to running-container versions |
+| **M9 / L5** | `permissions: contents: read` added to `frontend-build.yml` + `deploy-dev.yml` | valid YAML ✓ |
+
+**Held for a build/CI-verified pass (NOT applied — blind edits here risk all-agents-down / all-CI-broken, against the verification rule):**
+- **M5 (base-image pips + Go-tarball SHA)** — needs a base-image rebuild to verify; the live agent is from an older image (`cryptography` not even importable) so it can't supply a reliable pin set.
+- **M4 (dev `docker/frontend/Dockerfile`)** — deliberately deletes the lockfile for cross-arch native-binary resolution; switching to `npm ci` risks arch breakage and is dev-only.
+- **M8 (SHA-pin ~15 first-party actions)** — mechanical but needs the exact commit SHA per action + a CI run; a wrong SHA breaks all CI.
+- **M2, M6, M7, L7** — the Q3 policy items (backlog_metadata drain-null, git-history scrub, Google scope narrowing, docs policy) were not green-lit in the disposition and/or need an owner decision; left for follow-up.
+
+---
+
+
+## Findings
+
+| # | Sev | Conf | Status | Category | Finding | File:Line |
+|---|-----|------|--------|----------|---------|-----------|
+| H1 | **HIGH** | 9 | VERIFIED (2× refuted-confirmed) | Access-control tier | Terminal WS at accessor tier → chat-shared user gets `/bin/bash` in the container, dumps `CLAUDE_CODE_OAUTH_TOKEN`/`TRINITY_MCP_API_KEY`/`.env`, RCE as agent | `services/agent_service/terminal.py:124,203` |
+| M1 | MED | 9 | VERIFIED | Access-control tier | Schedule enable/disable/trigger accessor-tier while update/delete require owner | `routers/schedules.py:405,424,443` |
+| M2 | MED | 9 | VERIFIED | Data-at-rest plaintext | `backlog_metadata` caller content not nulled at drain; persists on running rows + permanently on **FAILED** rows; G-04 queued-only | `services/backlog_service.py:92`, `db/schedules/queue.py:127`, `db/schedules/retention.py:346` |
+| M3 | MED | 8 | VERIFIED | Supply-chain CVE | HIGH advisories (`ip-address` SSRF, `undici` desync) transitive in mcp-server + helper-mcp **prod** trees; `ip-address` override floor sits *inside* the vulnerable range | `src/mcp-server/package.json`, `src/helper-mcp` |
+| M4 | MED | 9 | VERIFIED | Supply-chain process | Prod images build via `npm install` (not `npm ci`); dev frontend `rm -f package-lock.json` — lockfiles bypassed as a control | `src/mcp-server/Dockerfile:11`, `docker/frontend/Dockerfile.prod:12`, `docker/frontend/Dockerfile:9` |
+| M5 | MED | 9 | VERIFIED | Supply-chain pinning | Base-image agent-server pips fully unpinned; base CLIs `@latest`/no-version; backend `aiohttp`/`slackify-markdown` unpinned; base `curl\|bash` + Go tarball no SHA | `docker/base-image/Dockerfile:38,42,78,111`, `docker/backend/Dockerfile` |
+| M6 | MED | 9 | VERIFIED | Secrets (history) | Revoked third-party (Resend) API key recoverable from git history; scrub follow-up still open | `src/cli/trinity_cli/_notify.py` (deleted @ `3f906af4`) |
+| M7 | MED | 6 | VERIFIED | OAuth scope | Google OAuth requests full `.../auth/drive` (read/write/delete all Drive) where `drive.file` suffices | `routers/credentials.py:209` |
+| M8 | MED | 9 | VERIFIED | CI/CD hardening | First-party `actions/*` + `codeql-action/*` on floating major tags, not SHA-pinned | `.github/workflows/*` (~15 files) |
+| M9 | MED | 8 | VERIFIED | CI/CD hardening | `frontend-build.yml` has no `permissions:` block (fork-reachable `pull_request`) | `frontend-build.yml` |
+| L1 | LOW | 8 | VERIFIED (refuted-confirmed) | Access-control IDOR | `GET /event-subscriptions/{id}` has no owner check (PUT/DELETE do); bounded by ~96-bit id | `routers/event_subscriptions.py:229` |
+| L2 | LOW | 6 | VERIFIED · PERSISTENT | Auth/timing | Telegram secret token compared with `!=`, not constant-time | `adapters/transports/telegram_webhook.py:54` |
+| L3 | LOW | 6 | MITIGATED (CSP) · PERSISTENT | Stored HTML-injection | Brain-orb raw `innerHTML` of agent `data.json` strings; prod CSP blocks script-exec | `public/brain-orb/orb.js:441,462,646` |
+| L4 | LOW | 6 | VERIFIED · PERSISTENT | CI/CD injection | `publish-cli.yml` interpolates git-tag value into `run:` `sed` (trusted-actor only) | `publish-cli.yml:73` |
+| L5 | LOW | 7 | VERIFIED | CI/CD hardening | `deploy-dev.yml` has no `permissions:` block | `deploy-dev.yml` |
+| L6 | LOW | 6 | VERIFIED · PERSISTENT | Crypto config | Placeholder `SECRET_KEY` printed-not-raised (asymmetric with `REDIS_URL` hard-fail) | `config.py:74` |
+| L7 | LOW | 7 | VERIFIED · PERSISTENT | Business confidentiality | Paid-module ids named in live public docs outside the enterprise-docs-guard pattern | `architecture.md`, `feature-flows/*` |
+
+**Accepted-risk / INFO (not scored):** Dependabot review-bypassing auto-merge PAT (A4, unchanged); `pipenet` dormant public-exposure lib in the mcp-server prod tree; `python-multipart==0.0.20` (its two known advisories are fixed in ≤0.0.20 — likely last cycle's F7 was miscalibrated; verify + bump anyway); dead `POST /api/internal/decrypt-and-inject` reference in `startup.sh:541`/`models.py:975` (fails closed 404 — housekeeping); `ops.py` fleet-stop/pause and `logs.py` retention PUT lack `reject_agent_principal` (availability/DoS-class, excluded per rules — a consistency gap with the hardened destructive routes).
+
+---
+
+## H1 — Terminal WebSocket hands a chat-shared user a container shell (top finding)
+
+**Code.** `@router.websocket("/{agent_name}/terminal")` (`routers/agents.py:1632`) → `handle_terminal_session`, whose only authz gate is `terminal.py:124`:
+```python
+if not db.can_user_access_agent(user_email, agent_name) and user_role != "admin":
+```
+`can_user_access_agent` returns True for owner **OR shared OR** admin (the accessor tier); the owner-only predicate `can_user_share_agent` is *not* used here. `mode=bash` (a first-class `?mode=` query param the frontend `AgentTerminal.vue` itself defaults to) resolves to `cmd = ["/bin/bash"]` (`terminal.py:203`) with no further gate.
+
+**Exploit path (traced end-to-end by an independent fresh-context refuter).**
+1. Owner shares an agent for chat: `POST /{name}/share` inserts an `agent_sharing` row and auto-whitelists the collaborator's email as role `user` (`routers/sharing.py:67,104`).
+2. The collaborator logs in via email OTP (their email is now whitelisted) → valid platform JWT.
+3. They connect `wss://host/api/agents/{name}/terminal?mode=bash` (prod nginx proxies `/api/` with WS upgrade, no `auth_request` — `src/frontend/nginx.conf:38-54`, copied into `Dockerfile.prod:46`) against a running agent, sending the raw JWT in the first WS message.
+4. The `docker exec` runs `/bin/bash` as `user="developer"` in `/home/developer` and **inherits the container `Config.Env`**, so `printenv` dumps `CLAUDE_CODE_OAUTH_TOKEN` (`crud.py:1564`) and `TRINITY_MCP_API_KEY` (`crud.py:1611`); `.env` / `.credentials.enc` are directly readable. Arbitrary code executes as the agent identity, and the leaked MCP key enables lateral movement to every agent that key can reach.
+
+**Why HIGH (re-rated from last cycle's bundled MEDIUM).** The consequence is full credential exfiltration + RCE-as-agent + lateral movement, and the accessor/owner split exists precisely to prevent this — the sibling **SSH-access** endpoint is deliberately `require_admin`, which is the exact inconsistency. The one factor short of CRITICAL is the precondition: the actor must be a *deliberately-shared* collaborator who turns malicious (a semi-trusted insider), not an anonymous remote attacker. The Terminal tab being commented out in the owner UI (`AgentDetail.vue:883`) lowers discoverability but is not a security control — the backend route is registered unconditionally and reachable by a direct WS connection.
+
+**Fix.** Gate the terminal WS (and especially `mode=bash`) at owner/admin tier (`can_user_share_agent` / delete-tier), matching the SSH endpoint. Same one-line pattern as M1.
+
+## M1 — Schedule control at accessor tier
+
+`enable_schedule` / `disable_schedule` / `trigger_schedule` (`schedules.py:405,424,443`) take `name: AuthorizedAgent` (accessor tier) and the DB setter takes no username/owner check, while `update_schedule` (`:296`) and `delete_schedule` (`:378`) pass `current_user.username` and 403 on non-owner. A chat-shared user can flip owner-intent schedule state (re-enable work the owner paused, disable the owner's automation) and fire executions (LLM spend) — but cannot edit/delete them, an inconsistent boundary. Fix: move the three to `OwnedAgentByName`.
+
+## M2 — Plaintext caller content in `backlog_metadata` (narrowed since last audit)
+
+`backlog_service.enqueue` json.dumps the full request — `message`, `system_prompt`, `user_message`, `user_email` — into `schedule_executions.backlog_metadata` (`backlog_service.py:78-104`). #1449 added `scrub_terminal_backlog_metadata` (`retention.py:331`) which NULLs the blob every 5-min cleanup cycle **unconditionally** — a real improvement — **but only for authoritative terminals (success/cancelled/skipped)**; FAILED is deliberately excluded (resurrectable via late CAS), and the drain-claim itself (`queue.py:127`) never nulls it. Net residual: plaintext caller content lives on the `running` row for the whole execution, up to ~5 min after an authoritative terminal, and **up to 90 days on FAILED rows**. Canary G-04 scans only `status='queued'`, so a secret a caller embeds in a task body is unscanned once drained. Exposure = DB-at-rest / backup, not API-serialized; platform *credentials* are excluded by design. Fix: null at drain-claim (the `RETURNING` already captures it), and scrub FAILED rows once past the late-CAS resurrection window instead of waiting for the 90-day DELETE.
+
+## M3 / M4 / M5 — Supply chain
+
+- **M3 (advisory drift, NEW).** `npm audit` on the production trees: mcp-server (7 vulns, 3 high) and helper-mcp (5 vulns, 2 high) both ship `ip-address <=10.3.0` (HIGH — SSRF/trust-boundary-bypass class) and mcp-server ships `undici 7.0.0–7.28.0` (HIGH — response-desync/CRLF/cache-poisoning). These front every agent's Trinity MCP key. Notably `src/mcp-server/package.json` pins an `ip-address` override floor `>=10.2.0` that is *inside* the vulnerable range. Transitive (reachability unproven → MEDIUM, not HIGH). Fix: `npm audit fix`; raise the `ip-address` override above 10.3.0. The frontend `dompurify`/`mermaid` moderates are not reachable (plain `sanitize()`, no `CUSTOM_ELEMENT_HANDLING`) but DOMPurify is the H-005 XSS boundary — bump it anyway.
+- **M4 (process, PERSISTENT).** `src/mcp-server/Dockerfile:11` and `docker/frontend/Dockerfile.prod:12` build with `npm install` (floating semver), and `docker/frontend/Dockerfile:9` (dev) actively `rm -f package-lock.json`. Lockfiles exist and are tracked — the gap is build-time enforcement. Fix: `npm ci`.
+- **M5 (pinning, PERSISTENT + NEW).** `docker/base-image/Dockerfile:111-119` installs the agent-server pips (`fastapi`/`uvicorn`/`httpx`/`pydantic`/`cryptography`/…) with **zero pins**; base CLIs are `@latest` (`:78`) / unversioned (`:81`) while Codex is correctly pinned with rationale (`:88`); `docker/backend/Dockerfile` floats `aiohttp` and `slackify-markdown` amid an otherwise exact-pinned set (NEW); base image `curl … | bash -` (`:38`) and the Go tarball fetch (`:42`) have no integrity check. Fix: pin the pips + the two backend strays; add SHA256 to the Go fetch.
+
+## M6 — Revoked API key recoverable from git history
+
+`src/cli/trinity_cli/_notify.py` (added `3986c50b`, removed `3f906af4`, refs #1158/#1162) shipped an obfuscated Resend API key (XOR-split base85 halves) used to email access requests during `trinity init`. **The removal commit documents the key was revoked in the provider console** (independently verified: the file is absent from `dev`, and the commit message states the revocation). Per audit policy a revoked-but-leaked secret in a *public* repo's permanent, indexed history stays a **MEDIUM** finding — the credential is dead, but the architecture doc's own "git-history-scrub follow-up" has not happened. See the incident-response note below.
+
+## M7 — Over-broad Google OAuth scope
+
+`credentials.py:209` requests `openid email profile https://www.googleapis.com/auth/drive` — a Google "restricted" scope granting read/write/delete over the user's **entire** Drive, for a credential-injection helper where `.../auth/drive.file` (per-file) would be least-privilege. A compromised/prompt-injected agent holding the injected token can exfiltrate or destroy the whole Drive, not just files it created. Conditional on the operator having configured Google OAuth. No tokens/auth-codes are logged (verified). Fix: narrow to `drive.file` unless full Drive is a documented product requirement.
+
+## Cleared / verified-clean (high-value negatives)
+
+- **Platform isolation intact:** #589 two-network split (agents never on `trinity-platform`; redis/scheduler/vector never on the agent net; hard-coded at all three create sites `crud.py:1977` / `lifecycle.py:1231` / `system_agent_service.py:488`); Redis ACL (`backend`/`scheduler` are `-@dangerous`, both passwords fail-closed mandatory `${VAR:?}`, `config.py` raises on credential-less `REDIS_URL`); Redis host port loopback-only.
+- **Agent boundaries intact:** `base_image` allowlist (`fnmatch` vs `trinity-agent-base:*`, enforced on create + both recreate paths); all 5 agent-scoped self-boundaries (heartbeat / result-callback / reports / reminders / mcp-key) reject sibling keys via `authorize_heartbeat`; backend→agent `X-Trinity-Agent-Token` derived + fail-closed, middleware exempts only exact `/health`+OPTIONS incl. WS; agents cannot route to Redis.
+- **Vendored parity byte-identical:** `credential_paths.py`, `model_context.py`, `safe_yaml.py` (all three backend↔agent-server copies), parity tests present.
+- **Injection/SSRF clean:** `db/` layer parameterized (the f-string `text()` sites bind all user values, interpolate only generated placeholders/registry identifiers); `execute_command_in_container` is exec-form (no host shell); `skill_sources` github.com-only allowlist + credential rejection on write AND clone; channel media SSRF two-tier with `follow_redirects=False` + per-hop re-validation; template-registry https-only + private-IP-blocked + admin-only.
+- **Auth/crypto clean:** JWT HS256 with `jti` blacklist revocation on logout (#187); no md5/sha1/DES/ECB on security paths; SSH admin+public-key-only (never returns private keys); auth rate-limiting per-account + per-IP Redis-backed, OTP capped, inline-auth account-scoped (#591); CORS explicit allowlist (no wildcard); 422 handler strips `input`+`ctx` (no `SecretStr` leak), `hide_parameters=True` on the engine.
+- **AI surfaces clean:** every `v-html` routes through DOMPurify; MCP dedicated-tool descriptions name-only (#846 holds); voice-token mint locks the full `LiveConnectConfig` with no write tools, response field `ephemeral_token`; webhook `context` framed + capped (and currently a no-op end-to-end — the scheduler ignores caller context, fail-safe).
+- **CI clean:** no `pull_request_target`; no `github.event` shell interpolation; all *third-party* actions SHA-pinned; fork PRs receive no secrets and handle the empty case; new workflows (`secret-scan`, `pg-migrations`, `enterprise-docs-guard`, `publish-helper-mcp`) least-privileged; enterprise-docs-guard covers the seam files.
+- **Secrets clean:** no tracked `.env` (never committed); all AKIA/`sk-`/`ghp_`/`xox` history hits are synthetic test fixtures; `CLAUDE.local.md` untracked.
+
+## Adversarial verification (fresh-context refutation)
+
+Both disputed findings were handed to independent skeptic agents instructed to refute them:
+- **Terminal WS (H1)** → **CONFIRMED on all five angles.** The refuter proved prod-reachability (nginx WS-upgrade proxy, no `auth_request`), that no C-002 ticket re-checks ownership (raw JWT in the first WS message), that `mode=bash` is unrestricted and client-selectable, that `/share` grants `can_user_access_agent`=True, and that the exec inherits the credential-bearing container env. Severity elevated to HIGH.
+- **Event-subscription IDOR (L1)** → **CONFIRMED (code fact) but severity tempered to LOW.** The missing owner-check is real and asymmetric with PUT/DELETE, but the ~96-bit `esub_` id has no cross-tenant harvest surface (create/list/MCP all access-gated; the WS broadcasts only the `evt_` id), so it is a defense-in-depth consistency fix, not a drainable leak.
+
+## Trend vs 2026-07-13
+
+**Resolved (4):**
+- **A7** — Slack `download_file` SSRF → now two-tier host-gated with `follow_redirects=False` (#1951/#1932).
+- **A10** — `/user-memory` self-gate → now execution-ownership check + server-resolved email.
+- **A9 (exfil half)** — E2E secrets on `pull_request` → confirmed fork PRs receive no secrets + empty-case handled (the missing-`permissions:`-block half persists as M9).
+- **F7** — `python-multipart==0.0.20` → its two known advisories are fixed in ≤0.0.20; likely a prior miscalibration (verify + bump regardless).
+
+**Improved (1):** **F4** (`backlog_metadata`) — #1449 now scrubs authoritative-terminal rows; residual narrowed to running + FAILED rows (M2).
+
+**Persistent (9):** F1 terminal (now **H1**, re-rated up) + F1 schedule (M1), F2/npm-install (M4), F5/unpinned (M5), F6/enterprise-docs (L7), A1/brain-orb (L3, CSP), A2/Slack-code (mitigated — rate-limiter verified intact), A5/SECRET_KEY (L6), A6/Telegram (L2), A8/publish-cli (L4), A4/dependabot (accepted). CODEOWNERS covers workflows (verified); `require_code_owner_reviews` enforcement is a live-GitHub check to re-confirm (prior F3).
+
+**New (7):** M3 (`ip-address`/`undici` advisories), M6 (revoked key in history), M7 (Google Drive scope), M8 (first-party actions unpinned), backend `aiohttp`/`slackify-markdown` unpinned (folded into M5), L1 (event-subscription IDOR), `pipenet` dormant lib (INFO).
+
+## STRIDE (delta)
+
+The material change since last cycle is the sharpened **Elevation of Privilege** picture on the shared-user tier (H1/M1): a chat-shared collaborator escalates to container-root-equivalent (H1) and to schedule-control/spend (M1). **Information Disclosure**: L1 (bounded IDOR) and M2 (plaintext caller PII at rest) are additive but bounded; M6 is a permanent-but-dead history disclosure. **Tampering/Spoofing** on the agent-identity and internal-secret boundaries remains closed (all self-boundaries + `X-Trinity-Agent-Token` verified). No new **Repudiation** gap (audit chain intact). **DoS** items (ops fleet-stop by agent key) are noted but out of scope per rules.
+
+## Data classification (unchanged)
+
+- **RESTRICTED** — agent `CLAUDE_CODE_OAUTH_TOKEN` / `TRINITY_MCP_API_KEY` (container env), `.credentials.enc` (AES-256-GCM), channel/subscription/PAT tokens (AES-256-GCM in SQLite), `SECRET_KEY`, Redis ACL passwords. *H1 exposes the first two to a shared user — the headline risk.*
+- **CONFIDENTIAL** — caller task content in `backlog_metadata` (M2), chat/session content, event-subscription config (L1), audit log.
+- **INTERNAL** — agent metadata, schedules, execution rows, canary violations.
+- **PUBLIC** — shared-file downloads (token-gated), public chat, `/api/version`.
+
+## Remediation roadmap (recommended disposition)
+
+1. **H1 — move the terminal WS (and `mode=bash`) to owner/admin tier.** **Fix now.** One-line dependency change; closes full credential exfiltration + RCE-as-agent for shared users. Pair with M1 (same fix on the three schedule-control routes).
+2. **M3/M4 — `npm ci` in the three Dockerfiles + `npm audit fix` + raise the `ip-address` override above 10.3.0.** **Fix now** (mechanical; restores the lockfile control and clears the two HIGH advisories in the MCP prod tree).
+3. **M5 — pin the base-image agent-server pips + the two backend strays; add SHA256 to the Go fetch.** **Fix now** (mechanical).
+4. **M2 — null `backlog_metadata` at drain-claim; scrub FAILED rows past the resurrection window; widen G-04.** **Fold into #1449 follow-up.**
+5. **M7 — narrow Google OAuth to `drive.file`** unless full Drive is a product requirement. **Owner decision.**
+6. **M8/M9 — SHA-pin first-party actions; add `permissions: contents: read` to `frontend-build.yml` (and `deploy-dev.yml`, L5).** **Fix now** (hygiene).
+7. **M6 / L7 — history scrub for the revoked key; policy decision on paid-module names in public docs** (bless release-marketing vs. genericize + extend the guard token list). **Owner decision.**
+8. Quick one-liners: L2 (`hmac.compare_digest` for Telegram), L4 (pass the tag via `env:` in publish-cli), L6 (`raise` on placeholder `SECRET_KEY` like `REDIS_URL`), reconcile the dead `/decrypt-and-inject` route reference. **Re-confirm `require_code_owner_reviews` on dev/main in GitHub branch protection.**
+
+## Incident-response note — M6 (revoked leaked key)
+
+1. **Rotation: DONE** — the removal commit (`3f906af4`) documents the Resend key was revoked in the provider console. No active-compromise risk.
+2. **History scrub: OPEN** — the key remains recoverable via `git show 3986c50b:…` in the public, indexed history. Complete the standing git-history-scrub follow-up (`git filter-repo`/BFG + coordinated force-push).
+3. **Exposure audit** — the key was public for the window between `3986c50b` and `3f906af4`; confirm no anomalous provider-side use in that window.
+4. **Recurrence guard** — the `re_`-prefixed pattern is already in the gitleaks config (`secret-scan.yml`); confirmed present.
+
+---
+*Read-only assessment. Reports: `docs/security-reports/cso-2026-08-09.{md,json}`. Not a substitute for professional penetration testing.*

--- a/src/backend/routers/event_subscriptions.py
+++ b/src/backend/routers/event_subscriptions.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from models import EmitEventRequest
 
 from database import db
-from dependencies import get_current_user, AuthorizedAgent, OwnedAgent, assert_agent_owner
+from dependencies import get_current_user, AuthorizedAgent, OwnedAgent, assert_agent_owner, assert_agent_access
 from db_models import (
     User,
     EventSubscriptionCreate,
@@ -234,6 +234,10 @@ async def get_event_subscription(
     sub = db.get_event_subscription(subscription_id)
     if not sub:
         raise HTTPException(status_code=404, detail="Event subscription not found")
+    # CSO L1: gate the cross-tenant read at accessor tier (mirrors the list route
+    # /api/agents/{name}/event-subscriptions and the owner-gated PUT/DELETE below),
+    # so an authenticated caller can't read another tenant's subscription config.
+    assert_agent_access(current_user, sub.subscriber_agent)
     return sub
 
 

--- a/src/backend/routers/schedules.py
+++ b/src/backend/routers/schedules.py
@@ -30,6 +30,7 @@ from dependencies import (
     get_current_user,
     get_authorized_agent,
     AuthorizedAgent,
+    OwnedAgentByName,
     CurrentUser,
     assert_admin,
     assert_agent_access,
@@ -402,7 +403,7 @@ async def delete_schedule(
 
 @router.post("/{name}/schedules/{schedule_id}/enable")
 async def enable_schedule(
-    name: AuthorizedAgent,
+    name: OwnedAgentByName,  # CSO M1: owner-tier (matches update/delete), not accessor
     schedule_id: str
 ):
     """Enable a schedule."""
@@ -421,7 +422,7 @@ async def enable_schedule(
 
 @router.post("/{name}/schedules/{schedule_id}/disable")
 async def disable_schedule(
-    name: AuthorizedAgent,
+    name: OwnedAgentByName,  # CSO M1: owner-tier (matches update/delete), not accessor
     schedule_id: str
 ):
     """Disable a schedule."""
@@ -440,7 +441,7 @@ async def disable_schedule(
 
 @router.post("/{name}/schedules/{schedule_id}/trigger")
 async def trigger_schedule(
-    name: AuthorizedAgent,
+    name: OwnedAgentByName,  # CSO M1: owner-tier (matches update/delete), not accessor
     schedule_id: str,
     current_user: User = Depends(get_current_user),
     x_source_agent: Optional[str] = Header(None),

--- a/src/backend/services/agent_service/terminal.py
+++ b/src/backend/services/agent_service/terminal.py
@@ -120,8 +120,13 @@ class TerminalSessionManager:
                 user_email = user.get("email") or user.get("sub") or "unknown"
                 user_role = user.get("role", "user")
 
-                # Check access to this agent
-                if not db.can_user_access_agent(user_email, agent_name) and user_role != "admin":
+                # Check access to this agent.
+                # SECURITY (CSO H1): a container shell exposes .env / .credentials.enc
+                # and the baked CLAUDE_CODE_OAUTH_TOKEN / TRINITY_MCP_API_KEY, so it
+                # must be gated at OWNER/admin tier (can_user_share_agent), not the
+                # accessor tier (can_user_access_agent, which admits chat-shared
+                # collaborators). Mirrors the deliberately admin-only SSH endpoint.
+                if not db.can_user_share_agent(user_email, agent_name) and user_role != "admin":
                     await websocket.send_text(json.dumps({
                         "type": "error",
                         "message": "You don't have access to this agent",

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -2263,9 +2263,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3188,9 +3188,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
@@ -3331,9 +3331,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/helper-mcp/package-lock.json
+++ b/src/helper-mcp/package-lock.json
@@ -467,24 +467,24 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -951,9 +951,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1103,9 +1103,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.29",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
-      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1154,9 +1154,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/src/mcp-server/Dockerfile
+++ b/src/mcp-server/Dockerfile
@@ -8,15 +8,17 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies (use npm install instead of ci for flexibility)
-RUN npm install --production
+# Install production dependencies from the tracked lockfile (CSO M4:
+# npm ci is lockfile-exact and fails on drift, restoring the lockfile as a
+# supply-chain control; npm install floated semver ranges).
+RUN npm ci --omit=dev
 
 # Copy TypeScript config and source
 COPY tsconfig.json ./
 COPY src ./src
 
-# Install dev dependencies for build
-RUN npm install && npm run build && npm prune --production
+# Install dev dependencies (from lock) to build, then prune to production.
+RUN npm ci && npm run build && npm prune --production
 
 # Run as non-root (CSO hardening, issue #874).
 # node:22-alpine ships a built-in `node` user at UID 1000.

--- a/src/mcp-server/package-lock.json
+++ b/src/mcp-server/package-lock.json
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.2.tgz",
-      "integrity": "sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -484,12 +484,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -690,21 +690,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1164,12 +1177,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1541,9 +1555,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1690,9 +1704,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2537,17 +2551,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2577,9 +2608,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/src/mcp-server/package.json
+++ b/src/mcp-server/package.json
@@ -35,7 +35,7 @@
     "axios": ">=1.15.2",
     "fast-uri": "^3.1.5",
     "@hono/node-server": ">=1.19.13",
-    "ip-address": ">=10.2.0",
+    "ip-address": ">=10.5.0",
     "qs": ">=6.15.2",
     "esbuild": ">=0.28.1"
   }


### PR DESCRIPTION
## Summary

Fixes surfaced by the `/cso full` audit (`docs/security-reports/cso-2026-08-09.md`). One HIGH plus access-control and supply-chain hardening. The report + structured JSON are included in this PR.

### HIGH
- **H1 — terminal WebSocket privilege escalation.** `services/agent_service/terminal.py` gated a `/bin/bash` container shell at *accessor* tier (`can_user_access_agent`), so a chat-only **shared** collaborator could open the terminal against a running agent and dump `CLAUDE_CODE_OAUTH_TOKEN` / `TRINITY_MCP_API_KEY` / `.env` (RCE as the agent, lateral movement via the MCP key). Now gated at owner/admin tier (`can_user_share_agent`), matching the deliberately admin-only SSH endpoint. Confirmed prod-reachable + exploitable by two independent fresh-context refutations.

### Access control
- **M1** — schedule `enable`/`disable`/`trigger` moved from `AuthorizedAgent` → `OwnedAgentByName` (they were accessor-tier while `update`/`delete` required ownership; a shared user could flip owner-intent schedule state and burn LLM spend).
- **L1** — `GET /event-subscriptions/{id}` gains `assert_agent_access` (the owner check its `PUT`/`DELETE` siblings already enforce; bounded IDOR by ~96-bit id, but the asymmetry is real).

### Supply chain
- **M3** — `npm audit fix` on mcp-server + helper-mcp + frontend clears the HIGH `ip-address` (SSRF) and `undici` (response-desync) advisories in the MCP prod tree; `ip-address` override floor raised to `>=10.5.0`. **0 vulnerabilities** in all three trees.
- **M4** — `npm install` → `npm ci` in the mcp-server and frontend prod Dockerfiles, restoring the tracked lockfile as a control.
- **M5 (partial)** — backend `Dockerfile` pins `aiohttp==3.14.3`, `slackify-markdown==0.2.4` (were floating amid an otherwise exact-pinned set).

### CI hygiene
- **M9 / L5** — least-privilege `permissions: contents: read` added to `frontend-build.yml` and `deploy-dev.yml`.

## Verification
- `py_compile` on all changed backend files; `test_186_enumeration_uniformity` (36) and `test_subscription_bola` pass.
- `npm audit` → **0 vulnerabilities** on mcp-server / helper-mcp / frontend; mcp-server `tsc` and frontend `vite build` both succeed; `npm ci` exits 0 (lockfiles in sync).
- Backend pins read from the live running backend's own resolved versions.

Full integration verification of the H1/M1 auth changes (shared-user 403 vs owner 200) runs on CI.

## Deliberately held (need a build/CI-verified pass — see report)
- **M5** base-image pip pins + Go-tarball SHA (needs a base-image rebuild; a wrong pin takes down every agent).
- **M4** dev frontend Dockerfile (deletes the lockfile for cross-arch native binaries; dev-only).
- **M8** SHA-pinning ~15 first-party actions (needs exact SHAs + a CI run).
- **M2 / M6 / M7 / L7** — policy/owner-decision items (backlog_metadata drain-null, git-history scrub, Google-scope narrowing, docs policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)