### PR TITLE
fix(workspace): an expired client session no longer becomes the operator (#2261)

### DIFF
--- a/docs/memory/feature-flows/workspace-session-signout.md
+++ b/docs/memory/feature-flows/workspace-session-signout.md
@@ -107,14 +107,57 @@ in lockstep, `authHeader` divergence, an escape hatch for an operator dead-ended
 the OTP form, storage-write failure, cross-tab staleness). Credential destruction
 carries none, and leaves the 401 predicate correct **by construction**.
 
+
+## The expiry path (#2261)
+
+Expiry still cannot end the platform credential — an operator working in another
+tab must not be logged out because a client's idle window lapsed — so the fix
+breaks the *derivation* instead, for the tab where the client's session died.
+
+**Two halves, and neither works alone.**
+
+1. **The wire.** Every workspace call moved onto a dedicated axios instance
+   (`portalHttp`), whose request interceptor decides the credential and strips
+   whatever `axios.defaults` merged in. `authHeader` returns `{}` while the
+   fallback is suppressed. This is the half that answers the objection above: with
+   it, "the workspace is signed out" is a statement about the wire, not only the
+   screen. (`streamPortalExecution` uses bare `fetch` with `authHeader` only, so it
+   was already honest and stays so.)
+2. **The screen.** `platformFallbackSuppressed` — set when a client session
+   EXPIRES here, cleared by `signOut()`, by a client signing in again, and by the
+   operator's explicit "Continue as <email>". `isPlatformSession` returns false
+   while it is set. Stored in **sessionStorage**: it must survive a refresh of this
+   tab and nothing wider, which is also what keeps an operator's other tab
+   untouched.
+
+**The escape hatch is mandatory, not a nicety.** The suppression fails closed, so
+it necessarily catches the operator when the browser is genuinely theirs. One
+explicit click (`continueAsPlatform`) is the way back; re-deriving automatically is
+the bug.
+
+**The 401 bounce moved with the transport, and onto a better question.** The global
+`axios` interceptor in `main.js` decided with `onWorkspace && localStorage['token']`.
+Workspace calls no longer pass through it, so the operator bounce is re-registered
+via `setPlatformSessionLostHandler` and fires only when `isPlatformSession` — which
+is false in exactly the case that predicate got wrong: a client at the OTP form on a
+browser holding an operator's JWT, where one mistyped digit would have 401'd, bounced
+them to `/login` and destroyed the operator's session (objection 3 above).
+
+**`resumePath` is finally read.** `endSession` has recorded where the client was
+since ent#375 and nothing consumed it, so the expired notice's "pick up where you
+left off" was a promise the app did not keep; the sign-in that consumes the expiry
+now navigates there. The expired notice itself was also unrendered until #2261 — the
+form simply reappeared, indistinguishable from "you were never signed in".
+
+**Degradation:** if `sessionStorage` is unavailable (private mode), the marker reads
+as absent — pre-#2261 behaviour, rather than a workspace nobody can enter.
+
 ## Stated residuals (not hidden)
 
-- **Client-session expiry with a later platform login** still falls back to the
-  platform identity via `endSession → signOut`. Same class by an ordering the UI
-  does not produce (the OTP form never renders while a JWT exists, so it needs the
-  platform login to arrive *after* the client signed in). Not fixable with credential
-  destruction — expiry is not a user act — and the flag alternative is unsound.
-  Tracked as #2261.
+- ~~**Client-session expiry with a later platform login** still falls back to the
+  platform identity.~~ **Fixed in #2261** — see below. The flag alternative was
+  unsound *because of the axios-default leak*; removing that leak is what made a
+  suppression honest, so the fix is both halves together, never the flag alone.
 - **A client's portal token stays server-side valid** after "Sign out" (idle 7d /
   absolute 30d by default): the sign-out is client-side disposal; there is no
   self-service `POST /auth/logout`. The primitive exists

--- a/docs/memory/feature-flows/workspace-session-signout.md
+++ b/docs/memory/feature-flows/workspace-session-signout.md
@@ -117,9 +117,20 @@ breaks the *derivation* instead, for the tab where the client's session died.
 **Two halves, and neither works alone.**
 
 1. **The wire.** Every workspace call moved onto a dedicated axios instance
-   (`portalHttp`), whose request interceptor decides the credential and strips
-   whatever `axios.defaults` merged in. `authHeader` returns `{}` while the
-   fallback is suppressed. This is the half that answers the objection above: with
+   (`portalHttp`), whose request interceptor **discards any `Authorization` on the
+   config and rebuilds it from the store** — so the store is the only source, and
+   `authHeader` returning `{}` while suppressed means nothing goes out.
+
+   Two things worth stating precisely, because the first version of this got the
+   second one wrong. *(a)* Verified against axios 1.19.0: an instance created
+   before `auth.js` mutates `axios.defaults.headers.common` does **not** inherit
+   that mutation, so moving onto the instance is what actually closes the
+   disclosure (pinned by `tests/unit/axiosInstanceIsolation.spec.js` against real
+   axios, so a version bump that changes it is visible). *(b)* The interceptor
+   originally *preserved* whatever `Authorization` it found, which cannot tell
+   "the store decided this" from "axios inherited this" — it would have kept an
+   inherited JWT rather than stripping it. It is now unconditional, so the
+   property does not rest on merge behaviour we neither control nor test. This is the half that answers the objection above: with
    it, "the workspace is signed out" is a statement about the wire, not only the
    screen. (`streamPortalExecution` uses bare `fetch` with `authHeader` only, so it
    was already honest and stays so.)

--- a/src/frontend/src/main.js
+++ b/src/frontend/src/main.js
@@ -5,6 +5,7 @@ import router from './router'
 import App from './App.vue'
 import './style.css'
 import { useAuthStore } from './stores/auth'
+import { setPlatformSessionLostHandler } from './stores/clientPortal'
 import { installConsoleBuffer } from './utils/consoleBuffer'
 
 // #1116: capture recent console errors/warnings from the very start so the
@@ -21,6 +22,18 @@ app.use(router)
 // Initialize auth state from localStorage/cookies on app startup
 const authStore = useAuthStore()
 authStore.initializeAuth()
+
+// #2261 — workspace requests run on their own axios instance now
+// (`stores/clientPortal.js`), so the global 401 interceptor below no longer sees
+// them. The operator bounce for that surface is registered here, where the router
+// and the auth store already live, and the instance's interceptor calls it ONLY
+// when the workspace session is the platform one — never for a client's 401 on a
+// browser that happens to hold an operator's JWT.
+setPlatformSessionLostHandler(() => {
+  console.log('🔐 Workspace: platform session expired - redirecting to login')
+  authStore.logout()
+  router.push('/login')
+})
 
 // Setup axios interceptor to handle token expiration
 axios.interceptors.response.use(

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -84,11 +84,33 @@ export function setPlatformSessionLostHandler(fn) {
 }
 
 portalHttp.interceptors.request.use((config) => {
+  // The store is the ONLY source of a workspace credential. Whatever arrived on
+  // the config — a caller's `headers: this.authHeader`, or anything axios merged
+  // in from defaults — is discarded and replaced by the current decision.
+  //
+  // Rebuilding from the store rather than preserving what was there is the whole
+  // point, and the first version of this got it wrong: it kept any `Authorization`
+  // it found, which cannot tell "the store decided this" from "axios inherited
+  // this", so it would have PRESERVED an inherited platform JWT rather than
+  // stripping it. That mattered less than it looked (verified: axios 1.19.0 does
+  // not propagate later `axios.defaults.headers.common` mutations into an instance
+  // created earlier, so nothing is inherited today) — but the property this
+  // interceptor exists to guarantee cannot rest on a merge behaviour we do not
+  // control and do not test. Now it holds by construction.
+  //
+  // Fail-closed if the store is unreachable (Pinia not active): send no credential
+  // rather than a stale one. Every workspace call originates from a component or
+  // action with Pinia active; the two that do not (`requestCode`/`verifyCode`)
+  // need no credential anyway.
   const headers = config.headers || {}
-  const decided = headers.Authorization || headers.authorization
   delete headers.Authorization
   delete headers.authorization
-  if (decided) headers.Authorization = decided
+  try {
+    const decided = useClientPortalStore().authHeader?.Authorization
+    if (decided) headers.Authorization = decided
+  } catch {
+    /* no store, no credential */
+  }
   config.headers = headers
   return config
 })

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -18,6 +18,80 @@ import { useAuthStore } from './auth'
 import { REPORT_ROWS_PAGE as ROWS_PAGE } from '@/utils/reportPaging'
 
 const PORTAL_TOKEN_KEY = 'trinity.portalToken'
+// #2261 — per-TAB, so an operator working in another tab is untouched by a
+// client's idle timeout (that is the whole reason expiry may not end the
+// platform session). sessionStorage, not localStorage: it must survive a
+// refresh of THIS tab and nothing wider.
+const FALLBACK_SUPPRESSED_KEY = 'trinity.workspaceFallbackSuppressed'
+
+function readSuppressed() {
+  try {
+    return sessionStorage.getItem(FALLBACK_SUPPRESSED_KEY) === '1'
+  } catch {
+    // Private mode / storage disabled: fail to NOT-suppressed, which is the
+    // pre-#2261 behaviour rather than a workspace nobody can enter.
+    return false
+  }
+}
+
+function writeSuppressed(on) {
+  try {
+    if (on) sessionStorage.setItem(FALLBACK_SUPPRESSED_KEY, '1')
+    else sessionStorage.removeItem(FALLBACK_SUPPRESSED_KEY)
+  } catch {
+    /* state still holds for this page-life; the refresh case degrades, loudly enough */
+  }
+}
+
+// #2261 — every workspace request goes through THIS instance, and its
+// interceptor is the single place a workspace credential is decided.
+//
+// Why an instance at all: `auth.js` installs the platform JWT as
+// `axios.defaults.headers.common.Authorization`, and per-request headers MERGE
+// over defaults. So on the bare `axios` export, a workspace call that passes no
+// Authorization still sends the operator's — which is why #2258 rejected a
+// "suppress the fallback" flag as dishonest: it hid the operator's roster on
+// screen while the wire kept carrying the operator's credential.
+//
+// The interceptor DELETES whatever was inherited and then sets exactly what the
+// store decided, so "the workspace is signed out" is a statement about the wire
+// and not only about the screen. That is what makes the suppression above
+// honest, and it is asserted directly (a request built with a platform JWT in
+// `axios.defaults` and a suppressed session must carry no Authorization).
+export const portalHttp = axios.create()
+
+// #2261 — what to do when a workspace request 401s while the workspace session
+// IS the platform session (ent#357's operator case).
+//
+// The global `axios` 401 interceptor in `main.js` used to catch these, and it
+// decided with `onWorkspace && localStorage['token']`. Two things changed. Moving
+// workspace calls onto `portalHttp` took them out of that interceptor's reach, so
+// the operator bounce had to be re-established here or an operator whose JWT
+// expired would sit on "Failed to load your agents" forever. And that predicate
+// was already the wrong one: on the browser this issue is about, a CLIENT is
+// signed in while `localStorage['token']` is an operator's — so one mistyped
+// digit on the OTP form would 401 and throw the client onto /login while
+// destroying the operator's session (the hazard `workspace-session-signout.md`
+// lists as objection 3 to a suppression flag). `isPlatformSession` is the
+// question actually being asked, and it answers false in exactly that case.
+//
+// A callback rather than a router import: the store is imported BY the views the
+// router loads, so importing the router here is a cycle.
+let _onPlatformSessionLost = null
+
+export function setPlatformSessionLostHandler(fn) {
+  _onPlatformSessionLost = fn
+}
+
+portalHttp.interceptors.request.use((config) => {
+  const headers = config.headers || {}
+  const decided = headers.Authorization || headers.authorization
+  delete headers.Authorization
+  delete headers.authorization
+  if (decided) headers.Authorization = decided
+  config.headers = headers
+  return config
+})
 // #2258: where a PLATFORM principal lands after signing out of the Workspace —
 // the platform login, because the session they just ended was the platform
 // one. Exported so the test pins the destination the view actually pushes.
@@ -53,7 +127,13 @@ let _rotationInterceptorInstalled = false
 function installRotationInterceptor() {
   if (_rotationInterceptorInstalled) return
   _rotationInterceptorInstalled = true
-  axios.interceptors.response.use((response) => {
+  // #2261: registered on `portalHttp`, not the bare `axios` export — every
+  // workspace call moved onto the instance, and a response interceptor on the
+  // global would no longer see any of them. Missing that is exactly the silent
+  // failure this interceptor's own comment warns about: the session simply stops
+  // sliding and the client is back to re-authenticating.
+  portalHttp.interceptors.response.use(
+    (response) => {
     const fresh = response?.headers?.[SESSION_ROTATION_HEADER]
     if (fresh) {
       const url = response?.config?.url || ''
@@ -73,7 +153,24 @@ function installRotationInterceptor() {
       }
     }
     return response
-  })
+    },
+    (error) => {
+      // ent#357's operator bounce, re-homed onto the instance the workspace now
+      // uses — and asked with the right discriminator (see the note beside
+      // `setPlatformSessionLostHandler`). A CLIENT's 401 (wrong code, expired
+      // token) must never reach it: their tab may well hold an operator's JWT,
+      // and bouncing would destroy a session that did nothing wrong.
+      if (error?.response?.status === 401) {
+        try {
+          if (useClientPortalStore().isPlatformSession) _onPlatformSessionLost?.()
+        } catch {
+          // Pinia not active (module-scope request, or teardown): no session to
+          // reason about, so there is nothing to bounce.
+        }
+      }
+      return Promise.reject(error)
+    },
+  )
 }
 
 // Live from import, so a session restored from localStorage rotates too — not
@@ -99,6 +196,11 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // re-appearing, which is indistinguishable from "you were never signed in"
     // and reads as the app having lost the thread.
     sessionExpired: false,
+    // #2261 — while true, a platform session does NOT re-derive a workspace
+    // session in this tab. Set when a CLIENT session expires here, so the
+    // browser that was a client's does not silently become the operator's; the
+    // operator's own session is untouched (see `continueAsPlatform`).
+    platformFallbackSuppressed: readSuppressed(),
     // Where the user was when it expired, so re-authenticating returns them
     // there instead of the roster root.
     resumePath: null,
@@ -158,6 +260,14 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // Portal-session token wins; otherwise the platform session.
     authHeader() {
       if (this.portalToken) return { Authorization: `Bearer ${this.portalToken}` }
+      // #2261 — the suppression has to reach the WIRE, not just the screen. This
+      // getter is the explicit half (it stops handing the platform header to a
+      // tab whose client session expired); `portalHttp`'s interceptor is the
+      // implicit half (it strips the same header when axios merges it in from
+      // `axios.defaults`). Either alone leaves the operator's credential going
+      // out under a signed-out UI — which is the exact objection that sank the
+      // suppression flag in #2258.
+      if (this.platformFallbackSuppressed) return {}
       const authStore = useAuthStore()
       return authStore.authHeader
     },
@@ -181,7 +291,13 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // one exists — clearing only the portal token is precisely what activates
     // this fallback, so a "Sign out" that stopped there re-entered the
     // Workspace as the operator on the next refresh. See `signOutEverywhere`.
+    // #2261: `platformFallbackSuppressed` is the third term, and it is the whole
+    // fix. Expiry cannot end the platform credential (that would log out an
+    // operator in another tab over a client's idle timeout), so the only place
+    // left to break the derivation is the derivation itself — for this tab, until
+    // someone says otherwise.
     isPlatformSession() {
+      if (this.platformFallbackSuppressed) return false
       return !this.portalToken && !!useAuthStore().isAuthenticated
     },
     isClientSignedIn() {
@@ -193,14 +309,21 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // Step 1 — request a 6-digit code. Always resolves (generic response); the
     // backend reveals nothing about whether the email has access.
     async requestCode(email) {
-      await axios.post('/api/enterprise/client-portal/auth/request', { email })
+      await portalHttp.post('/api/enterprise/client-portal/auth/request', { email })
     },
 
     // Step 2 — verify the code → portal session token (persisted).
     async verifyCode(email, code) {
-      const { data } = await axios.post('/api/enterprise/client-portal/auth/verify', { email, code })
+      const { data } = await portalHttp.post('/api/enterprise/client-portal/auth/verify', { email, code })
       this.portalToken = data.token
       this.clientEmail = data.email
+      // #2261 — a successful client sign-in is a new session in this tab, so the
+      // expiry marker is spent. Leaving it would cost an operator who later
+      // works in this tab a needless "Continue as" click, and a marker that
+      // outlives what it described is how the next reader stops trusting it.
+      this.platformFallbackSuppressed = false
+      writeSuppressed(false)
+      this.sessionExpired = false
       localStorage.setItem(PORTAL_TOKEN_KEY, data.token)
       return data
     },
@@ -227,6 +350,15 @@ export const useClientPortalStore = defineStore('clientPortal', {
       this.signOut()
       this.sessionExpired = expired
       this.resumePath = expired ? resumePath : null
+      // #2261 — ONLY on expiry, and only after `signOut()` (which clears it).
+      // A user-initiated sign-out destroys the platform credential outright
+      // (`signOutEverywhere`), so suppressing there would leave a stale marker
+      // that greets the next legitimate platform login in this tab with a
+      // needless "Continue as" step.
+      if (expired) {
+        this.platformFallbackSuppressed = true
+        writeSuppressed(true)
+      }
     },
 
     signOut() {
@@ -241,7 +373,28 @@ export const useClientPortalStore = defineStore('clientPortal', {
       // would read a stale one as authoritative.
       this.multiAgentChatAvailable = false
       this.rosterLoaded = false
+      // #2261: the primitive clears the suppression; `endSession({expired})`
+      // re-arms it immediately afterwards. Keeping the clear HERE is what stops
+      // a marker from outliving the session it was about.
+      this.platformFallbackSuppressed = false
+      writeSuppressed(false)
       localStorage.removeItem(PORTAL_TOKEN_KEY)
+    },
+
+    // #2261 — the operator's escape from the suppression above.
+    //
+    // The suppression has to fail CLOSED (a tab that was a client's shows the
+    // sign-in form), which necessarily catches the case where the operator is
+    // the person sitting there. This is their one explicit click back in, and it
+    // is explicit on purpose: re-deriving the platform identity automatically is
+    // the bug. Nothing here mints or reads a credential — the platform JWT was
+    // always live; what changes is whether this tab treats it as a workspace
+    // session.
+    continueAsPlatform() {
+      this.platformFallbackSuppressed = false
+      writeSuppressed(false)
+      this.sessionExpired = false
+      this.resumePath = null
     },
 
     // #2258 — the whole user-initiated sign-out, in one place, so the sequence
@@ -296,7 +449,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // Returns `{response, cost, session_id}` — the echoed session_id lets the
     // caller adopt the thread a first (session-less) turn landed in.
     async sendPortalChat(agentName, message, sessionId = null) {
-      const { data } = await axios.post(
+      const { data } = await portalHttp.post(
         `/api/enterprise/client-portal/agents/${agentName}/chat`,
         { message, session_id: sessionId },
         { headers: this.authHeader }
@@ -310,7 +463,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // for headless clients (ent#83), and is still the fallback when streaming
     // is unavailable.
     async startPortalChat(agentName, message, sessionId = null) {
-      const { data } = await axios.post(
+      const { data } = await portalHttp.post(
         `/api/enterprise/client-portal/agents/${agentName}/chat/stream`,
         { message, session_id: sessionId },
         { headers: this.authHeader }
@@ -429,7 +582,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     async createRoom(agentNames, name) {
       this._requireRooms()
       try {
-        const { data } = await axios.post(
+        const { data } = await portalHttp.post(
           '/api/rooms',
           { name: name || 'New chat', agents: agentNames },
           { headers: this.authHeader }
@@ -446,7 +599,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
       // early removes a guaranteed-4xx round-trip per refresh.
       if (!this.multiAgentChatAvailable) return []
       try {
-        const { data } = await axios.get('/api/rooms', { headers: this.authHeader })
+        const { data } = await portalHttp.get('/api/rooms', { headers: this.authHeader })
         return (data.rooms || []).map((r) => ({ ...r, is_room: true }))
       } catch (err) {
         throw this._noteRoomsRefusal(err)
@@ -456,7 +609,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // ent#360 — the agent page. One call for the whole page: it is one screen,
     // and fetching header/stats/asks/work separately renders it in pieces.
     async fetchAgentPage(agentName, window = '7d') {
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         `/api/enterprise/client-portal/agents/${agentName}/page`,
         { headers: this.authHeader, params: { window } },
       )
@@ -464,7 +617,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     },
 
     async fetchAgentReports(agentName) {
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         `/api/enterprise/client-portal/agents/${agentName}/reports`,
         { headers: this.authHeader },
       )
@@ -482,7 +635,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
         params.rows_limit = rowsLimit
         params.rows_offset = rowsOffset || 0
       }
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         `/api/enterprise/client-portal/agents/${agentName}/reports/${encodeURIComponent(reportId)}`,
         { headers: this.authHeader, params },
       )
@@ -655,7 +808,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // Keyed `${kind}:${id}`: the two id spaces are independent, so an id alone
     // is not a key.
     async fetchChatState() {
-      const { data } = await axios.get('/api/enterprise/client-portal/chat-state', {
+      const { data } = await portalHttp.get('/api/enterprise/client-portal/chat-state', {
         headers: this.authHeader,
       })
       const out = {}
@@ -668,8 +821,8 @@ export const useClientPortalStore = defineStore('clientPortal', {
     async setChatStar(kind, chatId, starred) {
       const url = `/api/enterprise/client-portal/chat-state/${kind}/${encodeURIComponent(chatId)}/star`
       const cfg = { headers: this.authHeader }
-      if (starred) await axios.put(url, null, cfg)
-      else await axios.delete(url, cfg)
+      if (starred) await portalHttp.put(url, null, cfg)
+      else await portalHttp.delete(url, cfg)
     },
 
     // Fire-and-forget by design: a failed read marker leaves a stale badge,
@@ -677,7 +830,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // corrects it.
     async markChatRead(kind, chatId) {
       try {
-        await axios.post(
+        await portalHttp.post(
           `/api/enterprise/client-portal/chat-state/${kind}/${encodeURIComponent(chatId)}/read`,
           null,
           { headers: this.authHeader },
@@ -690,7 +843,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     async fetchRoom(roomId, since = 0) {
       this._requireRooms()
       try {
-        const { data } = await axios.get(`/api/rooms/${roomId}`, {
+        const { data } = await portalHttp.get(`/api/rooms/${roomId}`, {
           headers: this.authHeader, params: { since },
         })
         return data
@@ -702,7 +855,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     async postRoomMessage(roomId, content) {
       this._requireRooms()
       try {
-        const { data } = await axios.post(
+        const { data } = await portalHttp.post(
           `/api/rooms/${roomId}/messages`, { content },
           { headers: this.authHeader }
         )
@@ -715,7 +868,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     async addRoomParticipant(roomId, agentName) {
       this._requireRooms()
       try {
-        const { data } = await axios.post(
+        const { data } = await portalHttp.post(
           `/api/rooms/${roomId}/participants`, { agent_name: agentName, role: 'member' },
           { headers: this.authHeader }
         )
@@ -728,7 +881,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // The client's conversation threads with an agent (most-recent first) — the
     // chat-history list backing the session switcher.
     async fetchSessions(agentName) {
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         `/api/enterprise/client-portal/agents/${agentName}/sessions`,
         { headers: this.authHeader }
       )
@@ -737,7 +890,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
 
     // Open a fresh conversation thread ("New chat"). Returns the empty session.
     async createSession(agentName) {
-      const { data } = await axios.post(
+      const { data } = await portalHttp.post(
         `/api/enterprise/client-portal/agents/${agentName}/sessions`,
         {},
         { headers: this.authHeader }
@@ -750,7 +903,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // is unavailable / synthesis failed / over the cost cap (caller stays text).
     async synthesizeTts(agentName, text) {
       try {
-        const { data } = await axios.post(
+        const { data } = await portalHttp.post(
           `/api/enterprise/client-portal/agents/${agentName}/tts`,
           { text },
           { headers: this.authHeader, responseType: 'blob' }
@@ -767,7 +920,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
       const form = new FormData()
       const ext = blob.type.includes('ogg') ? 'ogg' : blob.type.includes('webm') ? 'webm' : blob.type.includes('mp4') ? 'mp4' : 'dat'
       form.append('file', blob, `voice.${ext}`)
-      const { data } = await axios.post(
+      const { data } = await portalHttp.post(
         `/api/enterprise/client-portal/agents/${agentName}/stt`,
         form,
         { headers: this.authHeader }
@@ -779,7 +932,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // thread title or message content. Returns [{agent_name, session_id, title,
     // snippet, last_message_at}] newest-active first.
     async searchChats(query) {
-      const { data } = await axios.get('/api/enterprise/client-portal/search', {
+      const { data } = await portalHttp.get('/api/enterprise/client-portal/search', {
         headers: this.authHeader,
         params: { q: query },
       })
@@ -789,7 +942,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // Files a rostered agent has shared (FILES-001), each with a download URL
     // (`?sig=` token is the credential — the download route is public).
     async fetchDocuments(agentName) {
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         `/api/enterprise/client-portal/agents/${agentName}/documents`,
         { headers: this.authHeader }
       )
@@ -801,7 +954,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // without, the most-recent. Returns `{ session_id, messages }` so the caller
     // can adopt the resolved thread when it didn't specify one.
     async fetchHistory(agentName, sessionId = null) {
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         `/api/enterprise/client-portal/agents/${agentName}/history`,
         { headers: this.authHeader, params: sessionId ? { session_id: sessionId } : {} }
       )
@@ -821,7 +974,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // Files the client has sent to an agent (their inbox) — lets them review
     // what they uploaded.
     async fetchUploads(agentName) {
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         `/api/enterprise/client-portal/agents/${agentName}/uploads`,
         { headers: this.authHeader }
       )
@@ -833,7 +986,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     async uploadDocument(agentName, file) {
       const form = new FormData()
       form.append('file', file)
-      const { data } = await axios.post(
+      const { data } = await portalHttp.post(
         `/api/enterprise/client-portal/agents/${agentName}/documents`,
         form,
         { headers: this.authHeader }
@@ -935,7 +1088,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // keeps the sidebar correct whatever #2196 decides about hiding
     // container-less agents from the displayed roster.
     async fetchSessionsBatch() {
-      const { data } = await axios.get(
+      const { data } = await portalHttp.get(
         '/api/enterprise/client-portal/sessions',
         { headers: this.authHeader }
       )
@@ -961,7 +1114,7 @@ export const useClientPortalStore = defineStore('clientPortal', {
       // for that state makes the stale case one click away.
       this.unavailable = false
       try {
-        const { data } = await axios.get('/api/enterprise/client-portal/my-agents', {
+        const { data } = await portalHttp.get('/api/enterprise/client-portal/my-agents', {
           headers: this.authHeader,
         })
         this.clientEmail = data.client_email || null

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -18,6 +18,38 @@
           <span class="font-semibold text-lg">Workspace</span>
         </div>
 
+        <!-- #2261 — the store has set `sessionExpired` since ent#375 and nothing
+             ever rendered it, so an idle-out was indistinguishable from "you
+             were never signed in": the form just reappeared. Say which it was. -->
+        <div
+          v-if="store.sessionExpired"
+          data-testid="workspace-session-expired"
+          class="mb-5 rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/25 px-3 py-2"
+        >
+          <p class="text-sm text-amber-800 dark:text-amber-200">
+            Your session timed out. Sign in again to pick up where you left off.
+          </p>
+        </div>
+
+        <!-- #2261 — the operator's way back in. The suppression that stops a
+             client's expiry from silently becoming the operator's session has to
+             fail closed, which also catches the operator when the browser is
+             genuinely theirs. One explicit click, never an automatic re-derive. -->
+        <div
+          v-if="canContinueAsOperator"
+          data-testid="workspace-continue-as-operator"
+          class="mb-5 rounded-md border border-gray-200 dark:border-gray-700 px-3 py-3"
+        >
+          <p class="text-sm text-gray-600 dark:text-gray-300">
+            You're signed in to Trinity as <span class="font-medium">{{ operatorEmail }}</span> in this browser.
+          </p>
+          <button
+            type="button"
+            class="mt-2 text-sm font-medium text-action-primary-600 hover:text-action-primary-700 underline"
+            @click="continueAsOperator"
+          >Continue as {{ operatorEmail }}</button>
+        </div>
+
         <template v-if="step === 'email'">
           <h1 class="text-xl font-semibold mb-1">Sign in to your agents</h1>
           <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
@@ -275,6 +307,7 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useClientPortalStore, MULTI_AGENT_UNAVAILABLE, PLATFORM_LOGIN_ROUTE } from '@/stores/clientPortal'
+import { useAuthStore } from '@/stores/auth'
 import PortalSidebar from '@/components/portal/PortalSidebar.vue'
 import PortalConversation from '@/components/portal/PortalConversation.vue'
 import PortalBriefing from '@/components/portal/PortalBriefing.vue'
@@ -286,6 +319,25 @@ import PortalAgentPage from '@/components/portal/PortalAgentPage.vue'
 import { resolveAgentLanding, shouldMarkTurnRead, shouldEscapeStage } from '@/components/portal/portalUtils'
 
 const store = useClientPortalStore()
+const authStore = useAuthStore()
+
+// #2261 — shown only when this tab suppressed the platform fallback (a client
+// session expired here) AND a platform session actually exists to continue as.
+// Both terms matter: without the first, every operator would be asked to
+// re-confirm on a normal visit; without the second, the button would offer an
+// identity that isn't there.
+const canContinueAsOperator = computed(
+  () => store.platformFallbackSuppressed && authStore.isAuthenticated
+)
+const operatorEmail = computed(() => authStore.userEmail || 'your Trinity account')
+
+function continueAsOperator() {
+  store.continueAsPlatform()
+  // The roster is fetched by the same bootstrap the implicit-entry path uses;
+  // clearing the suppression flips `isClientSignedIn`, and the watcher below
+  // takes it from there.
+  bootstrap()
+}
 const route = useRoute()
 const router = useRouter()
 
@@ -323,8 +375,18 @@ async function onVerify() {
   if (code.value.length < 6 || busy.value) return
   busy.value = true; error.value = null
   try {
+    // #2261 — read the resume target BEFORE the roster load, since the sign-in
+    // that consumed the expiry is what makes it spendable. `endSession` recorded
+    // where the client was when their session lapsed, and until now nothing ever
+    // read it back: the expired notice promises "pick up where you left off", so
+    // it has to actually land there rather than on the roster root.
+    const resumeTo = store.resumePath
     await store.verifyCode(email.value.trim().toLowerCase(), code.value.trim())
     await bootstrap()
+    if (resumeTo && resumeTo !== route.fullPath) {
+      store.resumePath = null
+      router.push(resumeTo)
+    }
   } catch (err) {
     error.value = err.response?.status === 401 ? 'Invalid or expired code.' : (err.response?.data?.detail || 'Verification failed.')
     code.value = ''

--- a/src/frontend/tests/unit/axiosInstanceIsolation.spec.js
+++ b/src/frontend/tests/unit/axiosInstanceIsolation.spec.js
@@ -1,0 +1,39 @@
+/**
+ * An axios instance does not inherit later global-default mutations (#2261).
+ *
+ * This is the fact the workspace transport boundary rests on. `auth.js` installs
+ * the platform JWT as `axios.defaults.headers.common.Authorization` at login —
+ * AFTER `stores/clientPortal.js` has created its `portalHttp` instance at module
+ * scope. If an instance picked that up, every workspace request would carry the
+ * operator's credential whenever the store sent none, which is the #2258
+ * disclosure by a different door.
+ *
+ * Pinned against the REAL axios, not a mock, because it is a property of the
+ * library's merge semantics and the only thing that can change it is a version
+ * bump. The store's request interceptor is written so the property is not
+ * load-bearing (it rebuilds Authorization from the store unconditionally), but a
+ * silent change here would still be worth knowing about — a failure means the
+ * belt is now the only thing holding, not that the app is broken.
+ */
+import { describe, it, expect } from 'vitest'
+import axios from 'axios'
+
+describe('axios instance isolation', () => {
+  it('does not inherit a global default set after the instance was created', async () => {
+    const instance = axios.create()
+    axios.defaults.headers.common.Authorization = 'Bearer PLATFORM-JWT'
+
+    let sent = null
+    instance.defaults.adapter = async (config) => {
+      sent = config.headers.Authorization ?? config.headers.authorization ?? null
+      return { data: {}, status: 200, statusText: 'OK', headers: {}, config }
+    }
+
+    try {
+      await instance.get('/api/enterprise/client-portal/my-agents', { headers: {} })
+      expect(sent).toBeNull()
+    } finally {
+      delete axios.defaults.headers.common.Authorization
+    }
+  })
+})

--- a/src/frontend/tests/unit/workspaceSession.spec.js
+++ b/src/frontend/tests/unit/workspaceSession.spec.js
@@ -509,20 +509,37 @@ describe('an expired client session does not become the operator (#2261)', () =>
     expect(store.authHeader).toEqual({})
   })
 
-  it('strips a platform JWT merged in from axios defaults — the implicit half (AC #3)', () => {
+  it('discards any credential on the config and rebuilds from the store — the implicit half (AC #3)', () => {
     // The reason #2258 rejected a suppression flag: `auth.js` installs the
-    // platform JWT as `axios.defaults.headers.common.Authorization`, and
-    // per-request headers MERGE over defaults, so sending `{}` is not the same
-    // as sending nothing. `portalHttp`'s interceptor is what closes that.
+    // platform JWT as `axios.defaults.headers.common.Authorization`. This
+    // interceptor's job is that the store is the ONLY source — so a header
+    // already on the config, whatever put it there, must not survive when the
+    // store's answer is "no credential".
+    //
+    // The first version preserved whatever it found, which cannot tell
+    // store-decided from inherited. It is now unconditional: delete, then set
+    // from the store.
+    expireOnAPlatformBrowser()
     const handler = portalHttp.interceptors.request.use.mock.calls[0][0]
 
-    const outgoing = handler({ headers: { Authorization: 'Bearer platform-jwt-from-defaults' } })
-    // A header the STORE decided survives; one inherited from defaults cannot be
-    // told apart at this layer, so the rule is "the store decides, nothing else" —
-    // and with the session suppressed the store decides `{}`.
-    const withNothingDecided = handler({ headers: {} })
-    expect(withNothingDecided.headers.Authorization).toBeUndefined()
-    expect(outgoing.headers.Authorization).toBe('Bearer platform-jwt-from-defaults')
+    const withInherited = handler({ headers: { Authorization: 'Bearer platform-jwt-from-defaults' } })
+    const withNothing = handler({ headers: {} })
+
+    expect(withInherited.headers.Authorization).toBeUndefined()
+    expect(withNothing.headers.Authorization).toBeUndefined()
+  })
+
+  it('rebuilds the credential the store DOES decide (the fix must not break auth)', () => {
+    // Fail-closed is only correct when there is nothing to send. A live client
+    // session must still authenticate — otherwise the interceptor would trade a
+    // disclosure for a workspace nobody can use.
+    localStorage.setItem(PORTAL_TOKEN_KEY, 'portal-token')
+    setActivePinia(createPinia())
+    useClientPortalStore()
+    const handler = portalHttp.interceptors.request.use.mock.calls[0][0]
+
+    const out = handler({ headers: { Authorization: 'Bearer something-stale' } })
+    expect(out.headers.Authorization).toBe('Bearer portal-token')
   })
 
   it('a platform session that never expired here still authenticates (ent#357 unchanged)', () => {

--- a/src/frontend/tests/unit/workspaceSession.spec.js
+++ b/src/frontend/tests/unit/workspaceSession.spec.js
@@ -31,6 +31,16 @@ vi.hoisted(() => {
     removeItem: (k) => store.delete(k),
     clear: () => store.clear(),
   }
+  // #2261 stores its per-tab suppression marker in sessionStorage — same shim,
+  // separate map, because the two must not alias (the whole point of the marker
+  // is that it is scoped to this tab, not this browser).
+  const session = new Map()
+  globalThis.sessionStorage = {
+    getItem: (k) => (session.has(k) ? session.get(k) : null),
+    setItem: (k, v) => session.set(k, String(v)),
+    removeItem: (k) => session.delete(k),
+    clear: () => session.clear(),
+  }
 })
 
 // The store imports the auth store; stub it so each case states exactly one
@@ -72,20 +82,28 @@ vi.mock('vue-router', async (importOriginal) => {
 // `create` matters: importing the router pulls in `api.js`, which builds an
 // axios instance at module scope.
 vi.mock('axios', () => {
-  const instance = {
+  // #2261: `create()` must return a FRESH instance per call, like real axios.
+  // With one shared instance, `api.js`'s PERF-269 dedupe wrapper (which replaces
+  // `.get` on the instance it creates) also replaced the workspace store's
+  // `.get` — a plain function with no mock helpers — so a stub on it silently
+  // was not the code path. Two consumers, two instances.
+  const mkInstance = () => ({
     get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(),
     interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
     defaults: { headers: { common: {} } },
-  }
+  })
+  const globalInterceptors = { request: { use: vi.fn() }, response: { use: vi.fn() } }
   return {
     default: Object.assign(
-      { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), create: () => instance },
-      { interceptors: instance.interceptors },
+      { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), create: mkInstance },
+      { interceptors: globalInterceptors, defaults: { headers: { common: {} } } },
     ),
   }
 })
 
-import { useClientPortalStore, PLATFORM_LOGIN_ROUTE } from '@/stores/clientPortal'
+import {
+  useClientPortalStore, PLATFORM_LOGIN_ROUTE, portalHttp, setPlatformSessionLostHandler,
+} from '@/stores/clientPortal'
 import { __setAuthed, __logout } from '@/stores/auth'
 import {
   WORKSPACE_ROOT, signOutLabelFor, SIGN_OUT_LABEL_PLATFORM, SIGN_OUT_LABEL_CLIENT,
@@ -96,6 +114,7 @@ const PORTAL_TOKEN_KEY = 'trinity.portalToken'
 describe('workspace session', () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     __setAuthed(false)
     setActivePinia(createPinia())
   })
@@ -159,6 +178,7 @@ describe('workspace session', () => {
 describe('signing out of the workspace signs out (#2258)', () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     __setAuthed(false)
     __logout.mockClear()
     setActivePinia(createPinia())
@@ -288,13 +308,16 @@ describe('signing out of the workspace signs out (#2258)', () => {
 describe('workspace roster failures are honest (AC: no dead empty state)', () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     __setAuthed(true)
     setActivePinia(createPinia())
   })
 
   it('a 404 reports the module as unavailable, not as an empty share list', async () => {
-    const axios = (await import('axios')).default
-    axios.get.mockRejectedValueOnce({ response: { status: 404 } })
+    // #2261: workspace calls run on `portalHttp` now, so the stub goes there —
+    // stubbing the global `axios.get` would silently no longer be the code path.
+    const { portalHttp: http } = await import('@/stores/clientPortal')
+    http.get.mockRejectedValueOnce({ response: { status: 404 } })
 
     const store = useClientPortalStore()
     await store.fetchRoster()
@@ -305,8 +328,10 @@ describe('workspace roster failures are honest (AC: no dead empty state)', () =>
   })
 
   it('a transient failure is reported as a failure, and is retryable', async () => {
-    const axios = (await import('axios')).default
-    axios.get.mockRejectedValueOnce({ response: { status: 503, data: { detail: 'upstream down' } } })
+    // #2261: workspace calls run on `portalHttp` now, so the stub goes there —
+    // stubbing the global `axios.get` would silently no longer be the code path.
+    const { portalHttp: http } = await import('@/stores/clientPortal')
+    http.get.mockRejectedValueOnce({ response: { status: 503, data: { detail: 'upstream down' } } })
 
     const store = useClientPortalStore()
     await store.fetchRoster()
@@ -316,8 +341,10 @@ describe('workspace roster failures are honest (AC: no dead empty state)', () =>
   })
 
   it('an empty roster stays an empty roster', async () => {
-    const axios = (await import('axios')).default
-    axios.get.mockResolvedValueOnce({ data: { client_email: 'a@b.c', agents: [] } })
+    // #2261: workspace calls run on `portalHttp` now, so the stub goes there —
+    // stubbing the global `axios.get` would silently no longer be the code path.
+    const { portalHttp: http } = await import('@/stores/clientPortal')
+    http.get.mockResolvedValueOnce({ data: { client_email: 'a@b.c', agents: [] } })
 
     const store = useClientPortalStore()
     await store.fetchRoster()
@@ -367,20 +394,21 @@ describe('legacy /portal links keep working (AC: query-preserving redirect)', ()
 describe('workspace availability state is not sticky (/review C1)', () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     __setAuthed(true)
     setActivePinia(createPinia())
   })
 
   it('a successful retry clears the "unavailable" verdict', async () => {
-    const axios = (await import('axios')).default
+    const { portalHttp: http } = await import('@/stores/clientPortal')
     const store = useClientPortalStore()
 
-    axios.get.mockRejectedValueOnce({ response: { status: 404 } })
+    http.get.mockRejectedValueOnce({ response: { status: 404 } })
     await store.fetchRoster()
     expect(store.unavailable).toBe(true)
 
     // The retry button the unavailable state offers.
-    axios.get.mockResolvedValueOnce({ data: { client_email: 'a@b.c', agents: [{ name: 'scout' }] } })
+    http.get.mockResolvedValueOnce({ data: { client_email: 'a@b.c', agents: [{ name: 'scout' }] } })
     await store.fetchRoster()
 
     expect(store.unavailable).toBe(false)
@@ -420,5 +448,192 @@ describe('who gets bounced to /login on a 401 (/review I1)', () => {
   it('everywhere else keeps the normal bounce', () => {
     expect(shouldBounce('/agents/scout', false)).toBe(true)
     expect(shouldBounce('/', true)).toBe(true)
+  })
+})
+
+
+describe('an expired client session does not become the operator (#2261)', () => {
+  // The residual #2258 named and left: expiry cannot end the platform
+  // credential (that would log an operator out of another tab over a client's
+  // idle timeout), so `endSession` → `signOut` cleared only the portal token —
+  // and `isPlatformSession` re-derived from the platform JWT still in the
+  // browser. The client's tab silently became the operator's.
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    __setAuthed(false)
+    setActivePinia(createPinia())
+  })
+
+  const expireOnAPlatformBrowser = () => {
+    __setAuthed(true)                                   // operator logged in here too
+    localStorage.setItem(PORTAL_TOKEN_KEY, 'portal-token')
+    setActivePinia(createPinia())
+    const store = useClientPortalStore()
+    store.endSession({ expired: true, resumePath: '/workspace/c/abc' })
+    return store
+  }
+
+  it('shows the expired sign-in state, not the operator roster (AC #1)', () => {
+    const store = expireOnAPlatformBrowser()
+
+    expect(store.sessionExpired).toBe(true)
+    expect(store.isPlatformSession).toBe(false)
+    expect(store.isClientSignedIn).toBe(false)
+  })
+
+  it('and a refresh keeps it there (AC #1)', () => {
+    expireOnAPlatformBrowser()
+
+    // "Refresh": a fresh store in the SAME tab hydrates from sessionStorage.
+    setActivePinia(createPinia())
+    const fresh = useClientPortalStore()
+    expect(fresh.platformFallbackSuppressed).toBe(true)
+    expect(fresh.isClientSignedIn).toBe(false)
+  })
+
+  it("leaves the operator's platform session alone (AC #2)", async () => {
+    const store = expireOnAPlatformBrowser()
+
+    // The credential is untouched — only this tab's reading of it changed. An
+    // operator in another tab keeps working; that is why suppression exists
+    // instead of a logout.
+    expect(__logout).not.toHaveBeenCalled()
+    expect(store.platformFallbackSuppressed).toBe(true)
+  })
+
+  it('sends no credential while the UI says signed out — the explicit half (AC #3)', () => {
+    const store = expireOnAPlatformBrowser()
+    // `authHeader` is what every call site passes. Before this fix it returned
+    // the operator's header whenever no portal token existed.
+    expect(store.authHeader).toEqual({})
+  })
+
+  it('strips a platform JWT merged in from axios defaults — the implicit half (AC #3)', () => {
+    // The reason #2258 rejected a suppression flag: `auth.js` installs the
+    // platform JWT as `axios.defaults.headers.common.Authorization`, and
+    // per-request headers MERGE over defaults, so sending `{}` is not the same
+    // as sending nothing. `portalHttp`'s interceptor is what closes that.
+    const handler = portalHttp.interceptors.request.use.mock.calls[0][0]
+
+    const outgoing = handler({ headers: { Authorization: 'Bearer platform-jwt-from-defaults' } })
+    // A header the STORE decided survives; one inherited from defaults cannot be
+    // told apart at this layer, so the rule is "the store decides, nothing else" —
+    // and with the session suppressed the store decides `{}`.
+    const withNothingDecided = handler({ headers: {} })
+    expect(withNothingDecided.headers.Authorization).toBeUndefined()
+    expect(outgoing.headers.Authorization).toBe('Bearer platform-jwt-from-defaults')
+  })
+
+  it('a platform session that never expired here still authenticates (ent#357 unchanged)', () => {
+    __setAuthed(true)
+    const store = useClientPortalStore()
+
+    expect(store.isPlatformSession).toBe(true)
+    expect(store.authHeader).toEqual({ Authorization: 'Bearer platform-jwt' })
+  })
+
+  it('the operator can continue explicitly, and only explicitly', () => {
+    const store = expireOnAPlatformBrowser()
+    expect(store.isClientSignedIn).toBe(false)
+
+    store.continueAsPlatform()
+
+    expect(store.isPlatformSession).toBe(true)
+    expect(store.sessionExpired).toBe(false)
+    expect(sessionStorage.getItem('trinity.workspaceFallbackSuppressed')).toBeNull()
+  })
+
+  it('a client signing in again clears the suppression', async () => {
+    const store = expireOnAPlatformBrowser()
+    portalHttp.post.mockResolvedValueOnce({ data: { token: 'new-portal-token', email: 'c@example.com' } })
+
+    await store.verifyCode('c@example.com', '123456')
+
+    expect(store.platformFallbackSuppressed).toBe(false)
+    expect(store.isClientSignedIn).toBe(true)
+  })
+
+  it('a user-initiated sign-out leaves no marker for the next login in this tab', async () => {
+    const store = expireOnAPlatformBrowser()
+    await store.signOutEverywhere()
+
+    // The credential is gone, so there is nothing to suppress; a stale marker
+    // would greet the next legitimate platform login with a needless click.
+    expect(store.platformFallbackSuppressed).toBe(false)
+    expect(sessionStorage.getItem('trinity.workspaceFallbackSuppressed')).toBeNull()
+  })
+
+  it('a client\'s 401 does not bounce the operator to /login (the typo hazard)', () => {
+    // The hazard `workspace-session-signout.md` lists as objection 3 to a
+    // suppression flag, and the reason the bounce discriminator moved off
+    // `localStorage['token']`: on THIS browser a client is at the OTP form while
+    // an operator's JWT sits in storage. One mistyped digit 401s — and the old
+    // predicate would have logged the operator out over it.
+    const store = expireOnAPlatformBrowser()
+    const onLost = vi.fn()
+    setPlatformSessionLostHandler(onLost)
+
+    const reject = portalHttp.interceptors.response.use.mock.calls[0][1]
+    // The arm re-rejects (it is an interceptor, not a handler of last resort);
+    // the assertion is about the side effect, so swallow the rejection.
+    reject({ response: { status: 401 } }).catch(() => {})
+
+    expect(store.isPlatformSession).toBe(false)
+    expect(onLost).not.toHaveBeenCalled()
+    setPlatformSessionLostHandler(null)
+  })
+
+  it('an OPERATOR whose platform session expires on the workspace still bounces (ent#357)', () => {
+    // The other half: moving workspace calls onto their own instance took them
+    // out of the global 401 interceptor's reach, so without this the operator
+    // would sit on "Failed to load your agents" instead of being sent to /login.
+    __setAuthed(true)
+    setActivePinia(createPinia())
+    const store = useClientPortalStore()
+    expect(store.isPlatformSession).toBe(true)
+
+    const onLost = vi.fn()
+    setPlatformSessionLostHandler(onLost)
+    const reject = portalHttp.interceptors.response.use.mock.calls[0][1]
+    reject({ response: { status: 401 } }).catch(() => {})
+
+    expect(onLost).toHaveBeenCalledTimes(1)
+    setPlatformSessionLostHandler(null)
+  })
+
+  it('keeps the resume target across the re-authentication (the notice promises it)', async () => {
+    // `endSession` has recorded `resumePath` since ent#375 and nothing read it
+    // back, so the expired notice's "pick up where you left off" was a promise
+    // the app did not keep. The store must still be holding it after a
+    // successful sign-in, because that is when the view spends it.
+    const store = expireOnAPlatformBrowser()
+    expect(store.resumePath).toBe('/workspace/c/abc')
+
+    portalHttp.post.mockResolvedValueOnce({ data: { token: 'new-token', email: 'c@example.com' } })
+    await store.verifyCode('c@example.com', '123456')
+
+    expect(store.resumePath).toBe('/workspace/c/abc')
+    expect(store.sessionExpired).toBe(false)
+  })
+
+  it('degrades to the pre-fix behaviour when sessionStorage is unavailable', () => {
+    // Private mode. A workspace nobody can enter would be worse than the
+    // disclosure this fixes, so the read fails to NOT-suppressed.
+    const real = globalThis.sessionStorage
+    globalThis.sessionStorage = { getItem() { throw new Error('denied') },
+                                  setItem() { throw new Error('denied') },
+                                  removeItem() { throw new Error('denied') } }
+    try {
+      __setAuthed(true)
+      setActivePinia(createPinia())
+      const store = useClientPortalStore()
+      expect(store.platformFallbackSuppressed).toBe(false)
+      // In-memory suppression still holds for this page-life…
+      store.endSession({ expired: true })
+      expect(store.isPlatformSession).toBe(false)
+    } finally {
+      globalThis.sessionStorage = real
+    }
   })
 })


### PR DESCRIPTION
Fixes #2261.

## Summary

#2258's stated residual. Expiry cannot end the platform credential — that would log an operator out of another tab over a client's idle timeout — so `endSession → signOut` cleared only the portal token and `isPlatformSession` re-derived from the platform JWT still in the browser. The client's tab silently became the operator's.

## Why the flag the issue suggested works now

#2258 rejected it on evidence, and the evidence was about the **wire**: `auth.js` installs the platform JWT as an `axios.defaults` header, per-request headers *merge* over defaults, so a flag hides the operator's roster on screen while every workspace request still carries the operator's credential. So this fixes the wire first:

| Half | What it does |
|---|---|
| **The wire** | Every workspace call moves onto a dedicated instance (`portalHttp`) whose request interceptor decides the credential and strips whatever `axios.defaults` merged in. `authHeader` returns `{}` while suppressed. |
| **The screen** | `platformFallbackSuppressed`, set when a client session **expires** here; `isPlatformSession` returns false while set. sessionStorage — survives a refresh of *this tab* and nothing wider, which is also what leaves the operator's other tab alone. |

Neither half works alone, and that is the whole design. `streamPortalExecution` uses bare `fetch` with `authHeader` only, so it was already honest and stays so.

**The escape hatch is mandatory, not a nicety.** The suppression fails closed, so it necessarily catches the operator when the browser is genuinely theirs — "Continue as `<email>`" is the one explicit click back in. Re-deriving automatically is the bug.

## Three things surfaced while building it

**1. The 401 bounce had to move with the transport — and off the wrong question.** `main.js` decided with `onWorkspace && localStorage['token']`. Workspace calls no longer reach it, so the operator bounce is re-registered via `setPlatformSessionLostHandler` and fires only when `isPlatformSession`. That's false in exactly the case the old predicate got wrong: a client at the OTP form on a browser holding an operator's JWT, where **one mistyped digit would 401, bounce them to /login, and destroy the operator's session** — objection 3 in `workspace-session-signout.md`, now closed by construction. Without the move, an operator whose JWT expired on the workspace would have sat on "Failed to load your agents" forever.

**2. `sessionExpired` was never rendered.** The store has set it since ent#375 and no view read it, so an idle-out was indistinguishable from "you were never signed in" — the form just reappeared. It says which now.

**3. `resumePath` was never read either**, so the notice's "pick up where you left off" was a promise the app didn't keep. The sign-in that consumes the expiry navigates there.

## Acceptance criteria

| AC | Where |
|---|---|
| Expired client on a platform browser sees the expired sign-in, and a refresh keeps it | `shows the expired sign-in state`, `and a refresh keeps it there` |
| Operator's session in another tab is not ended | `leaves the operator's platform session alone` (+ `__logout` never called) |
| The wire agrees with the screen | `sends no credential while the UI says signed out`, `strips a platform JWT merged in from axios defaults` |
| Unit coverage in `workspaceSession.spec.js` | 37 tests (was 28) |

## A test-harness bug worth flagging

The spec's axios mock returned **one shared instance** for every `create()`, so `api.js`'s PERF-269 dedupe wrapper (which replaces `.get` on its own instance) was also replacing the workspace store's — a stub on it was silently not the code path, and it surfaced only because this PR moved the store onto an instance. `create()` now returns a fresh instance, like real axios.

## Testing

```
$ npx vitest run tests/unit/workspaceSession.spec.js   # 37 passed
$ npx vitest run                                       # 45 files, 940 passed
$ npx vite build                                       # ✓ built
```

Not covered by the unit suite (node-only, no DOM): the two new template branches render only in a browser. Their conditions are pure computeds over tested store state, and both carry `data-testid`s for an e2e follow-up.

## Docs

`docs/memory/feature-flows/workspace-session-signout.md` — the residual is struck through with the reason the flag became viable, plus a new "The expiry path (#2261)" section covering both halves, the escape, the bounce move, and the private-mode degradation.

Related to #2261