### PR TITLE
test(e2e): derive the grid layout key, make missing fixtures skip honestly (#2199)

### DIFF
--- a/src/frontend/e2e/README.md
+++ b/src/frontend/e2e/README.md
@@ -52,13 +52,67 @@ test('@interactive create agent end-to-end', async ({ page }) => { ... })
 
 ## CI
 
-CI runs e2e only on PRs **labeled `ui`** — add the label to any frontend PR
-that should be exercised end-to-end. The workflow lives at
-`.github/workflows/frontend-e2e.yml` and stands up the full Trinity stack
-before running tests (~5 min total).
+The workflow lives at `.github/workflows/frontend-e2e.yml` and stands up the
+full Trinity stack before running tests (~5 min total). Since #1526 the `ui`
+label is **no longer the gate** — the suite runs on:
 
-To make e2e a required check on a PR, add the `ui` label and wait for the
-workflow to complete.
+1. **Nightly** on `dev` (07:00 UTC) — a red night opens/updates a tracking issue.
+2. **Any PR touching `src/frontend/**`** — automatically, via the `changes` job.
+3. **The `ui` label** — still a manual opt-in on NON-frontend PRs, or to force a run.
+4. **`workflow_dispatch`** — on demand.
+
+Two things follow, and both matter when you are judging whether a change is
+covered:
+
+- **CI runs `npm run test:e2e:smoke` only.** `@visual` and `@interactive`
+  specs never run there, so a green CI says nothing about them.
+- **The workflow is advisory, not a required merge gate** (an explicit decision
+  in #1526 — promoting it needs a flake budget first, #596). `dev`'s required
+  checks are `Analyze (python)`, `Analyze (javascript-typescript)`,
+  `schema-parity`, and `verify-non-root`.
+
+So a claim about the **full** suite has to be evidenced by a local run against
+a live stack, not by a CI badge.
+
+## Fixture agents
+
+Some specs need a real agent on the stack. Each reads an env var with a
+`testfix` default — an agent that does **not** exist on a typical instance:
+
+| Spec | Env var | Needs |
+|---|---|---|
+| `loops-panel` | `LOOPS_TEST_AGENT` | exists, running, **Claude runtime** |
+| `continue-as-chat` | `SESSION_TEST_AGENT` | exists, running, **Claude runtime** |
+| `workspace-absorbs-session` (`@interactive` only) | `SESSION_TEST_AGENT` | exists |
+| `portal-agent-page-overview` | `PORTAL_TEST_AGENT` | exists, visible to admin |
+| `timeline-cancelled-bar`, `honest-failed-states` | `TEST_AGENT` | exists |
+| `circuit-breaker-badge` | `TEST_AGENT` | exists |
+
+**The contract (#2199): a missing fixture reads as SKIPPED, never broken —
+and the probe must be authenticated.** `GET /api/agents/{name}` is behind
+`AuthorizedAgent` and Trinity's JWT lives in localStorage, not a cookie, so an
+unauthenticated probe 401s and the test skips on *every* run: silent false
+confidence, which is worse than a red test. Use the shared
+`e2e/helpers/agent-probe.js` — do not hand-roll a probe.
+
+> **Known gap:** `circuit-breaker-badge.spec.js` still carries the legacy
+> unauthenticated probe, so both its tests skip on every run. It was left as-is
+> deliberately: with an authenticated probe its `@smoke` test **fails** (the
+> `circuit-open-badge` element never appears, though the `data-testid` is still
+> present in `AgentHeader.vue`), which looks like a product defect. Un-skipping
+> it would turn the nightly signal red for a cause that belongs in its own
+> issue. Convert it to an explicit `test.skip(true, 'blocked by #NNNN')` once
+> that issue exists.
+
+The probe checks **existence only**. If a spec needs the agent running or on a
+particular runtime, say so in the spec header: reporting a *present but
+unsuitable* fixture as "absent" would be a false diagnosis.
+
+```bash
+# point the fixture-dependent specs at a real agent
+LOOPS_TEST_AGENT=my-agent SESSION_TEST_AGENT=my-agent PORTAL_TEST_AGENT=my-agent \
+  ADMIN_PASSWORD=<pw> npm run test:e2e
+```
 
 ## Adding tests
 

--- a/src/frontend/e2e/README.md
+++ b/src/frontend/e2e/README.md
@@ -92,7 +92,11 @@ Some specs need a real agent on the stack. Each reads an env var with a
 and the probe must be authenticated.** `GET /api/agents/{name}` is behind
 `AuthorizedAgent` and Trinity's JWT lives in localStorage, not a cookie, so an
 unauthenticated probe 401s and the test skips on *every* run: silent false
-confidence, which is worse than a red test. Use the shared
+confidence, which is worse than a red test. The inverse holds too: **only a
+definitive 404 reads as "fixture absent"** — a 401/403 (setup didn't run, JWT
+died with a backend restart), a 5xx, or a transport error means the *probe*
+broke, and `agentExists` throws so the test fails with the real diagnosis
+instead of skipping under a false "agent not found". Use the shared
 `e2e/helpers/agent-probe.js` — do not hand-roll a probe.
 
 > **Known gap:** `circuit-breaker-badge.spec.js` still carries the legacy

--- a/src/frontend/e2e/README.md
+++ b/src/frontend/e2e/README.md
@@ -101,12 +101,14 @@ instead of skipping under a false "agent not found". Use the shared
 
 > **Known gap:** `circuit-breaker-badge.spec.js` still carries the legacy
 > unauthenticated probe, so both its tests skip on every run. It was left as-is
-> deliberately: with an authenticated probe its `@smoke` test **fails** (the
-> `circuit-open-badge` element never appears, though the `data-testid` is still
-> present in `AgentHeader.vue`), which looks like a product defect. Un-skipping
-> it would turn the nightly signal red for a cause that belongs in its own
-> issue. Convert it to an explicit `test.skip(true, 'blocked by #NNNN')` once
-> that issue exists.
+> deliberately: with an authenticated probe its `@smoke` test **fails** — a
+> **test** defect, not a product one (#2210): the spec mocks the standalone
+> `/circuit-breaker` endpoint, which the agent page never calls (the badge reads
+> the `circuit_breaker` block embedded in the `GET /api/agents/{name}`
+> response), so one test fails and the sibling passes vacuously. Un-skipping it
+> here would turn the nightly signal red for a cause that belongs in #2210.
+> Convert the probes per #2210, then `test.skip(true, 'blocked by #2210')`
+> until it lands.
 
 The probe checks **existence only**. If a spec needs the agent running or on a
 particular runtime, say so in the spec header: reporting a *present but

--- a/src/frontend/e2e/continue-as-chat.spec.js
+++ b/src/frontend/e2e/continue-as-chat.spec.js
@@ -1,4 +1,5 @@
 import { test, expect, request } from '@playwright/test'
+import { agentExists, missingAgentReason } from './helpers/agent-probe.js'
 
 /**
  * "Continue as Chat" (EXEC-023) e2e — #1672.
@@ -26,6 +27,11 @@ import { test, expect, request } from '@playwright/test'
  *
  * Required env: ADMIN_PASSWORD (auth.setup.js) + SESSION_TEST_AGENT (default
  * "testfix"); the agent must exist, be running, and use the Claude runtime.
+ *
+ * A MISSING fixture agent reads as SKIPPED, never broken (#2199). Note the
+ * probe only proves EXISTENCE — if the agent exists but is stopped or on a
+ * non-Claude runtime, the failures below are real and must not be read as
+ * "fixture absent".
  */
 
 const TEST_AGENT = process.env.SESSION_TEST_AGENT || 'testfix'
@@ -34,14 +40,35 @@ const FLAG_KEY = 'session_tab_enabled'
 let api
 let token
 let priorFlag
+// `flagTouched` gates the restore: without it, a failure BEFORE the flag was
+// ever written leaves priorFlag === undefined, and afterAll's `=== null` test
+// is false, so it PUT `{ value: undefined }` onto a fleet-wide platform
+// setting (#2199).
+let flagTouched = false
+let agentReady = false
+let skipReason = ''
 
 test.beforeAll(async ({ baseURL }) => {
   api = await request.newContext({ baseURL })
   const loginResp = await api.post('/api/token', {
     form: { username: 'admin', password: process.env.ADMIN_PASSWORD || '' },
   })
-  if (!loginResp.ok()) throw new Error(`Admin login failed: ${loginResp.status()}`)
+  if (!loginResp.ok()) {
+    // Environment gap, not a product failure — skip rather than throw (#2199).
+    skipReason = `admin login failed (${loginResp.status()}) — check ADMIN_PASSWORD`
+    return
+  }
   token = (await loginResp.json()).access_token
+
+  // Probe BEFORE mutating the platform flag, and `return` on failure. Setting
+  // a flag alone does NOT abort beforeAll: without this early return execution
+  // falls straight through and flips a FLEET-WIDE setting for a run that is
+  // guaranteed to skip (#2199).
+  if (!(await agentExists(TEST_AGENT, { baseURL, token }))) {
+    skipReason = missingAgentReason(TEST_AGENT, 'SESSION_TEST_AGENT')
+    return
+  }
+  agentReady = true
 
   // Session mode ON is the interesting case: it is the DEFAULT the resume landing
   // must override. With the flag off, Chat is always legacy and the bug can't show.
@@ -54,15 +81,19 @@ test.beforeAll(async ({ baseURL }) => {
     data: { value: 'true' },
   })
   if (!setResp.ok()) throw new Error(`Failed to enable session_tab flag: ${setResp.status()}`)
+  flagTouched = true
 })
 
 test.afterAll(async () => {
   if (!api) return
-  const headers = { Authorization: `Bearer ${token}` }
-  if (priorFlag === null) {
-    await api.delete(`/api/settings/${FLAG_KEY}`, { headers })
-  } else {
-    await api.put(`/api/settings/${FLAG_KEY}`, { headers, data: { value: priorFlag } })
+  // Restore ONLY what we actually flipped.
+  if (flagTouched) {
+    const headers = { Authorization: `Bearer ${token}` }
+    if (priorFlag === null) {
+      await api.delete(`/api/settings/${FLAG_KEY}`, { headers })
+    } else {
+      await api.put(`/api/settings/${FLAG_KEY}`, { headers, data: { value: priorFlag } })
+    }
   }
   await api.dispose()
 })
@@ -100,6 +131,10 @@ async function createResumableExecution() {
 }
 
 test.describe('continue as chat (#1672)', () => {
+  test.beforeEach(() => {
+    test.skip(!agentReady, skipReason)
+  })
+
   test('@interactive KeepAlive navigation lands in legacy chat with the resume banner', async ({ page }) => {
     const execution = await createResumableExecution()
 

--- a/src/frontend/e2e/dashboard-grid-view.spec.js
+++ b/src/frontend/e2e/dashboard-grid-view.spec.js
@@ -1,4 +1,6 @@
 import { test, expect } from '@playwright/test'
+import { ALL_LAYOUT_KEYS, LAYOUT_KEY, WIDGET_PREFS_KEY } from '../src/utils/gridStorageKeys.js'
+import { isWidgetKey } from '../src/utils/gridWidgets.js'
 
 /**
  * Dashboard Grid view e2e (trinity-enterprise#47).
@@ -17,7 +19,9 @@ import { test, expect } from '@playwright/test'
  * localStorage.
  */
 
-const LAYOUT_KEY = 'trinity-grid-layout-v1'
+// LAYOUT_KEY / ALL_LAYOUT_KEYS / WIDGET_PREFS_KEY are imported from the store's
+// own module (#2199) — a hand-copied literal here silently desynced on the
+// #2042 v1->v2 bump and both read-back assertions below resolved `null`.
 const MODE_KEY = 'trinity-dashboard-view'
 
 async function gotoGrid(page) {
@@ -29,11 +33,17 @@ async function gotoGrid(page) {
 test.describe('dashboard grid view (trinity-enterprise#47)', () => {
   test.beforeEach(async ({ page }) => {
     // Fresh layout + default mode for deterministic assertions.
+    // ALL generations, not just the current one: `_loadSavedRaw` migrates a v1
+    // blob into v2 when v2 is absent, so clearing only LAYOUT_KEY lets a stale
+    // layout be migrated straight back in and the board is not clean (#2199).
+    // The argument is SPREAD into one flat array and the callback iterates it —
+    // nesting it would call removeItem() with an Array and silently clear
+    // nothing, which looks identical to a working cleanup.
     await page.addInitScript(
-      ([layoutKey]) => {
-        localStorage.removeItem(layoutKey)
+      (keys) => {
+        keys.forEach((k) => localStorage.removeItem(k))
       },
-      [LAYOUT_KEY]
+      [...ALL_LAYOUT_KEYS, WIDGET_PREFS_KEY]
     )
   })
 
@@ -151,12 +161,25 @@ test.describe('dashboard grid view (trinity-enterprise#47)', () => {
     await page.getByRole('button', { name: 'Reset', exact: true }).click()
     const reset = await page.evaluate((k) => localStorage.getItem(k), LAYOUT_KEY)
     expect(reset).toBeTruthy()
-    // Reset yields the deterministic default: every position is a small
-    // non-negative reading-order cell.
-    const positions = Object.values(JSON.parse(reset))
-    for (const p of positions) {
+    // Reset yields the deterministic default. Layout v2 holds TWO occupant
+    // kinds (#2042 / ent#325), so the shape differs by kind and asserting
+    // `r >= 0` across the whole map is a stale v1-era assumption — v1 held
+    // agent keys only. Agents land in non-negative reading-order cells;
+    // info tiles are seeded into the band ABOVE the fleet (negative rows,
+    // `seedWidgetCells` band [-3, -1] — "spill upward, never into the
+    // agents"). `isWidgetKey` is imported rather than matching a hand-copied
+    // 'widget:' literal, for the same reason the layout key is (#2199).
+    const entries = Object.entries(JSON.parse(reset))
+    expect(entries.length).toBeGreaterThan(0)
+    for (const [key, p] of entries) {
+      expect(Number.isInteger(p.c)).toBe(true)
+      expect(Number.isInteger(p.r)).toBe(true)
       expect(p.c).toBeGreaterThanOrEqual(0)
-      expect(p.r).toBeGreaterThanOrEqual(0)
+      if (isWidgetKey(key)) {
+        expect(p.r).toBeLessThan(0)
+      } else {
+        expect(p.r).toBeGreaterThanOrEqual(0)
+      }
     }
   })
 

--- a/src/frontend/e2e/grid-org-overlay.spec.js
+++ b/src/frontend/e2e/grid-org-overlay.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { ALL_LAYOUT_KEYS } from '../src/utils/gridStorageKeys.js'
 
 /**
  * Grid org overlay e2e (trinity-enterprise#305).
@@ -9,7 +10,10 @@ import { test, expect } from '@playwright/test'
  * create org facts via the tags API on it and clean up after themselves.
  */
 
-const LAYOUT_KEY = 'trinity-grid-layout-v1'
+// Layout keys come from the store's own module (#2199) — this file's
+// hand-copied 'v1' literal silently stopped clearing the real (v2) layout
+// after the #2042 bump. ORG_KEY stays local on purpose: it has never been
+// bumped and this copy matches composables/useOrgOverlay.js.
 const ORG_KEY = 'trinity-grid-org-v1'
 
 async function gotoGrid(page) {
@@ -54,12 +58,13 @@ test.describe('grid org overlay (trinity-enterprise#305)', () => {
   let priorSystemTags = null
 
   test.beforeEach(async ({ page }) => {
+    // Spread into one flat array and iterate — nesting would call removeItem()
+    // with an Array and silently clear nothing (#2199).
     await page.addInitScript(
-      ([layoutKey, orgKey]) => {
-        localStorage.removeItem(layoutKey)
-        localStorage.removeItem(orgKey)
+      (keys) => {
+        keys.forEach((k) => localStorage.removeItem(k))
       },
-      [LAYOUT_KEY, ORG_KEY]
+      [...ALL_LAYOUT_KEYS, ORG_KEY]
     )
     priorSystemTags = null
   })

--- a/src/frontend/e2e/helpers/agent-probe.js
+++ b/src/frontend/e2e/helpers/agent-probe.js
@@ -1,0 +1,93 @@
+import { request } from '@playwright/test'
+import fs from 'fs'
+
+/**
+ * Shared fixture-agent existence probe (#2199).
+ *
+ * ⚠️ THE PROBE MUST BE AUTHENTICATED. ⚠️
+ * `GET /api/agents/{name}` sits behind `AuthorizedAgent`, and Trinity's JWT
+ * lives in localStorage — NOT in a cookie. So a bare
+ * `request.newContext({ baseURL })` carries no credential, 401s, and makes
+ * `test.skip()` fire on EVERY run: the test reads as "skipped" forever and
+ * nobody notices it stopped covering anything. That is silent false
+ * confidence, and it is strictly worse than a red test.
+ *
+ * This is not hypothetical — it is the live defect in
+ * `circuit-breaker-badge.spec.js` and `honest-failed-states.spec.js`, both of
+ * which probe unauthenticated against a default of `trinity-system` (an agent
+ * that ALWAYS exists), so their 401 is unconditional.
+ *
+ * One shared helper exists precisely so that anti-pattern cannot be
+ * re-derived independently in each spec. Consume this; do not hand-roll a
+ * probe.
+ *
+ * SCOPE: existence only. It deliberately does NOT check that the agent is
+ * running or on a particular runtime — reporting a *present but unsuitable*
+ * fixture as "absent" would be a false claim, and a materially different
+ * diagnosis. Specs needing a running Claude-runtime agent say so in their own
+ * header (see e2e/README.md → Fixture agents).
+ *
+ * NOTE: this file lives under `e2e/helpers/` and is NOT collected as a test.
+ * Playwright's default testMatch only picks up files ending in `.spec` or
+ * `.test` (with a js/ts/jsx/tsx extension), and the setup project matches
+ * `setup.js`; `agent-probe.js` matches neither.
+ */
+
+/**
+ * Harvest the JWT the `setup` project persisted into the storageState file.
+ *
+ * The path stays a plain relative literal: every documented invocation runs
+ * with cwd = `src/frontend` (see e2e/README.md), and an `import.meta.url`
+ * derivation's survival through Playwright's esbuild transform is unverified.
+ *
+ * @returns {string|undefined} the token, or undefined when setup has not run
+ */
+export function tokenFromStorageState() {
+  try {
+    const state = JSON.parse(fs.readFileSync('e2e/.auth/admin.json', 'utf8'))
+    return state.origins
+      ?.flatMap((o) => o.localStorage || [])
+      .find((i) => i.name === 'token')?.value
+  } catch {
+    // No storageState yet (setup didn't run). Returning undefined makes the
+    // probe 401 and the caller skip — the correct degraded state.
+    return undefined
+  }
+}
+
+/**
+ * Does this agent exist on the stack under test?
+ *
+ * @param {string} name      agent name to probe
+ * @param {object} opts
+ * @param {string} opts.baseURL  Playwright `baseURL` fixture
+ * @param {string} [opts.token]  bearer token; falls back to the storageState
+ *                               harvest when omitted (specs that already mint
+ *                               their own admin token should pass it in)
+ * @returns {Promise<boolean>}
+ */
+export async function agentExists(name, { baseURL, token } = {}) {
+  const bearer = token || tokenFromStorageState()
+  const api = await request.newContext({
+    baseURL,
+    extraHTTPHeaders: bearer ? { Authorization: `Bearer ${bearer}` } : {},
+  })
+  const ok = await api
+    .get(`/api/agents/${name}`)
+    .then((r) => r.ok())
+    .catch(() => false)
+  await api.dispose()
+  return ok
+}
+
+/**
+ * Uniform skip reason that names the env var used to override the fixture, so
+ * a reader of the run output knows exactly how to make the test run.
+ *
+ * @param {string} name    the agent that was not found
+ * @param {string} envVar  the override env var for this spec
+ * @returns {string}
+ */
+export function missingAgentReason(name, envVar) {
+  return `agent '${name}' not found on this stack — set ${envVar} to an existing agent`
+}

--- a/src/frontend/e2e/helpers/agent-probe.js
+++ b/src/frontend/e2e/helpers/agent-probe.js
@@ -13,13 +13,23 @@ import fs from 'fs'
  * confidence, and it is strictly worse than a red test.
  *
  * This is not hypothetical — it is the live defect in
- * `circuit-breaker-badge.spec.js` and `honest-failed-states.spec.js`, both of
- * which probe unauthenticated against a default of `trinity-system` (an agent
- * that ALWAYS exists), so their 401 is unconditional.
+ * `circuit-breaker-badge.spec.js` (left in place deliberately — see the Known
+ * gap note in e2e/README.md), and was the defect in
+ * `honest-failed-states.spec.js` until #2199 fixed it: both probed
+ * unauthenticated against a default of `trinity-system` (an agent that ALWAYS
+ * exists), so their 401 was unconditional.
  *
  * One shared helper exists precisely so that anti-pattern cannot be
  * re-derived independently in each spec. Consume this; do not hand-roll a
  * probe.
+ *
+ * ⚠️ A BROKEN PROBE IS LOUD, NEVER A SKIP. ⚠️
+ * Only a definitive 404 — the platform's uniform "no such agent" answer
+ * (Invariant #8) — reads as "fixture absent". A 401/403 (no/stale token: the
+ * setup project didn't run, or the backend restarted mid-run and invalidated
+ * the JWT), a 5xx, or a transport error mean the PROBE broke, not that the
+ * agent is missing — so `agentExists` THROWS, failing the test with the real
+ * diagnosis instead of skipping under a false "agent not found" reason.
  *
  * SCOPE: existence only. It deliberately does NOT check that the agent is
  * running or on a particular runtime — reporting a *present but unsuitable*
@@ -50,7 +60,9 @@ export function tokenFromStorageState() {
       .find((i) => i.name === 'token')?.value
   } catch {
     // No storageState yet (setup didn't run). Returning undefined makes the
-    // probe 401 and the caller skip — the correct degraded state.
+    // probe go out unauthenticated and 401 — which `agentExists` reports as a
+    // LOUD failure, not a skip (the file being absent is an environment fault,
+    // not evidence the fixture agent is missing).
     return undefined
   }
 }
@@ -58,13 +70,21 @@ export function tokenFromStorageState() {
 /**
  * Does this agent exist on the stack under test?
  *
+ * `false` means exactly one thing: the stack answered a definitive 404
+ * ("no such agent", the uniform Invariant #8 shape). Every other failure —
+ * 401/403 (probe unauthenticated: setup didn't run, or the JWT died with a
+ * backend restart), 5xx, or a transport error — THROWS, because collapsing it
+ * into `false` would make the caller skip under a false "agent not found"
+ * reason: the `circuit-breaker-badge` defect wearing a new hat.
+ *
  * @param {string} name      agent name to probe
  * @param {object} opts
  * @param {string} opts.baseURL  Playwright `baseURL` fixture
  * @param {string} [opts.token]  bearer token; falls back to the storageState
  *                               harvest when omitted (specs that already mint
  *                               their own admin token should pass it in)
- * @returns {Promise<boolean>}
+ * @returns {Promise<boolean>} true = exists; false = definitive 404
+ * @throws when the probe itself broke — the test must FAIL, not skip
  */
 export async function agentExists(name, { baseURL, token } = {}) {
   const bearer = token || tokenFromStorageState()
@@ -72,12 +92,29 @@ export async function agentExists(name, { baseURL, token } = {}) {
     baseURL,
     extraHTTPHeaders: bearer ? { Authorization: `Bearer ${bearer}` } : {},
   })
-  const ok = await api
-    .get(`/api/agents/${name}`)
-    .then((r) => r.ok())
-    .catch(() => false)
-  await api.dispose()
-  return ok
+  try {
+    let resp
+    try {
+      resp = await api.get(`/api/agents/${name}`)
+    } catch (err) {
+      throw new Error(
+        `agent probe for '${name}' could not reach the stack at ${baseURL}: ` +
+          `${err.message} — a broken probe must fail loudly, never skip (#2199)`
+      )
+    }
+    if (resp.ok()) return true
+    if (resp.status() === 404) return false
+    throw new Error(
+      `agent probe for '${name}' broke: HTTP ${resp.status()} from ` +
+        `GET /api/agents/${name}` +
+        (bearer
+          ? ''
+          : ' (no bearer token — did the setup project write e2e/.auth/admin.json?)') +
+        ` — auth/stack fault, not a missing fixture; refusing to skip (#2199)`
+    )
+  } finally {
+    await api.dispose()
+  }
 }
 
 /**

--- a/src/frontend/e2e/honest-failed-states.spec.js
+++ b/src/frontend/e2e/honest-failed-states.spec.js
@@ -102,17 +102,31 @@ test.describe('schedule toggle — a failed verb is visible, not console-only (#
   test.beforeEach(async ({ page, baseURL }) => {
     // Authenticated: /schedules is behind auth, so an anonymous context 401s,
     // yields [] and skips claiming "no schedules" — a FALSE diagnosis of a real
-    // auth failure. Same class as the agent probe (#2199).
+    // auth failure. Same class as the agent probe (#2199), and the same
+    // contract: only definitive answers skip — a 404 (agent absent) or a real
+    // empty list. A 401/5xx/transport error is a broken probe and must FAIL.
     const token = tokenFromStorageState()
     const api = await request.newContext({
       baseURL,
       extraHTTPHeaders: token ? { Authorization: `Bearer ${token}` } : {},
     })
-    const schedules = await api
-      .get(`/api/agents/${TEST_AGENT}/schedules`)
-      .then((r) => (r.ok() ? r.json() : []))
-      .catch(() => [])
-    await api.dispose()
+    let schedules
+    try {
+      const resp = await api.get(`/api/agents/${TEST_AGENT}/schedules`)
+      if (resp.status() === 404) {
+        // Definitive: the agent itself is absent (uniform Invariant #8 shape).
+        test.skip(true, missingAgentReason(TEST_AGENT, 'TEST_AGENT'))
+      }
+      if (!resp.ok()) {
+        throw new Error(
+          `schedules probe for '${TEST_AGENT}' broke: HTTP ${resp.status()} — ` +
+            `auth/stack fault, not "no schedules"; refusing to skip (#2199)`
+        )
+      }
+      schedules = await resp.json()
+    } finally {
+      await api.dispose()
+    }
     test.skip(
       !Array.isArray(schedules) || schedules.length === 0,
       `TEST_AGENT '${TEST_AGENT}' has no schedules to toggle`

--- a/src/frontend/e2e/honest-failed-states.spec.js
+++ b/src/frontend/e2e/honest-failed-states.spec.js
@@ -1,4 +1,9 @@
 import { test, expect, request } from '@playwright/test'
+import {
+  agentExists,
+  missingAgentReason,
+  tokenFromStorageState,
+} from './helpers/agent-probe.js'
 
 /**
  * Honest loading / empty / failed states (#1926, design-system p15 + p25).
@@ -74,13 +79,10 @@ test.describe('notifications — failed fetch is not "No events yet" (#1926)', (
 
 test.describe('task history — failed fetch is not "No tasks yet" (#1926)', () => {
   test.beforeEach(async ({ page, baseURL }) => {
-    const api = await request.newContext({ baseURL })
-    const ok = await api
-      .get(`/api/agents/${TEST_AGENT}`)
-      .then((r) => r.ok())
-      .catch(() => false)
-    await api.dispose()
-    test.skip(!ok, `TEST_AGENT '${TEST_AGENT}' not found on this stack`)
+    test.skip(
+      !(await agentExists(TEST_AGENT, { baseURL })),
+      missingAgentReason(TEST_AGENT, 'TEST_AGENT')
+    )
   })
 
   test('renders the failed state and keeps the card footprint', async ({ page }) => {
@@ -98,7 +100,14 @@ test.describe('task history — failed fetch is not "No tasks yet" (#1926)', () 
 
 test.describe('schedule toggle — a failed verb is visible, not console-only (#1926)', () => {
   test.beforeEach(async ({ page, baseURL }) => {
-    const api = await request.newContext({ baseURL })
+    // Authenticated: /schedules is behind auth, so an anonymous context 401s,
+    // yields [] and skips claiming "no schedules" — a FALSE diagnosis of a real
+    // auth failure. Same class as the agent probe (#2199).
+    const token = tokenFromStorageState()
+    const api = await request.newContext({
+      baseURL,
+      extraHTTPHeaders: token ? { Authorization: `Bearer ${token}` } : {},
+    })
     const schedules = await api
       .get(`/api/agents/${TEST_AGENT}/schedules`)
       .then((r) => (r.ok() ? r.json() : []))

--- a/src/frontend/e2e/loops-panel.spec.js
+++ b/src/frontend/e2e/loops-panel.spec.js
@@ -1,4 +1,5 @@
 import { test, expect, request } from '@playwright/test'
+import { agentExists, missingAgentReason } from './helpers/agent-probe.js'
 
 /**
  * Loops tab e2e (#1106 / #740 Phase 2).
@@ -16,14 +17,23 @@ import { test, expect, request } from '@playwright/test'
  * "Run Loop" button.
  *
  * Required env: ADMIN_PASSWORD (enforced by auth.setup.js) and
- * LOOPS_TEST_AGENT (defaults to "testfix"). The agent must already exist;
+ * LOOPS_TEST_AGENT (defaults to "testfix"). The agent must already exist,
+ * and must be on the Claude runtime for the start/run test to be meaningful;
  * beforeAll starts it if it isn't running.
+ *
+ * A MISSING fixture agent reads as SKIPPED, never broken (#2199) — the probe
+ * is authenticated (see e2e/helpers/agent-probe.js for why that matters).
  */
 
 const TEST_AGENT = process.env.LOOPS_TEST_AGENT || 'testfix'
 
 let api
 let token
+// Set by beforeAll; read by the beforeEach guard. `test.skip()` is called from
+// beforeEach (the verified in-repo pattern) — NOT from beforeAll, where it does
+// not apply to the tests.
+let agentReady = false
+let skipReason = ''
 
 test.beforeAll(async ({ baseURL }) => {
   api = await request.newContext({ baseURL })
@@ -31,9 +41,18 @@ test.beforeAll(async ({ baseURL }) => {
     form: { username: 'admin', password: process.env.ADMIN_PASSWORD || '' },
   })
   if (!loginResp.ok()) {
-    throw new Error(`Admin login failed: ${loginResp.status()}`)
+    // A missing/incorrect ADMIN_PASSWORD is an environment gap, not a product
+    // failure — skip rather than throw (#2199).
+    skipReason = `admin login failed (${loginResp.status()}) — check ADMIN_PASSWORD`
+    return
   }
   token = (await loginResp.json()).access_token
+
+  if (!(await agentExists(TEST_AGENT, { baseURL, token }))) {
+    skipReason = missingAgentReason(TEST_AGENT, 'LOOPS_TEST_AGENT')
+    return
+  }
+  agentReady = true
 
   // Ensure the agent is running so the "Run Loop" button is enabled.
   // Best-effort: a 409/already-running response is fine.
@@ -47,6 +66,10 @@ test.afterAll(async () => {
 })
 
 test.describe('loops tab', () => {
+  test.beforeEach(() => {
+    test.skip(!agentReady, skipReason)
+  })
+
   test('@interactive tab is visible and Run Loop opens the form', async ({ page }) => {
     await page.goto(`/agents/${TEST_AGENT}`)
 

--- a/src/frontend/e2e/portal-agent-page-overview.spec.js
+++ b/src/frontend/e2e/portal-agent-page-overview.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { agentExists, missingAgentReason } from './helpers/agent-probe.js'
 
 /**
  * Workspace agent page — Overview geometry (#2169).
@@ -33,6 +34,11 @@ import { test, expect } from '@playwright/test'
  *
  * Required env: ADMIN_PASSWORD (auth.setup.js) and PORTAL_TEST_AGENT
  * (defaults to "testfix"). The agent must exist and be visible to the admin.
+ *
+ * A MISSING fixture agent reads as SKIPPED, never broken (#2199). All five
+ * tests need the agent, so the guard is describe-level. Without it each one
+ * hangs ~20s on a heading that never renders and then fails — a test-only
+ * cause presenting as a product failure.
  */
 
 const TEST_AGENT = process.env.PORTAL_TEST_AGENT || 'testfix'
@@ -99,6 +105,13 @@ const openAgent = async (page) => {
 }
 
 test.describe('Workspace agent page Overview layout', () => {
+  test.beforeEach(async ({ baseURL }) => {
+    test.skip(
+      !(await agentExists(TEST_AGENT, { baseURL })),
+      missingAgentReason(TEST_AGENT, 'PORTAL_TEST_AGENT')
+    )
+  })
+
   test('@interactive the top row is two equal columns at every split width', async ({ page }) => {
     await openAgent(page)
 

--- a/src/frontend/e2e/system-install.spec.js
+++ b/src/frontend/e2e/system-install.spec.js
@@ -116,9 +116,20 @@ test.describe('System install surface', () => {
     // table), so an unscoped getByText is a strict-mode violation. Scoping also
     // makes this assert the name is in the AGENTS table specifically, rather than
     // `.first()`, which would pass on whichever element happened to come first.
-    const agentsSection = page.locator('section').filter({
-      has: page.getByRole('heading', { name: /Agents to create/ }),
-    })
+    //
+    // Anchored on the heading's NEAREST ancestor section (#2199). The previous
+    // `page.locator('section').filter({ has: heading })` was necessary but not
+    // sufficient: `filter({ has })` matches EVERY section containing the
+    // heading, and ent#384 wrapped this surface in the Library's own tabbed
+    // `<section id="systems">` (views/Library.vue). Both the outer wrapper and
+    // the inner agents section then matched, the outer one holds all four
+    // renders, and the assertion resolved to 4 elements again. `.last()` would
+    // work today but is positional — a second wrapper is exactly how this broke
+    // twice, so anchor upward from the heading instead, which is stable no
+    // matter how many ancestors are added.
+    const agentsSection = page
+      .getByRole('heading', { name: /Agents to create/ })
+      .locator('xpath=ancestor::section[1]')
     await expect(agentsSection.getByText('e2e-preview-only-alpha')).toBeVisible()
     await expect(agentsSection.getByText('e2e-preview-only-beta')).toBeVisible()
 

--- a/src/frontend/e2e/workspace-absorbs-session.spec.js
+++ b/src/frontend/e2e/workspace-absorbs-session.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { agentExists, missingAgentReason } from './helpers/agent-probe.js'
 
 /**
  * Session surface retirement (ent#358).
@@ -24,6 +25,11 @@ import { test, expect } from '@playwright/test'
  *
  * Required env: ADMIN_PASSWORD (enforced by auth.setup.js) and
  * SESSION_TEST_AGENT (defaults to "testfix"). The agent must already exist.
+ *
+ * A MISSING fixture agent reads as SKIPPED, never broken (#2199). The guard is
+ * INSIDE the @interactive test on purpose: a describe-level beforeEach would
+ * also skip the two @smoke tests above, which are deliberately fixture-free
+ * (the redirect fires before the agent is fetched) and are the tier CI runs.
  */
 
 const TEST_AGENT = process.env.SESSION_TEST_AGENT || 'testfix'
@@ -48,7 +54,12 @@ test.describe('session surface retired into the Workspace', () => {
 
   // @interactive — needs SESSION_TEST_AGENT to exist; the smoke job has no
   // guaranteed agent, and a missing one renders "Agent not found" (no tabs).
-  test('@interactive the Chat tab has no session-mode toggle', async ({ page }) => {
+  test('@interactive the Chat tab has no session-mode toggle', async ({ page, baseURL }) => {
+    test.skip(
+      !(await agentExists(TEST_AGENT, { baseURL })),
+      missingAgentReason(TEST_AGENT, 'SESSION_TEST_AGENT')
+    )
+
     await page.goto(`/agents/${TEST_AGENT}?tab=chat`)
 
     await expect(page.getByText('Session mode')).toHaveCount(0)

--- a/src/frontend/src/stores/fleetGrid.js
+++ b/src/frontend/src/stores/fleetGrid.js
@@ -17,6 +17,11 @@ import {
   widgetKey,
 } from '@/utils/gridWidgets'
 import { serverSkewMs } from '@/utils/timestamps'
+import {
+  LAYOUT_KEY_V1,
+  LAYOUT_KEY,
+  WIDGET_PREFS_KEY,
+} from '@/utils/gridStorageKeys'
 
 /**
  * Fleet Grid store (trinity-enterprise#47) — owns the Dashboard Grid view's
@@ -34,17 +39,6 @@ import { serverSkewMs } from '@/utils/timestamps'
  *     while the Grid is mounted.
  */
 
-// ent#325: layout v2 admits `widget:*` keys alongside agents. The key is
-// bumped rather than reused so a v1 client and a v2 client on the same browser
-// cannot fight over one blob — and the migration is a one-time COPY, leaving
-// v1 in place, so downgrading is not a data-loss event.
-const LAYOUT_KEY_V1 = 'trinity-grid-layout-v1'
-const LAYOUT_KEY = 'trinity-grid-layout-v2'
-// Sparse `{ widgetId: boolean }` OVERRIDE map — see gridWidgets.isWidgetEnabled.
-// Its own key: the org overlay (#305) persists Zones/Lines under keys of its
-// own and the tile prefs must not be entangled with either, so that "Reset
-// tiles" cannot clobber an overlay toggle (ent#325 scope note).
-const WIDGET_PREFS_KEY = 'trinity-grid-widgets-v1'
 const ANALYTICS_WINDOW = '14d' // one fetch feeds Activity·14d + Context·7d (last 7 entries)
 const ANALYTICS_STALE_MS = 5 * 60 * 1000
 const HYDRATE_CONCURRENCY = 4

--- a/src/frontend/src/utils/gridStorageKeys.js
+++ b/src/frontend/src/utils/gridStorageKeys.js
@@ -1,0 +1,45 @@
+/**
+ * Dashboard Grid localStorage keys — the single source of truth (#2199).
+ *
+ * ⚠️ ZERO IMPORTS. KEEP IT THAT WAY. ⚠️
+ * This module is imported by `stores/fleetGrid.js` through the Vite `@` alias
+ * AND by Playwright specs through a plain relative path
+ * (`../src/utils/gridStorageKeys.js`). Playwright reads neither `vite.config.js`
+ * nor a tsconfig `paths` map, so a single `import … from '@/…'` added here
+ * would fail to resolve at test time and break every grid spec at once.
+ * `utils/gridLayout.js` is the established zero-import precedent.
+ *
+ * Why this file exists: #2042 (ent#325) bumped the layout key v1 → v2 in the
+ * store, but `dashboard-grid-view.spec.js` and `grid-org-overlay.spec.js` each
+ * carried their own hand-copied `'trinity-grid-layout-v1'` literal. The specs
+ * went green→red silently — the read-backs simply resolved `null`. A shared
+ * export makes the next bump propagate to every consumer automatically.
+ * `tests/unit/gridStorageKeys.spec.js` guards against a new hand-copy.
+ */
+
+// ent#325: layout v2 admits `widget:*` keys alongside agents. The key is
+// bumped rather than reused so a v1 client and a v2 client on the same browser
+// cannot fight over one blob — and the migration is a one-time COPY, leaving
+// v1 in place, so downgrading is not a data-loss event.
+export const LAYOUT_KEY_V1 = 'trinity-grid-layout-v1'
+export const LAYOUT_KEY = 'trinity-grid-layout-v2'
+
+// Sparse `{ widgetId: boolean }` OVERRIDE map — see gridWidgets.isWidgetEnabled.
+// Its own key: the org overlay (#305) persists Zones/Lines under keys of its
+// own and the tile prefs must not be entangled with either, so that "Reset
+// tiles" cannot clobber an overlay toggle (ent#325 scope note).
+export const WIDGET_PREFS_KEY = 'trinity-grid-widgets-v1'
+
+/**
+ * EVERY generation of the layout blob, newest first.
+ *
+ * Load-bearing, not decoration: `fleetGrid._loadSavedRaw` migrates a v1 blob
+ * into v2 when v2 is absent, so a test cleanup that clears only `LAYOUT_KEY`
+ * lets a stale v1 layout be migrated straight back in — the board is not
+ * clean and drag/tidy assertions become order-dependent. Clear all of them.
+ */
+export const ALL_LAYOUT_KEYS = [LAYOUT_KEY, LAYOUT_KEY_V1]
+
+// NOT here by design: `ORG_KEY = 'trinity-grid-org-v1'` stays in
+// `composables/useOrgOverlay.js`. It has never been bumped and the spec copy
+// matches, so there is no desync to fix and no reason to edit a composable.

--- a/src/frontend/tests/unit/gridStorageKeys.spec.js
+++ b/src/frontend/tests/unit/gridStorageKeys.spec.js
@@ -1,0 +1,96 @@
+/**
+ * #2199 — the Grid layout storage key must have exactly ONE source of truth.
+ *
+ * #2042 (ent#325) bumped the layout key v1 -> v2 in `stores/fleetGrid.js`, but
+ * `e2e/dashboard-grid-view.spec.js` and `e2e/grid-org-overlay.spec.js` each
+ * carried their own hand-copied `'trinity-grid-layout-v1'`. Nothing failed
+ * loudly: the read-backs simply resolved `null` and the `removeItem` cleanup
+ * silently stopped clearing anything. Two e2e tests went red for a reason that
+ * looked like a product bug, and one cleanup went quietly dead.
+ *
+ * The fix is `src/utils/gridStorageKeys.js`, imported by the store and by the
+ * specs. This guard is the ratchet on top of it: the module fixes today's
+ * desync, but it cannot stop a NEW spec from hand-copying the literal again.
+ *
+ * It earns its place because it is the only automatically-enforced part of
+ * that change — `.github/workflows/frontend-build.yml` runs `npm run test:unit`
+ * on every PR touching `src/frontend/**`, whereas the e2e suite is advisory,
+ * smoke-only in CI (#1526), and none of the affected tests are @smoke.
+ *
+ * Source-structure guard, the same shape as `agentDetailDeepLink.spec.js` and
+ * the Python AST guards. Deliberately scoped to the LAYOUT key family: the
+ * other hand-copied storage keys in e2e/ currently match their source and a
+ * blanket rule would force an unrelated refactor.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { join } from 'path'
+
+const E2E_DIR = fileURLToPath(new URL('../../e2e', import.meta.url))
+const STORE = fileURLToPath(new URL('../../src/stores/fleetGrid.js', import.meta.url))
+const MODULE = fileURLToPath(new URL('../../src/utils/gridStorageKeys.js', import.meta.url))
+
+/** The one file allowed to hold the literals. */
+const SOURCE_OF_TRUTH = 'gridStorageKeys.js'
+
+/** Any generation of the layout key, as a quoted string literal. */
+const LAYOUT_LITERAL = /['"`]trinity-grid-layout-[^'"`]*['"`]/
+
+/** Strip comments so prose naming the key (like this file's own docstring) is not scanned. */
+function stripComments(code) {
+  return code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
+}
+
+function jsFilesUnder(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.auth' || entry === 'test-results') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...jsFilesUnder(full))
+    else if (entry.endsWith('.js')) out.push(full)
+  }
+  return out
+}
+
+describe('#2199 grid layout storage key has one source of truth', () => {
+  it('exports every generation, and ALL_LAYOUT_KEYS covers them', async () => {
+    const mod = await import('../../src/utils/gridStorageKeys.js')
+    expect(mod.LAYOUT_KEY).toBe('trinity-grid-layout-v2')
+    expect(mod.LAYOUT_KEY_V1).toBe('trinity-grid-layout-v1')
+    // Load-bearing: `_loadSavedRaw` migrates v1 -> v2, so a cleanup that misses
+    // a generation lets a stale blob be migrated straight back in.
+    expect(mod.ALL_LAYOUT_KEYS).toContain(mod.LAYOUT_KEY)
+    expect(mod.ALL_LAYOUT_KEYS).toContain(mod.LAYOUT_KEY_V1)
+  })
+
+  it('the constants module imports nothing (Playwright must resolve it)', () => {
+    // Playwright reads neither the Vite `@` alias nor a tsconfig `paths` map,
+    // so one aliased import here would break every grid spec at once.
+    const source = stripComments(readFileSync(MODULE, 'utf8'))
+    expect(source).not.toMatch(/^\s*import\s/m)
+  })
+
+  it('no e2e spec hand-copies a layout key literal', () => {
+    const offenders = jsFilesUnder(E2E_DIR)
+      .filter((f) => LAYOUT_LITERAL.test(stripComments(readFileSync(f, 'utf8'))))
+      .map((f) => f.slice(E2E_DIR.length + 1))
+
+    expect(
+      offenders,
+      `import { LAYOUT_KEY, ALL_LAYOUT_KEYS } from '../src/utils/gridStorageKeys.js' ` +
+        `instead of hand-copying the literal (#2199)`
+    ).toEqual([])
+  })
+
+  it('fleetGrid.js imports the keys rather than declaring them', () => {
+    const source = stripComments(readFileSync(STORE, 'utf8'))
+    expect(source).not.toMatch(LAYOUT_LITERAL)
+    expect(source).toMatch(/from\s+['"]@\/utils\/gridStorageKeys['"]/)
+  })
+
+  it('the source-of-truth module is the only place holding the literals', () => {
+    expect(MODULE.endsWith(SOURCE_OF_TRUTH)).toBe(true)
+    expect(readFileSync(MODULE, 'utf8')).toMatch(LAYOUT_LITERAL)
+  })
+})


### PR DESCRIPTION
Fixes #2199

## Summary

6 failing tests fixed across 11 files.

- **Grid layout key derived, not hand-copied**: the layout localStorage key is now imported from a new zero-dependency `src/utils/gridStorageKeys.js` — the store imports it via the `@` alias, the Playwright specs via a plain relative path (Playwright resolves neither `vite.config.js` nor a tsconfig `paths` map, hence zero imports by documented design). A vitest source guard (`tests/unit/gridStorageKeys.spec.js`, 5 tests) pins store-imports, values, and the zero-import property so the next key bump propagates instead of silently desyncing the specs again (#2042's v1→v2 bump is how this broke).
- **Missing fixture agents skip honestly** via ONE shared **authenticated** probe (`e2e/helpers/agent-probe.js`) with a two-sided contract: a definitive **404 → skip** with an honest reason; **401/403/5xx/transport → THROW** with the real diagnosis. The anti-pattern this PR eradicates — an unauthenticated probe whose 401 read as "agent not found" — produced silent skips with false reasons on every run.

## Scope corrections vs the issue

- `system-install` was **NOT** already fixed upstream — `0f36de8f` (#2125) was necessary but insufficient once ent#384 wrapped the Library in tab `<section>`s. Fixed here with an `ancestor::section[1]` anchor (positional `.last()` rejected — it's how this broke twice), with red-before/green-after AND a non-vacuity probe.
- Also included: the 5th `testfix` consumer the issue missed (`portal-agent-page-overview` — didn't exist at the sweep's commit) and the 6th stale v1-key holder (`grid-org-overlay` cleanup — silently cleared nothing).

## Found in passing, fixed

A 3rd instance of the unauthenticated-probe anti-pattern in `honest-failed-states`: 401 → `[]` → skip claiming "has no schedules" — a false diagnosis.

## Evidence

Full-suite: **95 → 97 passed / 8 failed / 19 skipped**. All 8 residual failures map 1:1 to open issues:

- 7× `dashboard-type-filter` → #2200 (PR in flight from this same run)
- 1× `dashboard-stats-overflow` → #2197 (its "Toolbar/stats overlap at 640px" half)

Five-run verification protocol, including proof the skip guards aren't permanently skipping: **9 passed / 0 skipped** with `*_TEST_AGENT=acme-sage`.

## Note for #2197's owner

`dashboard-stats-overflow.spec.js:4,:100` cites the CLOSED #1830 — anyone tracing the failure lands on a closed issue; the one-line citation fix belongs in #2197.

## Cross-refs

- #2210 — the circuit-breaker spec defect (mocks the standalone `/circuit-breaker` endpoint the agent page never calls; one test fails, one passes vacuously). The README known-gap note now points at it; `circuit-breaker-badge.spec.js` is left **byte-identical** here.

## CI honesty note

None of the 6 fixed tests are `@smoke`; `frontend-e2e` is smoke-only + advisory (#1526) with `retries: 2` — the evidence above is local full-suite runs on a branch-serving dev server, not CI.

## Follow-ups (listed, NOT filed)

- `grid-org-overlay` zone assertions are strict-mode-ambiguous on any stack with pre-existing `dept-*` tags (two independent base reproductions)
- `loops-panel:93` has a 90s assertion timeout inside a 30s test timeout (unreachable by construction)
- convert `circuit-breaker-badge` probes per #2210 then `test.skip(true, 'blocked by #2210')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
