### PR TITLE
feat(workspace): sidebar IA — agents block, starred chats, unread badges (ent#359)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -339,6 +339,7 @@
 | Persistent Chat Tracking | [persistent-chat-tracking.md](feature-flows/persistent-chat-tracking.md) | Database-backed chat persistence |
 | Session Tab | [session-tab.md](feature-flows/session-tab.md) | The `--resume` engine — each turn reattaches to the same Claude memory (SESSION_TAB_2026-04). Its Agent Detail surface retired in ent#358; the engine and endpoints are live |
 | Workspace absorbs Session | [workspace-absorbs-session.md](feature-flows/workspace-absorbs-session.md) | ent#358 — one continuous-conversation surface, with the continuity parity that had to land before the other could be removed |
+| Workspace sidebar IA | [workspace-sidebar-ia.md](feature-flows/workspace-sidebar-ia.md) | ent#359 — agents block on top, starred chats, per-agent unread badges; why the per-viewer state could not be a column on the chat row |
 | Web Terminal | [web-terminal.md](feature-flows/web-terminal.md) | Browser-based terminal for System Agent |
 | Self-Execute | [self-execute.md](feature-flows/self-execute.md) | Agent background task during chat (SELF-EXEC-001) |
 

--- a/docs/memory/feature-flows/workspace-sidebar-ia.md
+++ b/docs/memory/feature-flows/workspace-sidebar-ia.md
@@ -1,0 +1,147 @@
+# Feature: Workspace sidebar IA — agents block, starred chats, unread badges
+
+> **Status**: ✅ Implemented (2026-08-12)
+> **Issue**: abilityai/trinity-enterprise#359
+> **Requirement**: `docs/memory/requirements/core-agent.md` §5.10
+> **Related**: [workspace-absorbs-session.md](workspace-absorbs-session.md) (why the roster's role changed)
+
+## Overview
+
+The sidebar had four things stacked in one column — New chat, Search, an Agents
+roster, date-grouped history — all rendered with the same weight. That was
+coherent while an agent was a *menu entry you pick to start a chat*. Once the
+Workspace absorbed the Session surface (ent#358) and became the only place a
+continuing conversation lives, an agent became a **destination** and a chat
+became the record of visiting one. Two kinds of thing, one visual treatment.
+
+This change separates them, and adds the two pieces of state that make a list of
+conversations navigable rather than merely complete: **which ones you keep coming
+back to**, and **which ones are waiting on you**.
+
+## The thing that decided the design
+
+Both new features are *per-viewer*. That single word rules out the obvious
+implementation.
+
+A star is one person's bookmark. A room (`shared_sessions`) has several
+participants. A `starred` column on the chat row would therefore render one
+participant's star in every other participant's sidebar — and incidentally tell
+them which conversations their colleagues care about. Rooms also live in the
+private enterprise submodule while threads live in OSS, so a per-kind column
+would put half of one feature in each repo.
+
+So: one table, keyed by the viewer.
+
+```sql
+enterprise_portal_chat_state (
+  client_email, chat_kind, chat_id,   -- PK
+  starred_at, last_read_at, updated_at
+)
+```
+
+`client_email` is the primary-key prefix, so the row **is** the tenant scope —
+there is no filter to forget on a read path and no way to address another
+viewer's state. `chat_kind` (`thread` | `room`) is needed because the two id
+spaces are independent: thread `x` and room `x` are different chats.
+
+## Flow
+
+### 1. Reading state
+
+`GET /chat-state` returns one entry per chat the viewer has state for:
+`{kind, id, starred, unread}`. One call rather than a field on each list,
+because threads and rooms come from **different endpoints** (and different repos)
+but sort into a single list — attaching state per-list would reshuffle the
+sidebar as the second response landed.
+
+The shell merges it onto the thread list in `decorate()`; a chat-state failure
+costs the stars and badges, never the list.
+
+### 2. What "unread" means
+
+Agent messages newer than that thread's `last_read_at`.
+
+The subtle half is the **absent** cursor. A thread with no `last_read_at`
+reports **nothing** unread, rather than its whole history. Unread is defined
+relative to a cursor; inventing one at the beginning of time would have lit up
+every historical conversation in every install the day this shipped — noise that
+teaches people to ignore the badge, which is worse than having no badge.
+
+A cursor is written the first time the viewer opens or sends in a thread
+(`openThread`, `openRoom`, `onSessionAdopted`), so any live conversation
+acquires one immediately and the first reply the viewer *doesn't* see is the
+first thing that badges.
+
+### 3. Where the counts surface
+
+| Count | Where | Why there |
+|---|---|---|
+| per chat | the chat row | which conversation to open |
+| per agent | the agent row in the agents block | which agent is waiting |
+| total | the **wordmark** | the agents block now occupies the top of a *scrolling* region, so a fleet-wide signal parked there scrolls away |
+
+A room credits its unread to **every** agent in it — there is no single agent a
+room is "with", so if three agents share a room you are behind on, all three
+rows should say so. (Rooms report 0 today; see Known Limitations.)
+
+### 4. Starred chats are lifted, not copied
+
+`partitionStarred()` splits the list before `groupThreadsByDate()` ever sees it,
+so a starred chat appears in the Starred section and **nowhere else**. Copying it
+above the groups would make the list lie about how many conversations exist,
+and both rows would go to the same place — the duplicate carries no information.
+
+### 5. Clicking an agent
+
+With unread, the agent row opens the conversation it is waiting in. With nothing
+unread it starts a new chat, exactly as before.
+
+A badge reading "2 replies" next to a control that opens an *empty* chat is a
+contradiction: the count is the reason the user clicked. This is **not** a
+stand-in for the agent page — that is ent#360, and it is a different thing (a
+destination with its own content, not a shortcut to a conversation).
+
+## Files
+
+| Layer | File | Change |
+|---|---|---|
+| Schema | `db/schema.py`, `db/tables.py`, `db/migrations.py`, `migrations/versions/0038_portal_chat_state.py` | one table, four tracks (Invariant #3) |
+| DB | `client_portal/db.py` | state accessors + the unread aggregate |
+| Service | `client_portal/service.py` | kind/id validation, row cap, star + read + combined read |
+| Router | `client_portal/router.py` | 4 endpoints |
+| Store | `stores/clientPortal.js` | `fetchChatState`, `setChatStar`, `markChatRead` |
+| Shell | `views/Portal.vue` | merge state onto threads, optimistic star, mark-read on open |
+| UI | `components/portal/PortalSidebar.vue` | agents block, starred section, wordmark badge |
+| UI | `components/portal/PortalChatRow.vue` | **new** — one row shared by both sections |
+| UI | `components/portal/PortalStarButton.vue` | **new** — one star for its three homes |
+| UI | `components/portal/PortalConversation.vue`, `PortalRoom.vue` | header star |
+| Utils | `components/portal/portalUtils.js` | `partitionStarred`, `unreadByAgent`, `totalUnread`, `rowAgents` |
+
+## Security notes
+
+- **No roster gate on the three chat-state routes.** Every row is keyed by the
+  caller's own email; there is no agent to authorize against.
+- **No existence check on `chat_id`, on purpose.** A 404 for an unknown chat
+  would answer "does chat X exist?" for every id in the install (invariant #8).
+  The write lands in the caller's own namespace, so an unknown id gains them
+  nothing — a per-viewer row cap (`MAX_CHAT_STATE_ROWS`) bounds the write
+  instead of validation. The cap applies only to writes that **create** a row:
+  capping updates would freeze a user at the ceiling out of unstarring, which is
+  the only action that gets them back under it.
+
+## Tests
+
+| Test | Pins |
+|---|---|
+| `tests/unit/test_ent359_portal_chat_state.py` | cross-viewer isolation; kind/id key separation; email-case normalisation; no-cursor ⇒ nothing unread; only agent messages after the cursor count; re-reading clears; star and read don't overwrite each other; unstar keeps the cursor; validation; unknown ids don't 404; the cap bounds new rows but never freezes owned ones; mark-read at the cap is a no-op |
+| `src/frontend/tests/unit/portalSidebarIA.spec.js` | starred lifted out of every date group and appearing once; per-agent sums; a room crediting every participant; wordmark total; row-avatar cap and overflow |
+| `src/frontend/tests/unit/portalUndefinedCalls.spec.js` | (existing guard) the two new SFCs call nothing undefined |
+
+## Known Limitations
+
+| Limitation | Detail |
+|---|---|
+| **Rooms report `unread: 0`** | A room already has its own seq cursor (`since`), which is a different model from a timestamp cursor. Stars work for rooms; unread does not, so a room never badges. Reconciling the two is follow-up work. |
+| **Unread needs one open first** | A thread the viewer has never opened *since this shipped* has no cursor and so never badges, by design (see above). It acquires one the first time they open or send. |
+| **The agent badge counts replies, not questions** | "Waiting on the user" is read here as "the agent replied and you haven't read it". An agent blocked on an operator-queue approval is a different signal and is not surfaced here — that queue belongs to operators, and a Workspace viewer may be an external client with no standing in it. |
+| **Optimistic star, no cross-tab sync** | A star toggled in one tab does not appear in another until its next `refreshThreads`. |

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -354,6 +354,55 @@
   abilityai/trinity-enterprise#286 and is **not** a prerequisite of this change.
 - **Flow**: `docs/memory/feature-flows/session-tab.md`
 
+### 5.10 Workspace sidebar IA — agents block, starred chats, unread badges
+- **Status**: ✅ Implemented (2026-08-12)
+- **Requirement ID**: WORKSPACE_SIDEBAR_IA
+- **GitHub Issue**: abilityai/trinity-enterprise#359
+- **Description**: The sidebar is restructured around what an agent now is. The
+  roster moves to the top of the scroll region as its own surface, and chats
+  follow with starred ones pinned above the date groups.
+- **Why the roster gets its own surface**: once the Workspace became the only
+  continuous-conversation surface (5.9), an agent stopped being an entry in a
+  new-chat menu and became a destination. Rendering roster and chat history with
+  identical visual weight is what made the old sidebar read as one
+  undifferentiated list.
+- **Key Features**:
+  - Agents block renders **first**, on its own surface (card + ring); each row
+    carries avatar, name, description, and a count badge when that agent has
+    replies the viewer has not read
+  - The aggregate "waiting on you" count sits on the **wordmark**, since the
+    agents block now occupies the top of a scrolling region
+  - Starred chats are **lifted out of** the date groups, not copied above them —
+    a starred chat appears exactly once
+  - Star / unstar from the chat row **and** from the chat header (1:1 and room)
+  - A multi-agent chat row shows every participant's avatar (capped at 3 + a
+    "+N" chip), so a room is visually distinct from a 1:1
+  - Clicking an agent that is waiting on you opens the conversation it is
+    waiting in; with nothing unread it starts a new chat as before
+  - Search still replaces both lists while active; an empty roster still ends in
+    a next action (create an agent / ask whoever invited you)
+- **Per-viewer state**: `enterprise_portal_chat_state`
+  `(client_email, chat_kind, chat_id) → starred_at, last_read_at`. Deliberately
+  **not** a column on the chat row: a room is shared between participants, so a
+  star stored there would be one person's bookmark rendered in everyone else's
+  sidebar, and rooms live in the private submodule while threads do not. The
+  caller's email is the primary-key prefix, so the row **is** the tenant scope.
+- **Unread is defined relative to a cursor**: a thread with no `last_read_at`
+  reports nothing unread rather than reporting its whole history. Treating
+  "never read" as "all unread" would have badged every historical conversation
+  in every install the day this shipped. A cursor is written the first time the
+  viewer opens or sends in a thread.
+- **Endpoints**: `GET /api/enterprise/client-portal/chat-state`,
+  `PUT|DELETE .../chat-state/{kind}/{id}/star`, `POST .../chat-state/{kind}/{id}/read`.
+  No roster gate (every row is keyed by the caller's own email) and no existence
+  check on the id — a 404 for an unknown chat would be an enumeration oracle
+  (invariant #8); a per-viewer row cap bounds the write instead.
+- **Known gap**: rooms report `unread: 0`. A room keeps its own seq cursor, and
+  reconciling the two cursor models is follow-up work; stars work for both kinds.
+- **Not this issue**: opening an agent's own **page** (a destination with its own
+  content rather than a chat) is abilityai/trinity-enterprise#360.
+- **Flow**: `docs/memory/feature-flows/workspace-sidebar-ia.md`
+
 ---
 
 ## 6. Activity Monitoring

--- a/src/backend/client_portal/db.py
+++ b/src/backend/client_portal/db.py
@@ -13,7 +13,10 @@ from typing import Optional
 from sqlalchemy import select, func, and_, or_, text, bindparam
 
 from db.engine import get_engine, make_insert
-from db.tables import system_settings, agent_sharing, agent_ownership, users
+from db.tables import (
+    system_settings, agent_sharing, agent_ownership, users,
+    enterprise_portal_chat_state,
+)
 from utils.helpers import utc_now_iso
 
 
@@ -499,3 +502,124 @@ def list_agent_share_emails(agent_name: str) -> list[str]:
     )
     with get_engine().connect() as conn:
         return [r[0] for r in conn.execute(stmt) if r[0]]
+
+
+# --- Per-user chat state: stars + read cursor (ent#359) -----------------------
+# Every function here is keyed on the caller's own (lower-cased) email, so the
+# key IS the tenant scope: there is no way to address, read, or overwrite another
+# user's state, and no filter that could be forgotten.
+
+CHAT_KINDS = ("thread", "room")
+
+# A ceiling on rows one user can create. `star` and `read` both write a row, and
+# neither validates that the chat exists (see the router: a 404 for an unknown id
+# would be an enumeration oracle). Without a cap, that is an unbounded write
+# primitive for anyone holding a portal session.
+MAX_CHAT_STATE_ROWS = 1000
+
+
+def get_chat_state(client_email: str) -> list[dict]:
+    """Every chat-state row for one user: ``chat_kind``, ``chat_id``,
+    ``starred_at``, ``last_read_at``.
+
+    Unbounded read, bounded set: the write path caps how many rows a user can
+    create (``MAX_CHAT_STATE_ROWS``), so there is nothing here to paginate."""
+    stmt = text(
+        "SELECT chat_kind, chat_id, starred_at, last_read_at "
+        "FROM enterprise_portal_chat_state WHERE client_email = :email"
+    )
+    with get_engine().connect() as conn:
+        return [dict(r) for r in conn.execute(
+            stmt, {"email": (client_email or "").lower()}
+        ).mappings()]
+
+
+def count_chat_state_rows(client_email: str) -> int:
+    stmt = text(
+        "SELECT COUNT(*) FROM enterprise_portal_chat_state WHERE client_email = :email"
+    )
+    with get_engine().connect() as conn:
+        return int(conn.execute(stmt, {"email": (client_email or "").lower()}).scalar() or 0)
+
+
+def chat_state_row_exists(client_email: str, chat_kind: str, chat_id: str) -> bool:
+    """Whether this user already has a row for this chat. The row cap must only
+    apply to writes that CREATE one — otherwise a user at the ceiling stops being
+    able to advance a read cursor they already own."""
+    stmt = text(
+        "SELECT 1 FROM enterprise_portal_chat_state "
+        "WHERE client_email = :email AND chat_kind = :kind AND chat_id = :id"
+    )
+    with get_engine().connect() as conn:
+        return conn.execute(stmt, {
+            "email": (client_email or "").lower(), "kind": chat_kind, "id": chat_id,
+        }).first() is not None
+
+
+def _upsert_chat_state(client_email: str, chat_kind: str, chat_id: str,
+                       now: str, **fields) -> None:
+    """Set the named columns on one (user, kind, id) row, inserting it if absent.
+
+    Only the columns in ``fields`` are touched, so marking a chat read cannot
+    clear its star and vice versa.
+    """
+    email = (client_email or "").lower()
+    values = {
+        "client_email": email, "chat_kind": chat_kind, "chat_id": chat_id,
+        "updated_at": now, **fields,
+    }
+    stmt = (
+        make_insert(enterprise_portal_chat_state)
+        .values(**values)
+        .on_conflict_do_update(
+            index_elements=[
+                enterprise_portal_chat_state.c.client_email,
+                enterprise_portal_chat_state.c.chat_kind,
+                enterprise_portal_chat_state.c.chat_id,
+            ],
+            set_={"updated_at": now, **fields},
+        )
+    )
+    with get_engine().begin() as conn:
+        conn.execute(stmt)
+
+
+def set_chat_star(client_email: str, chat_kind: str, chat_id: str,
+                  starred: bool, now: str) -> None:
+    """Star or unstar one chat for one user. Unstar keeps the row — it still
+    carries the read cursor, and dropping it would mark the chat unread again."""
+    _upsert_chat_state(client_email, chat_kind, chat_id, now,
+                       starred_at=now if starred else None)
+
+
+def mark_chat_read(client_email: str, chat_kind: str, chat_id: str, now: str) -> None:
+    """Advance one chat's read cursor for one user."""
+    _upsert_chat_state(client_email, chat_kind, chat_id, now, last_read_at=now)
+
+
+def count_unread_by_session(client_email: str) -> dict[str, int]:
+    """Per-thread count of agent messages newer than that thread's read cursor.
+
+    A thread with NO cursor reports nothing rather than reporting its whole
+    history as unread. "Unread" is defined relative to a cursor; inventing one at
+    the beginning of time would light up every historical chat the first time
+    this shipped, which is noise, not information. A cursor is written the first
+    time the user opens or sends in a thread, so any live conversation acquires
+    one immediately. (Rooms keep their own seq cursor and are not counted here —
+    see the feature flow's Known Limitations.)
+    """
+    stmt = text(
+        "SELECT m.session_id AS session_id, COUNT(*) AS n "
+        "FROM enterprise_portal_messages m "
+        "JOIN enterprise_portal_chat_state st "
+        "  ON st.client_email = :email AND st.chat_kind = 'thread' "
+        " AND st.chat_id = m.session_id "
+        "WHERE m.client_email = :email "
+        "  AND m.role = 'assistant' "
+        "  AND st.last_read_at IS NOT NULL "
+        "  AND m.created_at > st.last_read_at "
+        "GROUP BY m.session_id"
+    )
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, {"email": (client_email or "").lower()}).mappings()
+        return {r["session_id"]: int(r["n"]) for r in rows if r["session_id"]}

--- a/src/backend/client_portal/models.py
+++ b/src/backend/client_portal/models.py
@@ -142,6 +142,26 @@ class PortalSessions(BaseModel):
     sessions: list[PortalSessionSummary]
 
 
+class PortalChatStateEntry(BaseModel):
+    """One chat's per-viewer state (ent#359). ``kind`` is ``thread`` (a portal
+    session) or ``room`` (a multi-agent room) — two independent id spaces, so
+    both fields are needed to address a chat."""
+    kind: str
+    id: str
+    starred: bool = False
+    unread: int = 0
+
+
+class PortalChatState(BaseModel):
+    """The signed-in viewer's star + unread state across every chat (ent#359).
+
+    One call rather than a field on each list: threads and rooms are served by
+    different endpoints (and live in different repos), and the sidebar has to
+    order them together.
+    """
+    chats: list[PortalChatStateEntry] = []
+
+
 class PortalSearchResult(BaseModel):
     """One matching conversation from a cross-chat search."""
     agent_name: str

--- a/src/backend/client_portal/router.py
+++ b/src/backend/client_portal/router.py
@@ -58,6 +58,7 @@ from .models import (
     PortalSearchResults,
     PortalSession,
     PortalSessions,
+    PortalChatState,
     PortalSessionSummary,
     PortalTtsRequest,
     PortalTurnStarted,
@@ -471,6 +472,55 @@ def portal_search(q: str = "", limit: int = 30, principal: PortalPrincipal = Dep
     # No agent gate here: search is scoped to the caller's own portal rows by
     # email, so there is no roster decision to mirror.
     return service.search_chats(principal.email, q, limit=min(max(limit, 1), 50))
+
+
+# --- Per-user chat state: stars + unread (ent#359) ----------------------------
+#
+# No roster gate on any of the three. Every row is keyed by the caller's own
+# email, so these read and write exactly one tenant's state and there is no agent
+# to authorize against. Neither writer checks that the chat exists, deliberately:
+# a 404 for an unknown id would turn `star` into an existence oracle over every
+# chat id in the install (OSS invariant #8). The service's row cap is what bounds
+# writing junk ids instead.
+
+@router.get("/chat-state", response_model=PortalChatState)
+def portal_chat_state(principal: PortalPrincipal = Depends(get_portal_principal)):
+    """Star + unread state for the signed-in viewer's chats, both kinds."""
+    return service.get_chat_state(principal.email)
+
+
+@router.put("/chat-state/{chat_kind}/{chat_id}/star", status_code=204)
+def portal_star_chat(chat_kind: str, chat_id: str,
+                     principal: PortalPrincipal = Depends(get_portal_principal)):
+    """Pin a chat above the sidebar's date groups, for this viewer only."""
+    try:
+        service.set_chat_star(principal.email, chat_kind, chat_id, True)
+    except ClientPortalError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    return Response(status_code=204)
+
+
+@router.delete("/chat-state/{chat_kind}/{chat_id}/star", status_code=204)
+def portal_unstar_chat(chat_kind: str, chat_id: str,
+                       principal: PortalPrincipal = Depends(get_portal_principal)):
+    """Unpin a chat. Keeps the row — it still carries the read cursor."""
+    try:
+        service.set_chat_star(principal.email, chat_kind, chat_id, False)
+    except ClientPortalError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    return Response(status_code=204)
+
+
+@router.post("/chat-state/{chat_kind}/{chat_id}/read", status_code=204)
+def portal_mark_chat_read(chat_kind: str, chat_id: str,
+                          principal: PortalPrincipal = Depends(get_portal_principal)):
+    """Advance this viewer's read cursor — clears the chat's unread count and
+    its share of the agent row's badge."""
+    try:
+        service.mark_chat_read(principal.email, chat_kind, chat_id)
+    except ClientPortalError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    return Response(status_code=204)
 
 
 @router.post("/agents/{agent_name}/chat", response_model=PortalChatResponse)

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1058,7 +1058,15 @@ def _inflight_exec_key(execution_id: str) -> str:
     return f"portal_inflight_exec:{execution_id}"
 
 
-def mark_turn_inflight(session_id: str, execution_id: str, ttl_seconds: int = 3600) -> None:
+# The marker describes a turn in progress, so its TTL is the turn's own bound
+# plus slack — not an hour. The client now waits as long as the marker says a
+# turn is running, so an over-long TTL is a spinner that outlives the work: a
+# backend restart mid-turn would leave the composer disabled for the remainder.
+PORTAL_INFLIGHT_TTL_SECONDS = 300 + 60
+
+
+def mark_turn_inflight(session_id: str, execution_id: str,
+                       ttl_seconds: int = PORTAL_INFLIGHT_TTL_SECONDS) -> None:
     """Record that ``session_id`` has a turn running, and WHICH one.
 
     The value is the execution id, not a bare flag: a client that reloads has
@@ -1077,17 +1085,33 @@ def mark_turn_inflight(session_id: str, execution_id: str, ttl_seconds: int = 36
 
 
 def clear_turn_inflight(session_id: str, execution_id: str | None = None) -> None:
-    """Turn is done. Best-effort — the TTL is the backstop."""
+    """This turn is done. Best-effort — the TTL is the backstop.
+
+    Compare-and-delete on the session marker: a second turn on the same thread
+    OVERWRITES it, so an unconditional delete lets a turn that finished (or
+    fast-failed on the resume lock) wipe the marker of one still running. The
+    watching client then sees "nothing in flight", gives up, and offers a Retry
+    that dispatches and bills the turn a second time — the exact double-spend
+    the marker exists to prevent.
+
+    The per-execution key is always safe to delete: it names only this turn.
+    """
     try:
         from redis_breaker_util import get_breaker_redis
         client = get_breaker_redis()
-        if client is not None:
-            if execution_id is None:
-                value = client.get(_inflight_key(session_id))
-                execution_id = value.decode() if isinstance(value, bytes) else value
+        if client is None:
+            return
+        current = client.get(_inflight_key(session_id))
+        current = current.decode() if isinstance(current, bytes) else current
+        if execution_id is None or current == execution_id:
             client.delete(_inflight_key(session_id))
-            if execution_id:
-                client.delete(_inflight_exec_key(execution_id))
+        elif current:
+            logger.info(
+                "portal: leaving inflight marker for session %s — it now names %s, not %s",
+                session_id, current, execution_id,
+            )
+        if execution_id:
+            client.delete(_inflight_exec_key(execution_id))
     except Exception as e:  # noqa: BLE001
         logger.warning("portal inflight DEL failed for %s: %s", session_id, e)
 

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1103,15 +1103,26 @@ def clear_turn_inflight(session_id: str, execution_id: str | None = None) -> Non
             return
         current = client.get(_inflight_key(session_id))
         current = current.decode() if isinstance(current, bytes) else current
-        if execution_id is None or current == execution_id:
+
+        if execution_id is None:
+            # No id given: clear whatever this session currently names. The
+            # reverse key has to be resolved from the session marker here —
+            # skipping it leaves the SSE proxy reporting a finished turn as
+            # still in flight until the TTL expires.
+            if current:
+                client.delete(_inflight_exec_key(current))
+            client.delete(_inflight_key(session_id))
+            return
+
+        if current == execution_id:
             client.delete(_inflight_key(session_id))
         elif current:
             logger.info(
                 "portal: leaving inflight marker for session %s — it now names %s, not %s",
                 session_id, current, execution_id,
             )
-        if execution_id:
-            client.delete(_inflight_exec_key(execution_id))
+        # Always safe: this key names only the turn being cleared.
+        client.delete(_inflight_exec_key(execution_id))
     except Exception as e:  # noqa: BLE001
         logger.warning("portal inflight DEL failed for %s: %s", session_id, e)
 

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -2000,3 +2000,87 @@ def get_agent_client_roster(agent_name: str) -> list[dict]:
             ),
         })
     return out
+
+
+# --- Per-user chat state: stars + unread (ent#359) ----------------------------
+
+# A chat id is a hex/urlsafe token in both id spaces. The bound exists because
+# neither writer validates that the chat exists (see below), so the id is
+# attacker-chosen text that lands in a primary key.
+MAX_CHAT_ID_LEN = 128
+
+
+def _validate_chat_ref(chat_kind: str, chat_id: str) -> tuple[str, str]:
+    kind = (chat_kind or "").strip().lower()
+    if kind not in db.CHAT_KINDS:
+        raise ClientPortalError(400, "Unknown chat kind")
+    cid = (chat_id or "").strip()
+    if not cid or len(cid) > MAX_CHAT_ID_LEN:
+        raise ClientPortalError(400, "Invalid chat id")
+    return kind, cid
+
+
+def _would_create_row_past_cap(email: str, kind: str, cid: str) -> bool:
+    """True when this write would ADD a row and the caller is already at the
+    ceiling. Updating a row the caller already owns is always allowed — capping
+    that would freeze an existing chat's star and read cursor, punishing the
+    user for state they legitimately accumulated."""
+    if db.chat_state_row_exists(email, kind, cid):
+        return False
+    return db.count_chat_state_rows(email) >= db.MAX_CHAT_STATE_ROWS
+
+
+def get_chat_state(email: str) -> dict:
+    """Star + unread state for every chat the caller has state for.
+
+    Unread is computed for threads only; a room carries its own seq cursor and
+    is reported as starred-or-not with `unread = 0`.
+    """
+    rows = db.get_chat_state(email)
+    unread = db.count_unread_by_session(email)
+    seen = set()
+    chats = []
+    for r in rows:
+        kind, cid = r.get("chat_kind"), r.get("chat_id")
+        if not kind or not cid:
+            continue
+        seen.add((kind, cid))
+        chats.append({
+            "kind": kind,
+            "id": cid,
+            "starred": bool(r.get("starred_at")),
+            "unread": unread.get(cid, 0) if kind == "thread" else 0,
+        })
+    # A thread can have unread messages without a state row only if the cursor
+    # was cleared out from under us; carry it anyway rather than losing a count.
+    for sid, n in unread.items():
+        if ("thread", sid) not in seen:
+            chats.append({"kind": "thread", "id": sid, "starred": False, "unread": n})
+    return {"chats": chats}
+
+
+def set_chat_star(email: str, chat_kind: str, chat_id: str, starred: bool) -> None:
+    """Star / unstar one chat for the calling viewer.
+
+    Deliberately does NOT verify that the chat exists. The write lands in a row
+    keyed by the caller's own email, so an unknown or someone else's id gains
+    them nothing — while a 404 for "no such chat" would be an existence oracle
+    over every chat id in the install (OSS invariant #8). The row cap is what
+    bounds the write instead.
+    """
+    kind, cid = _validate_chat_ref(chat_kind, chat_id)
+    if _would_create_row_past_cap(email, kind, cid):
+        raise ClientPortalError(409, "Too many saved chats — unstar some first")
+    db.set_chat_star(email, kind, cid, starred, utc_now_iso())
+
+
+def mark_chat_read(email: str, chat_kind: str, chat_id: str) -> None:
+    """Advance the caller's read cursor on one chat. Same non-validation and
+    same cap as `set_chat_star`."""
+    kind, cid = _validate_chat_ref(chat_kind, chat_id)
+    if _would_create_row_past_cap(email, kind, cid):
+        # Silently no-op rather than erroring: a read marker is incidental to
+        # what the user asked for (opening a chat), and failing the open because
+        # a bookkeeping table is full would be absurd.
+        return
+    db.mark_chat_read(email, kind, cid, utc_now_iso())

--- a/src/backend/db/migrations.py
+++ b/src/backend/db/migrations.py
@@ -3419,6 +3419,33 @@ def _migrate_portal_session_resume(cursor, conn):
     conn.commit()
 
 
+def _migrate_portal_chat_state(cursor, conn):
+    """Per-user star + read cursor for Workspace chats (ent#359).
+
+    A star belongs to the person who starred it, and a room is shared between
+    several people — so this cannot be a column on the chat row without one
+    user's star appearing in everyone else's sidebar. Keyed by the caller's own
+    email, which makes the row itself the per-user scope.
+
+    ``chat_kind`` distinguishes a portal thread from a room: the two id spaces
+    are independent, so the pair is the key, not the id alone.
+    """
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS enterprise_portal_chat_state (
+            client_email TEXT NOT NULL,
+            chat_kind TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            starred_at TEXT,
+            last_read_at TEXT,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (client_email, chat_kind, chat_id)
+        )
+        """
+    )
+    conn.commit()
+
+
 MIGRATIONS = [
     ("agent_sharing", _migrate_agent_sharing_table),
     ("schedule_executions_observability", _migrate_schedule_executions_observability),
@@ -3528,4 +3555,5 @@ MIGRATIONS = [
     ("agent_ownership_a2a_exposed", _migrate_agent_ownership_a2a_exposed),
     ("client_portal_tables_to_oss", _migrate_client_portal_tables_to_oss),
     ("portal_session_resume", _migrate_portal_session_resume),
+    ("portal_chat_state", _migrate_portal_chat_state),
 ]

--- a/src/backend/db/schema.py
+++ b/src/backend/db/schema.py
@@ -552,6 +552,27 @@ TABLES = {
         )
     """,
 
+    # ent#359 — per-user chat state for the Workspace sidebar: which chats the
+    # user starred, and how far they have read.
+    #
+    # A separate table rather than columns on the chat row, for two reasons. A
+    # room (`shared_sessions`) is shared between several users, so a star stored
+    # on the room row would be one user's star imposed on everyone in it. And
+    # rooms live in the enterprise submodule, so a per-kind column would put half
+    # of one feature in each repo. Keyed by the caller's own email, so the row IS
+    # the per-user scope — there is nothing to filter on read.
+    "enterprise_portal_chat_state": """
+        CREATE TABLE IF NOT EXISTS enterprise_portal_chat_state (
+            client_email TEXT NOT NULL,
+            chat_kind TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            starred_at TEXT,
+            last_read_at TEXT,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (client_email, chat_kind, chat_id)
+        )
+    """,
+
     "enterprise_client_blocks": """
         CREATE TABLE IF NOT EXISTS enterprise_client_blocks (
             email TEXT PRIMARY KEY,

--- a/src/backend/db/tables.py
+++ b/src/backend/db/tables.py
@@ -485,6 +485,21 @@ enterprise_portal_messages = Table(
     Column("created_at", Text),
 )
 
+# ent#359 — per-user star + read cursor for a Workspace chat of either kind
+# (`thread` = enterprise_portal_sessions, `room` = the enterprise shared_sessions
+# room). Separate from the chat row because a room is shared between users and a
+# star is not; see db/schema.py for the full rationale.
+enterprise_portal_chat_state = Table(
+    "enterprise_portal_chat_state",
+    metadata,
+    Column("client_email", Text, primary_key=True),
+    Column("chat_kind", Text, primary_key=True),
+    Column("chat_id", Text, primary_key=True),
+    Column("starred_at", Text),
+    Column("last_read_at", Text),
+    Column("updated_at", Text),
+)
+
 enterprise_client_blocks = Table(
     "enterprise_client_blocks",
     metadata,

--- a/src/backend/migrations/versions/0038_portal_chat_state.py
+++ b/src/backend/migrations/versions/0038_portal_chat_state.py
@@ -1,0 +1,50 @@
+"""enterprise_portal_chat_state — per-user star + read cursor for Workspace chats (ent#359)
+
+The sidebar gains starred chats pinned above the date groups, and a per-agent
+"waiting on you" badge. Both need state that belongs to the *viewer*, not to the
+conversation.
+
+That rules out a column on the chat row. A room (``shared_sessions``) is shared
+between several participants, so a ``starred`` column there would be one user's
+star rendered in everybody else's sidebar; and rooms live in the enterprise
+submodule, so a per-kind column would split one feature across two repos.
+
+Keying on the caller's own email makes the row itself the per-user scope — there
+is nothing to filter on read, and no way to address another user's state.
+``chat_kind`` separates the two independent id spaces (``thread`` = a portal
+session, ``room`` = a room).
+
+Mirrors the SQLite ``portal_chat_state`` migration + ``db/schema.py`` /
+``db/tables.py`` (Invariant #3, dual-track).
+
+Revision ID: 0038_portal_chat_state
+Revises: 0037_portal_session_resume
+Create Date: 2026-08-12
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0038_portal_chat_state"
+down_revision = "0037_portal_session_resume"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS enterprise_portal_chat_state (
+            client_email TEXT NOT NULL,
+            chat_kind TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            starred_at TEXT,
+            last_read_at TEXT,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (client_email, chat_kind, chat_id)
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS enterprise_portal_chat_state")

--- a/src/frontend/src/components/portal/PortalChatRow.vue
+++ b/src/frontend/src/components/portal/PortalChatRow.vue
@@ -1,0 +1,73 @@
+<template>
+  <!-- A row, not a <button>: it holds a second control (the star), and nesting
+       an interactive element inside a button is invalid HTML — browsers vary on
+       which click wins, so the star would sometimes open the chat instead. -->
+  <div
+    class="group w-full flex items-center gap-2 rounded-lg px-2.5 py-2 text-left cursor-pointer hover:bg-white dark:hover:bg-gray-900 transition"
+    :class="active ? 'bg-white dark:bg-gray-900 ring-1 ring-gray-200 dark:ring-gray-800' : ''"
+    role="button"
+    tabindex="0"
+    @click="$emit('open')"
+    @keydown.enter.prevent="$emit('open')"
+    @keydown.space.prevent="$emit('open')"
+  >
+    <!-- ent#359: a multi-agent chat shows every participant. One avatar for a
+         room of three is the same row a 1:1 draws, which is exactly the
+         distinction the sidebar has to make visible. -->
+    <span class="shrink-0 flex items-center" :class="avatars.shown.length > 1 ? '-space-x-1.5' : ''">
+      <PortalAvatar
+        v-for="n in avatars.shown"
+        :key="n"
+        :name="n"
+        :avatar-url="avatarFor(n)"
+        :size="22"
+        class="ring-2 ring-gray-50 dark:ring-gray-950 rounded-full"
+      />
+      <span
+        v-if="avatars.overflow"
+        class="w-[22px] h-[22px] rounded-full bg-gray-200 dark:bg-gray-700 text-[10px] font-semibold text-gray-600 dark:text-gray-300 flex items-center justify-center ring-2 ring-gray-50 dark:ring-gray-950"
+        :title="allAgentNames"
+      >+{{ avatars.overflow }}</span>
+    </span>
+
+    <span class="text-sm truncate flex-1" :class="unread ? 'font-semibold' : ''">{{ title }}</span>
+
+    <span
+      v-if="unread"
+      class="shrink-0 min-w-[1.125rem] px-1 h-[1.125rem] rounded-full bg-action-primary-600 text-white text-[10px] font-semibold flex items-center justify-center"
+    >{{ unread > 99 ? '99+' : unread }}</span>
+
+    <PortalStarButton
+      :starred="!!thread.starred"
+      dense
+      reveal-on-hover
+      @toggle="$emit('toggle-star')"
+    />
+  </div>
+</template>
+
+<script setup>
+/**
+ * One chat row in the Workspace sidebar (ent#359) — a thread or a room.
+ *
+ * Extracted from PortalSidebar because the starred section and each date group
+ * render the identical row, and three copies of a row that carries a star
+ * toggle, an unread badge and stacked avatars is three places for them to drift.
+ */
+import { computed } from 'vue'
+import PortalAvatar from './PortalAvatar.vue'
+import PortalStarButton from './PortalStarButton.vue'
+import { rowAgents, threadTitle } from './portalUtils'
+
+const props = defineProps({
+  thread: { type: Object, required: true },
+  active: { type: Boolean, default: false },
+  avatarFor: { type: Function, default: () => null },
+})
+defineEmits(['open', 'toggle-star'])
+
+const avatars = computed(() => rowAgents(props.thread))
+const allAgentNames = computed(() => (props.thread.agent_names || []).join(', '))
+const unread = computed(() => Number(props.thread.unread) || 0)
+const title = computed(() => threadTitle(props.thread))
+</script>

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -417,7 +417,12 @@ async function deliver(text) {
       currentSessionId.value = data.session_id
       emit('session-adopted', data.session_id)
     }
-    if (startedNew || currentSessionId.value) emit('sessions-changed')
+    // ent#359: carry WHICH thread finished. The shell marks a completed turn
+    // read only when the user is still looking at it — this event fires even
+    // after the user has navigated away (the send is an async closure that
+    // outlives the component), and without the id the shell cannot tell the two
+    // apart, so it cleared the badge for a reply the user never saw.
+    if (startedNew || currentSessionId.value) emit('sessions-changed', currentSessionId.value)
     attachments.value = []
     return true
   } catch (err) {

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -42,6 +42,15 @@
       </div>
 
       <div class="ml-auto flex items-center gap-1">
+        <!-- ent#359 AC #4: star from the header too. Hidden until the thread
+             exists — a chat with no id yet cannot be pinned, and rendering a
+             control that silently does nothing is the dead end this family of
+             issues keeps removing. -->
+        <PortalStarButton
+          v-if="currentSessionId"
+          :starred="starred"
+          @toggle="$emit('toggle-star', { id: currentSessionId, is_room: false, starred })"
+        />
         <button
           v-if="ttsEnabled"
           class="p-2 rounded-lg transition"
@@ -190,6 +199,7 @@ import { useClientPortalStore } from '@/stores/clientPortal'
 import { renderMarkdown } from '@/utils/markdown'
 import { agentDisplayName } from '@/utils/agentName'
 import PortalAvatar from './PortalAvatar.vue'
+import PortalStarButton from './PortalStarButton.vue'
 import { deliveryFailureReason } from './portalUtils'
 
 const props = defineProps({
@@ -197,8 +207,11 @@ const props = defineProps({
   roster: { type: Array, default: () => [] },
   sessionId: { type: String, default: null },   // current thread, or null for a new chat
   prefill: { type: String, default: '' },
+  // ent#359: whether the CURRENT thread is starred. Owned by the shell (it
+  // holds the per-viewer chat state), rendered here.
+  starred: { type: Boolean, default: false },
 })
-const emit = defineEmits(['switch-agent', 'session-adopted', 'sessions-changed', 'open-files', 'open-menu'])
+const emit = defineEmits(['switch-agent', 'session-adopted', 'sessions-changed', 'open-files', 'open-menu', 'toggle-star'])
 
 const store = useClientPortalStore()
 const messages = ref([])

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -248,9 +248,14 @@ async function reattach(executionId) {
   elapsed.value = 0
   clearInterval(elapsedTimer)
   elapsedTimer = setInterval(() => { elapsed.value += 1 }, 1000)
+  // The baseline is what is on screen right now: this client reloaded INTO a
+  // running turn, so every assistant message it can see predates that turn.
+  // Passing nothing made `assistants.length > undefined` false on every poll,
+  // so the reply never rendered and the user had to reload a second time.
+  const baseline = messages.value.filter((m) => m.role === 'assistant').length
   try {
     await store.streamPortalExecution(props.agent.name, executionId, onStreamEvent)
-    const data = await awaitPersistedReply(currentSessionId.value)
+    const data = await awaitPersistedReply(currentSessionId.value, baseline)
     if (data?.response) messages.value.push({ role: 'assistant', content: data.response })
   } catch { /* the reply lands in history on the next load */ }
   finally {
@@ -448,10 +453,16 @@ function onStreamEvent(evt) {
 // first poll — the answer to the wrong question, while a second turn ran unseen.
 const REPLY_POLL_MS = 700
 const REPLY_IDLE_GIVE_UP = 8      // ~5.6s of the server saying "nothing running"
+// An absolute ceiling on top of the server's answer. The marker is TTL-bounded
+// server-side, but a stuck or unreachable marker must not leave the composer
+// disabled forever — this caps the spinner at a little beyond the longest turn.
+const REPLY_MAX_WAIT_MS = 6 * 60 * 1000
 
 async function awaitPersistedReply(sessionId, baselineAssistants) {
   let idlePolls = 0
+  const deadline = Date.now() + REPLY_MAX_WAIT_MS
   for (;;) {
+    if (Date.now() > deadline) return null
     let data
     try {
       data = await store.fetchHistory(props.agent.name, sessionId || null)
@@ -481,6 +492,21 @@ async function persistedAssistantCount(sessionId) {
   } catch {
     return 0
   }
+}
+
+// Mark a sent message as undelivered, THROUGH the reactive array.
+//
+// `messages` is a ref([]), so pushing a plain object stores the raw target and
+// Vue only proxies it when you read `messages.value[i]`. Mutating the local
+// variable you pushed writes past the proxy: the value changes, nothing
+// re-renders, and the failure is invisible.
+function markFailed(index, content, error) {
+  const row = messages.value[index]
+  // The array can be replaced under us (thread switch, history reload). Only
+  // mark the row if it is still the message we sent.
+  if (!row || row.role !== 'user' || row.content !== content) return
+  row.failed = true
+  row.error = error || null
 }
 
 async function send() {

--- a/src/frontend/src/components/portal/PortalRoom.vue
+++ b/src/frontend/src/components/portal/PortalRoom.vue
@@ -32,6 +32,11 @@
       </div>
 
       <div class="flex items-center gap-1" :class="{ 'ml-auto': !budgetWarning }">
+        <!-- ent#359 AC #4: star from the header, same as a 1:1. -->
+        <PortalStarButton
+          :starred="starred"
+          @toggle="$emit('toggle-star', { id: roomId, is_room: true, starred })"
+        />
         <button
           v-if="!isClosed"
           class="px-2 py-1.5 rounded-lg text-xs font-medium text-action-primary-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
@@ -171,12 +176,16 @@ import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
 import { renderMarkdown } from '@/utils/markdown'
 import PortalAvatar from './PortalAvatar.vue'
+import PortalStarButton from './PortalStarButton.vue'
 
 const props = defineProps({
   roomId: { type: String, required: true },
   roster: { type: Array, default: () => [] },
+  // ent#359: star state is per-viewer and owned by the shell, not by the room —
+  // a room is shared, a star is not.
+  starred: { type: Boolean, default: false },
 })
-defineEmits(['open-menu', 'rooms-changed'])
+defineEmits(['open-menu', 'rooms-changed', 'toggle-star'])
 
 const store = useClientPortalStore()
 

--- a/src/frontend/src/components/portal/PortalSidebar.vue
+++ b/src/frontend/src/components/portal/PortalSidebar.vue
@@ -1,9 +1,16 @@
 <template>
   <aside class="flex flex-col h-full w-72 bg-gray-50 dark:bg-gray-950 border-r border-gray-200 dark:border-gray-800">
-    <!-- Brand -->
+    <!-- Brand. ent#359: the aggregate "waiting on you" count lives here, because
+         the agents block now occupies the top of the scroll region and would
+         otherwise scroll a fleet-wide signal out of view. -->
     <div class="shrink-0 flex items-center gap-2 px-4 h-14 border-b border-gray-200 dark:border-gray-800">
       <svg class="w-6 h-6 text-action-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
       <span class="font-semibold">Workspace</span>
+      <span
+        v-if="totalWaiting"
+        class="ml-auto shrink-0 min-w-[1.25rem] px-1.5 h-5 rounded-full bg-action-primary-600 text-white text-[11px] font-semibold flex items-center justify-center"
+        :title="`${totalWaiting} ${totalWaiting === 1 ? 'reply' : 'replies'} you haven't read`"
+      >{{ totalWaiting > 99 ? '99+' : totalWaiting }}</span>
     </div>
 
     <div class="p-3 space-y-2">
@@ -57,39 +64,73 @@
       </div>
 
       <template v-else>
-        <!-- Agents -->
-        <div class="px-2 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Agents</div>
-        <button
-          v-for="a in roster"
-          :key="a.name"
-          class="w-full flex items-center gap-2.5 rounded-lg px-2.5 py-2 hover:bg-white dark:hover:bg-gray-900 transition"
-          :title="`New chat with ${a.name}`"
-          @click="$emit('new-chat-with-agent', a.name)"
-        >
-          <PortalAvatar :name="a.name" :avatar-url="a.avatar_url" :size="26" />
-          <span class="min-w-0 text-left">
-            <span class="block text-sm truncate">{{ a.name }}</span>
-            <span v-if="a.description" class="block text-xs text-gray-400 truncate">{{ a.description }}</span>
-          </span>
-        </button>
+        <!-- ============================ AGENTS ============================ -->
+        <!-- ent#359: its own surface, not just a labelled run of rows. An agent
+             is a destination now; a chat is a record of visiting one. Giving the
+             two the same visual weight is what made the old sidebar read as one
+             undifferentiated list. -->
+        <section class="mt-2 rounded-xl bg-white dark:bg-gray-900 ring-1 ring-gray-200 dark:ring-gray-800 p-1.5">
+          <div class="px-1.5 pt-1 pb-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Agents</div>
 
-        <!-- Unified, date-grouped history across all agents -->
-        <div v-for="g in grouped" :key="g.label" class="mt-3">
-          <div class="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">{{ g.label }}</div>
           <button
-            v-for="t in g.threads"
-            :key="t.id"
-            class="w-full flex items-center gap-2 rounded-lg px-2.5 py-2 text-left hover:bg-white dark:hover:bg-gray-900 transition"
-            :class="t.id === currentSessionId ? 'bg-white dark:bg-gray-900 ring-1 ring-gray-200 dark:ring-gray-800' : ''"
-            @click="$emit('open-thread', t)"
+            v-for="a in roster"
+            :key="a.name"
+            class="w-full flex items-center gap-2.5 rounded-lg px-2 py-2 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+            :title="agentRowTitle(a.name)"
+            @click="onAgentClick(a.name)"
           >
-            <PortalAvatar :name="t.agent_name" :avatar-url="avatarFor(t.agent_name)" :size="22" />
-            <span class="text-sm truncate flex-1">{{ threadTitle(t) }}</span>
+            <PortalAvatar :name="a.name" :avatar-url="a.avatar_url" :size="26" />
+            <span class="min-w-0 text-left flex-1">
+              <span class="block text-sm truncate">{{ a.name }}</span>
+              <span v-if="a.description" class="block text-xs text-gray-400 truncate">{{ a.description }}</span>
+            </span>
+            <span
+              v-if="waitingFor(a.name)"
+              class="shrink-0 min-w-[1.25rem] px-1.5 h-5 rounded-full bg-action-primary-600 text-white text-[11px] font-semibold flex items-center justify-center"
+            >{{ waitingFor(a.name) > 99 ? '99+' : waitingFor(a.name) }}</span>
           </button>
+
+          <!-- ent#357/#359 AC: an empty roster keeps a next action. Which one
+               depends on who is looking — a platform user can go make an agent,
+               an external client can only ask whoever invited them. -->
+          <div v-if="!roster.length" class="px-2 py-3 text-xs text-gray-500 dark:text-gray-400">
+            <template v-if="isPlatformSession">
+              No agents yet.
+              <a href="/" class="text-action-primary-600 hover:underline">Create one →</a>
+            </template>
+            <template v-else>
+              No agents shared with you yet — ask whoever invited you to share one.
+            </template>
+          </div>
+        </section>
+
+        <!-- ============================ CHATS ============================= -->
+        <!-- Starred first, and LIFTED OUT of the date groups below (a starred
+             chat appears exactly once — see partitionStarred). -->
+        <div v-if="starred.length" class="mt-3">
+          <div class="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Starred</div>
+          <ChatRow
+            v-for="t in starred"
+            :key="rowKey(t)"
+            :thread="t"
+            :active="isActive(t)"
+            :avatar-for="avatarFor"
+            @open="$emit('open-thread', t)"
+            @toggle-star="$emit('toggle-star', t)"
+          />
         </div>
 
-        <div v-if="!roster.length && !threads.length" class="px-2 py-8 text-center text-xs text-gray-400">
-          No agents shared with you yet.
+        <div v-for="g in grouped" :key="g.label" class="mt-3">
+          <div class="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">{{ g.label }}</div>
+          <ChatRow
+            v-for="t in g.threads"
+            :key="rowKey(t)"
+            :thread="t"
+            :active="isActive(t)"
+            :avatar-for="avatarFor"
+            @open="$emit('open-thread', t)"
+            @toggle-star="$emit('toggle-star', t)"
+          />
         </div>
       </template>
     </div>
@@ -114,21 +155,68 @@
 <script setup>
 import { computed } from 'vue'
 import PortalAvatar from './PortalAvatar.vue'
-import { groupThreadsByDate, threadTitle } from './portalUtils'
+import ChatRow from './PortalChatRow.vue'
+import {
+  groupThreadsByDate, partitionStarred, unreadByAgent, totalUnread,
+} from './portalUtils'
 
 const props = defineProps({
   roster: { type: Array, default: () => [] },
-  threads: { type: Array, default: () => [] },     // merged, agent-tagged
+  threads: { type: Array, default: () => [] },     // merged, agent-tagged, star/unread-tagged
   clientEmail: { type: String, default: '' },
   currentSessionId: { type: String, default: null },
+  currentRoomId: { type: String, default: null },
+  isPlatformSession: { type: Boolean, default: false },
   search: { type: String, default: '' },
   searching: { type: Boolean, default: false },
   searchResults: { type: Array, default: () => [] },
 })
-defineEmits(['new-chat', 'new-chat-with-agent', 'open-thread', 'update:search', 'sign-out'])
+const emit = defineEmits([
+  'new-chat', 'new-chat-with-agent', 'open-thread', 'toggle-star',
+  'update:search', 'sign-out',
+])
 
 const isSearching = computed(() => (props.search || '').trim().length >= 2)
-const grouped = computed(() => groupThreadsByDate(props.threads))
+
+const split = computed(() => partitionStarred(props.threads))
+const starred = computed(() => split.value.starred)
+const grouped = computed(() => groupThreadsByDate(split.value.rest))
+
+const waiting = computed(() => unreadByAgent(props.threads))
+const waitingFor = (name) => waiting.value[name] || 0
+const totalWaiting = computed(() => totalUnread(props.threads))
+
+// A row key has to include the kind: thread ids and room ids are independent
+// spaces, so two chats of different kinds could collide on a bare id.
+const rowKey = (t) => `${t.is_room ? 'room' : 'thread'}:${t.id || t.session_id}`
+const isActive = (t) => (t.is_room
+  ? t.id === props.currentRoomId
+  : (t.id || t.session_id) === props.currentSessionId)
+
+// ent#359: clicking an agent that is waiting on you opens the conversation it
+// is waiting in, rather than a blank one. A badge that says "2 replies" next to
+// a control that starts an empty chat is a contradiction — the count is the
+// reason you clicked. With nothing unread the row keeps its old behaviour.
+//
+// (Opening an agent's own PAGE is ent#360; this is not a substitute for it.)
+function latestUnreadFor(name) {
+  return props.threads.find((t) => {
+    if (!(Number(t?.unread) > 0)) return false
+    const names = Array.isArray(t.agent_names) && t.agent_names.length
+      ? t.agent_names : [t.agent_name]
+    return names.includes(name)
+  }) || null
+}
+function onAgentClick(name) {
+  const unread = latestUnreadFor(name)
+  if (unread) emit('open-thread', unread)
+  else emit('new-chat-with-agent', name)
+}
+function agentRowTitle(name) {
+  const n = waitingFor(name)
+  if (!n) return `New chat with ${name}`
+  return `${n} unread ${n === 1 ? 'reply' : 'replies'} — open the latest`
+}
 
 // ent#186: history + search rows show the conversation's agent avatar instead of
 // a bare color dot. The URL is resolved from the roster already loaded at sign-in

--- a/src/frontend/src/components/portal/PortalStarButton.vue
+++ b/src/frontend/src/components/portal/PortalStarButton.vue
@@ -7,7 +7,7 @@
       starred
         ? 'text-amber-500'
         : revealOnHover
-          ? 'text-gray-300 dark:text-gray-600 opacity-0 group-hover:opacity-100 focus:opacity-100 hover:text-amber-500'
+          ? 'text-gray-300 dark:text-gray-600 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 hover:text-amber-500'
           : 'text-gray-400 hover:text-amber-500',
     ]"
     :title="starred ? 'Unstar this chat' : 'Star this chat'"
@@ -39,6 +39,11 @@
  * outline star on every row is noise. It applies only when NOT starred — a star
  * that is set is state, and state that appears only on hover is state the user
  * cannot see.
+ *
+ * And it applies only from `sm:` up. There is no hover on a touch screen, so
+ * hiding the control behind one would have left mobile users able to UNstar
+ * (that star is always drawn) but never to star — the feature reachable in
+ * exactly one direction. Below `sm` the outline star is simply always visible.
  */
 defineProps({
   starred: { type: Boolean, default: false },

--- a/src/frontend/src/components/portal/PortalStarButton.vue
+++ b/src/frontend/src/components/portal/PortalStarButton.vue
@@ -1,0 +1,49 @@
+<template>
+  <button
+    type="button"
+    class="shrink-0 rounded transition"
+    :class="[
+      dense ? 'p-0.5' : 'p-2 hover:bg-gray-100 dark:hover:bg-gray-800',
+      starred
+        ? 'text-amber-500'
+        : revealOnHover
+          ? 'text-gray-300 dark:text-gray-600 opacity-0 group-hover:opacity-100 focus:opacity-100 hover:text-amber-500'
+          : 'text-gray-400 hover:text-amber-500',
+    ]"
+    :title="starred ? 'Unstar this chat' : 'Star this chat'"
+    :aria-label="starred ? 'Unstar this chat' : 'Star this chat'"
+    :aria-pressed="starred"
+    @click.stop="$emit('toggle')"
+  >
+    <svg
+      :class="dense ? 'w-4 h-4' : 'w-5 h-5'"
+      :fill="starred ? 'currentColor' : 'none'"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M11.48 3.5a.56.56 0 011.04 0l2.13 4.82 5.24.53c.48.05.67.65.31.97l-3.94 3.5 1.12 5.16c.1.47-.4.84-.82.6L12 16.5l-4.56 2.58c-.42.24-.92-.13-.82-.6l1.12-5.16-3.94-3.5c-.36-.32-.17-.92.31-.97l5.24-.53 2.13-4.82z" />
+    </svg>
+  </button>
+</template>
+
+<script setup>
+/**
+ * The star toggle (ent#359) — one component for its three homes: the sidebar
+ * row, the 1:1 chat header, and the room header.
+ *
+ * AC #4 asks for star/unstar from BOTH the header and the row, which is exactly
+ * the setup where an inline copy per site drifts: three icons, three hover
+ * rules, three `aria-pressed` states to keep honest.
+ *
+ * `revealOnHover` is for the dense sidebar row, where a permanently visible
+ * outline star on every row is noise. It applies only when NOT starred — a star
+ * that is set is state, and state that appears only on hover is state the user
+ * cannot see.
+ */
+defineProps({
+  starred: { type: Boolean, default: false },
+  dense: { type: Boolean, default: false },
+  revealOnHover: { type: Boolean, default: false },
+})
+defineEmits(['toggle'])
+</script>

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -70,6 +70,19 @@ export function totalUnread(threads) {
     .reduce((sum, t) => sum + (Number(t?.unread) || 0), 0)
 }
 
+// ent#359: whether a turn that just finished should clear its unread badge.
+//
+// Only when the user is still looking at that thread. The conversation's send
+// is an async closure that outlives its component, so the "turn done" event
+// fires even after the user navigated away mid-turn — which is the main way a
+// reply legitimately arrives unseen. Marking read unconditionally cleared
+// exactly the badge the feature exists to show, making it near-unreachable in
+// normal use (open a chat, and it is marked read; stay, and it is marked read;
+// leave, and it was marked read anyway).
+export function shouldMarkTurnRead(completedSessionId, openSessionId) {
+  return !!completedSessionId && completedSessionId === openSessionId
+}
+
 // Normalise a room onto the thread shape the sidebar renders, so one list
 // component handles both kinds.
 //

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -70,6 +70,30 @@ export function totalUnread(threads) {
     .reduce((sum, t) => sum + (Number(t?.unread) || 0), 0)
 }
 
+// Normalise a room onto the thread shape the sidebar renders, so one list
+// component handles both kinds.
+//
+// The `agents` / `participants` split is the interesting part, and it shipped
+// wrong once: the rooms LIST returns `agents` (identities of the agent
+// participants still in the room), while `participants` — objects with
+// `kind`/`identity` — is the DETAIL shape. Reading only the detail shape here
+// produced an empty list for EVERY room, so a room row drew no avatars at all,
+// and the unit test did not catch it because it mocked the response with the
+// field production does not send. Both shapes are accepted, and both are
+// pinned in portalSidebarIA.spec.js.
+export function normalizeRoomRow(r) {
+  const fromList = Array.isArray(r?.agents) ? r.agents : null
+  const fromDetail = (r?.participants || [])
+    .filter((p) => p && p.kind === 'agent')
+    .map((p) => p.identity)
+  return {
+    ...r,
+    title: r?.name,
+    last_message_at: r?.last_message_at || r?.created_at,
+    agent_names: fromList && fromList.length ? fromList : fromDetail,
+  }
+}
+
 // The avatars to show on one chat row: every participant for a room, the single
 // agent for a thread. Capped — a room with eight agents must not push the title
 // out of the row.

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -33,6 +33,55 @@ export function groupThreadsByDate(threads) {
     .filter((g) => g.threads.length)
 }
 
+// ent#359: starred chats are LIFTED OUT of the date groups, not merely copied
+// above them. Showing a chat twice — once pinned, once in "Today" — makes the
+// list lie about how many conversations there are, and clicking either row goes
+// to the same place, so the duplicate carries no information.
+export function partitionStarred(threads) {
+  const list = Array.isArray(threads) ? threads : []
+  return {
+    starred: list.filter((t) => t && t.starred),
+    rest: list.filter((t) => !(t && t.starred)),
+  }
+}
+
+// ent#359: per-agent "waiting on you" counts for the agents block, summed from
+// the unread counts already attached to each chat.
+//
+// A room contributes to every agent in it, because there is no single agent the
+// conversation is "with" — if three agents are in a room you are behind on, all
+// three rows should say so. Rooms report `unread: 0` today (the backend counts
+// threads only), so this is the shape being right ahead of the data.
+export function unreadByAgent(threads) {
+  const out = {}
+  for (const t of Array.isArray(threads) ? threads : []) {
+    const n = Number(t?.unread) || 0
+    if (n <= 0) continue
+    const names = Array.isArray(t.agent_names) && t.agent_names.length
+      ? t.agent_names
+      : (t.agent_name ? [t.agent_name] : [])
+    for (const name of names) out[name] = (out[name] || 0) + n
+  }
+  return out
+}
+
+export function totalUnread(threads) {
+  return (Array.isArray(threads) ? threads : [])
+    .reduce((sum, t) => sum + (Number(t?.unread) || 0), 0)
+}
+
+// The avatars to show on one chat row: every participant for a room, the single
+// agent for a thread. Capped — a room with eight agents must not push the title
+// out of the row.
+export const ROW_AVATAR_LIMIT = 3
+
+export function rowAgents(t, limit = ROW_AVATAR_LIMIT) {
+  const names = Array.isArray(t?.agent_names) && t.agent_names.length
+    ? t.agent_names
+    : (t?.agent_name ? [t.agent_name] : [])
+  return { shown: names.slice(0, limit), overflow: Math.max(0, names.length - limit) }
+}
+
 export function shortDate(iso) {
   try { return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) }
   catch { return '' }

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -8,6 +8,7 @@
  * ent#356 moved the module into OSS core, so it ships in every build.
  */
 import { defineStore } from 'pinia'
+import { normalizeRoomRow } from '@/components/portal/portalUtils'
 import axios from 'axios'
 import { useAuthStore } from './auth'
 
@@ -437,16 +438,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
       let rooms = []
       try { rooms = await this.fetchRooms() } catch { rooms = [] }
 
-      const merged = lists.flat().concat(rooms.map((r) => ({
-        ...r,
-        // Normalised onto the thread shape the sidebar already renders, so one
-        // list component handles both kinds.
-        title: r.name,
-        last_message_at: r.last_message_at || r.created_at,
-        agent_names: (r.participants || [])
-          .filter((p) => p.kind === 'agent')
-          .map((p) => p.identity),
-      })))
+      const merged = lists.flat().concat(rooms.map(normalizeRoomRow))
       merged.sort((x, y) => {
         const tx = x.last_message_at || x.created_at || ''
         const ty = y.last_message_at || y.created_at || ''

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -241,6 +241,44 @@ export const useClientPortalStore = defineStore('clientPortal', {
       return (data.rooms || []).map((r) => ({ ...r, is_room: true }))
     },
 
+    // ent#359 — per-viewer star + unread state, for BOTH chat kinds in one call.
+    // Threads and rooms come from different endpoints (and different repos) but
+    // sort into a single sidebar list, so their view state has to arrive
+    // together or the list would reshuffle as the second response landed.
+    //
+    // Keyed `${kind}:${id}`: the two id spaces are independent, so an id alone
+    // is not a key.
+    async fetchChatState() {
+      const { data } = await axios.get('/api/enterprise/client-portal/chat-state', {
+        headers: this.authHeader,
+      })
+      const out = {}
+      for (const c of data.chats || []) {
+        if (c && c.kind && c.id) out[`${c.kind}:${c.id}`] = c
+      }
+      return out
+    },
+
+    async setChatStar(kind, chatId, starred) {
+      const url = `/api/enterprise/client-portal/chat-state/${kind}/${encodeURIComponent(chatId)}/star`
+      const cfg = { headers: this.authHeader }
+      if (starred) await axios.put(url, null, cfg)
+      else await axios.delete(url, cfg)
+    },
+
+    // Fire-and-forget by design: a failed read marker leaves a stale badge,
+    // which is not worth interrupting navigation over, and the next state fetch
+    // corrects it.
+    async markChatRead(kind, chatId) {
+      try {
+        await axios.post(
+          `/api/enterprise/client-portal/chat-state/${kind}/${encodeURIComponent(chatId)}/read`,
+          null,
+          { headers: this.authHeader },
+        )
+      } catch { /* stale badge only */ }
+    },
+
     // `since` is the seq cursor: 0 loads the whole transcript, a later value
     // fetches only what the client has not seen.
     async fetchRoom(roomId, since = 0) {

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -65,12 +65,15 @@
           :threads="threads"
           :client-email="store.clientEmail"
           :current-session-id="activeSessionId"
+          :current-room-id="activeRoomIdFromRoute"
+          :is-platform-session="store.isPlatformSession"
           v-model:search="search"
           :searching="searching"
           :search-results="searchResults"
           @new-chat="newChat"
           @new-chat-with-agent="newChatWithAgent"
           @open-thread="openThread"
+          @toggle-star="toggleStar"
           @sign-out="onSignOut"
         />
       </div>
@@ -82,12 +85,15 @@
             :threads="threads"
             :client-email="store.clientEmail"
             :current-session-id="activeSessionId"
+            :current-room-id="activeRoomIdFromRoute"
+            :is-platform-session="store.isPlatformSession"
             v-model:search="search"
             :searching="searching"
             :search-results="searchResults"
             @new-chat="() => { mobileNav = false; newChat() }"
             @new-chat-with-agent="(n) => { mobileNav = false; newChatWithAgent(n) }"
             @open-thread="(t) => { mobileNav = false; openThread(t) }"
+            @toggle-star="toggleStar"
             @sign-out="onSignOut"
           />
         </div>
@@ -103,8 +109,10 @@
           :key="activeRoomIdFromRoute"
           :room-id="activeRoomIdFromRoute"
           :roster="store.agents"
+          :starred="isStarred('room', activeRoomIdFromRoute)"
           @open-menu="mobileNav = true"
           @rooms-changed="refreshThreads"
+          @toggle-star="toggleStar"
         />
 
         <PortalConversation
@@ -114,11 +122,13 @@
           :roster="store.agents"
           :session-id="pendingSession"
           :prefill="prefill"
+          :starred="isStarred('thread', activeSessionId || pendingSession)"
           @switch-agent="switchAgent"
           @session-adopted="onSessionAdopted"
-          @sessions-changed="refreshThreads"
+          @sessions-changed="onConversationTurnDone"
           @open-files="filesOpen = true"
           @open-menu="mobileNav = true"
+          @toggle-star="toggleStar"
         >
           <template #empty>
             <PortalBriefing :agent="activeAgent" @use-playbook="usePlaybook" />
@@ -330,6 +340,7 @@ const pickerError = ref(null)
 function openRoom(roomId) {
   if (!roomId) return
   unreachableAgent.value = null
+  markRead('room', roomId)
   activeRoomId.value = roomId
   pendingSession.value = null
   convGen.value++
@@ -347,6 +358,7 @@ function openThread(t) {
   // ent#361: a room row in the merged sidebar opens the room, not a thread.
   if (t.is_room) { openRoom(t.id); return }
   const sid = t.id || t.session_id
+  markRead('thread', sid)
   activeAgentName.value = t.agent_name || activeAgentName.value
   pendingSession.value = sid; prefill.value = ''; convGen.value++
   search.value = ''
@@ -355,12 +367,82 @@ function openThread(t) {
 function onSessionAdopted(id) {
   pendingSession.value = id
   if (route.params.sessionId !== id) router.replace(`/workspace/c/${id}`)
+  // A thread you are actively talking in is by definition read. This is also
+  // what gives a brand-new thread its read cursor, so the very next reply the
+  // user does NOT see is the first thing that badges.
+  markRead('thread', id)
   refreshThreads()
 }
 function usePlaybook(text) { prefill.value = ''; nextTick(() => { prefill.value = text }) }
 
+// ent#359 — per-viewer star + unread state, merged onto the thread list.
+//
+// Kept out of `fetchAllSessions` on purpose: that call fans out over the roster
+// and degrades per agent, while this is one call for the whole viewer. Merging
+// here means a chat-state failure costs the stars and badges, never the list.
+const chatState = ref({})
+const chatKey = (t) => `${t.is_room ? 'room' : 'thread'}:${t.id || t.session_id}`
+
+const isStarred = (kind, id) => !!(id && chatState.value[`${kind}:${id}`]?.starred)
+
+function decorate(list) {
+  return list.map((t) => {
+    const s = chatState.value[chatKey(t)]
+    return { ...t, starred: !!s?.starred, unread: Number(s?.unread) || 0 }
+  })
+}
+
 async function refreshThreads() {
-  threads.value = await store.fetchAllSessions()
+  const [list, state] = await Promise.all([
+    store.fetchAllSessions(),
+    store.fetchChatState().catch(() => chatState.value),
+  ])
+  chatState.value = state || {}
+  threads.value = decorate(list)
+}
+
+// A turn finishing in the conversation the user is LOOKING AT is read by
+// definition. Without this, the reply the user just watched arrive would land
+// after the read cursor set at dispatch and badge the chat they are sitting in
+// — a notification for something they are actively reading.
+function onConversationTurnDone() {
+  markRead('thread', activeSessionId.value || pendingSession.value)
+  return refreshThreads()
+}
+
+// Optimistic: a star is a personal bookmark, and waiting on a round trip to
+// redraw it makes the control feel broken. Reverted in place on failure so the
+// list never claims a star the server rejected.
+async function toggleStar(t) {
+  const key = chatKey(t)
+  const next = !t.starred
+  const before = chatState.value[key]
+  chatState.value = {
+    ...chatState.value,
+    [key]: { ...(before || { kind: t.is_room ? 'room' : 'thread', id: t.id }), starred: next },
+  }
+  threads.value = decorate(threads.value)
+  try {
+    await store.setChatStar(t.is_room ? 'room' : 'thread', t.id || t.session_id, next)
+  } catch {
+    const reverted = { ...chatState.value }
+    if (before) reverted[key] = before
+    else delete reverted[key]
+    chatState.value = reverted
+    threads.value = decorate(threads.value)
+  }
+}
+
+// Opening a chat is what "reading" it means here. Clear the badge locally first
+// so the count does not linger for a round trip, then persist.
+function markRead(kind, id) {
+  if (!id) return
+  const key = `${kind}:${id}`
+  if (chatState.value[key]?.unread) {
+    chatState.value = { ...chatState.value, [key]: { ...chatState.value[key], unread: 0 } }
+    threads.value = decorate(threads.value)
+  }
+  store.markChatRead(kind, id)
 }
 
 // ---- Cross-chat search (sidebar) ----------------------------------------------

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -212,7 +212,7 @@ import PortalFilesPanel from '@/components/portal/PortalFilesPanel.vue'
 import PortalCodeInput from '@/components/portal/PortalCodeInput.vue'
 import PortalAgentPicker from '@/components/portal/PortalAgentPicker.vue'
 import PortalRoom from '@/components/portal/PortalRoom.vue'
-import { resolveAgentLanding } from '@/components/portal/portalUtils'
+import { resolveAgentLanding, shouldMarkTurnRead } from '@/components/portal/portalUtils'
 
 const store = useClientPortalStore()
 const route = useRoute()
@@ -405,8 +405,14 @@ async function refreshThreads() {
 // definition. Without this, the reply the user just watched arrive would land
 // after the read cursor set at dispatch and badge the chat they are sitting in
 // — a notification for something they are actively reading.
-function onConversationTurnDone() {
-  markRead('thread', activeSessionId.value || pendingSession.value)
+function onConversationTurnDone(sessionId) {
+  // Only if the user is STILL in that thread. The conversation's send is an
+  // async closure that outlives the component, so this fires even when they
+  // have navigated away mid-turn — which is the main way a reply legitimately
+  // arrives unseen. Marking read unconditionally cleared exactly the badge the
+  // feature exists to show, and made it near-unreachable in normal use.
+  const open = activeSessionId.value || pendingSession.value
+  if (shouldMarkTurnRead(sessionId, open)) markRead('thread', sessionId)
   return refreshThreads()
 }
 

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -257,6 +257,10 @@ const activeAgentName = ref(null)
 // ent#361: the room a multi-agent chat is being held in, if any.
 const activeRoomId = ref(null)
 // The agent a deep link named that this caller cannot reach (ent#358 review).
+// Set when a deep link names an agent this caller cannot reach. Cleared by
+// every navigation away from it — `activeAgent` returns null while it is set,
+// so a latch that never clears leaves the whole Workspace stuck on the
+// access-denied panel for the rest of the SPA session.
 const unreachableAgent = ref(null)
 const pendingSession = ref(null)      // session to load when the conversation (re)mounts
 const prefill = ref('')
@@ -289,6 +293,7 @@ function newChat() {
 }
 
 function startBlankChat() {
+  unreachableAgent.value = null
   pendingSession.value = null; prefill.value = ''; convGen.value++
   if (route.params.sessionId) router.push('/workspace')
 }
@@ -324,18 +329,21 @@ const pickerError = ref(null)
 
 function openRoom(roomId) {
   if (!roomId) return
+  unreachableAgent.value = null
   activeRoomId.value = roomId
   pendingSession.value = null
   convGen.value++
   router.push(`/workspace/r/${roomId}`)
 }
 function newChatWithAgent(name) {
+  unreachableAgent.value = null
   activeAgentName.value = name
   pendingSession.value = null; prefill.value = ''; convGen.value++
   if (route.params.sessionId) router.push('/workspace')
 }
 function switchAgent(name) { newChatWithAgent(name) }   // mid-thread = plain new chat, no carry-over
 function openThread(t) {
+  unreachableAgent.value = null
   // ent#361: a room row in the merged sidebar opens the room, not a thread.
   if (t.is_room) { openRoom(t.id); return }
   const sid = t.id || t.session_id

--- a/src/frontend/tests/unit/portalSidebarIA.spec.js
+++ b/src/frontend/tests/unit/portalSidebarIA.spec.js
@@ -1,0 +1,103 @@
+/**
+ * Workspace sidebar IA — starred chats, per-agent badges, participant avatars
+ * (ent#359).
+ *
+ * These are the pure functions behind the restructured sidebar, tested without
+ * mounting it. The behaviours worth pinning are the ones where the "obvious"
+ * implementation is subtly wrong:
+ *
+ *   * starred chats are LIFTED OUT of the date groups, not copied above them
+ *     (copying makes the list lie about how many conversations exist), and
+ *   * a room contributes its unread to EVERY agent in it, because there is no
+ *     single agent the conversation is "with".
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  partitionStarred, unreadByAgent, totalUnread, rowAgents, groupThreadsByDate,
+} from '../../src/components/portal/portalUtils'
+
+const iso = (d) => new Date(d).toISOString()
+const today = iso(Date.now())
+const longAgo = iso(Date.now() - 30 * 86400000)
+
+describe('starred chats', () => {
+  it('lifts a starred chat out of its date group so it appears exactly once', () => {
+    const threads = [
+      { id: 'a', starred: true, last_message_at: today },
+      { id: 'b', starred: false, last_message_at: today },
+    ]
+    const { starred, rest } = partitionStarred(threads)
+    const grouped = groupThreadsByDate(rest)
+    const idsInGroups = grouped.flatMap((g) => g.threads.map((t) => t.id))
+
+    expect(starred.map((t) => t.id)).toEqual(['a'])
+    expect(idsInGroups).toEqual(['b'])
+    // The whole point: 'a' is in the starred section and NOWHERE else.
+    expect(idsInGroups).not.toContain('a')
+  })
+
+  it('keeps starred chats out of every group regardless of age', () => {
+    const { rest } = partitionStarred([{ id: 'old', starred: true, last_message_at: longAgo }])
+    expect(groupThreadsByDate(rest)).toEqual([])
+  })
+
+  it('tolerates a missing/!array thread list rather than throwing at render', () => {
+    expect(partitionStarred(undefined)).toEqual({ starred: [], rest: [] })
+  })
+})
+
+describe('per-agent "waiting on you" counts', () => {
+  it('sums a thread’s unread onto its agent', () => {
+    expect(unreadByAgent([
+      { agent_name: 'scribe', unread: 2 },
+      { agent_name: 'scribe', unread: 1 },
+      { agent_name: 'recon', unread: 3 },
+    ])).toEqual({ scribe: 3, recon: 3 })
+  })
+
+  it('credits a room’s unread to every agent in it', () => {
+    // If three agents share a room you are behind on, all three rows should say
+    // so — there is no one agent the room is "with".
+    expect(unreadByAgent([
+      { is_room: true, agent_names: ['scribe', 'recon'], unread: 2 },
+    ])).toEqual({ scribe: 2, recon: 2 })
+  })
+
+  it('ignores chats with nothing unread', () => {
+    expect(unreadByAgent([
+      { agent_name: 'scribe', unread: 0 },
+      { agent_name: 'recon' },
+    ])).toEqual({})
+  })
+
+  it('totals across every chat for the wordmark badge', () => {
+    expect(totalUnread([
+      { unread: 2 }, { unread: 0 }, { unread: 5 }, {},
+    ])).toBe(7)
+  })
+})
+
+describe('row avatars', () => {
+  it('shows one avatar for a 1:1', () => {
+    expect(rowAgents({ agent_name: 'scribe' })).toEqual({ shown: ['scribe'], overflow: 0 })
+  })
+
+  it('shows every participant of a small room', () => {
+    expect(rowAgents({ agent_names: ['a', 'b'] })).toEqual({ shown: ['a', 'b'], overflow: 0 })
+  })
+
+  it('caps a crowded room and reports the remainder', () => {
+    // A room with eight agents must not push the title out of the row.
+    expect(rowAgents({ agent_names: ['a', 'b', 'c', 'd', 'e'] }))
+      .toEqual({ shown: ['a', 'b', 'c'], overflow: 2 })
+  })
+
+  it('prefers agent_names when both are present (a room carries both)', () => {
+    expect(rowAgents({ agent_name: 'ignored', agent_names: ['a', 'b'] }).shown)
+      .toEqual(['a', 'b'])
+  })
+
+  it('returns nothing rather than [undefined] for a chat with no agent', () => {
+    expect(rowAgents({})).toEqual({ shown: [], overflow: 0 })
+  })
+})

--- a/src/frontend/tests/unit/portalSidebarIA.spec.js
+++ b/src/frontend/tests/unit/portalSidebarIA.spec.js
@@ -14,6 +14,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   partitionStarred, unreadByAgent, totalUnread, rowAgents, groupThreadsByDate,
+  normalizeRoomRow,
 } from '../../src/components/portal/portalUtils'
 
 const iso = (d) => new Date(d).toISOString()
@@ -74,6 +75,44 @@ describe('per-agent "waiting on you" counts', () => {
     expect(totalUnread([
       { unread: 2 }, { unread: 0 }, { unread: 5 }, {},
     ])).toBe(7)
+  })
+})
+
+describe('normalising a room onto the thread shape', () => {
+  // This shipped wrong once and no test caught it, because the test mocked the
+  // response with the field production does not send. `GET /api/rooms` returns
+  // `agents`; `participants` is the DETAIL shape from `GET /api/rooms/{id}`.
+  it('reads agent identities from the LIST shape (`agents`)', () => {
+    expect(normalizeRoomRow({ id: 'r1', name: 'QA', agents: ['a', 'b'] }).agent_names)
+      .toEqual(['a', 'b'])
+  })
+
+  it('still reads the DETAIL shape (`participants`)', () => {
+    expect(normalizeRoomRow({
+      id: 'r1',
+      participants: [
+        { kind: 'agent', identity: 'a' },
+        { kind: 'user', identity: 'me@example.com' },
+        { kind: 'agent', identity: 'b' },
+      ],
+    }).agent_names).toEqual(['a', 'b'])
+  })
+
+  it('gives a room with neither shape an empty list, not undefined', () => {
+    expect(normalizeRoomRow({ id: 'r1' }).agent_names).toEqual([])
+  })
+
+  it('maps name → title and falls back to created_at for sorting', () => {
+    const row = normalizeRoomRow({ id: 'r1', name: 'QA', created_at: '2026-01-01T00:00:00Z' })
+    expect(row.title).toBe('QA')
+    expect(row.last_message_at).toBe('2026-01-01T00:00:00Z')
+  })
+
+  it('prefers a real last_message_at over created_at', () => {
+    const row = normalizeRoomRow({
+      id: 'r1', created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-02-02T00:00:00Z',
+    })
+    expect(row.last_message_at).toBe('2026-02-02T00:00:00Z')
   })
 })
 

--- a/src/frontend/tests/unit/portalSidebarIA.spec.js
+++ b/src/frontend/tests/unit/portalSidebarIA.spec.js
@@ -14,7 +14,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   partitionStarred, unreadByAgent, totalUnread, rowAgents, groupThreadsByDate,
-  normalizeRoomRow,
+  normalizeRoomRow, shouldMarkTurnRead,
 } from '../../src/components/portal/portalUtils'
 
 const iso = (d) => new Date(d).toISOString()
@@ -113,6 +113,30 @@ describe('normalising a room onto the thread shape', () => {
       id: 'r1', created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-02-02T00:00:00Z',
     })
     expect(row.last_message_at).toBe('2026-02-02T00:00:00Z')
+  })
+})
+
+describe('clearing a badge when a turn finishes', () => {
+  // The gate that makes the badge reachable at all. Without it the feature was
+  // near-dead: open a chat and it is marked read; stay in it and it is marked
+  // read; navigate away mid-turn and it was STILL marked read, because the
+  // send is an async closure that outlives the component and fired the same
+  // event either way.
+  it('clears it when the user is still in that thread', () => {
+    expect(shouldMarkTurnRead('t1', 't1')).toBe(true)
+  })
+
+  it('leaves it when the user moved to another chat mid-turn', () => {
+    expect(shouldMarkTurnRead('t1', 't2')).toBe(false)
+  })
+
+  it('leaves it when the user moved to a blank new chat', () => {
+    expect(shouldMarkTurnRead('t1', null)).toBe(false)
+  })
+
+  it('is false for a turn with no thread id rather than matching a null open one', () => {
+    expect(shouldMarkTurnRead(null, null)).toBe(false)
+    expect(shouldMarkTurnRead(undefined, undefined)).toBe(false)
   })
 })
 

--- a/src/frontend/tests/unit/portalUndefinedCalls.spec.js
+++ b/src/frontend/tests/unit/portalUndefinedCalls.spec.js
@@ -1,0 +1,111 @@
+/**
+ * Every function called in the portal SFCs must actually exist.
+ *
+ * A block-level edit to PortalConversation.vue deleted `markFailed` while both
+ * of its call sites remained. `vite build` compiles that happily — it is a
+ * runtime `ReferenceError` — and there is no ESLint in this project, so the
+ * whole test suite and CI went green while EVERY failed send in the Workspace
+ * threw and rendered no error and no Retry. That is the second time the same
+ * user-visible bug shipped, so it gets a guard rather than another fix.
+ *
+ * Deliberately narrow: it checks the `<script setup>` block of the portal
+ * components for calls to bare identifiers that are neither defined there nor
+ * imported. It is not a type checker and does not try to be — it catches
+ * exactly the "called something that isn't there" class.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const portalDir = join(here, '../../src/components/portal')
+const viewsDir = join(here, '../../src/views')
+
+// Language, DOM and framework names a component may call without defining.
+const AMBIENT = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'return', 'typeof', 'await', 'new',
+  'function', 'super', 'this', 'Array', 'Object', 'String', 'Number', 'Boolean',
+  'Math', 'JSON', 'Date', 'Promise', 'Error', 'Set', 'Map', 'RegExp', 'BigInt',
+  'parseInt', 'parseFloat', 'isNaN', 'encodeURIComponent', 'decodeURIComponent',
+  'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'requestAnimationFrame',
+  'fetch', 'console', 'window', 'document', 'navigator', 'localStorage', 'alert',
+  'FormData', 'File', 'Blob', 'FileReader', 'URL', 'TextDecoder', 'AbortController',
+  'defineProps', 'defineEmits', 'defineExpose', 'withDefaults', 'MediaRecorder',
+  'SpeechRecognition', 'webkitSpeechRecognition', 'Audio', 'CustomEvent', 'Event',
+  // Keywords that precede a parenthesised list rather than call anything.
+  'async', 'else', 'do', 'try',
+])
+
+function scriptOf(source) {
+  const m = source.match(/<script setup[^>]*>([\s\S]*?)<\/script>/)
+  if (!m) return ''
+  // Strip comments and string/template literals first: prose like "a chat (…)"
+  // in a comment otherwise reads as a call to `chat`.
+  return m[1]
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+    .replace(/`(?:\\.|\$\{[^}]*\}|[^`\\])*`/g, '``')
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+}
+
+function definedNames(script) {
+  const names = new Set()
+  for (const re of [
+    /\bfunction\s+([A-Za-z_$][\w$]*)/g,
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)/g,
+    /\b(?:const|let|var)\s*\{([^}]*)\}/g,     // destructured
+    /import\s+([A-Za-z_$][\w$]*)\s+from/g,
+    /import\s*\{([^}]*)\}\s*from/g,
+    // `const x = (…) => …` is caught above, but a plain reassignment or a
+    // template-only helper defined as an expression needs this.
+    /\b([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(/g,
+  ]) {
+    let m
+    while ((m = re.exec(script))) {
+      for (const part of m[1].split(',')) {
+        // `a as b` binds b; `{ a: b }` binds b; `x = 1` binds x.
+        const name = part
+          .split(/\bas\b/).pop()
+          .split(':').pop()
+          .split('=')[0]
+          .trim()
+          .replace(/^\.\.\./, '')
+        if (name) names.add(name)
+      }
+    }
+  }
+  return names
+}
+
+function calledNames(script) {
+  const names = new Set()
+  // A bare `name(` not preceded by `.`, and not a declaration site.
+  const re = /(^|[^\w$.])([a-z_$][\w$]*)\s*\(/g
+  let m
+  while ((m = re.exec(script))) names.add(m[2])
+  return names
+}
+
+function sfcFiles() {
+  const files = readdirSync(portalDir)
+    .filter((f) => f.endsWith('.vue'))
+    .map((f) => ['components/portal/' + f, join(portalDir, f)])
+  files.push(['views/Portal.vue', join(viewsDir, 'Portal.vue')])
+  return files
+}
+
+describe('portal components call only functions that exist', () => {
+  for (const [label, path] of sfcFiles()) {
+    it(`${label} has no calls to undefined identifiers`, () => {
+      const script = scriptOf(readFileSync(path, 'utf8'))
+      if (!script) return
+      const defined = definedNames(script)
+      const missing = [...calledNames(script)].filter(
+        (n) => !defined.has(n) && !AMBIENT.has(n)
+      )
+      expect(missing, `${label} calls undefined: ${missing.join(', ')}`).toEqual([])
+    })
+  }
+})

--- a/tests/unit/test_ent359_portal_chat_state.py
+++ b/tests/unit/test_ent359_portal_chat_state.py
@@ -1,0 +1,283 @@
+"""Per-viewer star + unread state for the Workspace sidebar (ent#359).
+
+The sidebar gains two things that are only meaningful relative to *who is
+looking*: starred chats pinned above the date groups, and a per-agent "waiting
+on you" badge. Everything worth testing here follows from that one word.
+
+Three properties, in order of how badly they fail:
+
+  * **Isolation.** A star is one person's bookmark and a room is shared between
+    several people. If this state were reachable across users — or had been
+    stored on the room row, which is the obvious-looking design — one
+    participant's star would appear in every other participant's sidebar, and
+    one client would learn which chats another client keeps.
+
+  * **The unread definition.** "Unread" is relative to a read cursor. A thread
+    with no cursor must report NOTHING rather than reporting its whole history,
+    or the day this shipped every historical conversation in every install would
+    have lit up with a badge — noise that trains people to ignore the badge,
+    which is worse than not having one.
+
+  * **The row cap.** Neither writer verifies the chat exists, deliberately: a
+    404 for an unknown id would turn `star` into an existence oracle over every
+    chat id in the install (OSS invariant #8). The cap is what stands in for
+    that validation, so it has to bound NEW rows without freezing the ones a
+    user legitimately owns.
+
+Runs against a throwaway sqlite carrying the real tables, so the unread SQL —
+the join and the `created_at > last_read_at` predicate — is the code under test
+rather than a mock of it.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ALICE = "alice@example.com"
+BOB = "bob@example.com"
+NOW = "2026-08-12T10:00:00Z"
+
+
+@pytest.fixture()
+def chat_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "trinity-chat-state.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+
+    from db.engine import get_engine
+    from db.tables import (
+        metadata as oss_metadata,
+        enterprise_portal_chat_state,
+        enterprise_portal_messages,
+        enterprise_portal_sessions,
+    )
+    oss_metadata.create_all(get_engine(), tables=[
+        enterprise_portal_chat_state,
+        enterprise_portal_messages,
+        enterprise_portal_sessions,
+    ])
+    yield get_engine()
+
+
+def _msg(engine, *, session_id, email, role, at, agent="scribe"):
+    from db.tables import enterprise_portal_messages as m
+    import uuid
+    with engine.begin() as conn:
+        conn.execute(m.insert().values(
+            id=uuid.uuid4().hex, agent_name=agent, client_email=email.lower(),
+            session_id=session_id, role=role, content="hi", cost=None, created_at=at,
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Isolation — the property that a column on the chat row could not have given us
+# ---------------------------------------------------------------------------
+
+def test_a_star_is_visible_only_to_the_person_who_set_it(chat_db):
+    """The reason this is a separate table and not a `starred` column.
+
+    A room is shared. Had the star lived on the room row, Alice starring a room
+    would have pinned it in Bob's sidebar too — and told him she cares about it.
+    """
+    from client_portal import db as pdb
+
+    pdb.set_chat_star(ALICE, "room", "room-1", True, NOW)
+
+    assert [c["chat_id"] for c in pdb.get_chat_state(ALICE)] == ["room-1"]
+    assert pdb.get_chat_state(BOB) == []
+
+
+def test_state_is_keyed_by_kind_so_the_two_id_spaces_cannot_collide(chat_db):
+    """Thread ids and room ids are independent. Starring thread `x` must not
+    star room `x`."""
+    from client_portal import db as pdb
+
+    pdb.set_chat_star(ALICE, "thread", "x", True, NOW)
+    rows = {(r["chat_kind"], r["chat_id"]): r for r in pdb.get_chat_state(ALICE)}
+
+    assert ("thread", "x") in rows
+    assert ("room", "x") not in rows
+
+
+def test_email_case_does_not_fork_a_users_state(chat_db):
+    """Sign-in normalises to lower-case, but a caller reaching the service with
+    the address as typed must not get a second, empty set of stars."""
+    from client_portal import db as pdb
+
+    pdb.set_chat_star("Alice@Example.com", "thread", "t1", True, NOW)
+    assert [c["chat_id"] for c in pdb.get_chat_state(ALICE)] == ["t1"]
+
+
+# ---------------------------------------------------------------------------
+# Unread — defined relative to a cursor, and only relative to a cursor
+# ---------------------------------------------------------------------------
+
+def test_a_thread_with_no_read_cursor_reports_nothing_unread(chat_db):
+    """The alternative — treating "never read" as "all unread" — would have
+    badged every historical conversation on the day this shipped."""
+    from client_portal import db as pdb
+
+    _msg(chat_db, session_id="t1", email=ALICE, role="assistant", at="2026-08-12T09:00:00Z")
+
+    assert pdb.count_unread_by_session(ALICE) == {}
+
+
+def test_only_agent_messages_after_the_cursor_count(chat_db):
+    from client_portal import db as pdb
+
+    _msg(chat_db, session_id="t1", email=ALICE, role="assistant", at="2026-08-12T09:00:00Z")
+    pdb.mark_chat_read(ALICE, "thread", "t1", "2026-08-12T09:30:00Z")
+    _msg(chat_db, session_id="t1", email=ALICE, role="assistant", at="2026-08-12T09:40:00Z")
+    _msg(chat_db, session_id="t1", email=ALICE, role="assistant", at="2026-08-12T09:50:00Z")
+
+    assert pdb.count_unread_by_session(ALICE) == {"t1": 2}
+
+
+def test_the_users_own_messages_are_never_unread(chat_db):
+    """Sending marks the thread read, so a user's own turn arriving "after the
+    cursor" must not badge the chat they are sitting in."""
+    from client_portal import db as pdb
+
+    pdb.mark_chat_read(ALICE, "thread", "t1", "2026-08-12T09:00:00Z")
+    _msg(chat_db, session_id="t1", email=ALICE, role="user", at="2026-08-12T09:10:00Z")
+
+    assert pdb.count_unread_by_session(ALICE) == {}
+
+
+def test_reading_again_clears_the_count(chat_db):
+    from client_portal import db as pdb
+
+    pdb.mark_chat_read(ALICE, "thread", "t1", "2026-08-12T09:00:00Z")
+    _msg(chat_db, session_id="t1", email=ALICE, role="assistant", at="2026-08-12T09:10:00Z")
+    assert pdb.count_unread_by_session(ALICE) == {"t1": 1}
+
+    pdb.mark_chat_read(ALICE, "thread", "t1", "2026-08-12T09:20:00Z")
+    assert pdb.count_unread_by_session(ALICE) == {}
+
+
+def test_one_users_unread_is_not_another_users_unread(chat_db):
+    from client_portal import db as pdb
+
+    pdb.mark_chat_read(ALICE, "thread", "t1", "2026-08-12T09:00:00Z")
+    pdb.mark_chat_read(BOB, "thread", "t2", "2026-08-12T09:00:00Z")
+    _msg(chat_db, session_id="t1", email=ALICE, role="assistant", at="2026-08-12T09:10:00Z")
+
+    assert pdb.count_unread_by_session(ALICE) == {"t1": 1}
+    assert pdb.count_unread_by_session(BOB) == {}
+
+
+def test_star_and_read_do_not_overwrite_each_other(chat_db):
+    """Both write the same row. A partial upsert that wrote every column would
+    make opening a chat silently unstar it."""
+    from client_portal import db as pdb
+
+    pdb.set_chat_star(ALICE, "thread", "t1", True, NOW)
+    pdb.mark_chat_read(ALICE, "thread", "t1", "2026-08-12T11:00:00Z")
+
+    row = pdb.get_chat_state(ALICE)[0]
+    assert row["starred_at"] and row["last_read_at"] == "2026-08-12T11:00:00Z"
+
+    pdb.set_chat_star(ALICE, "thread", "t1", False, "2026-08-12T12:00:00Z")
+    row = pdb.get_chat_state(ALICE)[0]
+    assert row["starred_at"] is None
+    # Unstar keeps the cursor: dropping the row would mark the whole thread
+    # unread again, so unstarring a chat would light up a badge for it.
+    assert row["last_read_at"] == "2026-08-12T11:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Service rules — validation, cap, and the shape the router returns
+# ---------------------------------------------------------------------------
+
+def test_unknown_chat_kind_is_rejected(chat_db):
+    from client_portal import service as svc
+
+    with pytest.raises(svc.ClientPortalError) as e:
+        svc.set_chat_star(ALICE, "sqlmap", "t1", True)
+    assert e.value.status_code == 400
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "x" * 129])
+def test_out_of_bounds_chat_ids_are_rejected(chat_db, bad):
+    """The id is attacker-chosen text that lands in a primary key, because the
+    writers deliberately do not check that the chat exists."""
+    from client_portal import service as svc
+
+    with pytest.raises(svc.ClientPortalError) as e:
+        svc.set_chat_star(ALICE, "thread", bad, True)
+    assert e.value.status_code == 400
+
+
+def test_starring_an_unknown_chat_succeeds_rather_than_leaking_existence(chat_db):
+    """A 404 here would answer "does chat X exist?" for every id in the install.
+    The write is confined to the caller's own rows, so it costs nothing."""
+    from client_portal import service as svc
+
+    svc.set_chat_star(ALICE, "thread", "no-such-chat", True)
+
+    from client_portal import db as pdb
+    assert [c["chat_id"] for c in pdb.get_chat_state(ALICE)] == ["no-such-chat"]
+
+
+def test_the_row_cap_stops_new_rows(chat_db, monkeypatch):
+    from client_portal import db as pdb
+    from client_portal import service as svc
+
+    monkeypatch.setattr(pdb, "MAX_CHAT_STATE_ROWS", 2)
+    svc.set_chat_star(ALICE, "thread", "t1", True)
+    svc.set_chat_star(ALICE, "thread", "t2", True)
+
+    with pytest.raises(svc.ClientPortalError) as e:
+        svc.set_chat_star(ALICE, "thread", "t3", True)
+    assert e.value.status_code == 409
+
+
+def test_the_cap_never_freezes_a_row_the_user_already_owns(chat_db, monkeypatch):
+    """A cap that applied to updates would leave a user at the ceiling unable to
+    unstar (the only action that gets them back under it) or to advance a read
+    cursor they already have — punishing them for state they legitimately
+    accumulated."""
+    from client_portal import db as pdb
+    from client_portal import service as svc
+
+    monkeypatch.setattr(pdb, "MAX_CHAT_STATE_ROWS", 2)
+    svc.set_chat_star(ALICE, "thread", "t1", True)
+    svc.set_chat_star(ALICE, "thread", "t2", True)
+
+    svc.mark_chat_read(ALICE, "thread", "t1")          # update, not insert
+    svc.set_chat_star(ALICE, "thread", "t1", False)    # the way back under the cap
+
+    rows = {r["chat_id"]: r for r in pdb.get_chat_state(ALICE)}
+    assert rows["t1"]["last_read_at"] is not None
+    assert rows["t1"]["starred_at"] is None
+
+
+def test_mark_read_at_the_cap_is_a_no_op_not_an_error(chat_db, monkeypatch):
+    """Opening a chat must not fail because a bookkeeping table is full."""
+    from client_portal import db as pdb
+    from client_portal import service as svc
+
+    monkeypatch.setattr(pdb, "MAX_CHAT_STATE_ROWS", 1)
+    svc.set_chat_star(ALICE, "thread", "t1", True)
+
+    svc.mark_chat_read(ALICE, "thread", "brand-new")   # must not raise
+
+    assert [c["chat_id"] for c in pdb.get_chat_state(ALICE)] == ["t1"]
+
+
+def test_get_chat_state_reports_stars_and_unread_together(chat_db):
+    from client_portal import service as svc
+
+    svc.set_chat_star(ALICE, "room", "r1", True)
+    svc.mark_chat_read(ALICE, "thread", "t1")
+    _msg(chat_db, session_id="t1", email=ALICE, role="assistant", at="2099-01-01T00:00:00Z")
+
+    by_ref = {(c["kind"], c["id"]): c for c in svc.get_chat_state(ALICE)["chats"]}
+
+    assert by_ref[("room", "r1")]["starred"] is True
+    assert by_ref[("room", "r1")]["unread"] == 0        # rooms carry their own cursor
+    assert by_ref[("thread", "t1")]["unread"] == 1
+    assert by_ref[("thread", "t1")]["starred"] is False


### PR DESCRIPTION
Closes the sidebar half of the Workspace family. Issue: [ent#359](https://github.com/Abilityai/trinity-enterprise/issues/359).

The sidebar stacked New chat, Search, an Agents roster and date-grouped history in one column, all at the same visual weight. That was coherent while an agent was *a menu entry you pick to start a chat*. Once the Workspace absorbed the Session surface (ent#358) and became the only place a continuing conversation lives, an agent became a **destination** and a chat became the record of visiting one — two kinds of thing, one treatment.

The roster now sits at the top of the scroll region on its own surface; chats follow, with starred ones pinned above the date groups.

## The decision worth reviewing

Both new features — stars and unread — are **per-viewer**. That one word rules out the obvious implementation.

A star is one person's bookmark. A room has several participants. A `starred` column on the chat row would render one participant's star in every other participant's sidebar, and incidentally tell them which conversations their colleagues care about. Rooms also live in the private submodule while threads live in OSS, so a per-kind column would put half of one feature in each repo.

Hence `enterprise_portal_chat_state (client_email, chat_kind, chat_id) → starred_at, last_read_at`. The caller's email is the primary-key prefix, so **the row is the tenant scope** — there is no filter to forget on a read path and no way to address another viewer's state. `chat_kind` is required because thread ids and room ids are independent spaces.

## Two judgement calls I'd rather flag than bury

**1. "Waiting on the user" is defined as unread agent replies.** The AC names a badge but the codebase has no such concept, so I picked one. The alternative reading — an agent blocked on an operator-queue approval — I deliberately rejected: that queue belongs to operators, and a Workspace viewer may be an external client with no standing in it. If the operator-queue sense was intended, that is a different and larger change and I'd redo it rather than leave the label ambiguous.

**2. A thread with no read cursor reports NOTHING unread**, not its whole history. Treating "never read" as "all unread" would have badged every historical conversation in every install the day this shipped — noise that teaches people to ignore the badge, which is worse than not having one. A cursor is written the first time the viewer opens or sends in a thread, so live conversations acquire one immediately and the first reply they *don't* see is the first thing that badges. The cost is stated in Known Limitations.

## AC coverage

| AC | |
|---|---|
| Agents block first, visually distinct | own surface (card + ring) above the chat list |
| avatar, name, description, count badge | ✓ |
| Starred pinned above date groups, lifted out | `partitionStarred` runs *before* grouping — a starred chat appears exactly once, not once pinned and once in "Today" |
| Star/unstar from header and row | `PortalStarButton.vue`, one component for its three homes |
| Multi-agent chats show all participants | stacked avatars, capped at 3 + a "+N" chip |
| Search replaces the lists while active | unchanged |
| Empty roster keeps a next-action | create-an-agent (platform) / ask-your-inviter (client) |

Plus the aggregate count on the wordmark, since the agents block now occupies the top of a *scrolling* region.

Clicking an agent that is waiting on you opens the conversation it is waiting in. A badge reading "2 replies" next to a control that opens an *empty* chat is a contradiction — the count is the reason you clicked. (An agent's own page is ent#360; this is not a substitute for it.)

## Security

No roster gate and no existence check on `chat_id`, both deliberate: every row is keyed by the caller's own email, and a 404 for an unknown chat would be an enumeration oracle over every chat id in the install (invariant #8). A per-viewer row cap bounds the write instead — applied **only** to writes that create a row, so a user at the ceiling can still unstar, which is the only way back under it.

## Verification

- **9690 passed**, 16 skipped, 1 xfailed. The 3 failures are `test_pat_propagation_properties.py::TestKnownGaps` — pre-existing on `dev`, tracked as #2017; neither that test nor `github_pat_propagation_service.py` is touched by this branch (0-line diff).
- 18 new backend tests; 116 frontend tests (10 files); `vite build` clean.
- SQLite migration verified **in isolation** against a DB that predates the table: right columns, composite PK, idempotent on re-run. (Checking only that the table exists after boot proves nothing — `schema.py`'s `CREATE TABLE IF NOT EXISTS` would satisfy that alone.)
- Route registration + table creation confirmed on a real app boot.

## Stacking

Branched off `fix/2120-review-regressions` (#2138), so this diff includes those five fixes until that merges. **#2138 should go first** — `dev` currently has a `markFailed` ReferenceError on every failed Workspace send.

## Known limitations

| | |
|---|---|
| Rooms report `unread: 0` | a room keeps its own seq cursor, a different model from a timestamp cursor; stars work for both kinds, unread does not |
| Unread needs one open first | by design, see above |
| Optimistic star, no cross-tab sync | a star toggled in one tab appears in another on its next refresh |

Docs: requirements §5.10, flow `docs/memory/feature-flows/workspace-sidebar-ia.md`.

Related to abilityai/trinity-enterprise#359