### PR TITLE
fix(grid): un-break the info-tile chassis — clipped peg, dead Tiles menu, dead tokens (ent#325)

### DIFF
--- a/src/frontend/src/components/FleetGrid.vue
+++ b/src/frontend/src/components/FleetGrid.vue
@@ -831,7 +831,17 @@ let panTX = 0
 let panTY = 0
 
 function onCanvasPointerDown(e) {
+  // The Tiles control is chrome, not canvas. Without this bail the pointerdown
+  // starts a pan and `setPointerCapture` retargets the resulting click at the
+  // canvas, so the button's own @click never fires and the menu cannot be
+  // opened at all — every other control in this cluster is already listed
+  // below, and ent#325 shipped without adding its own.
+  const inTilesCtl = !!e.target.closest('.gv-tilesctl')
+  // A pointer-down anywhere else dismisses the open menu, the way a menu
+  // should; the menu body itself stops propagation, so its own clicks are safe.
+  if (tilesMenuOpen.value && !inTilesCtl) tilesMenuOpen.value = false
   if (
+    inTilesCtl ||
     e.target.closest('.gv-tile') ||
     e.target.closest('.gv-zoomctl') ||
     e.target.closest('.gv-legend') ||
@@ -878,10 +888,11 @@ function tidyUp() {
   nextTick(fitView)
 }
 
-// Esc backs out of org modes (new-department popover, then assign mode).
+// Esc backs out of the open popover / org mode, innermost first.
 function onOrgKeydown(e) {
   if (e.key !== 'Escape') return
-  if (newDeptOpen.value) closeNewDept()
+  if (tilesMenuOpen.value) tilesMenuOpen.value = false
+  else if (newDeptOpen.value) closeNewDept()
   else if (assignMode.value) endAssignMode()
 }
 
@@ -1500,7 +1511,11 @@ onBeforeUnmount(() => {
 .gv-tilesctl > button:hover,
 .gv-tilesctl > button.on {
   background: var(--gv-btn-bg-hover);
-  color: var(--gv-fg);
+  /* --gv-btn-text, not --gv-fg: the latter is defined in NEITHER theme block,
+     so it resolved to guaranteed-invalid and the colour silently fell back to
+     whatever the page happened to inherit. This is the sibling .gv-orgctl
+     button's own token, which is what this control is styled after. */
+  color: var(--gv-btn-text);
 }
 .gv-tilesmenu {
   min-width: 190px;
@@ -1520,7 +1535,7 @@ onBeforeUnmount(() => {
   padding: 5px 6px;
   border-radius: 6px;
   font-size: 12px;
-  color: var(--gv-fg);
+  color: var(--gv-text);
   cursor: pointer;
 }
 .gv-tilesmenu label:hover {
@@ -1535,7 +1550,12 @@ onBeforeUnmount(() => {
 .gv-tilesmenu .reset {
   margin-top: 4px;
   border: 0;
-  border-top: 1px solid var(--gv-tile-border, rgba(0, 0, 0, 0.08));
+  /* --gv-border, not --gv-tile-border: the latter is another name ent#325's
+     token sweep renamed away and left live here, so this separator drew at a
+     permanently-live `rgba(0,0,0,.08)` — black at 8% on the dark panel, i.e.
+     invisible in exactly one theme. Fallback is the token's LIGHT value, per
+     the convention that pass established. */
+  border-top: 1px solid var(--gv-border, #e5e7eb);
   background: transparent;
   color: var(--gv-muted);
   font: inherit;
@@ -1545,7 +1565,7 @@ onBeforeUnmount(() => {
   cursor: pointer;
 }
 .gv-tilesmenu .reset:hover {
-  color: var(--gv-fg);
+  color: var(--gv-text);
 }
 /* The widget chassis reuses .gv-tile wholesale (drag physics, snap, focus
    ring). Only the drop shadow differs, so an info tile reads as board

--- a/src/frontend/src/components/InfoTile.vue
+++ b/src/frontend/src/components/InfoTile.vue
@@ -115,7 +115,12 @@ defineProps({
   background: var(--gv-tile, rgba(255, 255, 255, 0.9));
   border: 1px solid var(--gv-border, #e5e7eb);
   box-shadow: var(--gv-tile-shadow, 0 1px 2px rgba(0, 0, 0, 0.06));
-  overflow: hidden;
+  /* Deliberately NOT `overflow: hidden`: this box is the peg's containing
+     block, so clipping here amputates the half-inset peg into a 16px sliver
+     jammed against the left border with the glyph sliced down the middle —
+     the defect the tiles shipped with. `.it-body` already clips the content
+     that actually needs it, and `AgentTile`'s avatar overhangs its own tile
+     the same way (`gridLayout.GAP_X` is sized for exactly that). */
 }
 .it.is-error {
   border-color: var(--gv-danger-border, rgba(220, 38, 38, 0.35));

--- a/src/frontend/tests/unit/gridTokens.spec.js
+++ b/src/frontend/tests/unit/gridTokens.spec.js
@@ -25,6 +25,7 @@
  * nobody defined — failing silently in exactly one theme.
  */
 import { describe, it, expect } from 'vitest'
+import { DEPT_SLOT_COUNT } from '@/utils/gridOrg'
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -58,6 +59,28 @@ function tileComponents() {
 
 const TILE_COMPONENTS = tileComponents()
 
+/**
+ * Everything that CONSUMES the grid cascade — which is not the same set as the
+ * tiles, and that gap is why this guard shipped green over three dead tokens.
+ *
+ * `FleetGrid.vue` is here even though it DEFINES the cascade: it also reads it,
+ * in its own chrome (`.gv-tilesctl`, `.gv-tilesmenu`, the legend). ent#325's
+ * token sweep renamed `--gv-fg` -> `--gv-text` and `--gv-tile-border` ->
+ * `--gv-border` in the tile components and left BOTH stale names live in the
+ * definer, where a tiles-only sweep structurally could not see them: four dead
+ * references, three of them in the Tiles menu, one a separator whose
+ * permanently-live `rgba(0,0,0,.08)` fallback is invisible on the dark panel.
+ * Policing only the consumers you expect is how the second half of a rename
+ * survives its own fix.
+ *
+ * `AgentTile.vue` is the lattice's other occupant, on the same reasoning.
+ */
+const CASCADE_CONSUMERS = [
+  ...TILE_COMPONENTS,
+  'components/FleetGrid.vue',
+  'components/AgentTile.vue',
+].sort()
+
 /** The two blocks in FleetGrid.vue that establish the cascade. */
 const LIGHT_SELECTOR = '.fleet-canvas {'
 const DARK_SELECTOR = ':root.dark .fleet-canvas {'
@@ -80,21 +103,44 @@ function definedTokens() {
   return found
 }
 
-/** `--gv-x` names read via var() in one file. */
+/**
+ * `--gv-x` names read via var() in one file.
+ *
+ * A capture ending in `-` is the HEAD of an interpolated name — AgentTile's
+ * `var(--gv-dept-${dept.slot})`, whose full name only exists at runtime. It is
+ * a real reference, so it is not silently dropped: the families are guarded by
+ * their own test below instead of being matched against the defined set.
+ */
 function consumedTokens(relPath) {
   const text = readFileSync(join(SRC, relPath), 'utf8')
-  return [...text.matchAll(/var\((--gv-[a-z0-9-]+)/g)].map((m) => m[1])
+  return [...text.matchAll(/var\((--gv-[a-z0-9-]+)/g)]
+    .map((m) => m[1])
+    .filter((t) => !t.endsWith('-'))
 }
 
-/** Token names declared inside one `{ … }` block of FleetGrid.vue. */
+/**
+ * Token names declared inside the block(s) with this selector in FleetGrid.vue.
+ *
+ * EVERY such block, not the first: the file opens a second `.fleet-canvas` /
+ * `:root.dark .fleet-canvas` pair further down for the org-overlay palette
+ * (`--gv-wire`, `--gv-dept-0..7`), and a first-match-only read left that whole
+ * pair unguarded — a dept slot defined in one theme would have passed.
+ */
 function tokensInBlock(selector) {
   const text = readFileSync(join(SRC, 'components/FleetGrid.vue'), 'utf8')
-  const start = text.indexOf(`\n${selector}`)
-  expect(start, `cascade block "${selector}" not found in FleetGrid.vue`).toBeGreaterThan(-1)
-  const end = text.indexOf('\n}', start)
-  return new Set(
-    [...text.slice(start, end).matchAll(/^\s*(--gv-[a-z0-9-]+)\s*:/gm)].map((m) => m[1]),
-  )
+  const found = new Set()
+  let blocks = 0
+  let from = 0
+  for (;;) {
+    const start = text.indexOf(`\n${selector}`, from)
+    if (start === -1) break
+    blocks++
+    const end = text.indexOf('\n}', start)
+    for (const m of text.slice(start, end).matchAll(/^\s*(--gv-[a-z0-9-]+)\s*:/gm)) found.add(m[1])
+    from = end
+  }
+  expect(blocks, `cascade block "${selector}" not found in FleetGrid.vue`).toBeGreaterThan(0)
+  return found
 }
 
 describe('grid tile design tokens (ent#325)', () => {
@@ -107,7 +153,13 @@ describe('grid tile design tokens (ent#325)', () => {
     expect(TILE_COMPONENTS).toContain('components/tiles/parts/TileRowList.vue')
   })
 
-  it.each(TILE_COMPONENTS)('%s consumes only tokens that exist', (relPath) => {
+  it('discovered the cascade consumers beyond the tiles', () => {
+    // The tiles-only set is what let a rename survive in the definer itself.
+    expect(CASCADE_CONSUMERS).toContain('components/FleetGrid.vue')
+    expect(CASCADE_CONSUMERS).toContain('components/AgentTile.vue')
+  })
+
+  it.each(CASCADE_CONSUMERS)('%s consumes only tokens that exist', (relPath) => {
     const defined = definedTokens()
     const undefinedTokens = [...new Set(consumedTokens(relPath))]
       .filter((t) => !defined.has(t))
@@ -127,7 +179,7 @@ describe('grid tile design tokens (ent#325)', () => {
     const light = tokensInBlock(LIGHT_SELECTOR)
     const dark = tokensInBlock(DARK_SELECTOR)
 
-    const consumed = new Set(TILE_COMPONENTS.flatMap(consumedTokens))
+    const consumed = new Set(CASCADE_CONSUMERS.flatMap(consumedTokens))
     const oneThemeOnly = [...consumed]
       .filter((t) => light.has(t) !== dark.has(t))
       .map((t) => `${t} (${light.has(t) ? 'light only' : 'dark only'})`)
@@ -138,6 +190,21 @@ describe('grid tile design tokens (ent#325)', () => {
       'these tokens are defined in one theme block only — they resolve in that ' +
         'theme and fall back in the other',
     ).toEqual([])
+  })
+
+  it('defines every department palette slot in BOTH themes', () => {
+    // AgentTile builds this name at runtime, so the sweep above cannot resolve
+    // it. gridOrg hashes a department name into DEPT_SLOT_COUNT slots, so every
+    // one must exist in both blocks or some departments lose their ribbon
+    // colour in exactly one theme — and which ones depends on a string hash.
+    const light = tokensInBlock(LIGHT_SELECTOR)
+    const dark = tokensInBlock(DARK_SELECTOR)
+    const missing = []
+    for (let i = 0; i < DEPT_SLOT_COUNT; i++) {
+      if (!light.has(`--gv-dept-${i}`)) missing.push(`--gv-dept-${i} (light)`)
+      if (!dark.has(`--gv-dept-${i}`)) missing.push(`--gv-dept-${i} (dark)`)
+    }
+    expect(missing).toEqual([])
   })
 
   it('the light and dark blocks declare the same token set', () => {


### PR DESCRIPTION
Reported from the Grid dashboard: both info tiles render with a badge sliced in half, and the **Tiles menu that would hide them cannot be opened** — so there is no way out of the state.

Four defects. One of them is a class this feature has already been fixed for once, which is the interesting part.

## 1 — `.it { overflow: hidden }` clipped its own peg

`.it` **is** the peg's containing block, so the 32px badge at `left: -16px` was amputated to a 16px sliver jammed against the tile's left border, glyph sliced down the middle. That is the artifact in the report.

`.it-body` already carries the clip the content actually needs, so the rule on `.it` was pure damage. `AgentTile`'s avatar overhangs its own tile the same way and has always rendered — which is what proves nothing else in the chassis clips, and that the overhang was intended. Measured after: the peg sits **14px** outside the tile edge (`left: -16px` from a padding box two 1px borders in), inside the 20px half-gap `gridLayout.GAP_X` budgets for exactly this.

## 2 — the Tiles menu could not be opened at all

`.gv-tilesctl` was never added to `onCanvasPointerDown`'s bail list, which every other floating control in the cluster is already in. So a pointer-down on the button started a canvas **pan** and called `setPointerCapture`: pointerup then targeted the canvas, `click` retargeted to the common ancestor, and the button's own `@click` never fired. The board lurched instead.

Added the bail, plus pointer-down-outside dismiss and Esc-to-close, matching the sibling `newDept` popover.

## 3 & 4 — four dead token references, all in this menu's CSS

`--gv-fg` (×3) and `--gv-tile-border` (×1) are defined **nowhere** in `src/`, so both resolved to guaranteed-invalid. The label ink and the button's hover ink silently inherited whatever the page handed them, and the separator above "Reset to defaults" drew at a permanently-live `rgba(0,0,0,.08)` — black at 8% on the dark panel, invisible in exactly one theme.

Now `--gv-text`, `--gv-btn-text` (the token the sibling `.gv-orgctl` buttons use, which this control is styled after) and `--gv-border`, fallbacks set to each token's light value.

## Why 3 and 4 survived a fix for their own class

`d2f91d80` swept exactly this — it renamed `--gv-fg` → `--gv-text` and `--gv-tile-border` → `--gv-border`, and shipped `tests/unit/gridTokens.spec.js` so it could not recur.

Both stale names survived in `FleetGrid.vue`, because the guard sweeps the **tile components** and `FleetGrid.vue` is only ever treated as the *definer* of the cascade — never as a consumer of it, which it also is, in its own chrome. Policing only the consumers you expect is how the second half of a rename outlives its own fix.

So the guard is widened rather than the four references merely patched:

- swept set is now `CASCADE_CONSUMERS` = the auto-discovered tiles + `FleetGrid.vue` + `AgentTile.vue`, the lattice's other occupant.
- `tokensInBlock` reads **every** block with the selector, not the first. The file opens a second `.fleet-canvas` / `:root.dark .fleet-canvas` pair further down for the org palette, so a first-match-only read left `--gv-wire` and `--gv-dept-0..7` entirely unguarded.
- a capture ending in `-` is recognised as the head of an interpolated name (`var(--gv-dept-${dept.slot})`), and that family gets its own test over `DEPT_SLOT_COUNT` in both themes rather than being silently dropped — a slot missing from one theme costs some departments their ribbon colour, and which ones depends on a string hash.

## Verification

**Reverted the fix to prove the guard bites** — with the four references restored, the widened guard fails naming both dead tokens:

```
AssertionError: components/FleetGrid.vue reads 2 token(s) defined nowhere in src/…
  expected [ '--gv-fg', '--gv-tile-border' ] to deeply equal []
```

**Driven against a running stack, not only built:**

| Check | Result |
|---|---|
| `.it` computed `overflow` | `visible` |
| peg geometry | 14px outside the tile edge, whole |
| `Tiles ▾` click | menu opens; `.gv-world` transform byte-identical before/after → no pan |
| uncheck a tile | leaves the board, persists `{"recent-failures":false}` |
| re-check | returns |
| outside pointer-down / Esc | both dismiss |

278 unit tests, `vite build` and `check:tokens` green. No colour literals added, so the raw-color ratchet is untouched.

## Scope

Frontend only, 3 files. No backend, no schema, no endpoint, no new dependency. Affects every info tile on the Grid — both shipped ones and the six epic ent#94 queues behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


