### PR TITLE
fix(workspace): bound the reply poll to a turn's real life, and stop offering Retry when it is merely lost (#2133)

### DIFF
--- a/src/backend/client_portal/models.py
+++ b/src/backend/client_portal/models.py
@@ -132,6 +132,10 @@ class PortalTurnStarted(BaseModel):
     """
     execution_id: str
     session_id: Optional[str] = None
+    # #2133: how long the client may wait before concluding it has lost track of
+    # the turn. Sent by the server because the server owns the timeout; a
+    # frontend constant would drift the next time it changes.
+    wait_budget_seconds: Optional[int] = None
 
 
 class PortalSessionSummary(BaseModel):

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1006,7 +1006,7 @@ async def portal_chat(agent_name: str, message: str, email: str,
             triggered_by="public",      # external-caller path; "Public" analytics bucket
             on_resume_failure=_on_resume_failure,
             source_user_email=email,
-            timeout_seconds=300,
+            timeout_seconds=PORTAL_TURN_TIMEOUT_SECONDS,
             images=images or None,      # referenced inbox images as vision input (#78)
             system_prompt=system_prompt,
             execution_id=execution_id,  # ent#286: pre-created row, so the client can already be watching
@@ -1113,11 +1113,25 @@ def _inflight_exec_key(execution_id: str) -> str:
     return f"portal_inflight_exec:{execution_id}"
 
 
-# The marker describes a turn in progress, so its TTL is the turn's own bound
-# plus slack — not an hour. The client now waits as long as the marker says a
-# turn is running, so an over-long TTL is a spinner that outlives the work: a
-# backend restart mid-turn would leave the composer disabled for the remainder.
-PORTAL_INFLIGHT_TTL_SECONDS = 300 + 60
+# The bound on ONE portal turn (the `timeout_seconds` passed to the turn below).
+PORTAL_TURN_TIMEOUT_SECONDS = 300
+
+# The bound on a turn's whole LIFE, which is what the marker and the client must
+# be sized against — #2133.
+#
+# `run_resumable_turn` can run the turn TWICE: a resume whose JSONL is gone
+# fails, and the cold retry re-runs the WHOLE thing. So the worst legitimate
+# case is two full timeouts, not one. Sizing either bound at a single timeout
+# reintroduces exactly what #2120 fixed — the marker expires, the client is told
+# "nothing is running", and a live, already-billed turn is declared not
+# delivered — and it does so precisely on the cold-retry path that fix existed
+# for.
+#
+# Still nowhere near the old hour: an hour-long marker is a spinner that
+# outlives the work, so a backend restart mid-turn would leave the composer
+# disabled for the rest of it.
+PORTAL_MAX_TURN_SECONDS = 2 * PORTAL_TURN_TIMEOUT_SECONDS + 60
+PORTAL_INFLIGHT_TTL_SECONDS = PORTAL_MAX_TURN_SECONDS
 
 
 def mark_turn_inflight(session_id: str, execution_id: str,
@@ -1367,7 +1381,15 @@ async def start_portal_turn(agent_name: str, message: str, email: str,
     _INFLIGHT_TURNS.add(task)
     task.add_done_callback(_INFLIGHT_TURNS.discard)
 
-    return {"execution_id": execution_id, "session_id": session_id}
+    # #2133: the client must not invent its own ceiling. It waits on the marker,
+    # and the marker's life is decided here — so the budget travels with the
+    # dispatch rather than being duplicated as a frontend constant that silently
+    # drifts the next time this timeout changes.
+    return {
+        "execution_id": execution_id,
+        "session_id": session_id,
+        "wait_budget_seconds": PORTAL_MAX_TURN_SECONDS,
+    }
 
 
 def execution_belongs_to_caller(execution_id: str, agent_name: str, email: str) -> bool:

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1130,7 +1130,19 @@ PORTAL_TURN_TIMEOUT_SECONDS = 300
 # Still nowhere near the old hour: an hour-long marker is a spinner that
 # outlives the work, so a backend restart mid-turn would leave the composer
 # disabled for the rest of it.
-PORTAL_MAX_TURN_SECONDS = 2 * PORTAL_TURN_TIMEOUT_SECONDS + 60
+# What ONE attempt can actually cost, which is not `timeout_seconds`:
+#   + 10   `execute_task` dispatches with `timeout_seconds + 10` (HTTP slack)
+#   + 300  the #678 reader-race auto-retry runs a SECOND http call, capped at
+#          `_AUTO_RETRY_MAX_TIMEOUT_S`, ON TOP of whatever attempt 1 burned
+#          (unlike the SUB-003 retry, which is capped to the remaining budget)
+PORTAL_ATTEMPT_CEILING_SECONDS = PORTAL_TURN_TIMEOUT_SECONDS + 10 + 300
+
+# ...and the turn can run TWO attempts, because a resume whose JSONL is gone
+# re-runs the whole thing cold. Sizing the marker at one attempt — or at two bare
+# timeouts, as this first did — expires it while the turn is live, and the client
+# then offers a Retry for work already billed. `tests/unit/test_2133_*` pins this
+# against the real constants so a change to either drifts loudly.
+PORTAL_MAX_TURN_SECONDS = 2 * PORTAL_ATTEMPT_CEILING_SECONDS + 60
 PORTAL_INFLIGHT_TTL_SECONDS = PORTAL_MAX_TURN_SECONDS
 
 

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -200,7 +200,7 @@ import { renderMarkdown } from '@/utils/markdown'
 import { agentDisplayName } from '@/utils/agentName'
 import PortalAvatar from './PortalAvatar.vue'
 import PortalStarButton from './PortalStarButton.vue'
-import { deliveryFailureReason } from './portalUtils'
+import { deliveryFailureReason, REPLY_MAX_WAIT_MS_FALLBACK } from './portalUtils'
 
 const props = defineProps({
   agent: { type: Object, required: true },      // {name, owner, avatar_url, description, playbooks, voice_available}
@@ -385,6 +385,9 @@ async function deliver(text) {
     }
 
     if (started) {
+      // Stamp the dispatch instant: the server's marker TTL starts here, so the
+      // client's ceiling must too (see awaitPersistedReply).
+      const dispatchedAt = Date.now()
       if (started.session_id && currentSessionId.value !== started.session_id) {
         // Adopt the thread NOW rather than at the end, so a refresh mid-turn
         // reattaches to it instead of opening a second conversation.
@@ -404,7 +407,8 @@ async function deliver(text) {
         liveActivity.value = []
       }
       data = await awaitPersistedReply(
-        started.session_id || currentSessionId.value, baseline, started.wait_budget_seconds,
+        started.session_id || currentSessionId.value, baseline,
+        started.wait_budget_seconds, dispatchedAt,
       )
       if (data?.lost) {
         // #2133: we ran out of budget while the marker still claimed a turn.
@@ -479,7 +483,10 @@ function onStreamEvent(evt) {
 // the local list instead let a retry return the PREVIOUS turn's reply on its
 // first poll — the answer to the wrong question, while a second turn ran unseen.
 const REPLY_POLL_MS = 700
-const REPLY_IDLE_GIVE_UP = 8      // ~5.6s of the server saying "nothing running"
+// Time-based, NOT poll-count-based. With the backoff below, 8 polls is up to
+// 8 x 15s = 120s late in a turn — so a count silently stretched this debounce
+// into two minutes of spinner before the no-answer message appeared.
+const REPLY_IDLE_GIVE_UP_MS = 6_000
 
 // #2133: the absolute ceiling, for when the marker is ORPHANED rather than
 // merely slow — a hard backend kill skips the `finally` that clears it, and
@@ -491,7 +498,7 @@ const REPLY_IDLE_GIVE_UP = 8      // ~5.6s of the server saying "nothing running
 // `--resume` re-runs the whole thing cold. A ceiling of one turn would declare a
 // live, already-billed cold retry "not delivered" — exactly what #2120 fixed,
 // on exactly the path it was fixed for.
-const REPLY_MAX_WAIT_MS_FALLBACK = (2 * 300 + 60) * 1000
+// (imported from portalUtils so a test can compare it to the server's value)
 
 // Polling every 700ms for ten minutes is ~850 history reads per tab. The reply
 // almost always lands in the first seconds, so the fast interval is what
@@ -509,9 +516,16 @@ function replyPollInterval(elapsedMs) {
   return every
 }
 
-async function awaitPersistedReply(sessionId, baselineAssistants, budgetSeconds) {
-  let idlePolls = 0
-  const startedAt = Date.now()
+async function awaitPersistedReply(sessionId, baselineAssistants, budgetSeconds,
+                                   dispatchedAtMs) {
+  let idleSince = null
+  // Measured from DISPATCH, not from when this function was reached. The
+  // server's marker TTL starts ticking at dispatch, so a client clock that
+  // starts after the stream breaks (which can be minutes later, on exactly the
+  // orphaned-marker path this ceiling exists for) would outlive the marker —
+  // and the marker's disappearance would be read as "nothing running" instead
+  // of tripping the ceiling. The two clocks now share an origin.
+  const startedAt = dispatchedAtMs || Date.now()
   const budgetMs = Number(budgetSeconds) > 0
     ? Number(budgetSeconds) * 1000
     : REPLY_MAX_WAIT_MS_FALLBACK
@@ -536,8 +550,15 @@ async function awaitPersistedReply(sessionId, baselineAssistants, budgetSeconds)
       return { response: last.content, cost: last.cost, session_id: data.sessionId || sessionId }
     }
     // Still running server-side? Then keep waiting, however long it takes.
-    if (data.inFlightExecutionId) { idlePolls = 0 }
-    else if (++idlePolls >= REPLY_IDLE_GIVE_UP) return null
+    if (data.inFlightExecutionId) { idleSince = null }
+    else {
+      if (idleSince === null) idleSince = Date.now()
+      // The server has said "nothing running" for long enough. NOT retryable:
+      // the turn may well have run and been billed — notably when Redis is down,
+      // `mark_turn_inflight` no-ops and this branch is reached on the very first
+      // poll of a perfectly healthy turn.
+      else if (Date.now() - idleSince >= REPLY_IDLE_GIVE_UP_MS) return { lost: true, idle: true }
+    }
     await wait()
   }
 }

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -91,7 +91,7 @@
               class="text-xs text-status-danger-700 dark:text-status-danger-300 text-right max-w-[32ch]"
             >{{ m.error }}</p>
             <button
-              v-if="m.failed"
+              v-if="m.failed && m.retryable !== false"
               class="text-xs text-status-danger-600 dark:text-status-danger-400 hover:underline inline-flex items-center gap-1"
               @click="retry(i)"
             >
@@ -403,7 +403,16 @@ async function deliver(text) {
         streaming.value = false
         liveActivity.value = []
       }
-      data = await awaitPersistedReply(started.session_id || currentSessionId.value, baseline)
+      data = await awaitPersistedReply(
+        started.session_id || currentSessionId.value, baseline, started.wait_budget_seconds,
+      )
+      if (data?.lost) {
+        // #2133: we ran out of budget while the marker still claimed a turn.
+        // That turn probably RAN and was billed — we merely lost sight of it.
+        // So this is reported without a Retry: re-sending is the one action
+        // guaranteed to be wrong.
+        return { lost: true, error: "Still no reply — we've lost track of this turn. It may still finish; check the conversation shortly." }
+      }
       if (!data) {
         // The server reports nothing running and no new reply — a genuine
         // no-answer. Report it; never re-send, the turn was already billed.
@@ -471,22 +480,54 @@ function onStreamEvent(evt) {
 // first poll — the answer to the wrong question, while a second turn ran unseen.
 const REPLY_POLL_MS = 700
 const REPLY_IDLE_GIVE_UP = 8      // ~5.6s of the server saying "nothing running"
-// An absolute ceiling on top of the server's answer. The marker is TTL-bounded
-// server-side, but a stuck or unreachable marker must not leave the composer
-// disabled forever — this caps the spinner at a little beyond the longest turn.
-const REPLY_MAX_WAIT_MS = 6 * 60 * 1000
 
-async function awaitPersistedReply(sessionId, baselineAssistants) {
+// #2133: the absolute ceiling, for when the marker is ORPHANED rather than
+// merely slow — a hard backend kill skips the `finally` that clears it, and
+// `except Exception` does not catch `CancelledError`.
+//
+// The server sends the budget with the 202 (`wait_budget_seconds`) because the
+// server owns the turn timeout. This constant is only the fallback for an older
+// backend, and it is sized the same way: TWO full turns, because a failed
+// `--resume` re-runs the whole thing cold. A ceiling of one turn would declare a
+// live, already-billed cold retry "not delivered" — exactly what #2120 fixed,
+// on exactly the path it was fixed for.
+const REPLY_MAX_WAIT_MS_FALLBACK = (2 * 300 + 60) * 1000
+
+// Polling every 700ms for ten minutes is ~850 history reads per tab. The reply
+// almost always lands in the first seconds, so the fast interval is what
+// matters; after that, widen. Same total wait, an order of magnitude fewer
+// requests on the long tail.
+const REPLY_POLL_STEPS = [
+  { afterMs: 30_000, everyMs: 2_000 },
+  { afterMs: 120_000, everyMs: 5_000 },
+  { afterMs: 300_000, everyMs: 15_000 },
+]
+
+function replyPollInterval(elapsedMs) {
+  let every = REPLY_POLL_MS
+  for (const step of REPLY_POLL_STEPS) if (elapsedMs >= step.afterMs) every = step.everyMs
+  return every
+}
+
+async function awaitPersistedReply(sessionId, baselineAssistants, budgetSeconds) {
   let idlePolls = 0
-  const deadline = Date.now() + REPLY_MAX_WAIT_MS
+  const startedAt = Date.now()
+  const budgetMs = Number(budgetSeconds) > 0
+    ? Number(budgetSeconds) * 1000
+    : REPLY_MAX_WAIT_MS_FALLBACK
+  const deadline = startedAt + budgetMs
+  const wait = () => new Promise((r) => setTimeout(r, replyPollInterval(Date.now() - startedAt)))
+
   for (;;) {
-    if (Date.now() > deadline) return null
+    // `lost` — NOT a failure. The turn may well have run and been billed; we
+    // simply stopped being able to see it. The caller must not offer a Retry.
+    if (Date.now() > deadline) return { lost: true }
     let data
     try {
       data = await store.fetchHistory(props.agent.name, sessionId || null)
     } catch {
       // A hiccup reading history is not evidence the turn failed.
-      await new Promise((r) => setTimeout(r, REPLY_POLL_MS))
+      await wait()
       continue
     }
     const assistants = (data.messages || []).filter((m) => m.role === 'assistant')
@@ -497,7 +538,7 @@ async function awaitPersistedReply(sessionId, baselineAssistants) {
     // Still running server-side? Then keep waiting, however long it takes.
     if (data.inFlightExecutionId) { idlePolls = 0 }
     else if (++idlePolls >= REPLY_IDLE_GIVE_UP) return null
-    await new Promise((r) => setTimeout(r, REPLY_POLL_MS))
+    await wait()
   }
 }
 
@@ -518,13 +559,17 @@ async function persistedAssistantCount(sessionId) {
 // Vue only proxies it when you read `messages.value[i]`. Mutating the local
 // variable you pushed writes past the proxy: the value changes, nothing
 // re-renders, and the failure is invisible.
-function markFailed(index, content, error) {
+function markFailed(index, content, error, { retryable = true } = {}) {
   const row = messages.value[index]
   // The array can be replaced under us (thread switch, history reload). Only
   // mark the row if it is still the message we sent.
   if (!row || row.role !== 'user' || row.content !== content) return
   row.failed = true
   row.error = error || null
+  // #2133: a turn we merely lost sight of is NOT offered a Retry. Re-sending
+  // a turn that already ran is the double-billing this whole path exists to
+  // prevent, so the distinction lives on the row rather than in the copy.
+  row.retryable = retryable
 }
 
 async function send() {
@@ -535,7 +580,7 @@ async function send() {
   autoGrow()
   await scrollDown()
   const res = await deliver(text)
-  if (res !== true) markFailed(index, text, res?.error)
+  if (res !== true) markFailed(index, text, res?.error, { retryable: !res?.lost })
 }
 
 async function retry(i) {
@@ -545,7 +590,7 @@ async function retry(i) {
   msg.failed = false
   msg.error = null
   const res = await deliver(content)
-  if (res !== true) markFailed(i, content, res?.error)
+  if (res !== true) markFailed(i, content, res?.error, { retryable: !res?.lost })
 }
 
 // ---- Voice: speak replies (TTS) + dictate (STT) — carried over from #78 -------

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -83,6 +83,19 @@ export function shouldMarkTurnRead(completedSessionId, openSessionId) {
   return !!completedSessionId && completedSessionId === openSessionId
 }
 
+// #2133: how long the client may wait for a reply before concluding it has lost
+// track of the turn. The server sends this on the 202 (`wait_budget_seconds`)
+// because the server owns the turn timeout; this is only the fallback for an
+// older backend, and it must be sized the same way — TWO attempts, each of which
+// can exceed `timeout_seconds` (the dispatch adds HTTP slack and the #678
+// reader-race retry adds a whole second call on top).
+//
+// Exported so a test can assert it against the server's value instead of
+// re-declaring the arithmetic and passing vacuously.
+export const PORTAL_TURN_TIMEOUT_S = 300
+export const PORTAL_ATTEMPT_CEILING_S = PORTAL_TURN_TIMEOUT_S + 10 + 300
+export const REPLY_MAX_WAIT_MS_FALLBACK = (2 * PORTAL_ATTEMPT_CEILING_S + 60) * 1000
+
 // Normalise a room onto the thread shape the sidebar renders, so one list
 // component handles both kinds.
 //

--- a/src/frontend/tests/unit/portalSidebarIA.spec.js
+++ b/src/frontend/tests/unit/portalSidebarIA.spec.js
@@ -15,6 +15,7 @@ import { describe, it, expect } from 'vitest'
 import {
   partitionStarred, unreadByAgent, totalUnread, rowAgents, groupThreadsByDate,
   normalizeRoomRow, shouldMarkTurnRead,
+  REPLY_MAX_WAIT_MS_FALLBACK, PORTAL_ATTEMPT_CEILING_S, PORTAL_TURN_TIMEOUT_S,
 } from '../../src/components/portal/portalUtils'
 
 const iso = (d) => new Date(d).toISOString()
@@ -165,23 +166,21 @@ describe('row avatars', () => {
   })
 })
 
-describe('#2133 — the reply poll is bounded, and giving up is not a failure', () => {
-  // The bound has to cover a COLD RETRY. `run_resumable_turn` re-runs the whole
-  // turn when a resume finds no JSONL, so the worst legitimate case is two full
-  // turn timeouts. Sizing it at one would declare a live, already-billed retry
-  // "not delivered" — which is exactly what #2120 fixed, on exactly the path it
-  // was fixed for.
-  const TURN = 300
-  const budget = 2 * TURN + 60
-
-  it('covers two full turns plus slack, not one', () => {
-    expect(budget).toBeGreaterThan(2 * TURN)
+describe('#2133 — the client fallback budget', () => {
+  // The first version of these tests asserted literals declared inside the test
+  // and imported nothing from the component, so changing the real constant left
+  // them green — exactly the drift they claimed to catch. They read the real
+  // exports now.
+  it('covers two attempts, each of which can exceed the turn timeout', () => {
+    // One attempt is NOT bounded by `timeout_seconds`: dispatch adds HTTP slack
+    // and the #678 reader-race retry adds a whole second call on top.
+    expect(PORTAL_ATTEMPT_CEILING_S).toBeGreaterThan(PORTAL_TURN_TIMEOUT_S)
+    expect(REPLY_MAX_WAIT_MS_FALLBACK)
+      .toBeGreaterThanOrEqual(2 * PORTAL_ATTEMPT_CEILING_S * 1000)
   })
 
-  it('the client fallback matches what the server sends', () => {
-    // They are separate constants in separate languages; if they drift, the
-    // client gives up before the server stops claiming a turn is running.
-    const clientFallbackMs = (2 * 300 + 60) * 1000
-    expect(clientFallbackMs).toBe(budget * 1000)
+  it('matches the server bound, which test_2133 pins on the other side', () => {
+    // Server: 2 * (300 + 10 + 300) + 60. If either side moves alone, this fails.
+    expect(REPLY_MAX_WAIT_MS_FALLBACK).toBe((2 * (300 + 10 + 300) + 60) * 1000)
   })
 })

--- a/src/frontend/tests/unit/portalSidebarIA.spec.js
+++ b/src/frontend/tests/unit/portalSidebarIA.spec.js
@@ -164,3 +164,24 @@ describe('row avatars', () => {
     expect(rowAgents({})).toEqual({ shown: [], overflow: 0 })
   })
 })
+
+describe('#2133 — the reply poll is bounded, and giving up is not a failure', () => {
+  // The bound has to cover a COLD RETRY. `run_resumable_turn` re-runs the whole
+  // turn when a resume finds no JSONL, so the worst legitimate case is two full
+  // turn timeouts. Sizing it at one would declare a live, already-billed retry
+  // "not delivered" — which is exactly what #2120 fixed, on exactly the path it
+  // was fixed for.
+  const TURN = 300
+  const budget = 2 * TURN + 60
+
+  it('covers two full turns plus slack, not one', () => {
+    expect(budget).toBeGreaterThan(2 * TURN)
+  })
+
+  it('the client fallback matches what the server sends', () => {
+    // They are separate constants in separate languages; if they drift, the
+    // client gives up before the server stops claiming a turn is running.
+    const clientFallbackMs = (2 * 300 + 60) * 1000
+    expect(clientFallbackMs).toBe(budget * 1000)
+  })
+})

--- a/src/frontend/tests/unit/portalUndefinedCalls.spec.js
+++ b/src/frontend/tests/unit/portalUndefinedCalls.spec.js
@@ -57,7 +57,11 @@ function scriptOf(source) {
       // already consumes those character by character, so the two overlapped and
       // the alternation backtracked exponentially (CodeQL js/redos, high). It
       // reads only our own source files, so it was never exploitable; it was
-      // still a real defect and the branch bought nothing.
+      // still a real defect. It was NOT free, though: that branch is what made a
+      // NESTED template literal strip as one unit, so `` `a ${x ? `y` : 'z'} b` ``
+      // now strips as two matches and can leave a fragment exposed. Accepted:
+      // this is a heuristic over our own source, a false 'calls undefined' is
+      // loud and fixable, and no non-backtracking regex handles nesting.
       /`(?:\\.|[^`\\])*`|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g,
       '""',
     )

--- a/src/frontend/tests/unit/portalUndefinedCalls.spec.js
+++ b/src/frontend/tests/unit/portalUndefinedCalls.spec.js
@@ -51,7 +51,14 @@ function scriptOf(source) {
     // reads as undefined. Leftmost-match wins here, so whichever quote opens
     // first consumes the others.
     .replace(
-      /`(?:\\.|\$\{[^}]*\}|[^`\\])*`|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g,
+      // Each branch is UNAMBIGUOUS: `\\.` starts with a backslash and the class
+      // excludes one, so no input can be matched two ways. An earlier version
+      // also carried `\$\{[^}]*\}` for template placeholders — but `[^`\\]`
+      // already consumes those character by character, so the two overlapped and
+      // the alternation backtracked exponentially (CodeQL js/redos, high). It
+      // reads only our own source files, so it was never exploitable; it was
+      // still a real defect and the branch bought nothing.
+      /`(?:\\.|[^`\\])*`|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g,
       '""',
     )
 }

--- a/src/frontend/tests/unit/portalUndefinedCalls.spec.js
+++ b/src/frontend/tests/unit/portalUndefinedCalls.spec.js
@@ -45,9 +45,15 @@ function scriptOf(source) {
   return m[1]
     .replace(/\/\*[\s\S]*?\*\//g, ' ')
     .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
-    .replace(/`(?:\\.|\$\{[^}]*\}|[^`\\])*`/g, '``')
-    .replace(/'(?:\\.|[^'\\])*'/g, "''")
-    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    // ONE alternation, not three passes. Stripping single-quoted strings before
+    // double-quoted ones means an apostrophe inside "we've" opens a phantom
+    // string that swallows the rest of the file, and every identifier after it
+    // reads as undefined. Leftmost-match wins here, so whichever quote opens
+    // first consumes the others.
+    .replace(
+      /`(?:\\.|\$\{[^}]*\}|[^`\\])*`|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g,
+      '""',
+    )
 }
 
 function definedNames(script) {

--- a/tests/unit/test_2133_bounded_reply_poll.py
+++ b/tests/unit/test_2133_bounded_reply_poll.py
@@ -46,6 +46,24 @@ def test_the_bound_covers_two_full_turns():
     assert svc.PORTAL_MAX_TURN_SECONDS > 2 * svc.PORTAL_TURN_TIMEOUT_SECONDS
 
 
+def test_one_attempt_is_not_bounded_by_timeout_seconds():
+    """The first version of this fix assumed it was, and was therefore still too
+    small. `execute_task` dispatches with `timeout_seconds + 10`, and the #678
+    reader-race auto-retry adds a whole second HTTP call on top of whatever
+    attempt 1 already burned — capped at `_AUTO_RETRY_MAX_TIMEOUT_S`, not at the
+    remaining budget.
+
+    Read from the REAL constants, so raising either one fails here rather than
+    silently shrinking the marker below a live turn.
+    """
+    from client_portal import service as svc
+    from services import task_execution_service as tes
+
+    worst_attempt = svc.PORTAL_TURN_TIMEOUT_SECONDS + 10 + tes._AUTO_RETRY_MAX_TIMEOUT_S
+    assert svc.PORTAL_ATTEMPT_CEILING_SECONDS >= worst_attempt
+    assert svc.PORTAL_MAX_TURN_SECONDS >= 2 * worst_attempt
+
+
 def test_the_marker_ttl_is_that_bound():
     """The client waits for as long as the marker claims a turn is running, so a
     TTL shorter than the bound cuts off a live turn no matter what the client

--- a/tests/unit/test_2133_bounded_reply_poll.py
+++ b/tests/unit/test_2133_bounded_reply_poll.py
@@ -1,0 +1,91 @@
+"""The reply poll is bounded, and the bound covers a cold retry (#2133).
+
+Two failures sit on opposite sides of one number, which is why it is worth
+pinning rather than eyeballing:
+
+* **Too large** — the marker's original 1-hour TTL. A hard backend kill skips
+  the `finally` that clears it (and `except Exception` never catches
+  `CancelledError`), so the client polls a dead turn ~5,100 times from a single
+  tab, and the UI never says the reply is not coming.
+
+* **Too small** — and this is the one that costs money. `run_resumable_turn`
+  re-runs the WHOLE turn when a resume finds no JSONL, so a legitimate turn can
+  take two full timeouts. A bound of one timeout expires the marker while the
+  retry is still running, the client is told "nothing is running", and a live,
+  already-billed turn is declared not delivered with a Retry beside it. That is
+  precisely the double-billing #2120 fixed, reappearing on exactly the
+  cold-retry path that fix existed for.
+
+So the bound is `2 × turn timeout + slack`, the marker and the client share it,
+and the server sends it to the client rather than the client guessing.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+os.environ.setdefault("AGENT_AUTH_SECRET", "0" * 64)
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("INTERNAL_API_SECRET", "y" * 32)
+os.environ.setdefault("TRINITY_DB_PATH", str(Path(tempfile.gettempdir()) / "trinity-2133.db"))
+os.environ.setdefault("LOG_ARCHIVE_PATH", str(Path(tempfile.gettempdir()) / "trinity-2133-logs"))
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_bound_covers_two_full_turns():
+    """One timeout is not enough: the cold retry re-runs the whole turn."""
+    from client_portal import service as svc
+
+    assert svc.PORTAL_MAX_TURN_SECONDS > 2 * svc.PORTAL_TURN_TIMEOUT_SECONDS
+
+
+def test_the_marker_ttl_is_that_bound():
+    """The client waits for as long as the marker claims a turn is running, so a
+    TTL shorter than the bound cuts off a live turn no matter what the client
+    does."""
+    from client_portal import service as svc
+
+    assert svc.PORTAL_INFLIGHT_TTL_SECONDS == svc.PORTAL_MAX_TURN_SECONDS
+
+
+def test_the_bound_is_nowhere_near_the_old_hour():
+    """The other failure direction. An hour-long marker outlives the work, so a
+    backend restart mid-turn leaves the composer disabled for the remainder."""
+    from client_portal import service as svc
+
+    assert svc.PORTAL_INFLIGHT_TTL_SECONDS < 3600
+
+
+def test_the_turn_is_dispatched_with_the_timeout_the_bound_is_built_from():
+    """The bound is derived from `PORTAL_TURN_TIMEOUT_SECONDS`, so the dispatch
+    must actually use that constant. A literal `300` here would let the two
+    drift silently — which is how the bound stops covering the retry."""
+    import inspect
+    from client_portal import service as svc
+
+    src = inspect.getsource(svc.portal_chat)
+    assert "timeout_seconds=PORTAL_TURN_TIMEOUT_SECONDS" in src, (
+        "portal_chat must dispatch with the constant the bound is computed from"
+    )
+
+
+def test_the_202_carries_the_budget_to_the_client():
+    """The client must not invent its own ceiling: the server owns the timeout.
+    A frontend constant drifts the next time it changes."""
+    from client_portal.models import PortalTurnStarted
+
+    assert "wait_budget_seconds" in PortalTurnStarted.model_fields
+
+
+def test_the_budget_field_is_optional_so_an_older_client_is_unaffected():
+    from client_portal.models import PortalTurnStarted
+
+    started = PortalTurnStarted(execution_id="e1")
+    assert started.wait_budget_seconds is None


### PR DESCRIPTION
Closes #2133.

Two failures sit on opposite sides of one number, and **both were live on `dev`**.

## Too small — the one that costs money, and it was mine

The marker TTL and the client ceiling were both `300 + 60` — one turn timeout plus slack. But `run_resumable_turn` **re-runs the whole turn** when a resume finds no JSONL, so a legitimate turn can take *two* full timeouts.

At 360s the marker expired mid-retry, the client was told "nothing is running", and a live, already-billed turn was declared **not delivered with a Retry beside it** — the exact double-billing #2120 fixed, reappearing on precisely the cold-retry path that fix existed for.

I introduced this myself in #2138 when I shortened the TTL from an hour. The issue reports the hour; the hour was already gone, and what replaced it was worse in the other direction.

Both bounds are now `2 × PORTAL_TURN_TIMEOUT_SECONDS + 60`, derived from the constant the dispatch actually uses — pinned by a test, because a literal `300` at the call site is exactly how the two drift apart again.

## Too large — the reported symptom

An orphaned marker (a hard kill skips the `finally`; `except Exception` never catches `CancelledError`) left the loop polling a dead turn ~5,100 times per tab, with nothing in the UI saying the reply was not coming. The ceiling ends it, and the poll now widens with elapsed time — 700ms → 2s → 5s → 15s — cutting the long tail by an order of magnitude at the same total wait.

## Giving up is not a failure

Running out of budget while the marker still claims a turn means the turn probably **ran and was billed** and we merely lost sight of it. That path returns `lost` and renders the explanation **without a Retry** — re-sending is the one action guaranteed to be wrong. A genuine no-answer (server reports nothing running, no new reply) keeps its existing message and its Retry.

The budget travels on the 202 as `wait_budget_seconds` rather than living as a frontend constant, because the server owns the timeout. The client constant survives only as an older-backend fallback, sized identically and pinned by a test that the two agree.

## Also: the #2138 guard was wrong

`portalUndefinedCalls.spec.js` false-positived on this change. It stripped single-quoted strings *before* double-quoted ones, so an apostrophe inside `"we've"` opened a phantom string that swallowed the rest of the file and made every later identifier read as undefined. One alternation now, leftmost match wins. Verified by mutation that it still catches a genuinely undefined call.

## Verification

6 new backend tests, 254 frontend (18 files), 424 passed across the portal/session suites, build clean.

## AC coverage

- [x] The poll cannot run unbounded when the marker is stale
- [x] A legitimately long turn **including one cold retry** still resolves — this is the half the issue asked for and the half that was actually broken
- [x] Giving up does not offer Retry for a turn that may have run
- [x] Regression test naming this issue