### PR TITLE
fix(workspace): align the composer buttons to the input, not to its wrapper (#2259)

### DIFF
--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -166,9 +166,17 @@
         </div>
         <form class="flex items-end gap-2" @submit.prevent="send">
           <input ref="fileInput" type="file" class="hidden" @change="onPickFile" />
+          <!-- #2259: the composer's action buttons are `h-11 w-11` (44px, on the
+               4px grid) rather than `p-2.5` around a 20px icon (40px, off it).
+               `items-end` pins them to the bottom so they stay beside the LAST
+               line as the field grows, and at 44px against the 46px single-line
+               composer the icon's centre lands within 1px of the text line in
+               both states. Sizing the box explicitly (instead of padding an
+               icon) also keeps the three buttons identical when one of them
+               swaps its glyph. -->
           <button
             type="button"
-            class="shrink-0 p-2.5 rounded-xl text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+            class="shrink-0 h-11 w-11 flex items-center justify-center rounded-xl text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
             title="Attach a file for the agent"
             @click="fileInput?.click()"
           >
@@ -177,7 +185,7 @@
           <button
             v-if="sttSupported"
             type="button"
-            class="shrink-0 p-2.5 rounded-xl transition disabled:opacity-50"
+            class="shrink-0 h-11 w-11 flex items-center justify-center rounded-xl transition disabled:opacity-50"
             :class="listening ? 'text-status-danger-600 dark:text-status-danger-400 animate-pulse' : 'text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'"
             :title="micTitle"
             :aria-label="micTitle"
@@ -191,7 +199,16 @@
                wrapper is new. It must inherit the flex sizing the textarea used
                to carry (`flex-1 min-w-0`) — a bare `relative` div collapses the
                field to content width — and it deliberately carries no z-index,
-               so it creates no stacking context of its own. -->
+               so it creates no stacking context of its own.
+
+               #2259: it must ALSO not be taller than the textarea it wraps. A
+               `<textarea>` is inline-block, so inside this block wrapper it sat
+               on the baseline and the line box reserved 6px of descender space
+               below it. `items-end` aligns the flex ITEM — this wrapper — so the
+               buttons bottom-aligned to that dead space and Send hung 6px below
+               the visible input edge. The `block` on the textarea removes the
+               line box entirely; it also re-anchors the typeahead's
+               `absolute bottom-full` to the real field. Do not drop it. -->
           <div ref="composerWrap" class="relative flex-1 min-w-0">
             <PortalTypeahead
               v-if="typeaheadOpen"
@@ -209,7 +226,7 @@
               v-model="input"
               rows="1"
               :placeholder="composerPlaceholder"
-              class="w-full resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
+              class="block w-full resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
               @input="onComposerInput"
               @keydown="onComposerKeydown"
               @click="onComposerCaret"
@@ -218,7 +235,7 @@
           </div>
           <button
             type="submit"
-            class="shrink-0 p-2.5 rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-40 disabled:hover:bg-action-primary-600 transition"
+            class="shrink-0 h-11 w-11 flex items-center justify-center rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-40 disabled:hover:bg-action-primary-600 transition"
             :disabled="sending || !input.trim()"
             title="Send"
           >

--- a/src/frontend/src/components/portal/PortalRoom.vue
+++ b/src/frontend/src/components/portal/PortalRoom.vue
@@ -132,7 +132,14 @@
         <form v-else class="flex items-end gap-2" @submit.prevent="send">
           <!-- ent#392: `@` typeahead over the room's WAKE-SET. Same anchored
                wrapper as the 1:1 composer; it must carry the flex sizing the
-               textarea used to hold, or the field collapses to content width. -->
+               textarea used to hold, or the field collapses to content width.
+
+               #2259: and the same `block` on the textarea. A `<textarea>` is
+               inline-block, so in this block wrapper it sat on the baseline and
+               the line box reserved 6px below it; `items-end` then aligned Send
+               to that dead space instead of to the visible input edge. Twin of
+               PortalConversation — the two composers are the same markup in two
+               files, so a fix landing in only one silently keeps the bug. -->
           <div ref="composerWrap" class="relative flex-1 min-w-0">
             <PortalTypeahead
               v-if="typeaheadOpen"
@@ -149,7 +156,7 @@
               v-model="input"
               rows="1"
               :placeholder="placeholder"
-              class="w-full resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
+              class="block w-full resize-none rounded-2xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm px-4 py-2.5 leading-6 focus:ring-2 focus:ring-action-primary-500/40 focus:border-action-primary-500 focus:outline-none max-h-40"
               @keydown="onComposerKeydown"
               @input="onComposerInput"
               @click="onComposerCaret"
@@ -158,7 +165,7 @@
           </div>
           <button
             type="submit"
-            class="shrink-0 p-2.5 rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-40 transition"
+            class="shrink-0 h-11 w-11 flex items-center justify-center rounded-xl bg-action-primary-600 hover:bg-action-primary-700 text-white disabled:opacity-40 transition"
             :disabled="!input.trim() || sending"
             title="Send"
           >
@@ -580,12 +587,23 @@ watch(() => props.roomId, async () => {
   loading.value = true
   resetTypeahead()
   await load({ full: true })
+  // Same reason as on mount: switching rooms can swap a closed room for an open
+  // one, which mounts a fresh textarea that has never been measured.
+  autoGrowAfterUpdate()
 })
 
 onMounted(async () => {
   document.addEventListener('click', onDocClick)
   window.addEventListener('resize', onViewportResize)
   await load({ full: true })
+  // #2259: and only NOW — the composer sits behind `v-if="!isClosed"`, so before
+  // the room resolves there is no textarea to measure and an eager call would
+  // silently no-op on the null ref. Without this the field mounts with `overflow-y`
+  // still at its stylesheet `auto`: the very state #2211 replaced with an explicit
+  // `hidden` ("the scrollbar must be gone rather than merely unused"). It is
+  // invisible at rest only because the untouched `rows="1"` box happens to fit its
+  // one line — a coincidence, not the contract.
+  autoGrowAfterUpdate()
   startPolling()
 })
 // Review finding: `overflow-y` is now pinned, so the height must be recomputed when

--- a/src/frontend/tests/unit/portalComposerAlignment.spec.js
+++ b/src/frontend/tests/unit/portalComposerAlignment.spec.js
@@ -1,0 +1,113 @@
+/**
+ * #2259 — the composer's buttons must align to the INPUT, not to its wrapper.
+ *
+ * ent#392 wrapped the textarea in a `relative` div so the typeahead popup had
+ * something to anchor to. A `<textarea>` is inline-block, so inside that block
+ * wrapper it sat on the baseline and the line box reserved descender space
+ * beneath it — the wrapper rendered 6px taller than the field it contained.
+ * `items-end` aligns the flex ITEM, i.e. the wrapper, so the buttons
+ * bottom-aligned to that dead space and Send hung 6px below the visible input
+ * edge. Measured on dev before the fix (Chromium, 1440px):
+ *
+ *     wrapper  : top 693  bottom 745  h 52
+ *     textarea : top 693  bottom 739  h 46   <- 6px of dead space
+ *     sendBtn  : top 705  bottom 745  h 40   <- flush with the wrapper, not the field
+ *
+ * `block` on the textarea removes the line box, so wrapper height == field height.
+ *
+ * These are SOURCE assertions rather than rendered ones because this project has
+ * no component-mount harness (`vitest` runs `environment: 'node'`), which is the
+ * same reason `portalComposerTypeahead.spec.js` reads the SFC as text. The
+ * geometry itself was verified in a real browser against this branch; what a test
+ * can hold here is that neither file quietly loses the two classes that produce
+ * it. Both files are asserted together because the composer is the same markup in
+ * two places — the #2211 lesson, where a fix landing in one left the twin broken.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const read = (name) =>
+  readFileSync(fileURLToPath(new URL(`../../src/components/portal/${name}`, import.meta.url)), 'utf8')
+
+/**
+ * The composer `<form>` only. Scoping matters: both files hold other textareas
+ * and other `<button>`s (the voice-error dismiss, the agent picker), and a
+ * file-wide match would assert this layout of controls that have nothing to do
+ * with it.
+ */
+function composerForm(src) {
+  const start = src.search(/<form[^>]*class="[^"]*\bitems-end\b/)
+  if (start === -1) return ''
+  const end = src.indexOf('</form>', start)
+  if (end === -1) return ''
+  // Comments are stripped, not skipped past: the block explaining THIS fix names
+  // `<textarea>` in prose, and a tag matcher run over the raw source picks that
+  // up and then asserts the layout of a sentence.
+  return src.slice(start, end).replace(/<!--[\s\S]*?-->/g, '')
+}
+
+const SURFACES = [
+  ['PortalConversation.vue', read('PortalConversation.vue')],
+  ['PortalRoom.vue', read('PortalRoom.vue')],
+]
+
+/** The composer textarea's tag, with its attributes. */
+function textareaTag(src) {
+  const m = composerForm(src).match(/<textarea[\s\S]*?>/)
+  return m ? m[0] : ''
+}
+
+describe('#2259 workspace composer alignment', () => {
+  describe.each(SURFACES)('%s', (_name, src) => {
+    it('renders the textarea as a block, so the wrapper cannot be taller than the field', () => {
+      // The whole defect in one class. Without it the wrapper carries ~6px of
+      // baseline descender space and every `items-end` alignment below is
+      // measured against a box the user cannot see.
+      expect(textareaTag(src)).toMatch(/class="[^"]*\bblock\b/)
+    })
+
+    it('still lets the field fill the flex track', () => {
+      // `block` must be ADDITIVE — a textarea that stopped being `w-full` would
+      // collapse to its `cols` width, trading one layout bug for another.
+      expect(textareaTag(src)).toMatch(/class="[^"]*\bw-full\b/)
+      expect(src).toContain('relative flex-1 min-w-0')
+    })
+
+    it('keeps the row bottom-aligned so the buttons follow the last line as it grows', () => {
+      // Centring would drift the buttons upward with every added line.
+      expect(src).toMatch(/<form[^>]*class="[^"]*\bitems-end\b/)
+    })
+
+    it('sizes every action button as a 44px box rather than padding around an icon', () => {
+      // 44px is on the 4px grid the design contract asks for, and against the
+      // 46px single-line composer it puts the icon's centre within 1px of the
+      // text line — in the collapsed AND the grown state, since `items-end`
+      // measures from the bottom either way. `p-2.5` gave a 40px box, i.e. an
+      // icon sitting 3px low even once the wrapper gap was gone.
+      const composerButtons = composerForm(src).match(/<button[\s\S]*?>/g) || []
+      expect(composerButtons.length).toBeGreaterThan(0)
+      for (const b of composerButtons) {
+        expect(b).toMatch(/\bh-11\b/)
+        expect(b).toMatch(/\bw-11\b/)
+        // A fixed box only centres its glyph if it is told to.
+        expect(b).toMatch(/\bitems-center\b/)
+        expect(b).toMatch(/\bjustify-center\b/)
+      }
+    })
+  })
+
+  it('initialises the room composer once the room has resolved', () => {
+    // PortalRoom's composer sits behind `v-if="!isClosed"`, so it does not exist
+    // when the component mounts. It gained `autoGrow()` in #2211 but nothing ever
+    // called it at startup, leaving `overflow-y` at its stylesheet `auto` — the
+    // state #2211 replaced with an explicit `hidden`. Invisible at rest only
+    // because the untouched `rows="1"` box happens to fit its one line.
+    const src = read('PortalRoom.vue')
+    const mounted = src.match(/onMounted\(async \(\) => \{[\s\S]*?\n\}\)/)
+    expect(mounted, 'PortalRoom must have an async onMounted').toBeTruthy()
+    expect(mounted[0]).toMatch(/await load\(\{ full: true \}\)[\s\S]*autoGrowAfterUpdate\(\)/)
+    // Deferred, not synchronous: the textarea is patched in on the next tick.
+    expect(src).toMatch(/function autoGrowAfterUpdate\(\)\s*\{\s*nextTick\(autoGrow\)/)
+  })
+})

--- a/src/frontend/tests/unit/portalComposerAlignment.spec.js
+++ b/src/frontend/tests/unit/portalComposerAlignment.spec.js
@@ -44,7 +44,29 @@ function composerForm(src) {
   // Comments are stripped, not skipped past: the block explaining THIS fix names
   // `<textarea>` in prose, and a tag matcher run over the raw source picks that
   // up and then asserts the layout of a sentence.
-  return src.slice(start, end).replace(/<!--[\s\S]*?-->/g, '')
+  return stripHtmlComments(src.slice(start, end))
+}
+
+/**
+ * Remove every `<!-- … -->` span. Index-walked rather than a single regex
+ * `replace`: this is a source-text scrub of a checked-in SFC, not an HTML
+ * sanitizer, but CodeQL cannot tell the two apart and flags a one-pass
+ * `<!--…-->` replace as an incomplete multi-character sanitization (a `<!--`
+ * assembled from the halves of two removed spans survives it). The walk has no
+ * such residue: everything between an opener and its closer is dropped, and an
+ * unterminated opener drops the rest of the input.
+ */
+function stripHtmlComments(text) {
+  let out = ''
+  let i = 0
+  for (;;) {
+    const open = text.indexOf('<!--', i)
+    if (open === -1) return out + text.slice(i)
+    out += text.slice(i, open)
+    const close = text.indexOf('-->', open + 4)
+    if (close === -1) return out
+    i = close + 3
+  }
 }
 
 const SURFACES = [

--- a/src/frontend/tests/unit/portalComposerTypeahead.spec.js
+++ b/src/frontend/tests/unit/portalComposerTypeahead.spec.js
@@ -682,7 +682,10 @@ describe('PortalConversation wiring', () => {
   it('anchors the popup without collapsing the flex field', () => {
     const src = convSource()
     expect(src).toContain('relative flex-1 min-w-0')
-    expect(src).toMatch(/<textarea[\s\S]{0,400}class="w-full/)
+    // Matched on the class LIST, not on `class="w-full` — #2259 prepends `block`
+    // to the same attribute, and an anchored match would read that as the field
+    // having lost its width.
+    expect(src).toMatch(/<textarea[\s\S]{0,400}class="[^"]*\bw-full\b/)
   })
 
   it('advertises both triggers in the placeholder, and @ only with the capability', () => {


### PR DESCRIPTION
Fixes #2259

## What was wrong

The Workspace composer's buttons bottom-aligned to a box the user cannot see.

ent#392 wrapped the textarea in a `relative` div so the typeahead popup had something to anchor to. A `<textarea>` is **inline-block**, so inside that block wrapper it sat on the baseline and the line box reserved 6px of descender space beneath it. The row is `flex items-end`, which aligns the flex **item** — the wrapper — so Send hung 6px below the visible input edge. Measured on `dev` before the fix (Chromium, 1440px):

```
wrapper  : top 693  bottom 745  h 52
textarea : top 693  bottom 739  h 46   <- 6px of dead space
sendBtn  : top 705  bottom 745  h 40   <- flush with the wrapper, not the field
```

This is **not** #2211 — that fixed the composer's own height/scrollbar arithmetic, and the numbers above are from a tree that already has it. The reporter was running a stale checkout, which is why the scrollbar was in the screenshot alongside this.

## The fix

**`block` on the textarea** removes the line box, so the wrapper is exactly as tall as the field and `items-end` finally aligns the buttons to the input. It also re-anchors the popup's `absolute bottom-full` to the real field — it now clears it by its declared `mb-2` rather than 8px + a phantom 6px.

That alone left the icons 3px low, because the buttons were `p-2.5` around a 20px icon (40px, off the 4px grid) against a 46px single-line composer. They are now a **44px box with a centred glyph**: bottoms flush, icon centre within 1px of the text line in the collapsed **and** grown states — `items-end` measures from the bottom either way, so the icons track the last line as the field grows. 44px is also the WCAG 2.5.5 minimum target size, which 40px missed.

Landed in **both** composers (`PortalConversation` + `PortalRoom`) — the #2211 lesson.

### One extra, in-class

`PortalRoom` never initialised its field at all. It gained `autoGrow()` in #2211, but nothing called it at startup: the composer sits behind `v-if="!isClosed"` and does not exist when the component mounts, so an eager call no-ops on a null ref. It therefore rendered with `overflow-y` at its stylesheet `auto` — the state #2211 replaced with an explicit `hidden` ("the scrollbar must be gone rather than merely unused"). Invisible at rest only because the untouched `rows="1"` box happens to fit its one line, i.e. a coincidence rather than the contract. Now initialised after `load()` resolves, on mount and on room switch.

`components/rooms/RoomComposer.vue` carries the same shape but is unreferenced — deliberately left alone rather than revived.

## Verification

Measured in Chromium against this branch (local Vite → the running backend), on both surfaces:

| | 1:1 collapsed | 1:1 grown (3 lines) | room |
|---|---|---|---|
| wrapper gap | 0px | 0px | 0px |
| button bottom vs input bottom | 0px | 0px | 0px |
| icon centre vs text line | 1px | 1px (last line) | 1px |
| `overflow-y` | `hidden` | `hidden` | `hidden` |
| scrollbar rendered | no | no | no |
| typeahead clears field | yes (`mb-2`) | — | — |

Checked in light and dark. Typeahead popup opens, clears the field and stays in the viewport.

- `npx vitest run` — **884 passed (41 files)**
- New `tests/unit/portalComposerAlignment.spec.js` (9 assertions across both files), confirmed **red** on the pre-fix source and green after
- One existing assertion in `portalComposerTypeahead.spec.js` was anchored on `class="w-full` and read the added `block` as the field losing its width — rematched on the class list, same intent
- `node src/frontend/scripts/scan-raw-colors.mjs src/frontend` — no per-file regression (the change adds no colour classes)

Semantic tokens only; no new colours, no backend change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
