### PR TITLE
fix(a2a): a blank credential leaves the stored secret alone, in every spelling (#2175 F5b)

### DIFF
--- a/docs/memory/requirements/mcp.md
+++ b/docs/memory/requirements/mcp.md
@@ -546,6 +546,24 @@ are *refused* by `ipaddress` rather than folded, so the normalisation can never
 equate two addresses a resolver would treat differently. The card stays a hint: a
 card declaring a different address, port or scheme is still refused.
 
+#### FR-5b — A blank credential means "leave it alone", in every spelling (#2175 F5b)
+`upsert_endpoint` documents three credential paths — omit (leave), set,
+`clear_credential` (remove). A whitespace-only value was a fourth: it skipped the
+header-safety check (`if credential.strip() and …`) and then took the
+`elif credential:` branch, because `"   "` is truthy, writing `""`. So `None` and
+`""` preserved the stored secret while `"   "` destroyed it. Not reachable over
+HTTP (`A2AOutboundEndpointUpsert._validate_credential` normalises a blank
+`SecretStr` to `None`, so the API surface is honest) — a public-module-function
+defect, over a partner secret the caller may hold no other copy of.
+
+Every blank spelling now collapses to `None` in ONE normalisation applied after
+the validity checks and before either write path, so a future third write site
+cannot reintroduce the fourth path. `clear_credential` stays the only removal
+path. The length cap is still measured on the raw value, so the bound an operator
+is told about does not move when their secret carries surrounding whitespace, and
+the header-safety guard still refuses a credential with an *interior* space —
+only an entirely blank one is "leave it alone".
+
 #### FR-6 — `message/send` only; no SSE; no fake `stream` parameter
 Filed AC4 (stream token chunks back to the calling agent over SSE) is
 **rejected**: an MCP tool call is one request and one response — a FastMCP

--- a/src/backend/services/a2a_outbound.py
+++ b/src/backend/services/a2a_outbound.py
@@ -349,9 +349,18 @@ def upsert_endpoint(
     regardless: a stored row is not trusted, a DNS record can move, and the
     settings row could be written by some future path that skips this function.
 
-    A credential is **write-only**: omitted leaves an existing one untouched
-    (so an operator can rename or repoint without re-typing a secret they may
-    not have), and `clear_credential=True` removes it.
+    A credential is **write-only**, and there are exactly THREE paths (#2175 F5b):
+    omitting it leaves an existing one untouched (so an operator can rename or
+    repoint without re-typing a secret they may not have), passing one sets it,
+    and `clear_credential=True` is the only way to remove it. **Every blank
+    spelling — `None`, `""`, `"   "` — means "leave it alone."** A whitespace-only
+    value used to be a fourth path that silently destroyed the stored secret: it
+    skipped the header-safety check (`if credential.strip() and …`) and then took
+    the `elif credential:` branch, because `"   "` is truthy, writing `""`. Not
+    reachable over HTTP — `A2AOutboundEndpointUpsert._validate_credential`
+    normalises a blank `SecretStr` to `None` — but this is a public module
+    function, and "blank clears the secret" is the wrong default for a value the
+    caller may hold no other copy of.
     """
     import uuid
 
@@ -384,6 +393,13 @@ def upsert_endpoint(
                 "Endpoint credential contains characters that are not valid in an "
                 "HTTP header (whitespace, line breaks or control characters)."
             )
+    # #2175 F5b: ONE normalisation, immediately after the checks above — every
+    # blank spelling collapses to None ("leave it alone") before either write
+    # path can see it. Done here rather than at each branch so a future third
+    # write site cannot reintroduce the fourth path. The length cap is still
+    # measured on the raw value, so the bound an operator is told about does not
+    # move when their secret has surrounding whitespace.
+    clean_credential = (credential or "").strip() or None
     try:
         validate_a2a_endpoint_url(clean_url)
     except A2AEndpointUrlError as exc:
@@ -397,8 +413,8 @@ def upsert_endpoint(
             record["url"] = clean_url
             if clear_credential:
                 record.pop("credential", None)
-            elif credential:
-                record["credential"] = credential.strip()
+            elif clean_credential:
+                record["credential"] = clean_credential
             _store_endpoint_records(records)
             return _public_record(record)
 
@@ -424,8 +440,8 @@ def upsert_endpoint(
         "name": clean_name,
         "url": clean_url,
     }
-    if credential and not clear_credential:
-        record["credential"] = credential.strip()
+    if clean_credential and not clear_credential:
+        record["credential"] = clean_credential
     records.append(record)
     _store_endpoint_records(records)
     return _public_record(record)

--- a/tests/unit/test_2175_blank_credential.py
+++ b/tests/unit/test_2175_blank_credential.py
@@ -1,0 +1,133 @@
+"""A blank credential leaves the stored secret alone — every spelling (#2175 F5b).
+
+`upsert_endpoint` documents three paths: omit (leave), set, `clear_credential`
+(remove). A whitespace-only value was a fourth: it skipped the header-safety
+check (`if credential.strip() and …`) and then took the `elif credential:` branch,
+because `"   "` is truthy, writing `""` — so `None` and `""` preserved the secret
+while `"   "` destroyed it.
+
+Not reachable over HTTP — `A2AOutboundEndpointUpsert._validate_credential`
+normalises a blank `SecretStr` to `None`, so the API surface is honest — which is
+what makes this a public-module-function defect rather than an API one, and why
+the test drives the function rather than the route. The value at stake is a
+partner secret the caller may hold no other copy of.
+
+True unit tests: no Docker, no backend. The store is a real encrypt/decrypt cycle
+over an in-memory `system_settings` stand-in, for the reason the sibling fixtures
+record — stubbing `CredentialEncryptionService` by string target passes alone and
+fails inside the full suite once `conftest.py` restores `sys.modules`.
+"""
+from __future__ import annotations
+
+import pytest
+
+PEER_URL = "https://peer.example.com/a2a"
+
+
+@pytest.fixture
+def store(monkeypatch):
+    import secrets
+
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", secrets.token_hex(32))
+
+    import database
+    from services import a2a_outbound
+
+    backing = {}
+    monkeypatch.setattr(database.db, "get_setting_value",
+                        lambda key, default=None: backing.get(key, default), raising=False)
+    monkeypatch.setattr(database.db, "set_setting",
+                        lambda key, value: backing.__setitem__(key, value), raising=False)
+    monkeypatch.setattr("utils.url_validation.validate_a2a_endpoint_url", lambda url: None)
+    a2a_outbound.clear_provider()
+    return a2a_outbound
+
+
+def _credential(store, name="partner"):
+    resolved = store.resolve_endpoint("bot", name)
+    return resolved.credential if resolved else None
+
+
+# --------------------------------------------------------------------------- #
+# The defect
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("blank", ["   ", "\t", "\n", " \t\n ", ""])
+def test_a_blank_credential_never_overwrites_a_stored_one(store, blank):
+    """`None` and `""` already preserved; `"   "` did not. All spellings now do."""
+    store.upsert_endpoint("partner", PEER_URL, "real-secret")
+    store.upsert_endpoint("partner", PEER_URL, blank)
+    assert _credential(store) == "real-secret", f"a blank {blank!r} destroyed the secret"
+
+
+def test_omitting_the_credential_still_preserves_it(store):
+    store.upsert_endpoint("partner", PEER_URL, "real-secret")
+    store.upsert_endpoint("partner", "https://peer.example.com/a2a/moved")
+    assert _credential(store) == "real-secret"
+    assert store.resolve_endpoint("bot", "partner").url.endswith("/moved")
+
+
+def test_clear_credential_remains_the_only_removal_path(store):
+    store.upsert_endpoint("partner", PEER_URL, "real-secret")
+    store.upsert_endpoint("partner", PEER_URL, "   ")
+    assert _credential(store) == "real-secret"
+
+    store.upsert_endpoint("partner", PEER_URL, clear_credential=True)
+    assert _credential(store) is None
+
+
+def test_a_blank_credential_on_creation_stores_no_credential(store):
+    """The create path takes the same normalisation: blank means "none given",
+    never an empty-string credential that `has_credentials` then reports False
+    for while the key exists."""
+    record = store.upsert_endpoint("partner", PEER_URL, "   ")
+    assert record["has_credentials"] is False
+    assert _credential(store) is None
+    stored = store._load_endpoint_records()[0]
+    assert "credential" not in stored, "a blank credential was persisted as a key"
+
+
+# --------------------------------------------------------------------------- #
+# ...without disturbing a real one
+# --------------------------------------------------------------------------- #
+def test_a_real_credential_is_still_set_and_stripped(store):
+    store.upsert_endpoint("partner", PEER_URL, "  real-secret  ")
+    assert _credential(store) == "real-secret"
+
+
+def test_a_real_credential_still_replaces_an_existing_one(store):
+    store.upsert_endpoint("partner", PEER_URL, "old-secret")
+    store.upsert_endpoint("partner", PEER_URL, "new-secret")
+    assert _credential(store) == "new-secret"
+
+
+def test_clear_credential_wins_over_a_supplied_one(store):
+    """Unchanged precedence: `clear_credential` is checked first on both paths."""
+    store.upsert_endpoint("partner", PEER_URL, "old-secret")
+    store.upsert_endpoint("partner", PEER_URL, "new-secret", clear_credential=True)
+    assert _credential(store) is None
+
+
+def test_the_header_safety_check_still_refuses_an_unsafe_credential(store):
+    """The guard the blank case used to skip past. A credential with an interior
+    space is still refused — only an ENTIRELY blank one is now "leave it alone"."""
+    with pytest.raises(store.EndpointValidationError):
+        store.upsert_endpoint("partner", PEER_URL, "has a space")
+    with pytest.raises(store.EndpointValidationError):
+        store.upsert_endpoint("partner", PEER_URL, "line\nbreak")
+
+
+def test_the_length_cap_is_still_measured_on_the_raw_value(store):
+    """The bound an operator is told about must not move because their secret has
+    surrounding whitespace."""
+    too_long = " " * 10 + "x" * store.MAX_ENDPOINT_CREDENTIAL_LEN
+    with pytest.raises(store.EndpointValidationError) as exc:
+        store.upsert_endpoint("partner", PEER_URL, too_long)
+    assert "too long" in str(exc.value)
+
+
+def test_a_blank_credential_never_reaches_the_wire_as_an_empty_bearer(store):
+    """The end the defect is measured at: an endpoint that looks credentialed but
+    resolves to `""` would send `Authorization: Bearer ` with nothing after it."""
+    store.upsert_endpoint("partner", PEER_URL, "   ")
+    resolved = store.resolve_endpoint("bot", "partner")
+    assert resolved.credential is None, "an empty-string credential survived to the caller"

--- a/tests/unit/test_736_a2a_outbound_edges.py
+++ b/tests/unit/test_736_a2a_outbound_edges.py
@@ -881,20 +881,8 @@ def test_G4_a_blank_credential_never_overwrites_a_stored_one(store, credential):
     assert store.resolve_endpoint("bot", "partner").credential is None
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "BUG (finding F5b): a WHITESPACE-ONLY credential is the one blank "
-        "spelling that destroys the stored secret. `upsert_endpoint` skips the "
-        "header-safety check on it (`if credential.strip() and …`) but then takes "
-        "the `elif credential:` branch, because '   ' is truthy, and writes "
-        "`''`. So `None` and `''` preserve, `'   '` silently clears — a fourth "
-        "path through a model the docstring describes as three (omit / set / "
-        "clear_credential). Not reachable over HTTP (the request model normalises "
-        "blank to None), so this is a public-module-function defect, not an API "
-        "one. Tracked as ent#396. See /edge-cases report 2026-08-13."
-    ),
-)
+# Fixed by #2175 F5b: every blank credential spelling now collapses to None in a
+# single normalisation, so this is a live regression test rather than an xfail.
 def test_G4_a_whitespace_only_credential_does_not_silently_clear_the_stored_one(store):
     store.upsert_endpoint("partner", PEER_URL, "real-secret")
     store.upsert_endpoint("partner", PEER_URL, "   ")


### PR DESCRIPTION
Closes the last open item of #2175. **F1, F2 and F3 are already fixed** — each was filed on
the enterprise tracker and has its own PR:

| Finding | Issue | PR |
|---|---|---|
| F1 — IPv6 literal origins compared textually | ent#399 | #2181 |
| F2 — port `:0` normalised three ways | ent#398 | #2180 |
| F3 — reason derived by substring-matching prose | ent#397 | #2182 |
| **F5b — whitespace-only credential clears the secret** | — | **this PR** |

## What this fixes

`upsert_endpoint` documents three credential paths: omit (leave), set,
`clear_credential` (remove). A whitespace-only value was a fourth — it skipped the
header-safety check (`if credential.strip() and …`) and then took the `elif credential:`
branch, because `"   "` is truthy, writing `""`:

```
update with None     -> PRESERVED
update with ""       -> PRESERVED
update with "   "    -> DESTROYED
update with "\t"     -> DESTROYED
```

Not reachable over HTTP (`A2AOutboundEndpointUpsert._validate_credential` normalises a blank
`SecretStr` to `None`, so the API surface is honest) — which is what makes it a
public-module-function defect. The value at stake is a partner secret the caller may hold no
other copy of, and "blank clears it" is the wrong default for that.

## Change

One normalisation — `clean_credential = (credential or "").strip() or None` — applied after
the validity checks and before **either** write path, so a future third write site cannot
reintroduce the fourth path.

Deliberately unchanged:
- `clear_credential` remains the only removal path;
- the **length cap is still measured on the raw value**, so the bound an operator is told
  about does not move when their secret carries surrounding whitespace;
- the header-safety guard still refuses a credential with an *interior* space — only an
  entirely blank one means "leave it alone".

## Verification on real code

```
[dev]      "   " -> DESTROYED (now None)    "\t" -> DESTROYED
[branch]   "   " -> PRESERVED               "\t" -> PRESERVED
           None and "" preserved on both
```

## Tests

`tests/unit/test_2175_blank_credential.py` — 14 cases: every blank spelling, omission, the
create path storing no `credential` key at all (rather than an empty string
`has_credentials` then reports False for), a real credential still set / replaced / stripped,
`clear_credential` precedence, the header-safety guard, the raw length cap, and that no
empty-string credential can reach the caller as an empty `Authorization: Bearer ` header.

Green: 14 new, 264 across the A2A suites.

## Note on the xfail marker

The AC asks for `test_G4_a_whitespace_only_credential_does_not_silently_clear_the_stored_one`
to be retired. That test is in `tests/unit/test_736_a2a_outbound_edges.py`, which is **not on
`dev`** — it arrives with PR #2178, where G4 is the strict-xfail. It must be un-xfailed when
#2178 lands (alongside G7, D7, E6 and D12, all now fixed); this file holds the property on
`dev` meanwhile. Flagged on #2178.

Closes #2175

> Closing keyword added at merge time: F1 (#2181), F2 (#2180) and F3 (#2182) have all
> landed, so this PR is the last of the four findings and #2175 is fully resolved.
> A bare `Related to` would have left it stranded in `status-in-progress` —
> `issue-status-on-merge.yml` promotes only on `Fixes`/`Closes`/`Resolves` + `#N`.
