### PR TITLE
fix(a2a): one port normalisation for validation, pinning and origin comparison (ent#398)

### DIFF
--- a/docs/memory/requirements/mcp.md
+++ b/docs/memory/requirements/mcp.md
@@ -504,6 +504,27 @@ remove are by id-or-name, so for a colliding string the update edits the record
 *named* that and the delete reaches the id-owning one first. Both are documented;
 neither is destructive.
 
+#### FR-4a — Port normalisation happens once (ent#398)
+The port of an endpoint authority is read by validation, by connection pinning and
+by the card's origin comparison. Each spelled its own normalisation, and they
+disagreed on `:0`: the validator coalesced it to the scheme default
+(`parsed.port or 443` — `0` is falsy), `_pinned_url` dropped it and therefore
+connected to 443, and `_same_origin` compared it literally as port 0. A `:0`
+endpoint validated, would have connected correctly, and was then permanently
+refused `card_origin_mismatch` against any card declaring the ordinary form —
+fail-closed, but permanently broken with a reason code pointing at the wrong thing.
+
+All three now consume `utils.url_validation.effective_port(port, scheme)`: `0` and
+absent both mean the scheme default (port 0 is not a connectable destination, and
+browsers refuse `:0` rather than dialing it), an explicit port is preserved, and an
+unknown scheme yields `None` for the caller to interpret. The default-port
+equivalence FR-2 relies on — Trinity's own card emits no explicit port, so
+`https://h` and `https://h:443` must be one origin — is preserved and pinned by
+test. `_pinned_url` now omits a port equal to the scheme default rather than
+spelling it out (same destination, consistent with that equivalence); the `Host`
+header still reflects what the operator typed, which is the one place an explicit
+`:443` is observable to a peer.
+
 #### FR-6 — `message/send` only; no SSE; no fake `stream` parameter
 Filed AC4 (stream token chunks back to the calling agent over SSE) is
 **rejected**: an MCP tool call is one request and one response — a FastMCP

--- a/src/backend/services/a2a_client.py
+++ b/src/backend/services/a2a_client.py
@@ -79,8 +79,10 @@ from utils.credential_sanitizer import (
 )
 from utils.url_validation import (
     A2AEndpointUrlError,
+    SCHEME_DEFAULT_PORTS,
     ValidatedPublicUrl,
     canonical_host as _canonical_host,
+    effective_port,
     validate_a2a_endpoint_url,
 )
 
@@ -210,7 +212,14 @@ def _pinned_url(url: str, address: str) -> str:
     """
     parts = urlsplit(url)
     host = f"[{address}]" if ":" in address else address
-    netloc = f"{host}:{parts.port}" if parts.port else host
+    # ent#398: through the shared normalisation, so the port this connects to is
+    # the same one the validator approved and `_same_origin` compares. A port
+    # equal to the scheme default is omitted rather than spelled out — same
+    # destination, and it keeps the pinned URL in the form the default-port
+    # equivalence rule below is written against.
+    port = effective_port(parts.port, parts.scheme)
+    default = SCHEME_DEFAULT_PORTS.get((parts.scheme or "").lower())
+    netloc = host if (port is None or port == default) else f"{host}:{port}"
     return urlunsplit((parts.scheme, netloc, parts.path or "/", parts.query, ""))
 
 
@@ -257,11 +266,17 @@ def _same_origin(a: str, b: str) -> bool:
         if not scheme or not host:
             return None
         try:
-            port = p.port
+            # ent#398: the same normalisation the validator and the pinned URL
+            # use. Spelling it a third time here is how `:0` came to mean port 0
+            # on this side and 443 on the other two — the registered endpoint
+            # validated, would have connected, and was refused card_origin_mismatch
+            # forever. `-1` stands for "unknown scheme, no default": it makes two
+            # such URLs comparable to each other without ever matching a real port.
+            port = effective_port(p.port, scheme)
         except ValueError:
             return None
         if port is None:
-            port = 443 if scheme == "https" else 80 if scheme == "http" else -1
+            port = -1
         return (scheme, host, port)
 
     ka, kb = _key(a), _key(b)

--- a/src/backend/utils/url_validation.py
+++ b/src/backend/utils/url_validation.py
@@ -372,8 +372,41 @@ class ValidatedPublicUrl:
 
     url: str
     hostname: str          # IDNA A-label, lowercased, trailing dot stripped
-    port: int              # explicit port, else the scheme default (443)
+    port: int              # `effective_port` of the authority — never 0, never None
     addresses: Tuple[str, ...]
+
+
+#: The port a scheme addresses when the authority names none.
+SCHEME_DEFAULT_PORTS = {"https": 443, "http": 80}
+
+
+def effective_port(port: Optional[int], scheme: str) -> Optional[int]:
+    """The port a URL actually addresses. `None` when the scheme has no default.
+
+    ONE normalisation for a field that had three (ent#398). Along a single call
+    path, `:0` used to mean three different things: the validator coalesced it to
+    443 (`parsed.port or 443` — `0` is falsy), `_pinned_url` dropped it and
+    therefore connected to 443, and `_same_origin` compared it literally as port
+    0. So a `:0` endpoint validated, would have connected correctly, and was then
+    permanently refused `card_origin_mismatch` against any card declaring the
+    ordinary form — fail-closed, but permanently broken with a reason code that
+    points at the wrong thing.
+
+    Three independent normalisations of one field is the actual hazard: today
+    they disagree harmlessly, and it is an edit to any one of them that turns
+    that into something else. Validation, connection pinning and origin
+    comparison now all consume this.
+
+    `0` is treated as "no port given", matching the validator's shipped
+    behaviour (and browsers, which refuse `:0` outright rather than dialing it):
+    port 0 is not a connectable destination, so the alternative reading — dial
+    port 0 — is not a reading anyone wants. An unknown scheme yields `None`; the
+    caller decides what that means, because "no default port" is not the same
+    answer for a comparison as it is for a connection.
+    """
+    if port:
+        return port
+    return SCHEME_DEFAULT_PORTS.get((scheme or "").lower())
 
 
 def canonical_host(hostname: str) -> Optional[str]:
@@ -489,7 +522,10 @@ def _validate_public_https_url(
         raise ValueError(f"{label} must have a valid hostname")
 
     try:
-        port = parsed.port or 443
+        # ent#398: the ONE normalisation, shared with `_pinned_url` and
+        # `_same_origin`. The scheme is https by construction here (checked
+        # above), so the default is never absent.
+        port = effective_port(parsed.port, parsed.scheme) or 443
     except ValueError:
         # urlparse raises on a non-numeric / out-of-range port only when `.port`
         # is read, so this is the first place a junk authority surfaces.

--- a/tests/unit/test_ent398_port_normalisation.py
+++ b/tests/unit/test_ent398_port_normalisation.py
@@ -1,0 +1,222 @@
+"""One port normalisation, consumed by validation, pinning and origin comparison (ent#398).
+
+Port `:0` used to mean three different things along one outbound A2A call path:
+
+    _validate_public_https_url   `parsed.port or 443`  -> 443   (0 is falsy)
+    _pinned_url                  `if parts.port`       -> dropped, i.e. 443
+    _same_origin._key            `p.port`              -> literally 0
+
+So a `:0` endpoint validated, would have connected correctly, and was then
+permanently refused `card_origin_mismatch` against any card declaring the
+ordinary form. Fail-closed, hence P3 — the damage is a permanently broken
+endpoint with a reason code that points at the wrong thing.
+
+The hazard worth pinning is not `:0` itself but the three independent
+normalisations: today they disagree harmlessly, and an edit to any one of them is
+what turns that into something else. These tests hold all three to one answer,
+and pin the default-port equivalence #736 depends on (Trinity's own card emits no
+port, so `https://h` and `https://h:443` must compare equal or Trinity becomes
+unreachable by its own rule).
+
+DNS is stubbed, never dialled — the property under test is the predicate, not the
+resolver (the `test_ent14_registry_url_ssrf.py` rule).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import socket
+import sys
+
+import pytest
+
+_backend_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "src", "backend")
+)
+sys.path.insert(0, _backend_path)
+
+# tests/utils shadows src/backend/utils — load the backend module directly, with
+# the same snapshot/restore of the `sys.modules` entry that
+# test_736_a2a_url_validation.py documents (the entry is installed at import
+# time, so the pre-stub value has to be captured at module scope).
+_spec = importlib.util.spec_from_file_location(
+    "backend_url_validation_ent398",
+    os.path.join(_backend_path, "utils", "url_validation.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_STUBBED_MODULE_NAMES = ["backend_url_validation_ent398"]
+_PRE_STUB_SYS_MODULES = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+sys.modules["backend_url_validation_ent398"] = _mod
+_spec.loader.exec_module(_mod)
+
+from services import a2a_client  # noqa: E402  (after the sys.path insert above)
+
+validate = _mod.validate_a2a_endpoint_url
+effective_port = _mod.effective_port
+
+PUBLIC_V4 = "93.184.216.34"
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    try:
+        yield
+    finally:
+        for name, value in _PRE_STUB_SYS_MODULES.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+@pytest.fixture
+def resolves(monkeypatch):
+    """Point every hostname at a chosen set of addresses."""
+
+    def _set(*addresses):
+        def _getaddrinfo(host, port, *a, **k):
+            out = []
+            for addr in addresses:
+                if ":" in addr:
+                    out.append((socket.AF_INET6, socket.SOCK_STREAM, 6, "", (addr, 0, 0, 0)))
+                else:
+                    out.append((socket.AF_INET, socket.SOCK_STREAM, 6, "", (addr, 0)))
+            return out
+
+        monkeypatch.setattr(_mod.socket, "getaddrinfo", _getaddrinfo)
+
+    return _set
+
+
+# --------------------------------------------------------------------------- #
+# The normalisation itself
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "port,scheme,expected",
+    [
+        (8443, "https", 8443),      # explicit, non-default
+        (443, "https", 443),        # explicit, default
+        (None, "https", 443),       # absent -> scheme default
+        (0, "https", 443),          # THE bug: `:0` is "no port given", not port 0
+        (0, "HTTPS", 443),          # scheme case-insensitive
+        (None, "http", 80),
+        (0, "http", 80),
+        (None, "ftp", None),        # no default to give
+        (0, "", None),
+        (8443, "ftp", 8443),        # an explicit port needs no default
+    ],
+)
+def test_effective_port_is_one_answer_for_every_spelling(port, scheme, expected):
+    assert effective_port(port, scheme) == expected
+
+
+# --------------------------------------------------------------------------- #
+# The three consumers agree — the ent#398 acceptance criterion
+# --------------------------------------------------------------------------- #
+def test_a_zero_port_is_normalised_consistently_across_the_call_path(resolves):
+    """Mirrors `test_736_a2a_outbound_edges.py::test_D7…`, which is pinned as a
+    strict-xfail on the branch that carries it (PR #2178) and must be un-xfailed
+    when that lands. Held here too so `dev` cannot regress in the meantime."""
+    resolves(PUBLIC_V4)
+    validated = validate("https://peer.example.com:0/a2a")
+
+    # The validator decided `:0` means the scheme default...
+    assert validated.port == 443
+    # ...the pinned URL agrees — it omits the port, i.e. 443...
+    assert a2a_client._pinned_url(validated.url, PUBLIC_V4) == f"https://{PUBLIC_V4}/a2a"
+    # ...and so does the origin comparison, which used to read it as port 0.
+    assert a2a_client._same_origin(validated.url, "https://peer.example.com/a2a") is True
+
+
+def test_a_zero_port_endpoint_matches_a_card_that_spells_the_default(resolves):
+    """The end-to-end symptom: `card_origin_mismatch` forever, for an endpoint
+    that validates and would connect."""
+    resolves(PUBLIC_V4)
+    validated = validate("https://peer.example.com:0/a2a")
+    for card_url in (
+        "https://peer.example.com/a2a",
+        "https://peer.example.com:443/a2a",
+        "https://peer.example.com:0/a2a",
+    ):
+        assert a2a_client._same_origin(validated.url, card_url) is True, card_url
+
+
+def test_the_host_header_of_a_zero_port_endpoint_carries_no_port(resolves):
+    """The fourth reader of this field. It answers a deliberately different
+    question — "what did the operator type?", since an added `:443` changes what
+    a peer sees — but `:0` must still resolve to the bare host, or the request
+    carries an authority nothing else in the path agrees with."""
+    resolves(PUBLIC_V4)
+    validated = validate("https://peer.example.com:0/a2a")
+    assert a2a_client._host_header(validated) == "peer.example.com"
+
+
+# --------------------------------------------------------------------------- #
+# The properties the fix must not break
+# --------------------------------------------------------------------------- #
+def test_default_port_equivalence_is_preserved(resolves):
+    """#736 depends on this: Trinity's own card emits no explicit port, so
+    treating `https://h` and `https://h:443` as different origins would make
+    Trinity unreachable by its own rule and break #738 federation."""
+    assert a2a_client._same_origin("https://h.example/a2a", "https://h.example:443/a2a") is True
+    assert a2a_client._same_origin("https://h.example:443/a2a", "https://h.example/a2a") is True
+
+
+def test_a_real_non_default_port_still_distinguishes_origins():
+    assert a2a_client._same_origin("https://h.example:8443/a2a", "https://h.example/a2a") is False
+    assert a2a_client._same_origin("https://h.example:8443/a2a", "https://h.example:8443/a2a") is True
+
+
+def test_a_non_default_port_survives_pinning():
+    assert a2a_client._pinned_url("https://h.example:8443/a2a", PUBLIC_V4) == \
+        f"https://{PUBLIC_V4}:8443/a2a"
+    assert a2a_client._pinned_url("https://h.example:8443/a2a", "2606:4700::1111") == \
+        "https://[2606:4700::1111]:8443/a2a"
+
+
+def test_an_explicit_default_port_is_pinned_as_the_bare_host():
+    """A behaviour change, deliberate and equivalent: `:443` is now omitted from
+    the pinned URL rather than spelled out. Same destination, and it keeps the
+    pinned form consistent with the default-port equivalence rule above. The
+    `Host` header, which is where an explicit `:443` is actually observable to a
+    peer, still preserves what the operator typed."""
+    assert a2a_client._pinned_url("https://h.example:443/a2a", PUBLIC_V4) == \
+        f"https://{PUBLIC_V4}/a2a"
+
+
+def test_pinning_preserves_the_rest_of_the_request():
+    """Regression net around the netloc change: path, query and IPv6 bracketing."""
+    assert a2a_client._pinned_url("https://h.example/a2a?x=1&y=2", PUBLIC_V4) == \
+        f"https://{PUBLIC_V4}/a2a?x=1&y=2"
+    assert a2a_client._pinned_url("https://h.example/a2a#frag", PUBLIC_V4) == \
+        f"https://{PUBLIC_V4}/a2a"
+    assert a2a_client._pinned_url("https://h.example", PUBLIC_V4) == f"https://{PUBLIC_V4}/"
+    assert a2a_client._pinned_url("https://h.example/a2a", "2606:4700::1111") == \
+        "https://[2606:4700::1111]/a2a"
+
+
+def test_an_ordinary_endpoint_still_validates_to_its_own_port(resolves):
+    resolves(PUBLIC_V4)
+    assert validate("https://peer.example.com/a2a").port == 443
+    assert validate("https://peer.example.com:8443/a2a").port == 8443
+
+
+def test_a_junk_port_is_still_a_named_refusal_not_a_traceback(resolves):
+    """`urlparse` raises only when `.port` is read, so the normalisation must not
+    move that read out from under its except clause."""
+    resolves(PUBLIC_V4)
+    with pytest.raises(_mod.A2AEndpointUrlError) as exc:
+        validate("https://peer.example.com:notaport/a2a")
+    assert exc.value.reason == "endpoint_invalid"
+
+    with pytest.raises(_mod.A2AEndpointUrlError):
+        validate("https://peer.example.com:99999/a2a")
+
+
+def test_an_unknown_scheme_compares_to_itself_and_to_nothing_else():
+    """`-1` for "no default port" keeps two such URLs comparable without ever
+    colliding with a real port."""
+    assert a2a_client._same_origin("ftp://h.example/a2a", "ftp://h.example/a2a") is True
+    assert a2a_client._same_origin("ftp://h.example/a2a", "https://h.example/a2a") is False


### PR DESCRIPTION
## What this fixes

Port `:0` was normalised three different ways along one outbound A2A call path:

| Step | Treatment of `:0` |
|---|---|
| `_validate_public_https_url` | coalesced to 443 (`parsed.port or 443` — `0` is falsy) |
| `_pinned_url` | dropped; connects to 443 |
| `_same_origin` | compared **literally as port 0** |

So a `:0` endpoint validated, would have connected correctly, and was then permanently
refused `card_origin_mismatch` against any card declaring the ordinary form. Fail-closed —
nothing leaks or misroutes — so the damage is a permanently broken endpoint with a reason
code that points at the wrong thing. The hazard worth fixing is the three independent
normalisations: today they disagree harmlessly, and an edit to any one of them is what turns
that into something else.

## Changes

- **`utils.url_validation.effective_port(port, scheme)`** + `SCHEME_DEFAULT_PORTS` — one
  answer: `0` and absent both mean the scheme default (port 0 is not a connectable
  destination, and browsers refuse `:0` rather than dialing it), an explicit port is
  preserved, an unknown scheme yields `None` for the caller to interpret.
- **All three sites consume it.** `_same_origin` keeps `-1` for "unknown scheme, no default"
  so two such URLs stay comparable without ever matching a real port; the junk-port read
  stays inside its `except` clause, so a bad authority is still a named refusal
  (`endpoint_invalid`) rather than a traceback.
- **`_pinned_url` omits a port equal to the scheme default** instead of spelling it out —
  same destination, and consistent with the default-port equivalence the card comparison is
  built on. This is the one behaviour change beyond `:0`; the `Host` header still preserves
  what the operator typed, which is the only place an explicit `:443` is observable to a peer.

The AC offered "refuse `:0` at registration" as the alternative. Not taken: the pinned D7
test asserts the coalescing reading (`validated.port == 443` and the origin comparison
agreeing), `:0` is already accepted today so refusing it would break endpoints that
currently validate, and the fix wanted is the single normalisation either way.

## Verification on a real instance

Same input, same DNS stub, run against the live instance's own backend code:

```
dev baseline (worktree identical to dev on both files)
  validator port : 443
  pinned url     : https://93.184.216.34/a2a
  same_origin    : False   -> REFUSED card_origin_mismatch

this branch
  validator port : 443
  pinned url     : https://93.184.216.34/a2a
  same_origin    : True    -> would proceed
```

## Tests

`tests/unit/test_ent398_port_normalisation.py` — 21 cases: the normalisation truth table
(explicit / default / absent / `0` / unknown scheme / case), the three consumers agreeing on
one `:0` endpoint, the end-to-end card comparison against all three spellings of the card,
the `Host` header, **default-port equivalence both ways** (the #736/#738 property Trinity's
own card depends on), non-default ports surviving pinning incl. IPv6, path/query/fragment
preserved around the netloc change, junk ports still named refusals, unknown-scheme
comparison.

Green: 21 new, 658 across every A2A / URL-validation / registry suite.

## Coordination with PR #2178

The AC's fourth item — un-xfail `test_736_a2a_outbound_edges.py::test_D7_…` — cannot be done
here: that file is **not on `dev`**, it arrives with PR #2178 (still open), where D7 is pinned
strict-xfail. When #2178 lands, its D7 must be un-xfailed or it will XPASS-strict and redden
CI. This PR holds the same property on `dev` in the meantime, so there is no window where the
behaviour is unpinned.

Same applies to that PR's **G7** for the sibling finding: the delete fix landed on `dev` in
#2177, so G7 will XPASS too — and #2177 also added a create-time guard that refuses G7's own
setup (it creates the collision through `upsert_endpoint`). Flagged on #2178.

Fixes abilityai/trinity-enterprise#398