### PR TITLE
fix(agents): apply the ?tab= deep-link before the mount awaits (#2130)

### DIFF
--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -1265,6 +1265,17 @@ onMounted(async () => {
   // worth of requests on a view that is unmounting.
   if (redirectRetiredSessionLink()) return
 
+  // #2130: apply the ?tab=/resume landing BEFORE any await. It reads only
+  // route.query and writes local refs — nothing in it needs loaded agent data,
+  // and the whole tab area sits behind `v-if="agent"`, so writing activeTab
+  // early just makes the FIRST render land on the requested tab. Running it
+  // after the awaits below meant the deep-link waited on the slowest unrelated
+  // mount call: on a RUNNING agent that batch also holds the
+  // checkDashboardExists/checkBrainOrbCapability container round-trips (~10s
+  // measured), so the page showed Overview for that window and then stole a tab
+  // the user had clicked in the meantime.
+  applyDeepLinkRouting()
+
   // Load agent first (other calls may depend on agent data)
   await loadAgent()
 
@@ -1285,9 +1296,6 @@ onMounted(async () => {
   ])
   startEmotionCycling()
   startAllPolling()
-
-  // Handle tab / resume deep-link (from Timeline or ExecutionDetail navigation)
-  applyDeepLinkRouting()
 })
 
 // onActivated fires when component is shown (after being cached by KeepAlive)
@@ -1295,6 +1303,14 @@ onActivated(async () => {
   // ent#358: same guard as onMounted — AgentDetail is KeepAlive-cached, so a
   // session deep-link opened on an already-visited agent lands here instead.
   if (redirectRetiredSessionLink()) return
+
+  // EXEC-023 (#1672): re-apply the full tab + resume landing here, not just the
+  // tab — onMounted does NOT fire for a KeepAlive-cached instance, so this is
+  // the path the common "Continue as Chat" navigation actually takes.
+  // #2130: and apply it BEFORE the awaits below, for the same reason as
+  // onMounted — this hook re-awaits loadAgent() plus, on a running agent, the
+  // two container round-trips.
+  applyDeepLinkRouting()
 
   // Restart polling when returning to this view
   startAllPolling()
@@ -1308,11 +1324,6 @@ onActivated(async () => {
     await checkDashboardExists()
     await checkBrainOrbCapability()
   }
-
-  // EXEC-023 (#1672): re-apply the full tab + resume landing here, not just the
-  // tab. onMounted does NOT fire for a KeepAlive-cached instance, so this is the
-  // path the common "Continue as Chat" navigation actually takes.
-  applyDeepLinkRouting()
 
   // DEPRECATED: Terminal tab hidden (candidate for removal)
   // if (activeTab.value === 'terminal') {

--- a/src/frontend/tests/unit/agentDetailDeepLink.spec.js
+++ b/src/frontend/tests/unit/agentDetailDeepLink.spec.js
@@ -1,0 +1,103 @@
+/**
+ * #2130 — the ?tab= deep-link landing must be applied BEFORE any await in the
+ * lifecycle hooks that own it.
+ *
+ * `applyDeepLinkRouting()` reads only `route.query` and writes local refs, so it
+ * has no dependency on loaded agent data. It used to be called at the END of
+ * `onMounted` / `onActivated`, after `await Promise.allSettled([...])`. On a
+ * RUNNING agent that batch also holds `checkDashboardExists()` and
+ * `checkBrainOrbCapability()` — container round-trips — so the deep-linked tab
+ * was applied ~10s late. For that whole window the page showed Overview, and
+ * then it STOLE a tab the user had clicked in the meantime
+ * (measured: open `?tab=git`, click Reports at 2s, page jumps to Git at ~10s).
+ *
+ * There is no component-mount harness in this project (no @vue/test-utils), and
+ * the defect is one of lifecycle ORDERING rather than of any pure function, so
+ * this is a source-structure guard — the same shape as the Python AST guards
+ * (`test_ent109_git_env_seam.py`, `test_1891_python_version_parity.py`).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+const SRC = fileURLToPath(new URL('../../src/views/AgentDetail.vue', import.meta.url))
+const source = readFileSync(SRC, 'utf8')
+
+/** Strip line + block comments so prose like "before any await" isn't scanned. */
+function stripComments(code) {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, '')   // block comments
+    .replace(/^[ \t]*\/\/.*$/gm, '')      // whole-line // comments
+    .replace(/([^:])\/\/.*$/gm, '$1')      // trailing // comments (keep URLs)
+}
+
+/** Return the body of `hook(async () => { ... })` via brace matching. */
+function hookBody(hookName) {
+  const start = source.indexOf(`${hookName}(async () => {`)
+  expect(start, `${hookName}(async () => { … }) not found`).toBeGreaterThan(-1)
+  const open = source.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(open + 1, i)
+    }
+  }
+  throw new Error(`unbalanced braces in ${hookName}`)
+}
+
+describe('#2130 AgentDetail ?tab= deep-link ordering', () => {
+  for (const hook of ['onMounted', 'onActivated']) {
+    it(`${hook} applies the deep-link before its first await`, () => {
+      const body = stripComments(hookBody(hook))
+
+      const applyAt = body.indexOf('applyDeepLinkRouting()')
+      expect(applyAt, `${hook} must call applyDeepLinkRouting()`).toBeGreaterThan(-1)
+
+      const awaitAt = body.search(/\bawait\b/)
+      if (awaitAt === -1) return // no awaits at all — trivially fine
+
+      expect(
+        applyAt,
+        `${hook} calls applyDeepLinkRouting() AFTER an await. The ?tab= landing ` +
+        `then waits on unrelated network work (on a running agent that includes ` +
+        `container round-trips, ~10s), showing Overview meanwhile and overriding ` +
+        `a tab the user clicked in that window. Apply it before the awaits.`
+      ).toBeLessThan(awaitAt)
+    })
+
+    it(`${hook} still applies it exactly once`, () => {
+      const body = stripComments(hookBody(hook))
+      const calls = body.match(/applyDeepLinkRouting\(\)/g) || []
+      expect(calls.length, `${hook} should call applyDeepLinkRouting() exactly once`).toBe(1)
+    })
+  }
+
+  it('the retired-session redirect still guards ahead of the deep-link (ent#358)', () => {
+    // The redirect navigates away and early-returns; applying a tab first would
+    // be wasted work on an unmounting view.
+    for (const hook of ['onMounted', 'onActivated']) {
+      const body = stripComments(hookBody(hook))
+      const redirectAt = body.indexOf('redirectRetiredSessionLink()')
+      const applyAt = body.indexOf('applyDeepLinkRouting()')
+      expect(redirectAt, `${hook} must keep the ent#358 guard`).toBeGreaterThan(-1)
+      expect(redirectAt, `${hook}: ent#358 guard must precede the deep-link`).toBeLessThan(applyAt)
+    }
+  })
+
+  it('applyDeepLinkRouting reads only route state (no loaded-agent dependency)', () => {
+    // This is what makes the early call correct — if it ever starts reading
+    // `agent.value`, the ordering above has to be reconsidered.
+    const start = source.indexOf('function applyDeepLinkRouting() {')
+    expect(start).toBeGreaterThan(-1)
+    const open = source.indexOf('{', start)
+    let depth = 0, end = -1
+    for (let i = open; i < source.length; i++) {
+      if (source[i] === '{') depth++
+      else if (source[i] === '}') { depth--; if (depth === 0) { end = i; break } }
+    }
+    const body = source.slice(open + 1, end)
+    expect(body).not.toMatch(/\bagent\.value\b/)
+  })
+})


### PR DESCRIPTION
Closes #2130

## The bug

On a **running** agent an `?tab=` deep-link landed on **Overview** for ~10 seconds, then yanked the user to the requested tab — **overriding a tab they had clicked in the meantime**. On a stopped agent it applied immediately.

Found while UI-testing the v0.9.0 freeze.

## Root cause

`onMounted` called `applyDeepLinkRouting()` only *after* `await Promise.allSettled([...])`. For a running agent that batch also holds `checkDashboardExists()` and `checkBrainOrbCapability()` — container round-trips — and `allSettled` waits for the slowest, so the landing tab was applied whenever that finished. `onActivated` (the KeepAlive path, and the one ExecutionDetail → "Continue as Chat" actually takes) had the same ordering.

## Evidence

Same agent, same URLs, only the running state differing:

| State | `?tab=git` | `?tab=reports` | `?tab=schedules` | `?tab=credentials` |
|---|---|---|---|---|
| stopped | Git | Reports | Schedules | Credentials |
| **running** | **Overview** | **Overview** | **Overview** | **Overview** |

Active-tab trace, running, `?tab=git`:

```
0.5s..9.5s: Overview   →   10s: Git
```

Hijack: open `?tab=git`, click **Reports** at 2s → page jumps to **Git** at ~10s (`clicked=Reports -> final=Git`).

## The fix

Hoist `applyDeepLinkRouting()` above the awaits in both hooks.

It reads only `route.query` and writes local refs — no dependency on loaded agent data — and the whole tab area sits behind `v-if="agent"`, so writing `activeTab` early only decides which tab the **first** render shows. With nothing applied late, nothing can be overridden; the race is removed rather than patched.

The ent#358 `redirectRetiredSessionLink()` guard stays first in both hooks — it navigates away and early-returns, so an unmounting view still does no deep-link work.

## Verification (live, against the local stack)

After the fix, on a **running** agent:

- deep-linked tab is active at the **first 0.5s sample** (was 10s)
- a click at 2s **survives** (`clicked=Reports -> final=Reports`, only one state observed)

Regressions, all green:

- stopped agents: `?tab=` git / reports / schedules / credentials all still land correctly
- ent#358: `?tab=session` still redirects to `/workspace?agent=…`
- EXEC-023 (#1672): `?tab=chat&resumeSessionId=…` still lands on Chat, no JS errors
- KeepAlive re-entry (`onActivated`) honours a new `?tab=`
- no `?tab=` still defaults to Overview

`vitest` 136/136 · `vite build` green · raw-color ratchet exit 0 (no class changes).

## Test

No `@vue/test-utils` in this project, and the defect is lifecycle **ordering** rather than a pure function, so `tests/unit/agentDetailDeepLink.spec.js` is a source-structure guard — the shape already used by the Python AST guards (`test_ent109_git_env_seam.py`, `test_1891_python_version_parity.py`). It asserts the call precedes the first await in both hooks, stays behind the ent#358 guard, happens exactly once, and that `applyDeepLinkRouting` never starts reading `agent.value` — the property that makes the early call correct.

Proven non-vacuous: **2 failed** on the pre-fix source, **6 pass** after.

## Not in scope

`DEEP_LINK_TABS` omits `a2a`, `loops`, `playbooks`, `access`, `nevermined`, so those `?tab=` values silently fall back to Overview even on a stopped agent. Several are permission-gated panels (`v-if="… && agent.can_share"`), so adding them needs a non-owner blank-panel decision — noted in #2130, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
