### PR TITLE
fix(workspace): Overview layout — activity + recent work share a 50/50 row, asks below, avatars get an edge (#2169)

### DIFF
--- a/docs/memory/feature-flows/workspace-agent-page.md
+++ b/docs/memory/feature-flows/workspace-agent-page.md
@@ -195,11 +195,21 @@ column that cap does not bind below ~1656px.
 332px — where the 30-day x-axis (one truncating 9px label per day) reads as
 nothing and a nine-bucket legend wraps three to five lines. At 1280px the column
 is ~460px. A layout that technically satisfies "two columns" while making the
-left one unreadable fails the purpose. **Known residual:** the 30-day x-axis
-still truncates in a half-width column (measured 5/6 shown ticks at 1280, 3/6 at
-1600); 7d and 14d are clean. The fix is width-responsive tick density inside
-`StackedBarChart.vue`, which the operator Overview also consumes — out of scope
-here, deliberately.
+left one unreadable fails the purpose.
+
+**Known residual, accepted:** the 30-day window's x-axis is ellipsis-clipped in a
+half-width column. Measured over a 1280→2000 sweep (Chromium, macOS system
+font — glyph widths are platform-dependent, so treat the band, not the counts, as
+the finding): all six ticks clipped at 1280–1320, four at 1360–1520, one at
+1600–1640, **none from ~1680 up**. It is bounded on the other side too — below
+1280 the row stacks and the chart is full width, which is *wider* than the
+pre-#2169 `max-w-2xl` cap, so it is clean there as well. So the affected band is
+roughly **1280–1680 on the 30-day window only**: 7d (the default) and 14d measure
+zero clipped ticks at every width, and the clipping is ellipsis-marked rather
+than silently wrong — the bars, the legend totals, and the hover tooltip's full
+date are all unaffected. The fix is width-responsive tick density inside
+`StackedBarChart.vue::showLabel`, which the operator Overview also consumes —
+out of scope here, deliberately.
 
 **Moving asks below reverses #2161's DOM-order decision**, on instruction. The
 residual is bounded rather than a priority inversion: the header carrying the

--- a/docs/memory/feature-flows/workspace-agent-page.md
+++ b/docs/memory/feature-flows/workspace-agent-page.md
@@ -158,25 +158,104 @@ keep asks where they are: the page's own reason to exist is that an agent can
 reach you when no chat is open, and a tab is a place you have to *go*. The defect
 was that they were unbounded, not that they were present. So they are contained
 instead — compact cards, the question clamped, the first five with a counted
-"Show all" toggle, and a two-column split beside recent work on wide screens.
+"Show all" toggle.
 
 Two constraints on that layout:
 
-* **Asks are first in DOM order**, so the mobile stack keeps the priority the
-  page was built around.
+* ~~**Asks are first in DOM order**, so the mobile stack keeps the priority the
+  page was built around.~~ **Superseded by #2169** — see below. Asks now sit
+  below the top row on every breakpoint, which on a narrow viewport puts them
+  third.
 * **No nested scroll region.** #2101 settled this on this surface: the page has
   one scroll axis, and a pane that scrolls inside a page that scrolls traps the
   gesture on touch. Containment is first-N-plus-toggle, not `overflow-y-auto`.
+  **Still true after #2169** — the section moved, its containment did not change.
 
 The badge reads `20+` at the cap, because `MAX_ASKS` truncates server-side — a
 bare "20" against 50 pending is a wrong number, not a rounded one.
+
+### The Overview row is unconditional, and asks moved below it (#2169)
+
+#2161 put asks and recent work in a grid whose column count was **bound to
+`asks.length`** (`:class="{ 'lg:grid-cols-2': asks.length }"`), with the chart
+alone above in a `max-w-2xl` section. That made the page's shape a function of
+its data: an agent with nothing waiting collapsed to one column, so the layout
+changed whenever a transient operator-queue item opened or closed.
+
+The top row is now **unconditional** and its occupants are the chart (left) and
+recent work (right); asks sit **below it at full width**, still only when there
+are any and still with no empty-state placeholder — an agent with nothing
+waiting must not advertise the section. Nothing has to collapse, because both
+row occupants already own an empty state ("No activity in this window." /
+"Nothing yet."). The chart's `max-w-2xl` went with the move: inside a half-width
+column that cap does not bind below ~1656px.
+
+**The split is `xl`, not `lg`, and that is arithmetic.** The Workspace holds a
+288px sidebar plus page padding and the 24px gap, so at 1024px each column is
+332px — where the 30-day x-axis (one truncating 9px label per day) reads as
+nothing and a nine-bucket legend wraps three to five lines. At 1280px the column
+is ~460px. A layout that technically satisfies "two columns" while making the
+left one unreadable fails the purpose. **Known residual:** the 30-day x-axis
+still truncates in a half-width column (measured 5/6 shown ticks at 1280, 3/6 at
+1600); 7d and 14d are clean. The fix is width-responsive tick density inside
+`StackedBarChart.vue`, which the operator Overview also consumes — out of scope
+here, deliberately.
+
+**Moving asks below reverses #2161's DOM-order decision**, on instruction. The
+residual is bounded rather than a priority inversion: the header carrying the
+Overview tab's ask-count badge is `shrink-0` and sits **outside** the page
+scroller, so a narrow viewport shows the count at every scroll position; only the
+ask text moves below the fold. If it needs reversing, the costed alternative is
+~3 lines — keep the asks section first in DOM inside the same grid with
+`xl:col-span-2 xl:order-last` — which reads identically on desktop and keeps asks
+first on mobile, at the price of a DOM/visual order split.
+
+The **loading skeleton** gained the same `xl` split. It was one column in front
+of what is now a two-column row, so every load ended in a reflow — and the
+no-asks agent this issue is about is exactly the case where skeleton and loaded
+state used to agree. Measured after the change: skeleton blocks and loaded
+sections land on identical boxes (x 312/876, y 198, w 540).
+
+### The avatar has an edge (#2169)
+
+`PortalAvatar` was a bare `rounded-full` span, so an image avatar with light
+edges bled into the sidebar and chat surfaces. It now carries
+`border border-gray-300 dark:border-gray-700` — the contract's `border-strong`
+pair, one line in the one shared component, reaching all fourteen call sites.
+
+Three things settled by measurement rather than preference:
+
+* **`border`, not `ring-inset`.** An inset ring paints below child content and
+  the `<img>` is exactly the padding box, so it is invisible on precisely the
+  image avatars this fixes — the edge would show on initials avatars only.
+* **`border`, not an outer ring.** `PortalChatRow` already passes
+  `ring-2 ring-gray-50 dark:ring-gray-950` into this component as the
+  stacked-avatar separator, and all Tailwind rings share `--tw-ring-*` and one
+  `box-shadow`. Border and ring are independent properties and compose; verified
+  at 5× magnification that the separator gap survives.
+* **`border-strong`, not `border`.** The reported case is the light theme:
+  `gray-200` against the sidebar's `gray-50` ground measures 1.19:1, an arc too
+  faint to see at 26px. `gray-300` is 1.41:1.
+
+`box-sizing: border-box` means the outer footprint is unchanged — measured exact
+at all nine sizes in use (16, 18, 20, 22, 26, 28, 30, 52, 64) — and the image
+insets 1px per side rather than clipping. The `+N` overflow chip in
+`PortalChatRow` is hand-rolled rather than a `PortalAvatar`, so it carries the
+same recipe explicitly; without it a four-agent row draws three hairlined circles
+and one bare blob.
+
+Geometry is the one thing this project's unit tests structurally cannot see (no
+layout engine, no mount harness — the ent#245 class), so it is pinned by
+`e2e/portal-agent-page-overview.spec.js` (`@interactive`) and verified in the
+browser in both themes.
 
 ### The chart is the operator surface's chart
 
 The header's bespoke full-bleed CSS bar strip is gone; the Overview opens with a
 bounded card rendering `StackedBarChart.vue`, the same component Agent Detail
 uses (#1107). The payload already carried everything it needs, so this is a
-deletion plus a mount.
+deletion plus a mount. (#2169 moved that card into the left half of the top row
+and dropped its width cap; the component and its props are unchanged.)
 
 Two things moved to make that honest rather than duplicated:
 
@@ -246,7 +325,9 @@ destination" is finally true.
 | DB | `client_portal/db.py` | `first_try_stats` |
 | Router | `client_portal/router.py` | 3 endpoints, roster-gated |
 | Models | `client_portal/models.py` | page / ask / work / stats / report models; `schedule_name`, `buckets` (#2161) |
-| UI | `components/portal/PortalAgentPage.vue` | **new** — header, stats strip, 5 tabs; chart card + contained asks (#2161) |
+| UI | `components/portal/PortalAgentPage.vue` | **new** — header, stats strip, 5 tabs; chart card + contained asks (#2161); unconditional `xl` 50/50 top row, asks below it, two-column skeleton (#2169) |
+| UI | `components/portal/PortalAvatar.vue` | 1px `border-strong` edge, both themes (#2169) |
+| UI | `components/portal/PortalChatRow.vue` | same edge on the hand-rolled `+N` overflow chip (#2169) |
 | UI | `components/portal/PortalSidebar.vue` | roster row emits `open-agent` |
 | UI | `components/portal/portalUtils.js` | `shouldEscapeStage`, `PORTAL_BUCKET_LABELS` (#2161) |
 | UI | `components/StackedBarChart.vue` | optional `labels` prop (#2161) |

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -442,9 +442,26 @@
   - Stats strip: tasks in window, completed rate, first-try rate, window selector
     (shown only on the tabs the window drives)
   - Tabs: Overview · Reports · Files · What it can do · Activity
-  - Overview: activity chart (the shared `StackedBarChart`, #1107 — bounded, not
-    a full-bleed strip), then **open asks** beside recent work, then this user's
-    chats. Asks stay first in DOM order so the mobile stack keeps the priority
+  - Overview: an **unconditional 50/50 top row** — the activity chart (the shared
+    `StackedBarChart`, #1107 — bounded, not a full-bleed strip) on the left,
+    recent work on the right — then **open asks** full width below it, then this
+    user's chats. The row splits at `xl`, not `lg`, and stacks below that: with
+    the Workspace's 288px sidebar a 1024px viewport leaves each column 332px,
+    where a 30-day x-axis truncates to nothing (#2169). The column count is
+    independent of the data — both occupants own an empty state, so the split
+    never collapses; keying it off `asks.length` was the #2169 defect
+  - **#2161's "asks stay first in DOM order so the mobile stack keeps the
+    priority" is superseded by #2169**, deliberately and on instruction:
+    below `xl` asks are now third. Recorded rather than dropped, because the
+    rationale was real. The residual is bounded — the Overview tab's ask-count
+    badge sits in the header, outside the page scroller, so a narrow viewport
+    still shows the count at every scroll position; only the ask text moves
+    below the fold. What #2161 decided about the asks *card* is untouched:
+    they stay on the Overview (not a tab), contained in place, no nested scroll
+  - `PortalAvatar` carries a 1px `border-strong` edge in both themes (#2169), so
+    an image avatar with light edges does not bleed into the surface behind it.
+    One shared component, fourteen call sites; `box-sizing: border-box` keeps
+    every outer footprint unchanged
   - Everything DB-sourced, so a **stopped** agent renders degraded, not empty:
     health `unknown` (monitoring is default-OFF, so "unhealthy" would be a lie),
     empty sections, and a failing data source degrades that section only

--- a/src/frontend/e2e/portal-agent-page-overview.spec.js
+++ b/src/frontend/e2e/portal-agent-page-overview.spec.js
@@ -1,0 +1,177 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Workspace agent page — Overview geometry (#2169).
+ *
+ * The three defects this pins are all layout, and layout is the one thing the
+ * unit suite structurally cannot see: node/vitest has no layout engine and this
+ * project has no component-mount harness, so a source guard can prove the class
+ * is on the element and nothing more. The recorded precedent is ent#245 — a
+ * wrapper interposed a box, percentage-sized children rendered 24px inside a
+ * 32px zone, and it was green in every unit and e2e test because nothing
+ * measured. So the assertions here are all `getBoundingClientRect`.
+ *
+ * What must hold:
+ *   1. the top row is TWO equal columns whether or not the agent has open asks
+ *      — the column count used to be bound to `asks.length`, so the page
+ *      changed shape when a transient operator-queue item opened or closed
+ *   2. "Waiting on you", when present, is BELOW that row and full width — not a
+ *      third column inside it
+ *   3. below the `xl` breakpoint the row stacks, with no horizontal overflow
+ *   4. every avatar keeps its outer footprint — the edge is drawn inside the
+ *      box (border-box), so no row alignment moves
+ *
+ * The breakpoint is `xl` (1280) and not `lg` (1024) on measurement, not taste:
+ * the Workspace holds a 288px sidebar, so at 1024 each column is ~332px, where
+ * the 30-day x-axis truncates to nothing and the nine-bucket legend wraps three
+ * to five lines. 1024 is therefore asserted as a STACKED width here, which is
+ * the opposite of what an `lg` reading of the issue would expect.
+ *
+ * @interactive — needs a live stack and a real agent on the caller's roster.
+ * The portal is reachable from the cached admin session
+ * (`isClientSignedIn = !!portalToken || isPlatformSession`).
+ *
+ * Required env: ADMIN_PASSWORD (auth.setup.js) and PORTAL_TEST_AGENT
+ * (defaults to "testfix"). The agent must exist and be visible to the admin.
+ */
+
+const TEST_AGENT = process.env.PORTAL_TEST_AGENT || 'testfix'
+
+const STACKED = [640, 900, 1024, 1279]
+const SPLIT = [1280, 1440, 1600]
+
+// Locate the two top-row sections by their headings and report their boxes.
+// Headings rather than classes: a class selector re-encodes the implementation
+// the test exists to check, so it would pass on a grid that renders wrong.
+const PROBE = () => {
+  const heading = (text) =>
+    [...document.querySelectorAll('h2')].find((h) =>
+      (h.textContent || '').trim().startsWith(text)
+    )
+
+  const sectionFor = (text) => {
+    const h = heading(text)
+    return h ? h.closest('section') : null
+  }
+
+  const box = (el) => {
+    if (!el) return null
+    const r = el.getBoundingClientRect()
+    return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) }
+  }
+
+  const activity = sectionFor('Activity ·')
+  const work = sectionFor('Recent work')
+  const asks = sectionFor('Waiting on you')
+
+  return {
+    found: { activity: !!activity, work: !!work, asks: !!asks },
+    activity: box(activity),
+    work: box(work),
+    asks: box(asks),
+    // Page-level horizontal overflow, the failure a narrow viewport produces.
+    overflowX: Math.round(
+      document.documentElement.scrollWidth - document.documentElement.clientWidth
+    ),
+  }
+}
+
+// Outer footprint of every portal avatar, keyed by its title (the agent name).
+// The edge is a border on a border-box element, so these must be exactly the
+// sizes the call sites pass — 1px of growth here shifts every row it sits in.
+const AVATAR_PROBE = () =>
+  [...document.querySelectorAll('span.rounded-full')]
+    .filter((s) => s.style && s.style.width && s.style.height)
+    .map((s) => {
+      const r = s.getBoundingClientRect()
+      return {
+        declared: parseInt(s.style.width, 10),
+        w: Math.round(r.width),
+        h: Math.round(r.height),
+      }
+    })
+
+const openAgent = async (page) => {
+  await page.goto(`/workspace/a/${TEST_AGENT}`)
+  // The Overview heading only renders once the page payload lands; the header
+  // and tabs paint from the route, so waiting on the shell would race.
+  await expect(page.getByRole('heading', { name: /^Activity ·/ })).toBeVisible({ timeout: 20000 })
+}
+
+test.describe('Workspace agent page Overview layout', () => {
+  test('@interactive the top row is two equal columns at every split width', async ({ page }) => {
+    await openAgent(page)
+
+    for (const width of SPLIT) {
+      await page.setViewportSize({ width, height: 900 })
+      const m = await page.evaluate(PROBE)
+
+      expect(m.found, `sections present at ${width}`).toMatchObject({ activity: true, work: true })
+      // Same row: equal top edge, side by side.
+      expect(Math.abs(m.activity.y - m.work.y), `same row at ${width}`).toBeLessThanOrEqual(1)
+      expect(m.work.x, `recent work sits right of activity at ${width}`).toBeGreaterThan(m.activity.x)
+      // 50/50, within a pixel of rounding.
+      expect(Math.abs(m.activity.w - m.work.w), `equal columns at ${width}`).toBeLessThanOrEqual(1)
+      expect(m.overflowX, `no horizontal overflow at ${width}`).toBeLessThanOrEqual(1)
+    }
+  })
+
+  test('@interactive the split does not depend on whether asks are present', async ({ page }) => {
+    // The headline AC. This is the assertion the unit guards cannot make: the
+    // conditional-class defect showed up as a DIFFERENT COLUMN WIDTH for the
+    // same agent depending on a transient operator-queue item, so what is
+    // compared here is geometry against an agent-independent expectation —
+    // each column is half the row, whichever of the two states this agent is in.
+    await openAgent(page)
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    const m = await page.evaluate(PROBE)
+    const rowWidth = m.work.x + m.work.w - m.activity.x
+
+    expect(Math.abs(m.activity.w - m.work.w)).toBeLessThanOrEqual(1)
+    // Neither column is the full row — which is exactly what the collapsed,
+    // no-asks state used to render.
+    expect(m.activity.w).toBeLessThan(rowWidth * 0.75)
+    expect(m.activity.w).toBeGreaterThan(rowWidth * 0.25)
+  })
+
+  test('@interactive asks, when present, sit below the row at full width', async ({ page }) => {
+    await openAgent(page)
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    const m = await page.evaluate(PROBE)
+    test.skip(!m.found.asks, `agent "${TEST_AGENT}" has no open asks — nothing to place`)
+
+    const rowBottom = Math.max(m.activity.y + m.activity.h, m.work.y + m.work.h)
+    expect(m.asks.y, 'below the row, not a third column in it').toBeGreaterThanOrEqual(rowBottom)
+    // Full width: spans from the activity column's left edge to recent work's
+    // right edge. A third grid child would be half of that.
+    const rowWidth = m.work.x + m.work.w - m.activity.x
+    expect(Math.abs(m.asks.w - rowWidth)).toBeLessThanOrEqual(2)
+  })
+
+  test('@interactive the row stacks below the breakpoint with no overflow', async ({ page }) => {
+    await openAgent(page)
+
+    for (const width of STACKED) {
+      await page.setViewportSize({ width, height: 900 })
+      const m = await page.evaluate(PROBE)
+
+      expect(m.work.y, `stacked at ${width}`).toBeGreaterThan(m.activity.y)
+      expect(Math.abs(m.activity.x - m.work.x), `same left edge at ${width}`).toBeLessThanOrEqual(1)
+      expect(m.overflowX, `no horizontal overflow at ${width}`).toBeLessThanOrEqual(1)
+    }
+  })
+
+  test('@interactive the avatar edge does not change any outer footprint', async ({ page }) => {
+    await openAgent(page)
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    const avatars = await page.evaluate(AVATAR_PROBE)
+    expect(avatars.length, 'at least the page header avatar').toBeGreaterThan(0)
+    for (const a of avatars) {
+      expect(a.w, `avatar declared ${a.declared}px renders ${a.w}px wide`).toBe(a.declared)
+      expect(a.h, `avatar declared ${a.declared}px renders ${a.h}px tall`).toBe(a.declared)
+    }
+  })
+})

--- a/src/frontend/src/components/portal/PortalAgentPage.vue
+++ b/src/frontend/src/components/portal/PortalAgentPage.vue
@@ -88,8 +88,16 @@
            payload arrives in one response, so this is honesty about WHERE
            content will appear rather than progressive arrival — the header and
            tabs above are already rendered from the route, so the page never
-           looks blank or hung while this fills in. -->
-      <div v-if="loading && !page" class="space-y-6" aria-busy="true">
+           looks blank or hung while this fills in.
+
+           The two blocks sit side by side at `xl`, mirroring the Overview's top
+           row (#2169). A one-column skeleton in front of a two-column row means
+           every load ends in a reflow — and the agent this issue is about, the
+           one with no asks, is exactly the case where skeleton and loaded state
+           used to agree. `grid gap-6` also supplies the row gap `space-y-6` did
+           when stacked. `tab` is 'overview' on first paint, which is the only
+           moment this renders. -->
+      <div v-if="loading && !page" class="grid gap-6 xl:grid-cols-2" aria-busy="true">
         <div v-for="sec in 2" :key="sec" class="animate-pulse">
           <div class="h-3 w-32 rounded bg-gray-200 dark:bg-gray-800 mb-3"></div>
           <div class="space-y-2">
@@ -102,62 +110,41 @@
 
       <!-- ---------------------------- OVERVIEW ---------------------------- -->
       <template v-else-if="tab === 'overview'">
-        <!-- Activity, in the same visual language as the operator Overview
-             (#1107): bounded, stacked by what triggered the work, both themes.
-             An empty window and an unreadable one are different sentences — a
-             blank chart frame for either would be the dead empty state. -->
-        <section class="mb-6 max-w-2xl">
-          <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
-            Activity · last {{ windowLabel }}
-          </h2>
-          <div class="rounded-xl border border-gray-200 dark:border-gray-800 px-3.5 py-3">
-            <p v-if="stats.unavailable" class="text-sm text-gray-400">Stats are unavailable right now.</p>
-            <p v-else-if="!hasActivity" class="text-sm text-gray-400">No activity in this window.</p>
-            <StackedBarChart
-              v-else
-              :data="stats.timeline || []"
-              :buckets="chartBuckets"
-              :colors="BUCKET_COLORS"
-              :labels="PORTAL_BUCKET_LABELS"
-              :height="110"
-            />
-          </div>
-        </section>
+        <!-- The top row is unconditional (#2169). It used to key its column
+             count off the ask count, so an agent with nothing waiting collapsed
+             to one column and the page changed shape whenever a transient
+             operator-queue item opened or closed — a layout that reports the
+             data instead of holding still for it. Both occupants own an empty
+             state ("No activity in this window." / "Nothing yet."), so the split
+             never has to collapse: structure is stable, only content varies.
 
-        <!-- Asks lead — that is the reason the page exists, it is where the
-             agent reaches the user when no chat is open. On a wide screen they
-             sit beside recent work rather than pushing it below the fold; they
-             stay FIRST in DOM order so the mobile stack keeps the priority. -->
-        <div class="mb-6 grid gap-6" :class="{ 'lg:grid-cols-2': asks.length }">
-          <section v-if="asks.length">
-            <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Waiting on you</h2>
-            <div
-              v-for="a in visibleAsks"
-              :key="a.id"
-              class="mb-2 rounded-xl border border-amber-300/70 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/10 px-3 py-2.5"
-            >
-              <div class="text-sm font-medium">{{ a.title || 'The agent needs a decision' }}</div>
-              <p v-if="a.question" class="mt-0.5 text-xs text-gray-600 dark:text-gray-300 line-clamp-3">{{ a.question }}</p>
-              <div v-if="a.options?.length" class="mt-1.5 flex flex-wrap gap-1">
-                <span v-for="o in a.options" :key="o" class="text-[11px] rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-1.5 py-0.5">{{ o }}</span>
-              </div>
-              <!-- Answering writes to the operator queue, an operator surface
-                   with its own auth. Rather than render a control that 403s for
-                   a client, the answer path is the conversation. -->
-              <button class="mt-1.5 text-xs text-action-primary-600 hover:underline" @click="$emit('start-chat', agentName)">
-                Reply in chat →
-              </button>
+             Two columns at `xl`, not `lg`, and that is arithmetic rather than
+             taste. The Workspace keeps a 288px sidebar plus 24px page padding
+             and a 24px gap, so at 1024px each column is 332px — where the 30d
+             x-axis (one truncating 9px label per day) reads as nothing and the
+             nine-bucket legend wraps three to five lines. At 1280px the column
+             is ~460px and both are legible. Below `xl` it stacks. -->
+        <div class="mb-6 grid gap-6 xl:grid-cols-2">
+          <!-- Activity, in the same visual language as the operator Overview
+               (#1107): bounded, stacked by what triggered the work, both themes.
+               An empty window and an unreadable one are different sentences — a
+               blank chart frame for either would be the dead empty state. -->
+          <section>
+            <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
+              Activity · last {{ windowLabel }}
+            </h2>
+            <div class="rounded-xl border border-gray-200 dark:border-gray-800 px-3.5 py-3">
+              <p v-if="stats.unavailable" class="text-sm text-gray-400">Stats are unavailable right now.</p>
+              <p v-else-if="!hasActivity" class="text-sm text-gray-400">No activity in this window.</p>
+              <StackedBarChart
+                v-else
+                :data="stats.timeline || []"
+                :buckets="chartBuckets"
+                :colors="BUCKET_COLORS"
+                :labels="PORTAL_BUCKET_LABELS"
+                :height="110"
+              />
             </div>
-            <!-- In place, not a nested scroll region: this page has one scroll
-                 axis (#2101), and a pane that scrolls inside a page that scrolls
-                 traps the gesture on touch. -->
-            <button
-              v-if="asks.length > ASKS_PREVIEW"
-              class="text-xs text-action-primary-600 hover:underline"
-              @click="allAsks = !allAsks"
-            >
-              {{ allAsks ? 'Show fewer' : `Show all ${asksBadge}` }}
-            </button>
           </section>
 
           <section>
@@ -173,6 +160,51 @@
             </ul>
           </section>
         </div>
+
+        <!-- Asks sit BELOW that row, full width, and only when there are any
+             (#2169). No empty state: an agent with nothing waiting must not
+             advertise the section.
+
+             This supersedes #2161's "asks are first in DOM order so the mobile
+             stack keeps the priority" — deliberately, on instruction, not by
+             oversight. The residual is bounded: the Overview tab's ask-count
+             badge lives in the header, which is `shrink-0` and sits OUTSIDE the
+             page scroller, so a narrow viewport still shows the count at every
+             scroll position; only the ask text moves below the fold.
+
+             Everything #2161 built into the card survives: compact cards, a
+             clamped question, the first five plus a counted toggle, and no
+             nested scroll region (#2101) — this page has one scroll axis. -->
+        <section v-if="asks.length" class="mb-6">
+          <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Waiting on you</h2>
+          <div
+            v-for="a in visibleAsks"
+            :key="a.id"
+            class="mb-2 rounded-xl border border-amber-300/70 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/10 px-3 py-2.5"
+          >
+            <div class="text-sm font-medium">{{ a.title || 'The agent needs a decision' }}</div>
+            <p v-if="a.question" class="mt-0.5 text-xs text-gray-600 dark:text-gray-300 line-clamp-3">{{ a.question }}</p>
+            <div v-if="a.options?.length" class="mt-1.5 flex flex-wrap gap-1">
+              <span v-for="o in a.options" :key="o" class="text-[11px] rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-1.5 py-0.5">{{ o }}</span>
+            </div>
+            <!-- Answering writes to the operator queue, an operator surface
+                 with its own auth. Rather than render a control that 403s for
+                 a client, the answer path is the conversation. -->
+            <button class="mt-1.5 text-xs text-action-primary-600 hover:underline" @click="$emit('start-chat', agentName)">
+              Reply in chat →
+            </button>
+          </div>
+          <!-- In place, not a nested scroll region: this page has one scroll
+               axis (#2101), and a pane that scrolls inside a page that scrolls
+               traps the gesture on touch. -->
+          <button
+            v-if="asks.length > ASKS_PREVIEW"
+            class="text-xs text-action-primary-600 hover:underline"
+            @click="allAsks = !allAsks"
+          >
+            {{ allAsks ? 'Show fewer' : `Show all ${asksBadge}` }}
+          </button>
+        </section>
 
         <section>
           <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Your chats with {{ agentName }}</h2>

--- a/src/frontend/src/components/portal/PortalAgentPage.vue
+++ b/src/frontend/src/components/portal/PortalAgentPage.vue
@@ -123,7 +123,14 @@
              and a 24px gap, so at 1024px each column is 332px — where the 30d
              x-axis (one truncating 9px label per day) reads as nothing and the
              nine-bucket legend wraps three to five lines. At 1280px the column
-             is ~460px and both are legible. Below `xl` it stacks. -->
+             is ~460px, which the legend needs and gets. Below `xl` it stacks.
+
+             `xl` reduces the x-axis residual rather than removing it: on the 30d
+             window the ticks stay ellipsis-clipped from 1280 to about 1680, and
+             are clean above that AND below 1280, where the row stacks and the
+             chart runs full width. 7d (the default) and 14d are clean at every
+             width. Accepted, not overlooked — the fix is width-responsive tick
+             density in StackedBarChart, which the operator Overview shares. -->
         <div class="mb-6 grid gap-6 xl:grid-cols-2">
           <!-- Activity, in the same visual language as the operator Overview
                (#1107): bounded, stacked by what triggered the work, both themes.

--- a/src/frontend/src/components/portal/PortalAvatar.vue
+++ b/src/frontend/src/components/portal/PortalAvatar.vue
@@ -1,6 +1,23 @@
 <template>
+  <!-- The edge (#2169). Gray is not a lapse from semantic tokens: the design
+       contract has no semantic token for a neutral edge — `status-*`/`action-*`
+       would claim this decoration reports a result or affords a click — and it
+       names this exact pair, `border-strong gray-300/gray-700`, as the shade for
+       separation. Do NOT "fix" it to a token, and do not soften it to the
+       lighter `border gray-200/gray-750`: measured against the sidebar ground
+       (gray-50) that is 1.19:1, an arc too faint to see at 26px, and the light
+       theme with a light-edged image avatar is precisely the case reported.
+       `border-strong` is 1.41:1 there.
+
+       `border`, not a ring: an inset ring paints below child content and the
+       <img> is exactly the padding box, so `ring-inset` is invisible on image
+       avatars — inverted from the case this fixes — and an outer ring collides
+       with the `ring-2` separator PortalChatRow already passes in (all Tailwind
+       rings share one box-shadow). Border and ring are independent properties.
+       box-sizing is border-box, so the outer footprint is unchanged at every
+       size and the image insets by 1px rather than clipping. -->
   <span
-    class="inline-flex shrink-0 items-center justify-center rounded-full overflow-hidden text-white font-semibold select-none"
+    class="inline-flex shrink-0 items-center justify-center rounded-full overflow-hidden border border-gray-300 dark:border-gray-700 text-white font-semibold select-none"
     :style="{ width: size + 'px', height: size + 'px', background: showImage ? 'transparent' : tint, fontSize: Math.round(size * 0.4) + 'px' }"
     :title="name"
   >

--- a/src/frontend/src/components/portal/PortalChatRow.vue
+++ b/src/frontend/src/components/portal/PortalChatRow.vue
@@ -23,9 +23,18 @@
         :size="22"
         class="ring-2 ring-gray-50 dark:ring-gray-950 rounded-full"
       />
+      <!-- The +N chip is hand-rolled rather than a PortalAvatar, so it does not
+           inherit that component's edge (#2169). Without this line a 4-agent row
+           draws three hairlined circles and one bare blob — and in light theme
+           the chip's own gray-200 fill would otherwise sit flush against the
+           gray-50 ground. Same `border-strong` recipe, class-sized and
+           border-box, so it stays 22px and `-space-x-1.5` is unaffected. In dark
+           the border matches the gray-700 fill and reads as a solid disc, which
+           is correct: there the chip is already separated from the gray-950
+           ground by its fill, and one recipe beats a second per-component one. -->
       <span
         v-if="avatars.overflow"
-        class="w-[22px] h-[22px] rounded-full bg-gray-200 dark:bg-gray-700 text-[10px] font-semibold text-gray-600 dark:text-gray-300 flex items-center justify-center ring-2 ring-gray-50 dark:ring-gray-950"
+        class="w-[22px] h-[22px] rounded-full border border-gray-300 dark:border-gray-700 bg-gray-200 dark:bg-gray-700 text-[10px] font-semibold text-gray-600 dark:text-gray-300 flex items-center justify-center ring-2 ring-gray-50 dark:ring-gray-950"
         :title="allAgentNames"
       >+{{ avatars.overflow }}</span>
     </span>

--- a/src/frontend/tests/unit/portalAgentPageUx.spec.js
+++ b/src/frontend/tests/unit/portalAgentPageUx.spec.js
@@ -1,7 +1,15 @@
 /**
- * #2161 — Workspace agent page UX repairs.
+ * #2161 / #2169 — Workspace agent page UX repairs.
  *
- * Two of the four defects are load-bearing enough to pin, and they fail in
+ * #2169 amended the containment block below rather than deleting from it. Two
+ * of its guards pinned rules that #2169 deliberately reverses — asks first in
+ * DOM order, and a two-column grid conditional on `asks.length` — and a deleted
+ * guard leaves no record that a rule was retired on purpose. They now assert the
+ * replacement rule and name the old one as the defect, the same way #2161 itself
+ * rewrote `workspaceRoomsGate.spec.js` F24. The chart guards and the
+ * scroll-region guard are untouched and must keep passing.
+ *
+ * Two of the four #2161 defects are load-bearing enough to pin, and they fail in
  * opposite ways:
  *
  *   1. **"Start a chat" did nothing.** Not a broken handler — the handler ran
@@ -233,9 +241,21 @@ describe('Overview containment', () => {
     expect(src).not.toMatch(/id:\s*'asks'/)
   })
 
-  it('puts asks first in DOM order so the mobile stack keeps the priority', () => {
+  it('orders the Overview activity → recent work → asks', () => {
+    // Reverses #2161's "asks first in DOM order so the mobile stack keeps the
+    // priority" (#2169). The reversal is deliberate and instructed, not a
+    // regression, and it is pinned rather than deleted so a later reader can
+    // see the rule was retired on purpose — the precedent is #2161 itself
+    // rewriting workspaceRoomsGate F24. The mobile residual is bounded: the
+    // ask-count badge lives in the header, outside the page scroller.
     const src = pageSource()
-    expect(src.indexOf('Waiting on you')).toBeLessThan(src.indexOf('>Recent work<'))
+    // Presence first. `indexOf` returns -1 for a deleted marker, and -1 is less
+    // than everything, so an ordering assertion alone passes on deletion.
+    expect(src).toContain('Activity · last')
+    expect(src).toContain('>Recent work<')
+    expect(src).toContain('Waiting on you')
+    expect(src.indexOf('Activity · last')).toBeLessThan(src.indexOf('>Recent work<'))
+    expect(src.indexOf('>Recent work<')).toBeLessThan(src.indexOf('Waiting on you'))
   })
 
   it('does not nest a scroll region inside the page scroller', () => {
@@ -255,9 +275,68 @@ describe('Overview containment', () => {
     expect(src).toMatch(/asks\.value\.length >= ASKS_CAP \? `\$\{ASKS_CAP\}\+`/)
   })
 
-  it('does not leave recent work at half width when there are no asks', () => {
-    // The asks column is v-if'd away when empty, so an unconditional two-column
-    // grid strands recent work in the left half with dead space beside it.
-    expect(pageSource()).toMatch(/'lg:grid-cols-2':\s*asks\.length/)
+  it('keeps the top row two columns whether or not there are asks', () => {
+    // The #2169 defect, inverted. The column count used to be bound to
+    // `asks.length`, so the page changed shape when a transient operator-queue
+    // item opened or closed. Both directions are asserted: the negative alone
+    // passes if the grid is deleted outright, and a looser positive says
+    // nothing about the two classes living on the SAME element.
+    const src = pageSource()
+    expect(src).not.toMatch(/grid-cols-2'?\s*:\s*asks\.length/)
+    expect(src).toMatch(/class="[^"]*\bgrid\b[^"]*\bxl:grid-cols-2\b[^"]*"/)
+  })
+
+  it('puts asks outside the top row, not in it as a third column', () => {
+    // Every other guard here is satisfied by an asks section left INSIDE the
+    // grid as a third child — half width, under the chart — so AC #3 could fail
+    // with a green suite. What separates the two layouts is whether the row's
+    // <div> has CLOSED by the time the asks section opens, and a bare
+    // `slice(grid, asks)).toContain('</div>')` does not answer that: the chart's
+    // own bordered card closes inside the row. So match the row's opening tag to
+    // its close by depth.
+    const src = pageSource()
+    const overview = src.indexOf("tab === 'overview'")
+    expect(overview).toBeGreaterThan(-1)
+
+    const gridClass = src.indexOf('xl:grid-cols-2', overview)
+    expect(gridClass).toBeGreaterThan(-1)
+    const gridOpen = src.lastIndexOf('<div', gridClass)
+    expect(gridOpen).toBeGreaterThan(overview)
+
+    let depth = 0
+    let i = gridOpen
+    let gridClose = -1
+    while (i < src.length) {
+      const open = src.indexOf('<div', i)
+      const close = src.indexOf('</div>', i)
+      if (close === -1) break
+      if (open !== -1 && open < close) { depth += 1; i = open + 4; continue }
+      depth -= 1
+      if (depth === 0) { gridClose = close; break }
+      i = close + 6
+    }
+    expect(gridClose).toBeGreaterThan(-1)
+
+    const asksAt = src.indexOf('Waiting on you')
+    expect(asksAt).toBeGreaterThan(gridClose)
+  })
+
+  it('lets the activity chart fill its column', () => {
+    // The chart carried `max-w-2xl` when it sat alone above a full-width row.
+    // Inside a half-width column that cap is dead weight below ~1656px, and the
+    // section it capped is now one of two equal columns.
+    const src = pageSource()
+    expect(src).toContain('Activity · last')
+    expect(src).not.toMatch(/max-w-2xl/)
+  })
+
+  it('does not advertise an asks section for an agent with nothing waiting', () => {
+    expect(pageSource()).toMatch(/<section v-if="asks\.length"/)
+  })
+
+  it('shapes the loading skeleton like the row it precedes', () => {
+    // Layout stability (contract principles #4/#6): a one-column skeleton in
+    // front of a two-column row reflows the page on every load.
+    expect(pageSource()).toMatch(/loading && !page"[^>]*class="[^"]*\bgrid\b[^"]*\bxl:grid-cols-2\b/)
   })
 })

--- a/src/frontend/tests/unit/portalAgentPageUx.spec.js
+++ b/src/frontend/tests/unit/portalAgentPageUx.spec.js
@@ -63,6 +63,18 @@ const portalSource = () => stripComments(readFileSync(PORTAL, 'utf8'))
 const pageSource = () => stripComments(readFileSync(PAGE, 'utf8'))
 const chartSource = () => stripComments(readFileSync(CHART, 'utf8'))
 
+// The Overview tab's template block only. Every `<template v-else-if="tab ===
+// '...'">` sibling — and the tab-agnostic loading skeleton above them all —
+// lives in the same file, so a file-wide match answers a question about the
+// wrong markup: the skeleton and the Overview row deliberately carry the same
+// grid classes, which is exactly why one cannot stand in for the other.
+const overviewBlock = (src) => {
+  const start = src.indexOf("tab === 'overview'")
+  expect(start).toBeGreaterThan(-1)
+  const end = src.indexOf("tab === '", start + 1)
+  return src.slice(start, end === -1 ? undefined : end)
+}
+
 // ---------------------------------------------------------------------------
 // 1. The stage escape
 // ---------------------------------------------------------------------------
@@ -281,9 +293,17 @@ describe('Overview containment', () => {
     // item opened or closed. Both directions are asserted: the negative alone
     // passes if the grid is deleted outright, and a looser positive says
     // nothing about the two classes living on the SAME element.
+    //
+    // The positive is scoped to the Overview block, and that scoping is the
+    // whole assertion. A file-wide match is satisfied by the LOADING SKELETON,
+    // which this same change gave the identical `grid gap-6 xl:grid-cols-2`
+    // string — so with the row's grid deleted outright, or its two classes
+    // split across two elements, the negative passed vacuously and the positive
+    // passed on the skeleton, and the headline AC failed with a green suite.
+    // Verified by planting both violations (learnings L2).
     const src = pageSource()
     expect(src).not.toMatch(/grid-cols-2'?\s*:\s*asks\.length/)
-    expect(src).toMatch(/class="[^"]*\bgrid\b[^"]*\bxl:grid-cols-2\b[^"]*"/)
+    expect(overviewBlock(src)).toMatch(/class="[^"]*\bgrid\b[^"]*\bxl:grid-cols-2\b[^"]*"/)
   })
 
   it('puts asks outside the top row, not in it as a third column', () => {

--- a/src/frontend/tests/unit/portalAvatarEdge.spec.js
+++ b/src/frontend/tests/unit/portalAvatarEdge.spec.js
@@ -1,0 +1,106 @@
+/**
+ * #2169 — the portal avatar's edge.
+ *
+ * A bare `rounded-full` span has no boundary, so an image avatar whose own edges
+ * are light bleeds into the sidebar and chat surfaces it sits on. `PortalAvatar`
+ * is the one shared component behind fourteen call sites, so the edge is one
+ * line there — and until this file, `PortalAvatar` had zero test references of
+ * any kind.
+ *
+ * What a source guard can and cannot do here is worth stating, because the
+ * distinction is why the browser pass is blocking rather than optional. Node has
+ * no layout engine and this project has no component-mount harness, so nothing
+ * below observes geometry: not the outer footprint, not the 1px inset on the
+ * <img>, not whether the edge is actually visible against a given ground. That
+ * is the ent#245 class recorded in learnings — a wrapper that interposes a box
+ * squashes percentage-sized children, silently, green in every unit test.
+ *
+ * What a source guard IS good for is the cross-component interaction, which is
+ * the last assertion here: `PortalChatRow` passes its own `ring-2` separator
+ * into this component, and "tidying up" that ring after the border landed would
+ * silently collapse the stacked-avatar gap with nothing failing.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+import { stripComments } from './helpers/stripComments'
+
+const AVATAR = fileURLToPath(new URL('../../src/components/portal/PortalAvatar.vue', import.meta.url))
+const CHAT_ROW = fileURLToPath(new URL('../../src/components/portal/PortalChatRow.vue', import.meta.url))
+
+const avatarSource = () => stripComments(readFileSync(AVATAR, 'utf8'))
+const chatRowSource = () => stripComments(readFileSync(CHAT_ROW, 'utf8'))
+
+// The root <span> carries the size style, so it is the element the edge belongs
+// on — an edge on the <img> would be absent for an initials avatar.
+const rootSpanClasses = (src) => {
+  const at = src.indexOf('<span')
+  expect(at).toBeGreaterThan(-1)
+  const attrs = src.slice(at, src.indexOf('>', at))
+  const m = attrs.match(/\sclass="([^"]*)"/)
+  expect(m).not.toBeNull()
+  return m[1]
+}
+
+describe('PortalAvatar edge', () => {
+  it('draws a border on the root span, in both themes', () => {
+    // A half-themed edge is the failure mode no other check sees: it looks
+    // right in whichever theme the author had open and vanishes in the other.
+    const classes = rootSpanClasses(avatarSource())
+    expect(classes).toMatch(/\bborder\b/)
+    expect(classes).toMatch(/\bborder-gray-\d+\b/)
+    expect(classes).toMatch(/\bdark:border-gray-\d+\b/)
+  })
+
+  it('uses gray, the contract shade for a neutral edge', () => {
+    // There is no semantic token for decoration that separates; `status-*` /
+    // `action-*` would claim this reports a result or affords a click. Gray is
+    // the sanctioned answer, and a raw non-gray palette class is not.
+    const classes = rootSpanClasses(avatarSource())
+    expect(classes).not.toMatch(/\b(dark:)?border-(red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+/)
+    expect(classes).not.toMatch(/border-\[#/)
+  })
+
+  it('is still a circle that clips its image', () => {
+    // A border on a square is a box, and dropping `overflow-hidden` lets a
+    // non-square image escape the radius the edge is drawn on.
+    const classes = rootSpanClasses(avatarSource())
+    expect(classes).toMatch(/\brounded-full\b/)
+    expect(classes).toMatch(/\boverflow-hidden\b/)
+  })
+
+  it('is not a ring, which would not survive the composition', () => {
+    // An inset ring paints below child content, and the <img> is exactly the
+    // padding box — so it is invisible on precisely the image avatars this
+    // fixes. An outer ring shares `--tw-ring-*` and one box-shadow with the
+    // separator ring PortalChatRow passes in, so the two collide.
+    expect(avatarSource()).not.toMatch(/\bring-(inset|\d)/)
+  })
+
+  it('leaves the stacked-row separator ring intact', () => {
+    // Two components, one element: the consumer paints a ring in the sidebar
+    // ground colour to punch a gap between overlapping avatars. Border and ring
+    // are independent properties and compose; removing the ring as "redundant"
+    // after adding the border would merge the stack back into a blob.
+    //
+    // Scoped to the <PortalAvatar> tag itself. A file-wide match for the ring
+    // string passes with the ring deleted from the avatar, because the +N chip
+    // beside it carries the identical classes — verified by planting exactly
+    // that violation and watching this guard stay green (learnings L2).
+    const src = chatRowSource()
+    const at = src.indexOf('<PortalAvatar')
+    expect(at).toBeGreaterThan(-1)
+    const tag = src.slice(at, src.indexOf('/>', at))
+    expect(tag).toMatch(/ring-2 ring-gray-50 dark:ring-gray-950/)
+  })
+
+  it('gives the +N overflow chip the same edge', () => {
+    // AC #6 says every instance, and the chip is hand-rolled rather than a
+    // PortalAvatar, so it inherits nothing. Without this a four-agent row draws
+    // three hairlined circles and one bare blob.
+    const src = chatRowSource()
+    const chip = src.slice(src.indexOf('avatars.overflow'))
+    expect(chip).toMatch(/\bborder border-gray-\d+ dark:border-gray-\d+\b/)
+  })
+})


### PR DESCRIPTION
Fixes #2169

The Workspace Overview's top row keyed its column count off `asks.length`, so the page changed shape whenever a transient operator-queue item opened or closed — and the agent this issue reports, the one with nothing waiting, collapsed to a single column. Portal avatars had no edge, so a light-edged image avatar bled into the surface behind it.

## What changed

The Overview top row is now an **unconditional** 50/50 grid — activity chart left, recent work right. It never has to collapse, because both occupants already own an empty state (*"No activity in this window." / "Nothing yet."*), so structure holds still and only content varies. The chart's `max-w-2xl` cap went with the move; inside a half-width column it does not bind below ~1656px.

**Asks moved below that row, full width**, still rendered only when there are any — an agent with nothing waiting must not advertise the section. Everything #2161 built into the card survives: compact cards, clamped question, first five plus a counted toggle, and no nested scroll region (#2101).

The **loading skeleton** was changed to match. It was one column in front of what is now a two-column row, so every load ended in a reflow — and the no-asks agent is exactly the case where skeleton and loaded state used to agree. Measured after: skeleton blocks and loaded sections land on identical boxes (x 312/876, y 198, w 540).

`PortalAvatar.vue` gained a 1px edge, and so did the hand-rolled `+N` chip in `PortalChatRow.vue:28` — without the second, a four-agent row draws three hairlined circles and one bare blob.

## The breakpoint is `xl`, not the `lg` in the issue text

Arithmetic, not taste. The Workspace holds a 288px sidebar plus page padding and a 24px gap, so at 1024px each column is 332px — where the 30-day x-axis (one truncating 9px label per day) reads as nothing and the nine-bucket legend wraps three to five lines. At 1280px the column is ~460px, which the legend needs and gets. A layout that technically satisfies "two columns" while making the left one unreadable fails the purpose.

**The issue's AC was amended by the orchestrator to `xl`.** Reviewers reading an older copy of the issue text will see `lg`; that is the discrepancy, and it is deliberate.

## Named tradeoff: asks now sit below the row at *every* breakpoint

This reverses #2161's deliberate "asks are first in DOM order so the mobile stack keeps the priority" decision. Implemented as specified, not by oversight — flagging it because it is a real priority inversion on narrow viewports.

The residual is bounded: the Overview tab's ask-count badge sits `shrink-0` in the header, **outside** the page scroller (verified live at 640 and 375), so a narrow viewport shows the count at every scroll position. Only the ask text moves below the fold.

**Costed reversal if you want it back:** keep the asks `<section>` first in DOM inside the same grid with `xl:col-span-2 xl:order-last`. Desktop renders identically, mobile keeps asks first, ~3 lines, one commit to undo — at the price of a DOM/visual order split.

## Accepted known residual: 30d x-axis clipping, ~1280–1680

The 30-day window's x-axis is ellipsis-clipped in a half-width column. Measured over a 1280→2000 sweep (Chromium, macOS system font — glyph widths are platform-dependent, so treat the band, not the counts, as the finding):

| width | ticks clipped (of 6) |
|---|---|
| 1280–1320 | 6 |
| 1360–1520 | 4 |
| 1600–1640 | 1 |
| ~1680+ | 0 |

Bounded on the other side too: **below 1280 the row stacks** and the chart runs full width — *wider* than the pre-#2169 `max-w-2xl` cap — so it is clean there as well. **7d (the default) and 14d measure zero clipped ticks at every width.** The clipping is ellipsis-marked rather than silently wrong; bars, legend totals and the hover tooltip's full date are unaffected.

The fix is width-responsive tick density in `StackedBarChart.vue::showLabel`, which the **operator** Overview (#1107) also consumes — deliberately out of scope for a client-facing P1.

## Raw-color delta is reviewer-enforced — CI cannot catch it

`raw_gray` **+2** on each of `PortalAvatar.vue` and `PortalChatRow.vue`; `raw_nongray` **0**, unchanged. Measured both sides:

```
origin/dev:  PortalChatRow.vue  12 gray   (PortalAvatar.vue: 0, not listed)
branch:      PortalAvatar.vue    2 gray
             PortalChatRow.vue  14 gray
```

It is `docs/memory/design-system-contract.md:15`'s `border-strong` gray-300/gray-700 recipe verbatim, and **no semantic neutral-edge token exists** — `status-*`/`action-*` would claim this decoration reports a result or affords a click.

Please eyeball it rather than trusting the checks, because two independent gaps mean a green run is not evidence here:

- **Both files are absent from `raw-color-baseline.json`** (it carries 6 portal files; neither of these), so the per-file ratchet has nothing to compare against.
- **`check:tokens` never inspects `border-gray-*`** — grepped the checker, no such rule. It passes: `Design-token check OK: 11 tokens equivalent to source palettes; all references resolve; dark ink ladder holds in 13 swept files`.
- **No CI workflow invokes `scan-raw-colors` at all** — grepped `.github/workflows/`, zero hits. The ratchet is advisory.

## Verification

`verify-local` **PASS** (`--skip-agent`; agent stages skipped, correct — this branch touches no `docker/base-image/**`).

Live both-themes visual pass on the branch's own dev server. An agent with **zero asks** renders 540/540 — the state that used to collapse. The reported light-theme defect quantified: a near-white avatar on white ground is **1.017:1 (invisible)**; the edge lifts it to **1.474:1**. Avatar footprint unchanged at all nine sizes in use (16, 18, 20, 22, 26, 28, 30, 52, 64); image insets 1px, never clipped.

Three geometry choices settled by measurement, not preference:
- **`border`, not `ring-inset`** — an inset ring paints below child content and the `<img>` is exactly the padding box, so it is invisible on precisely the image avatars this fixes.
- **`border`, not an outer ring** — `PortalChatRow` already passes `ring-2` in as the stacked-avatar separator, and all Tailwind rings share one `box-shadow`. Border and ring are independent properties and compose.
- **`border-strong`, not `border`** — `gray-200` on the sidebar's `gray-50` ground is 1.19:1, an arc too faint to see at 26px. `gray-300` is 1.41:1.

### Tests

`cd src/frontend && npx vitest run` → **23 files / 342 tests passed**.

Backend was swept in full on this branch during verification: `9960 passed, 3 failed, 17 skipped, 1 xfailed`. The 3 failures are **pre-existing on `dev`** — `[XPASS(strict)]` reds in `test_pat_propagation_properties.py::TestKnownGaps::test_a_backslash_in_the_token_does_not_raise`, reproduced on a pristine `origin/dev` checkout. Not re-run here (concurrent ship workers share uncached settings state and manufacture phantom reds).

New coverage: `tests/unit/portalAvatarEdge.spec.js` (6 cases) and 6 added structure guards in `portalAgentPageUx.spec.js`. Note commit `775505ff` — the headline placement guard was passing against the *skeleton*, not the row; it now measures the row.

### e2e caveat — read before running

`e2e/portal-agent-page-overview.spec.js` needs `PORTAL_TEST_AGENT` pointed at an agent **with an open ask**, or the headline placement case (`asks, when present, sit below the row at full width`, line 143) **silently skips**:

- with such an agent → `expected 6, skipped 0`
- without → `expected 5, skipped 1`

The unconfigured default fails loud rather than skipping, so a misconfigured run is not mistaken for a pass.

## Rebase expectation

`PortalAgentPage.vue`, `docs/memory/requirements/core-agent.md` §5.11 and `docs/memory/feature-flows/workspace-agent-page.md` each have a second writer this wave (#2162). All edits here were surgical — verified disjoint hunk ranges, `<script setup>` untouched — so resolution is **take both sides**.

**After any rebase, re-run `npx vitest run`**: the structure guards read the whole file off disk and use offsets, so a clean textual merge can still move them.

## Follow-ups (listed, not filed)

- Width-responsive tick density in `StackedBarChart.vue::showLabel` — closes the 30d x-axis band; shared with the operator Overview, so it needs its own change.
- Retiring the 4 `raw_nongray` amber classes on the ask card — needs design sign-off, it is a real amber→yellow hue shift.
- Adding the three portal files to `raw-color-baseline.json` so the ratchet covers them.
- The stale `.claude/agents/test-runner.md` frontend counts (private submodule, separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
