### PR TITLE
fix(deploy): stop shipping the dev instance OSS-only, and blame the right layer (#2246)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -98,7 +98,37 @@ jobs:
             # actually syncs it, and (b) judge success by the populated
             # marker file, never the exit code.
             git config submodule.src/backend/enterprise.update checkout
-            git submodule update --init --recursive src/backend/enterprise || true
+
+            # #2246 — transport, not just authorization. `.gitmodules` uses SSH
+            # for this submodule (and HTTPS for `.claude`), so this is the only
+            # one that can die at `Host key verification failed` — which is
+            # exactly what it had been doing on every retained run since
+            # 2026-07-29, one layer BEFORE any credential was offered.
+            #
+            # When ENT_SUBMODULE_PAT is configured, rewrite the SSH URL to HTTPS for
+            # the duration of this one command. `-c` exports GIT_CONFIG_PARAMETERS,
+            # which child processes inherit — so the submodule's own clone picks it
+            # up while the token NEVER lands in .git/config on the VM disk. That
+            # clears the host-key layer and the authorization layer together, which
+            # a known_hosts entry alone does not (docs/ENTERPRISE.md).
+            #
+            # Absent the secret this is byte-identical to the previous behaviour,
+            # so the VM-side fix documented in docs/ENTERPRISE.md remains valid.
+            ENT_PAT="${{ secrets.ENT_SUBMODULE_PAT }}"
+            ENT_LOG=$(mktemp)
+            if [ -n "$ENT_PAT" ]; then
+              echo "ENTERPRISE: using HTTPS transport (ENT_SUBMODULE_PAT configured)"
+              git -c "url.https://x-access-token:${ENT_PAT}@github.com/.insteadOf=git@github.com:" \
+                  -c "url.https://x-access-token:${ENT_PAT}@github.com/.insteadOf=https://github.com/" \
+                  submodule update --init --recursive src/backend/enterprise >"$ENT_LOG" 2>&1 || true
+            else
+              git submodule update --init --recursive src/backend/enterprise >"$ENT_LOG" 2>&1 || true
+            fi
+            # Echo what happened either way — the previous version discarded the
+            # clone's own output, which is why the cause had to be reconstructed
+            # from a single unexpired run's logs.
+            sed 's/^/ENTERPRISE| /' "$ENT_LOG" || true
+
             if [ -f src/backend/enterprise/backend/__init__.py ]; then
               ENT_SHA=$(git -C src/backend/enterprise rev-parse --short HEAD 2>/dev/null || echo "unknown")
               echo "ENTERPRISE: initialized at ${ENT_SHA}"
@@ -114,9 +144,16 @@ jobs:
               fi
             else
               echo "::warning::Enterprise submodule init failed — deploying in OSS-only mode"
-              echo "ENTERPRISE: confirm the dev VM has read access to Abilityai/trinity-enterprise"
-              echo "ENTERPRISE: (deploy key, PAT in a credential helper, or org membership all work)"
+              # #2246 — classify the cause instead of asserting one. The previous
+              # two lines named an AUTHORIZATION remedy unconditionally, while the
+              # clone was actually failing host-key verification; following that
+              # hint installs a deploy key and changes nothing. The classifier
+              # prints the remedy that matches the observed output, and says
+              # "unknown" rather than guessing.
+              bash scripts/ci/classify-submodule-failure.sh "$ENT_LOG" \
+                | sed 's/^/ENTERPRISE: /' || true
             fi
+            rm -f "$ENT_LOG"
 
             # Compose file list: base prod + enterprise overlay. The
             # overlay bind-mounts ./src/backend/enterprise into
@@ -265,9 +302,12 @@ jobs:
             # existing error check below would have PRINTED this and moved on,
             # because it ends in `|| echo "No errors"`.
             #
-            # Guarded on the populated marker file, so a deploy where the
-            # submodule genuinely failed to init falls through to the
-            # ::warning:: path above. An OSS-only deploy is NEVER failed here.
+            # Guarded on the populated marker file — which is precisely the blind
+            # spot #2246 found. These assertions catch "mounted but not
+            # registered"; they structurally CANNOT fire on "not mounted at all",
+            # which is the state the dev VM was actually in for weeks. The loud
+            # check guarded the louder failure while the quiet one shipped. The
+            # else-branch below closes that.
             if [ -f src/backend/enterprise/backend/__init__.py ]; then
               if printf '%s\n' "$BOOT_LOG" | grep -q 'Trinity Enterprise registration FAILED'; then
                 echo "::error::Enterprise registration FAILED — the submodule is mounted but this instance is running OSS-only (every entitled route will 403). See trinity#2068."
@@ -287,6 +327,42 @@ jobs:
               if printf '%s\n' "$BOOT_LOG" | grep -q 'FAILED module(s)'; then
                 echo "::warning::Enterprise registration completed with FAILED module(s) — some entitled features are unavailable on this instance"
                 printf '%s\n' "$BOOT_LOG" | grep 'FAILED module(s)' | head -5
+              fi
+            else
+              # #2246 — an unentitled dev instance is a FAILED deploy, not a
+              # degraded one, and this is the deliberate decision the issue asked
+              # for. Reasoning, so a future reader can disagree on the record:
+              #
+              #  * dev exists to exercise what prod will run. With the submodule
+              #    unmounted, `enterprise_features` is empty, every
+              #    `requires_entitlement` route 403s, and gated Vue stays hidden —
+              #    so the recorded gitlink is never exercised anywhere before prod.
+              #    That is a release-time pointer surprise waiting to happen, and
+              #    it silently voids dev as a validation surface for every
+              #    enterprise-tracker issue.
+              #  * it hid for weeks BECAUSE it was only a ::warning::. Warnings do
+              #    not change a run's conclusion, and nobody reads a green run's
+              #    log. 200 consecutive runs carried it.
+              #  * #847's rule — a private submodule must never break OSS — is
+              #    about the OSS *build*, and it still holds: it is enforced by
+              #    build-without-submodule.yml and by the conditional import in
+              #    main.py. This workflow deploys the core team's dev VM, where
+              #    the submodule is expected; asserting that here does not weaken
+              #    the OSS guarantee anywhere.
+              #
+              # It fails at the END, deliberately, not at the submodule step: the
+              # pull has already happened, so aborting early would leave the VM
+              # half-updated and fix nothing. The instance comes up, gets health-
+              # checked, and THEN the run goes red with an accurate reason.
+              #
+              # Escape hatch without editing this file: set the repo variable
+              # DEPLOY_ALLOW_OSS_ONLY=true to demote this back to a warning (for a
+              # VM that legitimately has no enterprise access).
+              if [ "${{ vars.DEPLOY_ALLOW_OSS_ONLY }}" = "true" ]; then
+                echo "::warning::Deployed in OSS-only mode — enterprise submodule not mounted (allowed by DEPLOY_ALLOW_OSS_ONLY)"
+              else
+                echo "::error::Deployed in OSS-only mode — the enterprise submodule is NOT mounted, so this instance runs unentitled: enterprise_features is empty and every requires_entitlement route 403s. See the ENTERPRISE: lines above for the classified cause, and trinity#2246."
+                exit 1
               fi
             fi
 

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -94,6 +94,60 @@ The URL override lives only in your clone's `.git/config` — never commit a
 token anywhere. Prefer a credential helper over embedding the token in the URL
 where possible.
 
+> **Option A fails one layer earlier than you expect (#2246).** SSH verifies the
+> *server's* identity before it offers your key, so a host with no `github.com`
+> entry in its `~/.ssh/known_hosts` dies at:
+>
+> ```
+> Host key verification failed.
+> fatal: Could not read from remote repository.
+> ```
+>
+> That message is **not** about access — authentication was never attempted — but
+> git helpfully appends "Please make sure you have the correct access rights",
+> which sends most people after credentials they already have. It is also
+> asymmetric: `.gitmodules` uses HTTPS for `.claude` and SSH only for
+> `src/backend/enterprise`, so this is the one submodule that can fail this way.
+> The dev VM shipped OSS-only for weeks on exactly this. Either trust the key:
+>
+> ```bash
+> ssh-keyscan github.com >> ~/.ssh/known_hosts
+> ```
+>
+> …or take **Option B**, which needs no `known_hosts` entry and clears the
+> authorization layer in the same step. On an unattended host, prefer B.
+
+### Unattended hosts: dev VM / CI (#2246)
+
+A deploy host is the case where "it silently degraded" costs the most, because
+nobody is watching the log. Two things make it durable:
+
+**Pin the transport in the host's clone, once.** Option B's `git config` above
+survives pulls, rebuilds of the containers, and every future
+`git submodule update` — but **not** a rebuild of the VM itself. Re-applying it
+belongs in whatever provisions the host, next to the checkout step; otherwise the
+next rebuild silently reintroduces the OSS-only deploy.
+
+**Or hand the token to the workflow instead of the host.** `deploy-dev.yml` reads
+an optional `ENT_SUBMODULE_PAT` repo secret and, when present, rewrites the SSH URL
+to HTTPS **for the duration of that one command**:
+
+```bash
+git -c "url.https://x-access-token:${PAT}@github.com/.insteadOf=git@github.com:" \
+    submodule update --init --recursive src/backend/enterprise
+```
+
+`git -c` exports `GIT_CONFIG_PARAMETERS`, which the submodule's own clone process
+inherits (verified — with the rewrite in place the child clones the rewritten
+URL), so the token never lands in the host's `.git/config`. With the secret
+unset the command is byte-identical to the plain form, so this is additive: the
+host-side override above remains a valid, independent fix.
+
+Whichever route you take, the deploy now **fails** rather than warning when the
+submodule is not mounted — an unentitled dev instance means the recorded gitlink
+is never exercised before prod. Set the repo variable `DEPLOY_ALLOW_OSS_ONLY=true`
+if a particular host legitimately has no enterprise access.
+
 ### 3. Get the code into the container
 
 The enterprise tree reaches the backend via a **bind-mount**, never the image —

--- a/scripts/ci/classify-submodule-failure.sh
+++ b/scripts/ci/classify-submodule-failure.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Classify WHY a `git submodule update` failed, so the printed remedy matches the
+# actual cause (#2246).
+#
+# The dev deploy has been shipping OSS-only since at least 2026-07-29 — every run
+# in the retained history carries `Enterprise submodule init failed`. The clone was
+# dying at SSH host-key verification, one layer BEFORE authentication, while the
+# workflow's diagnostic said:
+#
+#     ENTERPRISE: confirm the dev VM has read access to Abilityai/trinity-enterprise
+#     ENTERPRISE: (deploy key, PAT in a credential helper, or org membership all work)
+#
+# Every one of those remedies is an authorization fix. Anyone who followed the hint
+# would install a deploy key, redeploy, and get the identical warning — which is a
+# plausible reason this sat unfixed for weeks. A diagnostic that names the wrong
+# layer is worse than none: it spends someone's afternoon proving the hint wrong.
+#
+# Usage:
+#     bash scripts/ci/classify-submodule-failure.sh <file-with-captured-output>
+#     … | bash scripts/ci/classify-submodule-failure.sh -
+#
+# Prints a `CLASS: <name>` line followed by remedy lines, and exits 0 always — a
+# classifier must never be the thing that fails a deploy. The caller decides.
+#
+# Classes are ordered most-specific-first and the FIRST match wins, because a
+# failing clone can emit several of these strings at once: a host-key rejection
+# also prints "Could not read from remote repository", and git's own
+# "Failed to clone … a second time, aborting" wraps whatever the real cause was.
+set -uo pipefail
+
+SRC="${1:--}"
+if [ "$SRC" = "-" ]; then
+    OUTPUT="$(cat)"
+else
+    OUTPUT="$(cat "$SRC" 2>/dev/null || true)"
+fi
+
+emit() { printf '%s\n' "$@"; }
+
+# ---------------------------------------------------------------------------
+# 1. Host key — the layer this issue was actually about.
+# ---------------------------------------------------------------------------
+if printf '%s' "$OUTPUT" | grep -qE 'Host key verification failed|REMOTE HOST IDENTIFICATION HAS CHANGED|No (ED25519|RSA|ECDSA) host key is known'; then
+    emit "CLASS: host-key" \
+         "CAUSE: SSH refused the server's identity before any credential was offered." \
+         "       The deploying user has no github.com entry in ~/.ssh/known_hosts (or a stale one)." \
+         "NOTE:  This is NOT an access problem — authentication was never attempted, so this" \
+         "       failure tells you nothing yet about whether the VM's credentials would work." \
+         "FIX A: ssh-keyscan github.com >> ~/.ssh/known_hosts   (clears this layer only)" \
+         "FIX B (preferred): switch this submodule to HTTPS so no known_hosts entry is needed —" \
+         "       git config submodule.src/backend/enterprise.url \\" \
+         "         https://github.com/Abilityai/trinity-enterprise.git" \
+         "       plus a credential helper or the ENT_SUBMODULE_PAT secret; see docs/ENTERPRISE.md" \
+         "       (\"Dev VM / CI hosts\"). Resolves host-key AND authorization in one step." \
+         "WHY B: .gitmodules uses SSH for src/backend/enterprise and HTTPS for .claude, so only" \
+         "       this submodule can fail this way. HTTPS removes the asymmetry."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Authorization — what the old diagnostic assumed unconditionally.
+# ---------------------------------------------------------------------------
+if printf '%s' "$OUTPUT" | grep -qE 'Permission denied \(publickey|Repository not found|could not read Username|Authentication failed|remote: (Invalid username or password|Write access|Support for password authentication)|HTTP Basic: Access denied|fatal: unable to access .*: The requested URL returned error: (401|403)'; then
+    emit "CLASS: authorization" \
+         "CAUSE: The transport connected and the credential was rejected (or absent)." \
+         "FIX:   Give the deploying user read access to Abilityai/trinity-enterprise —" \
+         "       a deploy key, a PAT in a credential helper, the ENT_SUBMODULE_PAT secret," \
+         "       or org membership all work. See docs/ENTERPRISE.md."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Network / DNS — nothing to fix on the repo side.
+# ---------------------------------------------------------------------------
+if printf '%s' "$OUTPUT" | grep -qE 'Could not resolve host|Connection timed out|Connection refused|Network is unreachable|Operation timed out|Failed to connect to github.com'; then
+    emit "CLASS: network" \
+         "CAUSE: github.com was unreachable from the deploying host." \
+         "FIX:   Transient or egress-blocked. Re-run; if it persists, check the VM's" \
+         "       outbound 443/22 and DNS rather than any repo credential."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Nothing matched. Say so plainly and hand back the evidence — a wrong guess
+#    is what this script exists to stop, so it does not guess here.
+# ---------------------------------------------------------------------------
+if [ -z "${OUTPUT//[[:space:]]/}" ]; then
+    emit "CLASS: no-output" \
+         "CAUSE: The submodule update produced no output, yet the tree is unpopulated." \
+         "FIX:   Check that .gitmodules still lists src/backend/enterprise, and that" \
+         "       'git config submodule.src/backend/enterprise.update' is 'checkout' —" \
+         "       an 'update = none' submodule (#1443) is SKIPPED and exits 0 silently."
+    exit 0
+fi
+
+emit "CLASS: unknown" \
+     "CAUSE: Unrecognised failure — classifying it as access would be a guess." \
+     "FIX:   Read the captured output below and, if it is a recurring shape," \
+     "       add it to scripts/ci/classify-submodule-failure.sh (#2246)." \
+     "--- captured output (last 20 lines) ---"
+printf '%s\n' "$OUTPUT" | tail -20
+exit 0

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -2380,6 +2380,18 @@
         "reliability"
       ],
       "description": "Calendar-rot detector (#2247). Re-runs the calendar-sensitive test files in a subprocess under tests/clockshift.py with the clock +7 days and -365 days, so a fixture pinned to a literal date inside a RELATIVE window fails on the first run instead of on some future Tuesday — the failure mode that left five ent#96 tests red on dev for two days with no red check anywhere (invisible on PRs because base and head fail identically, invisible on pushes because the diff job does not run there). A subprocess because the shift must be installed before the module binds `from datetime import datetime`, which an autouse fixture cannot do. Also guards the detector's own no-op failure mode: it asserts the plugin exists AND that importing it actually moves `datetime.now()`, since a vanished plugin would make every shifted run pass by shifting nothing. Proven to detect: reverting the ent#96 fixture to its pre-#2243 state turns both directions red. ~37s, almost all pytest boot; the file list is short for that reason and excludes the ~176s test_1771c_schedules_analytics_edges."
+    },
+    {
+      "file": "unit/test_2246_oss_only_deploy_is_loud.py",
+      "feature": "#2246",
+      "added": "2026-08-17",
+      "categories": [
+        "ci",
+        "unit",
+        "infrastructure",
+        "deployment"
+      ],
+      "description": "Dev deploy must not ship OSS-only silently (#2246). Behavioural half: runs scripts/ci/classify-submodule-failure.sh over the verbatim output of the real failure and asserts CLASS: host-key — plus, crucially, that the host-key remedy does NOT mention read access / deploy keys / org membership, which is what the old unconditional diagnostic said while the clone was dying one layer earlier at SSH host-key verification (follow that hint and you install a deploy key and get the identical warning). Also pins that a genuine credential failure still says access, that a DNS failure is neither — host-key output also contains 'Could not read from remote repository', so ordering is load-bearing — that silence is its own class (an `update = none` submodule is SKIPPED and exits 0, #1443), and that an unrecognised shape is admitted rather than guessed. Static half over deploy-dev.yml: the not-mounted branch EXISTS (the #2068 ::error:: assertions sit inside `if [ -f …/enterprise/backend/__init__.py ]`, so they structurally cannot fire on the state the VM was actually in), it fails the run rather than warning (direction, not presence — a ::warning:: is exactly how this hid across 200 consecutive runs), the escape hatch is an opt-in repo variable, the clone output is captured and classified, the optional PAT transport uses `git -c … insteadOf` so no token persists to the VM's .git/config, and the submodule step contains no `exit 1` — failing there would leave the VM half-updated after the pull."
     }
   ]
 }

--- a/tests/unit/test_2246_oss_only_deploy_is_loud.py
+++ b/tests/unit/test_2246_oss_only_deploy_is_loud.py
@@ -1,0 +1,203 @@
+"""#2246 — an OSS-only dev deploy must be loud, and its diagnostic must name the right layer.
+
+Every retained ``Deploy to Dev`` run (200, 2026-07-29 → 2026-08-17) carried
+``Enterprise submodule init failed`` and deployed the dev instance unentitled:
+``enterprise_features`` empty, every ``requires_entitlement`` route 403, gated Vue
+hidden. The job reported success each time, so the recorded gitlink was never
+exercised anywhere before prod.
+
+Two independent defects kept it invisible, and this file pins the fix for both:
+
+  1. **The diagnostic named the wrong layer.** The clone died at SSH host-key
+     verification — one layer BEFORE authentication — while the workflow printed
+     "confirm the dev VM has read access". Following that hint installs a deploy
+     key and produces the identical warning, which is a plausible reason it sat
+     for weeks. So the remedy is now CLASSIFIED from the clone's own output, and
+     the host-key case must not mention the access remedies.
+  2. **The loud check guarded the louder failure.** #2068's ``::error::``
+     assertions live inside ``if [ -f …/enterprise/backend/__init__.py ]``, so
+     they catch *mounted but not registered* and structurally cannot fire on *not
+     mounted at all* — the state actually in production on dev. A ``::warning::``
+     does not change a run's conclusion, and nobody reads a green run's log.
+
+The classifier half is a real behavioural test (the script runs, on the exact
+output from the issue). The workflow half is a static guard, in the shape of
+``test_2204_deploy_self_heal.py`` — a workflow cannot be executed in a unit test,
+and the property worth pinning is the DIRECTION of the decision (fail, not warn),
+which a future edit could silently reverse.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO / "scripts" / "ci" / "classify-submodule-failure.sh"
+_WORKFLOW = _REPO / ".github" / "workflows" / "deploy-dev.yml"
+
+# Verbatim from the run that still had logs when #2246 was filed. Note it also
+# contains "Could not read from remote repository" — the string an authorization
+# failure prints too, which is why ordering in the classifier is load-bearing.
+HOST_KEY_OUTPUT = """Cloning into '/home/deploy/trinity/src/backend/enterprise'...
+Host key verification failed.
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+fatal: clone of 'git@github.com:Abilityai/trinity-enterprise.git' into submodule path '/home/deploy/trinity/src/backend/enterprise' failed
+Failed to clone 'src/backend/enterprise' a second time, aborting
+"""
+
+AUTH_OUTPUT = """Cloning into '/home/deploy/trinity/src/backend/enterprise'...
+git@github.com: Permission denied (publickey).
+fatal: Could not read from remote repository.
+Failed to clone 'src/backend/enterprise' a second time, aborting
+"""
+
+AUTH_HTTPS_OUTPUT = """Cloning into '/home/deploy/trinity/src/backend/enterprise'...
+remote: Repository not found.
+fatal: repository 'https://github.com/Abilityai/trinity-enterprise.git/' not found
+"""
+
+NETWORK_OUTPUT = """Cloning into '/home/deploy/trinity/src/backend/enterprise'...
+ssh: Could not resolve hostname github.com: Temporary failure in name resolution
+fatal: Could not read from remote repository.
+"""
+
+
+def classify(text: str) -> str:
+    proc = subprocess.run(
+        ["bash", str(_SCRIPT), "-"], input=text, capture_output=True, text=True, timeout=30
+    )
+    # A classifier that fails the deploy it is diagnosing would be worse than the
+    # bug: the caller decides, always.
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def klass(text: str) -> str:
+    first = classify(text).splitlines()[0]
+    assert first.startswith("CLASS: "), first
+    return first[len("CLASS: ") :]
+
+
+# ---------------------------------------------------------------------------
+# The classifier: right layer, right remedy
+# ---------------------------------------------------------------------------
+
+def test_the_real_failure_is_classified_as_host_key_not_access():
+    assert klass(HOST_KEY_OUTPUT) == "host-key"
+
+
+def test_the_host_key_remedy_does_not_send_anyone_after_credentials():
+    """The whole defect: an authorization remedy for a pre-authorization failure."""
+    out = classify(HOST_KEY_OUTPUT).lower()
+    assert "known_hosts" in out
+    assert "ssh-keyscan" in out
+    # The old wording, which cost someone an afternoon proving it wrong.
+    assert "read access" not in out
+    assert "deploy key" not in out
+    assert "org membership" not in out
+    # And it says so explicitly rather than leaving the reader to infer it.
+    assert "not an access problem" in out
+
+
+@pytest.mark.parametrize(
+    "output", [AUTH_OUTPUT, AUTH_HTTPS_OUTPUT], ids=["ssh-publickey", "https-not-found"]
+)
+def test_a_genuine_credential_failure_still_says_access(output):
+    out = classify(output)
+    assert klass(output) == "authorization"
+    assert "deploy key" in out.lower()
+
+
+def test_a_dns_failure_is_neither_of_the_above():
+    """Host-key output also contains 'Could not read from remote repository', so a
+    naive classifier bins everything together."""
+    assert klass(NETWORK_OUTPUT) == "network"
+
+
+def test_silence_is_its_own_class_because_update_none_exits_zero():
+    """#1443 made this submodule `update = none`; a skipped submodule prints
+    nothing and exits 0, so an empty capture is a distinct diagnosis."""
+    out = classify("")
+    assert klass("") == "no-output"
+    assert "update = none" in out or "'checkout'" in out
+
+
+def test_an_unrecognised_failure_is_admitted_not_guessed():
+    out = classify("fatal: something nobody has seen before\n")
+    assert klass("fatal: something nobody has seen before") == "unknown"
+    assert "would be a guess" in out
+    # It hands back the evidence rather than swallowing it.
+    assert "something nobody has seen before" in out
+
+
+# ---------------------------------------------------------------------------
+# The workflow: the OSS-only state now changes the run's conclusion
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def workflow() -> str:
+    return _WORKFLOW.read_text()
+
+
+def test_the_not_mounted_branch_exists_at_all(workflow):
+    """The #2068 assertions are guarded on the marker file; without an else-branch
+    the not-mounted state has no assertion anywhere in the workflow."""
+    registration = workflow.split("=== Enterprise registration")[1]
+    assert "::error::Deployed in OSS-only mode" in registration
+
+
+def test_an_oss_only_deploy_fails_the_run(workflow):
+    """DIRECTION, not presence: demoting this back to a bare warning is exactly
+    how the bug hid for 200 runs.
+
+    Scanned by line rather than by splitting on ``fi`` — the error message itself
+    contains "classi**fi**ed", which is the kind of thing that makes a static
+    guard pass or fail for the wrong reason.
+    """
+    lines = workflow.splitlines()
+    idx = next(
+        i for i, line in enumerate(lines) if "::error::Deployed in OSS-only mode" in line
+    )
+    following = [line.strip() for line in lines[idx + 1 : idx + 4]]
+    assert "exit 1" in following, following
+
+
+def test_the_escape_hatch_is_opt_in_and_not_the_default(workflow):
+    """A VM with no enterprise access can demote it — but must say so explicitly."""
+    assert 'vars.DEPLOY_ALLOW_OSS_ONLY }}" = "true"' in workflow
+    # Being a repo variable rather than an edit keeps the default loud.
+    assert workflow.count("DEPLOY_ALLOW_OSS_ONLY") >= 2
+
+
+def test_the_clone_output_is_captured_and_classified(workflow):
+    """The cause had to be reconstructed from one unexpired run because the clone's
+    own output was discarded."""
+    submodule = workflow.split("=== Submodule (enterprise)")[1].split("=== Volume ownership")[0]
+    assert "classify-submodule-failure.sh" in submodule
+    assert 'ENT_LOG=$(mktemp)' in submodule
+    # The old unconditional access hint must be gone from the workflow itself.
+    assert "confirm the dev VM has read access" not in workflow
+
+
+def test_the_pat_transport_never_persists_the_token(workflow):
+    """HTTPS+PAT clears host-key AND authorization at once, but a token written
+    into the VM's .git/config would outlive the deploy."""
+    submodule = workflow.split("=== Submodule (enterprise)")[1].split("=== Volume ownership")[0]
+    assert "insteadOf" in submodule
+    assert "git -c " in submodule
+    # `git config submodule.<path>.url <token URL>` is the persisting form.
+    assert "config submodule.src/backend/enterprise.url" not in submodule
+
+
+def test_the_deploy_is_not_aborted_before_the_instance_is_up(workflow):
+    """Failing at the submodule step would leave the VM half-updated (the pull has
+    already happened) and fix nothing; the run goes red after the health check."""
+    submodule = workflow.split("=== Submodule (enterprise)")[1].split("=== Volume ownership")[0]
+    assert "exit 1" not in submodule


### PR DESCRIPTION
## What was happening

200 retained `Deploy to Dev` runs, 2026-07-29 → 2026-08-17, every one carrying `Enterprise submodule init failed` and every one reporting **success**. Dev has been serving OSS-only the whole time: `enterprise_features` empty, every `requires_entitlement` route 403, gated Vue hidden — so the enterprise gitlink recorded on `dev` has never been exercised anywhere before prod.

Two independent defects kept it invisible. This PR fixes both, plus documents the VM-side half it cannot apply.

### Defect 1 — the diagnostic named the wrong layer

The clone died at SSH **host-key verification**, before any credential was offered, while the workflow printed:

> `ENTERPRISE: confirm the dev VM has read access to Abilityai/trinity-enterprise`
> `ENTERPRISE: (deploy key, PAT in a credential helper, or org membership all work)`

All authorization remedies, for a pre-authorization failure. Install a deploy key, redeploy, get the identical warning. Git compounds it by appending its own *"Please make sure you have the correct access rights"* to a host-key rejection.

Now: the clone's output is **captured** (it was being discarded entirely — the cause had to be reconstructed from the one run whose logs hadn't expired) and passed to `scripts/ci/classify-submodule-failure.sh`, which distinguishes **host-key / authorization / network**, has a distinct class for silence (an `update = none` submodule is *skipped* and exits 0, #1443), says `unknown` and hands back the evidence rather than guessing, and always exits 0 — a classifier must never be the thing that fails a deploy.

Ordering is load-bearing: a host-key rejection **also** prints `Could not read from remote repository`, so the most specific pattern has to win. That's asserted.

### Defect 2 — the loud check guarded the louder failure

#2068's `::error::` assertions sit inside `if [ -f …/enterprise/backend/__init__.py ]`. They catch *mounted but not registered*; they structurally **cannot** fire on *not mounted at all* — the state dev was actually in. The quiet path was the one shipping.

That branch now exists and it **fails the run**. The deliberate decision the AC asked for, with reasoning recorded in the workflow:

- dev exists to exercise what prod will run; unentitled, it silently voids dev as the validation surface for every enterprise-tracker issue and leaves prod as the first place enterprise code runs
- it hid *because* it was a `::warning::` — warnings don't change a run's conclusion, and nobody reads a green run's log; 200 consecutive runs carried it
- #847's "a private submodule must never break OSS" is about the OSS **build** and still holds — enforced by `build-without-submodule.yml` and `main.py`'s conditional import, neither of which this touches

It fails **at the end**, after the instance is up and health-checked: the pull has already happened, so aborting at the submodule step would leave the VM half-updated and fix nothing. `DEPLOY_ALLOW_OSS_ONLY=true` (repo variable) demotes it back to a warning for a host that legitimately has no access.

### Optional, additive: fix it from CI instead of from the VM

When the `ENT_SUBMODULE_PAT` secret is set, the SSH URL is rewritten to HTTPS for that one command, clearing host-key **and** authorization together:

```bash
git -c "url.https://x-access-token:${PAT}@github.com/.insteadOf=git@github.com:" \
    submodule update --init --recursive src/backend/enterprise
```

No token lands in the VM's `.git/config`. With the secret unset the command is byte-identical to before, so the host-side fix stays independently valid.

Secret named `ENT_SUBMODULE_PAT`, **not** `ENTERPRISE_PAT`: the latter matches `enterprise-docs-guard`'s `\benterprise_[a-z_]+` pattern case-insensitively, and widening a security guard to fit a name I chose is the wrong trade.

## Verification — reproduced, not simulated

A scratch repo with the same SSH gitlink and an empty `known_hosts` reproduces the issue's exact output:

```
ENTERPRISE| No ED25519 host key is known for github.com and you have requested strict checking.
ENTERPRISE| Host key verification failed.
ENTERPRISE| fatal: Could not read from remote repository.
ENTERPRISE| Please make sure you have the correct access rights      ← the misleading line
ENTERPRISE| Failed to clone 'src/backend/enterprise' a second time, aborting
=== marker file present? NO -> OSS-only path taken
=== new diagnostic:
ENTERPRISE: CLASS: host-key
ENTERPRISE: NOTE:  This is NOT an access problem — authentication was never attempted…
```

The PAT rewrite's **mechanism** was verified rather than assumed: pointed at a local stand-in remote, the child clone reports `transport 'file' not allowed` — i.e. it is acting on the *rewritten* URL, proving `git -c` reaches the submodule's own clone via `GIT_CONFIG_PARAMETERS`; with the file protocol allowed it checks out and the marker appears.

| check | result |
|---|---|
| new tests | **13 passed** (`test_2246_oss_only_deploy_is_loud.py`) |
| all five deploy-workflow guards together | **86 passed**, 2 skipped |
| workflow YAML | parses; the full 346-line deploy script passes `bash -n` |
| `enterprise-docs-guard` pattern, run locally | clean |

## Remaining — needs someone with the right access

The VM half cannot be applied from CI or from this PR. **Either**:

1. add the `ENT_SUBMODULE_PAT` repo secret (repo admin — nothing else to do), **or**
2. on the dev VM: `ssh-keyscan github.com >> ~/.ssh/known_hosts`

Both are documented in `docs/ENTERPRISE.md` → *Unattended hosts: dev VM / CI*, including why route 2 must be re-applied by whatever provisions the host (it does not survive a VM rebuild — which is AC6).

Until one is done, the next deploy **fails loudly with the correct cause** instead of passing quietly. The three ACs that assert live dev state (`ENTERPRISE: initialized at <sha>`, SHA matches the gitlink, `edition: "enterprise"`) can only be ticked after that step — the first deploy after it is the proof.

Fixes #2246

🤖 Generated with [Claude Code](https://claude.com/claude-code)