### PR TITLE
chore(release): v0.9.0 day-1 recheck — enterprise pin → 2d64baa + freeze-plan update

### DIFF
--- a/docs/releases/v0.9.0-freeze-plan.md
+++ b/docs/releases/v0.9.0-freeze-plan.md
@@ -15,6 +15,23 @@ absorb rooms) — and ent#362 promoted SHOULD→MUST (it is the prerequisite of 
 now carries an explicit AC: tagging/@mentioning an agent from ANY existing chat — incl. a 1:1 —
 creates a group discussion; ent#361 bumped p2→p1).
 
+RECHECK 2026-08-12 (day 1 of freeze week): MUST-immediate 3/3 resolved — #2095 merged (C1),
+compose passthrough merged as #2100 (C3), submodule pin bumped to enterprise-main tip 2d64baa
+(C2 — the bump also ships the ent#218 rooms fix, the ent#220 partial, and ent#375's enterprise
+half; target moved past bce1175 because enterprise main advanced). Review-only items all landed
+(#2024 #2030 #1976 #2083 #2079 merged; ent#346 closed via a553f8f2). Still in review: #2076
+(1 failing check), #2042 (changes requested). trinity#2101 was RE-SCOPED — the tool-activity
+symptom cannot exist until ent#286 streaming lands (per-turn grouping now rides B7); the actual
+bug (briefing hint grid) is fixed and merged (#2113), so B9-as-filed is done. ent#380 merged
+(#2103). Scope adds per eugene: **A15 ent#384** (Library skills assignment, in progress) and
+**A16 #1958** (dev required checks run no unit tests — pulled in as the freeze-week guard:
+freeze week is maximum merge traffic and this gap is how two green PRs redden dev on contact).
+P0/P1 bug triage: every other open P0/P1 is already `status-in-dev` (in the payload, closes at
+cut); #2060 stays C12-conditional; #1819 stays held behind B11's mootness call. Staffing:
+**dolho owns all Workspace (Wave B) items as of 2026-08-12**. Critical path unchanged:
+B8/ent#362 (high) → B6/ent#361. Next recheck 2026-08-15 — the go/no-go on demoting unstarted
+Wave A items to next cycle.
+
 Generated 2026-08-11 by /release-plan v1.0 (full mode). Payload: v0.8.5..origin/dev.
 
 Payload: 127 issues (89 public / 38 private) · 371 commits · 1027 files (+144,822 / −32,860) · since v0.8.5 (2026-07-26, 16d)
@@ -80,7 +97,7 @@ for the new freeze.
 | 2 | C2 duplicate portal mount + false entitlement | Submodule pin bump → bce1175 (PR to dev) | COMPLETE | <1h | trinity-ability | ent#356 |
 | 3 | C3 inert skill-source kill switch | Compose passthrough for TRINITY_DEFAULT_SKILL_SOURCE(_REF) both composes + .env.example uncomment | COMPLETE | <1h | any | ent#237 residual (file) |
 
-### MUST — Wave A: payload-story completions (due 2026-08-19) — 14 items
+### MUST — Wave A: payload-story completions (due 2026-08-19) — 16 items
 Ordered by unblocks-what, then coherence-per-effort. Every item completes a story v0.9.0 already ships.
 | # | Completes | Action | Est | Issue |
 |---|-----------|--------|-----|-------|
@@ -98,10 +115,13 @@ Ordered by unblocks-what, then coherence-per-effort. Every item completes a stor
 | A12 | Rooms engine (substrate under Workspace chats) | Land ent#218 (billed reply lost) + ent#220 (budget/idempotency, role enforcement) | in-progress | ent#218 ent#220 |
 | A13 | Docs | Merge PR #2079 (user-docs reconcile) + re-run after waves land | review | — |
 | A14 | Skills content (optional within A) | Publish create-agent wizards as a library source | med | ent#321 |
+| A15 | Library skills section becomes actionable (added 2026-08-12) | Per-skill agent list + assign dropdown, tabbed Library with a Skills tab (in progress) | med | ent#384 |
+| A16 | Freeze-week guard (added 2026-08-12) | Wire unit tests into dev's required checks — two green PRs must not redden dev on contact | low | #1958 |
 
 ### MUST — Wave B: Workspace as a product, not a promise (due 2026-08-19) — core 11
 The user-designated controlled track (ent#78). Core = what "Workspace shipped" means in v0.9.0.
 Expanded 2026-08-11 evening: whole family release-required per eugene.
+Owner: **dolho** (all Wave B items, as of 2026-08-12). Critical path: B8 → B6.
 | # | Action | Est | Issue |
 |---|--------|-----|-------|
 | B1 | Merge PR #2083 — rename + one-click open | review | ent#357 |
@@ -112,7 +132,7 @@ Expanded 2026-08-11 evening: whole family release-required per eugene.
 | B6 | Multi-agent chats — create with N agents, add mid-chat; **AC: @mention from ANY existing chat (incl. 1:1) creates a group discussion** | low | ent#361 (p1) |
 | B7 | Portal-session streaming path (in-progress) | med | ent#286 |
 | B8 | Admit a workspace user as a room participant (promoted from S1 — prerequisite of B6) | high | ent#362 |
-| B9 | Workspace chat: group/collapse tool activity — bounded viewport, reply stays primary | low | trinity#2101 |
+| B9 | ~~Workspace chat: group/collapse tool activity~~ **DONE as re-scoped** — trinity#2101 turned out to be the briefing hint grid (fixed, #2113); tool-activity grouping rides B7/ent#286 | — | trinity#2101 |
 | B10 | Skill hints in workspace chat (chat projection of ent#178/ent#360 set) | med | ent#380 |
 | B11 | Retire the Sessions page + nav entry (after B6/B8 parity; decides #1819 mootness) | low | ent#381 |
 


### PR DESCRIPTION
## Summary

Two changes from the 2026-08-12 freeze-week recheck (`/release-plan recheck`):

**1. Enterprise submodule pin d1c5ebb → 2d64baa** (MUST-immediate #2, overdue today).
The pin was left behind when the OSS half of the client_portal move (#2084, ent#356) merged — entitled builds mount a duplicate router on the same prefix and advertise a false `client_portal` entitlement (freeze-plan C2). Target is the enterprise-main **tip**, not just bce1175, because enterprise main advanced; the bump ships:
- bce1175 — remove client_portal from the enterprise tree (ent#356)
- e0a2ef4 — rooms: message budget counts conversation, not bookkeeping (ent#218)
- 0bee510 — rooms: post the reply before advancing the cursor (ent#220 partial)
- 2d64baa — workspace: managed session-policy API (ent#375 enterprise half; OSS half merged as #2099)

**2. Freeze-plan update** (`docs/releases/v0.9.0-freeze-plan.md`):
- Day-1 RECHECK section: MUST-immediate 3/3 resolved, review-only items landed, #2076/#2042 still in review, trinity#2101 re-scope recorded
- Wave A +2 per eugene: **A15** ent#384 (Library skills assignment, in progress) · **A16** #1958 (unit tests in dev's required checks — freeze-week guard)
- P0/P1 triage: all other open P0/P1 already `status-in-dev`; #2060 stays C12-conditional; #1819 held behind B11
- Wave B owner recorded: **dolho** (all Workspace items as of 2026-08-12); critical path B8/ent#362 → B6/ent#361

## Test plan
- Docs + submodule-pointer only; no code paths change in this repo
- Pin ancestry verified: d1c5ebb and bce1175 are both ancestors of 2d64baa on enterprise `main`; single Alembic head on the enterprise track was converged in d1c5ebb (trinity#2068) and no new revisions landed after it in this range except via reviewed enterprise PRs #374–#378

🤖 Generated with [Claude Code](https://claude.com/claude-code)