### PR TITLE
Show Claude subscription usage without metered cost

### DIFF
--- a/docs/memory/feature-flows/subscription-usage-tracking.md
+++ b/docs/memory/feature-flows/subscription-usage-tracking.md
@@ -1,20 +1,20 @@
 # Feature: Subscription Usage Tracking
 
 ## Overview
-Per-subscription rolling token and cost usage across two time windows (5h and 7d), covering both chat messages and scheduled task executions.
+Per-subscription non-billing activity across two rolling windows (5h and 7d), covering both chat messages and scheduled task executions. Allowance utilization is a separate provider-backed signal: if Trinity cannot obtain a reliable percentage/window/reset, the API and UI return an explicit unavailable state instead of substituting token totals or Claude Code's dollar estimate.
 
 ## User Story
-As a platform admin, I want to see aggregate token usage per Claude Max/Pro subscription so that I can understand load distribution across shared subscriptions and detect overuse.
+As a platform admin, I want to see which named Claude subscription funds each agent and its provider-backed allowance utilization when available, without mistaking an estimated dollar value for subscription spend.
 
 ## Entry Points
 - **API**: `GET /api/subscriptions/{subscription_id}/usage`
-- No direct UI entry point — intended for admin inspection and future dashboard integration. Accepts subscription UUID or name as the path parameter.
+- **UI**: agent header, Dashboard timeline/grid/list, and Settings subscription table. Accepts subscription UUID or name as the API path parameter.
 
 ## Backend Layer
 
 ### Endpoint
-- `src/backend/routers/subscriptions.py:118` - `get_subscription_usage()`
-  - Admin-only (`require_admin`)
+- `src/backend/routers/subscriptions.py` - `get_subscription_usage()`
+  - Admin-only (`assert_admin` after authentication)
   - Resolves path param by UUID first, falls back to name lookup
   - Returns `SubscriptionUsage` Pydantic model
 
@@ -26,17 +26,27 @@ Authorization: Bearer <admin_token>
 Response shape:
 ```json
 {
+  "billing_mode": "subscription",
+  "provider": "anthropic",
   "subscription_id": "<uuid>",
+  "subscription_name": "studio-max",
+  "subscription_type": "max",
+  "utilization": {
+    "status": "unavailable",
+    "percent": null,
+    "window": null,
+    "resets_at": null,
+    "last_updated_at": null,
+    "reason": "provider_signal_unavailable"
+  },
   "window_5h": {
     "input_tokens": 12000,
     "output_tokens": 4500,
-    "cost_usd": 0.18,
     "message_count": 37
   },
   "window_7d": {
     "input_tokens": 210000,
     "output_tokens": 75000,
-    "cost_usd": 3.12,
     "message_count": 512
   },
   "agents": ["agent-a", "agent-b"]
@@ -47,11 +57,14 @@ Response shape:
 1. Try `db.get_subscription(subscription_id)` by UUID
 2. If not found, try `db.get_subscription_by_name(subscription_id)`
 3. If still not found, raise 404
-4. Call `db.get_subscription_usage(subscription.id)` with the resolved UUID
+4. Call `db.get_subscription_usage(...)` with the resolved UUID and public subscription identity
 
 ### Business Logic
 - `agents` field reflects **current** assignments from `agent_ownership`, not historical data
 - Usage windows query historical records via the snapshotted `subscription_id` column — correct even when agents switch subscriptions between queries
+
+### Provider Signal Limitation
+Claude setup-token authentication currently gives Trinity no reliable allowance counter. An `available` utilization state requires an authenticated provider signal that supplies, at minimum, percentage consumed, the named allowance window, observation time, and reset time when defined. Local token totals, rate-limit errors, and Claude Code dollar estimates are not valid substitutes; until that signal exists Trinity returns `provider_signal_unavailable`.
 
 ## Data Layer
 
@@ -83,7 +96,6 @@ Two windows computed by `_query_window(cutoff)`:
 SELECT
     COALESCE(SUM(context_used), 0)   AS input_tokens,
     COALESCE(SUM(output_tokens), 0)  AS output_tokens,
-    COALESCE(SUM(cost), 0.0)         AS cost_usd,
     COUNT(*)                          AS message_count
 FROM chat_messages
 WHERE subscription_id = ?
@@ -95,7 +107,6 @@ WHERE subscription_id = ?
 ```sql
 SELECT
     COALESCE(SUM(context_used), 0) AS input_tokens,
-    COALESCE(SUM(cost), 0.0)       AS cost_usd,
     COUNT(*)                        AS exec_count
 FROM schedule_executions
 WHERE subscription_id = ?
@@ -106,8 +117,8 @@ WHERE subscription_id = ?
 Totals are summed: `input_tokens = chat.input_tokens + exec.input_tokens`, `message_count = chat.message_count + exec.exec_count`.
 
 ### Pydantic Models
-- `src/backend/db_models.py:672` - `SubscriptionUsageWindow` (input_tokens, output_tokens, cost_usd, message_count)
-- `src/backend/db_models.py:680` - `SubscriptionUsage` (subscription_id, window_5h, window_7d, agents)
+- `src/backend/db_models.py` - `SubscriptionUsageWindow` (input_tokens, output_tokens, message_count)
+- `src/backend/db_models.py` - discriminated agent usage models plus `SubscriptionUsage` (identity, utilization, activity windows, agents)
 
 ## Subscription ID Snapshot Strategy
 

--- a/docs/memory/requirements/security.md
+++ b/docs/memory/requirements/security.md
@@ -166,11 +166,15 @@
 - **Requirement ID**: SUB-004
 - **Extends**: SUB-002
 - **Priority**: MEDIUM
-- **Description**: Track token usage (input, output, cost) per subscription across all agents, enabling admins to see how much each subscription is being consumed. Snapshots subscription_id at execution time so usage history survives SUB-003 auto-switches.
+- **Description**: Track non-billing activity per subscription across all agents while presenting Claude subscription usage as an allowance percentage/window only when backed by a reliable provider signal. Snapshot `subscription_id` at execution time so activity history survives SUB-003 auto-switches. Claude Code's recorded dollar estimate is not subscription spend and must not appear on subscription-backed agent, dashboard, Settings, or subscription-usage surfaces.
 - **Key Features**:
   - `subscription_id` column added to `task_executions` and `chat_sessions` tables (nullable, safe migration)
-  - Admin-only `/api/subscriptions/{name}/usage` endpoint with dual-window aggregation (24h + 7d)
-  - Per-agent breakdown of input/output tokens, execution count, and estimated cost
+  - Discriminated `subscription` / `api` / `unconfigured` usage presentation on agent auth and fleet payloads
+  - Subscription identity always includes provider, named subscription, and plan where known
+  - Subscription utilization includes percent, allowance window, reset, and last-updated metadata when provider-backed; otherwise every unknown field is null with `provider_signal_unavailable`
+  - API-key usage is explicitly `Anthropic API · metered` and retains USD cost semantics
+  - Admin-only `/api/subscriptions/{name}/usage` endpoint with 5h + 7d non-billing activity windows and the same honest utilization state
+  - Per-subscription input/output tokens and execution/message count; no dollar estimate on subscription usage
   - Snapshot strategy: subscription_id captured at execution time, not looked up retroactively
 - **Database**: `subscription_id` columns on `task_executions`, `chat_sessions`
 - **Files**:
@@ -178,7 +182,8 @@
   - `src/backend/routers/subscriptions.py` - Usage endpoint
   - `src/backend/routers/chat.py` - Subscription ID capture at execution time
   - `src/backend/db/chat.py` - Session creation with subscription_id
-  - `src/frontend/src/views/Settings.vue` - Usage display (if applicable)
+  - `src/frontend/src/utils/usagePresentation.js` - Shared subscription/API presentation policy
+  - `src/frontend/src/views/Settings.vue` and dashboard/agent header components - Usage display
 
 ### 20.6 Credential Rotation via Hot-Reload, not Container Recreate (#1089)
 - **Status**: ✅ Implemented (2026-06-13)

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -2384,9 +2384,19 @@ class DatabaseManager:
     def select_best_alternative_subscription(self, current_subscription_id: str):
         return self._subscription_ops.select_best_alternative_subscription(current_subscription_id)
 
-    def get_subscription_usage(self, subscription_id: str):
+    def get_subscription_usage(
+        self,
+        subscription_id: str,
+        *,
+        subscription_name: str,
+        subscription_type: str | None = None,
+    ):
         """Return rolling usage totals for a subscription (SUB-004)."""
-        return self._subscription_ops.get_subscription_usage(subscription_id)
+        return self._subscription_ops.get_subscription_usage(
+            subscription_id,
+            subscription_name=subscription_name,
+            subscription_type=subscription_type,
+        )
 
     # =========================================================================
     # Agent Monitoring (delegated to db/monitoring.py) - MON-001

--- a/src/backend/db/agent_settings/metadata.py
+++ b/src/backend/db/agent_settings/metadata.py
@@ -298,6 +298,9 @@ class MetadataMixin:
                 COALESCE(ao.autonomy_enabled, 0) as autonomy_enabled,
                 COALESCE(ao.read_only_mode, 0) as read_only_enabled,
                 COALESCE(ao.use_platform_api_key, 1) as use_platform_api_key,
+                ao.subscription_id,
+                sc.name as subscription_name,
+                sc.subscription_type,
                 COALESCE(ao.mcp_exposed, 0) as mcp_exposed,
                 COALESCE(ao.a2a_exposed, 0) as a2a_exposed,
                 ao.memory_limit,
@@ -311,6 +314,7 @@ class MetadataMixin:
                 END as is_shared_with_user
             FROM agent_ownership ao
             LEFT JOIN users u ON ao.owner_id = u.id
+            LEFT JOIN subscription_credentials sc ON sc.id = ao.subscription_id
             LEFT JOIN agent_git_config gc ON gc.agent_name = ao.agent_name
             LEFT JOIN agent_sharing s ON s.agent_name = ao.agent_name
                 AND LOWER(s.shared_with_email) = LOWER(:user_email)
@@ -330,6 +334,15 @@ class MetadataMixin:
                     "autonomy_enabled": bool(row["autonomy_enabled"]),
                     "read_only_enabled": bool(row["read_only_enabled"]),
                     "use_platform_api_key": bool(row["use_platform_api_key"]),
+                    "subscription": (
+                        {
+                            "id": row["subscription_id"],
+                            "name": row["subscription_name"],
+                            "subscription_type": row["subscription_type"],
+                        }
+                        if row["subscription_id"] and row["subscription_name"]
+                        else None
+                    ),
                     "mcp_exposed": bool(row["mcp_exposed"]),
                     "a2a_exposed": bool(row["a2a_exposed"]),
                     "memory_limit": row["memory_limit"],

--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -27,7 +27,13 @@ from .tables import (
     schedule_executions,
     users,
 )
-from db_models import SubscriptionCredential, SubscriptionUsage, SubscriptionUsageWindow, SubscriptionWithAgents
+from db_models import (
+    SubscriptionCredential,
+    SubscriptionUsage,
+    SubscriptionUsageWindow,
+    SubscriptionUtilizationUnavailable,
+    SubscriptionWithAgents,
+)
 from utils.helpers import iso_cutoff, utc_now_iso
 
 
@@ -699,7 +705,13 @@ class SubscriptionOperations:
     # Usage Tracking (SUB-004: Per-subscription usage windows)
     # =========================================================================
 
-    def get_subscription_usage(self, subscription_id: str) -> SubscriptionUsage:
+    def get_subscription_usage(
+        self,
+        subscription_id: str,
+        *,
+        subscription_name: str,
+        subscription_type: Optional[str] = None,
+    ) -> SubscriptionUsage:
         """
         Return rolling usage totals for a subscription across two time windows:
         - window_5h: last 5 hours
@@ -725,7 +737,6 @@ class SubscriptionOperations:
                     select(
                         func.coalesce(func.sum(chat_messages.c.context_used), 0).label("input_tokens"),
                         func.coalesce(func.sum(chat_messages.c.output_tokens), 0).label("output_tokens"),
-                        func.coalesce(func.sum(chat_messages.c.cost), 0.0).label("cost_usd"),
                         func.count().label("message_count"),
                     ).where(
                         and_(
@@ -740,7 +751,6 @@ class SubscriptionOperations:
                 exec_row = conn.execute(
                     select(
                         func.coalesce(func.sum(schedule_executions.c.context_used), 0).label("input_tokens"),
-                        func.coalesce(func.sum(schedule_executions.c.cost), 0.0).label("cost_usd"),
                         func.count().label("exec_count"),
                     ).where(
                         and_(
@@ -754,7 +764,6 @@ class SubscriptionOperations:
                 return SubscriptionUsageWindow(
                     input_tokens=int(chat_row["input_tokens"] or 0) + int(exec_row["input_tokens"] or 0),
                     output_tokens=int(chat_row["output_tokens"] or 0),
-                    cost_usd=float(chat_row["cost_usd"] or 0.0) + float(exec_row["cost_usd"] or 0.0),
                     message_count=int(chat_row["message_count"] or 0) + int(exec_row["exec_count"] or 0),
                 )
 
@@ -774,6 +783,9 @@ class SubscriptionOperations:
 
         return SubscriptionUsage(
             subscription_id=subscription_id,
+            subscription_name=subscription_name,
+            subscription_type=subscription_type,
+            utilization=SubscriptionUtilizationUnavailable(),
             window_5h=window_5h,
             window_7d=window_7d,
             agents=agents,

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -7,7 +7,7 @@ For API request/response models, see models.py.
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional, List
+from typing import Annotated, Any, Dict, Literal, Optional, List, Union
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -886,9 +886,80 @@ class SubscriptionCredential(BaseModel):
     agent_count: int = 0  # Number of agents using this subscription
 
 
+class ClaudeSubscriptionIdentity(BaseModel):
+    """Public identity for the subscription funding a Claude agent."""
+
+    id: str
+    name: str
+    plan: Optional[str] = None
+
+
+class SubscriptionUtilizationAvailable(BaseModel):
+    """A provider-backed allowance signal with enough context to interpret it."""
+
+    status: Literal["available"] = "available"
+    percent: float = Field(ge=0, le=100)
+    window: str
+    resets_at: Optional[str] = None
+    last_updated_at: str
+
+
+class SubscriptionUtilizationUnavailable(BaseModel):
+    """Honest state when Trinity has no reliable allowance counter."""
+
+    status: Literal["unavailable"] = "unavailable"
+    percent: None = None
+    window: None = None
+    resets_at: None = None
+    last_updated_at: None = None
+    reason: Literal["provider_signal_unavailable"] = "provider_signal_unavailable"
+
+
+SubscriptionUtilization = Annotated[
+    Union[SubscriptionUtilizationAvailable, SubscriptionUtilizationUnavailable],
+    Field(discriminator="status"),
+]
+
+
+class SubscriptionUsagePresentation(BaseModel):
+    """Allowance-oriented usage for Claude Max/Pro subscription auth."""
+
+    billing_mode: Literal["subscription"] = "subscription"
+    provider: Literal["anthropic"] = "anthropic"
+    subscription: ClaudeSubscriptionIdentity
+    utilization: SubscriptionUtilization
+
+
+class ApiMeteredUsagePresentation(BaseModel):
+    """Cost-oriented usage descriptor for Anthropic API-key auth."""
+
+    billing_mode: Literal["api"] = "api"
+    provider: Literal["anthropic"] = "anthropic"
+    metering: Literal["metered"] = "metered"
+    cost_currency: Literal["USD"] = "USD"
+
+
+class UnconfiguredUsagePresentation(BaseModel):
+    """No Claude billing identity is configured for the agent."""
+
+    billing_mode: Literal["unconfigured"] = "unconfigured"
+    provider: Literal["anthropic"] = "anthropic"
+
+
+AgentUsagePresentation = Annotated[
+    Union[
+        SubscriptionUsagePresentation,
+        ApiMeteredUsagePresentation,
+        UnconfiguredUsagePresentation,
+    ],
+    Field(discriminator="billing_mode"),
+]
+
+
 class SubscriptionWithAgents(SubscriptionCredential):
     """Subscription with list of assigned agents."""
     agents: List[str] = []
+    usage: Optional[SubscriptionUsagePresentation] = None
 
 
 class AgentAuthStatus(BaseModel):
@@ -898,19 +969,24 @@ class AgentAuthStatus(BaseModel):
     subscription_name: Optional[str] = None
     subscription_id: Optional[str] = None
     has_api_key: bool = False
+    usage: Optional[AgentUsagePresentation] = None
 
 
 class SubscriptionUsageWindow(BaseModel):
-    """Usage totals for a rolling time window. (SUB-004)"""
+    """Non-billing activity totals for a subscription window. (SUB-004)"""
     input_tokens: int = 0
     output_tokens: int = 0
-    cost_usd: float = 0.0
     message_count: int = 0
 
 
 class SubscriptionUsage(BaseModel):
-    """Per-subscription usage across rolling time windows. (SUB-004)"""
+    """Allowance-oriented subscription usage plus non-billing activity."""
+    billing_mode: Literal["subscription"] = "subscription"
+    provider: Literal["anthropic"] = "anthropic"
     subscription_id: str
+    subscription_name: str
+    subscription_type: Optional[str] = None
+    utilization: SubscriptionUtilization
     window_5h: SubscriptionUsageWindow
     window_7d: SubscriptionUsageWindow
     agents: List[str] = []  # agents currently assigned to this subscription

--- a/src/backend/routers/agents.py
+++ b/src/backend/routers/agents.py
@@ -52,6 +52,7 @@ from services.platform_audit_service import (
 from services.agent_service import (
     # Helpers - re-exported for external modules
     get_accessible_agents,
+    is_claude_runtime,
     # Lifecycle
     start_agent_internal,
     # CRUD
@@ -406,6 +407,15 @@ async def get_agent_endpoint(agent_name: AuthorizedAgentByName, request: Request
     agent_dict["autonomy_enabled"] = db.get_autonomy_enabled(agent_name)
     read_only_data = db.get_read_only_mode(agent_name)
     agent_dict["read_only_enabled"] = read_only_data["enabled"]
+    from services.subscription_service import build_agent_usage_presentation
+    agent_dict["usage"] = (
+        build_agent_usage_presentation(
+            subscription=db.get_agent_subscription(agent_name),
+            has_api_key=db.get_use_platform_api_key(agent_name) or False,
+        ).model_dump(mode="json")
+        if is_claude_runtime(agent_dict.get("runtime"))
+        else None
+    )
 
     # Avatar URL (AVATAR-001)
     identity = db.get_avatar_identity(agent_name)

--- a/src/backend/routers/subscriptions.py
+++ b/src/backend/routers/subscriptions.py
@@ -24,6 +24,7 @@ from db_models import (
     SubscriptionWithAgents,
     AgentAuthStatus,
 )
+from services.subscription_service import build_agent_usage_presentation
 
 router = APIRouter(prefix="/api/subscriptions", tags=["subscriptions"])
 logger = logging.getLogger(__name__)
@@ -135,8 +136,20 @@ async def list_subscriptions(
     that owner's subscriptions, which are the only ones it can assign anyway.
     """
     if current_user.role == "admin" and not getattr(current_user, "agent_name", None):
-        return db.list_subscriptions_with_agents()
-    return db.list_subscriptions_with_agents(owner_id=current_user.id)
+        subscriptions = db.list_subscriptions_with_agents()
+    else:
+        subscriptions = db.list_subscriptions_with_agents(owner_id=current_user.id)
+
+    return [
+        SubscriptionWithAgents(
+            **subscription.model_dump(exclude={"usage"}),
+            usage=build_agent_usage_presentation(
+                subscription=subscription,
+                has_api_key=False,
+            ),
+        )
+        for subscription in subscriptions
+    ]
 
 
 @router.get("/{subscription_id}/usage", response_model=SubscriptionUsage)
@@ -147,9 +160,8 @@ async def get_subscription_usage(
     """
     Get rolling usage statistics for a subscription (SUB-004).
 
-    Returns token and cost aggregates across two rolling windows (the docstring
-    said "Admin-only" while the gate has always been `get_current_user` — noted
-    while auditing this module for ent#293):
+    Returns non-billing activity aggregates across two rolling windows. The
+    authenticated caller is then restricted by the explicit admin assertion:
     - window_5h: last 5 hours
     - window_7d: last 7 days
 
@@ -166,7 +178,11 @@ async def get_subscription_usage(
         raise HTTPException(status_code=404, detail="Subscription not found")
 
     try:
-        return db.get_subscription_usage(subscription.id)
+        return db.get_subscription_usage(
+            subscription.id,
+            subscription_name=subscription.name,
+            subscription_type=subscription.subscription_type,
+        )
     except Exception as e:
         logger.error(f"Failed to get usage for subscription {subscription_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve usage data")
@@ -197,7 +213,11 @@ async def get_subscription(
 
     return SubscriptionWithAgents(
         **subscription.model_dump(),
-        agents=agents
+        agents=agents,
+        usage=build_agent_usage_presentation(
+            subscription=subscription,
+            has_api_key=False,
+        ),
     )
 
 

--- a/src/backend/services/agent_service/__init__.py
+++ b/src/backend/services/agent_service/__init__.py
@@ -12,6 +12,7 @@ from .helpers import (
     get_latest_version,
     check_shared_folder_mounts_match,
     check_api_key_env_matches,
+    is_claude_runtime,
     validate_base_image,
 )
 from .lifecycle import (
@@ -97,6 +98,7 @@ __all__ = [
     "get_latest_version",
     "check_shared_folder_mounts_match",
     "check_api_key_env_matches",
+    "is_claude_runtime",
     "validate_base_image",
     # Lifecycle
     "inject_assigned_credentials",

--- a/src/backend/services/agent_service/helpers.py
+++ b/src/backend/services/agent_service/helpers.py
@@ -228,6 +228,8 @@ def get_accessible_agents(current_user: User) -> list:
     all_metadata = db.get_all_agent_metadata(user_email)
 
     accessible_agents = []
+    from services.subscription_service import build_agent_usage_presentation
+
     for agent in all_agents:
         agent_dict = agent.dict() if hasattr(agent, 'dict') else dict(agent)
         agent_name = agent_dict.get("name")
@@ -250,6 +252,14 @@ def get_accessible_agents(current_user: User) -> list:
             agent_dict["github_repo"] = None
             agent_dict["memory_limit"] = None
             agent_dict["cpu_limit"] = None
+            agent_dict["usage"] = (
+                build_agent_usage_presentation(
+                    subscription=None,
+                    has_api_key=False,
+                ).model_dump(mode="json")
+                if is_claude_runtime(agent_dict.get("runtime"))
+                else None
+            )
             accessible_agents.append(agent_dict)
             continue
 
@@ -274,6 +284,14 @@ def get_accessible_agents(current_user: User) -> list:
         agent_dict["cpu_limit"] = metadata.get("cpu_limit")
         agent_dict["mcp_exposed"] = metadata.get("mcp_exposed", False)  # #846
         agent_dict["a2a_exposed"] = metadata.get("a2a_exposed", False)  # ent#157
+        agent_dict["usage"] = (
+            build_agent_usage_presentation(
+                subscription=metadata.get("subscription"),
+                has_api_key=metadata.get("use_platform_api_key", False),
+            ).model_dump(mode="json")
+            if is_claude_runtime(agent_dict.get("runtime"))
+            else None
+        )
 
         # Avatar URL (AVATAR-001)
         avatar_updated_at = metadata.get("avatar_updated_at")

--- a/src/backend/services/subscription_service.py
+++ b/src/backend/services/subscription_service.py
@@ -9,12 +9,53 @@ No file injection is needed — the token is part of the container environment.
 """
 
 import logging
-from typing import Optional
+from collections.abc import Mapping
+from typing import Any, Optional
 
 from database import db
-from db_models import AgentAuthStatus
+from services.agent_service import is_claude_runtime
+from services.docker_service import get_agent_runtime
+from db_models import (
+    AgentAuthStatus,
+    AgentUsagePresentation,
+    ApiMeteredUsagePresentation,
+    ClaudeSubscriptionIdentity,
+    SubscriptionUsagePresentation,
+    SubscriptionUtilizationUnavailable,
+    UnconfiguredUsagePresentation,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _subscription_value(subscription: Any, key: str) -> Any:
+    if isinstance(subscription, Mapping):
+        return subscription.get(key)
+    return getattr(subscription, key, None)
+
+
+def build_agent_usage_presentation(
+    *, subscription: Optional[Any], has_api_key: bool
+) -> AgentUsagePresentation:
+    """Build the billing-mode discriminator consumed by every agent UI.
+
+    Trinity has no provider-backed Claude allowance counter today. Subscription
+    auth therefore returns an explicit unavailable state, with every percentage,
+    window, reset, and freshness field null. Estimated Claude Code dollar values
+    must never be used as a substitute for that missing signal.
+    """
+    if subscription is not None:
+        return SubscriptionUsagePresentation(
+            subscription=ClaudeSubscriptionIdentity(
+                id=_subscription_value(subscription, "id"),
+                name=_subscription_value(subscription, "name"),
+                plan=_subscription_value(subscription, "subscription_type"),
+            ),
+            utilization=SubscriptionUtilizationUnavailable(),
+        )
+    if has_api_key:
+        return ApiMeteredUsagePresentation()
+    return UnconfiguredUsagePresentation()
 
 
 async def get_agent_auth_mode(agent_name: str) -> AgentAuthStatus:
@@ -53,4 +94,12 @@ async def get_agent_auth_mode(agent_name: str) -> AgentAuthStatus:
         subscription_name=subscription.name if subscription else None,
         subscription_id=subscription.id if subscription else None,
         has_api_key=has_api_key,
+        usage=(
+            build_agent_usage_presentation(
+                subscription=subscription,
+                has_api_key=has_api_key,
+            )
+            if is_claude_runtime(get_agent_runtime(agent_name))
+            else None
+        ),
     )

--- a/src/frontend/src/components/AgentHeader.vue
+++ b/src/frontend/src/components/AgentHeader.vue
@@ -165,7 +165,7 @@
               Shared by {{ agent.owner }}
             </span>
             <!-- Auth method badge / subscription switcher -->
-            <div v-if="authStatus" class="relative inline-flex items-center">
+            <div v-if="authStatus && resolvedUsage" class="relative inline-flex items-center">
               <span
                 class="px-2 py-0.5 text-xs font-medium rounded-full flex items-center gap-0.5"
                 :class="authStatus.auth_mode === 'subscription'
@@ -173,18 +173,10 @@
                   : authStatus.auth_mode === 'api_key'
                     ? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
                     : 'bg-status-danger-100 dark:bg-status-danger-900/50 text-status-danger-600 dark:text-status-danger-400'"
-                :title="authStatus.auth_mode === 'subscription'
-                  ? `Using subscription: ${authStatus.subscription_name}`
-                  : authStatus.auth_mode === 'api_key'
-                    ? 'Using platform API key'
-                    : 'No auth configured'"
+                :title="usageDetail(resolvedUsage)"
               >
                 <span v-if="subscriptionChanging" class="inline-block w-2 h-2 border border-current border-t-transparent rounded-full animate-spin mr-0.5"></span>
-                {{ authStatus.auth_mode === 'subscription'
-                  ? authStatus.subscription_name
-                  : authStatus.auth_mode === 'api_key'
-                    ? 'API Key'
-                    : 'No Auth' }}
+                {{ usageBadgeLabel(resolvedUsage) }}
                 <svg v-if="subscriptions !== null && agent.can_share" class="w-2.5 h-2.5 ml-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                 </svg>
@@ -371,54 +363,57 @@
       </div>
     </div>
 
-    <!-- TOKEN USAGE ROW: 7-day sparkline + today vs average trend -->
+    <!-- AUTH-AWARE USAGE ROW: subscriptions are allowance-oriented; APIs are metered. -->
     <div
-      v-if="tokenStats && (tokenStats.lifetime_executions > 0)"
+      v-if="resolvedUsage?.billing_mode === 'subscription' || (tokenStats && tokenStats.lifetime_executions > 0)"
       class="px-4 py-2 border-t border-gray-100 dark:border-gray-700 flex items-center space-x-4 text-xs"
     >
-      <!-- 7-day cost sparkline -->
-      <div class="flex items-center space-x-1.5">
-        <span class="text-gray-400 dark:text-gray-500">7d</span>
-        <SparklineChart
-          :data="tokenCostSparkline"
-          color="#f59e0b"
-          :y-max="tokenCostSparklineMax"
-          :width="56"
-          :height="16"
-        />
-      </div>
-      <!-- Today's cost -->
-      <div class="flex items-center space-x-1">
-        <span class="text-gray-400 dark:text-gray-500">Today</span>
-        <span class="font-mono text-gray-700 dark:text-gray-300">{{ formatCost(tokenStats.cost_24h) }}</span>
-      </div>
-      <!-- Trend vs 7d average -->
-      <div v-if="tokenStats.avg_daily_cost > 0" class="flex items-center space-x-1">
-        <span
-          :class="trendClass"
-          class="flex items-center space-x-0.5 font-mono"
-          :title="`7d avg: ${formatCost(tokenStats.avg_daily_cost)}/day`"
+      <template v-if="resolvedUsage?.billing_mode === 'subscription'">
+        <div class="flex items-center space-x-2 min-w-0" :title="usageDetail(resolvedUsage)">
+          <span class="text-gray-400 dark:text-gray-500">Subscription allowance</span>
+          <span class="font-medium text-state-autonomous-700 dark:text-state-autonomous-300 truncate">
+            {{ dashboardUsageText(resolvedUsage) }}
+          </span>
+        </div>
+        <div
+          v-if="resolvedUsage.utilization?.status === 'available'"
+          class="flex-1 max-w-48 h-1.5 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden"
         >
-          <!-- Arrow icon -->
-          <svg v-if="tokenStats.trend_cost_pct > 5" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 15l7-7 7 7" />
-          </svg>
-          <svg v-else-if="tokenStats.trend_cost_pct < -5" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7" />
-          </svg>
-          <svg v-else class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 12h14" />
-          </svg>
-          <span>{{ formatTrendPct(tokenStats.trend_cost_pct) }} vs avg</span>
-        </span>
-      </div>
-      <!-- Lifetime cost -->
-      <div class="ml-auto flex items-center space-x-1 text-gray-400 dark:text-gray-500">
-        <span>Lifetime</span>
-        <span class="font-mono text-gray-600 dark:text-gray-400">{{ formatCost(tokenStats.lifetime_cost) }}</span>
-        <span class="text-gray-300 dark:text-gray-600">·</span>
-        <span class="font-mono">{{ tokenStats.lifetime_executions }} runs</span>
-      </div>
+          <div
+            class="h-full bg-state-autonomous-500 rounded-full"
+            :style="{ width: `${resolvedUsage.utilization.percent}%` }"
+          ></div>
+        </div>
+        <span class="ml-auto text-gray-400 dark:text-gray-500">{{ usageDetail(resolvedUsage) }}</span>
+      </template>
+      <template v-else-if="shouldShowMeteredCost(resolvedUsage)">
+        <span class="font-medium text-gray-500 dark:text-gray-400">Anthropic API · metered</span>
+        <div class="flex items-center space-x-1.5">
+          <span class="text-gray-400 dark:text-gray-500">7d</span>
+          <SparklineChart
+            :data="tokenCostSparkline"
+            color="#f59e0b"
+            :y-max="tokenCostSparklineMax"
+            :width="56"
+            :height="16"
+          />
+        </div>
+        <div class="flex items-center space-x-1">
+          <span class="text-gray-400 dark:text-gray-500">Today</span>
+          <span class="font-mono text-gray-700 dark:text-gray-300">{{ formatCost(tokenStats.cost_24h) }}</span>
+        </div>
+        <div v-if="tokenStats.avg_daily_cost > 0" class="flex items-center space-x-1">
+          <span :class="trendClass" class="font-mono" :title="`7d avg: ${formatCost(tokenStats.avg_daily_cost)}/day`">
+            {{ formatTrendPct(tokenStats.trend_cost_pct) }} vs avg
+          </span>
+        </div>
+        <div class="ml-auto flex items-center space-x-1 text-gray-400 dark:text-gray-500">
+          <span>Lifetime</span>
+          <span class="font-mono text-gray-600 dark:text-gray-400">{{ formatCost(tokenStats.lifetime_cost) }}</span>
+          <span class="text-gray-300 dark:text-gray-600">·</span>
+          <span class="font-mono">{{ tokenStats.lifetime_executions }} runs</span>
+        </div>
+      </template>
     </div>
 
     <!-- ROW 3: Git Controls (only when hasGitSync) -->
@@ -516,6 +511,12 @@ import { useRouter } from 'vue-router'
 import AgentAvatar from './AgentAvatar.vue'
 import RuntimeBadge from './RuntimeBadge.vue'
 import { agentDisplayName, hasDistinctLabel } from '../utils/agentName'
+import {
+  dashboardUsageText,
+  shouldShowMeteredCost,
+  usageBadgeLabel,
+  usageDetail,
+} from '../utils/usagePresentation'
 import SparklineChart from './SparklineChart.vue'
 import RunningStateToggle from './RunningStateToggle.vue'
 import AutonomyToggle from './AutonomyToggle.vue'
@@ -658,6 +659,8 @@ const props = defineProps({
     default: false
   }
 })
+
+const resolvedUsage = computed(() => props.authStatus?.usage || props.agent?.usage || null)
 
 const emit = defineEmits([
   'toggle',

--- a/src/frontend/src/components/AgentListPanel.vue
+++ b/src/frontend/src/components/AgentListPanel.vue
@@ -562,9 +562,13 @@
             <div class="flex items-center text-[11px] text-gray-500 dark:text-gray-400 gap-x-1.5 whitespace-nowrap">
               <template v-if="hasExecutionStats(agent.name)">
                 <span class="font-medium text-gray-700 dark:text-gray-300">{{ getExecutionStats(agent.name).taskCount }} tasks</span>
-                <template v-if="getExecutionStats(agent.name).totalCost > 0">
+                <template v-if="shouldShowMeteredCost(agent.usage) && getExecutionStats(agent.name).totalCost > 0">
                   <span class="text-gray-300 dark:text-gray-600">·</span>
-                  <span class="font-medium text-gray-700 dark:text-gray-300">{{ formatCostCompact(getExecutionStats(agent.name).totalCost) }}</span>
+                  <span class="font-medium text-gray-700 dark:text-gray-300" title="Anthropic API · metered">{{ formatCostCompact(getExecutionStats(agent.name).totalCost) }}</span>
+                </template>
+                <template v-else-if="agent.usage?.billing_mode === 'subscription'">
+                  <span class="text-gray-300 dark:text-gray-600">·</span>
+                  <span class="font-medium text-gray-700 dark:text-gray-300" :title="usageDetail(agent.usage)">{{ dashboardUsageText(agent.usage) }}</span>
                 </template>
               </template>
               <span v-else class="text-gray-400 dark:text-gray-500">--</span>
@@ -702,6 +706,11 @@ import CapacityMeter from './CapacityMeter.vue'
 import { ServerIcon } from '@heroicons/vue/24/outline'
 import axios from 'axios'
 import { syncHealthColor, syncHealthLabel as syncHealthLabelFn } from '../utils/syncHealth'
+import {
+  dashboardUsageText,
+  shouldShowMeteredCost,
+  usageDetail,
+} from '../utils/usagePresentation'
 
 const props = defineProps({
   // The chassis-visible fleet (networkStore.visibleAgents — server-side tag

--- a/src/frontend/src/components/AgentTile.vue
+++ b/src/frontend/src/components/AgentTile.vue
@@ -131,7 +131,14 @@
       </span>
       <span v-if="hasTasks" class="t-stats">
         <b>{{ stats.taskCount }}</b> tasks <span class="dim">·</span>
-        <b>{{ formatCostCompact(stats.totalCost || 0) }}</b> <span class="dim">·</span>
+        <template v-if="shouldShowMeteredCost(agent.usage)">
+          <b title="Anthropic API · metered">{{ formatCostCompact(stats.totalCost || 0) }}</b>
+          <span class="dim">·</span>
+        </template>
+        <b v-else-if="agent.usage?.billing_mode === 'subscription'" :title="usageDetail(agent.usage)">
+          {{ dashboardUsageText(agent.usage) }}
+        </b>
+        <span v-if="agent.usage?.billing_mode === 'subscription'" class="dim">·</span>
         {{ lastExecutionDisplay }}
       </span>
       <span v-else class="t-stats empty">No tasks (24h)</span>
@@ -176,6 +183,11 @@
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { formatCostCompact } from '../composables/useFormatters'
+import {
+  dashboardUsageText,
+  shouldShowMeteredCost,
+  usageDetail,
+} from '../utils/usagePresentation'
 import AgentAvatar from './AgentAvatar.vue'
 import RuntimeBadge from './RuntimeBadge.vue'
 import { agentDisplayName, agentNameTooltip } from '../utils/agentName'
@@ -331,6 +343,19 @@ const chips = computed(() => {
       title: runnerStatus.value.enabled
         ? `${runnerStatus.value.grant_count} grant(s) across ${runnerStatus.value.exposed_skill_count} skill(s)`
         : 'The skill runner exists but skill execution is turned off',
+    })
+  }
+  if (props.agent.usage?.billing_mode === 'subscription') {
+    out.push({
+      kind: 'calm',
+      text: dashboardUsageText(props.agent.usage),
+      title: usageDetail(props.agent.usage),
+    })
+  } else if (props.agent.usage?.billing_mode === 'api') {
+    out.push({
+      kind: 'calm',
+      text: 'API · metered',
+      title: usageDetail(props.agent.usage),
     })
   }
   // Calm facts after problems. The system agent gets these too — an empty

--- a/src/frontend/src/components/ReplayTimeline.vue
+++ b/src/frontend/src/components/ReplayTimeline.vue
@@ -217,9 +217,13 @@
                   <span>tasks</span>
                   <span class="text-gray-300 dark:text-gray-500">·</span>
                   <span :class="getSuccessRateClass(row.executionStats.successRate)" class="font-medium">{{ Math.round(row.executionStats.successRate || 0) }}%</span>
-                  <template v-if="row.executionStats.totalCost > 0">
+                  <template v-if="shouldShowMeteredCost(row.usage) && row.executionStats.totalCost > 0">
+                    <span class="text-gray-300 dark:text-gray-400">·</span>
+                    <span class="font-medium" title="Anthropic API · metered">{{ formatCostCompact(row.executionStats.totalCost) }}</span>
+                  </template>
+                  <template v-else-if="row.usage?.billing_mode === 'subscription'">
                     <span class="text-gray-300 dark:text-gray-500">·</span>
-                    <span class="font-medium">{{ formatCostCompact(row.executionStats.totalCost) }}</span>
+                    <span class="font-medium" :title="usageDetail(row.usage)">{{ dashboardUsageText(row.usage) }}</span>
                   </template>
                 </template>
                 <template v-else>
@@ -399,6 +403,11 @@
 <script setup>
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import { formatCostCompact } from '../composables/useFormatters'
+import {
+  dashboardUsageText,
+  shouldShowMeteredCost,
+  usageDetail,
+} from '../utils/usagePresentation'
 import { useRouter } from 'vue-router'
 import { useAgentsStore } from '../stores/agents'
 import { agentNameTooltip, agentDisplayName, hasDistinctLabel } from '../utils/agentName'
@@ -787,6 +796,7 @@ const agentRows = computed(() => {
       contextPercent: ctxStats.contextPercent || 0,
       activityState: ctxStats.activityState || (agent.status === 'running' ? 'idle' : 'offline'),
       executionStats: execStats,
+      usage: agent.usage || null,
       slotStats: slotData
     }
   })

--- a/src/frontend/src/components/TasksPanel.vue
+++ b/src/frontend/src/components/TasksPanel.vue
@@ -78,9 +78,19 @@
           {{ successRate }}%
         </p>
       </div>
-      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
-        <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Total Cost</p>
-        <p class="text-base font-semibold text-gray-900 dark:text-white font-mono">{{ formatCostCompact(totalCost) }}</p>
+      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2" :title="usageDetail(usage)">
+        <template v-if="shouldShowMeteredCost(usage)">
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">API Cost · Metered</p>
+          <p class="text-base font-semibold text-gray-900 dark:text-white font-mono">{{ formatCostCompact(totalCost) }}</p>
+        </template>
+        <template v-else-if="usage?.billing_mode === 'subscription'">
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Subscription Allowance</p>
+          <p class="text-base font-semibold text-gray-900 dark:text-white">{{ dashboardUsageText(usage) }}</p>
+        </template>
+        <template v-else>
+          <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Usage</p>
+          <p class="text-base font-semibold text-gray-500 dark:text-gray-400">Not configured</p>
+        </template>
       </div>
       <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
         <p class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Avg Duration</p>
@@ -256,7 +266,7 @@
               <div class="flex items-center space-x-4 mt-2 text-xs text-gray-500 dark:text-gray-400">
                 <span v-if="task.model_used" class="font-mono bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">{{ task.model_used }}</span>
                 <span v-if="task.duration_ms" class="font-mono">{{ formatDuration(task.duration_ms) }}</span>
-                <span v-if="task.cost" class="font-mono">{{ formatCost(task.cost) }}</span>
+                <span v-if="shouldShowMeteredCost(usage) && task.cost" class="font-mono" title="Anthropic API · metered">{{ formatCost(task.cost) }}</span>
                 <div v-if="task.context_used && task.context_max" class="flex items-center space-x-1">
                   <div class="w-16 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
                     <div
@@ -548,6 +558,11 @@ import { formatCost, formatCostCompact } from '../composables/useFormatters'
 import ModelSelector from './ModelSelector.vue'
 import LoadFailed from './LoadFailed.vue'
 import { apiErrorMessage } from '../utils/apiError'
+import {
+  dashboardUsageText,
+  shouldShowMeteredCost,
+  usageDetail,
+} from '../utils/usagePresentation'
 
 // Template ref for highlighted task element
 const highlightedTaskRef = ref(null)
@@ -560,6 +575,10 @@ const props = defineProps({
   agentStatus: {
     type: String,
     default: 'stopped'
+  },
+  usage: {
+    type: Object,
+    default: null
   },
   highlightExecutionId: {
     type: String,

--- a/src/frontend/src/utils/usagePresentation.js
+++ b/src/frontend/src/utils/usagePresentation.js
@@ -1,0 +1,58 @@
+function formatPercent(value) {
+  if (!Number.isFinite(value)) return '—'
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}
+
+function formatTimestamp(value) {
+  if (!value) return 'never'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'unknown'
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+export function shouldShowMeteredCost(usage) {
+  return usage?.billing_mode === 'api'
+}
+
+export function usageBadgeLabel(usage) {
+  if (usage?.billing_mode === 'subscription') {
+    return `Claude subscription · ${usage.subscription?.name || 'Unnamed'}`
+  }
+  if (usage?.billing_mode === 'api') return 'Anthropic API · metered'
+  return 'Claude auth not configured'
+}
+
+export function dashboardUsageText(usage) {
+  if (usage?.billing_mode === 'subscription') {
+    const name = usage.subscription?.name || 'Subscription'
+    const utilization = usage.utilization
+    if (utilization?.status === 'available') {
+      return `${name} · ${formatPercent(utilization.percent)}% used`
+    }
+    return `${name} · usage unavailable`
+  }
+  if (usage?.billing_mode === 'api') return 'API · metered'
+  return 'Usage not configured'
+}
+
+export function usageDetail(usage) {
+  if (usage?.billing_mode === 'subscription') {
+    const utilization = usage.utilization
+    if (utilization?.status === 'available') {
+      const reset = utilization.resets_at
+        ? ` · Resets ${formatTimestamp(utilization.resets_at)}`
+        : ''
+      return `${formatPercent(utilization.percent)}% of ${utilization.window}${reset} · Updated ${formatTimestamp(utilization.last_updated_at)}`
+    }
+    return `Usage unavailable · Last updated: ${formatTimestamp(utilization?.last_updated_at)}`
+  }
+  if (usage?.billing_mode === 'api') {
+    return 'Metered Anthropic API usage; dollar values are cost-oriented.'
+  }
+  return 'No Claude subscription or Anthropic API billing identity is configured.'
+}

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -137,7 +137,7 @@
             <!-- Tasks Tab Content (#1500: fullscreen flex-fill like Chat; padding
                  lives on TasksPanel's scroll root so content scrolls under it) -->
             <div v-if="activeTab === 'tasks'" class="flex-1 min-h-0 flex flex-col overflow-hidden">
-              <TasksPanel :agent-name="agent.name" :agent-status="agent.status" :highlight-execution-id="route.query.execution" :initial-message="taskPrefillMessage" @create-schedule="handleCreateSchedule" />
+              <TasksPanel :agent-name="agent.name" :agent-status="agent.status" :usage="authStatus?.usage || agent.usage" :highlight-execution-id="route.query.execution" :initial-message="taskPrefillMessage" @create-schedule="handleCreateSchedule" />
             </div>
 
             <!-- Chat Tab Content.

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -1263,6 +1263,9 @@
                           Type
                         </th>
                         <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                          Allowance usage
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                           Agents
                         </th>
                         <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -1275,12 +1278,12 @@
                     </thead>
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                       <tr v-if="loadingSubscriptions">
-                        <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+                        <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
                           <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-action-primary-600 mx-auto"></div>
                         </td>
                       </tr>
                       <tr v-else-if="subscriptions.length === 0">
-                        <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+                        <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
                           No subscriptions registered. Add one above using your Claude credentials.
                         </td>
                       </tr>
@@ -1300,6 +1303,9 @@
                               {{ sub.subscription_type === 'max' ? 'Max' : sub.subscription_type === 'pro' ? 'Pro' : sub.subscription_type }}
                             </span>
                             <span v-else class="text-sm text-gray-500 dark:text-gray-400">—</span>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-300">
+                            <span :title="usageDetail(sub.usage)">{{ dashboardUsageText(sub.usage) }}</span>
                           </td>
                           <td class="px-6 py-4 whitespace-nowrap">
                             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">
@@ -1321,7 +1327,7 @@
                         </tr>
                         <!-- Expanded Details Row -->
                         <tr v-if="expandedSubscriptions.has(sub.id)" class="bg-gray-50 dark:bg-gray-700/50">
-                          <td colspan="5" class="px-6 py-4">
+                          <td colspan="6" class="px-6 py-4">
                             <div class="text-sm">
                               <div class="mb-2 text-gray-600 dark:text-gray-400">
                                 <strong>Owner:</strong> {{ sub.owner_email || 'Unknown' }}
@@ -2364,6 +2370,7 @@ import { agentDisplayName, agentOptionLabel } from '../utils/agentName'
 import { useSettingsStore } from '../stores/settings'
 import { useSessionsStore } from '../stores/sessions'
 import { apiErrorMessage } from '../utils/apiError'
+import { dashboardUsageText, usageDetail } from '../utils/usagePresentation'
 import { useEnterpriseStore } from '../stores/enterprise'
 import NavBar from '../components/NavBar.vue'
 import McpKeysTab from '../components/settings/McpKeysTab.vue'

--- a/src/frontend/tests/unit/usagePresentation.spec.js
+++ b/src/frontend/tests/unit/usagePresentation.spec.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  dashboardUsageText,
+  shouldShowMeteredCost,
+  usageBadgeLabel,
+  usageDetail,
+} from '@/utils/usagePresentation'
+
+const subscription = (utilization) => ({
+  billing_mode: 'subscription',
+  provider: 'anthropic',
+  subscription: { id: 'sub-1', name: 'studio-max', plan: 'max' },
+  utilization,
+})
+
+describe('Claude subscription usage presentation', () => {
+  it('shows the named subscription and suppresses dollar cost', () => {
+    const usage = subscription({
+      status: 'unavailable',
+      percent: null,
+      window: null,
+      resets_at: null,
+      last_updated_at: null,
+      reason: 'provider_signal_unavailable',
+    })
+
+    expect(usageBadgeLabel(usage)).toBe('Claude subscription · studio-max')
+    expect(dashboardUsageText(usage)).toBe('studio-max · usage unavailable')
+    expect(usageDetail(usage)).toBe('Usage unavailable · Last updated: never')
+    expect(shouldShowMeteredCost(usage)).toBe(false)
+  })
+
+  it('shows percentage, window, reset, and freshness when a signal exists', () => {
+    const usage = subscription({
+      status: 'available',
+      percent: 42.5,
+      window: '5-hour rolling window',
+      resets_at: '2026-08-13T20:00:00Z',
+      last_updated_at: '2026-08-13T18:00:00Z',
+    })
+
+    expect(dashboardUsageText(usage)).toBe('studio-max · 42.5% used')
+    expect(usageDetail(usage)).toContain('42.5% of 5-hour rolling window')
+    expect(usageDetail(usage)).toContain('Resets')
+    expect(usageDetail(usage)).toContain('Updated')
+    expect(shouldShowMeteredCost(usage)).toBe(false)
+  })
+})
+
+describe('Anthropic API usage presentation', () => {
+  const usage = {
+    billing_mode: 'api',
+    provider: 'anthropic',
+    metering: 'metered',
+    cost_currency: 'USD',
+  }
+
+  it('labels API usage as metered and preserves cost semantics', () => {
+    expect(usageBadgeLabel(usage)).toBe('Anthropic API · metered')
+    expect(dashboardUsageText(usage)).toBe('API · metered')
+    expect(shouldShowMeteredCost(usage)).toBe(true)
+  })
+})
+
+describe('other runtimes', () => {
+  it('does not infer Anthropic API cost semantics without Claude usage data', () => {
+    expect(shouldShowMeteredCost(null)).toBe(false)
+    expect(dashboardUsageText(null)).toBe('Usage not configured')
+  })
+})

--- a/tests/test_subscription_usage.py
+++ b/tests/test_subscription_usage.py
@@ -21,8 +21,11 @@ from testkit.assertions import (
 
 VALID_TOKEN = "sk-ant-oat01-test-sub-usage-token-12345"
 
-USAGE_WINDOW_FIELDS = ["input_tokens", "output_tokens", "cost_usd", "message_count"]
-USAGE_FIELDS = ["subscription_id", "window_5h", "window_7d", "agents"]
+USAGE_WINDOW_FIELDS = ["input_tokens", "output_tokens", "message_count"]
+USAGE_FIELDS = [
+    "billing_mode", "provider", "subscription_id", "subscription_name",
+    "subscription_type", "utilization", "window_5h", "window_7d", "agents",
+]
 
 
 # =============================================================================
@@ -60,6 +63,11 @@ class TestSubscriptionUsage:
         assert_status(response, 200)
         data = assert_json_response(response)
         assert_has_fields(data, USAGE_FIELDS)
+        assert data["billing_mode"] == "subscription"
+        assert data["provider"] == "anthropic"
+        assert data["subscription_name"] == self.subscription["name"]
+        assert data["utilization"]["status"] == "unavailable"
+        assert data["utilization"]["percent"] is None
 
     @pytest.mark.smoke
     def test_usage_window_fields(self, api_client: TrinityApiClient):
@@ -82,7 +90,7 @@ class TestSubscriptionUsage:
             window = data[window_key]
             assert window["input_tokens"] == 0, f"{window_key}.input_tokens should be 0"
             assert window["output_tokens"] == 0, f"{window_key}.output_tokens should be 0"
-            assert window["cost_usd"] == 0.0, f"{window_key}.cost_usd should be 0"
+            assert "cost_usd" not in window, f"{window_key} must not expose subscription dollars"
             assert window["message_count"] == 0, f"{window_key}.message_count should be 0"
 
     @pytest.mark.smoke

--- a/tests/unit/test_subscription_usage_presentation.py
+++ b/tests/unit/test_subscription_usage_presentation.py
@@ -1,0 +1,100 @@
+"""Claude subscription and metered API usage must never share semantics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from db_models import SubscriptionUsageWindow, SubscriptionUtilizationAvailable
+from services import subscription_service
+from services.subscription_service import build_agent_usage_presentation
+
+
+def test_subscription_usage_names_the_subscription_and_has_no_cost_metric():
+    usage = build_agent_usage_presentation(
+        subscription=SimpleNamespace(
+            id="sub-1",
+            name="studio-max",
+            subscription_type="max",
+        ),
+        has_api_key=True,
+    )
+
+    payload = usage.model_dump(mode="json")
+    assert payload["billing_mode"] == "subscription"
+    assert payload["provider"] == "anthropic"
+    assert payload["subscription"] == {
+        "id": "sub-1",
+        "name": "studio-max",
+        "plan": "max",
+    }
+    assert payload["utilization"]["status"] == "unavailable"
+    assert payload["utilization"]["percent"] is None
+    assert payload["utilization"]["last_updated_at"] is None
+    assert payload["utilization"]["reason"] == "provider_signal_unavailable"
+    assert "cost" not in payload
+
+
+def test_api_usage_is_explicitly_metered_and_cost_oriented():
+    usage = build_agent_usage_presentation(subscription=None, has_api_key=True)
+
+    assert usage.model_dump(mode="json") == {
+        "billing_mode": "api",
+        "provider": "anthropic",
+        "metering": "metered",
+        "cost_currency": "USD",
+    }
+
+
+def test_unconfigured_usage_does_not_claim_subscription_or_api_billing():
+    usage = build_agent_usage_presentation(subscription=None, has_api_key=False)
+
+    assert usage.model_dump(mode="json") == {
+        "billing_mode": "unconfigured",
+        "provider": "anthropic",
+    }
+
+
+def test_available_subscription_utilization_carries_percent_window_and_freshness():
+    utilization = SubscriptionUtilizationAvailable(
+        percent=42.5,
+        window="5-hour rolling window",
+        resets_at="2026-08-13T20:00:00Z",
+        last_updated_at="2026-08-13T18:00:00Z",
+    )
+
+    payload = utilization.model_dump(mode="json")
+    assert payload == {
+        "status": "available",
+        "percent": 42.5,
+        "window": "5-hour rolling window",
+        "resets_at": "2026-08-13T20:00:00Z",
+        "last_updated_at": "2026-08-13T18:00:00Z",
+    }
+
+
+def test_subscription_activity_window_has_no_dollar_cost_field():
+    payload = SubscriptionUsageWindow(
+        input_tokens=1200,
+        output_tokens=300,
+        message_count=4,
+    ).model_dump()
+
+    assert payload == {
+        "input_tokens": 1200,
+        "output_tokens": 300,
+        "message_count": 4,
+    }
+
+
+@pytest.mark.asyncio
+async def test_non_claude_runtime_does_not_receive_anthropic_usage(monkeypatch):
+    monkeypatch.setattr(subscription_service.db, "get_agent_subscription", lambda _name: None)
+    monkeypatch.setattr(subscription_service.db, "get_use_platform_api_key", lambda _name: True)
+    monkeypatch.setattr(subscription_service, "get_agent_runtime", lambda _name: "codex")
+
+    status = await subscription_service.get_agent_auth_mode("codex-agent")
+
+    assert status.auth_mode == "api_key"
+    assert status.usage is None


### PR DESCRIPTION
## Summary

- add a discriminated `subscription` / `api` / `unconfigured` usage contract to agent auth, agent list/detail, and subscription responses
- show each Claude subscription-backed agent's named subscription and provider-backed allowance percentage/window/reset metadata when available
- return an explicit `provider_signal_unavailable` state today because Trinity has no reliable Claude allowance counter; never substitute token totals or Claude Code dollar estimates
- keep Anthropic API usage explicitly labelled `API · metered` with USD cost semantics
- update the agent header, Tasks summary, Dashboard grid/list/timeline, and Settings subscriptions table
- suppress Anthropic presentation entirely for non-Claude runtimes

## Provider data limitation

Claude setup-token authentication currently exposes no reliable allowance percentage/window/reset signal to Trinity. The new model supports an available state, but production responses remain honest and explicit until an authenticated provider signal can supply percent consumed, window identity, observation time, and reset time when defined.

## Verification

- `pytest tests/unit/test_subscription_usage_presentation.py -q` — 6 passed
- frontend unit suite — 311 passed
- focused Ruff — passed
- focused mypy — passed
- Python compileall — passed
- design-token check — passed
- production Vite build — passed
- staged Gitleaks scan — no leaks
- headed local Playwright review verified subscription, API-metered, and Settings presentation states

## Notes

- No credentials, subscriptions, or provider authentication were changed.
- No deployment or merge was performed.