### PR TITLE
feat(workspace): give each agent a page (ent#360)

### DIFF
--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -342,6 +342,7 @@
 | Session Tab | [session-tab.md](feature-flows/session-tab.md) | The `--resume` engine — each turn reattaches to the same Claude memory (SESSION_TAB_2026-04). Its Agent Detail surface retired in ent#358; the engine and endpoints are live |
 | Workspace absorbs Session | [workspace-absorbs-session.md](feature-flows/workspace-absorbs-session.md) | ent#358 — one continuous-conversation surface, with the continuity parity that had to land before the other could be removed |
 | Workspace sidebar IA | [workspace-sidebar-ia.md](feature-flows/workspace-sidebar-ia.md) | ent#359 — agents block on top, starred chats, per-agent unread badges; why the per-viewer state could not be a column on the chat row |
+| Workspace agent page | [workspace-agent-page.md](feature-flows/workspace-agent-page.md) | ent#360 — an agent becomes a destination; what the page deliberately does NOT carry, and why that is enforced by projection rather than by template |
 | Web Terminal | [web-terminal.md](feature-flows/web-terminal.md) | Browser-based terminal for System Agent |
 | Self-Execute | [self-execute.md](feature-flows/self-execute.md) | Agent background task during chat (SELF-EXEC-001) |
 

--- a/docs/memory/feature-flows/workspace-agent-page.md
+++ b/docs/memory/feature-flows/workspace-agent-page.md
@@ -1,0 +1,130 @@
+# Feature: the Workspace agent page
+
+> **Status**: ✅ Implemented (2026-08-13)
+> **Issue**: abilityai/trinity-enterprise#360
+> **Requirement**: `docs/memory/requirements/core-agent.md` §5.11
+> **Related**: [workspace-sidebar-ia.md](workspace-sidebar-ia.md) (the roster row that opens it), [workspace-absorbs-session.md](workspace-absorbs-session.md)
+
+## Overview
+
+An agent had no home. A roster row emitted `new-chat-with-agent`, so there was
+nowhere to see what an agent had been doing, nowhere for it to ask you something
+while no chat was open, and nowhere to show what it can do. Clicking an agent now
+opens its page; starting a chat is an explicit button there.
+
+## The two constraints, and why both are subtractive
+
+**It reports; it does not configure.** No schedules, no skill editing, no logs,
+no costs. Model and plan are not shown at all — the AC permits them
+"informational and visibility-gated", and the cheapest way to satisfy a gate is
+to not open the door. Building agents stays operator-side.
+
+**The viewer may be an external client.** The same page serves a portal-token
+client and a platform user. That is what makes this a security surface rather
+than a layout exercise, and it decides *where* the exclusions live.
+
+## Exclusion by projection, not by template
+
+Every field the page must not show is dropped in `client_portal/agent_page.py`,
+before the payload exists. Nothing is filtered in the Vue component.
+
+The reason is failure mode, not taste: a template filter is correct until
+somebody adds a column to a list view, and nothing fails when they do. A field
+that never leaves the service cannot be surfaced by a later edit.
+
+| Surface | Underlying accessor also returns | Why it must not ship |
+|---|---|---|
+| `recent_work` | `message`, `cost`, `model_used`, `source_user_email` | `message` is another user's prompt; `cost` and `model_used` are excluded by AC #7 |
+| `asks` | `context`, and `alert`-type items | `context` is free-form agent JSON and a known credential-leak surface (canary G-04 exists because secrets turn up there). `alert` items are platform-generated ops telemetry — sync-failing, git-bloat, breaker dormancy — not an agent asking a person anything |
+| report detail | any report in the install | Report ids are global. The roster gate proves only that the caller may reach **this** agent, so without an ownership check the page becomes a reader for every report on the instance. A foreign id returns the same 404 as a missing one, so it is not an existence oracle either (invariant #8) |
+
+## Flow
+
+```
+GET /api/enterprise/client-portal/agents/{name}/page?window=7d
+  ├─ _require_roster ............ uniform 404 for an agent off the roster
+  ├─ get_roster ................. identity + "what it can do" (briefing, #138/ent#380)
+  └─ agent_page.build_page
+       ├─ _health ............... last persisted health check
+       ├─ _stats ................ db.get_agent_analytics (#1107) + first_try_stats
+       ├─ _asks ................. operator queue, filtered + projected
+       └─ _recent_work .......... executions, projected to shape only
+```
+
+One call rather than five, because the page is one screen: fetching header,
+stats, asks and work separately renders it in pieces, and a stats call that
+outruns the header shows numbers above a nameless card. Reports and Files are
+separate — most visits never open those tabs, so they fetch on first open.
+
+`GET /api/agents/{name}/analytics` is reused as the Technical Notes ask, but
+through the **DB accessor**, not over HTTP: the platform endpoint is JWT-gated
+and a portal-token client cannot call it.
+
+## Degradation — AC #6
+
+Everything is DB-sourced, so a stopped agent renders degraded rather than empty,
+and a failing data source degrades **only its own section** (a page that 500s
+because the operator queue is unhappy is worse than one without its asks).
+
+Health reports `unknown`, never `unhealthy`, when nothing has ever checked the
+agent. Monitoring is default-OFF (#1121), so on many installs that is every
+agent, and "unhealthy" there would be a lie about the whole fleet.
+
+## The two AC #3 metrics
+
+**First-try rate** is real: successes with `retry_count` 0 over the window
+(`client_portal/db.py::first_try_stats`). It is deliberately distinct from the
+success rate the analytics accessor reports, which counts a retried-then-
+succeeded execution as a success — the right answer to "does it get there in the
+end", the wrong answer to "does it get there first time". `retry_count` is NULL
+on rows predating #678, read as zero, since such a success genuinely had no
+retry. No terminal executions ⇒ `rate: null`, not `0.0`: a fresh agent has no
+first-try rate, and 0% reads as "it fails every time".
+
+**Rating tally is not shipped.** There is no rating, thumbs or feedback
+mechanism anywhere in Trinity — no table, no column, no endpoint. It has no data
+source, so it was omitted rather than invented. A number a user reads as "how
+well is this agent doing" has to come from something real.
+
+## What this supersedes
+
+ent#359 made a roster row with unread open the *unread chat*, because a badge
+reading "2 replies" beside a control that opened a **blank** chat was a
+contradiction. The page resolves that properly: the row opens the page, the
+badge still shows on the row, and the page's Overview lists the chats this agent
+belongs to with their unread counts. Nothing is lost, and "an agent is a
+destination" is finally true.
+
+## Files
+
+| Layer | File | Change |
+|---|---|---|
+| Service | `client_portal/agent_page.py` | **new** — assembly + every projection |
+| DB | `client_portal/db.py` | `first_try_stats` |
+| Router | `client_portal/router.py` | 3 endpoints, roster-gated |
+| Models | `client_portal/models.py` | page / ask / work / stats / report models |
+| UI | `components/portal/PortalAgentPage.vue` | **new** — header, stats strip, 5 tabs |
+| UI | `components/portal/PortalSidebar.vue` | roster row emits `open-agent` |
+| UI | `views/Portal.vue`, `router/index.js` | `/workspace/a/:agentName` |
+| Store | `stores/clientPortal.js` | `fetchAgentPage`, `fetchAgentReports`, `fetchAgentReport` |
+
+## Tests
+
+`tests/unit/test_ent360_workspace_agent_page.py` — the projections (no
+message/cost/model; alerts excluded; `context` never present, asserted against
+the rendered repr too), cross-agent report isolation and its 404 uniformity,
+degradation (health `unknown`, per-section failure, capabilities from the
+briefing), and the first-try arithmetic including the NULL-`retry_count` and
+no-terminal-rows cases.
+
+Verified live against the running instance: 37 executions, 89% completed, 33/37
+first try, and `recent_work` carrying exactly the six safe keys.
+
+## Known Limitations
+
+| Limitation | Detail |
+|---|---|
+| **Asks are read-only** | Answering writes to the operator queue, an operator surface with its own auth. Rather than render a control that 403s for a client, the card offers "Reply in chat →". |
+| **No rating tally** | See above — no data source exists. |
+| **Files tab is a list, not the panel** | It lists documents and uploads; the upload flow stays in the existing files panel. |
+| **"What it can do" is the briefing** | A projection of the roster briefing (#138/ent#380). ent#178 (unified exposable-skills config) is the mechanism this becomes a view of; it deliberately does not build a competing one. |

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -403,6 +403,48 @@
   content rather than a chat) is abilityai/trinity-enterprise#360.
 - **Flow**: `docs/memory/feature-flows/workspace-sidebar-ia.md`
 
+### 5.11 Workspace agent page
+- **Status**: ✅ Implemented (2026-08-13)
+- **Requirement ID**: WORKSPACE_AGENT_PAGE
+- **GitHub Issue**: abilityai/trinity-enterprise#360
+- **Description**: Each agent gets a page in the Workspace — identity, health,
+  recent work, reports, files, what it can do, and the place where the agent
+  surfaces what it needs from the user. A roster row opens it; **Start a chat**
+  is an explicit button there.
+- **It reports; it does not configure.** No schedules, no skill editing, no
+  logs, no costs. Model and plan are not shown at all — the AC permits them
+  "informational and visibility-gated", and the cheapest way to satisfy a gate
+  is to not open the door. Building agents stays operator-side.
+- **The viewer may be an external client.** The same page serves a portal-token
+  client and a platform user, so exclusions are enforced by **projection in the
+  service**, never by filtering in the template: a field that never leaves the
+  service cannot be surfaced by a later UI edit. Three that matter —
+  `recent_work` drops `message`/`cost`/`model_used`/`source_user_email`; `asks`
+  admits only agent-authored `approval`/`question` items (never platform
+  `alert`s) and never their `context` (free-form agent JSON, a known
+  credential-leak surface); report reads are agent-scoped, since report ids are
+  global and the roster gate only proves the caller may reach *this* agent.
+- **Key Features**:
+  - Header: avatar, name, description, health, last active
+  - Stats strip: activity chart, tasks in window, completed rate, first-try rate
+  - Tabs: Overview · Reports · Files · What it can do · Activity
+  - Overview leads with **open asks**, then recent work, then this user's chats
+  - Everything DB-sourced, so a **stopped** agent renders degraded, not empty:
+    health `unknown` (monitoring is default-OFF, so "unhealthy" would be a lie),
+    empty sections, and a failing data source degrades that section only
+  - Endpoints: `GET /agents/{name}/page?window=`, `.../reports`,
+    `.../reports/{id}` under the client-portal prefix, all roster-gated
+- **Not met**: the AC's **rating tally**. There is no rating, thumbs or feedback
+  mechanism anywhere in Trinity, so it has no data source and was omitted rather
+  than invented — a number a user reads as "how well is this agent doing" has to
+  come from something real. The **first-try rate** beside it IS real: successes
+  with `retry_count` 0, distinct from the success rate (which counts a
+  retried-then-succeeded execution as a success).
+- **Supersedes**: ent#359's interim roster-click behaviour (a row with unread
+  opened the unread chat). The page resolves that properly — its Overview lists
+  the chats the agent belongs to, unread counts included.
+- **Flow**: `docs/memory/feature-flows/workspace-agent-page.md`
+
 ---
 
 ## 6. Activity Monitoring

--- a/src/backend/client_portal/agent_page.py
+++ b/src/backend/client_portal/agent_page.py
@@ -1,0 +1,254 @@
+"""The Workspace agent page (ent#360).
+
+An agent had no home. A roster row started a chat, so there was nowhere to see
+what an agent has been doing, nowhere for it to ask you something while no chat
+is open, and nowhere to show what it can do. This assembles that page.
+
+Two constraints shape everything here, and both are subtractive:
+
+**It reports; it does not configure.** No schedules, no skill editing, no logs,
+no costs (ent#360 AC #7). Building agents stays operator-side. Model and plan
+are simply not shown — the AC allows them "informational and visibility-gated",
+and the cheapest way to satisfy a gate is to not open the door.
+
+**The viewer may be an external client, not an operator.** Every field below is
+chosen with that in mind, because the same page serves a portal-token client and
+a platform user. Three places where that bites:
+
+* `recent_work` is projected down to status/trigger/time/duration. The
+  underlying accessor also returns `message`, `cost`, `model_used` and
+  `source_user_email` — another user's prompt, and two things AC #7 excludes.
+* `asks` carries only agent-authored `approval`/`question` items, never
+  `alert`. Alerts are platform-generated (sync-failing, git-bloat, breaker
+  dormancy) and are operations telemetry, not something the agent is asking a
+  person. `context` is never exposed at all: it is free-form agent JSON and has
+  been a credential-leak surface before (canary G-04).
+* Everything is DB-sourced, so the page renders for a stopped agent (AC #6) —
+  degraded, not empty.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from database import db
+
+from . import db as portal_db
+
+logger = logging.getLogger(__name__)
+
+# ent#360 AC: the stats strip is a window. Same set the Agent Detail Overview
+# offers (#1107), so the analytics accessor is reused rather than reimplemented.
+WINDOWS = {"7d": 168, "14d": 336, "30d": 720}
+DEFAULT_WINDOW = "7d"
+
+# Only these reach a Workspace viewer. `alert` is platform-generated operations
+# telemetry, not a question an agent is asking a person.
+ASK_TYPES = ("approval", "question")
+MAX_ASKS = 20
+MAX_RECENT_WORK = 20
+MAX_CHATS = 20
+
+
+def _health(agent_name: str) -> dict:
+    """Coarse health for the header, from the last persisted check.
+
+    Never the live Docker state: AC #6 wants this page to render for a stopped
+    agent, and a probe that needs the container is exactly what cannot answer
+    then. `unknown` is an honest answer for an agent monitoring has never
+    checked — monitoring is default-OFF (#1121), so on many installs that is
+    every agent, and rendering "unhealthy" there would be a lie.
+    """
+    try:
+        row = db.get_latest_health_check(agent_name)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent page: health read failed for %s: %s", agent_name, e)
+        return {"status": "unknown", "checked_at": None}
+    if not row:
+        return {"status": "unknown", "checked_at": None}
+    return {
+        "status": row.get("status") or "unknown",
+        "checked_at": row.get("checked_at"),
+    }
+
+
+def _stats(agent_name: str, window: str) -> dict:
+    """Activity chart + headline numbers, from the existing analytics accessor.
+
+    The issue's Technical Notes name that accessor specifically, so this adds no
+    query of its own: it reshapes what #1107 already computes.
+    """
+    hours = WINDOWS.get(window, WINDOWS[DEFAULT_WINDOW])
+    try:
+        a = db.get_agent_analytics(agent_name, hours)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent page: analytics failed for %s: %s", agent_name, e)
+        return {
+            "window": window, "window_hours": hours, "total_executions": 0,
+            "success_rate": None, "timeline": [], "by_type": [],
+            "first_try": {"terminal": 0, "first_try": 0, "rate": None},
+            "unavailable": True,
+        }
+    return {
+        "window": window,
+        "window_hours": a.get("window_hours", hours),
+        "total_executions": a.get("total_executions", 0),
+        "success_rate": a.get("success_rate"),
+        # Per-day counts for the chart. `by_type` per day is kept so the chart
+        # can stack by what triggered the work, as the Overview one does.
+        "timeline": a.get("timeline", []),
+        "by_type": a.get("by_type", []),
+        # AC #3's "first-try rate". Distinct from success_rate above, which
+        # counts a retried-then-succeeded execution as a success.
+        "first_try": portal_db.first_try_stats(agent_name, hours),
+        "unavailable": False,
+    }
+
+
+def _asks(agent_name: str) -> list[dict]:
+    """What this agent is waiting on a person for.
+
+    Read-only here. Answering an approval writes to the operator queue, which is
+    an operator surface with its own auth; the page offers "reply in chat"
+    instead, so neither audience lands on a control that does nothing.
+    """
+    try:
+        items = db.list_operator_queue_items(
+            status="pending", agent_name=agent_name, limit=MAX_ASKS,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent page: operator queue read failed for %s: %s", agent_name, e)
+        return []
+    out = []
+    for it in items:
+        if it.get("type") not in ASK_TYPES:
+            continue
+        out.append({
+            "id": it.get("id"),
+            "type": it.get("type"),
+            "priority": it.get("priority"),
+            "title": it.get("title"),
+            "question": it.get("question"),
+            "options": it.get("options"),
+            "created_at": it.get("created_at"),
+            # `context` is deliberately absent — free-form agent JSON, and a
+            # known credential-leak surface (canary G-04).
+        })
+    return out
+
+
+def _recent_work(agent_name: str, limit: int = MAX_RECENT_WORK) -> list[dict]:
+    """What the agent has been doing — shape only, no content.
+
+    The accessor returns `message`, `cost`, `model_used` and `source_user_email`
+    among others. A Workspace viewer may be an external client, so the prompt
+    text of somebody else's task, the spend, and the model are all projected
+    away here rather than filtered in the UI: a field that never leaves the
+    service cannot be leaked by a later template change.
+    """
+    try:
+        rows = db.get_agent_executions_summary(agent_name, limit=limit)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent page: executions read failed for %s: %s", agent_name, e)
+        return []
+    return [{
+        "id": r.get("id"),
+        "status": r.get("status"),
+        "triggered_by": r.get("triggered_by"),
+        "started_at": r.get("started_at"),
+        "completed_at": r.get("completed_at"),
+        "duration_ms": r.get("duration_ms"),
+    } for r in rows]
+
+
+def reports(agent_name: str, limit: int = 20, offset: int = 0) -> list[dict]:
+    """Metadata for the Reports tab (payload fetched separately when expanded).
+
+    Reuses the existing report surface (#918) exactly as the Technical Notes
+    ask. Metadata only: a payload is up to 256 KB and belongs on expansion.
+    """
+    try:
+        rows = db.get_reports_for_agent(agent_name, limit=limit, offset=offset)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent page: reports read failed for %s: %s", agent_name, e)
+        return []
+    return [{
+        "id": r.get("id"),
+        "report_type": r.get("report_type"),
+        "title": r.get("title"),
+        "display_hint": r.get("display_hint"),
+        "period_start": r.get("period_start"),
+        "period_end": r.get("period_end"),
+        "created_at": r.get("created_at"),
+    } for r in rows]
+
+
+def build_page(email: str, agent_name: str, card: Optional[dict],
+               window: str = DEFAULT_WINDOW) -> dict:
+    """Assemble the page. `card` is the caller's roster entry (identity + what
+    it can do), already resolved and access-checked by the caller.
+
+    On the "rating tally" named in AC #3: there is no rating, thumbs or feedback
+    mechanism anywhere in Trinity, so it has no data source and is omitted
+    rather than invented — a number a user reads as "how well is this agent
+    doing" has to come from something real. Recorded in the requirement as the
+    one AC bullet not met. (The first-try rate beside it IS real: it comes from
+    `retry_count`, see `portal_db.first_try_stats`.)
+    """
+    card = card or {}
+    return {
+        "agent_name": agent_name,
+        "header": {
+            "name": agent_name,
+            "description": card.get("description"),
+            "avatar_url": card.get("avatar_url"),
+            "owner": card.get("owner"),
+            "health": _health(agent_name),
+            "last_active": _last_active(agent_name),
+        },
+        # "What it can do" — a projection of the briefing the roster already
+        # carries (#138 / ent#380), NOT a second mechanism. ent#178 is the
+        # unified exposable-skills config this becomes a view of when it lands.
+        "capabilities": card.get("playbooks") or [],
+        "stats": _stats(agent_name, window),
+        "asks": _asks(agent_name),
+        "recent_work": _recent_work(agent_name),
+    }
+
+
+def _last_active(agent_name: str) -> Optional[str]:
+    """When this agent last did anything, from its newest execution row."""
+    try:
+        rows = db.get_agent_executions_summary(agent_name, limit=1)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent page: last-active read failed for %s: %s", agent_name, e)
+        return None
+    return rows[0].get("started_at") if rows else None
+
+
+def report_detail(agent_name: str, report_id: str) -> Optional[dict]:
+    """One report's full payload, scoped to the agent whose page is open.
+
+    The agent check is the point: report ids are global, and without it any
+    rostered agent's page would read any report in the install. A foreign id
+    returns None → the router's 404, identical to a nonexistent one, so this
+    cannot be used to test whether a report exists (invariant #8).
+    """
+    try:
+        row = db.get_report(report_id)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("agent page: report read failed for %s: %s", report_id, e)
+        return None
+    if not row or row.get("agent_name") != agent_name:
+        return None
+    return {
+        "id": row.get("id"),
+        "agent_name": row.get("agent_name"),
+        "report_type": row.get("report_type"),
+        "title": row.get("title"),
+        "display_hint": row.get("display_hint"),
+        "payload": row.get("payload"),
+        "period_start": row.get("period_start"),
+        "period_end": row.get("period_end"),
+        "created_at": row.get("created_at"),
+    }

--- a/src/backend/client_portal/db.py
+++ b/src/backend/client_portal/db.py
@@ -17,7 +17,7 @@ from db.tables import (
     system_settings, agent_sharing, agent_ownership, users,
     enterprise_portal_chat_state,
 )
-from utils.helpers import utc_now_iso
+from utils.helpers import iso_cutoff, utc_now_iso
 
 
 def get_setting(key: str, default: str = "") -> str:
@@ -623,3 +623,44 @@ def count_unread_by_session(client_email: str) -> dict[str, int]:
     with get_engine().connect() as conn:
         rows = conn.execute(stmt, {"email": (client_email or "").lower()}).mappings()
         return {r["session_id"]: int(r["n"]) for r in rows if r["session_id"]}
+
+
+# --- Agent page: first-try rate (ent#360) ------------------------------------
+
+def first_try_stats(agent_name: str, hours: int) -> dict:
+    """Terminal executions in the window, and how many succeeded on the FIRST
+    attempt (``retry_count`` 0 or NULL).
+
+    Distinct from the success rate the analytics accessor already reports: an
+    execution that failed, was retried and then succeeded counts as a success
+    there, which is the right answer to "does this agent get there in the end"
+    and the wrong answer to "does it get there first time".
+
+    `retry_count` is NULL on rows written before #678, so NULL is read as zero —
+    a pre-#678 success genuinely had no retry.
+
+    Cutoff via `iso_cutoff` rather than SQL `datetime('now', ...)`: the column is
+    an ISO-Z string and the two formats do not compare (Invariant #16).
+    """
+    stmt = text(
+        "SELECT "
+        "  COUNT(*) AS terminal, "
+        "  SUM(CASE WHEN status = 'success' AND COALESCE(retry_count, 0) = 0 "
+        "           THEN 1 ELSE 0 END) AS first_try "
+        "FROM schedule_executions "
+        "WHERE agent_name = :agent AND started_at >= :cutoff "
+        "  AND status IN ('success', 'failed', 'error')"
+    )
+    with get_engine().connect() as conn:
+        row = conn.execute(stmt, {
+            "agent": agent_name, "cutoff": iso_cutoff(hours),
+        }).mappings().first()
+    terminal = int((row or {}).get("terminal") or 0)
+    first_try = int((row or {}).get("first_try") or 0)
+    return {
+        "terminal": terminal,
+        "first_try": first_try,
+        # None, not 0.0, with nothing to divide: a fresh agent has no first-try
+        # rate, and rendering 0% would read as "it fails every time".
+        "rate": (first_try / terminal) if terminal else None,
+    }

--- a/src/backend/client_portal/models.py
+++ b/src/backend/client_portal/models.py
@@ -149,6 +149,93 @@ class PortalSessions(BaseModel):
     sessions: list[PortalSessionSummary]
 
 
+class PortalAgentAsk(BaseModel):
+    """One thing the agent is waiting on a person for (ent#360).
+
+    Agent-authored `approval`/`question` items only. `context` is deliberately
+    absent — free-form agent JSON, and a known credential-leak surface.
+    """
+    id: str
+    type: str
+    priority: Optional[str] = None
+    title: Optional[str] = None
+    question: Optional[str] = None
+    options: Optional[list] = None
+    created_at: Optional[str] = None
+
+
+class PortalAgentWork(BaseModel):
+    """One execution, shape only. No message, response, cost or model — the
+    viewer may be an external client, and AC #7 excludes costs outright."""
+    id: Optional[str] = None
+    status: Optional[str] = None
+    triggered_by: Optional[str] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    duration_ms: Optional[int] = None
+
+
+class PortalFirstTry(BaseModel):
+    """Successes that needed no retry, over the window. `rate` is None with no
+    terminal executions — a fresh agent has no first-try rate, and 0% would read
+    as "it fails every time"."""
+    terminal: int = 0
+    first_try: int = 0
+    rate: Optional[float] = None
+
+
+class PortalAgentStats(BaseModel):
+    window: str
+    window_hours: int
+    total_executions: int = 0
+    success_rate: Optional[float] = None
+    first_try: PortalFirstTry = Field(default_factory=PortalFirstTry)
+    timeline: list = Field(default_factory=list)
+    by_type: list = Field(default_factory=list)
+    unavailable: bool = False
+
+
+class PortalAgentHealth(BaseModel):
+    status: str = "unknown"
+    checked_at: Optional[str] = None
+
+
+class PortalAgentHeader(BaseModel):
+    name: str
+    description: Optional[str] = None
+    avatar_url: Optional[str] = None
+    owner: Optional[str] = None
+    health: PortalAgentHealth = Field(default_factory=PortalAgentHealth)
+    last_active: Optional[str] = None
+
+
+class PortalAgentPage(BaseModel):
+    """The Workspace agent page (ent#360) — one call, because the page is one
+    screen and five round trips would render it in pieces."""
+    agent_name: str
+    header: PortalAgentHeader
+    capabilities: list[PortalPlaybook] = Field(default_factory=list)
+    stats: PortalAgentStats
+    asks: list[PortalAgentAsk] = Field(default_factory=list)
+    recent_work: list[PortalAgentWork] = Field(default_factory=list)
+
+
+class PortalAgentReport(BaseModel):
+    """Report metadata for the agent page's Reports tab (#918 surface reused)."""
+    id: str
+    report_type: Optional[str] = None
+    title: Optional[str] = None
+    display_hint: Optional[str] = None
+    period_start: Optional[str] = None
+    period_end: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class PortalAgentReports(BaseModel):
+    agent_name: str
+    reports: list[PortalAgentReport] = Field(default_factory=list)
+
+
 class PortalChatStateEntry(BaseModel):
     """One chat's per-viewer state (ent#359). ``kind`` is ``thread`` (a portal
     session) or ``room`` (a multi-agent room) — two independent id spaces, so

--- a/src/backend/client_portal/router.py
+++ b/src/backend/client_portal/router.py
@@ -36,7 +36,7 @@ from services.agent_auth import agent_httpx_client
 from services.docker_service import get_agent_container
 from services.platform_audit_service import AuditEventType, platform_audit_service
 
-from . import service
+from . import agent_page, service
 from .models import (
     PortalAuthRequest,
     PortalAuthVerify,
@@ -58,6 +58,8 @@ from .models import (
     PortalSearchResults,
     PortalSession,
     PortalSessions,
+    PortalAgentPage,
+    PortalAgentReports,
     PortalChatState,
     PortalSessionSummary,
     PortalTtsRequest,
@@ -521,6 +523,74 @@ def portal_mark_chat_read(chat_kind: str, chat_id: str,
     except ClientPortalError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
     return Response(status_code=204)
+
+
+# --- The agent page (ent#360) -------------------------------------------------
+#
+# Roster-gated like every other per-agent route. Read-only by construction:
+# nothing here writes, and the payload carries no schedules, skills, logs, costs
+# or model — AC #7 keeps configuration operator-side, and the viewer may be an
+# external client rather than an operator.
+
+@router.get("/agents/{agent_name}/page", response_model=PortalAgentPage)
+async def portal_agent_page(
+    agent_name: str,
+    window: str = "7d",
+    principal: PortalPrincipal = Depends(get_portal_principal),
+):
+    """Everything the agent page needs, in one call.
+
+    One request rather than five because the page is one screen: fetching the
+    header, stats, asks and recent work separately renders it in pieces, and a
+    stats call that outruns the header shows numbers above a nameless card.
+    """
+    email = principal.email
+    _require_roster(agent_name, email, principal.is_platform)
+    if window not in agent_page.WINDOWS:
+        raise HTTPException(status_code=422, detail="Unknown window")
+    # The roster is the source of identity + "what it can do": the briefing is
+    # already resolved there (#138/ent#380), so the page projects it rather than
+    # building a second, divergent notion of an agent's capabilities.
+    roster = await service.get_roster(email, include_owned=principal.is_platform)
+    card = next((a for a in roster.agents if a.name == agent_name), None)
+    return agent_page.build_page(
+        email, agent_name, card.model_dump() if card else None, window=window,
+    )
+
+
+@router.get("/agents/{agent_name}/reports", response_model=PortalAgentReports)
+def portal_agent_reports(
+    agent_name: str,
+    limit: int = 20,
+    offset: int = 0,
+    principal: PortalPrincipal = Depends(get_portal_principal),
+):
+    """Report metadata for the page's Reports tab. Payloads are fetched per
+    report on expansion — one is capped at 256 KB and a list of them is not a
+    list view."""
+    _require_roster(agent_name, principal.email, principal.is_platform)
+    return {
+        "agent_name": agent_name,
+        "reports": agent_page.reports(
+            agent_name, limit=min(max(limit, 1), 50), offset=max(offset, 0)
+        ),
+    }
+
+
+@router.get("/agents/{agent_name}/reports/{report_id}")
+def portal_agent_report_detail(
+    agent_name: str,
+    report_id: str,
+    principal: PortalPrincipal = Depends(get_portal_principal),
+):
+    """One report's payload. The report must belong to the path agent — a report
+    id from another agent returns the same 404 as one that does not exist, so
+    this is not a cross-agent read oracle."""
+    _require_roster(agent_name, principal.email, principal.is_platform)
+    report = agent_page.report_detail(agent_name, report_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+    return report
 
 
 @router.post("/agents/{agent_name}/chat", response_model=PortalChatResponse)

--- a/src/frontend/src/components/portal/PortalAgentPage.vue
+++ b/src/frontend/src/components/portal/PortalAgentPage.vue
@@ -1,0 +1,376 @@
+<template>
+  <div class="flex-1 min-w-0 flex flex-col min-h-0">
+    <!-- Header -->
+    <header class="shrink-0 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+      <div class="flex items-start gap-3 px-3 sm:px-6 pt-4">
+        <button class="sm:hidden -ml-1 p-2 text-gray-500" aria-label="Menu" @click="$emit('open-menu')">
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+
+        <PortalAvatar :name="agentName" :avatar-url="page?.header?.avatar_url" :size="52" />
+
+        <div class="min-w-0 flex-1">
+          <h1 class="text-lg font-semibold truncate">{{ agentName }}</h1>
+          <p v-if="page?.header?.description" class="text-sm text-gray-500 dark:text-gray-400 line-clamp-2">
+            {{ page.header.description }}
+          </p>
+          <div class="mt-1 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+            <span class="inline-flex items-center gap-1.5">
+              <span class="w-2 h-2 rounded-full" :class="healthDot"></span>{{ healthLabel }}
+            </span>
+            <span v-if="page?.header?.last_active">Last active {{ relative(page.header.last_active) }}</span>
+          </div>
+        </div>
+
+        <button
+          class="shrink-0 rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white text-sm font-medium px-3.5 py-2 transition"
+          @click="$emit('start-chat', agentName)"
+        >Start a chat</button>
+      </div>
+
+      <!-- Stats strip -->
+      <div class="px-3 sm:px-6 pt-4">
+        <div class="flex flex-wrap items-end gap-x-8 gap-y-3">
+          <div>
+            <div class="text-xl font-semibold tabular-nums">{{ stats.total_executions }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">tasks · last {{ windowLabel }}</div>
+          </div>
+          <div>
+            <div class="text-xl font-semibold tabular-nums">{{ pct(stats.success_rate) }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">completed</div>
+          </div>
+          <div>
+            <div class="text-xl font-semibold tabular-nums">{{ pct(stats.first_try?.rate) }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400" title="Succeeded without needing a retry">first try</div>
+          </div>
+
+          <!-- Activity chart: CSS bars, no charting dependency for a strip. -->
+          <div class="flex-1 min-w-[140px] flex items-end gap-[3px] h-10" :aria-label="`Activity over the last ${windowLabel}`">
+            <div
+              v-for="d in stats.timeline || []"
+              :key="d.date"
+              class="flex-1 rounded-sm bg-action-primary-500/70 dark:bg-action-primary-500/50 min-h-[2px]"
+              :style="{ height: barHeight(d) }"
+              :title="`${d.date}: ${d.total ?? 0}`"
+            ></div>
+          </div>
+
+          <select
+            v-model="timeWindow"
+            class="text-xs rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1"
+            aria-label="Time window"
+          >
+            <option value="7d">7 days</option>
+            <option value="14d">14 days</option>
+            <option value="30d">30 days</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Tabs -->
+      <nav class="px-3 sm:px-6 mt-3 flex gap-1 overflow-x-auto" role="tablist">
+        <button
+          v-for="t in TABS"
+          :key="t.id"
+          role="tab"
+          :aria-selected="tab === t.id"
+          class="shrink-0 px-3 py-2 text-sm border-b-2 -mb-px transition"
+          :class="tab === t.id
+            ? 'border-action-primary-600 text-action-primary-600 dark:text-action-primary-400 font-medium'
+            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'"
+          @click="tab = t.id"
+        >
+          {{ t.label }}
+          <span v-if="t.id === 'overview' && asks.length" class="ml-1 px-1.5 rounded-full bg-action-primary-600 text-white text-[10px]">{{ asks.length }}</span>
+        </button>
+      </nav>
+    </header>
+
+    <div class="flex-1 min-h-0 overflow-y-auto px-3 sm:px-6 py-5">
+      <p v-if="loading && !page" class="text-sm text-gray-400">Loading…</p>
+      <p v-else-if="error" class="text-sm text-status-danger-600 dark:text-status-danger-400">{{ error }}</p>
+
+      <!-- ---------------------------- OVERVIEW ---------------------------- -->
+      <template v-else-if="tab === 'overview'">
+        <!-- AC #5: open asks lead. This is the reason the page exists — it is
+             where the agent can reach the user when no chat is open. -->
+        <section v-if="asks.length" class="mb-6">
+          <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Waiting on you</h2>
+          <div
+            v-for="a in asks"
+            :key="a.id"
+            class="mb-2 rounded-xl border border-amber-300/70 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/10 px-3.5 py-3"
+          >
+            <div class="text-sm font-medium">{{ a.title || 'The agent needs a decision' }}</div>
+            <p v-if="a.question" class="mt-0.5 text-sm text-gray-600 dark:text-gray-300 whitespace-pre-wrap">{{ a.question }}</p>
+            <div v-if="a.options?.length" class="mt-1.5 flex flex-wrap gap-1.5">
+              <span v-for="o in a.options" :key="o" class="text-xs rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-2 py-0.5">{{ o }}</span>
+            </div>
+            <!-- Answering writes to the operator queue, an operator surface with
+                 its own auth. Rather than render a control that 403s for a
+                 client, the answer path is the conversation. -->
+            <button class="mt-2 text-xs text-action-primary-600 hover:underline" @click="$emit('start-chat', agentName)">
+              Reply in chat →
+            </button>
+          </div>
+        </section>
+
+        <section class="mb-6">
+          <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Recent work</h2>
+          <p v-if="!recentWork.length" class="text-sm text-gray-400">Nothing yet.</p>
+          <ul v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+            <li v-for="w in recentWork.slice(0, 8)" :key="w.id" class="py-2 flex items-center gap-3 text-sm">
+              <span class="w-2 h-2 rounded-full shrink-0" :class="statusDot(w.status)"></span>
+              <span class="flex-1 truncate text-gray-600 dark:text-gray-300">{{ triggerLabel(w.triggered_by) }}</span>
+              <span class="text-xs text-gray-400 tabular-nums">{{ duration(w.duration_ms) }}</span>
+              <span class="text-xs text-gray-400 shrink-0">{{ relative(w.started_at) }}</span>
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Your chats with {{ agentName }}</h2>
+          <p v-if="!chats.length" class="text-sm text-gray-400">No conversations yet.</p>
+          <ul v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+            <li v-for="c in chats.slice(0, 8)" :key="c.id">
+              <button class="w-full py-2 flex items-center gap-3 text-left text-sm hover:opacity-80" @click="$emit('open-thread', c)">
+                <span class="flex-1 truncate">{{ c.title || 'New chat' }}</span>
+                <span v-if="c.unread" class="shrink-0 min-w-[1.125rem] px-1 h-[1.125rem] rounded-full bg-action-primary-600 text-white text-[10px] font-semibold flex items-center justify-center">{{ c.unread }}</span>
+                <span class="text-xs text-gray-400 shrink-0">{{ relative(c.last_message_at) }}</span>
+              </button>
+            </li>
+          </ul>
+        </section>
+      </template>
+
+      <!-- ---------------------------- REPORTS ----------------------------- -->
+      <template v-else-if="tab === 'reports'">
+        <p v-if="!reports.length" class="text-sm text-gray-400">This agent hasn't published any reports.</p>
+        <div v-for="r in reports" :key="r.id" class="mb-2 rounded-xl border border-gray-200 dark:border-gray-800">
+          <button class="w-full px-3.5 py-3 flex items-center gap-3 text-left" @click="toggleReport(r.id)">
+            <span class="min-w-0 flex-1">
+              <span class="block text-sm font-medium truncate">{{ r.title || r.report_type }}</span>
+              <span class="block text-xs text-gray-400">{{ r.report_type }} · {{ relative(r.created_at) }}</span>
+            </span>
+            <svg class="w-4 h-4 text-gray-400 shrink-0 transition" :class="{ 'rotate-180': openReport === r.id }" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          <div v-if="openReport === r.id" class="px-3.5 pb-3 border-t border-gray-100 dark:border-gray-800">
+            <p v-if="!reportPayloads[r.id]" class="pt-3 text-xs text-gray-400">Loading…</p>
+            <pre v-else class="pt-3 text-xs overflow-x-auto whitespace-pre-wrap break-words">{{ pretty(reportPayloads[r.id]) }}</pre>
+          </div>
+        </div>
+      </template>
+
+      <!-- ----------------------------- FILES ------------------------------ -->
+      <template v-else-if="tab === 'files'">
+        <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Shared with you</h2>
+        <p v-if="!documents.length" class="text-sm text-gray-400 mb-5">No files yet.</p>
+        <ul v-else class="mb-5 divide-y divide-gray-100 dark:divide-gray-800">
+          <li v-for="d in documents" :key="d.name || d.filename" class="py-2 flex items-center gap-3 text-sm">
+            <span class="flex-1 truncate">{{ d.filename || d.name }}</span>
+            <span class="text-xs text-gray-400">{{ size(d.size_bytes ?? d.size) }}</span>
+          </li>
+        </ul>
+
+        <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">You sent</h2>
+        <p v-if="!uploads.length" class="text-sm text-gray-400">Nothing uploaded.</p>
+        <ul v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+          <li v-for="u in uploads" :key="u.name || u.filename" class="py-2 flex items-center gap-3 text-sm">
+            <span class="flex-1 truncate">{{ u.filename || u.name }}</span>
+            <span class="text-xs text-gray-400">{{ size(u.size_bytes ?? u.size) }}</span>
+          </li>
+        </ul>
+      </template>
+
+      <!-- ------------------------ WHAT IT CAN DO -------------------------- -->
+      <template v-else-if="tab === 'capabilities'">
+        <p v-if="!capabilities.length" class="text-sm text-gray-400">
+          This agent hasn't published anything it can do yet.
+        </p>
+        <div v-else class="grid gap-2 sm:grid-cols-2">
+          <button
+            v-for="c in capabilities"
+            :key="c.title"
+            class="text-left rounded-xl border border-gray-200 dark:border-gray-800 px-3.5 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition"
+            @click="$emit('start-chat', agentName, c.starter_prompt)"
+          >
+            <div class="text-sm font-medium">{{ c.title }}</div>
+            <div v-if="c.description" class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{{ c.description }}</div>
+          </button>
+        </div>
+      </template>
+
+      <!-- ---------------------------- ACTIVITY ---------------------------- -->
+      <template v-else-if="tab === 'activity'">
+        <p v-if="!recentWork.length" class="text-sm text-gray-400">No activity in this window.</p>
+        <ul v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+          <li v-for="w in recentWork" :key="w.id" class="py-2.5 flex items-center gap-3 text-sm">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="statusDot(w.status)"></span>
+            <span class="flex-1 truncate text-gray-600 dark:text-gray-300">{{ triggerLabel(w.triggered_by) }}</span>
+            <span class="text-xs text-gray-400 tabular-nums">{{ duration(w.duration_ms) }}</span>
+            <span class="text-xs text-gray-400 shrink-0">{{ relative(w.started_at) }}</span>
+          </li>
+        </ul>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * The Workspace agent page (ent#360).
+ *
+ * An agent had no home: a roster row started a chat, so there was nowhere to
+ * see what it has been doing, nowhere for it to ask you something when no chat
+ * is open, and nowhere to show what it can do.
+ *
+ * It REPORTS; it does not configure (AC #7) — no schedules, no skill editing,
+ * no logs, no costs, no model. That is enforced in the service, which never
+ * sends those fields, rather than here: a field that does not arrive cannot be
+ * rendered by a later edit.
+ *
+ * Everything is DB-sourced, so the page renders for a stopped agent (AC #6) —
+ * degraded (health "unknown", empty sections), never blank.
+ */
+import { ref, computed, watch, onMounted } from 'vue'
+import { useClientPortalStore } from '@/stores/clientPortal'
+import PortalAvatar from './PortalAvatar.vue'
+
+const props = defineProps({
+  agentName: { type: String, required: true },
+  // Chats are already loaded by the shell; re-fetching them here would show a
+  // different list from the sidebar for a moment.
+  threads: { type: Array, default: () => [] },
+})
+defineEmits(['start-chat', 'open-thread', 'open-menu'])
+
+const store = useClientPortalStore()
+
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'reports', label: 'Reports' },
+  { id: 'files', label: 'Files' },
+  { id: 'capabilities', label: 'What it can do' },
+  { id: 'activity', label: 'Activity' },
+]
+
+const tab = ref('overview')
+const timeWindow = ref('7d')
+const page = ref(null)
+const loading = ref(false)
+const error = ref(null)
+const reports = ref([])
+const openReport = ref(null)
+const reportPayloads = ref({})
+const documents = ref([])
+const uploads = ref([])
+
+const stats = computed(() => page.value?.stats || { total_executions: 0, timeline: [] })
+const asks = computed(() => page.value?.asks || [])
+const recentWork = computed(() => page.value?.recent_work || [])
+const capabilities = computed(() => page.value?.capabilities || [])
+const chats = computed(() => props.threads.filter(
+  (t) => !t.is_room && t.agent_name === props.agentName,
+))
+
+const windowLabel = computed(() => ({ '7d': '7 days', '14d': '14 days', '30d': '30 days' }[timeWindow.value]))
+
+const healthLabel = computed(() => ({
+  healthy: 'Healthy', unhealthy: 'Unhealthy', degraded: 'Degraded',
+}[page.value?.header?.health?.status] || 'Status unknown'))
+const healthDot = computed(() => ({
+  healthy: 'bg-status-success-500', unhealthy: 'bg-status-danger-500', degraded: 'bg-status-warning-500',
+}[page.value?.header?.health?.status] || 'bg-gray-300 dark:bg-gray-600'))
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    page.value = await store.fetchAgentPage(props.agentName, timeWindow.value)
+  } catch (e) {
+    error.value = e?.response?.status === 404
+      ? "You don't have access to this agent."
+      : "Couldn't load this agent right now."
+  } finally {
+    loading.value = false
+  }
+}
+
+// Each tab fetches only when first opened: the page is one call, and Reports /
+// Files are separate surfaces that most visits never look at.
+watch(tab, async (t) => {
+  try {
+    if (t === 'reports' && !reports.value.length) {
+      reports.value = await store.fetchAgentReports(props.agentName)
+    } else if (t === 'files' && !documents.value.length && !uploads.value.length) {
+      const [d, u] = await Promise.all([
+        store.fetchDocuments(props.agentName).catch(() => []),
+        store.fetchUploads(props.agentName).catch(() => []),
+      ])
+      documents.value = d || []
+      uploads.value = u || []
+    }
+  } catch { /* the empty state is the honest answer */ }
+})
+
+// The agent can change without a remount (sidebar → another agent), so reset
+// every per-agent cache. Leaving them would show one agent's reports under
+// another's name — the class of bug ent#359's review found twice.
+watch(() => props.agentName, () => {
+  page.value = null
+  reports.value = []
+  reportPayloads.value = {}
+  openReport.value = null
+  documents.value = []
+  uploads.value = []
+  tab.value = 'overview'
+  load()
+})
+watch(timeWindow, load)
+onMounted(load)
+
+async function toggleReport(id) {
+  if (openReport.value === id) { openReport.value = null; return }
+  openReport.value = id
+  if (reportPayloads.value[id]) return
+  try {
+    const r = await store.fetchAgentReport(props.agentName, id)
+    reportPayloads.value = { ...reportPayloads.value, [id]: r?.payload ?? {} }
+  } catch {
+    reportPayloads.value = { ...reportPayloads.value, [id]: { error: 'Could not load this report.' } }
+  }
+}
+
+const maxBar = computed(() => Math.max(1, ...(stats.value.timeline || []).map((d) => d.total || 0)))
+const barHeight = (d) => `${Math.max(4, Math.round(((d.total || 0) / maxBar.value) * 100))}%`
+
+const pct = (v) => (v === null || v === undefined ? '—' : `${Math.round(v * 100)}%`)
+const pretty = (v) => { try { return JSON.stringify(v, null, 2) } catch { return String(v) } }
+const size = (b) => (b === null || b === undefined ? '' : b > 1048576 ? `${(b / 1048576).toFixed(1)} MB` : `${Math.max(1, Math.round(b / 1024))} KB`)
+const duration = (ms) => (!ms ? '' : ms < 1000 ? `${ms}ms` : ms < 60000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms / 60000)}m`)
+
+const statusDot = (s) => ({
+  success: 'bg-status-success-500', failed: 'bg-status-danger-500', error: 'bg-status-danger-500',
+  running: 'bg-action-primary-500', queued: 'bg-gray-300 dark:bg-gray-600',
+}[s] || 'bg-gray-300 dark:bg-gray-600')
+
+// Trigger names are internal; the page is for someone in the driver seat.
+const triggerLabel = (t) => ({
+  manual: 'Chat', chat: 'Chat', schedule: 'Scheduled run', webhook: 'Webhook',
+  loop: 'Loop', reminder: 'Reminder', event: 'Event', voip: 'Phone call',
+  voice: 'Voice', mcp: 'Tool call', fan_out: 'Fan-out',
+}[t] || (t ? t.replace(/_/g, ' ') : 'Task'))
+
+function relative(iso) {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const mins = Math.round((Date.now() - then) / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.round(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.round(hrs / 24)
+  return days < 30 ? `${days}d ago` : new Date(iso).toLocaleDateString()
+}
+</script>

--- a/src/frontend/src/components/portal/PortalSidebar.vue
+++ b/src/frontend/src/components/portal/PortalSidebar.vue
@@ -172,7 +172,7 @@ const props = defineProps({
   searchResults: { type: Array, default: () => [] },
 })
 const emit = defineEmits([
-  'new-chat', 'new-chat-with-agent', 'open-thread', 'toggle-star',
+  'new-chat', 'new-chat-with-agent', 'open-agent', 'open-thread', 'toggle-star',
   'update:search', 'sign-out',
 ])
 
@@ -193,29 +193,22 @@ const isActive = (t) => (t.is_room
   ? t.id === props.currentRoomId
   : (t.id || t.session_id) === props.currentSessionId)
 
-// ent#359: clicking an agent that is waiting on you opens the conversation it
-// is waiting in, rather than a blank one. A badge that says "2 replies" next to
-// a control that starts an empty chat is a contradiction — the count is the
-// reason you clicked. With nothing unread the row keeps its old behaviour.
+// ent#360 AC #1: a roster row opens the agent's PAGE. It is a destination now —
+// somewhere to see what it has been doing, what it is waiting on you for, and
+// what it can do — so starting a chat is an explicit act taken there.
 //
-// (Opening an agent's own PAGE is ent#360; this is not a substitute for it.)
-function latestUnreadFor(name) {
-  return props.threads.find((t) => {
-    if (!(Number(t?.unread) > 0)) return false
-    const names = Array.isArray(t.agent_names) && t.agent_names.length
-      ? t.agent_names : [t.agent_name]
-    return names.includes(name)
-  }) || null
-}
+// This supersedes ent#359's interim behaviour (a row with unread opened the
+// unread chat). That existed because a badge next to a control that opened a
+// BLANK chat was a contradiction; the page resolves it properly, since its
+// Overview lists the chats this agent belongs to, unread count included.
 function onAgentClick(name) {
-  const unread = latestUnreadFor(name)
-  if (unread) emit('open-thread', unread)
-  else emit('new-chat-with-agent', name)
+  emit('open-agent', name)
 }
 function agentRowTitle(name) {
   const n = waitingFor(name)
-  if (!n) return `New chat with ${name}`
-  return `${n} unread ${n === 1 ? 'reply' : 'replies'} — open the latest`
+  return n
+    ? `${name} — ${n} unread ${n === 1 ? 'reply' : 'replies'}`
+    : `Open ${name}`
 }
 
 // ent#186: history + search rows show the conversation's agent avatar instead of

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -254,6 +254,15 @@ export const routes = [
     component: () => import('../views/Portal.vue'),
     meta: { title: 'Workspace', hideHelpWidget: true }
   },
+  {
+    // ent#360: an agent is a destination, so it gets a URL. Deliberately NOT
+    // `/workspace/:name` — that would collide with any future literal segment
+    // and make every unknown path resolve to an agent page.
+    path: '/workspace/a/:agentName',
+    name: 'WorkspaceAgent',
+    component: () => import('../views/Portal.vue'),
+    meta: { title: 'Workspace', hideHelpWidget: true }
+  },
   // ent#357 legacy paths. Function form so query AND hash survive the hop —
   // these URLs were handed to real clients by email, and a client landing on a
   // dead link has no way to report it. `/portal/c/:sessionId` keeps the thread.

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -355,6 +355,32 @@ export const useClientPortalStore = defineStore('clientPortal', {
       }
     },
 
+    // ent#360 — the agent page. One call for the whole page: it is one screen,
+    // and fetching header/stats/asks/work separately renders it in pieces.
+    async fetchAgentPage(agentName, window = '7d') {
+      const { data } = await axios.get(
+        `/api/enterprise/client-portal/agents/${agentName}/page`,
+        { headers: this.authHeader, params: { window } },
+      )
+      return data
+    },
+
+    async fetchAgentReports(agentName) {
+      const { data } = await axios.get(
+        `/api/enterprise/client-portal/agents/${agentName}/reports`,
+        { headers: this.authHeader },
+      )
+      return data.reports || []
+    },
+
+    async fetchAgentReport(agentName, reportId) {
+      const { data } = await axios.get(
+        `/api/enterprise/client-portal/agents/${agentName}/reports/${encodeURIComponent(reportId)}`,
+        { headers: this.authHeader },
+      )
+      return data
+    },
+
     // ent#359 — per-viewer star + unread state, for BOTH chat kinds in one call.
     // Threads and rooms come from different endpoints (and different repos) but
     // sort into a single sidebar list, so their view state has to arrive

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -72,6 +72,7 @@
           :search-results="searchResults"
           @new-chat="newChat"
           @new-chat-with-agent="newChatWithAgent"
+          @open-agent="openAgentPage"
           @open-thread="openThread"
           @toggle-star="toggleStar"
           @sign-out="onSignOut"
@@ -92,6 +93,7 @@
             :search-results="searchResults"
             @new-chat="() => { mobileNav = false; newChat() }"
             @new-chat-with-agent="(n) => { mobileNav = false; newChatWithAgent(n) }"
+            @open-agent="(n) => { mobileNav = false; openAgentPage(n) }"
             @open-thread="(t) => { mobileNav = false; openThread(t) }"
             @toggle-star="toggleStar"
             @sign-out="onSignOut"
@@ -104,8 +106,20 @@
         <!-- ent#361: a room takes the stage when the URL names one. The
              single-agent conversation is untouched below — different
              substrate, different component, no shared state. -->
+        <!-- ent#360: an agent is a destination with its own URL. Takes the
+             stage ahead of room/chat, since a route can only name one. -->
+        <PortalAgentPage
+          v-if="activeAgentPageName"
+          :key="activeAgentPageName"
+          :agent-name="activeAgentPageName"
+          :threads="threads"
+          @start-chat="onStartChatFromPage"
+          @open-thread="openThread"
+          @open-menu="mobileNav = true"
+        />
+
         <PortalRoom
-          v-if="activeRoomIdFromRoute && store.multiAgentChatAvailable"
+          v-else-if="activeRoomIdFromRoute && store.multiAgentChatAvailable"
           :key="activeRoomIdFromRoute"
           :room-id="activeRoomIdFromRoute"
           :roster="store.agents"
@@ -192,7 +206,7 @@
           </p>
         </div>
 
-        <div v-else-if="!activeRoomIdFromRoute" :class="STAGE_WRAP">
+        <div v-else-if="!activeRoomIdFromRoute && !activeAgentPageName" :class="STAGE_WRAP">
           <svg :class="STAGE_ICON" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
           <template v-if="store.unavailable">
             <p :class="STAGE_TITLE">{{ WORKSPACE_UNAVAILABLE_TITLE }}</p>
@@ -255,6 +269,7 @@ import PortalFilesPanel from '@/components/portal/PortalFilesPanel.vue'
 import PortalCodeInput from '@/components/portal/PortalCodeInput.vue'
 import PortalAgentPicker from '@/components/portal/PortalAgentPicker.vue'
 import PortalRoom from '@/components/portal/PortalRoom.vue'
+import PortalAgentPage from '@/components/portal/PortalAgentPage.vue'
 import { resolveAgentLanding, shouldMarkTurnRead } from '@/components/portal/portalUtils'
 
 const store = useClientPortalStore()
@@ -324,6 +339,8 @@ const convGen = ref(0)                // bumps on explicit thread switches → r
 const activeSessionId = computed(() => route.params.sessionId || null)
 // ent#361: `/workspace/r/:roomId` is the multi-agent chat.
 const activeRoomIdFromRoute = computed(() => route.params.roomId || null)
+// ent#360: `/workspace/a/:agentName`.
+const activeAgentPageName = computed(() => route.params.agentName || null)
 const activeAgent = computed(() => {
   // Never substitute a different agent for one the caller asked for by name.
   if (unreachableAgent.value) return null
@@ -443,6 +460,25 @@ function openRoom(roomId) {
   convGen.value++
   router.push(`/workspace/r/${roomId}`)
 }
+// ent#360 AC #1: a roster row opens the agent's PAGE. Starting a chat is an
+// explicit act there — which also resolves the tension ent#359 left behind,
+// where a row carrying an unread badge opened the unread chat instead. The
+// count still shows on the row; the page's Overview lists the chats it belongs
+// to, so the conversation is one click further, not lost.
+function openAgentPage(name) {
+  if (!name) return
+  unreachableAgent.value = null
+  pendingSession.value = null
+  activeRoomId.value = null
+  router.push(`/workspace/a/${encodeURIComponent(name)}`)
+}
+
+// "Start a chat" from the page, optionally seeded by a capability card.
+function onStartChatFromPage(name, starter) {
+  newChatWithAgent(name)
+  if (starter) usePlaybook(starter)
+}
+
 function newChatWithAgent(name) {
   unreachableAgent.value = null
   activeAgentName.value = name

--- a/src/frontend/tests/unit/workspaceRoomsGate.spec.js
+++ b/src/frontend/tests/unit/workspaceRoomsGate.spec.js
@@ -212,9 +212,16 @@ describe('#2128 structure guards', () => {
     const src = portalSource()
     const roomAt = src.indexOf('<PortalRoom')
     expect(roomAt, '<PortalRoom is gone').toBeGreaterThan(-1)
-    const vIfAt = src.indexOf('v-if=', roomAt)
-    expect(vIfAt, '<PortalRoom has no v-if').toBeGreaterThan(-1)
-    const vIf = src.slice(vIfAt, src.indexOf('\n', vIfAt))
+
+    // Scoped to PortalRoom's OWN element, and accepting `v-else-if` as well as
+    // `v-if` (ent#360 put the agent page ahead of it in the chain, so the room
+    // is no longer the first branch). Both matter: an unscoped `indexOf('v-if=')`
+    // walks past a `v-else-if` — the string does not contain `v-if=` — into the
+    // NEXT branch's `v-if`, which reports a missing gate that is in fact present.
+    const element = src.slice(roomAt, src.indexOf('/>', roomAt))
+    const condAt = element.search(/v-(?:else-)?if=/)
+    expect(condAt, '<PortalRoom has no v-if / v-else-if').toBeGreaterThan(-1)
+    const vIf = element.slice(condAt, element.indexOf('\n', condAt))
     expect(
       vIf,
       'PortalRoom must not mount when rooms are unavailable — its onMounted ' +

--- a/tests/unit/test_ent360_workspace_agent_page.py
+++ b/tests/unit/test_ent360_workspace_agent_page.py
@@ -1,0 +1,269 @@
+"""The Workspace agent page (ent#360).
+
+The page is a read surface, so almost nothing here is about what it shows. It is
+about what it must NOT show, because two constraints collide on one payload:
+
+  * **AC #7** — it reports, it does not configure. No costs, no model, no logs.
+  * **The viewer may be an external client**, not an operator. The same page
+    serves a portal-token client and a platform user.
+
+Both are enforced by *projection* in the service rather than by filtering in the
+template, so the tests assert on absence: a field that never leaves the service
+cannot be surfaced by a later UI edit. That is the whole reason these are worth
+writing — a page that renders correctly today and leaks `cost` after someone
+adds a column to a list view is the failure mode.
+
+The other half is the cross-agent report read: report ids are global, so without
+an agent check any rostered agent's page would read any report in the install.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+AGENT = "scribe"
+OTHER = "recon"
+EMAIL = "alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# What must never reach a Workspace viewer
+# ---------------------------------------------------------------------------
+
+def test_recent_work_carries_no_message_cost_or_model(monkeypatch):
+    """The underlying accessor returns all three. `message` is another user's
+    prompt; `cost` and `model_used` are excluded by AC #7."""
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "get_agent_executions_summary", lambda *a, **k: [{
+        "id": "e1", "status": "success", "triggered_by": "schedule",
+        "started_at": "2026-08-13T10:00:00Z", "completed_at": "2026-08-13T10:00:09Z",
+        "duration_ms": 9000,
+        # Everything below must be projected away.
+        "message": "reconcile the Q3 invoices for ACME",
+        "cost": 0.42, "model_used": "claude-opus-5",
+        "source_user_email": "someone.else@example.com",
+        "claude_session_id": "uuid-1234",
+    }])
+
+    row = agent_page._recent_work(AGENT)[0]
+
+    assert row == {
+        "id": "e1", "status": "success", "triggered_by": "schedule",
+        "started_at": "2026-08-13T10:00:00Z", "completed_at": "2026-08-13T10:00:09Z",
+        "duration_ms": 9000,
+    }
+
+
+def test_asks_exclude_platform_alerts(monkeypatch):
+    """`alert` items are platform-generated ops telemetry — sync-failing,
+    git-bloat, breaker dormancy — not something an agent is asking a person.
+    Surfacing them on a client's page is both noise and disclosure."""
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "list_operator_queue_items", lambda **k: [
+        {"id": "1", "type": "alert", "title": "sync failing", "question": "n/a"},
+        {"id": "2", "type": "question", "title": "Which invoice?", "question": "A or B?"},
+        {"id": "3", "type": "approval", "title": "Send it?", "question": "ok?"},
+    ])
+
+    got = agent_page._asks(AGENT)
+
+    assert [a["id"] for a in got] == ["2", "3"]
+
+
+def test_asks_never_carry_context(monkeypatch):
+    """`context` is free-form agent JSON and a known credential-leak surface
+    (canary G-04 exists because secrets have turned up in agent-authored
+    metadata). It is not filtered in the UI — it never leaves the service."""
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "list_operator_queue_items", lambda **k: [{
+        "id": "1", "type": "question", "title": "t", "question": "q",
+        "context": {"api_key": "sk-live-should-never-appear"},
+    }])
+
+    ask = agent_page._asks(AGENT)[0]
+
+    assert "context" not in ask
+    assert "sk-live" not in repr(ask)
+
+
+# ---------------------------------------------------------------------------
+# Cross-agent isolation on the report read
+# ---------------------------------------------------------------------------
+
+def test_a_report_belonging_to_another_agent_is_not_readable(monkeypatch):
+    """Report ids are global. The roster gate only proves the caller may reach
+    THIS agent, so without the ownership check its page becomes a reader for
+    every report in the install."""
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: {
+        "id": rid, "agent_name": OTHER, "title": "someone else's numbers",
+        "payload": {"secret": 1},
+    })
+
+    assert agent_page.report_detail(AGENT, "r1") is None
+
+
+def test_a_missing_report_and_a_foreign_one_are_indistinguishable(monkeypatch):
+    """Both return None → the same 404. A different answer would let a caller
+    test whether a report id exists (invariant #8)."""
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: None)
+    missing = agent_page.report_detail(AGENT, "nope")
+
+    monkeypatch.setattr(agent_page.db, "get_report",
+                        lambda rid: {"id": rid, "agent_name": OTHER, "payload": {}})
+    foreign = agent_page.report_detail(AGENT, "r1")
+
+    assert missing is None and foreign is None
+
+
+def test_the_agents_own_report_is_returned(monkeypatch):
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: {
+        "id": rid, "agent_name": AGENT, "title": "Weekly", "payload": {"rows": []},
+        "report_type": "recon.weekly", "display_hint": "table",
+        "period_start": None, "period_end": None, "created_at": "2026-08-13T00:00:00Z",
+    })
+
+    got = agent_page.report_detail(AGENT, "r1")
+
+    assert got["id"] == "r1" and got["payload"] == {"rows": []}
+
+
+# ---------------------------------------------------------------------------
+# Degradation — AC #6: renders for a stopped agent, degraded not empty
+# ---------------------------------------------------------------------------
+
+def test_health_is_unknown_rather_than_unhealthy_when_never_checked(monkeypatch):
+    """Monitoring is default-OFF (#1121), so on many installs no agent has ever
+    been checked. Rendering "unhealthy" there would be a lie about every agent
+    on the instance."""
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "get_latest_health_check", lambda *a, **k: None)
+
+    assert agent_page._health(AGENT) == {"status": "unknown", "checked_at": None}
+
+
+def test_a_failing_data_source_degrades_that_section_only(monkeypatch):
+    """A page that 500s because the operator queue is unhappy is worse than one
+    that renders without its asks section."""
+    from client_portal import agent_page
+
+    def boom(*a, **k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(agent_page.db, "list_operator_queue_items", boom)
+    monkeypatch.setattr(agent_page.db, "get_agent_executions_summary", boom)
+    monkeypatch.setattr(agent_page.db, "get_latest_health_check", boom)
+    monkeypatch.setattr(agent_page.db, "get_agent_analytics", boom)
+
+    page = agent_page.build_page(EMAIL, AGENT, {"description": "d"}, window="7d")
+
+    assert page["asks"] == [] and page["recent_work"] == []
+    assert page["header"]["health"]["status"] == "unknown"
+    assert page["stats"]["unavailable"] is True
+    assert page["header"]["description"] == "d"   # what IS known still renders
+
+
+def test_capabilities_come_from_the_roster_briefing(monkeypatch):
+    """"What it can do" is a projection of the briefing the roster already
+    carries (#138/ent#380), not a second mechanism — ent#178 is the unified
+    config it becomes a view of."""
+    from client_portal import agent_page
+
+    monkeypatch.setattr(agent_page.db, "get_latest_health_check", lambda *a, **k: None)
+    monkeypatch.setattr(agent_page.db, "get_agent_executions_summary", lambda *a, **k: [])
+    monkeypatch.setattr(agent_page.db, "list_operator_queue_items", lambda **k: [])
+    monkeypatch.setattr(agent_page.db, "get_agent_analytics", lambda *a, **k: {})
+    monkeypatch.setattr(agent_page.portal_db, "first_try_stats",
+                        lambda *a, **k: {"terminal": 0, "first_try": 0, "rate": None})
+
+    card = {"playbooks": [{"title": "Weekly report", "starter_prompt": "run it"}]}
+    page = agent_page.build_page(EMAIL, AGENT, card, window="7d")
+
+    assert page["capabilities"] == card["playbooks"]
+
+
+# ---------------------------------------------------------------------------
+# first-try rate — the AC #3 metric that DOES have a source
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def exec_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "trinity-agent-page.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+    from db.engine import get_engine
+    from db.tables import metadata as oss_metadata, schedule_executions
+    oss_metadata.create_all(get_engine(), tables=[schedule_executions])
+    yield get_engine()
+
+
+def _exec(engine, *, eid, status, retry_count, at="2099-01-01T00:00:00Z", agent=AGENT):
+    from db.tables import schedule_executions as se
+    with engine.begin() as conn:
+        conn.execute(se.insert().values(
+            id=eid, schedule_id="__manual__", agent_name=agent, status=status,
+            started_at=at, message="m", triggered_by="manual", retry_count=retry_count,
+        ))
+
+
+def test_first_try_excludes_a_success_that_needed_a_retry(exec_db):
+    """Distinct from the success rate the analytics accessor reports, which
+    counts a retried-then-succeeded execution as a success — the right answer to
+    "does it get there in the end", the wrong one to "does it get there first
+    time"."""
+    from client_portal import db as pdb
+
+    _exec(exec_db, eid="a", status="success", retry_count=0)
+    _exec(exec_db, eid="b", status="success", retry_count=2)
+    _exec(exec_db, eid="c", status="failed", retry_count=0)
+
+    got = pdb.first_try_stats(AGENT, 720)
+
+    assert got["terminal"] == 3
+    assert got["first_try"] == 1
+
+
+def test_a_pre_retry_column_row_counts_as_first_try(exec_db):
+    """`retry_count` is NULL on rows written before #678 — such a success
+    genuinely had no retry, so NULL reads as zero rather than excluding it."""
+    from client_portal import db as pdb
+
+    _exec(exec_db, eid="a", status="success", retry_count=None)
+
+    assert pdb.first_try_stats(AGENT, 720)["first_try"] == 1
+
+
+def test_another_agents_executions_are_not_counted(exec_db):
+    from client_portal import db as pdb
+
+    _exec(exec_db, eid="a", status="success", retry_count=0, agent=OTHER)
+
+    assert pdb.first_try_stats(AGENT, 720)["terminal"] == 0
+
+
+def test_no_terminal_executions_reports_no_rate_rather_than_zero(exec_db):
+    """0% would read as "it fails every time"; a fresh agent simply has no
+    first-try rate yet."""
+    from client_portal import db as pdb
+
+    assert pdb.first_try_stats(AGENT, 720)["rate"] is None
+
+
+def test_running_and_queued_rows_are_not_terminal(exec_db):
+    from client_portal import db as pdb
+
+    _exec(exec_db, eid="a", status="running", retry_count=0)
+    _exec(exec_db, eid="b", status="queued", retry_count=0)
+
+    assert pdb.first_try_stats(AGENT, 720)["terminal"] == 0


### PR DESCRIPTION
Issue: [ent#360](https://github.com/Abilityai/trinity-enterprise/issues/360). The last unstarted item on the release-required Workspace list.

An agent had no home. A roster row emitted `new-chat-with-agent`, so there was nowhere to see what an agent had been doing, nowhere for it to ask you something while no chat was open, and nowhere to show what it can do.

Header · stats strip · five tabs (Overview · Reports · Files · What it can do · Activity). Overview leads with what the agent is waiting on you for, then recent work, then your chats with it.

## The half worth reviewing

The page **reports; it does not configure** — no schedules, no skill editing, no logs, no costs, and model/plan are not shown at all. And the same page serves an **external portal-token client** as well as a platform user, which makes this a security surface rather than a layout exercise.

So every exclusion is a **projection in the service**, before the payload exists — not a filter in the template. A template filter is correct right up until someone adds a column to a list view, and nothing fails when they do. A field that never leaves the service cannot be surfaced by a later edit.

| Surface | What the accessor also returns | Why it must not ship |
|---|---|---|
| `recent_work` | `message`, `cost`, `model_used`, `source_user_email` | `message` is another user's prompt; the other two are excluded by AC #7 |
| `asks` | `context`, and `alert` items | `context` is free-form agent JSON and a known credential-leak surface (canary G-04 exists because secrets turn up there). `alert`s are ops telemetry — sync-failing, git-bloat, breaker — not an agent asking a person anything |
| report detail | any report in the install | Report ids are global; the roster gate proves only that the caller may reach **this** agent. A foreign id answers with the same 404 as a missing one, so it is not an existence oracle either |

## Two AC #3 metrics, opposite outcomes

**First-try rate ships and is real**: successes with `retry_count` 0. Deliberately distinct from the success rate, which counts a retried-then-succeeded execution as a success — the right answer to "does it get there in the end", the wrong one to "does it get there first time". NULL `retry_count` (pre-#678 rows) reads as zero; no terminal rows ⇒ `null`, not `0.0`, because 0% reads as "it fails every time".

**Rating tally does not ship.** There is no rating, thumbs or feedback mechanism anywhere in Trinity — no table, no column, no endpoint. It has no data source, so I omitted it rather than inventing one; a number a user reads as "how well is this agent doing" has to come from something real. This is the one AC bullet not met, and it is recorded as such in the requirement rather than quietly dropped.

## Degradation (AC #6)

Everything is DB-sourced, so a stopped agent renders degraded rather than empty, and a failing data source degrades **only its own section** — a page that 500s because the operator queue is unhappy is worse than one without its asks. Health reports `unknown`, never `unhealthy`, when nothing has ever checked the agent: monitoring is default-OFF (#1121), so on many installs that is every agent and "unhealthy" would be a lie about the whole fleet.

## Reuse, as the Technical Notes ask

`get_agent_analytics` (#1107) via the **DB accessor**, not over HTTP — the platform endpoint is JWT-gated and a portal-token client cannot call it. Reports and files reuse their existing surfaces. "What it can do" projects the roster briefing (#138/ent#380) rather than building the competing mechanism ent#178 will own.

## Supersedes

ent#359 made a roster row with unread open the *unread chat*, because a badge reading "2 replies" next to a control that opened a **blank** chat was a contradiction. The page resolves it properly — the row opens the page, the badge still shows, and Overview lists the chats with their counts. "An agent is a destination" is finally true.

## Verification

Live against the running instance: `header` with real health + last-active, 37 executions, 89% completed, **33/37 first try**, `recent_work` carrying exactly the six safe keys, and 404 / 422 / 401 on the roster, window and auth gates.

14 new backend tests (projections, cross-agent report isolation, 404 uniformity, degradation, first-try arithmetic); 442 passed across the portal+session suites; 169 frontend tests; build clean.

## Stacking

Branched off #2139 (ent#359), so this diff carries that work until it merges. **#2139 first.**

Docs: requirements §5.11, flow `docs/memory/feature-flows/workspace-agent-page.md`.

Related to abilityai/trinity-enterprise#360