### PR TITLE
fix(telegram): escape-first markdown→HTML converter + entity-safe splitting (#2277)

### DIFF
--- a/src/backend/adapters/telegram_adapter.py
+++ b/src/backend/adapters/telegram_adapter.py
@@ -14,6 +14,7 @@ Supports:
 """
 
 import asyncio
+import html
 import logging
 import re
 from datetime import datetime, timezone
@@ -1139,36 +1140,110 @@ class TelegramAdapter(ChannelAdapter):
         """Convert standard markdown to Telegram HTML format."""
         return self._markdown_to_html(text)
 
+    # Fenced code: optional language becomes <pre><code class="language-X">
+    # (Telegram renders syntax highlighting for it). Issue #2277.
+    _MD_FENCE_RE = re.compile(r"```(\w*)[ \t]*\n?(.*?)```", re.DOTALL)
+    # Tags this converter emits — consumed by the entity-safe splitter.
+    _HTML_TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9-]*)((?:\s[^<>]*)?)>")
+
     @staticmethod
     def _markdown_to_html(text: str) -> str:
-        """Convert common Markdown to Telegram HTML. Plain text fallback on failure."""
+        """Convert common Markdown to Telegram HTML, escape-first (#2277).
+
+        Code spans are stashed before everything else so their content is
+        escaped exactly once and never styled; all remaining text is
+        HTML-escaped BEFORE conversion so raw <, >, & survive parse_mode=HTML
+        instead of tripping "can't parse entities" (which used to strip all
+        formatting from precisely the messages that contain code).
+        """
+        original = text
         try:
-            # Bold: **text** or __text__
-            text = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', text)
-            text = re.sub(r'__(.+?)__', r'<b>\1</b>', text)
-            # Italic: *text* or _text_ (but not inside words like file_name)
-            text = re.sub(r'(?<!\w)\*([^*]+?)\*(?!\w)', r'<i>\1</i>', text)
-            # Code blocks: ```text```
-            text = re.sub(r'```(\w*)\n?(.*?)```', r'<pre>\2</pre>', text, flags=re.DOTALL)
+            stash = []
+
+            def _hold(fragment):
+                stash.append(fragment)
+                return f"\x00{len(stash) - 1}\x00"
+
+            def _fence(m):
+                lang = m.group(1)
+                cls = f' class="language-{lang}"' if lang else ""
+                body = html.escape(m.group(2), quote=False)
+                return _hold(f"<pre><code{cls}>{body}</code></pre>")
+
+            text = TelegramAdapter._MD_FENCE_RE.sub(_fence, text)
             # Inline code: `text`
-            text = re.sub(r'`([^`]+)`', r'<code>\1</code>', text)
+            text = re.sub(
+                r"`([^`\n]+)`",
+                lambda m: _hold(f"<code>{html.escape(m.group(1), quote=False)}</code>"),
+                text,
+            )
+
+            text = html.escape(text, quote=False)
+
+            # Tables are readable only in monospace; stashed pre-styling so
+            # cells never carry nested tags into <pre> (invalid in Telegram).
+            text = re.sub(
+                r"(?m)^(?:\|.*\|[ \t]*\n?){2,}",
+                lambda m: _hold(f"<pre>{m.group(0).rstrip()}</pre>") + "\n",
+                text,
+            )
+
+            # Links: [text](url)
+            text = re.sub(
+                r"\[([^\]\n]+)\]\((https?://[^)\s]+)\)", r'<a href="\2">\1</a>', text
+            )
+            # Headers: #/## emphasized, ###+ plain bold
+            text = re.sub(r"(?m)^#{1,2}[ \t]+(.+?)[ \t]*#*[ \t]*$", r"<b><u>\1</u></b>", text)
+            text = re.sub(r"(?m)^#{3,6}[ \t]+(.+?)[ \t]*#*[ \t]*$", r"<b>\1</b>", text)
+            # Horizontal rules (before bold/italic so *** and ___ don't pair up)
+            text = re.sub(r"(?m)^(?:---+|\*\*\*+|___+)[ \t]*$", "———", text)
+            # Bullets (before italic so a leading * is never an emphasis opener)
+            text = re.sub(r"(?m)^([ \t]*)[-*][ \t]+", r"\1• ", text)
+            # Bold: **text** or __text__
+            text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+            text = re.sub(r"__(.+?)__", r"<b>\1</b>", text)
+            # Italic: *text* (but not inside words like file_name)
+            text = re.sub(r"(?<!\w)\*([^*\n]+?)\*(?!\w)", r"<i>\1</i>", text)
             # Strikethrough: ~~text~~
-            text = re.sub(r'~~(.+?)~~', r'<s>\1</s>', text)
-            return text
+            text = re.sub(r"~~(.+?)~~", r"<s>\1</s>", text)
+            # Spoiler: ||text||
+            text = re.sub(r"\|\|(.+?)\|\|", r"<tg-spoiler>\1</tg-spoiler>", text)
+
+            # "> " runs → <blockquote>; long runs collapse client-side.
+            def _quote(m):
+                lines = [
+                    re.sub(r"^&gt;[ \t]?", "", ln)
+                    for ln in m.group(0).rstrip("\n").split("\n")
+                ]
+                body = "\n".join(lines)
+                attr = " expandable" if len(lines) > 5 or len(body) > 400 else ""
+                return f"<blockquote{attr}>{body}</blockquote>\n"
+
+            text = re.sub(r"(?m)^(?:&gt;[ \t]?.*\n?)+", _quote, text)
+
+            return re.sub(r"\x00(\d+)\x00", lambda m: stash[int(m.group(1))], text)
         except Exception:
-            return text
+            logger.warning("Telegram markdown→HTML conversion failed", exc_info=True)
+            return html.escape(original, quote=False)
 
     @staticmethod
     def _strip_html(text: str) -> str:
-        """Strip HTML tags for plain text fallback."""
-        return re.sub(r'<[^>]+>', '', text)
+        """Strip HTML tags and unescape entities for plain text fallback."""
+        return html.unescape(re.sub(r"<[^>]+>", "", text))
 
     @staticmethod
     def _split_message(text: str) -> list:
-        """Split text into chunks respecting Telegram's 4096 char limit."""
+        """Split text into chunks respecting Telegram's 4096 char limit.
+
+        Entity-safe (#2277): never cuts inside a <tag>, and tags still open at
+        a cut are closed there and reopened in the next chunk — otherwise the
+        continuation fails HTML parse and falls back to unformatted text.
+        """
         if len(text) <= TELEGRAM_MAX_MESSAGE_LENGTH:
             return [text]
 
+        # Reserve room for the closing tags a cut can append.
+        limit = TELEGRAM_MAX_MESSAGE_LENGTH - 100
         chunks = []
         while text:
             if len(text) <= TELEGRAM_MAX_MESSAGE_LENGTH:
@@ -1176,15 +1251,36 @@ class TelegramAdapter(ChannelAdapter):
                 break
 
             # Find a good split point — paragraph, then sentence, then hard cut
-            split_at = TELEGRAM_MAX_MESSAGE_LENGTH
+            split_at = limit
             for sep in ["\n\n", "\n", ". ", " "]:
-                idx = text.rfind(sep, 0, TELEGRAM_MAX_MESSAGE_LENGTH)
-                if idx > TELEGRAM_MAX_MESSAGE_LENGTH // 2:
+                idx = text.rfind(sep, 0, limit)
+                if idx > limit // 2:
                     split_at = idx + len(sep)
                     break
 
-            chunks.append(text[:split_at])
-            text = text[split_at:]
+            head = text[:split_at]
+            if head.rfind("<") > head.rfind(">"):
+                # Cut landed inside a tag — back up to its opening bracket.
+                split_at = head.rfind("<")
+                if split_at <= 0:
+                    split_at = limit
+                head = text[:split_at]
+
+            open_tags = []
+            for m in TelegramAdapter._HTML_TAG_RE.finditer(head):
+                if m.group(1):
+                    if open_tags and open_tags[-1][0] == m.group(2).lower():
+                        open_tags.pop()
+                else:
+                    open_tags.append((m.group(2).lower(), m.group(3) or ""))
+
+            chunks.append(
+                head + "".join(f"</{name}>" for name, _ in reversed(open_tags))
+            )
+            text = (
+                "".join(f"<{name}{attrs}>" for name, attrs in open_tags)
+                + text[split_at:]
+            )
 
         return chunks
 

--- a/src/backend/adapters/telegram_adapter.py
+++ b/src/backend/adapters/telegram_adapter.py
@@ -1226,7 +1226,7 @@ class TelegramAdapter(ChannelAdapter):
                     return f"<b><u>{body}</u></b>"
                 return f"<b>{body}</b>"
 
-            text = re.sub(r"(?m)^(#{1,6})[ \t]+(.+)$", _header, text)
+            text = re.sub(r"(?m)^(#{1,6})[ \t]+(\S.*)$", _header, text)
             # Horizontal rules (before bold/italic so *** and ___ don't pair up)
             text = re.sub(r"(?m)^(?:---+|\*\*\*+|___+)[ \t]*$", "———", text)
             # Bullets (before italic so a leading * is never an emphasis opener)

--- a/src/backend/adapters/telegram_adapter.py
+++ b/src/backend/adapters/telegram_adapter.py
@@ -1141,10 +1141,39 @@ class TelegramAdapter(ChannelAdapter):
         return self._markdown_to_html(text)
 
     # Fenced code: optional language becomes <pre><code class="language-X">
-    # (Telegram renders syntax highlighting for it). Issue #2277.
-    _MD_FENCE_RE = re.compile(r"```(\w*)[ \t]*\n?(.*?)```", re.DOTALL)
+    # (Telegram renders syntax highlighting for it). Fences are parsed by a
+    # linear split on the ``` delimiter — one regex over the whole (agent- and
+    # user-length) text is superlinear here (py/polynomial-redos). Issue #2277.
+    _MD_FENCE_LANG_RE = re.compile(r"\w{0,32}[ \t]*")
     # Tags this converter emits — consumed by the entity-safe splitter.
     _HTML_TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9-]*)((?:\s[^<>]*)?)>")
+
+    @staticmethod
+    def _stash_fenced_code(text: str, hold) -> str:
+        """Replace each closed ``` fence with a stashed <pre><code> block.
+
+        Linear scan via str.split — every fence body is visited exactly once,
+        and a trailing unclosed fence stays literal text.
+        """
+        parts = text.split("```")
+        if len(parts) < 3:
+            return text
+        out = [parts[0]]
+        i = 1
+        while i + 1 < len(parts):
+            block = parts[i]
+            first, sep, rest = block.partition("\n")
+            if sep and TelegramAdapter._MD_FENCE_LANG_RE.fullmatch(first):
+                lang, code = first.strip(), rest
+            else:
+                lang, code = "", block
+            cls = f' class="language-{lang}"' if lang else ""
+            out.append(hold(f"<pre><code{cls}>{html.escape(code, quote=False)}</code></pre>"))
+            out.append(parts[i + 1])
+            i += 2
+        if i < len(parts):
+            out.append("```" + parts[i])
+        return "".join(out)
 
     @staticmethod
     def _markdown_to_html(text: str) -> str:
@@ -1164,13 +1193,7 @@ class TelegramAdapter(ChannelAdapter):
                 stash.append(fragment)
                 return f"\x00{len(stash) - 1}\x00"
 
-            def _fence(m):
-                lang = m.group(1)
-                cls = f' class="language-{lang}"' if lang else ""
-                body = html.escape(m.group(2), quote=False)
-                return _hold(f"<pre><code{cls}>{body}</code></pre>")
-
-            text = TelegramAdapter._MD_FENCE_RE.sub(_fence, text)
+            text = TelegramAdapter._stash_fenced_code(text, _hold)
             # Inline code: `text`
             text = re.sub(
                 r"`([^`\n]+)`",
@@ -1190,11 +1213,20 @@ class TelegramAdapter(ChannelAdapter):
 
             # Links: [text](url)
             text = re.sub(
-                r"\[([^\]\n]+)\]\((https?://[^)\s]+)\)", r'<a href="\2">\1</a>', text
+                r"\[([^\]\n]{1,256})\]\((https?://[^)\s]{1,1024})\)", r'<a href="\2">\1</a>', text
             )
-            # Headers: #/## emphasized, ###+ plain bold
-            text = re.sub(r"(?m)^#{1,2}[ \t]+(.+?)[ \t]*#*[ \t]*$", r"<b><u>\1</u></b>", text)
-            text = re.sub(r"(?m)^#{3,6}[ \t]+(.+?)[ \t]*#*[ \t]*$", r"<b>\1</b>", text)
+            # Headers: #/## emphasized, ###+ plain bold. Trailing #/space
+            # trimming happens in code — expressing it in-pattern needs
+            # ambiguous adjacent quantifiers (py/polynomial-redos).
+            def _header(m):
+                body = m.group(2).rstrip().rstrip("#").rstrip()
+                if not body:
+                    return m.group(0)
+                if len(m.group(1)) <= 2:
+                    return f"<b><u>{body}</u></b>"
+                return f"<b>{body}</b>"
+
+            text = re.sub(r"(?m)^(#{1,6})[ \t]+(.+)$", _header, text)
             # Horizontal rules (before bold/italic so *** and ___ don't pair up)
             text = re.sub(r"(?m)^(?:---+|\*\*\*+|___+)[ \t]*$", "———", text)
             # Bullets (before italic so a leading * is never an emphasis opener)
@@ -1229,7 +1261,7 @@ class TelegramAdapter(ChannelAdapter):
     @staticmethod
     def _strip_html(text: str) -> str:
         """Strip HTML tags and unescape entities for plain text fallback."""
-        return html.unescape(re.sub(r"<[^>]+>", "", text))
+        return html.unescape(re.sub(r"<[^<>]*>", "", text))
 
     @staticmethod
     def _split_message(text: str) -> list:

--- a/src/backend/services/channel_completion_report.py
+++ b/src/backend/services/channel_completion_report.py
@@ -223,14 +223,11 @@ def _resolve_telegram(
     # the binding agent's bot but a DIFFERENT agent did the work, the head line
     # names the worker.
     attribution = executing_agent if binding_agent != executing_agent else None
-    # D5 rendering: pre-escape &/</> BEFORE markdown→HTML — _markdown_to_html
-    # escapes nothing, and failure errors routinely carry `<class 'ValueError'>`
-    # / tracebacks; unescaped they trip "can't parse entities" and the adapter's
-    # strip-HTML fallback then DELETES the `<...>` substrings. Pre-escaping
-    # keeps literals intact while backticks still render as <code>.
+    # D5 rendering: _markdown_to_html is escape-first (#2277) — `<class
+    # 'ValueError'>` / traceback literals survive as text on their own; a
+    # pre-escape here would double-escape into visible &amp;lt; artifacts.
     text = adapter.format_response(
-        html.escape(_summarize(status, summary_or_error, executing_agent=attribution),
-                    quote=False)
+        _summarize(status, summary_or_error, executing_agent=attribution)
     )
     # D5 cap: entity expansion can exceed Telegram's 4096 hard cap; "message too
     # long" is a 400 the parse-fallback does not catch → silent loss. A cap cut

--- a/src/backend/services/proactive_message_service.py
+++ b/src/backend/services/proactive_message_service.py
@@ -478,12 +478,17 @@ class ProactiveMessageService:
         try:
             # The chat_link contains telegram_user_id which is the chat_id for DMs
             chat_id = chat_link["telegram_user_id"]
-            result = await adapter._send_message(
-                bot_token=bot_token,
-                chat_id=chat_id,
-                text=text,
-                parse_mode="HTML",
-            )
+            # #2277: proactive sends must go through the same markdown→HTML
+            # converter and entity-safe splitter as send_response — raw agent
+            # markdown under parse_mode=HTML loses all formatting on any `<`.
+            result = None
+            for chunk in adapter._split_message(adapter.format_response(text)):
+                result = await adapter._send_message(
+                    bot_token=bot_token,
+                    chat_id=chat_id,
+                    text=chunk,
+                    parse_mode="HTML",
+                )
             if result:
                 message_id = result.get("message_id")
                 # #1600: resolve the recipient's session key through the adapter

--- a/tests/unit/test_2277_telegram_markdown_html.py
+++ b/tests/unit/test_2277_telegram_markdown_html.py
@@ -208,3 +208,22 @@ def test_realistic_agent_report_parses_clean():
     assert '<a href="https://docs.ability.ai/guides">runbook</a>' in out
     assert 'class="language-bash"' in out
     assert "&lt;org disabled&gt;" in out
+
+
+# ------------------------------------------------------- pathological inputs ---
+
+
+def test_pathological_inputs_stay_correct():
+    # The input shapes CodeQL flagged for superlinear backtracking (#2295):
+    # unclosed fence + tab runs, bracket runs, header + tab runs, '<' runs.
+    out = md("```" + "\t" * 5000)  # unclosed fence stays literal text
+    assert "```" in out and _balanced(out)
+    assert md("[" * 3000) == "[" * 3000
+    assert _balanced(md("#" + "\t" * 4000))
+    assert strip("<" * 4000) == "<" * 4000
+
+
+def test_unclosed_fence_is_literal():
+    out = md("before\n```python\nno closer here")
+    assert "<pre>" not in out
+    assert "```" in out

--- a/tests/unit/test_2277_telegram_markdown_html.py
+++ b/tests/unit/test_2277_telegram_markdown_html.py
@@ -1,0 +1,210 @@
+"""Escape-first Telegram markdown→HTML conversion + entity-safe splitting (#2277).
+
+The property that matters most here is the **escape-first rule**: every send
+path uses parse_mode=HTML, so any raw `<`, `>`, `&` an agent emits (type hints,
+tracebacks, pasted XML) used to trip Telegram's "can't parse entities" and the
+adapter's fallback then stripped ALL formatting — precisely the messages that
+contain code arrived as plain text. The converter now escapes everything
+outside stashed code spans BEFORE styling, so those literals survive.
+
+Second property: `_split_message` must never emit a chunk that fails HTML
+parse on its own — a cut inside an open tag makes Telegram reject the
+continuation chunk. Tags open at a cut are closed there and reopened in the
+next chunk.
+
+Module: src/backend/adapters/telegram_adapter.py (+ the proactive path in
+        services/proactive_message_service.py now routes through the same
+        converter, and services/channel_completion_report.py dropped its
+        pre-escape workaround so it no longer double-escapes)
+Issue:  https://github.com/Abilityai/trinity/issues/2277
+"""
+
+import re
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent.parent / "src" / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from adapters.telegram_adapter import (  # noqa: E402
+    TELEGRAM_MAX_MESSAGE_LENGTH,
+    TelegramAdapter,
+)
+
+md = TelegramAdapter._markdown_to_html
+split = TelegramAdapter._split_message
+strip = TelegramAdapter._strip_html
+
+
+def _balanced(chunk: str) -> bool:
+    """Telegram-style entity check: every tag closed, properly nested."""
+    stack = []
+    for m in TelegramAdapter._HTML_TAG_RE.finditer(chunk):
+        if m.group(1):
+            if not stack or stack[-1] != m.group(2).lower():
+                return False
+            stack.pop()
+        else:
+            stack.append(m.group(2).lower())
+    return not stack
+
+
+def _no_raw_angles(chunk: str) -> bool:
+    """Outside of tags, no bare < or > may remain."""
+    outside = re.sub(r"<[^>]+>", "", chunk)
+    return "<" not in outside and ">" not in outside
+
+
+# ---------------------------------------------------------------- escaping ---
+
+
+def test_raw_angle_brackets_survive_as_escaped_literals():
+    out = md("error in Optional<str> -> None & co")
+    assert "Optional&lt;str&gt;" in out
+    assert "&amp; co" in out
+    assert _balanced(out) and _no_raw_angles(out)
+
+
+def test_plain_text_passthrough():
+    assert md("hello") == "hello"
+
+
+def test_strip_html_unescapes_for_plain_fallback():
+    # The old fallback DELETED `<...>` substrings from failure reports.
+    assert (
+        strip(md("err: <class 'ValueError'> & `x<1`"))
+        == "err: <class 'ValueError'> & x<1"
+    )
+
+
+# ------------------------------------------------------------ inline styles ---
+
+
+def test_inline_styles():
+    out = md("**b** and *i* and ~~s~~ and ||sp|| but file_name and 2*3*4 stay")
+    assert "<b>b</b>" in out
+    assert "<i>i</i>" in out
+    assert "<s>s</s>" in out
+    assert "<tg-spoiler>sp</tg-spoiler>" in out
+    assert "file_name" in out and "2*3*4" in out
+
+
+def test_headers():
+    out = md("# Big\n## Also big\n### Small\nplain # not a header")
+    assert "<b><u>Big</u></b>" in out
+    assert "<b><u>Also big</u></b>" in out
+    assert "<b>Small</b>" in out
+    assert "plain # not a header" in out
+
+
+def test_links_with_query_string():
+    out = md("see [docs](https://example.com/a?b=1&c=2) ok")
+    assert '<a href="https://example.com/a?b=1&amp;c=2">docs</a>' in out
+
+
+def test_bullets_and_hr_do_not_become_emphasis():
+    out = md("- item one\n* item two\n---\ndone")
+    assert "• item one" in out and "• item two" in out
+    assert "<i>" not in out
+
+
+# -------------------------------------------------------------- code spans ---
+
+
+def test_fence_keeps_language_and_escapes_content():
+    out = md("```python\nif a < b:\n    print('x & y')\n```")
+    assert '<pre><code class="language-python">' in out
+    assert "a &lt; b" in out and "x &amp; y" in out
+
+
+def test_bare_fence():
+    out = md("```\nplain <code>\n```")
+    assert out.startswith("<pre><code>")
+    assert "&lt;code&gt;" in out
+
+
+def test_inline_code_protected_from_styling():
+    out = md("run `pip install **notbold** <x>` now")
+    assert "<code>pip install **notbold** &lt;x&gt;</code>" in out
+
+
+# -------------------------------------------------------------- blockquotes ---
+
+
+def test_short_blockquote():
+    out = md("> one\n> two\nafter")
+    assert "<blockquote>one\ntwo</blockquote>" in out
+    assert " expandable" not in out
+
+
+def test_long_blockquote_collapses():
+    out = md("\n".join(f"> line {i}" for i in range(8)))
+    assert "<blockquote expandable>" in out
+
+
+def test_styled_quote_nests():
+    out = md("> **hot** take")
+    assert "<blockquote><b>hot</b> take</blockquote>" in out
+
+
+# ------------------------------------------------------------------- tables ---
+
+
+def test_table_becomes_pre_without_nested_tags():
+    out = md("| a | b |\n|---|---|\n| **x** | <y> |\n")
+    assert out.strip().startswith("<pre>")
+    assert "**x**" in out  # cells are NOT styled — nested tags are invalid in <pre>
+    assert "&lt;y&gt;" in out
+    assert _balanced(out)
+
+
+# ---------------------------------------------------------------- splitting ---
+
+
+def test_split_is_entity_safe_across_pre_block():
+    big = (
+        "# Report\n```python\n"
+        + "\n".join(f"value_{i} = {i}  # < & >" for i in range(400))
+        + "\n```\ntail **bold**"
+    )
+    chunks = split(md(big))
+    assert len(chunks) >= 2
+    assert all(len(c) <= TELEGRAM_MAX_MESSAGE_LENGTH for c in chunks)
+    assert all(_balanced(c) for c in chunks)
+    assert all(_no_raw_angles(c) for c in chunks)
+    # the cut closed <pre><code> and the continuation reopened it
+    assert chunks[1].startswith("<pre><code")
+    # nothing was duplicated or lost across the cut
+    text_only = "".join(re.sub(r"</?[a-zA-Z][^>]*>", "", c) for c in chunks)
+    assert text_only.count("value_399") == 1
+
+
+def test_plain_long_text_splits_at_paragraphs():
+    chunks = split(("para. " * 300 + "\n\n") * 4)
+    assert len(chunks) >= 2
+    assert all(len(c) <= TELEGRAM_MAX_MESSAGE_LENGTH for c in chunks)
+
+
+def test_short_text_is_single_chunk():
+    assert split("hello") == ["hello"]
+
+
+# ------------------------------------------------------------ whole pipeline ---
+
+
+def test_realistic_agent_report_parses_clean():
+    report = (
+        "# Fleet brief\n\n**2 agents** need attention:\n\n"
+        "| agent | status |\n|---|---|\n| pm | DORMANT |\n\n"
+        "> Root cause: token expired -> 403 <org disabled>\n> Fix: stop+start\n\n"
+        "Run `trinity restart pm` or see [runbook](https://docs.ability.ai/guides).\n\n"
+        '```bash\ndocker restart agent-pm && echo "ok < done"\n```\n'
+    )
+    out = md(report)
+    assert _balanced(out) and _no_raw_angles(out)
+    assert "<b>2 agents</b>" in out
+    assert "<blockquote>" in out
+    assert '<a href="https://docs.ability.ai/guides">runbook</a>' in out
+    assert 'class="language-bash"' in out
+    assert "&lt;org disabled&gt;" in out


### PR DESCRIPTION
Closes #2277.

## What

- **`adapters/telegram_adapter.py`** — `_markdown_to_html` rewritten as an escape-first pipeline: fenced/inline code stashed first (escaped exactly once, language preserved → `<pre><code class="language-X">` renders Telegram syntax highlighting), everything else HTML-escaped **before** styling; adds headers, `[text](url)` links, blockquotes (auto-`expandable` when long), tables as `<pre>`, `||spoilers||`, bullets, and hrs. `_split_message` is now entity-safe: tags open at a cut are closed there and reopened in the next chunk, so every chunk parses on its own. `_strip_html` unescapes entities so the plain-text fallback preserves `<...>` literals instead of deleting them.
- **`services/proactive_message_service.py`** — proactive Telegram sends were shipping **raw unconverted markdown** under `parse_mode=HTML`; they now route through the same converter + splitter as `send_response`.
- **`services/channel_completion_report.py`** — drops its local pre-escape workaround (D5), which would double-escape into visible `&amp;lt;` artifacts now that the converter escapes properly.

## Why

Any agent output containing `<`, `>`, or `&` (type hints, tracebacks, pasted XML) tripped Telegram's *can't parse entities*, and the fallback at `telegram_adapter.py:938` stripped every tag — precisely the messages that contain code arrived as unformatted plain text. Details and file:line evidence in #2277.

## Verification

- 18 new unit tests in `tests/unit/test_2277_telegram_markdown_html.py` (escaping, every markdown construct, entity-balance across split chunks, whole-pipeline report case) — green against the production backend image.
- Running live on a v0.8.5 deployment (18-agent fleet) since 2026-08-18 as a hotfix overlay: zero parse fallbacks in logs, rich formatting confirmed end-to-end in Telegram (highlighted code, expandable quotes, spoilers, tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWGToBEJ6eF3ALMEFaeW9L
