### PR TITLE
fix(dashboard): keep the Executions tile's failure rails on the chart baseline

### DIFF
--- a/src/frontend/src/components/tiles/ExecutionsTile.vue
+++ b/src/frontend/src/components/tiles/ExecutionsTile.vue
@@ -54,8 +54,13 @@
           ></i>
         </span>
         <!-- The failure rail sits BELOW the stack on its own scale, so failures
-             are never hidden inside a column and never steal height from it. -->
-        <i class="ex-rail" :style="{ height: col.failPx + 'px' }"></i>
+             are never hidden inside a column and never steal height from it.
+             Rendered ONLY when there is something to draw: `.ex-col` spaces its
+             children with `gap`, and flex gap applies to a zero-height item too
+             — so an always-present empty rail lifted every failure-free stack
+             2px off the baseline while a real rail reached it, and the red read
+             as hanging below the chart. Every column now ends on one baseline. -->
+        <i v-if="col.failPx" class="ex-rail" :style="{ height: col.failPx + 'px' }"></i>
       </div>
     </div>
 
@@ -270,6 +275,9 @@ function retry() {
   justify-content: flex-end;
   align-items: stretch;
   height: 100%;
+  /* COL_GAP in utils/executionsTile.js. Only ever separates a stack from a
+     RENDERED rail — the rail is `v-if`'d, because gap does not care that an
+     item is 0px tall and would otherwise float every failure-free column. */
   gap: 2px;
 }
 .ex-stack {

--- a/src/frontend/tests/unit/executionsTile.spec.js
+++ b/src/frontend/tests/unit/executionsTile.spec.js
@@ -368,6 +368,15 @@ describe('#2228 legend fitting', () => {
     expect(Number(h[1])).toBe(CHART_HEIGHT + COL_GAP + RAIL_HEIGHT + CHART_PAD)
   })
 
+  it('renders the failure rail only when there is one, so every column ends on the baseline', () => {
+    // `.ex-col` spaces stack and rail with `gap`, and flex gap applies to a
+    // 0px-tall item exactly as to a 6px one. An always-present empty rail
+    // therefore lifted every failure-free stack 2px above the chart baseline
+    // while a real rail reached it — the red read as hanging BELOW the chart.
+    // The rail has to be absent, not merely 0px, for the columns to align.
+    expect(TILE_CSS).toMatch(/<i\s+v-if="col\.failPx"\s+class="ex-rail"/)
+  })
+
   it('draws the chart against the same budget the CSS reserves', () => {
     // The defaults are what the component relies on; a column taller than the
     // container it is drawn into overflows into the legend's rows.


### PR DESCRIPTION
## Summary
- The fleet **Executions** grid tile drew its red failure rails hanging **below** the baseline of the other columns.
- Root cause: `.ex-col` spaces stack + rail with `gap: 2px`, and the rail `<i>` was rendered for every column even at `height: 0`. Flex gap applies to a zero-height item too, so every failure-free stack floated 2px above the chart bottom while a failed column's rail reached it.
- Fix: `v-if` the rail so it exists only when there is one to draw. Every column now ends on one baseline; failed columns show the red rail flush on it with the stack lifted above. Chart budget (`CHART_HEIGHT + COL_GAP + RAIL_HEIGHT + pad`) is unchanged.
- Spec pin added in `executionsTile.spec.js` (a source guard — a 0px rail and an absent one are indistinguishable to the pure shaping module). Verified it fails on the pre-fix template.

## Test plan
- [x] `npx vitest run tests/unit/executionsTile.spec.js` → 38 passed
- [x] Live check on the local dashboard grid: measured every `.ex-col` — rail-less stacks and failure rails all end at the chart bottom (previously stacks ended 2px above it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)