### PR TITLE
fix(tests): re-point five stale mocks at the seams they claim to stub (#2242)

### DIFF
--- a/tests/test_audit_log_unit.py
+++ b/tests/test_audit_log_unit.py
@@ -97,6 +97,21 @@ def audit_db(monkeypatch):
         END
         """
     )
+    # #2242/#2015: the hash-chain toggle is a durable `system_settings` row now,
+    # not an instance attribute. Without this table the fixture's `db` was a
+    # MagicMock that swallowed the write, the (deliberately fail-CLOSED) reader
+    # answered "off", and nothing was ever hashed — so two tests named after the
+    # hash chain were asserting that a disabled chain produces no hashes.
+    # Same DDL as db/schema.py's `system_settings`.
+    cursor.execute(
+        """
+        CREATE TABLE system_settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
     conn.commit()
     conn.close()
 
@@ -365,6 +380,26 @@ def audit_service(audit_db, monkeypatch, audit_ops):
     fake_db.create_audit_entry = audit_ops.create_audit_entry
     fake_db.get_audit_entries = audit_ops.get_audit_entries
     fake_db.get_audit_entries_range = audit_ops.get_audit_entries_range
+    # #2242: the three seams #2015 added, wired to the SAME temp DB rather than
+    # left as MagicMocks.
+    #
+    # `create_audit_entry_chained` is the real one because the chain head is read
+    # inside the insert transaction — a stub would have to reimplement exactly the
+    # part that makes the chain a chain.
+    #
+    # Settings go through a real `SettingsOperations` (engine-based, so it binds to
+    # the temp file via the DATABASE_URL the audit_db fixture sets) so
+    # `enable_hash_chain()` genuinely persists and `hash_chain_enabled` genuinely
+    # reads it back. Deliberately NOT `fake_db.get_setting_value.return_value =
+    # "true"`: that would force the flag on and bypass the fail-closed reader the
+    # #2015 design turns on, which is the one behaviour most worth not faking.
+    monkeypatch.delitem(sys.modules, "db.settings", raising=False)
+    from db.settings import SettingsOperations
+
+    settings_ops = SettingsOperations()
+    fake_db.create_audit_entry_chained = audit_ops.create_audit_entry_chained
+    fake_db.get_setting_value = settings_ops.get_setting_value
+    fake_db.set_setting = settings_ops.set_setting
     fake_db_module.db = fake_db
     monkeypatch.setitem(sys.modules, "database", fake_db_module)
 

--- a/tests/test_cb_probe_execution_close.py
+++ b/tests/test_cb_probe_execution_close.py
@@ -128,6 +128,25 @@ def _restore_complete_stubs(monkeypatch):
 # Fix A: Circuit breaker fast-fail
 # ===========================================================================
 
+def _activity_double(*, activity_id=None):
+    """The activity-service seam, with EVERY awaited method awaitable.
+
+    #1804 added `close_execution_activity` to the terminal path
+    (`task_execution_service._write_terminal_and_gate`) — and this double was
+    inlined at SEVEN call sites, each wiring only `track_activity` and
+    `complete_activity`. So the new await got a plain `MagicMock` and three tests
+    died with "object MagicMock can't be used in 'await' expression": not noise,
+    but three fast-fail assertions that had quietly stopped running (#2242).
+
+    One factory, so the next seam change is one edit instead of seven silent
+    drifts. Anything the service awaits belongs here.
+    """
+    return MagicMock(
+        track_activity=AsyncMock(return_value=activity_id),
+        complete_activity=AsyncMock(),
+        close_execution_activity=AsyncMock(),
+    )
+
 class TestCircuitBreakerFastFail:
     """execute_task closes the execution record immediately when CB is open."""
 
@@ -183,9 +202,7 @@ class TestCircuitBreakerFastFail:
         mock_capacity.acquire = AsyncMock(return_value=admitted)
         mock_capacity.release = AsyncMock()
 
-        mock_activity_svc = MagicMock()
-        mock_activity_svc.track_activity = AsyncMock(return_value="act-001")
-        mock_activity_svc.complete_activity = AsyncMock()
+        mock_activity_svc = _activity_double(activity_id="act-001")
 
         mock_circuit = MagicMock()
         mock_circuit.allow_request.return_value = False
@@ -212,6 +229,17 @@ class TestCircuitBreakerFastFail:
         call_kwargs = mock_db.update_execution_status.call_args
         assert call_kwargs.kwargs.get("status") == TaskExecutionStatus.FAILED
 
+        # #2242: restoring the await is not the same as testing what the seam now
+        # does. #1804's rule is that the CAS winner OWNS the activity close — a
+        # fast-fail that writes FAILED and leaves the activity `started` is
+        # exactly the bug that issue fixed, and it would satisfy every assertion
+        # above. `update_execution_status` returns a truthy MagicMock here, so the
+        # CAS is won and the close must have happened in the terminal's own state.
+        mock_activity_svc.close_execution_activity.assert_awaited_once()
+        close_args = mock_activity_svc.close_execution_activity.await_args
+        assert close_args.args[0] == "exec-test-001"
+        assert close_args.args[1] == TaskExecutionStatus.FAILED
+
     @pytest.mark.asyncio
     async def test_cb_open_does_not_call_agent(self):
         """When CB is open, agent_post_with_retry is never called."""
@@ -236,10 +264,7 @@ class TestCircuitBreakerFastFail:
         with (
             patch("services.task_execution_service.db", mock_db),
             patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
-            patch("services.task_execution_service.activity_service", MagicMock(
-                track_activity=AsyncMock(return_value="act-001"),
-                complete_activity=AsyncMock(),
-            )),
+            patch("services.task_execution_service.activity_service", _activity_double(activity_id="act-001")),
             patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
             patch("services.task_execution_service.agent_post_with_retry", mock_post),
         ):
@@ -275,10 +300,7 @@ class TestCircuitBreakerFastFail:
         with (
             patch("services.task_execution_service.db", mock_db),
             patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
-            patch("services.task_execution_service.activity_service", MagicMock(
-                track_activity=AsyncMock(return_value=None),
-                complete_activity=AsyncMock(),
-            )),
+            patch("services.task_execution_service.activity_service", _activity_double()),
             patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
         ):
             svc = TaskExecutionService()
@@ -326,10 +348,7 @@ class TestCircuitBreakerFastFail:
         with (
             patch("services.task_execution_service.db", mock_db),
             patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
-            patch("services.task_execution_service.activity_service", MagicMock(
-                track_activity=AsyncMock(return_value="act-001"),
-                complete_activity=AsyncMock(),
-            )),
+            patch("services.task_execution_service.activity_service", _activity_double(activity_id="act-001")),
             patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
             patch("services.task_execution_service.agent_post_with_retry", mock_post),
         ):
@@ -393,10 +412,7 @@ class TestCancelledErrorInExecuteTask:
         with (
             patch("services.task_execution_service.db", mock_db),
             patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
-            patch("services.task_execution_service.activity_service", MagicMock(
-                track_activity=AsyncMock(return_value=None),
-                complete_activity=AsyncMock(),
-            )),
+            patch("services.task_execution_service.activity_service", _activity_double()),
             patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
             patch("services.task_execution_service.agent_post_with_retry", mock_post),
         ):
@@ -438,10 +454,7 @@ class TestCancelledErrorInExecuteTask:
         with (
             patch("services.task_execution_service.db", mock_db),
             patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
-            patch("services.task_execution_service.activity_service", MagicMock(
-                track_activity=AsyncMock(return_value=None),
-                complete_activity=AsyncMock(),
-            )),
+            patch("services.task_execution_service.activity_service", _activity_double()),
             patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
             patch("services.task_execution_service.agent_post_with_retry", mock_post),
         ):
@@ -478,10 +491,7 @@ class TestCancelledErrorInExecuteTask:
         with (
             patch("services.task_execution_service.db", mock_db),
             patch("services.task_execution_service.get_capacity_manager", return_value=mock_capacity),
-            patch("services.task_execution_service.activity_service", MagicMock(
-                track_activity=AsyncMock(return_value=None),
-                complete_activity=AsyncMock(),
-            )),
+            patch("services.task_execution_service.activity_service", _activity_double()),
             patch("services.task_execution_service.CircuitState", return_value=mock_circuit),
             patch("services.task_execution_service.agent_post_with_retry", mock_post),
         ):

--- a/tests/test_github_pat_propagation_unit.py
+++ b/tests/test_github_pat_propagation_unit.py
@@ -40,6 +40,23 @@ if "utils.helpers" not in sys.modules:
 # (#211 sys.modules-pollution fix).
 _fake_database = types.ModuleType("database")
 _fake_database.db = MagicMock()
+# #2242: `_propagate_to_agent` lazily runs `from services import git_service`, and
+# git_service's module header is `from database import db, AgentGitConfig,
+# GitSyncResult`. A stub carrying only `db` therefore raised
+# `ImportError: cannot import name 'AgentGitConfig' from 'database'` — and because
+# it happened inside `asyncio.gather(..., return_exceptions=True)`, it surfaced not
+# as an import error but as every agent landing in `failed` with `updated` empty.
+# Four tests named after propagation outcomes were really asserting an import
+# failure.
+#
+# The REAL models, not more MagicMocks: they are plain pydantic classes with no
+# heavy imports, and stubbing them would re-mock the very shape these tests exist
+# to exercise. If the model gains a required field, this should notice.
+from db_models import AgentGitConfig as _RealAgentGitConfig  # noqa: E402
+from db_models import GitSyncResult as _RealGitSyncResult  # noqa: E402
+
+_fake_database.AgentGitConfig = _RealAgentGitConfig
+_fake_database.GitSyncResult = _RealGitSyncResult
 
 _fake_services_pkg = types.ModuleType("services")
 _fake_services_pkg.__path__ = [os.path.join(_backend_path, "services")]
@@ -49,6 +66,17 @@ _fake_docker_service.list_all_agents_fast = MagicMock(return_value=[])
 # #1264: github_pat_propagation_service now imports get_agent_container at module
 # top, so the stub must expose it for the fresh module load to succeed.
 _fake_docker_service.get_agent_container = MagicMock(return_value=None)
+# #2242: the second layer of the same drift. With `AgentGitConfig` restored above,
+# `from services import git_service` gets one import further and then dies on
+# git_service's own `from services.docker_service import get_agent_container,
+# execute_command_in_container`. Stubbing this one name lets the REAL git_service
+# load — which is the point: the propagation path calls
+# `git_service.update_remote_pat(...)`, so the alternative (stubbing git_service
+# itself) would have let that call's signature drift unnoticed, which is the exact
+# class of bug this issue is about.
+_fake_docker_service.execute_command_in_container = MagicMock(
+    return_value={"exit_code": 0, "output": ""}
+)
 
 _STUB_MODULES = {
     "database": _fake_database,
@@ -216,10 +244,24 @@ async def test_skips_agent_with_per_agent_pat(service):
 
 @pytest.mark.asyncio
 async def test_skips_agent_without_github_pat_in_env(service):
-    """Agents whose .env does not contain GITHUB_PAT are skipped (AC)."""
+    """An agent with NO git config and no GITHUB_PAT line is skipped (AC, #1967).
+
+    #2242: the skip is conditional now, and the mock was hiding which condition.
+    #1967 replaced "the `.env` already has a GITHUB_PAT line" with "Trinity
+    manages a repo for this agent" as the eligibility signal — a
+    template-provisioned agent has a git config from creation but no `.env` yet,
+    and that population is exactly what the old gate excluded. Since `db` is a
+    blanket MagicMock, `db.get_git_config(...).github_repo` was truthy, so this
+    test was silently exercising `add_if_missing=True` — the WRITE path — while
+    asserting the skip. It only looked like a skip because the propagation died on
+    an import error before reaching either.
+    """
     with patch.object(service, "list_all_agents_fast", return_value=[_agent("a1")]), \
          patch.object(service, "db") as mock_db:
         mock_db.has_agent_github_pat.return_value = False
+        # The condition under test, stated instead of inherited from MagicMock:
+        # no git config => conservative behaviour => never create the line.
+        mock_db.get_git_config.return_value = None
 
         client_cm, _ = _make_async_client(
             read_responses={"a1": {"files": {".env": 'OTHER="x"\n'}}},
@@ -232,6 +274,40 @@ async def test_skips_agent_without_github_pat_in_env(service):
     assert result.updated == []
     assert any(s.status == "skipped_no_pat" and s.agent_name == "a1"
                for s in result.skipped)
+
+
+@pytest.mark.asyncio
+async def test_agent_with_git_config_gets_the_line_written(service):
+    """The other side of #1967 — and the branch the stale mock was accidentally
+    running while the test above claimed to assert the skip (#2242).
+
+    An agent Trinity manages a repo for gets `GITHUB_PAT` WRITTEN even though its
+    `.env` has no such line. Without this, nothing covered the eligibility rule
+    that #1967 introduced: the skip test would have gone green again under a
+    re-mocked `get_git_config`, and the write path would have stayed untested.
+    """
+    with patch.object(service, "list_all_agents_fast", return_value=[_agent("a1")]), \
+         patch.object(service, "db") as mock_db:
+        mock_db.has_agent_github_pat.return_value = False
+        git_config = MagicMock()
+        git_config.github_repo = "Abilityai/agent-a1"
+        mock_db.get_git_config.return_value = git_config
+
+        client_cm, client = _make_async_client(
+            read_responses={"a1": {"files": {".env": 'OTHER="x"\n'}}},
+            inject_responses={"a1": {"status": "success", "files_written": [".env"]}},
+        )
+        with patch("services.github_pat_propagation_service.httpx.AsyncClient",
+                   return_value=client_cm):
+            result = await service.propagate_github_pat("ghp_new")
+
+    assert result.updated == ["a1"], result
+    assert not any(s.status == "skipped_no_pat" for s in result.skipped)
+    # The written payload carries the new token on the mirrors (#1574), which is
+    # what "the line was created" means at this seam.
+    written = client.post.call_args_list[-1].kwargs["json"]["files"][".env"]
+    assert 'GITHUB_PAT="ghp_new"' in written
+    assert 'OTHER="x"' in written, "the pre-existing content must survive"
 
 
 @pytest.mark.asyncio
@@ -283,7 +359,20 @@ async def test_non_running_agents_ignored(service):
     assert result.total_running == 1
     assert result.updated == ["a2"]
     # Stopped agent never hit the wire.
-    assert all("a1" not in str(c) for c in client.get.call_args_list)
+    # #2242: assert on the URL, not on `str(call)`. The old form searched the
+    # WHOLE call repr for "a1", and that repr now includes the #1159
+    # `X-Trinity-Agent-Token` — a 64-char HMAC hex which contains "a1" roughly
+    # half the time (observed: ...db83a1d7ab65a1a2239d...). It only looked stable
+    # because the stale stub meant no request was ever made, so the generator was
+    # vacuously true over an empty list: fixing the import above is what exposed
+    # it. A substring search across a repr that carries a credential digest is not
+    # a test of which host was contacted.
+    contacted = [
+        (call.args[0] if call.args else call.kwargs.get("url", ""))
+        for call in client.get.call_args_list
+    ]
+    assert contacted, "the running agent should have been read"
+    assert all("http://agent-a1:" not in url for url in contacted), contacted
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -203,31 +203,49 @@ class TestSkillsLibrarySync:
 
     pytestmark = pytest.mark.smoke
 
-    def test_sync_requires_url_configured(self, api_client: TrinityApiClient):
-        """POST /api/skills/library/sync fails gracefully when URL not configured."""
-        # Check if URL is configured
-        status_response = api_client.get("/api/skills/library/status")
-        status = status_response.json()
+    def test_sync_never_500s_whatever_the_configuration(self, api_client: TrinityApiClient):
+        """Sync answers with a named error or a real result — never a 500 (#2242).
 
-        if status.get("url"):
-            pytest.skip("Skills library URL is configured - can't test unconfigured state")
+        Was `test_sync_requires_url_configured`, which asked
+        `if status.get("url"): skip`. ent#237 replaced the single
+        `skills_library_url` setting with the `skill_sources` table, so `url` reads
+        `None` on every modern install — including ones that DO have sources. The
+        skip stopped firing, the sync ran against the migrated source, succeeded,
+        and the test failed asserting 400 against 200 while its name still claimed
+        to be testing the unconfigured state.
 
+        Swapping the key does not repair it: an API test cannot dictate what the
+        target instance has configured (observed live — `/status` reported
+        `configured: false` moments before `/sync` found an enabled source and
+        cloned it). So the deterministic "no sources → 400, named" contract moved to
+        a unit test that owns its own configuration,
+        `tests/unit/test_ent237_skill_sources.py::TestSyncBookkeeping::test_sync_with_no_sources_configured_fails_by_name`,
+        and what stays here is the property that holds on ANY instance and is worth
+        an end-to-end check: the route degrades by name rather than crashing.
+        """
         response = api_client.post("/api/skills/library/sync")
 
-        # Should fail with informative error (not 500)
-        assert_status(response, 400)
+        assert response.status_code in (200, 400, 409), response.text
         data = response.json()
-        assert "detail" in data
-        assert "not configured" in data["detail"].lower() or "url" in data["detail"].lower()
+        if response.status_code == 200:
+            # Configured: a real result, in the multi-source shape ent#237 added.
+            assert data.get("success") is True, data
+            assert isinstance(data.get("sources"), list)
+        else:
+            # 400 unconfigured / bad source; 409 a sync already running.
+            assert "detail" in data
+            assert data["detail"], "an error status must name its reason"
 
     def test_sync_returns_structure_when_configured(self, api_client: TrinityApiClient):
         """POST /api/skills/library/sync returns expected structure when configured."""
-        # Check if URL is configured
+        # #2242: gate on `configured` (ent#237: "at least one source exists"), not
+        # the legacy `url`, which is None on every modern install — so this test
+        # was skipping unconditionally and had stopped asserting anything at all.
         status_response = api_client.get("/api/skills/library/status")
         status = status_response.json()
 
-        if not status.get("url"):
-            pytest.skip("Skills library URL not configured")
+        if not (status.get("configured") or status.get("sources")):
+            pytest.skip("No skills sources configured on this instance")
 
         response = api_client.post("/api/skills/library/sync")
 

--- a/tests/unit/test_ent237_skill_sources.py
+++ b/tests/unit/test_ent237_skill_sources.py
@@ -348,6 +348,33 @@ class TestSyncBookkeeping:
         """Bookkeeping runs on the tail of a sync and is never load-bearing."""
         sources_db.record_sync("src_00000000", success=True, commit_sha="x")
 
+    def test_sync_with_no_sources_configured_fails_by_name(self, service):
+        """The "nothing configured" contract, deterministically (#2242).
+
+        This branch used to be covered only by
+        `tests/test_skills.py::TestSkillsLibrarySync::test_sync_requires_url_configured`,
+        an API test that gated itself on `status["url"]`. ent#237 replaced the
+        single `skills_library_url` setting with the `skill_sources` table, so that
+        key reads `None` on every modern install — including ones that DO have
+        sources. The guard therefore stopped skipping, the sync ran against a
+        migrated source, succeeded, and the test failed asserting 400 against a
+        200. The subject is a property of the service, not of whatever an instance
+        happens to be configured with, so it belongs here, where the configuration
+        is the fixture's to decide.
+
+        The error STRING is asserted because the router returns it verbatim as the
+        HTTP `detail` (`routers/skills.py::sync_library`) — it is operator-facing
+        text, not an internal label.
+        """
+        result = service.sync_library()
+
+        assert result["success"] is False
+        assert result["error"] == "No skill sources configured"
+        assert result["sources"] == []
+        # Not `busy`: the router maps busy → 409 (retryable contention) and
+        # everything else → 400, so an unconfigured library must not look busy.
+        assert not result.get("busy")
+
 
 class TestAssignmentProvenance:
     def test_assignment_records_its_source(self, sources_db, tmp_path, monkeypatch):

--- a/tests/unit/test_ent308_inbox_dir_collision.py
+++ b/tests/unit/test_ent308_inbox_dir_collision.py
@@ -32,6 +32,26 @@ import pytest
 
 @pytest.fixture()
 def portal_db(tmp_path, monkeypatch):
+    """Seed the three tables these tests read — WITHOUT assuming an empty DB.
+
+    #2242: this fixture was written for its own temp SQLite file, but `get_engine()`
+    honours `DATABASE_URL`, and the PostgreSQL tier sets it. So on that tier the
+    fixture ran against the tier's ONE shared database and its
+    `insert(users).values(id=1, ...)` hit
+    `UniqueViolation: duplicate key value violates unique constraint "users_pkey"`
+    against a user a previous test had already seeded — a setup error, so the test
+    never even ran. (It reaches that tier at all because the tier selects on
+    `-k "postgres or alembic or migration or dual_backend"` and these test NAMES
+    contain "migration"; that keyword match is incidental, not a dual-backend
+    claim.)
+
+    Fixed in two parts: seed idempotently, and own the rows this fixture's tests
+    actually assert on. The claimant assertions in
+    `test_a_two_claimant_inbox_is_never_migrated` compare an exact tuple, so a
+    leftover `agent_sharing` row for the same agent from an earlier test would
+    break them on a shared database even after the pkey clash is gone — hence the
+    delete at both ends rather than only at teardown.
+    """
     db_file = tmp_path / "trinity-308.db"
     monkeypatch.setenv("TRINITY_DB_PATH", str(db_file))
     import db.connection as conn_mod
@@ -41,14 +61,31 @@ def portal_db(tmp_path, monkeypatch):
     from db.tables import metadata as m, agent_sharing, agent_ownership, users
     m.create_all(get_engine(), tables=[agent_sharing, agent_ownership, users])
 
-    from sqlalchemy import insert
+    from sqlalchemy import delete, insert, select
+
+    def _clear_shares(conn):
+        conn.execute(delete(agent_sharing).where(agent_sharing.c.agent_name == "atlas"))
+
     with get_engine().begin() as conn:
-        conn.execute(insert(users).values(
-            id=1, username="admin", role="admin", email="admin@example.com",
-            created_at="t", updated_at="t"))
-        conn.execute(insert(agent_ownership).values(
-            agent_name="atlas", owner_id=1, created_at="t", is_system=0, deleted_at=None))
+        # Present-or-insert, not insert-and-hope: on a shared database the row may
+        # already be there, and on a private one it never is.
+        if not conn.execute(select(users.c.id).where(users.c.id == 1)).first():
+            conn.execute(insert(users).values(
+                id=1, username="admin", role="admin", email="admin@example.com",
+                created_at="t", updated_at="t"))
+        if not conn.execute(
+            select(agent_ownership.c.agent_name)
+            .where(agent_ownership.c.agent_name == "atlas")
+        ).first():
+            conn.execute(insert(agent_ownership).values(
+                agent_name="atlas", owner_id=1, created_at="t", is_system=0,
+                deleted_at=None))
+        _clear_shares(conn)
+
     yield get_engine()
+
+    with get_engine().begin() as conn:
+        _clear_shares(conn)
 
 
 def _share(engine, agent: str, email: str) -> None:
@@ -173,7 +210,7 @@ def test_migration_check_fails_closed_on_a_db_error(portal_db, monkeypatch):
     assert service._legacy_migration_is_safe("atlas", "solo@example.com") is False
 
 
-def test_migration_is_conditional_inside_the_container(portal_db):
+def test_migration_is_conditional_inside_the_container():
     """The rename is decided in the container, not by a read-then-write from the
     backend: two concurrent requests would otherwise both see 'legacy exists' and
     race. Folded into the listing script so it also costs no extra docker exec.
@@ -192,7 +229,7 @@ def test_migration_is_conditional_inside_the_container(portal_db):
     assert "except OSError" in script, "a failed rename must degrade to an empty listing, not crash"
 
 
-def test_no_legacy_dir_is_passed_when_migration_is_unsafe(portal_db, monkeypatch):
+def test_no_legacy_dir_is_passed_when_migration_is_unsafe():
     """The refusal has to reach the container command, not just the log."""
     from client_portal.service import _inbox_list_cmd, _client_inbox
     import base64 as _b64


### PR DESCRIPTION
Nine failures, none of them a product defect — and every one a test that had quietly stopped asserting its own name. Each fix targets the **current** contract; where the old assertion no longer describes anything real, it is replaced rather than re-mocked.

## 1. Circuit-breaker fast-fail (3)

`#1804` added `await activity_service.close_execution_activity(...)` to `_write_terminal_and_gate`, and the activity double was inlined at **seven** call sites wiring only `track_activity`/`complete_activity` — so the new await got a plain `MagicMock`. One `_activity_double()` factory now serves all seven, so the next seam change is one edit instead of seven silent drifts.

The fast-fail test also now asserts #1804's actual rule — **the CAS winner owns the close**. Restoring the await is not the same as testing it: a fast-fail that writes FAILED and orphans the activity is precisely the bug #1804 fixed, and it would satisfy every other assertion in that test.

## 2. Audit hash chain (2)

`#2015` moved the toggle from an in-process attribute to a durable `system_settings` row. The fixture now creates that table (schema.py's DDL) and wires `set_setting`/`get_setting_value` through a real engine-bound `SettingsOperations` on the same temp DB, plus the real `create_audit_entry_chained`.

Deliberately **not** `get_setting_value.return_value = "true"` — forcing the flag on would bypass the fail-CLOSED reader, which is the behaviour least worth faking (the issue's own technical note). And the chained writer is the real one because the chain head is read *inside* the insert transaction: a stub would have to reimplement the part that makes the chain a chain.

## 3. GitHub PAT propagation (4)

`_propagate_to_agent` lazily runs `from services import git_service`, whose header is `from database import db, AgentGitConfig, GitSyncResult`. A stub carrying only `db` raised `ImportError` **inside** `asyncio.gather(return_exceptions=True)`, so it surfaced as every agent landing in `failed` — four tests named after propagation outcomes were asserting an import failure.

Fixed with the real pydantic models plus one more docker symbol, so the **real** git_service loads and `update_remote_pat`'s signature is genuinely covered. Stubbing git_service itself would have let that drift unnoticed — this issue's own bug class.

**Fixing the import then exposed two things it had been hiding:**

- `assert all("a1" not in str(c) ...)` searched the *whole call repr* for an agent name, and that repr now carries the #1159 `X-Trinity-Agent-Token` — a 64-char HMAC hex containing "a1" about half the time (observed: `...db83a1d7ab65a1a2239d...`). It only looked stable because no request was ever made, so the generator was vacuously true over an empty list. Now it asserts the URL.
- `db` as a blanket MagicMock made `get_git_config(...).github_repo` truthy, so **#1967's eligibility signal silently flipped**: the "skips an agent without GITHUB_PAT" test was exercising the WRITE path while asserting the skip. It now states its condition (no git config), and a **new test** covers the other branch — an agent Trinity manages a repo for gets the line created — which nothing covered before.

## 4. Skills-library sync (1)

ent#237 replaced `skills_library_url` with the `skill_sources` table, so `status["url"]` is `None` on every modern install — *including ones with sources*. The guard `if status.get("url"): skip` stopped firing, sync ran against the migrated source, succeeded, and the test failed asserting 400 against 200.

Swapping the key does not repair it: an API test cannot dictate the target instance's configuration — observed live, `/status` reported `configured: false` moments before `/sync` found an enabled source and cloned it. So:

- the deterministic contract moved to a unit test that owns its configuration: `test_ent237_skill_sources.py::TestSyncBookkeeping::test_sync_with_no_sources_configured_fails_by_name`, asserting the error string the router returns verbatim as `detail`
- the API test now checks what holds on **any** instance: the route degrades by name and never 500s
- its sibling `test_sync_returns_structure_when_configured` gated on the same dead key and had been skipping **unconditionally** — it now gates on `configured`

## 5. PostgreSQL tier (1 error)

`portal_db` was written for its own temp SQLite file, but `get_engine()` honours `DATABASE_URL` and the PG tier sets it — so the fixture seeded `users(id=1)` into the tier's **one shared** database and hit `UniqueViolation: users_pkey` against a user an earlier test had inserted, failing in *setup*.

Seeding is now present-or-insert, and the fixture clears its own `agent_sharing` rows at both ends — the two-claimant test compares an exact tuple, so leftover shares would break it on a shared DB even after the pkey clash was gone. The failing test also **never touched the database at all** (it base64-decodes a shell script), so it and one sibling no longer request the fixture. It reaches that tier only because the tier selects on `-k "…or migration or…"` and these test names contain "migration" — an incidental keyword match, not a dual-backend claim.

## Verification

| what | result |
|---|---|
| all five affected files together | **136 passed** (SQLite + the live instance for the API tier) |
| `test_ent237_skill_sources.py` with the new case | 95 passed |
| **PG cluster, proven the hard way** | reproduced on unfixed `dev` against a deliberately pre-seeded shared PostgreSQL → **3 setup errors**; then **23 passed** on this branch against that same seeded database, **twice in a row** to prove the share-row cleanup |
| `tests/lint_sys_modules.py` | clean — 140/206 baseline, one violation removed |
| `tests/lint_root_test_placement.py` | clean |

Fixes #2242
🤖 Generated with [Claude Code](https://claude.com/claude-code)
