### PR TITLE
fix(workspace): repair regressions the #2120 review fixes introduced (ent#358, ent#286)

### DIFF
--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1058,7 +1058,15 @@ def _inflight_exec_key(execution_id: str) -> str:
     return f"portal_inflight_exec:{execution_id}"
 
 
-def mark_turn_inflight(session_id: str, execution_id: str, ttl_seconds: int = 3600) -> None:
+# The marker describes a turn in progress, so its TTL is the turn's own bound
+# plus slack — not an hour. The client now waits as long as the marker says a
+# turn is running, so an over-long TTL is a spinner that outlives the work: a
+# backend restart mid-turn would leave the composer disabled for the remainder.
+PORTAL_INFLIGHT_TTL_SECONDS = 300 + 60
+
+
+def mark_turn_inflight(session_id: str, execution_id: str,
+                       ttl_seconds: int = PORTAL_INFLIGHT_TTL_SECONDS) -> None:
     """Record that ``session_id`` has a turn running, and WHICH one.
 
     The value is the execution id, not a bare flag: a client that reloads has
@@ -1077,17 +1085,33 @@ def mark_turn_inflight(session_id: str, execution_id: str, ttl_seconds: int = 36
 
 
 def clear_turn_inflight(session_id: str, execution_id: str | None = None) -> None:
-    """Turn is done. Best-effort — the TTL is the backstop."""
+    """This turn is done. Best-effort — the TTL is the backstop.
+
+    Compare-and-delete on the session marker: a second turn on the same thread
+    OVERWRITES it, so an unconditional delete lets a turn that finished (or
+    fast-failed on the resume lock) wipe the marker of one still running. The
+    watching client then sees "nothing in flight", gives up, and offers a Retry
+    that dispatches and bills the turn a second time — the exact double-spend
+    the marker exists to prevent.
+
+    The per-execution key is always safe to delete: it names only this turn.
+    """
     try:
         from redis_breaker_util import get_breaker_redis
         client = get_breaker_redis()
-        if client is not None:
-            if execution_id is None:
-                value = client.get(_inflight_key(session_id))
-                execution_id = value.decode() if isinstance(value, bytes) else value
+        if client is None:
+            return
+        current = client.get(_inflight_key(session_id))
+        current = current.decode() if isinstance(current, bytes) else current
+        if execution_id is None or current == execution_id:
             client.delete(_inflight_key(session_id))
-            if execution_id:
-                client.delete(_inflight_exec_key(execution_id))
+        elif current:
+            logger.info(
+                "portal: leaving inflight marker for session %s — it now names %s, not %s",
+                session_id, current, execution_id,
+            )
+        if execution_id:
+            client.delete(_inflight_exec_key(execution_id))
     except Exception as e:  # noqa: BLE001
         logger.warning("portal inflight DEL failed for %s: %s", session_id, e)
 

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1103,15 +1103,26 @@ def clear_turn_inflight(session_id: str, execution_id: str | None = None) -> Non
             return
         current = client.get(_inflight_key(session_id))
         current = current.decode() if isinstance(current, bytes) else current
-        if execution_id is None or current == execution_id:
+
+        if execution_id is None:
+            # No id given: clear whatever this session currently names. The
+            # reverse key has to be resolved from the session marker here —
+            # skipping it leaves the SSE proxy reporting a finished turn as
+            # still in flight until the TTL expires.
+            if current:
+                client.delete(_inflight_exec_key(current))
+            client.delete(_inflight_key(session_id))
+            return
+
+        if current == execution_id:
             client.delete(_inflight_key(session_id))
         elif current:
             logger.info(
                 "portal: leaving inflight marker for session %s — it now names %s, not %s",
                 session_id, current, execution_id,
             )
-        if execution_id:
-            client.delete(_inflight_exec_key(execution_id))
+        # Always safe: this key names only the turn being cleared.
+        client.delete(_inflight_exec_key(execution_id))
     except Exception as e:  # noqa: BLE001
         logger.warning("portal inflight DEL failed for %s: %s", session_id, e)
 

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -248,9 +248,14 @@ async function reattach(executionId) {
   elapsed.value = 0
   clearInterval(elapsedTimer)
   elapsedTimer = setInterval(() => { elapsed.value += 1 }, 1000)
+  // The baseline is what is on screen right now: this client reloaded INTO a
+  // running turn, so every assistant message it can see predates that turn.
+  // Passing nothing made `assistants.length > undefined` false on every poll,
+  // so the reply never rendered and the user had to reload a second time.
+  const baseline = messages.value.filter((m) => m.role === 'assistant').length
   try {
     await store.streamPortalExecution(props.agent.name, executionId, onStreamEvent)
-    const data = await awaitPersistedReply(currentSessionId.value)
+    const data = await awaitPersistedReply(currentSessionId.value, baseline)
     if (data?.response) messages.value.push({ role: 'assistant', content: data.response })
   } catch { /* the reply lands in history on the next load */ }
   finally {
@@ -448,10 +453,16 @@ function onStreamEvent(evt) {
 // first poll — the answer to the wrong question, while a second turn ran unseen.
 const REPLY_POLL_MS = 700
 const REPLY_IDLE_GIVE_UP = 8      // ~5.6s of the server saying "nothing running"
+// An absolute ceiling on top of the server's answer. The marker is TTL-bounded
+// server-side, but a stuck or unreachable marker must not leave the composer
+// disabled forever — this caps the spinner at a little beyond the longest turn.
+const REPLY_MAX_WAIT_MS = 6 * 60 * 1000
 
 async function awaitPersistedReply(sessionId, baselineAssistants) {
   let idlePolls = 0
+  const deadline = Date.now() + REPLY_MAX_WAIT_MS
   for (;;) {
+    if (Date.now() > deadline) return null
     let data
     try {
       data = await store.fetchHistory(props.agent.name, sessionId || null)
@@ -481,6 +492,21 @@ async function persistedAssistantCount(sessionId) {
   } catch {
     return 0
   }
+}
+
+// Mark a sent message as undelivered, THROUGH the reactive array.
+//
+// `messages` is a ref([]), so pushing a plain object stores the raw target and
+// Vue only proxies it when you read `messages.value[i]`. Mutating the local
+// variable you pushed writes past the proxy: the value changes, nothing
+// re-renders, and the failure is invisible.
+function markFailed(index, content, error) {
+  const row = messages.value[index]
+  // The array can be replaced under us (thread switch, history reload). Only
+  // mark the row if it is still the message we sent.
+  if (!row || row.role !== 'user' || row.content !== content) return
+  row.failed = true
+  row.error = error || null
 }
 
 async function send() {

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -257,6 +257,10 @@ const activeAgentName = ref(null)
 // ent#361: the room a multi-agent chat is being held in, if any.
 const activeRoomId = ref(null)
 // The agent a deep link named that this caller cannot reach (ent#358 review).
+// Set when a deep link names an agent this caller cannot reach. Cleared by
+// every navigation away from it — `activeAgent` returns null while it is set,
+// so a latch that never clears leaves the whole Workspace stuck on the
+// access-denied panel for the rest of the SPA session.
 const unreachableAgent = ref(null)
 const pendingSession = ref(null)      // session to load when the conversation (re)mounts
 const prefill = ref('')
@@ -289,6 +293,7 @@ function newChat() {
 }
 
 function startBlankChat() {
+  unreachableAgent.value = null
   pendingSession.value = null; prefill.value = ''; convGen.value++
   if (route.params.sessionId) router.push('/workspace')
 }
@@ -324,18 +329,21 @@ const pickerError = ref(null)
 
 function openRoom(roomId) {
   if (!roomId) return
+  unreachableAgent.value = null
   activeRoomId.value = roomId
   pendingSession.value = null
   convGen.value++
   router.push(`/workspace/r/${roomId}`)
 }
 function newChatWithAgent(name) {
+  unreachableAgent.value = null
   activeAgentName.value = name
   pendingSession.value = null; prefill.value = ''; convGen.value++
   if (route.params.sessionId) router.push('/workspace')
 }
 function switchAgent(name) { newChatWithAgent(name) }   // mid-thread = plain new chat, no carry-over
 function openThread(t) {
+  unreachableAgent.value = null
   // ent#361: a room row in the merged sidebar opens the room, not a thread.
   if (t.is_room) { openRoom(t.id); return }
   const sid = t.id || t.session_id

--- a/src/frontend/tests/unit/portalUndefinedCalls.spec.js
+++ b/src/frontend/tests/unit/portalUndefinedCalls.spec.js
@@ -1,0 +1,111 @@
+/**
+ * Every function called in the portal SFCs must actually exist.
+ *
+ * A block-level edit to PortalConversation.vue deleted `markFailed` while both
+ * of its call sites remained. `vite build` compiles that happily — it is a
+ * runtime `ReferenceError` — and there is no ESLint in this project, so the
+ * whole test suite and CI went green while EVERY failed send in the Workspace
+ * threw and rendered no error and no Retry. That is the second time the same
+ * user-visible bug shipped, so it gets a guard rather than another fix.
+ *
+ * Deliberately narrow: it checks the `<script setup>` block of the portal
+ * components for calls to bare identifiers that are neither defined there nor
+ * imported. It is not a type checker and does not try to be — it catches
+ * exactly the "called something that isn't there" class.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const portalDir = join(here, '../../src/components/portal')
+const viewsDir = join(here, '../../src/views')
+
+// Language, DOM and framework names a component may call without defining.
+const AMBIENT = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'return', 'typeof', 'await', 'new',
+  'function', 'super', 'this', 'Array', 'Object', 'String', 'Number', 'Boolean',
+  'Math', 'JSON', 'Date', 'Promise', 'Error', 'Set', 'Map', 'RegExp', 'BigInt',
+  'parseInt', 'parseFloat', 'isNaN', 'encodeURIComponent', 'decodeURIComponent',
+  'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'requestAnimationFrame',
+  'fetch', 'console', 'window', 'document', 'navigator', 'localStorage', 'alert',
+  'FormData', 'File', 'Blob', 'FileReader', 'URL', 'TextDecoder', 'AbortController',
+  'defineProps', 'defineEmits', 'defineExpose', 'withDefaults', 'MediaRecorder',
+  'SpeechRecognition', 'webkitSpeechRecognition', 'Audio', 'CustomEvent', 'Event',
+  // Keywords that precede a parenthesised list rather than call anything.
+  'async', 'else', 'do', 'try',
+])
+
+function scriptOf(source) {
+  const m = source.match(/<script setup[^>]*>([\s\S]*?)<\/script>/)
+  if (!m) return ''
+  // Strip comments and string/template literals first: prose like "a chat (…)"
+  // in a comment otherwise reads as a call to `chat`.
+  return m[1]
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+    .replace(/`(?:\\.|\$\{[^}]*\}|[^`\\])*`/g, '``')
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+}
+
+function definedNames(script) {
+  const names = new Set()
+  for (const re of [
+    /\bfunction\s+([A-Za-z_$][\w$]*)/g,
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)/g,
+    /\b(?:const|let|var)\s*\{([^}]*)\}/g,     // destructured
+    /import\s+([A-Za-z_$][\w$]*)\s+from/g,
+    /import\s*\{([^}]*)\}\s*from/g,
+    // `const x = (…) => …` is caught above, but a plain reassignment or a
+    // template-only helper defined as an expression needs this.
+    /\b([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(/g,
+  ]) {
+    let m
+    while ((m = re.exec(script))) {
+      for (const part of m[1].split(',')) {
+        // `a as b` binds b; `{ a: b }` binds b; `x = 1` binds x.
+        const name = part
+          .split(/\bas\b/).pop()
+          .split(':').pop()
+          .split('=')[0]
+          .trim()
+          .replace(/^\.\.\./, '')
+        if (name) names.add(name)
+      }
+    }
+  }
+  return names
+}
+
+function calledNames(script) {
+  const names = new Set()
+  // A bare `name(` not preceded by `.`, and not a declaration site.
+  const re = /(^|[^\w$.])([a-z_$][\w$]*)\s*\(/g
+  let m
+  while ((m = re.exec(script))) names.add(m[2])
+  return names
+}
+
+function sfcFiles() {
+  const files = readdirSync(portalDir)
+    .filter((f) => f.endsWith('.vue'))
+    .map((f) => ['components/portal/' + f, join(portalDir, f)])
+  files.push(['views/Portal.vue', join(viewsDir, 'Portal.vue')])
+  return files
+}
+
+describe('portal components call only functions that exist', () => {
+  for (const [label, path] of sfcFiles()) {
+    it(`${label} has no calls to undefined identifiers`, () => {
+      const script = scriptOf(readFileSync(path, 'utf8'))
+      if (!script) return
+      const defined = definedNames(script)
+      const missing = [...calledNames(script)].filter(
+        (n) => !defined.has(n) && !AMBIENT.has(n)
+      )
+      expect(missing, `${label} calls undefined: ${missing.join(', ')}`).toEqual([])
+    })
+  }
+})


### PR DESCRIPTION
Follow-up to #2120 (merged). A re-review after its fix commit found that **the fixes themselves regressed three user-visible paths**, and #2120 has since merged — so these are live on `dev` right now.

## The urgent one

`markFailed` is **called at two sites and never defined.** A block-level edit removed it along with the code around it.

`vite build` compiles that happily — it is a runtime `ReferenceError` — and this project has **no ESLint**, so the full suite and CI went green while **every failed Workspace send throws and renders no error and no Retry button.** That is the same user-visible bug reported three times now: once originally, once after a fix that set state the view never re-read, and now this.

So it gets a guard rather than a fourth fix: `portalUndefinedCalls.spec.js` fails on a call to an identifier the SFC neither defines nor imports.

## The other four

| | |
|---|---|
| `reattach()` never rendered its reply | called `awaitPersistedReply` without the new `baselineAssistants` arg, so `assistants.length > undefined` was false on every poll. A user who reloaded mid-turn watched the indicator vanish and had to reload *again* to see an answer that had already arrived. |
| The access-denied latch never cleared | `activeAgent` returns null while `unreachableAgent` is set, and only mount-time code cleared it — one stale deep link wedged the **entire** Workspace on the access-denied panel for the rest of the session. |
| `clear_turn_inflight` deleted unconditionally | a second turn overwrites the session marker, so a finishing (or fast-failing) turn wiped the marker of one still running; the watching client then saw "nothing in flight", gave up, and offered a Retry that **dispatches and bills the turn again** — the exact double-spend the marker exists to prevent. Now compare-and-delete. |
| The marker outlived its turn by an hour | TTL 3600s against a 300s turn, and the reply wait is now gated on that marker — a backend restart mid-turn would leave the composer disabled and spinning for up to an hour. TTL is now the turn's bound plus slack; the client also carries an absolute ceiling. |

## Verification

102 frontend tests (9 files), build clean. The new guard fails on the pre-fix tree, which is the point.

## Worth saying plainly

Every one of these came from the commit that fixed the previous review's findings. Two rounds of review have now found that my fixes introduced defects at roughly the rate they removed them, and the only reason this round was caught is that the review was re-run. A third pass against this branch before merge is warranted — I am not a reliable judge of code I wrote in the same session.

Related to abilityai/trinity-enterprise#358, abilityai/trinity-enterprise#286