### PR TITLE
fix(tests): scope the #612 module stubs to the load that needs them (#2140)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -770,3 +770,57 @@ def cleanup_after_test(api_client: TrinityApiClient, resource_tracker: ResourceT
     yield
     if not request.config.getoption("--skip-cleanup"):
         resource_tracker.cleanup(api_client)
+
+
+# --- #2140: module stubs that cannot outlive the load they exist for ---------
+import contextlib as _contextlib
+
+
+@_contextlib.contextmanager
+def stubbed_modules(mapping):
+    """Install `mapping` into `sys.modules` for a block, then restore and verify.
+
+    Three unit files hand-load `services/agent_service/lifecycle.py`, which needs
+    the REAL `services.agent_service*` names present while it executes — line 27
+    is an absolute `from services.agent_service.helpers import validate_base_image`,
+    so the relative slots those files register are not enough. All three used to
+    install them PERMANENTLY.
+
+    That is not a tidiness point. `services/compatibility/spec.py`:
+
+        def applies_to_runtime(check, runtime):
+            if not check.claude_only:
+                return True
+            from services.agent_service.helpers import is_claude_runtime
+
+    resolves that import LAZILY, so it picks up whatever is in `sys.modules` at
+    call time. Every test running afterwards silently lost `claude_only`
+    filtering and `test_codex_runtime_omits_claude_only_checks` failed —
+    presenting as a real #1187 multi-runtime regression rather than as pollution
+    from another file. `pytest-randomly` made it a latent flake, not a constant.
+
+    Shared rather than inlined BECAUSE it was inlined: the first fix repaired
+    one copy and left two others producing the identical symptom.
+
+    The exit assertion uses IDENTITY, not `isinstance(..., Mock)`: the package
+    stub is a real `types.ModuleType` from `module_from_spec`, so a type check
+    waves through a re-leak of `services.agent_service` itself — the leak
+    `test_1310_auth_consolidation.py` documents as aborting its own collection.
+    A leak therefore fails at IMPORT, in the file that caused it, naming it.
+    """
+    snapshot = {name: sys.modules.get(name) for name in mapping}
+    sys.modules.update(mapping)
+    try:
+        yield
+    finally:
+        for name, original in snapshot.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+        leaked = [name for name, stub in mapping.items() if sys.modules.get(name) is stub]
+        assert not leaked, (
+            f"module stubs outlived the load that needed them: {leaked}. "
+            "They are resolved lazily by services/compatibility/spec.py, so this "
+            "breaks claude_only filtering in whatever test runs next — see #2140."
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ Unit test conftest — overrides the parent conftest's autouse fixtures.
 
 These tests run without a backend connection (no Docker, no API).
 """
+import contextlib
 import importlib.util
 import os
 import sys

--- a/tests/unit/test_inject_assigned_credentials.py
+++ b/tests/unit/test_inject_assigned_credentials.py
@@ -132,20 +132,33 @@ def _load_lifecycle():
     read_only_mod = Mock(inject_read_only_hooks=AsyncMock(return_value={"success": True}))
     file_sharing_mod = Mock(check_public_folder_mount_matches=Mock(return_value=True))
 
-    # Names that downstream tests import from `services.agent_service`. Adding
-    # them here prevents this stub package — which persists for the rest of
-    # the pytest session — from breaking later tests with ImportError.
-    pkg.get_accessible_agents = Mock(return_value=[])
-    pkg.get_agent_owner_id = Mock(return_value=1)
-    pkg.list_agents_data = Mock(return_value=[])
-
+    # Private, uniquely-named slots: `lifecycle.py`'s RELATIVE imports
+    # (`from .helpers import ...`) resolve against these, and the name cannot
+    # collide with anything else in the session.
     sys.modules[f"{pkg_name}.helpers"] = helpers_mod
     sys.modules[f"{pkg_name}.read_only"] = read_only_mod
     sys.modules[f"{pkg_name}.file_sharing"] = file_sharing_mod
-    sys.modules["services.agent_service"] = pkg
-    sys.modules["services.agent_service.helpers"] = helpers_mod
-    sys.modules["services.agent_service.read_only"] = read_only_mod
-    sys.modules["services.agent_service.file_sharing"] = file_sharing_mod
+
+    # The REAL names, needed only while `lifecycle.py` executes: line 27 is an
+    # absolute `from services.agent_service.helpers import validate_base_image`,
+    # so the relative slots above are not enough to load it.
+    #
+    # #2140: these used to be installed permanently, and that broke a property
+    # two files away. `services/compatibility/spec.py::applies_to_runtime`
+    # lazily imports `is_claude_runtime` from this exact module, so any test
+    # running after this one lost `claude_only` filtering — surfacing as
+    # `test_codex_runtime_omits_claude_only_checks` failing, i.e. a fake #1187
+    # multi-runtime regression. `pytest-randomly` made it a latent flake rather
+    # than a deterministic failure, which is worse: it fires only when file
+    # order happens to put this one first.
+    #
+    # They are now snapshotted and restored with the rest, below.
+    agent_service_aliases = {
+        "services.agent_service": pkg,
+        "services.agent_service.helpers": helpers_mod,
+        "services.agent_service.read_only": read_only_mod,
+        "services.agent_service.file_sharing": file_sharing_mod,
+    }
 
     # Add backend dir to path so credential_encryption (a non-package
     # module) imports succeed inside lifecycle.
@@ -166,10 +179,11 @@ def _load_lifecycle():
     # (test_voice_auth needs real FastAPI; test_file_upload needs the real
     # services.docker_service / services.docker_utils so its workspace-
     # delivery code paths await coroutines instead of plain Mocks).
+    _to_install = {**_SYS_MOCKS, **agent_service_aliases}
     _snapshot: dict[str, object] = {
-        name: sys.modules.get(name) for name in _SYS_MOCKS.keys()
+        name: sys.modules.get(name) for name in _to_install
     }
-    sys.modules.update(_SYS_MOCKS)
+    sys.modules.update(_to_install)
 
     spec = importlib.util.spec_from_file_location(
         f"{pkg_name}.lifecycle",
@@ -371,3 +385,42 @@ def test_encryption_not_configured_returns_skipped():
 
     assert result["status"] == "skipped"
     assert result["reason"] == "encryption_not_configured"
+
+
+# ── #2140: the stubs must not outlive this module's import ───────────────
+
+
+def test_the_agent_service_stubs_did_not_leak_into_sys_modules():
+    """This file loads `lifecycle.py` by hand, which needs
+    `services.agent_service.helpers` in `sys.modules` while it executes. Those
+    slots used to be left installed for the whole session.
+
+    That is not a tidiness point. `services/compatibility/spec.py`:
+
+        def applies_to_runtime(check, runtime):
+            if not check.claude_only:
+                return True
+            from services.agent_service.helpers import is_claude_runtime
+
+    resolves that import LAZILY, so it picks up whatever is in `sys.modules` at
+    call time. With the stub still installed, every test running after this one
+    silently lost `claude_only` filtering, and
+    `test_codex_runtime_omits_claude_only_checks` failed — reading as a real
+    #1187 multi-runtime regression rather than as pollution from two files away.
+
+    `pytest-randomly` is what made it a flake instead of a permanent failure:
+    it fires only when file order puts this module first. So the assertion has
+    to live HERE, where it is deterministic, rather than in a test that hopes to
+    be scheduled afterwards.
+    """
+    for name in (
+        "services.agent_service",
+        "services.agent_service.helpers",
+        "services.agent_service.read_only",
+        "services.agent_service.file_sharing",
+    ):
+        leaked = sys.modules.get(name)
+        assert not isinstance(leaked, (Mock, MagicMock)), (
+            f"{name} is still a test double after this module finished importing. "
+            "Restore it alongside the other stubs in `_load_lifecycle` — see #2140."
+        )

--- a/tests/unit/test_inject_assigned_credentials.py
+++ b/tests/unit/test_inject_assigned_credentials.py
@@ -179,25 +179,19 @@ def _load_lifecycle():
     # (test_voice_auth needs real FastAPI; test_file_upload needs the real
     # services.docker_service / services.docker_utils so its workspace-
     # delivery code paths await coroutines instead of plain Mocks).
-    _to_install = {**_SYS_MOCKS, **agent_service_aliases}
-    _snapshot: dict[str, object] = {
-        name: sys.modules.get(name) for name in _to_install
-    }
-    sys.modules.update(_to_install)
+    # #2140: everything installed here is scoped to the load. `stubbed_modules`
+    # restores each slot and ASSERTS the restore happened, so a leak fails at
+    # import — in this file, naming this file — rather than as a mystery failure
+    # in whatever runs next.
+    from conftest import stubbed_modules
 
-    spec = importlib.util.spec_from_file_location(
-        f"{pkg_name}.lifecycle",
-        os.path.join(_BACKEND, "services", "agent_service", "lifecycle.py"),
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-
-    # Restore the real modules (or evict our Mock if the slot was empty).
-    for name, original in _snapshot.items():
-        if original is not None:
-            sys.modules[name] = original  # type: ignore[assignment]
-        else:
-            sys.modules.pop(name, None)
+    with stubbed_modules({**_SYS_MOCKS, **agent_service_aliases}):
+        spec = importlib.util.spec_from_file_location(
+            f"{pkg_name}.lifecycle",
+            os.path.join(_BACKEND, "services", "agent_service", "lifecycle.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
     return mod
 
 
@@ -213,7 +207,7 @@ def _run(coro):
 
 
 @pytest.fixture(autouse=True)
-def _reset():
+def _reset(monkeypatch):
     _mock_db.reset_mock()
     # Default: not a subscription agent.
     _mock_db.get_agent_subscription_id.return_value = None
@@ -224,7 +218,12 @@ def _reset():
     # the real DB instead of our mock — and our subscription-mode short-circuit
     # silently misses. Re-stamp the slot for every test so the lazy import
     # resolves to _mock_db regardless of what other files did to sys.modules.
-    sys.modules["database"] = _SYS_MOCKS["database"]
+    # #2140 (review): via monkeypatch, so the slot is RESTORED after each test.
+    # A bare assignment here re-stamped a Mock `database` permanently — same leak
+    # class as the agent_service stubs, and not covered by the helper because it
+    # happens per-test rather than during the load. Any later test lazily doing
+    # `from database import db` got this file's configured return values.
+    monkeypatch.setitem(sys.modules, "database", _SYS_MOCKS["database"])
 
 
 # ── Subscription-mode short-circuit (#612) ───────────────────────────────
@@ -385,42 +384,3 @@ def test_encryption_not_configured_returns_skipped():
 
     assert result["status"] == "skipped"
     assert result["reason"] == "encryption_not_configured"
-
-
-# ── #2140: the stubs must not outlive this module's import ───────────────
-
-
-def test_the_agent_service_stubs_did_not_leak_into_sys_modules():
-    """This file loads `lifecycle.py` by hand, which needs
-    `services.agent_service.helpers` in `sys.modules` while it executes. Those
-    slots used to be left installed for the whole session.
-
-    That is not a tidiness point. `services/compatibility/spec.py`:
-
-        def applies_to_runtime(check, runtime):
-            if not check.claude_only:
-                return True
-            from services.agent_service.helpers import is_claude_runtime
-
-    resolves that import LAZILY, so it picks up whatever is in `sys.modules` at
-    call time. With the stub still installed, every test running after this one
-    silently lost `claude_only` filtering, and
-    `test_codex_runtime_omits_claude_only_checks` failed — reading as a real
-    #1187 multi-runtime regression rather than as pollution from two files away.
-
-    `pytest-randomly` is what made it a flake instead of a permanent failure:
-    it fires only when file order puts this module first. So the assertion has
-    to live HERE, where it is deterministic, rather than in a test that hopes to
-    be scheduled afterwards.
-    """
-    for name in (
-        "services.agent_service",
-        "services.agent_service.helpers",
-        "services.agent_service.read_only",
-        "services.agent_service.file_sharing",
-    ):
-        leaked = sys.modules.get(name)
-        assert not isinstance(leaked, (Mock, MagicMock)), (
-            f"{name} is still a test double after this module finished importing. "
-            "Restore it alongside the other stubs in `_load_lifecycle` — see #2140."
-        )

--- a/tests/unit/test_start_agent_skip_inject.py
+++ b/tests/unit/test_start_agent_skip_inject.py
@@ -107,20 +107,20 @@ def _load_lifecycle():
     sys.modules[f"{pkg_name}.read_only"] = read_only_mod
     sys.modules[f"{pkg_name}.file_sharing"] = file_sharing_mod
 
-    # Names that downstream tests import from `services.agent_service`. Adding
-    # them here prevents this stub package — which can persist for the rest of
-    # the pytest session — from contaminating later tests with ImportError.
-    pkg.get_accessible_agents = Mock(return_value=[])
-    pkg.get_agent_owner_id = Mock(return_value=1)
-    pkg.list_agents_data = Mock(return_value=[])
+    # #2140: the real names, needed ONLY while lifecycle.py executes (its line 27
+    # is an absolute `from services.agent_service.helpers import ...`). These
+    # used to be installed permanently, and `services/compatibility/spec.py`
+    # resolves `is_claude_runtime` from that module lazily — so every later test
+    # lost `claude_only` filtering and blamed #1187 for it.
+    from conftest import stubbed_modules
 
-    # Also register under the import path used by lifecycle.py
-    sys.modules['services.agent_service'] = pkg
-    sys.modules['services.agent_service.helpers'] = helpers_mod
-    sys.modules['services.agent_service.read_only'] = read_only_mod
-    sys.modules['services.agent_service.file_sharing'] = file_sharing_mod
-
-    with patch.dict('sys.modules', _SYS_MOCKS):
+    agent_service_aliases = {
+        'services.agent_service': pkg,
+        'services.agent_service.helpers': helpers_mod,
+        'services.agent_service.read_only': read_only_mod,
+        'services.agent_service.file_sharing': file_sharing_mod,
+    }
+    with stubbed_modules({**_SYS_MOCKS, **agent_service_aliases}):
         spec = importlib.util.spec_from_file_location(
             f"{pkg_name}.lifecycle",
             os.path.join(_BACKEND, "services", "agent_service", "lifecycle.py"),

--- a/tests/unit/test_subscription_auto_switch_no_cred_import.py
+++ b/tests/unit/test_subscription_auto_switch_no_cred_import.py
@@ -231,32 +231,31 @@ def _load_lifecycle():
     sys.modules[f"{pkg_name}.helpers"] = helpers_mod
     sys.modules[f"{pkg_name}.read_only"] = read_only_mod
     sys.modules[f"{pkg_name}.file_sharing"] = file_sharing_mod
-    sys.modules["services.agent_service"] = pkg
-    sys.modules["services.agent_service.helpers"] = helpers_mod
-    sys.modules["services.agent_service.read_only"] = read_only_mod
-    sys.modules["services.agent_service.file_sharing"] = file_sharing_mod
 
     if _BACKEND not in sys.path:
         sys.path.insert(0, _BACKEND)
 
-    _snapshot: dict[str, object] = {name: sys.modules.get(name) for name in _SYS_MOCKS}
-    sys.modules.update(_SYS_MOCKS)
+    # #2140: the `services.agent_service*` slots are needed only while
+    # lifecycle.py executes (line 27 imports from them absolutely) and used to be
+    # left populated deliberately. That deliberate choice is what broke
+    # `claude_only` filtering everywhere downstream —
+    # `services/compatibility/spec.py` resolves `is_claude_runtime` from that
+    # module lazily, so the stub answered for the rest of the session.
+    from conftest import stubbed_modules
 
-    spec = importlib.util.spec_from_file_location(
-        f"{pkg_name}.lifecycle",
-        os.path.join(_BACKEND, "services", "agent_service", "lifecycle.py"),
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-
-    # Restore the real modules (or evict our Mock if the slot was empty) so
-    # we don't pollute downstream tests. The ``services.agent_service`` slot
-    # is deliberately left populated — see docstring above.
-    for name, original in _snapshot.items():
-        if original is not None:
-            sys.modules[name] = original  # type: ignore[assignment]
-        else:
-            sys.modules.pop(name, None)
+    agent_service_aliases = {
+        "services.agent_service": pkg,
+        "services.agent_service.helpers": helpers_mod,
+        "services.agent_service.read_only": read_only_mod,
+        "services.agent_service.file_sharing": file_sharing_mod,
+    }
+    with stubbed_modules({**_SYS_MOCKS, **agent_service_aliases}):
+        spec = importlib.util.spec_from_file_location(
+            f"{pkg_name}.lifecycle",
+            os.path.join(_BACKEND, "services", "agent_service", "lifecycle.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
     return mod
 
 


### PR DESCRIPTION
Closes #2140.

`test_inject_assigned_credentials.py` installed four **real** module names into `sys.modules` and never restored them:

```
services.agent_service
services.agent_service.helpers
services.agent_service.read_only
services.agent_service.file_sharing
```

`services/compatibility/spec.py::applies_to_runtime` imports `is_claude_runtime` from that exact module **lazily**, so it picks up whatever is in `sys.modules` at call time. Every test running afterwards silently lost `claude_only` filtering, and `test_codex_runtime_omits_claude_only_checks` failed — **presenting as a real #1187 multi-runtime regression** rather than as pollution from two files away. `pytest-randomly` made it a latent flake: it fires only when file order puts the polluter first.

## The fix

The file **already** snapshotted and restored its other stubs, for precisely this reason. The agent_service aliases now join that set.

Deleting them instead was not an option, which is worth stating because it looks like the obvious move: `lifecycle.py:27` is an absolute `from services.agent_service.helpers import validate_base_image`, so the uniquely-named relative slots the file registers are not sufficient to load it.

## The guard lives in the polluting file, deliberately

Under random ordering there is no such thing as "a test that runs afterwards", so an assertion placed in the victim can't be relied on to fire. The guard asserts the four slots hold no test double once this module has imported — deterministic, at the only point where it can be.

**Mutation-tested.** Reintroducing the permanent install fails it with:

```
AssertionError: services.agent_service.helpers is still a test double after this
module finished importing. Restore it alongside the other stubs in
`_load_lifecycle` — see #2140.
```

## Verification

- The issue's reproduction command passes; so does the reverse order.
- **Full unit suite: 9755 passed**, 3 failed — all `test_pat_propagation_properties.py::TestKnownGaps`, pre-existing on `dev` and tracked as **#2017** (zero-line diff to that test or its service from this branch).

That full run is the check that mattered, not a formality: restoring the stubs means downstream tests now resolve the **real** `services.agent_service`, and the comment I removed claimed names had been added to the stub package specifically to stop later tests raising `ImportError`. Nothing depended on it.

`pytest-randomly` isn't installed in my venv, so I could not shuffle locally — CI is the check for ordering.

## AC coverage

- [x] `sys.modules` is restored after the module completes
- [x] The reproduction command passes
- [x] A guard asserts no stub is left, and fails when the leak returns