### PR TITLE
docs(release): v0.9.0 freeze plan — Workspace family release-required

### DIFF
--- a/docs/releases/v0.9.0-freeze-plan.md
+++ b/docs/releases/v0.9.0-freeze-plan.md
@@ -8,6 +8,13 @@ the move), #1819 rooms-UI polish is likely mooted (confirm with dolho before spe
 and **Workspace delivery becomes the controlled track** (land #2083 now; ent#78 absorb-items
 are the next-cycle plan) · Freeze = **2026-08-12** (tomorrow). SUPERSEDED same day: scope expanded with Wave A (payload-story completions) + Wave B (Workspace) per eugene; freeze re-set to **2026-08-19**, with the 3 mechanical MUSTs still due 2026-08-12.
 
+EXPANDED 2026-08-11 (evening, per eugene): the Workspace family is **release-required**. Three
+gaps filed — trinity#2101 (workspace chat renders tool activity as one unbounded flat list),
+ent#380 (skill hints in workspace chat), ent#381 (retire the Sessions page once workspace chats
+absorb rooms) — and ent#362 promoted SHOULD→MUST (it is the prerequisite of B6/ent#361, which
+now carries an explicit AC: tagging/@mentioning an agent from ANY existing chat — incl. a 1:1 —
+creates a group discussion; ent#361 bumped p2→p1).
+
 Generated 2026-08-11 by /release-plan v1.0 (full mode). Payload: v0.8.5..origin/dev.
 
 Payload: 127 issues (89 public / 38 private) · 371 commits · 1027 files (+144,822 / −32,860) · since v0.8.5 (2026-07-26, 16d)
@@ -92,8 +99,9 @@ Ordered by unblocks-what, then coherence-per-effort. Every item completes a stor
 | A13 | Docs | Merge PR #2079 (user-docs reconcile) + re-run after waves land | review | — |
 | A14 | Skills content (optional within A) | Publish create-agent wizards as a library source | med | ent#321 |
 
-### MUST — Wave B: Workspace as a product, not a promise (due 2026-08-19) — core 7
+### MUST — Wave B: Workspace as a product, not a promise (due 2026-08-19) — core 11
 The user-designated controlled track (ent#78). Core = what "Workspace shipped" means in v0.9.0.
+Expanded 2026-08-11 evening: whole family release-required per eugene.
 | # | Action | Est | Issue |
 |---|--------|-----|-------|
 | B1 | Merge PR #2083 — rename + one-click open | review | ent#357 |
@@ -101,18 +109,21 @@ The user-designated controlled track (ent#78). Core = what "Workspace shipped" m
 | B3 | Absorb the Session tab | med | ent#358 |
 | B4 | Sidebar IA — agents block, starred + dated chats | low | ent#359 |
 | B5 | Agent page — clicking an agent opens its page | med | ent#360 |
-| B6 | Multi-agent chats — create with N agents, add mid-chat | low | ent#361 |
+| B6 | Multi-agent chats — create with N agents, add mid-chat; **AC: @mention from ANY existing chat (incl. 1:1) creates a group discussion** | low | ent#361 (p1) |
 | B7 | Portal-session streaming path (in-progress) | med | ent#286 |
+| B8 | Admit a workspace user as a room participant (promoted from S1 — prerequisite of B6) | high | ent#362 |
+| B9 | Workspace chat: group/collapse tool activity — bounded viewport, reply stays primary | low | trinity#2101 |
+| B10 | Skill hints in workspace chat (chat projection of ent#178/ent#360 set) | med | ent#380 |
+| B11 | Retire the Sessions page + nav entry (after B6/B8 parity; decides #1819 mootness) | low | ent#381 |
 
 ### SHOULD — Wave B collaboration layer (droppable to next cycle without breaking coherence)
 | # | Action | Est | Issue |
 |---|--------|-----|-------|
-| S1 | Admit a workspace user as a room participant | high | ent#362 |
 | S2 | Tell an agent when a room is user-facing | low | ent#363 |
 | S3 | Agent-initiated asks — one item, three renderings | high | ent#364 |
 | S4 | Deliverables as first-class objects | med | ent#365 |
 | S5 | Rate a message / rate a deliverable | med | ent#366 |
-| S6 | #1819 rooms-UI dark-mode polish — only if NOT mooted by B3–B6 (confirm with dolho first) | low | #1819 |
+| S6 | #1819 rooms-UI dark-mode polish — only if NOT mooted; the mootness decision is now an explicit AC of B11/ent#381 (confirm with dolho first) | low | #1819 |
 
 ### FENCE (gating + docs only) — 2 items
 | # | Cluster | Checklist | Est |


### PR DESCRIPTION
## Summary

2026-08-11 evening expansion of the v0.9.0 freeze plan, per eugene: the Workspace family becomes a release requirement.

- **Wave B MUST grows 7 → 11**: adds trinity#2101 (workspace chat renders tool activity as one unbounded flat list), abilityai/trinity-enterprise#380 (skill hints in workspace chat), abilityai/trinity-enterprise#381 (retire the Sessions page + nav entry), and promotes abilityai/trinity-enterprise#362 from SHOULD (it is the prerequisite of ent#361).
- **ent#361** gains the explicit AC — @mention from ANY existing chat (incl. a 1:1) creates a group discussion — and moves p2 → p1 (comment on the issue records it).
- S6 (#1819) now points at ent#381 as the mootness decision point.

Docs-only change to `docs/releases/v0.9.0-freeze-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)