### PR TITLE
docs(releases): v0.9.0 commit-reconciled addendum

### DIFF
--- a/docs/releases/0.9.0.md
+++ b/docs/releases/0.9.0.md
@@ -3,7 +3,7 @@
 **Released**: 2026-08-17
 **Tag**: `v0.9.0` &nbsp;·&nbsp; **Diff**: [v0.8.5...v0.9.0](https://github.com/abilityai/trinity/compare/v0.8.5...v0.9.0)
 
-499 commits · 1,367 files (+220k/−38k) · 149 public + 60 private-tracker issues (+21 enterprise PRs closed at merge) · enterprise submodule e898cef → 65182c1.
+499 commits · 1,367 files (+220k/−38k) · 155 public + 62 private-tracker issues (+21 enterprise PRs closed at merge; see the commit-reconciled addendum) · enterprise submodule e898cef → 65182c1.
 
 Freeze plan and coherence review: [`v0.9.0-freeze-plan.md`](v0.9.0-freeze-plan.md).
 
@@ -482,10 +482,36 @@ PostgreSQL is the forward path; migration guide at
   `MCP_INLINE_AUTH_ENABLED`.
 - **Pull-mode pilot routes agent-to-agent work only** — cron/schedule triggers
   stay on push dispatch (#2048 / #1081).
-- **`@abilityai/trinity-docs-mcp` is not yet on npm** (trinity-enterprise#330) —
-  the helper MCP server is vendored into the main MCP server's `ask_trinity`
-  tool (ent#328) meanwhile.
 - **`deploy_local_agent` archive path** still lacks integrity verification
   (#2060). Codex API-key auth remains inert (#2208); subscription auth works.
 - **CI**: `dev`'s required checks still run no unit tests (#1958) — the release
   PR is the first full-suite run over a payload.
+
+## Commit-reconciled addendum (post-release)
+
+Post-release reconciliation of the release PR's commit payload (#1781 head
+`e9eb40da` → #2268 head `bcf67116`) against the `status-in-dev` issue set
+surfaced shipped work the label-driven notes above missed:
+
+**Post-v0.8.5 hotfixes promoted to `main` on 2026-07-28 (#1839, untagged)** —
+in the v0.8.5→v0.9.0 diff but in neither release's notes:
+
+- #1795 agent base image hardcoded `TZ=America/New_York` — agents ran 4h off UTC
+- #1790 Cornelius seeder marked itself seeded on a volume-conflict 409 — Cornelius never provisioned
+- #1793 / #1759 a nonexistent `local:` template silently created an empty agent (200) — now rejected, and the missing `local:default` ships (v0.8.5's Known-limitations entry for #1759 is resolved)
+- #1830 Dashboard stats bar right controls overlapped host telemetry below ~1170px — elastic degrade instead of clipping
+
+**Shipped in the payload, closed outside the label sweep:**
+
+- #2186 starting a stopped agent 500'd when a recreate was needed — `require_running` gate narrowed to the one call site (#2187)
+- #2259 Workspace composer buttons aligned to the input, not to the typeahead wrapper (#2260) — was still `status-in-progress`; closed by reconciliation
+- ent#336 canary S-03 built its TTL floor from the agent cap, not the execution's own timeout — every shorter-timeout scheduled run paged critical (via #2022)
+- ent#339 canary S-03's `below_floor` arm is an internal-coherence check, not a dispatch-timeout check — documented honestly (via #2022)
+
+**Correction:** the Known-limitations line claiming `@abilityai/trinity-docs-mcp`
+was not yet on npm has been removed — the helper MCP server has been published
+as the unscoped `trinity-docs-mcp` (0.1.0; `npx -y trinity-docs-mcp` per the
+README). trinity-enterprise#330 closed as completed.
+
+Headline count corrected: **155 public + 62 private-tracker issues.**
+


### PR DESCRIPTION
Post-release (Step 10b-2 of `/release`) addendum to `docs/releases/0.9.0.md`:

- **Post-v0.8.5 hotfixes promoted to `main` 2026-07-28** (#1839, untagged): #1795 #1790 #1793 #1759 #1830 — in the v0.8.5→v0.9.0 diff, in neither release's notes
- Shipped but outside the label sweep: #2186, #2259 (closed by reconciliation), ent#336, ent#339
- Correction: `trinity-docs-mcp` **is** on npm (unscoped, 0.1.0) — the Known-limitations line removed; ent#330 closed
- Headline count 149+60 → **155 public + 62 private**

The GitHub Release body is updated from this file. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)