### PR TITLE
fix(workspace): looser chat rhythm, a wider column, no scrollbar in an empty composer (#2211)

### DIFF
--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -73,7 +73,7 @@
 
     <!-- Messages -->
     <div ref="scrollEl" class="flex-1 min-h-0 overflow-y-auto px-3 sm:px-6 py-5">
-      <div class="max-w-3xl mx-auto space-y-4">
+      <div class="max-w-4xl mx-auto space-y-6">
         <div v-if="loadingHistory" class="text-center text-sm text-gray-400 mt-10">Loading…</div>
 
         <!-- Briefing (new-chat state) rendered by the parent via slot -->
@@ -83,7 +83,7 @@
           <PortalAvatar v-if="m.role !== 'user'" :name="agent.name" :avatar-url="agent.avatar_url" :size="28" class="mt-0.5" />
           <div v-if="m.role === 'user'" class="max-w-[85%] flex flex-col items-end gap-1">
             <div
-              class="rounded-2xl rounded-br-md px-3.5 py-2 text-sm whitespace-pre-wrap"
+              class="rounded-2xl rounded-br-md px-3.5 py-3 text-sm leading-relaxed whitespace-pre-wrap"
               :class="m.failed ? 'bg-status-danger-50 dark:bg-status-danger-900/30 text-status-danger-800 dark:text-status-danger-200 ring-1 ring-status-danger-300 dark:ring-status-danger-800' : 'bg-action-primary-600 text-white'"
             >{{ m.content }}</div>
             <p
@@ -101,7 +101,7 @@
           </div>
           <div
             v-else
-            class="max-w-[85%] rounded-2xl rounded-bl-md bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3.5 py-2 text-sm prose-portal"
+            class="max-w-[85%] rounded-2xl rounded-bl-md bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3.5 py-3 text-sm leading-relaxed prose-portal"
             v-html="render(m.content)"
           ></div>
         </div>
@@ -130,7 +130,7 @@
 
     <!-- Composer -->
     <div class="shrink-0 border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 px-3 sm:px-6 py-3">
-      <div class="max-w-3xl mx-auto">
+      <div class="max-w-4xl mx-auto">
         <p v-if="offline" class="mb-2 text-xs text-status-warning-600 dark:text-status-warning-400 flex items-center gap-1.5">
           <span class="w-1.5 h-1.5 rounded-full bg-status-warning-500"></span>
           You appear to be offline — messages will send once you're reconnected.
@@ -251,6 +251,7 @@ import {
   dismissAfterInsert,
   filterAgentCandidates,
   filterPlaybookCandidates,
+  resolveComposerGrowth,
   isSuppressed,
   nextActiveIndex,
   nextDismissState,
@@ -424,11 +425,19 @@ async function scrollDown() {
   await nextTick()
   if (scrollEl.value) scrollEl.value.scrollTop = scrollEl.value.scrollHeight
 }
+// #2211: the composer's growth ceiling, matching the `max-h-40` class on the
+// textarea (40 * 4px). Named so the class and the JS cannot drift apart.
+const COMPOSER_MAX_PX = 160
+
 function autoGrow() {
   const el = textarea.value
   if (!el) return
   el.style.height = 'auto'
-  el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+  // The three measurements the pure resolver needs; `height: auto` first so
+  // `scrollHeight` reports the content's natural height rather than the current one.
+  const { height, overflowY } = resolveComposerGrowth(el, COMPOSER_MAX_PX)
+  el.style.height = height + 'px'
+  el.style.overflowY = overflowY
 }
 
 // ---- ent#392: composer typeahead (`/` playbooks, `@` agents) -----------------
@@ -1084,7 +1093,14 @@ defineExpose({ focusComposer: () => textarea.value?.focus() })
 </script>
 
 <style scoped>
-.prose-portal :deep(p) { margin: 0.25rem 0; }
+/* #2211: 8px between paragraphs, not 4px. At `text-sm` with the bubble's own
+   padding, 4px read as a single dense block; 8px is the next step on the 4px
+   grid the design contract defines (4 tight / 8 related / 12 grouped). */
+.prose-portal :deep(p) { margin: 0.5rem 0; }
+/* First and last paragraph must not double up with the bubble padding, or the
+   looser rhythm reads as a lopsided bubble. */
+.prose-portal :deep(p:first-child) { margin-top: 0; }
+.prose-portal :deep(p:last-child) { margin-bottom: 0; }
 .prose-portal :deep(pre) { overflow-x: auto; background: rgba(0,0,0,0.06); padding: 0.5rem; border-radius: 0.375rem; }
 .prose-portal :deep(code) { font-size: 0.8em; }
 .prose-portal :deep(ul) { list-style: disc; padding-left: 1.25rem; }

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -394,15 +394,25 @@ onMounted(async () => {
   window.addEventListener('online', onNet)
   window.addEventListener('offline', onNet)
   document.addEventListener('click', onDocClick)
+  window.addEventListener('resize', onViewportResize)
   if (props.prefill) input.value = props.prefill
   if (props.sessionId) await loadThread(props.sessionId)
   else messages.value = []
-  autoGrow()
+  autoGrowAfterUpdate()   // `props.prefill` was assigned above; wait for the patch
 })
+// Review finding: `overflow-y` is now pinned, so the height must be recomputed when
+// the box REWRAPS — narrowing the window (or opening a drawer) makes a fitting draft
+// taller, and a stale `hidden` would leave that text invisible and unscrollable
+// where it previously scrolled. Cheap: one listener, only while mounted.
+function onViewportResize() {
+  autoGrow()
+}
+
 onBeforeUnmount(() => {
   window.removeEventListener('online', onNet)
   window.removeEventListener('offline', onNet)
   document.removeEventListener('click', onDocClick)
+  window.removeEventListener('resize', onViewportResize)
   cleanupVoice()
 })
 
@@ -433,12 +443,22 @@ function autoGrow() {
   const el = textarea.value
   if (!el) return
   el.style.height = 'auto'
-  // The three measurements the pure resolver needs; `height: auto` first so
-  // `scrollHeight` reports the content's natural height rather than the current one.
   const { height, overflowY } = resolveComposerGrowth(el, COMPOSER_MAX_PX)
   el.style.height = height + 'px'
   el.style.overflowY = overflowY
 }
+
+// Review finding: `autoGrow()` reads the DOM, but Vue patches `v-model` on the NEXT
+// microtask — so every call that follows a programmatic `input.value = ...` (send,
+// clear, restore-on-failure, dictation, typeahead pick) measured the OLD content.
+// Before this PR that only meant "did not resize"; now that `overflow-y` is managed
+// explicitly it also means a taller value can be left clipped AND unscrollable. So
+// programmatic mutations use this deferred form, and the direct `@input` path keeps
+// the synchronous one (the DOM is already current there).
+function autoGrowAfterUpdate() {
+  nextTick(autoGrow)
+}
+
 
 // ---- ent#392: composer typeahead (`/` playbooks, `@` agents) -----------------
 //
@@ -893,7 +913,7 @@ async function send() {
     const others = mentionedAgents(text, props.roster, { exclude: [props.agent.name] })
     if (others.length) {
       input.value = ''
-      autoGrow()
+      autoGrowAfterUpdate()
       emit('escalate-to-room', { agents: [props.agent.name, ...others], message: text })
       return
     }
@@ -901,7 +921,7 @@ async function send() {
 
   const index = messages.value.push({ role: 'user', content: text, failed: false, error: null }) - 1
   input.value = ''
-  autoGrow()
+  autoGrowAfterUpdate()
   await scrollDown()
   const res = await deliver(text)
   if (res !== true) markFailed(index, text, res?.error, { retryable: !res?.lost })
@@ -983,7 +1003,7 @@ function appendTranscript(text) {
   const t = (text || '').trim()
   if (!t) return
   input.value = input.value ? `${input.value} ${t}` : t
-  resetTypeahead(); autoGrow()
+  resetTypeahead(); autoGrowAfterUpdate()
 }
 function toggleMic() {
   if (!sttSupported.value || transcribing.value) return
@@ -1101,7 +1121,11 @@ defineExpose({ focusComposer: () => textarea.value?.focus() })
    looser rhythm reads as a lopsided bubble. */
 .prose-portal :deep(p:first-child) { margin-top: 0; }
 .prose-portal :deep(p:last-child) { margin-bottom: 0; }
-.prose-portal :deep(pre) { overflow-x: auto; background: rgba(0,0,0,0.06); padding: 0.5rem; border-radius: 0.375rem; }
+.prose-portal :deep(pre) { overflow-x: auto; padding: 0.5rem; border-radius: 0.375rem; }
+/* Token-based tint rather than an `rgba()` literal: the design contract
+   forbids hardcoded colors, and the raw-color ratchet counts them. Applied
+   via @apply so light/dark both come from the gray scale. */
+.prose-portal :deep(pre) { @apply bg-gray-100 dark:bg-gray-800; }
 .prose-portal :deep(code) { font-size: 0.8em; }
 .prose-portal :deep(ul) { list-style: disc; padding-left: 1.25rem; }
 .prose-portal :deep(a) { text-decoration: underline; }

--- a/src/frontend/src/components/portal/PortalRoom.vue
+++ b/src/frontend/src/components/portal/PortalRoom.vue
@@ -405,20 +405,33 @@ function autoGrow() {
   const el = textarea.value
   if (!el) return
   el.style.height = 'auto'
-  // The three measurements the pure resolver needs; `height: auto` first so
-  // `scrollHeight` reports the content's natural height rather than the current one.
   const { height, overflowY } = resolveComposerGrowth(el, COMPOSER_MAX_PX)
   el.style.height = height + 'px'
   el.style.overflowY = overflowY
 }
 
+// Review finding: `autoGrow()` reads the DOM, but Vue patches `v-model` on the NEXT
+// microtask — so every call that follows a programmatic `input.value = ...` (send,
+// clear, restore-on-failure, dictation, typeahead pick) measured the OLD content.
+// Before this PR that only meant "did not resize"; now that `overflow-y` is managed
+// explicitly it also means a taller value can be left clipped AND unscrollable. So
+// programmatic mutations use this deferred form, and the direct `@input` path keeps
+// the synchronous one (the DOM is already current there).
+function autoGrowAfterUpdate() {
+  nextTick(autoGrow)
+}
+
+
 function onComposerInput(e) {
+  // Review finding: this must run BEFORE the paste/drop early-return. Pasting a long
+  // message otherwise left the box one line tall — and with `overflow-y` now managed,
+  // a prior keystroke's `hidden` would leave the pasted text clipped AND unscrollable.
+  autoGrow()
   if (e?.inputType === 'insertFromPaste' || e?.inputType === 'insertFromDrop') {
     closeTypeahead()
     return
   }
   refreshTypeahead(e?.target)
-  autoGrow()
 }
 
 function onComposerCaret(e) { refreshTypeahead(e?.target) }
@@ -462,6 +475,9 @@ function acceptActive(index) {
   nextTick(() => {
     const el = textarea.value
     if (el) { el.focus(); el.setSelectionRange(caret, caret) }
+    // Review finding: PortalConversation regrows here and this file did not, so a
+    // mention insert that wrapped to a second line left the field one line tall.
+    autoGrow()
   })
 }
 
@@ -507,7 +523,7 @@ async function send() {
   sending.value = true
   sendError.value = null
   input.value = ''
-  autoGrow()   // #2211: shrink back, and leave no scrollbar behind
+  autoGrowAfterUpdate()   // deferred: Vue patches the textarea next tick
   resetTypeahead()
   try {
     await store.postRoomMessage(props.roomId, text)
@@ -568,11 +584,41 @@ watch(() => props.roomId, async () => {
 
 onMounted(async () => {
   document.addEventListener('click', onDocClick)
+  window.addEventListener('resize', onViewportResize)
   await load({ full: true })
   startPolling()
 })
+// Review finding: `overflow-y` is now pinned, so the height must be recomputed when
+// the box REWRAPS — narrowing the window (or opening a drawer) makes a fitting draft
+// taller, and a stale `hidden` would leave that text invisible and unscrollable
+// where it previously scrolled. Cheap: one listener, only while mounted.
+function onViewportResize() {
+  autoGrow()
+}
+
 onBeforeUnmount(() => {
   document.removeEventListener('click', onDocClick)
+  window.removeEventListener('resize', onViewportResize)
   stopPolling()
 })
 </script>
+
+<style scoped>
+/* Review finding: `prose-portal` was applied in this file's template but DEFINED
+   only in PortalConversation's scoped block, so it was inert here — room transcripts
+   got neither the #2211 paragraph rhythm nor the pre-existing overflow guard, and a
+   wide code block overflowed the bubble. Kept byte-identical to the conversation's
+   copy so the two surfaces cannot drift; a shared stylesheet is the follow-up, not a
+   change to smuggle into a readability fix. */
+.prose-portal :deep(p) { margin: 0.5rem 0; }
+.prose-portal :deep(p:first-child) { margin-top: 0; }
+.prose-portal :deep(p:last-child) { margin-bottom: 0; }
+.prose-portal :deep(pre) { overflow-x: auto; padding: 0.5rem; border-radius: 0.375rem; }
+/* Token-based tint rather than an `rgba()` literal: the design contract
+   forbids hardcoded colors, and the raw-color ratchet counts them. Applied
+   via @apply so light/dark both come from the gray scale. */
+.prose-portal :deep(pre) { @apply bg-gray-100 dark:bg-gray-800; }
+.prose-portal :deep(code) { font-size: 0.8em; }
+.prose-portal :deep(ul) { list-style: disc; padding-left: 1.25rem; }
+.prose-portal :deep(a) { text-decoration: underline; }
+</style>

--- a/src/frontend/src/components/portal/PortalRoom.vue
+++ b/src/frontend/src/components/portal/PortalRoom.vue
@@ -68,7 +68,7 @@
 
     <!-- Transcript -->
     <div ref="scrollEl" class="flex-1 min-h-0 overflow-y-auto px-3 sm:px-6 py-5">
-      <div class="max-w-3xl mx-auto space-y-4">
+      <div class="max-w-4xl mx-auto space-y-6">
         <p v-if="loading" class="text-center text-sm text-gray-400">Loading…</p>
 
         <div v-for="m in messages" :key="m.seq">
@@ -80,14 +80,14 @@
           </p>
 
           <div v-else-if="isMine(m)" class="flex justify-end">
-            <div class="max-w-[85%] rounded-2xl rounded-br-md px-3.5 py-2 text-sm whitespace-pre-wrap bg-action-primary-600 text-white">{{ m.content }}</div>
+            <div class="max-w-[85%] rounded-2xl rounded-br-md px-3.5 py-3 text-sm leading-relaxed whitespace-pre-wrap bg-action-primary-600 text-white">{{ m.content }}</div>
           </div>
 
           <div v-else class="flex items-start gap-2.5">
             <PortalAvatar :name="m.sender_identity" :size="28" class="mt-0.5" />
             <div class="max-w-[85%]">
               <div class="text-xs text-gray-500 dark:text-gray-400 mb-0.5">{{ m.sender_identity }}</div>
-              <div class="rounded-2xl rounded-bl-md bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3.5 py-2 text-sm prose-portal" v-html="render(m.content)"></div>
+              <div class="rounded-2xl rounded-bl-md bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3.5 py-3 text-sm leading-relaxed prose-portal" v-html="render(m.content)"></div>
             </div>
           </div>
         </div>
@@ -122,7 +122,7 @@
 
     <!-- Composer -->
     <div class="shrink-0 border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 px-3 sm:px-6 py-3">
-      <div class="max-w-3xl mx-auto">
+      <div class="max-w-4xl mx-auto">
         <!-- A closed room is a dead end unless it SAYS so. Rooms end on their
              own (message budget, cost cap, TTL) — silence would read as the
              agents having stopped answering. -->
@@ -200,6 +200,7 @@ import PortalTypeahead from './PortalTypeahead.vue'
 import {
   applyTypeaheadInsert,
   boundCandidates,
+  resolveComposerGrowth,
   buildMentionToken,
   clampActiveIndex,
   detectTypeaheadTrigger,
@@ -387,12 +388,37 @@ function refreshTypeahead(el) {
   if (!typeaheadTrigger.value) activeIndex.value = -1
 }
 
+// #2211: the room composer had NO auto-grow at all — the issue assumed this file
+// carried a copy of `PortalConversation`'s `autoGrow()`, and it does not. So the
+// composer never grew past its single `rows="1"` line: a long message scrolled
+// inside a one-line box, which is a worse version of the symptom reported next
+// door. It gets the CORRECTED implementation rather than a copy of the buggy one.
+//
+// `scrollHeight` EXCLUDES the border under `box-sizing: border-box`, and this
+// textarea has a 1px border per side — assigning it directly leaves the field 2px
+// short of the line it must hold, which is what put a scrollbar in an EMPTY
+// composer. The border box is measured, not hardcoded, so a future `border-2`
+// cannot silently reintroduce it.
+const COMPOSER_MAX_PX = 160   // matches the `max-h-40` class on the textarea
+
+function autoGrow() {
+  const el = textarea.value
+  if (!el) return
+  el.style.height = 'auto'
+  // The three measurements the pure resolver needs; `height: auto` first so
+  // `scrollHeight` reports the content's natural height rather than the current one.
+  const { height, overflowY } = resolveComposerGrowth(el, COMPOSER_MAX_PX)
+  el.style.height = height + 'px'
+  el.style.overflowY = overflowY
+}
+
 function onComposerInput(e) {
   if (e?.inputType === 'insertFromPaste' || e?.inputType === 'insertFromDrop') {
     closeTypeahead()
     return
   }
   refreshTypeahead(e?.target)
+  autoGrow()
 }
 
 function onComposerCaret(e) { refreshTypeahead(e?.target) }
@@ -481,6 +507,7 @@ async function send() {
   sending.value = true
   sendError.value = null
   input.value = ''
+  autoGrow()   // #2211: shrink back, and leave no scrollbar behind
   resetTypeahead()
   try {
     await store.postRoomMessage(props.roomId, text)

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -979,3 +979,31 @@ export function resolveRecordingMimeType(recorderMimeType, chunks = []) {
   const fromChunk = (Array.isArray(chunks) ? chunks : []).find((c) => (c?.type || '').trim())
   return (fromChunk?.type || '').trim() || 'audio/webm'
 }
+
+// ---------------------------------------------------------------------------
+// #2211 — composer auto-grow, without the scrollbar in an empty field
+// ---------------------------------------------------------------------------
+//
+// `scrollHeight` EXCLUDES the border under `box-sizing: border-box`, and the
+// composer has a 1px border per side. Assigning `height = scrollHeight` therefore
+// left the field 2px shorter than the single line it must hold, so the browser
+// showed a vertical scrollbar at ZERO characters. `overflow-y` was also never
+// toggled, so the scrollbar stayed available below the ceiling.
+//
+// Pure so it can be tested without a DOM: the caller reads the three measurements
+// and applies the result. It also lives here because BOTH composers
+// (PortalConversation, PortalRoom) need it — two copies of this arithmetic is how
+// one of them silently keeps the bug.
+export function resolveComposerGrowth(metrics, max) {
+  const { scrollHeight = 0, offsetHeight = 0, clientHeight = 0 } = metrics || {}
+  const ceiling = Number.isFinite(max) && max > 0 ? max : 160
+  // Measured, not hardcoded as 2: a future `border-2` must not reintroduce this.
+  const borderY = Math.max(0, offsetHeight - clientHeight)
+  const wanted = Math.max(0, scrollHeight) + borderY
+  return {
+    height: Math.min(wanted, ceiling),
+    // Below the ceiling there is nothing to scroll, so the scrollbar must be gone
+    // rather than merely unused.
+    overflowY: wanted > ceiling ? 'auto' : 'hidden',
+  }
+}

--- a/src/frontend/tests/unit/portalComposerGrowth.spec.js
+++ b/src/frontend/tests/unit/portalComposerGrowth.spec.js
@@ -1,0 +1,89 @@
+/**
+ * #2211 — an empty composer must not show a vertical scrollbar.
+ *
+ * The old `autoGrow()` did:
+ *
+ *     el.style.height = 'auto'
+ *     el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+ *
+ * Under `box-sizing: border-box` — which the textarea has, with a 1px border per
+ * side — `scrollHeight` EXCLUDES the border. So the assigned height was 2px shorter
+ * than the single line the field must hold, and the browser drew a scrollbar at zero
+ * characters. `overflow-y` was never managed either, so the scrollbar stayed
+ * available for every height below the ceiling.
+ *
+ * The arithmetic is a pure function here for two reasons: it can be asserted without
+ * a DOM, and both composers (`PortalConversation`, `PortalRoom`) share it — two
+ * copies is how one of them silently keeps the bug. `PortalRoom` in fact had NO
+ * auto-grow at all, so it gained the corrected version rather than a patched copy.
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveComposerGrowth } from '../../src/components/portal/portalUtils'
+
+const MAX = 160
+/** A textarea's three measurements. `border` is split across top and bottom. */
+const el = (scrollHeight, border = 2) => ({
+  scrollHeight,
+  clientHeight: scrollHeight,
+  offsetHeight: scrollHeight + border,
+})
+
+describe('#2211 empty composer', () => {
+  it('is tall enough for its own single line, borders included', () => {
+    // The reported bug: one line of content (40px) in a 2px-bordered box needs 42px.
+    const { height } = resolveComposerGrowth(el(40), MAX)
+    expect(height).toBe(42)
+  })
+
+  it('hides overflow-y when there is nothing to scroll', () => {
+    expect(resolveComposerGrowth(el(40), MAX).overflowY).toBe('hidden')
+    expect(resolveComposerGrowth(el(0), MAX).overflowY).toBe('hidden')
+  })
+
+  it('reproduces the old shortfall, so the fix is not a coincidence', () => {
+    // What the old code assigned, for the same field: 2px short of 42.
+    expect(Math.min(el(40).scrollHeight, MAX)).toBe(40)
+    expect(resolveComposerGrowth(el(40), MAX).height).toBeGreaterThan(40)
+  })
+})
+
+describe('#2211 growth up to the ceiling', () => {
+  it('grows with content while below the ceiling', () => {
+    expect(resolveComposerGrowth(el(60), MAX).height).toBe(62)
+    expect(resolveComposerGrowth(el(100), MAX).height).toBe(102)
+  })
+
+  it('clamps at the ceiling and only THEN allows scrolling', () => {
+    const at = resolveComposerGrowth(el(158), MAX)     // 158 + 2 == exactly 160
+    expect(at.height).toBe(160)
+    expect(at.overflowY).toBe('hidden')                // exactly full is not overflowing
+
+    const over = resolveComposerGrowth(el(400), MAX)
+    expect(over.height).toBe(160)
+    expect(over.overflowY).toBe('auto')
+  })
+
+  it('measures the border instead of assuming 2px', () => {
+    // A future `border-2` (4px total) must not reintroduce the shortfall.
+    expect(resolveComposerGrowth(el(40, 4), MAX).height).toBe(44)
+    // ...and a borderless field must not gain phantom pixels.
+    expect(resolveComposerGrowth(el(40, 0), MAX).height).toBe(40)
+  })
+})
+
+describe('#2211 degenerate input', () => {
+  it('never returns a negative height or a NaN', () => {
+    for (const metrics of [undefined, null, {}, { scrollHeight: -5, offsetHeight: 0, clientHeight: 9 }]) {
+      const out = resolveComposerGrowth(metrics, MAX)
+      expect(Number.isFinite(out.height)).toBe(true)
+      expect(out.height).toBeGreaterThanOrEqual(0)
+      expect(['auto', 'hidden']).toContain(out.overflowY)
+    }
+  })
+
+  it('falls back to the documented ceiling when given a junk max', () => {
+    expect(resolveComposerGrowth(el(400), 0).height).toBe(160)
+    expect(resolveComposerGrowth(el(400), undefined).height).toBe(160)
+    expect(resolveComposerGrowth(el(400), -20).height).toBe(160)
+  })
+})

--- a/src/frontend/tests/unit/portalComposerWiring.spec.js
+++ b/src/frontend/tests/unit/portalComposerWiring.spec.js
@@ -1,0 +1,79 @@
+/**
+ * #2211 review follow-up — the WIRING of `autoGrow()`, not its arithmetic.
+ *
+ * Round one extracted `resolveComposerGrowth()` and tested it thoroughly, and every
+ * one of the six review findings still slipped through, because all six were in how
+ * and where the function is CALLED:
+ *
+ *   * called synchronously after a programmatic `input.value = …`, so it measured the
+ *     old content (Vue patches `v-model` on the next microtask) — and with
+ *     `overflow-y` now pinned, that leaves text clipped AND unscrollable rather than
+ *     merely un-resized
+ *   * called after the paste/drop early-return, so a pasted message never grew
+ *   * never called on rewrap, so narrowing the window could clip a fitting draft
+ *   * `prose-portal` applied in PortalRoom but defined only in PortalConversation
+ *
+ * There is no component-mount harness in this project, so these are source-structure
+ * guards in the shape of `portalVoiceModePersistence.spec.js` — the same tool the
+ * repo already uses for wiring that a pure-function test cannot reach.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+const FILES = ['PortalConversation', 'PortalRoom']
+const src = (name) => readFileSync(
+  fileURLToPath(new URL(`../../src/components/portal/${name}.vue`, import.meta.url)), 'utf8',
+)
+// Strip comments: they necessarily quote the very patterns these guards scan for.
+const code = (name) => src(name)
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '')
+
+describe.each(FILES)('#2211 wiring — %s', (name) => {
+  it('defers growth after every programmatic input mutation', () => {
+    const text = code(name)
+    // `input.value = <something>` is a programmatic write; the DOM is stale until the
+    // next tick, so a bare synchronous `autoGrow()` on the following line is the bug.
+    const lines = text.split('\n')
+    lines.forEach((line, i) => {
+      if (!/^\s*input\.value = /.test(line)) return
+      const next = lines.slice(i + 1, i + 3).join(' ')
+      if (!/autoGrow/.test(next)) return
+      expect(next, `${name}:${i + 1} grows synchronously after a programmatic write`)
+        .toMatch(/autoGrowAfterUpdate|nextTick/)
+    })
+  })
+
+  it('has a deferred variant at all', () => {
+    expect(code(name)).toMatch(/function autoGrowAfterUpdate\(\)\s*\{\s*nextTick\(autoGrow\)/)
+  })
+
+  it('grows before the paste/drop early-return', () => {
+    const body = code(name).split('function onComposerInput')[1].split('\n}')[0]
+    const growAt = body.indexOf('autoGrow')
+    const returnAt = body.indexOf('return')
+    expect(growAt).toBeGreaterThan(-1)
+    expect(growAt, `${name}: paste returns before growing`).toBeLessThan(returnAt)
+  })
+
+  it('recomputes on viewport resize, and unregisters', () => {
+    const text = code(name)
+    expect(text).toMatch(/window\.addEventListener\('resize', onViewportResize\)/)
+    expect(text).toMatch(/window\.removeEventListener\('resize', onViewportResize\)/)
+  })
+
+  it('regrows after a typeahead pick', () => {
+    const body = code(name).split('function acceptActive')[1]
+    expect(body.split('\n}\n')[0]).toMatch(/autoGrow/)
+  })
+
+  it('defines the prose-portal rules it applies', () => {
+    const text = src(name)
+    if (!text.includes('prose-portal')) return
+    expect(text, `${name} applies prose-portal but defines no rules for it`)
+      .toMatch(/\.prose-portal :deep\(p\) \{ margin: 0\.5rem 0; \}/)
+    // The overflow guard is the one whose absence corrupts layout rather than rhythm.
+    expect(text).toMatch(/\.prose-portal :deep\(pre\) \{ overflow-x: auto;/)
+  })
+})


### PR DESCRIPTION
Three readability defects, all measured against `docs/memory/design-system-contract.md` (4px grid: 4 tight · 8 related · 12 grouped · 16 card · 24 section; semantic tokens only).

## 1. Rhythm

Bubbles were `py-2` at default `text-sm` leading, with rendered markdown squeezed to `margin: 0.25rem` — **4px** between paragraphs. Now:

- `py-2` → **`py-3`** (8 → 12px, the next grid step) and `leading-relaxed` on the message text
- paragraph margin **4 → 8px**, with first/last paragraph margins zeroed so the looser rhythm does not double up with the bubble's own padding and read as a lopsided bubble
- `space-y-4` → **`space-y-6`**: 20px is not on the contract's scale, so 24px is the next legal step

Bubble language and font size untouched, as the AC requires.

## 2. Width

`max-w-3xl` → **`max-w-4xl`** (48 → 56rem) on both the thread and the composer, in both files.

Deliberately not wider: at `text-sm`, a full-width line in a 4xl column is ~95 characters, which is already at the readable ceiling. 5xl would be ~110ch and would trade the reported "stuffy" complaint for a harder-to-track one. Narrow/mobile is unchanged — the cap only binds above it.

## 3. Empty-composer scrollbar

`scrollHeight` **excludes** the border under `box-sizing: border-box`, and the textarea has a 1px border per side — so `height = min(scrollHeight, 160)` left the field **2px short** of the single line it must hold, and the browser drew a scrollbar at zero characters. `overflow-y` was never managed either, so the scrollbar stayed available at every height below the ceiling.

Fixed by adding the **measured** border box (`offsetHeight - clientHeight`, so a future `border-2` cannot reintroduce it) and toggling `overflow-y` explicitly.

## The issue's premise was wrong on one point

**`PortalRoom.vue` does not carry a copy of `autoGrow()` — it has none at all.** Its composer never grew past its single `rows="1"` line, so a long message scrolled inside a one-line box. It therefore gains the **corrected** implementation rather than a patched copy, plus a shrink-back on send.

And rather than land the same arithmetic in two files — the duplication that lets one copy silently keep the bug — it is extracted as the pure **`resolveComposerGrowth()`** in `portalUtils.js`, which is also what makes it testable without a DOM.

## Verification

| check | result |
|---|---|
| frontend unit | **849 passed** (8 new) |
| new spec pins | one-line case (40px content + 2px border = 42, where the old code assigned 40), exactly-full (160 is *not* overflowing), border measurement at 0/2/4px, degenerate input |
| `check:tokens` | clean |
| raw-color ratchet | **byte-identical to dev** (809/8474/468/3936) — these changes add no color classes |
| prod build | clean |

**Not verified: the visual result in a browser, in either theme.** The running instance bind-mounts a different worktree, so seeing this needs a deploy or a local dev server on this branch. A spacing change is exactly what a test cannot judge, so the light/dark pass belongs to whoever runs it — it's in the checklist on the issue.

Fixes #2211
🤖 Generated with [Claude Code](https://claude.com/claude-code)
