### PR TITLE
fix(workspace): Reports tab renders through the shared display_hint renderers, never a raw dump (#2162)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -650,7 +650,13 @@ directly). Agents call the MCP `report` tool, which POSTs to `POST /api/agents/{
   (`offset`/`limit`, true `total`); the UI fetches tabular reports through it, so expanding
   a 1.2 MB report transfers ~8 KB. Storage stays a single TEXT blob — no migration — and
   the slice is Python-side, so it bounds the response, not the read; off-row storage waits
-  on a payload distribution that justifies it.
+  on a payload distribution that justifies it. The **portal** detail route carries the same
+  window as two optional query params (`rows_offset`/`rows_limit`, #2162) rather than a second
+  route: `/rows` is `Depends(get_current_user)`, which a portal principal cannot satisfy, and
+  a clone on a client-facing prefix would need its own copy of the uniform-404 contract. There
+  the *server* decides tabularity from the real payload (a non-tabular one returns whole with
+  no `row_meta`, never a 400), and because paging re-reads the blob per request it is
+  rate-limited per (client, agent).
 - **Export** (#1536): `GET /api/reports/{id}/export?format=xlsx|pdf` →
   `services/report_export.py` (pure builders, lazily-imported `openpyxl`/`reportlab`, both
   pure-Python wheels). Shape mismatch degrades to a sensible sheet or JSON rather than
@@ -661,7 +667,21 @@ directly). Agents call the MCP `report` tool, which POSTs to `POST /api/agents/{
   `GET /api/reports/{id}` returns the full payload, lazy-loaded when a card expands.
 - **Fleet access**: `GET /api/reports` + `GET /api/reports/stats` filter via
   `accessible_agent_names` + `_narrow_to_agent` (admin = all). Renderers (`components/reports/`)
-  pick by `display_hint` → `report_type` prefix → JSON, with shape-validation fallback to JSON.
+  pick by `display_hint` → `report_type` prefix → fallback, with a shape check per hint.
+- **Three renderer surfaces, one fallback** (#2162): Agent Detail, the Operations fleet tab,
+  and the **Workspace agent page** all mount the same `ReportRenderer`. The third was added
+  after it shipped `JSON.stringify(payload)` to external clients — a disclosure defect
+  (`payload` is free-form agent JSON of the class `client_portal/agent_page.py` refuses to
+  expose for an ask's `context`, canary G-04), which a typed renderer narrows because it
+  reads only the keys its hint declares. This matters to the CI pin above: `test_1535`
+  regexes `payload.X` out of `ReportRenderer.vue`, so a third consumer widens that drift
+  guard's blast radius and **`shapeOk` must stay in that file** — extracting it is the
+  natural refactor and it empties the pinned set. The fallback is now `ReportSummary`
+  (bounded, humanised, credential-shaped tokens redacted at value level) with raw JSON behind
+  a collapsed operator-only disclosure; `allow-raw="false"` removes it entirely on the
+  client-facing surface. The prop names the POLICY, not the mechanism, because `json` is a
+  valid agent-chosen `display_hint` — a fallback-override prop or slot would have left an
+  agent able to request a raw dump in front of a client.
 - **Agent read-back** (#1538): `list_reports` / `get_report` MCP tools over the existing
   access-controlled REST endpoints — no new endpoint, no new tenant-boundary logic. The
   MCP layer adds the narrowing the backend cannot do (agent key → owner scope → `{self} ∪

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -676,12 +676,15 @@ directly). Agents call the MCP `report` tool, which POSTs to `POST /api/agents/{
   reads only the keys its hint declares. This matters to the CI pin above: `test_1535`
   regexes `payload.X` out of `ReportRenderer.vue`, so a third consumer widens that drift
   guard's blast radius and **`shapeOk` must stay in that file** — extracting it is the
-  natural refactor and it empties the pinned set. The fallback is now `ReportSummary`
-  (bounded, humanised, credential-shaped tokens redacted at value level) with raw JSON behind
-  a collapsed operator-only disclosure; `allow-raw="false"` removes it entirely on the
-  client-facing surface. The prop names the POLICY, not the mechanism, because `json` is a
-  valid agent-chosen `display_hint` — a fallback-override prop or slot would have left an
-  agent able to request a raw dump in front of a client.
+  natural refactor and it empties the pinned set. The fallback is **per-surface**: the default
+  stays `ReportJson`, so both operator surfaces render exactly what they always did, and only the
+  Workspace passes `:fallback-component="ReportSummary"` (bounded, humanised, credential-shaped
+  tokens redacted at value level, no raw payload reachable behind it). AC #2 asks for a client
+  fallback "deliberately stricter than the operator side", so the split IS the design — a global
+  summary would erase it, and a raw dump is a FEATURE when you are debugging an agent's own
+  output. The override deliberately catches an agent-chosen `display_hint: "json"` as well as a
+  shape mismatch, since `json` is a valid enum value and replacing only the mismatch path would
+  leave an agent able to request a dump in front of a client.
 - **Agent read-back** (#1538): `list_reports` / `get_report` MCP tools over the existing
   access-controlled REST endpoints — no new endpoint, no new tenant-boundary logic. The
   MCP layer adds the narrowing the backend cannot do (agent key → owner scope → `{self} ∪

--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -668,7 +668,7 @@ directly). Agents call the MCP `report` tool, which POSTs to `POST /api/agents/{
 - **Fleet access**: `GET /api/reports` + `GET /api/reports/stats` filter via
   `accessible_agent_names` + `_narrow_to_agent` (admin = all). Renderers (`components/reports/`)
   pick by `display_hint` → `report_type` prefix → fallback, with a shape check per hint.
-- **Three renderer surfaces, one fallback** (#2162): Agent Detail, the Operations fleet tab,
+- **Three renderer surfaces, a per-surface fallback** (#2162): Agent Detail, the Operations fleet tab,
   and the **Workspace agent page** all mount the same `ReportRenderer`. The third was added
   after it shipped `JSON.stringify(payload)` to external clients — a disclosure defect
   (`payload` is free-form agent JSON of the class `client_portal/agent_page.py` refuses to

--- a/docs/memory/feature-flows/agent-reports.md
+++ b/docs/memory/feature-flows/agent-reports.md
@@ -89,8 +89,10 @@ calling agent.
 - **Renderers** `components/reports/` — `ReportRenderer.vue` picks by `display_hint` →
   `report_type` prefix → fallback, validating payload shape and falling back on mismatch
   (Codex #10). Typed renderers: `ReportTable`, `ReportKpiTiles`, `ReportMarkdown`
-  (DOMPurify via `utils/markdown.js`), `ReportTimeline`; fallback `ReportSummary` (#2162),
-  with `ReportJson` retained behind its disclosure.
+  (DOMPurify via `utils/markdown.js`), `ReportTimeline`. The fallback is a **prop**, not a
+  fixture (#2162): `fallbackComponent` defaults to `ReportJson`, which is what both operator
+  panels still render, and only the client-facing Workspace passes `ReportSummary` — there is
+  no disclosure behind it, because a raw payload must be unreachable on that surface.
 - **Panels — THREE consumers, not two** (#2162) — `ReportsPanel.vue` (Agent Detail "Reports"
   tab), `ReportsPanelFleet.vue` (Operations → Reports tab; agent/type/time/search filters +
   KPI tiles from `GET /api/reports/stats`), and the **Workspace agent page's Reports tab**

--- a/docs/memory/feature-flows/agent-reports.md
+++ b/docs/memory/feature-flows/agent-reports.md
@@ -87,12 +87,17 @@ calling agent.
   `setActive` gate so a WS trigger only refetches while the panel is mounted). Wired into
   `utils/websocket.js` `agent_report` dispatch.
 - **Renderers** `components/reports/` — `ReportRenderer.vue` picks by `display_hint` →
-  `report_type` prefix → JSON, validating payload shape and falling back to `ReportJson` on
-  mismatch (Codex #10). Typed renderers: `ReportTable`, `ReportKpiTiles`, `ReportMarkdown`
-  (DOMPurify via `utils/markdown.js`), `ReportTimeline`, `ReportJson`.
-- **Panels** — `ReportsPanel.vue` (Agent Detail "Reports" tab) and `ReportsPanelFleet.vue`
-  (Operations → Reports tab; agent/type/time/search filters + KPI tiles from
-  `GET /api/reports/stats`). Lists show metadata; full payload lazy-loads on expand.
+  `report_type` prefix → fallback, validating payload shape and falling back on mismatch
+  (Codex #10). Typed renderers: `ReportTable`, `ReportKpiTiles`, `ReportMarkdown`
+  (DOMPurify via `utils/markdown.js`), `ReportTimeline`; fallback `ReportSummary` (#2162),
+  with `ReportJson` retained behind its disclosure.
+- **Panels — THREE consumers, not two** (#2162) — `ReportsPanel.vue` (Agent Detail "Reports"
+  tab), `ReportsPanelFleet.vue` (Operations → Reports tab; agent/type/time/search filters +
+  KPI tiles from `GET /api/reports/stats`), and the **Workspace agent page's Reports tab**
+  (`components/portal/PortalAgentPage.vue`, client-facing — see
+  [workspace-agent-page.md](workspace-agent-page.md)). Lists show metadata; full payload
+  lazy-loads on expand. Enumerating them is load-bearing: this list said "two" while the
+  third shipped a raw JSON dump to external clients.
 
 ### Renderer payload contracts
 | hint | expected payload shape |
@@ -101,7 +106,17 @@ calling agent.
 | `kpi` | `{ tiles: Array<{label, value, unit?}> }` |
 | `markdown` | `{ markdown: string }` |
 | `timeline` | `{ events: Array<{ts?, label, detail?}> }` |
-| `json` (or anything malformed) | rendered as a pretty-printed JSON viewer |
+| `json` (or anything malformed) | `ReportSummary` — a bounded, humanised key-value view (#2162) |
+
+**The fallback, since #2162.** It was `ReportJson`, a pretty-printed dump. That is fine for
+an operator and unacceptable for an external client, so the shared fallback became a bounded
+summary (≤40 entries with a counted remainder, ~200-char values, depth 1 — a nested value is
+described as "12 items", never serialised) with credential-shaped tokens redacted at **value**
+level, mirroring canary G-04's prefix set. Raw JSON stays one click away inside a collapsed
+disclosure; a surface passing `allow-raw="false"` loses even that. One fallback rather than a
+per-surface one, so a client and an operator looking at the same row never see different
+renderings of it. The prop is named for the POLICY because `json` is a valid agent-chosen
+hint — a fallback-override prop or slot would only have covered the mismatch path.
 
 ## Retention
 `cleanup_service._sweep_retention_772` prunes `agent_reports` older than
@@ -202,6 +217,17 @@ transfers **8,699 bytes** instead of 1.16 MB.
 is needed to know whether to page. Non-tabular payloads answer 400 on the rows route rather
 than being given an invented row axis, and no-access answers 404 exactly like
 `GET /reports/{id}`, so the sibling route cannot be used to probe an id.
+
+**The client-facing surface windows differently, on purpose (#2162).** This route is
+`Depends(get_current_user)`, which a portal principal — a verified email with no `users` row —
+structurally cannot satisfy, so the Workspace could not reuse it and a clone on a
+client-facing prefix would have needed its own copy of the uniform-404 contract. Its detail
+route took two optional query params instead (`rows_offset`/`rows_limit`), and the **server**
+decides tabularity from the real payload rather than trusting `display_hint`: a non-tabular
+payload comes back whole with no `row_meta` instead of a 400, which removes the
+predict-then-recover round trip the operator client needs. Same honest residual as below, plus
+one more — paging re-reads the blob per request, so on a prefix a client can loop it is
+rate-limited per (client, agent).
 
 **Honest residual.** The slice happens in Python after the whole blob is read from the
 column, so it bounds the RESPONSE, not the read. Moving the slice into SQL needs the rows

--- a/docs/memory/feature-flows/agent-reports.md
+++ b/docs/memory/feature-flows/agent-reports.md
@@ -106,17 +106,18 @@ calling agent.
 | `kpi` | `{ tiles: Array<{label, value, unit?}> }` |
 | `markdown` | `{ markdown: string }` |
 | `timeline` | `{ events: Array<{ts?, label, detail?}> }` |
-| `json` (or anything malformed) | `ReportSummary` — a bounded, humanised key-value view (#2162) |
+| `json` (or anything malformed) | `ReportJson` by default; the overriding surface's `fallbackComponent` (#2162) |
 
-**The fallback, since #2162.** It was `ReportJson`, a pretty-printed dump. That is fine for
-an operator and unacceptable for an external client, so the shared fallback became a bounded
-summary (≤40 entries with a counted remainder, ~200-char values, depth 1 — a nested value is
-described as "12 items", never serialised) with credential-shaped tokens redacted at **value**
-level, mirroring canary G-04's prefix set. Raw JSON stays one click away inside a collapsed
-disclosure; a surface passing `allow-raw="false"` loses even that. One fallback rather than a
-per-surface one, so a client and an operator looking at the same row never see different
-renderings of it. The prop is named for the POLICY because `json` is a valid agent-chosen
-hint — a fallback-override prop or slot would only have covered the mismatch path.
+**The fallback is per-surface, since #2162.** `ReportJson` — a pretty-printed dump — stays the
+default, and both operator panels keep it: it is the useful answer when you are debugging an
+agent's own output. It is unacceptable for an external client, so `ReportRenderer` takes a
+`fallbackComponent` prop and the Workspace passes `ReportSummary`, a bounded summary (≤40 entries
+with a counted remainder, ~200-char values, depth 1 — a nested value is described as "12 items",
+never serialised) with credential-shaped tokens redacted at **value** level, mirroring canary
+G-04's prefix set, and no raw payload behind it. AC #2 asks for a client fallback "deliberately
+stricter than the operator side", so the split is the design. The override covers an
+agent-chosen `json` hint as well as a shape mismatch — replacing only the mismatch path would
+leave an agent able to request a dump in front of a client.
 
 ## Retention
 `cleanup_service._sweep_retention_772` prunes `agent_reports` older than

--- a/docs/memory/feature-flows/workspace-agent-page.md
+++ b/docs/memory/feature-flows/workspace-agent-page.md
@@ -107,23 +107,27 @@ is how the payload that legitimately crosses is *presented*. The payload itself
 remains agent-authored untrusted content of the same class as `asks.title` and
 the schedule name — bounded and escaped, never trusted.
 
-**The fallback is the one place the three renderer surfaces deliberately differ.**
-The shared set's fallback WAS the raw JSON viewer, so reuse alone could not
-satisfy "never a raw dump to a client". `ReportSummary` replaces it everywhere —
-a bounded key-value view (≤40 entries with a counted remainder, ~200-char values,
-depth 1, so a nested value is described as "12 items" and never serialised) with
-credential-shaped tokens redacted at **value** level. A key-name allow-list was
-rejected twice over: the fallback fires precisely on payloads nobody has seen, so
-an allow-list blanks nearly all of them, and an allowed key's value carries the
-secret anyway (`{"status": "failed: sk-…"}`). Operators keep the raw payload one
-click away inside a collapsed disclosure; this surface passes `allow-raw="false"`
-and it is gone.
+**The fallback is the one place this surface deliberately differs from the
+operator ones.** The shared set's fallback is the raw JSON viewer, so reuse alone
+could not satisfy "never a raw dump to a client" — and AC #2 asks for a fallback
+*"deliberately stricter than the operator side, because the audience is an
+external client"*, i.e. it asks for a SPLIT, not for a stricter default
+everywhere. So `ReportRenderer` gained a `fallbackComponent` override defaulting
+to `ReportJson` — every operator call site passes nothing and renders exactly what
+it always did, because a raw payload is the useful answer when you are debugging
+an agent's own output — and this page passes `ReportSummary`: a bounded key-value
+view (≤40 entries with a counted remainder, ~200-char values, depth 1, so a
+nested value is described as "12 items" and never serialised) with
+credential-shaped tokens redacted at **value** level, and no raw payload
+reachable behind it at all. A key-name allow-list was rejected twice over: the
+fallback fires precisely on payloads nobody has seen, so an allow-list blanks
+nearly all of them, and an allowed key's value carries the secret anyway
+(`{"status": "failed: sk-…"}`).
 
-`allow-raw` is a **policy** name, not a mechanism name, and that is what makes it
-correct: `json` is a valid agent-chosen `display_hint`
-(`src/mcp-server/src/tools/reports.ts`), so a "fallback override" prop or slot
-would have replaced only the *mismatch* path and left an agent able to put a raw
-dump in front of a client by asking for one.
+The override deliberately catches an agent-chosen `display_hint: "json"`
+(`src/mcp-server/src/tools/reports.ts`) as well as a shape mismatch — replacing
+only the *mismatch* path would leave an agent able to put a raw dump in front of
+a client by asking for one.
 
 **Honest residual.** A key-value summary still names every top-level key. It
 bounds and humanises; it does not eliminate the class, and a well-shaped
@@ -342,9 +346,9 @@ destination" is finally true.
 | Store | `stores/clientPortal.js` | `fetchAgentPage`, `fetchAgentReports`, `fetchAgentReport`; the whole Reports orchestration + generation guard (#2162) |
 | Service | `client_portal/agent_page.py` | `_window_rows` + `report_detail(rows_offset, rows_limit)` (#2162) |
 | Router | `client_portal/router.py` | `rows_offset`/`rows_limit` on the existing detail route, rate-limited (#2162) |
-| UI | `components/reports/ReportSummary.vue` | **new** — the shared human-readable fallback, `allow-raw` policy (#2162) |
+| UI | `components/reports/ReportSummary.vue` | **new** — the CLIENT-FACING human-readable fallback; no raw escape hatch (#2162) |
 | UI | `components/reports/reportSummary.js` | **new** — the bounded, redacting summariser (pure) (#2162) |
-| UI | `components/reports/ReportRenderer.vue` | fallback → `ReportSummary`; forwards `allow-raw`; `shapeOk` untouched (#2162) |
+| UI | `components/reports/ReportRenderer.vue` | `fallbackComponent` override, default `ReportJson` (operator unchanged); `shapeOk` untouched (#2162) |
 | UI | `components/reports/{ReportTable,ReportKpiTiles}.vue` | dark ink pair on meta text — AC #4 (#2162) |
 | UI | `components/reports/ReportTimeline.vue` | `bg-blue-500` → `bg-status-info-500` (#2162) |
 | UI | `utils/reportPaging.js` | **new** — the one frontend page-size constant, shared with `stores/reports.js` (#2162) |
@@ -404,7 +408,7 @@ is the only paging signal), and that a failed fetch never lands in the payload m
 
 `src/frontend/tests/unit/portalReportsRendering.spec.js` — the wiring no unit test
 can reach: the tab holds no `<pre>` and no serialiser, mounts the shared
-`ReportRenderer`, passes `:allow-raw="false"`, and adds no second scroll axis.
+`ReportRenderer`, passes `:fallback-component`, and adds no second scroll axis.
 Guards the **mechanism** rather than the spelling — a prop declared and never used
 would pass a call-site scan — and re-asserts the five CI-pinned `payload.X` keys
 are still inside `ReportRenderer.vue`, the file `test_1535` regexes them out of.

--- a/docs/memory/feature-flows/workspace-agent-page.md
+++ b/docs/memory/feature-flows/workspace-agent-page.md
@@ -88,6 +88,93 @@ mechanism anywhere in Trinity — no table, no column, no endpoint. It has no da
 source, so it was omitted rather than invented. A number a user reads as "how
 well is this agent doing" has to come from something real.
 
+## The Reports tab (#2162)
+
+The tab shipped `<pre>{{ JSON.stringify(payload, null, 2) }}</pre>`. Read beside
+this document's own thesis, that is not a cosmetic gap: the section above refuses
+to expose an ask's `context` at all because free-form agent JSON has been a
+credential-leak surface (canary G-04) — and `agent_reports.payload` is the *same
+category*, filed by the same agents, and was being dumped key-for-key to an
+external client. Routing it through the shared `components/reports/` renderer set
+**narrows** what crosses, because a typed renderer reads only the keys its hint
+declares (`tiles`, `columns`+`rows`, `markdown`, `events`) and never the rest of
+the payload.
+
+**Rendering is presentation, and this does not move the exclusion boundary.**
+Everything the page must not show is still dropped in `client_portal/agent_page.py`
+before the payload exists; nothing is filtered in the Vue component. What changed
+is how the payload that legitimately crosses is *presented*. The payload itself
+remains agent-authored untrusted content of the same class as `asks.title` and
+the schedule name — bounded and escaped, never trusted.
+
+**The fallback is the one place the three renderer surfaces deliberately differ.**
+The shared set's fallback WAS the raw JSON viewer, so reuse alone could not
+satisfy "never a raw dump to a client". `ReportSummary` replaces it everywhere —
+a bounded key-value view (≤40 entries with a counted remainder, ~200-char values,
+depth 1, so a nested value is described as "12 items" and never serialised) with
+credential-shaped tokens redacted at **value** level. A key-name allow-list was
+rejected twice over: the fallback fires precisely on payloads nobody has seen, so
+an allow-list blanks nearly all of them, and an allowed key's value carries the
+secret anyway (`{"status": "failed: sk-…"}`). Operators keep the raw payload one
+click away inside a collapsed disclosure; this surface passes `allow-raw="false"`
+and it is gone.
+
+`allow-raw` is a **policy** name, not a mechanism name, and that is what makes it
+correct: `json` is a valid agent-chosen `display_hint`
+(`src/mcp-server/src/tools/reports.ts`), so a "fallback override" prop or slot
+would have replaced only the *mismatch* path and left an agent able to put a raw
+dump in front of a client by asking for one.
+
+**Honest residual.** A key-value summary still names every top-level key. It
+bounds and humanises; it does not eliminate the class, and a well-shaped
+`markdown` or `table` report still renders its values as authored. The general
+fix is a G-04-style scrub at the portal read boundary — a security change to a
+shipping read path, which deserves its own review rather than riding a UI fix.
+
+**Row windowing without a second route.** AC #3 wants #1537's windowed-rows
+pattern, and the operator reader `GET /api/reports/{id}/rows` is
+`Depends(get_current_user)` — which a portal principal (a verified email with no
+`users` row) structurally cannot satisfy, the same fact #2128 hit with
+feature-flags. Rather than clone it onto a client-facing prefix, the **existing**
+detail route took two optional params:
+
+```
+GET .../agents/{name}/reports/{id}?rows_offset=&rows_limit=
+   tabular payload  -> payload {columns, rows: window} + row_meta {total, offset, limit}
+   anything else    -> payload whole, no row_meta        (rows_limit ignored)
+```
+
+The **server** decides tabularity from the real payload, so the client never
+predicts a shape from an agent-authored `display_hint` that can disagree with what
+was filed — which deletes the 400-and-recover branch a client-side prediction
+would need. `rows_limit` absent is byte-identical to before. No new route means no
+second gate and no second copy of the 404-uniformity contract: a foreign report id
+and a missing one stay indistinguishable through the windowed path too.
+
+**Read amplification is real and mitigated, not hidden.** The slice happens in
+Python after the whole (≤5 MiB) blob is read out of the column, so paging
+*multiplies* reads — the route that exists to cut transfer raises them. Acceptable
+behind an operator JWT; on a prefix a client can loop it is an amplification
+primitive, so the route is rate-limited per (client, agent) after the roster gate.
+A report whose total fits one page costs exactly **one** request and shows no
+footer, so only genuinely large tables page at all.
+
+**Bounded by rows, not by a nested scroll region.** The page has one scroll axis
+(#2101, and the asks list above made the same call); a 100-row window plus
+`ReportTable`'s stated total and an explicit "Load more" satisfies "contained with
+a stated total" without a second scroll axis.
+
+**The store owns the state, and every await is generation-guarded.** A reset
+cannot cancel a promise already in flight, so the `reportsLoaded` flag that
+contract #15 requires (an empty state must gate on a *succeeded* fetch, never on
+list length) would otherwise have turned a transient wrong-render into a permanent
+one: switch agents mid-fetch, the old agent's list lands in the cleared state, and
+the new agent is marked loaded-with-the-wrong-data for the life of the mount.
+Every report request captures a generation counter before its first await and
+discards its result if a reset bumped it. The component additionally gates each
+read on the state belonging to the agent on screen — the store is a singleton that
+outlives it, and a fresh **mount** for a different agent fires no props watcher.
+
 ## The UX repairs (#2161)
 
 The page shipped with four defects, and fixing them forced two of ent#360's own
@@ -252,7 +339,15 @@ destination" is finally true.
 | UI | `components/StackedBarChart.vue` | optional `labels` prop (#2161) |
 | UI | `utils/executionBuckets.js` | **new** — `BUCKET_COLORS` + chart helpers, shared with `OverviewPanel.vue` (#2161) |
 | UI | `views/Portal.vue`, `router/index.js` | `/workspace/a/:agentName`; shared stage escape (#2161) |
-| Store | `stores/clientPortal.js` | `fetchAgentPage`, `fetchAgentReports`, `fetchAgentReport` |
+| Store | `stores/clientPortal.js` | `fetchAgentPage`, `fetchAgentReports`, `fetchAgentReport`; the whole Reports orchestration + generation guard (#2162) |
+| Service | `client_portal/agent_page.py` | `_window_rows` + `report_detail(rows_offset, rows_limit)` (#2162) |
+| Router | `client_portal/router.py` | `rows_offset`/`rows_limit` on the existing detail route, rate-limited (#2162) |
+| UI | `components/reports/ReportSummary.vue` | **new** — the shared human-readable fallback, `allow-raw` policy (#2162) |
+| UI | `components/reports/reportSummary.js` | **new** — the bounded, redacting summariser (pure) (#2162) |
+| UI | `components/reports/ReportRenderer.vue` | fallback → `ReportSummary`; forwards `allow-raw`; `shapeOk` untouched (#2162) |
+| UI | `components/reports/{ReportTable,ReportKpiTiles}.vue` | dark ink pair on meta text — AC #4 (#2162) |
+| UI | `components/reports/ReportTimeline.vue` | `bg-blue-500` → `bg-status-info-500` (#2162) |
+| UI | `utils/reportPaging.js` | **new** — the one frontend page-size constant, shared with `stores/reports.js` (#2162) |
 
 ## Tests
 
@@ -282,6 +377,37 @@ route **nobody has written yet** still escapes, which is the property a
 param-enumerating guard cannot have and the reason this bug shipped twice. Also
 pins that the chart is stacked by untranslated buckets while the labels ride the
 separate prop — the mistake that renders a blank chart.
+
+`tests/unit/test_2162_portal_report_window.py` — the row window: `rows_limit`
+absent returns today's payload unchanged, a tabular payload windows with a TRUE
+total, a non-tabular one comes back whole with no `row_meta` (never a 400), the
+offset/limit clamps, and the inherited gate — foreign and missing ids stay
+indistinguishable 404s through the windowed path. Plus the route wiring: both
+params optional, bounded by the shared `REPORT_ROWS_PAGE_MAX`, rate-limited
+*after* the roster gate, and resolvable by FastAPI under postponed annotations.
+
+`src/frontend/tests/unit/reportSummary.spec.js` — the fallback summariser. The
+two that define it are negatives: no output path ever serialises the payload
+(behaviourally, and by scanning the module source), and a credential-shaped token
+is redacted **at value level** — as a whole value, embedded mid-string under an
+innocuous key, and past the truncation point. Redaction runs before both
+truncation and key humanisation; the humanisation ordering was caught by its own
+test, since rewriting `_` to a space destroys the very shape every pattern keys
+on.
+
+`src/frontend/tests/unit/portalReportsStore.spec.js` — the store contract against
+a mocked axios (`fleetGridFailuresFetch.spec.js` shape). The agent-switch race is
+the one that matters: agent A's list, failure, payload and load-more page each
+resolve *after* a switch to B and must all be discarded, with B left NOT marked
+loaded. Plus the load-more terminal guard, windowed-vs-whole (`row_meta` present
+is the only paging signal), and that a failed fetch never lands in the payload map.
+
+`src/frontend/tests/unit/portalReportsRendering.spec.js` — the wiring no unit test
+can reach: the tab holds no `<pre>` and no serialiser, mounts the shared
+`ReportRenderer`, passes `:allow-raw="false"`, and adds no second scroll axis.
+Guards the **mechanism** rather than the spelling — a prop declared and never used
+would pass a call-site scan — and re-asserts the five CI-pinned `payload.X` keys
+are still inside `ReportRenderer.vue`, the file `test_1535` regexes them out of.
 
 `src/frontend/tests/unit/workspaceRoomsGate.spec.js` — F24 was **rewritten**, not
 deleted. It used to require each exit function to contain `route.params.roomId`;

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -437,6 +437,19 @@
   id misses by construction; a failing read costs the labels, not the rows. It is
   **not assumed to be human-written** — schedule creation is `AuthorizedAgent`, so
   an agent-scoped key can author it — and is therefore capped and escaped.
+- **Reports are rendered, never dumped (#2162)**: the Reports tab drives the shared
+  `components/reports/` renderer set (`display_hint` → `report_type` prefix → shape check),
+  the same dispatch Agent Detail uses — reused, not forked, because those renderer keys are
+  CI-pinned as the canonical contract (`test_1535_report_prompt_guidance.py`). It shipped
+  dumping `JSON.stringify(payload)` at an external client, which is the *same* disclosure this
+  section already refuses for an ask's `context`: a typed renderer reads only the keys its hint
+  declares, so this strictly narrows what crosses. The one deliberate divergence from the
+  operator surfaces is the fallback: an unrecognised payload gets a bounded, humanised key-value
+  summary with credential-shaped tokens redacted, and this surface passes `allow-raw="false"`
+  so no raw payload is reachable behind it. Honest limit — a summary still names every top-level
+  key; it bounds and humanises the residual rather than removing it. A `table` payload is
+  fetched a window at a time (`rows_offset`/`rows_limit`) so a large report never transfers
+  whole, and the tab grows by an explicit "Load more" rather than a nested scroll region.
 - **Key Features**:
   - Header: avatar, name, description, health, last active
   - Stats strip: tasks in window, completed rate, first-try rate, window selector
@@ -449,7 +462,9 @@
     health `unknown` (monitoring is default-OFF, so "unhealthy" would be a lie),
     empty sections, and a failing data source degrades that section only
   - Endpoints: `GET /agents/{name}/page?window=`, `.../reports`,
-    `.../reports/{id}` under the client-portal prefix, all roster-gated
+    `.../reports/{id}` (optional `rows_offset`/`rows_limit` window a tabular payload,
+    #2162 — two query params on the existing route, not a second route) under the
+    client-portal prefix, all roster-gated
 - **Not met**: the AC's **rating tally**. There is no rating, thumbs or feedback
   mechanism anywhere in Trinity, so it has no data source and was omitted rather
   than invented — a number a user reads as "how well is this agent doing" has to

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -444,9 +444,10 @@
   dumping `JSON.stringify(payload)` at an external client, which is the *same* disclosure this
   section already refuses for an ask's `context`: a typed renderer reads only the keys its hint
   declares, so this strictly narrows what crosses. The one deliberate divergence from the
-  operator surfaces is the fallback: an unrecognised payload gets a bounded, humanised key-value
-  summary with credential-shaped tokens redacted, and this surface passes `allow-raw="false"`
-  so no raw payload is reachable behind it. Honest limit — a summary still names every top-level
+  operator surfaces is the fallback: they keep the raw JSON viewer (useful when you are
+  debugging an agent's own output), while this surface passes `:fallback-component` and an
+  unrecognised payload gets a bounded, humanised key-value summary with credential-shaped tokens
+  redacted and no raw payload reachable behind it. Honest limit — a summary still names every top-level
   key; it bounds and humanises the residual rather than removing it. A `table` payload is
   fetched a window at a time (`rows_offset`/`rows_limit`) so a large report never transfers
   whole, and the tab grows by an explicit "Load more" rather than a nested scroll region.

--- a/docs/memory/requirements/lifecycle-observability.md
+++ b/docs/memory/requirements/lifecycle-observability.md
@@ -317,18 +317,20 @@ endpoint — reports flow agent → MCP → backend.
   `display_hint`, then `report_type` prefix; each validates payload shape and falls back on
   mismatch. List shows metadata; full payload lazy-loads on expand.
 
-  **The fallback is a human-readable summary, not a raw dump (#2162).** It was the JSON viewer,
-  which is defensible for an operator and never for an external client: `payload` is free-form
-  agent-authored JSON of the same class as an ask's `context`, which the Workspace refuses to
-  expose at all (a known credential-leak surface, canary G-04). The shared fallback is now a
-  bounded, humanised key-value summary (≤40 entries, truncated values, depth 1, credential-shaped
-  tokens redacted), with raw JSON one click away behind a collapsed disclosure. **The one place
-  the three surfaces deliberately differ** is that disclosure: the Workspace passes
-  `allow-raw="false"` and therefore never shows a raw payload — the policy is named on the
-  component, so it covers both a shape mismatch and an agent that explicitly asked for
-  `display_hint: "json"`. A typed renderer reads only the keys its hint declares, so routing a
-  client through the shared set **strictly reduces** what is exposed; the summary bounds and
-  humanises the residual rather than eliminating it (a boundary-side scrub is the general fix).
+  **The fallback is per-surface, and the client-facing one is stricter (#2162).** The shared
+  default stays the JSON viewer: an operator reading a malformed report is debugging an agent's
+  own output, where the raw payload is the useful answer. For an external client it is not —
+  `payload` is free-form agent-authored JSON of the same class as an ask's `context`, which the
+  Workspace refuses to expose at all (a known credential-leak surface, canary G-04). So
+  `ReportRenderer` takes a `fallbackComponent` override (default `ReportJson`, so every operator
+  call site is untouched) and the Workspace passes `ReportSummary`: a bounded, humanised key-value
+  view (≤40 entries, truncated values, depth 1, credential-shaped tokens redacted) with **no raw
+  payload reachable behind it at all**. The override covers an agent-chosen
+  `display_hint: "json"` as well as a shape mismatch — `json` is a valid value in the MCP tool's
+  enum, so replacing only the mismatch path would leave an agent able to dump on request. A typed
+  renderer reads only the keys its hint declares, so routing a client through the shared set
+  **strictly reduces** what is exposed; the summary bounds and humanises the residual rather than
+  eliminating it (a boundary-side scrub is the general fix).
 
   **Enumerating the surfaces here is load-bearing**: FR-5 said "two" while a third shipped a raw
   dump to clients for two releases, which is how #2162 happened. A fourth consumer belongs in

--- a/docs/memory/requirements/lifecycle-observability.md
+++ b/docs/memory/requirements/lifecycle-observability.md
@@ -311,10 +311,41 @@ endpoint — reports flow agent → MCP → backend.
 - **FR-4 — Real-time**: a **thin** `agent_report` WebSocket trigger (agent_name, report_id,
   report_type, created_at — never title/payload, since `/ws` is unfiltered SCOPE_ALL); the
   frontend refetches via the access-controlled REST endpoints.
-- **FR-5 — Frontend**: Agent Detail "Reports" tab + Operations → "Reports" fleet tab. Generic
-  + typed renderers (table / KPI tiles / markdown / timeline / JSON) chosen by `display_hint`,
-  then `report_type` prefix, then JSON; each renderer validates payload shape and falls back to
-  the JSON viewer on mismatch. List shows metadata; full payload lazy-loads on expand.
+- **FR-5 — Frontend**: **three** surfaces share one renderer set — Agent Detail "Reports" tab,
+  Operations → "Reports" fleet tab, and the **Workspace agent page's Reports tab** (§5.11 of
+  `core-agent.md`). Typed renderers (table / KPI tiles / markdown / timeline) chosen by
+  `display_hint`, then `report_type` prefix; each validates payload shape and falls back on
+  mismatch. List shows metadata; full payload lazy-loads on expand.
+
+  **The fallback is a human-readable summary, not a raw dump (#2162).** It was the JSON viewer,
+  which is defensible for an operator and never for an external client: `payload` is free-form
+  agent-authored JSON of the same class as an ask's `context`, which the Workspace refuses to
+  expose at all (a known credential-leak surface, canary G-04). The shared fallback is now a
+  bounded, humanised key-value summary (≤40 entries, truncated values, depth 1, credential-shaped
+  tokens redacted), with raw JSON one click away behind a collapsed disclosure. **The one place
+  the three surfaces deliberately differ** is that disclosure: the Workspace passes
+  `allow-raw="false"` and therefore never shows a raw payload — the policy is named on the
+  component, so it covers both a shape mismatch and an agent that explicitly asked for
+  `display_hint: "json"`. A typed renderer reads only the keys its hint declares, so routing a
+  client through the shared set **strictly reduces** what is exposed; the summary bounds and
+  humanises the residual rather than eliminating it (a boundary-side scrub is the general fix).
+
+  **Enumerating the surfaces here is load-bearing**: FR-5 said "two" while a third shipped a raw
+  dump to clients for two releases, which is how #2162 happened. A fourth consumer belongs in
+  this list before it ships.
+- **FR-5a — Client-facing row windowing (#2162)**: the Workspace cannot use FR-9's
+  `GET /api/reports/{id}/rows` — that route is `Depends(get_current_user)` and a portal principal
+  is a verified email with no `users` row (the #2128 structural fact). Rather than clone the
+  route on a client-facing prefix, the **existing** portal detail route takes two optional query
+  params, `rows_offset` / `rows_limit`, and windows `payload["rows"]` **only when the payload
+  really is `{columns, rows}`**, attaching `row_meta {total, offset, limit}` when it does.
+  `rows_limit` absent → byte-identical to before, so the change is purely additive; a non-tabular
+  payload with `rows_limit` set returns whole with no `row_meta` — never a 400, because the
+  server holds the payload and the client should not have to guess its shape from an
+  agent-authored `display_hint` that can disagree with it. Inherits the detail route's roster
+  gate and its uniform 404 rather than re-deriving either. Same honest limit as FR-9: the slice
+  is Python-side after the whole blob is read, so it bounds the **response**, not the read — and
+  because it is client-reachable and loopable it is **rate-limited** per (client, agent).
 - **FR-6 — Retention**: cleanup sweep deletes `agent_reports` older than
   `agent_reports_retention_days` (default 90; `0` disables), chunked like the #772 sweeps.
 - **FR-8 — Agent read-back** (#1538, epic #1534): MCP `list_reports` (metadata; filters
@@ -384,7 +415,10 @@ endpoint — reports flow agent → MCP → backend.
   something only agents whose own CLAUDE.md mentions it ever do. Documents the call, when to
   reach for it (results a human re-reads: scheduled-run findings, batch summaries, KPI
   snapshots), the payload shape per `display_hint` — the shapes FR-5's renderers dispatch on,
-  since a mismatch fails silently as a raw-JSON fallback — the aggregate-before-publishing
+  since a mismatch fails silently into the fallback (a bounded key-value summary since #2162,
+  and on the client-facing Workspace surface that is *all* the reader gets, with no raw payload
+  behind it — so a wrong shape costs the intended presentation outright) — the
+  aggregate-before-publishing
   expectation given the FR-3 cap, and the reports-are-one-way boundary against §26's operator
   queue. Runtime-aware for free via `_adapt_instructions_for_runtime` (#1187: Codex gets bare
   `report`, not `mcp__trinity__report`), and the Codex orientation note lists the tool.

--- a/src/backend/client_portal/agent_page.py
+++ b/src/backend/client_portal/agent_page.py
@@ -46,6 +46,7 @@ import logging
 from typing import Optional
 
 from database import db
+from models import REPORT_ROWS_PAGE_MAX
 
 from . import db as portal_db
 
@@ -242,7 +243,8 @@ def reports(agent_name: str, limit: int = 20, offset: int = 0) -> list[dict]:
     """Metadata for the Reports tab (payload fetched separately when expanded).
 
     Reuses the existing report surface (#918) exactly as the Technical Notes
-    ask. Metadata only: a payload is up to 256 KB and belongs on expansion.
+    ask. Metadata only: a payload is up to 5 MiB (`REPORT_PAYLOAD_MAX_BYTES`,
+    raised from 256 KB in #1537) and belongs on expansion.
     """
     try:
         rows = db.get_reports_for_agent(agent_name, limit=limit, offset=offset)
@@ -303,13 +305,70 @@ def _last_active(agent_name: str) -> Optional[str]:
     return rows[0].get("started_at") if rows else None
 
 
-def report_detail(agent_name: str, report_id: str) -> Optional[dict]:
+def _window_rows(payload, offset: int, limit: int):
+    """Slice a tabular payload's `rows`, or leave it alone (#2162).
+
+    Returns `(payload, row_meta)` — `row_meta` is None whenever no window was
+    applied, which is how the caller (and, downstream, the renderer's footer)
+    tells a windowed table from a whole document.
+
+    **The server decides tabularity, from the real payload.** `display_hint` is
+    agent-authored and can disagree with what was actually filed, so a client
+    that predicted the shape would need a 400 and a recovery re-fetch for the
+    disagreement. Answering "here it is whole, and no, that wasn't a table"
+    removes that branch: one request, always. Every other display_hint is a
+    bounded document (a KPI tile set, a markdown body) with no row axis to
+    slice, so there is nothing to answer 400 about.
+
+    Subtractive on `rows` only: sibling keys are returned exactly as filed, the
+    same as the unwindowed path. The copy is shallow so the source row is never
+    truncated in place.
+    """
+    if not isinstance(payload, dict):
+        return payload, None
+    columns = payload.get("columns")
+    rows = payload.get("rows")
+    if not isinstance(columns, list) or not isinstance(rows, list):
+        return payload, None
+
+    # A negative offset would silently serve rows counted from the END under an
+    # honest-looking total; an unbounded limit would defeat the point of the
+    # window. The route validates both (422), but the clamp is what actually
+    # bounds the response and must not depend on one caller doing so.
+    offset = max(0, int(offset))
+    limit = max(1, min(int(limit), REPORT_ROWS_PAGE_MAX))
+
+    windowed = dict(payload)
+    windowed["rows"] = rows[offset:offset + limit]
+    # `total` is the TRUE row count, not the window — it is what "Showing 100 of
+    # 12,431" reads, and a windowed total would hide the rest behind a footer
+    # that never appears.
+    return windowed, {"total": len(rows), "offset": offset, "limit": limit}
+
+
+def report_detail(agent_name: str, report_id: str, *,
+                  rows_offset: int = 0,
+                  rows_limit: Optional[int] = None) -> Optional[dict]:
     """One report's full payload, scoped to the agent whose page is open.
 
     The agent check is the point: report ids are global, and without it any
     rostered agent's page would read any report in the install. A foreign id
     returns None → the router's 404, identical to a nonexistent one, so this
     cannot be used to test whether a report exists (invariant #8).
+
+    `rows_limit` (#2162) windows a tabular payload's rows, so a large table is
+    never shipped whole to a client — the #1537 pattern, reached here through
+    two optional params rather than a second route. The operator row reader is
+    `Depends(get_current_user)`, which a portal principal (a verified email with
+    no `users` row) structurally cannot satisfy; cloning it on a client-facing
+    prefix would mean a second hand-written gate beside the one above, and that
+    is how a 404-uniformity contract drifts. Absent `rows_limit`, this returns
+    byte-for-byte what it returned before the parameter existed.
+
+    Honest limit, same as the operator route's: the slice happens in Python
+    after the whole blob is read out of the column, so this bounds the RESPONSE,
+    not the read — and therefore paging MULTIPLIES reads. That is why the route
+    rate-limits (a client can loop it; an operator on a JWT is a different risk).
     """
     try:
         row = db.get_report(report_id)
@@ -318,14 +377,26 @@ def report_detail(agent_name: str, report_id: str) -> Optional[dict]:
         return None
     if not row or row.get("agent_name") != agent_name:
         return None
-    return {
+
+    payload = row.get("payload")
+    row_meta = None
+    if rows_limit is not None:
+        payload, row_meta = _window_rows(payload, rows_offset, rows_limit)
+
+    detail = {
         "id": row.get("id"),
         "agent_name": row.get("agent_name"),
         "report_type": row.get("report_type"),
         "title": row.get("title"),
         "display_hint": row.get("display_hint"),
-        "payload": row.get("payload"),
+        "payload": payload,
         "period_start": row.get("period_start"),
         "period_end": row.get("period_end"),
         "created_at": row.get("created_at"),
     }
+    # Present ONLY when a window was actually applied: the client keys "is this
+    # paged?" off its presence, so an always-present key with null fields would
+    # make every bounded document render a Load-more footer it can never satisfy.
+    if row_meta is not None:
+        detail["row_meta"] = row_meta
+    return detail

--- a/src/backend/client_portal/router.py
+++ b/src/backend/client_portal/router.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import os
+from typing import Optional
 
 import httpx
 from fastapi import (
@@ -30,8 +31,7 @@ from dependencies import (
     reject_agent_principal,
     require_admin,
 )
-from models import User
-
+from models import REPORT_ROWS_PAGE_MAX, User
 from services.agent_auth import agent_httpx_client
 from services.docker_service import get_agent_container
 from services.platform_audit_service import AuditEventType, platform_audit_service
@@ -568,8 +568,8 @@ def portal_agent_reports(
     principal: PortalPrincipal = Depends(get_portal_principal),
 ):
     """Report metadata for the page's Reports tab. Payloads are fetched per
-    report on expansion — one is capped at 256 KB and a list of them is not a
-    list view."""
+    report on expansion — one is capped at 5 MiB (`REPORT_PAYLOAD_MAX_BYTES`,
+    raised from 256 KB in #1537) and a list of them is not a list view."""
     _require_roster(agent_name, principal.email, principal.is_platform)
     return {
         "agent_name": agent_name,
@@ -583,13 +583,39 @@ def portal_agent_reports(
 def portal_agent_report_detail(
     agent_name: str,
     report_id: str,
+    rows_offset: int = Query(0, ge=0),
+    rows_limit: Optional[int] = Query(None, ge=1, le=REPORT_ROWS_PAGE_MAX),
     principal: PortalPrincipal = Depends(get_portal_principal),
 ):
     """One report's payload. The report must belong to the path agent — a report
     id from another agent returns the same 404 as one that does not exist, so
-    this is not a cross-agent read oracle."""
-    _require_roster(agent_name, principal.email, principal.is_platform)
-    report = agent_page.report_detail(agent_name, report_id)
+    this is not a cross-agent read oracle.
+
+    `rows_offset`/`rows_limit` (#2162) window a **tabular** payload's rows, so a
+    large table is not shipped whole to a client — #1537's pattern, without
+    #1537's route: the operator row reader is JWT-gated and a portal principal
+    cannot reach it, and a second route here would need a second copy of the
+    uniform-404 contract above. Both params are optional and default to today's
+    behaviour; a non-tabular payload with `rows_limit` set comes back whole with
+    no `row_meta` rather than a 400, because the server holds the payload and the
+    client should not have to guess its shape from an agent-authored hint.
+
+    Bounds come from `models.REPORT_ROWS_PAGE_MAX`, the same constant the
+    operator reader uses — imported, never re-typed, so the two page sizes cannot
+    drift apart with each side's tests pinning its own version.
+    """
+    email = principal.email
+    _require_roster(agent_name, email, principal.is_platform)
+    from services import rate_limiter
+
+    # Paging re-reads and re-parses the whole (≤5 MiB) blob per request, so the
+    # route that exists to cut TRANSFER raises READS — fine behind an operator
+    # JWT, an amplification primitive on a prefix a client can loop. Keyed after
+    # the roster gate so an unreachable agent can never mint limiter keys.
+    rate_limiter.enforce(f"portal_report_detail:{email}:{agent_name}", 60, 60)
+    report = agent_page.report_detail(
+        agent_name, report_id, rows_offset=rows_offset, rows_limit=rows_limit,
+    )
     if report is None:
         raise HTTPException(status_code=404, detail="Report not found")
     return report

--- a/src/frontend/src/components/portal/PortalAgentPage.vue
+++ b/src/frontend/src/components/portal/PortalAgentPage.vue
@@ -190,8 +190,27 @@
       </template>
 
       <!-- ---------------------------- REPORTS ----------------------------- -->
+      <!-- #2162: reports render through the SHARED components/reports/ set, the
+           same dispatch Agent Detail uses. This dumped JSON.stringify(payload)
+           at external clients — a disclosure defect, not only an ugly one: the
+           payload is free-form agent JSON of the same class as an ask's
+           `context`, which this page refuses to expose at all. A typed renderer
+           reads only the keys its hint declares, so this narrows what crosses.
+           `:allow-raw="false"` is the one place this surface diverges from the
+           operator ones: no raw payload is reachable behind the fallback. -->
       <template v-else-if="tab === 'reports'">
-        <p v-if="!reports.length" class="text-sm text-gray-400">This agent hasn't published any reports.</p>
+        <div v-if="!reportsLoaded && !reportsError" class="space-y-2" aria-busy="true">
+          <div v-for="row in 3" :key="row" class="animate-pulse h-14 rounded-xl bg-gray-100 dark:bg-gray-800/60"></div>
+          <span class="sr-only">Loading this agent's reports…</span>
+        </div>
+        <LoadFailed
+          v-else-if="reportsError"
+          dense
+          title="Couldn't load reports"
+          :message="reportsError"
+          @retry="loadReports"
+        />
+        <p v-else-if="!reports.length" class="text-sm text-gray-500 dark:text-gray-400">This agent hasn't published any reports.</p>
         <div v-for="r in reports" :key="r.id" class="mb-2 rounded-xl border border-gray-200 dark:border-gray-800">
           <button class="w-full px-3.5 py-3 flex items-center gap-3 text-left" @click="toggleReport(r.id)">
             <span class="min-w-0 flex-1">
@@ -201,8 +220,28 @@
             <svg class="w-4 h-4 text-gray-400 shrink-0 transition" :class="{ 'rotate-180': openReport === r.id }" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
           </button>
           <div v-if="openReport === r.id" class="px-3.5 pb-3 border-t border-gray-100 dark:border-gray-800">
-            <p v-if="!reportPayloads[r.id]" class="pt-3 text-xs text-gray-400">Loading…</p>
-            <pre v-else class="pt-3 text-xs overflow-x-auto whitespace-pre-wrap break-words">{{ pretty(reportPayloads[r.id]) }}</pre>
+            <InlineError
+              v-if="reportErrors[r.id]"
+              class="mt-3"
+              :message="reportErrors[r.id]"
+              retryable
+              @retry="retryReport(r.id)"
+              @dismiss="dismissReportError(r.id)"
+            />
+            <div v-else-if="!reportPayloads[r.id]" class="pt-3 space-y-2" aria-busy="true">
+              <div v-for="row in 2" :key="row" class="animate-pulse h-8 rounded-lg bg-gray-100 dark:bg-gray-800/60"></div>
+              <span class="sr-only">Loading this report…</span>
+            </div>
+            <div v-else class="pt-3">
+              <ReportRenderer
+                :report-type="r.report_type"
+                :display-hint="r.display_hint"
+                :payload="reportPayloads[r.id]"
+                :meta="reportRowMeta[r.id]"
+                :load-more="reportRowMeta[r.id] ? () => loadMoreRows(r.id) : null"
+                :allow-raw="false"
+              />
+            </div>
           </div>
         </div>
       </template>
@@ -282,6 +321,9 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
 import { BUCKET_COLORS, bucketsForChart, hasChartActivity } from '@/utils/executionBuckets'
 import StackedBarChart from '@/components/StackedBarChart.vue'
+import InlineError from '@/components/InlineError.vue'
+import LoadFailed from '@/components/LoadFailed.vue'
+import ReportRenderer from '@/components/reports/ReportRenderer.vue'
 import PortalAvatar from './PortalAvatar.vue'
 import { PORTAL_BUCKET_LABELS } from './portalUtils'
 
@@ -321,9 +363,25 @@ const timeWindow = ref('7d')
 const page = ref(null)
 const loading = ref(false)
 const error = ref(null)
-const reports = ref([])
+// Only the "which card is open" bit is local (#2162). Everything else about
+// reports — the list, its loaded/failed flags, per-report payloads, row meta,
+// per-report errors — lives in the store (design contract #21), which is also
+// what makes the agent-switch race testable: a reset there invalidates requests
+// already in flight, which clearing a ref here cannot do.
 const openReport = ref(null)
-const reportPayloads = ref({})
+// The store is a singleton and outlives this component, so a fresh MOUNT for a
+// different agent would otherwise read the previous one's reports as "already
+// loaded" and never refetch — the props watcher below only fires on a change
+// within one instance, not on a remount. Every read is therefore gated on the
+// state actually belonging to the agent on screen; the store's generation
+// counter covers the in-flight half, this covers the at-rest half.
+const reportsMine = computed(() => store.reportsAgent === props.agentName)
+const reports = computed(() => (reportsMine.value ? store.reports : []))
+const reportsLoaded = computed(() => reportsMine.value && store.reportsLoaded)
+const reportsError = computed(() => (reportsMine.value ? store.reportsError : null))
+const reportPayloads = computed(() => (reportsMine.value ? store.reportPayloads : {}))
+const reportRowMeta = computed(() => (reportsMine.value ? store.reportRowMeta : {}))
+const reportErrors = computed(() => (reportsMine.value ? store.reportErrors : {}))
 const documents = ref([])
 const uploads = ref([])
 
@@ -387,8 +445,11 @@ async function load() {
 // Files are separate surfaces that most visits never look at.
 watch(tab, async (t) => {
   try {
-    if (t === 'reports' && !reports.value.length) {
-      reports.value = await store.fetchAgentReports(props.agentName)
+    // Gated on the LOADED FLAG, not on list length: an agent with genuinely
+    // zero reports would otherwise refetch on every entry to the tab, and a
+    // failed fetch would look identical to an empty one (contract #15).
+    if (t === 'reports' && !reportsLoaded.value) {
+      await loadReports()
     } else if (t === 'files' && !documents.value.length && !uploads.value.length) {
       const [d, u] = await Promise.all([
         store.fetchDocuments(props.agentName).catch(() => []),
@@ -406,8 +467,11 @@ watch(tab, async (t) => {
 watch(() => props.agentName, () => {
   pageCache.clear()   // #2160: keyed by name, but never serve one agent's page for another
   page.value = null
-  reports.value = []
-  reportPayloads.value = {}
+  // #2162: the store owns report state AND the generation counter, so this also
+  // invalidates any report request already in flight for the previous agent —
+  // the half a plain ref-clear cannot do, and the reason `reportsLoaded` is safe
+  // to add at all (it would otherwise make a transient wrong-render permanent).
+  store.resetAgentReports(props.agentName)
   openReport.value = null
   documents.value = []
   uploads.value = []
@@ -418,20 +482,32 @@ watch(() => props.agentName, () => {
 watch(timeWindow, load)
 onMounted(load)
 
+function loadReports() {
+  return store.loadAgentReports(props.agentName)
+}
+
 async function toggleReport(id) {
   if (openReport.value === id) { openReport.value = null; return }
   openReport.value = id
-  if (reportPayloads.value[id]) return
-  try {
-    const r = await store.fetchAgentReport(props.agentName, id)
-    reportPayloads.value = { ...reportPayloads.value, [id]: r?.payload ?? {} }
-  } catch {
-    reportPayloads.value = { ...reportPayloads.value, [id]: { error: 'Could not load this report.' } }
-  }
+  // The store owns the already-loaded / already-in-flight guards, so a rapid
+  // expand-collapse-expand cannot fire duplicate requests — which matters here
+  // because each one re-reads the whole blob server-side.
+  await store.loadAgentReport(props.agentName, id)
+}
+
+function retryReport(id) {
+  return store.loadAgentReport(props.agentName, id)
+}
+
+function dismissReportError(id) {
+  store.clearReportError(id)
+}
+
+function loadMoreRows(id) {
+  return store.loadMoreReportRows(props.agentName, id)
 }
 
 const pct = (v) => (v === null || v === undefined ? '—' : `${Math.round(v * 100)}%`)
-const pretty = (v) => { try { return JSON.stringify(v, null, 2) } catch { return String(v) } }
 const size = (b) => (b === null || b === undefined ? '' : b > 1048576 ? `${(b / 1048576).toFixed(1)} MB` : `${Math.max(1, Math.round(b / 1024))} KB`)
 const duration = (ms) => (!ms ? '' : ms < 1000 ? `${ms}ms` : ms < 60000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms / 60000)}m`)
 

--- a/src/frontend/src/components/portal/PortalAgentPage.vue
+++ b/src/frontend/src/components/portal/PortalAgentPage.vue
@@ -196,8 +196,10 @@
            payload is free-form agent JSON of the same class as an ask's
            `context`, which this page refuses to expose at all. A typed renderer
            reads only the keys its hint declares, so this narrows what crosses.
-           `:allow-raw="false"` is the one place this surface diverges from the
-           operator ones: no raw payload is reachable behind the fallback. -->
+           `:fallback-component` is the one place this surface diverges from
+           the operator ones: where they show the raw JSON viewer, a client gets
+           a bounded, humanised summary and no raw payload at all (AC #2 asks
+           for a fallback stricter than the operator side, precisely here). -->
       <template v-else-if="tab === 'reports'">
         <div v-if="!reportsLoaded && !reportsError" class="space-y-2" aria-busy="true">
           <div v-for="row in 3" :key="row" class="animate-pulse h-14 rounded-xl bg-gray-100 dark:bg-gray-800/60"></div>
@@ -239,7 +241,7 @@
                 :payload="reportPayloads[r.id]"
                 :meta="reportRowMeta[r.id]"
                 :load-more="reportRowMeta[r.id] ? () => loadMoreRows(r.id) : null"
-                :allow-raw="false"
+                :fallback-component="ReportSummary"
               />
             </div>
           </div>
@@ -324,6 +326,7 @@ import StackedBarChart from '@/components/StackedBarChart.vue'
 import InlineError from '@/components/InlineError.vue'
 import LoadFailed from '@/components/LoadFailed.vue'
 import ReportRenderer from '@/components/reports/ReportRenderer.vue'
+import ReportSummary from '@/components/reports/ReportSummary.vue'
 import PortalAvatar from './PortalAvatar.vue'
 import { PORTAL_BUCKET_LABELS } from './portalUtils'
 

--- a/src/frontend/src/components/reports/ReportKpiTiles.vue
+++ b/src/frontend/src/components/reports/ReportKpiTiles.vue
@@ -5,7 +5,7 @@
       :key="idx"
       class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2"
     >
-      <p class="text-[10px] uppercase tracking-wide text-gray-500">{{ tile.label }}</p>
+      <p class="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ tile.label }}</p>
       <p class="text-base font-semibold text-gray-900 dark:text-gray-100">
         {{ tile.value }}<span v-if="tile.unit" class="text-xs text-gray-400 ml-0.5">{{ tile.unit }}</span>
       </p>

--- a/src/frontend/src/components/reports/ReportRenderer.vue
+++ b/src/frontend/src/components/reports/ReportRenderer.vue
@@ -1,5 +1,11 @@
 <template>
-  <component :is="rendererComponent" :payload="payload" :meta="meta" :load-more="loadMore" />
+  <component
+    :is="rendererComponent"
+    :payload="payload"
+    :meta="meta"
+    :load-more="loadMore"
+    v-bind="summaryProps"
+  />
 </template>
 
 <script setup>
@@ -8,12 +14,18 @@ import ReportTable from './ReportTable.vue'
 import ReportKpiTiles from './ReportKpiTiles.vue'
 import ReportMarkdown from './ReportMarkdown.vue'
 import ReportTimeline from './ReportTimeline.vue'
-import ReportJson from './ReportJson.vue'
+import ReportSummary from './ReportSummary.vue'
 
-// Picks a renderer by: explicit display_hint -> report_type prefix -> JSON.
+// Picks a renderer by: explicit display_hint -> report_type prefix -> fallback.
 // Each typed renderer requires a minimal payload shape; on mismatch we fall
-// back to the JSON viewer so a malformed payload degrades instead of throwing
-// (review/Codex #10).
+// back so a malformed payload degrades instead of throwing (review/Codex #10).
+//
+// #2162: the fallback is now the human-readable ReportSummary rather than the
+// raw JSON viewer. `json` is a valid agent-chosen display_hint, so the two ways
+// of arriving there are DIFFERENT (a mismatch is a defect; a chosen `json` is
+// not) and the summary is told which it was. Raw JSON is still one click away
+// for operators, inside ReportSummary's disclosure; a surface that must never
+// show a raw payload passes `allow-raw="false"` and the disclosure is gone.
 const props = defineProps({
   reportType: { type: String, default: '' },
   displayHint: { type: String, default: null },
@@ -23,6 +35,9 @@ const props = defineProps({
   // a null default).
   meta: { type: Object, default: null },
   loadMore: { type: Function, default: null },
+  // Policy, forwarded to the fallback: may this surface disclose the raw
+  // payload at all? Default true keeps every existing call site byte-identical.
+  allowRaw: { type: Boolean, default: true },
 })
 
 const COMPONENTS = {
@@ -30,7 +45,7 @@ const COMPONENTS = {
   kpi: ReportKpiTiles,
   markdown: ReportMarkdown,
   timeline: ReportTimeline,
-  json: ReportJson,
+  json: ReportSummary,
 }
 
 const VALID_HINTS = Object.keys(COMPONENTS)
@@ -66,12 +81,23 @@ function prefixHint(type) {
   return 'json'
 }
 
-const resolvedHint = computed(() => {
+// Resolves the hint AND records how it got there. `json` reached by shape
+// mismatch is a malformed report and says so; `json` chosen by the agent is not.
+const resolved = computed(() => {
   let hint = props.displayHint
   if (!hint || !VALID_HINTS.includes(hint)) hint = prefixHint(props.reportType)
-  if (!shapeOk(hint, props.payload)) hint = 'json'
-  return hint
+  if (!shapeOk(hint, props.payload)) return { hint: 'json', mismatch: true }
+  return { hint, mismatch: false }
 })
 
-const rendererComponent = computed(() => COMPONENTS[resolvedHint.value] || ReportJson)
+const rendererComponent = computed(() => COMPONENTS[resolved.value.hint] || ReportSummary)
+
+// Bound only when the fallback is what renders. Passing these unconditionally
+// would land `fallback="false"` on a typed renderer's root element as a stray
+// DOM attribute (Vue only drops null/undefined, not false).
+const summaryProps = computed(() => (
+  rendererComponent.value === ReportSummary
+    ? { fallback: resolved.value.mismatch, allowRaw: props.allowRaw }
+    : {}
+))
 </script>

--- a/src/frontend/src/components/reports/ReportRenderer.vue
+++ b/src/frontend/src/components/reports/ReportRenderer.vue
@@ -4,7 +4,7 @@
     :payload="payload"
     :meta="meta"
     :load-more="loadMore"
-    v-bind="summaryProps"
+    v-bind="fallbackProps"
   />
 </template>
 
@@ -14,18 +14,20 @@ import ReportTable from './ReportTable.vue'
 import ReportKpiTiles from './ReportKpiTiles.vue'
 import ReportMarkdown from './ReportMarkdown.vue'
 import ReportTimeline from './ReportTimeline.vue'
-import ReportSummary from './ReportSummary.vue'
+import ReportJson from './ReportJson.vue'
 
 // Picks a renderer by: explicit display_hint -> report_type prefix -> fallback.
 // Each typed renderer requires a minimal payload shape; on mismatch we fall
-// back so a malformed payload degrades instead of throwing (review/Codex #10).
+// back to the JSON viewer so a malformed payload degrades instead of throwing
+// (review/Codex #10).
 //
-// #2162: the fallback is now the human-readable ReportSummary rather than the
-// raw JSON viewer. `json` is a valid agent-chosen display_hint, so the two ways
-// of arriving there are DIFFERENT (a mismatch is a defect; a chosen `json` is
-// not) and the summary is told which it was. Raw JSON is still one click away
-// for operators, inside ReportSummary's disclosure; a surface that must never
-// show a raw payload passes `allow-raw="false"` and the disclosure is gone.
+// #2162: the fallback is OVERRIDABLE per surface, and the operator default is
+// unchanged. A raw JSON dump is a feature when you are debugging an agent's own
+// output and a defect when the reader is that agent's customer — so the
+// Workspace passes `ReportSummary` and every operator call site passes nothing.
+// The override covers an agent-chosen `display_hint: "json"` as well as a shape
+// mismatch, which matters: `json` is a valid value in the MCP tool's enum, so a
+// portal that only replaced the mismatch path would still dump on request.
 const props = defineProps({
   reportType: { type: String, default: '' },
   displayHint: { type: String, default: null },
@@ -35,9 +37,10 @@ const props = defineProps({
   // a null default).
   meta: { type: Object, default: null },
   loadMore: { type: Function, default: null },
-  // Policy, forwarded to the fallback: may this surface disclose the raw
-  // payload at all? Default true keeps every existing call site byte-identical.
-  allowRaw: { type: Boolean, default: true },
+  // Rendered instead of ReportJson wherever the dispatch lands on `json` —
+  // by mismatch OR by the agent asking for it. Null default keeps every
+  // operator call site byte-identical.
+  fallbackComponent: { type: [Object, Function], default: null },
 })
 
 const COMPONENTS = {
@@ -45,7 +48,7 @@ const COMPONENTS = {
   kpi: ReportKpiTiles,
   markdown: ReportMarkdown,
   timeline: ReportTimeline,
-  json: ReportSummary,
+  json: ReportJson,
 }
 
 const VALID_HINTS = Object.keys(COMPONENTS)
@@ -90,14 +93,18 @@ const resolved = computed(() => {
   return { hint, mismatch: false }
 })
 
-const rendererComponent = computed(() => COMPONENTS[resolved.value.hint] || ReportSummary)
+const rendererComponent = computed(() => {
+  if (resolved.value.hint === 'json') return props.fallbackComponent || ReportJson
+  return COMPONENTS[resolved.value.hint] || props.fallbackComponent || ReportJson
+})
 
-// Bound only when the fallback is what renders. Passing these unconditionally
+// Bound only when a custom fallback is what renders. Passing it unconditionally
 // would land `fallback="false"` on a typed renderer's root element as a stray
-// DOM attribute (Vue only drops null/undefined, not false).
-const summaryProps = computed(() => (
-  rendererComponent.value === ReportSummary
-    ? { fallback: resolved.value.mismatch, allowRaw: props.allowRaw }
+// DOM attribute (Vue only drops null/undefined, not false), and ReportJson
+// declares no such prop.
+const fallbackProps = computed(() => (
+  props.fallbackComponent && rendererComponent.value === props.fallbackComponent
+    ? { fallback: resolved.value.mismatch }
     : {}
 ))
 </script>

--- a/src/frontend/src/components/reports/ReportSummary.vue
+++ b/src/frontend/src/components/reports/ReportSummary.vue
@@ -37,35 +37,25 @@
     <p v-if="truncated" class="mt-2 text-xs text-gray-500 dark:text-gray-400">
       +{{ truncated.toLocaleString() }} more {{ truncated === 1 ? 'field' : 'fields' }} not shown
     </p>
-
-    <details v-if="allowRaw" class="mt-3">
-      <summary class="text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none">
-        Show raw JSON
-      </summary>
-      <div class="mt-2"><ReportJson :payload="payload" /></div>
-    </details>
   </div>
 </template>
 
 <script setup>
 /**
- * The shared fallback for a payload no typed renderer can present (#2162).
+ * The CLIENT-FACING fallback for a payload no typed renderer can present (#2162).
  *
- * It replaces `ReportJson` in that role on EVERY surface, not only the
- * client-facing one. Two fallbacks would mean a client says "this report looks
- * wrong", the operator opens Agent Detail, and the two are looking at different
- * renderings of the same row — and it would leave a component in the shared
- * `components/reports/` directory with exactly one caller, inviting a third
- * variant. Nothing is lost for the operator: the raw payload moves one click
- * away rather than disappearing, and "what is actually in this report?" is now
- * answered before you have to read JSON.
+ * Passed to `ReportRenderer` as `:fallback-component` by the Workspace agent
+ * page, and by nothing else. The operator surfaces keep `ReportJson`, and that
+ * split IS the design rather than an omission — AC #2 asks for a fallback
+ * "deliberately stricter than the operator side, because the audience is an
+ * external client". A raw dump is a FEATURE when you are debugging an agent's
+ * own output and a defect when the reader is that agent's customer.
  *
- * `allow-raw` is a POLICY, not a mechanism: *this surface never shows a raw
- * payload*. Named that way because it must cover two different routes to the
- * same place — a shape mismatch, and an agent that deliberately set
- * `display_hint: "json"` (a valid value in the MCP tool's enum). A "fallback
- * override" prop or slot would only have covered the first, silently leaving the
- * second able to put a raw dump in front of an external client.
+ * So there is deliberately no raw-payload escape hatch in here, and adding one
+ * would re-open the bug: the override covers an agent-chosen
+ * `display_hint: "json"` as well as a shape mismatch (`json` is a valid value in
+ * the MCP tool's enum), so a disclosure would hand the client the dump by either
+ * route.
  *
  * All the logic lives in `reportSummary.js`; this file is a dumb renderer,
  * because there is no component-mount harness here and logic written inline
@@ -73,7 +63,6 @@
  */
 import { computed } from 'vue'
 
-import ReportJson from './ReportJson.vue'
 import { summarizePayload } from './reportSummary'
 
 const props = defineProps({
@@ -82,8 +71,6 @@ const props = defineProps({
   // caption only — a deliberate `json` report is not malformed and must not be
   // labelled as such.
   fallback: { type: Boolean, default: false },
-  // Operator default. The Workspace passes false.
-  allowRaw: { type: Boolean, default: true },
 })
 
 const summary = computed(() => summarizePayload(props.payload))

--- a/src/frontend/src/components/reports/ReportSummary.vue
+++ b/src/frontend/src/components/reports/ReportSummary.vue
@@ -1,0 +1,92 @@
+<template>
+  <div>
+    <!-- Principle 15/25: a shape mismatch must stay VISIBLE. A tidy summary of
+         a malformed payload otherwise looks intentional, which degrades more
+         silently than the JSON dump it replaces — the reader can no longer tell
+         "this is how the agent filed it" from "this is not what it meant". -->
+    <p v-if="fallback" class="mb-2 text-xs text-gray-500 dark:text-gray-400">
+      Unrecognised report format — showing a summary of what it contains.
+    </p>
+
+    <p v-if="!entries.length" class="text-sm text-gray-500 dark:text-gray-400">
+      This report has no readable content.
+    </p>
+
+    <dl v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+      <div
+        v-for="entry in entries"
+        :key="entry.key || entry.label"
+        class="py-1.5 sm:flex sm:gap-3 sm:items-baseline"
+      >
+        <dt class="text-xs text-gray-500 dark:text-gray-400 break-words sm:w-44 sm:shrink-0">
+          {{ entry.label }}
+        </dt>
+        <!-- A described container ("12 items") is metadata about the payload,
+             not content the agent wrote, so it reads at meta weight. -->
+        <dd
+          class="min-w-0 text-sm break-words sm:flex-1"
+          :class="entry.hint === 'text'
+            ? 'text-gray-800 dark:text-gray-200'
+            : 'text-gray-500 dark:text-gray-400'"
+        >{{ entry.value }}</dd>
+      </div>
+    </dl>
+
+    <!-- Bounded AND stated (principle 28): a silent cut would make a 200-key
+         payload look like a 40-key one. -->
+    <p v-if="truncated" class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+      +{{ truncated.toLocaleString() }} more {{ truncated === 1 ? 'field' : 'fields' }} not shown
+    </p>
+
+    <details v-if="allowRaw" class="mt-3">
+      <summary class="text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none">
+        Show raw JSON
+      </summary>
+      <div class="mt-2"><ReportJson :payload="payload" /></div>
+    </details>
+  </div>
+</template>
+
+<script setup>
+/**
+ * The shared fallback for a payload no typed renderer can present (#2162).
+ *
+ * It replaces `ReportJson` in that role on EVERY surface, not only the
+ * client-facing one. Two fallbacks would mean a client says "this report looks
+ * wrong", the operator opens Agent Detail, and the two are looking at different
+ * renderings of the same row — and it would leave a component in the shared
+ * `components/reports/` directory with exactly one caller, inviting a third
+ * variant. Nothing is lost for the operator: the raw payload moves one click
+ * away rather than disappearing, and "what is actually in this report?" is now
+ * answered before you have to read JSON.
+ *
+ * `allow-raw` is a POLICY, not a mechanism: *this surface never shows a raw
+ * payload*. Named that way because it must cover two different routes to the
+ * same place — a shape mismatch, and an agent that deliberately set
+ * `display_hint: "json"` (a valid value in the MCP tool's enum). A "fallback
+ * override" prop or slot would only have covered the first, silently leaving the
+ * second able to put a raw dump in front of an external client.
+ *
+ * All the logic lives in `reportSummary.js`; this file is a dumb renderer,
+ * because there is no component-mount harness here and logic written inline
+ * would ship untested.
+ */
+import { computed } from 'vue'
+
+import ReportJson from './ReportJson.vue'
+import { summarizePayload } from './reportSummary'
+
+const props = defineProps({
+  payload: { type: [Object, Array, String, Number, Boolean], default: () => ({}) },
+  // True when this was reached by SHAPE MISMATCH rather than chosen. Drives the
+  // caption only — a deliberate `json` report is not malformed and must not be
+  // labelled as such.
+  fallback: { type: Boolean, default: false },
+  // Operator default. The Workspace passes false.
+  allowRaw: { type: Boolean, default: true },
+})
+
+const summary = computed(() => summarizePayload(props.payload))
+const entries = computed(() => summary.value.entries)
+const truncated = computed(() => summary.value.truncated)
+</script>

--- a/src/frontend/src/components/reports/ReportTable.vue
+++ b/src/frontend/src/components/reports/ReportTable.vue
@@ -2,7 +2,7 @@
   <div class="overflow-x-auto">
     <table class="min-w-full text-sm">
       <thead>
-        <tr class="text-left text-xs text-gray-500 border-b border-gray-200 dark:border-gray-700">
+        <tr class="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
           <th v-for="col in columns" :key="col" class="py-1.5 pr-4 font-medium">{{ col }}</th>
         </tr>
       </thead>
@@ -26,7 +26,7 @@
     <!-- #1537: a tabular report is fetched a page at a time, so the card shows
          how much of the set it is holding and can pull the next window. -->
     <div v-if="meta && meta.total > rows.length" class="mt-2 flex items-center gap-3">
-      <span class="text-xs text-gray-500">
+      <span class="text-xs text-gray-500 dark:text-gray-400">
         Showing {{ rows.length.toLocaleString() }} of {{ meta.total.toLocaleString() }} rows
       </span>
       <button

--- a/src/frontend/src/components/reports/ReportTimeline.vue
+++ b/src/frontend/src/components/reports/ReportTimeline.vue
@@ -1,7 +1,7 @@
 <template>
   <ol class="relative border-l border-gray-200 dark:border-gray-700 ml-2">
     <li v-for="(ev, idx) in events" :key="idx" class="mb-4 ml-4">
-      <div class="absolute -left-1.5 w-3 h-3 rounded-full bg-blue-500 border border-white dark:border-gray-900"></div>
+      <div class="absolute -left-1.5 w-3 h-3 rounded-full bg-status-info-500 border border-white dark:border-gray-900"></div>
       <time v-if="ev.ts" class="text-[11px] text-gray-400">{{ ev.ts }}</time>
       <p class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ ev.label }}</p>
       <p v-if="ev.detail" class="text-xs text-gray-500 dark:text-gray-400">{{ ev.detail }}</p>

--- a/src/frontend/src/components/reports/reportSummary.js
+++ b/src/frontend/src/components/reports/reportSummary.js
@@ -1,0 +1,207 @@
+/**
+ * Summarise an unrecognised report payload for a human (#2162).
+ *
+ * The shared renderer set's fallback used to be the raw JSON viewer. That is
+ * defensible for an operator and wrong for an external client: `payload` is
+ * free-form agent-authored JSON, the same category as an operator-queue ask's
+ * `context`, which the Workspace refuses to expose at all because it has been a
+ * credential-leak surface before (canary G-04). The Reports tab was dumping it
+ * key-for-key.
+ *
+ * This is the readable replacement — and the whole of the fallback's logic,
+ * deliberately: there is no component-mount harness in this project, so a
+ * summariser written inline in a `.vue` template would be untestable. The
+ * component around it is a dumb renderer.
+ *
+ * Three properties, each load-bearing:
+ *
+ *   1. **It never stringifies the payload.** Not once, not for a nested value.
+ *      `JSON.stringify` anywhere in here would reintroduce the bug through the
+ *      component that exists to fix it, so depth is 1 and a nested value is
+ *      described ("12 items", "4 fields") rather than serialised.
+ *
+ *   2. **It is bounded.** ≤40 entries with a counted remainder, values truncated
+ *      at ~200 chars. An agent can file 5 MiB; a summary that grows with the
+ *      payload is the same unbounded page the design contract's principle 28
+ *      forbids, just with nicer type.
+ *
+ *   3. **It redacts credential-shaped tokens at VALUE level, anywhere in the
+ *      string.** Not by key name: an allow-list of "safe" keys is both a dead
+ *      end here (the fallback fires precisely on payloads nobody has seen, so an
+ *      allow-list blanks nearly all of them) and ineffective, because an
+ *      allowed key's value can carry the secret — `{"status": "failed: sk-…"}`
+ *      is the case that motivated this. Patterns mirror G-04's set.
+ *
+ * **Honest scope.** This is defense-in-depth on the FALLBACK path only. A
+ * well-shaped `markdown` or `table` report still renders its values as authored,
+ * and a key-value summary still names every top-level key — it bounds and
+ * humanises the residual, it does not eliminate the class. The general fix is a
+ * scrub at the portal read boundary, which is a security change to a shipping
+ * read path and deserves its own review rather than riding a UI fix. The helper
+ * below is written so it can move there without rework.
+ */
+
+// Entries beyond this are counted, not rendered. A report with more than 40
+// top-level keys is not something a person reads as a list anyway.
+export const MAX_ENTRIES = 40
+
+// Long enough for a sentence or an id, short enough that one pathological
+// value cannot own the card.
+export const MAX_VALUE_CHARS = 200
+
+// Keys are agent-authored too, so the label gets the same treatment as a value
+// (bounded and redacted) — just with less room.
+export const MAX_LABEL_CHARS = 80
+
+export const REDACTED = '[redacted]'
+
+/**
+ * Credential-shaped tokens, mirroring `canary/invariants/g04_*.py`'s prefix set.
+ *
+ * Two deliberate differences from the detector: these consume the WHOLE token
+ * (a detector only needs to prove a prefix exists; a redactor that stops after
+ * one character leaves the rest of the secret on screen), and they are applied
+ * as replacements rather than reported by name.
+ *
+ * `\b` before each prefix is what keeps "task-force" from matching `sk-`; it
+ * treats `_` as a word character exactly as the Python side does, so the two
+ * agree on `my_github_pat_x` (no match, no boundary) by construction.
+ */
+const SECRET_PATTERNS = [
+  // OpenAI / Anthropic-style secret keys ("sk-…", "sk-ant-…", "sk-proj-…").
+  /\bsk-[A-Za-z0-9][A-Za-z0-9_-]*/g,
+  // Stripe live secret key.
+  /\bsk_live_[A-Za-z0-9]+/g,
+  // GitHub: classic PAT, OAuth, server, user, fine-grained.
+  /\bghp_[A-Za-z0-9]+/g,
+  /\bgho_[A-Za-z0-9]+/g,
+  /\bghs_[A-Za-z0-9]+/g,
+  /\bghu_[A-Za-z0-9]+/g,
+  /\bgithub_pat_[A-Za-z0-9_]+/g,
+  // Slack bot / user OAuth tokens.
+  /\bxoxb-[A-Za-z0-9-]+/g,
+  /\bxoxp-[A-Za-z0-9-]+/g,
+  // AWS access key id.
+  /\bAKIA[A-Z0-9]{4}[A-Z0-9]*/g,
+  // Google API key.
+  /\bAIza[A-Za-z0-9_-]+/g,
+]
+
+/**
+ * Replace credential-shaped tokens with a marker.
+ *
+ * Runs BEFORE truncation, always: truncating first can slice a token so its
+ * prefix survives without the pattern matching, which leaves a recognisable
+ * fragment on screen under a value that looks handled.
+ */
+export function redactSecrets(text) {
+  let out = String(text)
+  for (const pattern of SECRET_PATTERNS) {
+    // Fresh lastIndex per call — these are module-level /g regexes.
+    pattern.lastIndex = 0
+    out = out.replace(pattern, REDACTED)
+  }
+  return out
+}
+
+function clip(text, max) {
+  const s = String(text)
+  return s.length > max ? `${s.slice(0, max)}…` : s
+}
+
+/** Redact, then bound. Order matters — see `redactSecrets`. */
+function safeText(value, max) {
+  return clip(redactSecrets(value), max)
+}
+
+function plural(n, noun) {
+  return `${n.toLocaleString()} ${noun}${n === 1 ? '' : 's'}`
+}
+
+/**
+ * One top-level value, described at depth 1.
+ *
+ * Returns `{value, hint}` where `hint` is `'text' | 'count' | 'empty'` — the
+ * component styles by it so a described container ("12 items") reads as
+ * metadata rather than as content the agent wrote.
+ */
+export function describeValue(value) {
+  if (value === null || value === undefined) return { value: '—', hint: 'empty' }
+  if (Array.isArray(value)) return { value: plural(value.length, 'item'), hint: 'count' }
+  if (typeof value === 'object') {
+    return { value: plural(Object.keys(value).length, 'field'), hint: 'count' }
+  }
+  if (typeof value === 'boolean') return { value: value ? 'Yes' : 'No', hint: 'text' }
+  if (typeof value === 'number') {
+    return { value: Number.isFinite(value) ? value.toLocaleString() : String(value), hint: 'text' }
+  }
+  const text = safeText(value, MAX_VALUE_CHARS)
+  if (!text.trim()) return { value: '—', hint: 'empty' }
+  return { value: text, hint: 'text' }
+}
+
+/**
+ * `total_leads` → `Total leads`, `createdAt` → `Created at`.
+ *
+ * Bounded and redacted like a value: a payload key is as agent-authored as a
+ * payload value, and nothing stops one being a token.
+ *
+ * **Redaction runs on the RAW key, before humanisation** — the same ordering
+ * rule as truncation, and for a sharper reason: humanising rewrites `_` and `-`
+ * to spaces, which is exactly the shape every one of these patterns keys on. A
+ * `ghp_…` key humanised first becomes `ghp …`, matches nothing, and the tail
+ * ships. (Caught by its own test, which is why the order is stated here.)
+ */
+export function humaniseKey(key) {
+  const redacted = redactSecrets(key)
+  const spaced = redacted
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!spaced) return clip(redacted, MAX_LABEL_CHARS)
+  const lower = spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase()
+  return clip(lower, MAX_LABEL_CHARS)
+}
+
+/**
+ * `payload` → `{ entries: [{key, label, value, hint}], truncated }`.
+ *
+ * `truncated` is how many top-level entries were dropped at the cap, so the
+ * component can say "+N more" instead of silently showing a prefix — the
+ * difference between a bounded view and a wrong one.
+ *
+ * An empty result means "nothing readable was filed", which the component
+ * renders as its own sentence rather than as an empty list.
+ */
+export function summarizePayload(payload) {
+  if (payload === null || payload === undefined) return { entries: [], truncated: 0 }
+
+  // A root-level array is described as a whole rather than exploded into
+  // `0`, `1`, `2` … — numbered keys are not a human-readable summary, they are
+  // a JSON dump with the braces removed.
+  if (Array.isArray(payload)) {
+    if (!payload.length) return { entries: [], truncated: 0 }
+    return {
+      entries: [{ key: '', label: 'Items', ...describeValue(payload) }],
+      truncated: 0,
+    }
+  }
+
+  if (typeof payload !== 'object') {
+    const described = describeValue(payload)
+    if (described.hint === 'empty') return { entries: [], truncated: 0 }
+    return { entries: [{ key: '', label: 'Value', ...described }], truncated: 0 }
+  }
+
+  const keys = Object.keys(payload)
+  const shown = keys.slice(0, MAX_ENTRIES)
+  return {
+    entries: shown.map((key) => ({
+      key,
+      label: humaniseKey(key),
+      ...describeValue(payload[key]),
+    })),
+    truncated: Math.max(0, keys.length - shown.length),
+  }
+}

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -467,7 +467,9 @@ export const useClientPortalStore = defineStore('clientPortal', {
         this.reportsLoaded = true
       } catch {
         if (gen !== this._reportsGeneration) return
-        this.reportsError = "Couldn't load this agent's reports."
+        // Paired with `LoadFailed`'s title ("Couldn't load reports"), so this
+        // says what to DO rather than restating what happened (contract #25).
+        this.reportsError = 'The request failed. Check your connection and try again.'
       }
     },
 
@@ -508,8 +510,14 @@ export const useClientPortalStore = defineStore('clientPortal', {
           ...this.reportErrors, [reportId]: 'Could not load this report.',
         }
       } finally {
-        const { [reportId]: _done, ...stillInFlight } = this._reportInFlight
-        this._reportInFlight = stillInFlight
+        // Generation-guarded like every other write: a reset already emptied
+        // this map, so clearing "our" key afterwards would clear a NEW request's
+        // marker instead and let a duplicate through — the guard leaking through
+        // its own bookkeeping.
+        if (gen === this._reportsGeneration) {
+          const { [reportId]: _done, ...stillInFlight } = this._reportInFlight
+          this._reportInFlight = stillInFlight
+        }
       }
     },
 
@@ -556,8 +564,14 @@ export const useClientPortalStore = defineStore('clientPortal', {
           ...this.reportErrors, [reportId]: 'Could not load more rows.',
         }
       } finally {
-        const { [reportId]: _done, ...stillInFlight } = this._reportInFlight
-        this._reportInFlight = stillInFlight
+        // Generation-guarded like every other write: a reset already emptied
+        // this map, so clearing "our" key afterwards would clear a NEW request's
+        // marker instead and let a duplicate through — the guard leaking through
+        // its own bookkeeping.
+        if (gen === this._reportsGeneration) {
+          const { [reportId]: _done, ...stillInFlight } = this._reportInFlight
+          this._reportInFlight = stillInFlight
+        }
       }
     },
 

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -11,6 +11,11 @@ import { defineStore } from 'pinia'
 import { normalizeRoomRow } from '@/components/portal/portalUtils'
 import axios from 'axios'
 import { useAuthStore } from './auth'
+// #2162: the page size for a windowed report read. A dependency-free leaf
+// shared with the operator reports store — never re-typed here, since the
+// backend already owns REPORT_ROWS_PAGE_DEFAULT and a third hand-written copy
+// is the shape that drifts while each side's tests pin its own version.
+import { REPORT_ROWS_PAGE as ROWS_PAGE } from '@/utils/reportPaging'
 
 const PORTAL_TOKEN_KEY = 'trinity.portalToken'
 // Mirrors `SESSION_ROTATION_HEADER` in client_portal/portal_auth.py (ent#375).
@@ -107,6 +112,27 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // without it a hard-loaded /workspace/r/:id would flash a refusal it then
     // takes back on an entitled instance.
     rosterLoaded: false,
+
+    // --- Reports tab (#2162) ---
+    // Which agent the report state below belongs to, and a monotonic counter
+    // every report request captures before its first await. A reset bumps it,
+    // so a response that arrives after an agent switch is discarded instead of
+    // landing under the new agent's name.
+    reportsAgent: null,
+    _reportsGeneration: 0,
+    reports: [],
+    // Set ONLY by a fetch that succeeded — the empty state reads it, and
+    // "loaded" must never mean "failed and returned nothing" (contract #15).
+    reportsLoaded: false,
+    reportsError: null,
+    reportPayloads: {},
+    // id -> {total, loaded}; present only for a payload the server actually
+    // windowed, so a bounded document never renders a paging footer.
+    reportRowMeta: {},
+    // id -> message. Deliberately NOT stored inside reportPayloads: an error
+    // object there would be handed to the renderer and presented as a report.
+    reportErrors: {},
+    _reportInFlight: {},
   }),
 
   getters: {
@@ -373,12 +399,166 @@ export const useClientPortalStore = defineStore('clientPortal', {
       return data.reports || []
     },
 
-    async fetchAgentReport(agentName, reportId) {
+    // #2162: `rowsLimit` windows a TABULAR payload server-side. Sent on every
+    // expand — the server decides whether the payload actually has a row axis,
+    // so the client never predicts the shape from an agent-authored
+    // `display_hint` that can disagree with what was filed. A non-tabular
+    // payload simply comes back whole with no `row_meta`.
+    async fetchAgentReport(agentName, reportId, { rowsOffset, rowsLimit } = {}) {
+      const params = {}
+      if (rowsLimit !== undefined && rowsLimit !== null) {
+        params.rows_limit = rowsLimit
+        params.rows_offset = rowsOffset || 0
+      }
       const { data } = await axios.get(
         `/api/enterprise/client-portal/agents/${agentName}/reports/${encodeURIComponent(reportId)}`,
-        { headers: this.authHeader },
+        { headers: this.authHeader, params },
       )
       return data
+    },
+
+    // --- Reports tab orchestration (#2162) --------------------------------
+    //
+    // Lives in the store, not the component (design contract #21: loading flags
+    // belong to stores). That is not only tidiness — it is what makes the three
+    // riskiest paths here testable at all, since this project has no
+    // component-mount harness but does unit-test store fetchers against a
+    // mocked axios.
+    //
+    // EVERY await is generation-guarded. Clearing refs on agent switch cannot
+    // cancel a promise already in flight, so without this:
+    //
+    //   on agent A, open Reports   → fetch starts
+    //   click agent B              → state cleared
+    //   A's fetch resolves         → writes A's reports into the cleared state
+    //   open Reports on B          → "already loaded" → no refetch
+    //                              → A's reports render under B's name
+    //
+    // …which is the ent#359 class of bug, and adding a `reportsLoaded` flag
+    // makes it PERMANENT rather than self-correcting: B stays marked
+    // loaded-with-A's-data for the life of the mount. The flag and the guard
+    // have to ship together.
+
+    /** Drop all report state and invalidate every in-flight report request. */
+    resetAgentReports(agentName = null) {
+      this._reportsGeneration += 1
+      this.reportsAgent = agentName
+      this.reports = []
+      this.reportsLoaded = false
+      this.reportsError = null
+      this.reportPayloads = {}
+      this.reportRowMeta = {}
+      this.reportErrors = {}
+      this._reportInFlight = {}
+    },
+
+    async loadAgentReports(agentName) {
+      // Self-correcting: a caller that loads for a different agent without
+      // resetting first gets the reset anyway, rather than merging two agents.
+      if (this.reportsAgent !== agentName) this.resetAgentReports(agentName)
+      const gen = this._reportsGeneration
+      this.reportsError = null
+      try {
+        const rows = await this.fetchAgentReports(agentName)
+        if (gen !== this._reportsGeneration) return
+        this.reports = rows
+        // Only a SUCCEEDED fetch may set this: the empty state gates on it, and
+        // an empty list after a failure is the wrong sentence (contract #15).
+        this.reportsLoaded = true
+      } catch {
+        if (gen !== this._reportsGeneration) return
+        this.reportsError = "Couldn't load this agent's reports."
+      }
+    },
+
+    async loadAgentReport(agentName, reportId) {
+      if (this.reportPayloads[reportId] || this._reportInFlight[reportId]) return
+      const gen = this._reportsGeneration
+      this._reportInFlight = { ...this._reportInFlight, [reportId]: true }
+      // Clear a previous failure up front, so a retry that succeeds does not
+      // leave the error banner sitting under a rendered report.
+      const { [reportId]: _dropped, ...remainingErrors } = this.reportErrors
+      this.reportErrors = remainingErrors
+      try {
+        const data = await this.fetchAgentReport(agentName, reportId, {
+          rowsOffset: 0, rowsLimit: ROWS_PAGE,
+        })
+        if (gen !== this._reportsGeneration) return
+        const payload = data?.payload ?? {}
+        this.reportPayloads = { ...this.reportPayloads, [reportId]: payload }
+        // `row_meta` present ⇒ the server windowed a real table. Absent ⇒ a
+        // bounded document, and no paging footer must render for it.
+        const meta = data?.row_meta
+        if (meta && Array.isArray(payload.rows)) {
+          this.reportRowMeta = {
+            ...this.reportRowMeta,
+            [reportId]: { total: meta.total, loaded: payload.rows.length },
+          }
+        }
+      } catch {
+        if (gen !== this._reportsGeneration) return
+        // Deliberately NOT written into reportPayloads: a `{error: …}` object
+        // there would be handed to the renderer and presented AS a report.
+        //
+        // Retryable regardless of status: the read swallows a DB fault into the
+        // same 404 a missing report gets (invariant #8), so the client cannot
+        // tell a transient failure from a gone report — and stranding someone on
+        // a transient one is the worse of the two mistakes.
+        this.reportErrors = {
+          ...this.reportErrors, [reportId]: 'Could not load this report.',
+        }
+      } finally {
+        const { [reportId]: _done, ...stillInFlight } = this._reportInFlight
+        this._reportInFlight = stillInFlight
+      }
+    },
+
+    /** Dismiss one report's error banner without retrying (contract #18). */
+    clearReportError(reportId) {
+      if (!this.reportErrors[reportId]) return
+      const { [reportId]: _dropped, ...rest } = this.reportErrors
+      this.reportErrors = rest
+    },
+
+    async loadMoreReportRows(agentName, reportId) {
+      const meta = this.reportRowMeta[reportId]
+      const current = this.reportPayloads[reportId]
+      // Terminal guard. Without it a click at loaded === total appends [],
+      // `loaded` never moves, and ReportTable's `meta.total > rows.length`
+      // never goes false — a permanently visible, permanently inert button.
+      if (!meta || !current || meta.loaded >= meta.total) return
+      if (this._reportInFlight[reportId]) return
+      const gen = this._reportsGeneration
+      this._reportInFlight = { ...this._reportInFlight, [reportId]: true }
+      try {
+        const data = await this.fetchAgentReport(agentName, reportId, {
+          rowsOffset: meta.loaded, rowsLimit: ROWS_PAGE,
+        })
+        if (gen !== this._reportsGeneration) return
+        const next = data?.payload?.rows
+        const nextMeta = data?.row_meta
+        if (!Array.isArray(next) || !nextMeta) return
+        // Re-read through the store rather than trusting the `current` captured
+        // before the await — the same reason the operator store captures it.
+        const held = this.reportPayloads[reportId]
+        if (!held || !Array.isArray(held.rows)) return
+        const merged = [...held.rows, ...next]
+        this.reportPayloads = {
+          ...this.reportPayloads, [reportId]: { ...held, rows: merged },
+        }
+        this.reportRowMeta = {
+          ...this.reportRowMeta,
+          [reportId]: { total: nextMeta.total, loaded: merged.length },
+        }
+      } catch {
+        if (gen !== this._reportsGeneration) return
+        this.reportErrors = {
+          ...this.reportErrors, [reportId]: 'Could not load more rows.',
+        }
+      } finally {
+        const { [reportId]: _done, ...stillInFlight } = this._reportInFlight
+        this._reportInFlight = stillInFlight
+      }
     },
 
     // ent#359 — per-viewer star + unread state, for BOTH chat kinds in one call.

--- a/src/frontend/src/stores/reports.js
+++ b/src/frontend/src/stores/reports.js
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
 
-// Mirrors REPORT_ROWS_PAGE_DEFAULT (#1537).
-const ROWS_PAGE = 100
+// The page size moved to a dependency-free leaf in #2162 so the Workspace
+// store can share this one number instead of typing a third copy of it.
+import { REPORT_ROWS_PAGE as ROWS_PAGE } from '../utils/reportPaging'
 import { ref } from 'vue'
 import api from '../api'
 

--- a/src/frontend/src/utils/reportPaging.js
+++ b/src/frontend/src/utils/reportPaging.js
@@ -1,0 +1,15 @@
+/**
+ * How many rows one page of a tabular report holds.
+ *
+ * Mirrors the backend's `REPORT_ROWS_PAGE_DEFAULT` (#1537). It lives in a
+ * dependency-free leaf, rather than in either store, because BOTH the operator
+ * reports store and the Workspace portal store need it (#2162) and neither may
+ * import the other: `stores/reports.js` pulls in the shared `api.js` client,
+ * which the portal store deliberately does not use, and importing it from there
+ * drags that whole graph — plus its axios interceptors — into every spec that
+ * touches the portal store.
+ *
+ * One frontend copy, not two. A page size typed separately in each store drifts,
+ * and each store's own tests then pin its own version of the drift.
+ */
+export const REPORT_ROWS_PAGE = 100

--- a/src/frontend/tests/unit/portalReportsRendering.spec.js
+++ b/src/frontend/tests/unit/portalReportsRendering.spec.js
@@ -15,10 +15,10 @@
  * wiring no unit test can reach: which component the tab mounts, which props it
  * passes, and that the CI-pinned dispatch keys stayed where the pin reads them.
  *
- * Guards check the MECHANISM, not the spelling. Asserting that `:allow-raw`
- * appears at a call site would pass just as happily against a prop that is
- * declared and never used, and the whole point of that prop is that a raw
- * payload is unreachable on this surface.
+ * Guards check the MECHANISM, not the spelling. Asserting that
+ * `:fallback-component` appears at a call site would pass just as happily
+ * against a prop that is declared and never used, and the whole point of that
+ * prop is that a raw payload is unreachable on this surface.
  *
  * Comments are stripped before every scan — a comment explaining what must not
  * be written necessarily contains the offending string.
@@ -76,8 +76,11 @@ describe('the Reports tab', () => {
     }
   })
 
-  it('forbids the raw-payload disclosure on this surface', () => {
-    expect(reportsBlock()).toContain(':allow-raw="false"')
+  it('overrides the fallback so a client never gets a raw payload', () => {
+    // AC #2: stricter than the operator side, deliberately. The operator
+    // surfaces pass nothing here and keep the JSON viewer.
+    expect(reportsBlock()).toContain(':fallback-component="ReportSummary"')
+    expect(src(PAGE)).toContain("from '@/components/reports/ReportSummary.vue'")
   })
 
   it('passes paging handles only when the server actually windowed', () => {
@@ -124,25 +127,27 @@ describe('the Reports tab', () => {
 // ---------------------------------------------------------------------------
 
 describe('ReportRenderer', () => {
-  it('dispatches the fallback to ReportSummary, not to the JSON viewer', () => {
+  it('keeps the JSON viewer as the DEFAULT fallback (operator unchanged)', () => {
+    // The operator surfaces are debugging an agent's own output, where a raw
+    // dump is a feature. AC #2 makes the portal stricter than them, not all
+    // three stricter together — a global summary erases the split it asks for.
     const renderer = src(RENDERER)
-    // The MAP is what decides; a mere import would prove nothing.
-    expect(renderer).toMatch(/json:\s*ReportSummary/)
-    // …and the defensive default has to agree with it, or a hint outside the
-    // map silently reopens the raw dump.
-    expect(renderer).toMatch(/COMPONENTS\[[^\]]+\]\s*\|\|\s*ReportSummary/)
+    expect(renderer).toMatch(/json:\s*ReportJson/)
+    expect(renderer).toMatch(/fallbackComponent:\s*\{[^}]*default:\s*null/)
   })
 
-  it('actually forwards allowRaw rather than only declaring it', () => {
+  it('actually renders the override rather than only declaring the prop', () => {
     const renderer = src(RENDERER)
-    expect(renderer).toMatch(/allowRaw:\s*\{\s*type:\s*Boolean/)
-    // Consumed in the binding that reaches the fallback.
-    expect(renderer).toMatch(/allowRaw:\s*props\.allowRaw/)
-    expect(renderer).toContain('v-bind="summaryProps"')
+    // Consumed in the dispatch itself — a declared-but-unused prop would pass a
+    // call-site scan while the client still got a raw dump.
+    expect(renderer).toMatch(/props\.fallbackComponent \|\| ReportJson/)
+    expect(renderer).toContain('v-bind="fallbackProps"')
   })
 
-  it('defaults allowRaw to true, so operator call sites are unchanged', () => {
-    expect(src(RENDERER)).toMatch(/allowRaw:\s*\{\s*type:\s*Boolean,\s*default:\s*true\s*\}/)
+  it('does not import the client-facing summary into the shared renderer', () => {
+    // It arrives as a prop from the one surface that wants it; importing it
+    // here is how a "portal-only" component quietly becomes global again.
+    expect(src(RENDERER)).not.toContain('ReportSummary.vue')
   })
 
   it('tells the fallback whether it was reached by shape MISMATCH', () => {
@@ -150,6 +155,13 @@ describe('ReportRenderer', () => {
     // "the agent asked for this" must not read the same to a reader.
     expect(src(RENDERER)).toMatch(/mismatch:\s*true/)
     expect(src(RENDERER)).toMatch(/fallback:\s*resolved\.value\.mismatch/)
+  })
+
+  it('routes an agent-chosen `json` hint through the override too', () => {
+    // Not only the mismatch path: `display_hint: "json"` is a valid value in the
+    // MCP tool's enum, so an override that covered only mismatches would let an
+    // agent put a raw dump in front of a client by asking for one.
+    expect(src(RENDERER)).toMatch(/hint === 'json'\) return props\.fallbackComponent/)
   })
 
   it('still reads all five CI-pinned payload keys IN THIS FILE', () => {
@@ -184,6 +196,15 @@ const NONGRAY_RE = new RegExp(`\\b(?:${NONGRAY_FAMILIES.join('|')})-(?:50|\\d{3}
 const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g
 
 describe('token discipline', () => {
+  it('ReportSummary.vue exposes no raw-payload escape hatch', () => {
+    // Portal-only, so there is nothing to disclose behind. A `<details>Show raw
+    // JSON</details>` here would hand the client the dump this issue removes.
+    const content = src(SUMMARY)
+    expect(content).not.toContain('ReportJson.vue')
+    expect(content).not.toContain('<details')
+    expect(content).not.toContain('JSON.stringify')
+  })
+
   it.each([
     ['ReportSummary.vue', SUMMARY],
     ['ReportRenderer.vue', RENDERER],

--- a/src/frontend/tests/unit/portalReportsRendering.spec.js
+++ b/src/frontend/tests/unit/portalReportsRendering.spec.js
@@ -1,0 +1,240 @@
+/**
+ * The Workspace Reports tab renders reports; it does not dump them (#2162).
+ *
+ * The tab shipped `<pre>{{ JSON.stringify(payload, null, 2) }}</pre>` to
+ * external clients. That is a DISCLOSURE defect, not only an ugly one: the
+ * payload is free-form agent-authored JSON, the same category as an
+ * operator-queue ask's `context`, which `client_portal/agent_page.py` refuses to
+ * expose at all because it has been a credential-leak surface before (canary
+ * G-04). A typed renderer reads only the keys its hint declares, so routing the
+ * tab through the shared set strictly narrows what crosses.
+ *
+ * This project has no component-mount harness (no `@vue/test-utils`), so the
+ * behaviour lives in `portalReportsStore.spec.js` (store fetchers, mocked axios)
+ * and `reportSummary.spec.js` (the pure summariser). What is left here is the
+ * wiring no unit test can reach: which component the tab mounts, which props it
+ * passes, and that the CI-pinned dispatch keys stayed where the pin reads them.
+ *
+ * Guards check the MECHANISM, not the spelling. Asserting that `:allow-raw`
+ * appears at a call site would pass just as happily against a prop that is
+ * declared and never used, and the whole point of that prop is that a raw
+ * payload is unreachable on this surface.
+ *
+ * Comments are stripped before every scan — a comment explaining what must not
+ * be written necessarily contains the offending string.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+import { stripComments } from './helpers/stripComments'
+
+const src = (p) => stripComments(readFileSync(fileURLToPath(new URL(p, import.meta.url)), 'utf8'))
+
+const PAGE = '../../src/components/portal/PortalAgentPage.vue'
+const RENDERER = '../../src/components/reports/ReportRenderer.vue'
+const SUMMARY = '../../src/components/reports/ReportSummary.vue'
+
+/** The Reports tab's template block, isolated from the rest of the page. */
+function reportsBlock() {
+  const page = src(PAGE)
+  const start = page.indexOf("tab === 'reports'")
+  expect(start).toBeGreaterThan(-1)
+  const end = page.indexOf("tab === 'files'", start)
+  expect(end).toBeGreaterThan(start)
+  return page.slice(start, end)
+}
+
+// ---------------------------------------------------------------------------
+// 1. The dump is gone, and the shared renderer is what replaced it
+// ---------------------------------------------------------------------------
+
+describe('the Reports tab', () => {
+  it('contains no raw payload dump', () => {
+    const block = reportsBlock()
+    expect(block).not.toContain('<pre')
+    expect(block).not.toContain('pretty(')
+    expect(block).not.toContain('JSON.stringify')
+  })
+
+  it('has no `pretty` helper left behind anywhere on the page', () => {
+    // Its only call site was the dump. A dead JSON serialiser sitting in this
+    // file is an invitation to wire it back into a template.
+    expect(src(PAGE)).not.toContain('const pretty')
+  })
+
+  it('mounts the SHARED renderer rather than a portal-local fork', () => {
+    const page = src(PAGE)
+    expect(page).toContain("from '@/components/reports/ReportRenderer.vue'")
+    expect(reportsBlock()).toContain('<ReportRenderer')
+  })
+
+  it('forwards the fields the dispatch needs', () => {
+    const block = reportsBlock()
+    for (const attr of [':report-type=', ':display-hint=', ':payload=']) {
+      expect(block).toContain(attr)
+    }
+  })
+
+  it('forbids the raw-payload disclosure on this surface', () => {
+    expect(reportsBlock()).toContain(':allow-raw="false"')
+  })
+
+  it('passes paging handles only when the server actually windowed', () => {
+    // `row_meta` present is the only signal a payload was paged. Passing a
+    // load-more callback unconditionally would put a footer under a bounded
+    // document that can never satisfy it.
+    const block = reportsBlock()
+    expect(block).toContain(':meta="reportRowMeta[r.id]"')
+    expect(block).toMatch(/:load-more="reportRowMeta\[r\.id\] \?/)
+  })
+
+  it('distinguishes loading, empty and failed (contract #15)', () => {
+    const block = reportsBlock()
+    // Empty copy gates on the LOADED FLAG, never on list length — otherwise a
+    // failed fetch renders "this agent hasn't published any reports".
+    expect(block).toMatch(/v-else-if="!reports\.length"/)
+    expect(block).toContain('reportsLoaded')
+    expect(block).toContain('<LoadFailed')
+    expect(block).toContain('<InlineError')
+  })
+
+  it('never renders a failed fetch through the renderer', () => {
+    // The old catch wrote `{error: …}` into the payload map, which the renderer
+    // would have presented AS a report — worse than the bug being fixed.
+    expect(src(PAGE)).not.toContain("[id]: { error:")
+  })
+
+  it('does not introduce a second scroll axis inside the page', () => {
+    // The page has ONE scroll axis (#2101). Growth is bounded by the row window
+    // plus an explicit "Load more", not by a nested scroll region.
+    expect(reportsBlock()).not.toMatch(/overflow-y-(auto|scroll)/)
+    expect(reportsBlock()).not.toMatch(/\bmax-h-/)
+  })
+
+  it('leaves the Overview block alone (#2169 owns it)', () => {
+    const page = src(PAGE)
+    expect(page).toContain("tab === 'overview'")
+    expect(page).toContain('StackedBarChart')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. The renderer wiring — mechanism, not spelling
+// ---------------------------------------------------------------------------
+
+describe('ReportRenderer', () => {
+  it('dispatches the fallback to ReportSummary, not to the JSON viewer', () => {
+    const renderer = src(RENDERER)
+    // The MAP is what decides; a mere import would prove nothing.
+    expect(renderer).toMatch(/json:\s*ReportSummary/)
+    // …and the defensive default has to agree with it, or a hint outside the
+    // map silently reopens the raw dump.
+    expect(renderer).toMatch(/COMPONENTS\[[^\]]+\]\s*\|\|\s*ReportSummary/)
+  })
+
+  it('actually forwards allowRaw rather than only declaring it', () => {
+    const renderer = src(RENDERER)
+    expect(renderer).toMatch(/allowRaw:\s*\{\s*type:\s*Boolean/)
+    // Consumed in the binding that reaches the fallback.
+    expect(renderer).toMatch(/allowRaw:\s*props\.allowRaw/)
+    expect(renderer).toContain('v-bind="summaryProps"')
+  })
+
+  it('defaults allowRaw to true, so operator call sites are unchanged', () => {
+    expect(src(RENDERER)).toMatch(/allowRaw:\s*\{\s*type:\s*Boolean,\s*default:\s*true\s*\}/)
+  })
+
+  it('tells the fallback whether it was reached by shape MISMATCH', () => {
+    // `json` is a valid agent-chosen display_hint, so "the shape was wrong" and
+    // "the agent asked for this" must not read the same to a reader.
+    expect(src(RENDERER)).toMatch(/mismatch:\s*true/)
+    expect(src(RENDERER)).toMatch(/fallback:\s*resolved\.value\.mismatch/)
+  })
+
+  it('still reads all five CI-pinned payload keys IN THIS FILE', () => {
+    // Belt for `tests/unit/test_1535_report_prompt_guidance.py`, which regexes
+    // `payload.X` out of this exact file and asserts the five are present. The
+    // tempting refactor — extract `shapeOk` into a shared module — empties that
+    // set and breaks the cross-surface drift guard.
+    const keys = new Set(
+      [...src(RENDERER).matchAll(/payload\.([a-zA-Z_]+)/g)].map((m) => m[1]),
+    )
+    for (const key of ['columns', 'rows', 'tiles', 'events', 'markdown']) {
+      expect(keys).toContain(key)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Tokens and themes (AC #4)
+// ---------------------------------------------------------------------------
+
+// Mirrors `scan-raw-colors.mjs`'s own list. Gray is deliberately EXCLUDED:
+// `tailwind.config.js` keeps gray as the raw palette and defines semantic
+// families only for status/state/brand/accent/action, so there is no neutral
+// token and the design contract's own ink rules are written in gray classes.
+// The meaningful gate is therefore zero NON-gray raw classes and zero hexes.
+const NONGRAY_FAMILIES = [
+  'red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal',
+  'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink',
+  'rose', 'slate', 'zinc', 'neutral', 'stone',
+]
+const NONGRAY_RE = new RegExp(`\\b(?:${NONGRAY_FAMILIES.join('|')})-(?:50|\\d{3})\\b`, 'g')
+const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g
+
+describe('token discipline', () => {
+  it.each([
+    ['ReportSummary.vue', SUMMARY],
+    ['ReportRenderer.vue', RENDERER],
+  ])('%s uses no raw non-gray palette class and no hex', (_name, path) => {
+    const content = src(path)
+    expect(content.match(NONGRAY_RE) || []).toEqual([])
+    expect(content.match(HEX_RE) || []).toEqual([])
+  })
+
+  it('the Reports tab block uses no raw non-gray palette class and no hex', () => {
+    const block = reportsBlock()
+    expect(block.match(NONGRAY_RE) || []).toEqual([])
+    expect(block.match(HEX_RE) || []).toEqual([])
+  })
+
+  it('every gray in ReportSummary.vue pairs with a dark variant on the ink ladder', () => {
+    // AC #4. The contract: dark meta text is gray-300/400, gray-500 is the
+    // floor and decoration-only. `check:tokens` will NOT catch a regression
+    // here — its INK_LADDER_SWEPT list covers 13 files and includes neither
+    // components/reports/ nor components/portal/.
+    const content = src(SUMMARY)
+    const lightMeta = [...content.matchAll(/(?<!dark:)\btext-gray-500\b/g)]
+    expect(lightMeta.length).toBeGreaterThan(0)
+    // Each occurrence of the light tertiary must be followed by its dark pair
+    // in the same class attribute.
+    for (const m of lightMeta) {
+      const tail = content.slice(m.index, m.index + 120)
+      expect(tail).toMatch(/dark:text-gray-[34]00/)
+    }
+    expect(content).not.toMatch(/dark:text-gray-500/)
+  })
+
+  it.each([
+    ['ReportTable.vue', '../../src/components/reports/ReportTable.vue'],
+    ['ReportKpiTiles.vue', '../../src/components/reports/ReportKpiTiles.vue'],
+  ])('%s no longer ships bare gray-500 meta text into dark mode', (_name, path) => {
+    // These are REUSED verbatim on the client-facing surface, so "we didn't
+    // edit those files" does not make AC #4 free — it makes their meta text
+    // render visibly darker than everything around it, in the theme the AC
+    // names. `ReportTimeline.vue` already paired correctly, which is what
+    // proves these two were oversights rather than a house style.
+    const content = src(path)
+    for (const m of content.matchAll(/\btext-gray-500\b/g)) {
+      const tail = content.slice(m.index, m.index + 120)
+      expect(tail).toMatch(/dark:text-gray-[34]00/)
+    }
+  })
+
+  it('ReportTimeline.vue uses the semantic token, not a raw blue', () => {
+    const content = src('../../src/components/reports/ReportTimeline.vue')
+    expect(content).toContain('bg-status-info-500')
+    expect(content.match(NONGRAY_RE) || []).toEqual([])
+  })
+})

--- a/src/frontend/tests/unit/portalReportsStore.spec.js
+++ b/src/frontend/tests/unit/portalReportsStore.spec.js
@@ -353,3 +353,37 @@ describe('in-flight and cache guards', () => {
     expect(store.reportErrors).toEqual({})
   })
 })
+
+// ---------------------------------------------------------------------------
+// 6. The guard's own bookkeeping
+// ---------------------------------------------------------------------------
+
+describe('in-flight bookkeeping is itself generation-guarded', () => {
+  it('a late finally does not clear a NEW request\'s in-flight marker', async () => {
+    // The subtle one: `resetAgentReports` empties `_reportInFlight`, so an
+    // unguarded `finally` from the OLD request would delete the key a new
+    // request just wrote — letting a duplicate through the very guard that
+    // exists to prevent it.
+    const stale = deferred()
+    axios.get.mockReturnValueOnce(stale.promise)
+    const first = store.loadAgentReport('alpha', 'r1')
+
+    store.resetAgentReports('beta')
+
+    const fresh = deferred()
+    axios.get.mockReturnValueOnce(fresh.promise)
+    const second = store.loadAgentReport('beta', 'r1')
+
+    // Agent A's request settles now, after B's is already in flight.
+    stale.resolve({ data: { payload: { markdown: 'alpha' } } })
+    await first
+
+    // A third expand must still be refused — B's marker has to have survived.
+    const third = store.loadAgentReport('beta', 'r1')
+    fresh.resolve({ data: { payload: { markdown: 'beta' } } })
+    await Promise.all([second, third])
+
+    expect(axios.get).toHaveBeenCalledTimes(2)
+    expect(store.reportPayloads.r1).toEqual({ markdown: 'beta' })
+  })
+})

--- a/src/frontend/tests/unit/portalReportsStore.spec.js
+++ b/src/frontend/tests/unit/portalReportsStore.spec.js
@@ -1,0 +1,355 @@
+/**
+ * The Workspace Reports tab's store contract (#2162).
+ *
+ * Wiring the shared renderers into the tab is mostly template work, but it
+ * moves three failure modes into the store, and each of them is invisible to a
+ * source-structure guard:
+ *
+ *   1. **The agent-switch race.** A reset cannot cancel a promise already in
+ *      flight. Today the wrong render is transient — the tab guard is
+ *      `!reports.length`, so opening Reports on the new agent refetches and
+ *      self-corrects. The moment a `reportsLoaded` flag is added (and contract
+ *      #15 requires one, so the empty state stops firing after a failure) that
+ *      accidental correction is GONE: the new agent is marked
+ *      loaded-with-the-old-agent's-data for the life of the mount. The flag and
+ *      the generation guard have to ship together, which is why they are pinned
+ *      together here.
+ *
+ *   2. **The "Load more" terminal guard.** Without it a click at
+ *      `loaded === total` appends nothing, `loaded` never moves, and
+ *      `ReportTable`'s `meta.total > rows.length` never goes false — a
+ *      permanently visible, permanently inert button.
+ *
+ *   3. **Windowed vs whole.** `row_meta` is the ONLY signal that a payload was
+ *      actually paged. Synthesising one for a bounded document would put a
+ *      Load-more footer under a KPI tile set that can never satisfy it.
+ *
+ * Store fetchers ARE testable in this project even without a component-mount
+ * harness — `fleetGridFailuresFetch.spec.js` established the vi.mock('axios') +
+ * Pinia shape, and its subject is the same class of proof: that the store only
+ * ever hands the UI an honest input.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// The store reads localStorage at state construction and installs an axios
+// interceptor at import; vitest runs these in `environment: 'node'`. Harness
+// requirement, same shape as workspaceRoomsGate.spec.js.
+vi.hoisted(() => {
+  const store = new Map()
+  globalThis.localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+  }
+  globalThis.window = globalThis.window || { location: { pathname: '/workspace' } }
+})
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: true,
+    authHeader: { Authorization: 'Bearer platform-jwt' },
+  }),
+}))
+
+vi.mock('axios', () => {
+  const inst = {
+    get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(),
+    interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
+    defaults: { headers: { common: {} } },
+  }
+  return { default: Object.assign(inst, { create: () => inst }) }
+})
+
+import axios from 'axios'
+import { useClientPortalStore } from '@/stores/clientPortal'
+import { REPORT_ROWS_PAGE } from '@/utils/reportPaging'
+
+/** A deferred promise, so a response can be resolved AFTER an agent switch. */
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+const tabular = (total, from = 0, count = REPORT_ROWS_PAGE) => ({
+  payload: {
+    columns: ['name'],
+    rows: Array.from({ length: count }, (_, i) => [`row-${from + i}`]),
+  },
+  row_meta: { total, offset: from, limit: REPORT_ROWS_PAGE },
+})
+
+let store
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  store = useClientPortalStore()
+  store.resetAgentReports('alpha')
+})
+
+// ---------------------------------------------------------------------------
+// 1. The agent-switch race
+// ---------------------------------------------------------------------------
+
+describe('the agent-switch race', () => {
+  it("discards agent A's list when it resolves after a switch to B", async () => {
+    const inflight = deferred()
+    axios.get.mockReturnValueOnce(inflight.promise)
+
+    const loading = store.loadAgentReports('alpha')
+
+    // The user clicks agent B while A's request is still open.
+    store.resetAgentReports('beta')
+
+    inflight.resolve({ data: { reports: [{ id: 'a1', title: "alpha's report" }] } })
+    await loading
+
+    expect(store.reports).toEqual([])
+    // The decisive assertion: B must NOT be marked loaded. If it were, the tab
+    // guard would skip the refetch and A's reports would render under B's name
+    // for the life of the mount.
+    expect(store.reportsLoaded).toBe(false)
+    expect(store.reportsAgent).toBe('beta')
+  })
+
+  it("discards agent A's FAILURE after a switch, so B shows no stale error", async () => {
+    const inflight = deferred()
+    axios.get.mockReturnValueOnce(inflight.promise)
+
+    const loading = store.loadAgentReports('alpha')
+    store.resetAgentReports('beta')
+    inflight.reject(new Error('network'))
+    await loading
+
+    expect(store.reportsError).toBeNull()
+  })
+
+  it('discards a late report PAYLOAD, so one agent\'s report cannot open under another', async () => {
+    const inflight = deferred()
+    axios.get.mockReturnValueOnce(inflight.promise)
+
+    const loading = store.loadAgentReport('alpha', 'r1')
+    store.resetAgentReports('beta')
+    inflight.resolve({ data: { payload: { secret: 'alpha only' } } })
+    await loading
+
+    expect(store.reportPayloads).toEqual({})
+  })
+
+  it('discards a late "load more" page rather than merging it into another agent', async () => {
+    axios.get.mockResolvedValueOnce({ data: tabular(500) })
+    await store.loadAgentReport('alpha', 'r1')
+
+    const inflight = deferred()
+    axios.get.mockReturnValueOnce(inflight.promise)
+    const more = store.loadMoreReportRows('alpha', 'r1')
+
+    store.resetAgentReports('beta')
+    inflight.resolve({ data: tabular(500, REPORT_ROWS_PAGE) })
+    await more
+
+    expect(store.reportPayloads).toEqual({})
+    expect(store.reportRowMeta).toEqual({})
+  })
+
+  it('self-corrects when a load is issued for a different agent without a reset', async () => {
+    axios.get.mockResolvedValueOnce({ data: { reports: [{ id: 'a1' }] } })
+    await store.loadAgentReports('alpha')
+    expect(store.reports).toHaveLength(1)
+
+    axios.get.mockResolvedValueOnce({ data: { reports: [] } })
+    await store.loadAgentReports('beta')
+
+    expect(store.reportsAgent).toBe('beta')
+    expect(store.reports).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. "Load more"
+// ---------------------------------------------------------------------------
+
+describe('load more', () => {
+  it('issues no request once every row is held', async () => {
+    // total === one page, so the first fetch already holds everything.
+    axios.get.mockResolvedValueOnce({ data: tabular(REPORT_ROWS_PAGE) })
+    await store.loadAgentReport('alpha', 'r1')
+    expect(store.reportRowMeta.r1).toEqual({ total: REPORT_ROWS_PAGE, loaded: REPORT_ROWS_PAGE })
+
+    axios.get.mockClear()
+    await store.loadMoreReportRows('alpha', 'r1')
+
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  it('issues no request for a report that was never windowed', async () => {
+    axios.get.mockResolvedValueOnce({ data: { payload: { tiles: [] } } })
+    await store.loadAgentReport('alpha', 'r1')
+
+    axios.get.mockClear()
+    await store.loadMoreReportRows('alpha', 'r1')
+
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  it('appends the next page and advances loaded against a stable total', async () => {
+    axios.get.mockResolvedValueOnce({ data: tabular(250) })
+    await store.loadAgentReport('alpha', 'r1')
+
+    axios.get.mockResolvedValueOnce({ data: tabular(250, REPORT_ROWS_PAGE) })
+    await store.loadMoreReportRows('alpha', 'r1')
+
+    expect(store.reportPayloads.r1.rows).toHaveLength(REPORT_ROWS_PAGE * 2)
+    expect(store.reportPayloads.r1.rows[REPORT_ROWS_PAGE][0]).toBe(`row-${REPORT_ROWS_PAGE}`)
+    expect(store.reportRowMeta.r1).toEqual({ total: 250, loaded: REPORT_ROWS_PAGE * 2 })
+    // The offset asked for is where the previous page ended, not a page index.
+    expect(axios.get.mock.calls.at(-1)[1].params).toEqual({
+      rows_offset: REPORT_ROWS_PAGE, rows_limit: REPORT_ROWS_PAGE,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Windowed vs whole
+// ---------------------------------------------------------------------------
+
+describe('the fetch shape', () => {
+  it('always asks for a window — the SERVER decides whether one applies', async () => {
+    axios.get.mockResolvedValueOnce({ data: tabular(500) })
+    await store.loadAgentReport('alpha', 'r1')
+
+    const [url, config] = axios.get.mock.calls[0]
+    expect(url).toContain('/agents/alpha/reports/r1')
+    expect(config.params).toEqual({ rows_offset: 0, rows_limit: REPORT_ROWS_PAGE })
+  })
+
+  it('threads row_meta through as {total, loaded}', async () => {
+    axios.get.mockResolvedValueOnce({ data: tabular(12431) })
+    await store.loadAgentReport('alpha', 'r1')
+
+    expect(store.reportRowMeta.r1).toEqual({ total: 12431, loaded: REPORT_ROWS_PAGE })
+  })
+
+  it('records NO meta when the server sent none, so no paging footer renders', async () => {
+    axios.get.mockResolvedValueOnce({ data: { payload: { markdown: '# hi' } } })
+    await store.loadAgentReport('alpha', 'r1')
+
+    expect(store.reportPayloads.r1).toEqual({ markdown: '# hi' })
+    expect(store.reportRowMeta.r1).toBeUndefined()
+  })
+
+  it('records no meta when row_meta arrives without a row list', async () => {
+    // Defensive: meta without rows would produce {total: N, loaded: undefined}
+    // and a footer comparing against NaN.
+    axios.get.mockResolvedValueOnce({ data: { payload: { tiles: [] }, row_meta: { total: 9 } } })
+    await store.loadAgentReport('alpha', 'r1')
+
+    expect(store.reportRowMeta.r1).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Honest states
+// ---------------------------------------------------------------------------
+
+describe('honest states', () => {
+  it('a failed list fetch sets the error and leaves loaded FALSE', async () => {
+    axios.get.mockRejectedValueOnce(new Error('boom'))
+    await store.loadAgentReports('alpha')
+
+    expect(store.reportsError).toBeTruthy()
+    // The empty copy gates on `reportsLoaded`, so this is what stops "this
+    // agent hasn't published any reports" from rendering for a network fault.
+    expect(store.reportsLoaded).toBe(false)
+    expect(store.reports).toEqual([])
+  })
+
+  it('a successful retry clears the error', async () => {
+    axios.get.mockRejectedValueOnce(new Error('boom'))
+    await store.loadAgentReports('alpha')
+
+    axios.get.mockResolvedValueOnce({ data: { reports: [{ id: 'r1' }] } })
+    await store.loadAgentReports('alpha')
+
+    expect(store.reportsError).toBeNull()
+    expect(store.reportsLoaded).toBe(true)
+  })
+
+  it('a failed payload fetch records an error and NO payload', async () => {
+    axios.get.mockRejectedValueOnce(new Error('boom'))
+    await store.loadAgentReport('alpha', 'r1')
+
+    expect(store.reportErrors.r1).toBeTruthy()
+    // Never in reportPayloads: an {error: …} object there is handed to the
+    // renderer and presented AS a report — worse than the bug being fixed.
+    expect(store.reportPayloads.r1).toBeUndefined()
+  })
+
+  it('a retry after a failed payload fetch clears the error and renders', async () => {
+    axios.get.mockRejectedValueOnce(new Error('boom'))
+    await store.loadAgentReport('alpha', 'r1')
+
+    axios.get.mockResolvedValueOnce({ data: { payload: { markdown: 'ok' } } })
+    await store.loadAgentReport('alpha', 'r1')
+
+    expect(store.reportErrors.r1).toBeUndefined()
+    expect(store.reportPayloads.r1).toEqual({ markdown: 'ok' })
+  })
+
+  it('clearReportError dismisses without retrying', async () => {
+    axios.get.mockRejectedValueOnce(new Error('boom'))
+    await store.loadAgentReport('alpha', 'r1')
+
+    axios.get.mockClear()
+    store.clearReportError('r1')
+
+    expect(store.reportErrors.r1).toBeUndefined()
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. Duplicate work
+// ---------------------------------------------------------------------------
+
+describe('in-flight and cache guards', () => {
+  it('a rapid double expand issues ONE request', async () => {
+    const inflight = deferred()
+    axios.get.mockReturnValueOnce(inflight.promise)
+
+    const first = store.loadAgentReport('alpha', 'r1')
+    const second = store.loadAgentReport('alpha', 'r1')
+
+    inflight.resolve({ data: { payload: { markdown: 'hi' } } })
+    await Promise.all([first, second])
+
+    // Each request re-reads the whole blob server-side, so a duplicate is not
+    // merely wasteful here.
+    expect(axios.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-expanding an already-loaded report issues no request', async () => {
+    axios.get.mockResolvedValueOnce({ data: { payload: { markdown: 'hi' } } })
+    await store.loadAgentReport('alpha', 'r1')
+
+    axios.get.mockClear()
+    await store.loadAgentReport('alpha', 'r1')
+
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  it('resetAgentReports drops every per-report cache, not only the list', async () => {
+    axios.get.mockResolvedValueOnce({ data: tabular(500) })
+    await store.loadAgentReport('alpha', 'r1')
+
+    store.resetAgentReports('beta')
+
+    expect(store.reportPayloads).toEqual({})
+    expect(store.reportRowMeta).toEqual({})
+    expect(store.reportErrors).toEqual({})
+  })
+})

--- a/src/frontend/tests/unit/reportSummary.spec.js
+++ b/src/frontend/tests/unit/reportSummary.spec.js
@@ -1,0 +1,271 @@
+/**
+ * The fallback summariser (#2162).
+ *
+ * The Workspace Reports tab rendered `JSON.stringify(payload, null, 2)` to
+ * external clients. Routing it through the shared typed renderers fixes the
+ * well-shaped case; this module is the other half — what an UNRECOGNISED
+ * payload becomes, on a surface where a raw dump is not an acceptable answer.
+ *
+ * It is a pure module for a reason beyond taste: there is no component-mount
+ * harness in this project (no `@vue/test-utils`), so logic living inside the
+ * `.vue` would have exactly zero coverage. Everything worth asserting about the
+ * fallback is asserted here.
+ *
+ * The two tests that matter most are negatives:
+ *
+ *   * **No output path ever stringifies the payload.** That would reintroduce
+ *     the bug inside the component written to fix it, and it would do so
+ *     silently — the card would still look "handled".
+ *   * **A credential-shaped token is redacted at VALUE level, anywhere in the
+ *     string.** A key-name allow-list would miss `{"status": "failed: sk-…"}`,
+ *     which is precisely the shape that motivated the redaction.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+import { stripComments } from './helpers/stripComments'
+import {
+  summarizePayload,
+  describeValue,
+  humaniseKey,
+  redactSecrets,
+  MAX_ENTRIES,
+  MAX_VALUE_CHARS,
+  REDACTED,
+} from '@/components/reports/reportSummary'
+
+const MODULE = fileURLToPath(
+  new URL('../../src/components/reports/reportSummary.js', import.meta.url),
+)
+
+// ---------------------------------------------------------------------------
+// Shape description — depth 1, never a serialisation
+// ---------------------------------------------------------------------------
+
+describe('describeValue', () => {
+  it('describes a nested object by its field count', () => {
+    expect(describeValue({ a: 1, b: 2, c: 3 })).toEqual({ value: '3 fields', hint: 'count' })
+  })
+
+  it('describes an array by its item count', () => {
+    expect(describeValue([1, 2])).toEqual({ value: '2 items', hint: 'count' })
+  })
+
+  it('is singular for one', () => {
+    expect(describeValue([1]).value).toBe('1 item')
+    expect(describeValue({ only: true }).value).toBe('1 field')
+  })
+
+  it('renders null and undefined as an em dash, not as "null"', () => {
+    expect(describeValue(null)).toEqual({ value: '—', hint: 'empty' })
+    expect(describeValue(undefined)).toEqual({ value: '—', hint: 'empty' })
+  })
+
+  it('renders a whitespace-only string as empty rather than as blank content', () => {
+    expect(describeValue('   ').hint).toBe('empty')
+  })
+
+  it('renders booleans as words', () => {
+    expect(describeValue(true).value).toBe('Yes')
+    expect(describeValue(false).value).toBe('No')
+  })
+
+  it('keeps a non-finite number readable instead of printing nothing', () => {
+    expect(describeValue(Number.NaN).value).toBe('NaN')
+    expect(describeValue(Infinity).value).toBe('Infinity')
+  })
+
+  it('truncates a long string with an ellipsis', () => {
+    const long = 'x'.repeat(MAX_VALUE_CHARS + 50)
+    const out = describeValue(long).value
+    expect(out.length).toBe(MAX_VALUE_CHARS + 1) // + the ellipsis
+    expect(out.endsWith('…')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Key humanisation
+// ---------------------------------------------------------------------------
+
+describe('humaniseKey', () => {
+  it('turns snake_case into a sentence', () => {
+    expect(humaniseKey('total_leads')).toBe('Total leads')
+  })
+
+  it('turns camelCase into a sentence', () => {
+    expect(humaniseKey('createdAt')).toBe('Created at')
+  })
+
+  it('handles kebab-case and repeated separators', () => {
+    expect(humaniseKey('last--run-at')).toBe('Last run at')
+  })
+
+  it('survives a key that is only separators', () => {
+    expect(humaniseKey('__')).toBe('__')
+  })
+
+  it('redacts and bounds a key, because keys are agent-authored too', () => {
+    expect(humaniseKey('ghp_abcdef123456')).not.toContain('abcdef123456')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Redaction — the part a key-name allow-list cannot do
+// ---------------------------------------------------------------------------
+
+describe('redactSecrets', () => {
+  const SECRETS = [
+    'sk-abcdef1234567890',
+    'sk-ant-api03-abcdef1234',
+    'sk_live_abcdef1234567890',
+    'ghp_abcdefghijklmnop1234',
+    'gho_abcdefghijklmnop1234',
+    'ghs_abcdefghijklmnop1234',
+    'ghu_abcdefghijklmnop1234',
+    'github_pat_11ABCDEFG_abcdefgh',
+    'xoxb-123456789-abcdef',
+    'xoxp-123456789-abcdef',
+    'AKIAIOSFODNN7EXAMPLE',
+    'AIzaSyD-abcdefghijklmnopqrstuvwxyz12345',
+  ]
+
+  it.each(SECRETS)('redacts %s as a whole value', (secret) => {
+    const out = redactSecrets(secret)
+    expect(out).toBe(REDACTED)
+  })
+
+  it.each(SECRETS)('redacts %s embedded mid-string under an innocuous key', (secret) => {
+    // The case a key-name allow-list misses entirely: the key is `status`, which
+    // any sane allow-list would permit, and the secret is in the VALUE.
+    const { entries } = summarizePayload({ status: `failed: ${secret} rejected` })
+    expect(entries[0].value).toContain(REDACTED)
+    expect(entries[0].value).not.toContain(secret)
+  })
+
+  it('redacts the whole token, not just its prefix', () => {
+    const out = redactSecrets('key=ghp_SUPERSECRETTAIL9999 end')
+    expect(out).not.toContain('SUPERSECRETTAIL')
+    expect(out).toBe('key=[redacted] end')
+  })
+
+  it('redacts BEFORE truncating, so a long value cannot leak a fragment', () => {
+    // Secret sits past the truncation point: truncate-then-redact would cut the
+    // token mid-way and leave a recognisable head on screen.
+    const padding = 'a'.repeat(MAX_VALUE_CHARS - 10)
+    const { entries } = summarizePayload({ note: `${padding} ghp_LEAKEDTAILVALUE1234` })
+    expect(entries[0].value).not.toContain('LEAKEDTAIL')
+  })
+
+  it('redacts every occurrence, not only the first', () => {
+    const out = redactSecrets('a sk-one1111 b sk-two2222 c')
+    expect(out).toBe('a [redacted] b [redacted] c')
+  })
+
+  it('is stable across repeated calls (module-level /g regex lastIndex)', () => {
+    const input = 'ghp_abcdefghijkl'
+    expect(redactSecrets(input)).toBe(redactSecrets(input))
+    expect(redactSecrets(input)).toBe(REDACTED)
+  })
+
+  it('does not fire on ordinary words that contain a prefix as a substring', () => {
+    // "task-force" contains "sk-"; there is no word boundary before it.
+    const out = redactSecrets('task-force risk-register github_patch notes')
+    expect(out).toBe('task-force risk-register github_patch notes')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarizePayload
+// ---------------------------------------------------------------------------
+
+describe('summarizePayload', () => {
+  it('lists top-level keys as humanised label/value pairs', () => {
+    const { entries, truncated } = summarizePayload({
+      total_leads: 42,
+      source: 'linkedin',
+      breakdown: { a: 1, b: 2 },
+      recent: [1, 2, 3],
+      missing: null,
+    })
+
+    expect(truncated).toBe(0)
+    expect(entries.map((e) => [e.label, e.value])).toEqual([
+      ['Total leads', '42'],
+      ['Source', 'linkedin'],
+      ['Breakdown', '2 fields'],
+      ['Recent', '3 items'],
+      ['Missing', '—'],
+    ])
+  })
+
+  it('caps the entry list and counts the remainder', () => {
+    const payload = {}
+    for (let i = 0; i < MAX_ENTRIES + 7; i += 1) payload[`key_${i}`] = i
+
+    const { entries, truncated } = summarizePayload(payload)
+
+    expect(entries).toHaveLength(MAX_ENTRIES)
+    expect(truncated).toBe(7)
+  })
+
+  it('describes a root-level array as N items, not as numbered keys', () => {
+    // Exploding it into `0`, `1`, `2` … is a JSON dump with the braces removed.
+    const { entries } = summarizePayload([{ a: 1 }, { a: 2 }, { a: 3 }])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].label).toBe('Items')
+    expect(entries[0].value).toBe('3 items')
+  })
+
+  it('returns nothing readable for null, undefined, {} and []', () => {
+    for (const payload of [null, undefined, {}, []]) {
+      expect(summarizePayload(payload)).toEqual({ entries: [], truncated: 0 })
+    }
+  })
+
+  it('describes a scalar root payload as a single value', () => {
+    const { entries } = summarizePayload('all clear')
+    expect(entries).toEqual([{ key: '', label: 'Value', value: 'all clear', hint: 'text' }])
+  })
+
+  it('does not throw on a payload holding odd values', () => {
+    expect(() => summarizePayload({
+      fn: () => {}, sym: Symbol('x'), big: 10n, nested: { deep: { deeper: {} } },
+    })).not.toThrow()
+  })
+
+  // -------------------------------------------------------------------------
+  // The negative that defines the feature
+  // -------------------------------------------------------------------------
+
+  it('never emits a JSON serialisation of the payload', () => {
+    const payload = {
+      customer: { name: 'ACME', contact: { email: 'ops@acme.test' } },
+      rows: [{ id: 1, secret: 'sk-deadbeef1234' }],
+    }
+
+    const { entries } = summarizePayload(payload)
+    const rendered = entries.map((e) => `${e.label}${e.value}`).join('|')
+
+    // Not the whole payload…
+    expect(rendered).not.toContain(JSON.stringify(payload))
+    // …and not any nested value verbatim either: depth is 1, so a nested object
+    // is described by shape and its contents never reach the screen.
+    expect(rendered).not.toContain('ACME')
+    expect(rendered).not.toContain('ops@acme.test')
+    expect(rendered).not.toContain('deadbeef')
+  })
+
+  it('has no JSON serialisation call anywhere in the module source', () => {
+    // The behavioural test above proves the shipped paths are clean; this one
+    // stops a future "just show the nested object" edit from reopening the bug
+    // through a path no test happens to exercise.
+    //
+    // Comments stripped first: the module's own docstring explains why it must
+    // never serialise, and an unstripped scan would fail on that explanation —
+    // the trap `helpers/stripComments` exists for.
+    const src = stripComments(readFileSync(MODULE, 'utf8'))
+    expect(src).not.toContain('JSON.stringify')
+  })
+})

--- a/src/frontend/tests/unit/reportSummary.spec.js
+++ b/src/frontend/tests/unit/reportSummary.spec.js
@@ -149,12 +149,25 @@ describe('redactSecrets', () => {
     expect(out).toBe('key=[redacted] end')
   })
 
-  it('redacts BEFORE truncating, so a long value cannot leak a fragment', () => {
-    // Secret sits past the truncation point: truncate-then-redact would cut the
-    // token mid-way and leave a recognisable head on screen.
+  it('redacts a value whose secret straddles the truncation point', () => {
     const padding = 'a'.repeat(MAX_VALUE_CHARS - 10)
     const { entries } = summarizePayload({ note: `${padding} ghp_LEAKEDTAILVALUE1234` })
     expect(entries[0].value).not.toContain('LEAKEDTAIL')
+  })
+
+  it('redacts BEFORE truncating — proven with a pattern that needs a minimum tail', () => {
+    // The `ghp_` case above passes under EITHER order and therefore pins
+    // nothing: `\bghp_[A-Za-z0-9]+` needs one character after the prefix, so
+    // the head that survives a cut still matches and is still replaced. (Broken
+    // deliberately during review to check; it stayed green.)
+    //
+    // `\bAKIA[A-Z0-9]{4}` needs FOUR, so cutting the token mid-way leaves a
+    // head the pattern no longer recognises — the residue that truncate-first
+    // ships to the screen. `AKIAIO` here carries two characters of a real AWS
+    // key id, which is the whole difference between the two orders.
+    const padding = 'a'.repeat(MAX_VALUE_CHARS - 7)
+    const { entries } = summarizePayload({ note: `${padding} AKIAIOSFODNN7EXAMPLE` })
+    expect(entries[0].value).not.toContain('AKIA')
   })
 
   it('redacts every occurrence, not only the first', () => {

--- a/tests/unit/test_2162_portal_report_window.py
+++ b/tests/unit/test_2162_portal_report_window.py
@@ -1,0 +1,305 @@
+"""Client-facing row windowing on the Workspace report read (#2162).
+
+The Workspace Reports tab dumped `JSON.stringify(payload)` at external clients.
+Routing it through the shared typed renderers is a frontend change — except for
+one acceptance criterion: a `table` payload must not transfer wholesale, and the
+operator row reader (`GET /api/reports/{id}/rows`, #1537) is
+`Depends(get_current_user)`, which a portal principal — a verified email with no
+`users` row — structurally cannot satisfy (the #2128 fact).
+
+The answer is two optional query params on the **existing** portal detail route,
+not a second route. Three properties are worth pinning, and each is a way this
+could go quietly wrong:
+
+  1. **Additive.** With `rows_limit` absent the response is byte-for-byte what it
+     was. This route ships today; a windowing bug that changes the default path
+     would be a regression in every non-tabular report at once.
+
+  2. **The SERVER decides tabularity, from the real payload.** `display_hint` is
+     agent-authored and can disagree with what was actually filed, so a client
+     that predicted the shape and asked for the wrong reader would need a 400 and
+     a recovery re-fetch. Here a non-tabular payload with `rows_limit` set simply
+     comes back whole with no `row_meta` — never a 400, never a mangled payload.
+
+  3. **The gate is inherited, not re-derived.** The window rides `report_detail`,
+     so a foreign report id and a missing one stay indistinguishable 404s
+     (invariant #8) on the windowed path too. A second hand-written gate on a
+     client-facing prefix is how those two answers drift apart.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+AGENT = "scribe"
+OTHER = "recon"
+
+TABULAR = {
+    "columns": ["name", "score"],
+    "rows": [[f"row-{i}", i] for i in range(250)],
+    # A tabular report may carry siblings; windowing is subtractive on `rows`
+    # only and must leave everything else exactly as filed.
+    "generated_at": "2026-08-13T00:00:00Z",
+}
+
+
+def _row(payload, agent=AGENT):
+    return {
+        "id": "r1",
+        "agent_name": agent,
+        "report_type": "recon.leads",
+        "title": "Leads",
+        "display_hint": "table",
+        "payload": payload,
+        "period_start": None,
+        "period_end": None,
+        "created_at": "2026-08-13T00:00:00Z",
+    }
+
+
+@pytest.fixture
+def agent_page(monkeypatch):
+    from client_portal import agent_page as mod
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# 1. Additive: the default path is untouched
+# ---------------------------------------------------------------------------
+
+def test_without_rows_limit_the_response_is_unchanged(agent_page, monkeypatch):
+    """The route ships today. `rows_limit=None` must return exactly what it
+    returned before this feature existed — including no `row_meta` key at all,
+    since the frontend keys "is this windowed?" off its presence."""
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(TABULAR))
+
+    got = agent_page.report_detail(AGENT, "r1")
+
+    assert got["payload"] == TABULAR
+    assert len(got["payload"]["rows"]) == 250
+    assert "row_meta" not in got
+
+
+def test_windowing_does_not_mutate_the_source_payload(agent_page, monkeypatch):
+    """The windowed copy is a new dict. `db.get_report` decodes fresh per call
+    today, so this is hygiene rather than a live bug — but a shared-dict caller
+    (or a cache added later) would otherwise find the row list truncated in
+    place, i.e. data loss that only shows up on the second read."""
+    payload = {"columns": ["a"], "rows": [[i] for i in range(10)]}
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(payload))
+
+    agent_page.report_detail(AGENT, "r1", rows_limit=2)
+
+    assert len(payload["rows"]) == 10
+
+
+# ---------------------------------------------------------------------------
+# 2. The window itself
+# ---------------------------------------------------------------------------
+
+def test_a_tabular_payload_is_windowed_with_a_true_total(agent_page, monkeypatch):
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(TABULAR))
+
+    got = agent_page.report_detail(AGENT, "r1", rows_offset=0, rows_limit=100)
+
+    assert got["payload"]["columns"] == ["name", "score"]
+    assert got["payload"]["rows"] == TABULAR["rows"][:100]
+    # The TRUE total, not the window size — this is what "Showing 100 of 250"
+    # reads, and a windowed total would make the footer lie and hide the rest.
+    assert got["row_meta"] == {"total": 250, "offset": 0, "limit": 100}
+    # Siblings survive.
+    assert got["payload"]["generated_at"] == "2026-08-13T00:00:00Z"
+
+
+def test_a_later_page_starts_where_the_previous_one_ended(agent_page, monkeypatch):
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(TABULAR))
+
+    got = agent_page.report_detail(AGENT, "r1", rows_offset=100, rows_limit=100)
+
+    assert got["payload"]["rows"] == TABULAR["rows"][100:200]
+    assert got["row_meta"] == {"total": 250, "offset": 100, "limit": 100}
+
+
+def test_an_offset_past_the_end_is_empty_with_an_honest_total(agent_page, monkeypatch):
+    """Not an error: the table shrank, or a stale client asked. Empty rows plus
+    the real total lets the UI show "0 of N" and stop, rather than dead-end."""
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(TABULAR))
+
+    got = agent_page.report_detail(AGENT, "r1", rows_offset=9999, rows_limit=100)
+
+    assert got["payload"]["rows"] == []
+    assert got["row_meta"]["total"] == 250
+
+
+def test_limit_is_clamped_at_the_shared_ceiling(agent_page, monkeypatch):
+    """The route declares `le=REPORT_ROWS_PAGE_MAX`, so an over-large limit is a
+    422 before it reaches here. The service clamps anyway: it is importable and
+    the clamp is the thing that actually bounds the response, so it must not
+    depend on one caller's validation being present."""
+    from models import REPORT_ROWS_PAGE_MAX
+
+    big = {"columns": ["a"], "rows": [[i] for i in range(REPORT_ROWS_PAGE_MAX + 500)]}
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(big))
+
+    got = agent_page.report_detail(AGENT, "r1", rows_limit=REPORT_ROWS_PAGE_MAX * 10)
+
+    assert len(got["payload"]["rows"]) == REPORT_ROWS_PAGE_MAX
+    assert got["row_meta"]["limit"] == REPORT_ROWS_PAGE_MAX
+
+
+def test_a_negative_offset_reads_from_the_start(agent_page, monkeypatch):
+    """Python would treat a negative offset as "from the end" and silently serve
+    the WRONG rows under an honest-looking total."""
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(TABULAR))
+
+    got = agent_page.report_detail(AGENT, "r1", rows_offset=-50, rows_limit=10)
+
+    assert got["payload"]["rows"] == TABULAR["rows"][:10]
+    assert got["row_meta"]["offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-tabular payloads: whole, silent, never a 400
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("payload", [
+    {"tiles": [{"label": "Leads", "value": 12}]},          # kpi
+    {"markdown": "# Weekly\n\nAll good."},                  # markdown
+    {"columns": ["a"], "rows": "not-a-list"},               # half-tabular
+    {"rows": [[1]]},                                        # rows without columns
+    {},                                                     # empty
+    [1, 2, 3],                                              # root-level array
+    None,                                                   # nothing filed
+])
+def test_a_non_tabular_payload_is_returned_whole_with_no_row_meta(
+    agent_page, monkeypatch, payload,
+):
+    """`display_hint` is agent-authored and may disagree with what was filed, so
+    the client is allowed to ask for a window on anything. The server holds the
+    payload and answers honestly: whole payload, no `row_meta`, no 400. The
+    frontend then renders no "Load more" footer, which is exactly right for a
+    document with no row axis."""
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(payload))
+
+    got = agent_page.report_detail(AGENT, "r1", rows_limit=100)
+
+    assert got["payload"] == payload
+    assert "row_meta" not in got
+
+
+# ---------------------------------------------------------------------------
+# 4. The inherited gate still holds on the windowed path
+# ---------------------------------------------------------------------------
+
+def test_a_foreign_report_stays_unreadable_when_windowed(agent_page, monkeypatch):
+    """Report ids are global and the roster gate only proves the caller may
+    reach THIS agent. The window rides the same read, so it cannot become a
+    second, laxer door onto every report in the install."""
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row(TABULAR, agent=OTHER))
+
+    assert agent_page.report_detail(AGENT, "r1", rows_limit=100) is None
+
+
+def test_missing_and_foreign_stay_indistinguishable_when_windowed(agent_page, monkeypatch):
+    """Both None → the same 404. A different answer on the windowed path would
+    reopen the existence oracle invariant #8 closed on the unwindowed one."""
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: None)
+    missing = agent_page.report_detail(AGENT, "nope", rows_limit=100)
+
+    monkeypatch.setattr(agent_page.db, "get_report", lambda rid: _row({}, agent=OTHER))
+    foreign = agent_page.report_detail(AGENT, "r1", rows_limit=100)
+
+    assert missing is None and foreign is None
+
+
+def test_a_read_failure_is_still_swallowed_into_a_404(agent_page, monkeypatch):
+    """Unchanged behaviour, re-asserted through the new parameter: a DB fault
+    must not become a 500 that distinguishes itself from a missing report."""
+    def boom(_rid):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(agent_page.db, "get_report", boom)
+
+    assert agent_page.report_detail(AGENT, "r1", rows_limit=100) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. The route wiring
+# ---------------------------------------------------------------------------
+
+def _bound(query_param, name: str):
+    """Read a `ge`/`le` off a FastAPI `Query`, whichever shape it carries.
+
+    Pydantic v2 moved the constraints from attributes onto `metadata` as
+    annotated-types markers, so reading only `q.le` silently yields None — i.e.
+    a bounds assertion that passes against an UNBOUNDED param. Checked both ways
+    rather than pinned to the installed version.
+    """
+    direct = getattr(query_param, name, None)
+    if direct is not None:
+        return direct
+    for marker in getattr(query_param, "metadata", []) or []:
+        if hasattr(marker, name):
+            return getattr(marker, name)
+    return None
+
+
+def test_the_route_declares_both_params_within_the_shared_bounds():
+    """The page size is a shared constant (`models.REPORT_ROWS_PAGE_MAX`), not a
+    third hand-typed mirror — a mirrored constant drifts and the mirror's own
+    tests then pin the drift."""
+    import inspect
+
+    from client_portal import router as portal_router
+    from models import REPORT_ROWS_PAGE_MAX
+
+    sig = inspect.signature(portal_router.portal_agent_report_detail)
+    assert "rows_offset" in sig.parameters
+    assert "rows_limit" in sig.parameters
+
+    limit = sig.parameters["rows_limit"].default
+    assert limit.default is None, "rows_limit must default to None (unwindowed)"
+    assert _bound(limit, "le") == REPORT_ROWS_PAGE_MAX
+    assert _bound(limit, "ge") == 1
+    assert _bound(sig.parameters["rows_offset"].default, "ge") == 0
+
+
+def test_the_windowed_read_is_rate_limited():
+    """Each windowed request re-reads and re-parses the whole (≤5 MiB) blob, so
+    paging MULTIPLIES server work — the route that exists to cut transfer raises
+    reads. Acceptable behind a JWT; on a client-facing prefix a loopable
+    amplifier needs a limiter, like its `portal_tts`/`portal_stt` siblings."""
+    import inspect
+
+    from client_portal import router as portal_router
+
+    src = inspect.getsource(portal_router.portal_agent_report_detail)
+    assert "rate_limiter.enforce" in src
+    assert "portal_report_detail:" in src
+    # Access-first: the limiter must never key on an unvalidated path param.
+    assert src.index("_require_roster") < src.index("rate_limiter.enforce")
+
+
+def test_fastapi_can_build_the_route_with_the_new_params():
+    """`client_portal/router.py` uses `from __future__ import annotations`, so
+    every annotation is a STRING that FastAPI must resolve at include time. An
+    `Optional[int]` whose name is missing from the module namespace fails there
+    — at app startup, not import — which no other test in this file would catch,
+    since importing the module works either way."""
+    from fastapi import FastAPI
+
+    from client_portal.router import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    route = next(
+        r for r in app.routes
+        if getattr(r, "path", "").endswith("/agents/{agent_name}/reports/{report_id}")
+    )
+    params = {p.name: p for p in route.dependant.query_params}
+    assert {"rows_offset", "rows_limit"} <= set(params)
+    # Both optional: the unwindowed call must stay a bare GET.
+    assert params["rows_limit"].field_info.default is None
+    assert params["rows_offset"].field_info.default == 0


### PR DESCRIPTION
Fixes #2162

## This is a disclosure fix, not a cosmetic one

The Workspace Reports tab dumped an agent-authored payload key-for-key to an **external client**. That is the same class the sibling surface already refuses: `agent_page.py` deliberately withholds the free-form `asks.context` because it "has been a credential-leak surface before (canary G-04)". Reports carry an equally free-form, equally agent-authored blob, and shipped it whole to the agent's customer.

The tab now renders through the shared `display_hint` renderers, with a client-facing summary fallback instead of a `<pre>`.

## What this does NOT fix — stated precisely

Typed renderers **narrow** what crosses: each reads only its declared keys, so an unexpected sibling key is not rendered. The fallback **bounds, humanises and redacts**. Neither **eliminates** the class:

- a key-value summary still names every top-level key;
- a well-shaped `markdown` / `table` / `kpi` / `timeline` report still renders its values **as authored**.

The universal control is a **boundary-side scrub** at the portal serialization edge, deliberately out of scope here and listed as the first follow-up. Please do not read this PR as closing the leak class.

The redactor is **defense-in-depth on the fallback path only**. It mirrors the prefix set in `canary/invariants/g04_*.py` and consumes the whole token. That is a limit, not protection — it does nothing for the four typed paths above.

## Operator surfaces are behaviourally unchanged

`git diff origin/dev...HEAD -- ReportsPanel.vue ReportsPanelFleet.vue` is **empty**. `ReportRenderer`'s new `fallbackComponent` prop defaults to `null` and resolves `props.fallbackComponent || ReportJson`, so operator call sites — which pass nothing — reduce exactly to pre-branch behaviour.

The human-readable fallback is **portal-scoped by design**. AC #2 asks for a fallback *"deliberately stricter than the operator side, because the audience is an external client."* A raw dump is a feature when you are debugging your own agent and a defect when the reader is that agent's customer.

The portal override also covers an agent-chosen **`display_hint: "json"`** — a valid value in the MCP tool's enum — not merely a shape mismatch. That closes a second route to a raw dump.

## The only operator-visible deltas

Three dark-ink meta-text pairs and one `bg-blue-500 → bg-status-info-500` swap that resolves to the **identical** colour (`status-info` aliases `colors.blue`).

The dark fix was **necessary, not cosmetic**. Measured on rendered DOM, those sites **failed WCAG AA in dark**:

| site | before | after | threshold |
|---|---|---|---|
| table thead / footer | 3.67 | **6.99** | 4.5 |
| KPI tile label | 3.04 | **5.78** | 4.5 |

Light is unchanged at 4.83.

## Backend surface

Two optional query params (`rows_offset`, `rows_limit`) on the **existing** portal detail route. No new route, gate, `db.` accessor, table or column ⇒ **CLAUDE.md Rule #9 dual-track does not engage** — no SQLite migration, no Alembic revision.

Verified mechanically: nothing touched under `db/`, `migrations/`, `schema.py`, `tables.py`, `models.py`, `main.py`; **zero `@router.` changes**; zero `Depends(` changes **in Python** (the 6 `Depends(` hits in the diff are all prose in docstrings and markdown explaining why the operator `/rows` route is JWT-gated).

`REPORT_ROWS_PAGE_MAX` is **imported** from `models.py:503` where it already lives — never re-typed — so the two page sizes cannot drift with each side's tests pinning its own version.

Auth and scoping are inherited from the existing route. The **uniform-404 property (Invariant #8) survives**: `report_detail` returns `None` on `row["agent_name"] != agent_name` *before* any windowing runs, so a foreign report id is still indistinguishable from a nonexistent one. Pinned by `test_missing_and_foreign_stay_indistinguishable_when_windowed`.

## The route gains a rate limiter it did not previously have

`services/rate_limiter.py::enforce`, key `portal_report_detail:{email}:{agent_name}`, 60/60s, placed **after** `_require_roster` so an unvalidated path param can never mint unbounded limiter keys.

The windowed read re-reads and re-parses the ≤5 MiB blob per page, so the route that exists to cut **transfer** raises **reads**. Amplification is therefore strictly *better* than pre-branch, which had no limit at all.

Residual, stated: fail-open on a Redis outage, and the key is per-agent, so a client rostered on N agents scales linearly.

## Verification

- `verify-local` **PASS** (`--skip-agent`; agent stages correctly skipped — no `docker/base-image/**` change).
- **Live both-themes visual pass** on this branch's own dev server, all six report shapes — **`<pre>` count 0 in every case**.
- **Row window end-to-end**: "Showing 100 of 260 rows" → Load-more → "Showing 200 of 260". **Without** `rows_limit` the response is byte-for-byte back-compatible.
- At **414px** a wide table absorbs 658px of overflow inside its own container while the page never scrolls horizontally.
- The operator/client split was demonstrated **on the same report simultaneously** — operator shows the raw `<pre>`, portal shows the summary.
- `npm run check:tokens` → OK, "dark ink ladder holds in 13 swept files".
- Production `vite build` succeeds.

### Tests

- `cd src/frontend && npx vitest run` → **25 files / 428 tests passed**
- `pytest tests/unit/test_2162_portal_report_window.py test_1535_report_prompt_guidance.py test_918_report_endpoint.py -q` → **32 passed**
- Full backend sweep on this branch (measured in WAVE-4): **9980 passed, 3 failed, 17 skipped, 1 xfailed**. The 3 are the **pre-existing** `[XPASS(strict)]` reds on `dev`, reproduced on a pristine `origin/dev` checkout — not from this branch. The +20 over sibling branches is this branch's own new tests.

The 14 backend tests are overwhelmingly **non-happy-path**: foreign report, missing/foreign indistinguishability, read-failure→404, limit clamping, negative offset, offset past end, non-mutation of the source payload, rate limiting, route param bounds, and FastAPI route buildability.

## AC #4 is not machine-guarded — please read this bit

`check:tokens`' `INK_LADDER_SWEPT` covers exactly **13** files and includes **neither** `components/reports/` **nor** `components/portal/`. CI therefore **structurally cannot see** the theme work in this PR; it was verified by hand with the measured contrast above.

Suggest adding both directories to the swept list so the fix is *guarded* rather than re-earned. They are clean now, so it should pass as-is.

## Honest note on the raw-colour ratchet

This branch **adds 21 raw-gray class occurrences** (`ReportSummary.vue` +14, `PortalAgentPage.vue` +4, `ReportTable.vue` +2, `ReportKpiTiles.vue` +1; `ReportTimeline.vue` −1 non-gray), which nudges the count of files exceeding `raw-color-baseline.json` from **19 → 20**.

That increase **is the arithmetic of the dark-mode fix itself**: repairing `text-gray-500` to `text-gray-500 dark:text-gray-400` necessarily adds a second raw-gray occurrence. The scanner counts occurrences, while the design system's both-themes rule *requires* adding the dark variant — so the metric moves the wrong way for a change that strictly improves compliance.

No conversion is available: `tailwind.config.js` defines semantic tokens for `status-*`, `state-*`, `brand-*`, `accent-*`, `action-*` — **semantic roles only**. Neutral ink has no token (`gray` is deliberately kept as the raw palette), which is exactly why `bg-blue-500 → bg-status-info-500` *was* converted (info has a token) and the gray pairs were not (they have none).

## Rebase expectation

`PortalAgentPage.vue`, `workspace-agent-page.md` (`## Files` table) and `core-agent.md` §5.11 each have a second writer this wave (#2169). Verified disjoint — my `PortalAgentPage.vue` hunks are all at old line ≥192, #2169's Overview block is 103–191. Resolution is **"take both sides"**.

## Follow-ups — listed, deliberately NOT filed

1. **Boundary-side G-04 scrub** at the portal serialization edge — the only fix that covers `table` / `markdown` / `kpi` / `timeline`.
2. Operator stores branch on the **literal** `display_hint`, so a prefix-resolved table never pages.
3. The operator `/rows` **400 dead-ends its own UI**.
4. `scan-raw-colors.mjs` is **not CI-wired** and its baseline is stale (generated 2026-07-31); measured today, **19 files on pristine `origin/dev` already exceed it**. It also has no self-compare mode — only `--baseline` (write) and `--json` — so the "may only shrink" ratchet in CLAUDE.md Rule #10 is currently unenforced by anything.
5. Renderer-set fallthrough attrs stringify a function into a DOM attribute (pre-existing; fix is `inheritAttrs: false` across the set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
