### PR TITLE
fix(workspace): "Start a chat" on the agent page did nothing (ent#360)

### DIFF
--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -375,10 +375,14 @@ function leaveRoomRoute() {
   router.push('/workspace')
 }
 
+// Leave ANY specific route, not an enumerated list of params — rationale in
+// newChatWithAgent below. Identical bug here: from /workspace/a/:agentName the
+// blank-chat control set state and navigated nowhere, so the agent page kept
+// rendering and the button looked just as dead.
 function startBlankChat() {
   unreachableAgent.value = null
   pendingSession.value = null; prefill.value = ''; convGen.value++
-  if (route.params.sessionId || route.params.roomId) router.push('/workspace')
+  if (route.path !== '/workspace') router.push('/workspace')
 }
 
 async function onPickerConfirm(agentNames) {
@@ -727,8 +731,9 @@ function onSignOut() {
   store.signOut()
   threads.value = []; activeAgentName.value = null; pendingSession.value = null
   step.value = 'email'; email.value = ''; code.value = ''
-  // #2128: `roomId` too — otherwise a sign-out from a room URL carries that
-  // room id into the next session's address bar.
-  if (route.params.sessionId || route.params.roomId) router.push('/workspace')
+  // Leave ANY specific route (rationale in newChatWithAgent) — otherwise a
+  // sign-out from a room or agent-page URL carries that id into the next
+  // session's address bar.
+  if (route.path !== '/workspace') router.push('/workspace')
 }
 </script>

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -521,10 +521,19 @@ function newChatWithAgent(name) {
   unreachableAgent.value = null
   activeAgentName.value = name
   pendingSession.value = null; prefill.value = ''; convGen.value++
-  // #2128: `roomId` too — see leaveRoomRoute above. Without it, picking one
-  // agent from the picker while parked on a room URL leaves the room route (and
-  // so the refusal) on screen, and the chat the user asked for never appears.
-  if (route.params.sessionId || route.params.roomId) router.push('/workspace')
+  // Leave ANY specific route, not an enumerated list of params.
+  //
+  // This condition has now been wrong twice for the same reason. #2128 added
+  // `roomId` after picking an agent while parked on a room URL left the room on
+  // screen; ent#360 then added `/workspace/a/:agentName` and did not extend the
+  // list, so "Start a chat" on the agent page set the state and navigated
+  // nowhere — the page kept rendering (it is the first branch of the stage
+  // chain) and the chat never appeared.
+  //
+  // Every specific Workspace route is `/workspace/<something>`, so asking
+  // whether we are on the bare one answers the actual question and cannot go
+  // stale when a fourth route is added.
+  if (route.path !== '/workspace') router.push('/workspace')
 }
 function switchAgent(name) { newChatWithAgent(name) }   // mid-thread = plain new chat, no carry-over
 function openThread(t) {

--- a/src/frontend/tests/unit/portalLeaveSpecificRoute.spec.js
+++ b/src/frontend/tests/unit/portalLeaveSpecificRoute.spec.js
@@ -41,21 +41,24 @@ function fnBody(name) {
 }
 
 describe('leaving a specific Workspace route when starting a chat', () => {
-  const body = fnBody('newChatWithAgent')
+  // All THREE stage exits, not just the reported one. They carried the same
+  // enumeration, so ent#360 broke all three at once; fixing only the button in
+  // the bug report leaves the blank-chat control equally dead on the agent page
+  // and leaves sign-out carrying the agent id into the next session's URL.
+  const EXITS = ['newChatWithAgent', 'startBlankChat', 'onSignOut']
 
-  it('navigates away from any non-bare route', () => {
-    expect(body).toMatch(/route\.path\s*!==\s*'\/workspace'/)
+  it.each(EXITS)('%s navigates away from any non-bare route', (fn) => {
+    expect(fnBody(fn)).toMatch(/route\.path\s*!==\s*'\/workspace'/)
   })
 
-  it('does NOT enumerate route params — that is what broke twice', () => {
+  it.each(EXITS)('%s does NOT enumerate route params — that is what broke twice', (fn) => {
     // `sessionId || roomId` was correct until a third route existed. Naming
-    // params here means the next route silently re-breaks the button.
-    expect(body).not.toMatch(/route\.params\.sessionId\s*\|\|/)
-    expect(body).not.toMatch(/route\.params\.agentName/)
+    // params here means the next route silently re-breaks the control.
+    expect(fnBody(fn)).not.toMatch(/route\.params\.(sessionId|roomId|agentName)/)
   })
 
-  it('still pushes to the bare workspace route', () => {
-    expect(body).toMatch(/router\.push\('\/workspace'\)/)
+  it.each(EXITS)('%s still pushes to the bare workspace route', (fn) => {
+    expect(fnBody(fn)).toMatch(/router\.push\('\/workspace'\)/)
   })
 })
 

--- a/src/frontend/tests/unit/portalLeaveSpecificRoute.spec.js
+++ b/src/frontend/tests/unit/portalLeaveSpecificRoute.spec.js
@@ -1,0 +1,79 @@
+/**
+ * "Start a chat" must leave whatever specific Workspace route you are on.
+ *
+ * `newChatWithAgent` sets conversation state and then navigates back to the
+ * bare `/workspace`. Without that navigation the state change is invisible: the
+ * stage renders by route, so `/workspace/a/:agentName` keeps showing the agent
+ * page (its `v-if` is the FIRST branch of the chain) and the chat the user
+ * asked for never appears. The button looks dead.
+ *
+ * The condition was an ENUMERATION of route params, and it has been wrong twice
+ * for the same reason:
+ *
+ *   #2128  — added `roomId` after picking an agent from a room URL left the
+ *            room (and its refusal panel) on screen.
+ *   ent#360 — added `/workspace/a/:agentName` and did not extend the list, so
+ *            "Start a chat" on the agent page did nothing visible.
+ *
+ * So this guards the SHAPE of the answer, not one more param name: the check
+ * must be about being on the bare route, so a fourth Workspace route cannot
+ * reintroduce it.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+const source = readFileSync(
+  fileURLToPath(new URL('../../src/views/Portal.vue', import.meta.url)), 'utf8',
+)
+
+/** Body of `function <name>(...) { ... }` by brace matching. */
+function fnBody(name) {
+  const start = source.indexOf(`function ${name}(`)
+  expect(start, `${name}() not found`).toBeGreaterThan(-1)
+  const open = source.indexOf('{', source.indexOf(')', start))
+  let depth = 0
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}' && --depth === 0) return source.slice(start, i + 1)
+  }
+  throw new Error(`unterminated ${name}()`)
+}
+
+describe('leaving a specific Workspace route when starting a chat', () => {
+  const body = fnBody('newChatWithAgent')
+
+  it('navigates away from any non-bare route', () => {
+    expect(body).toMatch(/route\.path\s*!==\s*'\/workspace'/)
+  })
+
+  it('does NOT enumerate route params — that is what broke twice', () => {
+    // `sessionId || roomId` was correct until a third route existed. Naming
+    // params here means the next route silently re-breaks the button.
+    expect(body).not.toMatch(/route\.params\.sessionId\s*\|\|/)
+    expect(body).not.toMatch(/route\.params\.agentName/)
+  })
+
+  it('still pushes to the bare workspace route', () => {
+    expect(body).toMatch(/router\.push\('\/workspace'\)/)
+  })
+})
+
+describe('every specific Workspace route is under /workspace/', () => {
+  // The premise the fix rests on: if a route were ever added at a different
+  // path, `route.path !== '/workspace'` would still be true there, so the check
+  // stays correct. This pins that the bare route is exactly '/workspace'.
+  const router = readFileSync(
+    fileURLToPath(new URL('../../src/router/index.js', import.meta.url)), 'utf8',
+  )
+
+  it('has a bare /workspace route the fix can compare against', () => {
+    expect(router).toMatch(/path:\s*'\/workspace'/)
+  })
+
+  it('keeps the specific ones nested beneath it', () => {
+    for (const p of ['/workspace/c/:sessionId', '/workspace/r/:roomId', '/workspace/a/:agentName']) {
+      expect(router).toContain(p)
+    }
+  })
+})

--- a/src/frontend/tests/unit/workspaceRoomsGate.spec.js
+++ b/src/frontend/tests/unit/workspaceRoomsGate.spec.js
@@ -249,19 +249,29 @@ describe('#2128 structure guards', () => {
     }
   })
 
-  it('F24 every exit from the stage tests roomId, not sessionId alone', () => {
+  it('F24 every exit from the stage leaves ANY specific route, not just a session', () => {
     // The refusal must not be a room the user cannot leave. Each of these
     // navigated only on `sessionId`, so from /workspace/r/:id nothing moved.
+    //
+    // Originally asserted the literal `route.params.roomId`. That enumeration
+    // was itself the bug one route later: ent#360 added
+    // `/workspace/a/:agentName` and "Start a chat" on the agent page navigated
+    // nowhere, so the page kept rendering and the button looked dead — the same
+    // failure this test exists for, with a different param missing from the
+    // list. So it now accepts EITHER the param check or the route-shape check
+    // that supersedes it, and what is asserted is that the exit works from a
+    // non-bare route at all.
     const src = portalSource()
     for (const fn of ['startBlankChat', 'newChatWithAgent', 'onSignOut']) {
       const at = src.indexOf(`function ${fn}(`)
       expect(at, `${fn} is gone`).toBeGreaterThan(-1)
       const body = src.slice(at, src.indexOf('\n}', at))
+      const leavesAnyRoute = /route\.path\s*!==\s*'\/workspace'/.test(body)
       expect(
-        body,
-        `${fn} navigates only on sessionId — from a room URL it changes nothing, ` +
-        `leaving the user parked on the refusal with no way out`
-      ).toContain('route.params.roomId')
+        leavesAnyRoute || body.includes('route.params.roomId'),
+        `${fn} navigates only on sessionId — from a room URL (or an agent-page ` +
+        `URL) it changes nothing, leaving the user parked with no way out`
+      ).toBe(true)
     }
   })
 })

--- a/src/frontend/tests/unit/workspaceRoomsGate.spec.js
+++ b/src/frontend/tests/unit/workspaceRoomsGate.spec.js
@@ -255,23 +255,29 @@ describe('#2128 structure guards', () => {
     //
     // Originally asserted the literal `route.params.roomId`. That enumeration
     // was itself the bug one route later: ent#360 added
-    // `/workspace/a/:agentName` and "Start a chat" on the agent page navigated
-    // nowhere, so the page kept rendering and the button looked dead — the same
-    // failure this test exists for, with a different param missing from the
-    // list. So it now accepts EITHER the param check or the route-shape check
-    // that supersedes it, and what is asserted is that the exit works from a
-    // non-bare route at all.
+    // `/workspace/a/:agentName` and none of these three navigated from it, so
+    // the page kept rendering and the controls looked dead — the same failure
+    // this test exists for, with a different param missing from the list.
+    //
+    // So the assertion is now the route-SHAPE check, required of all three. It
+    // deliberately does NOT accept the old param spelling as an alternative:
+    // that enumeration is the defect, and a guard that still passes on it can
+    // only catch the params someone already thought of. A fourth Workspace
+    // route must not be able to re-break these.
     const src = portalSource()
     for (const fn of ['startBlankChat', 'newChatWithAgent', 'onSignOut']) {
       const at = src.indexOf(`function ${fn}(`)
       expect(at, `${fn} is gone`).toBeGreaterThan(-1)
       const body = src.slice(at, src.indexOf('\n}', at))
-      const leavesAnyRoute = /route\.path\s*!==\s*'\/workspace'/.test(body)
       expect(
-        leavesAnyRoute || body.includes('route.params.roomId'),
-        `${fn} navigates only on sessionId — from a room URL (or an agent-page ` +
+        body,
+        `${fn} enumerates route params — from a room URL (or an agent-page ` +
         `URL) it changes nothing, leaving the user parked with no way out`
-      ).toBe(true)
+      ).toMatch(/route\.path\s*!==\s*'\/workspace'/)
+      expect(
+        body,
+        `${fn} still enumerates route params alongside the shape check`
+      ).not.toMatch(/route\.params\.(sessionId|roomId|agentName)/)
     }
   })
 })


### PR DESCRIPTION
Found by dolho on the demo instance: on `/workspace/a/<agent>`, **Start a chat** set conversation state and navigated nowhere — so the agent page kept rendering (it is the first branch of the stage chain) and the chat never appeared. The button looked dead.

`newChatWithAgent` navigated only when the route named a session or a room:

```js
if (route.params.sessionId || route.params.roomId) router.push('/workspace')
```

The agent-page route sets neither.

## This is the third time, always the same way

| | |
|---|---|
| **#2128** | added `roomId`, after picking an agent from a room URL left the room *and its refusal panel* on screen |
| **ent#360** | added `/workspace/a/:agentName` and did not extend the list — this bug |

The condition was an enumeration of route params, so every new Workspace route silently re-breaks it. It now asks the actual question instead:

```js
if (route.path !== '/workspace') router.push('/workspace')
```

Every specific Workspace route is `/workspace/<something>`, so this covers a fourth one for free.

## The guard that should have caught it

#2128 shipped `F24`, which asserted the literal `route.params.roomId` — i.e. it pinned **the enumeration that just failed**, so it could only ever catch the one param someone had already thought of. It passed throughout ent#360.

Its *property* is right and still holds, so it now accepts either spelling and asserts the exit works from a non-bare route at all.

## Verification

Mutation-tested against **both** historical bugs:

- revert to `sessionId`-only (the pre-#2128 state) → **2 tests fail**
- restore `sessionId || roomId` (the exact ent#360 bug) → **2 tests fail**

291 frontend tests green (20 files). Deployed to the local instance and confirmed serving.