### PR TITLE
fix(analytics): give room turns their own bucket; keep them out of the alert set (ent#220)

### DIFF
--- a/src/backend/db/schedules/analytics.py
+++ b/src/backend/db/schedules/analytics.py
@@ -41,6 +41,13 @@ _TRIGGER_BUCKETS = {
     "schedule": "Scheduled", "webhook": "Scheduled",
     "loop": "Loops",  # #1150: first-class bucket so loop bursts don't read as cron load
     "reminder": "Reminders",  # #1296: agent self-direction, not operator cron
+    # ent#220: a room turn is an agent woken by an @mention in a shared room.
+    # It was unmapped, so every one landed in `Other` — the catch-all that is
+    # supposed to mean "a trigger nobody has classified yet", quietly turned
+    # into "rooms". A first-class bucket for the same reason Loops and
+    # Reminders got one: room traffic is a distinct spend shape (one human
+    # message can bill N agent turns) and reading it as unclassified hides that.
+    "room": "Rooms",
     "agent": "Agent-to-agent", "fan_out": "Agent-to-agent",
     "self_task": "Agent-to-agent", "a2a": "Agent-to-agent",  # ent#157 inbound A2A tasks
     "voip": "Voice", "voice": "Voice",
@@ -50,7 +57,7 @@ _TRIGGER_BUCKETS = {
 # Stack / legend order; "Other" last so unmapped triggers are visible.
 _BUCKET_ORDER = [
     "Chat/Tasks", "MCP", "Channels", "Public",
-    "Scheduled", "Loops", "Reminders", "Agent-to-agent", "Voice", "Other",
+    "Scheduled", "Loops", "Reminders", "Rooms", "Agent-to-agent", "Voice", "Other",
 ]
 
 

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -265,6 +265,17 @@ _AUTONOMOUS_TRIGGERS = frozenset(
     # install is reading the reply. The interactive-ish triggers deliberately
     # left out (`manual`, `mcp`, `public`, `chat`, `session`) all have a human
     # looking at the "Unknown command" text as it comes back.
+    #
+    # `room` (ent#169/#220) is deliberately NOT here, and the reason is worth
+    # keeping because the absence reads like an oversight. A room turn's reply
+    # — including its failure line — is posted straight into the room's
+    # transcript, which is a durable, client-facing surface someone is looking
+    # at. It is the `chat`/`public` case, not the `schedule` case: the text is
+    # already where the reader is. Adding it would ALSO route an external
+    # Workspace client's typo into the operator queue, one alert per unresolved
+    # command, on the one trigger an untrusted participant can drive — operator
+    # fatigue by design (the #1632 concern), for a message the room already
+    # shows.
     {"schedule", "webhook", "loop", "event", "fan_out", "agent", "reminder", "a2a"}
 )
 

--- a/tests/unit/test_ent220_room_trigger_bucket.py
+++ b/tests/unit/test_ent220_room_trigger_bucket.py
@@ -1,0 +1,102 @@
+"""`room` gets a first-class analytics bucket; it stays out of the alert set (ent#220).
+
+Two cross-repo residuals from the ent#169 review, decided in opposite directions
+because they answer different questions:
+
+* **`_TRIGGER_BUCKETS`** — a room turn was unmapped, so every one landed in
+  `Other`. That bucket means "a trigger nobody has classified yet"; letting the
+  Workspace's whole traffic live there quietly redefines it as "rooms", and hides
+  a distinct spend shape (one human message can bill N agent turns). Fixed —
+  `Rooms`, the same treatment `loop` (#1150) and `reminder` (#1296) got.
+
+* **`_AUTONOMOUS_TRIGGERS`** — deliberately NOT added, which is the part that
+  needs a test, since an absence looks like an oversight. That set means "no
+  human will see the reply, so an unresolved slash command earns an Operating
+  Room alert". A room turn's reply lands in the room's own transcript, where the
+  reader already is; and `room` is the one trigger an untrusted external
+  Workspace client can drive, so adding it would turn a client's typo into an
+  operator alert.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("REDIS_URL", "redis://test:test@redis:6379")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+os.environ.setdefault("REDIS_BACKEND_PASSWORD", "test")
+os.environ.setdefault("AGENT_AUTH_SECRET", "0" * 64)
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("INTERNAL_API_SECRET", "y" * 32)
+os.environ.setdefault("TRINITY_DB_PATH", str(Path(tempfile.gettempdir()) / "trinity-ent220.db"))
+os.environ.setdefault("LOG_ARCHIVE_PATH", str(Path(tempfile.gettempdir()) / "trinity-ent220-logs"))
+
+import pytest
+
+from db.schedules.analytics import _BUCKET_ORDER, _TRIGGER_BUCKETS, _bucket_for_trigger
+
+pytestmark = pytest.mark.unit
+
+
+def test_a_room_turn_is_bucketed_as_rooms_not_other():
+    assert _bucket_for_trigger("room") == "Rooms"
+    assert _TRIGGER_BUCKETS["room"] == "Rooms"
+
+
+def test_rooms_is_in_the_stack_order_before_the_catch_all():
+    """A bucket missing from the order sorts after everything real (the map's
+    own fallback), which would put Rooms past `Other` — the position reserved
+    for "unclassified"."""
+    assert "Rooms" in _BUCKET_ORDER
+    assert _BUCKET_ORDER.index("Rooms") < _BUCKET_ORDER.index("Other")
+    assert _BUCKET_ORDER[-1] == "Other"
+
+
+def test_other_still_means_unclassified():
+    """The bucket this change reclaims: `Other` must go back to meaning a
+    trigger nobody has mapped yet."""
+    assert _bucket_for_trigger("some_future_trigger") == "Other"
+    assert _bucket_for_trigger(None) == "Other"
+    assert _bucket_for_trigger("") == "Other"
+
+
+def test_every_mapped_bucket_has_a_place_in_the_order():
+    """The invariant that makes the chart and its legend agree — a bucket in the
+    map but not the order renders in a different position everywhere it is
+    drawn (the #1107 lesson `_fold_trigger_buckets` records)."""
+    missing = sorted(set(_TRIGGER_BUCKETS.values()) - set(_BUCKET_ORDER))
+    assert missing == [], f"buckets with no stack position: {missing}"
+
+
+def test_room_is_not_an_autonomous_trigger():
+    """Decided, not overlooked. A room turn's reply — and its failure line — is
+    posted into the transcript the reader is already watching, so it is the
+    `chat`/`public` case. `room` is also the one trigger an untrusted external
+    Workspace client can drive: alerting on it would route a client's typo into
+    the operator queue, one per unresolved command."""
+    from services.task_execution_service import _AUTONOMOUS_TRIGGERS
+
+    assert "room" not in _AUTONOMOUS_TRIGGERS
+    # The interactive-ish set it belongs with, spelled out so a future edit that
+    # adds `room` has to explain why it disagrees with these.
+    for interactive in ("chat", "public", "manual", "mcp", "session"):
+        assert interactive not in _AUTONOMOUS_TRIGGERS
+
+
+def test_the_alerting_set_still_holds_the_unwatched_triggers():
+    """The other half: this change must not quietly drop anything FROM the set."""
+    from services.task_execution_service import _AUTONOMOUS_TRIGGERS
+
+    for unwatched in ("schedule", "webhook", "loop", "event", "fan_out",
+                      "agent", "reminder", "a2a"):
+        assert unwatched in _AUTONOMOUS_TRIGGERS
+
+
+def test_room_is_a_recognised_execution_filter():
+    """The third place a trigger name has to be listed — the executions filter
+    allow-list, where an unknown value degrades to "no filter" and silently
+    returns everything."""
+    from routers.executions import _VALID_TRIGGERS
+
+    assert "room" in _VALID_TRIGGERS


### PR DESCRIPTION
The OSS half of trinity-enterprise#220's cross-repo residuals. The enterprise half (chain
shielding + perf/atomicity) is trinity-enterprise#401.

Two residuals from the ent#169 review, decided in **opposite directions**, because they answer
different questions.

## `_TRIGGER_BUCKETS` — fixed

`room` was unmapped, so every room turn landed in `Other`. That bucket means *"a trigger nobody
has classified yet"*; letting the Workspace's entire traffic live there quietly redefines it as
"rooms", and hides a distinct spend shape — one human message can bill N agent turns.

Now a first-class `Rooms` bucket, placed in `_BUCKET_ORDER` before the catch-all — the same
treatment `loop` (#1150) and `reminder` (#1296) each got, for the same reason.

## `_AUTONOMOUS_TRIGGERS` — deliberately NOT changed

That set means *"no human will see the reply, so an unresolved slash command earns an Operating
Room alert"*. `room` does not belong in it:

- a room turn's reply — **including its failure line** — is posted into the room's own
  transcript, a durable client-facing surface the reader is already looking at. It is the
  `chat`/`public` case, not the `schedule` case;
- `room` is the one trigger an **untrusted external Workspace client** can drive. Alerting on it
  would route a client's typo into the operator queue, one alert per unresolved command —
  operator fatigue by construction (#1632's concern) for a message the room already shows.

The reasoning is now in the code next to the set, because the absence otherwise reads as an
oversight — which is exactly how it got filed as a residual.

## Tests

`tests/unit/test_ent220_room_trigger_bucket.py` — the bucket and its position before `Other`,
`Other` going back to meaning *unclassified*, every mapped bucket having a stack position (the
#1107 invariant that keeps a chart and its legend in agreement), and **both directions** of the
alert-set decision, including that nothing was silently dropped from it.

201 passed / 0 failed across the analytics, trigger-bucket and rooms suites.

## Note for the grid tiles (ent#96 / epic ent#94)

`Rooms` reaches the executions tile and the #1107 Overview chart through the backend-served
`trigger_order`, so neither needs a frontend change. It renders with the catch-all colour until
a `--gv-bk-rooms` token is added — I'll fold that into #2184 rather than here, since that PR
owns the tile's token map.

Related to trinity-enterprise#220
