### PR TITLE
fix(git): let repo discovery cross a mount boundary, so a home-rooted repo is found (#2245)

### DIFF
--- a/src/backend/services/git_service.py
+++ b/src/backend/services/git_service.py
@@ -1601,12 +1601,30 @@ async def _git_toplevel(container_name: str) -> Optional[str]:
     otherwise make git refuse to answer and silently drop the caller onto the
     fallback heuristic that this function exists to replace.
 
+    ``GIT_DISCOVERY_ACROSS_FILESYSTEM=1`` because the walk up has a second way to
+    stop that has nothing to do with repositories (#2245): git halts discovery at
+    a filesystem boundary by default, so on an agent whose ``workspace/`` is its
+    own mount — a bind mount, a distinct volume, an overlay — a probe started
+    inside it never reaches a repository rooted at the home directory. Git says so
+    in as many words: *"Stopping at filesystem boundary
+    (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)"*, exit 128. This function would then
+    return None and the caller would fall through to the content heuristic, which
+    answers ``/home/developer/workspace`` for exactly that topology — the
+    misclassification #2075 exists to eliminate, reintroduced by a mount.
+
+    Crossing the boundary is safe here specifically because the containment check
+    below is unchanged: discovery may walk out of the mount, but an answer outside
+    the agent home is still refused before it is trusted. (Carried over from #2076,
+    a competing #2075 fix closed as superseded — this flag was the one thing it had
+    that #2077 did not.)
+
     Returns None when there is no repository at or above the probe point, or
     when git answers with a path outside the agent home (never trusted).
     """
     script = (
         f"start={shlex.quote(LEGACY_WORKSPACE_DIR)}; "
         f'[ -d "$start" ] || start={shlex.quote(AGENT_HOME_DIR)}; '
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM=1 "
         "git -c safe.directory='*' -C \"$start\" rev-parse --show-toplevel "
         "2>/dev/null"
     )

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -2310,6 +2310,18 @@
         "voice"
       ],
       "description": "Portal dictation gate (#2212). `stt_available` is a SEPARATE roster-card bit from `voice_available`: transcription needs only the platform ElevenLabs key, narration additionally needs an effective voice, so the single-bit design could not express \"can dictate, cannot narrate\" — which is why the mic rendered on a pure browser capability check and was a dead control on a provider-less instance. Asserts the truth table in both directions (key without voice → stt yes / tts no; no key → both no, failing closed like `voice_available`), that the model default is absent-not-present so an older payload hides the mic rather than rendering a dead one, and — the load-bearing one — that the card bit and `transcribe_portal_audio`'s own 404 gate are the SAME condition, since drift between what the client sees and what /stt will do IS the dead-control bug. Pure unit: no DB, no HTTP, no ElevenLabs."
+    },
+    {
+      "file": "unit/test_2075_detect_git_dir.py",
+      "feature": "#2075, #2245",
+      "added": "2026-08-17",
+      "categories": [
+        "backend",
+        "unit",
+        "git",
+        "reliability"
+      ],
+      "description": "Repo-root detection for an agent container. #2075: the root was chosen by a CONTENT probe, so any non-empty /home/developer/workspace was declared a legacy repo root even when the repository was rooted at /home/developer — every path-based consumer (compatibility collector, .gitignore migration and its .git guard, compatibility fix endpoint) then read and wrote a subdirectory as if it were the root. Most cases run the REAL probe script the production code emits against real git repos in tmp_path, so the string under test is the shipped one. #2245 adds the filesystem-boundary half: git halts discovery at a mount point unless GIT_DISCOVERY_ACROSS_FILESYSTEM is set, so an agent whose workspace/ is its own mount made a home-rooted repo look absent (exit 128, 'Stopping at filesystem boundary') and fell back to the very heuristic #2075 removed. A unit test cannot create a mount, so the boundary itself was verified in a container and recorded in the file's comments; what is pinned here is the plumbing (a git shim on PATH reports the env var git ACTUALLY received — a static substring check would pass on a script where the assignment landed after a pipe or in the wrong quoting layer) and the containment guard that makes crossing safe (an answer outside the agent home is still refused, asserted over five paths a boundary-crossing walk could now produce)."
     }
   ]
 }

--- a/tests/unit/test_2075_detect_git_dir.py
+++ b/tests/unit/test_2075_detect_git_dir.py
@@ -17,6 +17,7 @@ The shell tests below run the *real* probe script produced by the production
 code against real git repos in a temp directory — the only difference from
 production is the host filesystem vs. the agent container.
 """
+import os
 import shlex
 import subprocess
 import sys
@@ -249,3 +250,145 @@ async def test_successful_probe_skips_the_content_heuristic(monkeypatch):
     with patch.object(gs, "execute_command_in_container", AsyncMock(side_effect=_exec)):
         assert await gs._detect_git_dir("agent-x") == "/home/developer"
     assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# #2245 — a filesystem boundary must not look like "no repository"
+# ---------------------------------------------------------------------------
+#
+# Git stops discovery at a mount point by default, and says so exactly:
+#
+#   fatal: not a git repository (or any parent up to mount point /home/developer)
+#   Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+#
+# So on an agent whose `workspace/` is its own mount (bind mount, distinct
+# volume, overlay), the probe started inside it never reaches a repository rooted
+# at the home directory: `_git_toplevel` returns None, the caller falls through to
+# the content heuristic, and a populated `workspace/` answers
+# `/home/developer/workspace` — the #2075 misclassification, reintroduced by a
+# mount rather than by a heuristic.
+#
+# Verified in the real topology before writing these tests, since a unit test
+# cannot create a mount (user namespaces are unavailable in CI sandboxes and
+# `mount` needs privilege). In a `trinity-agent-base` container with a tmpfs at
+# `/home/developer/workspace` and a repo at `/home/developer`:
+#
+#   st_dev home      : 220
+#   st_dev workspace : 1048621          <- a genuine boundary
+#   pre-fix  probe   : exit=128, "Stopping at filesystem boundary ..."
+#   post-fix probe   : exit=0,   "/home/developer"
+#
+# What is testable here without a mount is the plumbing and the guard: that the
+# variable actually reaches the git process, and that crossing the boundary did
+# not loosen the containment check which is what makes crossing safe.
+
+
+def _git_shim(bin_dir: Path, record: Path) -> None:
+    """A fake `git` that records the environment it was invoked with."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "git"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        f'{{ printf "GIT_DISCOVERY_ACROSS_FILESYSTEM=%s\\n" "${{GIT_DISCOVERY_ACROSS_FILESYSTEM:-<unset>}}";'
+        f'  printf "ARGS=%s\\n" "$*"; }} >> {shlex.quote(str(record))}\n'
+        "echo /home/developer\n"
+    )
+    shim.chmod(0o755)
+
+
+@pytest.mark.asyncio
+async def test_the_probe_exports_the_discovery_flag_to_git(tmp_path, monkeypatch):
+    """The variable must reach the git PROCESS, not merely appear in the script.
+
+    A static substring check would pass on a script where the assignment landed
+    after a pipe, inside the wrong quoting layer, or on the shell rather than on
+    `git` — all of which leave the flag unset where it matters. So this runs the
+    real script with a `git` shim on PATH and reads back the environment git
+    actually saw.
+    """
+    gs = _load_git_service(monkeypatch)
+    record = tmp_path / "env.txt"
+    _git_shim(tmp_path / "bin", record)
+    monkeypatch.setenv("PATH", f"{tmp_path / 'bin'}:{os.environ['PATH']}")
+
+    async def _exec(container_name: str, command: str, timeout: int = 5):
+        proc = subprocess.run(shlex.split(command), capture_output=True, text=True)
+        return {"exit_code": proc.returncode, "output": proc.stdout + proc.stderr}
+
+    with patch.object(gs, "execute_command_in_container", AsyncMock(side_effect=_exec)):
+        assert await gs._git_toplevel("agent-x") == "/home/developer"
+
+    seen = record.read_text()
+    assert "GIT_DISCOVERY_ACROSS_FILESYSTEM=1" in seen, seen
+    # The probe start point is unchanged by the fix: still `workspace/` when it
+    # exists, which is what makes the walk-up (and therefore the boundary) matter.
+    assert "rev-parse --show-toplevel" in seen, seen
+    assert "-C /home/developer/workspace" in seen or "-C /home/developer" in seen, seen
+
+
+@pytest.mark.asyncio
+async def test_crossing_the_boundary_does_not_loosen_containment(monkeypatch):
+    """Discovery may now leave the mount; the answer still may not leave home.
+
+    This is the whole safety argument for the flag, so it is pinned separately
+    from `test_toplevel_outside_agent_home_is_rejected`: crossing a boundary is
+    precisely what lets git return a path from an enclosing tree, so the refusal
+    has to hold for answers that a boundary-crossing walk could now produce.
+    """
+    gs = _load_git_service(monkeypatch)
+
+    for outside in ("/", "/home", "/home/developer-other", "/etc", "/opt/repo"):
+        async def _exec(container_name: str, command: str, timeout: int = 5, _o=outside):
+            assert "GIT_DISCOVERY_ACROSS_FILESYSTEM=1" in command
+            return {"exit_code": 0, "output": f"{_o}\n"}
+
+        with patch.object(gs, "execute_command_in_container", AsyncMock(side_effect=_exec)):
+            assert await gs._git_toplevel("agent-x") is None, outside
+
+
+def test_a_boundary_is_not_evidence_of_a_missing_repo(tmp_path, monkeypatch):
+    """The bug in one assertion: git failing from inside `workspace/` while a
+    home-rooted repo exists must NOT resolve to `workspace/`.
+
+    On the host there is no boundary, so the failure is simulated at the seam git
+    would fail at — a non-zero probe — while the filesystem still holds the
+    home-rooted repo and a populated `workspace/`. Pre-#2245 that combination is
+    what the content heuristic turned into `/home/developer/workspace`; the point
+    of the flag is that the probe no longer fails in the first place, and this
+    records what the wrong answer looked like.
+    """
+    gs = _load_git_service(monkeypatch)
+    home = _make_home(tmp_path)
+    _git(home, "init", "-q")
+    (home / "workspace" / "cache.db").write_text("data")
+
+    # Sanity: with a working probe (no boundary) the real script gets it right.
+    assert _detect_against_fs(gs, home) == str(home)
+
+    # And this is the pre-fix path — kept as documentation of the failure mode
+    # the flag removes, not as an aspiration: a boundary-failed probe still
+    # degrades to the heuristic, which is why the probe must not fail.
+    import asyncio
+
+    async def _boundary_failure(container_name: str, command: str, timeout: int = 5):
+        if "rev-parse" in command:
+            return {"exit_code": 128, "output":
+                    "fatal: not a git repository (or any parent up to mount point "
+                    f"{home})\nStopping at filesystem boundary "
+                    "(GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\n"}
+        return {"exit_code": 0, "output": "1\n"}
+
+    with patch.object(gs, "AGENT_HOME_DIR", str(home)), \
+         patch.object(gs, "LEGACY_WORKSPACE_DIR", str(home / "workspace")), \
+         patch.object(gs, "execute_command_in_container",
+                      AsyncMock(side_effect=_boundary_failure)):
+        degraded = asyncio.run(gs._detect_git_dir("agent-x"))
+    # The literal, not `home / "workspace"`: `_detect_git_dir_fallback` embeds
+    # `/home/developer/workspace` directly rather than reading the module constants
+    # the probe uses, so patching them does not move it. Worth stating — it means
+    # the fallback answers the same path whatever the constants say (harmless in
+    # production, where they agree) and it is why this assertion is spelled out
+    # rather than derived from `home`.
+    assert degraded == "/home/developer/workspace", (
+        "if this ever stops being the fallback's answer, the comment above is stale"
+    )


### PR DESCRIPTION
One flag, plus the tests that make it stick.

## The bug

`_git_toplevel` (#2077, for #2075) starts inside `workspace/` when it exists and asks git to walk up. Git halts repository discovery at a filesystem boundary by default — and says so in as many words:

```
fatal: not a git repository (or any parent up to mount point /home/developer)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

So on an agent whose `workspace/` is its own mount (bind mount, distinct volume, overlay), the probe never reaches a repository rooted at the home directory. `_git_toplevel` returns None, `_detect_git_dir` falls through to the pre-#2075 content heuristic, and a populated `workspace/` answers `/home/developer/workspace` — the exact misclassification #2075 exists to eliminate, reintroduced by a mount instead of by a heuristic. Every path-based consumer then reads and writes a subdirectory as if it were the repo root: the compatibility collector, the #462 `.gitignore` migration *and its `.git` guard*, the compatibility fix endpoint.

Crossing is safe because the containment check is untouched — discovery may walk out of the mount, but an answer outside the agent home is still refused before it is trusted.

## Verified in the real topology, not argued

A unit test cannot create a mount (user namespaces are blocked in the sandbox, `mount` needs privilege), so I built the topology in a `trinity-agent-base` container with a tmpfs at `/home/developer/workspace` and a repo at `/home/developer`:

```
st_dev home      : 220
st_dev workspace : 1048621        <- a genuine boundary
pre-fix  probe   : exit=128, "Stopping at filesystem boundary ..."
post-fix probe   : exit=0,   "/home/developer"
```

Then the **shipped** script, extracted from the source so the string under test is the one that ships:

```
start=/home/developer/workspace; [ -d "$start" ] || start=/home/developer; \
GIT_DISCOVERY_ACROSS_FILESYSTEM=1 git -c safe.directory='*' -C "$start" rev-parse --show-toplevel
-> exit=0 output=[/home/developer]
```

And the direction that must **not** change — a genuinely workspace-rooted legacy repo inside the mounted workspace:

```
legacy workspace-rooted repo still wins: [/home/developer/workspace]
```

So the flag lets the walk continue past a boundary without letting it skip a nearer repository.

## Tests (3 new, in the file the AC names)

- **the plumbing, behaviourally**: a `git` shim on PATH records the environment git *actually received*. A static substring check on the script would pass on a version where the assignment landed after a pipe or inside the wrong quoting layer — both leave the flag unset exactly where it matters.
- **containment, separately pinned**: asserted over five paths a boundary-crossing walk could now produce (`/`, `/home`, `/home/developer-other`, `/etc`, `/opt/repo`), because that guard is the entire safety argument for the flag.
- **the failure mode, documented**: one test records the degraded answer a boundary-failed probe produces, so the comment explaining why the probe must not fail cannot go stale silently.

The container-verified boundary evidence is written into the file's comments, since it is the one part the test suite structurally cannot reproduce.

## Verification

| check | result |
|---|---|
| `test_2075_detect_git_dir.py` + `test_2069_gitignore_at_creation.py` | **40 passed** |
| real mount boundary, container | pre-fix exit 128 → post-fix `/home/developer` |
| legacy workspace-rooted repo | still `/home/developer/workspace` |
| `tests/lint_sys_modules.py` | clean (140/206 baseline, no new) |

Also registered the test file in `tests/registry.json` — a pre-existing omission from #2077, worth closing while adding coverage to it.

Fixes #2245
🤖 Generated with [Claude Code](https://claude.com/claude-code)
