### PR TITLE
fix(ci): dev deploy serialises, self-heals, and can no longer fail silently (#2204)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,6 +8,23 @@ on:
 permissions:
   contents: read
 
+# #2204: serialise deploys. Measured up to FOUR runs executing concurrently
+# against the one dev VM (2026-08-12T12:49:51-12:50:15, overlapping 960-1215s),
+# each running `docker compose build --no-cache` then `up -d` on the same host
+# and compose project: concurrent recreates of the same container, and four
+# concurrent full image builds on one box.
+#
+# cancel-in-progress MUST stay false. Cancelling mid-run is precisely what
+# strands a half-recreated container -- compose renames the outgoing container
+# to a <12-hex>_<name> backup and removes it once the replacement is up, so a
+# run killed in between leaves the backup resident (see the reaper below).
+# GitHub supersedes the *pending* run rather than the running one, so this
+# converges on "current deploy finishes, then the newest commit deploys"
+# without ever interrupting a deploy in flight.
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -170,6 +187,32 @@ jobs:
               BUILD_DATE="${BUILD_DATE}" \
               docker compose ${COMPOSE_FILES} build --no-cache backend frontend mcp-server scheduler
 
+            echo "=== Reap stale compose backup containers (#2204) ==="
+            # Compose renames the outgoing container to <12-hex>_<name> before
+            # starting its replacement, then removes the backup once the new one
+            # is up. A run that dies in between leaves the backup resident, and
+            # every later deploy hits "container name is already in use" at the
+            # identical point.
+            #
+            # HONEST SCOPE: this is hygiene, NOT the fix for the #2204 outage.
+            # That outage was a corrupted database crash-looping the backend;
+            # host inspection found no orphan at all, and clearing one would
+            # only have moved the failure to the health check below. Do not
+            # record this block as the fix for that incident.
+            #
+            # Both guards are load-bearing under the `set -e` at the top of this
+            # script: `grep` exits 1 when nothing matches, and `docker rm -f`
+            # exits 1 when given no arguments. Unguarded, either would abort
+            # EVERY healthy deploy -- the no-orphan path is the common one.
+            STALE=$(sudo docker ps -a --format '{{.Names}}' | grep -E '^[0-9a-f]{12}_trinity-' || true)
+            if [ -n "$STALE" ]; then
+              echo "Reaping stale compose backup containers:"
+              printf '%s\n' "$STALE"
+              printf '%s\n' "$STALE" | xargs -r sudo docker rm -f
+            else
+              echo "No stale compose backup containers."
+            fi
+
             echo "=== Restart ==="
             sudo docker compose ${COMPOSE_FILES} up -d backend frontend mcp-server scheduler
 
@@ -179,6 +222,27 @@ jobs:
             SCHED=$(sudo docker inspect trinity-scheduler --format='{{.State.Health.Status}}')
             echo "Scheduler: $SCHED"
             [ "$SCHED" = "healthy" ] || echo "WARNING: scheduler not healthy yet"
+
+            echo "=== Backend boot log ==="
+            # ONE read, several consumers (enterprise registration below, and
+            # the #2204 seeding check). Scope it to the CURRENT container run,
+            # so a line left over from a previous boot cannot fail today's
+            # deploy.
+            #
+            # The --tail fallback does NOT carry that property, and is sound
+            # only here: `up -d` just recreated this container, so its whole log
+            # is a few hundred lines and every boot line is inside the window.
+            # On a long-running container it would be wrong in both directions
+            # -- deep enough to catch a previous boot's failure line, and too
+            # shallow to reach the current boot's success line (a live instance
+            # measured 14k lines since start). Don't lift this block somewhere
+            # the container isn't newly started.
+            BOOT_SINCE=$(sudo docker inspect -f '{{.State.StartedAt}}' trinity-backend 2>/dev/null || echo "")
+            if [ -n "$BOOT_SINCE" ]; then
+              BOOT_LOG=$(sudo docker logs trinity-backend --since "$BOOT_SINCE" 2>&1 || true)
+            else
+              BOOT_LOG=$(sudo docker logs trinity-backend --tail 2000 2>&1 || true)
+            fi
 
             echo "=== Enterprise registration (#2068) ==="
             # The enterprise version-line is upgraded during module
@@ -205,45 +269,153 @@ jobs:
             # submodule genuinely failed to init falls through to the
             # ::warning:: path above. An OSS-only deploy is NEVER failed here.
             if [ -f src/backend/enterprise/backend/__init__.py ]; then
-              # Scope the read to the CURRENT container run, so a FAILED line
-              # left over from a previous boot cannot fail today's deploy.
-              #
-              # The --tail fallback below does NOT carry that property, and is
-              # sound only here: `up -d` just recreated this container, so its
-              # whole log is a few hundred lines and every boot line is inside
-              # the window. On a long-running container it would be wrong in
-              # both directions — deep enough to catch a previous boot's FAILED
-              # line, and too shallow to reach the current boot's success line
-              # (a live instance measured 14k lines since start). Don't lift
-              # this block somewhere the container isn't newly started.
-              ENT_SINCE=$(sudo docker inspect -f '{{.State.StartedAt}}' trinity-backend 2>/dev/null || echo "")
-              if [ -n "$ENT_SINCE" ]; then
-                ENT_LOG=$(sudo docker logs trinity-backend --since "$ENT_SINCE" 2>&1 || true)
-              else
-                ENT_LOG=$(sudo docker logs trinity-backend --tail 2000 2>&1 || true)
-              fi
-              if printf '%s\n' "$ENT_LOG" | grep -q 'Trinity Enterprise registration FAILED'; then
+              if printf '%s\n' "$BOOT_LOG" | grep -q 'Trinity Enterprise registration FAILED'; then
                 echo "::error::Enterprise registration FAILED — the submodule is mounted but this instance is running OSS-only (every entitled route will 403). See trinity#2068."
-                printf '%s\n' "$ENT_LOG" | grep -A 20 'Trinity Enterprise registration FAILED' | head -40
+                printf '%s\n' "$BOOT_LOG" | grep -A 20 'Trinity Enterprise registration FAILED' | head -40
                 exit 1
-              elif printf '%s\n' "$ENT_LOG" | grep -q 'Trinity Enterprise modules registered'; then
+              elif printf '%s\n' "$BOOT_LOG" | grep -q 'Trinity Enterprise modules registered'; then
                 echo "ENTERPRISE: modules registered"
               else
                 echo "::error::Enterprise submodule is mounted but the backend never printed 'Trinity Enterprise modules registered' — registration did not complete. See trinity#2068."
-                printf '%s\n' "$ENT_LOG" | grep -i 'enterprise' | tail -20
+                printf '%s\n' "$BOOT_LOG" | grep -i 'enterprise' | tail -20
                 exit 1
               fi
               # Partial degradation: registration finished, but some modules
               # failed — the success line still prints. Out of scope for #2068
               # and not a deploy blocker on its own, so warn rather than fail;
               # failing on it deserves its own decision.
-              if printf '%s\n' "$ENT_LOG" | grep -q 'FAILED module(s)'; then
+              if printf '%s\n' "$BOOT_LOG" | grep -q 'FAILED module(s)'; then
                 echo "::warning::Enterprise registration completed with FAILED module(s) — some entitled features are unavailable on this instance"
-                printf '%s\n' "$ENT_LOG" | grep 'FAILED module(s)' | head -5
+                printf '%s\n' "$BOOT_LOG" | grep 'FAILED module(s)' | head -5
               fi
             fi
+
+            echo "=== Agent seeding check (#2204) ==="
+            # A green deploy is not evidence the instance is CORRECT. Agent
+            # creation failures are logged, never raised, so this workflow can
+            # report success with the fleet incomplete -- observed 2026-08-15,
+            # when a seeded agent lost an SSH port race (#2215) and was simply
+            # never created while the deploy stayed green.
+            #
+            # Same precedent as the enterprise-registration grep above: assert
+            # on post-deploy STATE, not on the job's conclusion. That is the
+            # difference between this and the `Error check` below, which ends in
+            # `|| echo "No errors"` and therefore only ever PRINTS.
+            #
+            # This cannot wedge the pipeline. Seeding is first-run-only behind
+            # the durable `cornelius_seeded` / `default_system_seeded` flags, and
+            # BOOT_LOG is scoped to the current container run -- so this fails
+            # exactly once, on the deploy that actually left the instance
+            # incomplete, and later deploys are clean.
+            if printf '%s\n' "$BOOT_LOG" | grep -q 'Failed to create agent'; then
+              echo "::error::An agent failed to be created during boot -- this instance is running with an incomplete fleet. See trinity#2215."
+              printf '%s\n' "$BOOT_LOG" | grep 'Failed to create agent' | head -10
+              exit 1
+            fi
+            echo "No agent creation failures."
 
             echo "=== Error check ==="
             sudo docker logs trinity-backend --tail 50 2>&1 | grep -iE 'error|exception|failed' | head -10 || echo "No errors"
 
             echo "=== Done ==="
+
+  # #2204: a red deploy must not be able to run silently. 39 consecutive
+  # failures over five days produced no alert, no issue, and no signal on any of
+  # the ~39 PRs that merged into the broken branch -- the SECOND occurrence of
+  # that class (the first ran four days / thirty merges).
+  #
+  # Deliberately a separate JOB, not a step inside the deploy script. An alert
+  # sent from inside the SSH session shares a failure domain with the thing it
+  # is alerting on: Tailscale down, SSH refused, or a wedged host means no
+  # alert at all, precisely when one is most needed. A job-level `if: failure()`
+  # fires even when the host is unreachable.
+  #
+  # A Slack webhook was considered and REJECTED: no webhook secret exists in
+  # this repo or at org level, so `secrets.SLACK_WEBHOOK_URL` would render empty
+  # and the step would no-op silently -- the packaging-gap class recorded six
+  # times in docs/memory/learnings.md (#1039, #1056, #1707, #1871, ent#14,
+  # ent#31). An alert that silently never fires is worse than none, because it
+  # retires the concern. GITHUB_TOKEN needs no provisioning and cannot ship
+  # inert. If a webhook secret is added later, a sibling step is trivially
+  # additive -- but it must not REPLACE this one, for the failure-domain reason
+  # above.
+  #
+  # `if: failure()` deliberately does NOT fire on `cancelled`: with
+  # cancel-in-progress:false a superseded PENDING run is cancelled, and that is
+  # not a deploy failure. (See learnings.md 2026-07-28 on `if: always()` +
+  # a cancelled clause silently defeating cancel-in-progress.)
+  notify-failure:
+    needs: deploy
+    if: failure()
+    runs-on: ubuntu-latest
+    # Job-level `permissions:` REPLACES the workflow-level block, so this grant
+    # is scoped to this job alone; the deploy job keeps `contents: read`.
+    # Elevation works despite the repo default of read-only -- claim.yml
+    # already relies on it.
+    permissions:
+      issues: write
+    steps:
+      - name: File a deploy-failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+
+          # ONE open issue at a time. Re-filing per failure would have produced
+          # 39 issues during the outage this fixes; commenting per failure would
+          # have produced 39 notifications. An open issue IS the signal, so a
+          # further failure while one is open is a deliberate no-op.
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label deploy-failure --state open \
+            --json number --jq '.[0].number // empty' 2>/dev/null || true)
+
+          if [ -n "$EXISTING" ]; then
+            echo "Deploy failure already tracked at #${EXISTING} -- not re-filing."
+            exit 0
+          fi
+
+          cat > /tmp/deploy-failure-body.md <<BODY
+          ## Summary
+
+          \`Deploy to Dev\` failed. This issue was filed automatically by the
+          workflow itself, so that a red deploy cannot run silently (trinity#2204).
+
+          - **Failed run**: ${RUN_URL}
+          - **Commit**: \`${COMMIT_SHA}\`
+
+          ## What this means
+
+          The dev instance is **not** running this commit. Every merge to
+          \`dev\` from now until this is fixed ships nothing, and no other
+          signal will report that -- CI stays green and PRs merge cleanly.
+
+          ## First checks
+
+          1. Open the failed run above and read the last \`===\` section header
+             reached. The deploy script is sectioned (\`Pull\`, \`Build\`,
+             \`Restart\`, \`Health\`, \`Agent seeding check\`) so the header
+             names the stage.
+          2. If it failed at \`Agent seeding check\`, the instance is up but its
+             fleet is incomplete -- see trinity#2215.
+          3. If it failed at \`Restart\` with a container-name conflict, the
+             reaper should have cleared it; check whether the pattern matched.
+          4. If it failed at \`Health\`, the backend is not becoming healthy.
+             Check \`docker logs trinity-backend\` on the host -- a database
+             that cannot be opened crash-loops every worker before uvicorn
+             binds, and the other services then sit in \`Created\` behind
+             \`depends_on: service_healthy\`.
+
+          ## Closing this issue
+
+          Close it once a \`Deploy to Dev\` run is green. While it stays open,
+          further failures will **not** file duplicates, so do not leave it open
+          after the deploy recovers -- a stale open issue suppresses the alert
+          for the next outage.
+          BODY
+
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "bug(ci): Deploy to Dev is failing on \`dev\`" \
+            --label "deploy-failure,priority-p1,type-bug,status-ready,theme-infrastructure" \
+            --body-file /tmp/deploy-failure-body.md

--- a/tests/unit/test_2204_deploy_self_heal.py
+++ b/tests/unit/test_2204_deploy_self_heal.py
@@ -1,0 +1,248 @@
+"""Static guard: the dev deploy self-heals, serialises, and cannot fail silently (#2204).
+
+``Deploy to Dev`` failed on every run for five days — 39+ consecutive failures,
+no successful deploy in between, and **no alert of any kind**. CI stayed green,
+PRs merged cleanly, issues auto-promoted to ``status-in-dev``, and the instance
+sat on a five-day-old build. It was the SECOND occurrence of that class; the
+first ran four days and thirty merges.
+
+The outage's root cause was a corrupted database (the backend crash-looped
+before uvicorn could bind, so every other service sat in ``Created`` behind
+``depends_on: service_healthy``). That is not what this guard is about — a
+corrupted file is not a thing a workflow can prevent. What this guard pins is
+the set of properties that decide whether the NEXT such outage is noticed in
+minutes or in days:
+
+  1. **Deploys are serialised.** Up to four runs were measured executing
+     concurrently against the one dev VM, each running ``docker compose build
+     --no-cache`` then ``up -d`` on the same host and project.
+  2. **An interrupted run cannot wedge its successors.** Compose renames the
+     outgoing container to ``<12-hex>_<name>`` before starting the replacement;
+     a run killed in between leaves that backup resident and every later deploy
+     hits a name conflict at the identical point.
+  3. **A green deploy means the instance is correct**, not merely that the job
+     exited 0. Agent-creation failures are logged and never raised, so a deploy
+     can report success with the fleet incomplete (observed: an agent lost an
+     SSH port race, #2215, and the deploy stayed green).
+  4. **A red deploy is announced.** Nothing watched this workflow.
+
+Rule 2's guards are the subtle half and the reason this file exists rather than
+a code comment. ``set -e`` is active for the whole SSH script, ``grep`` exits 1
+when nothing matches, and ``docker rm -f`` exits 1 when given no arguments — so
+an *unguarded* reaper would abort every HEALTHY deploy, which is the common
+path. A fix for a wedged pipeline that wedges the pipeline harder is the
+failure mode worth a CI gate.
+
+Rule 1's direction is likewise load-bearing: ``cancel-in-progress: true`` would
+kill a deploy mid-recreate, which is exactly what strands the backup container
+in rule 2. The flag being present is not the property; its VALUE is.
+
+Pure static check over the workflow file — no backend imports, no network.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy-dev.yml"
+
+
+def _text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _doc(text: str | None = None) -> dict:
+    return yaml.safe_load(text if text is not None else _text())
+
+
+def _deploy_script(doc: dict) -> str:
+    """The shell that actually runs on the dev VM."""
+    for step in doc["jobs"]["deploy"]["steps"]:
+        with_ = step.get("with") or {}
+        if "script" in with_:
+            return with_["script"]
+    raise AssertionError("deploy job has no ssh-action step carrying a `script:`")
+
+
+# --------------------------------------------------------------------------
+# The checks, written as functions so the meta-test can feed them mutated input.
+# Each raises AssertionError with a message naming the property, not the line.
+# --------------------------------------------------------------------------
+
+def check_deploys_are_serialised(doc: dict) -> None:
+    conc = doc.get("concurrency")
+    assert conc, (
+        "deploy-dev.yml has no `concurrency:` group — concurrent deploys run "
+        "`docker compose up -d` against one host (#2204)"
+    )
+    assert conc.get("group"), "`concurrency.group` must name a group"
+    # PyYAML maps `false` -> False. An absent key is ALSO wrong: the GitHub
+    # default is false, but relying on a default for a property whose inverse
+    # re-creates the bug is how it silently flips later.
+    assert conc.get("cancel-in-progress") is False, (
+        "`cancel-in-progress` must be explicitly false: cancelling a deploy "
+        "mid-recreate is precisely what strands a <12-hex>_<name> backup "
+        "container and wedges every later run (#2204)"
+    )
+
+
+def check_reaper_present_and_guarded(script: str) -> None:
+    assert "^[0-9a-f]{12}_trinity-" in script, (
+        "no reaper for stale compose backup containers — an interrupted deploy "
+        "can wedge every successor (#2204)"
+    )
+    reaper = script[script.index("^[0-9a-f]{12}_trinity-"):]
+    reaper = reaper[: reaper.index("=== Restart ===")]
+
+    assert "|| true" in reaper, (
+        "the reaper's `grep` is unguarded: it exits 1 when nothing matches and "
+        "`set -e` is active, so a deploy with NO orphans — the common case — "
+        "would abort (#2204)"
+    )
+    assert "xargs -r" in reaper, (
+        "the reaper must pipe through `xargs -r`: `docker rm -f` with no "
+        "arguments exits 1, aborting every healthy deploy under `set -e` (#2204)"
+    )
+
+
+def check_reaper_runs_before_up(script: str) -> None:
+    assert script.index("^[0-9a-f]{12}_trinity-") < script.index("up -d"), (
+        "the reaper must run BEFORE `docker compose up -d` — reaping after the "
+        "conflict has already failed the run accomplishes nothing (#2204)"
+    )
+
+
+def check_seeding_failure_fails_the_deploy(script: str) -> None:
+    assert "Failed to create agent" in script, (
+        "nothing asserts post-deploy state: agent-creation errors are logged, "
+        "never raised, so a deploy reports success with an incomplete fleet "
+        "(#2204 / #2215)"
+    )
+    block = script[script.index("=== Agent seeding check"):]
+    block = block[: block.index("=== Error check ===")]
+    assert "exit 1" in block, (
+        "the seeding check only PRINTS. That is the `Error check` block's "
+        "behaviour (it ends in `|| echo \"No errors\"`) and is exactly the "
+        "silence #2204 is about — it must fail the deploy"
+    )
+
+
+def check_failure_is_announced(doc: dict) -> None:
+    job = doc["jobs"].get("notify-failure")
+    assert job, "no job announces a failed deploy — a red deploy can run silently (#2204)"
+    assert job.get("needs") == "deploy" or "deploy" in (job.get("needs") or []), (
+        "the notifier must depend on `deploy` so it observes that job's outcome"
+    )
+    # `always()` would also fire on `cancelled`, and with cancel-in-progress:false
+    # a superseded PENDING run is cancelled — filing an issue for that is noise
+    # that trains people to ignore the alert. See learnings.md 2026-07-28.
+    assert job.get("if") == "failure()", (
+        "the notifier must be `if: failure()`, not `always()` — a cancelled "
+        "superseded run is not a deploy failure (#2204)"
+    )
+    assert (job.get("permissions") or {}).get("issues") == "write", (
+        "the notifier needs `permissions: issues: write`; job-level permissions "
+        "REPLACE the workflow-level block, so it must be declared on the job"
+    )
+
+
+def check_notifier_does_not_spam(doc: dict) -> None:
+    run = doc["jobs"]["notify-failure"]["steps"][0]["run"]
+    assert "--label deploy-failure --state open" in run, (
+        "the notifier must look for an already-open deploy-failure issue; "
+        "re-filing per failure would have produced 39 issues in the outage "
+        "this fixes (#2204)"
+    )
+    assert "exit 0" in run, "the notifier must no-op when a failure is already tracked"
+
+
+# --------------------------------------------------------------------------
+# Live assertions
+# --------------------------------------------------------------------------
+
+def test_deploys_are_serialised():
+    check_deploys_are_serialised(_doc())
+
+
+def test_reaper_present_and_guarded():
+    check_reaper_present_and_guarded(_deploy_script(_doc()))
+
+
+def test_reaper_runs_before_up():
+    check_reaper_runs_before_up(_deploy_script(_doc()))
+
+
+def test_seeding_failure_fails_the_deploy():
+    check_seeding_failure_fails_the_deploy(_deploy_script(_doc()))
+
+
+def test_failure_is_announced():
+    check_failure_is_announced(_doc())
+
+
+def test_notifier_does_not_spam():
+    check_notifier_does_not_spam(_doc())
+
+
+def test_notify_job_is_not_inside_the_ssh_script():
+    """The alert must not share a failure domain with the thing it reports on.
+
+    An alert curled from inside the SSH session is unreachable in exactly the
+    states worth alerting about — Tailscale down, SSH refused, host wedged. A
+    job-level `if: failure()` fires even when the host never answered.
+    """
+    doc = _doc()
+    assert "notify-failure" in doc["jobs"]
+    script = _deploy_script(doc)
+    assert "gh issue create" not in script, (
+        "the failure alert moved inside the SSH script; it then cannot fire "
+        "when the host is unreachable (#2204)"
+    )
+
+
+# --------------------------------------------------------------------------
+# Meta-test: prove the guard actually goes red on the pre-fix content.
+#
+# learnings.md 2026-08-05: "when verifying that a new guard would have caught
+# the bug, delete the real line and watch it go red." A guard asserted only
+# against the fixed tree documents today's state instead of closing the class.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "mutation,checker,uses_script",
+    [
+        # Pre-fix: no concurrency block at all.
+        (lambda t: t.replace("concurrency:\n  group: deploy-dev\n  cancel-in-progress: false\n", ""),
+         check_deploys_are_serialised, False),
+        # The flip that re-creates the bug: cancelling mid-recreate.
+        (lambda t: t.replace("cancel-in-progress: false", "cancel-in-progress: true"),
+         check_deploys_are_serialised, False),
+        # The Gemini-caught trap: reaper present but grep unguarded.
+        (lambda t: t.replace("_trinity-' || true", "_trinity-'"),
+         check_reaper_present_and_guarded, True),
+        # Same class, one command over: `docker rm -f` with no args.
+        (lambda t: t.replace("xargs -r sudo docker rm -f", "xargs sudo docker rm -f"),
+         check_reaper_present_and_guarded, True),
+        # Pre-fix: the seeding check prints instead of failing.
+        (lambda t: t.replace(
+            "              printf '%s\\n' \"$BOOT_LOG\" | grep 'Failed to create agent' | head -10\n              exit 1\n",
+            "              printf '%s\\n' \"$BOOT_LOG\" | grep 'Failed to create agent' | head -10\n"),
+         check_seeding_failure_fails_the_deploy, True),
+        # `always()` would fire on cancelled runs too.
+        (lambda t: t.replace("    if: failure()\n", "    if: always()\n"),
+         check_failure_is_announced, False),
+    ],
+)
+def test_guard_rejects_pre_fix_content(mutation, checker, uses_script):
+    original = _text()
+    mutated = mutation(original)
+    assert mutated != original, (
+        "the mutation did not change the file — the meta-test would pass "
+        "against an unmodified tree and prove nothing"
+    )
+    doc = _doc(mutated)
+    target = _deploy_script(doc) if uses_script else doc
+    with pytest.raises(AssertionError):
+        checker(target)


### PR DESCRIPTION
## Summary

`Deploy to Dev` failed on **every run from 2026-08-10T15:50Z to 2026-08-15T18:12Z** — 39+ consecutive failures, no successful deploy in between, and **no alert of any kind**. CI stayed green and PRs merged cleanly while the dev instance sat on a five-day-old build. Second occurrence of the class; the first ran four days and thirty merges.

dev has since been restored manually (AC #1). This PR is the **prevention** half.

## The issue's diagnosis was wrong, and the record is corrected

#2204 attributed the outage to a self-perpetuating orphaned container. Host inspection found **no orphan at all**. The real blocker was a corrupted database — an HTTP response written over the SQLite header — which crash-looped every uvicorn worker at import, so the healthcheck failed 893 times and `trinity-{scheduler,frontend,mcp-server}` sat in `Created` behind `depends_on: backend: condition: service_healthy`.

The name conflict *was* real (it appears verbatim before `Process exited with status 1` in run `31878949909`), but it was a **downstream blocker, not the cause** — clearing it would have moved the failure four lines down to the health check, which could never pass. The issue body has been rewritten with the corrected postmortem, original diagnosis preserved in a collapsed section.

A corrupted file is not something a workflow can prevent. So this PR targets the properties that decide whether the *next* such outage is noticed in minutes or in days.

## Changes

**Serialise deploys** — measured up to **four** runs executing concurrently against the one dev VM (2026-08-12T12:49:51–12:50:15, overlapping 960–1215s), each running `docker compose build --no-cache` then `up -d` on the same host and project. `cancel-in-progress` is explicitly `false`: cancelling mid-run is exactly what strands a half-recreated container.

**Reap stale compose backups** before `up -d`, so one interrupted run cannot wedge its successors. Both guards are load-bearing under the script's `set -e` — `grep` exits 1 when nothing matches and `docker rm -f` exits 1 with no arguments, so an *unguarded* reaper would abort every **healthy** deploy, which is the common path.

**Assert post-deploy state**, not the job's conclusion. Agent-creation failures are logged and never raised, so a deploy can report success with the fleet incomplete — observed on the remediation run itself, where a seeded agent lost an SSH port race (#2215) and the deploy stayed green. Follows the existing enterprise-registration boot-log grep precedent; the single log read is hoisted so both consumers share it.

**File an issue on failure**, deduped to one open at a time.

## Two deliberate rejections

**Slack webhook → GitHub issue.** #2204 suggested reusing `CANARY_SLACK_WEBHOOK_URL`. That variable lives on the *instance*, not in Actions, and this repo has **no** webhook secret (repo secrets are `DEV_*`, `GCP_*`, `HOMEBREW_TAP_TOKEN`, `TAILSCALE_AUTH_KEY`; zero org secrets). `secrets.SLACK_WEBHOOK_URL` would render empty and no-op silently — the packaging-gap class recorded **six** times in `learnings.md` (#1039, #1056, #1707, #1871, ent#14, ent#31). An alert that silently never fires is worse than none. It is a separate **job**, not a step in the SSH script, because an alert sent from the host shares a failure domain with the thing it reports on.

**Pre-build prune → dropped.** Planned on the hypothesis that 39 `--no-cache` builds had filled the disk. Measured: **79% before, 80% after, no prune run at any tier.** The hypothesis was false, so the step was cut rather than shipped on speculation.

## Test plan

- [x] `pytest tests/unit/test_2204_deploy_self_heal.py -q` → **13 passed**
- [x] Six **meta-tests** mutate the workflow back to its pre-fix content and assert each check goes red (`learnings.md` 2026-08-05: a guard asserted only against the fixed tree documents today's state instead of closing the class)
- [x] Reaper shell logic executed both ways: zero matches survives `set -e` (exit 0); with matches it selects only `<12-hex>_trinity-*` and leaves `trinity-backend` / `agent-test` untouched
- [x] `notify-failure` script `bash -n` clean; heredoc rendered with test env — backticks literal, vars expanded
- [x] YAML parses; both jobs present with expected `if`/`permissions`
- [x] Other workflow-scanning guards still pass (`test_1891`, `test_2089`, `test_canary_env_prod_parity`) → 43 passed
- [ ] **Verified on merge**: the post-merge `Deploy to Dev` run goes green, and the reaper logs "No stale compose backup containers" rather than aborting

## Honest scope

The reaper is **hygiene, not the fix for this outage** — there was no orphan to reap. Both the inline comment and the guard's docstring say so, because recording it as the fix would bury the real cause.

## Spun out

- #2215 — fresh-install seeding races itself across workers; two seeders (different SETNX keys) over an unlocked check-then-act port allocator
- #2216 — shipped database backup tooling is never invoked; no scheduled backups, no recovery point
- #2217 — canary harness left disabled on a retired constraint (#1540 made it backend-agnostic), and nothing reports whether it is running

Fixes #2204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
