### PR TITLE
feat(workspace): composer typeahead — / for playbooks, @ for agents (ent#392)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1339,10 +1339,14 @@ degrade-to-plain-text this feature exists to close; and **a plain Enter never ac
 without an explicit selection**, since an accidental accept destroys typed work while an
 accidental send is what the user was reaching for. `@` is hidden — popup *and*
 placeholder — without the rooms capability, which it reads from the roster payload per
-the rule below. The **room** composer gets `@` scoped to its **agent participants**
-(the engine's `resolve_mentions` wakes only those; a non-participant mention is neither
-recognised nor recruited, verified against a running instance), while `/`-in-room is
-deferred — a room has no active-agent subject. **No backend change, no new endpoint, no
+the rule below. The **room** composer gets `@` scoped to its **agent participants** —
+established by *observing* the running server rather than reading the private rooms
+engine (`POST /api/rooms/{id}/messages` answered `woke: ["<participant>"]` for a
+participant and `woke: []` for a non-participant), so the list contains only names a
+pick is known to wake; whether a non-participant mention still joins someone by the
+ent#361 engine-side path (§5.12) is deliberately not claimed either way, and recruiting
+stays with the explicit "+ Add agent" control. `/`-in-room is deferred — a room has no
+active-agent subject. **No backend change, no new endpoint, no
 migration. OSS-core by decision (ent#392): deliberately ungated — no
 `requires_entitlement`, logic stays in the OSS tree. Recorded explicitly because
 CLAUDE.md's default for an enterprise-tracker feature is gated unless ruled otherwise, so

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1320,6 +1320,35 @@ in-place "Show all N" toggle — deliberately **no nested scroll region**: the c
 stays the single scroll axis, and the toggle counts the shipped list, never claiming the
 agent's full skill set). Hint *curation* stays the connector allow-list (ent#178 later).
 
+**Composer typeahead — `/` playbooks, `@` agents (ent#392).** The same briefing payload
+now also feeds a composer typeahead, which is what makes it reachable after turn 1 (the
+hint cards render on the empty-chat screen only). `/` lists the active agent's
+`playbooks[]` and splices the `starter_prompt` in **without sending** — the ent#138
+prefill contract; `@` lists reachable agents and inserts a token `mentionedAgents()`
+resolves (ent#361). All decidable logic is pure and exported from
+`components/portal/portalUtils.js` (`vitest` runs `environment: 'node'` with no
+component-mount harness, so a decision inside a component is one no test can reach); the
+components are dispatchers over it and `PortalTypeahead.vue` is presentational. Three
+properties are load-bearing rather than stylistic: the **trigger rule is stricter than
+the parser** (`MENTION_RE` is unanchored, so `user@example.com` parses as `@example` —
+the popup must never open on something the parser would not see); **un-mentionable slugs
+are excluded**, the predicate *derived* by asking `mentionedAgents` rather than copying
+the grammar, because `sanitize_agent_name` keeps `.` and caps nothing while the grammar
+allows neither, so listing `data.scout` would manufacture the silent
+degrade-to-plain-text this feature exists to close; and **a plain Enter never accepts
+without an explicit selection**, since an accidental accept destroys typed work while an
+accidental send is what the user was reaching for. `@` is hidden — popup *and*
+placeholder — without the rooms capability, which it reads from the roster payload per
+the rule below. The **room** composer gets `@` scoped to its **agent participants**
+(the engine's `resolve_mentions` wakes only those; a non-participant mention is neither
+recognised nor recruited, verified against a running instance), while `/`-in-room is
+deferred — a room has no active-agent subject. **No backend change, no new endpoint, no
+migration. OSS-core by decision (ent#392): deliberately ungated — no
+`requires_entitlement`, logic stays in the OSS tree. Recorded explicitly because
+CLAUDE.md's default for an enterprise-tracker feature is gated unless ruled otherwise, so
+the ruling must never be inferred later from the mere fact that it merged.** See
+[workspace-composer-typeahead.md](feature-flows/workspace-composer-typeahead.md).
+
 **The roster payload is *the* portal capability channel (#2128).** A portal principal
 cannot read `GET /api/settings/feature-flags` — that endpoint is `get_current_user`-gated
 and the frontend store behind it returns `[]` for any caller without a platform JWT, i.e.

--- a/docs/memory/feature-flows.md
+++ b/docs/memory/feature-flows.md
@@ -344,6 +344,7 @@
 | Workspace absorbs Session | [workspace-absorbs-session.md](feature-flows/workspace-absorbs-session.md) | ent#358 — one continuous-conversation surface, with the continuity parity that had to land before the other could be removed |
 | Workspace sidebar IA | [workspace-sidebar-ia.md](feature-flows/workspace-sidebar-ia.md) | ent#359 — agents block on top, starred chats, per-agent unread badges; why the per-viewer state could not be a column on the chat row |
 | Workspace agent page | [workspace-agent-page.md](feature-flows/workspace-agent-page.md) | ent#360 — an agent becomes a destination; what the page deliberately does NOT carry, and why that is enforced by projection rather than by template |
+| Workspace composer typeahead | [workspace-composer-typeahead.md](feature-flows/workspace-composer-typeahead.md) | ent#392 — `/` playbooks and `@` agents in the composer; why the trigger rule is stricter than the parser, why un-mentionable slugs are excluded, and why Enter never accepts implicitly |
 | Web Terminal | [web-terminal.md](feature-flows/web-terminal.md) | Browser-based terminal for System Agent |
 | Self-Execute | [self-execute.md](feature-flows/self-execute.md) | Agent background task during chat (SELF-EXEC-001) |
 

--- a/docs/memory/feature-flows/workspace-composer-typeahead.md
+++ b/docs/memory/feature-flows/workspace-composer-typeahead.md
@@ -132,6 +132,7 @@ happen:
 | caret keys while open | close, key passes | Same reason, from the keyboard |
 | non-collapsed selection | no trigger | The user is selecting, not composing a token |
 | click outside the wrapper | close **without** arming the Esc sentinel | Otherwise "type `@`, click away to read something, click back, keep typing" stays suppressed until the `@` is deleted |
+| an accepted pick | close **and settle** the token it inserted | The splice appends its separator only when the next char is not already whitespace, so a mid-sentence pick leaves the caret *inside* the new token — and `setSelectionRange()` fires a `select`, so the popup would reopen over its own successful choice. Editing the token back re-arms it |
 
 `resetTypeahead()` runs on every **programmatic** write to `input.value` —
 `send()`, the prefill watcher, the thread switch, and both dictation handlers.
@@ -153,8 +154,11 @@ this issue exists to fix — and a room needs it *more* than a 1:1 does, because
 
 But `mentionedAgents` is **never called on the room path** — room mention-waking
 resolves server-side inside `POST /api/rooms/{id}/messages` — so the round-trip
-proof above does not transfer. Two questions had to be settled against the real
-server rather than assumed, using the answer the endpoint already returns
+proof above does not transfer. It also cannot be replaced by reading the engine:
+the rooms module is a private submodule that OSS clones do not check out, so a
+source reading is neither reproducible from this repo nor pinned to the commit
+this branch builds against. The evidence is therefore what the **server
+answered**, using the fields the endpoint already returns
 (`{room_id, seq, mentions, woke}`):
 
 | Probe | Observed |
@@ -162,13 +166,22 @@ server rather than assumed, using the answer the endpoint already returns
 | `@<participant>` | `{"mentions": ["acme-scout"], "woke": ["acme-scout"]}` |
 | `@<non-participant>` | `{"mentions": [], "woke": []}` |
 
-So the grammar matches (a `buildMentionToken()` token is recognised and wakes the
-agent), and the candidate list must be the room's **agent participants**, not the
-roster: the engine's `resolve_mentions` keeps only `kind == "agent"` participants
-that have not left, and nothing outside the room is recruited. Offering the
-roster would manufacture a silent no-op — the same class as offering an
-un-mentionable slug. Recruiting a genuinely new agent stays with the explicit
-"+ Add agent" control, which is honest about spending money on another agent.
+Two things follow, and only two. The grammar matches: a `buildMentionToken()`
+token is recognised and wakes the agent, which is the property the `@` affordance
+depends on. And the candidate list should be the room's **agent participants**,
+because those are the names a pick is *known* to wake — offering the roster would
+put names in front of the user with no evidence that choosing one does anything,
+the same class of silent no-op as offering an un-mentionable slug.
+
+What is deliberately **not** concluded is that a non-participant mention has no
+effect at all. Requirements §5.12 records an engine-side newcomer-join path from
+ent#361 (`_join_mentioned_newcomers`), and two empty response fields do not
+disprove it — a join would surface as a participant change, which the probe did
+not look at. If that path is live, this list is narrower than the engine allows.
+That is an acceptable place to be narrow: recruiting a genuinely new agent stays
+with the explicit "+ Add agent" control, which is honest about spending money on
+another agent, and §5.12's own safety framing ("only a human may recruit") argues
+for keeping recruitment an explicit act rather than a side effect of typing.
 
 `/`-in-room is deferred: a room has N participants and no active agent, so
 "whose playbooks?" has no answer without inventing a two-step picker or per-row
@@ -215,12 +228,12 @@ No network call, no store action, no backend change anywhere on this path.
 
 | Layer | File | Change |
 |---|---|---|
-| Logic | `src/frontend/src/components/portal/portalUtils.js` | +21 pure exports (15 functions, 6 constants) beside `MENTION_RE`; `starterFor` lifted here |
+| Logic | `src/frontend/src/components/portal/portalUtils.js` | +22 pure exports (16 functions, 6 constants) beside `MENTION_RE`; `starterFor` lifted here |
 | UI | `src/frontend/src/components/portal/PortalTypeahead.vue` | **new** — presentational panel, two consumers |
 | UI | `src/frontend/src/components/portal/PortalConversation.vue` | anchored wrapper, dispatcher handlers, placeholder |
 | UI | `src/frontend/src/components/portal/PortalRoom.vue` | `@` over the room's wake-set; textarea ref + doc-click listener |
 | UI | `src/frontend/src/components/portal/PortalBriefing.vue` | imports `starterFor` instead of defining it |
-| Tests | `src/frontend/tests/unit/portalComposerTypeahead.spec.js` | **new** — 105 tests |
+| Tests | `src/frontend/tests/unit/portalComposerTypeahead.spec.js` | **new** — 111 tests |
 
 Backend, store and router are untouched: **no new endpoint, no new table, no
 migration.**
@@ -279,7 +292,7 @@ The one genuine *contract* — the mention grammar — is single-sourced by
 
 ## Tests
 
-`src/frontend/tests/unit/portalComposerTypeahead.spec.js` — 105 tests, node env.
+`src/frontend/tests/unit/portalComposerTypeahead.spec.js` — 111 tests, node env.
 
 | # | Area | What it pins |
 |---|---|---|
@@ -293,20 +306,23 @@ The one genuine *contract* — the mention grammar — is single-sourced by
 | 8 | `typeaheadEmptyMessage` | three distinct statements; room wording; silence without the capability; copy asserts nothing about operator configuration |
 | 9 | `resolveComposerKey` | all 16 Enter modifier combinations (the `.exact` table), open × hasActive × hasCandidates, IME, Tab/Shift+Tab, Escape, caret keys |
 | 10 | dismissal | Esc-then-keep-typing stays closed; retype re-arms; a cleared sentinel re-opens (the session-long-dead-feature guard) |
+| 10b | post-pick settle | a mid-sentence pick leaves a re-detectable trigger at the new caret; `dismissAfterInsert` suppresses exactly it; nothing to settle when a separator was appended; editing the name back re-arms |
 | 11 | active index | wrap both ends; no-op on empty; a stale index is **dropped**, not clamped |
 | 12 | bounds + `starterFor` | at / under / over the limit; honest overflow; null-safe starter |
 | 13 | `roomMentionSource` | participants not roster; label join; junk |
 | 14 | source guards | the `.exact` binding is gone and delegates to the tested keymap; `autoGrow` still on the input path; ≥4 `resetTypeahead()` call sites; `e.target` not the ref; wrapper flex classes; placeholder advertises both triggers; room scopes to participants and has no `/`; briefing imports `starterFor`; popup geometry, `mousedown`, overflow footer, listbox semantics, no new `v-html` |
 
-Four mutations were run against the finished suite to prove the guards can fail:
-baking a space into `buildMentionToken` (8 failures), accepting Enter without an
-explicit selection (1), dropping the mentionable filter (6), and dropping the
-forward scan (3).
+Seven mutations were run against the suite to prove the guards can fail, four at
+implementation and three more at review: baking a space into `buildMentionToken`
+(8 failures), accepting Enter without an explicit selection (1), dropping the
+mentionable filter (6), dropping the forward scan (3), removing the token-boundary
+rule (5 — the AC#6 loop), re-typing `isMentionable` as a hand-copied regex that
+drifted to allow dots (10), and dropping the post-pick settle (1).
 
 Commands:
 
 ```
-cd src/frontend && npx vitest run          # 23 files / 438 tests
+cd src/frontend && npx vitest run          # 23 files / 444 tests
 cd src/frontend && npm run check:tokens
 cd src/frontend && npm run build
 node src/frontend/scripts/scan-raw-colors.mjs src/frontend
@@ -322,12 +338,17 @@ node src/frontend/scripts/scan-raw-colors.mjs src/frontend
   creation, on both sides at once) is cross-repo.
 * A mention typed mid-word (`foo@bar`) still resolves on send — the parser is
   unanchored. The typeahead does not offer it; unchanged ent#361 behaviour.
-* After Esc, the same token cannot be re-opened without editing it back.
+* After Esc — or after a pick that settled the token it inserted — that same
+  token cannot be re-opened without editing it back. Appending to a just-picked
+  name therefore keeps the list shut; backspacing into it brings the list back.
 * No fuzzy matching. Playbook titles match on a word-start prefix (they are prose
   up to 200 chars, so a substring rule makes a one-character query match nearly
   everything); agent names also accept a substring, because they are short
   identifiers that frequently share a deployment prefix.
 * The empty line cannot distinguish "no playbooks configured" from "the agent was
   stopped when the roster was built", so it deliberately says neither.
-* The room `@` list is scoped to current participants; if the engine ever gains
-  mention-driven recruiting, this list has to widen with it.
+* The room `@` list is scoped to current participants — the names a pick is known
+  to wake. If the engine's ent#361 newcomer-join path does recruit on a
+  non-participant mention (not established here; see above), this list is
+  narrower than the engine allows and recruiting is reachable only through
+  "+ Add agent".

--- a/docs/memory/feature-flows/workspace-composer-typeahead.md
+++ b/docs/memory/feature-flows/workspace-composer-typeahead.md
@@ -3,7 +3,7 @@
 > **Status**: ✅ Implemented (2026-08-13)
 > **Issue**: abilityai/trinity-enterprise#392
 > **Requirement**: `docs/memory/requirements/core-agent.md` §5.13
-> **Related**: [workspace-agent-page.md](workspace-agent-page.md), [workspace-absorbs-session.md](workspace-absorbs-session.md), [workspace-sidebar-ia.md](workspace-sidebar-ia.md)
+> **Related**: `docs/memory/requirements/core-agent.md` §5.12 (ent#361 — the @mention grammar this round-trips through; it has no flow doc of its own), [workspace-agent-page.md](workspace-agent-page.md) (the other ent#380 briefing consumer), [workspace-absorbs-session.md](workspace-absorbs-session.md) (why this is the only composer left)
 
 ## Overview
 

--- a/docs/memory/feature-flows/workspace-composer-typeahead.md
+++ b/docs/memory/feature-flows/workspace-composer-typeahead.md
@@ -1,0 +1,333 @@
+# Feature: the Workspace composer typeahead (`/` playbooks, `@` agents)
+
+> **Status**: ✅ Implemented (2026-08-13)
+> **Issue**: abilityai/trinity-enterprise#392
+> **Requirement**: `docs/memory/requirements/core-agent.md` §5.13
+> **Related**: [workspace-agent-page.md](workspace-agent-page.md), [workspace-absorbs-session.md](workspace-absorbs-session.md), [workspace-sidebar-ia.md](workspace-sidebar-ia.md)
+
+## Overview
+
+The composer had two invocation syntaxes and no way to find either. A client can
+`@`-mention an agent to escalate a 1:1 into a group room (ent#361) and can ask an
+agent to run one of its playbooks — but both required knowing the exact name, and
+a near-miss parses as ordinary text with no feedback at all. The playbook hints
+(ent#138 / ent#380) render as cards on the **empty-chat screen only**, so the
+capability becomes invisible the moment a conversation has one turn in it.
+
+Typing `/` or `@` at a token boundary now opens a bounded list. `/` splices a
+playbook's `starter_prompt` into the composer without sending; `@` inserts a
+token `mentionedAgents()` resolves.
+
+**OSS-core by decision (ent#392): deliberately ungated** — no
+`requires_entitlement`, logic stays in the OSS tree. Recorded explicitly because
+CLAUDE.md's default for an enterprise-tracker feature is *gated unless ruled
+otherwise*, so the ruling must never be inferred later from the mere fact that it
+merged (the ent#326 / ent#384 discipline). It extends a surface that is already
+OSS-core (ent#356) over data the client already holds.
+
+## Why all the logic is pure, and the components hold none
+
+`vitest.config.js` is `environment: 'node'` and `@vue/test-utils` is not a
+dependency, so there is no component-mount harness. That is not merely a testing
+constraint — it decides the architecture: **a decision left inside a component is
+a decision no test can reach.** So every decidable thing is a pure export in
+`portalUtils.js` (adjacent to the grammar it round-trips through), the two
+composers are dispatchers, and `PortalTypeahead.vue` is presentational.
+
+The parts no unit test can reach — which handler the textarea binds, where the
+popup is anchored, whether the reset is called on every programmatic write — are
+covered by source-structure guards, the house idiom, with comments stripped first
+so prose about a rule is not scanned as code.
+
+## The trigger rule is stricter than the parser, on purpose
+
+`MENTION_RE` is unanchored: `foo@bar` matches `@bar` and `user@example.com`
+matches `@example`. Its safety comes entirely from roster resolution, which is
+right for *parsing* and wrong for *offering* — a popup that opened on an email
+address would fight the user for the rest of the sentence (AC#6).
+
+So the typeahead fires only on a trigger char at a **token start**, where "start"
+means *preceded by a non-word character* — deliberately not *preceded by
+whitespace*. A whitespace-only rule cannot fire after CJK (`你好@rec`), after an
+emoji, or after punctuation (`(@bob`, `"@bob`), while the non-word rule still
+closes every case the AC names: `50/50` (previous char `0`), `and/or` (`d`),
+`user@example.com` (`r`).
+
+The asymmetry is safe in the only direction that matters: **the popup can never
+open on something the parser would not see**, so it can never offer a token that
+silently degrades to plain text.
+
+Two further rules exist because the obvious version of the scan is wrong:
+
+* The backward scan is **floored** at 64 characters, not merely capped in its
+  result. An unfloored scan walks the whole composer on every keystroke, and a
+  pasted 100 KB blob then costs O(n) per key.
+* The scan carries a **forward** pass to the token end. Without it the splice
+  ends at the caret, so accepting *alice* with the caret parked at `@bo|b`
+  leaves `@alice b` — a correct mention turned into two wrong words.
+
+## Un-mentionable slugs, and why the predicate is derived
+
+`sanitize_agent_name` keeps `.` and imposes no length cap; the mention grammar
+allows neither. So `data.scout` is a perfectly ordinary agent whose mention reads
+as `@data` and resolves to nothing.
+
+Today nothing offers those names, which is why the failure is invisible. A
+typeahead that listed them would **manufacture** the exact silent
+degrade-to-plain-text the AC forbids, and make it look like a product bug.
+
+`isMentionable` therefore asks the real parser (`mentionedAgents(@name, [{name}])`
+resolves to exactly that name) rather than carrying a second copy of the grammar
+twelve lines from the first — in the file whose own header says drift in this
+grammar is its own bug class. It also rejects names containing `@` or whitespace,
+which a hand-written copy would have handled only by luck.
+
+Widening the grammar or tightening slug creation is the real fix and is
+cross-repo (it touches the private rooms engine); excluding is the correct local
+one.
+
+## No implicit selection — the asymmetry that decides it
+
+The roving index starts at "nothing chosen". A plain Enter accepts **only** with
+an explicit selection; otherwise it sends. Tab always accepts the top row.
+
+Accepting whenever the popup happens to be open destroys typed work three ways:
+the source-empty panel swallows the send entirely; a stale index after a roster
+refresh inserts the wrong row; and the popup may merely *happen* to be open —
+after a paste, or in prose like `Can you check /status of the deploy` — at which
+point Enter splices up to 500 characters of an unrelated starter into the middle
+of the message.
+
+The harm is asymmetric. An accidental accept destroys work; an accidental send is
+the thing the user was reaching for anyway. So Enter is safe by default and
+accepting costs one extra keystroke (`↓` then Enter, or just Tab, which nobody
+presses to send).
+
+The keymap also fixes something the current binding gets wrong: `@keydown.enter.exact`
+has no IME guard, so an IME user's candidate-commit Enter sends the message
+mid-word. The pure keymap passes a composing keystroke through.
+
+## The splice decides the separator; the token never carries one
+
+Baking a trailing space into `@name` produces `Hello @alice  there` and turns
+`@| x` into `@recon  x`. Omitting it entirely produces `@reconx`, which resolves
+to nothing — the AC#4 failure by a different route. So the token is the token,
+and the splice appends a space only when the character after the replaced token
+is not already whitespace.
+
+That is also why the round-trip property is asserted over the **spliced value**
+rather than the bare token: `mentionedAgents(buildMentionToken(n), roster)` is
+near-tautological and passes while the double-space bug ships.
+
+## Recomputation, dismissal, and the writes that fire no event
+
+`@input` alone is not enough, and three of these were regressions waiting to
+happen:
+
+| Event | Behaviour | Why |
+|---|---|---|
+| `@input` | recompute from `e.target` | Reading the v-model ref makes correctness depend on Vue's listener ordering — true today, an implementation detail |
+| `@input` with `inputType` `insertFromPaste`/`insertFromDrop` | close, do not open | A pasted message ending in `@name` must not open a picker whose next keystroke is Enter |
+| `@click` / `@select` | recompute | The caret moves with no input event; accepting against stale bounds splices over the wrong text |
+| caret keys while open | close, key passes | Same reason, from the keyboard |
+| non-collapsed selection | no trigger | The user is selecting, not composing a token |
+| click outside the wrapper | close **without** arming the Esc sentinel | Otherwise "type `@`, click away to read something, click back, keep typing" stays suppressed until the `@` is deleted |
+
+`resetTypeahead()` runs on every **programmatic** write to `input.value` —
+`send()`, the prefill watcher, the thread switch, and both dictation handlers.
+None of them fires an input event, so without it a sentinel armed while composing
+message 1 kills the popup for every later message that starts the same way: a
+feature dead for the rest of the session.
+
+Esc suppression is keyed on `{kind, start, query-prefix}`. Strict query equality
+un-dismisses on the very next keystroke (Esc has to mean *stop offering this*);
+keying on `start` alone is wrong in both directions — text inserted before the
+token shifts `start` and re-opens, while a full retype at the same offset stays
+suppressed forever.
+
+## The room composer: `@` ships, `/` does not
+
+`@`-in-room is live, first-class behaviour and undiscoverable in exactly the way
+this issue exists to fix — and a room needs it *more* than a 1:1 does, because a
+1:1 has one obvious counterpart and a room has many.
+
+But `mentionedAgents` is **never called on the room path** — room mention-waking
+resolves server-side inside `POST /api/rooms/{id}/messages` — so the round-trip
+proof above does not transfer. Two questions had to be settled against the real
+server rather than assumed, using the answer the endpoint already returns
+(`{room_id, seq, mentions, woke}`):
+
+| Probe | Observed |
+|---|---|
+| `@<participant>` | `{"mentions": ["acme-scout"], "woke": ["acme-scout"]}` |
+| `@<non-participant>` | `{"mentions": [], "woke": []}` |
+
+So the grammar matches (a `buildMentionToken()` token is recognised and wakes the
+agent), and the candidate list must be the room's **agent participants**, not the
+roster: the engine's `resolve_mentions` keeps only `kind == "agent"` participants
+that have not left, and nothing outside the room is recruited. Offering the
+roster would manufacture a silent no-op — the same class as offering an
+un-mentionable slug. Recruiting a genuinely new agent stays with the explicit
+"+ Add agent" control, which is honest about spending money on another agent.
+
+`/`-in-room is deferred: a room has N participants and no active agent, so
+"whose playbooks?" has no answer without inventing a two-step picker or per-row
+attribution that the issue does not specify. This is a design gap, not a missing
+field — every roster card already carries its own `playbooks`.
+
+## Flow
+
+```
+user types "/" or "@" at a token boundary
+        │
+        ▼
+detectTypeaheadTrigger(el.value, selectionStart, selectionEnd)   ← pure
+        │  null | {kind, start, end, query}
+        ▼
+kind === '/'  →  filterPlaybookCandidates(agent.playbooks, query)     ← pure
+kind === '@'  →  filterAgentCandidates(source, query, {exclude, enabled})
+                     · 1:1  source = props.roster,  exclude = [self]
+                     · room source = roomMentionSource(participants, roster)
+                     · enabled = store.multiAgentChatAvailable  (#2128)
+        │  {items, sourceCount | peerCount, mentionableCount, enabled}
+        ▼
+boundCandidates(items, 8) → {visible, overflow}                       ← pure
+        │
+        ├─ visible.length > 0                → PortalTypeahead renders rows
+        ├─ visible empty AND query === ''    → one honest line (never eats Enter)
+        └─ visible empty AND query !== ''    → popup CLOSES (AC#6)
+        │
+        ▼
+resolveComposerKey({key, modifiers, isComposing, open, hasActive, …})  ← pure
+        │  'move-down' | 'move-up' | 'accept' | 'dismiss' | 'close' | 'send' | 'pass'
+        ▼
+accept → applyTypeaheadInsert(input, trigger, insert)                 ← pure
+             insert = '/' ? starterFor(row) : buildMentionToken(row.name)
+        │  {value, caret}
+        ▼
+input.value = value ; nextTick → el.focus() → setSelectionRange(caret)
+                                  (focus BEFORE selection — Safari resets it)
+```
+
+No network call, no store action, no backend change anywhere on this path.
+
+## Files
+
+| Layer | File | Change |
+|---|---|---|
+| Logic | `src/frontend/src/components/portal/portalUtils.js` | +21 pure exports (15 functions, 6 constants) beside `MENTION_RE`; `starterFor` lifted here |
+| UI | `src/frontend/src/components/portal/PortalTypeahead.vue` | **new** — presentational panel, two consumers |
+| UI | `src/frontend/src/components/portal/PortalConversation.vue` | anchored wrapper, dispatcher handlers, placeholder |
+| UI | `src/frontend/src/components/portal/PortalRoom.vue` | `@` over the room's wake-set; textarea ref + doc-click listener |
+| UI | `src/frontend/src/components/portal/PortalBriefing.vue` | imports `starterFor` instead of defining it |
+| Tests | `src/frontend/tests/unit/portalComposerTypeahead.spec.js` | **new** — 105 tests |
+
+Backend, store and router are untouched: **no new endpoint, no new table, no
+migration.**
+
+## Rendering and containment
+
+The panel opens **upward** (`absolute bottom-full`) because the composer sits at
+the bottom of the pane, scrolls internally, and is bounded at
+`max-h-[min(14rem,40vh)]` — `Portal.vue`'s root is `h-screen overflow-hidden`, so
+on mobile landscape with the keyboard up a flat `max-h-56` clips against a
+composer sitting at ~y=250. Eight rows render, with a counted
+`N more — keep typing to filter` footer (principle 28: bounded viewport, stated
+total).
+
+`z-30` is the same tier as this component's own agent-picker dropdown and
+strictly below the two `z-40` overlays (mobile nav, files panel) that must cover
+it; the two `z-30` panels sit at opposite ends of the pane and cannot overlap.
+The new wrapper carries **no** z-index, so it creates no stacking context — and
+it must carry `flex-1 min-w-0`, because a bare `relative` div collapses the field
+to content width.
+
+Rows accept on `mousedown`, not `click`: a click blurs the textarea first and the
+caret is lost before the splice reads it.
+
+**ARIA, honestly**: `role="listbox"` on the panel, `role="option"` +
+`aria-selected` on rows, and an `aria-live="polite"` count. Deliberately **no**
+`aria-expanded` / `aria-activedescendant` on the textarea — those belong to
+`role="combobox"`, which is itself out of spec on a multiline control, and
+shipping a claim screen readers ignore is worse than shipping less.
+
+Titles and descriptions are agent- and operator-authored text arriving in a new
+place, so they render through `{{ }}` interpolation only. The portal's single
+`v-html` remains assistant message bodies via `renderMarkdown()` (DOMPurify), and
+a guard pins that count at 1 rather than asserting "no `v-html`", which is
+unwritable for that file.
+
+## How this differs from `usePlaybookAutocomplete`, and why it is not shared
+
+`src/frontend/src/composables/usePlaybookAutocomplete.js` already implements a
+`/`-typeahead for the **operator** chat surface. It was not reused, and the
+decisive reason is that **it has no tests at all** — refactoring it to serve a
+second consumer is unverifiable by construction. It also matches `p.name` (the
+portal shape has no `name`), inserts `/name ` as a *command* (which this issue
+puts out of scope), mutates five refs from `parse()`, and has no `@` mode.
+
+The divergences are recorded here as decisions so a future unification inherits
+reasons instead of re-deriving them: the boundary rule is **non-word** rather
+than whitespace (CJK / emoji / punctuation); the scan carries a **forward** pass
+so a mid-token caret does not leave a tail; the separator is decided by the
+splice rather than baked into the inserted string; and Enter **never** accepts
+implicitly. The dead `components/rooms/RoomComposer.vue` was read, not revived —
+it has no boundary check at all and papers over the token tail with `.trimStart()`.
+
+The one genuine *contract* — the mention grammar — is single-sourced by
+**deriving** from `mentionedAgents`, which is the thing that must not drift.
+
+## Tests
+
+`src/frontend/tests/unit/portalComposerTypeahead.spec.js` — 105 tests, node env.
+
+| # | Area | What it pins |
+|---|---|---|
+| 1 | `detectTypeaheadTrigger` | every worked case; forward scan; non-word boundary (CJK/emoji/punctuation); innermost trigger; the 64-char floor; out-of-range and non-numeric carets; non-collapsed selection |
+| 2 | AC#6 exhaustively | `50/50`, `and/or`, `user@example.com`, `a@b.c` yield `null` at **every** caret index (a loop, not a sample) |
+| 3 | `isMentionable` | the dotted / over-long / leading-punctuation matrix, plus agreement with `mentionedAgents` in both directions |
+| 4 | AC#4 round-trip | over the **spliced value**, across content before/after/both/neither and a next char of space, letter, newline, EOS — plus the negative: every excluded name is one the parser cannot resolve |
+| 5 | splice + separator | mid-token tail; the four separator cases through `buildMentionToken` (a baked-in space fails 8 assertions); returned caret; junk input |
+| 6 | `filterAgentCandidates` | slug **and** label; substring for shared deployment prefixes; case-insensitivity; self excluded; un-mentionable excluded; `enabled:false → []` (the #2128 gate, tested not grepped) |
+| 7 | `filterPlaybookCandidates` | word-start ranking beating source order; no substring free-for-all; source-empty vs filter-empty |
+| 8 | `typeaheadEmptyMessage` | three distinct statements; room wording; silence without the capability; copy asserts nothing about operator configuration |
+| 9 | `resolveComposerKey` | all 16 Enter modifier combinations (the `.exact` table), open × hasActive × hasCandidates, IME, Tab/Shift+Tab, Escape, caret keys |
+| 10 | dismissal | Esc-then-keep-typing stays closed; retype re-arms; a cleared sentinel re-opens (the session-long-dead-feature guard) |
+| 11 | active index | wrap both ends; no-op on empty; a stale index is **dropped**, not clamped |
+| 12 | bounds + `starterFor` | at / under / over the limit; honest overflow; null-safe starter |
+| 13 | `roomMentionSource` | participants not roster; label join; junk |
+| 14 | source guards | the `.exact` binding is gone and delegates to the tested keymap; `autoGrow` still on the input path; ≥4 `resetTypeahead()` call sites; `e.target` not the ref; wrapper flex classes; placeholder advertises both triggers; room scopes to participants and has no `/`; briefing imports `starterFor`; popup geometry, `mousedown`, overflow footer, listbox semantics, no new `v-html` |
+
+Four mutations were run against the finished suite to prove the guards can fail:
+baking a space into `buildMentionToken` (8 failures), accepting Enter without an
+explicit selection (1), dropping the mentionable filter (6), and dropping the
+forward scan (3).
+
+Commands:
+
+```
+cd src/frontend && npx vitest run          # 23 files / 438 tests
+cd src/frontend && npm run check:tokens
+cd src/frontend && npm run build
+node src/frontend/scripts/scan-raw-colors.mjs src/frontend
+```
+
+## Known limitations
+
+* **`/` in a room is not offered** — a room has no active-agent subject, so
+  "whose playbooks?" has no answer without a picker this issue does not specify.
+* Agents whose slug contains `.` or exceeds 100 characters never appear in the
+  `@` list. They were never mentionable; offering them would create the silent
+  failure AC#4 forbids. The fleet-wide fix (widen the grammar, or tighten slug
+  creation, on both sides at once) is cross-repo.
+* A mention typed mid-word (`foo@bar`) still resolves on send — the parser is
+  unanchored. The typeahead does not offer it; unchanged ent#361 behaviour.
+* After Esc, the same token cannot be re-opened without editing it back.
+* No fuzzy matching. Playbook titles match on a word-start prefix (they are prose
+  up to 200 chars, so a substring rule makes a one-character query match nearly
+  everything); agent names also accept a substring, because they are short
+  identifiers that frequently share a deployment prefix.
+* The empty line cannot distinguish "no playbooks configured" from "the agent was
+  stopped when the roster was built", so it deliberately says neither.
+* The room `@` list is scoped to current participants; if the engine ever gains
+  mention-driven recruiting, this list has to widen with it.

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -564,13 +564,20 @@
   operator configuration for the ordinary state of an idle fleet. "No peers" and
   "peers exist but none is mentionable" are separate statements.
 - **Scope**: `/` and `@` in the 1:1 composer; **`@` in the room composer**,
-  scoped to the room's **agent participants** — verified against the running
-  engine, not assumed (`resolve_mentions` keeps only agent participants that
-  have not left; a non-participant `@name` is neither recognised nor recruited),
-  because offering the roster there would manufacture a silent no-op. **`/` in a
-  room is deferred**: a room has N participants and no active agent, so "whose
-  playbooks?" has no answer without inventing a picker this issue does not
-  specify. Recruiting a new agent stays with the explicit "+ Add agent" control.
+  scoped to the room's **agent participants**. That scope was established by
+  *observing the running server*, not by reading the private rooms engine:
+  `POST /api/rooms/{id}/messages` answered `woke: ["<participant>"]` for a
+  participant mention and `woke: []` for a non-participant one, so the list
+  offers only names a pick is known to wake — offering the roster would put
+  names in front of the user with no evidence that choosing one does anything.
+  It is deliberately **not** claimed that a non-participant mention has no
+  effect: §5.12 records an engine-side newcomer-join path from ent#361, and two
+  empty response fields do not disprove it. If that path is live, this list is
+  narrower than the engine allows, and recruiting stays with the explicit
+  "+ Add agent" control — the honest home for an action that spends money on
+  another agent. **`/` in a room is deferred**: a room has N participants and no
+  active agent, so "whose playbooks?" has no answer without inventing a picker
+  this issue does not specify.
 - **Flow**: [workspace-composer-typeahead.md](../feature-flows/workspace-composer-typeahead.md)
 
 ---

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -512,6 +512,67 @@
   (#2128) — without it there is nowhere to escalate to, so an @mention stays
   ordinary text.
 
+### 5.13 Workspace composer typeahead — `/` playbooks, `@` agents
+- **Status**: ✅ Implemented (2026-08-13)
+- **Requirement ID**: WORKSPACE_COMPOSER_TYPEAHEAD
+- **GitHub Issue**: abilityai/trinity-enterprise#392
+- **Description**: The composer's two invocation syntaxes become discoverable.
+  Typing `/` at a token boundary opens a bounded list of the active agent's
+  `playbooks[]` (title + description) and selecting one **splices its
+  `starter_prompt` into the composer without sending** — the §5.11 briefing-card
+  prefill contract, now reachable after turn 1, where the cards are gone.
+  Typing `@` opens a bounded list of reachable agents, filtered on **slug and
+  display label** (the roster shows labels; the parser keys on slugs), and
+  selecting one inserts a token `mentionedAgents()` resolves (§5.12).
+- **OSS-core by decision (ent#392): deliberately ungated** — no
+  `requires_entitlement`, logic stays in the OSS tree. Recorded explicitly
+  because CLAUDE.md's default for an enterprise-tracker feature is *gated unless
+  ruled otherwise*, so the ruling must never be inferred later from the mere
+  fact that it merged (the ent#326 / ent#384 discipline). Rationale: it extends
+  a surface that is already OSS-core (the Workspace, ent#356) over data the
+  client already holds — no new endpoint, no new table, no migration.
+- **The trigger rule is deliberately STRICTER than the parser.** §5.12's
+  `MENTION_RE` is unanchored, so `user@example.com` *parses* as `@example`; the
+  typeahead only fires on a trigger char at a token start (preceded by a
+  **non-word** char — not merely whitespace, or it cannot fire after CJK, an
+  emoji or punctuation). Asymmetric in the only safe direction: the popup can
+  never open on something the parser would not see, so `50/50`, `and/or` and an
+  email address are left alone, and no offered token can fail to resolve.
+- **Un-mentionable slugs are excluded, so a selected mention can never degrade
+  to plain text** (the AC's central property). `sanitize_agent_name` keeps `.`
+  and imposes no length cap, while the mention grammar allows neither — so
+  `data.scout` is an ordinary agent whose mention resolves to nothing. Nothing
+  offers such names today, which is why the failure is invisible; a list that
+  included them would *manufacture* it. The predicate is **derived by asking
+  `mentionedAgents` itself**, never a second copy of the grammar.
+- **No implicit selection.** The roving index starts at "nothing chosen", and a
+  plain Enter accepts **only** with an explicit selection — otherwise it sends.
+  Tab accepts the top row. The harm is asymmetric: an accidental accept destroys
+  typed work (a popup that merely happens to be open — a paste, or prose like
+  "check /status of the deploy" — would splice up to 500 characters over the
+  message), while an accidental send is what the user was reaching for. Esc
+  dismisses and keeps the popup shut while the same token is still being typed.
+- **`@` is hidden without the rooms capability** (#2128) — in the popup *and* in
+  the placeholder, since a placeholder promising a capability the build lacks is
+  the same dead end in text form. The placeholder is the only part of this that
+  reaches a user who does not already know the feature exists.
+- **Honest empty state.** A source with nothing in it shows one line; a query
+  that matches nothing **closes** the popup. The copy never claims what the
+  client cannot observe: `_agent_briefing` returns `[]` for a stopped or slow
+  agent exactly as it does for one with no playbooks, and the roster is fetched
+  once at mount — so "no playbooks exposed" would be a false claim about
+  operator configuration for the ordinary state of an idle fleet. "No peers" and
+  "peers exist but none is mentionable" are separate statements.
+- **Scope**: `/` and `@` in the 1:1 composer; **`@` in the room composer**,
+  scoped to the room's **agent participants** — verified against the running
+  engine, not assumed (`resolve_mentions` keeps only agent participants that
+  have not left; a non-participant `@name` is neither recognised nor recruited),
+  because offering the roster there would manufacture a silent no-op. **`/` in a
+  room is deferred**: a room has N participants and no active agent, so "whose
+  playbooks?" has no answer without inventing a picker this issue does not
+  specify. Recruiting a new agent stays with the explicit "+ Add agent" control.
+- **Flow**: [workspace-composer-typeahead.md](../feature-flows/workspace-composer-typeahead.md)
+
 ---
 
 ## 6. Activity Monitoring

--- a/src/frontend/src/components/portal/PortalBriefing.vue
+++ b/src/frontend/src/components/portal/PortalBriefing.vue
@@ -54,7 +54,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import PortalAvatar from './PortalAvatar.vue'
-import { planHintDisplay } from './portalUtils'
+import { planHintDisplay, starterFor } from './portalUtils'
 
 const props = defineProps({
   agent: { type: Object, required: true },
@@ -70,9 +70,8 @@ const playbooks = computed(() => props.agent.playbooks || [])
 const expanded = ref(false)
 const hintPlan = computed(() => planHintDisplay(playbooks.value, expanded.value))
 
-// Playbooks usually take an argument — pre-fill the composer with the starter
-// (never auto-run). Fall back to the title so a card always does something.
-function starterFor(p) {
-  return (p.starter_prompt || '').trim() || (p.title || '')
-}
+// `starterFor` (starter_prompt → else title, never auto-run) moved to
+// portalUtils.js in ent#392: the `/` typeahead inserts the same thing this card
+// does, and two copies of that rule would let a hint and its typeahead row
+// prefill different text.
 </script>

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -229,6 +229,7 @@ import {
   buildMentionToken,
   clampActiveIndex,
   detectTypeaheadTrigger,
+  dismissAfterInsert,
   filterAgentCandidates,
   filterPlaybookCandidates,
   isSuppressed,
@@ -538,6 +539,12 @@ function acceptActive(index) {
   const { value, caret } = applyTypeaheadInsert(input.value, t, insert)
   input.value = value
   closeTypeahead()
+  // A pick that lands mid-sentence leaves the caret inside the token it just
+  // inserted, and the setSelectionRange() below fires a `select` that would
+  // re-detect it — the popup reopening on top of its own successful choice.
+  // Suppress exactly that token; editing it back re-arms.
+  const settled = dismissAfterInsert(value, caret)
+  if (settled) dismissed.value = settled
   nextTick(() => {
     const el = textarea.value
     // focus() BEFORE setSelectionRange(): Safari resets and scrolls the

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -168,15 +168,34 @@
           >
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-14 0m7 7v3m0-3a4 4 0 004-4V7a4 4 0 10-8 0v6a4 4 0 004 4z" /></svg>
           </button>
-          <textarea
-            ref="textarea"
-            v-model="input"
-            rows="1"
-            :placeholder="listening ? 'Listening…' : `Message ${agentDisplayName(agent)}…`"
-            class="flex-1 resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
-            @input="autoGrow"
-            @keydown.enter.exact.prevent="send"
-          ></textarea>
+          <!-- ent#392: this is the composer's FIRST anchored overlay, so the
+               wrapper is new. It must inherit the flex sizing the textarea used
+               to carry (`flex-1 min-w-0`) — a bare `relative` div collapses the
+               field to content width — and it deliberately carries no z-index,
+               so it creates no stacking context of its own. -->
+          <div ref="composerWrap" class="relative flex-1 min-w-0">
+            <PortalTypeahead
+              v-if="typeaheadOpen"
+              :kind="typeaheadKind"
+              :rows="typeaheadRows"
+              :active-index="activeIndex"
+              :overflow="typeaheadBound.overflow"
+              :empty-message="typeaheadEmpty || ''"
+              @pick="acceptActive"
+              @hover="activeIndex = $event"
+            />
+            <textarea
+              ref="textarea"
+              v-model="input"
+              rows="1"
+              :placeholder="composerPlaceholder"
+              class="w-full resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
+              @input="onComposerInput"
+              @keydown="onComposerKeydown"
+              @click="onComposerCaret"
+              @select="onComposerCaret"
+            ></textarea>
+          </div>
           <button
             type="submit"
             class="shrink-0 p-2.5 rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-40 disabled:hover:bg-action-primary-600 transition"
@@ -200,7 +219,25 @@ import { renderMarkdown } from '@/utils/markdown'
 import { agentDisplayName } from '@/utils/agentName'
 import PortalAvatar from './PortalAvatar.vue'
 import PortalStarButton from './PortalStarButton.vue'
-import { deliveryFailureReason, mentionedAgents, REPLY_MAX_WAIT_MS_FALLBACK } from './portalUtils'
+import PortalTypeahead from './PortalTypeahead.vue'
+import {
+  deliveryFailureReason,
+  mentionedAgents,
+  REPLY_MAX_WAIT_MS_FALLBACK,
+  applyTypeaheadInsert,
+  boundCandidates,
+  buildMentionToken,
+  clampActiveIndex,
+  detectTypeaheadTrigger,
+  filterAgentCandidates,
+  filterPlaybookCandidates,
+  isSuppressed,
+  nextActiveIndex,
+  nextDismissState,
+  resolveComposerKey,
+  starterFor,
+  typeaheadEmptyMessage,
+} from './portalUtils'
 
 const props = defineProps({
   agent: { type: Object, required: true },      // {name, owner, avatar_url, description, playbooks, voice_available}
@@ -227,6 +264,15 @@ const textarea = ref(null)
 const fileInput = ref(null)
 const pickerRef = ref(null)
 const pickerOpen = ref(false)
+
+// ent#392 — composer typeahead state. Three refs, no decisions: `trigger` is
+// whatever the pure scanner last returned, `activeIndex` is the roving
+// selection (-1 = nothing chosen, which is what makes Enter send), `dismissed`
+// is the Esc sentinel.
+const composerWrap = ref(null)
+const typeaheadTrigger = ref(null)
+const activeIndex = ref(-1)
+const dismissed = ref(null)
 
 const render = (c) => renderMarkdown(c || '')
 
@@ -289,12 +335,13 @@ async function reattach(executionId) {
 
 watch(() => [props.agent.name, props.sessionId], async ([, sid], [oldName]) => {
   currentSessionId.value = sid
+  resetTypeahead()
   if (props.agent.name !== oldName || sid) await loadThread(sid)
   else { messages.value = []; currentSessionId.value = null }   // brand-new chat
 })
 
 watch(() => props.prefill, (v) => {
-  if (v) { input.value = v; nextTick(() => { autoGrow(); textarea.value?.focus() }) }
+  if (v) { input.value = v; resetTypeahead(); nextTick(() => { autoGrow(); textarea.value?.focus() }) }
 })
 
 onMounted(async () => {
@@ -314,7 +361,14 @@ onBeforeUnmount(() => {
 })
 
 function onNet() { offline.value = navigator.onLine === false }
-function onDocClick(e) { if (pickerOpen.value && pickerRef.value && !pickerRef.value.contains(e.target)) pickerOpen.value = false }
+function onDocClick(e) {
+  if (pickerOpen.value && pickerRef.value && !pickerRef.value.contains(e.target)) pickerOpen.value = false
+  // Outside the composer AND its popup closes the typeahead WITHOUT arming the
+  // Esc sentinel; a click inside the textarea recomputes via @click, and a click
+  // on the popup's own padding or scrollbar must not close it. This also covers
+  // the files drawer and the mobile nav, whose buttons live outside the wrapper.
+  if (typeaheadTrigger.value && composerWrap.value && !composerWrap.value.contains(e.target)) closeTypeahead()
+}
 
 function pickAgent(a) {
   pickerOpen.value = false
@@ -330,6 +384,167 @@ function autoGrow() {
   if (!el) return
   el.style.height = 'auto'
   el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+}
+
+// ---- ent#392: composer typeahead (`/` playbooks, `@` agents) -----------------
+//
+// A DISPATCHER. Every decision — what counts as a trigger, what is offered, what
+// a key does, what a pick splices — lives in the pure exports of portalUtils.js,
+// because `vitest` runs `environment: 'node'` with no component-mount harness,
+// so a decision left here is a decision no test can reach.
+
+const typeaheadKind = computed(() => typeaheadTrigger.value?.kind || '/')
+
+const typeaheadResult = computed(() => {
+  const t = typeaheadTrigger.value
+  if (!t) return null
+  if (t.kind === '/') {
+    return { kind: '/', enabled: true, ...filterPlaybookCandidates(props.agent?.playbooks, t.query) }
+  }
+  return {
+    kind: '@',
+    ...filterAgentCandidates(props.roster, t.query, {
+      exclude: [props.agent?.name],
+      // #2128: with no rooms substrate an @mention is deliberately ordinary
+      // text, so offering a picker for it is a dead-end affordance. The gate
+      // lives in the pure filter, so it is tested rather than grepped.
+      enabled: store.multiAgentChatAvailable,
+    }),
+  }
+})
+
+const typeaheadBound = computed(() => boundCandidates(typeaheadResult.value?.items || []))
+
+// The two empty conditions are NOT the same: a source with nothing in it shows
+// one honest line, while a query that matches nothing CLOSES the popup (AC#6 —
+// the user is writing "50/50", not picking). Restricting the line to a bare
+// trigger keeps a playbook-less agent from floating a panel over the rest of the
+// message as they keep typing.
+const typeaheadEmpty = computed(() => {
+  const t = typeaheadTrigger.value
+  const r = typeaheadResult.value
+  if (!t || !r || r.items.length || t.query !== '') return null
+  return typeaheadEmptyMessage(r.kind, r)
+})
+
+// A computed, not an imperative ref: it self-heals when the roster refreshes,
+// the capability flips, or playbooks arrive late.
+const typeaheadOpen = computed(() => {
+  const t = typeaheadTrigger.value
+  const r = typeaheadResult.value
+  if (!t || !r || r.enabled === false) return false
+  if (isSuppressed(dismissed.value, t)) return false
+  return typeaheadBound.value.visible.length > 0 || !!typeaheadEmpty.value
+})
+
+const typeaheadRows = computed(() => typeaheadBound.value.visible.map((c, i) => (
+  typeaheadKind.value === '/'
+    ? { key: `pb-${i}-${c.title}`, primary: c.title, secondary: c.description || '' }
+    // The slug rides along beside the label: it IS the token, and teaching it is
+    // half of why this exists.
+    : { key: `ag-${c.name}`, primary: agentDisplayName(c), secondary: `@${c.name}` }
+)))
+
+// The selection has to follow the list. A stale index is DROPPED rather than
+// clamped to a neighbour — "whatever is now at index 5" is not the row the user
+// chose, and inserting it is how the wrong agent (or `@undefined`) ships.
+watch(typeaheadBound, (b) => { activeIndex.value = clampActiveIndex(activeIndex.value, b.visible.length) })
+
+// The only part of this change that reaches a user who does not already know the
+// feature exists. `@` is advertised only with the capability — a placeholder
+// promising something the build cannot do is the #2128 dead end in text form.
+const composerPlaceholder = computed(() => {
+  if (listening.value) return 'Listening…'
+  const base = `Message ${agentDisplayName(props.agent)}…  ·  / for playbooks`
+  return store.multiAgentChatAvailable ? `${base}  ·  @ to add an agent` : base
+})
+
+function closeTypeahead() {
+  typeaheadTrigger.value = null
+  activeIndex.value = -1
+}
+
+// ONLY Esc arms the sentinel. A click-outside, an agent switch or a capability
+// flip closes without arming — otherwise "type @, click away to read something,
+// click back, keep typing" stays suppressed until the @ is deleted.
+function dismissTypeahead() {
+  dismissed.value = nextDismissState(typeaheadTrigger.value)
+  closeTypeahead()
+}
+
+// Called from every path that writes `input.value` PROGRAMMATICALLY — send(),
+// the prefill watcher, the thread switch, and both dictation handlers. None of
+// them fires an input event, so without this a sentinel armed while composing
+// message 1 kills the popup for every later message that starts the same way: a
+// feature that is dead for the rest of the session.
+function resetTypeahead() {
+  closeTypeahead()
+  dismissed.value = null
+}
+
+function refreshTypeahead(el) {
+  if (!el) return
+  // Read the EVENT TARGET, never the v-model ref: reading the ref makes
+  // correctness depend on Vue's internal listener ordering, which is true today
+  // and an implementation detail.
+  typeaheadTrigger.value = detectTypeaheadTrigger(el.value, el.selectionStart, el.selectionEnd)
+  if (!typeaheadTrigger.value) activeIndex.value = -1
+}
+
+function onComposerInput(e) {
+  autoGrow()
+  // A paste that happens to end in a token must not open a popup nobody asked
+  // for, whose very next keystroke is Enter.
+  if (e?.inputType === 'insertFromPaste' || e?.inputType === 'insertFromDrop') {
+    closeTypeahead()
+    return
+  }
+  refreshTypeahead(e?.target)
+}
+
+// The caret moves with no input event — a click, a drag-select — and accepting
+// against bounds computed for where it used to be splices over the wrong text.
+function onComposerCaret(e) { refreshTypeahead(e?.target) }
+
+function onComposerKeydown(e) {
+  const length = typeaheadBound.value.visible.length
+  switch (resolveComposerKey({
+    key: e.key,
+    shiftKey: e.shiftKey,
+    ctrlKey: e.ctrlKey,
+    metaKey: e.metaKey,
+    altKey: e.altKey,
+    isComposing: e.isComposing,
+    keyCode: e.keyCode,
+    open: typeaheadOpen.value,
+    hasActive: activeIndex.value >= 0,
+    hasCandidates: length > 0,
+  })) {
+    case 'move-down': e.preventDefault(); activeIndex.value = nextActiveIndex(activeIndex.value, 1, length); break
+    case 'move-up': e.preventDefault(); activeIndex.value = nextActiveIndex(activeIndex.value, -1, length); break
+    case 'accept': e.preventDefault(); acceptActive(activeIndex.value >= 0 ? activeIndex.value : 0); break
+    case 'dismiss': e.preventDefault(); dismissTypeahead(); break
+    case 'close': closeTypeahead(); break
+    case 'send': e.preventDefault(); send(); break
+    default: break
+  }
+}
+
+function acceptActive(index) {
+  const t = typeaheadTrigger.value
+  const row = typeaheadBound.value.visible[index]
+  if (!t || !row) return                  // never insert `@undefined`
+  const insert = t.kind === '/' ? starterFor(row) : buildMentionToken(row.name)
+  const { value, caret } = applyTypeaheadInsert(input.value, t, insert)
+  input.value = value
+  closeTypeahead()
+  nextTick(() => {
+    const el = textarea.value
+    // focus() BEFORE setSelectionRange(): Safari resets and scrolls the
+    // selection when focusing a textarea that did not previously have focus.
+    if (el) { el.focus(); el.setSelectionRange(caret, caret) }
+    autoGrow()
+  })
 }
 
 // ---- Attachments: upload to the agent inbox; the next turn sees them ----------
@@ -603,6 +818,10 @@ function markFailed(index, content, error, { retryable = true } = {}) {
 async function send() {
   const text = input.value.trim()
   if (!text || sending.value) return
+  // The composer is about to be cleared programmatically, which fires no input
+  // event — so the popup and its Esc sentinel are cleared here rather than left
+  // armed against a message that no longer exists.
+  resetTypeahead()
 
   // ent#361: @mentioning another agent from a 1:1 makes this a group discussion.
   // Handled BEFORE the message is appended: the conversation moves to a room, so
@@ -672,7 +891,7 @@ function toggleMic() {
 function toggleSpeech() {
   if (listening.value) { try { recog?.stop() } catch { /* noop */ } return }
   recog = new SpeechRec(); recog.lang = 'en-US'; recog.interimResults = false; recog.maxAlternatives = 1
-  recog.onresult = (e) => { const t = e.results?.[0]?.[0]?.transcript || ''; if (t) { input.value = input.value ? `${input.value} ${t}` : t; autoGrow() } }
+  recog.onresult = (e) => { const t = e.results?.[0]?.[0]?.transcript || ''; if (t) { input.value = input.value ? `${input.value} ${t}` : t; resetTypeahead(); autoGrow() } }
   recog.onend = () => { listening.value = false }
   recog.onerror = () => { listening.value = false }
   listening.value = true
@@ -689,7 +908,7 @@ async function toggleRecord() {
     const blob = new Blob(recChunks, { type: mediaRec?.mimeType || 'audio/webm' }); recChunks = []
     if (blob.size < 1500) return
     transcribing.value = true
-    try { const t = await store.transcribeStt(props.agent.name, blob); if (t) { input.value = input.value ? `${input.value} ${t}` : t; autoGrow() } }
+    try { const t = await store.transcribeStt(props.agent.name, blob); if (t) { input.value = input.value ? `${input.value} ${t}` : t; resetTypeahead(); autoGrow() } }
     catch { /* keep text mode */ } finally { transcribing.value = false }
   }
   listening.value = true

--- a/src/frontend/src/components/portal/PortalRoom.vue
+++ b/src/frontend/src/components/portal/PortalRoom.vue
@@ -321,8 +321,10 @@ const addable = computed(() => {
 // this issue does not specify. Stated as a scope limitation (AC#9).
 //
 // Recruiting a NEW agent stays with the explicit "+ Add agent" control, which is
-// the honest place for it — that spends money on another agent, and a mention
-// cannot do it anyway.
+// the honest place for it — that spends money on another agent, and the probe
+// above saw a non-participant mention wake nobody. Whether it recruits by some
+// other path is OPEN, not settled here (requirements §5.12 records an
+// engine-side newcomer-join from ent#361).
 
 const mentionSource = computed(() => roomMentionSource(agentParticipants.value, props.roster))
 

--- a/src/frontend/src/components/portal/PortalRoom.vue
+++ b/src/frontend/src/components/portal/PortalRoom.vue
@@ -130,13 +130,32 @@
           This conversation has ended{{ room?.stop_reason ? ` (${closedReason})` : '' }}. Start a new chat to keep going.
         </p>
         <form v-else class="flex items-end gap-2" @submit.prevent="send">
-          <textarea
-            v-model="input"
-            rows="1"
-            :placeholder="placeholder"
-            class="flex-1 resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
-            @keydown.enter.exact.prevent="send"
-          ></textarea>
+          <!-- ent#392: `@` typeahead over the room's WAKE-SET. Same anchored
+               wrapper as the 1:1 composer; it must carry the flex sizing the
+               textarea used to hold, or the field collapses to content width. -->
+          <div ref="composerWrap" class="relative flex-1 min-w-0">
+            <PortalTypeahead
+              v-if="typeaheadOpen"
+              kind="@"
+              :rows="typeaheadRows"
+              :active-index="activeIndex"
+              :overflow="typeaheadBound.overflow"
+              :empty-message="typeaheadEmpty || ''"
+              @pick="acceptActive"
+              @hover="activeIndex = $event"
+            />
+            <textarea
+              ref="textarea"
+              v-model="input"
+              rows="1"
+              :placeholder="placeholder"
+              class="w-full resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
+              @keydown="onComposerKeydown"
+              @input="onComposerInput"
+              @click="onComposerCaret"
+              @select="onComposerCaret"
+            ></textarea>
+          </div>
           <button
             type="submit"
             class="shrink-0 p-2.5 rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-40 transition"
@@ -177,6 +196,22 @@ import { useClientPortalStore } from '@/stores/clientPortal'
 import { renderMarkdown } from '@/utils/markdown'
 import PortalAvatar from './PortalAvatar.vue'
 import PortalStarButton from './PortalStarButton.vue'
+import PortalTypeahead from './PortalTypeahead.vue'
+import {
+  applyTypeaheadInsert,
+  boundCandidates,
+  buildMentionToken,
+  clampActiveIndex,
+  detectTypeaheadTrigger,
+  filterAgentCandidates,
+  isSuppressed,
+  nextActiveIndex,
+  nextDismissState,
+  resolveComposerKey,
+  roomMentionSource,
+  typeaheadEmptyMessage,
+} from './portalUtils'
+import { agentDisplayName } from '@/utils/agentName'
 
 const props = defineProps({
   roomId: { type: String, required: true },
@@ -199,6 +234,14 @@ const scrollEl = ref(null)
 const addOpen = ref(false)
 const adding = ref(false)
 const addError = ref(null)
+
+// ent#392 — composer typeahead state (`@` only; see the block below for why
+// there is no `/` here).
+const textarea = ref(null)
+const composerWrap = ref(null)
+const typeaheadTrigger = ref(null)
+const activeIndex = ref(-1)
+const dismissed = ref(null)
 
 let pollTimer = null
 const POLL_MS = 3000
@@ -258,6 +301,139 @@ const addable = computed(() => {
   return (props.roster || []).filter((a) => !here.has(a.name))
 })
 
+// ---- ent#392: `@` typeahead over the room's wake-set ------------------------
+//
+// @mention-waking is first-class here and completely undiscoverable — a room has
+// many counterparts, so it needs the affordance more than a 1:1 does. The
+// candidate list is the AGENT PARTICIPANTS, never the roster, and that is not an
+// assumption: posting `@<participant>` to a live instance answered
+// {"mentions":["acme-scout"],"woke":["acme-scout"]} while `@<non-participant>`
+// answered {"mentions":[],"woke":[]}. The engine's `resolve_mentions` keeps only
+// agent participants that have not left, and nothing outside the room is
+// recruited — so offering the roster would manufacture a silent no-op, the same
+// class as offering a slug the grammar cannot carry.
+//
+// There is deliberately NO `/` typeahead: a room has N participants and no
+// active agent, so "whose playbooks?" has no answer without inventing a picker
+// this issue does not specify. Stated as a scope limitation (AC#9).
+//
+// Recruiting a NEW agent stays with the explicit "+ Add agent" control, which is
+// the honest place for it — that spends money on another agent, and a mention
+// cannot do it anyway.
+
+const mentionSource = computed(() => roomMentionSource(agentParticipants.value, props.roster))
+
+const typeaheadResult = computed(() => {
+  const t = typeaheadTrigger.value
+  if (!t || t.kind !== '@') return null
+  return filterAgentCandidates(mentionSource.value, t.query)
+})
+
+const typeaheadBound = computed(() => boundCandidates(typeaheadResult.value?.items || []))
+
+const typeaheadEmpty = computed(() => {
+  const t = typeaheadTrigger.value
+  const r = typeaheadResult.value
+  if (!t || !r || r.items.length || t.query !== '') return null
+  return typeaheadEmptyMessage('@', r, { scope: 'room' })
+})
+
+const typeaheadOpen = computed(() => {
+  const t = typeaheadTrigger.value
+  const r = typeaheadResult.value
+  if (!t || !r || isClosed.value) return false
+  if (isSuppressed(dismissed.value, t)) return false
+  return typeaheadBound.value.visible.length > 0 || !!typeaheadEmpty.value
+})
+
+const typeaheadRows = computed(() => typeaheadBound.value.visible.map((a) => ({
+  key: `ag-${a.name}`,
+  primary: agentDisplayName(a),
+  secondary: `@${a.name}`,
+})))
+
+watch(typeaheadBound, (b) => { activeIndex.value = clampActiveIndex(activeIndex.value, b.visible.length) })
+
+function closeTypeahead() {
+  typeaheadTrigger.value = null
+  activeIndex.value = -1
+}
+
+function dismissTypeahead() {
+  dismissed.value = nextDismissState(typeaheadTrigger.value)
+  closeTypeahead()
+}
+
+// Every programmatic write to `input.value` — send() clearing it, and send()
+// giving it back on failure — fires no input event, so the sentinel is cleared
+// here or it outlives the message it was armed against.
+function resetTypeahead() {
+  closeTypeahead()
+  dismissed.value = null
+}
+
+function refreshTypeahead(el) {
+  if (!el) return
+  const t = detectTypeaheadTrigger(el.value, el.selectionStart, el.selectionEnd)
+  // A room has no `/` surface, so a `/` trigger is simply not a trigger here —
+  // dropped at the edge rather than filtered downstream, so nothing below has to
+  // remember that this composer is single-kind.
+  typeaheadTrigger.value = t && t.kind === '@' ? t : null
+  if (!typeaheadTrigger.value) activeIndex.value = -1
+}
+
+function onComposerInput(e) {
+  if (e?.inputType === 'insertFromPaste' || e?.inputType === 'insertFromDrop') {
+    closeTypeahead()
+    return
+  }
+  refreshTypeahead(e?.target)
+}
+
+function onComposerCaret(e) { refreshTypeahead(e?.target) }
+
+function onComposerKeydown(e) {
+  const length = typeaheadBound.value.visible.length
+  switch (resolveComposerKey({
+    key: e.key,
+    shiftKey: e.shiftKey,
+    ctrlKey: e.ctrlKey,
+    metaKey: e.metaKey,
+    altKey: e.altKey,
+    isComposing: e.isComposing,
+    keyCode: e.keyCode,
+    open: typeaheadOpen.value,
+    hasActive: activeIndex.value >= 0,
+    hasCandidates: length > 0,
+  })) {
+    case 'move-down': e.preventDefault(); activeIndex.value = nextActiveIndex(activeIndex.value, 1, length); break
+    case 'move-up': e.preventDefault(); activeIndex.value = nextActiveIndex(activeIndex.value, -1, length); break
+    case 'accept': e.preventDefault(); acceptActive(activeIndex.value >= 0 ? activeIndex.value : 0); break
+    case 'dismiss': e.preventDefault(); dismissTypeahead(); break
+    case 'close': closeTypeahead(); break
+    case 'send': e.preventDefault(); send(); break
+    default: break
+  }
+}
+
+function acceptActive(index) {
+  const t = typeaheadTrigger.value
+  const row = typeaheadBound.value.visible[index]
+  if (!t || !row) return
+  const { value, caret } = applyTypeaheadInsert(input.value, t, buildMentionToken(row.name))
+  input.value = value
+  closeTypeahead()
+  nextTick(() => {
+    const el = textarea.value
+    if (el) { el.focus(); el.setSelectionRange(caret, caret) }
+  })
+}
+
+// Outside the composer and its popup closes without arming the Esc sentinel.
+function onDocClick(e) {
+  if (typeaheadTrigger.value && composerWrap.value && !composerWrap.value.contains(e.target)) closeTypeahead()
+}
+
 function isMine(m) {
   // Anything not an agent and not the room itself is this client — the room is
   // per-client here, so a human sender is the caller.
@@ -295,6 +471,7 @@ async function send() {
   sending.value = true
   sendError.value = null
   input.value = ''
+  resetTypeahead()
   try {
     await store.postRoomMessage(props.roomId, text)
     // The post returns once the mentioned agents have been woken; their replies
@@ -305,6 +482,7 @@ async function send() {
     sendError.value = detail?.message || (typeof detail === 'string' ? detail : null)
       || 'That message was not delivered.'
     input.value = text        // give it back rather than losing what they typed
+    resetTypeahead()
   } finally {
     sending.value = false
     await scrollDown()
@@ -347,12 +525,17 @@ function stopPolling() {
 watch(() => props.roomId, async () => {
   messages.value = []
   loading.value = true
+  resetTypeahead()
   await load({ full: true })
 })
 
 onMounted(async () => {
+  document.addEventListener('click', onDocClick)
   await load({ full: true })
   startPolling()
 })
-onBeforeUnmount(stopPolling)
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocClick)
+  stopPolling()
+})
 </script>

--- a/src/frontend/src/components/portal/PortalRoom.vue
+++ b/src/frontend/src/components/portal/PortalRoom.vue
@@ -203,6 +203,7 @@ import {
   buildMentionToken,
   clampActiveIndex,
   detectTypeaheadTrigger,
+  dismissAfterInsert,
   filterAgentCandidates,
   isSuppressed,
   nextActiveIndex,
@@ -308,10 +309,12 @@ const addable = computed(() => {
 // candidate list is the AGENT PARTICIPANTS, never the roster, and that is not an
 // assumption: posting `@<participant>` to a live instance answered
 // {"mentions":["acme-scout"],"woke":["acme-scout"]} while `@<non-participant>`
-// answered {"mentions":[],"woke":[]}. The engine's `resolve_mentions` keeps only
-// agent participants that have not left, and nothing outside the room is
-// recruited — so offering the roster would manufacture a silent no-op, the same
-// class as offering a slug the grammar cannot carry.
+// answered {"mentions":[],"woke":[]}. Participants demonstrably wake; a
+// non-participant demonstrably wakes nobody on that turn — so offering the
+// roster would put names in front of the user with no evidence that choosing
+// one does anything, the same class of silent no-op as offering a slug the
+// grammar cannot carry. See roomMentionSource() in portalUtils.js for what this
+// deliberately does not claim about recruiting.
 //
 // There is deliberately NO `/` typeahead: a room has N participants and no
 // active agent, so "whose playbooks?" has no answer without inventing a picker
@@ -423,6 +426,11 @@ function acceptActive(index) {
   const { value, caret } = applyTypeaheadInsert(input.value, t, buildMentionToken(row.name))
   input.value = value
   closeTypeahead()
+  // See PortalConversation: a mid-sentence pick leaves the caret inside the
+  // token, and setSelectionRange() fires a `select` that would reopen the popup
+  // over its own successful choice.
+  const settled = dismissAfterInsert(value, caret)
+  if (settled) dismissed.value = settled
   nextTick(() => {
     const el = textarea.value
     if (el) { el.focus(); el.setSelectionRange(caret, caret) }

--- a/src/frontend/src/components/portal/PortalTypeahead.vue
+++ b/src/frontend/src/components/portal/PortalTypeahead.vue
@@ -1,0 +1,109 @@
+<template>
+  <!-- ent#392: the composer typeahead panel. Presentational ONLY — it holds no
+       decisions. What is offered, what is selected and what a pick inserts are
+       all resolved by the pure functions in portalUtils.js, because this project
+       has no component-mount harness and a decision living here is a decision no
+       test can reach.
+
+       Opens UPWARD (`bottom-full`): the composer sits at the bottom of the pane,
+       so a downward panel would land off-screen. `max-h-[min(14rem,40vh)]` rather
+       than a flat `max-h-56`: Portal.vue's root is `h-screen overflow-hidden`, so
+       on mobile landscape with the keyboard up a fixed 224px panel clips against
+       a composer sitting at ~y=250.
+
+       z-30 is the same tier as this component's own agent-picker dropdown and
+       strictly below the two z-40 overlays (mobile nav, files panel) that must
+       cover it; the two z-30 panels sit at opposite ends of the pane and cannot
+       overlap. The parent wrapper deliberately carries no z-index, so it creates
+       no stacking context of its own. -->
+  <div
+    class="absolute bottom-full left-0 right-0 mb-2 z-30 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-xl overflow-hidden"
+    @mousedown.prevent
+  >
+    <div class="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 dark:border-gray-800">
+      <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{{ heading }}</span>
+      <span class="text-[11px] text-gray-400 dark:text-gray-500 hidden sm:block">
+        <kbd class="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-[10px] font-mono">↑↓</kbd>
+        move
+        <kbd class="ml-1.5 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-[10px] font-mono">Tab</kbd>
+        insert
+        <kbd class="ml-1.5 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-[10px] font-mono">Esc</kbd>
+        close
+      </span>
+    </div>
+
+    <ul
+      v-if="rows.length"
+      ref="listEl"
+      role="listbox"
+      :aria-label="heading"
+      class="max-h-[min(14rem,40vh)] overflow-y-auto py-1"
+    >
+      <li
+        v-for="(row, i) in rows"
+        :key="row.key"
+        role="option"
+        :aria-selected="i === activeIndex"
+        class="flex items-start gap-2.5 px-3 py-2 cursor-pointer"
+        :class="i === activeIndex
+          ? 'bg-action-primary-50 dark:bg-action-primary-900/30'
+          : 'hover:bg-gray-100 dark:hover:bg-gray-800'"
+        @mousedown="$emit('pick', i)"
+        @mouseenter="$emit('hover', i)"
+      >
+        <span class="shrink-0 mt-0.5 text-xs font-mono font-semibold text-action-primary-600 dark:text-action-primary-400">{{ kind }}</span>
+        <span class="min-w-0 flex-1">
+          <!-- Interpolation, never raw HTML: titles and descriptions are
+               agent/operator-authored text arriving in a new place. -->
+          <span class="block text-sm text-gray-900 dark:text-gray-100 line-clamp-2 break-words">{{ row.primary }}</span>
+          <span v-if="row.secondary" class="block text-xs text-gray-500 dark:text-gray-400 line-clamp-1 break-words">{{ row.secondary }}</span>
+        </span>
+      </li>
+    </ul>
+
+    <!-- The honest empty line. It appears only on a bare trigger (the caller
+         closes the popup once a query matches nothing), and it must never be a
+         claim about operator configuration the client cannot observe. -->
+    <p v-else-if="emptyMessage" class="px-3 py-2.5 text-xs text-gray-500 dark:text-gray-400">{{ emptyMessage }}</p>
+
+    <div
+      v-if="overflow > 0"
+      class="px-3 py-1.5 border-t border-gray-100 dark:border-gray-800 text-[11px] text-gray-400 dark:text-gray-500"
+    >
+      {{ overflow }} more — keep typing to filter
+    </div>
+
+    <p class="sr-only" aria-live="polite">{{ status }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch, nextTick } from 'vue'
+
+const props = defineProps({
+  kind: { type: String, required: true },          // '/' | '@'
+  rows: { type: Array, default: () => [] },        // [{key, primary, secondary}]
+  activeIndex: { type: Number, default: -1 },
+  overflow: { type: Number, default: 0 },
+  emptyMessage: { type: String, default: '' },
+})
+defineEmits(['pick', 'hover'])
+
+const listEl = ref(null)
+
+const heading = computed(() => (props.kind === '/' ? 'Playbooks' : 'Agents'))
+
+const status = computed(() => {
+  if (!props.rows.length) return props.emptyMessage || 'No suggestions'
+  const n = props.rows.length + props.overflow
+  return `${n} suggestion${n === 1 ? '' : 's'}. Use the arrow keys to choose one.`
+})
+
+// Keep the chosen row in view without moving the page (principle 5: updates
+// preserve scroll). `nearest` so arrowing down one row scrolls one row.
+watch(() => props.activeIndex, async (i) => {
+  if (i < 0) return
+  await nextTick()
+  listEl.value?.children?.[i]?.scrollIntoView({ block: 'nearest' })
+})
+</script>

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -336,3 +336,375 @@ export const PORTAL_BUCKET_LABELS = {
   'Channels': 'Messaging',
   'Public': 'Public link',
 }
+
+// ---------------------------------------------------------------------------
+// ent#392 — composer typeahead: `/` for the agent's playbooks, `@` for agents.
+//
+// Both invocation syntaxes already worked and neither was discoverable: a
+// client had to know the exact slug, and a near-miss parses as plain text with
+// no feedback. Everything below is PURE and exported, because this project has
+// no component-mount harness (`vitest` runs `environment: 'node'`) — so any
+// decision left inside the component is a decision no test can reach. The
+// components are dispatchers over these functions.
+//
+// OSS-core by decision (ent#392): deliberately ungated — no
+// `requires_entitlement`, logic stays in the OSS tree. Recorded explicitly
+// because CLAUDE.md's default for an enterprise-tracker feature is gated unless
+// ruled otherwise, so the ruling must never be inferred later from the mere
+// fact that it merged (the ent#326 / ent#384 discipline).
+// ---------------------------------------------------------------------------
+
+// The longest token the typeahead will look back over. This FLOORS the backward
+// scan rather than merely capping the result: an unfloored scan walks the whole
+// composer on every keystroke, and a pasted 100 KB blob then costs O(n) per key.
+export const MAX_TYPEAHEAD_QUERY = 64
+
+// Rows drawn at once. The `/` source is already belted to 24 server-side
+// (`_bound_briefing_hints`, #2101), so this is layout, not safety.
+export const TYPEAHEAD_LIMIT = 8
+
+// "Preceded by a non-WORD char" — deliberately NOT "preceded by whitespace".
+// A whitespace-only rule cannot fire in CJK (你好@rec), after an emoji, or after
+// punctuation ((@bob, "@bob), while the non-word rule still closes every AC#6
+// case: `50/50` (prev '0'), `and/or` (prev 'd'), `user@example.com` (prev 'r').
+const WORD_CHAR_RE = /[A-Za-z0-9_]/
+const WS_RE = /\s/
+
+// Keys that move the caret without producing an input event. While the popup is
+// open they close it and pass through: the alternative is accepting against
+// bounds computed for a caret that has since moved.
+const CARET_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'Home', 'End', 'PageUp', 'PageDown'])
+
+/**
+ * Find the trigger token the caret is sitting in.
+ *
+ * → `null` | `{ kind: '/' | '@', start, end, query }`, where `[start, end)` is
+ * the whole token — `start` from a backward scan, `end` from a FORWARD one.
+ *
+ * The forward scan is load-bearing. Without it the splice ends at the caret, so
+ * accepting *alice* with the caret parked at `@bo|b` leaves `@alice b` — a
+ * dangling tail that turns a correct mention into two wrong words.
+ *
+ * The trigger rule is deliberately STRICTER than `MENTION_RE`, which is
+ * unanchored and therefore parses `user@example.com` as `@example`. Being
+ * stricter is safe in the only direction that matters: the popup can never open
+ * on something the parser would not see, so it can never offer a token that
+ * silently degrades to plain text.
+ *
+ * `caretEnd` defaults to `caret`; a non-collapsed selection yields no trigger
+ * (the user is selecting, not composing a token).
+ */
+export function detectTypeaheadTrigger(text, caret, caretEnd) {
+  const s = String(text ?? '')
+  const clamp = (n, fallback) => {
+    const v = Number.isFinite(n) ? Math.trunc(n) : fallback
+    return Math.min(Math.max(v, 0), s.length)
+  }
+  const c = clamp(caret, s.length)
+  if (caretEnd !== undefined && caretEnd !== null && clamp(caretEnd, c) !== c) return null
+
+  const floor = Math.max(0, c - MAX_TYPEAHEAD_QUERY - 1)
+  let start = -1
+  let kind = null
+  for (let i = c - 1; i >= floor; i--) {
+    const ch = s[i]
+    if (WS_RE.test(ch)) return null                       // token boundary crossed
+    if (ch !== '/' && ch !== '@') continue
+    if (i === 0 || !WORD_CHAR_RE.test(s[i - 1])) { start = i; kind = ch; break }
+    // A trigger char mid-word is not a trigger, but the scan CONTINUES past it:
+    // that is what turns `see /etc/hosts` into a query of `etc/hosts`, which the
+    // next rule then rejects. Returning null here instead would leave the same
+    // input matching prose playbook titles through a shorter query.
+  }
+  if (start < 0) return null
+
+  const query = s.slice(start + 1, c)
+  // A query carrying a second trigger char is not a token anyone is naming.
+  // (`@@bo` and `/@rec` do NOT hit this: the backward scan finds the INNERMOST
+  // trigger, so their query is clean.)
+  if (query.includes('/') || query.includes('@')) return null
+
+  let end = c
+  while (end < s.length && !WS_RE.test(s[end])) end++
+  return { kind, start, end, query }
+}
+
+/**
+ * Splice a chosen insert over the whole trigger token.
+ *
+ * Pure, DOM-free, and it takes no live caret — the trigger already carries its
+ * own bounds, so this cannot splice against a caret that moved.
+ *
+ * The separator is decided HERE, never baked into the token. Baking a trailing
+ * space into `@name` produced `Hello @alice  there` and turned `@| x` into
+ * `@recon  x`; dropping it produced `@reconx`, which resolves to nothing and
+ * degrades to plain text — the exact AC#4 failure this feature exists to close.
+ */
+export function applyTypeaheadInsert(text, trigger, insert, { separator = ' ' } = {}) {
+  const s = String(text ?? '')
+  if (!trigger || !Number.isInteger(trigger.start) || !Number.isInteger(trigger.end)) {
+    return { value: s, caret: s.length }
+  }
+  const start = Math.min(Math.max(trigger.start, 0), s.length)
+  const end = Math.min(Math.max(trigger.end, start), s.length)
+  const body = String(insert ?? '')
+  const nextChar = s.slice(end, end + 1)
+  const spliced = body + (separator && !(nextChar && WS_RE.test(nextChar)) ? separator : '')
+  return { value: s.slice(0, start) + spliced + s.slice(end), caret: start + spliced.length }
+}
+
+// The mention token, and ONLY the token — see the separator rule above.
+export function buildMentionToken(name) { return `@${name}` }
+
+/**
+ * Can this agent be reached by an @mention at all?
+ *
+ * DERIVED from the real parser, never re-typed. Agent slugs are minted by
+ * `sanitize_agent_name`, whose alphabet is `[a-zA-Z0-9_.-]` with NO length cap,
+ * while the mention grammar allows no dot and stops at 100 characters. So
+ * `data.scout` is a perfectly ordinary agent that `MENTION_RE` reads as `@data`
+ * — a token that resolves to nothing and stays plain text. Nothing offers those
+ * names today, so the failure is invisible; a typeahead that listed them would
+ * MANUFACTURE it and make it look like a product bug.
+ *
+ * Asking `mentionedAgents` itself (rather than writing a second regex twelve
+ * lines from the first) is the point: this file's own header says drift in this
+ * grammar is its own bug class, and a hand-copied predicate is drift waiting to
+ * happen. It also rejects names containing `@` or whitespace, which a
+ * hand-written copy would have handled only by luck.
+ *
+ * (`MENTION_RE` carries /g. `matchAll` clones the regex, so `lastIndex` is never
+ * advanced — but never call `.test()`/`.exec()` on it from new code.)
+ */
+export function isMentionable(name) {
+  const n = String(name ?? '')
+  if (!n) return false
+  return mentionedAgents(buildMentionToken(n), [{ name: n }]).length === 1
+}
+
+// The `/` fallback rule, lifted out of PortalBriefing.vue so the card and the
+// typeahead cannot diverge on what a hint inserts. Null-safe: the typeahead can
+// reach it with a row from a roster that refreshed underneath it.
+export function starterFor(p) {
+  return String(p?.starter_prompt ?? '').trim() || String(p?.title ?? '')
+}
+
+// Empty-state copy. Exported so a test pins WHICH condition selects which line,
+// and phrased so it never claims what the client cannot observe: `_agent_briefing`
+// returns `[]` for a stopped or slow agent exactly as it does for one with no
+// playbooks, and the roster is fetched once at mount. "This agent has no
+// playbooks exposed" would therefore be a false claim about operator
+// configuration for the ordinary state of an idle fleet.
+export const EMPTY_REASON_NO_PLAYBOOKS = 'No playbooks are available for this agent right now.'
+export const EMPTY_REASON_NO_PEERS = 'No other agents are shared with you.'
+export const EMPTY_REASON_NO_MENTIONABLE_PEERS =
+  "The other agents shared with you can't be @mentioned — their names aren't valid mention handles."
+export const EMPTY_REASON_NO_ROOM_PEERS = 'No other agents are in this conversation yet.'
+
+function rank(haystack, query) {
+  const h = String(haystack ?? '').toLowerCase()
+  const q = String(query ?? '').toLowerCase()
+  if (!q) return 0
+  if (!h) return -1
+  if (h.startsWith(q)) return 0
+  // Word-start prefix: hint titles are PROSE up to 200 chars, not slugs, so a
+  // bare substring rule makes a one-character query match nearly everything.
+  for (let i = 1; i < h.length; i++) {
+    if (!WORD_CHAR_RE.test(h[i - 1]) && h.startsWith(q, i)) return 1
+  }
+  return -1
+}
+
+// Stable rank-then-original-order. `Array.prototype.sort` is stable in every
+// engine we target, but the index tiebreak makes that explicit rather than
+// assumed.
+function rankedBy(list, score) {
+  return list
+    .map((item, i) => ({ item, i, r: score(item) }))
+    .filter((e) => e.r >= 0)
+    .sort((a, b) => (a.r - b.r) || (a.i - b.i))
+    .map((e) => e.item)
+}
+
+/**
+ * `/` candidates.
+ *
+ * Returns a RECORD, not a bare array, because the popup has two different empty
+ * states and the component must not re-derive which one it is: a source with no
+ * playbooks shows one honest line, a query that matches nothing CLOSES the popup
+ * (AC#6 — the user is writing "50/50", not picking).
+ */
+export function filterPlaybookCandidates(playbooks, query) {
+  const source = (Array.isArray(playbooks) ? playbooks : [])
+    .filter((p) => p && String(p.title ?? '').trim())
+  const q = String(query ?? '')
+  return {
+    items: q ? rankedBy(source, (p) => rank(p.title, q)) : source.slice(),
+    sourceCount: source.length,
+  }
+}
+
+/**
+ * `@` candidates.
+ *
+ * `enabled` is the #2128 capability gate, and it lives HERE rather than in the
+ * component so it is tested rather than grepped: without a rooms substrate an
+ * @mention is deliberately ordinary text, so offering a picker for it is a
+ * dead-end affordance.
+ *
+ * Matching is case-insensitive on the slug AND the display label (AC#3 — the
+ * roster shows labels, the parser keys on slugs), and unlike the playbook rule
+ * it accepts a plain SUBSTRING. That divergence is deliberate: agent names are
+ * short identifiers, frequently sharing a deployment prefix (`acme-scout`,
+ * `acme-scribe`), so a strict prefix rule would fail the obvious query.
+ */
+export function filterAgentCandidates(roster, query, {
+  exclude = [],
+  requireMentionable = true,
+  enabled = true,
+} = {}) {
+  if (!enabled) return { items: [], enabled: false, peerCount: 0, mentionableCount: 0 }
+  const skip = new Set((Array.isArray(exclude) ? exclude : []).filter(Boolean))
+  const peers = (Array.isArray(roster) ? roster : [])
+    .filter((a) => a && a.name && !skip.has(a.name))
+  const reachable = requireMentionable ? peers.filter((a) => isMentionable(a.name)) : peers
+  const q = String(query ?? '').toLowerCase()
+  const items = q
+    ? rankedBy(reachable, (a) => {
+      const slug = String(a.name).toLowerCase()
+      const label = String(a.display_label || a.name).toLowerCase()
+      const r = Math.min(...[rank(slug, q), rank(label, q)].map((n) => (n < 0 ? 99 : n)))
+      if (r < 99) return r
+      return (slug.includes(q) || label.includes(q)) ? 2 : -1
+    })
+    : reachable.slice()
+  return { items, enabled: true, peerCount: peers.length, mentionableCount: reachable.length }
+}
+
+/**
+ * Which honest line the popup shows when the source itself is empty.
+ *
+ * "No peers" and "peers exist but none is mentionable" are DIFFERENT statements
+ * and neither may be told in place of the other — the second one is the P-3
+ * class made visible instead of silent.
+ */
+export function typeaheadEmptyMessage(kind, result, { scope = 'roster' } = {}) {
+  if (kind === '/') return EMPTY_REASON_NO_PLAYBOOKS
+  if (!result || result.enabled === false) return null
+  if (result.peerCount > 0 && result.mentionableCount === 0) return EMPTY_REASON_NO_MENTIONABLE_PEERS
+  return scope === 'room' ? EMPTY_REASON_NO_ROOM_PEERS : EMPTY_REASON_NO_PEERS
+}
+
+// Bounded window + honest overflow count — the `planHintDisplay` house pattern
+// (principle 28: unbounded data is contained, and the total is stated).
+export function boundCandidates(list, limit = TYPEAHEAD_LIMIT) {
+  const all = Array.isArray(list) ? list : []
+  const n = Number.isInteger(limit) && limit > 0 ? limit : TYPEAHEAD_LIMIT
+  return { visible: all.slice(0, n), overflow: Math.max(0, all.length - n) }
+}
+
+/**
+ * The room's `@` wake-set.
+ *
+ * VERIFIED against the running engine, not assumed: posting `@<participant>`
+ * answered `{"mentions":["acme-scout"],"woke":["acme-scout"]}`, while
+ * `@<non-participant>` answered `{"mentions":[],"woke":[]}`. The engine's
+ * `resolve_mentions` keeps only `kind == "agent" and not left_at`, so an @name
+ * outside the room is left as plain text and nothing is recruited. Offering the
+ * full roster here would therefore manufacture a silent no-op — the same class
+ * as listing an un-mentionable slug.
+ *
+ * Participants arrive as bare identities; the roster is joined in only to
+ * recover display labels, so a participant the caller cannot see in their
+ * roster still appears (it is in the room, so it is wakeable).
+ */
+export function roomMentionSource(participantNames, roster) {
+  const byName = new Map(
+    (Array.isArray(roster) ? roster : []).filter((a) => a && a.name).map((a) => [a.name, a]),
+  )
+  return (Array.isArray(participantNames) ? participantNames : [])
+    .filter(Boolean)
+    .map((n) => byName.get(n) || { name: n })
+}
+
+/**
+ * The composer keymap, as data.
+ *
+ * A truth table rather than a substring assertion, and it fixes one thing the
+ * current binding gets wrong: `@keydown.enter.exact` has no IME guard, so an IME
+ * user's candidate-commit Enter sends the message mid-word.
+ *
+ * NO IMPLICIT SELECTION. `activeIndex` starts at -1 and a plain Enter accepts
+ * ONLY with an explicit selection; otherwise it sends. The harm is asymmetric:
+ * an accidental accept destroys typed work (a popup that merely happens to be
+ * open — a paste, or prose like "check /status of the deploy" — would splice up
+ * to 500 characters over the message), while an accidental send is the thing the
+ * user was reaching for anyway. Tab still accepts the top row, and nobody
+ * presses Tab to send.
+ */
+export function resolveComposerKey({
+  key, shiftKey = false, ctrlKey = false, metaKey = false, altKey = false,
+  isComposing = false, keyCode = 0,
+  open = false, hasActive = false, hasCandidates = false,
+} = {}) {
+  if (isComposing || keyCode === 229) return 'pass'
+  // A faithful reproduction of Vue's `.exact`: any modifier falls through
+  // unprevented and inserts a newline, exactly as today.
+  const plainEnter = key === 'Enter' && !shiftKey && !ctrlKey && !metaKey && !altKey
+
+  if (open) {
+    if (key === 'Escape') return 'dismiss'
+    if (key === 'ArrowDown') return hasCandidates ? 'move-down' : 'close'
+    if (key === 'ArrowUp') return hasCandidates ? 'move-up' : 'close'
+    if (key === 'Tab' && !shiftKey) return hasCandidates ? 'accept' : 'pass'
+    if (plainEnter && hasCandidates && hasActive) return 'accept'
+    if (CARET_KEYS.has(key)) return 'close'
+  }
+  if (plainEnter) return 'send'
+  return 'pass'
+}
+
+/**
+ * Esc dismissal, as state rather than a boolean.
+ *
+ * ONLY Esc arms it. A click-outside, a capability change or an agent switch
+ * closes WITHOUT arming — otherwise "type `@`, click away to read a message,
+ * click back, type `b`" stays suppressed until the user deletes the `@`.
+ *
+ * Suppression then holds while the user is still editing the token they
+ * dismissed: same kind, same start, and a query that EXTENDS the dismissed one.
+ * Strict query equality was rejected because it un-dismisses on the very next
+ * keystroke (Esc has to mean "stop offering this"); keying on `start` alone was
+ * rejected because it is wrong in both directions — text inserted before the
+ * token shifts `start` and re-opens, while a full retype at the same offset
+ * stays suppressed forever.
+ */
+export function nextDismissState(trigger) {
+  if (!trigger) return null
+  return { kind: trigger.kind, start: trigger.start, query: trigger.query }
+}
+
+export function isSuppressed(dismissed, trigger) {
+  if (!dismissed || !trigger) return false
+  if (dismissed.kind !== trigger.kind || dismissed.start !== trigger.start) return false
+  return String(trigger.query ?? '').startsWith(String(dismissed.query ?? ''))
+}
+
+// Roving selection. `-1` means "nothing chosen", which is the state Enter reads
+// (see resolveComposerKey), so it must survive an empty list.
+export function nextActiveIndex(current, delta, length) {
+  const n = Number.isInteger(length) ? length : 0
+  if (n <= 0) return -1
+  const cur = Number.isInteger(current) ? current : -1
+  if (cur < 0) return delta > 0 ? 0 : n - 1
+  return ((cur + delta) % n + n) % n
+}
+
+// A stale index is dropped, not clamped to a neighbour: after a roster refresh
+// under an open popup, "the row that is now at index 5" is not the row the user
+// chose, and inserting it is how `@undefined` (or the wrong agent) ships.
+export function clampActiveIndex(current, length) {
+  const n = Number.isInteger(length) ? length : 0
+  if (n <= 0) return -1
+  return Number.isInteger(current) && current >= 0 && current < n ? current : -1
+}

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -606,13 +606,25 @@ export function boundCandidates(list, limit = TYPEAHEAD_LIMIT) {
 /**
  * The room's `@` wake-set.
  *
- * VERIFIED against the running engine, not assumed: posting `@<participant>`
- * answered `{"mentions":["acme-scout"],"woke":["acme-scout"]}`, while
- * `@<non-participant>` answered `{"mentions":[],"woke":[]}`. The engine's
- * `resolve_mentions` keeps only `kind == "agent" and not left_at`, so an @name
- * outside the room is left as plain text and nothing is recruited. Offering the
- * full roster here would therefore manufacture a silent no-op — the same class
- * as listing an un-mentionable slug.
+ * Established by OBSERVING the running server, not by reading the engine: the
+ * rooms module is a private submodule that is not even checked out here, so the
+ * only trustworthy evidence is what `POST /api/rooms/{id}/messages` answers.
+ * Posting `@<participant>` returned `{"mentions":["acme-scout"],"woke":["acme-scout"]}`;
+ * posting `@<non-participant>` returned `{"mentions":[],"woke":[]}`.
+ *
+ * So a participant mention demonstrably wakes, and a non-participant mention
+ * demonstrably wakes nobody on that turn — which is all this list needs, and
+ * exactly why it is the participants. Offering the roster would put names in
+ * front of the user with no evidence that choosing one does anything, the same
+ * class of silent no-op as listing an un-mentionable slug.
+ *
+ * What is deliberately NOT claimed: that a non-participant mention has no effect
+ * at all. requirements §5.12 records an engine-side newcomer-join path from
+ * ent#361, and two empty response fields do not disprove it — a join would show
+ * up as a participant change, which was not observed either way. If that path is
+ * live, this list is narrower than the engine allows; recruiting then stays with
+ * the explicit "+ Add agent" control, which is the honest home for an action
+ * that spends money on another agent.
  *
  * Participants arrive as bare identities; the roster is joined in only to
  * recover display labels, so a participant the caller cannot see in their
@@ -688,6 +700,32 @@ export function isSuppressed(dismissed, trigger) {
   if (!dismissed || !trigger) return false
   if (dismissed.kind !== trigger.kind || dismissed.start !== trigger.start) return false
   return String(trigger.query ?? '').startsWith(String(dismissed.query ?? ''))
+}
+
+/**
+ * The sentinel an ACCEPT has to arm — and why accepting needs one at all.
+ *
+ * The splice only appends its separator when the character after the replaced
+ * token is not already whitespace, so accepting mid-sentence leaves the caret
+ * INSIDE the token that was just inserted: `Hello @bo| there` becomes
+ * `Hello @alice| there`. Any recompute at that caret therefore re-detects the
+ * very token the user just finished choosing — and one is guaranteed to happen,
+ * because `setSelectionRange()` fires a `select` event whenever it moves the
+ * caret, which is exactly what the accept does on `nextTick`. The popup would
+ * reopen by itself, listing the agent that was just picked.
+ *
+ * Nothing is destroyed by that (the roving index is cleared, so Enter still
+ * sends) but the panel visibly comes back over the composer having been
+ * dismissed by a successful choice, which is the one outcome a pick must not
+ * produce. Suppressing the resulting token is the honest statement: it has been
+ * chosen, so stop offering it. Editing it back re-arms, exactly as after Esc,
+ * because `isSuppressed` only holds while the query still EXTENDS the sentinel.
+ *
+ * Returns `null` when the caret landed past a separator (the common
+ * end-of-message case), where nothing needs suppressing.
+ */
+export function dismissAfterInsert(value, caret) {
+  return nextDismissState(detectTypeaheadTrigger(value, caret))
 }
 
 // Roving selection. `-1` means "nothing chosen", which is the state Enter reads

--- a/src/frontend/tests/unit/portalComposerTypeahead.spec.js
+++ b/src/frontend/tests/unit/portalComposerTypeahead.spec.js
@@ -1,0 +1,720 @@
+/**
+ * ent#392 — Workspace composer typeahead (`/` playbooks, `@` agents).
+ *
+ * Both invocation syntaxes already worked; neither was discoverable. The risk in
+ * adding the affordance is not that it fails loudly — it is that it succeeds
+ * quietly at the wrong thing:
+ *
+ *   1. **A selected mention must always escalate.** Agent slugs may contain `.`
+ *      and have no length cap; the mention grammar allows neither. So offering
+ *      `data.scout` would MANUFACTURE the silent degrade-to-plain-text that AC#4
+ *      forbids. The round-trip below is asserted over the SPLICED VALUE, not the
+ *      bare token — asserting the token alone is near-tautological and passes
+ *      while a double-space splice ships.
+ *
+ *   2. **Enter must never be swallowed.** A popup that merely happens to be open
+ *      (a paste, or prose like "check /status of the deploy") would otherwise
+ *      splice up to 500 characters over the message the user meant to send.
+ *
+ * There is no component-mount harness in this project (no `@vue/test-utils`), so
+ * every decision worth pinning lives in a pure export and is tested here
+ * directly; the parts no unit test can reach (which handler the textarea binds,
+ * where the popup is anchored) are covered by source-structure guards at the
+ * bottom, comments stripped first so prose about a rule is not scanned as code.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+import { stripComments } from './helpers/stripComments'
+
+import {
+  MAX_TYPEAHEAD_QUERY,
+  TYPEAHEAD_LIMIT,
+  detectTypeaheadTrigger,
+  applyTypeaheadInsert,
+  buildMentionToken,
+  isMentionable,
+  starterFor,
+  filterPlaybookCandidates,
+  filterAgentCandidates,
+  typeaheadEmptyMessage,
+  boundCandidates,
+  roomMentionSource,
+  resolveComposerKey,
+  nextDismissState,
+  isSuppressed,
+  nextActiveIndex,
+  clampActiveIndex,
+  mentionedAgents,
+  EMPTY_REASON_NO_PLAYBOOKS,
+  EMPTY_REASON_NO_PEERS,
+  EMPTY_REASON_NO_MENTIONABLE_PEERS,
+  EMPTY_REASON_NO_ROOM_PEERS,
+} from '@/components/portal/portalUtils'
+
+const CONV = fileURLToPath(new URL('../../src/components/portal/PortalConversation.vue', import.meta.url))
+const ROOM = fileURLToPath(new URL('../../src/components/portal/PortalRoom.vue', import.meta.url))
+const BRIEF = fileURLToPath(new URL('../../src/components/portal/PortalBriefing.vue', import.meta.url))
+const POPUP = fileURLToPath(new URL('../../src/components/portal/PortalTypeahead.vue', import.meta.url))
+
+const convSource = () => stripComments(readFileSync(CONV, 'utf8'))
+const roomSource = () => stripComments(readFileSync(ROOM, 'utf8'))
+const briefSource = () => stripComments(readFileSync(BRIEF, 'utf8'))
+const popupSource = () => stripComments(readFileSync(POPUP, 'utf8'))
+
+// ---------------------------------------------------------------------------
+// 1. detectTypeaheadTrigger — the scan
+// ---------------------------------------------------------------------------
+describe('detectTypeaheadTrigger', () => {
+  const at = (text, caret) => detectTypeaheadTrigger(text, caret === undefined ? text.length : caret)
+
+  it('fires on a bare trigger at index 0', () => {
+    expect(at('/')).toEqual({ kind: '/', start: 0, end: 1, query: '' })
+    expect(at('@')).toEqual({ kind: '@', start: 0, end: 1, query: '' })
+  })
+
+  it('fires mid-text after whitespace and after a newline', () => {
+    expect(at('Hi /wee')).toEqual({ kind: '/', start: 3, end: 7, query: 'wee' })
+    expect(at('Ask @sc')).toEqual({ kind: '@', start: 4, end: 7, query: 'sc' })
+    expect(at('line1\n@bo')).toEqual({ kind: '@', start: 6, end: 9, query: 'bo' })
+  })
+
+  it('scans FORWARD to the token end, so a caret parked mid-token still spans it', () => {
+    // Without the forward scan the splice ends at the caret and leaves a tail.
+    expect(at('@bob', 3)).toEqual({ kind: '@', start: 0, end: 4, query: 'bo' })
+    expect(at('Hello @bob there', 10)).toEqual({ kind: '@', start: 6, end: 10, query: 'bob' })
+  })
+
+  it('boundary rule is non-word, not whitespace — CJK, emoji and punctuation all trigger', () => {
+    for (const text of ['你好@rec', '🎉@rec', '(@bob', '"@bob', '-@bob']) {
+      expect(at(text)?.kind, text).toBe('@')
+    }
+  })
+
+  it('finds the INNERMOST trigger', () => {
+    expect(at('@@bo')).toEqual({ kind: '@', start: 1, end: 4, query: 'bo' })
+    expect(at('/@rec')).toEqual({ kind: '@', start: 1, end: 5, query: 'rec' })
+  })
+
+  it('rejects a query carrying a second trigger char', () => {
+    expect(at('see /etc/hosts')).toBeNull()
+  })
+
+  it('stops at a token boundary behind the caret', () => {
+    expect(at('@a b')).toBeNull()
+  })
+
+  it('floors the backward scan at MAX_TYPEAHEAD_QUERY (O(1) per keystroke)', () => {
+    expect(at('/' + 'a'.repeat(MAX_TYPEAHEAD_QUERY))?.query).toHaveLength(MAX_TYPEAHEAD_QUERY)
+    expect(at('/' + 'a'.repeat(MAX_TYPEAHEAD_QUERY + 1))).toBeNull()
+    // A 100 KB paste is not a 100 KB walk.
+    expect(at('x'.repeat(100000))).toBeNull()
+  })
+
+  it('survives absent, out-of-range and non-numeric input', () => {
+    expect(detectTypeaheadTrigger(null, 0)).toBeNull()
+    expect(detectTypeaheadTrigger(undefined, 3)).toBeNull()
+    expect(detectTypeaheadTrigger('', 0)).toBeNull()
+    expect(detectTypeaheadTrigger('@bo', 999)).toEqual({ kind: '@', start: 0, end: 3, query: 'bo' })
+    expect(detectTypeaheadTrigger('@bo', -5)).toBeNull()
+    expect(detectTypeaheadTrigger('@bo', NaN)).toEqual({ kind: '@', start: 0, end: 3, query: 'bo' })
+  })
+
+  it('yields nothing while a selection is non-collapsed', () => {
+    expect(detectTypeaheadTrigger('@bo', 3, 3)).not.toBeNull()
+    expect(detectTypeaheadTrigger('@bo', 1, 3)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. AC#6 exhaustively — the popup never fights ordinary prose
+// ---------------------------------------------------------------------------
+describe('AC#6: literal / and @ stay literal', () => {
+  it.each(['50/50', 'and/or', 'user@example.com', 'a@b.c'])(
+    '%s yields no trigger at ANY caret position', (text) => {
+      for (let caret = 0; caret <= text.length; caret++) {
+        expect(detectTypeaheadTrigger(text, caret), `${text} @${caret}`).toBeNull()
+      }
+    })
+})
+
+// ---------------------------------------------------------------------------
+// 3. isMentionable — the P-3 matrix
+// ---------------------------------------------------------------------------
+describe('isMentionable', () => {
+  it.each([
+    ['data.scout', false],      // sanitize_agent_name keeps '.', MENTION_RE does not
+    ['v2.1-bot', false],
+    ['a'.repeat(101), false],   // grammar caps at 100
+    ['_lead', false],           // first char must be alphanumeric
+    ['-lead', false],
+    ['', false],
+    ['a@b', false],             // a name carrying the trigger char itself
+    ['a b', false],
+    ['ok-agent', true],
+    ['under_score', true],
+    ['a', true],
+    ['a'.repeat(100), true],
+  ])('%s → %s', (name, expected) => {
+    expect(isMentionable(name)).toBe(expected)
+  })
+
+  it('is derived from the parser, so it cannot drift from it', () => {
+    // Every name it accepts round-trips; every name it rejects does not. The
+    // second half is the one that matters: it is what keeps an un-mentionable
+    // slug out of the list instead of manufacturing a silent failure.
+    for (const n of ['ok-agent', 'a', 'under_score', 'data.scout', '_lead', 'a'.repeat(101)]) {
+      const resolves = mentionedAgents(buildMentionToken(n), [{ name: n }]).length === 1
+      expect(isMentionable(n)).toBe(resolves)
+    }
+  })
+
+  it('rejects nullish input rather than throwing', () => {
+    expect(isMentionable(null)).toBe(false)
+    expect(isMentionable(undefined)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. AC#4 round-trip — asserted over the SPLICED VALUE
+// ---------------------------------------------------------------------------
+describe('AC#4: a selected mention always escalates', () => {
+  const roster = [{ name: 'alice' }, { name: 'ok-agent' }, { name: 'a' }, { name: 'under_score' }]
+
+  // content before / after / both / neither, and a next char that is a space, a
+  // letter, a newline and end-of-string.
+  const surroundings = [
+    ['', ''], ['Hello ', ''], ['', ' there'], ['Hello ', ' there'],
+    ['', 'x'], ['', '\nnext line'], ['multi\nline ', ''],
+  ]
+
+  it.each(roster.map((a) => a.name))('a spliced @%s resolves through mentionedAgents', (name) => {
+    for (const [before, after] of surroundings) {
+      const text = `${before}@bo${after}`
+      const caret = before.length + 3
+      const trigger = detectTypeaheadTrigger(text, caret)
+      expect(trigger, `no trigger for ${JSON.stringify(text)}`).not.toBeNull()
+      const { value } = applyTypeaheadInsert(text, trigger, buildMentionToken(name))
+      expect(mentionedAgents(value, roster), value).toContain(name)
+    }
+  })
+
+  it('the NEGATIVE direction: every name the list excludes is one the parser cannot resolve', () => {
+    const unusable = ['data.scout', 'v2.1-bot', '_lead', 'a'.repeat(101)]
+    const wide = unusable.map((name) => ({ name }))
+    for (const name of unusable) {
+      expect(isMentionable(name)).toBe(false)
+      const { value } = applyTypeaheadInsert('@bo', detectTypeaheadTrigger('@bo', 3), buildMentionToken(name))
+      expect(mentionedAgents(value, wide)).not.toContain(name)
+    }
+    // …and none of them is ever offered.
+    expect(filterAgentCandidates(wide, '').items).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. applyTypeaheadInsert — the splice and its separator
+// ---------------------------------------------------------------------------
+describe('applyTypeaheadInsert', () => {
+  const splice = (text, caret, insert) =>
+    applyTypeaheadInsert(text, detectTypeaheadTrigger(text, caret), insert)
+
+  it('replaces the WHOLE token, leaving no tail', () => {
+    expect(splice('@bob', 3, buildMentionToken('alice')).value).toBe('@alice ')
+  })
+
+  // The insert goes through buildMentionToken, NOT a literal string: the
+  // separator must be decided by the splice, and baking a trailing space into
+  // the token is the regression this table exists to catch (it produced
+  // "Hello @alice  there" and "@recon  x").
+  it('carries no separator of its own', () => {
+    expect(buildMentionToken('alice')).toBe('@alice')
+    expect(buildMentionToken('alice')).not.toMatch(/\s/)
+  })
+
+  it.each([
+    ['Hello @bob there', 10, 'alice', 'Hello @alice there'],  // next char is a space → no second one
+    ['Hello @bob there', 9, 'alice', 'Hello @alice there'],   // caret mid-token, same result
+    ['Ask @al', 7, 'alice', 'Ask @alice '],                   // end of string → trailing space
+    ['@ x', 1, 'recon', '@recon x'],                          // never two spaces
+    ['@bo\nnext', 3, 'alice', '@alice\nnext'],                // a newline is whitespace too
+  ])('%s (caret %i) → %s', (text, caret, name, expected) => {
+    expect(splice(text, caret, buildMentionToken(name)).value).toBe(expected)
+  })
+
+  it('returns a caret positioned after the insert', () => {
+    const r = splice('Ask @al', 7, buildMentionToken('alice'))
+    expect(r.caret).toBe(r.value.length)
+    const mid = splice('Hello @bob there', 10, buildMentionToken('alice'))
+    expect(mid.value.slice(0, mid.caret)).toBe('Hello @alice')
+  })
+
+  it('splices a multi-word starter prompt at index 0', () => {
+    const r = splice('/we', 3, 'Give me the weekly summary')
+    expect(r.value).toBe('Give me the weekly summary ')
+    expect(r.caret).toBe(r.value.length)
+  })
+
+  it('is a no-op without a trigger, and never throws on junk', () => {
+    expect(applyTypeaheadInsert('hi', null, 'x')).toEqual({ value: 'hi', caret: 2 })
+    expect(applyTypeaheadInsert(null, null, null)).toEqual({ value: '', caret: 0 })
+    expect(applyTypeaheadInsert('hi', { start: 99, end: 99 }, '!').value).toBe('hi! ')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 6. filterAgentCandidates — AC#3 + the #2128 capability gate
+// ---------------------------------------------------------------------------
+describe('filterAgentCandidates', () => {
+  const roster = [
+    { name: 'acme-scout', display_label: 'Data Scout' },
+    { name: 'acme-scribe', display_label: 'Scribe' },
+    { name: 'cornelius' },
+    { name: 'data.scout' },              // structurally un-mentionable
+    { name: 'self-agent' },
+  ]
+  const opts = { exclude: ['self-agent'] }
+
+  it('matches on the SLUG', () => {
+    expect(filterAgentCandidates(roster, 'scribe', opts).items.map((a) => a.name)).toEqual(['acme-scribe'])
+  })
+
+  it('matches on the DISPLAY LABEL, which is what the roster shows', () => {
+    expect(filterAgentCandidates(roster, 'Data', opts).items.map((a) => a.name)).toEqual(['acme-scout'])
+  })
+
+  it('matches a shared deployment prefix by substring, not prefix only', () => {
+    expect(filterAgentCandidates(roster, 'scout', opts).items.map((a) => a.name)).toEqual(['acme-scout'])
+  })
+
+  it('is case-insensitive', () => {
+    expect(filterAgentCandidates(roster, 'CORNEL', opts).items.map((a) => a.name)).toEqual(['cornelius'])
+  })
+
+  it('excludes self', () => {
+    expect(filterAgentCandidates(roster, '', opts).items.map((a) => a.name)).not.toContain('self-agent')
+  })
+
+  it('excludes un-mentionable slugs — the whole point of AC#4', () => {
+    expect(filterAgentCandidates(roster, '', opts).items.map((a) => a.name)).not.toContain('data.scout')
+    expect(filterAgentCandidates(roster, 'data', opts).items.map((a) => a.name)).toEqual(['acme-scout'])
+  })
+
+  it('reports peers and mentionable peers separately, so the empty state can be honest', () => {
+    const r = filterAgentCandidates(roster, '', opts)
+    expect(r.peerCount).toBe(4)
+    expect(r.mentionableCount).toBe(3)
+  })
+
+  it('is INERT without the rooms capability (#2128) — tested, not grepped', () => {
+    const r = filterAgentCandidates(roster, '', { ...opts, enabled: false })
+    expect(r.items).toEqual([])
+    expect(r.enabled).toBe(false)
+  })
+
+  it('survives a missing or malformed roster', () => {
+    expect(filterAgentCandidates(undefined, 'x').items).toEqual([])
+    expect(filterAgentCandidates([null, {}, { name: '' }], '').items).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 7. filterPlaybookCandidates — prose titles, not slugs
+// ---------------------------------------------------------------------------
+describe('filterPlaybookCandidates', () => {
+  const playbooks = [
+    { title: 'Weekly research digest', description: 'Roll up the week', starter_prompt: 'Give me the digest' },
+    { title: 'Research a competitor' },
+    { title: 'Draft a status update', description: null },
+    { title: '   ' },                    // no usable title
+  ]
+
+  it('ranks a whole-title prefix above a word-start prefix, beating source order', () => {
+    expect(filterPlaybookCandidates(playbooks, 'res').items.map((p) => p.title))
+      .toEqual(['Research a competitor', 'Weekly research digest'])
+  })
+
+  it('matches a word-start prefix inside a prose title', () => {
+    expect(filterPlaybookCandidates(playbooks, 'dig').items.map((p) => p.title)).toEqual(['Weekly research digest'])
+    expect(filterPlaybookCandidates(playbooks, 'stat').items.map((p) => p.title)).toEqual(['Draft a status update'])
+  })
+
+  it('does NOT match an arbitrary substring — a one-char query must not match everything', () => {
+    expect(filterPlaybookCandidates(playbooks, 'e').items).toEqual([])
+  })
+
+  it('drops entries with no usable title', () => {
+    const r = filterPlaybookCandidates(playbooks, '')
+    expect(r.sourceCount).toBe(3)
+    expect(r.items.map((p) => p.title)).not.toContain('   ')
+  })
+
+  it('distinguishes source-empty from filter-empty', () => {
+    expect(filterPlaybookCandidates([], '')).toEqual({ items: [], sourceCount: 0 })
+    const filtered = filterPlaybookCandidates(playbooks, 'zzzz')
+    expect(filtered.items).toEqual([])
+    expect(filtered.sourceCount).toBe(3)
+  })
+
+  it('survives a null/non-array source (a stopped or slow agent yields no playbooks)', () => {
+    expect(filterPlaybookCandidates(null, '').items).toEqual([])
+    expect(filterPlaybookCandidates(undefined, 'x').items).toEqual([])
+    expect(filterPlaybookCandidates('nope', '').items).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 8. typeaheadEmptyMessage — three different statements, never substituted
+// ---------------------------------------------------------------------------
+describe('typeaheadEmptyMessage', () => {
+  it('says nothing about operator configuration for the `/` case', () => {
+    expect(typeaheadEmptyMessage('/', { sourceCount: 0 })).toBe(EMPTY_REASON_NO_PLAYBOOKS)
+    // The client cannot tell "none exposed" from "the agent was stopped when the
+    // roster was built", so the copy claims neither.
+    expect(EMPTY_REASON_NO_PLAYBOOKS).not.toMatch(/exposed|configured|none/i)
+  })
+
+  it('distinguishes "no peers" from "peers exist but none is mentionable"', () => {
+    expect(typeaheadEmptyMessage('@', { enabled: true, peerCount: 0, mentionableCount: 0 }))
+      .toBe(EMPTY_REASON_NO_PEERS)
+    expect(typeaheadEmptyMessage('@', { enabled: true, peerCount: 3, mentionableCount: 0 }))
+      .toBe(EMPTY_REASON_NO_MENTIONABLE_PEERS)
+    expect(EMPTY_REASON_NO_PEERS).not.toBe(EMPTY_REASON_NO_MENTIONABLE_PEERS)
+  })
+
+  it('uses room wording in a room, where "shared with you" is the wrong statement', () => {
+    expect(typeaheadEmptyMessage('@', { enabled: true, peerCount: 0, mentionableCount: 0 }, { scope: 'room' }))
+      .toBe(EMPTY_REASON_NO_ROOM_PEERS)
+  })
+
+  it('says nothing at all when the capability is absent — no dead-end affordance', () => {
+    expect(typeaheadEmptyMessage('@', { enabled: false, peerCount: 5, mentionableCount: 5 })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 9. resolveComposerKey — the truth table
+// ---------------------------------------------------------------------------
+describe('resolveComposerKey', () => {
+  const enter = (over = {}) => resolveComposerKey({ key: 'Enter', ...over })
+
+  it('reproduces Vue `.exact` across all 16 modifier combinations', () => {
+    for (const shiftKey of [false, true]) {
+      for (const ctrlKey of [false, true]) {
+        for (const metaKey of [false, true]) {
+          for (const altKey of [false, true]) {
+            const plain = !shiftKey && !ctrlKey && !metaKey && !altKey
+            const mods = { shiftKey, ctrlKey, metaKey, altKey }
+            expect(enter({ ...mods }), JSON.stringify(mods)).toBe(plain ? 'send' : 'pass')
+            // Open with a selection: only the plain one accepts; the rest still
+            // fall through unprevented and insert a newline, exactly as today.
+            expect(enter({ ...mods, open: true, hasCandidates: true, hasActive: true }))
+              .toBe(plain ? 'accept' : 'pass')
+          }
+        }
+      }
+    }
+  })
+
+  it('NEVER swallows Enter when nothing is explicitly selected (A-9)', () => {
+    expect(enter({ open: true, hasCandidates: true, hasActive: false })).toBe('send')
+    expect(enter({ open: true, hasCandidates: false, hasActive: false })).toBe('send')  // empty-state panel
+    expect(enter({ open: false })).toBe('send')
+  })
+
+  it('is byte-identical to today when the popup is closed', () => {
+    for (const key of ['Enter', 'a', 'Escape', 'Tab', 'ArrowDown', 'ArrowUp', 'Home']) {
+      expect(resolveComposerKey({ key, open: false })).toBe(key === 'Enter' ? 'send' : 'pass')
+    }
+  })
+
+  it('passes an IME composition through — the current binding sends mid-word', () => {
+    expect(enter({ isComposing: true })).toBe('pass')
+    expect(enter({ keyCode: 229 })).toBe('pass')
+    expect(enter({ isComposing: true, open: true, hasCandidates: true, hasActive: true })).toBe('pass')
+  })
+
+  it('moves with the arrows only when there is something to move over', () => {
+    const open = { open: true, hasCandidates: true }
+    expect(resolveComposerKey({ key: 'ArrowDown', ...open })).toBe('move-down')
+    expect(resolveComposerKey({ key: 'ArrowUp', ...open })).toBe('move-up')
+    expect(resolveComposerKey({ key: 'ArrowDown', open: true, hasCandidates: false })).toBe('close')
+  })
+
+  it('accepts the top row on Tab, and lets Shift+Tab leave the composer', () => {
+    expect(resolveComposerKey({ key: 'Tab', open: true, hasCandidates: true })).toBe('accept')
+    expect(resolveComposerKey({ key: 'Tab', open: true, hasCandidates: true, shiftKey: true })).toBe('pass')
+    expect(resolveComposerKey({ key: 'Tab', open: true, hasCandidates: false })).toBe('pass')
+  })
+
+  it('dismisses on Escape only while open (principle 23)', () => {
+    expect(resolveComposerKey({ key: 'Escape', open: true })).toBe('dismiss')
+    expect(resolveComposerKey({ key: 'Escape', open: false })).toBe('pass')
+  })
+
+  it('closes on a caret-moving key rather than accepting against stale bounds', () => {
+    for (const key of ['ArrowLeft', 'ArrowRight', 'Home', 'End', 'PageUp', 'PageDown']) {
+      expect(resolveComposerKey({ key, open: true, hasCandidates: true })).toBe('close')
+    }
+  })
+
+  it('survives being called with nothing', () => {
+    expect(resolveComposerKey()).toBe('pass')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 10. Dismissal state
+// ---------------------------------------------------------------------------
+describe('Esc dismissal', () => {
+  const trig = (text, caret) => detectTypeaheadTrigger(text, caret ?? text.length)
+
+  it('stays closed while the same token keeps being typed', () => {
+    const d = nextDismissState(trig('@b'))
+    expect(isSuppressed(d, trig('@b'))).toBe(true)
+    expect(isSuppressed(d, trig('@bo'))).toBe(true)
+    expect(isSuppressed(d, trig('@bob'))).toBe(true)
+  })
+
+  it('re-arms when the token is retyped from scratch, or a different kind appears', () => {
+    const d = nextDismissState(trig('@bo'))
+    expect(isSuppressed(d, trig('@b'))).toBe(false)      // deleted back past the dismissal
+    expect(isSuppressed(d, trig('@'))).toBe(false)
+    expect(isSuppressed(d, trig('/bo'))).toBe(false)     // different kind at the same offset
+    expect(isSuppressed(d, trig('Hi @bo'))).toBe(false)  // different start
+  })
+
+  it('a cleared sentinel re-opens everything — the session-long-dead-feature guard', () => {
+    // send() clears input.value programmatically, so no input event fires and
+    // nothing recomputes. Without resetTypeahead() a sentinel armed in message 1
+    // kills the popup for every later message starting with the same token.
+    expect(isSuppressed(null, trig('@bo'))).toBe(false)
+    expect(isSuppressed(nextDismissState(null), trig('@bo'))).toBe(false)
+  })
+
+  it('never suppresses without a trigger to compare against', () => {
+    expect(isSuppressed(nextDismissState(trig('@bo')), null)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 11. Roving selection
+// ---------------------------------------------------------------------------
+describe('active index', () => {
+  it('starts at nothing and wraps at both ends', () => {
+    expect(nextActiveIndex(-1, +1, 3)).toBe(0)
+    expect(nextActiveIndex(-1, -1, 3)).toBe(2)
+    expect(nextActiveIndex(2, +1, 3)).toBe(0)
+    expect(nextActiveIndex(0, -1, 3)).toBe(2)
+  })
+
+  it('is a no-op on an empty list', () => {
+    expect(nextActiveIndex(-1, +1, 0)).toBe(-1)
+    expect(nextActiveIndex(1, -1, 0)).toBe(-1)
+  })
+
+  it('DROPS a stale index rather than clamping it to a neighbour', () => {
+    // After a roster refresh, "whatever is now at index 5" is not what the user
+    // chose. -1 then makes Enter send instead of inserting the wrong agent.
+    expect(clampActiveIndex(5, 2)).toBe(-1)
+    expect(clampActiveIndex(1, 2)).toBe(1)
+    expect(clampActiveIndex(-1, 2)).toBe(-1)
+    expect(clampActiveIndex(0, 0)).toBe(-1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 12. Bounds + shared helpers
+// ---------------------------------------------------------------------------
+describe('boundCandidates', () => {
+  const list = (n) => Array.from({ length: n }, (_, i) => i)
+
+  it.each([
+    [TYPEAHEAD_LIMIT - 1, TYPEAHEAD_LIMIT - 1, 0],
+    [TYPEAHEAD_LIMIT, TYPEAHEAD_LIMIT, 0],
+    [TYPEAHEAD_LIMIT + 1, TYPEAHEAD_LIMIT, 1],
+    [24, TYPEAHEAD_LIMIT, 24 - TYPEAHEAD_LIMIT],
+  ])('%i items → %i visible, %i overflow', (n, visible, overflow) => {
+    const r = boundCandidates(list(n))
+    expect(r.visible).toHaveLength(visible)
+    expect(r.overflow).toBe(overflow)
+  })
+
+  it('survives junk', () => {
+    expect(boundCandidates(null)).toEqual({ visible: [], overflow: 0 })
+    expect(boundCandidates(list(3), 0).visible).toHaveLength(3)
+  })
+})
+
+describe('starterFor', () => {
+  it('prefers the starter prompt, falls back to the title', () => {
+    expect(starterFor({ starter_prompt: 'Run it', title: 'T' })).toBe('Run it')
+    expect(starterFor({ starter_prompt: '   ', title: 'T' })).toBe('T')
+    expect(starterFor({ title: 'T' })).toBe('T')
+  })
+
+  it('does not throw on a nullish argument', () => {
+    expect(starterFor(null)).toBe('')
+    expect(starterFor(undefined)).toBe('')
+    expect(starterFor({})).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 13. The room wake-set — verified against the running engine
+// ---------------------------------------------------------------------------
+describe('roomMentionSource', () => {
+  // Observed on a live instance (room_b30d6afc16d94d07, participants
+  // acme-scout + acme-scribe):
+  //   POST @acme-scout   → {"mentions":["acme-scout"],"woke":["acme-scout"]}
+  //   POST @cornelius    → {"mentions":[],"woke":[]}
+  // The engine's resolve_mentions keeps only agent participants that have not
+  // left; nothing outside the room is recruited. Offering the roster here would
+  // manufacture a silent no-op.
+  const roster = [
+    { name: 'acme-scout', display_label: 'Data Scout' },
+    { name: 'cornelius', display_label: 'Cornelius' },
+  ]
+
+  it('is the participant list, never the roster', () => {
+    const src = roomMentionSource(['acme-scout'], roster)
+    expect(src.map((a) => a.name)).toEqual(['acme-scout'])
+    expect(src.map((a) => a.name)).not.toContain('cornelius')
+  })
+
+  it('joins the roster only to recover display labels', () => {
+    expect(roomMentionSource(['acme-scout'], roster)[0].display_label).toBe('Data Scout')
+    // A participant the caller cannot see in their roster is still in the room,
+    // so it is still wakeable.
+    expect(roomMentionSource(['ghost'], roster)).toEqual([{ name: 'ghost' }])
+  })
+
+  it('feeds the same tested filter, so the room reuses the 1:1 logic verbatim', () => {
+    const src = roomMentionSource(['acme-scout', 'data.scout'], roster)
+    expect(filterAgentCandidates(src, 'scout').items.map((a) => a.name)).toEqual(['acme-scout'])
+  })
+
+  it('survives junk', () => {
+    expect(roomMentionSource(null, null)).toEqual([])
+    expect(roomMentionSource([null, ''], [])).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 14. Source-structure guards — the half no unit test can reach
+// ---------------------------------------------------------------------------
+describe('PortalConversation wiring', () => {
+  it('no longer binds the raw .exact handler, and delegates to the TESTED keymap', () => {
+    const src = convSource()
+    expect(src).not.toContain('@keydown.enter.exact.prevent')
+    expect(src).toContain('resolveComposerKey')
+  })
+
+  it('still reaches autoGrow from the input path', () => {
+    // Forgetting this silently kills textarea growth for everyone, and nothing
+    // else in this suite would catch it.
+    expect(convSource()).toMatch(/@input="onComposerInput"/)
+    expect(convSource()).toMatch(/function onComposerInput[\s\S]{0,200}autoGrow\(\)/)
+  })
+
+  it('clears the dismissal sentinel on every PROGRAMMATIC write to input.value', () => {
+    // send(), the prefill watcher and both dictation handlers all write the
+    // model directly, which fires no input event.
+    const calls = convSource().replace('function resetTypeahead()', '')
+    expect((calls.match(/resetTypeahead\(\)/g) || []).length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('reads the event target, not the v-model ref, when detecting a trigger', () => {
+    // Reading the ref makes correctness depend on Vue's internal listener
+    // ordering — true today, an implementation detail.
+    expect(convSource()).toMatch(/detectTypeaheadTrigger\(\s*el\.value/)
+  })
+
+  it('anchors the popup without collapsing the flex field', () => {
+    const src = convSource()
+    expect(src).toContain('relative flex-1 min-w-0')
+    expect(src).toMatch(/<textarea[\s\S]{0,400}class="w-full/)
+  })
+
+  it('advertises both triggers in the placeholder, and @ only with the capability', () => {
+    const src = convSource()
+    expect(src).toMatch(/for playbooks/)
+    expect(src).toMatch(/multiAgentChatAvailable[\s\S]{0,120}@ to add an agent/)
+  })
+})
+
+describe('PortalRoom wiring', () => {
+  it('scopes its @ list to the room participants, not the roster', () => {
+    const src = roomSource()
+    expect(src).toContain('roomMentionSource(agentParticipants.value')
+    expect(src).not.toMatch(/filterAgentCandidates\(\s*props\.roster/)
+  })
+
+  it('uses the same tested keymap and popup as the 1:1 composer', () => {
+    const src = roomSource()
+    expect(src).not.toContain('@keydown.enter.exact.prevent')
+    expect(src).toContain('resolveComposerKey')
+    expect(src).toContain('PortalTypeahead')
+  })
+
+  it('does NOT offer a / typeahead — a room has no active-agent subject', () => {
+    expect(roomSource()).not.toContain('filterPlaybookCandidates')
+  })
+})
+
+describe('PortalBriefing de-duplication', () => {
+  it('imports starterFor rather than defining a second copy', () => {
+    const src = briefSource()
+    expect(src).toMatch(/import \{[^}]*starterFor[^}]*\} from '\.\/portalUtils'/)
+    expect(src).not.toMatch(/function starterFor/)
+  })
+})
+
+describe('PortalTypeahead markup', () => {
+  // Anchored on the stable role="listbox" element, never on a comment marker —
+  // stripComments deletes those by design.
+  const listblock = () => {
+    const src = popupSource()
+    const i = src.indexOf('role="listbox"')
+    expect(i).toBeGreaterThan(-1)
+    return src
+  }
+
+  it('opens upward, scrolls internally and is height-bounded (AC#8, principle 28)', () => {
+    const src = listblock()
+    expect(src).toContain('bottom-full')
+    expect(src).toContain('overflow-y-auto')
+    expect(src).toMatch(/max-h-\[min\(/)
+  })
+
+  it('accepts on mousedown, so the textarea never loses its caret to a blur', () => {
+    expect(listblock()).toContain('mousedown')
+    expect(listblock()).toContain('.prevent')
+  })
+
+  it('states the overflow rather than silently truncating', () => {
+    expect(listblock()).toMatch(/more — keep typing/)
+  })
+
+  it('renders agent- and playbook-authored text through interpolation, never v-html', () => {
+    expect(popupSource()).not.toContain('v-html')
+  })
+
+  it('carries listbox/option semantics but claims no combobox on the textarea', () => {
+    expect(popupSource()).toContain('role="option"')
+    expect(popupSource()).toContain('aria-selected')
+    expect(popupSource()).toContain('aria-live="polite"')
+    // aria-expanded/aria-activedescendant belong to role="combobox", which is
+    // itself out of spec on a multiline control. Shipping a claim screen readers
+    // ignore is worse than shipping less.
+    expect(convSource()).not.toContain('aria-expanded')
+    expect(convSource()).not.toContain('aria-activedescendant')
+  })
+
+  it('keeps the conversation file free of NEW v-html sites', () => {
+    // A whole-file assertion is unwritable — the assistant message body
+    // legitimately uses one, through renderMarkdown()/DOMPurify.
+    expect((convSource().match(/v-html/g) || []).length).toBe(1)
+  })
+})

--- a/src/frontend/tests/unit/portalComposerTypeahead.spec.js
+++ b/src/frontend/tests/unit/portalComposerTypeahead.spec.js
@@ -44,6 +44,7 @@ import {
   resolveComposerKey,
   nextDismissState,
   isSuppressed,
+  dismissAfterInsert,
   nextActiveIndex,
   clampActiveIndex,
   mentionedAgents,
@@ -498,6 +499,47 @@ describe('Esc dismissal', () => {
   })
 })
 
+describe('a pick settles the token it inserted', () => {
+  // The splice only appends its separator when the next character is not
+  // already whitespace, so a mid-sentence pick leaves the caret INSIDE the
+  // freshly inserted token. That is not hypothetical: the accept moves the
+  // caret with setSelectionRange(), which fires a `select` event, which is
+  // bound to the same recompute as a click — so without a sentinel the popup
+  // reopens on top of its own successful choice, listing what was just picked.
+  const pick = (text, caret, name) => {
+    const trigger = detectTypeaheadTrigger(text, caret)
+    return applyTypeaheadInsert(text, trigger, buildMentionToken(name))
+  }
+
+  it.each([
+    ['Hello @bo there', 9],
+    ['@ x', 1],
+  ])('mid-sentence (%s) leaves the caret inside the inserted token', (text, caret) => {
+    const { value, caret: c } = pick(text, caret, 'alice')
+    // The bug this guards: a recompute here finds a trigger again.
+    const reopened = detectTypeaheadTrigger(value, c)
+    expect(reopened, value).not.toBeNull()
+    expect(reopened.query).toBe('alice')
+    // …which the accept suppresses, so the popup stays shut.
+    expect(isSuppressed(dismissAfterInsert(value, c), reopened)).toBe(true)
+  })
+
+  it('needs no sentinel when the splice appended a separator', () => {
+    const { value, caret } = pick('Ask @al', 7, 'alice')
+    expect(value).toBe('Ask @alice ')
+    expect(detectTypeaheadTrigger(value, caret)).toBeNull()
+    // Nothing to suppress — and returning null leaves any earlier sentinel alone.
+    expect(dismissAfterInsert(value, caret)).toBeNull()
+  })
+
+  it('re-arms as soon as the settled token is edited back', () => {
+    const { value, caret } = pick('Hello @bo there', 9, 'alice')
+    const settled = dismissAfterInsert(value, caret)
+    // Backspacing into the name is the user asking for the list again.
+    expect(isSuppressed(settled, detectTypeaheadTrigger('Hello @alic there', 11))).toBe(false)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // 11. Roving selection
 // ---------------------------------------------------------------------------
@@ -562,16 +604,18 @@ describe('starterFor', () => {
 })
 
 // ---------------------------------------------------------------------------
-// 13. The room wake-set — verified against the running engine
+// 13. The room wake-set — established by observing the running server
 // ---------------------------------------------------------------------------
 describe('roomMentionSource', () => {
-  // Observed on a live instance (room_b30d6afc16d94d07, participants
-  // acme-scout + acme-scribe):
+  // The rooms engine is a private submodule that is not checked out here, so the
+  // evidence is what the server answered, not what its source says. Observed on
+  // a live instance (room_b30d6afc16d94d07, participants acme-scout +
+  // acme-scribe):
   //   POST @acme-scout   → {"mentions":["acme-scout"],"woke":["acme-scout"]}
   //   POST @cornelius    → {"mentions":[],"woke":[]}
-  // The engine's resolve_mentions keeps only agent participants that have not
-  // left; nothing outside the room is recruited. Offering the roster here would
-  // manufacture a silent no-op.
+  // A participant wakes; a non-participant wakes nobody on that turn. That is
+  // what makes the participants the right candidate set — offering the roster
+  // would list names with no evidence that picking one does anything.
   const roster = [
     { name: 'acme-scout', display_label: 'Data Scout' },
     { name: 'cornelius', display_label: 'Cornelius' },
@@ -631,6 +675,10 @@ describe('PortalConversation wiring', () => {
     expect(convSource()).toMatch(/detectTypeaheadTrigger\(\s*el\.value/)
   })
 
+  it('settles the token a pick inserted, so the popup cannot reopen over its own choice', () => {
+    expect(convSource()).toMatch(/dismissAfterInsert\(value, caret\)[\s\S]{0,80}dismissed\.value/)
+  })
+
   it('anchors the popup without collapsing the flex field', () => {
     const src = convSource()
     expect(src).toContain('relative flex-1 min-w-0')
@@ -656,6 +704,10 @@ describe('PortalRoom wiring', () => {
     expect(src).not.toContain('@keydown.enter.exact.prevent')
     expect(src).toContain('resolveComposerKey')
     expect(src).toContain('PortalTypeahead')
+  })
+
+  it('settles the token a pick inserted, exactly as the 1:1 composer does', () => {
+    expect(roomSource()).toMatch(/dismissAfterInsert\(value, caret\)[\s\S]{0,80}dismissed\.value/)
   })
 
   it('does NOT offer a / typeahead — a room has no active-agent subject', () => {


### PR DESCRIPTION
Fixes Abilityai/trinity-enterprise#392

> Note the qualified cross-repo form. `Abilityai/trinity#392` in **this** repo is an
> unrelated merged PR ("feat(ui): add floating help chat widget"), so a bare `#392`
> would point at the wrong thing. GitHub auto-closes same-repo only — the private
> issue needs a **manual `status-in-dev` bump and close at release**.

## What changed

The Workspace composer's two invocation syntaxes become discoverable.

- **`/`** opens the active agent's `playbooks[]` and splices the selected entry's
  **`starter_prompt` into the composer without sending** — the same prefill contract the
  ent#138 briefing cards already use, now reachable *after turn 1*, where those cards are
  gone.
- **`@`** opens reachable agents and inserts a mention token that round-trips through the
  existing `mentionedAgents()` parser (ent#361).

One new presentational component (`PortalTypeahead.vue`) plus a new pure-logic layer in
`portalUtils.js` (+22 exports), wired into the 1:1 composer (`PortalConversation.vue`) and
the room composer (`PortalRoom.vue`). `PortalBriefing.vue` now imports the `starterFor`
helper instead of defining its own copy.

All decidable logic is **pure and exported**, because `vitest` here runs
`environment: 'node'` with no component-mount harness — a decision made inside a component
is a decision no test can reach. The components are dispatchers; the panel is presentational.

**Backend, store and router are untouched: no new endpoint, no new table, no migration.**

## OSS-core by decision — deliberately ungated

No `requires_entitlement`, logic stays in the OSS tree.

Recording this explicitly because CLAUDE.md's default for an enterprise-tracker feature is
*gated unless ruled otherwise* — so the ruling must never be inferred later from the mere
fact that it merged (the ent#326 / ent#384 discipline). Rationale: it extends a surface
that is already OSS-core (the Workspace, ent#356) over data the client already holds.

The ruling is written into four places so it cannot be lost: requirements §5.13,
`architecture.md`, the flow doc, and the `portalUtils.js` header.

## `/`-in-room is deferred, explicitly

The issue's AC permits this. A room has N participants and **no active agent**, so
"whose playbooks?" has no answer without inventing a participant-picker the issue does not
specify. `@` ships in rooms; `/` does not.

## Room `@` ships — and here is exactly what justifies its scope

The candidate list is scoped to the room's **agent participants**. That scope was
established by **observing the running server**, not by reading the private rooms engine.
Carrying the observations as what they are:

| probe | server response |
|---|---|
| mention a **participant** | `{"mentions":["acme-scout"],"woke":["acme-scout"]}` |
| mention a **non-participant** | `{"mentions":[],"woke":[]}` |

Confirmed live in the UI: the sidebar listed 10 agents, and the room's `@` offered exactly
2 — the participants. So the list offers only names a pick is *known* to wake; offering the
whole roster would put names in front of the user with no evidence that choosing one does
anything.

### The recruiting question is OPEN — please don't tidy this hedge away

The probe only ever read **two response fields** and **never inspected the participant
list afterwards**. An empty `woke` therefore does **not** prove a non-participant was not
*recruited* into the room. Requirements §5.12 records an engine-side
`_join_mentioned_newcomers` path from ent#361.

If that path is live, our participants-only scoping is **narrower than the engine allows** —
which is the safe direction — but it is *not proven*, and the doc says so rather than
claiming a behaviour we did not observe. Recruiting stays with the explicit "+ Add agent"
control, the honest home for an action that spends money on another agent.

Settling this properly means observing the participant list after a non-participant
mention. Listed as a follow-up below, not filed.

## Deviations from the AC, named

**A-9 keyboard.** The AC says "Enter/Tab to accept". Shipped instead:

- plain **Enter** accepts **only when an item was explicitly selected**; otherwise it **sends**
- **Tab** accepts the top row
- Esc dismisses, and keeps the popup shut while the same token is still being typed

The harm is asymmetric. An accidental *accept* destroys typed work — a popup that merely
happens to be open (a paste, or prose like "check /status of the deploy") would splice up to
500 characters over the message. An accidental *send* is what the user was reaching for.
So the roving index starts at "nothing chosen". Verified live: typing `@scout` and pressing
Enter **sent it as a message** rather than splicing to `@acme-scout`.

## Two rules that are load-bearing, not stylistic

**The trigger rule is deliberately stricter than the parser.** `MENTION_RE` is unanchored,
so `user@example.com` *parses* as `@example`. The typeahead only fires on a trigger char at
a token start (preceded by a **non-word** char — not merely whitespace, or it could not fire
after CJK, an emoji, or punctuation). Asymmetric in the only safe direction: the popup can
never open on something the parser would not see, so `50/50`, `and/or` and email addresses
are left alone. Test #2 asserts this at **every caret index** of those strings, as a loop
rather than a sample.

**Some agents are structurally un-mentionable, and are excluded.** `sanitize_agent_name`
permits `.` and imposes no length cap; the mention grammar permits neither. So a slug like
`data.scout` parses as `@data`, matches nothing, and **silently degrades to plain text** —
the exact failure this feature exists to close. Nothing offers such names today, which is
why the failure is currently invisible; a list that included them would *manufacture* it.
The exclusion predicate is **derived by asking `mentionedAgents` itself**, never a second
hand-written copy of the grammar — a mutation that re-typed it as a copied regex which
drifted to allow dots fails 10 assertions.

**Agent matching is substring; playbooks stay word-start-prefix.** A strict prefix fails
`scout` → `acme-scout`, and a shared deployment prefix makes exactly that the common query.
Ranked whole-prefix → word-start → substring, so substring hits never outrank real prefixes.

## Verification

| gate | result |
|---|---|
| `cd src/frontend && npx vitest run` | **23 files / 444 tests passed** (111 of them new) |
| `npm run check:tokens` | OK — 11 tokens equivalent, all refs resolve, dark ink ladder holds |
| `npm run build` | ✓ built |
| `verify-local --skip-agent` | **PASS** |
| backend sweep (measured WAVE-4, this branch) | `9960 passed, 3 failed, 17 skipped, 1 xfailed` |

The 3 backend failures are **pre-existing on `dev`** — `[XPASS(strict)]` in
`test_pat_propagation_properties.py::TestKnownGaps::test_a_backslash_in_the_token_does_not_raise`,
reproduced on a pristine `origin/dev` checkout. Not re-run here: three ship workers are
running concurrently and share uncached settings state, which manufactures phantom reds.

`verify-local` was run with `--skip-agent`; the agent stages were skipped **correctly** —
the diff is `src/frontend/**` + docs with zero backend surface.

**Live visual pass**, both themes, 11 cases — including the mid-sentence-pick regression
that this branch's own review found (the caret lands *inside* the inserted token, which is
the exact re-detect condition, and the panel must stay closed; commit `c7520aa8`).

Honest caveat on the evidence: the **`/` list case was a route-injected probe**, because
every agent on the test instance is stopped, so `_agent_briefing` legitimately returns no
playbooks. The `@` cases were driven against real server state.

Seven mutations were run against the suite to prove the guards can actually fail — baking a
space into `buildMentionToken` (8 failures), accepting Enter without an explicit selection
(1), dropping the mentionable filter (6), dropping the forward scan (3), removing the
token-boundary rule (5), the drifted-regex copy (10), dropping the post-pick settle (1).

## One design-system note

The new `PortalTypeahead.vue` carries **26 raw `gray-*` Tailwind classes**, so
`scan-raw-colors.mjs` counts a new baseline entry. Deliberately not "fixed" here:

- it adds **0 raw non-gray** and **0 hardcoded hex** — the branch's repo-wide totals for
  both are byte-identical to `dev` (810 / 454)
- the three *modified* portal files add **zero** raw colors; the entire delta is the new file
- every color is either light/dark paired or the theme-neutral `text-gray-400` that is the
  **established idiom of this exact directory** (PortalSidebar 10 uses, PortalConversation 9,
  PortalFilesPanel 9); the new file's 26 is *below* its siblings (PortalRoom 46, PortalConversation 59)
- the scanner is measurement-only by its own docstring ("Exit code is always 0"), and is
  referenced by **no workflow**

Converting only this one file to tokens would make it diverge from its four immediate
neighbours. Flagging rather than churning; a directory-wide pass is the right shape and is
not this issue.

## Follow-ups — listed, deliberately NOT filed

1. Delete the orphaned `src/frontend/src/components/rooms/` — zero importers.
2. Settle the recruiting question by observing the **participant list** after a
   non-participant mention (see above).
3. Unify the three typeahead implementations behind one primitive — requires first putting
   the untested operator surface under test.
4. The `MENTION_RE` vs `sanitize_agent_name` divergence (cross-repo: the grammar and the
   name sanitizer disagree about `.` and length).
5. A room-scoped variant of the "shared with you" empty-state wording.

## CI note

`frontend-build.yml` runs on this PR but is **not** a required check on `dev`. Its green
should be **read**, not relied on.
