### PR TITLE
fix(dashboard): Executions tile stops slicing its legend and says what it hides (#2228)

### DIFF
--- a/src/frontend/src/components/tiles/ExecutionsTile.vue
+++ b/src/frontend/src/components/tiles/ExecutionsTile.vue
@@ -59,11 +59,34 @@
       </div>
     </div>
 
+    <!-- Exactly LEGEND_ROWS whole rows (#2228). The clamp below hides a third
+         row outright rather than slicing one, and `legendFit` guarantees there
+         is nothing in it to hide — anything that would not fit is handed to the
+         `+N` chip, which names it rather than dropping it silently. -->
     <div class="ex-legend">
-      <span v-for="b in legend" :key="b.name" class="ex-key" :title="`${b.name}: ${b.total}`">
-        <i :class="'ex-dot ex-bk-' + b.token"></i>{{ b.name }}
+      <span
+        v-for="k in legend.shown"
+        :key="k.fail ? '\u0000failed' : k.name"
+        class="ex-key"
+        :class="{ 'ex-key-fail': k.fail }"
+        :title="`${k.name}: ${k.total}`"
+      >
+        <i class="ex-dot" :class="k.fail ? 'ex-dot-fail' : 'ex-bk-' + k.token"></i>{{ k.name }}
       </span>
-      <span v-if="head.failed" class="ex-key ex-key-fail"><i class="ex-dot ex-dot-fail"></i>failed</span>
+      <span v-if="legend.hidden.length" class="ex-key ex-key-more" :title="hiddenTitle">
+        <!-- Dots only while they still identify WHICH buckets are hidden. Past
+             three the swatches stop being a mapping and become decoration, so
+             the count carries it alone and the title stays authoritative. -->
+        <template v-if="legend.hidden.length <= 3">
+          <i
+            v-for="k in legend.hidden"
+            :key="k.name"
+            class="ex-dot"
+            :class="k.fail ? 'ex-dot-fail' : 'ex-bk-' + k.token"
+          ></i>
+        </template>
+        +{{ legend.hidden.length }}
+      </span>
     </div>
   </InfoTile>
 </template>
@@ -98,9 +121,12 @@ import { computed } from 'vue'
 import InfoTile from '../InfoTile.vue'
 import { useFleetGridStore } from '@/stores/fleetGrid'
 import {
+  CHART_HEIGHT,
   chartColumns,
   headline,
-  presentBuckets,
+  legendFit,
+  legendKeys,
+  RAIL_HEIGHT,
   tileState,
 } from '@/utils/executionsTile'
 
@@ -115,9 +141,23 @@ const gridStore = useFleetGridStore()
 const buckets = computed(() => gridStore.execTimeline || [])
 const head = computed(() => headline(buckets.value))
 const columns = computed(() =>
-  chartColumns(buckets.value, { triggerOrder: gridStore.execTriggerOrder }),
+  chartColumns(buckets.value, {
+    triggerOrder: gridStore.execTriggerOrder,
+    chartHeight: CHART_HEIGHT,
+    railHeight: RAIL_HEIGHT,
+  }),
 )
-const legend = computed(() => presentBuckets(gridStore.execTriggerOrder, buckets.value))
+const legend = computed(() =>
+  legendFit(legendKeys(gridStore.execTriggerOrder, buckets.value)),
+)
+
+/**
+ * What the `+N` chip is standing in for. Bucket names and counts only — the
+ * same backend vocabulary the columns already report on hover.
+ */
+const hiddenTitle = computed(
+  () => `Not shown: ${legend.value.hidden.map((k) => `${k.name}: ${k.total}`).join(' · ')}`,
+)
 
 const state = computed(() =>
   tileState({
@@ -168,6 +208,10 @@ function retry() {
   align-items: baseline;
   gap: 4px;
   font-size: 12px;
+  /* Pinned, not inherited: with the default line-height the baseline-aligned
+     mix of 20px and 12px text made this box 22.1px, and every px here comes
+     straight out of the legend at the other end of a fixed-height tile. */
+  line-height: 1;
   color: var(--gv-muted);
   margin-bottom: 6px;
 }
@@ -211,7 +255,11 @@ function retry() {
   display: flex;
   align-items: flex-end;
   gap: 2px;
-  height: 78px;
+  /* CHART_HEIGHT + COL_GAP + RAIL_HEIGHT + this padding, from
+     utils/executionsTile.js — the tallest a column can be, and nothing more.
+     It carried 4px of dead space, which is part of how the body came to
+     overflow (#2228). Pinned by executionsTile.spec.js. */
+  height: 70px;
   padding-bottom: 2px;
 }
 .ex-col {
@@ -247,30 +295,66 @@ function retry() {
   border-radius: 1px;
 }
 
+/* The legend occupies a WHOLE number of rows (#2228).
+   `max-height: 26px` was ~1.7 rows, so `overflow: hidden` cut row two through
+   its glyphs instead of hiding it. Pitch is now pinned rather than inherited:
+   `--ex-row` is set as `.ex-key`'s line-height, so the clamp is arithmetic over
+   values this file owns and cannot drift with a font change.
+   The row count MUST equal `LEGEND_ROWS` in utils/executionsTile.js — the
+   packer decides what fits, this decides how much is shown, and a disagreement
+   reintroduces silent truncation. Pinned by executionsTile.spec.js. */
 .ex-legend {
+  --ex-row: 13px;
+  --ex-row-gap: 2px;
   display: flex;
   flex-wrap: wrap;
-  gap: 2px 8px;
+  column-gap: 8px;
+  row-gap: var(--ex-row-gap);
   margin-top: 6px;
   font-size: 10px;
   color: var(--gv-muted);
   overflow: hidden;
-  max-height: 26px;
+  /* HEIGHT, not max-height: a ceiling grows and shrinks with the key count, so
+     the chart above would resize every time a bucket appeared or went quiet.
+     Reserved space is the price of a layout that never moves.
+     2 rows: 13 + 2 + 13 = 28px. A third row would begin at 30px and is
+     therefore hidden whole — rows are never partially rendered. */
+  height: calc(var(--ex-row) * 2 + var(--ex-row-gap));
 }
 .ex-key {
   display: inline-flex;
   align-items: center;
   gap: 3px;
   white-space: nowrap;
+  /* Pins the row pitch the clamp is computed from. */
+  line-height: var(--ex-row);
+  /* A key wider than the whole row is force-placed by the packer rather than
+     dropped; clip it here so it cannot widen the tile. */
+  max-width: 100%;
+  overflow: hidden;
 }
 .ex-key-fail {
   color: var(--gv-red-text);
+}
+/* The overflow chip. Zero vertical padding keeps it on the same 13px pitch as
+   every other key, so it can never be the thing that creates a third row. */
+.ex-key-more {
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--gv-seg-bg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  cursor: default;
 }
 .ex-dot {
   width: 6px;
   height: 6px;
   border-radius: 2px;
   display: inline-block;
+  /* A flex item by virtue of `.ex-key`; without this the swatch is the first
+     thing squeezed when a long label meets `overflow: hidden`, and a legend
+     whose colour chip has been compressed to a sliver decodes nothing. */
+  flex: none;
 }
 .ex-dot-fail {
   background: var(--gv-red);

--- a/src/frontend/src/utils/executionsTile.js
+++ b/src/frontend/src/utils/executionsTile.js
@@ -12,6 +12,8 @@
  * or the Overview chart (ent#96 AC1).
  */
 
+import { CELL_W } from './gridLayout'
+
 /** Bucket name -> the `--gv-bk-*` token that colours it. */
 export const BUCKET_TOKENS = {
   'Chat/Tasks': 'man',
@@ -69,6 +71,33 @@ export function presentBuckets(triggerOrder, buckets) {
     .map((name) => ({ name, total: totals.get(name), token: bucketToken(name) }))
 }
 
+/* -------------------------------------------------------------------------
+ * The tile's vertical budget (#2228)
+ *
+ * `.it-body` is `overflow: hidden` at a fixed `CELL_H`, so the head, the chart
+ * and the legend compete for one fixed number of pixels — measured at 134. The
+ * tile shipped needing ~138 of them, which is the SECOND clip behind #2228:
+ * even a legend that clamps to whole rows has its last row shaved off by the
+ * body if the column above it is too tall. Fixing the legend alone leaves the
+ * symptom on screen.
+ *
+ * So the chart states its budget here, in the same module the legend's does,
+ * and `.ex-chart`'s CSS height is exactly CHART_HEIGHT + COL_GAP + RAIL_HEIGHT
+ * + 2px padding — the tallest a column can be and nothing more. The container
+ * previously stood 4px above that, which was pure dead space paid for at the
+ * legend's expense. Pinned by executionsTile.spec.js, because a stylesheet and
+ * a JS constant cannot check each other.
+ * ------------------------------------------------------------------------- */
+
+/** Pixel budget for a column's stack. */
+export const CHART_HEIGHT = 60
+/** Pixel budget for the failure rail beneath it. */
+export const RAIL_HEIGHT = 6
+/** `.ex-col` gap between the stack and its rail. */
+export const COL_GAP = 2
+/** `.ex-chart` padding-bottom. */
+export const CHART_PAD = 2
+
 /**
  * One rendered column per bucket.
  *
@@ -81,7 +110,7 @@ export function presentBuckets(triggerOrder, buckets) {
  * floors at 1px: rounding a real execution to nothing would show an empty hour
  * that was not empty.
  */
-export function chartColumns(buckets, { triggerOrder = [], chartHeight = 64, railHeight = 6 } = {}) {
+export function chartColumns(buckets, { triggerOrder = [], chartHeight = CHART_HEIGHT, railHeight = RAIL_HEIGHT } = {}) {
   const rows = Array.isArray(buckets) ? buckets : []
   const order = stackOrder(triggerOrder, rows)
   const maxTotal = Math.max(1, ...rows.map((b) => b?.total || 0))
@@ -167,4 +196,139 @@ export function tileState({ loaded, error, buckets }) {
   if (!loaded) return 'loading'
   const total = headline(buckets).total
   return total ? 'ready' : 'empty'
+}
+
+/* -------------------------------------------------------------------------
+ * Legend fitting (#2228)
+ *
+ * The legend shipped as a wrapping flex row clamped by `max-height: 26px` with
+ * `overflow: hidden`. 26px is not a whole number of legend rows, so the clamp
+ * landed *inside* row two and sliced it through the glyphs — and whatever fell
+ * past it vanished with no indication, leaving colours in the chart with no
+ * decoder anywhere on the tile.
+ *
+ * Both halves are fixed here rather than in CSS alone, because CSS can clamp
+ * but cannot say WHAT it dropped. The clamp pins a whole number of rows; this
+ * packer decides which keys occupy them and hands the remainder to a `+N` chip.
+ *
+ * The width model is deliberately PESSIMISTIC, and the invariant it maintains
+ * is per KEY, not in aggregate: the estimate must be >= what the browser
+ * actually renders for every name. Only then is the packer's row assignment a
+ * subset of what the browser fits, so the browser can never need a row the
+ * packer did not plan for. An aggregate-only margin is not enough — greedy
+ * packing wastes space at the end of each row, so a model that is generous
+ * overall but tight on one name still lets a real third row form, which the
+ * clamp then eats silently. That is precisely the defect this removes.
+ *
+ * The two directions are not symmetric, which is why the bias is one-sided:
+ * over-reserving shows a `+N` that was not strictly necessary, under-reserving
+ * loses keys with no trace.
+ *
+ * Calibration, measured in the running app (Chromium, macOS system sans, 10px,
+ * 334px rows) rather than estimated: every label renders between 3.4 and 5.5
+ * px/char, so the model clears all eleven with 18-59% of headroom — enough to
+ * absorb a different platform font. Observed fleets sit around eight keys and
+ * fit with room to spare.
+ *
+ * The browser does in fact wrap the complete ten-bucket vocabulary plus
+ * `failed` into two rows; the model, being conservative, shows `+2` there. That
+ * gap is accepted rather than tuned away: closing it means calibrating to
+ * within a couple of percent of one browser's metrics on one platform, and the
+ * penalty for guessing low is a silently eaten row. The keys it gives up are
+ * the last in stack order — `Other` and `failed` — which is the right end to
+ * lose from: the headline already states the failure count in red just above,
+ * and the chip names both.
+ * ------------------------------------------------------------------------- */
+
+/** Rows the legend may occupy. The CSS clamp MUST agree; pinned by spec. */
+export const LEGEND_ROWS = 2
+
+/**
+ * Usable legend width in px.
+ *
+ * Derived from the lattice cell rather than hardcoded, so a change to CELL_W
+ * moves the packer with the tile it describes instead of leaving a stale
+ * literal behind.
+ *
+ * 50 = InfoTile's horizontal padding (30 left + 16 right) plus its 1px borders,
+ * rounded up. The padding alone gives 46, which measures 4px WIDER than the
+ * element really is — an error in the one direction the model must never take,
+ * since believing there is more room than exists is how a third row forms. The
+ * live tile reports a 334px content box, which is exactly CELL_W - 50.
+ */
+export const LEGEND_WIDTH = CELL_W - 50
+
+// Per-key geometry, matching the `.ex-key` rule in ExecutionsTile.vue.
+const DOT_W = 6 //     `.ex-dot` width
+const DOT_GAP = 3 //   `.ex-key` gap between dot and label
+const KEY_GAP = 8 //   `.ex-legend` column-gap
+const CHIP_W = 50 //   the `+N` chip at its widest (three dots + count + padding)
+const CHAR_PX = 5.7 // per-char estimate at font-size 10px
+const KEY_PAD = 4 //   flat per-key allowance, see below
+
+/**
+ * Estimated rendered width of one legend key at `font-size: 10px`.
+ *
+ * 5.7px/char sits above the measured per-char cost of every name in the
+ * vocabulary, which ranges from 3.4 (`failed`) to 5.5 (`MCP`). `KEY_PAD` covers
+ * the direction a flat per-char figure is weakest in: short all-caps names,
+ * where every glyph is a wide one and there are too few characters for the
+ * per-char margin to absorb the difference. Paying that as a constant is
+ * cheaper than inflating CHAR_PX, which would tax every long name for a problem
+ * only the short ones have.
+ *
+ * Zoom is a transform on the whole lattice, so the model is zoom-invariant.
+ */
+export function keyWidth(name) {
+  return DOT_W + DOT_GAP + KEY_PAD + String(name || '').length * CHAR_PX
+}
+
+/** The full legend key list: present buckets in stack order, then `failed`. */
+export function legendKeys(triggerOrder, buckets) {
+  const keys = presentBuckets(triggerOrder, buckets)
+  const failed = headline(buckets).failed
+  if (failed) keys.push({ name: 'failed', total: failed, token: null, fail: true })
+  return keys
+}
+
+function pack(keys, { width, rows, reserveChip }) {
+  const shown = []
+  let row = 0
+  let used = 0
+  let i = 0
+
+  while (i < keys.length) {
+    const key = keys[i]
+    const lastRow = row === rows - 1
+    // The chip shares the last row, so its width comes out of that budget only.
+    const budget = lastRow && reserveChip ? Math.max(0, width - KEY_GAP - CHIP_W) : width
+    const w = keyWidth(key.name)
+    const need = used ? used + KEY_GAP + w : w
+
+    // `used === 0` force-places a key wider than a whole row: CSS clips it, and
+    // a key that fits nowhere must never spin the packer.
+    if (need <= budget || used === 0) {
+      shown.push(key)
+      used = need
+      i += 1
+      continue
+    }
+    if (lastRow) return { shown, hidden: keys.slice(i) }
+    row += 1
+    used = 0
+  }
+  return { shown, hidden: [] }
+}
+
+/**
+ * Split the legend into what fits and what does not.
+ *
+ * Two passes on purpose: the chip only exists if something is hidden, so
+ * reserving room for it up front would truncate sets that fit without it.
+ */
+export function legendFit(keys, { width = LEGEND_WIDTH, rows = LEGEND_ROWS } = {}) {
+  const list = Array.isArray(keys) ? keys : []
+  const first = pack(list, { width, rows, reserveChip: false })
+  if (!first.hidden.length) return first
+  return pack(list, { width, rows, reserveChip: true })
 }

--- a/src/frontend/tests/unit/executionsTile.spec.js
+++ b/src/frontend/tests/unit/executionsTile.spec.js
@@ -16,16 +16,29 @@
  *     rule ent#100 established.
  */
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   BUCKET_TOKENS,
+  CHART_HEIGHT,
+  CHART_PAD,
+  COL_GAP,
   bucketToken,
   chartColumns,
   headline,
   hourLabel,
+  keyWidth,
+  LEGEND_ROWS,
+  LEGEND_WIDTH,
+  legendFit,
+  legendKeys,
   presentBuckets,
+  RAIL_HEIGHT,
   stackOrder,
   tileState,
 } from '@/utils/executionsTile'
+import { CELL_W } from '@/utils/gridLayout'
 
 const ORDER = [
   'Chat/Tasks', 'MCP', 'Channels', 'Public',
@@ -175,5 +188,191 @@ describe('#96 tile state — a green claim needs positive evidence', () => {
 
   it('only claims "no executions" after a successful read', () => {
     expect(tileState({ loaded: true, error: false, buckets: [] })).toBe('empty')
+  })
+})
+
+/**
+ * Legend fitting (#2228).
+ *
+ * The legend clamped itself with `max-height: 26px` — about 1.7 rows — so
+ * `overflow: hidden` sliced row two through its glyphs, and every key past the
+ * clamp disappeared with no `+N` and no tooltip: a colour rendered in the chart
+ * with no decoder anywhere on the tile.
+ *
+ * These pin the two halves of the fix and, critically, that they AGREE. The
+ * packer decides what fits; the CSS decides how much is shown. If the two
+ * disagree about the row count the bug returns silently in whichever direction
+ * drifted, which is why the last test reads the component's own stylesheet
+ * rather than trusting the comment in it.
+ */
+describe('#2228 legend fitting', () => {
+  const FULL = [
+    'Chat/Tasks', 'MCP', 'Channels', 'Public', 'Scheduled',
+    'Loops', 'Reminders', 'Agent-to-agent', 'Voice', 'Other',
+  ]
+
+  function keys(names) {
+    return names.map((name) => ({ name, total: 1, token: bucketToken(name) }))
+  }
+
+  it('shows every key when the set fits', () => {
+    const fit = legendFit(keys(['Chat/Tasks', 'Scheduled']))
+    expect(fit.shown.map((k) => k.name)).toEqual(['Chat/Tasks', 'Scheduled'])
+    expect(fit.hidden).toEqual([])
+  })
+
+  it('fits a real fleet without a chip — truncation is the tail case, not the norm', () => {
+    // The set from the #2228 report: eight keys, which is what the clamp used
+    // to slice. If this ever starts truncating, ordinary fleets have begun
+    // seeing `+N` and the width model needs re-deriving — not this test
+    // relaxing.
+    const observed = [
+      ...keys(['Chat/Tasks', 'MCP', 'Channels', 'Public', 'Scheduled', 'Agent-to-agent', 'Other']),
+      { name: 'failed', total: 1, token: null, fail: true },
+    ]
+    const fit = legendFit(observed)
+    expect(fit.hidden).toEqual([])
+    expect(fit.shown).toHaveLength(8)
+  })
+
+  it('surrenders only a short announced tail on the complete vocabulary', () => {
+    // All ten buckets plus `failed` sit past two rows under a deliberately
+    // pessimistic model, and the chip has to occupy the last row itself, which
+    // costs one key beyond the true overflow. Both effects are accepted: the
+    // result is a `+2` that names what it hides, not a silent slice. What must
+    // NOT drift is the size of that tail — a model change that starts hiding
+    // half the vocabulary is a regression even though nothing is lost.
+    const fit = legendFit([...keys(FULL), { name: 'failed', total: 3, token: null, fail: true }])
+    expect(fit.hidden.length).toBeLessThanOrEqual(3)
+    // The tail comes off the END, so the buckets a fleet uses most — which the
+    // backend orders first — always keep their key.
+    expect(fit.shown.map((k) => k.name)).toEqual(FULL.slice(0, fit.shown.length))
+  })
+
+  it('never estimates a key narrower than the browser renders it', () => {
+    // The invariant the whole model rests on. These are measured upper bounds
+    // for 10px system sans; the estimate must sit above every one of them, or
+    // the browser can form a row the packer did not plan for and the clamp
+    // eats it silently.
+    const MEASURED_MAX = {
+      'Chat/Tasks': 51, MCP: 20, Channels: 42, Public: 32, Scheduled: 47,
+      Loops: 26, Reminders: 47, 'Agent-to-agent': 68, Voice: 27, Other: 28,
+      failed: 30,
+    }
+    for (const [name, px] of Object.entries(MEASURED_MAX)) {
+      // keyWidth includes the 6px dot and its 3px gap, which the label figures
+      // above do not.
+      expect(keyWidth(name), name).toBeGreaterThan(px + 9)
+    }
+  })
+
+  it('never silently drops a key: what does not fit is returned as hidden', () => {
+    const many = keys(Array.from({ length: 40 }, (_, i) => `Bucket-number-${i}`))
+    const fit = legendFit(many)
+    expect(fit.hidden.length).toBeGreaterThan(0)
+    // The union is the input, in order — nothing is lost between the two lists.
+    expect([...fit.shown, ...fit.hidden].map((k) => k.name)).toEqual(many.map((k) => k.name))
+  })
+
+  it('keeps the shown keys in stack order, so legend and chart agree', () => {
+    const fit = legendFit(keys(FULL.concat(FULL.map((n) => n + '-x'))))
+    const names = fit.shown.map((k) => k.name)
+    expect(names).toEqual(FULL.concat(FULL.map((n) => n + '-x')).slice(0, names.length))
+  })
+
+  it('reserves room for the +N chip only when it truncates', () => {
+    // A set that fits exactly without the chip must not be truncated to make
+    // space for a chip that would then have nothing to report.
+    const exact = legendFit(keys(FULL))
+    expect(exact.hidden).toEqual([])
+    // ...and one that overflows loses at least the overflowing key.
+    const over = legendFit(keys(FULL), { rows: 1 })
+    expect(over.hidden.length).toBeGreaterThan(0)
+  })
+
+  it('honours the row budget: one row holds strictly less than two', () => {
+    const one = legendFit(keys(FULL), { rows: 1 })
+    const two = legendFit(keys(FULL), { rows: 2 })
+    expect(one.shown.length).toBeLessThan(two.shown.length)
+  })
+
+  it('force-places a key wider than an entire row rather than spinning', () => {
+    const huge = keys(['x'.repeat(500), 'Scheduled'])
+    const fit = legendFit(huge)
+    expect(fit.shown[0].name).toHaveLength(500)
+    expect([...fit.shown, ...fit.hidden]).toHaveLength(2)
+  })
+
+  it('is total on junk input', () => {
+    expect(legendFit(null)).toEqual({ shown: [], hidden: [] })
+    expect(legendFit(undefined)).toEqual({ shown: [], hidden: [] })
+    expect(() => legendFit([{ total: 1 }])).not.toThrow()
+  })
+
+  it('appends `failed` last and flags it, so it never takes a bucket colour', () => {
+    const rows = [bucket('09', { Scheduled: { total: 4, failed: 1 } })]
+    const built = legendKeys(ORDER, rows)
+    expect(built.at(-1)).toMatchObject({ name: 'failed', total: 1, fail: true })
+  })
+
+  it('omits `failed` entirely when nothing failed', () => {
+    const rows = [bucket('09', { Scheduled: { total: 4 } })]
+    expect(legendKeys(ORDER, rows).some((k) => k.fail)).toBe(false)
+  })
+
+  it('derives its width from the lattice cell, and never wider than the real box', () => {
+    // A tile that grows must widen the legend budget with it; a hardcoded
+    // literal would leave the packer describing a tile that no longer exists.
+    expect(LEGEND_WIDTH).toBe(CELL_W - 50)
+    // 334px is the content box the live tile reports. Counting only InfoTile's
+    // padding and forgetting its 1px borders gives 338 — four px WIDER than the
+    // element is, which is the one direction that manufactures a third row.
+    expect(LEGEND_WIDTH).toBeLessThanOrEqual(334)
+  })
+
+  // The stylesheet and these constants describe one shared budget and cannot
+  // check each other at runtime, so the source is parsed. jsdom would not help:
+  // it does no cascade resolution, so a mid-row clamp looks identical to a
+  // clean one under getComputedStyle. Same rationale as gridTokens.spec.js.
+  const TILE_CSS = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src',
+         'components', 'tiles', 'ExecutionsTile.vue'),
+    'utf8',
+  )
+
+  it('sizes the legend to exactly LEGEND_ROWS whole rows', () => {
+    const clamp = TILE_CSS.match(
+      /\n\s*height:\s*calc\(var\(--ex-row\)\s*\*\s*(\d+)\s*\+\s*var\(--ex-row-gap\)\)/,
+    )
+    expect(clamp, 'legend must size with the row-arithmetic calc, not a raw px value').toBeTruthy()
+    expect(Number(clamp[1])).toBe(LEGEND_ROWS)
+    // The pitch the arithmetic assumes has to be asserted on `.ex-key`, not
+    // inherited from whatever the cascade happens to supply.
+    expect(TILE_CSS).toMatch(/line-height:\s*var\(--ex-row\)/)
+  })
+
+  it('fixes the legend height rather than capping it, so the chart never reflows', () => {
+    // `max-height` grows and shrinks with the key count, which resizes the
+    // chart above whenever a bucket appears or goes quiet. That is the layout
+    // instability the design contract forbids, and it is one character away.
+    expect(TILE_CSS).not.toMatch(/max-height:\s*calc\(var\(--ex-row\)/)
+  })
+
+  it('gives the chart exactly the height a full column needs — no dead space', () => {
+    // `.it-body` is `overflow: hidden` at a fixed CELL_H, so a chart container
+    // taller than its tallest possible column does not merely waste space: it
+    // takes those px off the bottom of the legend. Four px of dead space here
+    // is the second clip behind #2228, and it survived fixing the legend.
+    const h = TILE_CSS.match(/\.ex-chart\s*\{[^}]*?\n\s*height:\s*(\d+)px/s)
+    expect(h, '.ex-chart must declare an explicit height').toBeTruthy()
+    expect(Number(h[1])).toBe(CHART_HEIGHT + COL_GAP + RAIL_HEIGHT + CHART_PAD)
+  })
+
+  it('draws the chart against the same budget the CSS reserves', () => {
+    // The defaults are what the component relies on; a column taller than the
+    // container it is drawn into overflows into the legend's rows.
+    const tallest = chartColumns([bucket('09', { Scheduled: { total: 9, failed: 9 } })])[0]
+    expect(tallest.segments[0].px).toBeLessThanOrEqual(CHART_HEIGHT)
+    expect(tallest.failPx).toBeLessThanOrEqual(RAIL_HEIGHT)
   })
 })


### PR DESCRIPTION
## Summary

- The Executions tile's legend clamped with `max-height: 26px` — ~1.7 rows at its 15px pitch — so `overflow: hidden` **cut row two through the glyphs** instead of hiding it, and any key past the clamp vanished with no `+N` and no tooltip.
- Measuring the running tile found a **second clip** behind the same symptom: `.it-body` is `overflow: hidden` at a fixed `CELL_H` and offers **134px**, while the tile already asked for **~138 before this change**. Fixing the legend alone leaves the symptom on screen.
- The legend is now a fixed two whole rows, the vertical budget is stated explicitly and fits, and anything that still does not fit is handed to a `+N` chip that names it.

## The two clips

| | before | after |
|---|---|---|
| `.ex-legend` row 2 | **sliced** (cut 11px into a 13px row) | fully visible |
| `.it-body` overflow | **6px** (4px before this branch) | **0px** |

## Changes

**`src/frontend/src/components/tiles/ExecutionsTile.vue`**
- `.ex-head` pins `line-height: 1` — baseline-aligning 20px and 12px text made the box 22.1px, and every px here comes out of the legend at the far end of a fixed-height tile.
- `.ex-chart` 78px → 70px = `CHART_HEIGHT + COL_GAP + RAIL_HEIGHT + padding`. It stood 4px above its tallest possible column: dead space paid for at the legend's expense.
- `.ex-legend` takes a fixed **28px** (two rows). `height`, not `max-height` — a ceiling grows with the key count and would resize the chart every time a bucket appeared or went quiet.
- Renders `legend.shown` plus a `+N` chip carrying the hidden swatches and naming them in its `title`.

**`src/frontend/src/utils/executionsTile.js`**
- `legendFit()` packs keys into the available rows and returns `{shown, hidden}`. CSS can clamp but cannot report *what* it dropped.
- The width model is pessimistic **per key, not in aggregate**: greedy packing wastes space at the end of each row, so a model generous overall but tight on one name still lets a real third row form. Over-reserving shows an unnecessary `+N`; under-reserving loses keys silently.
- `LEGEND_WIDTH = CELL_W - 50`, not `- 46`: counting only InfoTile's padding and forgetting its 1px borders claims 338px for an element that measures **334** — error in the one direction that manufactures a third row.
- `CHART_HEIGHT` / `RAIL_HEIGHT` / `COL_GAP` / `CHART_PAD` make the chart's share of the budget explicit beside the legend's.

## Test Plan

- [x] `npx vitest run` — **670 passed**, incl. 40 for this tile
- [x] Source-parsing guards pin the CSS budget to the JS constants (a stylesheet and a constant cannot check each other; jsdom does no cascade resolution, so a mid-row clamp looks identical to a clean one under `getComputedStyle` — same rationale as `gridTokens.spec.js`)
- [x] `vite build` clean; raw-color ratchet unchanged (tokens only, no new token)
- [x] Verified in the running app with the full 11-key vocabulary:

| check | result |
|---|---|
| legend rows / sliced keys | `2` / `0` |
| keys hidden by the body | `0` |
| `.it-body` overflow | `0px` (was `6`) |
| legend height @ 2 keys vs 11 keys | `28px` / `28px` → chart never reflows |
| width model vs measured labels | **0 violations** across all 11 |
| light + dark | same geometry; chip resolves real tokens in both |

Calibration figures in the comments are **measured, not estimated** — my first pass had them wrong in the unsafe direction, which is how the 334-vs-338 width error surfaced.

## Notes

Per CLAUDE.md tiered docs, a bug fix needs a descriptive commit message only — no `architecture.md` / feature-flow change. Behaviour on today's fleets is unchanged apart from the fix: eight keys still render without a chip.

Fixes #2228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
