### PR TITLE
fix(dashboard): arm the / hotkey at mount, not behind five fetches (#2200)

### DIFF
--- a/docs/memory/design-system-contract.md
+++ b/docs/memory/design-system-contract.md
@@ -75,7 +75,7 @@ Honest state:
 18. Verbs acknowledge in ~100ms and confirm completion; toasts for completed verbs, never errors. A failed verb surfaces an `InlineError` next to its control and persists until dismissed — never `console.error` alone, never `alert()` (#1926).
 19. Destructive actions: named verb, restated consequence, safe action focused first.
 22. Times are honest: relative for recency, absolute + timezone on hover/detail.
-23. Keyboard baseline: visible focus, Esc closes overlays, modal focus trap, tab order = visual order.
+23. Keyboard baseline: visible focus, Esc closes overlays, modal focus trap, tab order = visual order — and handlers are armed at mount, above every `await`, never behind fetched data. A surface that renders as interactive must already be interactive: the input-side twin of #15 (#2200).
 24. Encode identity in shape/icon as well as color — never hue alone.
 25. Errors say what happened, what it means, what to do — user vocabulary; codes/traces behind a disclosure.
 26. Set expectations: non-instant actions say what happens, how long, and where the result appears.

--- a/docs/memory/design-system.md
+++ b/docs/memory/design-system.md
@@ -356,7 +356,7 @@ The behavioral half of the standard (the visual half is §1–6). Confirmed in t
 20. Color via semantic tokens only; shared primitives; both themes first-class (#1430).
 21. Frontend invariants hold: domain-scoped stores, a single API client; loading flags live in stores, not components.
 22. Times carry honest context — relative for recency, absolute with timezone on hover or detail (see `docs/TIMEZONE_HANDLING.md`).
-23. Keyboard baseline: visible focus everywhere, Esc closes overlays, modals trap focus, tab order matches visual order.
+23. Keyboard baseline: visible focus everywhere, Esc closes overlays, modals trap focus, tab order matches visual order. Handlers are armed at mount, above every `await` — never behind fetched data. A surface that renders as interactive must already be interactive; this is the input-side twin of #15's honest-state rule for output. (#2200: the Dashboard `/` hotkey registered after `await Promise.allSettled([...5 fetches])` while the fleet painted on `fetchAgents()` alone, so keystrokes were silently dropped for an unbounded window. Guarded by `src/frontend/tests/unit/mountListenerOrdering.spec.js`.)
 24. Identity is encoded in form as well as color — classes and states are distinguishable by shape or icon, never by hue alone.
 25. Meaningful errors everywhere: every failure surface says what happened, what it means, and what to do — in user vocabulary; stack traces and HTTP codes go behind a details disclosure, never the headline.
 26. Expectation setting: non-instant actions state what will happen and roughly how long; multi-step operations show staged progress; say where the result will appear.

--- a/src/frontend/e2e/dashboard-hotkey-readiness.spec.js
+++ b/src/frontend/e2e/dashboard-hotkey-readiness.spec.js
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Dashboard `/` hotkey interaction readiness (#2200).
+ *
+ * The ent#261 type-to-filter hotkey used to be registered at the END of an
+ * `async onMounted`, after `await Promise.allSettled([...5 fetches...])`. The
+ * fleet paints as soon as `fetchAgents()` ALONE resolves (the `agents.length > 0`
+ * template gate), but the listener waited on the SLOWEST of the five — so the
+ * dashboard rendered as interactive while every `/` was silently dropped.
+ *
+ * WHY THIS SPEC EXISTS SEPARATELY from `dashboard-type-filter.spec.js`: that
+ * suite exercises the feature and is exposed to this bug only as a RACE — on a
+ * fast idle machine it can pass over the live defect, which is exactly how this
+ * shipped. This spec MANUFACTURES the window instead of hoping for it, so it is
+ * deterministic in both directions: it fails 100% of the time on the unfixed
+ * tree and passes 100% of the time on the fixed one.
+ *
+ * MECHANISM: delay one NON-PAINT fetch at the network boundary with
+ * `page.route` (already this suite's idiom — see `honest-failed-states.spec.js`,
+ * `agent-not-found.spec.js`, `circuit-breaker-badge.spec.js`). `/api/system-views`
+ * is in the awaited batch but gates nothing this spec asserts on.
+ *
+ * The agents endpoint is deliberately NOT intercepted — it is the paint gate. Delay
+ * that instead and the tiles never appear, the spec passes on the unfixed tree
+ * for the wrong reason, and it proves nothing.
+ *
+ * NOT a `waitForTimeout`: the delay is applied to a mocked RESPONSE, never to the
+ * test's own control flow. Every assertion below is an auto-retrying web-first
+ * expect. The AC forbids the test sleeping to let the product catch up; this
+ * makes the product's lateness observable and then refuses to wait for it.
+ *
+ * Runs against a live stack — every install has at least `trinity-system`.
+ */
+
+// The manufactured window. Assertions below use a timeout comfortably UNDER it,
+// so a dropped keypress can never be rescued by the listener arriving late.
+const STALL_MS = 2000
+const ASSERT_MS = 1200
+
+const pill = (page) => page.getByTestId('filter-pill')
+const pillInput = (page) => pill(page).getByRole('textbox', { name: 'Filter agents' })
+
+/** Hold one non-paint mount fetch open for STALL_MS, then let it through. */
+async function stallNonPaintFetch(page) {
+  await page.route('**/api/system-views**', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, STALL_MS))
+    await route.continue()
+  })
+}
+
+test.describe('dashboard hotkey readiness (#2200)', () => {
+  test('@smoke / opens the filter pill the moment the fleet paints, even while a mount fetch is still in flight', async ({
+    page,
+  }) => {
+    await stallNonPaintFetch(page)
+
+    await page.goto('/')
+
+    // The paint gate: tiles are visible as soon as fetchAgents() alone resolves.
+    // `/api/system-views` is still stalled at this point — this IS the window.
+    await expect(page.locator('[data-agent="trinity-system"]')).toBeVisible({ timeout: 15000 })
+
+    await page.keyboard.press('/')
+
+    // Unfixed: the listener does not exist yet, the keypress reaches `document`
+    // with defaultPrevented: false, and nothing consumes it — this times out.
+    await expect(pill(page), 'the `/` hotkey must be armed by the time the fleet is painted').toBeVisible({
+      timeout: ASSERT_MS,
+    })
+    await expect(pillInput(page)).toBeFocused({ timeout: ASSERT_MS })
+  })
+
+  test('the pill accepts typing in that same window, and the query survives the pending fetch', async ({ page }) => {
+    await stallNonPaintFetch(page)
+
+    await page.goto('/')
+    await expect(page.locator('[data-agent="trinity-system"]')).toBeVisible({ timeout: 15000 })
+
+    await page.keyboard.press('/')
+    await expect(pill(page)).toBeVisible({ timeout: ASSERT_MS })
+    // Always await focus before typing — keystrokes racing the nextTick focus
+    // land on body and are swallowed by the editable-target guard.
+    await expect(pillInput(page)).toBeFocused({ timeout: ASSERT_MS })
+
+    await page.keyboard.type('trinity')
+    await expect(pillInput(page)).toHaveValue('trinity')
+
+    // The intent is captured, not discarded: once the stalled fetch lands and the
+    // rest of the mount completes, the filter is still applied.
+    await expect(page.getByTestId('filter-match-count')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('[data-agent="trinity-system"]')).toBeVisible()
+  })
+})

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -822,6 +822,27 @@ function applyDeepLinkFilters() {
 }
 
 onMounted(async () => {
+  // Document-level interaction is armed FIRST, above every await (#2200).
+  //
+  // The fleet paints as soon as fetchAgents() ALONE resolves (the
+  // `agents.length > 0` template gate), but the await below waits on the
+  // SLOWEST of five fetches. Registering down there left a window — ~50ms
+  // measured, but `max(five) - fetchAgents()` and so unbounded on a large
+  // fleet or a cold DB — in which the dashboard rendered as interactive and
+  // every `/` was silently dropped. The slot was inherited, not chosen: the
+  // ent#261 hotkey was appended beside handleClickOutside, whose position had
+  // silently become post-await when PERF-269 introduced the parallel fetch.
+  //
+  // Safe by construction: neither handler reads fetched data — every guard in
+  // handleDashboardKeydown reads the event or a setup()-created ref, and
+  // handleClickOutside is a no-op while showTagDropdown is false. Registering
+  // early only means `/` and click-outside work sooner.
+  //
+  // Do NOT move these below an await. Guarded by
+  // tests/unit/mountListenerOrdering.spec.js.
+  document.addEventListener('click', handleClickOutside) // tag dropdown dismiss
+  document.addEventListener('keydown', handleDashboardKeydown) // ent#261 type-to-filter + Esc backstop
+
   // Initialize system views store (restores persisted view selection)
   systemViewsStore.initialize()
 
@@ -861,11 +882,6 @@ onMounted(async () => {
   if (networkStore.isTimelineMode) {
     networkStore.startActivityRefresh()
   }
-
-  // Add click outside listener for tag dropdown
-  document.addEventListener('click', handleClickOutside)
-  // Type-to-filter hotkey + Esc backstop (ent#261) — Dashboard-scoped.
-  document.addEventListener('keydown', handleDashboardKeydown)
 })
 
 onUnmounted(() => {

--- a/src/frontend/tests/unit/mountListenerOrdering.spec.js
+++ b/src/frontend/tests/unit/mountListenerOrdering.spec.js
@@ -29,6 +29,15 @@
  * (no dep, no script, no workflow), so that is filed as a follow-up rather than
  * bolted onto a P2 bug fix.
  *
+ * Known parser blind spots (regex scanner, no string tokenizer — verified by
+ * probe at review, #2200): an UNBALANCED `}` inside a string literal in a hook
+ * body silently truncates the scanned body (false PASS past it), and a `//`
+ * inside a string mangles the rest of that line (false PASS for a listener
+ * after it on the same line). Both are silent-direction misses; neither shape
+ * exists in the tree today, and the Dashboard-specific test below is the
+ * belt for the file this guard was minted for. The word `addEventListener` or
+ * `await` inside a string false-FAILS instead — loud and fixable, accepted.
+ *
  * There is no component-mount harness in this project (no @vue/test-utils), and
  * the defect is one of lifecycle ORDERING rather than of any pure function, so
  * this is a source-structure guard — the same shape as `agentDetailDeepLink.spec.js`

--- a/src/frontend/tests/unit/mountListenerOrdering.spec.js
+++ b/src/frontend/tests/unit/mountListenerOrdering.spec.js
@@ -1,0 +1,226 @@
+/**
+ * #2200 — document/window listeners must be armed BEFORE any await in the
+ * mount hook that owns them.
+ *
+ * `Dashboard.vue` registered the ent#261 `/` type-to-filter hotkey at the END of
+ * an `async onMounted`, after `await Promise.allSettled([...5 fetches...])`.
+ * The fleet paints as soon as `fetchAgents()` ALONE resolves (the template gate
+ * `agents.length > 0`), but the listener waited on the SLOWEST of the five — so
+ * there was a window in which the dashboard rendered as interactive and every
+ * `/` was silently dropped. Measured at ~50ms on an idle local instance, but the
+ * quantity is `max(five) - fetchAgents()` and is therefore UNBOUNDED: a large
+ * fleet, a cold DB, or one slow endpoint widens it without limit.
+ *
+ * The position was inherited, not chosen — the hotkey was appended beside a
+ * pre-existing `handleClickOutside` registration whose slot had silently BECOME
+ * post-await when PERF-269 introduced the parallel fetch. That is the mechanism
+ * this guard exists to catch: nobody edits the listener, and it breaks anyway.
+ *
+ * SCOPE — deliberately repo-wide, not one file. #2130 was the same class (sync
+ * work with no data dependency stranded after `await Promise.allSettled` in
+ * `onMounted`) and shipped a guard that hardcodes a single path
+ * (`agentDetailDeepLink.spec.js`), so it structurally could not see
+ * `Dashboard.vue` and the class recurred three days later.
+ *
+ * HONEST LIMITATION — this guard keys on `addEventListener`, so it catches the
+ * LISTENER variant only. It would NOT have caught #2130, which was a routing
+ * write. The general rule ("no sync work with no data dependency behind a mount
+ * await") needs real AST traversal; this repo has no ESLint toolchain at all
+ * (no dep, no script, no workflow), so that is filed as a follow-up rather than
+ * bolted onto a P2 bug fix.
+ *
+ * There is no component-mount harness in this project (no @vue/test-utils), and
+ * the defect is one of lifecycle ORDERING rather than of any pure function, so
+ * this is a source-structure guard — the same shape as `agentDetailDeepLink.spec.js`
+ * and the Python AST guards (`test_ent109_git_env_seam.py`).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { join, relative, sep } from 'path'
+import { fileURLToPath } from 'url'
+
+const SRC_ROOT = fileURLToPath(new URL('../../src', import.meta.url))
+
+const HOOKS = ['onMounted', 'onActivated']
+const LISTENER = /\b(?:document|window)\.addEventListener\s*\(/
+
+/**
+ * Files permitted to register a listener after a mount await.
+ *
+ * An allowlist that grows silently is a disabled guard, so: every entry carries
+ * its reason inline, `MAX_ALLOWLIST` pins the DIRECTION (may shrink, never grow
+ * without a deliberate reviewed edit), and a test below fails if an entry stops
+ * being needed — so a fixed file cannot leave a stale exemption behind.
+ */
+const ALLOWLIST = [
+  {
+    file: 'views/AgentWorkspace.vue',
+    reason:
+      "window.addEventListener('resize', resizeCanvas) sits after `await fetchAgent()`. " +
+      'A resize handler arriving late is self-correcting on the next resize — no user ' +
+      'input is dropped — and it is registered after the canvas bootstrap (initParticles/ ' +
+      'resizeCanvas/requestAnimationFrame) that gives it something to operate on. ' +
+      'Different risk profile, different fix, tracked separately.',
+  },
+]
+const MAX_ALLOWLIST = 1 // may shrink, never grow without a deliberate reviewed edit
+
+/** Strip line + block comments so prose like "before any await" isn't scanned. */
+function stripComments(code) {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/^[ \t]*\/\/.*$/gm, '') // whole-line // comments
+    .replace(/([^:])\/\/.*$/gm, '$1') // trailing // comments (keep URLs)
+}
+
+/** Every .vue/.js file under src/, as paths relative to src/ with POSIX separators. */
+function sourceFiles(dir = SRC_ROOT, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue
+      sourceFiles(full, out)
+    } else if (/\.(vue|js)$/.test(entry.name)) {
+      out.push(relative(SRC_ROOT, full).split(sep).join('/'))
+    }
+  }
+  return out
+}
+
+/** Bodies of every `hook(async ...)` in `code`, via brace matching. */
+function asyncHookBodies(code, hook) {
+  const bodies = []
+  const marker = `${hook}(async`
+  let from = 0
+  for (;;) {
+    const start = code.indexOf(marker, from)
+    if (start === -1) return bodies
+    const open = code.indexOf('{', start)
+    if (open === -1) return bodies
+    let depth = 0
+    let closed = false
+    for (let i = open; i < code.length; i++) {
+      if (code[i] === '{') depth++
+      else if (code[i] === '}') {
+        depth--
+        if (depth === 0) {
+          bodies.push(code.slice(open + 1, i))
+          from = i
+          closed = true
+          break
+        }
+      }
+    }
+    // Unbalanced braces would silently truncate the scan — fail loudly instead.
+    if (!closed) throw new Error(`unbalanced braces after ${marker}`)
+  }
+}
+
+/**
+ * Offending hook bodies in one file: those registering a listener after an await.
+ *
+ * `await` is matched at ANY depth, not just top level. That is conservative on
+ * purpose — a guard that false-PASSES is useless, while a false-FAIL is loud and
+ * fixable — and it costs nothing today: no hook body in the tree has a nested
+ * await ahead of its listener.
+ */
+function violations(relPath) {
+  const source = stripComments(readFileSync(join(SRC_ROOT, relPath), 'utf8'))
+  if (!LISTENER.test(source)) return []
+
+  const found = []
+  for (const hook of HOOKS) {
+    for (const body of asyncHookBodies(source, hook)) {
+      const awaitAt = body.search(/\bawait\b/)
+      if (awaitAt === -1) continue // no awaits — trivially fine
+      const after = body.slice(awaitAt)
+      const listenerAt = after.search(LISTENER)
+      if (listenerAt !== -1) found.push(hook)
+    }
+  }
+  return found
+}
+
+const FILES = sourceFiles()
+const ALLOWED = new Set(ALLOWLIST.map((e) => e.file))
+
+describe('#2200 mount-hook listener ordering', () => {
+  it('finds source files to scan (the guard is not vacuously green)', () => {
+    expect(FILES.length).toBeGreaterThan(100)
+    expect(FILES).toContain('views/Dashboard.vue')
+  })
+
+  it('no document/window listener is registered after an await in a mount hook', () => {
+    const offenders = []
+    for (const file of FILES) {
+      if (ALLOWED.has(file)) continue
+      for (const hook of violations(file)) offenders.push(`${file} (${hook})`)
+    }
+
+    expect(
+      offenders,
+      'These files register a document/window listener AFTER an await in a mount ' +
+        'hook. The surface paints — and reads as interactive — as soon as its own ' +
+        'data resolves, but the listener waits on every awaited call in the hook, ' +
+        'so user input in that window is silently dropped (#2200; ~50ms measured, ' +
+        'unbounded in principle). Register listeners at the TOP of the hook, above ' +
+        'any await:\n  ' + offenders.join('\n  ')
+    ).toEqual([])
+  })
+
+  it('Dashboard arms BOTH listeners before its first await (#2200 regression)', () => {
+    const source = stripComments(readFileSync(join(SRC_ROOT, 'views/Dashboard.vue'), 'utf8'))
+    const bodies = asyncHookBodies(source, 'onMounted')
+    expect(bodies.length, 'Dashboard.vue must have an async onMounted').toBe(1)
+    const body = bodies[0]
+
+    const awaitAt = body.search(/\bawait\b/)
+    expect(awaitAt, 'Dashboard onMounted should still await its parallel fetches').toBeGreaterThan(-1)
+
+    for (const handler of ['handleClickOutside', 'handleDashboardKeydown']) {
+      const at = body.indexOf(`addEventListener('${handler === 'handleClickOutside' ? 'click' : 'keydown'}', ${handler})`)
+      expect(at, `onMounted must register ${handler}`).toBeGreaterThan(-1)
+      expect(
+        at,
+        `Dashboard registers ${handler} AFTER the awaited fetches. The fleet paints ` +
+          'as soon as fetchAgents() alone resolves, so this leaves a window in which ' +
+          'the dashboard looks interactive and `/` is silently dropped (#2200).'
+      ).toBeLessThan(awaitAt)
+    }
+  })
+
+  it('teardown still pairs with the (now earlier) registration', () => {
+    // Hoisting must not silently drop a removeEventListener — that would trade a
+    // dead-window bug for a leak.
+    const source = stripComments(readFileSync(join(SRC_ROOT, 'views/Dashboard.vue'), 'utf8'))
+    for (const [event, handler] of [
+      ['click', 'handleClickOutside'],
+      ['keydown', 'handleDashboardKeydown'],
+    ]) {
+      expect(source).toContain(`document.addEventListener('${event}', ${handler})`)
+      expect(source).toContain(`document.removeEventListener('${event}', ${handler})`)
+    }
+  })
+
+  it('the allowlist has not grown', () => {
+    expect(
+      ALLOWLIST.length,
+      'Adding an allowlist entry disables this guard for a file. Fix the ordering ' +
+        'instead, or raise MAX_ALLOWLIST deliberately with the reason recorded inline.'
+    ).toBeLessThanOrEqual(MAX_ALLOWLIST)
+    for (const entry of ALLOWLIST) {
+      expect(entry.reason, `allowlist entry ${entry.file} must carry a reason`).toBeTruthy()
+    }
+  })
+
+  it('every allowlist entry is still needed (no stale exemptions)', () => {
+    for (const entry of ALLOWLIST) {
+      expect(FILES, `allowlisted file ${entry.file} no longer exists — drop the entry`).toContain(entry.file)
+      expect(
+        violations(entry.file).length,
+        `${entry.file} no longer registers a listener after an await — remove its ` +
+          'allowlist entry so the guard covers it again.'
+      ).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #2200

## Corrected root cause (differs from the issue body)

Not parent/child mount ordering — that gap is sub-millisecond. The listener registration sat **after `await Promise.allSettled([...5 fetches])`** in `Dashboard.vue`'s `onMounted`, so the dead window is `max(five fetches) − fetchAgents()` — **unbounded on a slow instance**, not "~50ms" (sibling #2130 measured ~10s for the same structural shape). The fleet paints as soon as `fetchAgents()` alone resolves (the `agents.length > 0` template gate), while the `/` hotkey waited on the slowest of five. The dashboard rendered as interactive; every `/` in that window was silently dropped.

## The fix

Both listeners (`keydown` + `click`) hoisted to the **very top** of `onMounted` — top, not merely above the await, because the drift that caused this was a slot that silently *became* post-await (PERF-269 introduced the parallel fetch under a registration that predated it). `handleClickOutside` is hoisted too — outside the stated ACs, but leaving it would re-create the exact "inherited slot beside an existing listener" configuration that produced this bug. Guards 0–5 in `handleDashboardKeydown` verified to read only `setup()`-created refs — arming early is safe by construction. `handleDashboardKeydown` itself is byte-identical.

## Recurrence class

**#2130 was the same class, fixed 3 days before this bug shipped, and its guard hardcoded one file path** (`agentDetailDeepLink.spec.js`) — so the class recurred. This PR's vitest guard (`tests/unit/mountListenerOrdering.spec.js`) is **repo-wide**: every `.vue` + `.js` under `src/frontend/src`, with one justified allowlist entry (`AgentWorkspace.vue` resize handler — self-correcting on the next resize, no input dropped) and `MAX_ALLOWLIST=1` direction-pinned (may shrink, never grow without a deliberate reviewed edit). Honest limitation, documented in-file: it keys on `addEventListener` and has two rare parser blind spots (unbalanced `}` or `//` inside a string literal in a hook body) — the AST-rule follow-up closes them for free.

## Tests

- **Forced-race e2e** (`e2e/dashboard-hotkey-readiness.spec.js`): `page.route` stalls `**/api/system-views` 2000ms; assertions run within 1200ms — a late listener **structurally cannot pass**. Fails 100% unfixed, passes 100% fixed. **Kept `@smoke`**: deterministic by construction, and it gives the smoke tier its first hotkey coverage that actually exercises the race.
- **Existing spec untouched — zero diff on `dashboard-type-filter.spec.js` by design** (a spec edit would destroy the evidence that the product, not the test, was wrong): pre-fix **32 failed / 8 passed** × `--repeat-each=5` → post-fix **40/40**. All e2e runs on a branch-serving Vite server, not localhost.
- **Vitest guard**: red-before/green-after; 6/6 post-rebase; full frontend suite 582/582.

**Evidence-honesty note**: the gate is **8/8** — the existing spec has 8 tests, all pressing `/`; the issue's "7" was a transcription of one race run. A green advisory `frontend-e2e` is corroboration, never proof: it ran green **12/12 over this live bug** (`retries: 2`, smoke tier covers 1-of-8, the least-exposed test).

## Docs

Interaction-readiness clause added to **Principle 23** in `design-system-contract.md` + the `design-system.md` §7 mirror (no renumbering; CLAUDE.md untouched): handlers are armed at mount, above every `await`, never behind fetched data — a surface that renders as interactive must already be interactive (the input-side twin of #15's honest-state rule).

## Follow-ups (listed, NOT filed)

- General-class AST/ESLint rule — would have caught **both** #2130 and #2200; the repo currently has no lint toolchain (no dep, no script, no workflow).
- `AgentWorkspace.vue:838-845` — same shape, lower stakes (resize handler; allowlisted with reason).
- Whether `connectWebSocket()` + the three pollers sit post-await deliberately or by the same drift.
- test-runner catalog drift — claims 52 tests / 3 missing files; actual is 30 files / 582 tests.

## Coordination

Zero file overlap with #2199's PR (verified file-by-file); independently mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
