### PR TITLE
fix(agents): recreate no longer starts a stopped agent silently (#2092)

### DIFF
--- a/src/backend/services/agent_service/lifecycle.py
+++ b/src/backend/services/agent_service/lifecycle.py
@@ -22,7 +22,7 @@ from services.docker_service import (
 )
 from services.docker_utils import (
     container_stop, container_remove, container_start, container_reload,
-    volume_get, volume_create, containers_run, image_get
+    volume_get, volume_create, containers_run, image_get, container_stop
 )
 from services.agent_service.helpers import validate_base_image
 from services.agent_runtime_state import clear_agent_breakers
@@ -772,13 +772,44 @@ async def recreate_container_with_updated_config(
     *,
     full_capabilities: Optional[bool] = None,
     env_overrides: Optional[dict] = None,
+    require_running: bool = True,
+    preserve_run_state: bool = False,
 ):
     """
     Recreate an agent container with updated configuration.
     Handles shared folder mounts and API key settings.
     Preserves the agent's workspace volume and other configuration.
 
+    **This function STARTS the replacement container.** That was true before
+    #2092 too, but only the call sites knew it: each in-tree caller pre-checked
+    `container.status == "running"` and refused otherwise, while this function
+    captured no run state, offered no way to preserve it, and said nothing about
+    the precondition — which documented `env_overrides` at length.
+
+    Recreating a deliberately-stopped agent therefore started it, silently and
+    with no log line saying the run state had changed. Out-of-tree ops tooling
+    doing a base-image adoption wave hit exactly that: two agents stopped eight
+    days earlier came back up. Note what did NOT contain it — `autonomy_enabled
+    = 0` gates cron fires and reminders (#1806) but not human-initiated inbound
+    chat, so a channel binding and a public link became reachable again. No
+    traffic arrived; the containment was luck.
+
     Args:
+        require_running: refuse (ValueError) unless ``old_container`` is
+            running. Default True, which is what every existing caller already
+            enforces for itself — so this changes no behaviour and converts the
+            silent start into a loud error for the next caller. Pass False to
+            recreate a stopped agent deliberately.
+        preserve_run_state: leave the replacement STOPPED when the original was
+            stopped. What a base-image adoption wave actually wants, and awkward
+            to do from outside: the caller would have to read the state before,
+            then stop the container after it is already up and its agent server
+            has begun booting — racing its own recreate. Here the stop is issued
+            immediately after the handoff. The replacement is still created via
+            ``containers_run`` and so boots briefly before being stopped; that is
+            visible in the container's log, and is the honest cost of not
+            duplicating the (heavily conditioned) creation call.
+
         env_overrides: #1854 — env vars to force onto the replacement,
             applied LAST (immediately before the container handoff), so they win
             over every derived rule in between. The caller owns the value; this
@@ -804,6 +835,18 @@ async def recreate_container_with_updated_config(
             satisfies (infinite recreate loop — the hazard this module already
             documents for the guardrails/PAT matchers).
     """
+    # #2092: the precondition, enforced rather than assumed. Read BEFORE any
+    # work, so a refusal costs nothing and cannot half-recreate.
+    was_running = getattr(old_container, "status", None) == "running"
+    if require_running and not was_running:
+        raise ValueError(
+            f"recreate_container_with_updated_config would START agent "
+            f"{agent_name!r}, whose container is "
+            f"{getattr(old_container, 'status', 'unknown')!r}. Pass "
+            f"require_running=False to do that deliberately, and "
+            f"preserve_run_state=True to leave it stopped afterwards (#2092)."
+        )
+
     # Extract configuration from old container
     old_config = old_container.attrs.get("Config", {})
     old_host_config = old_container.attrs.get("HostConfig", {})
@@ -1061,7 +1104,7 @@ async def recreate_container_with_updated_config(
         env_vars.update({str(k): str(v) for k, v in env_overrides.items() if k})
 
     try:
-        return await _provision_folders_and_run_agent_container(
+        new_container = await _provision_folders_and_run_agent_container(
             agent_name,
             image=image,
             env_vars=env_vars,
@@ -1073,6 +1116,11 @@ async def recreate_container_with_updated_config(
             full_capabilities=full_capabilities,
             restart_policy=restart_policy,
         )
+        # #2092: put the run state back. Here, NOT in the shared provisioning
+        # helper — that one also serves agent creation, where "the original was
+        # stopped" is meaningless and stopping the result would be wrong.
+        await _restore_stopped_state(agent_name, new_container, preserve_run_state, was_running)
+        return new_container
     except docker.errors.APIError as e:
         # #1809: 409 name-conflict — a concurrent start won the recreate race
         # and already ran the replacement. Adopt the winner's container instead
@@ -1086,6 +1134,34 @@ async def recreate_container_with_updated_config(
                 )
                 return existing
         raise
+
+
+async def _restore_stopped_state(agent_name, container, preserve_run_state, was_running):
+    """Stop a freshly recreated container when the original was stopped (#2092).
+
+    A recreate that changes whether an agent is running is exactly the event
+    that used to be silent, so both outcomes are logged.
+
+    A failed stop does NOT fail the recreate: the replacement exists and is
+    healthy, and failing here leaves the caller worse off than the outcome they
+    asked to avoid. But it logs at ERROR, because the agent is now running
+    against an explicit request that it not be.
+    """
+    if not (preserve_run_state and not was_running):
+        return
+    try:
+        await container_stop(container)
+        logger.info(
+            "Recreated container for agent %s and stopped it again "
+            "(preserve_run_state: it was not running before)",
+            agent_name,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.error(
+            "Recreated container for agent %s but could NOT stop it again "
+            "(preserve_run_state): %s. The agent is running.",
+            agent_name, e,
+        )
 
 
 async def _provision_folders_and_run_agent_container(

--- a/tests/unit/test_1854_agent_mcp_key.py
+++ b/tests/unit/test_1854_agent_mcp_key.py
@@ -530,7 +530,11 @@ def test_07c_env_overrides_are_applied_last(monkeypatch):
     body = src[start:end]
 
     override_at = body.rindex("env_overrides")
-    handoff_at = body.index("return await _provision_folders_and_run_agent_container")
+    # #2092 moved the handoff from `return await ...` to an assignment (the
+    # resulting container is needed to restore run state). Anchor on the CALL,
+    # which is what "the handoff" means — the ordering property this test exists
+    # for is unchanged.
+    handoff_at = body.index("await _provision_folders_and_run_agent_container(")
     copy_at = body.index('old_config.get("Env", [])')
 
     assert copy_at < override_at < handoff_at, (

--- a/tests/unit/test_2092_recreate_run_state.py
+++ b/tests/unit/test_2092_recreate_run_state.py
@@ -1,0 +1,173 @@
+"""`recreate_container_with_updated_config` no longer starts an agent silently (#2092).
+
+The function always ended in `containers_run(...)`, so it created AND started the
+replacement. Every in-tree caller pre-checked `container.status == "running"` and
+refused otherwise — a real and correct precondition, enforced only by convention,
+repeated per call site, and absent from a docstring that documented
+`env_overrides` at length.
+
+So recreating a deliberately-stopped agent started it, with no error and no log
+line saying the run state had changed. Out-of-tree ops tooling doing a
+base-image adoption wave hit it: two agents stopped eight days earlier came back
+up. `autonomy_enabled = 0` did not contain that — it gates cron and reminders
+(#1806), not human-initiated inbound chat — so a channel binding and a public
+link became reachable again.
+
+What is pinned here is the CONTRACT, not the plumbing: the default refuses,
+opting out is explicit, and opting out with `preserve_run_state` puts the state
+back. The container-creation body is not exercised — it needs Docker — so these
+drive the guard and the state restore around it.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+os.environ.setdefault("AGENT_AUTH_SECRET", "0" * 64)
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("INTERNAL_API_SECRET", "y" * 32)
+os.environ.setdefault("TRINITY_DB_PATH", str(Path(tempfile.gettempdir()) / "trinity-2092.db"))
+os.environ.setdefault("LOG_ARCHIVE_PATH", str(Path(tempfile.gettempdir()) / "trinity-2092-logs"))
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _Container:
+    def __init__(self, status="running"):
+        self.status = status
+        self.attrs = {"Config": {}, "HostConfig": {}}
+
+
+def _fn():
+    from services.agent_service.lifecycle import recreate_container_with_updated_config
+    return recreate_container_with_updated_config
+
+
+# ---------------------------------------------------------------------------
+# The guard
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["exited", "created", "paused", None])
+async def test_it_refuses_to_start_an_agent_that_was_not_running(status):
+    """The whole point: a caller that has not thought about run state gets an
+    error, not a running agent."""
+    with pytest.raises(ValueError) as e:
+        await _fn()("scribe", _Container(status), "alice")
+
+    assert "require_running=False" in str(e.value)
+    assert "scribe" in str(e.value)
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_names_the_way_out():
+    """An error that does not say what to do instead just gets worked around —
+    and the workaround here is the bug (`require_running=False` without
+    `preserve_run_state` silently starts the agent again)."""
+    with pytest.raises(ValueError) as e:
+        await _fn()("scribe", _Container("exited"), "alice")
+
+    assert "preserve_run_state=True" in str(e.value)
+
+
+@pytest.mark.asyncio
+async def test_it_refuses_BEFORE_doing_any_work(monkeypatch):
+    """Read the state first, so a refusal cannot half-recreate. If the guard sat
+    after the config extraction, a caller could be left with volumes moved and
+    no container."""
+    from services.agent_service import lifecycle
+
+    called = []
+    monkeypatch.setattr(lifecycle, "validate_base_image", lambda *a, **k: called.append("validate"))
+
+    with pytest.raises(ValueError):
+        await _fn()("scribe", _Container("exited"), "alice")
+
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
+# Contract shape — what existing callers rely on
+# ---------------------------------------------------------------------------
+
+def test_the_default_is_the_behaviour_every_current_caller_already_enforces():
+    """`require_running` defaults True, so this is not a behaviour change for
+    `repo_binding.py` or `agent_mcp_key_service.py` — both pre-check the same
+    condition and would never reach the raise."""
+    params = inspect.signature(_fn()).parameters
+
+    assert params["require_running"].default is True
+    assert params["preserve_run_state"].default is False
+
+
+def test_both_new_options_are_keyword_only():
+    """Positional would let a caller pass one by accident — the opposite of
+    making the choice explicit."""
+    params = inspect.signature(_fn()).parameters
+
+    for name in ("require_running", "preserve_run_state"):
+        assert params[name].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_the_docstring_states_that_it_starts_the_container():
+    """Request 1 of the issue. The precondition existed only at the call sites;
+    the next caller reads this docstring, not them."""
+    doc = inspect.getdoc(_fn()) or ""
+
+    assert "STARTS the replacement container" in doc
+    assert "require_running" in doc and "preserve_run_state" in doc
+
+
+def test_the_stop_is_conditional_on_the_ORIGINAL_state():
+    """`preserve_run_state` must restore what was there — not stop
+    unconditionally, which would break every normal recreate of a running agent.
+    """
+    from services.agent_service.lifecycle import _restore_stopped_state
+
+    src = inspect.getsource(_restore_stopped_state)
+
+    assert "if not (preserve_run_state and not was_running):" in src
+
+
+def test_a_failed_stop_does_not_fail_the_recreate_but_is_logged_loudly():
+    """The replacement exists and is healthy; failing the whole call over the
+    stop leaves the caller worse off than the outcome they asked to avoid. But
+    the agent IS running against their wishes, so it cannot be a warning."""
+    from services.agent_service.lifecycle import _restore_stopped_state
+
+    src = inspect.getsource(_restore_stopped_state)
+
+    assert "logger.error(" in src
+    assert "The agent is running" in src
+
+
+def test_the_stop_is_NOT_in_the_shared_provisioning_helper():
+    """I put it there first, and the tests above caught it.
+
+    `_provision_folders_and_run_agent_container` is the shared tail of BOTH the
+    recreate path and agent creation. "The original was stopped" is meaningless
+    for a brand-new agent, so a `preserve_run_state` branch living there would
+    fire for callers that never asked — the same class of surprise #2092 is
+    about, moved one function down.
+    """
+    from services.agent_service.lifecycle import _provision_folders_and_run_agent_container
+
+    src = inspect.getsource(_provision_folders_and_run_agent_container)
+
+    assert "preserve_run_state" not in src
+    assert "was_running" not in src
+
+
+def test_the_restore_runs_on_the_container_the_recreate_produced():
+    """Wired into the recreate function itself, not left as an unused helper."""
+    src = inspect.getsource(_fn())
+
+    assert "_restore_stopped_state(" in src


### PR DESCRIPTION
Closes #2092. All three requests, not just the two cheap ones.

`recreate_container_with_updated_config` always ended in `containers_run(...)`, so it created **and started** the replacement. Every in-tree caller pre-checked `container.status == "running"` and refused otherwise — a real and correct precondition, enforced only by convention, repeated at each call site, and absent from a docstring that documented `env_overrides` at length.

Recreating a deliberately-stopped agent therefore started it, with no error and no log line saying the run state had changed.

Worth restating from the report, because it shaped the blast radius: `autonomy_enabled = 0` did **not** contain it. That flag gates cron fires and reminders (#1806) but not human-initiated inbound chat, so a channel binding and an enabled public link became reachable again. No traffic arrived — the containment was luck.

## What changed

| Request | |
|---|---|
| **1. Document it** | The docstring now leads with the fact that this function starts the replacement, and says what a caller must do about it |
| **2. Enforce it** | `require_running=True` refuses with a `ValueError` naming the agent, its actual state, and both opt-outs. Checked **before any work**, so a refusal cannot half-recreate. Every current caller already enforces this for itself → no behaviour change for `repo_binding.py` or `agent_mcp_key_service.py` |
| **3. Preserve run state** | `preserve_run_state=True` stops the replacement when the original was stopped |

Both options are keyword-only — positional would let a caller pass one by accident, which is the opposite of making the choice explicit.

## The placement is the part to review

The restore lives in the recreate function, **not** in `_provision_folders_and_run_agent_container`.

I put it there first, and these tests caught it. That helper is the shared tail of **both** recreate and agent *creation*, where "the original was stopped" is meaningless — a `preserve_run_state` branch there would fire for callers that never asked. That is the same class of surprise this issue is about, moved one function down. There is now a test asserting it stays out.

A failed stop logs at **ERROR** and does not fail the recreate: the replacement exists and is healthy, and failing there leaves the caller worse off than the outcome they asked to avoid — but the agent is running against an explicit request, so it cannot be a warning.

## Honest note on scope

`preserve_run_state` still creates via `containers_run`, so the replacement boots briefly before being stopped. That is visible in its log. Avoiding it would mean duplicating the heavily-conditioned creation call to get a create-without-start path, which seemed a worse trade than one short boot — stated in the docstring rather than left for someone to discover.

## Adjacent edit

`test_1854_agent_mcp_key.py::test_07c` anchored on the literal `return await _provision_...`, which became an assignment (the resulting container is needed to restore state). Re-anchored on the **call** — same offset, same ordering property.

While verifying that didn't weaken it, I moved `env_overrides` up to the copy point and **the test still passed** — so that guard asserts "somewhere between the copy and the handoff", not "immediately before the handoff" as its docstring claims. Pre-existing, unrelated to this change, and left alone rather than widened into this PR. Flagging because #1854's whole hazard is an override being clobbered by the ~20 derived mutations in between, and the guard is looser than it reads.

## Verification

13 new tests; **344 passed** across the lifecycle / recreate / mcp-key / repo-binding / start-agent suites.