### PR TITLE
docs: v0.9.0 code-freeze plan

### DIFF
--- a/docs/releases/v0.9.0-freeze-plan.md
+++ b/docs/releases/v0.9.0-freeze-plan.md
@@ -1,0 +1,127 @@
+# Release Coherence Review — v0.9.0 — VERDICTS CONFIRMED 2026-08-11
+
+Confirmed by eugene 2026-08-11: C4 registry default-ON intended (ship + air-gapped note) ·
+C5 evaluations **FENCE** (foundation; F1 checklist active) · C10 rooms reframed — the surface
+is being absorbed into Workspace (ent#78: #358 absorbs Session tab, #361/#362 build Workspace
+chats on the room engine), so the engine bugs ent#218/ent#220 stay SHOULD (substrate survives
+the move), #1819 rooms-UI polish is likely mooted (confirm with dolho before spending on it),
+and **Workspace delivery becomes the controlled track** (land #2083 now; ent#78 absorb-items
+are the next-cycle plan) · Freeze = **2026-08-12** (tomorrow).
+
+Generated 2026-08-11 by /release-plan v1.0 (full mode). Payload: v0.8.5..origin/dev.
+
+Payload: 127 issues (89 public / 38 private) · 371 commits · 1027 files (+144,822 / −32,860) · since v0.8.5 (2026-07-26, 16d)
+Public types: 76 bugs · 8 features · 2 docs · 2 refactors · 1 epic
+Themes (union): reliability 47 · security 19 · devex 22 · ui-ux 20 · infrastructure 12 · channels 3
+
+Epic deep-dives were done via batched sub-issue GraphQL (reference.md fallback), not per-epic /roadmap — noted degradation (14 epics touched; identical data source).
+
+## Payload census
+- Clean (in-dev + in commits): 126 of 127 (all 89 public confirmed in commit subjects/bodies; 37/38 enterprise confirmed in subjects or submodule log)
+- Stale label (in-dev, no commits): 1 — ent#330 (npm publish of @abilityai/trinity-docs-mcp; an ops action outside the repo — verify it happened, else /groom)
+- Unlabeled (in commits, not in-dev): ~30 enterprise issues closed-on-merge (ent tracker closes at merge, not release) — ent#348 compliance-export, ent#163/186/144/308/309/311 client-portal, ent#222/223/224 Slack per-agent bots + consent + report-back, ent#117/118, ent#169/170 rooms, ent#12/39/69/123–125/139/151/162/181/183–187/199/206/213/219/239/241/277/356. **Release-notes risk**: these will be missing from notes unless the close-out list is built from submodule-pin ancestry (exactly what in-progress ent#331 proposes). Plus 3 no-issue commits (skills path sanitize, retention floor-by-seed, avatar color-scheme truncation).
+
+## Coherence clusters (proposed verdicts)
+
+| # | Cluster | Shipped | Missing | Visible? | Verdict (proposed) | Action | Est |
+|---|---------|---------|---------|----------|--------------------|--------|-----|
+| C1 | Schedule control regression | #2081 CSO hardening | enable/disable/trigger 422 for EVERY caller (#2094; `OwnedAgentByName` reads `{agent_name}`, routes declare `{name}`) | YES — breaks UI, REST, MCP | **COMPLETE** | Merge ready PR #2095 | hours |
+| C2 | client_portal OSS move (ent#356) | OSS half (#2084): `src/backend/client_portal/` mounted unconditionally | Enterprise half: pin still at d1c5ebb; removal commit bce1175 unpinned → entitled builds mount a **duplicate router on the same prefix** + advertise a false `client_portal` entitlement | YES (entitled installs) | **COMPLETE** | Bump submodule pin to bce1175 (one-commit PR) | <1h |
+| C3 | Skill-source seed kill switch (ent#237) | `TRINITY_DEFAULT_SKILL_SOURCE` seed + documented `""`-disables-it contract | Neither compose forwards the var → documented opt-out inert in every containerized deploy (#1039 class) | no | **COMPLETE** | Add passthrough to both composes (or delete the env promise) | <1h |
+| C4 | Template registry default-ON (ent#14) | Registry fetch ships **enabled**; bundled GitHub-repo floor emptied; kill switch + admin panel + SSRF guard all wired | Decision: default-ON confirmed? Upgrade note for air-gapped installs (new egress; catalog remotely controlled) | YES | **SHIP + NOTE** (decision needed) | Release-note upgrade line | 0 |
+| C5 | Evaluations foundation (ent#206/267) | Referee surface + Completion relabel; write fence correct | Zero consumers: no MCP read tool, no UI render — the documented "agent sees its own score" feedback loop is structurally impossible; reports.ts #1538 is the exact pattern to mirror | no | **SHOULD-COMPLETE** (else DEFER + amend flow doc + notes line) | Add MCP `list_evaluations`/`get_evaluation` read tools | ~0.5d |
+| C6 | Grid data foundation (ent#326/#325) | `GET /api/executions/timeline` merged 2026-08-11 | No consumer — widget chassis (ent#325) is PR #2042, ready; tiles #96/#98/#101 still backlog | no | **SHOULD-COMPLETE** (else DEFER, invisible) | Merge ready PR #2042 | review only |
+| C7 | Workspace coherence (ent#78) | Portal OSS-core, facelift, titles, delegated identity, security fixes (ent#308/309/311), rate limits, logout | ent#357 rename+one-click = ready PR #2083; exposure config has **no UI** (API-only enable switch); ent#286 streaming in progress | YES | **SHOULD-COMPLETE** #2083; exposure-panel → DEFER + file issue | Merge #2083; file exposure-panel issue | review only |
+| C8 | Credential/PAT rotation edges | #1967/#2016 rotation propagation + dup-line fix shipped | Siblings: #2017 (backslash token breaks rotation, PR #2024 ready), #2023 (quote-escaping write-only, PR #2030 ready) | edge cases | **SHOULD-COMPLETE** | Merge #2024, #2030 | review only |
+| C9 | Schedules UX polish | schedule fixes (#1796/#1808/#1945/#1969…) | #1968 manual trigger returns `undefined` execution_id — PR #1976 ready | YES | **SHOULD-COMPLETE** | Merge #1976 | review only |
+| C10 | Rooms residuals (ent#8 shipped in v0.8.5) | — | ent#218 (billed final reply discarded + 410 on landed message), ent#220 (budget/idempotency edge, role enforcement, participant cap — security-adjacent), #1819 (dark-mode glitches). All in-progress (dolho) | YES | **SHOULD-COMPLETE** if fixes land; else ship + Known-limitations lines | Land fixes or write notes lines | unknown (no PRs yet) |
+| C11 | git-dir detection follow-up | #2075 first fix shipped | PR #2076 (rev-parse-based root resolution) ready | no | **SHOULD-COMPLETE** | Merge #2076 | review only |
+| C12 | deploy-local completeness | #2006 shipped | #2060 in-progress (archive path silently deploys incomplete agents) | edge | **DEFER** unless fix lands (tracked, notes line optional) | — | — |
+| C13 | env-drift diagnostic (#1999) | endpoint + agent-server report | No UI renders it; undiscoverable (curl-only) | no | **DEFER** | File "drift badge in CredentialsPanel" issue; document as operator diagnostic | — |
+| C14 | A2A slice (ent#156: 157/158/160) | Inbound server (opt-in, default OFF per agent) + config UI + MCP tools — coherent | ent#159 signed cards **BLOCKED**; ent#178 unified skills config ready | YES (opt-in) | **SHIP AS INCREMENT** + notes line (unsigned cards) | Notes line | 0 |
+| C15 | Fresh-install provisioning (ent#122, 13/18) | Manifest-install UI, guided credentials, installable-agent standard, fork-to-own, import wizard, remote registry, tokenless clone, first-run seed | ent#137 archetype library (ready), ent#177 spike, ent#350 | YES | **SHIP AS INCREMENT** — release highlight | — | 0 |
+| C16 | Skills platform (ent#182, 6/17 + 5 in-dev) | Tab UI, lifecycle automation, multi-source, vendor-neutral layout, community repo, skill-runner + fixes | ent#242 skill-runner admin surface (ready), ent#342 toggles, ent#321 | YES | **SHIP AS INCREMENT** + notes line (runner admin is MCP/manual-only) | — | 0 |
+| C17 | Reports epic #1534 | ALL 5 children (#1535–#1539) | — | YES | **WHOLE** — release highlight | — | 0 |
+| C18 | MCP `display_label` gap | label endpoints + UI (pre-v0.8.5) | create_agent/MCP has no display_label | agents can't set labels | **DEFER** (pre-existing) | Optional backlog issue | — |
+
+## Seam findings
+- **B1 (MCP seam)**: 1 fracture (C5 evaluations read); bind-to-own-repo / credential-requirements / mcp-key lifecycle / skill sources / settings panels / manifests catalog / timeline / export-rows / telegram toggle / portal — all verified **no-MCP-by-design**.
+- **B2 (agent-server mirror)**: clean — all 4 vendored pairs byte-identical at origin/dev with parity tests (incl. the newly vendored mcp_validator, #2007). Latent note: `redact_url_userinfo` now lives in both credential_sanitizer copies with no cross-tree parity test — file a follow-up.
+- **C (migrations)**: clean — parity guard passes over the whole payload; 6 SQLite↔Alembic pairs semantically equivalent; single Alembic head `0036_client_portal_oss`; 2 immaterial notes (FK-stripping convention; REAL vs DOUBLE PRECISION on agent_evaluations.quality).
+- **D (reachability)**: C5, C6, C13, C7-exposure; portal /auth/exchange + internal mcp-auth + A2A public endpoints verified deliberate. Side note: A2A store calls use raw axios (Invariant #7 wobble) — file follow-up.
+- **E (dark flags)**: `MCP_INLINE_AUTH_ENABLED` intended-dark & fully wired; `CANARY_ENABLED` prod-forward is a fix; `audit_hash_chain_enabled` now durable; a2a per-agent opt-in; skills auto-sync admin-opt-in (env fallback tier inert — cosmetic). C3 + C4 above are the actionable two.
+
+## Self-declared incompleteness (spot checks — all filed)
+The payload's residual discipline is good: essentially every "deferred/residual/follow-up" grep hit resolves to a filed issue or an explicitly-recorded accepted risk (e.g. #2048 clarified pull-pilot honesty; #1085 BILLING; jsonl homograph residuals). No unfiled promise found that needs a freeze action beyond the clusters above.
+
+## Soak risk
+- `#2081` (CSO hardening) merged 2 days before this review and already produced one all-surfaces regression (#2094) — run a full `/verify-local` + UI smoke on schedules/credentials/ops surfaces during freeze week.
+- Churn hotspots: `agent_service/crud.py` (22 commits), `lifecycle.py` (18), `cleanup_service.py` (16), `task_execution_service.py` (12), `Settings.vue` (17), compose files (17 each).
+- Payload is hot: last merge landed the morning of this review (ent#326).
+
+## Code-Freeze Work Order — v0.9.0 (FINAL)
+Freeze: **2026-08-12** (tomorrow) · Go/No-Go: **GO** — MUST column ≈ 1 day of mechanical work, fits.
+SHOULD items land only if reviewed+merged by freeze; all droppable.
+
+### MUST LAND before freeze — 3 items, ~1d total
+| # | Repairs | Action | Verdict | Est | Owner | Issue |
+|---|---------|--------|---------|-----|-------|-------|
+| 1 | C1 schedule control broken on dev | Review + merge PR #2095 | COMPLETE | hours | dolho (author) / vybe review | #2094 |
+| 2 | C2 duplicate portal mount + false entitlement | Submodule pin bump → bce1175 (PR to dev) | COMPLETE | <1h | trinity-ability | ent#356 |
+| 3 | C3 inert skill-source kill switch | Compose passthrough for TRINITY_DEFAULT_SKILL_SOURCE(_REF) both composes + .env.example uncomment | COMPLETE | <1h | any | ent#237 residual (file) |
+
+### SHOULD LAND (droppable, review-only unless noted) — 7 items
+| # | Repairs | Action | Est |
+|---|---------|--------|-----|
+| 4 | C7 **Workspace delivery — the controlled track** (user decision) | Merge PR #2083 (rename + one-click, ent#357); ent#78 absorb-items (#358–#365) are the next-cycle plan, NOT this freeze | review |
+| 5 | C6 dead timeline endpoint | Merge PR #2042 (widget chassis, ent#325) | review |
+| 6 | C8 rotation edges | Merge PRs #2024 (#2017), #2030 (#2023) | review |
+| 7 | C9 undefined execution_id | Merge PR #1976 (#1968) | review |
+| 8 | C11 git-dir root | Merge PR #2076 (#2075 follow-up) | review |
+| 9 | C10 room-ENGINE bugs (substrate under future Workspace chats) | Land ent#218/ent#220 if fixes are ready by freeze; #1819 rooms-UI polish likely mooted by Workspace absorption — confirm with dolho before spending | unknown |
+| 10 | Docs | Merge PR #2079 (user-docs reconcile, 145 PRs) | review |
+
+### FENCE (gating + docs only) — 2 items
+| # | Cluster | Checklist | Est |
+|---|---------|-----------|-----|
+| F1 | C5 evaluations — **CONFIRMED FENCE** | ☐ No UI/notes claim of agent-visible scores · ☐ amend agent-evaluations.md feedback-loop sentence to future tense · ☐ Known-limitations line (drafted below) · ☐ file the MCP-read-tools issue (mirror reports.ts #1538) with status-ready | <1h |
+| F2 | C6 timeline (only if item 5 dropped) | ☐ No notes claim of grid data tiles · ☐ endpoint documented as foundation · invisible otherwise | <15min |
+
+### DEFER (explicitly acknowledged)
+| What | Tracked | Notes line? |
+|------|---------|-------------|
+| ent#159 signed A2A cards (blocked) | ent#159 | YES (unsigned cards) |
+| ent#242 skill-runner admin surface | ent#242 (ready) | YES |
+| C13 env-drift UI | file new issue | no (invisible diagnostic) |
+| C12 deploy-local completeness (#2060) | #2060 | optional |
+| C18 MCP display_label | optional issue | no |
+| Portal exposure Settings panel | file new issue | YES (API-only enable) |
+| redact_url_userinfo parity test; A2A raw-axios | file 2 small issues | no |
+| ent#330 npm publish | verify then /groom | no |
+| #2048 pull-pilot topology honesty (shipped as claim-fix) | #1081 umbrella | YES (pilot scope) |
+
+### Release-notes: Known limitations block (draft)
+```markdown
+## Known limitations
+- **Template catalog now resolves through a remote registry by default** — new outbound
+  fetch to the registry repo at runtime. Air-gapped / egress-controlled installs: set
+  `TEMPLATE_REGISTRY_ENABLED=false` (Settings → Template Registry has the live status).
+- **Agent evaluations ship as a foundation** — the referee surface and "Completion"
+  relabel are live; graders and agent/UI read surfaces follow (abilityai/trinity-enterprise#205).
+- **A2A inbound exposure is per-agent opt-in and cards are unsigned** — signed Agent
+  Cards (JWS) are tracked in abilityai/trinity-enterprise#159.
+- **Skill-runner has no admin surface yet** — enable/provision/sync via MCP/API only
+  (abilityai/trinity-enterprise#242).
+- **Workspace (client portal) exposure config is API-only** — no Settings panel yet.
+- **MCP keyless email sign-in (#848) ships dark** — enable via `MCP_INLINE_AUTH_ENABLED`.
+- **Pull-mode pilot routes agent-to-agent work only** — cron/schedule triggers stay on
+  push dispatch (#2048 / #1081).
+- (If rooms fixes miss the freeze) **Rooms**: budget termination can discard the final
+  agent reply (ent#218). The rooms UI is slated to be absorbed into Workspace
+  (abilityai/trinity-enterprise#78 — #358/#361/#362); the engine fixes track separately.
+```
+
+### Recommended remediation commands
+- /groom → ent#330 stale label (after verifying the npm publish)
+- /implement → work-order item 9 (evaluations MCP read tools) if COMPLETE confirmed
+- /release → after MUST LAND empties; paste the Known-limitations block into Step 5; build the enterprise close-out list from submodule-pin ancestry (ent#331)

--- a/docs/releases/v0.9.0-freeze-plan.md
+++ b/docs/releases/v0.9.0-freeze-plan.md
@@ -6,7 +6,7 @@ is being absorbed into Workspace (ent#78: #358 absorbs Session tab, #361/#362 bu
 chats on the room engine), so the engine bugs ent#218/ent#220 stay SHOULD (substrate survives
 the move), #1819 rooms-UI polish is likely mooted (confirm with dolho before spending on it),
 and **Workspace delivery becomes the controlled track** (land #2083 now; ent#78 absorb-items
-are the next-cycle plan) · Freeze = **2026-08-12** (tomorrow).
+are the next-cycle plan) · Freeze = **2026-08-12** (tomorrow). SUPERSEDED same day: scope expanded with Wave A (payload-story completions) + Wave B (Workspace) per eugene; freeze re-set to **2026-08-19**, with the 3 mechanical MUSTs still due 2026-08-12.
 
 Generated 2026-08-11 by /release-plan v1.0 (full mode). Payload: v0.8.5..origin/dev.
 
@@ -59,27 +59,60 @@ The payload's residual discipline is good: essentially every "deferred/residual/
 - Churn hotspots: `agent_service/crud.py` (22 commits), `lifecycle.py` (18), `cleanup_service.py` (16), `task_execution_service.py` (12), `Settings.vue` (17), compose files (17 each).
 - Payload is hot: last merge landed the morning of this review (ent#326).
 
-## Code-Freeze Work Order — v0.9.0 (FINAL)
-Freeze: **2026-08-12** (tomorrow) · Go/No-Go: **GO** — MUST column ≈ 1 day of mechanical work, fits.
-SHOULD items land only if reviewed+merged by freeze; all droppable.
+## Code-Freeze Work Order — v0.9.0 (FINAL — expanded 2026-08-11)
+Freeze: **2026-08-19** · Go/No-Go: **GO** (staffing-dependent — recheck mid-week via `/release-plan recheck`)
+Scope expanded by eugene 2026-08-11: pull in **Wave A** (payload-story completions) and **Wave B**
+(Workspace) so v0.9.0 ships logically complete pieces. The original 3 mechanical MUSTs keep their
+**2026-08-12** due date — #2094 means schedule control is broken on dev *today*; they do not wait
+for the new freeze.
 
-### MUST LAND before freeze — 3 items, ~1d total
+### MUST — immediate (due 2026-08-12, ~1d, unchanged)
 | # | Repairs | Action | Verdict | Est | Owner | Issue |
 |---|---------|--------|---------|-----|-------|-------|
 | 1 | C1 schedule control broken on dev | Review + merge PR #2095 | COMPLETE | hours | dolho (author) / vybe review | #2094 |
 | 2 | C2 duplicate portal mount + false entitlement | Submodule pin bump → bce1175 (PR to dev) | COMPLETE | <1h | trinity-ability | ent#356 |
 | 3 | C3 inert skill-source kill switch | Compose passthrough for TRINITY_DEFAULT_SKILL_SOURCE(_REF) both composes + .env.example uncomment | COMPLETE | <1h | any | ent#237 residual (file) |
 
-### SHOULD LAND (droppable, review-only unless noted) — 7 items
-| # | Repairs | Action | Est |
-|---|---------|--------|-----|
-| 4 | C7 **Workspace delivery — the controlled track** (user decision) | Merge PR #2083 (rename + one-click, ent#357); ent#78 absorb-items (#358–#365) are the next-cycle plan, NOT this freeze | review |
-| 5 | C6 dead timeline endpoint | Merge PR #2042 (widget chassis, ent#325) | review |
-| 6 | C8 rotation edges | Merge PRs #2024 (#2017), #2030 (#2023) | review |
-| 7 | C9 undefined execution_id | Merge PR #1976 (#1968) | review |
-| 8 | C11 git-dir root | Merge PR #2076 (#2075 follow-up) | review |
-| 9 | C10 room-ENGINE bugs (substrate under future Workspace chats) | Land ent#218/ent#220 if fixes are ready by freeze; #1819 rooms-UI polish likely mooted by Workspace absorption — confirm with dolho before spending | unknown |
-| 10 | Docs | Merge PR #2079 (user-docs reconcile, 145 PRs) | review |
+### MUST — Wave A: payload-story completions (due 2026-08-19) — 14 items
+Ordered by unblocks-what, then coherence-per-effort. Every item completes a story v0.9.0 already ships.
+| # | Completes | Action | Est | Issue |
+|---|-----------|--------|-----|-------|
+| A1 | Skills-source hardening (ent#293/297) | Close the agent-key PUT injection path into skill sources (in-progress) | med | ent#346 |
+| A2 | Ready-PR sweep (rotation edges, exec-id, git root) | Merge PRs #2024, #2030, #1976, #2076 | review | #2017 #2023 #1968 #2075 |
+| A3 | Grid widgets become visible | Merge PR #2042 (chassis), then tiles: next-schedules + recent-failures | review + 2×low | ent#325 ent#99 ent#100 |
+| A4 | Skill-runner story | Admin surface (enable/provision/sync) + per-agent skill-pack toggles | 2×med | ent#242 ent#342 |
+| A5 | A2A becomes bidirectional | `call_a2a_agent` outbound MCP tool + unified exposable-skills config | 2×med | #736 ent#178 |
+| A6 | Fresh-install story gets content | Archetype library (Cornelius, Ruby, Corbin) in the install surface | med | ent#137 |
+| A7 | Client roster becomes a control surface | Per-client block/revoke/approve + owner email on access request | med + low | ent#21 ent#29 |
+| A8 | Schedule-correctness sweep | Client-side cron validation + template.yaml schedules reconciled at deploy | low + med | #925 #1198 |
+| A9 | Volume-reclaim family | rename+recreate empties public/shared volumes | med | #1669 |
+| A10 | Operator-queue caps | Platform alert emitters routed through #1632 ingestion caps | med | #1677 |
+| A11 | Retention guard | never-raises contract + failed-alarm retry suppression | 2×low | #1833 #1834 |
+| A12 | Rooms engine (substrate under Workspace chats) | Land ent#218 (billed reply lost) + ent#220 (budget/idempotency, role enforcement) | in-progress | ent#218 ent#220 |
+| A13 | Docs | Merge PR #2079 (user-docs reconcile) + re-run after waves land | review | — |
+| A14 | Skills content (optional within A) | Publish create-agent wizards as a library source | med | ent#321 |
+
+### MUST — Wave B: Workspace as a product, not a promise (due 2026-08-19) — core 7
+The user-designated controlled track (ent#78). Core = what "Workspace shipped" means in v0.9.0.
+| # | Action | Est | Issue |
+|---|--------|-----|-------|
+| B1 | Merge PR #2083 — rename + one-click open | review | ent#357 |
+| B2 | Sessions survive — sliding renewal, not a 12h cliff | med | ent#375 |
+| B3 | Absorb the Session tab | med | ent#358 |
+| B4 | Sidebar IA — agents block, starred + dated chats | low | ent#359 |
+| B5 | Agent page — clicking an agent opens its page | med | ent#360 |
+| B6 | Multi-agent chats — create with N agents, add mid-chat | low | ent#361 |
+| B7 | Portal-session streaming path (in-progress) | med | ent#286 |
+
+### SHOULD — Wave B collaboration layer (droppable to next cycle without breaking coherence)
+| # | Action | Est | Issue |
+|---|--------|-----|-------|
+| S1 | Admit a workspace user as a room participant | high | ent#362 |
+| S2 | Tell an agent when a room is user-facing | low | ent#363 |
+| S3 | Agent-initiated asks — one item, three renderings | high | ent#364 |
+| S4 | Deliverables as first-class objects | med | ent#365 |
+| S5 | Rate a message / rate a deliverable | med | ent#366 |
+| S6 | #1819 rooms-UI dark-mode polish — only if NOT mooted by B3–B6 (confirm with dolho first) | low | #1819 |
 
 ### FENCE (gating + docs only) — 2 items
 | # | Cluster | Checklist | Est |
@@ -91,7 +124,6 @@ SHOULD items land only if reviewed+merged by freeze; all droppable.
 | What | Tracked | Notes line? |
 |------|---------|-------------|
 | ent#159 signed A2A cards (blocked) | ent#159 | YES (unsigned cards) |
-| ent#242 skill-runner admin surface | ent#242 (ready) | YES |
 | C13 env-drift UI | file new issue | no (invisible diagnostic) |
 | C12 deploy-local completeness (#2060) | #2060 | optional |
 | C18 MCP display_label | optional issue | no |
@@ -99,6 +131,11 @@ SHOULD items land only if reviewed+merged by freeze; all droppable.
 | redact_url_userinfo parity test; A2A raw-axios | file 2 small issues | no |
 | ent#330 npm publish | verify then /groom | no |
 | #2048 pull-pilot topology honesty (shipped as claim-fix) | #1081 umbrella | YES (pilot scope) |
+| Channels console rebuild + Sharing→Channels rename | ent#340 ent#225 (belongs with next IA wave) | no |
+| Onboarding wave, chat polish, subscription observability | ent#238/319/320/323 · #368/#370/ent#155 · ent#351/#471/ent#259 | no |
+
+**Known-limitations block below is now CONDITIONAL** — regenerate at `/release-plan recheck`:
+the skill-runner and rooms lines drop when A4/A12 land; an A2A line stays only for signed cards (ent#159).
 
 ### Release-notes: Known limitations block (draft)
 ```markdown


### PR DESCRIPTION
Output of /release-plan. Work order for the v0.9.0 freeze (2026-08-12): 3 MUST-LAND items (#2095, enterprise pin bump to bce1175, TRINITY_DEFAULT_SKILL_SOURCE compose passthrough), 7 SHOULD-LAND ready PRs, evaluations FENCE checklist, and the Known-limitations block for /release Step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)