### PR TITLE
fix(workspace): gate the multi-agent picker on a rooms capability the client can read (#2128)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1296,10 +1296,11 @@ allow-list ∩ `user_invocable` — the same policy the MCP connector advertises
 outright; an agent exposing none falls back to its template-declared `use_cases`
 ("What You Can Ask"), sanitized and capped (6 × 200 chars). Clicking a hint **pre-fills
 the composer, never auto-sends** (`PortalBriefing.vue` → `prefill`). The future curated
-exposable-skills config (ent#178) slots into this same seam. Chats are strictly
-single-agent (the picker starts a new chat), so hints scope to the active agent by
-construction. ent#380 also fixed the briefing's metadata read — #138 called a
-nonexistent agent `/info` route, so descriptions were silently always `None`.
+exposable-skills config (ent#178) slots into this same seam. A chat holds one agent —
+or, where the capability below is present, several — and the picker starts a new chat
+either way, so hints scope to the active agent by construction. ent#380 also fixed the
+briefing's metadata read — #138 called a nonexistent agent `/info` route, so descriptions
+were silently always `None`.
 
 **Briefing hint grid is bounded (#2101):** with no connector allow-list configured every
 `user_invocable` skill becomes a "Things you can ask" card, so the hint set is belted
@@ -1309,6 +1310,29 @@ described-cards-first via `portalUtils.planHintDisplay`, the rest behind a count
 in-place "Show all N" toggle — deliberately **no nested scroll region**: the chat pane
 stays the single scroll axis, and the toggle counts the shipped list, never claiming the
 agent's full skill set). Hint *curation* stays the connector allow-list (ent#178 later).
+
+**The roster payload is *the* portal capability channel (#2128).** A portal principal
+cannot read `GET /api/settings/feature-flags` — that endpoint is `get_current_user`-gated
+and the frontend store behind it returns `[]` for any caller without a platform JWT, i.e.
+for **every** external client, including on an instance where the capability is present.
+So any UI gate on this surface takes its signal from `PortalRoster`, which
+`get_portal_principal` already serves to both principal kinds and `Portal.vue::bootstrap()`
+already awaits first — one field, no new route, no new auth surface, no extra round-trip
+(`voice_available` is the per-agent precedent). Reach for this before adding a second
+channel: the platform entitlement store is structurally unavailable here.
+`multi_agent_chat_available` is the first such field — resolved once per roster load from
+the entitlement registry, **fail-closed** (an unreadable registry reports the capability
+absent, because promising an affordance that cannot work is the bug it fixes), and named
+for the *capability* rather than the module or the edition, since this payload is served
+to an operator's customer. When it is false the picker is single-select, all five room
+store actions refuse before issuing a request, and `/workspace/r/:roomId` renders an
+honest refusal instead of mounting the room; a definitive 404/403 from the room endpoint
+self-heals the flag mid-session, so an entitlement that lapses between roster load and
+confirm collapses the picker rather than dead-ending. The frontend gate is **UX, not
+containment** — a portal token legitimately reaches the room endpoints where they exist,
+and the real boundary is the serving module's own roster-scoped access plus
+membership-scoped uniform 404s. Room data is untouched by the flag and reappears intact
+if the capability returns.
 
 ### Enterprise Modules (#847)
 

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1326,9 +1326,17 @@ absent, because promising an affordance that cannot work is the bug it fixes), a
 for the *capability* rather than the module or the edition, since this payload is served
 to an operator's customer. When it is false the picker is single-select, all five room
 store actions refuse before issuing a request, and `/workspace/r/:roomId` renders an
-honest refusal instead of mounting the room; a definitive 404/403 from the room endpoint
-self-heals the flag mid-session, so an entitlement that lapses between roster load and
-confirm collapses the picker rather than dead-ending. The frontend gate is **UX, not
+honest refusal instead of mounting the room; a 404/403 from any of the five self-heals the
+flag mid-session, so a capability that lapses between roster load and confirm — or while a
+room is open, which nothing else converges, since the sidebar refresh is event-driven — is
+observed by the next room call rather than dead-ending. **The status alone is not the
+signal**: a serving module authors its own refusals as a structured `detail: {code, …}`
+(*you cannot reach that agent* → 403, *you are not in that room* → uniform 404), while
+absence is a plain string — the framework's own "Not Found" for an unmounted route, the
+entitlement gate's sentence for mounted-but-unlicensed. Only the string form lowers the
+flag; a coded refusal is passed through so the server's own words reach the user, because
+reading one denied request as absence would turn it into a session-long false claim about
+the operator's build. The frontend gate is **UX, not
 containment** — a portal token legitimately reaches the room endpoints where they exist,
 and the real boundary is the serving module's own roster-scoped access plus
 membership-scoped uniform 404s. Room data is untouched by the flag and reappears intact

--- a/docs/user-docs/collaboration/rooms.md
+++ b/docs/user-docs/collaboration/rooms.md
@@ -2,7 +2,7 @@
 
 A **room** is one shared, persistent conversation where several agents — and a human — can work a topic together across many turns. Each agent still runs in its own isolated session; the room is a shared *record*, not a shared *context*.
 
-> **Enterprise feature.** Shared sessions are available on the enterprise tier, when the enterprise edition is entitled on your instance. In a community build the room MCP tools return a `shared_sessions_not_enabled` result and the Sessions view is hidden.
+> **Enterprise feature.** Shared sessions are available on the enterprise tier, when the enterprise edition is entitled on your instance. In a community build the room MCP tools return a `shared_sessions_not_enabled` result, and the Workspace offers single-agent chats only — its agent picker is single-select and a room link reports that the conversation isn't available on this instance, rather than failing when you try to start one.
 
 ## Concepts
 

--- a/src/backend/client_portal/models.py
+++ b/src/backend/client_portal/models.py
@@ -63,6 +63,13 @@ class PortalRoster(BaseModel):
     """The client-facing roster: every agent the signed-in email may reach."""
     client_email: Optional[str] = None
     agents: list[PortalAgentCard]
+    # #2128 — whether a chat may include MORE THAN ONE agent on this instance.
+    # Named for the capability, never the module or the edition: this payload
+    # goes to an operator's customer, who can neither buy a missing module nor
+    # act on knowing it exists.
+    # Defaults False so an older client, a partial payload or a failed read
+    # never advertises an affordance that cannot work (the whole of this bug).
+    multi_agent_chat_available: bool = False
 
 
 class PortalAuthRequest(BaseModel):

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -232,10 +232,16 @@ def _multi_agent_chat_available() -> bool:
     """
     try:
         from services.entitlement_service import entitlement_service
-        # bool() is not decoration: a leaked MagicMock in a polluted test order
-        # makes this return a mock, and pydantic COERCES that to True on the
-        # response model rather than raising — so the field would silently
-        # report *available* on a community build.
+        # bool() so the return matches the annotation for ANY implementation of
+        # the registry. A non-bool falsy value (None from a partial stub) is a
+        # ValidationError on the response model's bool field, i.e. a 500 raised
+        # OUTSIDE this try — the cast makes it fail closed instead.
+        #
+        # It is NOT a defence against a leaked test double: a MagicMock is
+        # truthy, and pydantic coerces one to True anyway, so cast or not the
+        # field would read *available*. What actually catches that is the
+        # module-identity assertion in the test file, which fails loudly rather
+        # than going green on a lie (measured, #2128).
         return bool(entitlement_service.is_entitled(_ROOMS_FEATURE_ID))
     except Exception:  # noqa: BLE001 — a roster must never 500 over a capability bit
         logger.warning(

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -202,6 +202,48 @@ def portal_exchange(email: str | None) -> str | None:
     return create_portal_session_token(email)
 
 
+# #2128 — the rooms substrate that backs a multi-agent Workspace chat is served
+# by a private module that a community build simply does not have. The picker
+# offered multi-select regardless, so picking two agents dead-ended in a 404.
+#
+# The signal has to reach a PORTAL principal (an external client on an email-OTP
+# session, with no platform account), and that principal cannot read
+# `/api/settings/feature-flags` — it is `get_current_user`-gated. So the roster
+# carries the bit: one field on a payload the shell already awaits first.
+_ROOMS_FEATURE_ID = "shared_sessions"
+
+
+def _multi_agent_chat_available() -> bool:
+    """Is the rooms substrate that backs a multi-agent Workspace chat present?
+
+    Reads the entitlement registry rather than probing the route table: a module
+    that claims its id and then fails to mount has that claim withdrawn (ent#196),
+    so the registry already answers "mounted AND serving".
+
+    The import is deliberately function-local. The singleton is swapped in place
+    by the supported test seam, and a module-scope `from ... import` would freeze
+    the boot-time instance and silently bypass it — the same form
+    `dependencies.py` and `routers/settings.py` use, pinned by a static guard in
+    `tests/unit/test_926_version_endpoint.py`.
+
+    Fail-CLOSED. A read that cannot answer must not advertise the capability —
+    promising an affordance that cannot work is the bug being fixed, so the error
+    direction has to be "offer less", never "offer more".
+    """
+    try:
+        from services.entitlement_service import entitlement_service
+        # bool() is not decoration: a leaked MagicMock in a polluted test order
+        # makes this return a mock, and pydantic COERCES that to True on the
+        # response model rather than raising — so the field would silently
+        # report *available* on a community build.
+        return bool(entitlement_service.is_entitled(_ROOMS_FEATURE_ID))
+    except Exception:  # noqa: BLE001 — a roster must never 500 over a capability bit
+        logger.warning(
+            "[#2128] rooms capability read failed; reporting unavailable", exc_info=True
+        )
+        return False
+
+
 async def get_roster(email: str | None, include_owned: bool = False) -> PortalRoster:
     """The caller's "My Agents" roster — every agent shared with ``email``, plus
     (``include_owned``) the agents they OWN.
@@ -224,6 +266,9 @@ async def get_roster(email: str | None, include_owned: bool = False) -> PortalRo
     """
     from services import tts_service
     tts_ready = tts_service.is_available()  # global key check, once per roster load
+    # #2128: an instance-level capability, resolved once per roster load like
+    # `tts_ready` above — not a per-agent one, so it rides on the roster itself.
+    multi_agent_chat = _multi_agent_chat_available()
 
     rows = db.get_shared_roster(email or "")
     if include_owned:
@@ -263,7 +308,11 @@ async def get_roster(email: str | None, include_owned: bool = False) -> PortalRo
         if isinstance(b, tuple):
             card.description, card.playbooks = b
 
-    return PortalRoster(client_email=(email or None), agents=cards)
+    return PortalRoster(
+        client_email=(email or None),
+        agents=cards,
+        multi_agent_chat_available=multi_agent_chat,
+    )
 
 
 def _humanize_playbook(name: str) -> str:

--- a/src/frontend/src/components/portal/PortalAgentPicker.vue
+++ b/src/frontend/src/components/portal/PortalAgentPicker.vue
@@ -6,7 +6,8 @@
       <div class="shrink-0 px-4 pt-4 pb-3 border-b border-gray-200 dark:border-gray-800">
         <h2 class="text-sm font-semibold">Start a chat</h2>
         <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-          Pick one agent, or several to put them in the same conversation.
+          {{ multi ? 'Pick one agent, or several to put them in the same conversation.'
+            : 'Pick an agent to chat with.' }}
         </p>
       </div>
 
@@ -20,8 +21,9 @@
           type="button"
           class="w-full flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition"
           :class="{ 'bg-gray-50 dark:bg-gray-800': selected.includes(a.name) }"
-          role="checkbox"
-          :aria-checked="selected.includes(a.name)"
+          :role="multi ? 'checkbox' : null"
+          :aria-checked="multi ? selected.includes(a.name) : null"
+          :aria-pressed="multi ? null : selected.includes(a.name)"
           @click="toggle(a.name)"
         >
           <span
@@ -47,11 +49,16 @@
       <div class="shrink-0 px-4 py-3 border-t border-gray-200 dark:border-gray-800 flex items-center gap-2">
         <!-- The count is the only hint that picking two behaves differently
              (a room rather than a thread); the wording stays in the user's
-             vocabulary — they are choosing who is in the conversation. -->
+             vocabulary — they are choosing who is in the conversation. In
+             single-select the third clause is unreachable, so it is not shown:
+             #2128 hides the affordance rather than explaining its absence, and
+             an explanation here would put the operator's billing tier in front
+             of their customer to no purpose. -->
         <span class="text-xs text-gray-500 dark:text-gray-400 flex-1">
           {{ selected.length === 0 ? 'Nobody selected'
             : selected.length === 1 ? '1 agent'
-            : `${selected.length} agents — they will share this conversation` }}
+            : multi ? `${selected.length} agents — they will share this conversation`
+            : `${selected.length} agents` }}
         </span>
         <button
           type="button"
@@ -82,8 +89,9 @@
  * (the only substrate that models several agents and @mention-waking). The
  * caller decides which; this component only reports who was chosen.
  */
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import PortalAvatar from './PortalAvatar.vue'
+import { applyAgentSelection, collapseSelection } from './portalUtils'
 
 const props = defineProps({
   agents: { type: Array, default: () => [] },
@@ -91,16 +99,31 @@ const props = defineProps({
   // Shown in place rather than closing the dialog: dismissing on failure would
   // leave the user guessing whether a chat was created.
   error: { type: String, default: null },
+  // #2128 — may this chat hold more than one agent? A chat with two or more is
+  // a room, and a build without that substrate serves no room endpoint at all,
+  // so offering the multi-select there is an affordance that can only ever
+  // dead-end.
+  //
+  // Default FALSE, not true: a caller that forgets to bind gets the surface
+  // that works everywhere rather than reintroducing this bug. The component
+  // reports who was chosen and nothing else — it says nothing about WHY the
+  // affordance is missing, because the viewer here is the operator's customer.
+  multi: { type: Boolean, default: false },
 })
 const emit = defineEmits(['confirm', 'cancel'])
 
 const selected = ref([])
 
 function toggle(name) {
-  const i = selected.value.indexOf(name)
-  if (i === -1) selected.value.push(name)
-  else selected.value.splice(i, 1)
+  selected.value = applyAgentSelection(selected.value, name, { multi: props.multi })
 }
+
+// The capability can flip while the dialog is open — a late roster resolving,
+// or the store's self-heal firing on a definitive refusal. Collapse rather than
+// leaving a two-agent selection that Start can no longer confirm.
+watch(() => props.multi, (isMulti) => {
+  selected.value = collapseSelection(selected.value, { multi: isMulti })
+})
 
 function confirm() {
   if (!selected.value.length) return

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -125,3 +125,31 @@ export function deliveryFailureReason(err) {
   if (err.response.status === 429) return 'Too many messages just now — wait a moment and retry.'
   return `The message wasn't delivered (error ${err.response.status}).`
 }
+
+// #2128 — one place decides what a click does to the selection, so single- and
+// multi-select cannot drift, and the collapse case is testable with no harness.
+//
+// `multi: false` is the fail-safe shape: on a build with no rooms substrate a
+// chat can only ever hold one agent, so clicking another REPLACES the pick
+// rather than adding to it. Clicking the selected one clears it (the picker's
+// Start button is disabled on an empty selection, so "none" is a reachable and
+// harmless state — and a control you cannot un-press is worse).
+//
+// Always returns a NEW array; the caller's ref is never mutated in place.
+export function applyAgentSelection(selected, name, { multi = false } = {}) {
+  const list = Array.isArray(selected) ? selected : []
+  const has = list.includes(name)
+  if (!multi) return has ? [] : [name]
+  return has ? list.filter((n) => n !== name) : list.concat(name)
+}
+
+// Collapse an existing selection when the capability turns out to be absent —
+// a late roster, or the store's self-heal firing while the dialog is open.
+// Keeps the MOST RECENT pick: in single-select, the last thing you clicked is
+// what you chose. Identity when multi-select is live, or when there is nothing
+// to collapse.
+export function collapseSelection(selected, { multi = false } = {}) {
+  const list = Array.isArray(selected) ? selected : []
+  if (multi || list.length <= 1) return list
+  return [list[list.length - 1]]
+}

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -287,9 +287,26 @@ export const useClientPortalStore = defineStore('clientPortal', {
     //
     // 404/403 only. A network error or a 5xx is "could not ask", not "is
     // absent", and lowering on those would unmount a live room over a blip.
+    //
+    // But the STATUS ALONE IS NOT THE SIGNAL, and reading it as one is a live
+    // bug: on a fully entitled instance the rooms module answers "you cannot
+    // reach that agent" with a 403 and "you are not in that room" with a
+    // uniform 404. Lowering on those turns one denied request into a
+    // session-long false claim about the operator's build — and overwrites the
+    // only message that tells the user what to do.
+    //
+    // The two are cleanly separable by the BODY, because absence and denial are
+    // authored by different layers: a module that is SERVING answers with its
+    // own structured `detail: {code, message}`, while absence is a plain string
+    // — FastAPI's own "Not Found" when the route was never mounted, and the
+    // entitlement gate's one-sentence 403 when it is mounted but unlicensed. A
+    // coded detail therefore PROVES the substrate is present; treat it as an
+    // ordinary refusal and let the caller surface the server's own words.
     _noteRoomsRefusal(err) {
       const status = err?.response?.status
       if (status !== 404 && status !== 403) return err
+      const detail = err?.response?.data?.detail
+      if (detail && typeof detail === 'object' && detail.code) return err
       this.multiAgentChatAvailable = false
       err.code = 'rooms_unavailable'
       err.message = MULTI_AGENT_UNAVAILABLE

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -16,6 +16,19 @@ const PORTAL_TOKEN_KEY = 'trinity.portalToken'
 // Lower-case: axios normalises response header names.
 const SESSION_ROTATION_HEADER = 'x-trinity-session-token'
 
+// #2128 — the one sentence shown when a chat with several agents cannot be
+// started on this instance. Exported from the STORE, not from portalUtils: this
+// is the message the store's own guard throws, and no store in this codebase
+// imports from `@/components` — adding that edge would invert the dependency
+// direction for one string.
+//
+// It states the capability and stops. Never "not licensed", never an edition
+// name, never an upgrade prompt: the audience for this surface is the
+// operator's customer, who can neither buy the missing module nor act on
+// knowing it exists.
+export const MULTI_AGENT_UNAVAILABLE =
+  'Chats with more than one agent are not available on this instance.'
+
 // ent#375 — adopt a rotated session token wherever it arrives.
 //
 // ONE interceptor rather than touching all 13 request sites: a new portal call
@@ -79,6 +92,20 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // Where the user was when it expired, so re-authenticating returns them
     // there instead of the roster root.
     resumePath: null,
+    // #2128 — may a chat hold MORE THAN ONE agent on this instance? Carried on
+    // the roster payload, because the platform feature-flag endpoint is
+    // JWT-gated and an external client on a portal session cannot read it.
+    //
+    // Default false is the live policy for everything unconfigured, so it has
+    // to be the safe value: the picker renders single-select until a roster
+    // actually says otherwise, and the component never sees an undefined
+    // tri-state.
+    multiAgentChatAvailable: false,
+    // Set once a roster attempt REACHED A VERDICT for this session. The room
+    // route needs to tell "still loading" from "loaded, and the answer is no" —
+    // without it a hard-loaded /workspace/r/:id would flash a refusal it then
+    // takes back on an entitled instance.
+    rosterLoaded: false,
   }),
 
   getters: {
@@ -156,6 +183,12 @@ export const useClientPortalStore = defineStore('clientPortal', {
       this.agents = []
       this.sessionExpired = false
       this.resumePath = null
+      // #2128: both are per-session facts. A different client signing in on the
+      // same browser must not inherit the previous one's capability verdict,
+      // and `rosterLoaded` must go back to "no verdict yet" or the room route
+      // would read a stale one as authoritative.
+      this.multiAgentChatAvailable = false
+      this.rosterLoaded = false
       localStorage.removeItem(PORTAL_TOKEN_KEY)
     },
 
@@ -227,23 +260,73 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // rooms are the only substrate that models several agents, @mention-waking
     // and per-participant budgets. The sidebar merges both.
 
+    // #2128 — ONE chokepoint in front of every room call. A build with no rooms
+    // substrate must never issue one: the request is a guaranteed 4xx whose
+    // generic failure copy is the dead end this issue is about.
+    //
+    // Applied to all FIVE room actions, not just the two reachable today. Three
+    // of them have exactly one caller each, inside a component the render gate
+    // stops mounting — so gating them is redundant *for the current call graph*,
+    // which is precisely the claim `learnings.md` 2026-07-01 records failing: a
+    // kill-switch is only as airtight as its least-gated entry point. Cost:
+    // three lines. Deliberate, not oversight.
+    _requireRooms() {
+      if (this.multiAgentChatAvailable) return
+      const err = new Error(MULTI_AGENT_UNAVAILABLE)
+      // A typed code, never message-sniffing: the view has to tell this apart
+      // from a transport failure, which needs different copy.
+      err.code = 'rooms_unavailable'
+      throw err
+    },
+
+    // The capability can vanish BETWEEN the roster load and the confirm (an
+    // entitlement lapsing, an instance restarted into lockdown). A definitive
+    // refusal from the rooms endpoint itself is evidence the substrate is gone,
+    // so lower the flag and let the picker collapse on the same tick. Without
+    // this the gate is correct at load and still dead-ends mid-session.
+    //
+    // 404/403 only. A network error or a 5xx is "could not ask", not "is
+    // absent", and lowering on those would unmount a live room over a blip.
+    _noteRoomsRefusal(err) {
+      const status = err?.response?.status
+      if (status !== 404 && status !== 403) return err
+      this.multiAgentChatAvailable = false
+      err.code = 'rooms_unavailable'
+      err.message = MULTI_AGENT_UNAVAILABLE
+      return err
+    },
+
     async createRoom(agentNames, name) {
-      const { data } = await axios.post(
-        '/api/rooms',
-        { name: name || 'New chat', agents: agentNames },
-        { headers: this.authHeader }
-      )
-      return data
+      this._requireRooms()
+      try {
+        const { data } = await axios.post(
+          '/api/rooms',
+          { name: name || 'New chat', agents: agentNames },
+          { headers: this.authHeader }
+        )
+        return data
+      } catch (err) {
+        throw this._noteRoomsRefusal(err)
+      }
     },
 
     async fetchRooms() {
-      const { data } = await axios.get('/api/rooms', { headers: this.authHeader })
-      return (data.rooms || []).map((r) => ({ ...r, is_room: true }))
+      // Returns [] rather than throwing: this one is called on every sidebar
+      // refresh and its caller already treats "no rooms" as normal. Returning
+      // early removes a guaranteed-4xx round-trip per refresh.
+      if (!this.multiAgentChatAvailable) return []
+      try {
+        const { data } = await axios.get('/api/rooms', { headers: this.authHeader })
+        return (data.rooms || []).map((r) => ({ ...r, is_room: true }))
+      } catch (err) {
+        throw this._noteRoomsRefusal(err)
+      }
     },
 
     // `since` is the seq cursor: 0 loads the whole transcript, a later value
     // fetches only what the client has not seen.
     async fetchRoom(roomId, since = 0) {
+      this._requireRooms()
       const { data } = await axios.get(`/api/rooms/${roomId}`, {
         headers: this.authHeader, params: { since },
       })
@@ -251,6 +334,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     },
 
     async postRoomMessage(roomId, content) {
+      this._requireRooms()
       const { data } = await axios.post(
         `/api/rooms/${roomId}/messages`, { content },
         { headers: this.authHeader }
@@ -259,6 +343,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     },
 
     async addRoomParticipant(roomId, agentName) {
+      this._requireRooms()
       const { data } = await axios.post(
         `/api/rooms/${roomId}/participants`, { agent_name: agentName, role: 'member' },
         { headers: this.authHeader }
@@ -436,6 +521,19 @@ export const useClientPortalStore = defineStore('clientPortal', {
         // (ent#380) — shipped at sign-in so the new-chat screen renders with
         // zero extra fetches.
         this.agents = data.agents || []
+        // #2128 — a SUCCESSFUL roster is the only thing that may RAISE this
+        // flag, and strict `=== true` is what makes an older backend that omits
+        // the field (or a proxy that returns the string "false", or an HTML
+        // error body) read as absent rather than truthy.
+        //
+        // Deliberately NOT pre-reset at the top of this action, unlike the
+        // sibling `unavailable` above. That one resets to the OPTIMISTIC value
+        // so a stale 404 cannot paint over a roster that loaded fine; copying
+        // its shape here would invert its meaning — pessimistic mid-flight, so
+        // every background refetch would unmount a live room and flash a
+        // refusal at an entitled client before taking it back.
+        this.multiAgentChatAvailable = data.multi_agent_chat_available === true
+        this.rosterLoaded = true
       } catch (err) {
         // Two DIFFERENT failures, kept distinct — neither may swallow the other.
         //
@@ -458,6 +556,18 @@ export const useClientPortalStore = defineStore('clientPortal', {
           ? 'The workspace is not available on this instance.'
           : (err.response?.data?.detail || 'Failed to load your agents.')
         this.agents = []
+        // #2128: the attempt reached a verdict — the room route may stop
+        // showing its neutral placeholder and render the honest failure copy.
+        // `multiAgentChatAvailable` is deliberately left ALONE: a failed
+        // request is not evidence the capability went away.
+        //
+        // Assigned here rather than in `finally`, which runs AFTER this whole
+        // block — and CONDITIONALLY, because the 401 branch above already
+        // signed the session out. A bare `= true` in either place re-sets the
+        // flag the sign-out just cleared, and the field stops meaning "a
+        // verdict was reached for this session" and starts meaning "some
+        // attempt finished at some point".
+        this.rosterLoaded = this.isClientSignedIn
       } finally {
         this.loading = false
       }

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -302,6 +302,20 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // entitlement gate's one-sentence 403 when it is mounted but unlicensed. A
     // coded detail therefore PROVES the substrate is present; treat it as an
     // ordinary refusal and let the caller surface the server's own words.
+    //
+    // Runs on all FIVE room calls, for the same reason `_requireRooms` does —
+    // and here it is not redundant. `refreshThreads()` is event-driven, not
+    // periodic, so a capability that lapses while a room is OPEN is only ever
+    // observed by the room's own calls: without this the 3s poll swallows its
+    // 404 (`load()` only reports on a full load), sending shows the generic
+    // "That message was not delivered.", and the state never converges — the
+    // gate is correct at load and the room is a dead end for the rest of the
+    // session. With it, the poll lowers the flag, `<PortalRoom>` unmounts, and
+    // the room route's honest refusal takes the stage. That is AC #4 holding
+    // THROUGH a transition, and it is only safe because of the discriminator
+    // above: `/api/rooms/:id` answers a uniform coded 404 for a room the caller
+    // is not in, and reading THAT as absence would let a stale room link switch
+    // an entitled workspace to single-select.
     _noteRoomsRefusal(err) {
       const status = err?.response?.status
       if (status !== 404 && status !== 403) return err
@@ -344,28 +358,40 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // fetches only what the client has not seen.
     async fetchRoom(roomId, since = 0) {
       this._requireRooms()
-      const { data } = await axios.get(`/api/rooms/${roomId}`, {
-        headers: this.authHeader, params: { since },
-      })
-      return data
+      try {
+        const { data } = await axios.get(`/api/rooms/${roomId}`, {
+          headers: this.authHeader, params: { since },
+        })
+        return data
+      } catch (err) {
+        throw this._noteRoomsRefusal(err)
+      }
     },
 
     async postRoomMessage(roomId, content) {
       this._requireRooms()
-      const { data } = await axios.post(
-        `/api/rooms/${roomId}/messages`, { content },
-        { headers: this.authHeader }
-      )
-      return data   // {room_id, seq, mentions, woke}
+      try {
+        const { data } = await axios.post(
+          `/api/rooms/${roomId}/messages`, { content },
+          { headers: this.authHeader }
+        )
+        return data   // {room_id, seq, mentions, woke}
+      } catch (err) {
+        throw this._noteRoomsRefusal(err)
+      }
     },
 
     async addRoomParticipant(roomId, agentName) {
       this._requireRooms()
-      const { data } = await axios.post(
-        `/api/rooms/${roomId}/participants`, { agent_name: agentName, role: 'member' },
-        { headers: this.authHeader }
-      )
-      return data
+      try {
+        const { data } = await axios.post(
+          `/api/rooms/${roomId}/participants`, { agent_name: agentName, role: 'member' },
+          { headers: this.authHeader }
+        )
+        return data
+      } catch (err) {
+        throw this._noteRoomsRefusal(err)
+      }
     },
 
     // The client's conversation threads with an agent (most-recent first) — the

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -99,13 +99,55 @@
              single-agent conversation is untouched below — different
              substrate, different component, no shared state. -->
         <PortalRoom
-          v-if="activeRoomIdFromRoute"
+          v-if="activeRoomIdFromRoute && store.multiAgentChatAvailable"
           :key="activeRoomIdFromRoute"
           :room-id="activeRoomIdFromRoute"
           :roster="store.agents"
           @open-menu="mobileNav = true"
           @rooms-changed="refreshThreads"
         />
+
+        <!-- #2128: the URL names a room this instance cannot open. This branch
+             must catch EVERY remaining room-URL case, and its position between
+             the two components above and below is load-bearing: falling through
+             to PortalConversation opens a DIFFERENT agent's chat under a room
+             link (activeAgent defaults to the first roster entry), and falling
+             past that lands on the `!activeRoomIdFromRoute` block whose guard is
+             false here — rendering a completely blank <main>.
+
+             Gating the RENDER, not just a watcher, is also what stops
+             PortalRoom::onMounted issuing GET /api/rooms/:id at all.
+
+             Four sub-states, not one: fail-closed is right for the affordance
+             and wrong for the copy that explains it. Only a roster that loaded
+             CLEANLY and reported the capability absent may say "not available
+             on this instance" — saying it during a transient 5xx on an entitled
+             instance would be a false statement about the operator's build, on
+             the one surface whose whole bar is honest status. -->
+        <div v-else-if="activeRoomIdFromRoute" class="flex-1 flex flex-col items-center justify-center text-center px-6">
+          <svg class="w-10 h-10 text-gray-300 dark:text-gray-700 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
+          <template v-if="!store.rosterLoaded || store.loading">
+            <p class="text-sm text-gray-500 dark:text-gray-400">Opening this conversation…</p>
+          </template>
+          <template v-else-if="store.unavailable">
+            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ WORKSPACE_UNAVAILABLE_TITLE }}</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+              It isn't enabled here. Ask an administrator if you expected access.
+            </p>
+          </template>
+          <template v-else-if="store.error">
+            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ ROSTER_LOAD_FAILED_TITLE }}</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">{{ store.error }}</p>
+            <button class="mt-3 text-sm text-action-primary-600 hover:underline" @click="store.fetchRoster()">Try again</button>
+          </template>
+          <template v-else>
+            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">This conversation isn't available on this instance</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+              Chats with more than one agent aren't enabled here. Start a chat with a single agent instead.
+            </p>
+            <button class="mt-3 text-sm text-action-primary-600 hover:underline" @click="leaveRoomRoute">Start a new chat</button>
+          </template>
+        </div>
 
         <PortalConversation
           v-else-if="activeAgent"
@@ -143,13 +185,13 @@
         <div v-else-if="!activeRoomIdFromRoute" class="flex-1 flex flex-col items-center justify-center text-center px-6">
           <svg class="w-10 h-10 text-gray-300 dark:text-gray-700 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
           <template v-if="store.unavailable">
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">Workspace isn't available on this instance</p>
+            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ WORKSPACE_UNAVAILABLE_TITLE }}</p>
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
               It isn't enabled here. Ask an administrator if you expected access.
             </p>
           </template>
           <template v-else-if="store.error">
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">Couldn't load your agents</p>
+            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ ROSTER_LOAD_FAILED_TITLE }}</p>
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">{{ store.error }}</p>
             <button class="mt-3 text-sm text-action-primary-600 hover:underline" @click="store.fetchRoster()">Try again</button>
           </template>
@@ -180,6 +222,7 @@
     <PortalAgentPicker
       v-if="pickerOpen"
       :agents="store.agents"
+      :multi="store.multiAgentChatAvailable"
       :busy="pickerBusy"
       :error="pickerError"
       @confirm="onPickerConfirm"
@@ -194,7 +237,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useClientPortalStore } from '@/stores/clientPortal'
+import { useClientPortalStore, MULTI_AGENT_UNAVAILABLE } from '@/stores/clientPortal'
 import PortalSidebar from '@/components/portal/PortalSidebar.vue'
 import PortalConversation from '@/components/portal/PortalConversation.vue'
 import PortalBriefing from '@/components/portal/PortalBriefing.vue'
@@ -288,9 +331,21 @@ function newChat() {
   pickerOpen.value = true
 }
 
+// #2128 — every exit from the main stage tested ONLY `sessionId`, so on a
+// /workspace/r/:id URL none of them changed the route. That was invisible while
+// the room always rendered; the moment a room URL can resolve to a refusal, it
+// makes that refusal a state the user cannot leave by any control except the
+// one on the refusal itself — a dead end created by the very fix meant to
+// remove one. `roomId` belongs in the same test for the same reason.
+function leaveRoomRoute() {
+  activeRoomId.value = null
+  pendingSession.value = null; prefill.value = ''; convGen.value++
+  router.push('/workspace')
+}
+
 function startBlankChat() {
   pendingSession.value = null; prefill.value = ''; convGen.value++
-  if (route.params.sessionId) router.push('/workspace')
+  if (route.params.sessionId || route.params.roomId) router.push('/workspace')
 }
 
 async function onPickerConfirm(agentNames) {
@@ -312,15 +367,30 @@ async function onPickerConfirm(agentNames) {
   } catch (err) {
     // Keep the picker open with the reason: closing it would leave the user
     // guessing whether anything happened.
-    pickerError.value = err?.response?.data?.detail?.message
-      || err?.response?.data?.detail
-      || 'Could not start that chat.'
+    // #2128 — the store refuses a room call on an instance with no rooms
+    // substrate, and self-heals the flag on a definitive 404/403 mid-session,
+    // so the picker collapses to single-select on this same tick. A typed code,
+    // never message-sniffing: the generic path below must stay intact, because
+    // a `true` flag does not guarantee success (the client may lack access to
+    // one selected agent) and that reason still has to surface.
+    pickerError.value = err?.code === 'rooms_unavailable'
+      ? (err.message || MULTI_AGENT_UNAVAILABLE)
+      : (err?.response?.data?.detail?.message
+        || err?.response?.data?.detail
+        || 'Could not start that chat.')
   } finally {
     pickerBusy.value = false
   }
 }
 
 const pickerError = ref(null)
+
+// #2128 — shared by the room-route refusal branch and the no-room empty state
+// below it, which are the same four states rendered in the same file. Local
+// consts, not a module: both consumers live here, and a component extraction
+// for two <p> pairs is more abstraction than the duplication costs.
+const WORKSPACE_UNAVAILABLE_TITLE = "Workspace isn't available on this instance"
+const ROSTER_LOAD_FAILED_TITLE = "Couldn't load your agents"
 
 function openRoom(roomId) {
   if (!roomId) return
@@ -332,7 +402,10 @@ function openRoom(roomId) {
 function newChatWithAgent(name) {
   activeAgentName.value = name
   pendingSession.value = null; prefill.value = ''; convGen.value++
-  if (route.params.sessionId) router.push('/workspace')
+  // #2128: `roomId` too — see leaveRoomRoute above. Without it, picking one
+  // agent from the picker while parked on a room URL leaves the room route (and
+  // so the refusal) on screen, and the chat the user asked for never appears.
+  if (route.params.sessionId || route.params.roomId) router.push('/workspace')
 }
 function switchAgent(name) { newChatWithAgent(name) }   // mid-thread = plain new chat, no carry-over
 function openThread(t) {
@@ -438,6 +511,8 @@ function onSignOut() {
   store.signOut()
   threads.value = []; activeAgentName.value = null; pendingSession.value = null
   step.value = 'email'; email.value = ''; code.value = ''
-  if (route.params.sessionId) router.push('/workspace')
+  // #2128: `roomId` too — otherwise a sign-out from a room URL carries that
+  // room id into the next session's address bar.
+  if (route.params.sessionId || route.params.roomId) router.push('/workspace')
 }
 </script>

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -124,28 +124,28 @@
              on this instance" — saying it during a transient 5xx on an entitled
              instance would be a false statement about the operator's build, on
              the one surface whose whole bar is honest status. -->
-        <div v-else-if="activeRoomIdFromRoute" class="flex-1 flex flex-col items-center justify-center text-center px-6">
-          <svg class="w-10 h-10 text-gray-300 dark:text-gray-700 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
+        <div v-else-if="activeRoomIdFromRoute" :class="STAGE_WRAP">
+          <svg :class="STAGE_ICON" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
           <template v-if="!store.rosterLoaded || store.loading">
-            <p class="text-sm text-gray-500 dark:text-gray-400">Opening this conversation…</p>
+            <p :class="STAGE_BODY_LEAD">Opening this conversation…</p>
           </template>
           <template v-else-if="store.unavailable">
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ WORKSPACE_UNAVAILABLE_TITLE }}</p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+            <p :class="STAGE_TITLE">{{ WORKSPACE_UNAVAILABLE_TITLE }}</p>
+            <p :class="STAGE_BODY">
               It isn't enabled here. Ask an administrator if you expected access.
             </p>
           </template>
           <template v-else-if="store.error">
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ ROSTER_LOAD_FAILED_TITLE }}</p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">{{ store.error }}</p>
-            <button class="mt-3 text-sm text-action-primary-600 hover:underline" @click="store.fetchRoster()">Try again</button>
+            <p :class="STAGE_TITLE">{{ ROSTER_LOAD_FAILED_TITLE }}</p>
+            <p :class="STAGE_BODY">{{ store.error }}</p>
+            <button :class="STAGE_ACTION" @click="store.fetchRoster()">Try again</button>
           </template>
           <template v-else>
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">This conversation isn't available on this instance</p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+            <p :class="STAGE_TITLE">This conversation isn't available on this instance</p>
+            <p :class="STAGE_BODY">
               Chats with more than one agent aren't enabled here. Start a chat with a single agent instead.
             </p>
-            <button class="mt-3 text-sm text-action-primary-600 hover:underline" @click="leaveRoomRoute">Start a new chat</button>
+            <button :class="STAGE_ACTION" @click="leaveRoomRoute">Start a new chat</button>
           </template>
         </div>
 
@@ -172,43 +172,43 @@
              which reads as "your operator hasn't shared anything" whether the
              module is absent, the roster call failed, or the list is genuinely
              empty — a dead end in two of the three cases. -->
-        <div v-else-if="unreachableAgent" class="flex-1 flex flex-col items-center justify-center text-center px-6">
-          <svg class="w-10 h-10 text-gray-300 dark:text-gray-700 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" /></svg>
-          <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">
+        <div v-else-if="unreachableAgent" :class="STAGE_WRAP">
+          <svg :class="STAGE_ICON" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" /></svg>
+          <p :class="STAGE_TITLE">
             You don't have access to <span class="font-mono">{{ unreachableAgent }}</span>
           </p>
-          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+          <p :class="STAGE_BODY">
             That link points at an agent that isn't shared with you. Pick one from the sidebar, or ask whoever sent the link.
           </p>
         </div>
 
-        <div v-else-if="!activeRoomIdFromRoute" class="flex-1 flex flex-col items-center justify-center text-center px-6">
-          <svg class="w-10 h-10 text-gray-300 dark:text-gray-700 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
+        <div v-else-if="!activeRoomIdFromRoute" :class="STAGE_WRAP">
+          <svg :class="STAGE_ICON" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
           <template v-if="store.unavailable">
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ WORKSPACE_UNAVAILABLE_TITLE }}</p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+            <p :class="STAGE_TITLE">{{ WORKSPACE_UNAVAILABLE_TITLE }}</p>
+            <p :class="STAGE_BODY">
               It isn't enabled here. Ask an administrator if you expected access.
             </p>
           </template>
           <template v-else-if="store.error">
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">{{ ROSTER_LOAD_FAILED_TITLE }}</p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">{{ store.error }}</p>
-            <button class="mt-3 text-sm text-action-primary-600 hover:underline" @click="store.fetchRoster()">Try again</button>
+            <p :class="STAGE_TITLE">{{ ROSTER_LOAD_FAILED_TITLE }}</p>
+            <p :class="STAGE_BODY">{{ store.error }}</p>
+            <button :class="STAGE_ACTION" @click="store.fetchRoster()">Try again</button>
           </template>
           <!-- ent#357: an empty roster needs a next step, not just a statement.
                The two audiences need different ones: a signed-in user can go
                make an agent, an external client can only ask the person who
                invited them. -->
           <template v-else-if="store.isPlatformSession">
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">No agents here yet</p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+            <p :class="STAGE_TITLE">No agents here yet</p>
+            <p :class="STAGE_BODY">
               Agents you own, and agents shared with you, appear here.
             </p>
-            <a href="/" class="mt-3 text-sm text-action-primary-600 hover:underline">Go to your agents</a>
+            <a href="/" :class="STAGE_ACTION">Go to your agents</a>
           </template>
           <template v-else>
-            <p class="text-sm text-gray-700 dark:text-gray-300 font-medium">No agents shared with you yet</p>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+            <p :class="STAGE_TITLE">No agents shared with you yet</p>
+            <p :class="STAGE_BODY">
               Ask whoever invited you to share an agent with
               <span class="font-medium">{{ store.clientEmail || 'your email' }}</span>.
             </p>
@@ -391,6 +391,33 @@ const pickerError = ref(null)
 // for two <p> pairs is more abstraction than the duplication costs.
 const WORKSPACE_UNAVAILABLE_TITLE = "Workspace isn't available on this instance"
 const ROSTER_LOAD_FAILED_TITLE = "Couldn't load your agents"
+
+// #2128 — the ink for the three empty/refusal stages, written ONCE.
+//
+// This file renders nine of them (a room URL this instance can't open ×4, an
+// unreachable agent, an empty roster ×4) and every one used to carry its own
+// copy of the same class strings. That is design-system principle 4 —
+// loading/loaded/empty/failed share one footprint — held together by
+// copy-paste, and adding a state grew the file's raw-palette count by four
+// every time (the ratchet in CLAUDE.md §9 says per-file counts may only
+// shrink, and this branch had pushed 40 → 56).
+//
+// Hoisting is the whole remedy available here, and it is worth being precise
+// about why: `gray` has NO semantic token. It is the design system's residual
+// family — the contract's own colour section ends "Everything else is gray"
+// and prescribes these exact shades for the ink ladder — so there is nothing
+// to convert `text-gray-500 dark:text-gray-400` INTO. Repainting body copy in
+// `status-*` or `action-*` would be a defect, not compliance. What can be
+// fixed is the number of PLACES a raw shade is written, which is what makes a
+// future migration tractable, and that drops from twenty-odd to five.
+const STAGE_WRAP = 'flex-1 flex flex-col items-center justify-center text-center px-6'
+const STAGE_ICON = 'w-10 h-10 text-gray-300 dark:text-gray-700 mb-3'
+const STAGE_TITLE = 'text-sm text-gray-700 dark:text-gray-300 font-medium'
+const STAGE_BODY = 'mt-1 text-xs text-gray-500 dark:text-gray-400 max-w-xs'
+// The neutral "still resolving" line stands alone (no title above it), so it
+// carries the body ink without the top margin the paired form needs.
+const STAGE_BODY_LEAD = 'text-sm text-gray-500 dark:text-gray-400'
+const STAGE_ACTION = 'mt-3 text-sm text-action-primary-600 hover:underline'
 
 function openRoom(roomId) {
   if (!roomId) return

--- a/src/frontend/tests/unit/workspaceRoomsGate.spec.js
+++ b/src/frontend/tests/unit/workspaceRoomsGate.spec.js
@@ -191,6 +191,19 @@ describe('#2128 structure guards', () => {
       'room URL falls through and opens a DIFFERENT agent\'s conversation ' +
       '(activeAgent defaults to the first roster entry), or renders a blank <main>.'
     ).toBeLessThan(convAt)
+
+    // …and FOLLOW <PortalRoom>. The chain is load-bearing in both directions:
+    // put the refusal first and it shadows the room outright, so an ENTITLED
+    // instance never opens one. Today that also fails to compile (a `v-else-if`
+    // with nothing before it), which is a guarantee about Vue rather than about
+    // this file — assert the property directly rather than inherit it.
+    const roomAt = src.indexOf('<PortalRoom')
+    expect(roomAt, '<PortalRoom is gone').toBeGreaterThan(-1)
+    expect(
+      roomAt,
+      '<PortalRoom must come FIRST: the refusal is the fallback for a room URL ' +
+      'this instance cannot open, never the branch that handles one it can'
+    ).toBeLessThan(branchAt)
   })
 
   it('F18 the capability is a term in <PortalRoom>\'s own v-if', () => {

--- a/src/frontend/tests/unit/workspaceRoomsGate.spec.js
+++ b/src/frontend/tests/unit/workspaceRoomsGate.spec.js
@@ -1,0 +1,392 @@
+/**
+ * #2128 — the Workspace multi-agent picker is gated on a rooms capability the
+ * portal principal can actually read.
+ *
+ * A chat with two or more agents is a room, and `/api/rooms` is served only by a
+ * module a community build does not have. The picker offered multi-select
+ * anyway, so selecting two agents dead-ended in a generic "Could not start that
+ * chat." — an affordance that is always offered and can never work.
+ *
+ * The signal cannot come from the frontend entitlement store: it reads
+ * `/api/settings/feature-flags`, which is platform-JWT gated, and returns [] for
+ * any caller without one — i.e. for EVERY external client, including on an
+ * entitled instance. So the capability rides on the roster payload, and this
+ * file pins the three things that carry the fix:
+ *
+ *   1. the pure selection decisions (single vs multi), because there is no
+ *      component-mount harness in this project (no @vue/test-utils) and
+ *      anything that must be tested has to be a pure function;
+ *   2. the store contract — the flag is raised only by a successful roster,
+ *      lowered only by a definitive refusal, and every room call is gated;
+ *   3. source-structure guards for the parts (a prop default, a template branch
+ *      ORDER, a v-if term) that no unit test can reach — the same shape as
+ *      `agentDetailDeepLink.spec.js` and the Python AST guards.
+ *
+ * Every guard in (3) strips comments before scanning: a comment explaining what
+ * not to write necessarily contains the offending string, and a text scan will
+ * flag its own documentation.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+// The store reads localStorage at state construction and installs an axios
+// interceptor at import, and vitest runs these in `environment: 'node'` — so
+// these shims are a HARNESS REQUIREMENT, not a stylistic choice. Same shape as
+// workspaceSessionRenewal.spec.js.
+vi.hoisted(() => {
+  const store = new Map()
+  globalThis.localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+  }
+  globalThis.window = globalThis.window || { location: { pathname: '/workspace' } }
+})
+
+vi.mock('@/stores/auth', async () => {
+  const { ref } = await import('vue')
+  const authed = ref(false)
+  return {
+    useAuthStore: () => ({
+      get isAuthenticated() { return authed.value },
+      get authHeader() { return authed.value ? { Authorization: 'Bearer platform-jwt' } : {} },
+    }),
+    __setAuthed: (v) => { authed.value = v },
+  }
+})
+
+vi.mock('axios', () => {
+  const inst = {
+    get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+    defaults: { headers: { common: {} } },
+  }
+  return { default: Object.assign(inst, { create: () => inst }) }
+})
+
+import axios from 'axios'
+import { applyAgentSelection, collapseSelection } from '@/components/portal/portalUtils'
+import { useClientPortalStore, MULTI_AGENT_UNAVAILABLE } from '@/stores/clientPortal'
+
+const PORTAL = fileURLToPath(new URL('../../src/views/Portal.vue', import.meta.url))
+const PICKER = fileURLToPath(new URL('../../src/components/portal/PortalAgentPicker.vue', import.meta.url))
+
+/** Strip HTML/JS comments so prose about the rule isn't scanned as code. */
+function stripComments(code) {
+  return code
+    .replace(/<!--[\s\S]*?-->/g, '')      // Vue template comments
+    .replace(/\/\*[\s\S]*?\*\//g, '')     // JS block comments
+    .replace(/^[ \t]*\/\/.*$/gm, '')      // whole-line // comments
+    .replace(/([^:])\/\/.*$/gm, '$1')     // trailing // comments (keep URLs)
+}
+
+const portalSource = () => stripComments(readFileSync(PORTAL, 'utf8'))
+const pickerSource = () => stripComments(readFileSync(PICKER, 'utf8'))
+
+const rosterResponse = (extra = {}) => ({
+  data: { client_email: 'client@example.com', agents: [{ name: 'scout' }], ...extra },
+})
+
+function signedInStore() {
+  const store = useClientPortalStore()
+  store.portalToken = 'portal-token'
+  return store
+}
+
+// ---------------------------------------------------------------------------
+// F1-F9 — the pure selection decisions
+// ---------------------------------------------------------------------------
+
+describe('#2128 selection semantics (AC 1, AC 3)', () => {
+  it('F1 single-select: picking from nothing selects that one', () => {
+    expect(applyAgentSelection([], 'a', { multi: false })).toEqual(['a'])
+  })
+
+  it('F2 single-select: picking another REPLACES rather than adding', () => {
+    expect(applyAgentSelection(['a'], 'b', { multi: false })).toEqual(['b'])
+  })
+
+  it('F3 single-select: picking the selected one clears it', () => {
+    // Click-to-clear is why this is `aria-pressed` on a button and not a radio:
+    // a radio cannot be un-checked by activating it.
+    expect(applyAgentSelection(['a'], 'a', { multi: false })).toEqual([])
+  })
+
+  it('F4 multi-select: picking another ADDS (unchanged shipped behaviour)', () => {
+    expect(applyAgentSelection(['a'], 'b', { multi: true })).toEqual(['a', 'b'])
+  })
+
+  it('F5 multi-select: picking a selected one removes just that one', () => {
+    expect(applyAgentSelection(['a', 'b'], 'a', { multi: true })).toEqual(['b'])
+  })
+
+  it('F6 never mutates the input array', () => {
+    const input = ['a']
+    Object.freeze(input)
+    expect(() => applyAgentSelection(input, 'b', { multi: true })).not.toThrow()
+    expect(() => applyAgentSelection(input, 'a', { multi: true })).not.toThrow()
+    expect(input).toEqual(['a'])
+  })
+
+  it('F7 defaults to single-select when options are omitted', () => {
+    // The fail-safe direction: a caller that forgets gets the surface that
+    // works on every edition.
+    expect(applyAgentSelection(['a'], 'b')).toEqual(['b'])
+  })
+
+  it('F8 collapseSelection keeps the most recent pick', () => {
+    expect(collapseSelection(['a', 'b'], { multi: false })).toEqual(['b'])
+    expect(collapseSelection(['a', 'b', 'c'], { multi: false })).toEqual(['c'])
+  })
+
+  it('F9 collapseSelection is identity when multi, or with nothing to collapse', () => {
+    expect(collapseSelection(['a', 'b'], { multi: true })).toEqual(['a', 'b'])
+    expect(collapseSelection(['a'], { multi: false })).toEqual(['a'])
+    expect(collapseSelection([], { multi: false })).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F10-F13, F18, F23-F24 — source-structure guards
+// ---------------------------------------------------------------------------
+
+describe('#2128 structure guards', () => {
+  it('F10 the picker declares `multi` with a fail-safe default of false', () => {
+    // Anchored on the `multi` KEY, not on a bare /default:\s*false/ — the file
+    // already carries `busy: { type: Boolean, default: false }`, so a loose
+    // pattern would pass with the prop deleted entirely.
+    const src = pickerSource()
+    expect(
+      /multi\s*:\s*\{[^}]*default\s*:\s*false[^}]*\}/.test(src),
+      'PortalAgentPicker must declare a `multi` prop defaulting to false — a ' +
+      'caller that forgets to bind it must get single-select, not this bug again'
+    ).toBe(true)
+    expect(/multi\s*:\s*\{[^}]*default\s*:\s*true/.test(src)).toBe(false)
+  })
+
+  it('F11 Portal.vue binds the capability into the picker', () => {
+    expect(portalSource()).toContain(':multi="store.multiAgentChatAvailable"')
+  })
+
+  it('F12 the room-refusal branch sits BEFORE <PortalConversation', () => {
+    const src = portalSource()
+    // The EXACT v-else-if string: indexOf('activeRoomIdFromRoute') alone hits
+    // the PortalRoom v-if first and measures nothing.
+    const branchAt = src.indexOf('v-else-if="activeRoomIdFromRoute"')
+    const convAt = src.indexOf('<PortalConversation')
+
+    // Both asserted present BEFORE comparing: indexOf returns -1 on absence,
+    // and expect(-1).toBeLessThan(x) passes — so a deleted branch would go green.
+    expect(branchAt, 'the room-URL refusal branch is gone').toBeGreaterThan(-1)
+    expect(convAt, '<PortalConversation is gone').toBeGreaterThan(-1)
+    expect(
+      branchAt,
+      'the room-URL refusal branch must precede <PortalConversation. After it, a ' +
+      'room URL falls through and opens a DIFFERENT agent\'s conversation ' +
+      '(activeAgent defaults to the first roster entry), or renders a blank <main>.'
+    ).toBeLessThan(convAt)
+  })
+
+  it('F18 the capability is a term in <PortalRoom>\'s own v-if', () => {
+    // Nothing else implements AC #4. Someone simplifying the chain could drop
+    // this with every other test still green.
+    const src = portalSource()
+    const roomAt = src.indexOf('<PortalRoom')
+    expect(roomAt, '<PortalRoom is gone').toBeGreaterThan(-1)
+    const vIfAt = src.indexOf('v-if=', roomAt)
+    expect(vIfAt, '<PortalRoom has no v-if').toBeGreaterThan(-1)
+    const vIf = src.slice(vIfAt, src.indexOf('\n', vIfAt))
+    expect(
+      vIf,
+      'PortalRoom must not mount when rooms are unavailable — its onMounted ' +
+      'issues GET /api/rooms/:id, which is the 404 this issue is about'
+    ).toContain('store.multiAgentChatAvailable')
+  })
+
+  it('F23 only a cleanly-loaded roster may claim the capability is absent', () => {
+    const src = portalSource()
+    const branchAt = src.indexOf('v-else-if="activeRoomIdFromRoute"')
+    expect(branchAt).toBeGreaterThan(-1)
+    const branch = src.slice(branchAt, src.indexOf('<PortalConversation'))
+
+    // The honest-copy split: a transient 5xx on an ENTITLED instance must not
+    // render "aren't enabled here", which is a false statement about the
+    // operator's build.
+    for (const term of ['store.rosterLoaded', 'store.unavailable', 'store.error']) {
+      expect(branch, `the room branch must distinguish ${term}`).toContain(term)
+    }
+    const claimAt = branch.indexOf("isn't available on this instance")
+    expect(claimAt, 'the room branch never states the capability is absent').toBeGreaterThan(-1)
+    // …and that claim must come last, after all three qualifying arms.
+    for (const term of ['store.rosterLoaded', 'store.unavailable', 'store.error']) {
+      expect(branch.indexOf(term), `${term} must be tested before the claim`).toBeLessThan(claimAt)
+    }
+  })
+
+  it('F24 every exit from the stage tests roomId, not sessionId alone', () => {
+    // The refusal must not be a room the user cannot leave. Each of these
+    // navigated only on `sessionId`, so from /workspace/r/:id nothing moved.
+    const src = portalSource()
+    for (const fn of ['startBlankChat', 'newChatWithAgent', 'onSignOut']) {
+      const at = src.indexOf(`function ${fn}(`)
+      expect(at, `${fn} is gone`).toBeGreaterThan(-1)
+      const body = src.slice(at, src.indexOf('\n}', at))
+      expect(
+        body,
+        `${fn} navigates only on sessionId — from a room URL it changes nothing, ` +
+        `leaving the user parked on the refusal with no way out`
+      ).toContain('route.params.roomId')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F14-F17, F19-F22 — the store contract
+// ---------------------------------------------------------------------------
+
+describe('#2128 store gate', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('F14 a roster reporting the capability raises the flag', async () => {
+    const store = signedInStore()
+    axios.get.mockResolvedValueOnce(rosterResponse({ multi_agent_chat_available: true }))
+    await store.fetchRoster()
+    expect(store.multiAgentChatAvailable).toBe(true)
+    expect(store.rosterLoaded).toBe(true)
+  })
+
+  it('F15 a payload that omits the field reads as ABSENT', async () => {
+    // Strict `=== true`: an older backend, a proxied HTML body, or a string
+    // "false" must all fail closed.
+    const store = signedInStore()
+    for (const payload of [{}, { multi_agent_chat_available: 'false' }, { multi_agent_chat_available: 1 }]) {
+      axios.get.mockResolvedValueOnce(rosterResponse(payload))
+      await store.fetchRoster()
+      expect(store.multiAgentChatAvailable).toBe(false)
+    }
+  })
+
+  it('F16 createRoom refuses without issuing the request', async () => {
+    const store = signedInStore()
+    store.multiAgentChatAvailable = false
+    await expect(store.createRoom(['a', 'b'], 'x')).rejects.toMatchObject({
+      code: 'rooms_unavailable',
+      message: MULTI_AGENT_UNAVAILABLE,
+    })
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('F17 fetchRooms resolves empty without issuing the request', async () => {
+    const store = signedInStore()
+    store.multiAgentChatAvailable = false
+    await expect(store.fetchRooms()).resolves.toEqual([])
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  it('F19 a transport failure does NOT lower the flag', async () => {
+    // A failed request is not evidence the capability went away. Lowering here
+    // would unmount a live room and flash a refusal it then takes back.
+    const store = signedInStore()
+    axios.get.mockResolvedValueOnce(rosterResponse({ multi_agent_chat_available: true }))
+    await store.fetchRoster()
+    expect(store.multiAgentChatAvailable).toBe(true)
+
+    axios.get.mockRejectedValueOnce({ message: 'Network Error' })
+    await store.fetchRoster()
+    expect(store.multiAgentChatAvailable).toBe(true)
+    expect(store.rosterLoaded).toBe(true)
+  })
+
+  it.each([404, 403])('F20 a definitive %s from the rooms endpoint self-heals the flag', async (status) => {
+    // The entitlement can vanish BETWEEN the roster load and the confirm. Without
+    // this the picker still 404s mid-session and shows the generic dead-end copy.
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios.post.mockRejectedValueOnce({ response: { status } })
+
+    await expect(store.createRoom(['a', 'b'], 'x')).rejects.toMatchObject({
+      code: 'rooms_unavailable',
+    })
+    expect(store.multiAgentChatAvailable).toBe(false)
+  })
+
+  it('F20b a 500 from the rooms endpoint does NOT lower the flag', async () => {
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios.post.mockRejectedValueOnce({ response: { status: 500 } })
+    await expect(store.createRoom(['a', 'b'], 'x')).rejects.toBeTruthy()
+    expect(store.multiAgentChatAvailable).toBe(true)
+  })
+
+  it('F21 signOut clears both per-session flags', async () => {
+    const store = signedInStore()
+    axios.get.mockResolvedValueOnce(rosterResponse({ multi_agent_chat_available: true }))
+    await store.fetchRoster()
+
+    store.signOut()
+    expect(store.multiAgentChatAvailable).toBe(false)
+    expect(store.rosterLoaded).toBe(false)
+  })
+
+  it('F21b a 401 during roster load leaves the flags cleared', async () => {
+    // `endSession()` runs inside the catch, so anything assigned after it —
+    // in the catch OR in `finally` — would re-set what the sign-out just cleared.
+    const store = signedInStore()
+    axios.get.mockResolvedValueOnce(rosterResponse({ multi_agent_chat_available: true }))
+    await store.fetchRoster()
+
+    axios.get.mockRejectedValueOnce({ response: { status: 401 } })
+    await store.fetchRoster()
+    expect(store.multiAgentChatAvailable).toBe(false)
+    expect(store.rosterLoaded).toBe(false)
+  })
+
+  it('F22 all FIVE room actions are gated, and none issues a request', async () => {
+    // Three of these have exactly one caller each, inside a component the render
+    // gate stops mounting — "unreachable by construction" is a claim about
+    // today's call graph, in a file a sibling issue proposes to rewrite.
+    const store = signedInStore()
+    store.multiAgentChatAvailable = false
+
+    await expect(store.createRoom(['a', 'b'], 'x')).rejects.toMatchObject({ code: 'rooms_unavailable' })
+    await expect(store.fetchRoom('r1')).rejects.toMatchObject({ code: 'rooms_unavailable' })
+    await expect(store.postRoomMessage('r1', 'hi')).rejects.toMatchObject({ code: 'rooms_unavailable' })
+    await expect(store.addRoomParticipant('r1', 'scout')).rejects.toMatchObject({ code: 'rooms_unavailable' })
+    await expect(store.fetchRooms()).resolves.toEqual([])
+
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('F22b with the flag raised, the room actions issue their requests as before', async () => {
+    // The gate must not be a one-way ratchet — an entitled instance is unchanged.
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios.post.mockResolvedValueOnce({ data: { id: 'r1' } })
+    axios.get.mockResolvedValueOnce({ data: { rooms: [{ id: 'r1' }] } })
+
+    await expect(store.createRoom(['a', 'b'], 'x')).resolves.toEqual({ id: 'r1' })
+    await expect(store.fetchRooms()).resolves.toEqual([{ id: 'r1', is_room: true }])
+    expect(axios.post).toHaveBeenCalledWith(
+      '/api/rooms', { name: 'x', agents: ['a', 'b'] }, expect.anything()
+    )
+  })
+
+  it('F17b fetchAllSessions still degrades to threads-only with no rooms', async () => {
+    const store = signedInStore()
+    store.multiAgentChatAvailable = false
+    store.agents = []
+    await expect(store.fetchAllSessions()).resolves.toEqual([])
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+})

--- a/src/frontend/tests/unit/workspaceRoomsGate.spec.js
+++ b/src/frontend/tests/unit/workspaceRoomsGate.spec.js
@@ -320,6 +320,57 @@ describe('#2128 store gate', () => {
     expect(store.multiAgentChatAvailable).toBe(false)
   })
 
+  it.each([
+    [403, 'agent_not_accessible', "You do not have access to agent 'scout'"],
+    [404, 'room_not_found', 'Room not found'],
+    [410, 'room_closed', 'This room is closed'],
+  ])('F20c a coded %i refusal is a DENIAL, not an absent engine', async (status, code, message) => {
+    // The status alone is not the signal. On a fully ENTITLED instance the
+    // rooms module answers "you can't reach that agent" with a 403 and "you're
+    // not in that room" with a uniform 404 — both with its own structured
+    // detail. Lowering the capability on those turns one denied request into a
+    // session-long false claim about the operator's build, and replaces the
+    // only message that tells the user what to do.
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios.post.mockRejectedValueOnce({ response: { status, data: { detail: { code, message } } } })
+
+    await expect(store.createRoom(['a', 'b'], 'x')).rejects.toMatchObject({
+      response: { data: { detail: { code } } },
+    })
+    expect(
+      store.multiAgentChatAvailable,
+      'a refusal the serving module authored proves the module is SERVING'
+    ).toBe(true)
+  })
+
+  it('F20d a coded refusal keeps the server\'s own words', async () => {
+    // The generic path in onPickerConfirm reads `detail.message`; clobbering
+    // `err.code`/`err.message` would route it into the rooms-unavailable arm
+    // and the real reason would never reach the user.
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios.post.mockRejectedValueOnce({
+      response: { status: 403, data: { detail: { code: 'agent_not_accessible', message: 'nope' } } },
+    })
+    const err = await store.createRoom(['a', 'b'], 'x').catch((e) => e)
+    expect(err.code).toBeUndefined()
+    expect(err.message).not.toBe(MULTI_AGENT_UNAVAILABLE)
+  })
+
+  it.each([
+    [404, 'Not Found'],                                                   // route never mounted
+    [403, "Enterprise feature 'x' is not licensed for this instance."],   // mounted, unlicensed
+  ])('F20e a STRING-detail %i is absence and still self-heals', async (status, detail) => {
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios.post.mockRejectedValueOnce({ response: { status, data: { detail } } })
+    await expect(store.createRoom(['a', 'b'], 'x')).rejects.toMatchObject({
+      code: 'rooms_unavailable',
+    })
+    expect(store.multiAgentChatAvailable).toBe(false)
+  })
+
   it('F20b a 500 from the rooms endpoint does NOT lower the flag', async () => {
     const store = signedInStore()
     store.multiAgentChatAvailable = true

--- a/src/frontend/tests/unit/workspaceRoomsGate.spec.js
+++ b/src/frontend/tests/unit/workspaceRoomsGate.spec.js
@@ -371,6 +371,35 @@ describe('#2128 store gate', () => {
     expect(store.multiAgentChatAvailable).toBe(false)
   })
 
+  it.each([
+    ['fetchRoom', (s) => s.fetchRoom('r1'), 'get'],
+    ['postRoomMessage', (s) => s.postRoomMessage('r1', 'hi'), 'post'],
+    ['addRoomParticipant', (s) => s.addRoomParticipant('r1', 'scout'), 'post'],
+  ])('F20f %s self-heals too — nothing else converges an OPEN room', async (_n, call, verb) => {
+    // `refreshThreads()` is event-driven, not periodic, so a capability that
+    // lapses while a room is open is only ever observed by the room's own
+    // calls. Without the heal here the 3s poll swallows its 404 and the room
+    // is a dead end for the rest of the session.
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios[verb].mockRejectedValueOnce({ response: { status: 404, data: { detail: 'Not Found' } } })
+    await expect(call(store)).rejects.toMatchObject({ code: 'rooms_unavailable' })
+    expect(store.multiAgentChatAvailable).toBe(false)
+  })
+
+  it('F20g a room the caller is not in does NOT switch the workspace off', async () => {
+    // `/api/rooms/:id` answers a uniform CODED 404 for a room the caller is not
+    // a member of (enumeration-safety). Reading that as absence would let one
+    // stale room link flip an entitled workspace to single-select.
+    const store = signedInStore()
+    store.multiAgentChatAvailable = true
+    axios.get.mockRejectedValueOnce({
+      response: { status: 404, data: { detail: { code: 'room_not_found', message: 'Room not found' } } },
+    })
+    await expect(store.fetchRoom('someone-elses-room')).rejects.toBeTruthy()
+    expect(store.multiAgentChatAvailable).toBe(true)
+  })
+
   it('F20b a 500 from the rooms endpoint does NOT lower the flag', async () => {
     const store = signedInStore()
     store.multiAgentChatAvailable = true

--- a/tests/unit/test_2128_workspace_rooms_capability.py
+++ b/tests/unit/test_2128_workspace_rooms_capability.py
@@ -1,0 +1,310 @@
+"""The Workspace roster tells the client whether a chat may hold MORE THAN ONE
+agent (#2128).
+
+`PortalAgentPicker` lets a Workspace client select several agents, captioned
+"they will share this conversation". Two or more routes to `POST /api/rooms`,
+which a community build does not serve at all — so the affordance was always
+offered and could never work, dead-ending in a generic "Could not start that
+chat."
+
+The signal cannot come from the existing frontend entitlement store: that reads
+`GET /api/settings/feature-flags`, which is platform-JWT gated, while the whole
+point of the Workspace is that an external client reaches it on an email-OTP
+session with no platform account. So the roster carries the bit.
+
+What these tests pin, in order of how badly each would fail:
+
+  1. the bit is derived from the ROOMS feature id specifically, not from
+     "is anything enterprise registered" — a different module must not turn it on;
+  2. it fails CLOSED on every unreadable state, because the error direction that
+     matters is "offer less";
+  3. it reads the LIVE singleton, so the supported test seam is observed — a
+     module-scope import would freeze the boot-time instance;
+  4. the field is additive: nothing else on the roster moves.
+
+Runs against a throwaway sqlite seeded with the OSS tables the roster joins over
+(the `test_ent357_workspace_owned_roster.py` harness).
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ROOMS_FEATURE_ID = "shared_sessions"
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def roster_db(tmp_path, monkeypatch):
+    """Fresh sqlite with the OSS tables the roster joins over."""
+    db_file = tmp_path / "trinity-rooms-capability.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+
+    from db.engine import get_engine
+    from db.tables import (
+        metadata as oss_metadata, agent_ownership, agent_sharing, system_settings, users,
+    )
+    # `system_settings` too: `get_roster` does a function-local
+    # `from services import tts_service` for its voice check, so the real
+    # settings read runs against this database.
+    oss_metadata.create_all(
+        get_engine(), tables=[users, agent_ownership, agent_sharing, system_settings]
+    )
+    yield get_engine()
+
+
+@pytest.fixture()
+def entitlements(monkeypatch):
+    """A real, deterministic entitlement service, swapped through the supported
+    seam and restored afterwards.
+
+    B9 — the fixture pins `sys.modules["services.entitlement_service"]` to the
+    module it just imported instead of trusting a bare import to return the real
+    thing. Three test files replace that key with a bare `MagicMock()`, and until
+    #2128 it was absent from conftest's restore tuple, so in a polluted order the
+    import under test would resolve to a mock whose `is_entitled` returns a mock
+    — which pydantic coerces to True on a bool field, i.e. an OSS build silently
+    advertising the feature. The conftest key is the real fix; this is the belt
+    that makes THIS file's verdict independent of run order either way.
+    """
+    import importlib
+
+    module = importlib.import_module("services.entitlement_service")
+    monkeypatch.setitem(sys.modules, "services.entitlement_service", module)
+
+    original = module.entitlement_service
+    try:
+        yield module
+    finally:
+        module._set_for_testing(original)
+
+
+def _install(entitlements, *feature_ids, oss_only=False, monkeypatch=None):
+    """Install a fresh service with exactly `feature_ids` registered.
+
+    `oss_only` constructs the service AFTER setting the env var, because
+    `_oss_only` is read once in `__init__` — setting the variable on an
+    already-built instance does nothing at all, and a test written the obvious
+    way would pass for the wrong reason.
+    """
+    if oss_only:
+        assert monkeypatch is not None
+        monkeypatch.setenv("TRINITY_OSS_ONLY", "1")
+    svc = entitlements.EntitlementService()
+    for fid in feature_ids:
+        svc.register_module(fid)
+    entitlements._set_for_testing(svc)
+    return svc
+
+
+def _seed(engine, *, email="client@example.com"):
+    from db.tables import agent_ownership, agent_sharing, users
+    now = "2026-08-12T00:00:00Z"
+    with engine.begin() as conn:
+        conn.execute(users.insert().values(
+            id=1, username="owner", email="owner@example.com", role="user",
+            created_at=now, updated_at=now,
+        ))
+        for name in ("scout", "sage"):
+            conn.execute(agent_ownership.insert().values(
+                agent_name=name, owner_id=1, created_at=now, is_system=0, deleted_at=None,
+            ))
+            conn.execute(agent_sharing.insert().values(
+                agent_name=name, shared_with_email=email, shared_by_id=1, created_at=now,
+            ))
+    return email
+
+
+# ---------------------------------------------------------------------------
+# B1-B4 — the bit is derived from the ROOMS id, and only from it
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_registered_rooms_module_reports_available(roster_db, entitlements, monkeypatch):
+    """B1 — an entitled instance offers multi-agent chat."""
+    monkeypatch.delenv("TRINITY_OSS_ONLY", raising=False)
+    _install(entitlements, ROOMS_FEATURE_ID)
+    email = _seed(roster_db)
+
+    from client_portal import service
+    roster = await service.get_roster(email)
+    assert roster.multi_agent_chat_available is True
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_reports_unavailable(roster_db, entitlements, monkeypatch):
+    """B2 — a community build: nothing registered, so nothing is offered.
+
+    This is the assertion that goes green for the wrong reason if the helper
+    drops its `bool()` cast AND an earlier test leaked a MagicMock for the
+    registry — run this file after `test_ent123_tokenless_clone.py` to exercise
+    that path.
+    """
+    monkeypatch.delenv("TRINITY_OSS_ONLY", raising=False)
+    _install(entitlements)
+    email = _seed(roster_db)
+
+    from client_portal import service
+    roster = await service.get_roster(email)
+    assert roster.multi_agent_chat_available is False
+
+
+@pytest.mark.asyncio
+async def test_a_different_module_does_not_turn_it_on(roster_db, entitlements, monkeypatch):
+    """B3 — id-specific, not "is anything enterprise present".
+
+    The frontend's own gate is `hasAnyEnterprise` in places; copying that shape
+    here would advertise rooms on any instance carrying any other paid module.
+    """
+    monkeypatch.delenv("TRINITY_OSS_ONLY", raising=False)
+    _install(entitlements, "a2a")
+    email = _seed(roster_db)
+
+    from client_portal import service
+    roster = await service.get_roster(email)
+    assert roster.multi_agent_chat_available is False
+
+
+@pytest.mark.asyncio
+async def test_oss_only_lockdown_reports_unavailable(roster_db, entitlements, monkeypatch):
+    """B4 — `TRINITY_OSS_ONLY=1` wins over a registered module.
+
+    The service is constructed AFTER `setenv` on purpose: `_oss_only` is read
+    once in `__init__`, so setting the variable against the live singleton is
+    inert and the test would pass without proving anything.
+    """
+    _install(entitlements, ROOMS_FEATURE_ID, oss_only=True, monkeypatch=monkeypatch)
+    email = _seed(roster_db)
+
+    from client_portal import service
+    roster = await service.get_roster(email)
+    assert roster.multi_agent_chat_available is False
+
+
+# ---------------------------------------------------------------------------
+# B5 — fail closed, and never at the roster's expense
+# ---------------------------------------------------------------------------
+
+class _Raises:
+    def __init__(self, exc):
+        self._exc = exc
+
+    def is_entitled(self, feature_id):
+        raise self._exc
+
+
+class _NoSuchMethod:
+    """A registry object that has no `is_entitled` at all — the second silent
+    shape (AttributeError), not just an exception from inside the call."""
+
+
+@pytest.mark.parametrize("broken, label", [
+    (_Raises(RuntimeError("registry exploded")), "raises"),
+    (_NoSuchMethod(), "attribute missing"),
+])
+@pytest.mark.asyncio
+async def test_an_unreadable_registry_fails_closed(
+    roster_db, entitlements, monkeypatch, broken, label
+):
+    """B5a/B5b — unreadable is not "available", and the roster still loads.
+
+    Fail-open here would reintroduce the exact bug: a picker offering an
+    affordance that dead-ends.
+    """
+    monkeypatch.delenv("TRINITY_OSS_ONLY", raising=False)
+    entitlements._set_for_testing(broken)
+    email = _seed(roster_db)
+
+    from client_portal import service
+    roster = await service.get_roster(email)
+    assert roster.multi_agent_chat_available is False, label
+    assert sorted(a.name for a in roster.agents) == ["sage", "scout"], (
+        "a capability read failure emptied the roster"
+    )
+
+
+# ---------------------------------------------------------------------------
+# B6-B7 — the field is additive and safe by default
+# ---------------------------------------------------------------------------
+
+def test_the_model_default_is_unavailable():
+    """B6 — an older backend, a partial payload or a hand-built model must not
+    advertise the affordance."""
+    from client_portal.models import PortalRoster
+
+    assert PortalRoster(agents=[]).multi_agent_chat_available is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("registered", [(), (ROOMS_FEATURE_ID,)])
+async def test_the_rest_of_the_roster_is_unchanged(
+    roster_db, entitlements, monkeypatch, registered
+):
+    """B7 — additive in BOTH arms: agents, email and per-agent capabilities are
+    identical whether or not rooms are available."""
+    monkeypatch.delenv("TRINITY_OSS_ONLY", raising=False)
+    _install(entitlements, *registered)
+    email = _seed(roster_db)
+
+    from client_portal import service
+    roster = await service.get_roster(email)
+
+    assert roster.client_email == email
+    assert sorted(a.name for a in roster.agents) == ["sage", "scout"]
+    assert all(a.voice_available is False for a in roster.agents)
+
+
+# ---------------------------------------------------------------------------
+# B8-B9 — the seam really is observed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_roster_observes_a_singleton_swapped_after_import(
+    roster_db, entitlements, monkeypatch
+):
+    """B8 — the helper reads the LIVE singleton.
+
+    `_set_for_testing` rebinds a MODULE GLOBAL. A module-scope
+    `from services.entitlement_service import entitlement_service` would bind the
+    boot-time instance once and never see the swap — so this test is what makes
+    the function-local import load-bearing rather than stylistic. It swaps twice
+    against one already-imported `client_portal.service` so a cached binding
+    cannot satisfy both halves.
+    """
+    monkeypatch.delenv("TRINITY_OSS_ONLY", raising=False)
+    email = _seed(roster_db)
+    from client_portal import service
+
+    _install(entitlements, ROOMS_FEATURE_ID)
+    assert (await service.get_roster(email)).multi_agent_chat_available is True
+
+    _install(entitlements)
+    assert (await service.get_roster(email)).multi_agent_chat_available is False
+
+
+def test_the_registry_module_under_test_is_the_real_one(entitlements):
+    """B9 — identity check, not a bare import.
+
+    If a leaked `MagicMock` were sitting in `sys.modules` for this key, every
+    assertion above would be measuring the mock. Assert the module is real
+    before trusting any of them.
+    """
+    from unittest.mock import Mock
+
+    module = sys.modules["services.entitlement_service"]
+    assert module is entitlements
+    assert not isinstance(module, Mock), (
+        "services.entitlement_service is a leaked test stub — a mock's "
+        "is_entitled() returns a mock, which pydantic coerces to True"
+    )
+    assert hasattr(module, "EntitlementService")
+    assert hasattr(module, "_set_for_testing")

--- a/tests/unit/test_2128_workspace_rooms_capability.py
+++ b/tests/unit/test_2128_workspace_rooms_capability.py
@@ -68,13 +68,17 @@ def entitlements(monkeypatch):
     seam and restored afterwards.
 
     B9 — the fixture pins `sys.modules["services.entitlement_service"]` to the
-    module it just imported instead of trusting a bare import to return the real
-    thing. Three test files replace that key with a bare `MagicMock()`, and until
-    #2128 it was absent from conftest's restore tuple, so in a polluted order the
-    import under test would resolve to a mock whose `is_entitled` returns a mock
-    — which pydantic coerces to True on a bool field, i.e. an OSS build silently
-    advertising the feature. The conftest key is the real fix; this is the belt
-    that makes THIS file's verdict independent of run order either way.
+    module it just imported, instead of trusting a bare import to return the
+    real thing.
+
+    Three other test files replace that key with a bare `MagicMock()`. All three
+    restore it (`patch.dict(...).stop()` in a fixture `finally`, plus
+    `monkeypatch.delitem`), so there is no live leak today — measured on the full
+    unit tier, not assumed. But a mock's `is_entitled` returns a mock, and
+    pydantic coerces one to True on a bool field, so IF a future file ever left
+    one behind, the capability would read *available* on a community build. The
+    identity assertion below is what makes that fail loudly here rather than go
+    green on a lie (verified by planting exactly that leak).
     """
     import importlib
 
@@ -142,13 +146,7 @@ async def test_registered_rooms_module_reports_available(roster_db, entitlements
 
 @pytest.mark.asyncio
 async def test_empty_registry_reports_unavailable(roster_db, entitlements, monkeypatch):
-    """B2 — a community build: nothing registered, so nothing is offered.
-
-    This is the assertion that goes green for the wrong reason if the helper
-    drops its `bool()` cast AND an earlier test leaked a MagicMock for the
-    registry — run this file after `test_ent123_tokenless_clone.py` to exercise
-    that path.
-    """
+    """B2 — a community build: nothing registered, so nothing is offered."""
     monkeypatch.delenv("TRINITY_OSS_ONLY", raising=False)
     _install(entitlements)
     email = _seed(roster_db)


### PR DESCRIPTION
Fixes #2128

## The bug

On a build with no rooms engine, the Workspace agent picker let a client select 2+ agents — captioned *"they will share this conversation"* — and then failed. `Portal.vue::onPickerConfirm` routes 2+ agents to `store.createRoom()` → `POST /api/rooms`, and that route is served **only** by a private module. On a community build (or an unentitled / `TRINITY_OSS_ONLY` instance) the request 404s and the picker renders the generic `'Could not start that chat.'` The affordance was always offered and could never work.

Regression provenance: the retired Sessions surface *was* gated (`NavBar.vue` carried an entitlement `v-if`, and the route carried `requiresEntitlement`). #2120 removed both and moved the capability into the picker; no equivalent gate came with it, and `/workspace/r/:roomId` carries no entitlement meta.

The reason it isn't a one-liner: the existing entitlement signal is unreachable by the principal that needs it. `enterpriseStore.isEntitled()` reads `GET /api/settings/feature-flags`, which is `get_current_user`-gated, and the store behind it early-returns `[]` for any caller without a platform JWT — i.e. for **every** external client, *including on an instance where the capability is present*. Routing `meta.requiresEntitlement` onto the room route is likewise inert: the entitlement block is nested inside `if (to.meta.requiresAuth)`, and `/workspace*` deliberately carries no `requiresAuth`.

So the signal rides on **`PortalRoster`** — a payload `get_portal_principal` already serves to both principal kinds and `Portal.vue::bootstrap()` already awaits first. One field, no new route, no new auth surface, no extra round-trip (`voice_available` is the per-agent precedent).

## The decision: gate, don't degrade

Hide the multi-select rather than showing it disabled with a reason. The viewer on this surface is the **operator's customer** — someone who can neither buy the missing module nor act on knowing it exists. So the field is named for the *capability* (`multi_agent_chat_available`), never the module or the edition, and no string on this path says "not licensed", names an edition, or prompts an upgrade. Fail-closed throughout: an unreadable registry, an older backend that omits the field, a partial payload, or a failed read all report the capability **absent**, because promising an affordance that cannot work is the bug being fixed.

When the flag is false: the picker is single-select, all five room store actions refuse **before** issuing a request, and `/workspace/r/:roomId` renders an honest refusal instead of mounting the room.

## What review changed — a real bug the implementation had

The self-heal originally lowered the capability on **any** 403/404 from a room call. But the serving module answers **ordinary denials with those same codes on a fully entitled instance**: *you cannot reach that agent* → 403, *you are not in that room* → uniform 404. A client clicking a just-un-shared agent, or opening a stale link to a room they'd left, would have flipped the **whole workspace** to single-select for the rest of the session — and replaced an actionable *"you do not have access to agent x"* with a false claim about the operator's build.

It now discriminates on the **body shape**, which is sound because absence and denial are authored by different layers:

| Shape | Author | Meaning | Action |
|---|---|---|---|
| `detail` is a plain **string** | FastAPI's own `"Not Found"` for an unmounted route; the entitlement gate's one-sentence 403 | the substrate is **absent** | lower the flag |
| `detail` is an object with a **`code`** | the serving module's own `{code, message}` | the module is **serving**; this is an ordinary refusal | pass through, surface the server's own words |

Verified against the real submodule source, both directions: **every** refusal in `shared_sessions/router.py` goes through one `_raise(e: RoomError)` helper producing `detail={"code", "message", …}` — there is no plain-string 403/404 path anywhere in it — while `dependencies.requires_entitlement` raises a plain-string 403.

The self-heal is why AC #4 holds *through a transition*, not just at load: `refreshThreads()` is event-driven, not periodic, so a capability that lapses while a room is **open** is only ever observed by that room's own calls. Without it the 3s poll swallows its 404 and the room is a dead end for the rest of the session; with it the poll lowers the flag, `<PortalRoom>` unmounts, and the refusal takes the stage.

## Verification

- **WAVE-4 `verify-local`: PASS** (`result.json` → `"status": "pass"`) — prod image build + import smoke, boot + health, real agent container, integration suite. Prod frontend image built.
- **Unit: 3 failed / 9695 passed / 17 skipped / 1 xfailed.** The 3 are the known pre-existing `test_pat_propagation_properties.py::TestKnownGaps::test_a_backslash_in_the_token_does_not_raise` params — present on `dev` itself, unrelated to this branch. Baseline matches exactly.
- **Integration: 70 passed / 13 skipped / 2 deselected.**
- Scoped re-run on this branch: `test_2128_workspace_rooms_capability.py` 11 passed; the ten neighbouring backend portal suites + `test_models_centralized.py` 216 passed; frontend `npm run test:unit` 13 files / 174 tests passed; `npm run build` and `npm run check:tokens` clean; `enterprise-docs-guard` pattern clean.

Tests are the two named regression files — `tests/unit/test_2128_workspace_rooms_capability.py` (11 cases: fail-closed on a raising/incomplete registry, `TRINITY_OSS_ONLY` lockdown, a *different* module not turning it on, the model default, a singleton swapped after import, and a module-identity assertion so a leaked test double fails loudly instead of going green on a lie) and `src/frontend/tests/unit/workspaceRoomsGate.spec.js` (selection semantics, structure guards, and the store gate — including the four discriminator cases, a 500 and a transport failure **not** lowering the flag, all five actions gated, and sign-out clearing both per-session flags).

## Raw-color note

`views/Portal.vue` `raw_gray` went **56 → 24** by hoisting nine duplicated stage-ink strings to five named constants. Rendered output is byte-identical — each constant is the exact string it replaced.

Measured, for the record:

| | `raw_gray` |
|---|---|
| committed baseline (generated 2026-07-31 @ `5b289996`) | 20 |
| `origin/dev` today | **40** |
| this branch mid-way (before the hoist) | 56 |
| this branch now | **24** |

So the file is well below `dev` but still 4 above the committed baseline. **The baseline file is stale and was deliberately NOT regenerated** — hiding a 20-count drift that predates this branch behind this PR would be the wrong place to fix it.

Worth stating plainly: **`gray` has no semantic token.** The design-system contract's colour section ends *"Everything else is gray"* and prescribes these exact shades for the ink ladder, so there is nothing to convert `text-gray-500 dark:text-gray-400` *into* — repainting body copy in `status-*` or `action-*` would be a defect, not compliance. The ratchet can therefore only be satisfied by writing the markup **once**, which is what the hoist does: the number of places a raw shade is written drops from twenty-odd to five.

## Known limitations / residuals

Recorded here deliberately; **no issues filed.**

1. `requires_entitlement` returns an *unauthenticated* 403 naming the feature and its licensing state. Pre-existing and wider than this PR — this change does not add to it, and the frontend never surfaces that string on the portal path.
2. The raw-color baseline is stale (2026-07-31; `dev` measures 40 against a recorded 20) and **the ratchet has no CI job** — `scan-raw-colors.mjs` always exits 0 and its own docstring calls the comparison "the future CI ratchet".
3. `MAX_PARTICIPANTS = 12` server-side, with no corresponding cap in the picker — a client can select more and be refused on confirm.
4. A mid-open capability flip silently drops a 2nd selection: `collapseSelection` keeps the most recent pick without telling the user one was dropped.
5. Single-select still renders a checkbox-shaped indicator. `role`/`aria-pressed` are corrected, but no radio primitive exists in the design system, so the visual affordance is unchanged.
6. `Portal.vue::activeRoomId` is write-only dead state left by ent#361 — set by `openRoom()`/`leaveRoomRoute()`, read by nothing (the route param is authoritative). Left alone rather than removed, to keep this diff to the bug.
7. OSS operators get **no in-product signal** that multi-agent chat exists at all. That is the deliberate consequence of gate-don't-degrade for the *client* surface; whether the *operator* deserves a different answer is a product call, not a bug.
8. `_multi_agent_chat_available()`'s failure warning is unmemoized — a registry that raises logs once per roster load.

Adjacent-but-out-of-scope by design: #2136 (two room UIs, `components/rooms/*` orphaned, push-vs-poll), ent#387 (room budget surface), #2129 (the full rooms architecture/requirements/feature-flow write-up — which is why this PR adds only the ~6 lines describing the capability seam it introduces, and no rooms flow doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
