### PR TITLE
fix(tests): untrack the tests/.venv symlink pointing at a developer's home (#2080)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,12 @@ __pycache__/
 .Python
 env/
 venv/
+# No trailing slash: the slash forms match DIRECTORIES only, so a *symlink*
+# named .venv slipped past them and was committed (#2082 shipped one pointing
+# at a developer's home directory). These also match a symlink or a file.
+.venv
 .venv/
+.venv*
 .venv*/
 ENV/
 build/

--- a/tests/.venv
+++ b/tests/.venv
@@ -1,1 +1,0 @@
-/home/oleksii/Desktop/abilityai/trinity/.venv

--- a/tests/unit/test_2080_harness_contract.py
+++ b/tests/unit/test_2080_harness_contract.py
@@ -12,7 +12,9 @@ quiet, and each fails loudly rather than reducing what runs.
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -212,3 +214,55 @@ def test_the_audit_passes_an_allowlisted_skip(tmp_path):
     from harness.audit_skips import main
 
     assert main(["audit_skips.py", str(tmp_path)]) == 0
+
+
+# ---------------------------------------------------------------------------
+# The venv the runner bootstraps must not be a tracked path (#2082 follow-up)
+# ---------------------------------------------------------------------------
+
+def test_no_tracked_symlink_escapes_the_repo():
+    """A tracked symlink pointing outside the worktree is broken for everyone else.
+
+    #2082 committed `tests/.venv` as a symlink to
+    `/home/<dev>/Desktop/abilityai/trinity/.venv`. Two failures, neither loud:
+
+    1. It published a developer's local path and username to a public repo.
+    2. It broke the very runner that PR exists to fix. `run-full.sh` guards
+       creation with `[ ! -d .venv ]`, which is *false* for a dangling symlink,
+       so it fell through to `python3 -m venv .venv` against an absolute path
+       that does not exist on any other machine and exited 2.
+
+    `.gitignore` did not stop it because `.venv/` and `.venv*/` carry trailing
+    slashes and therefore match directories only — a symlink is not a directory.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files", "-s"], cwd=_REPO, capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+
+    offenders = []
+    for line in tracked:
+        meta, _, path = line.partition("\t")
+        if not meta.startswith("120000"):  # symlink blobs only
+            continue
+        target = (_REPO / path).parent / os.readlink(_REPO / path)
+        try:
+            target.resolve().relative_to(_REPO.resolve())
+        except ValueError:
+            offenders.append(f"{path} -> {os.readlink(_REPO / path)}")
+
+    assert not offenders, (
+        "tracked symlink(s) resolve outside the repository — these are dangling "
+        "on every other machine and may leak a local path:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_runner_venv_is_not_tracked():
+    """`tests/.venv` is created by the runner; it must never be a tracked path."""
+    tracked = subprocess.run(
+        ["git", "ls-files", "tests/.venv"], cwd=_REPO, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert tracked == "", (
+        "tests/.venv is tracked; run-full.sh creates it per-machine and a tracked "
+        "copy (dir, file or symlink) makes the bootstrap machine-specific"
+    )


### PR DESCRIPTION
Fixes #2080

Follow-up to #2082, caught while merging #2084 on top of it.

## What shipped

#2082 committed `tests/.venv` as a **symlink** to `/home/<dev>/Desktop/abilityai/trinity/.venv`.

```
$ git ls-tree dev tests/.venv
120000 blob 48f7e43    tests/.venv
$ git cat-file -p 48f7e43
/home/<dev>/Desktop/abilityai/trinity/.venv
```

## Two failures, neither loud

**1. Public-repo leak.** A symlink blob's *content is the path*, so a developer's local directory layout and username are now in a world-readable repo. This is why a pre-merge diff scan missed it: the checks look for keys, emails and IPs, and a filesystem path matches none of those patterns. I ran that scan on #2082 and passed it.

**2. It broke the runner #2082 exists to fix.** `run-full.sh:84` guards creation with `[ ! -d .venv ]`. For a **dangling** symlink that test is *false*, so the script falls through to `python3 -m venv .venv` against an absolute path that exists on exactly one machine:

```
$ [ ! -d tests/.venv ] && echo "would create"
would create          # and then venv creation targets a nonexistent absolute path -> exit 2
```

The one contributor for whom the target resolved saw nothing wrong. Everyone else gets `could not create venv` from the harness whose entire thesis is honest full-suite runs.

## Why `.gitignore` did not stop it

```
.venv/
.venv*/
```

Both carry **trailing slashes**, which match directories only. A symlink is not a directory, so it sailed past. Added the slashless forms and verified both a plain file and a symlink named `.venv` are now ignored.

## Guards

In `tests/unit/test_2080_harness_contract.py` — the suite #2080 created for precisely this "coverage disappears quietly" class:

- `test_no_tracked_symlink_escapes_the_repo` — walks `git ls-files -s` for `120000` blobs, fails any whose target resolves outside the worktree. Generic, so the next one is caught too.
- `test_runner_venv_is_not_tracked` — `tests/.venv` is per-machine state and must never be tracked in any form.

**Verified red, not assumed green:**

```
with the symlink re-introduced:  2 failed, 12 passed
after removal:                  14 passed
```

## Note

`#2080` is already `status-in-dev` from #2082; this carries the closing keyword only so the link is explicit. No behaviour change outside the test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)