### PR TITLE
refactor(frontend): ship the seven Base* design-system primitives (#2122)

### DIFF
--- a/docs/memory/design-system.md
+++ b/docs/memory/design-system.md
@@ -118,6 +118,20 @@ System UI stack — what the product already ships. **Six sizes, no more.**
 
 Shared primitives are the unit of consistency: **compose them, never re-implement them.** A hand-rolled button/input/badge/card is a defect even when it looks identical. All primitives consume tokens only, work in both themes, and are keyboard/focus correct.
 
+**Shipped implementations (#2122)** — the form/surface layer lives in `src/frontend/src/components/base/` (the Input/Select/Textarea field recipe is one shared constant, `base/fieldClasses.js`, so the three cannot drift):
+
+| Primitive | File | Reference adoption |
+|---|---|---|
+| BaseButton | `components/base/BaseButton.vue` | `ConfirmDialog.vue` actions · TemplateRegistryPanel Save/Reset |
+| BaseInput | `components/base/BaseInput.vue` | TemplateRegistryPanel registry URL |
+| BaseSelect | `components/base/BaseSelect.vue` | `ResourceModal.vue` memory/CPU |
+| BaseToggle | `components/base/BaseToggle.vue` | TemplateRegistryPanel enable switch |
+| BaseTextarea | `components/base/BaseTextarea.vue` | `SystemInstallPanel.vue` manifest editor (mono) |
+| BaseBadge | `components/base/BaseBadge.vue` | TemplateRegistryPanel status + Default chips |
+| BaseCard | `components/base/BaseCard.vue` | `CredentialSetupChecklist.vue` surface |
+
+The dark tinted-ground recipe `token-500 at 16%` is expressible as `token-500/16` because the config extends the opacity scale with `16` — before #2122 those classes silently compiled to **nothing** (16 is not in Tailwind's default scale), so the dark chips that used them shipped without a background. The behavioral/state primitives were already shipped and keep their homes: `ConfirmDialog.vue`, `OverflowTabs.vue`, `LoadFailed.vue`/`InlineError.vue`, `ScanlineReveal.vue`.
+
 ### BaseButton
 
 **Anatomy:** inline-flex, 7px icon gap, radius 6px, 1px transparent border, transition 120ms ease (background/border/color).

--- a/src/frontend/raw-color-baseline.json
+++ b/src/frontend/raw-color-baseline.json
@@ -85,7 +85,7 @@
     },
     "src/frontend/src/components/ConfirmDialog.vue": {
       "raw_nongray": 0,
-      "raw_gray": 18,
+      "raw_gray": 9,
       "hardcoded_colors": 0
     },
     "src/frontend/src/components/ConnectorChannelPanel.vue": {
@@ -290,7 +290,7 @@
     },
     "src/frontend/src/components/ResourceModal.vue": {
       "raw_nongray": 0,
-      "raw_gray": 25,
+      "raw_gray": 13,
       "hardcoded_colors": 0
     },
     "src/frontend/src/components/RunningStateToggle.vue": {

--- a/src/frontend/src/components/ConfirmDialog.vue
+++ b/src/frontend/src/components/ConfirmDialog.vue
@@ -50,29 +50,26 @@
             </div>
           </div>
 
-          <!-- Actions -->
+          <!-- Actions (BaseButton, #2122). The confirm is the unsafe action in
+               both dialog variants, so it renders as the danger button; the
+               header icon carries the danger/warning distinction. -->
           <div class="bg-gray-50 dark:bg-gray-900 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-            <button
-              type="button"
-              :class="[
-                'w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:ml-3 sm:w-auto sm:text-sm',
-                variant === 'danger'
-                  ? 'bg-status-danger-600 hover:bg-status-danger-700 focus:ring-status-danger-500'
-                  : 'bg-status-warning-600 hover:bg-status-warning-700 focus:ring-status-warning-500'
-              ]"
-              @click="onConfirm"
+            <BaseButton
+              variant="danger"
+              class="w-full sm:ml-3 sm:w-auto"
               data-testid="confirm-dialog-confirm"
+              @click="onConfirm"
             >
               {{ confirmText }}
-            </button>
-            <button
-              type="button"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-action-primary-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
-              @click="onCancel"
+            </BaseButton>
+            <BaseButton
+              variant="secondary"
+              class="mt-3 w-full sm:mt-0 sm:ml-3 sm:w-auto"
               data-testid="confirm-dialog-cancel"
+              @click="onCancel"
             >
               {{ cancelText }}
-            </button>
+            </BaseButton>
           </div>
         </div>
       </div>
@@ -82,6 +79,7 @@
 
 <script setup>
 import { ref, watch } from 'vue'
+import BaseButton from './base/BaseButton.vue'
 
 const props = defineProps({
   visible: {

--- a/src/frontend/src/components/CredentialSetupChecklist.vue
+++ b/src/frontend/src/components/CredentialSetupChecklist.vue
@@ -42,6 +42,7 @@
  * inject path. One writer, no new backend write surface.
  */
 import { computed, ref, watch } from 'vue'
+import BaseCard from './base/BaseCard.vue'
 
 const props = defineProps({
   report: { type: Object, default: null },
@@ -189,7 +190,9 @@ watch(
 </script>
 
 <template>
-  <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+  <!-- The surface is BaseCard (#2122); `flush` because the header/body
+       sections own their internal padding. -->
+  <BaseCard flush>
     <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-start justify-between gap-3">
       <div>
         <h3 class="text-lg font-medium text-gray-900 dark:text-white">Credential Setup</h3>
@@ -351,5 +354,5 @@ watch(
     <p v-else-if="loading" class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
       Checking credential requirements…
     </p>
-  </div>
+  </BaseCard>
 </template>

--- a/src/frontend/src/components/ResourceModal.vue
+++ b/src/frontend/src/components/ResourceModal.vue
@@ -44,40 +44,34 @@
 
         <!-- Resource Configuration Form -->
         <div class="mt-5 space-y-4">
-          <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Memory</label>
-            <select
-              :value="resourceLimits.memory ?? resourceLimits.current_memory"
-              @change="$emit('update:memory', $event.target.value || null)"
-              :disabled="loading"
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-action-primary-500 focus:border-action-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-            >
-              <option value="">Inherit default ({{ resourceLimits.current_memory || '4g' }})</option>
-              <option value="1g">1 GB</option>
-              <option value="2g">2 GB</option>
-              <option value="4g">4 GB</option>
-              <option value="8g">8 GB</option>
-              <option value="16g">16 GB</option>
-              <option value="32g">32 GB</option>
-              <option value="64g">64 GB</option>
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">CPU Cores</label>
-            <select
-              :value="resourceLimits.cpu ?? resourceLimits.current_cpu"
-              @change="$emit('update:cpu', $event.target.value || null)"
-              :disabled="loading"
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-action-primary-500 focus:border-action-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-            >
-              <option value="">Inherit default ({{ resourceLimits.current_cpu || '2' }})</option>
-              <option value="1">1 Core</option>
-              <option value="2">2 Cores</option>
-              <option value="4">4 Cores</option>
-              <option value="8">8 Cores</option>
-              <option value="16">16 Cores</option>
-            </select>
-          </div>
+          <BaseSelect
+            label="Memory"
+            :model-value="resourceLimits.memory ?? resourceLimits.current_memory"
+            :disabled="loading"
+            @update:model-value="$emit('update:memory', $event || null)"
+          >
+            <option value="">Inherit default ({{ resourceLimits.current_memory || '4g' }})</option>
+            <option value="1g">1 GB</option>
+            <option value="2g">2 GB</option>
+            <option value="4g">4 GB</option>
+            <option value="8g">8 GB</option>
+            <option value="16g">16 GB</option>
+            <option value="32g">32 GB</option>
+            <option value="64g">64 GB</option>
+          </BaseSelect>
+          <BaseSelect
+            label="CPU Cores"
+            :model-value="resourceLimits.cpu ?? resourceLimits.current_cpu"
+            :disabled="loading"
+            @update:model-value="$emit('update:cpu', $event || null)"
+          >
+            <option value="">Inherit default ({{ resourceLimits.current_cpu || '2' }})</option>
+            <option value="1">1 Core</option>
+            <option value="2">2 Cores</option>
+            <option value="4">4 Cores</option>
+            <option value="8">8 Cores</option>
+            <option value="16">16 Cores</option>
+          </BaseSelect>
         </div>
 
         <!-- Modal Actions -->
@@ -104,6 +98,8 @@
 </template>
 
 <script setup>
+import BaseSelect from './base/BaseSelect.vue'
+
 defineProps({
   show: Boolean,
   resourceLimits: {

--- a/src/frontend/src/components/base/BaseBadge.vue
+++ b/src/frontend/src/components/base/BaseBadge.vue
@@ -1,0 +1,50 @@
+<template>
+  <!--
+    The badge primitive (docs/memory/design-system.md §5, #2122).
+    The variant IS the token family name — light token-100/token-700,
+    dark token-500/16 / token-300. A badge answers ONE question — status,
+    mode, or identity — never two at once. Two facts = two badges.
+  -->
+  <span
+    :class="[
+      'inline-flex items-center gap-1.5 rounded-full px-[9px] py-[2.5px] text-[11.5px] font-[550] leading-[1.4] tracking-[.01em] whitespace-nowrap',
+      VARIANT_CLASSES[variant],
+    ]"
+  >
+    <span v-if="dot" class="h-1.5 w-1.5 flex-none rounded-full bg-current" aria-hidden="true"></span>
+    <slot />
+  </span>
+</template>
+
+<script setup>
+// Full literal class strings so Tailwind's content scan sees every one.
+const VARIANT_CLASSES = {
+  success: 'bg-status-success-100 text-status-success-700 dark:bg-status-success-500/16 dark:text-status-success-300',
+  warning: 'bg-status-warning-100 text-status-warning-700 dark:bg-status-warning-500/16 dark:text-status-warning-300',
+  danger: 'bg-status-danger-100 text-status-danger-700 dark:bg-status-danger-500/16 dark:text-status-danger-300',
+  info: 'bg-status-info-100 text-status-info-700 dark:bg-status-info-500/16 dark:text-status-info-300',
+  urgent: 'bg-status-urgent-100 text-status-urgent-700 dark:bg-status-urgent-500/16 dark:text-status-urgent-300',
+  autonomous: 'bg-state-autonomous-100 text-state-autonomous-700 dark:bg-state-autonomous-500/16 dark:text-state-autonomous-300',
+  locked: 'bg-state-locked-100 text-state-locked-700 dark:bg-state-locked-500/16 dark:text-state-locked-300',
+  claude: 'bg-brand-claude-100 text-brand-claude-700 dark:bg-brand-claude-500/16 dark:text-brand-claude-300',
+  gemini: 'bg-brand-gemini-100 text-brand-gemini-700 dark:bg-brand-gemini-500/16 dark:text-brand-gemini-300',
+  purple: 'bg-accent-purple-100 text-accent-purple-700 dark:bg-accent-purple-500/16 dark:text-accent-purple-300',
+  neutral: 'bg-gray-100 text-gray-600 dark:bg-gray-750 dark:text-gray-400',
+}
+
+defineProps({
+  variant: {
+    type: String,
+    default: 'neutral',
+    // Keep in sync with VARIANT_CLASSES (defineProps validators are hoisted
+    // and cannot reference it).
+    validator: (v) =>
+      ['success', 'warning', 'danger', 'info', 'urgent', 'autonomous', 'locked', 'claude', 'gemini', 'purple', 'neutral'].includes(v),
+  },
+  // Optional 6px status dot in currentColor.
+  dot: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>

--- a/src/frontend/src/components/base/BaseButton.vue
+++ b/src/frontend/src/components/base/BaseButton.vue
@@ -1,0 +1,83 @@
+<template>
+  <!--
+    The button primitive (docs/memory/design-system.md §5, #2122).
+    Four variants × two sizes; disabled opacity .45; in-flight = the one
+    sanctioned spinner (16px, inside a pressed control) + progressive label.
+    Focus ring on ALL variants — never `outline: none` alone.
+  -->
+  <button
+    :type="type"
+    :disabled="disabled || loading"
+    :aria-busy="loading || undefined"
+    :class="[
+      'inline-flex items-center justify-center gap-[7px] rounded-md border border-transparent font-medium leading-[1.35] transition-colors duration-[120ms]',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-offset-white dark:ring-offset-gray-800',
+      'focus-visible:ring-action-primary-500/40 dark:focus-visible:ring-action-primary-400/40',
+      'disabled:opacity-45 disabled:cursor-not-allowed',
+      SIZE_CLASSES[size],
+      VARIANT_CLASSES[variant],
+    ]"
+  >
+    <span
+      v-if="loading"
+      class="h-4 w-4 flex-none rounded-full border-2 border-current border-t-transparent animate-[spin_0.7s_linear_infinite]"
+      aria-hidden="true"
+    ></span>
+    <template v-if="loading && loadingLabel">{{ loadingLabel }}</template>
+    <slot v-else />
+  </button>
+</template>
+
+<script setup>
+const SIZE_CLASSES = {
+  md: 'text-[13.5px] px-3.5 py-[7px]',
+  sm: 'text-[12.5px] px-2.5 py-1',
+}
+
+const VARIANT_CLASSES = {
+  primary:
+    'bg-action-primary-600 hover:bg-action-primary-700 text-white ' +
+    'dark:bg-action-primary-500 dark:hover:bg-action-primary-400',
+  secondary:
+    'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 ' +
+    'border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-750',
+  danger:
+    'bg-status-danger-600 hover:bg-status-danger-700 text-white ' +
+    'dark:bg-status-danger-500 dark:hover:bg-status-danger-400',
+  ghost:
+    'bg-transparent text-action-primary-600 dark:text-action-primary-500 ' +
+    'hover:bg-action-primary-100 dark:hover:bg-action-primary-500/16',
+}
+
+defineProps({
+  variant: {
+    type: String,
+    default: 'primary',
+    validator: (v) => ['primary', 'secondary', 'danger', 'ghost'].includes(v),
+  },
+  size: {
+    type: String,
+    default: 'md',
+    validator: (v) => ['md', 'sm'].includes(v),
+  },
+  // Native type defaults to "submit" inside forms — always be explicit.
+  type: {
+    type: String,
+    default: 'button',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  // In-flight: acknowledges the press (principle 18). Pair with a
+  // progressive label ("Deploying…") via loadingLabel.
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  loadingLabel: {
+    type: String,
+    default: '',
+  },
+})
+</script>

--- a/src/frontend/src/components/base/BaseCard.vue
+++ b/src/frontend/src/components/base/BaseCard.vue
@@ -1,0 +1,25 @@
+<template>
+  <!--
+    The surface primitive (docs/memory/design-system.md §5, #2122).
+    ONE surface recipe everywhere: surface bg, 1px border, radius 8px,
+    padding 16, shadow-sm. Stat cards, tiles, and list panels are
+    COMPOSITIONS of it — pass `flush` when the composition owns its own
+    internal padding (header/body splits), and override nothing else.
+  -->
+  <div
+    class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-750 rounded-lg shadow-sm"
+    :class="flush ? '' : 'p-4'"
+  >
+    <slot />
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  // For header/body compositions that own their internal padding.
+  flush: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>

--- a/src/frontend/src/components/base/BaseInput.vue
+++ b/src/frontend/src/components/base/BaseInput.vue
@@ -1,0 +1,94 @@
+<template>
+  <!--
+    The input primitive (docs/memory/design-system.md §5, #2122).
+    Anatomy: label above → control → help below. `label`/`help` are optional so
+    the control can slot into composed layouts that own their own label.
+    An error names the problem and the fix with an example (principle 17) —
+    a bare red border is not an error message.
+  -->
+  <div :class="$attrs.class">
+    <label v-if="label" :for="controlId" :class="[LABEL_CLASS, 'mb-1']">{{ label }}</label>
+    <input
+      :id="controlId"
+      v-bind="controlAttrs"
+      :value="modelValue"
+      :type="type"
+      :disabled="disabled"
+      :aria-invalid="error ? 'true' : undefined"
+      :aria-describedby="describedBy"
+      :class="[FIELD_CLASS, error ? FIELD_INVALID_CLASS : FIELD_VALID_CLASS]"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+    <p v-if="error" :id="`${controlId}-error`" :class="[ERROR_TEXT_CLASS, 'mt-1']" role="alert">
+      <svg class="w-3.5 h-3.5 mt-px flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span>{{ error }}</span>
+    </p>
+    <p v-else-if="help" :id="`${controlId}-help`" :class="[HELP_CLASS, 'mt-1']">{{ help }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed, useAttrs, useId } from 'vue'
+import {
+  FIELD_CLASS,
+  FIELD_VALID_CLASS,
+  FIELD_INVALID_CLASS,
+  LABEL_CLASS,
+  HELP_CLASS,
+  ERROR_TEXT_CLASS,
+} from './fieldClasses'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: '',
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  help: {
+    type: String,
+    default: '',
+  },
+  // Named, actionable, with an example: "Invalid cron expression — expected
+  // 5 fields, got 4. Example: `0 9 * * 1`".
+  error: {
+    type: String,
+    default: '',
+  },
+  type: {
+    type: String,
+    default: 'text',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  id: {
+    type: String,
+    default: '',
+  },
+})
+
+defineEmits(['update:modelValue'])
+
+const attrs = useAttrs()
+const uid = useId()
+const controlId = computed(() => props.id || uid)
+// class/style stay on the wrapper; everything else (placeholder, spellcheck,
+// @keyup.enter, …) lands on the control.
+const controlAttrs = computed(() => {
+  const { class: _c, style: _s, ...rest } = attrs
+  return rest
+})
+const describedBy = computed(() => {
+  if (props.error) return `${controlId.value}-error`
+  if (props.help) return `${controlId.value}-help`
+  return undefined
+})
+</script>

--- a/src/frontend/src/components/base/BaseSelect.vue
+++ b/src/frontend/src/components/base/BaseSelect.vue
@@ -1,0 +1,98 @@
+<template>
+  <!--
+    The select primitive (docs/memory/design-system.md §5, #2122).
+    Same field recipe as BaseInput; `appearance: none` with a custom chevron
+    (tertiary ink, pointer-events none), padding-right 32px so text never
+    collides. Options come through the default slot as native <option>s.
+  -->
+  <div :class="$attrs.class">
+    <label v-if="label" :for="controlId" :class="[LABEL_CLASS, 'mb-1']">{{ label }}</label>
+    <div class="relative">
+      <select
+        :id="controlId"
+        v-bind="controlAttrs"
+        :value="modelValue"
+        :disabled="disabled"
+        :aria-invalid="error ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :class="[FIELD_CLASS, error ? FIELD_INVALID_CLASS : FIELD_VALID_CLASS, 'appearance-none pr-8']"
+        @change="$emit('update:modelValue', $event.target.value)"
+      >
+        <slot />
+      </select>
+      <svg
+        class="pointer-events-none absolute right-[10px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-500 dark:text-gray-400"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </div>
+    <p v-if="error" :id="`${controlId}-error`" :class="[ERROR_TEXT_CLASS, 'mt-1']" role="alert">
+      <svg class="w-3.5 h-3.5 mt-px flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span>{{ error }}</span>
+    </p>
+    <p v-else-if="help" :id="`${controlId}-help`" :class="[HELP_CLASS, 'mt-1']">{{ help }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed, useAttrs, useId } from 'vue'
+import {
+  FIELD_CLASS,
+  FIELD_VALID_CLASS,
+  FIELD_INVALID_CLASS,
+  LABEL_CLASS,
+  HELP_CLASS,
+  ERROR_TEXT_CLASS,
+} from './fieldClasses'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: '',
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  help: {
+    type: String,
+    default: '',
+  },
+  error: {
+    type: String,
+    default: '',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  id: {
+    type: String,
+    default: '',
+  },
+})
+
+defineEmits(['update:modelValue'])
+
+const attrs = useAttrs()
+const uid = useId()
+const controlId = computed(() => props.id || uid)
+const controlAttrs = computed(() => {
+  const { class: _c, style: _s, ...rest } = attrs
+  return rest
+})
+const describedBy = computed(() => {
+  if (props.error) return `${controlId.value}-error`
+  if (props.help) return `${controlId.value}-help`
+  return undefined
+})
+</script>

--- a/src/frontend/src/components/base/BaseTextarea.vue
+++ b/src/frontend/src/components/base/BaseTextarea.vue
@@ -1,0 +1,99 @@
+<template>
+  <!--
+    The textarea primitive (docs/memory/design-system.md §5, #2122).
+    BaseInput's field recipe + min-height 84px and VERTICAL resize only —
+    horizontal resize breaks layout (principles 6/7). The mono variant is
+    the voice of machine text: prompts, instructions, config.
+  -->
+  <div :class="$attrs.class">
+    <label v-if="label" :for="controlId" :class="[LABEL_CLASS, 'mb-1']">{{ label }}</label>
+    <textarea
+      :id="controlId"
+      v-bind="controlAttrs"
+      :value="modelValue"
+      :rows="rows"
+      :disabled="disabled"
+      :aria-invalid="error ? 'true' : undefined"
+      :aria-describedby="describedBy"
+      :class="[
+        FIELD_CLASS,
+        error ? FIELD_INVALID_CLASS : FIELD_VALID_CLASS,
+        'min-h-[84px] resize-y leading-normal',
+        mono ? 'font-mono text-[12.5px]' : '',
+      ]"
+      @input="$emit('update:modelValue', $event.target.value)"
+    ></textarea>
+    <p v-if="error" :id="`${controlId}-error`" :class="[ERROR_TEXT_CLASS, 'mt-1']" role="alert">
+      <svg class="w-3.5 h-3.5 mt-px flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span>{{ error }}</span>
+    </p>
+    <p v-else-if="help" :id="`${controlId}-help`" :class="[HELP_CLASS, 'mt-1']">{{ help }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed, useAttrs, useId } from 'vue'
+import {
+  FIELD_CLASS,
+  FIELD_VALID_CLASS,
+  FIELD_INVALID_CLASS,
+  LABEL_CLASS,
+  HELP_CLASS,
+  ERROR_TEXT_CLASS,
+} from './fieldClasses'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  help: {
+    type: String,
+    default: '',
+  },
+  error: {
+    type: String,
+    default: '',
+  },
+  // Machine text: prompts, instructions, cron, config.
+  mono: {
+    type: Boolean,
+    default: false,
+  },
+  rows: {
+    type: [String, Number],
+    default: 4,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  id: {
+    type: String,
+    default: '',
+  },
+})
+
+defineEmits(['update:modelValue'])
+
+const attrs = useAttrs()
+const uid = useId()
+const controlId = computed(() => props.id || uid)
+const controlAttrs = computed(() => {
+  const { class: _c, style: _s, ...rest } = attrs
+  return rest
+})
+const describedBy = computed(() => {
+  if (props.error) return `${controlId.value}-error`
+  if (props.help) return `${controlId.value}-help`
+  return undefined
+})
+</script>

--- a/src/frontend/src/components/base/BaseToggle.vue
+++ b/src/frontend/src/components/base/BaseToggle.vue
@@ -1,0 +1,62 @@
+<template>
+  <!--
+    The toggle primitive (docs/memory/design-system.md §5, #2122).
+    36×20 pill track, 16px knob travelling 2→18; border-strong off,
+    action-primary on. Toggles are for INSTANT-APPLY binary settings —
+    anything behind a Save button is a checkbox in a form, not a toggle.
+    Keyboard: focusable, Space/Enter toggles, visible focus ring.
+  -->
+  <button
+    type="button"
+    role="switch"
+    :aria-checked="String(!!modelValue)"
+    :aria-label="label ? undefined : ariaLabel"
+    :disabled="disabled"
+    class="group inline-flex items-center gap-2.5 focus-visible:outline-none disabled:opacity-45 disabled:cursor-not-allowed"
+    @click="$emit('update:modelValue', !modelValue)"
+  >
+    <span
+      :class="[
+        'relative inline-block h-5 w-9 flex-none rounded-full transition-colors duration-150',
+        'group-focus-visible:ring-2 group-focus-visible:ring-offset-2 ring-offset-white dark:ring-offset-gray-800',
+        'group-focus-visible:ring-action-primary-500/40 dark:group-focus-visible:ring-action-primary-400/40',
+        modelValue
+          ? 'bg-action-primary-600 dark:bg-action-primary-500'
+          : 'bg-gray-300 dark:bg-gray-700',
+      ]"
+      aria-hidden="true"
+    >
+      <span
+        :class="[
+          'absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-[left] duration-150',
+          modelValue ? 'left-[18px]' : 'left-0.5',
+        ]"
+      ></span>
+    </span>
+    <span v-if="label" class="text-[13.5px] text-gray-900 dark:text-gray-100">{{ label }}</span>
+  </button>
+</template>
+
+<script setup>
+defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  // Required for screen readers when no visible label is rendered.
+  ariaLabel: {
+    type: String,
+    default: '',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+defineEmits(['update:modelValue'])
+</script>

--- a/src/frontend/src/components/base/fieldClasses.js
+++ b/src/frontend/src/components/base/fieldClasses.js
@@ -1,0 +1,32 @@
+/**
+ * The shared field recipe for BaseInput / BaseSelect / BaseTextarea
+ * (docs/memory/design-system.md §5). One constant, three consumers —
+ * "these controls look identical" is a property, not a coincidence
+ * (the settings/fieldStyles.js lesson, ent#375).
+ */
+
+// Field bg, border-strong, radius 6px, padding 8×11, 13.5 primary ink.
+export const FIELD_CLASS =
+  'w-full rounded-md border bg-white dark:bg-gray-900 ' +
+  'px-[11px] py-2 text-[13.5px] text-gray-900 dark:text-gray-100 ' +
+  'placeholder:text-gray-500 dark:placeholder:text-gray-500 ' +
+  'focus:outline-none focus:ring-[3px] ' +
+  'disabled:opacity-45 disabled:cursor-not-allowed'
+
+// Focus = accent border + ring; the ring replaces the outline.
+export const FIELD_VALID_CLASS =
+  'border-gray-300 dark:border-gray-700 ' +
+  'focus:border-action-primary-600 dark:focus:border-action-primary-500 ' +
+  'focus:ring-action-primary-500/40 dark:focus:ring-action-primary-400/40'
+
+// Invalid = danger border, danger ring at 25%.
+export const FIELD_INVALID_CLASS =
+  'border-status-danger-500 focus:border-status-danger-500 ' +
+  'focus:ring-status-danger-500/25'
+
+export const LABEL_CLASS = 'block text-[13px] font-[550] text-gray-900 dark:text-gray-100'
+
+export const HELP_CLASS = 'text-xs text-gray-500 dark:text-gray-400'
+
+export const ERROR_TEXT_CLASS =
+  'flex items-start gap-1.5 text-[12.5px] text-status-danger-700 dark:text-status-danger-300'

--- a/src/frontend/src/components/settings/TemplateRegistryPanel.vue
+++ b/src/frontend/src/components/settings/TemplateRegistryPanel.vue
@@ -12,12 +12,7 @@
     <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
       <div class="flex items-center gap-2">
         <h2 class="text-lg font-medium text-gray-900 dark:text-white">Template registry</h2>
-        <span
-          v-if="config.source === 'default'"
-          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-        >
-          Default
-        </span>
+        <BaseBadge v-if="config.source === 'default'">Default</BaseBadge>
       </div>
       <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
         Where Trinity reads its list of GitHub starter templates from. If it can't be
@@ -75,25 +70,12 @@
               <template v-else>Off — only your bundled templates are listed.</template>
             </p>
           </div>
-          <button
-            type="button"
+          <BaseToggle
+            :model-value="!!config.enabled"
             :disabled="saving || config.hard_disabled"
-            role="switch"
-            :aria-checked="String(!!config.enabled)"
             aria-label="Use the remote template registry"
-            :class="[
-              'relative inline-flex h-6 w-11 flex-shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-45',
-              config.enabled ? 'bg-action-primary-600' : 'bg-gray-300 dark:bg-gray-600',
-            ]"
-            @click="toggle"
-          >
-            <span
-              :class="[
-                'inline-block h-5 w-5 transform rounded-full bg-white transition-transform mt-0.5',
-                config.enabled ? 'translate-x-5' : 'translate-x-0.5',
-              ]"
-            ></span>
-          </button>
+            @update:model-value="toggle"
+          />
         </div>
 
         <!-- URL -->
@@ -102,33 +84,32 @@
             Registry URL
           </label>
           <div class="mt-1 flex flex-col gap-2 sm:flex-row">
-            <input
+            <BaseInput
               id="template-registry-url"
               v-model="urlDraft"
               type="url"
               spellcheck="false"
               :placeholder="config.default_url"
               :disabled="saving"
-              class="flex-1 min-w-0 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 text-sm font-mono disabled:opacity-45"
+              class="flex-1 min-w-0"
               @keyup.enter="save"
             />
-            <div class="flex gap-2">
-              <button
-                type="button"
+            <div class="flex items-start gap-2">
+              <BaseButton
                 :disabled="saving || !dirty"
-                class="px-3 py-2 text-sm font-medium rounded-md text-white bg-action-primary-600 hover:bg-action-primary-700 focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-45"
+                :loading="saving"
+                loading-label="Saving…"
                 @click="save"
               >
-                {{ saving ? 'Saving…' : 'Save' }}
-              </button>
-              <button
-                type="button"
+                Save
+              </BaseButton>
+              <BaseButton
+                variant="secondary"
                 :disabled="saving || config.source !== 'settings'"
-                class="px-3 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-action-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-45"
                 @click="reset"
               >
                 Reset
-              </button>
+              </BaseButton>
             </div>
           </div>
           <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
@@ -143,14 +124,11 @@
              an operator can see that their registry 404s. -->
         <div class="rounded-md border border-gray-200 dark:border-gray-700 px-4 py-3">
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span
-              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium"
-              :class="statusChipClass"
-            >
+            <BaseBadge :variant="statusVariant">
               <!-- Shape as well as hue (principle 24). -->
               <span aria-hidden="true">{{ statusGlyph }}</span>
               {{ statusLabel }}
-            </span>
+            </BaseBadge>
             <span class="text-xs text-gray-500 dark:text-gray-400 tabular-nums">
               {{ status.template_count }} template{{ status.template_count === 1 ? '' : 's' }}
             </span>
@@ -195,6 +173,10 @@ import { ref, computed, onMounted } from 'vue'
 import api from '../../api'
 import InlineError from '../InlineError.vue'
 import LoadFailed from '../LoadFailed.vue'
+import BaseBadge from '../base/BaseBadge.vue'
+import BaseButton from '../base/BaseButton.vue'
+import BaseInput from '../base/BaseInput.vue'
+import BaseToggle from '../base/BaseToggle.vue'
 
 const EMPTY_STATUS = {
   last_fetch_at: null,
@@ -265,16 +247,10 @@ const statusGlyph = computed(() => {
   return '○'
 })
 
-const statusChipClass = computed(() => {
-  if (status.value.last_status === 'ok') {
-    return 'bg-status-success-100 text-status-success-700 dark:bg-status-success-500/16 dark:text-status-success-300'
-  }
-  if (status.value.last_status === 'failed') {
-    return status.value.stale
-      ? 'bg-status-warning-100 text-status-warning-700 dark:bg-status-warning-500/16 dark:text-status-warning-300'
-      : 'bg-status-danger-100 text-status-danger-700 dark:bg-status-danger-500/16 dark:text-status-danger-300'
-  }
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+const statusVariant = computed(() => {
+  if (status.value.last_status === 'ok') return 'success'
+  if (status.value.last_status === 'failed') return status.value.stale ? 'warning' : 'danger'
+  return 'neutral'
 })
 
 function fmt(iso) {

--- a/src/frontend/src/components/systems/SystemInstallPanel.vue
+++ b/src/frontend/src/components/systems/SystemInstallPanel.vue
@@ -186,16 +186,17 @@
             {{ store.manifestText.length }} characters
           </span>
         </div>
-        <textarea
+        <BaseTextarea
           id="manifest-yaml"
-          :value="store.manifestText"
+          mono
+          :model-value="store.manifestText"
           rows="16"
           spellcheck="false"
           placeholder="name: my-system&#10;agents:&#10;  worker:&#10;    template: local:default"
-          class="mt-1 w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 p-3 font-mono text-sm text-gray-900 dark:text-gray-100 focus:border-action-primary-500 focus:ring-action-primary-500"
+          class="mt-1"
           data-testid="manifest-textarea"
-          @input="store.setManifestText($event.target.value)"
-        ></textarea>
+          @update:model-value="store.setManifestText($event)"
+        />
       </div>
 
       <!-- Error -->
@@ -259,6 +260,7 @@ import { useRouter } from 'vue-router'
 import { useSystemsStore } from '../../stores/systems'
 import ManifestPreview from './ManifestPreview.vue'
 import DeployResult from './DeployResult.vue'
+import BaseTextarea from '../base/BaseTextarea.vue'
 
 // Mirrors the server-side byte cap on SystemDeployRequest.manifest. `file.size`
 // is in bytes and so is the server's validator, so the two agree exactly.

--- a/src/frontend/tailwind.config.js
+++ b/src/frontend/tailwind.config.js
@@ -35,6 +35,13 @@ export default {
         'accent-purple':     colors.purple,
         'action-primary':    colors.indigo,
       },
+      // The dark-theme tinted-ground recipe is `token-500 at 16%`
+      // (design-system.md §5 — badges, alerts, accent-soft). 16 is not in
+      // Tailwind's default opacity scale, so `/16` classes silently emitted
+      // NOTHING until this entry made the documented recipe expressible.
+      opacity: {
+        16: '.16',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

Fixes #2122 (sub-issue of epic #1430).

The design-system contract and `docs/memory/design-system.md` §5 instruct every frontend PR to compose `BaseButton`, `BaseInput`, `BaseSelect`, `BaseToggle`, `BaseTextarea`, `BaseBadge`, and `BaseCard` — but none of them existed. This PR builds all seven under `src/frontend/src/components/base/`, built to the written specs (token-only styling, light + dark first-class, `focus-visible` rings on every variant, named-error anatomy with icon + `aria-describedby`). The Input/Select/Textarea field recipe is one shared constant (`base/fieldClasses.js`) so the three controls cannot drift apart.

## Adoptions (one real surface per primitive, per the AC)

| Primitive | Surface |
|---|---|
| BaseButton | `ConfirmDialog.vue` actions (AC) + TemplateRegistryPanel Save/Reset (with in-flight spinner + progressive label) |
| BaseInput | TemplateRegistryPanel registry URL |
| BaseSelect | `ResourceModal.vue` memory/CPU selects |
| BaseToggle | TemplateRegistryPanel enable switch |
| BaseTextarea | `SystemInstallPanel.vue` manifest editor (mono variant) |
| BaseBadge | TemplateRegistryPanel status chip + Default chip |
| BaseCard | `CredentialSetupChecklist.vue` surface (`flush` composition) |

All `data-testid`s pass through to the real control elements — `system-install.spec.js` and `settings-tabs.spec.js` selectors still match; the e2e suite has no `toHaveScreenshot` assertions, so no snapshot churn.

## Bonus fix: the `/16` alpha classes never compiled

The documented dark tinted-ground recipe is `token-500 at 16%` (`dark:bg-status-success-500/16` — already shipped in TemplateRegistryPanel). **16 is not in Tailwind's default opacity scale, so those classes silently emitted nothing** — the dark status chips had no background. Verified by compiling the emitted CSS before/after. `tailwind.config.js` now extends the opacity scale with `16`, which fixes every existing `/16` usage and makes the documented recipe expressible for the new BaseBadge/BaseButton-ghost recipes.

## Ratchet & verification

- `npm run check:tokens` — green (`11 tokens equivalent; dark ink ladder holds in 13 swept files`)
- Raw-color scan: all touched files at **zero** raw non-gray / zero hardcoded; baseline entries **shrink** — `ConfirmDialog.vue` 18→9, `ResourceModal.vue` 25→13 raw-gray
- `vitest run` — 77/77 pass
- `vite build` — green; emitted CSS verified to contain the `/16` and arbitrary-value classes
- `docs/memory/design-system.md` §5 updated: shipped-implementation table with file paths + reference adoptions

## Out of scope (stays with epic #1430)

Fleet-wide migration of hand-rolled controls (the ratchet's job), the modal keyboard contract (#1923), ConfirmDialog adoption sweep (#1924), OverflowTabs sweep (#1925).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
