### PR TITLE
fix(tests): derive time from the clock, not the calendar; retire four stale xfails (#2243)

### DIFF
--- a/tests/clockshift.py
+++ b/tests/clockshift.py
@@ -31,6 +31,19 @@ Known limits, stated so a green run is not over-read: it moves
 database's own clock (`CURRENT_TIMESTAMP`, `now()`), nor any C-level time source
 a dependency reads directly, so a test whose expectations come from SQL-side
 time is out of its reach.
+
+One false-positive class is handled rather than documented, because a sweep whose
+output has to be triaged by hand is not a verdict. `datetime` cannot be patched
+in place (a C type with immutable attributes), so the shift installs a subclass —
+which splits the class identity: a library imported AFTER the swap type-checks
+against the subclass, while a value produced by code that imported `datetime`
+BEFORE it is an instance of the original. PyJWT does exactly this
+(`isinstance(payload["exp"], datetime)` in `api_jwt.encode`, guarding the
+datetime→epoch conversion), so under a naive swap ~30 auth/session tests failed
+with `TypeError: Object of type datetime is not JSON serializable` — a harness
+artifact indistinguishable, in a failure list, from a real calendar bug. The
+metaclass below makes `isinstance(any_real_datetime, _ShiftedDatetime)` true, so
+both identities satisfy such a check.
 """
 from __future__ import annotations
 
@@ -44,7 +57,23 @@ SHIFT = _dt.timedelta(days=_DAYS)
 _real_datetime = _dt.datetime
 
 
-class _ShiftedDatetime(_real_datetime):
+class _AnyDatetime(type):
+    """Make `isinstance(x, _ShiftedDatetime)` true for ANY real `datetime`.
+
+    Without this the swap narrows a widely-used type test: a real `datetime`
+    (built by a module that bound the name before the swap) is not an instance of
+    the subclass, so a library checking `isinstance(value, datetime)` silently
+    takes its else-branch. See the module docstring for the PyJWT case.
+    """
+
+    def __instancecheck__(cls, obj):
+        return isinstance(obj, _real_datetime)
+
+    def __subclasscheck__(cls, sub):
+        return issubclass(sub, _real_datetime)
+
+
+class _ShiftedDatetime(_real_datetime, metaclass=_AnyDatetime):
     """`datetime` with the three "what time is it" constructors moved.
 
     A subclass, not a stub: instances stay real `datetime`s, so comparisons and

--- a/tests/clockshift.py
+++ b/tests/clockshift.py
@@ -1,0 +1,74 @@
+"""Run the suite as if the machine clock were a year ahead (#2243).
+
+    PYTHONPATH=tests python -m pytest tests/unit -q -p clockshift
+
+(`PYTHONPATH=tests` because `-p` resolves plugins before pytest has put `tests/`
+on `sys.path`, and this file deliberately is not a `conftest` — it must not load
+for runs that did not ask for it.)
+
+Why this exists. Three sets of tests were permanently red on `dev` for one
+reason: they asserted against literal calendar strings — an hour bucket
+(`"2026-08-14T09"`) that the gap-filled axis stops reaching, and a `started_at`
+anchor (`"2026-01-01T00:00:00.000000Z"`) whose `duration_ms = now − started_at`
+grew past int32 and raised `NumericValueOutOfRange` on PostgreSQL. Both passed
+the day they were written and failed every day after. A grep can find date-shaped
+strings, but it cannot tell an inert fixture value from one that is compared
+against *now* — so the class is closed by running the clock forward and reading
+the failures, not by eyeballing literals.
+
+Not a test dependency and not a `freezegun`: it shifts the two clocks test code
+actually reads and adds nothing to `requirements`. Deliberately opt-in — it is a
+diagnostic for "is this suite date-independent?", not something CI runs by
+default.
+
+Loaded with `-p` so it lands BEFORE test modules run their
+`from datetime import datetime`, which is what makes the shift visible to code
+that binds the name at import time. Override the distance with
+`CLOCKSHIFT_DAYS` (e.g. `CLOCKSHIFT_DAYS=-400` to run a year in the past).
+
+Known limits, stated so a green run is not over-read: it moves
+`datetime.datetime.now/utcnow/today` and `time.time`. It does NOT move a
+database's own clock (`CURRENT_TIMESTAMP`, `now()`), nor any C-level time source
+a dependency reads directly, so a test whose expectations come from SQL-side
+time is out of its reach.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import time as _time
+
+_DAYS = int(os.environ.get("CLOCKSHIFT_DAYS", "365"))
+SHIFT = _dt.timedelta(days=_DAYS)
+
+_real_datetime = _dt.datetime
+
+
+class _ShiftedDatetime(_real_datetime):
+    """`datetime` with the three "what time is it" constructors moved.
+
+    A subclass, not a stub: instances stay real `datetime`s, so comparisons and
+    arithmetic against values parsed from the database keep working.
+    """
+
+    @classmethod
+    def now(cls, tz=None):
+        return _real_datetime.now(tz) + SHIFT
+
+    @classmethod
+    def utcnow(cls):
+        return _real_datetime.utcnow() + SHIFT
+
+    @classmethod
+    def today(cls):
+        return _real_datetime.today() + SHIFT
+
+
+_dt.datetime = _ShiftedDatetime
+
+_real_time = _time.time
+_time.time = lambda: _real_time() + SHIFT.total_seconds()
+
+
+def pytest_report_header(config):  # noqa: ARG001 — pytest hook signature
+    return f"clockshift: clocks moved {_DAYS:+d} days (#2243)"

--- a/tests/clockshift.py
+++ b/tests/clockshift.py
@@ -28,9 +28,26 @@ that binds the name at import time. Override the distance with
 
 Known limits, stated so a green run is not over-read: it moves
 `datetime.datetime.now/utcnow/today` and `time.time`. It does NOT move a
-database's own clock (`CURRENT_TIMESTAMP`, `now()`), nor any C-level time source
-a dependency reads directly, so a test whose expectations come from SQL-side
-time is out of its reach.
+database's own clock (`CURRENT_TIMESTAMP`, `now()`), nor the FILESYSTEM's, nor any
+C-level time source a dependency reads directly, so a test whose expectations come
+from SQL-side or inode time is out of its reach.
+
+The filesystem case is not hypothetical — a full-suite run at +365 days left
+exactly four failures beyond the environment-specific set, all of it one root
+cause, and it breaks in BOTH directions:
+
+  * `test_1595_git_maintenance.py::TestReapStaleGitLitter::test_fresh_locks_kept`
+    and `test_2216_backup_primitives.py::TestTmpSweep::test_sweeps_aged_orphan_keeps_fresh`
+    write a file NOW (real mtime) and expect the code to judge it fresh; against a
+    shifted `now` it looks a year old and gets reaped.
+  * `test_2216_db_backup_service.py::TestPreflightAndFailure::test_prune_runs_{even_when_backup_fails,on_no_space_skip_too}`
+    are the mirror: an artifact meant to be out-of-window looks freshly created,
+    so the prune correctly leaves it and the assertion fails.
+
+Those four tests are CORRECT; the instrument cannot see their clock. So a
+mtime-driven sweep test is not evidence of calendar rot under this harness, and
+shifting inode times (an `os.stat` interception) would be a much larger instrument
+than the problem justifies. Read a shifted run's failures with that in mind.
 
 One false-positive class is handled rather than documented, because a sweep whose
 output has to be triaged by hand is not a verdict. `datetime` cannot be patched

--- a/tests/unit/test_1771c_schedules_cas_edges.py
+++ b/tests/unit/test_1771c_schedules_cas_edges.py
@@ -129,15 +129,36 @@ def ops(db_backend):
         sys.modules.pop(_m, None)
 
 
+# A5b inserts `started_at=None` ON PURPOSE, to prove the NOT NULL constraint is
+# what stands between production and the `parse_iso_timestamp(None)` crash. So
+# "caller said nothing" needs a sentinel distinct from `None`; defaulting on
+# `None` would silently turn that probe into a passing insert (#2243).
+_UNSET = object()
+
+
 def insert_execution(
     exec_id: str,
     *,
     status: str = "running",
     agent_name: str = "agent-1",
-    started_at: str = "2026-01-01T00:00:00.000000Z",
+    started_at=_UNSET,
     **extra,
 ) -> str:
-    """Insert a ``schedule_executions`` row through the active engine."""
+    """Insert a ``schedule_executions`` row through the active engine.
+
+    ``started_at`` defaults to a few minutes ago, NOT a fixed calendar date
+    (#2243). The terminal write computes ``duration_ms = now − started_at``, so a
+    literal anchor produces a duration that grows by ~31.5 billion ms a year: the
+    old default (``2026-01-01T00:00:00.000000Z``) had already passed int32, which
+    is why nine of these cases raised ``NumericValueOutOfRange`` on PostgreSQL
+    while SQLite — untyped — kept quietly widening the value.
+
+    The column width is a separate product concern; this default is what makes
+    the tests date-independent, and it would keep them passing after the column
+    is widened, because a fixed anchor's duration only ever grows.
+    """
+    if started_at is _UNSET:
+        started_at = _recent_iso()
     cols = {
         "id": exec_id,
         "schedule_id": "sched-1",
@@ -164,6 +185,16 @@ def column_of(exec_id: str, col: str):
 
 def _iso(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+# A duration the int32 column holds comfortably, and one that stays the same size
+# whatever year the suite runs in (#2243).
+_RECENT_MINUTES = 5
+
+
+def _recent_iso() -> str:
+    """``utc_now_iso()``-shaped timestamp a few minutes in the past."""
+    return _iso(datetime.now(timezone.utc) - timedelta(minutes=_RECENT_MINUTES))
 
 
 # ===========================================================================
@@ -369,17 +400,34 @@ def test_a6_skewed_row_clamps_to_zero(ops):
 # ===========================================================================
 
 
+def _same_instant_in(form: str) -> str:
+    """One instant a few minutes ago, rendered in each stored form in the wild.
+
+    The formats are the point of A7; the fixed calendar date they used to carry
+    was not, and it is what pushed ``duration_ms`` past int32 (#2243). Deriving
+    all four from one recent instant keeps the variety and bounds the duration —
+    and, because it is a single instant, the four cases stay directly comparable.
+    """
+    moment = datetime.now(timezone.utc) - timedelta(minutes=_RECENT_MINUTES)
+    if form == "naive":       # scheduler pre-#1474 legacy
+        return moment.replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S")
+    if form == "zulu":        # utc_now_iso() form
+        return _iso(moment)
+    if form == "utc-offset":  # explicit UTC offset
+        return moment.replace(microsecond=0).isoformat()
+    if form == "plus5":       # non-UTC offset, same instant
+        return moment.replace(microsecond=0).astimezone(
+            timezone(timedelta(hours=5))
+        ).isoformat()
+    raise AssertionError(f"unknown form {form!r}")
+
+
 @pytest.mark.parametrize(
-    "started_at",
-    [
-        "2026-01-01T00:00:00",  # naive (scheduler pre-#1474 legacy)
-        "2026-01-01T00:00:00.000000Z",  # utc_now_iso() form
-        "2026-01-01T00:00:00+00:00",  # explicit UTC offset
-        "2026-01-01T05:00:00+05:00",  # non-UTC offset
-    ],
+    "form",
+    ["naive", "zulu", "utc-offset", "plus5"],
     ids=["A7-naive", "A7-zulu", "A7-utc-offset", "A7-plus5-offset"],
 )
-def test_a7_mixed_timestamp_formats_do_not_raise(ops, started_at):
+def test_a7_mixed_timestamp_formats_do_not_raise(ops, form):
     """A7 — the ``aware − naive`` TypeError class (#1474) must not reappear.
 
     ``parse_iso_timestamp`` normalizes naive → UTC-aware before the subtraction,
@@ -387,12 +435,16 @@ def test_a7_mixed_timestamp_formats_do_not_raise(ops, started_at):
     ``Z`` rows, offset-bearing rows) computes a duration rather than exploding
     mid-terminal-write. A crash here would strand the row ``running`` forever.
     """
-    eid = insert_execution(
-        f"a7-{started_at[-6:]}", status="running", started_at=started_at
-    )
+    started_at = _same_instant_in(form)
+    eid = insert_execution(f"a7-{form}", status="running", started_at=started_at)
 
     assert ops.update_execution_status(eid, "success") is True
-    assert isinstance(column_of(eid, "duration_ms"), int)
+    duration = column_of(eid, "duration_ms")
+    assert isinstance(duration, int)
+    # The naive form is read as UTC, so all four describe the same instant and
+    # land in the same bounded range — a form parsed with the wrong offset would
+    # show up here as a ±5h duration rather than a few minutes.
+    assert 0 <= duration < 2 * _RECENT_MINUTES * 60 * 1000
 
 
 # ===========================================================================

--- a/tests/unit/test_ent96_timeline_split.py
+++ b/tests/unit/test_ent96_timeline_split.py
@@ -24,6 +24,7 @@ no Docker.
 from __future__ import annotations
 
 import types
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -32,6 +33,27 @@ from db.schedules.stats import _shape_execution_timeline
 from db.schedules.analytics import _BUCKET_ORDER
 
 pytestmark = pytest.mark.unit
+
+
+# `_gap_fill` builds a continuous UTC axis relative to `datetime.now(timezone.utc)`
+# and keys it with `strftime("%Y-%m-%dT%H")`, so a literal hour is a valid bucket
+# only for as long as it stays inside the window. These tests asserted against
+# `"2026-08-14T09"`, so they passed the day they were written and failed every day
+# after — `KeyError` where the axis no longer reaches, `StopIteration` from the
+# `next(...)` lookups (#2243).
+#
+# The key is now derived from the same clock the axis is, so the assertions hold
+# on any run date. The offset must stay strictly INSIDE the window under test: an
+# interior bucket survives an hour boundary ticking between this call and the
+# `now` inside `_gap_fill`, which is what makes the derivation flake-free rather
+# than merely correct today. The narrowest window here is 6h.
+_BUCKET_FMT = "%Y-%m-%dT%H"
+_INTERIOR_OFFSET_HOURS = 2
+
+
+def _hour_bucket(offset_hours: int = _INTERIOR_OFFSET_HOURS) -> str:
+    """The axis key `_gap_fill` emits for the hour `offset_hours` ago."""
+    return (datetime.now(timezone.utc) - timedelta(hours=offset_hours)).strftime(_BUCKET_FMT)
 
 
 def _row(bucket, split_key, total, failed=0, success=None):
@@ -51,63 +73,68 @@ def _row(bucket, split_key, total, failed=0, success=None):
 # ---------------------------------------------------------------------------
 
 def test_split_rows_fold_to_one_row_per_interval():
+    hour, next_hour = _hour_bucket(), _hour_bucket(1)
     rows = [
-        _row("2026-08-14T09", "schedule", 10),
-        _row("2026-08-14T09", "mcp", 4),
-        _row("2026-08-14T10", "schedule", 2),
+        _row(hour, "schedule", 10),
+        _row(hour, "mcp", 4),
+        _row(next_hour, "schedule", 2),
     ]
     out = _shape_execution_timeline(rows, group_by="hour", hours=24, split="trigger")
     by_bucket = {r["bucket"]: r for r in out}
-    assert by_bucket["2026-08-14T09"]["total"] == 14
-    assert by_bucket["2026-08-14T09"]["by_trigger"] == {
+    assert by_bucket[hour]["total"] == 14
+    assert by_bucket[hour]["by_trigger"] == {
         "Scheduled": {"total": 10, "failed": 0},
         "MCP": {"total": 4, "failed": 0},
     }
 
 
 def test_the_breakdown_always_sums_to_its_own_column():
+    hour = _hour_bucket()
     rows = [
-        _row("2026-08-14T09", "schedule", 10, failed=2),
-        _row("2026-08-14T09", "chat", 5, failed=1),
-        _row("2026-08-14T09", "telegram", 1),
+        _row(hour, "schedule", 10, failed=2),
+        _row(hour, "chat", 5, failed=1),
+        _row(hour, "telegram", 1),
     ]
     out = _shape_execution_timeline(rows, group_by="hour", hours=24, split="trigger")
-    hour = next(r for r in out if r["bucket"] == "2026-08-14T09")
-    assert sum(e["total"] for e in hour["by_trigger"].values()) == hour["total"] == 16
-    assert sum(e["failed"] for e in hour["by_trigger"].values()) == hour["failed"] == 3
+    col = next(r for r in out if r["bucket"] == hour)
+    assert sum(e["total"] for e in col["by_trigger"].values()) == col["total"] == 16
+    assert sum(e["failed"] for e in col["by_trigger"].values()) == col["failed"] == 3
 
 
 def test_failures_are_carried_per_label_not_only_in_the_column_total():
+    hour = _hour_bucket()
     rows = [
-        _row("2026-08-14T09", "schedule", 10, failed=2),
-        _row("2026-08-14T09", "mcp", 4, failed=0),
+        _row(hour, "schedule", 10, failed=2),
+        _row(hour, "mcp", 4, failed=0),
     ]
     out = _shape_execution_timeline(rows, group_by="hour", hours=24, split="trigger")
-    hour = next(r for r in out if r["bucket"] == "2026-08-14T09")
-    assert hour["by_trigger"]["Scheduled"]["failed"] == 2
-    assert hour["by_trigger"]["MCP"]["failed"] == 0
+    col = next(r for r in out if r["bucket"] == hour)
+    assert col["by_trigger"]["Scheduled"]["failed"] == 2
+    assert col["by_trigger"]["MCP"]["failed"] == 0
 
 
 def test_an_unmapped_trigger_lands_in_Other_rather_than_vanishing():
     """The reason the fold is Python and not a SQL CASE: a trigger added to the
     platform but not to `_TRIGGER_BUCKETS` must still be visible."""
-    rows = [_row("2026-08-14T09", "brand_new_trigger", 3)]
+    hour = _hour_bucket()
+    rows = [_row(hour, "brand_new_trigger", 3)]
     out = _shape_execution_timeline(rows, group_by="hour", hours=24, split="trigger")
-    hour = next(r for r in out if r["bucket"] == "2026-08-14T09")
-    assert hour["by_trigger"] == {"Other": {"total": 3, "failed": 0}}
-    assert hour["total"] == 3
+    col = next(r for r in out if r["bucket"] == hour)
+    assert col["by_trigger"] == {"Other": {"total": 3, "failed": 0}}
+    assert col["total"] == 3
 
 
 def test_two_raw_triggers_in_one_bucket_merge_into_that_bucket():
     """`manual` and `chat` are both `Chat/Tasks` — the fold must add, not
     overwrite, or half the column disappears."""
+    hour = _hour_bucket()
     rows = [
-        _row("2026-08-14T09", "manual", 3),
-        _row("2026-08-14T09", "chat", 4),
+        _row(hour, "manual", 3),
+        _row(hour, "chat", 4),
     ]
     out = _shape_execution_timeline(rows, group_by="hour", hours=24, split="trigger")
-    hour = next(r for r in out if r["bucket"] == "2026-08-14T09")
-    assert hour["by_trigger"]["Chat/Tasks"] == {"total": 7, "failed": 0}
+    col = next(r for r in out if r["bucket"] == hour)
+    assert col["by_trigger"]["Chat/Tasks"] == {"total": 7, "failed": 0}
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +142,7 @@ def test_two_raw_triggers_in_one_bucket_merge_into_that_bucket():
 # ---------------------------------------------------------------------------
 
 def test_gap_filled_intervals_carry_an_empty_breakdown_not_a_missing_key():
-    rows = [_row("2026-08-14T09", "schedule", 1)]
+    rows = [_row(_hour_bucket(), "schedule", 1)]
     out = _shape_execution_timeline(rows, group_by="hour", hours=6, split="trigger")
     assert len(out) >= 6
     for row in out:
@@ -137,7 +164,7 @@ def test_the_axis_is_still_continuous_under_a_split():
 # ---------------------------------------------------------------------------
 
 def test_without_a_split_no_by_trigger_key_appears():
-    rows = [{"bucket": "2026-08-14T09", "total": 3, "failed": 0, "success": 3,
+    rows = [{"bucket": _hour_bucket(), "total": 3, "failed": 0, "success": 3,
              "cost": 0.0, "context_used": 0}]
     out = _shape_execution_timeline(rows, group_by="hour", hours=6)
     assert all("by_trigger" not in r for r in out)

--- a/tests/unit/test_pat_propagation_properties.py
+++ b/tests/unit/test_pat_propagation_properties.py
@@ -10,19 +10,28 @@ regex substitution that writes a credential into a file another process parses,
 so the honest question is a round-trip one — **after patching, does the agent
 read back exactly the token we rotated to?**
 
-That is stated once as a Hypothesis property and pinned as explicit cases for
-the two inputs where it does not hold. The oracle is the agent's own `.env`
-reader, copied here from
-`docker/base-image/agent_server/services/execution_env.parse_env_file` — the
-same last-wins, one-quote-pair semantics, because "what the agent sees" is the
-only definition of success that matters for a credential rotation.
+That is stated once as a Hypothesis property and pinned as explicit cases,
+because "what the agent sees" is the only definition of success that matters for
+a credential rotation.
+
+The oracle is the agent's own `.env` decoder — the REAL
+`execution_env.unquote_env_value`, loaded from the base image by path (#2243).
+It used to be a hand-written replica that only stripped quotes, and that replica
+had drifted out from under two of the assertions below: #2023 made the encoding
+reversible (escape the escape character, then the quote, and unescape both on
+read), so a replica that never unescapes reports corruption the real agent never
+sees. A second copy of an encoding is exactly what #2023 removed from product
+code; keeping one in the test that judges it put the verdict back in the copy.
 
 Cases marked `xfail(strict=True)` are real defects; product code is unchanged
-per the skill's protocol.
+per the skill's protocol. When one is fixed the marker flips the test RED
+(XPASS(strict)) rather than going quietly green — which is the point, and is how
+the three retired below announced themselves.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import re
 import sys
 from pathlib import Path
@@ -56,12 +65,36 @@ def svc():
 _ENV_LINE_KEYS = ("GITHUB_PAT", "GH_TOKEN", "GITHUB_TOKEN")
 
 
-def agent_reads(env_content: str) -> dict:
-    """Byte-faithful copy of the agent-server `.env` parser (last-wins).
+_READER_PATH = (
+    _REPO / "docker" / "base-image" / "agent_server" / "services" / "execution_env.py"
+)
 
-    Deliberately a copy and not an import: the agent server ships in its own
-    image and the backend cannot import from it. Kept small enough to audit
-    against the original by eye.
+
+def _real_reader():
+    """The agent's own decoder, loaded by path (the `test_2023_…` idiom).
+
+    Imported rather than reimplemented: the backend cannot import the agent-server
+    package (different image), but it CAN load the one module by path, and that is
+    the difference between judging the writer against the real inverse and judging
+    it against a replica that has to be kept in sync by hand (#2243).
+    """
+    spec = importlib.util.spec_from_file_location("_env_reader_pat_props", _READER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ENV_READER = _real_reader()
+
+
+def agent_reads(env_content: str) -> dict:
+    """What the agent's `.env` reader sees: last-wins keys, real value decoding.
+
+    The line scan is here because the property under test is about DUPLICATE
+    lines (#2016) and last-wins is the semantics that makes a duplicate
+    dangerous. The value decoding — the part that has an encoding contract and
+    can therefore drift — is delegated to `execution_env.unquote_env_value`
+    rather than re-implemented as `.strip('"')`.
     """
     out = {}
     for line in env_content.splitlines():
@@ -72,7 +105,7 @@ def agent_reads(env_content: str) -> dict:
         key = key.strip()
         if not key:
             continue
-        out[key] = value.strip().strip('"').strip("'")
+        out[key] = _ENV_READER.unquote_env_value(value)
     return out
 
 
@@ -170,24 +203,42 @@ class TestKnownGaps:
         )
 
     @pytest.mark.parametrize("pat", [r"tok\1", r"tok\g<1>", r"tok\slash"])
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: the new line is used as an `re.sub` REPLACEMENT, so a "
-               "backslash in the token is parsed as a group reference and "
-               "raises re.error mid-rotation. See /edge-cases report "
-               "2026-08-05, finding 3.",
-    )
-    def test_a_backslash_in_the_token_does_not_raise(self, svc, pat):
-        svc._patch_env_github_pat('GITHUB_PAT="old"\n', pat)
+    def test_a_backslash_in_the_token_round_trips(self, svc, pat):
+        """Finding 3 — FIXED by #2017 (PR #2024), marker retired.
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Writer/reader asymmetry: `_format_pat_line` escapes `\"` but "
-               "the agent's .env parser never unescapes it. Belongs to the "
-               ".env parse contract, not to #1979. See /edge-cases report "
-               "2026-08-05, finding 4.",
-    )
+        The bug: the new line was passed to `re.sub` as a replacement STRING, so
+        a backslash in the token was parsed as a group reference — `\\1` and
+        `\\g<1>` raised `re.error: invalid group reference` and aborted that
+        agent's rotation with a message about regex syntax. `_patch_env_github_pat`
+        now substitutes with a callable (`lambda _match: new_line`), which is
+        inserted verbatim.
+
+        The marker did its job: once the fix landed these three reported
+        XPASS(strict) — a FAILURE — instead of quietly documenting a bug that no
+        longer existed (#2243). Retired to a plain regression test, and it asserts
+        the ROUND TRIP rather than merely "does not raise": not raising was the
+        crash symptom, while writing a backslash the agent decodes back to the
+        same token is the actual contract. The written line carries the doubled
+        `\\\\` of the #2023 encoding, and the real reader reverses it.
+        """
+        patched = svc._patch_env_github_pat('GITHUB_PAT="old"\n', pat)
+        assert agent_reads(patched)["GITHUB_PAT"] == pat
+
     def test_a_quote_in_the_token_round_trips(self, svc):
+        """Finding 4 — FIXED by #2023, marker retired (#2243).
+
+        This carried `xfail(strict=True)` for "the writer escapes `\"` but the
+        agent's .env parser never unescapes it". That was true of the writer/reader
+        pair as it stood, and #2023 fixed BOTH halves: the encoding escapes the
+        escape character first and `unquote_env_value` reverses it in one scan.
+
+        The marker nevertheless kept reporting XFAIL — green — because the oracle
+        in this file was a replica that only stripped quotes. So the test went on
+        asserting a defect that no longer existed, and only the replica made the
+        claim look true. That is the same class as the three above, reached from
+        the other side: a stale marker hidden by a stale copy rather than an
+        XPASS. Fixing the oracle is what exposed it (#2243).
+        """
         pat = 'ghp_a"b'
         patched = svc._patch_env_github_pat('GITHUB_PAT="old"\n', pat)
         assert agent_reads(patched)["GITHUB_PAT"] == pat


### PR DESCRIPTION
## What this fixes

17 tests were permanently red on `dev` for reasons unrelated to the product. All three sets are fixed, and a fourth stale marker turned up while fixing the third.

### 1. Hard-coded time buckets — 5 failures

`test_ent96_timeline_split.py` asserted against the literal hour `"2026-08-14T09"`. `_gap_fill` builds a continuous UTC axis relative to `datetime.now(timezone.utc)`, so once that hour left the window the bucket stopped existing — `KeyError` on the dict lookups, `StopIteration` on the `next(...)` ones.

The key is now derived from the same clock the axis is, at an offset kept strictly inside the narrowest window under test (6h), so an hour boundary ticking between the test's `now` and `_gap_fill`'s cannot move it out. The row variable was renamed `col` so nothing depends on a rebind inside a generator expression.

### 2. Hard-coded `started_at` — 13 PostgreSQL failures

Not the 9 the issue lists: **the count grows with the calendar**, and I reproduced 13 on unmodified `dev` before changing anything.

`insert_execution` defaulted to `2026-01-01T00:00:00.000000Z`. The terminal write computes `duration_ms = now − started_at`, so a fixed anchor gains ~31.5 billion ms a year; it had already passed int32 and raised `NumericValueOutOfRange` on PostgreSQL, while SQLite — untyped — kept quietly widening the value.

- the default is now a few minutes ago, so the duration is bounded whatever year the suite runs in — and would stay bounded after the column is widened, since a fixed anchor's duration only ever grows
- **A7** kept its four timestamp-format variants (naive / `Z` / `+00:00` / `+05:00`) but renders them from **one** recent instant: the formats were the point of that case, the calendar date was not. It also gained a bound on the resulting duration, so a form parsed with the wrong offset now fails loudly (±5h) instead of passing
- **`started_at=None` still means SQL NULL.** A5b passes it deliberately to prove the `NOT NULL` constraint is what stands between production and `parse_iso_timestamp(None)`, so "caller said nothing" needed a sentinel — a `None` default silently turned that probe into a passing insert (the suite caught this mid-change)

### 3. Stale strict-xfails — 3 failures, and a fourth found

The three backslash params reported `XPASS(strict)` because #2017 (PR #2024) fixed the `re.sub`-replacement bug they pinned. Retired to plain regression tests that assert the **round trip** rather than merely "does not raise" — not raising was the crash symptom; writing a backslash the agent decodes back to the same token is the contract.

That required fixing the oracle, which exposed the fourth. `agent_reads` in this file was a hand-written replica that only stripped quotes — but #2023 made the `.env` encoding reversible (escape the escape character, then the quote; `unquote_env_value` reverses both in one scan). So:

- value decoding now delegates to the **real** agent-side reader, loaded by path via the idiom `test_2023_env_quote_round_trip.py` already uses; the line scan stays local because last-wins is what makes a duplicate PAT line dangerous (#2016)
- against the real reader, `test_a_quote_in_the_token_round_trips` XPASSes. It had been reporting **XFAIL — green** — for a gap #2023 closed, and only the replica made the claim look true. Same class as the three above reached from the other side: a stale marker hidden by a stale copy rather than by an XPASS. Measured (`ghp_a"b` round-trips exactly), then retired.

### 4. Closing the class, not patching it twice — `tests/clockshift.py`

Grep finds **124** files under `tests/` carrying literal ISO timestamps, and no grep can tell an inert fixture value from one compared against *now*. Running the clock forward can.

```
PYTHONPATH=tests python -m pytest tests/unit -q -p clockshift
```

Opt-in pytest plugin, `CLOCKSHIFT_DAYS`-tunable (negative works too), **no new test dependency** — the issue asked to prefer deriving over adding `freezegun`, so this shifts only what test code reads (`datetime.now/utcnow/today`, `time.time`) and documents its own limits: it does not move a database's own clock, so a test whose expectations come from SQL-side time is out of its reach. It is not a `conftest` on purpose — it must not load for runs that did not ask for it.

## Verification

| what | result |
|---|---|
| `test_ent96_timeline_split.py` | 14 passed — today **and** at `+365d` |
| `test_1771c_schedules_cas_edges.py` | **86 passed** (43 SQLite + 43 PostgreSQL), from 13 PG failures reproduced on unmodified `dev` first |
| PostgreSQL tier | throwaway `postgres:16-alpine` + `alembic upgrade head`, per `run-full.sh --tier postgres` |
| PAT properties + `test_2023` parity | 97 passed, **zero** xfail/xpass |
| fixed files under a shifted clock | green at `+365d` and at `-400d` |

The full-unit `+1y` sweep (the empirical answer to "any other calendar-dependent failures") is running against unmodified `dev` as the baseline; I'll post the residual list as a comment.

Not fixed, noted: `test_ent96_timeline_split.py` has no entry in `tests/registry.json`. Pre-existing and unrelated to this issue, so I left it rather than widen the diff.

Fixes #2243
🤖 Generated with [Claude Code](https://claude.com/claude-code)
