### PR TITLE
docs(releases): v0.9.0 Abilities Marketplace addendum

### DIFF
--- a/docs/releases/0.9.0.md
+++ b/docs/releases/0.9.0.md
@@ -75,6 +75,19 @@ Freeze plan and coherence review: [`v0.9.0-freeze-plan.md`](v0.9.0-freeze-plan.m
   `github:` agents (#2007), a committed self-healing plugin manifest (#1704),
   Codex runtime model/auth fixes (#1971/#2207), and behavioral-evaluation
   foundations — the referee surface (ent#267) and a cross-model referee (ent#277).
+- **Abilities marketplace: structure for agentic systems.** This release cycle
+  pairs the platform with a marketplace cycle that introduces **a new level of
+  organization into agentic systems** — the structural primitives fleets need to
+  collaborate: a shared **canon** (a canonical-data layer with
+  publish/consume/reconcile, deterministic linting, and per-counterpart
+  relations — add-canon 1.0→1.6), system-aware **orchestration** with
+  install-time divergence detection, a bundle-wide `--autonomous` run mode and
+  event choreography, **playbooks as the unit of inter-agent work**
+  (playbook-call), and repository-first **creation & in-place onboarding** —
+  the marketplace half of the platform's pre-installed Trinity plugin
+  (ent#411/#1704), a tighter integration of the plugin marketplace and the
+  platform. Full list in the [Abilities Marketplace](#abilities-marketplace-ecosystem)
+  section below.
 
 ## Features
 
@@ -330,6 +343,62 @@ Freeze plan and coherence review: [`v0.9.0-freeze-plan.md`](v0.9.0-freeze-plan.m
 - Skill paths sanitized at one chokepoint (no-issue)
 - Avatar generation: thinking-token truncation no longer drops the color-scheme block (no-issue)
 - 34 dependency bumps (dependabot)
+
+## Abilities Marketplace (ecosystem)
+
+*Added post-release by the marketplace sweep. Window: v0.8.5 → v0.9.0
+(2026-07-26 → 2026-08-17), plus the post-tag v0.9.0 platform-truth sync.
+Marketplace items reference `abilityai/abilities` PRs or short commit SHAs.*
+
+The [abilities](https://github.com/abilityai/abilities) plugin marketplace ships
+as part of the platform ecosystem, and this cycle is the thematic companion to
+v0.9.0: together they introduce **a new level of organization — and a new level
+of control — into agentic systems**, the structural primitives agents need to
+collaborate as *systems* rather than as individuals, with **tighter integration
+between the marketplace and the platform** (the platform now pre-installs the
+Trinity plugin in every agent image, ent#411/#1704; the marketplace answers with
+in-place onboarding and platform-truth syncs). Four primitives carry the theme:
+a shared **canon**, system-aware **orchestration**, **playbooks** as the unit of
+inter-agent work, and repository-first **creation & onboarding**.
+
+**Canon — a shared canonical-data layer (agent-dev)**
+- add-canon 1.0: fleet canon repo on plain git — per-agent owned folders with publish/consume/reconcile skills; add-orchestrator goes canon-aware (`5830340`)
+- add-canon 1.1: fleet enrollment — align mapped agents with the canon from the orchestrator; discover-agents canon coverage (`32e785e`)
+- add-canon 1.2: access verification + the deployed-credential story; new `/canon-doctor` runtime skill (`9bd3c47`)
+- add-canon 1.3: live-delivery guarantee — pull-first reconcile, fleet activation offer, undeliverable-agent visibility (`bd55171`)
+- add-canon-lint 1.0: deterministic (no-LLM) canon KB linting on push/PR + the two-zone lintable schema (ent#274) (`fb3a808`)
+- add-canon 1.5: the publish test — what belongs in canon; canon-publish review gate (`387f80f`)
+- add-canon 1.6: relations — per-counterpart collaboration memory, read before acting on a counterpart's ask, appended before closing (`749d924`)
+
+**Playbooks — the unit of inter-agent work (agent-dev / create-agent)**
+- playbook-call: playbooks become the unit of inter-agent work — agent-dev 1.14.0, create-agent 1.13.0 (`70c1e60`)
+- 9 generated schedule messages conformed to the playbook-call grammar (`898ede4`)
+- library-grade playbook authoring: create-playbook 2.12/2.13 (bundled tier templates) + adjust-playbook 1.8/1.9 Trinity-first refresh (`7c91354`, `ddf0420`)
+
+**Orchestration (agent-dev / add-orchestrator)**
+- install-time divergence detection — `--check` mode + overwrite-prompt wiring (abilityai/abilities#13)
+- `--autonomous` promoted to a bundle-wide run-mode convention (abilityai/abilities#14)
+- allowed-tools realigned with skill bodies (abilityai/abilities#9); stranded sync-fleet-to-head & profile-fleet universalized (abilityai/abilities#10)
+- event choreography: orchestrate v1.11 teaches the event layer's emit side; onboard v5.1 custom-events note (`4305e5e`)
+
+**Creation, deployment & onboarding — tighter platform integration (trinity / create-agent / agent-dev)**
+- deploy-as-is → onboard-in-place: `/trinity:onboard` 6.0 in-place mode, `/trinity:sync` plugin reconcile, `plugins:` blocks everywhere — the marketplace half of the platform's pre-installed Trinity plugin (ent#411 / #1704) (`b39a110`)
+- repository-first agent deployment across trinity, create-agent and agent-dev (`19e8f1f`)
+- `/trinity:start-here`: a guided, resumable first journey into Trinity, grounded in live platform docs (`5cd6a27`, `629aabb`)
+- create-agent 1.8.0: Trinity-connected deploy becomes the default (confirmation-gated) end-of-wizard action (`6988238`)
+
+**Fleet analysis & migration (agent-dev)**
+- agent-fleet-analysis v2.3: universal fleet analysis across paradigms — Claude Code, n8n exports, LangChain/CrewAI/AutoGen, freeform-coded agents (`aa14e23`)
+- agent-fleet-migrate v1.0: execute the fleet-analysis work order into a verified Claude Code fleet, non-destructively (`8ba9ac4`)
+
+**Collaboration conventions (agent-dev / create-agent)**
+- cross-actor project management: add-project-management v1.0/v1.1 (intake primitive, headless task creation, reconciler), then folded into agent-dev (`4c48dca`, `4a43766`, `2a07655`, `9b9b2d8`)
+- Request Dispatch SOP convention — create-agent 1.9.0 + agent-dev 1.7.0 (`1c351fd`)
+- loop-closure: close the loop with the user, hand back the loops owed to others (`9c9a9ab`)
+
+**Marketplace-wide**
+- platform-truth realignment with Trinity dev — five production blockers + stale contracts fixed (`dc855a3`); post-tag **v0.9.0 platform-truth refresh** of the trinity-knowledge pack — headless fork wait (#2127), `.mcp.json` public-URL rule (ent#394), agent-scoped report guard, autonomy banner (#1796) (`4e3d050`)
+- create-agent:website v1.3 (`13deed4`)
 
 ## ⚠️ Behavior changes / upgrade notes
 


### PR DESCRIPTION
Post-release addendum to `docs/releases/0.9.0.md` (Step 10b-2 mechanics of /release):

- New **Abilities Marketplace (ecosystem)** section — the abilityai/abilities sweep for the v0.8.5→v0.9.0 window, grouped by primitive: canon (add-canon 1.0→1.6 + canon-lint), playbooks as the unit of inter-agent work (playbook-call), orchestration (divergence detection, --autonomous, event choreography), creation/deploy/onboarding (onboard-in-place ent#411/#1704, repository-first deploy, /trinity:start-here), fleet analysis & migration, collaboration conventions, marketplace-wide platform-truth syncs.
- New Highlights bullet framing the cycle: a new level of organization and control in agentic systems; tighter integration of the plugin marketplace and the platform.

The GitHub Release body for v0.9.0 is updated from this same file so the public record is complete immediately; this PR lands the durable in-repo copy on dev (reaches main at the next cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)