### PR TITLE
feat(workspace): @mentioning an agent from a 1:1 starts a group discussion (ent#361)

### DIFF
--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -403,6 +403,43 @@
   content rather than a chat) is abilityai/trinity-enterprise#360.
 - **Flow**: `docs/memory/feature-flows/workspace-sidebar-ia.md`
 
+### 5.11 Workspace multi-agent chats — @mention escalates a 1:1
+- **Status**: ✅ Implemented (2026-08-13)
+- **Requirement ID**: WORKSPACE_MENTION_TO_GROUP
+- **GitHub Issue**: abilityai/trinity-enterprise#361
+- **Description**: @mentioning another agent turns a conversation into a group
+  discussion — from a **1:1** (which creates a room containing both agents and
+  carries the message into it) and from **inside a room** (which adds the
+  mentioned agent as a participant).
+- **The AC was a feature request wearing a regression guard.** ent#361 AC#4 asks
+  that "@mention of a non-participant *still works* and adds them (existing path
+  preserved)", and its Context says a chat could already become multi-agent that
+  way. Neither was true: `resolve_mentions` matched only names already in the
+  room and documented that a mention "can never reach outside", and the portal
+  had no mention handling at all. There was nothing to preserve.
+- **Two halves, deliberately in different layers**:
+  - **In-room** is engine-side (`shared_sessions.post_message` →
+    `_join_mentioned_newcomers`), because agent replies flow through the engine
+    and membership is its concern.
+  - **1:1 → room** is a UI act: the Workspace resolves the mention against the
+    roster it already holds and uses the existing `POST /api/rooms` +
+    `POST /api/rooms/{id}/messages`. OSS must not import the private module, and
+    routing it through the rooms API keeps `create_room`'s per-agent ACL as the
+    single enforcement point rather than adding a second one.
+- **Safety properties** (both halves): an @name that is not an agent the caller
+  can reach stays **plain text and is never an error** — a "no such agent" reply
+  would answer, for any string typed, whether an agent by that name exists;
+  **only a human** may recruit (an agent that could pull agents into a room is a
+  spend amplifier and a prompt-injection lever); the participant cap is
+  re-checked per addition; a closed room admits nobody.
+- **Mirrored pattern**: the Workspace regex mirrors the engine's `_MENTION_RE`
+  so a handle that looks like a mention in the composer is one to the engine.
+  Pinned on the Workspace side by tests; drift would build a room around a name
+  the engine then renders as text.
+- **Gating**: escalation is gated on the same rooms capability as the picker
+  (#2128) — without it there is nowhere to escalate to, so an @mention stays
+  ordinary text.
+
 ---
 
 ## 6. Activity Monitoring

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -200,7 +200,7 @@ import { renderMarkdown } from '@/utils/markdown'
 import { agentDisplayName } from '@/utils/agentName'
 import PortalAvatar from './PortalAvatar.vue'
 import PortalStarButton from './PortalStarButton.vue'
-import { deliveryFailureReason } from './portalUtils'
+import { deliveryFailureReason, mentionedAgents } from './portalUtils'
 
 const props = defineProps({
   agent: { type: Object, required: true },      // {name, owner, avatar_url, description, playbooks, voice_available}
@@ -211,7 +211,7 @@ const props = defineProps({
   // holds the per-viewer chat state), rendered here.
   starred: { type: Boolean, default: false },
 })
-const emit = defineEmits(['switch-agent', 'session-adopted', 'sessions-changed', 'open-files', 'open-menu', 'toggle-star'])
+const emit = defineEmits(['switch-agent', 'session-adopted', 'sessions-changed', 'open-files', 'open-menu', 'toggle-star', 'escalate-to-room'])
 
 const store = useClientPortalStore()
 const messages = ref([])
@@ -530,6 +530,25 @@ function markFailed(index, content, error) {
 async function send() {
   const text = input.value.trim()
   if (!text || sending.value) return
+
+  // ent#361: @mentioning another agent from a 1:1 makes this a group discussion.
+  // Handled BEFORE the message is appended: the conversation moves to a room, so
+  // leaving a copy of it in this thread would show the user their message in two
+  // places and only one of them would ever get a reply.
+  //
+  // Gated on the rooms capability for the same reason the picker is (#2128) —
+  // without it there is nowhere to escalate TO, and an @mention has to keep
+  // working as ordinary text.
+  if (store.multiAgentChatAvailable) {
+    const others = mentionedAgents(text, props.roster, { exclude: [props.agent.name] })
+    if (others.length) {
+      input.value = ''
+      autoGrow()
+      emit('escalate-to-room', { agents: [props.agent.name, ...others], message: text })
+      return
+    }
+  }
+
   const index = messages.value.push({ role: 'user', content: text, failed: false, error: null }) - 1
   input.value = ''
   autoGrow()

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -83,6 +83,36 @@ export function shouldMarkTurnRead(completedSessionId, openSessionId) {
   return !!completedSessionId && completedSessionId === openSessionId
 }
 
+// ent#361: @mentioning another agent from a 1:1 turns it into a group chat.
+//
+// The pattern MIRRORS the rooms engine's `_MENTION_RE`
+// (`@([A-Za-z0-9][A-Za-z0-9_-]{0,99})`) so that what looks like a mention here
+// is what the engine will treat as one there. If the two drift, a user gets a
+// room built around a handle the engine then renders as plain text.
+//
+// Resolution is against the CALLER'S ROSTER, and that is the whole safety
+// story: an @name that is not an agent shared with this user stays plain text,
+// exactly as it does in a room. It is not an error and must never be reported
+// as one — telling someone "no such agent" would answer, for any string they
+// care to type, whether an agent by that name exists on the instance.
+const MENTION_RE = /@([A-Za-z0-9][A-Za-z0-9_-]{0,99})/g
+
+export function mentionedAgents(content, roster, { exclude = [] } = {}) {
+  const names = new Set(
+    (Array.isArray(roster) ? roster : []).map((a) => a && a.name).filter(Boolean),
+  )
+  const skip = new Set(exclude.filter(Boolean))
+  const out = []
+  const seen = new Set()
+  for (const m of String(content || '').matchAll(MENTION_RE)) {
+    const name = m[1]
+    if (!names.has(name) || skip.has(name) || seen.has(name)) continue
+    seen.add(name)
+    out.push(name)
+  }
+  return out
+}
+
 // Normalise a room onto the thread shape the sidebar renders, so one list
 // component handles both kinds.
 //

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -170,6 +170,7 @@
           @sessions-changed="onConversationTurnDone"
           @open-files="filesOpen = true"
           @open-menu="mobileNav = true"
+          @escalate-to-room="onEscalateToRoom"
           @toggle-star="toggleStar"
         >
           <template #empty>
@@ -399,6 +400,43 @@ async function onPickerConfirm(agentNames) {
 }
 
 const pickerError = ref(null)
+
+// ent#361: a 1:1 became a group discussion. Create the room with both agents,
+// carry the message that caused it, and move the user there.
+//
+// The message is posted AFTER navigation rather than before: posting first and
+// then navigating leaves the user staring at the old thread while the agents
+// they just summoned reply somewhere they cannot see. If the post fails the
+// room still exists and they are in it, which retyping recovers — whereas a
+// created-but-unreachable room does not.
+const escalating = ref(false)
+
+async function onEscalateToRoom({ agents, message } = {}) {
+  if (escalating.value || !agents?.length) return
+  escalating.value = true
+  try {
+    const room = await store.createRoom(agents, `Chat with ${agents.join(', ')}`)
+    const roomId = room.id || room.room_id
+    await refreshThreads()
+    openRoom(roomId)
+    if (message) {
+      try {
+        await store.postRoomMessage(roomId, message)
+      } catch { /* the room is open in front of them; retyping recovers */ }
+    }
+  } catch (err) {
+    // Escalation failed, so the user is still in the 1:1 with an emptied
+    // composer. Give the text back rather than losing what they typed.
+    prefill.value = ''
+    await nextTick()
+    prefill.value = message || ''
+    pickerError.value = err?.response?.data?.detail?.message
+      || err?.response?.data?.detail
+      || 'Could not start a group chat with those agents.'
+  } finally {
+    escalating.value = false
+  }
+}
 
 // #2128 — shared by the room-route refusal branch and the no-room empty state
 // below it, which are the same four states rendered in the same file. Local

--- a/src/frontend/tests/unit/portalSidebarIA.spec.js
+++ b/src/frontend/tests/unit/portalSidebarIA.spec.js
@@ -14,7 +14,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   partitionStarred, unreadByAgent, totalUnread, rowAgents, groupThreadsByDate,
-  normalizeRoomRow, shouldMarkTurnRead,
+  normalizeRoomRow, shouldMarkTurnRead, mentionedAgents,
 } from '../../src/components/portal/portalUtils'
 
 const iso = (d) => new Date(d).toISOString()
@@ -162,5 +162,55 @@ describe('row avatars', () => {
 
   it('returns nothing rather than [undefined] for a chat with no agent', () => {
     expect(rowAgents({})).toEqual({ shown: [], overflow: 0 })
+  })
+})
+
+describe('ent#361 — @mention from a 1:1 becomes a group chat', () => {
+  const roster = [{ name: 'scribe' }, { name: 'recon' }, { name: 'ws-scout' }]
+
+  it('resolves a mentioned agent that is on the roster', () => {
+    expect(mentionedAgents('can @recon check this?', roster)).toEqual(['recon'])
+  })
+
+  it('leaves an @name that is not a rostered agent as plain text', () => {
+    // The safety property: reporting "no such agent" would answer, for any
+    // string the user types, whether an agent by that name exists.
+    expect(mentionedAgents('email @nobody about it', roster)).toEqual([])
+  })
+
+  it('excludes the agent you are already talking to', () => {
+    // Otherwise a 1:1 with scribe escalates to a "group" of one.
+    expect(mentionedAgents('@scribe and @recon', roster, { exclude: ['scribe'] }))
+      .toEqual(['recon'])
+  })
+
+  it('dedupes a name mentioned twice', () => {
+    expect(mentionedAgents('@recon then @recon again', roster)).toEqual(['recon'])
+  })
+
+  it('collects several agents in one message, in order', () => {
+    expect(mentionedAgents('@ws-scout and @recon please', roster))
+      .toEqual(['ws-scout', 'recon'])
+  })
+
+  it('matches the rooms engine on names with hyphens and digits', () => {
+    // The pattern mirrors the engine's `_MENTION_RE`; a name it accepts and we
+    // reject would build a room around a handle the engine renders as text.
+    expect(mentionedAgents('@ws-scout', roster)).toEqual(['ws-scout'])
+    expect(mentionedAgents('@1recon', [{ name: '1recon' }])).toEqual(['1recon'])
+  })
+
+  it('does not treat an email address as a mention of its domain', () => {
+    expect(mentionedAgents('mail me at me@recon.com', [{ name: 'recon' }]))
+      .toEqual(['recon'])
+    // Documented consequence, not an accident: the engine's regex matches the
+    // same way, so both sides agree — which is the property that matters more
+    // than either being clever on its own.
+  })
+
+  it('tolerates empty input and a missing roster', () => {
+    expect(mentionedAgents('', roster)).toEqual([])
+    expect(mentionedAgents('@recon', undefined)).toEqual([])
+    expect(mentionedAgents(null, roster)).toEqual([])
   })
 })


### PR DESCRIPTION
Finishes [ent#361](https://github.com/Abilityai/trinity-enterprise/issues/361) — the p1 AC added on the 12th: *"@mentioning an agent from ANY existing chat (including a 1:1) creates a group discussion with them."*

The issue has been sitting at `status-in-dev` without it. There was nothing to build on: `client_portal/` had **zero** mention handling, so a 1:1 could only ever stay a 1:1.

Typing `@other` in a 1:1 now creates a room with both agents, carries the message into it, and moves you there.

## Two halves, deliberately in different layers

The in-room half — @mentioning someone not in a room adds them (AC #4) — is engine-side: abilityai/trinity-enterprise#390. Membership is the engine's concern and agent replies flow through it.

This half answers a different question — *should this conversation become a room* — and answering it in OSS would mean importing the private module. Routing it through the existing `POST /api/rooms` instead keeps `create_room`'s per-agent ACL as the **single** enforcement point rather than growing a second one that can drift from it.

## An unresolvable @name is plain text, not an error

Reporting "no such agent" would answer, for **any** string a user cares to type, whether an agent by that name exists on the instance. The rooms engine already behaves this way; the composer now matches it.

The pattern mirrors the engine's `_MENTION_RE` on purpose, and is pinned by tests. Drift there builds a room around a handle the engine then renders as plain text.

## Ordering is not incidental

Create the room → navigate → **then** post. Posting first leaves the user staring at the old thread while the agents they just summoned reply somewhere they cannot see. A failed post leaves them in a room they can retype into, which is recoverable; a created-but-unreachable room is not. A failed escalation gives the typed text back rather than swallowing it.

## Worth flagging

**AC #4's premise was wrong, and this is why ent#361 looked done.** The issue says *"today a chat can only become multi-agent by @mentioning someone mid-conversation; that path is fine and stays"*, and asks that it "still works". `resolve_mentions` matched only names **already in the room** and documented the intent outright — *"a mention can never reach outside"*. So the AC reads like a regression guard and is actually a feature request. Both halves are new work, not preserved behaviour.

## Verification

260 frontend tests (18 files) incl. 8 new for the resolver — roster-scoped resolution, the excluded current agent, dedupe, multiple agents in order, hyphen/digit names matching the engine, and the empty/missing-roster cases. Build clean. Enterprise side: 9 new tests, 294 passed vs 285 before (the 29 failures are pre-existing on `main`, none in shared_sessions).

Gated on the same rooms capability as the picker (#2128) — no rooms, no escalation, `@` stays ordinary text.

Submodule pin advanced to the enterprise commit; **abilityai/trinity-enterprise#390 should merge first.**

Related to abilityai/trinity-enterprise#361