### PR TITLE
fix(workspace): roster shows container availability honestly — never hides an agent (#2196)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -155,7 +155,7 @@
 **Services (`services/`)** — 67 service modules:
 
 *Core:*
-- `docker_service.py` - Docker container management (single point of Docker interaction, Invariant #11)
+- `docker_service.py` - Docker container management (single point of Docker interaction, Invariant #11). Also owns the **tri-state** container-state pair `agent_container_states()` (batch, one `sparse=True` `containers.list()`) / `agent_container_state(name)` (single) added by #2196: `None` means *Docker could not be asked*, distinct from `{}` / `"missing"` meaning *Docker answered: no container*. Every older helper collapses those two into one falsy value, which is why a naive "drop agents with no container" reconcile empties a customer's roster on any Docker fault. `sparse=True` is load-bearing and constrains the code: the SDK default full-inspects **every** container, and under sparse `.name` returns `None` while `.labels` raises — so the key comes from `attrs["Names"][0]` and the status is classified **explicitly** to `running`/`stopped` rather than reusing `list_all_agents_fast`'s raw-status fall-through (which would pass `paused`/`removing` through to a consumer's `Literal`). `list_all_agents_fast`'s `[]`-on-fault contract is unchanged.
 - `docker_utils.py` - Docker utility helpers
 - `template_service.py` - GitHub template cloning and processing; owns the tolerant `credentials:` readers (`credential_shape_errors` / `credential_mcp_server_names` / `credential_env_file_names` / `credential_mcp_env_vars` / `declared_credential_names`) — read paths degrade + surface `credential_errors`, the `.env` writer raises `CredentialDeclarationError` → 400 (ent#128) — see [template-processing.md](feature-flows/template-processing.md). **ent#89:** both builders also surface the declared `schedules:` (normalized) + `schedule_errors` via `services/template_schedules.py`, the same tolerant-reader shape; **both GitHub catalog list paths are now fenced** per-template (`_safe_build_github_template`) — they were bare list comprehensions, so a raise in the untrusted GitHub builder 500'd the whole GitHub half of `GET /api/templates` (ent#128 PR-A fenced only the local path). `fetch_template_metadata_for_create(repo, pat, ref)` is the **creation-path** metadata read: resolved PAT + parsed ref, cache-bypassed, loud on any failure — the catalog cache uses the global platform PAT off the default branch and would silently return `{}` for a private repo read with a per-user token. **ent#14:** the GitHub half of the catalog resolves **admin override → remote registry (`template_registry_service`) → `DEFAULT_GITHUB_TEMPLATE_REPOS`** in **both** `get_all_templates()` and `get_github_template()` (the second feeds `GET /api/templates/{id}` *and* agent creation, so one ladder or the display fields diverge by surface); registry entries arrive as `admin_override` dicts and are fenced so any failure degrades to the bundled floor. The per-repo fetch *reason* is now cached beside the metadata and surfaced as `metadata_unavailable`, because "declares no `template.yaml`" and "could not read it" were the same value — and `fork_to_own: required` silently read as absent under a rate limit. `fetch_template_metadata_result_for_create` is the reason-preserving form of the creation read (the plain wrapper drops the reason, which is fine for schedules and wrong for a security gate): the `fork_to_own` gate decides from IT, not from `gh_template`, because the catalog read answers 404 for a private repo the platform PAT cannot see and would classify a `required` template as absent
 - "credential declaration standard" (ent#128): `credentials:` is FROZEN names-only; the sibling `credential_setup:` enriches it per variable and `normalize_credential_requirements(data, *, source_trust)` emits base-set-plus-overlay records as `credential_requirements` (never raises, never mutates — `_build_template` runs unfenced in `get_all_templates()`). Contract: [docs/schemas/trinity-agent-credentials.schema.json](../schemas/trinity-agent-credentials.schema.json)
@@ -1307,6 +1307,22 @@ through `client_portal/portal_auth.py::get_portal_principal`, which returns
 `(email, is_platform)`; the roster is every agent shared with that email, plus — for a
 platform session only — the agents they own.
 
+**Membership is a DB fact; container state is a projection onto the card (#2196).** The
+roster is built from `agent_ownership` / `agent_sharing` and is **never** filtered by
+whether a container exists. A live ownership row with no container is a routine state
+(#1747: identity lives in the row, and #834 Phase 1c recovery, a `docker system prune`
+or a crash mid-create all reach it), so hiding those rows would make "not shared with
+me" indistinguishable from "shared but containerless" on the one surface a client has.
+Filtering is also the dangerous direction at scale: every Docker read in the platform
+collapses *no container* and *Docker could not be asked* into one falsy value
+(`list_all_agents_fast` returns `[]` on any fault), so one daemon restart or one
+`DOCKER_GID` change would tell every paying customer they have no agents. Instead each
+card carries `availability` (`ready`/`stopped`/`unavailable`/`unknown`), resolved once
+per roster load in `get_roster` — **not** in `_roster_rows`, which stays pure SQL so
+#2198's batch-sessions gate does not inherit a Docker read, and **not** inside
+`_agent_briefing`, so #2163 stays free to defer/bound/cache the briefing. Invariant #11
+is untouched: every Docker read still happens inside `docker_service.py`.
+
 It was an entitled module and returned 404 in community builds; ent#356 moved it into
 OSS core (adoption: this is the main surface a non-operator uses to work with agents).
 The `/api/enterprise/client-portal` prefix and the `enterprise_portal_sessions` /
@@ -1406,6 +1422,28 @@ containment** — a portal token legitimately reaches the room endpoints where t
 and the real boundary is the serving module's own roster-scoped access plus
 membership-scoped uniform 404s. Room data is untouched by the flag and reappears intact
 if the capability returns.
+
+**`availability` is the second per-agent field on this channel, and it fails in the
+OPPOSITE direction (#2196).** `voice_available` and `multi_agent_chat_available` default
+**False** (fail-closed) because their bug is *promising an affordance that cannot work*.
+`availability` defaults **`"unknown"`** (fail-open) because its bug is the mirror image:
+*denying a working agent*, and — since a Docker fault would mark every card at once —
+*emptying a paying customer's roster over an infrastructure fault*. Same payload channel,
+opposite default, for a stated reason; the asymmetry is deliberate and is written into
+`PortalAgentCard` itself so it is not later "tidied" into consistency. It is resolved from
+the tri-state pair `docker_service.agent_container_states()` (batch, one **sparse**
+`containers.list()` per roster load) / `agent_container_state(name)` (single, for the
+agent page and each turn — routing one agent through the batch would make it pay a
+fleet-scale read, against #2160). Those two exist because no pre-existing Docker helper
+can distinguish *no container* from *Docker unreadable*: both return a falsy value, which
+is the single fact this design turns on. Both are awaited through a `docker_utils`
+executor wrapper (that module's mandatory async contract), and `list_all_agents_fast`'s
+`[]`-on-fault contract is deliberately left unchanged — ~60 stub sites depend on it. The
+portal seams `_availability_map` / `_agent_availability` are isinstance/enum-guarded (the
+`a2a_outbound` precedent, here failing in the safe direction) so a `sys.modules` MagicMock
+stub degrades to `unknown` rather than silently inverting the default inside the suite
+meant to prove it; `_availability_map` also narrows its result to the requested names,
+because the underlying call sees **every** agent container on the host.
 
 ### Enterprise Modules (#847)
 

--- a/docs/memory/feature-flows/async-docker-operations.md
+++ b/docs/memory/feature-flows/async-docker-operations.md
@@ -76,6 +76,26 @@ async def container_stop(container, timeout: int = 10) -> None:
 | `container_exec_run(container, cmd, user, workdir, environment)` | Execute command in container | 100ms-30s | 0s event loop block |
 | `api_exec_create(container_id, cmd, stdin, tty, ...)` | Create exec instance | 50-200ms | 0s event loop block |
 | `api_exec_start(exec_id, socket, tty)` | Start exec instance | 50-200ms | 0s event loop block |
+| `agent_container_states_async()` | Coarse state of EVERY agent container, one sparse list (#2196) | 50-200ms | 0s event loop block |
+| `agent_container_state_async(name)` | Coarse state of ONE agent (#2196) | 50-200ms | 0s event loop block |
+
+The two #2196 wrappers differ from every other entry above in one respect worth
+stating, because it constrains how they may be edited: their leaf is imported
+**inside the function body**, not at module scope. `client_portal` and its tests
+patch `sys.modules["services.docker_service"]`, and only the
+`from x import y` form resolves through `sys.modules` at call time — an
+`import x.y as m` alias binds the package attribute, which conftest's #762
+restore can leave pointing at a different object. Hoisting either import to the
+top of the module would silently disconnect that patch route, and a missed patch
+does not error: the real Docker read runs and the test fails on product
+behaviour.
+
+Their tri-state semantics are the leaf's (`docker_service.agent_container_states`
+/ `agent_container_state`): a value means Docker answered, `None` means it could
+not be asked. That distinction is the whole point — see
+[docker-socket-gid-detection.md](docker-socket-gid-detection.md) for the class of
+fault that makes "no container" and "cannot reach the daemon" indistinguishable
+everywhere else.
 
 ---
 
@@ -473,3 +493,4 @@ Container listing operations in `docker_service.py` are fast (<50ms) and do not 
 |------|---------|
 | 2026-02-24 | Initial implementation per DOCKER-001 requirements |
 | 2026-02-24 | Added exec wrappers (`container_exec_run`, `api_exec_create`, `api_exec_start`), expanded to SSH/Git/Terminal services (12 files total) |
+| 2026-08-15 | #2196: added `agent_container_states_async` / `agent_container_state_async` — the async form of the tri-state container-state reads the Workspace roster projects onto its cards |

--- a/docs/memory/feature-flows/docker-socket-gid-detection.md
+++ b/docs/memory/feature-flows/docker-socket-gid-detection.md
@@ -133,3 +133,11 @@ under a race is harmless. Still degrades to `[]` (never raises).
   the same Docker SDK surface
 - [container-capabilities.md](container-capabilities.md) — non-root container
   capability baseline
+- [workspace-agent-page.md](workspace-agent-page.md) — the first surface to
+  distinguish *this fault* from "the agent has no container" (#2196). Every older
+  Docker helper collapses the two into one falsy value (`list_all_agents_fast`
+  → `[]`, `get_agent_container` → `None`), which is exactly why a wrong GID here
+  reads downstream as "you have no agents" rather than as an infrastructure
+  fault. `docker_service.agent_container_states()` /
+  `agent_container_state(name)` return `None` for *unreadable* and a real answer
+  otherwise, so a consumer can render the difference

--- a/docs/memory/feature-flows/workspace-absorbs-session.md
+++ b/docs/memory/feature-flows/workspace-absorbs-session.md
@@ -179,6 +179,19 @@ synchronous send on any streaming failure — an older backend, a buffering prox
 a stopped agent — because streaming is an improvement to how a turn is *watched*,
 never a new way for one to fail.
 
+**That fallback is why `portal_chat`'s missing liveness gate mattered (#2196).**
+`start_portal_turn` refuses a turn the agent cannot run before creating anything;
+`portal_chat` had no such gate at all, and its 502 sits at the far end — *after*
+`_persist_user_turn`, which ent#286 deliberately moved earlier so a refresh
+mid-turn shows what was sent. Against a containerless agent the two decisions
+combined to leave a durable user message with no reply in the client's thread,
+plus an execution row. Since the browser reaches this path on any streaming
+failure, it was not a headless-only concern. `portal_chat` now gates on the same
+resolved availability, placed after the roster check (so a state-dependent
+refusal cannot become an existence oracle) and before `_resolve_session_id` (so a
+refused turn does not even open a thread). `start_portal_turn` passes the state
+it already resolved, so a streamed turn still costs one Docker read.
+
 **Reading a stream requires all three:** the agent on the caller's roster, the
 execution belonging to that agent, and the execution having been started by that
 caller (`source_user_email`). The third is the one that matters — executions are

--- a/docs/memory/feature-flows/workspace-agent-page.md
+++ b/docs/memory/feature-flows/workspace-agent-page.md
@@ -72,6 +72,18 @@ Health reports `unknown`, never `unhealthy`, when nothing has ever checked the
 agent. Monitoring is default-OFF (#1121), so on many installs that is every
 agent, and "unhealthy" there would be a lie about the whole fleet.
 
+**#2196 adds `header.availability` beside it — a second, independent fact, not a
+second health source.** It is a *projection of the roster card* (`get_agent_card`
+resolves it once, `build_page` copies it), never a second Docker read of its own.
+The two are rendered as two labelled facts because their freshness differs by
+construction: `health` is the last persisted `agent_health_checks` row and is
+stale by design, while `availability` is read at request time. Overloading the
+health dot would leave the viewer unable to tell which of the two they were
+looking at. `build_page` writes `card.get("availability") or "unknown"` — the
+bare `.get` is a 500, because `card` is documented-reachable as `None` (the agent
+vanished between the roster read and the page read) and an explicit `None` fails
+the `Literal`.
+
 ## The two AC #3 metrics
 
 **First-try rate** is real: successes with `retry_count` 0 over the window

--- a/docs/memory/feature-flows/workspace-composer-typeahead.md
+++ b/docs/memory/feature-flows/workspace-composer-typeahead.md
@@ -346,7 +346,12 @@ node src/frontend/scripts/scan-raw-colors.mjs src/frontend
   everything); agent names also accept a substring, because they are short
   identifiers that frequently share a deployment prefix.
 * The empty line cannot distinguish "no playbooks configured" from "the agent was
-  stopped when the roster was built", so it deliberately says neither.
+  stopped when the roster was built", so it deliberately says neither. **#2196
+  makes the underlying fact available** — each roster card now carries
+  `availability`, so the distinction is resolvable at this seam; wiring it into
+  the empty line (and annotating an `@`-candidate row with its state) is PR 2 of
+  that issue. Note the rule it must follow: **annotate, never filter** — an
+  unavailable agent stays mentionable, exactly as it stays on the roster.
 * The room `@` list is scoped to current participants — the names a pick is known
   to wake. If the engine's ent#361 newcomer-join path does recruit on a
   non-participant mention (not established here; see above), this list is

--- a/docs/memory/feature-flows/workspace-sidebar-ia.md
+++ b/docs/memory/feature-flows/workspace-sidebar-ia.md
@@ -84,6 +84,28 @@ A room credits its unread to **every** agent in it — there is no single agent 
 room is "with", so if three agents share a room you are behind on, all three
 rows should say so. (Rooms report 0 today; see Known Limitations.)
 
+### 3b. Availability on the agent row (#2196)
+
+Each roster card carries `availability` (`ready`/`stopped`/`unavailable`/
+`unknown`). The row renders a chip for the two non-ready states via the pure
+`portalUtils.availabilityChip()` — one rule, shared with the agent page and (in
+PR 2) the picker and the `@`-typeahead, so four surfaces cannot drift on it.
+
+Three decisions worth keeping:
+
+* **Label, do not disable.** Disabling the row would relocate the dead state
+  rather than remove it: a client whose agents are all *stopped* — a routine
+  resource-saving posture — would get an entirely inert Workspace. The chip sets
+  the expectation and the server's 502 stays the honest refusal.
+* **No re-sorting.** Ordering by availability would make rows jump as agents
+  start and stop; the design system's layout-stability rule forbids that, and the
+  top-5 fold is #2159's design.
+* **Reserve the chip's footprint**, so a row does not reflow when an agent's
+  state changes between refreshes.
+
+`agentRowTitle()` carries the same reason in the row's `title`, so the state is
+reachable without relying on colour.
+
 ### 4. Starred chats are lifted, not copied
 
 `partitionStarred()` splits the list before `groupThreadsByDate()` ever sees it,

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -370,6 +370,25 @@
   - Agents block renders **first**, on its own surface (card + ring); each row
     carries avatar, name, description, and a count badge when that agent has
     replies the viewer has not read
+  - **A row may also carry an availability state (#2196).** Roster membership is
+    a DB fact (`agent_ownership` / `agent_sharing`); whether the agent's
+    container currently exists and runs is a Docker fact **projected onto** the
+    card as `availability` — `ready` | `stopped` | `unavailable` | `unknown` —
+    and is **never** a membership filter. `stopped` and `unavailable` render a
+    chip explaining the state and naming the next action ("ask *{owner}* to
+    start it"); `ready` and `unknown` render as before. Nothing is hidden and no
+    control is disabled: a client whose agents are all stopped must still get a
+    Workspace they can read, star and search. The field's footprint is reserved
+    so a row does not reflow as an agent starts or stops, and the roster is not
+    re-sorted by it (rows would jump)
+  - **`unknown` is the fail-open default, deliberately inverted** from the other
+    roster capability bits (`voice_available`, `multi_agent_chat_available`),
+    which fail closed. Those bits' bug is *promising an affordance that cannot
+    work*; this field's bug is *denying a working agent* — and at scale
+    *emptying a paying customer's roster over an infrastructure fault*, since
+    every Docker read in the platform collapses "no container" and "Docker could
+    not be asked" into the same falsy value. When Docker is unreadable every
+    card reads `unknown` and the roster renders exactly as it does today
   - The aggregate "waiting on you" count sits on the **wordmark**, since the
     agents block now occupies the top of a scrolling region
   - Starred chats are **lifted out of** the date groups, not copied above them —
@@ -476,9 +495,27 @@
     an image avatar with light edges does not bleed into the surface behind it.
     One shared component, fourteen call sites; `box-sizing: border-box` keeps
     every outer footprint unchanged
-  - Everything DB-sourced, so a **stopped** agent renders degraded, not empty:
-    health `unknown` (monitoring is default-OFF, so "unhealthy" would be a lie),
-    empty sections, and a failing data source degrades that section only
+  - Everything DB-sourced, so an agent that cannot currently run renders
+    degraded, not empty: health `unknown` (monitoring is default-OFF, so
+    "unhealthy" would be a lie), empty sections, and a failing data source
+    degrades that section only
+  - **The two non-running states are distinct and both render (#2196)**: (a) a
+    **stopped** agent — container exists, not running — and (b) an agent with
+    **no container at all**, which #1747 documents as a *routine* state (an
+    agent's identity lives in `agent_ownership`, not Docker; #834 Phase 1c
+    recovery reaches it by design, as does a `docker system prune` or a crash
+    mid-create). Neither is hidden from the roster or the page. The decision
+    recorded for #2196's AC #2: **the ownership row is authoritative for
+    membership; container state is projected onto the card**. The header renders
+    availability as its **own labelled fact beside health**, never folded into
+    the health dot — health is the last persisted `agent_health_checks` row and
+    is stale by design, availability is a live read, and one widget carrying two
+    freshness semantics tells the viewer neither
+  - This is also why the Workspace roster and `GET /api/agents` legitimately
+    disagree (#2196 AC #4): the fleet list iterates Docker and so omits these
+    agents entirely, while the roster lists them and says why. Making the two
+    agree literally would require rewriting `/api/agents`, which #1747 argues
+    against; the difference is documented rather than papered over
   - Endpoints: `GET /agents/{name}/page?window=`, `.../reports`,
     `.../reports/{id}` (optional `rows_offset`/`rows_limit` window a tabular payload,
     #2162 — two query params on the existing route, not a second route) under the

--- a/src/backend/client_portal/agent_page.py
+++ b/src/backend/client_portal/agent_page.py
@@ -283,6 +283,14 @@ def build_page(email: str, agent_name: str, card: Optional[dict],
             "avatar_url": card.get("avatar_url"),
             "owner": card.get("owner"),
             "health": _health(agent_name),
+            # #2196: a projection of the card the caller already resolved, NOT a
+            # second Docker read — and `or "unknown"`, never a bare `.get`.
+            # `card` is documented-reachable as None (the agent vanished between
+            # the roster read and this one), which `card = card or {}` above
+            # turns into an explicit None here; a Literal-with-default REJECTS
+            # an explicit None, so the bare form would 500 the one page ent#360
+            # built to always render.
+            "availability": card.get("availability") or "unknown",
             "last_active": _last_active(agent_name),
         },
         # "What it can do" — a projection of the briefing the roster already

--- a/src/backend/client_portal/models.py
+++ b/src/backend/client_portal/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for the enterprise client-portal exposure config (#79)."""
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -56,6 +56,27 @@ class PortalAgentCard(BaseModel):
     # exposed-playbook tier, else the template `use_cases` fallback.
     description: Optional[str] = None
     playbooks: list[PortalPlaybook] = Field(default_factory=list)
+    # #2196 — whether this agent can currently run. Roster MEMBERSHIP is a DB
+    # fact (`agent_ownership` / `agent_sharing`); this is a Docker fact
+    # PROJECTED onto the card, and is never a membership filter. A live
+    # ownership row with no container is routine (#1747), so hiding those rows
+    # would make "not shared with me" indistinguishable from "shared but
+    # containerless" on the one surface a client has.
+    #
+    #   ready       container exists and runs        (renders as today)
+    #   stopped     container exists, not running    (chip)
+    #   unavailable no container at all — #2196      (chip)
+    #   unknown     Docker could not be asked        (renders as today)
+    #
+    # ⚠️ The default is fail-OPEN, which is the OPPOSITE of `voice_available`
+    # above and `PortalRoster.multi_agent_chat_available` below, and that
+    # inversion is deliberate — do not "tidy" it into consistency. Those bits
+    # fail closed because their bug is promising an affordance that cannot work.
+    # This one's bug is the mirror image: denying a working agent, and — since
+    # one unreadable Docker socket marks EVERY card at once — emptying a paying
+    # customer's roster over an infrastructure fault. When Docker is unreadable
+    # every card reads `unknown` and the roster renders exactly as it does today.
+    availability: Literal["ready", "stopped", "unavailable", "unknown"] = "unknown"
 
 
 class PortalTtsRequest(BaseModel):
@@ -226,6 +247,14 @@ class PortalAgentHeader(BaseModel):
     avatar_url: Optional[str] = None
     owner: Optional[str] = None
     health: PortalAgentHealth = Field(default_factory=PortalAgentHealth)
+    # #2196 — a projection of the roster card's field, NOT a second Docker read,
+    # and a SECOND FACT beside `health` rather than a replacement for it. The two
+    # differ in freshness by construction: `health` is the last persisted
+    # `agent_health_checks` row (stale by design, and `unknown` on most installs
+    # because monitoring is default-OFF), while this is read at request time.
+    # One widget carrying both freshness semantics would tell the viewer neither.
+    # Same fail-open default and rationale as `PortalAgentCard.availability`.
+    availability: Literal["ready", "stopped", "unavailable", "unknown"] = "unknown"
     last_active: Optional[str] = None
 
 

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -264,9 +264,142 @@ def _default_voice_id() -> str | None:
         return None
 
 
-def _row_to_card(r: dict, tts_ready: bool, default_voice_id: str | None = None) -> PortalAgentCard:
+# ---------------------------------------------------------------------------
+# #2196 — container state as a PROJECTION onto the roster, never a filter
+# ---------------------------------------------------------------------------
+#
+# The `agent_ownership` row is authoritative for who is on this roster. Whether
+# the agent's container currently exists and runs is a separate fact, resolved
+# here and attached to the card. It is deliberately NOT resolved in
+# `_roster_rows` (which stays pure SQL, so #2198's batch-sessions gate does not
+# inherit a Docker read) and NOT inside `_agent_briefing` (so #2163 stays free to
+# defer, bound or cache the briefing).
+
+# Docker's vocabulary and the card's are different words for related facts, and
+# passing one through as the other puts "running" onto a Literal["ready", ...].
+# ONE translation table, shared by both seams — two functions that must agree on
+# a mapping are exactly where a mapping drifts.
+_DOCKER_STATE_TO_AVAILABILITY = {
+    "running": "ready",
+    "stopped": "stopped",
+    "missing": "unavailable",
+}
+
+# Fail-OPEN: `unknown` means "Docker could not be asked", which is not evidence
+# the agent is down. The dominant fault modes — a daemon restart, a socket
+# permission change, a wrong `group_add` GID — leave agent containers running
+# and serving HTTP over the agent network, so refusing the turn would deny a
+# healthy agent. Defined once, so a later "consistency" tidy cannot restore the
+# fail-CLOSED bug this replaces (which refused every Workspace turn instance-wide
+# on one unreadable socket).
+_TURN_ALLOWED_AVAILABILITY = ("ready", "unknown")
+
+
+def _to_availability(docker_state) -> str:
+    """The single translation point between the two vocabularies.
+
+    Enum-guarded per VALUE, not merely per type: an unrecognised Docker string
+    (or a MagicMock, or None) resolves to `unknown`, which renders as today.
+    """
+    if not isinstance(docker_state, str):
+        return "unknown"
+    return _DOCKER_STATE_TO_AVAILABILITY.get(docker_state, "unknown")
+
+
+def _availability_allows_turn(availability: str) -> bool:
+    """Whether a turn may be dispatched. See `_TURN_ALLOWED_AVAILABILITY`."""
+    return availability in _TURN_ALLOWED_AVAILABILITY
+
+
+async def _availability_map(names: list[str]) -> dict[str, str]:
+    """`{agent_name: availability}` for exactly `names`, in one Docker call.
+
+    Two guards, both load-bearing:
+
+    * **The result is narrowed to `names`.** The underlying call sees EVERY
+      agent container on the host, including agents outside this caller's
+      roster and other tenants'. That map must never be returned, logged or
+      attached to a response.
+    * **The return type is validated** before it is trusted. A dozen test
+      modules install a `MagicMock` at `sys.modules["services.docker_service"]`,
+      and a MagicMock's `agent_container_states()` returns a truthy MagicMock
+      that is neither a dict nor None — left unguarded it would silently invert
+      the fail-open default inside the suite meant to prove it. Same shape as
+      `a2a_outbound`'s `isinstance(ResolvedEndpoint)` check, except that one
+      fails CLOSED (it decides where a credential is sent) and this one fails
+      OPEN (it decides whether to deny a working agent).
+
+    A name absent from a VALID map is `unavailable` — that is the real #2196
+    signal. An invalid or `None` map is `unknown` for every name.
+    """
+    if not names:
+        return {}                      # zero rows ⇒ zero Docker calls
+    try:
+        from services.docker_utils import agent_container_states_async
+        states = await agent_container_states_async()
+    except Exception as e:  # noqa: BLE001 — a roster must never 500 over Docker
+        logger.warning("[#2196] batch container-state read failed: %s", e)
+        return {n: "unknown" for n in names}
+    if not isinstance(states, dict):
+        # None (Docker unreadable) or a stubbed module — the safe direction.
+        return {n: "unknown" for n in names}
+    return {n: _to_availability(states.get(n, "missing")) for n in names}
+
+
+async def _agent_availability(agent_name: str) -> str:
+    """One agent's availability. Single Docker read, never the batch — routing
+    one agent through the fleet call is the cost #2160 exists to remove.
+
+    Same enum guard and same fail-open direction as `_availability_map`.
+    """
+    try:
+        from services.docker_utils import agent_container_state_async
+        state = await agent_container_state_async(agent_name)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[#2196] container-state read failed for %s: %s", agent_name, e)
+        return "unknown"
+    return _to_availability(state)
+
+
+# Client-visible copy. No infrastructure jargon — the viewer may be an external
+# client with no Trinity account. `POST /api/agents/{name}/start` recreates a
+# missing container (#1559), so "its owner needs to start it" is the correct next
+# action for BOTH non-running states. Neither says "try again": for these two
+# states retrying cannot work, which is the misleading half of the old copy.
+_AVAILABILITY_REFUSAL = {
+    "unavailable": "This agent isn't available right now — its owner needs to start it.",
+    "stopped": "This agent isn't running right now — its owner needs to start it.",
+}
+
+
+def _refusal_detail(availability: str) -> str:
+    """The 502 body for a turn refused BEFORE anything is created."""
+    return _AVAILABILITY_REFUSAL.get(
+        availability, "This agent can't take a message right now — its owner needs to start it."
+    )
+
+
+def _turn_failed_detail(availability: str) -> str:
+    """The 502 body for a turn that RAN and did not come back.
+
+    Distinct from `_refusal_detail`: here retrying genuinely may help, so the
+    instruction stays — but "it may be offline" is only honest when we could not
+    read the agent's state at dispatch.
+    """
+    if availability == "unknown":
+        return "The agent couldn't respond (it may be offline). Please try again."
+    return "The agent couldn't respond. Please try again."
+
+
+def _row_to_card(r: dict, tts_ready: bool, default_voice_id: str | None = None,
+                 availability: str = "unknown") -> PortalAgentCard:
     """One roster row → one card. Shared by the roster and the single-agent
-    lookup (#2160) so the two cannot disagree about how a card is built."""
+    lookup (#2160) so the two cannot disagree about how a card is built.
+
+    `availability` (#2196) is THREADED IN, never computed here: the roster
+    resolves it for the whole set in one Docker call while the agent page
+    resolves one agent's, and a per-card read would put the fleet cost back.
+    """
     from services import tts_service
     name = r["agent_name"]
     updated = r.get("avatar_updated_at")
@@ -301,6 +434,7 @@ def _row_to_card(r: dict, tts_ready: bool, default_voice_id: str | None = None) 
                 default_voice_id=default_voice_id,
             )
         ),
+        availability=availability,
     )
 
 
@@ -338,8 +472,12 @@ async def get_agent_card(email: str | None, agent_name: str,
                 if r["agent_name"] == agent_name), None)
     if row is None:
         return None
-    card = _row_to_card(row, tts_service.is_available(), _default_voice_id())
-    briefing = await _agent_briefing(agent_name)   # exactly one, not N
+    # #2196: the SINGLE tri-state read, not the batch — one agent's page must
+    # not pay a fleet-scale Docker call, which is this function's whole point.
+    availability = await _agent_availability(agent_name)
+    card = _row_to_card(row, tts_service.is_available(), _default_voice_id(),
+                        availability=availability)
+    briefing = await _agent_briefing(agent_name, availability)   # exactly one, not N
     if isinstance(briefing, tuple):
         card.description, card.playbooks = briefing
     return card
@@ -378,12 +516,23 @@ async def get_roster(email: str | None, include_owned: bool = False) -> PortalRo
     # (somehow) shared must appear once, and the shared row carries the sharing
     # metadata this roster was built around.
     rows = _roster_rows(email, include_owned)
-    cards = [_row_to_card(r, tts_ready, default_voice) for r in rows]
+    # #2196: container state for the whole set in ONE Docker call, resolved here
+    # beside the other once-per-load facts — not in `_roster_rows` (pure SQL, so
+    # #2198's batch-sessions gate does not inherit a Docker read) and not inside
+    # `_agent_briefing` (so #2163 can defer/bound/cache the briefing freely).
+    # It also REPLACES the per-card `get_agent_container()` the briefing used to
+    # make and throw away: N inspects become one list call.
+    availability = await _availability_map([r["agent_name"] for r in rows])
+    cards = [
+        _row_to_card(r, tts_ready, default_voice,
+                     availability=availability.get(r["agent_name"], "unknown"))
+        for r in rows
+    ]
 
     # #138 briefing enrichment — parallel + fail-soft (see _agent_briefing).
     import asyncio
     briefings = await asyncio.gather(
-        *[_agent_briefing(c.name) for c in cards], return_exceptions=True
+        *[_agent_briefing(c.name, c.availability) for c in cards], return_exceptions=True
     )
     for card, b in zip(cards, briefings):
         if isinstance(b, tuple):
@@ -473,7 +622,7 @@ def _use_case_hints(use_cases) -> list[PortalPlaybook]:
     return hints
 
 
-async def _agent_briefing(agent_name: str):
+async def _agent_briefing(agent_name: str, availability: str = "ready"):
     """Best-effort ``(description, hints)`` for the #138 new-chat briefing.
 
     Live agent data from ``/api/template/info`` — the template ``description``
@@ -483,15 +632,32 @@ async def _agent_briefing(agent_name: str):
     playbook is exposed. The curated exposable-skills config (ent#178) slots
     into this same seam once it exists. Any failure (agent stopped, slow, no
     connector) yields ``(None, [])`` so the roster stays fast and never errors.
+
+    #2196: this used to make its OWN ``get_agent_container()`` call per card and
+    throw the answer away, collapsing "no container" / "stopped" / "HTTP failed"
+    into one ``(None, [])``. The caller now resolves that state once — for the
+    whole roster in a single Docker call — and hands it in, so the enrichment
+    costs N HTTP calls instead of N inspects + N HTTP calls, and the answer is
+    used rather than discarded.
+
+    ``availability`` defaults to ``"ready"`` — "the caller asserts this agent can
+    run" — which is the honest contract for a direct call and keeps the existing
+    one-argument call sites and stubs working.
+
+    ``unknown`` is ATTEMPTED, not skipped, and the asymmetry with the turn gate
+    is deliberate rather than an oversight: this function reaches the agent at
+    ``http://agent-{name}:8000`` **by DNS over the agent network**, so a backend
+    Docker-socket fault — the exact class this design is built around — says
+    nothing about whether the agent answers HTTP. Skipping on ``unknown`` would
+    turn one unreadable socket into "no briefings fleet-wide" while every
+    briefing would in fact have worked.
     """
-    from services.docker_service import get_agent_container
     from services.agent_auth import agent_httpx_client
     from services.connector_service import resolve_exposed_playbooks
     from database import db as core_db
 
     try:
-        container = get_agent_container(agent_name)
-        if not container or getattr(container, "status", "") != "running":
+        if availability not in ("ready", "unknown"):
             return None, []
 
         base = f"http://agent-{agent_name}:8000"
@@ -919,7 +1085,8 @@ def _build_portal_system_prompt(agent_name: str, email: str) -> str | None:
 async def portal_chat(agent_name: str, message: str, email: str,
                       session_id: str | None = None,
                       include_owned: bool = False,
-                      execution_id: str | None = None) -> dict:
+                      execution_id: str | None = None,
+                      availability: str | None = None) -> dict:
     """Run one client chat turn against a rostered agent as a standard platform
     execution (``triggered_by="public"`` — the external-caller path, observable +
     cost-tracked). Scoped to the caller's roster; raises ``ClientPortalError`` on
@@ -938,6 +1105,26 @@ async def portal_chat(agent_name: str, message: str, email: str,
     if not agent_on_roster(agent_name, email, include_owned):
         # Uniform 404 — never disclose whether an agent the client can't reach exists.
         raise ClientPortalError(404, "Agent not found")
+
+    # #2196: refuse a turn the agent cannot run — HERE, before anything is
+    # created or written.
+    #
+    # This path had NO liveness gate at all. Its 502 lives at the far end, after
+    # `_persist_user_turn`, so a containerless agent left the client's thread
+    # holding a durable user message with no reply plus an orphan execution row —
+    # the worse of the two paths, because the wreckage persists in the
+    # conversation. It is not a dead path either: `/chat` is the documented
+    # headless integration surface (ent#83) AND the browser's fallback when
+    # streaming fails.
+    #
+    # Placed after the roster gate (so a non-holder cannot use a state-dependent
+    # refusal as an existence oracle) and before `_resolve_session_id` (so a
+    # refused turn does not even open a thread). `start_portal_turn` passes the
+    # state it already resolved, so a streamed turn still costs one Docker read.
+    if availability is None:
+        availability = await _agent_availability(agent_name)
+    if not _availability_allows_turn(availability):
+        raise ClientPortalError(502, _refusal_detail(availability))
 
     # Imported here, like every other service this module reaches for: the
     # portal package is imported during app construction, and the execution
@@ -1116,7 +1303,10 @@ async def portal_chat(agent_name: str, message: str, email: str,
             raise ClientPortalError(429, "The agent is busy. Please try again shortly.")
         if "timed out" in err:
             raise ClientPortalError(504, "The request timed out — try a simpler message.")
-        raise ClientPortalError(502, "The agent couldn't respond (it may be offline). Please try again.")
+        # #2196: the turn RAN and did not come back, so retrying may genuinely
+        # help and the instruction stays — but "it may be offline" is only
+        # honest when we could not read the agent's state at dispatch.
+        raise ClientPortalError(502, _turn_failed_detail(availability))
 
     # Cache the id the turn ran under so the NEXT turn resumes it.
     #
@@ -1388,7 +1578,7 @@ def _fail_unstarted_execution(execution_id: str, reason: str) -> None:
 
 
 def _agent_is_running(agent_name: str) -> bool:
-    """Whether the agent could take a turn right now.
+    """Whether the agent could take a turn right now — the named boolean seam.
 
     A named seam rather than an inline Docker call, so a caller (and a test) has
     ONE unambiguous thing to reason about. The inline version resolved
@@ -1398,12 +1588,23 @@ def _agent_is_running(agent_name: str) -> bool:
     `.status` is never "running", so a healthy agent read as stopped.
 
     Fails OPEN: a Docker read error is not evidence the agent is down, and
-    refusing a healthy turn is the worse error.
+    refusing a healthy turn is the worse error. **That was documented and not
+    true (#2196):** `get_agent_container` had already swallowed the exception and
+    returned None, so `bool(None)` was False and the `except` branch below was
+    unreachable — one unreadable socket refused EVERY Workspace turn on the
+    instance. Rebuilt over the tri-state read, the documented behaviour is now
+    the actual behaviour, and the rule itself lives in
+    `_availability_allows_turn` so this and the turn paths cannot drift.
+
+    Synchronous by design — this is the pre-#2196 signature, which the ent#286
+    tests patch and call directly. The turn paths do NOT call it: they need the
+    resolved state for the refusal copy as well as the gate, and calling both
+    would cost two Docker reads per turn, so they await `_agent_availability`
+    once and derive both from it through the same predicate.
     """
-    from services.docker_service import get_agent_container
+    from services.docker_service import agent_container_state
     try:
-        container = get_agent_container(agent_name)
-        return bool(container) and getattr(container, "status", None) == "running"
+        return _availability_allows_turn(_to_availability(agent_container_state(agent_name)))
     except Exception as e:  # noqa: BLE001
         logger.warning("portal running-check failed for %s: %s", agent_name, e)
         return True
@@ -1431,10 +1632,15 @@ async def start_portal_turn(agent_name: str, message: str, email: str,
     # execution row are left behind — and the client, having been told the turn
     # started, has no error to show. The synchronous path surfaces exactly this
     # as a 502, so this says the same thing at the same moment in the flow.
-    if not _agent_is_running(agent_name):
-        raise ClientPortalError(
-            502, "The agent couldn't respond (it may be offline). Please try again."
-        )
+    #
+    # #2196: ONE Docker read, resolved AFTER the roster gate (a state-dependent
+    # refusal reached before `agent_on_roster` would be an existence oracle for
+    # a non-holder — the Invariant #8 class) and used for BOTH the gate and the
+    # copy. Checking a boolean and then re-reading the state to word the refusal
+    # would cost two reads on the hottest portal path.
+    availability = await _agent_availability(agent_name)
+    if not _availability_allows_turn(availability):
+        raise ClientPortalError(502, _refusal_detail(availability))
 
     # Resolve the thread up front so the client can adopt it immediately rather
     # than waiting for the turn; `portal_chat` resolving it again is idempotent.
@@ -1467,7 +1673,9 @@ async def start_portal_turn(agent_name: str, message: str, email: str,
     async def _run() -> None:
         try:
             await portal_chat(agent_name, message, email, session_id=session_id,
-                              include_owned=include_owned, execution_id=execution_id)
+                              include_owned=include_owned, execution_id=execution_id,
+                              # #2196: already resolved above — one Docker read per turn.
+                              availability=availability)
         except ClientPortalError as e:
             # The client sees this on the stream (the agent's log ends) and in
             # the execution row; there is no request left to raise into.
@@ -1750,7 +1958,10 @@ async def portal_upload_document(agent_name: str, email: str, filename: str, dat
 
     container = get_agent_container(agent_name)
     if not container:
-        raise ClientPortalError(502, "The agent is not available. Try again later.")
+        # #2196: "Try again later" was wrong for the state that actually reaches
+        # here most often — an agent with no container, where waiting never
+        # helps. Same next action as the chat refusals, from the same table.
+        raise ClientPortalError(502, _AVAILABILITY_REFUSAL["unavailable"])
     # A stopped container still resolves; the docker exec below would raise. Give
     # the client a clear, non-500 signal instead.
     if getattr(container, "status", "running") != "running":

--- a/src/backend/services/docker_service.py
+++ b/src/backend/services/docker_service.py
@@ -3,7 +3,7 @@ Docker service for managing agent containers.
 """
 import logging
 import time
-from typing import List, Optional
+from typing import Dict, List, Optional
 import docker
 from models import AgentStatus
 from utils.helpers import parse_iso_timestamp, utc_now
@@ -20,6 +20,27 @@ logger = logging.getLogger(__name__)
 # under a race is harmless.
 _SOCKET_WARN_THROTTLE_S = 60.0
 _last_socket_warn_monotonic: Optional[float] = None
+
+# #2196: the tri-state readers below get their OWN throttle slots. Sharing
+# `_last_socket_warn_monotonic` would let whichever function warned first
+# silence the others for a full window — so a persistent fault on the roster
+# path could go unlogged because an unrelated poll had just reported it.
+_last_warn_monotonic: Dict[str, float] = {}
+
+
+def _warn_throttled(slot: str, message: str, *args) -> None:
+    """WARN at most once per `_SOCKET_WARN_THROTTLE_S` per `slot` (#2196).
+
+    Same rationale as `list_all_agents_fast`'s throttle: a denied socket is a
+    persistent condition on a per-request path, so an unthrottled warn floods
+    Vector — but the failure must stay diagnosable, and a silent Docker fault is
+    exactly what makes the tri-state distinction unverifiable in production.
+    """
+    now = time.monotonic()
+    last = _last_warn_monotonic.get(slot)
+    if last is None or now - last >= _SOCKET_WARN_THROTTLE_S:
+        _last_warn_monotonic[slot] = now
+        logger.warning(message, *args)
 
 
 # Initialize Docker client
@@ -235,6 +256,121 @@ def list_all_agents_fast() -> List[AgentStatus]:
             _last_socket_warn_monotonic = now
             logger.warning("Failed to list agents from Docker: %s", e)
         return []
+
+
+# #2196: the tri-state container-state readers.
+#
+# NO pre-existing helper in this module can distinguish "Docker says this agent
+# has no container" from "Docker could not be asked": `get_agent_container`
+# returns None for both, and `list_all_agents_fast` returns [] for both. That one
+# missing distinction is why a naive "hide agents with no container" reconcile is
+# dangerous — a daemon restart or a wrong `group_add` GID would report the whole
+# fleet as absent, which on the client-facing Workspace roster means telling a
+# paying customer they have no agents.
+#
+# So these two return `None` for *unreadable* and a real answer otherwise, and
+# every consumer is expected to treat `None` as "render as if nothing changed".
+# `list_all_agents_fast`'s []-on-fault contract is deliberately NOT changed —
+# ~60 stub sites and many callers depend on it.
+
+
+def agent_container_states() -> Optional[Dict[str, str]]:
+    """Every Trinity agent container's coarse state, in ONE Docker round trip.
+
+    Returns ``{agent_name: "running" | "stopped"}``, or ``None`` when Docker
+    could not be asked. ``{}`` is a real answer ("Docker looked; there are no
+    agent containers") and is deliberately distinct from ``None``.
+
+    ``sparse=True`` is load-bearing, and it constrains the body:
+
+    * Without it, docker-py's ``ContainerCollection.list`` runs a FULL INSPECT
+      per container (``containers.append(self.get(r['Id']))``), so this would
+      cost ``1 list + N_fleet inspects`` — worse than the N_roster inspects it
+      replaces for the typical 1-3-agent Workspace client on a large fleet.
+      With it, the cost is one HTTP call regardless of fleet size.
+    * Under sparse, ``container.name`` returns **None** (the summary carries
+      ``Names``, a list, not ``Name``) and ``container.labels`` **raises**
+      ``DockerException``. Both fail in the *safe* direction — every caller
+      would read "unknown" forever with a green test suite — so the key is taken
+      from ``attrs["Names"][0]`` and the label is never read here.
+      ``container.status`` is safe: its property handles both shapes.
+
+    Keyed by container NAME, never by the ``trinity.agent-name`` label: rename
+    moves the container name (``docker_utils.container_rename``) while the label
+    is written once at create and goes stale, so label-keying would report every
+    renamed agent as having no container. Same reason
+    ``list_all_agents_fast`` says "use container name as authoritative source".
+
+    The status is classified EXPLICITLY. ``list_all_agents_fast`` falls through
+    with ``else: normalized_status = docker_status``, which passes ``paused``,
+    ``restarting`` and — routinely, during any delete — ``removing`` straight to
+    the caller; consumers of this function map the result onto a closed set, so a
+    raw status escaping here would fail their validation instead of degrading.
+    """
+    if not docker_client:
+        return None
+    try:
+        containers = docker_client.containers.list(
+            all=True,
+            filters={"label": "trinity.platform=agent"},   # server-side; unaffected by sparse
+            sparse=True,
+        )
+        states: Dict[str, str] = {}
+        for container in containers:
+            raw = (container.attrs.get("Names") or [""])[0] or ""
+            name = raw.lstrip("/").removeprefix("agent-")
+            if not name:
+                continue
+            states[name] = "running" if container.status == "running" else "stopped"
+        return states
+    except Exception as e:  # noqa: BLE001 — unreadable Docker is a valid answer here
+        # Total by design: anything unexpected (no daemon, denied socket, a shape
+        # this code does not understand) resolves to "could not be asked", which
+        # every consumer renders as today's behaviour. A partial map would be
+        # worse — a skipped entry reads as "that agent has no container".
+        _warn_throttled(
+            "agent_container_states",
+            "Failed to read agent container states from Docker: %s", e,
+        )
+        return None
+
+
+def agent_container_state(name: str) -> Optional[str]:
+    """One agent's coarse state: ``"running"``/``"stopped"``/``"missing"``, or
+    ``None`` when Docker could not be asked.
+
+    The single-agent form exists so opening ONE agent's page (or taking one
+    turn) does not pay a fleet-scale read — the property #2160 exists to
+    protect. ``containers.get()`` is not sparse, so ``.labels`` is readable
+    here, and the ``trinity.platform`` check is what makes the two forms answer
+    the SAME question: the batch call filters on that label server-side, so
+    without this check a container merely *named* ``agent-x`` would read as
+    absent on the roster and present on the page.
+    """
+    if not docker_client:
+        return None
+    try:
+        container = docker_client.containers.get(f"agent-{name}")
+    except docker.errors.NotFound:
+        # The distinction `get_agent_container` cannot make: Docker answered,
+        # and the answer is "there is no such container".
+        return "missing"
+    except Exception as e:  # noqa: BLE001
+        _warn_throttled(
+            "agent_container_state",
+            "Failed to read container state for agent %s from Docker: %s", name, e,
+        )
+        return None
+    try:
+        if (container.labels or {}).get("trinity.platform") != "agent":
+            return "missing"
+        return "running" if container.status == "running" else "stopped"
+    except Exception as e:  # noqa: BLE001
+        _warn_throttled(
+            "agent_container_state",
+            "Failed to classify container state for agent %s: %s", name, e,
+        )
+        return None
 
 
 def get_agent_by_name(name: str) -> Optional[AgentStatus]:

--- a/src/backend/services/docker_utils.py
+++ b/src/backend/services/docker_utils.py
@@ -165,6 +165,40 @@ async def container_get(container_id: str) -> Any:
     )
 
 
+async def agent_container_states_async() -> Optional[Dict[str, str]]:
+    """Async form of ``docker_service.agent_container_states`` (#2196).
+
+    The tri-state semantics are the leaf's: a mapping (possibly empty) means
+    Docker answered; ``None`` means it could not be asked.
+
+    Exists because the Workspace roster is served from an ``async def`` route,
+    and this module's contract is mandatory there — a synchronous Docker read on
+    the event loop stalls every other request in the worker, including live
+    ``/chat/stream`` SSE for unrelated clients. Running it on the shared 4-worker
+    executor also bounds what concurrent sign-ins can do to the daemon.
+
+    The import is function-local **on purpose**: ``client_portal`` and the tests
+    around it patch ``sys.modules["services.docker_service"]``, and only the
+    ``from x import y`` form resolves through ``sys.modules`` at call time (an
+    ``import x.y as m`` alias binds the package attribute, which a stubbed suite
+    makes a different object).
+    """
+    from services.docker_service import agent_container_states
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(_docker_executor, agent_container_states)
+
+
+async def agent_container_state_async(name: str) -> Optional[str]:
+    """Async form of ``docker_service.agent_container_state`` (#2196).
+
+    Single-agent, so one agent's page (or one chat turn) never pays a
+    fleet-scale read — see #2160. Same function-local-import rule as above.
+    """
+    from services.docker_service import agent_container_state
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(_docker_executor, agent_container_state, name)
+
+
 # =============================================================================
 # Image Operations
 # =============================================================================

--- a/src/frontend/src/components/portal/PortalAgentPage.vue
+++ b/src/frontend/src/components/portal/PortalAgentPage.vue
@@ -18,6 +18,15 @@
             <span class="inline-flex items-center gap-1.5">
               <span class="w-2 h-2 rounded-full" :class="healthDot"></span>{{ healthLabel }}
             </span>
+            <!-- #2196: availability is its OWN labelled fact, beside health and
+                 never folded into that dot. The two differ in freshness by
+                 construction — health is the last persisted agent_health_checks
+                 row (stale by design, and `unknown` on most installs because
+                 monitoring is default-OFF), while this is read at request time.
+                 One widget carrying both would tell the viewer neither. -->
+            <span v-if="availability" class="inline-flex items-center gap-1.5" :title="availability.title">
+              <span class="w-2 h-2 rounded-full" :class="availabilityDot"></span>{{ availability.label }}
+            </span>
             <span v-if="page?.header?.last_active">Last active {{ relative(page.header.last_active) }}</span>
           </div>
         </div>
@@ -367,7 +376,7 @@ import LoadFailed from '@/components/LoadFailed.vue'
 import ReportRenderer from '@/components/reports/ReportRenderer.vue'
 import ReportSummary from '@/components/reports/ReportSummary.vue'
 import PortalAvatar from './PortalAvatar.vue'
-import { PORTAL_BUCKET_LABELS } from './portalUtils'
+import { PORTAL_BUCKET_LABELS, availabilityChip } from './portalUtils'
 
 const props = defineProps({
   agentName: { type: String, required: true },
@@ -455,6 +464,16 @@ const healthLabel = computed(() => ({
 const healthDot = computed(() => ({
   healthy: 'bg-status-success-500', unhealthy: 'bg-status-danger-500', degraded: 'bg-status-warning-500',
 }[page.value?.header?.health?.status] || 'bg-gray-300 dark:bg-gray-600'))
+
+// #2196: the same pure rule the sidebar row uses — one decision, four surfaces.
+// `owner` comes off the header so the copy can name who to ask.
+const availability = computed(() => availabilityChip(
+  { availability: page.value?.header?.availability, owner: page.value?.header?.owner },
+  { detailed: store.isPlatformSession },
+))
+const availabilityDot = computed(() => ({
+  warning: 'bg-status-warning-500', danger: 'bg-status-danger-500',
+}[availability.value?.variant] || 'bg-gray-300 dark:bg-gray-600'))
 
 // AC5 (#2160): `${name}:${window}` cache, the convention `stores/executions.js`
 // already uses. Flipping 7d → 30d → 7d refetched an identical payload every

--- a/src/frontend/src/components/portal/PortalSidebar.vue
+++ b/src/frontend/src/components/portal/PortalSidebar.vue
@@ -111,6 +111,19 @@
               <span class="block text-sm truncate">{{ agentLabel(a) }}</span>
               <span v-if="agentLabel(a) !== a.name" class="block text-xs text-gray-400 truncate font-mono">{{ a.name }}</span>
             </span>
+            <!-- #2196: the agent can't currently run. LABEL, never disable —
+                 disabling would relocate the dead state rather than remove it,
+                 since a client whose agents are all stopped (a routine
+                 resource-saving posture) would get an entirely inert Workspace.
+                 The chip sets the expectation; the server's 502 is the honest
+                 refusal. Nothing is rendered for `ready` or `unknown`.
+
+                 The slot's footprint is RESERVED (`min-w`, on the row always) so
+                 a row does not reflow when an agent starts or stops between
+                 refreshes — the same reason the roster is not re-sorted by this. -->
+            <span class="shrink-0 min-w-[4.5rem] flex justify-end">
+              <BaseBadge v-if="chipFor(a)" :variant="chipFor(a).variant">{{ chipFor(a).label }}</BaseBadge>
+            </span>
             <span
               v-if="waitingFor(a.name)"
               class="shrink-0 min-w-[1.25rem] px-1.5 h-5 rounded-full bg-action-primary-600 text-white text-[11px] font-semibold flex items-center justify-center"
@@ -194,8 +207,9 @@
 import { computed, ref } from 'vue'
 import PortalAvatar from './PortalAvatar.vue'
 import ChatRow from './PortalChatRow.vue'
+import BaseBadge from '@/components/base/BaseBadge.vue'
 import {
-  groupThreadsByDate, partitionStarred, unreadByAgent, totalUnread,
+  groupThreadsByDate, partitionStarred, unreadByAgent, totalUnread, availabilityChip,
 } from './portalUtils'
 
 const props = defineProps({
@@ -250,13 +264,23 @@ function onAgentClick(name) {
 // disagree about what an unset label means.
 const agentLabel = (a) => (a.display_label || '').trim() || a.name
 
+// #2196: one rule, from portalUtils, shared with the agent page (and, next,
+// the picker and the @-typeahead). `detailed` is the platform-session flag: an
+// operator looking at their own fleet sees stopped-vs-no-container, an external
+// client sees one label for both — the two differ only in whether the operator
+// deleted or lost the agent, and neither is actionable for a client.
+const chipFor = (a) => availabilityChip(a, { detailed: props.isPlatformSession })
+
 function agentRowTitle(a) {
   const n = waitingFor(a.name)
   const label = agentLabel(a)
   const who = label === a.name ? label : `${label} (${a.name})`
-  return n
+  const base = n
     ? `${who} — ${n} unread ${n === 1 ? 'reply' : 'replies'}`
     : `Open ${who}`
+  // The state must be reachable without relying on colour.
+  const chip = chipFor(a)
+  return chip ? `${base} — ${chip.title}` : base
 }
 
 // #2159: a long fleet made the agents block the whole sidebar, pushing chats

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -495,6 +495,74 @@ export function starterFor(p) {
 // playbooks, and the roster is fetched once at mount. "This agent has no
 // playbooks exposed" would therefore be a false claim about operator
 // configuration for the ordinary state of an idle fleet.
+// ---------------------------------------------------------------------------
+// #2196 — the availability chip
+// ---------------------------------------------------------------------------
+//
+// ONE rule, here, consumed by every surface that renders it (sidebar row today;
+// picker, @-typeahead and briefing line next). Four inline `v-if`s across four
+// components is how four surfaces end up disagreeing about the same agent — and
+// there is no component-mount harness in this project (`package.json` carries no
+// @vue/test-utils, jsdom or happy-dom), so a rule expressed in a template can
+// only be guarded by regexing source, which catches deletion but never a wrong
+// rule. A pure function is genuinely unit-tested.
+
+export const AVAILABILITY_READY = 'ready'
+export const AVAILABILITY_STOPPED = 'stopped'
+export const AVAILABILITY_UNAVAILABLE = 'unavailable'
+export const AVAILABILITY_UNKNOWN = 'unknown'
+
+/**
+ * The chip for one roster card, or `null` when nothing should be rendered.
+ *
+ * Null for `ready` AND for `unknown`: `unknown` means Trinity could not read
+ * container state at all (an unreadable Docker socket marks every card at once),
+ * so labelling it would put a warning on the whole roster over an infrastructure
+ * fault the viewer can neither see nor act on. Fail-open — render as before.
+ *
+ * `detailed` distinguishes STOPPED from NO-CONTAINER, and defaults to false.
+ * That is a disclosure decision, not a formatting one: to an external client the
+ * two states differ only in whether the operator deleted or lost the agent, and
+ * neither is actionable for them (starting an agent is an operator action, and
+ * the Workspace deliberately has no start control). A platform session — an
+ * operator looking at their own fleet — sees the distinction, because for them
+ * it is the difference between "start it" and "find out what happened to it".
+ *
+ * Nothing here is derived from a Docker string: `availability` is one of four
+ * server-chosen constants, and an unrecognised value renders nothing.
+ */
+export function availabilityChip(agent, { detailed = false } = {}) {
+  const state = String(agent?.availability ?? '')
+  if (state !== AVAILABILITY_STOPPED && state !== AVAILABILITY_UNAVAILABLE) return null
+
+  const owner = String(agent?.owner ?? '').trim()
+  // The card already carries the owner, so naming them costs nothing and is far
+  // more actionable than "its owner".
+  const who = owner ? owner : 'its owner'
+
+  if (!detailed) {
+    return {
+      state,
+      label: 'Unavailable',
+      variant: 'warning',
+      title: `This agent can't take a message right now — ask ${who} to start it.`,
+    }
+  }
+  return state === AVAILABILITY_STOPPED
+    ? {
+      state,
+      label: 'Stopped',
+      variant: 'warning',
+      title: `This agent is stopped — ask ${who} to start it.`,
+    }
+    : {
+      state,
+      label: 'Unavailable',
+      variant: 'danger',
+      title: `This agent has no running container — ask ${who} to start it.`,
+    }
+}
+
 export const EMPTY_REASON_NO_PLAYBOOKS = 'No playbooks are available for this agent right now.'
 export const EMPTY_REASON_NO_PEERS = 'No other agents are shared with you.'
 export const EMPTY_REASON_NO_MENTIONABLE_PEERS =

--- a/src/frontend/tests/unit/portalAvailabilityChip.spec.js
+++ b/src/frontend/tests/unit/portalAvailabilityChip.spec.js
@@ -1,0 +1,169 @@
+/**
+ * #2196 — the roster availability chip.
+ *
+ * The Workspace lists agents whose container no longer exists. The fix is NOT to
+ * hide them (see the backend tests for why that would empty a customer's roster
+ * on any Docker fault) — it is to label them. So the rule this file guards is:
+ * a chip for the two non-ready states, nothing for the other two, and no control
+ * ever disabled.
+ *
+ * The rule lives in `portalUtils.js` rather than as a `v-if` in four templates
+ * for a mechanical reason: this project has no component-mount harness
+ * (`package.json` carries no @vue/test-utils, jsdom or happy-dom), so a rule
+ * expressed in a template can only be guarded by regexing source — which catches
+ * deletion but never a WRONG rule, and breaks on any reformat. A pure function
+ * is genuinely executed. The source-regex assertions at the bottom are therefore
+ * scoped to what only source can answer: that the surfaces consume the shared
+ * helper, and that nothing became disabled.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+import { availabilityChip } from '../../src/components/portal/portalUtils'
+
+const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+const SIDEBAR = read('../../src/components/portal/PortalSidebar.vue')
+const AGENT_PAGE = read('../../src/components/portal/PortalAgentPage.vue')
+
+describe('#2196 which states get a chip', () => {
+  it('labels an agent whose container is gone', () => {
+    const chip = availabilityChip({ availability: 'unavailable', owner: 'alice' })
+    expect(chip).toBeTruthy()
+    expect(chip.label).toBe('Unavailable')
+  })
+
+  it('labels a stopped agent too', () => {
+    // Not a half-truth: a chip that appeared ONLY for containerless agents would
+    // imply stopped agents are fine to chat with. They are not — they get a 502.
+    expect(availabilityChip({ availability: 'stopped' })).toBeTruthy()
+  })
+
+  it('renders nothing for a healthy agent', () => {
+    expect(availabilityChip({ availability: 'ready' })).toBeNull()
+  })
+
+  it('renders nothing for `unknown` — the fail-open direction', () => {
+    // `unknown` means Trinity could not read container state at all, and one
+    // unreadable socket marks EVERY card at once. Labelling it would put a
+    // warning across the whole roster over an infrastructure fault the viewer
+    // can neither see nor act on.
+    expect(availabilityChip({ availability: 'unknown' })).toBeNull()
+  })
+
+  it('renders nothing for an absent or unrecognised value', () => {
+    // An older payload predates the field entirely; anything unexpected must
+    // degrade to today's appearance rather than to a scary chip.
+    expect(availabilityChip({})).toBeNull()
+    expect(availabilityChip(null)).toBeNull()
+    expect(availabilityChip({ availability: 'running' })).toBeNull()   // Docker's word, not the card's
+  })
+})
+
+describe('#2196 what the chip says', () => {
+  it('names the owner, because the card already carries them', () => {
+    const chip = availabilityChip({ availability: 'unavailable', owner: 'alice' })
+    expect(chip.title).toContain('alice')
+    expect(chip.title).toContain('start it')
+  })
+
+  it('falls back to "its owner" when the card has none', () => {
+    const chip = availabilityChip({ availability: 'unavailable' })
+    expect(chip.title).toContain('its owner')
+  })
+
+  it('never tells the viewer to try again', () => {
+    // For both of these states, retrying cannot work — that is the misleading
+    // half of the copy this issue is fixing.
+    for (const availability of ['stopped', 'unavailable']) {
+      for (const detailed of [false, true]) {
+        const chip = availabilityChip({ availability }, { detailed })
+        expect(chip.title.toLowerCase()).not.toContain('try again')
+      }
+    }
+  })
+
+  it('uses semantic variants only — never a raw palette colour', () => {
+    for (const availability of ['stopped', 'unavailable']) {
+      const chip = availabilityChip({ availability }, { detailed: true })
+      expect(chip.variant).toMatch(/^(warning|danger)$/)
+    }
+  })
+})
+
+describe('#2196 the two states are collapsed for an external client', () => {
+  it('shows one label for both to a client', () => {
+    // The states differ only in whether the operator deleted or lost the agent.
+    // Neither is actionable for an external client — the Workspace has no start
+    // control, by design — so distinguishing them discloses operator-internal
+    // state for no benefit.
+    const stopped = availabilityChip({ availability: 'stopped' })
+    const gone = availabilityChip({ availability: 'unavailable' })
+    expect(stopped.label).toBe(gone.label)
+    expect(stopped.title).toBe(gone.title)
+  })
+
+  it('distinguishes them for a platform session', () => {
+    // An operator looking at their own fleet: for them it IS the difference
+    // between "start it" and "find out what happened to it".
+    const stopped = availabilityChip({ availability: 'stopped' }, { detailed: true })
+    const gone = availabilityChip({ availability: 'unavailable' }, { detailed: true })
+    expect(stopped.label).not.toBe(gone.label)
+    expect(stopped.variant).not.toBe(gone.variant)
+  })
+
+  it('carries the raw state through so a caller can still branch on it', () => {
+    expect(availabilityChip({ availability: 'stopped' }).state).toBe('stopped')
+  })
+})
+
+describe('#2196 the surfaces consume the shared rule', () => {
+  it('the sidebar row renders the chip from portalUtils', () => {
+    expect(SIDEBAR).toMatch(/availabilityChip/)
+    expect(SIDEBAR).toMatch(/<BaseBadge[^>]*chipFor\(a\)\.variant/)
+  })
+
+  it('the agent page uses the SAME helper, not a second rule', () => {
+    // Four inline conditions across four components is how four surfaces end up
+    // disagreeing about the same agent.
+    expect(AGENT_PAGE).toMatch(/availabilityChip/)
+    expect(AGENT_PAGE).not.toMatch(/availability === 'unavailable'/)
+  })
+
+  it('the agent page keeps availability BESIDE health, not inside it', () => {
+    // Health is the last persisted agent_health_checks row — stale by design —
+    // while availability is read at request time. One dot carrying both
+    // freshness semantics tells the viewer neither.
+    expect(AGENT_PAGE).toMatch(/healthDot/)
+    expect(AGENT_PAGE).toMatch(/availabilityDot/)
+    expect(AGENT_PAGE).not.toMatch(/healthDot.*availability|availability.*: healthDot/)
+  })
+
+  it('nothing is disabled by availability', () => {
+    // The reversal that survived review: disabling would relocate the dead state
+    // rather than remove it — a client whose agents are all stopped (a routine
+    // resource-saving posture) would get an entirely inert Workspace.
+    for (const src of [SIDEBAR, AGENT_PAGE]) {
+      expect(src).not.toMatch(/:disabled="[^"]*availability/)
+      expect(src).not.toMatch(/:disabled="[^"]*chipFor/)
+    }
+  })
+
+  it('the roster is not re-sorted by availability', () => {
+    // Rows would jump as agents start and stop — the design system's
+    // layout-stability rule forbids that, and the top-5 fold is #2159's design.
+    const shown = SIDEBAR.match(/const shownAgents = computed\([\s\S]*?\)\)/)
+    expect(shown).toBeTruthy()
+    expect(shown[0]).not.toMatch(/sort|availability/)
+  })
+
+  it('the chip slot reserves its footprint so the row does not reflow', () => {
+    const block = SIDEBAR.slice(SIDEBAR.indexOf('v-for="a in shownAgents"'))
+    const row = block.slice(0, block.indexOf('</button>'))
+    expect(row).toMatch(/min-w-\[[\d.]+rem\][^"]*flex justify-end/)
+  })
+
+  it('the row title carries the state, so it is reachable without colour', () => {
+    expect(SIDEBAR).toMatch(/chip \? `\$\{base\} — \$\{chip\.title\}` : base/)
+  })
+})

--- a/tests/unit/test_2128_workspace_rooms_capability.py
+++ b/tests/unit/test_2128_workspace_rooms_capability.py
@@ -40,6 +40,34 @@ ROOMS_FEATURE_ID = "shared_sessions"
 # Harness
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _pin_container_state(monkeypatch):
+    """#2196: pin the container-state seams and quiet the briefing.
+
+    `get_roster` now projects container state onto every card, and the real
+    seam reads whatever Docker the machine happens to have (conftest re-imports
+    `services.docker_service` after every test, re-running `docker.from_env()`).
+    On a Docker-less machine every card reads `unknown`, which makes the
+    briefing ATTEMPT its HTTP call — so a capability-bit test would make real
+    network attempts to `agent-{name}:8000`. This file is about the rooms
+    capability bit; both reads are pinned inert.
+    """
+    from client_portal import service
+
+    async def _map(names):
+        return {n: "ready" for n in names}
+
+    async def _one(name):
+        return "ready"
+
+    async def _briefing(name, availability="ready"):
+        return (None, [])
+
+    monkeypatch.setattr(service, "_availability_map", _map)
+    monkeypatch.setattr(service, "_agent_availability", _one)
+    monkeypatch.setattr(service, "_agent_briefing", _briefing)
+
+
 @pytest.fixture()
 def roster_db(tmp_path, monkeypatch):
     """Fresh sqlite with the OSS tables the roster joins over."""

--- a/tests/unit/test_2160_agent_page_one_briefing.py
+++ b/tests/unit/test_2160_agent_page_one_briefing.py
@@ -54,9 +54,16 @@ def _rows(names, **extra):
 def svc(monkeypatch):
     from client_portal import service as s
 
+    counted = {"batch": 0, "single": 0}
+
     briefed = []
 
-    async def counting_briefing(name):
+    # #2196 gave `_agent_briefing` a second parameter: the container state the
+    # caller already resolved (it used to make that Docker call itself, per card,
+    # and discard the answer). A 1-arg stub here would raise TypeError inside
+    # `get_roster`'s list comprehension — synchronously, OUTSIDE `gather`, so the
+    # whole roster call would raise rather than degrade.
+    async def counting_briefing(name, availability="ready"):
         briefed.append(name)
         return ("desc", [])
 
@@ -64,14 +71,31 @@ def svc(monkeypatch):
     monkeypatch.setattr(s.db, "get_owned_roster", lambda e: [])
     monkeypatch.setattr(s, "_agent_briefing", counting_briefing)
 
+    # #2196: pin the container-state seams. `docker.from_env()` runs at import
+    # and conftest re-imports that module after every test, so on a machine with
+    # Docker up these would answer for real and the fixture's agents — which have
+    # no containers — would all read "unavailable". Stubbed here so the counts
+    # below stay about briefings, and the availability assertions stay about the
+    # code rather than about the developer's daemon.
+    async def _map(names):
+        counted["batch"] += 1
+        return {n: "ready" for n in names}
+
+    async def _one(name):
+        counted["single"] += 1
+        return "ready"
+
+    monkeypatch.setattr(s, "_availability_map", _map)
+    monkeypatch.setattr(s, "_agent_availability", _one)
+
     import services.tts_service as tts
     monkeypatch.setattr(tts, "is_available", lambda: False)
-    return s, briefed
+    return s, briefed, counted
 
 
 def test_one_agents_page_costs_one_briefing(svc):
     """The fix. Twelve agents in the fleet, one briefing issued."""
-    s, briefed = svc
+    s, briefed, _counted = svc
 
     card = asyncio.run(s.get_agent_card(EMAIL, "agent-3"))
 
@@ -82,7 +106,7 @@ def test_one_agents_page_costs_one_briefing(svc):
 def test_the_roster_still_briefs_everyone(svc):
     """The comparison that makes the number above meaningful — and the roster's
     own behaviour is deliberately unchanged (its cards all need briefings)."""
-    s, briefed = svc
+    s, briefed, _counted = svc
 
     asyncio.run(s.get_roster(EMAIL))
 
@@ -93,7 +117,7 @@ def test_the_cost_does_not_grow_with_the_fleet(svc, monkeypatch):
     """The property that actually matters: a bigger fleet must not make one
     agent's page slower. A count taken on a 2-agent fixture would have passed
     against the original code too."""
-    s, briefed = svc
+    s, briefed, _counted = svc
     monkeypatch.setattr(s.db, "get_shared_roster", lambda e: _rows([f"a{i}" for i in range(200)]))
 
     asyncio.run(s.get_agent_card(EMAIL, "a137"))
@@ -104,7 +128,7 @@ def test_the_cost_does_not_grow_with_the_fleet(svc, monkeypatch):
 def test_an_agent_off_the_roster_yields_no_card_and_no_briefing(svc):
     """The caller has already gated access, so None means "vanished between the
     two reads" — and an agent we will not render must not be contacted."""
-    s, briefed = svc
+    s, briefed, _counted = svc
 
     assert asyncio.run(s.get_agent_card(EMAIL, "not-mine")) is None
     assert briefed == []
@@ -115,7 +139,7 @@ def test_owned_agents_are_reachable_only_for_a_platform_session(svc, monkeypatch
     external client sees only what was shared, a platform session also sees what
     it owns. A second rule here would let the page reach an agent the sidebar
     does not list."""
-    s, _ = svc
+    s, _briefed, _counted = svc
     monkeypatch.setattr(s.db, "get_shared_roster", lambda e: [])
     monkeypatch.setattr(s.db, "get_owned_roster", lambda e: _rows(["mine"]))
 
@@ -138,7 +162,7 @@ def test_every_row_field_survives_the_extraction(svc, monkeypatch):
     The identity test below pins that both paths call one helper; it cannot
     catch a field missing from that helper. This pins the field.
     """
-    s, _ = svc
+    s, _briefed, _counted = svc
     labelled = _rows(["agent-3"], display_label="Due Diligence")
     monkeypatch.setattr(s.db, "get_shared_roster", lambda e: labelled)
 
@@ -147,13 +171,17 @@ def test_every_row_field_survives_the_extraction(svc, monkeypatch):
 
     assert page_card.display_label == "Due Diligence"
     assert roster_card.display_label == "Due Diligence"
+    # #2196's field rides the same builder and is subject to exactly the same
+    # silent-drop hazard the docstring above describes.
+    assert page_card.availability == "ready"
+    assert roster_card.availability == "ready"
 
 
 def test_an_unset_label_stays_none_rather_than_being_coalesced(svc):
     """NULL means "render the slug" and that decision belongs to the render site
     (ent#181). Coalescing to the slug here would make the two ends disagree
     about what unset means — the thing #2159 deliberately avoided."""
-    s, _ = svc
+    s, _briefed, _counted = svc
 
     card = asyncio.run(s.get_agent_card(EMAIL, "agent-3"))
 
@@ -181,3 +209,28 @@ def test_the_router_no_longer_builds_the_whole_roster():
     src = inspect.getsource(r.portal_agent_page)
     assert "get_agent_card(" in src
     assert "get_roster(" not in src
+
+
+def test_the_page_pays_a_single_container_read_not_the_fleet_one(svc):
+    """#2196 rides the #2160 property rather than undoing it.
+
+    The roster resolves container state for the whole set in ONE batch call; the
+    page resolves ONE agent's with the single-agent form. Routing the page
+    through the batch would put the fleet-scale read straight back, which is the
+    cost this whole file exists to keep out.
+    """
+    s, _briefed, counted = svc
+
+    asyncio.run(s.get_agent_card(EMAIL, "agent-3"))
+
+    assert counted == {"batch": 0, "single": 1}
+
+
+def test_a_roster_load_reads_docker_once_for_the_whole_set(svc):
+    """A structural count, not a duration: a per-card read would pass any timing
+    assertion on a small fixture and cost N inspects on a real fleet."""
+    s, _briefed, counted = svc
+
+    asyncio.run(s.get_roster(EMAIL))
+
+    assert counted == {"batch": 1, "single": 0}

--- a/tests/unit/test_2196_roster_availability.py
+++ b/tests/unit/test_2196_roster_availability.py
@@ -294,6 +294,32 @@ def test_a_magicmock_docker_module_reads_unknown_not_unavailable(roster_db, monk
     assert {c.availability for c in cards} == {"unknown"}
 
 
+def test_a_raising_leaf_reads_unknown_through_both_seams(monkeypatch):
+    """The seams' OWN except branches, driven by a leaf that raises.
+
+    The real leaves swallow their errors and return `None`, so the seams'
+    `except` arms are otherwise only reachable through a broken stub or an
+    import failure — exactly the two silent shapes the #2114 learning names for
+    a lazy cross-package import inside a fail-open handler. A raise must degrade
+    to `unknown` (render as today), never propagate into a roster 500 and never
+    read as `unavailable`.
+    """
+    from client_portal import service
+
+    def _boom_batch():
+        raise RuntimeError("docker exploded")
+
+    def _boom_single(name):
+        raise RuntimeError("docker exploded")
+
+    ds = _services_module("docker_service")
+    monkeypatch.setattr(ds, "agent_container_states", _boom_batch)
+    monkeypatch.setattr(ds, "agent_container_state", _boom_single)
+
+    assert _run(service._availability_map(["scout"])) == {"scout": "unknown"}
+    assert _run(service._agent_availability("scout")) == "unknown"
+
+
 def test_the_availability_map_never_returns_another_tenants_agents(monkeypatch):
     """The underlying call sees EVERY agent container on the host — other
     clients' agents, and agents outside this caller's roster entirely. That map

--- a/tests/unit/test_2196_roster_availability.py
+++ b/tests/unit/test_2196_roster_availability.py
@@ -1,0 +1,763 @@
+"""The Workspace roster keeps containerless agents and says why (#2196).
+
+The reported bug: the roster lists agents whose container no longer exists, so a
+client sees a row `/api/agents` does not have and clicking it fails opaquely.
+
+The decision this file pins is the one the issue exists to make — **the
+`agent_ownership` row is authoritative for membership; container state is
+projected onto the card, never used as a filter.** Two tests carry that weight:
+
+  * `test_a_containerless_agent_stays_on_the_roster_and_says_why` — the
+    anti-#1747 regression guard. If a future change starts filtering, it fails.
+  * `test_an_unreadable_docker_never_empties_the_roster` — the guard on the
+    failure mode that decided the design. Every Docker read in the platform
+    returns a falsy value for BOTH "no container" and "could not ask", so a
+    filter would tell every paying customer they have no agents the moment a
+    daemon restarts or a `DOCKER_GID` changes.
+
+PATCHING RULE (ent#356, and the reason #2196 built named seams at all):
+`client_portal.service` reaches its dependencies through function-local
+`from services.x import y`, which resolves `sys.modules["services.x"]` at call
+time. So:
+
+  * patch `client_portal.service._availability_map` / `._agent_availability`
+    directly — the preferred route, and what the seams are for;
+  * when the leaf must be patched, take the module object out of `sys.modules`
+    (`_services_module` below) or use `unittest.mock.patch("services.x.y")`;
+  * NEVER `monkeypatch.setattr("services.x.y", ...)` and never an
+    `import services.x as m` alias — both walk the package attribute, which
+    conftest's #762 restore can leave pointing at a different object.
+
+A missed patch does not error here. It lets the real read run, which on a
+Docker-less machine answers `None` → `"unknown"` — the value several of these
+tests assert. So every classification test below is written to prove it can
+produce a DIFFERENT value, and the seam-stubbing is asserted explicitly by
+`test_the_seam_is_stubbed_not_ambient`.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _services_module(name: str):
+    """The module object the product code will ACTUALLY resolve (see the
+    module docstring — `from services.x import y` reads `sys.modules`, every
+    other route walks the package attribute)."""
+    import importlib
+    import sys
+
+    importlib.import_module(f"services.{name}")
+    return sys.modules[f"services.{name}"]
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# A real sqlite roster (the ent#357 fixture shape — no mocks over the queries)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def roster_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "trinity-2196.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
+
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", str(db_file))
+
+    from db.engine import get_engine
+    from db.tables import (
+        metadata as oss_metadata, agent_ownership, agent_sharing, system_settings, users,
+    )
+    oss_metadata.create_all(
+        get_engine(), tables=[users, agent_ownership, agent_sharing, system_settings]
+    )
+
+    with get_engine().begin() as conn:
+        now = "2026-08-14T00:00:00Z"
+        conn.execute(users.insert().values(
+            id=1, username="alice", email="alice@example.com", role="user",
+            created_at=now, updated_at=now,
+        ))
+        for name in ("scout", "sage", "ghosted"):
+            conn.execute(agent_ownership.insert().values(
+                agent_name=name, owner_id=1, created_at=now, is_system=0, deleted_at=None,
+            ))
+            conn.execute(agent_sharing.insert().values(
+                agent_name=name, shared_with_email="bob@example.com",
+                shared_by_id=1, created_at=now,
+            ))
+    yield get_engine()
+
+
+@pytest.fixture(autouse=True)
+def _quiet_briefing(monkeypatch):
+    """The briefing is #138's concern, not this file's — and left live it would
+    make real HTTP attempts at every roster load."""
+    from client_portal import service as svc
+
+    real = svc._agent_briefing
+
+    async def _briefing(name, availability="ready"):
+        return (None, [])
+
+    monkeypatch.setattr(svc, "_agent_briefing", _briefing)
+    monkeypatch.setattr(_services_module("tts_service"), "is_available", lambda: False)
+    # Handed back so the one test that IS about the briefing can reach the real
+    # function rather than asserting against this stub.
+    return real
+
+
+def _pin_states(monkeypatch, states):
+    """Pin the LEAF `docker_service.agent_container_states`, so the real
+    `_availability_map` — narrowing, enum guard, absence rule — is what runs.
+
+    Patched on the `sys.modules` entry: that is the object `docker_utils`'
+    function-local `from services.docker_service import ...` resolves.
+    """
+    monkeypatch.setattr(
+        _services_module("docker_service"), "agent_container_states", lambda: states
+    )
+
+
+def _pin_state(monkeypatch, state):
+    """Same, for the single-agent read."""
+    monkeypatch.setattr(
+        _services_module("docker_service"), "agent_container_state", lambda name: state
+    )
+
+
+# ---------------------------------------------------------------------------
+# The two that carry the decision
+# ---------------------------------------------------------------------------
+
+def test_a_containerless_agent_stays_on_the_roster_and_says_why(roster_db, monkeypatch):
+    """THE anti-#1747 guard.
+
+    A live `agent_ownership` row whose container is gone is a routine state —
+    #834 Phase 1c recovery reaches it by design, as does a `docker system
+    prune` or a crash mid-create. On the one surface a client has, hiding the
+    row makes "not shared with me" indistinguishable from "shared but
+    containerless", so the state becomes undiagnosable rather than merely
+    unusable. It stays listed, and it says what is wrong.
+    """
+    from client_portal import service
+
+    _pin_states(monkeypatch, {"scout": "running", "sage": "exited"})   # `ghosted` absent
+
+    cards = {c.name: c for c in _run(service.get_roster("bob@example.com")).agents}
+
+    assert set(cards) == {"scout", "sage", "ghosted"}, "a row was FILTERED OUT"
+    assert cards["ghosted"].availability == "unavailable"
+
+
+def test_an_unreadable_docker_never_empties_the_roster(roster_db, monkeypatch):
+    """THE guard on the failure mode that decided the design.
+
+    `list_all_agents_fast` returns `[]` and `get_agent_container` returns `None`
+    on ANY Docker fault, so a filter built on either would empty a paying
+    customer's Workspace on one daemon restart. The tri-state read answers
+    `None` instead, every card reads `unknown`, and the roster renders exactly
+    as it does today: every row, no chip, nothing blocked.
+    """
+    from client_portal import service
+
+    _pin_states(monkeypatch, None)          # "Docker could not be asked"
+
+    cards = _run(service.get_roster("bob@example.com")).agents
+
+    assert {c.name for c in cards} == {"scout", "sage", "ghosted"}
+    assert {c.availability for c in cards} == {"unknown"}
+
+
+# ---------------------------------------------------------------------------
+# Classification — each proves it can produce a DIFFERENT value
+# ---------------------------------------------------------------------------
+
+def test_the_three_states_are_distinguished_in_one_roster(roster_db, monkeypatch):
+    from client_portal import service
+
+    _pin_states(monkeypatch, {"scout": "running", "sage": "stopped"})
+
+    cards = {c.name: c.availability for c in _run(service.get_roster("bob@example.com")).agents}
+
+    assert cards == {"scout": "ready", "sage": "stopped", "ghosted": "unavailable"}
+
+
+def test_the_seam_is_stubbed_not_ambient(roster_db, monkeypatch):
+    """Proves these assertions read the stub, not the developer's Docker.
+
+    `services/docker_service.py` runs `docker.from_env()` at import and
+    `tests/unit/conftest.py` re-imports it after every test, so on a machine
+    with Docker up the real seam answers with a real map — in which a fixture
+    agent does not appear, so it reads `unavailable`, not `unknown`. The same
+    call under two different stubs must therefore yield two different answers;
+    if it did not, every value below would be whatever the daemon happened to
+    say.
+    """
+    from client_portal import service
+
+    _pin_states(monkeypatch, None)
+    unreadable = {c.availability for c in _run(service.get_roster("bob@example.com")).agents}
+
+    _pin_states(monkeypatch, {})
+    empty_fleet = {c.availability for c in _run(service.get_roster("bob@example.com")).agents}
+
+    assert unreadable == {"unknown"}
+    assert empty_fleet == {"unavailable"}
+    assert unreadable != empty_fleet
+
+
+@pytest.mark.parametrize("docker_state,expected", [
+    ("running", "ready"),
+    ("stopped", "stopped"),
+    ("missing", "unavailable"),
+    (None, "unknown"),
+    ("paused", "unknown"),        # a status the classifier does not name
+    ("removing", "unknown"),
+    (object(), "unknown"),        # not even a string
+])
+def test_the_vocabulary_mapping(docker_state, expected):
+    """Docker's words and the card's words are different, and passing one
+    through as the other puts `"running"` onto a `Literal["ready", ...]`. ONE
+    translation table, guarded per VALUE — an unrecognised state degrades to
+    `unknown` rather than failing the card's validation."""
+    from client_portal import service
+
+    assert service._to_availability(docker_state) == expected
+
+
+def test_a_paused_or_removing_container_does_not_break_the_roster(roster_db, monkeypatch):
+    """`list_all_agents_fast` falls through with the RAW docker status for
+    `paused`/`restarting`/`removing`. `removing` happens routinely during any
+    agent delete, and copying that fall-through here would push it into the
+    card's `Literal` and 500 the entire roster for every client of the
+    instance. Classification is explicit for exactly this reason."""
+    import types
+    from client_portal import service
+
+    class _Sparse:
+        def __init__(self, name, status):
+            self.attrs = {"Names": [f"/agent-{name}"], "State": status}
+
+        @property
+        def status(self):
+            return self.attrs["State"]
+
+    # The REAL classifier, driven by the raw statuses Docker actually reports
+    # mid-delete and mid-pause — pinning the seam here instead would test the
+    # stub and prove nothing.
+    ds = _services_module("docker_service")
+    monkeypatch.setattr(ds, "docker_client", types.SimpleNamespace(
+        containers=types.SimpleNamespace(list=lambda **kw: [
+            _Sparse("scout", "paused"), _Sparse("sage", "removing"),
+            _Sparse("ghosted", "restarting"),
+        ])
+    ))
+
+    roster = _run(service.get_roster("bob@example.com"))     # must not raise
+    cards = {c.name: c.availability for c in roster.agents}
+
+    assert cards == {"scout": "stopped", "sage": "stopped", "ghosted": "stopped"}
+
+
+# ---------------------------------------------------------------------------
+# The seams' own guards
+# ---------------------------------------------------------------------------
+
+def test_a_magicmock_docker_module_reads_unknown_not_unavailable(roster_db, monkeypatch):
+    """A dozen test modules install a MagicMock at
+    `sys.modules["services.docker_service"]`. Its `agent_container_states()`
+    returns a truthy MagicMock — neither a dict nor None — which unguarded would
+    silently invert the fail-open default INSIDE the suite meant to prove it.
+
+    Same shape as `a2a_outbound`'s `isinstance(ResolvedEndpoint)` check, with
+    the direction flipped: that one fails closed because it decides where a
+    credential is sent; this one fails open because it decides whether to deny a
+    working agent.
+    """
+    from unittest.mock import MagicMock
+    from client_portal import service
+
+    monkeypatch.setattr(
+        _services_module("docker_service"), "agent_container_states", MagicMock()
+    )
+
+    cards = _run(service.get_roster("bob@example.com")).agents
+
+    assert {c.name for c in cards} == {"scout", "sage", "ghosted"}
+    assert {c.availability for c in cards} == {"unknown"}
+
+
+def test_the_availability_map_never_returns_another_tenants_agents(monkeypatch):
+    """The underlying call sees EVERY agent container on the host — other
+    clients' agents, and agents outside this caller's roster entirely. That map
+    must never be returned, logged, or attached to a response."""
+    from client_portal import service
+
+    _pin_states(monkeypatch, {
+        "scout": "running", "someone-elses-agent": "running", "internal-thing": "stopped",
+    })
+
+    out = _run(service._availability_map(["scout"]))
+
+    assert out == {"scout": "ready"}
+
+
+def test_a_one_agent_roster_body_names_no_other_agent(roster_db, monkeypatch):
+    """The same property end-to-end: nothing Docker-derived escapes onto the
+    payload beyond one of four server-chosen constants."""
+    from client_portal import service
+
+    _pin_states(monkeypatch, {
+        "scout": "running", "sage": "running", "ghosted": "running",
+        "another-tenants-agent": "running",
+    })
+
+    body = _run(service.get_roster("nobody@example.com")).model_dump_json()
+
+    assert "another-tenants-agent" not in body
+
+
+def test_an_empty_roster_asks_docker_nothing(monkeypatch):
+    """Zero rows ⇒ zero Docker calls: an external client with no shares must
+    not make the platform inspect its fleet."""
+    calls = []
+
+    def _boom():
+        calls.append(1)
+        return {}
+
+    monkeypatch.setattr(_services_module("docker_service"), "agent_container_states", _boom)
+
+    from client_portal import service
+    assert _run(service._availability_map([])) == {}
+    assert calls == []
+
+
+def test_a_renamed_agent_is_not_reported_unavailable(monkeypatch):
+    """The batch map is keyed by CONTAINER NAME, never by the
+    `trinity.agent-name` label.
+
+    Rename moves the container name (`docker_utils.container_rename`) and leaves
+    the label at whatever it was written as at create time. Key by the label and
+    every renamed agent reads `unavailable` — a silent regression on a working
+    agent, which is the exact direction this whole change exists to avoid.
+    """
+    import types
+    from client_portal import service
+
+    class _Sparse:
+        """The shape `containers.list(sparse=True)` actually returns."""
+
+        def __init__(self, attrs):
+            self.attrs = attrs
+
+        @property
+        def status(self):
+            state = self.attrs["State"]
+            return state["Status"] if isinstance(state, dict) else state
+
+    renamed = _Sparse({
+        "Names": ["/agent-new-name"],
+        "State": "running",
+        "Labels": {"trinity.platform": "agent", "trinity.agent-name": "old-name"},
+    })
+
+    fake = types.SimpleNamespace(
+        containers=types.SimpleNamespace(list=lambda **kw: [renamed])
+    )
+    ds = _services_module("docker_service")
+    monkeypatch.setattr(ds, "docker_client", fake)
+
+    states = ds.agent_container_states()
+
+    assert states == {"new-name": "running"}
+    assert _run(service._availability_map(["new-name"]))["new-name"] == "ready"
+    assert _run(service._availability_map(["old-name"]))["old-name"] == "unavailable"
+
+
+def test_the_batch_read_uses_the_sparse_attrs_shape(monkeypatch):
+    """The single test that catches the most likely TOTAL failure.
+
+    `containers.list()` defaults to `sparse=False` and full-inspects every
+    container, so `sparse=True` is required for the cost claim to hold at all.
+    But under sparse the summary carries `Names` (a list) rather than `Name`,
+    which makes docker-py's `.name` property return **None**, and `.labels`
+    **raise**. Both fail in the SAFE direction — every card would read
+    `"unknown"` forever while the suite stayed green and the feature simply
+    never worked in production.
+
+    A test against a hand-built object with a `.name` attribute proves nothing:
+    that is precisely the shape `sparse=True` does not produce. So the fixture
+    below exposes ONLY what a sparse container exposes.
+    """
+    import types
+    import docker.errors
+    from docker.models.containers import Container
+
+    ds = _services_module("docker_service")
+    captured = {}
+
+    # A REAL docker-py Container seeded with a real /containers/json summary —
+    # so `.name` and `.labels` behave exactly as they do against a live daemon.
+    sparse = Container(attrs={
+        "Id": "abc123",
+        "Names": ["/agent-scout"],
+        "State": "running",
+        "Image": "trinity-agent-base:latest",
+    })
+    assert sparse.name is None, "fixture is not sparse-shaped"
+    with pytest.raises(docker.errors.DockerException):
+        _ = sparse.labels
+
+    def _list(**kwargs):
+        captured.update(kwargs)
+        return [sparse]
+
+    monkeypatch.setattr(
+        ds, "docker_client", types.SimpleNamespace(containers=types.SimpleNamespace(list=_list))
+    )
+
+    assert ds.agent_container_states() == {"scout": "running"}
+    assert captured.get("sparse") is True, "the batch call must pass sparse=True"
+    assert captured.get("filters") == {"label": "trinity.platform=agent"}
+
+
+# ---------------------------------------------------------------------------
+# docker_service's own contract
+# ---------------------------------------------------------------------------
+
+def test_the_batch_read_distinguishes_empty_from_unreadable(monkeypatch):
+    import types
+
+    ds = _services_module("docker_service")
+
+    monkeypatch.setattr(ds, "docker_client", None)
+    assert ds.agent_container_states() is None            # could not be asked
+
+    def _boom(**kwargs):
+        raise RuntimeError("permission denied while trying to connect to the docker daemon")
+
+    monkeypatch.setattr(
+        ds, "docker_client", types.SimpleNamespace(containers=types.SimpleNamespace(list=_boom))
+    )
+    assert ds.agent_container_states() is None            # still: could not be asked
+
+    monkeypatch.setattr(
+        ds, "docker_client",
+        types.SimpleNamespace(containers=types.SimpleNamespace(list=lambda **kw: [])),
+    )
+    assert ds.agent_container_states() == {}              # Docker ANSWERED: none
+
+
+def test_the_single_read_reports_missing_only_when_docker_answered(monkeypatch):
+    import types
+    import docker.errors
+
+    ds = _services_module("docker_service")
+
+    def _get_notfound(name):
+        raise docker.errors.NotFound("no such container")
+
+    monkeypatch.setattr(
+        ds, "docker_client", types.SimpleNamespace(containers=types.SimpleNamespace(get=_get_notfound))
+    )
+    assert ds.agent_container_state("scout") == "missing"
+
+    def _get_boom(name):
+        raise RuntimeError("docker socket down")
+
+    monkeypatch.setattr(
+        ds, "docker_client", types.SimpleNamespace(containers=types.SimpleNamespace(get=_get_boom))
+    )
+    assert ds.agent_container_state("scout") is None
+
+    monkeypatch.setattr(ds, "docker_client", None)
+    assert ds.agent_container_state("scout") is None
+
+
+def test_the_two_forms_agree_about_an_unlabelled_container(monkeypatch):
+    """The batch call filters on `trinity.platform=agent` server-side, so a
+    container merely NAMED `agent-x` never appears in it. Without the same check
+    on the single form, one agent would read `unavailable` on the roster and
+    `ready` on its own page."""
+    import types
+
+    ds = _services_module("docker_service")
+
+    impostor = types.SimpleNamespace(
+        labels={"some.other": "thing"}, status="running", name="agent-scout",
+    )
+    monkeypatch.setattr(
+        ds, "docker_client",
+        types.SimpleNamespace(containers=types.SimpleNamespace(get=lambda n: impostor)),
+    )
+
+    assert ds.agent_container_state("scout") == "missing"
+
+
+def test_list_all_agents_fast_still_returns_empty_on_a_docker_fault(monkeypatch):
+    """Its []-on-fault contract is depended on by ~60 stub sites and many
+    callers, and #2196 deliberately did NOT change it — the new distinction was
+    added alongside rather than folded in."""
+    import types
+
+    ds = _services_module("docker_service")
+
+    def _boom(**kwargs):
+        raise RuntimeError("docker socket down")
+
+    monkeypatch.setattr(
+        ds, "docker_client", types.SimpleNamespace(containers=types.SimpleNamespace(list=_boom))
+    )
+    assert ds.list_all_agents_fast() == []
+
+    monkeypatch.setattr(ds, "docker_client", None)
+    assert ds.list_all_agents_fast() == []
+
+
+# ---------------------------------------------------------------------------
+# The page, the card default, and the turn gates
+# ---------------------------------------------------------------------------
+
+def test_the_page_and_the_roster_agree_about_the_same_agent(roster_db, monkeypatch):
+    """#2160's no-disagreement property, extended to the new field. The two
+    reads are deliberately DIFFERENT calls (batch vs single) so one agent's page
+    never pays a fleet-scale read — which is exactly the setup in which two
+    surfaces drift."""
+    from client_portal import service
+
+    _pin_states(monkeypatch, {"scout": "running"})       # `sage` has no container
+    _pin_state(monkeypatch, "missing")
+
+    roster = {c.name: c.availability for c in _run(service.get_roster("bob@example.com")).agents}
+    card = _run(service.get_agent_card("bob@example.com", "sage"))
+
+    assert roster["sage"] == "unavailable"
+    assert card.availability == "unavailable"
+
+
+def test_the_page_header_carries_the_cards_availability(roster_db, monkeypatch):
+    from client_portal import agent_page, service
+    from client_portal.models import PortalAgentPage
+
+    _pin_state(monkeypatch, "missing")
+    card = _run(service.get_agent_card("bob@example.com", "sage"))
+
+    page = agent_page.build_page("bob@example.com", "sage", card.model_dump())
+
+    assert page["header"]["availability"] == "unavailable"
+    PortalAgentPage(**page)      # the Literal must accept it
+
+
+def test_a_page_built_from_no_card_still_validates():
+    """`get_agent_card` returning None is documented-reachable (the agent
+    vanished between the roster read and this one), and `card = card or {}`
+    turns that into an explicit `None` from a bare `.get` — which a
+    `Literal`-with-default REJECTS, 500ing the one page ent#360 built to always
+    render. Hence `or "unknown"`."""
+    from client_portal import agent_page
+    from client_portal.models import PortalAgentPage
+
+    page = agent_page.build_page("bob@example.com", "sage", None)
+
+    assert page["header"]["availability"] == "unknown"
+    PortalAgentPage(**page)
+
+
+def test_the_card_default_is_fail_open():
+    """Deliberately the OPPOSITE of `voice_available` /
+    `multi_agent_chat_available`, which default False. Those fail closed because
+    their bug is promising an affordance that cannot work; this one's bug is
+    denying a working agent — and, since one unreadable socket marks every card
+    at once, emptying a customer's roster over an infrastructure fault."""
+    from client_portal.models import PortalAgentCard, PortalAgentHeader
+
+    assert PortalAgentCard(name="scout").availability == "unknown"
+    assert PortalAgentHeader(name="scout").availability == "unknown"
+    assert PortalAgentCard(name="scout").voice_available is False
+
+
+def test_the_briefing_is_skipped_only_for_states_that_cannot_answer(_quiet_briefing, monkeypatch):
+    """`unknown` is ATTEMPTED, not skipped — and the asymmetry with the turn
+    gate is the point rather than an oversight. The briefing reaches the agent at
+    `http://agent-{name}:8000` **by DNS over the agent network**, so a backend
+    Docker-socket fault says nothing about whether it answers HTTP. Skipping
+    would turn one unreadable socket into "no briefings fleet-wide" when every
+    briefing would in fact have worked.
+    """
+    briefing = _quiet_briefing        # the REAL function, not this file's stub
+    attempted = []
+
+    # Deliberately SYNCHRONOUS: `agent_httpx_client(...)` is called to obtain an
+    # async context manager, so a coroutine stub would record nothing until it
+    # was awaited — and it never is, because entering it fails first.
+    def _fake_client(name, timeout=None):
+        attempted.append(name)
+        raise RuntimeError("no agent here")
+
+    monkeypatch.setattr(_services_module("agent_auth"), "agent_httpx_client", _fake_client)
+
+    for availability, should_attempt in (
+        ("ready", True), ("unknown", True), ("stopped", False), ("unavailable", False),
+    ):
+        attempted.clear()
+        assert _run(briefing("scout", availability)) == (None, [])
+        assert bool(attempted) is should_attempt, availability
+
+
+def test_a_roster_load_makes_no_per_agent_container_lookup(roster_db, monkeypatch):
+    """`_agent_briefing` used to call `get_agent_container()` per card and throw
+    the answer away. N inspects became one list call, and the answer is now
+    used — which is why this change is cheaper than what it replaces, not an
+    added Docker dependency."""
+    from client_portal import service
+
+    calls = []
+    monkeypatch.setattr(
+        _services_module("docker_service"), "get_agent_container",
+        lambda name: calls.append(name),
+    )
+    _pin_states(monkeypatch, {"scout": "running", "sage": "running", "ghosted": "running"})
+
+    _run(service.get_roster("bob@example.com"))
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — refusing a turn honestly
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def turn(monkeypatch):
+    """`portal_chat` with everything but the availability gate stubbed."""
+    from client_portal import service as svc
+    from client_portal import db as portal_db
+
+    written = []
+
+    monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: "sess-1")
+    monkeypatch.setattr(portal_db, "get_portal_session", lambda *a, **kw: {"title": "t"})
+    monkeypatch.setattr(portal_db, "get_portal_messages", lambda *a, **kw: [])
+    monkeypatch.setattr(portal_db, "get_cached_claude_session_id", lambda sid: None)
+    monkeypatch.setattr(
+        portal_db, "add_portal_message",
+        lambda *a, **kw: written.append(a),
+    )
+    monkeypatch.setattr(portal_db, "touch_portal_session", lambda *a, **kw: None)
+    return svc, written
+
+
+def test_portal_chat_refuses_before_it_persists_the_user_turn(turn, monkeypatch):
+    """The real AC #3 hole, and the worse of the two paths.
+
+    `portal_chat` had NO liveness gate — its 502 lives at the far end, AFTER
+    `_persist_user_turn`. So a containerless agent left the client's thread
+    holding a durable user message with no reply, plus an execution row, plus a
+    "Please try again" that could never work. And this is not a dead path:
+    `/chat` is the documented headless integration surface (ent#83) and the
+    browser's fallback when streaming fails.
+    """
+    svc, written = turn
+    _pin_state(monkeypatch, "missing")
+
+    with pytest.raises(svc.ClientPortalError) as ei:
+        _run(svc.portal_chat("ghosted", "hello?", "bob@example.com"))
+
+    assert ei.value.status_code == 502
+    assert written == [], "a user message was persisted for a turn that was refused"
+
+
+def test_the_refusal_names_the_state_and_the_next_action(turn, monkeypatch):
+    """Two states, two messages, one next action — and no "try again", because
+    for both of these retrying cannot work. `POST /api/agents/{name}/start`
+    recreates a missing container (#1559), so "its owner needs to start it" is
+    correct for both. No infrastructure jargon: the viewer may be an external
+    client with no Trinity account.
+    """
+    svc, _ = turn
+
+    stopped = svc._refusal_detail("stopped")
+    gone = svc._refusal_detail("unavailable")
+
+    assert stopped != gone
+    for detail in (stopped, gone):
+        assert "try again" not in detail.lower()
+        assert "owner" in detail.lower() and "start it" in detail.lower()
+        for jargon in ("container", "docker", "502", "socket"):
+            assert jargon not in detail.lower()
+
+
+def test_an_unreadable_docker_does_not_refuse_the_turn(turn, monkeypatch):
+    """Fail OPEN at the gate. A Docker API fault — a daemon restart, a socket
+    permission change, a wrong `group_add` GID — leaves agent containers running
+    and serving HTTP, so "cannot ask Docker" is not "the agent is down".
+    Refusing here would deny every Workspace turn on the instance from one
+    unreadable socket, which is the bug `_agent_is_running` shipped with."""
+    svc, _ = turn
+    _pin_state(monkeypatch, None)
+
+    # Gets past the gate and fails later, on the stubbed execution stack — the
+    # point is that it is NOT the 502 refusal.
+    with pytest.raises(Exception) as ei:
+        _run(svc.portal_chat("scout", "hello?", "bob@example.com"))
+
+    assert svc._refusal_detail("unavailable") not in str(getattr(ei.value, "detail", ""))
+
+
+def test_the_terminal_failure_copy_only_says_offline_when_we_could_not_look():
+    """The far-end 502 is a different message from the pre-flight refusal: the
+    turn RAN, so retrying may genuinely help and the instruction stays. But
+    "it may be offline" is only honest when the agent's state could not be read
+    at dispatch."""
+    from client_portal import service
+
+    assert "offline" in service._turn_failed_detail("unknown").lower()
+    assert "offline" not in service._turn_failed_detail("ready").lower()
+    assert "try again" in service._turn_failed_detail("ready").lower()
+
+
+def test_the_roster_gate_still_runs_before_the_availability_gate():
+    """A state-dependent refusal reached BEFORE `agent_on_roster` would be an
+    existence oracle for a caller who holds no share — the Invariant #8 class.
+    Both turn entry points must answer the uniform 404 first."""
+    import inspect
+    from client_portal import service
+
+    for fn in (service.portal_chat, service.start_portal_turn):
+        src = inspect.getsource(fn)
+        assert src.index("agent_on_roster") < src.index("_availability_allows_turn"), fn.__name__
+
+
+def test_membership_is_resolved_by_pure_sql(monkeypatch):
+    """`_roster_rows` must stay pure SQL: #2198 resolves the roster through it
+    for a batch-sessions gate, and availability attached there would be
+    inherited by that endpoint. It is also the structural guarantee that
+    container state is a PROJECTION and never a membership filter."""
+    import inspect
+    from client_portal import service
+
+    src = inspect.getsource(service._roster_rows)
+    for forbidden in ("_availability_map", "_agent_availability", "docker"):
+        assert forbidden not in src, f"_roster_rows reaches for {forbidden}"
+
+
+def test_availability_is_not_computed_inside_the_briefing():
+    """#2163 is free to defer, bound or cache `_agent_briefing`. Anything
+    computed inside it breaks the moment that lands, so availability is resolved
+    by the caller and passed IN."""
+    import inspect
+    from client_portal import service
+
+    src = inspect.getsource(service._agent_briefing)
+    assert "_availability_map" not in src
+    assert "_agent_availability" not in src
+    assert "availability" in inspect.signature(service._agent_briefing).parameters

--- a/tests/unit/test_ent286_portal_streaming.py
+++ b/tests/unit/test_ent286_portal_streaming.py
@@ -60,16 +60,20 @@ def portal(monkeypatch):
     from client_portal import service as svc
     from database import db as core_db
 
-    state = types.SimpleNamespace(chat_calls=[], created=[], row=None)
+    state = types.SimpleNamespace(chat_calls=[], created=[], row=None, availability="ready")
 
     monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
     monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: s or SESSION)
 
+    # `availability` (#2196): `start_portal_turn` resolved the state for its own
+    # gate and hands it down, so the streamed turn costs ONE Docker read rather
+    # than one at dispatch and another inside `portal_chat`.
     async def _fake_chat(agent_name, message, email, session_id=None,
-                        include_owned=False, execution_id=None):
+                        include_owned=False, execution_id=None, availability=None):
         state.chat_calls.append({
             "agent": agent_name, "message": message, "email": email,
             "session_id": session_id, "execution_id": execution_id,
+            "availability": availability,
         })
         return {"response": "done", "cost": 0.01, "session_id": session_id}
 
@@ -83,15 +87,26 @@ def portal(monkeypatch):
     monkeypatch.setattr(core_db, "get_agent_subscription_id", lambda a: "sub-1")
     monkeypatch.setattr(core_db, "get_execution", lambda eid: state.row)
 
-    # Default: the agent is up. A turn is refused for a stopped agent, so every
-    # test that isn't ABOUT that needs the healthy case; the ones that are
-    # override this.
+    # Default: the agent is up. A turn is refused for an agent that cannot run,
+    # so every test that isn't ABOUT that needs the healthy case; the ones that
+    # are override this.
     #
     # Patched on the SEAM, not on services.docker_service: a sibling module
     # installs a MagicMock stub for that module at collection time, and patching
     # one copy while the code resolves another is why these tests passed alone
     # and failed in the full suite.
-    monkeypatch.setattr(svc, "_agent_is_running", lambda name: True)
+    #
+    # #2196 moved the seam from the boolean `_agent_is_running` to the tri-state
+    # `_agent_availability`, because the turn paths need the STATE — one Docker
+    # read has to answer both "may this dispatch?" and "what do we tell the
+    # client?". Patching the old boolean here would now be INERT, which is worse
+    # than no patch: the real read would run against whatever Docker the machine
+    # happens to have, and these tests would pass or fail by daemon.
+    async def _available(name):
+        return state.availability
+
+    state.availability = "ready"
+    monkeypatch.setattr(svc, "_agent_availability", _available)
     return svc, state
 
 
@@ -323,7 +338,8 @@ def test_the_marker_is_set_while_the_turn_is_still_running(portal, redis_stub, m
     seen = {}
 
     async def _slow_chat(agent_name, message, email, session_id=None,
-                         include_owned=False, execution_id=None):
+                         include_owned=False, execution_id=None,
+                         availability=None):
         seen["during"] = svc.get_turn_inflight(session_id)
         return {"response": "done", "cost": 0.0, "session_id": session_id}
 
@@ -343,19 +359,57 @@ def test_a_stopped_agent_is_refused_before_anything_is_created(portal, monkeypat
     result was the same message persisted twice, 320ms apart.
     """
     svc, state = portal
-    monkeypatch.setattr(svc, "_agent_is_running", lambda name: False)
+    state.availability = "stopped"
 
     with pytest.raises(svc.ClientPortalError) as excinfo:
         _run(svc.start_portal_turn(AGENT, "hello", EMAIL, SESSION))
 
     assert excinfo.value.status_code == 502
-    assert "offline" in excinfo.value.detail.lower()
+    # #2196: the copy names the state and the next action, and drops "try
+    # again" — for these two states retrying cannot work.
+    assert "start it" in excinfo.value.detail.lower()
+    assert "try again" not in excinfo.value.detail.lower()
     assert state.created == [], "an execution row was created for a turn that cannot run"
 
 
-def test_a_running_agent_still_dispatches(portal, monkeypatch):
+def test_a_containerless_agent_is_refused_with_its_own_copy(portal):
+    """#2196: "stopped" and "no container at all" are different refusals.
+
+    The old single message said "it may be offline… Please try again", which is
+    fair for a stopped agent and actively misleading for one whose container is
+    gone — retrying never works there, and that is the state a Workspace client
+    is most likely to hit (#1747 documents it as routine).
+    """
     svc, state = portal
-    monkeypatch.setattr(svc, "_agent_is_running", lambda name: True)
+    state.availability = "unavailable"
+
+    with pytest.raises(svc.ClientPortalError) as excinfo:
+        _run(svc.start_portal_turn(AGENT, "hello", EMAIL, SESSION))
+
+    assert excinfo.value.status_code == 502
+    assert excinfo.value.detail != svc._refusal_detail("stopped")
+    assert "try again" not in excinfo.value.detail.lower()
+    assert state.created == []
+
+
+def test_a_running_agent_still_dispatches(portal):
+    svc, state = portal
+    state.availability = "ready"
+
+    out = _run(svc.start_portal_turn(AGENT, "hello", EMAIL, SESSION))
+    assert out["execution_id"] == EXEC_ID
+
+
+def test_an_unreadable_docker_still_dispatches(portal):
+    """The fail-OPEN direction at the turn gate (#2196).
+
+    `unknown` means "Docker could not be asked", which is not evidence the agent
+    is down: a daemon restart or a socket-permission change leaves containers
+    running and answering HTTP over the agent network. Refusing here would turn
+    one unreadable socket into "no Workspace client can send a message".
+    """
+    svc, state = portal
+    state.availability = "unknown"
 
     out = _run(svc.start_portal_turn(AGENT, "hello", EMAIL, SESSION))
     assert out["execution_id"] == EXEC_ID
@@ -363,19 +417,71 @@ def test_a_running_agent_still_dispatches(portal, monkeypatch):
 
 def test_a_docker_hiccup_does_not_block_a_turn(portal, monkeypatch):
     """Fail OPEN on the running-check: Docker being briefly unreadable is not
-    evidence the agent is down, and refusing a healthy turn is the worse error."""
+    evidence the agent is down, and refusing a healthy turn is the worse error.
+
+    #2196 repointed this at `agent_container_state`, the tri-state read
+    `_agent_is_running` now uses. Left on `get_agent_container` it would have
+    passed VACUOUSLY — the raiser would never be called, and the fix's most
+    important behaviour would have lost its only guard.
+
+    It also matters that this exercises the REAL predicate: before #2196 the
+    docstring claimed fail-open while the code failed CLOSED, because
+    `get_agent_container` had already swallowed the error and returned None, so
+    the `except` branch was unreachable. A test that patched the boolean seam
+    with a lambda could never have caught that.
+    """
     svc, _ = portal
 
     def _boom(name):
         raise RuntimeError("docker socket down")
 
-    # Exercises the REAL seam so the fail-open branch is what is under test,
-    # not a lambda standing in for it. Patched on the sys.modules ENTRY, which
-    # is the exact object `_agent_is_running`'s in-function import resolves —
+    # Patched on the sys.modules ENTRY, which is the exact object
+    # `_agent_is_running`'s in-function import resolves —
     # `import services.docker_service as m` can bind a different copy when a
     # sibling module has stubbed it, which is the whole bug this file just hit.
     import sys
     module = sys.modules["services.docker_service"]
-    monkeypatch.setattr(module, "get_agent_container", _boom)
+    monkeypatch.setattr(module, "agent_container_state", _boom)
 
     assert svc._agent_is_running(AGENT) is True
+
+
+def test_the_running_check_reads_the_tri_state_and_fails_open_on_unknown(portal, monkeypatch):
+    """The unreadable-Docker case that does NOT raise.
+
+    `agent_container_state` returns `None` for "could not be asked" — it does
+    not raise — so the fail-open rule has to hold on the RETURN value too, not
+    only in the `except`. That is the exact shape of the bug #2196 fixed: the old
+    implementation's swallowed-error path made its documented `except` branch
+    dead code.
+    """
+    import sys
+    svc, _ = portal
+    module = sys.modules["services.docker_service"]
+
+    monkeypatch.setattr(module, "agent_container_state", lambda name: None)
+    assert svc._agent_is_running(AGENT) is True          # unreadable ⇒ allow
+
+    monkeypatch.setattr(module, "agent_container_state", lambda name: "missing")
+    assert svc._agent_is_running(AGENT) is False         # Docker answered: gone
+
+    monkeypatch.setattr(module, "agent_container_state", lambda name: "stopped")
+    assert svc._agent_is_running(AGENT) is False
+
+    monkeypatch.setattr(module, "agent_container_state", lambda name: "running")
+    assert svc._agent_is_running(AGENT) is True
+
+
+def test_the_streamed_turn_does_not_re_read_docker(portal):
+    """One Docker read per turn (#2196).
+
+    `start_portal_turn` gates on the resolved state and `portal_chat` gates on it
+    too — the `/chat` path has no other gate. Letting the background turn resolve
+    it again would double the read on the hottest portal path for no new
+    information, so the dispatch hands its answer down.
+    """
+    svc, state = portal
+
+    _run(_drain(svc.start_portal_turn(AGENT, "hello", EMAIL, SESSION)))
+
+    assert state.chat_calls[0]["availability"] == "ready"

--- a/tests/unit/test_ent356_portal_is_oss_core.py
+++ b/tests/unit/test_ent356_portal_is_oss_core.py
@@ -279,6 +279,10 @@ _PORTAL_TEST_FILES = (
     "test_ent308_inbox_dir_collision.py",
     "test_ent311_portal_signin_hardening.py",
     "test_ent357_workspace_owned_roster.py",
+    # #2196 — a new portal test file must be ADDED here or it silently escapes
+    # both guards below, which turns an unchecked file into a believed-checked
+    # one (the #1871 "the guard covered one of two APIs" class).
+    "test_2196_roster_availability.py",
 )
 
 

--- a/tests/unit/test_ent357_workspace_owned_roster.py
+++ b/tests/unit/test_ent357_workspace_owned_roster.py
@@ -20,6 +20,36 @@ from __future__ import annotations
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _pin_container_state(monkeypatch):
+    """#2196: pin the container-state seams and quiet the briefing.
+
+    `get_roster` now projects container state onto every card, and
+    `services/docker_service.py` runs `docker.from_env()` at import while
+    conftest re-imports it after every test — so unpinned, these tests read
+    whatever Docker the machine happens to have. Worse than nondeterministic
+    values: on a Docker-less machine every card reads `unknown`, which makes the
+    briefing ATTEMPT its HTTP call (`unknown` is deliberately attemptable), so a
+    membership test would make real network attempts to `agent-{name}:8000`.
+    Nothing here asserts availability or briefings; both are pinned inert so the
+    file stays about the roster union.
+    """
+    from client_portal import service
+
+    async def _map(names):
+        return {n: "ready" for n in names}
+
+    async def _one(name):
+        return "ready"
+
+    async def _briefing(name, availability="ready"):
+        return (None, [])
+
+    monkeypatch.setattr(service, "_availability_map", _map)
+    monkeypatch.setattr(service, "_agent_availability", _one)
+    monkeypatch.setattr(service, "_agent_briefing", _briefing)
+
+
 @pytest.fixture()
 def roster_db(tmp_path, monkeypatch):
     """Fresh sqlite with the OSS tables the roster joins over."""

--- a/tests/unit/test_ent358_workspace_absorbs_session.py
+++ b/tests/unit/test_ent358_workspace_absorbs_session.py
@@ -86,6 +86,29 @@ class _Recorder:
         return self._results.pop(0) if self._results else _Result()
 
 
+@pytest.fixture(autouse=True)
+def _pin_container_state(monkeypatch):
+    """#2196: pin the container-state seam for every test in this module.
+
+    `portal_chat` gained a liveness gate (it had none, and its 502 fired only
+    AFTER the user's message was durably written). Without this fixture the gate
+    would consult the developer's real Docker — where these fixture agents have
+    no container — so the module would pass in a Docker-less CI container and
+    fail on every workstation, or the reverse. Patched on the consuming module's
+    own attribute, which is why that read has a named seam at all.
+    """
+    from client_portal import service as svc
+
+    async def _map(names):
+        return {n: "ready" for n in names}
+
+    async def _one(name):
+        return "ready"
+
+    monkeypatch.setattr(svc, "_availability_map", _map)
+    monkeypatch.setattr(svc, "_agent_availability", _one)
+
+
 @pytest.fixture()
 def portal(monkeypatch):
     """`client_portal.service` with its DB, roster and execution stack stubbed.

--- a/tests/unit/test_ent79_portal_exposure.py
+++ b/tests/unit/test_ent79_portal_exposure.py
@@ -57,6 +57,34 @@ def _services_module(name: str):
     return sys.modules[f"services.{name}"]
 
 
+@pytest.fixture(autouse=True)
+def _pin_container_state(monkeypatch):
+    """#2196: pin the container-state seam for EVERY test in this module.
+
+    Not optional hygiene. `services/docker_service.py` runs `docker.from_env()`
+    at import, and `tests/unit/conftest.py` pops + re-imports it after every
+    test — so on any machine with Docker running (which local dev requires) the
+    real seam answers with a real map, a seeded fixture agent like `atlas` is not
+    in it, and every card reads "unavailable" instead of "unknown". That is green
+    in CI and red locally, on the one field whose whole purpose is to be
+    trustworthy.
+
+    Patched on `client_portal.service`'s own attribute — route (i) of this
+    file's PATCHING RULE, and precisely why #2196 gave these two reads named
+    seams instead of calling Docker inline.
+    """
+    from client_portal import service
+
+    async def _map(names):
+        return {n: "ready" for n in names}
+
+    async def _one(name):
+        return "ready"
+
+    monkeypatch.setattr(service, "_availability_map", _map)
+    monkeypatch.setattr(service, "_agent_availability", _one)
+
+
 
 @pytest.fixture()
 def portal_db(tmp_path, monkeypatch):
@@ -232,7 +260,7 @@ def test_roster_carries_briefing(roster_db, monkeypatch):
     from client_portal.models import PortalPlaybook
     monkeypatch.setattr(_services_module("tts_service"), "is_available", lambda: False)   # skip the global key check
 
-    async def fake_briefing(name):
+    async def fake_briefing(name, availability="ready"):
         if name == "atlas":
             return ("Atlas does research.", [
                 PortalPlaybook(title="Weekly report", description="A weekly digest",
@@ -257,7 +285,7 @@ def test_roster_briefing_is_fail_soft(roster_db, monkeypatch):
     from client_portal import service
     monkeypatch.setattr(_services_module("tts_service"), "is_available", lambda: False)
 
-    async def boom(name):
+    async def boom(name, availability="ready"):
         raise RuntimeError("agent unreachable")
 
     monkeypatch.setattr(service, "_agent_briefing", boom)
@@ -315,12 +343,11 @@ def _wire_briefing(monkeypatch, routes, connector_cfg=None):
 
     client = _FakeAgentClient(routes)
 
-    class _Running:
-        status = "running"
-
-    monkeypatch.setattr(
-        _services_module("docker_service"), "get_agent_container", lambda name: _Running()
-    )
+    # #2196: `_agent_briefing` no longer makes its own `get_agent_container()`
+    # call — the caller resolves container state once for the whole roster and
+    # hands it in (default `"ready"` for a direct call). The stub that used to
+    # live here is removed rather than left inert, since an inert patch reads
+    # like coverage that no longer exists.
 
     @asynccontextmanager
     async def fake_httpx(name, timeout=None):


### PR DESCRIPTION
Fixes #2196

## Summary

The Workspace roster stays **membership-honest and availability-honest at the same time**: the `agent_ownership` row remains authoritative for *who is on the roster*, while container state is projected as a 4-state `availability` field (`running | stopped | no_container | unknown`) on each roster card. Resolution happens in `get_roster` / `get_agent_card` via **one sparse batched Docker read** for the whole roster (not N per-card inspections). `_agent_briefing` loses its N discarded per-card Docker calls; `portal_chat` gains the previously **missing liveness gate BEFORE user-turn persistence** (a turn against a container that cannot run no longer persists the user message and then fails opaquely); and the `_agent_is_running` fail-closed bug is fixed (a Docker read failure no longer reads as "not running").

## Design decision: project availability, never hide the row

Hiding containerless agents from the roster was considered and **rejected**:

- `list_all_agents_fast()` returns `[]` on **any** Docker fault. A roster filtered through it would empty a paying customer's entire Workspace on a Docker blip, daemon restart, or `DOCKER_GID` change — indistinguishable from "you have no agents". Membership must not be a function of Docker health.
- The **narrowed #1747 argument**: agent identity lives in `agent_ownership`, not in the container. #1747 fixed the DELETE handler treating "no container" as "agent not found"; this PR extends the same principle to the roster read path — the row is the agent, the container is its runtime state. (Deliberately *not* overclaiming that #1747 ruled on listings; it ruled on the identity model, which listings inherit.)

So the roster always shows every shared/owned agent, and each card says honestly whether it can currently serve a turn.

## Trap note: `sparse=True` + `attrs["Names"][0]`

The batched read uses `containers.list(all=True, sparse=True)`. Under sparse listing, docker-py's `container.name` is **`None`** and `container.labels` **raises** — code written against the non-sparse attribute surface fails *silently green* (every name comparison is `None != anything`, so the availability map comes back empty and every card degrades). Names are therefore read from `attrs["Names"][0]` (leading-`/` stripped) and labels from `attrs`. This exact failure mode is pinned by a test that exercises **real docker-py sparse fixtures**, not mocks of our own wrapper.

## Acceptance-criteria notes

- **AC #4 (fleet endpoint and roster agree literally): not achievable as written.** `GET /api/agents` has an admin-only branch that surfaces **orphan containers** (containers with no ownership row) — the roster, keyed on ownership rows, structurally cannot show those. The intended difference is documented in the feature flows; the two surfaces agree on every row that has an ownership row.
- **AC #5 (canary invariant): answered as "no canary".** L-03 keys on rows referencing an agent *absent from `agent_ownership`* — a containerless agent with a live ownership row cannot fire it. A new invariant would need Docker evidence (the H-01 evidence class) to avoid paging on every stopped-but-healthy agent. Instead: an **operator-notification follow-up** (listed below) — the batch availability map makes it nearly free.

## Deviations from plan (5, from the review audit)

1. Compat-shim `_agent_is_running` **kept** (ent#286 streaming coverage still calls it) rather than deleted.
2. `portal_chat` takes an `availability` parameter (resolved by the caller) instead of re-reading Docker inside the turn path.
3. Owner naming for the chip states resolved **frontend-side** (`portalUtils.js`) rather than shipping display strings from the backend.
4. The availability classifier is exercised by a **classifier-driven test** (table of Docker states → expected 4-state) instead of per-endpoint duplication.
5. `.claude` test-runner catalog update ships via **trinity-dev** separately (submodule pointer deliberately not bumped here).

## Verification

WAVE-4 `verify-local` (full stack: prod images + base image + real agent boot, at base `58df9aed`):

| Surface | Result |
|---|---|
| Unit suite | **10,358 passed** (8 pre-existing reds — see below) |
| Integration suite | **70 passed** |
| Boot + image build | green |
| `latest-result.json` | `status: pass` |

The 8 unit reds are **pre-existing**: proven byte-identical at base `58df9aed` (same 8 failures with this branch's commits absent).

Post-rebase drift guard (on `origin/dev` @ f5fe15f3): `tests/unit/test_2196_roster_availability.py` → **36 passed**; seam-pinned files `test_ent357_workspace_owned_roster.py` + `test_2128_workspace_rooms_capability.py` → **22 passed**.

### Unverified-by-machine (for the human reviewer)

- **§11.15** — a fail-open turn against an unavailable container degrades to a *clean* FAILED via the transport breaker; proving it end-to-end needs a branch-serving stack (not reproducible in the unit/integration harness).
- **§11.8** — the visual reflow of the header availability fact: no reserved footprint, matches the file's existing `last_active` idiom; needs an eyeball, not a test.

## Follow-ups (listed, NOT filed)

- Operator notification for containerless **shared** agents — the batch availability map makes it nearly free.
- `is_ephemeral` roster exclusion — an access change across ~10 routes with a NULL-safety trap; out of scope here.
- `/my-agents` rate limiter — the endpoint now carries a free liveness map worth bounding.
- Portal test hygiene — pytest residue rows in `agent_ownership` from older portal suites.

## Merge order

**This PR merges BEFORE #2198's** — both touch `client_portal/service.py`; #2198 rebases after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
