### PR TITLE
fix(pull): claim envelope reads the flat backlog_metadata keys the producer writes (#2317)

### DIFF
--- a/docker/base-image/agent_server/services/pull_worker.py
+++ b/docker/base-image/agent_server/services/pull_worker.py
@@ -194,6 +194,25 @@ def _turn_timeout() -> int:
     return max(1, n)
 
 
+def _resolve_turn_timeout(overrides: Dict[str, Any]) -> int:
+    """The claimed row's own turn budget when the envelope carries one, else the
+    pool default (#2317).
+
+    The backend records a concrete ``timeout_seconds`` on every queued row
+    (``backlog_service.enqueue`` — the caller's override, or the agent's
+    ``execution_timeout_seconds``) and the PUSH path enforces it. Before #2317 the
+    claim envelope never carried it and this pool ran every pulled turn to
+    ``TRINITY_PULL_TURN_TIMEOUT`` instead, so a row asking for 60s got 900s.
+    Fail-soft: a missing / non-numeric / non-positive value falls back to the
+    pool default, never raises."""
+    raw = overrides.get("timeout_seconds")
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return _turn_timeout()
+    return n if n > 0 else _turn_timeout()
+
+
 # ---------------------------------------------------------------------------
 # Result body (§3.3 reply payload) construction
 # ---------------------------------------------------------------------------
@@ -373,7 +392,7 @@ async def _run_and_report(
     message = payload.get("message") or ""
     session_id = payload.get("session_id")
     overrides = payload.get("task_overrides") or {}
-    turn_timeout = _turn_timeout()
+    turn_timeout = _resolve_turn_timeout(overrides)
 
     agent_state.record_task_start()
     try:
@@ -416,7 +435,10 @@ async def _run_and_report(
         _persist_pull_result(execution_id, {"execution_id": execution_id, "body": body})
 
     # Deadline = now + (turn timeout + buffer) = the slot-lease TTL window.
-    deadline = time.monotonic() + turn_timeout + _SLOT_TTL_BUFFER_SECONDS
+    # #2317: keyed to the POOL's budget, not the row's — honouring a short
+    # per-task timeout must not also shrink the result-delivery retry window
+    # (the backend lease derives from the agent's execution_timeout, not the row's).
+    deadline = time.monotonic() + max(turn_timeout, _turn_timeout()) + _SLOT_TTL_BUFFER_SECONDS
     delivered = await _deliver_result(client, execution_id, body, backend_url, mcp_key, deadline)
     if delivered and persisted:
         _delete_pull_result(execution_id)

--- a/docs/planning/MESSAGE_ENVELOPE_SCHEMA.md
+++ b/docs/planning/MESSAGE_ENVELOPE_SCHEMA.md
@@ -177,6 +177,16 @@ Model selection is **not** a task field: per-call `model` is demoted to a
 session/schedule attribute (map #2, MODEL-001). `async_mode` disappears —
 everything is async; sync is the `?wait=true` edge adapter (map #4).
 
+> **Pilot reality (#2317).** The table above is the TARGET shape. Until the
+> demotion PRs land, the producer of a queued row (`backlog_service.enqueue`)
+> still records a per-task `model` and `timeout_seconds`, the push path enforces
+> both, and the pull worker reads both off `task_overrides` — so the claim
+> envelope built by `pull_coordination_service._build_claim_response` carries
+> `model` and `timeout_seconds` alongside the three fields above. They leave the
+> payload when the demotion that removes them from `ParallelTaskRequest` lands,
+> not before; dropping them from the wire earlier is a silent correctness
+> regression on the pull path (that was #2317).
+
 ### 2.3 `kind: event`
 
 Agent event pub/sub (EVT-001). Emitted once by a source agent; the projector

--- a/src/backend/services/pull_coordination_service.py
+++ b/src/backend/services/pull_coordination_service.py
@@ -155,6 +155,27 @@ class ResultApplyOutcome:
 
 
 # ---------------------------------------------------------------------------
+# Per-task settings carried on the claim envelope (#2317)
+# ---------------------------------------------------------------------------
+# `backlog_service.enqueue` persists a queued row's per-task settings as FLAT
+# keys inside `backlog_metadata`, and the PUSH drain (`_spawn_drain`) reads them
+# flat. The pull envelope must consume the SAME keys or a pulled turn silently
+# loses them. These are the keys that reach the RUNTIME (they map 1:1 onto
+# `execute_headless` kwargs the pull worker passes); the remaining metadata keys
+# are backend-side concerns (chat-session persistence + provenance) that neither
+# path sends to the agent. `tests/unit/test_2317_pull_envelope_parity.py` pins
+# that split against the producer itself, so a key added to `enqueue` cannot
+# silently belong to neither set.
+_TASK_OVERRIDE_KEYS = (
+    "model",           # --model            (push: ParallelTaskRequest.model)
+    "allowed_tools",   # --allowedTools     (push: ParallelTaskRequest.allowed_tools)
+    "max_turns",       # --max-turns        (push: ParallelTaskRequest.max_turns)
+    "timeout_seconds", # turn budget        (push: ParallelTaskRequest.timeout_seconds)
+    "system_prompt",   # --append-system-prompt; recomposed below (#1629)
+)
+
+
+# ---------------------------------------------------------------------------
 # Claim (GET /api/internal/next-task) — §3.1 / §3.2
 # ---------------------------------------------------------------------------
 
@@ -212,7 +233,17 @@ def _build_claim_response(row: Dict[str, Any]) -> Dict[str, Any]:
 
     payload: Dict[str, Any] = {
         "message": row.get("message"),
-        "session_id": meta.get("session_id"),
+        # #2317: session identity comes from the key the PRODUCER writes.
+        # `backlog_service.enqueue` records `resume_session_id` (the Claude Code
+        # session the caller asked to resume — EXEC-023) and `chat_session_id`
+        # (a Trinity chat-session row id, a BACKEND-side persistence concern the
+        # pull sink does not own). The envelope's `session_id` is the Claude Code
+        # session UUID (§2 shared payload fields) and the worker feeds it straight
+        # to `execute_headless(resume_session_id=...)`, so ONLY `resume_session_id`
+        # may source it — `chat_session_id` here would hand the runtime a Trinity
+        # row id and resume the wrong (or no) session. `session_id` is still read
+        # first for forward-compat with the §2 producer shape nothing writes yet.
+        "session_id": meta.get("session_id") or meta.get("resume_session_id"),
     }
     if meta.get("file_ids") is not None:
         payload["file_ids"] = meta.get("file_ids")
@@ -221,7 +252,22 @@ def _build_claim_response(row: Dict[str, Any]) -> Dict[str, Any]:
     # hand it to the worker via task_overrides.system_prompt — the field the pull
     # worker reads (`execute_headless(system_prompt=overrides.get("system_prompt"))`).
     # Fold in any caller override; fail-open leaves the caller prompt (or None).
-    overrides: Dict[str, Any] = dict(meta.get("task_overrides") or {})
+    #
+    # #2317: the per-task settings are sourced from the FLAT metadata keys the
+    # producer actually writes (see _TASK_OVERRIDE_KEYS above). This block used to
+    # read a nested `task_overrides` object alone — a key no producer has ever
+    # written — so `overrides` was always `{}` and every pulled turn silently ran
+    # with agent/global defaults instead of the row's model, tool allow-list, turn
+    # cap and timeout. The nested object is still honoured as an OVERLAY (the
+    # §2.2 quarantine shape a future producer may write) so it wins when present.
+    overrides: Dict[str, Any] = {
+        key: meta[key]
+        for key in _TASK_OVERRIDE_KEYS
+        if meta.get(key) is not None
+    }
+    nested = meta.get("task_overrides")
+    if isinstance(nested, dict):
+        overrides.update({k: v for k, v in nested.items() if v is not None})
     # ent#243: a caller override is what the worker will actually run, so it wins
     # over the row's recorded model_used; either may be absent → VERBOSE.
     overrides["system_prompt"] = _compose_pull_system_prompt(

--- a/tests/registry.json
+++ b/tests/registry.json
@@ -2394,6 +2394,19 @@
       "description": "Dev deploy must not ship OSS-only silently (#2246). Behavioural half: runs scripts/ci/classify-submodule-failure.sh over the verbatim output of the real failure and asserts CLASS: host-key \u2014 plus, crucially, that the host-key remedy does NOT mention read access / deploy keys / org membership, which is what the old unconditional diagnostic said while the clone was dying one layer earlier at SSH host-key verification (follow that hint and you install a deploy key and get the identical warning). Also pins that a genuine credential failure still says access, that a DNS failure is neither \u2014 host-key output also contains 'Could not read from remote repository', so ordering is load-bearing \u2014 that silence is its own class (an `update = none` submodule is SKIPPED and exits 0, #1443), and that an unrecognised shape is admitted rather than guessed. Static half over deploy-dev.yml: the not-mounted branch EXISTS (the #2068 ::error:: assertions sit inside `if [ -f \u2026/enterprise/backend/__init__.py ]`, so they structurally cannot fire on the state the VM was actually in), it fails the run rather than warning (direction, not presence \u2014 a ::warning:: is exactly how this hid across 200 consecutive runs), the escape hatch is an opt-in repo variable, the clone output is captured and classified, the optional PAT transport uses `git -c \u2026 insteadOf` so no token persists to the VM's .git/config, and the submodule step contains no `exit 1` \u2014 failing there would leave the VM half-updated after the pull."
     },
     {
+      "file": "unit/test_2317_pull_envelope_parity.py",
+      "feature": "#2317",
+      "added": "2026-08-19",
+      "categories": [
+        "backend",
+        "unit",
+        "reliability",
+        "regression",
+        "guard"
+      ],
+      "description": "Pull claim envelope <-> push drain parity on backlog_metadata (#2317). The envelope read a nested `task_overrides` key no producer writes, so every pull-claimed turn dropped the row's model / allowed_tools / max_turns / timeout_seconds, and `session_id` was read from a key the producer never writes (it records `resume_session_id`). Every test runs off ONE fixture built by the REAL producer (`BacklogService.enqueue`): exhaustive classification of the keys enqueue writes into runtime-facing vs backend-only (a new key reds the suite until classified); both consumers resolve the same keys to the same values, and to the producer's own recorded values; #1629/#1633 system-prompt composition preserved (caller_prompt threaded from the flat key, ent#243 model tier); session_id sourced from resume_session_id and never from the chat_session_id row id; nested task_overrides still overlays for forward-compat; absent settings omitted, not nulled. No live backend, no DB harness."
+    },
+    {
       "file": "unit/test_471_subscription_usage_observability.py",
       "feature": "#471",
       "added": "2026-08-19",

--- a/tests/unit/test_1081_pull_worker.py
+++ b/tests/unit/test_1081_pull_worker.py
@@ -376,3 +376,99 @@ class TestDeliverResult:
         ))
         assert ok is True
         assert max(sleeps) >= 7  # Retry-After floor respected
+
+
+# ===========================================================================
+# #2317 — the claimed row's own per-task settings reach the runtime
+# ===========================================================================
+class TestTaskOverridesReachTheRuntime:
+    """The backend records a concrete per-task `model` / `allowed_tools` /
+    `max_turns` / `timeout_seconds` on every queued row and the PUSH path
+    enforces them. Before #2317 the claim envelope carried none of it (it read a
+    `task_overrides` key no producer writes), so this pool silently ran every
+    pulled turn on agent/global defaults — including `TRINITY_PULL_TURN_TIMEOUT`
+    in place of the row's own turn budget."""
+
+    @staticmethod
+    def _stub_runtime(monkeypatch, runtime):
+        stub = types.ModuleType("agent_server.services.runtime_adapter")
+        stub.get_runtime = lambda: runtime
+        monkeypatch.setitem(sys.modules, "agent_server.services.runtime_adapter", stub)
+
+    def test_resolve_turn_timeout_prefers_the_rows_budget(self, monkeypatch):
+        monkeypatch.setenv("TRINITY_PULL_TURN_TIMEOUT", "900")
+        assert pw._resolve_turn_timeout({"timeout_seconds": 60}) == 60
+        assert pw._resolve_turn_timeout({"timeout_seconds": "120"}) == 120
+
+    def test_resolve_turn_timeout_falls_back_when_absent_or_junk(self, monkeypatch):
+        monkeypatch.setenv("TRINITY_PULL_TURN_TIMEOUT", "900")
+        assert pw._resolve_turn_timeout({}) == 900                        # absent
+        assert pw._resolve_turn_timeout({"timeout_seconds": None}) == 900  # null
+        assert pw._resolve_turn_timeout({"timeout_seconds": "soon"}) == 900
+        assert pw._resolve_turn_timeout({"timeout_seconds": 0}) == 900     # non-positive
+        assert pw._resolve_turn_timeout({"timeout_seconds": -5}) == 900
+
+    def test_every_override_is_forwarded_to_execute_headless(self, monkeypatch):
+        monkeypatch.setenv("TRINITY_PULL_TURN_TIMEOUT", "900")
+        md = SimpleNamespace(model_dump=lambda: {"cost_usd": 0.0})
+        runtime = SimpleNamespace(
+            execute_headless=AsyncMock(return_value=("done", [], md, "sess-1"))
+        )
+        self._stub_runtime(monkeypatch, runtime)
+
+        client = _FakeClient(post_responses=[_FakeResp(200, {"applied": True})])
+        claim = {
+            "execution_id": "exec-2317",
+            "claim_token": "tok",
+            "envelope": {"payload": {
+                "message": "run recon",
+                "session_id": "claude-sess-7",
+                "task_overrides": {
+                    "model": "opus",
+                    "allowed_tools": ["mcp__trinity__report"],
+                    "system_prompt": "PLATFORM::CALLER",
+                    "max_turns": 7,
+                    "timeout_seconds": 60,
+                },
+            }},
+        }
+        asyncio.run(pw._run_and_report(claim, client, "http://b", "s", "alpha"))
+
+        kwargs = runtime.execute_headless.call_args.kwargs
+        assert kwargs["model"] == "opus"
+        assert kwargs["allowed_tools"] == ["mcp__trinity__report"]
+        assert kwargs["system_prompt"] == "PLATFORM::CALLER"
+        assert kwargs["max_turns"] == 7
+        assert kwargs["timeout_seconds"] == 60          # the ROW's budget, not 900
+        assert kwargs["resume_session_id"] == "claude-sess-7"
+        assert kwargs["persist_session"] is True
+
+    def test_short_row_timeout_does_not_shrink_the_delivery_window(self, monkeypatch):
+        """A 60s turn budget must not cut the result-POST retry window down to
+        60s+buffer — the backend lease derives from the agent's
+        execution_timeout, not the row's, so the reaper would re-run a turn whose
+        terminal was still being retried."""
+        monkeypatch.setenv("TRINITY_PULL_TURN_TIMEOUT", "900")
+        md = SimpleNamespace(model_dump=lambda: {})
+        runtime = SimpleNamespace(
+            execute_headless=AsyncMock(return_value=("done", [], md, None))
+        )
+        self._stub_runtime(monkeypatch, runtime)
+
+        seen = {}
+
+        async def _capture_deadline(client, execution_id, body, url, key, deadline):
+            seen["deadline"] = deadline
+            return True
+
+        monkeypatch.setattr(pw, "_deliver_result", _capture_deadline)
+        claim = {
+            "execution_id": "exec-2317", "claim_token": "tok",
+            "envelope": {"payload": {
+                "message": "m", "task_overrides": {"timeout_seconds": 60},
+            }},
+        }
+        before = time.monotonic()
+        asyncio.run(pw._run_and_report(claim, _FakeClient(), "http://b", "s", "alpha"))
+        # 900 (pool budget) + 300 (slot-TTL buffer), NOT 60 + 300.
+        assert seen["deadline"] - before >= 900 + pw._SLOT_TTL_BUFFER_SECONDS - 5

--- a/tests/unit/test_2317_pull_envelope_parity.py
+++ b/tests/unit/test_2317_pull_envelope_parity.py
@@ -1,0 +1,444 @@
+"""Pull claim envelope ↔ push drain parity on `backlog_metadata` (#2317).
+
+`backlog_service.enqueue` is the ONLY producer of a queued row's
+`backlog_metadata`, and it writes every per-task setting as a **flat** key. The
+push drain (`BacklogService._spawn_drain`) reads them flat and rebuilds the
+request faithfully. The pull claim envelope
+(`pull_coordination_service._build_claim_response`) used to read a **nested**
+`task_overrides` object instead — a key no producer has ever written — so
+`overrides` was always `{}` and every pulled turn silently ran with agent/global
+defaults instead of the row's `model`, `allowed_tools`, `max_turns` and
+`timeout_seconds`. Session identity had the same shape of bug one line earlier
+(`meta["session_id"]`, versus the `resume_session_id` the producer writes).
+
+The divergence was invisible because the two consumers were only ever tested
+against **hand-written** metadata fixtures shaped like whatever the consumer
+under test happened to read. So the guard here is structural, and every test in
+this file runs off ONE shared fixture that the **real producer** built:
+
+  * `test_producer_keys_are_exhaustively_classified` — every key `enqueue`
+    writes is either runtime-facing (must ride the wire) or backend-only
+    (deliberately does not). A new key in `enqueue` fails here until someone
+    classifies it, which is the moment to ask whether the pull path needs it.
+  * `test_pull_envelope_and_push_drain_apply_the_same_settings` — both consumers
+    resolve the SAME producer keys to the SAME values.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# sys.modules hygiene (Issue #762)
+# ---------------------------------------------------------------------------
+# This file drives the REAL producer + BOTH real consumers, which means it
+# imports backend service modules and installs two throwaway stubs
+# (`database`, `services.chat_execution_service`) while doing it. Backend
+# modules bind `from database import db` AT IMPORT, so a service imported for
+# the first time while the stub is installed keeps the stub's fake FOREVER —
+# which is how an early version of this file reddened
+# `test_1081_pull_endpoints.py` under some pytest-randomly seeds (its service
+# tests got a `_FakeDb` with no `get_execution_timeout`). Two guards, both
+# needed:
+#   1. `_import_backend_modules()` imports every module this file touches
+#      BEFORE any stub goes in, so nothing binds a fake.
+#   2. this snapshot/restore pair rolls sys.modules back after every test, so
+#      a module this file imported first is handed back to its owner
+#      un-imported (the db-harness files re-import them against their engine).
+# Precedent for the named pair: tests/unit/test_telegram_webhook_backfill.py,
+# recognised by tests/lint_sys_modules.py.
+_STUBBED_MODULE_NAMES = [
+    "database",
+    "models",
+    "services.backlog_service",
+    "services.chat_execution_service",
+    "services.pull_coordination_service",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+def _import_backend_modules():
+    """Import (and cache) every backend module this file drives, BEFORE any
+    stub is installed — see the note above. Returns the two entry points."""
+    from models import ParallelTaskRequest                       # noqa: F401
+    from services import pull_coordination_service               # noqa: F401
+    from services.backlog_service import BacklogService
+
+    return ParallelTaskRequest, BacklogService
+
+
+# ---------------------------------------------------------------------------
+# The producer key classification (#2317)
+# ---------------------------------------------------------------------------
+# Keys that describe the TURN and must reach the runtime. Both paths carry them:
+# push via the rebuilt ParallelTaskRequest, pull via the claim envelope.
+_RUNTIME_KEYS = (
+    "message",
+    "model",
+    "allowed_tools",
+    "system_prompt",
+    "timeout_seconds",
+    "max_turns",
+    "resume_session_id",
+)
+
+# Keys that are BACKEND-side concerns and reach no agent on either path:
+# chat-session persistence + result injection (applied by
+# `chat_execution_service.run_async_task` after the turn returns; the pull sink's
+# equivalent is `pull_coordination_service.apply_task_result`) and the
+# provenance/identity block. `chat_session_id` belongs here and NOT in
+# `_RUNTIME_KEYS`: it is a Trinity `chat_sessions` row id, not the Claude Code
+# session UUID the envelope's `session_id` means — handing it to the runtime
+# would resume the wrong session.
+_BACKEND_ONLY_KEYS = (
+    "save_to_session",
+    "user_message",
+    "create_new_session",
+    "chat_session_id",
+    "inject_result",
+    "user_id",
+    "user_email",
+    "subscription_id",
+    "x_source_agent",
+    "x_mcp_key_id",
+    "x_mcp_key_name",
+    "triggered_by",
+    "collaboration_activity_id",
+    "is_self_task",
+    "self_task_activity_id",
+)
+
+
+# ---------------------------------------------------------------------------
+# The shared fixture — built by the REAL producer, not by hand
+# ---------------------------------------------------------------------------
+class _FakeDb:
+    """Minimal stand-in for the `database.db` singleton `enqueue` late-imports."""
+
+    def __init__(self) -> None:
+        self.queued: Dict[str, str] = {}
+
+    def get_queued_count(self, agent_name):        # noqa: D102 - fake
+        return 0
+
+    def get_max_backlog_depth(self, agent_name):   # noqa: D102 - fake
+        return 50
+
+    def update_execution_to_queued(self, execution_id, metadata, queued_at):
+        self.queued[execution_id] = metadata
+        return True
+
+
+@pytest.fixture
+def enqueued_metadata(monkeypatch) -> Dict[str, Any]:
+    """The `backlog_metadata` blob the real `BacklogService.enqueue` writes for a
+    request with EVERY per-task setting populated, parsed back to a dict.
+
+    This is the single source the two consumers are compared against — a
+    hand-written fixture is exactly what let #2317 hide.
+    """
+    ParallelTaskRequest, BacklogService = _import_backend_modules()
+
+    # Only NOW may the fake go in: `enqueue` late-imports `from database import
+    # db` per call, so it picks the fake up, while every module already imported
+    # above keeps the real singleton.
+    fake_db = _FakeDb()
+    monkeypatch.setitem(sys.modules, "database", types.SimpleNamespace(db=fake_db))
+
+    request = ParallelTaskRequest(
+        message="run the weekly recon and report",
+        model="opus",
+        allowed_tools=["mcp__trinity__report", "Read"],
+        system_prompt="CALLER-PROMPT",
+        timeout_seconds=90,
+        max_turns=7,
+        async_mode=True,
+        save_to_session=True,
+        user_message="original user text",
+        create_new_session=True,
+        chat_session_id="chat-session-row-42",
+        resume_session_id="7f0d5a1e-1111-4222-8333-claudesession",
+        inject_result=True,
+    )
+    ok = asyncio.run(
+        BacklogService().enqueue(
+            agent_name="alpha",
+            execution_id="exec-2317",
+            request=request,
+            effective_timeout=90,
+            user_id=7,
+            user_email="u@example.com",
+            subscription_id="sub-1",
+            x_source_agent="beta",
+            x_mcp_key_id="key-1",
+            x_mcp_key_name="key-name",
+            triggered_by="agent",
+            collaboration_activity_id="act-1",
+            is_self_task=False,
+            self_task_activity_id=None,
+        )
+    )
+    assert ok is True
+    return json.loads(fake_db.queued["exec-2317"])
+
+
+# ---------------------------------------------------------------------------
+# Consumers, driven off that one fixture
+# ---------------------------------------------------------------------------
+def _claim_payload(meta: Dict[str, Any]) -> Dict[str, Any]:
+    """The §3.1 envelope payload the PULL path serves for this metadata.
+
+    `compose_system_prompt` is stubbed to the identity on `caller_prompt` so the
+    parity comparison sees the caller's prompt rather than the platform preamble
+    (the composition itself is covered by `test_1081_pull_endpoints.py`).
+    """
+    _import_backend_modules()
+    from services import pull_coordination_service as pcs
+
+    row = {
+        "id": "exec-2317",
+        "agent_name": "alpha",
+        "message": meta["message"],
+        "backlog_metadata": json.dumps(meta),
+        "triggered_by": meta.get("triggered_by"),
+        "model_used": None,
+        "source_agent_name": meta.get("x_source_agent"),
+        "source_user_id": meta.get("user_id"),
+        "lease_expires_at": "2026-08-19T12:00:00+00:00",
+        "claim_token": "tok-abc",
+        "claimed_by_worker": "alpha#w1",
+        "redelivery_count": 0,
+    }
+    with patch.object(pcs, "_resolve_agent_runtime", return_value="claude-code"), \
+         patch.object(pcs, "is_execution_context_enabled", return_value=False), \
+         patch.object(pcs, "compose_system_prompt",
+                      side_effect=lambda **kw: kw["caller_prompt"]):
+        claim = pcs._build_claim_response(row)
+    return claim["envelope"]["payload"]
+
+
+def _drain_request(meta: Dict[str, Any], monkeypatch):
+    """The `ParallelTaskRequest` the PUSH drain rebuilds for this metadata.
+
+    `run_async_task` is stubbed in `sys.modules` (the drain late-imports it) so
+    nothing is dispatched; we only want the reconstructed request.
+    """
+    _, BacklogService = _import_backend_modules()
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_run_async_task(**kwargs):
+        captured.update(kwargs)
+
+        async def _noop():
+            return None
+
+        return _noop()
+
+    stub = types.ModuleType("services.chat_execution_service")
+    stub.run_async_task = _fake_run_async_task
+    monkeypatch.setitem(sys.modules, "services.chat_execution_service", stub)
+
+    async def _drive():
+        await BacklogService()._spawn_drain("alpha", "exec-2317", meta)
+        await asyncio.sleep(0)  # let the spawned task run to completion
+
+    asyncio.run(_drive())
+    assert captured, "_spawn_drain never called run_async_task"
+    return captured["request"]
+
+
+def _applied_by_pull(meta: Dict[str, Any]) -> Dict[str, Any]:
+    """Producer key → value as the PULL path applies it."""
+    payload = _claim_payload(meta)
+    overrides = payload["task_overrides"]
+    return {
+        "message": payload["message"],
+        "model": overrides.get("model"),
+        "allowed_tools": overrides.get("allowed_tools"),
+        "system_prompt": overrides.get("system_prompt"),
+        "timeout_seconds": overrides.get("timeout_seconds"),
+        "max_turns": overrides.get("max_turns"),
+        # The envelope's session_id IS the resume target (§2 shared fields); the
+        # worker feeds it to execute_headless(resume_session_id=...).
+        "resume_session_id": payload["session_id"],
+    }
+
+
+def _applied_by_push(meta: Dict[str, Any], monkeypatch) -> Dict[str, Any]:
+    """Producer key → value as the PUSH drain applies it."""
+    request = _drain_request(meta, monkeypatch)
+    return {
+        "message": request.message,
+        "model": request.model,
+        "allowed_tools": request.allowed_tools,
+        "system_prompt": request.system_prompt,
+        "timeout_seconds": request.timeout_seconds,
+        "max_turns": request.max_turns,
+        "resume_session_id": request.resume_session_id,
+    }
+
+
+# ===========================================================================
+# Structural guards
+# ===========================================================================
+class TestProducerKeyClassification:
+    def test_producer_keys_are_exhaustively_classified(self, enqueued_metadata):
+        """Every key `enqueue` writes is either runtime-facing or backend-only.
+
+        A new key in `backlog_service.enqueue` reds this test until it is added
+        to one of the two tuples — which is the point at which someone has to
+        decide whether the pull envelope must carry it. Without this, a setting
+        can be added to the producer and reach the push path only, silently
+        (that is exactly how #2317 shipped).
+        """
+        assert set(enqueued_metadata) == set(_RUNTIME_KEYS) | set(_BACKEND_ONLY_KEYS)
+
+    def test_envelope_override_keys_are_real_producer_keys(self, enqueued_metadata):
+        """The envelope's source list names keys the producer actually writes —
+        a typo (or a nested-only key like the `task_overrides` #2317 fixed) would
+        resolve to nothing and drop the setting silently."""
+        _import_backend_modules()
+        from services import pull_coordination_service as pcs
+
+        assert set(pcs._TASK_OVERRIDE_KEYS) <= set(enqueued_metadata)
+        # `message` + `resume_session_id` ride the payload itself, not the
+        # overrides sub-object; together they are the full runtime-facing set.
+        assert set(pcs._TASK_OVERRIDE_KEYS) | {"message", "resume_session_id"} == set(
+            _RUNTIME_KEYS
+        )
+
+
+class TestPullPushParity:
+    def test_pull_envelope_and_push_drain_apply_the_same_settings(
+        self, enqueued_metadata, monkeypatch
+    ):
+        """THE #2317 guard: one producer-built fixture, two consumers, identical
+        result. Pre-fix the pull side was
+        `{model: None, allowed_tools: None, max_turns: None, timeout_seconds: None,
+        resume_session_id: None}` against a fully-populated push side."""
+        pull = _applied_by_pull(enqueued_metadata)
+        push = _applied_by_push(enqueued_metadata, monkeypatch)
+        assert pull == push
+
+    def test_both_paths_apply_the_producers_recorded_values(
+        self, enqueued_metadata, monkeypatch
+    ):
+        """Stronger than equality: both consumers agree WITH THE PRODUCER, so the
+        pair cannot drift together into agreeing on the wrong thing."""
+        expected = {key: enqueued_metadata[key] for key in _RUNTIME_KEYS}
+        assert _applied_by_pull(enqueued_metadata) == expected
+        assert _applied_by_push(enqueued_metadata, monkeypatch) == expected
+
+
+class TestClaimEnvelopeShape:
+    def test_task_overrides_is_populated_not_empty(self, enqueued_metadata):
+        """Regression: `task_overrides` used to hold ONLY the composed
+        `system_prompt` (#1633), because the flat keys were never read."""
+        overrides = _claim_payload(enqueued_metadata)["task_overrides"]
+        assert overrides["model"] == "opus"
+        assert overrides["allowed_tools"] == ["mcp__trinity__report", "Read"]
+        assert overrides["max_turns"] == 7
+        assert overrides["timeout_seconds"] == 90
+
+    def test_session_id_is_the_claude_session_not_the_chat_row(
+        self, enqueued_metadata
+    ):
+        """`session_id` must resolve from `resume_session_id`. `chat_session_id`
+        is a Trinity DB row id — the worker passes this value straight to
+        `execute_headless(resume_session_id=...)`, so sourcing it there would
+        resume a session that does not exist."""
+        payload = _claim_payload(enqueued_metadata)
+        assert payload["session_id"] == enqueued_metadata["resume_session_id"]
+        assert payload["session_id"] != enqueued_metadata["chat_session_id"]
+
+    def test_system_prompt_is_still_composed_from_the_flat_caller_prompt(
+        self, enqueued_metadata
+    ):
+        """#1629/#1633 preserved: the platform prompt is composed at claim time
+        and the row's caller prompt is threaded in as `caller_prompt` — now read
+        from the flat `system_prompt` key the producer writes."""
+        _import_backend_modules()
+        from services import pull_coordination_service as pcs
+
+        row = {
+            "id": "exec-2317", "agent_name": "alpha",
+            "message": enqueued_metadata["message"],
+            "backlog_metadata": json.dumps(enqueued_metadata),
+            "triggered_by": "agent", "model_used": None,
+            "lease_expires_at": None, "claim_token": "t",
+            "claimed_by_worker": "w", "redelivery_count": 0,
+        }
+        with patch.object(pcs, "_resolve_agent_runtime", return_value="claude-code"), \
+             patch.object(pcs, "is_execution_context_enabled", return_value=False), \
+             patch.object(pcs, "compose_system_prompt",
+                          return_value="PLATFORM::CALLER") as compose:
+            claim = pcs._build_claim_response(row)
+
+        assert compose.call_args.kwargs["caller_prompt"] == "CALLER-PROMPT"
+        # ent#243: the row's own model selects the prompt tier.
+        assert compose.call_args.kwargs["execution_context"].model == "opus"
+        assert (
+            claim["envelope"]["payload"]["task_overrides"]["system_prompt"]
+            == "PLATFORM::CALLER"
+        )
+
+    def test_nested_task_overrides_still_overlays_the_flat_keys(
+        self, enqueued_metadata
+    ):
+        """Forward-compat: nothing writes the §2.2 nested quarantine object today,
+        but when a producer does it must WIN over the flat keys (it is the more
+        specific, per-task statement)."""
+        meta = dict(enqueued_metadata)
+        meta["task_overrides"] = {"model": "haiku", "allowed_tools": ["Read"]}
+        overrides = _claim_payload(meta)["task_overrides"]
+        assert overrides["model"] == "haiku"
+        assert overrides["allowed_tools"] == ["Read"]
+        # Flat keys the overlay did not mention still survive.
+        assert overrides["max_turns"] == 7
+        assert overrides["timeout_seconds"] == 90
+
+    def test_absent_settings_are_omitted_not_nulled(self):
+        """A minimal row (nothing but a message) must not put `"model": null` &c.
+        on the wire — the worker treats absent and null identically, and an empty
+        overrides object keeps the envelope honest about what the row asked for."""
+        _import_backend_modules()
+        from services import pull_coordination_service as pcs
+
+        row = {
+            "id": "e1", "agent_name": "alpha", "message": "hi",
+            "backlog_metadata": json.dumps({"message": "hi"}),
+            "triggered_by": "manual", "model_used": None,
+            "lease_expires_at": None, "claim_token": "t",
+            "claimed_by_worker": "w", "redelivery_count": 0,
+        }
+        with patch.object(pcs, "_resolve_agent_runtime", return_value="claude-code"), \
+             patch.object(pcs, "is_execution_context_enabled", return_value=False), \
+             patch.object(pcs, "compose_system_prompt", return_value=None):
+            claim = pcs._build_claim_response(row)
+
+        payload = claim["envelope"]["payload"]
+        assert payload["session_id"] is None
+        # Only the (None) composed system_prompt — no null model/tools/turn cap.
+        assert set(payload["task_overrides"]) == {"system_prompt"}


### PR DESCRIPTION
Closes #2317. Unblocks widening the #1766 pull soak (that issue's remaining ACs are independent; nothing here closes it).

## Mechanism

`backlog_service.enqueue` is the only producer of a queued row's `backlog_metadata`, and it writes every per-task setting as a **flat** key (`model`, `allowed_tools`, `system_prompt`, `timeout_seconds`, `max_turns`, `resume_session_id`, …).

The **push** drain reads them flat and rebuilds the request faithfully (`_spawn_drain`, `backlog_service.py`).

The **pull** claim envelope did not. `_build_claim_response` had:

```python
overrides: Dict[str, Any] = dict(meta.get("task_overrides") or {})
```

There is no `task_overrides` key in `backlog_metadata` — no producer has ever written one — so `overrides` was **always `{}`**. #1629 then wrote exactly one field into it (`system_prompt`, composed explicitly), which is why the platform prompt was the only setting that survived a pull-claimed turn. Everything else fell back to agent/global defaults, silently: nothing logged, nothing failed, the execution row recorded a normal `success`.

Same shape of bug one line earlier: the payload's `session_id` was read from `meta["session_id"]`, a key the producer never writes (it writes `resume_session_id`).

Evidence from the issue, measured on `eu2`/`cornelius-oracle`: `backlog_metadata LIKE '%task_overrides%'` matched **0 of 580 rows**, and the 18 executions that failed on their own configured timeout in the 7 pre-flip days became 0 after the pilot flip — the row's timeout no longer being enforced, presenting as a reliability improvement.

## Wire-shape decision: keep `task_overrides`, populate it

The agent-side consumer is `docker/base-image/agent_server/services/pull_worker.py::_run_and_report`:

```python
session_id = payload.get("session_id")
overrides  = payload.get("task_overrides") or {}
... execute_headless(model=overrides.get("model"),
                     allowed_tools=overrides.get("allowed_tools"),
                     system_prompt=overrides.get("system_prompt"),
                     max_turns=overrides.get("max_turns"),
                     resume_session_id=session_id, persist_session=bool(session_id))
```

So the consumer genuinely expects the nested object, and `MESSAGE_ENVELOPE_SCHEMA.md` §2.2 defines `task_overrides` as the deliberate quarantine sub-object for per-task knobs. **The wire field is therefore unchanged** — the fix populates it from the flat keys the producer actually writes, rather than renaming anything. Renaming would have meant a lock-step backend + agent-base-image change for no gain.

Two properties preserved on purpose:

- **A nested `task_overrides` still overlays the flat keys and wins.** Nothing writes it today, but it is the §2.2 target shape, and keeping it honoured means this change is purely additive (it also keeps `test_1081_pull_endpoints.py`'s existing #1629 fixtures meaningful).
- **#1629/#1633's composed `system_prompt` is byte-identical in behaviour.** The only difference is that the caller override handed to `compose_system_prompt(caller_prompt=…)` is now read from the flat `system_prompt` key it is actually stored under, and `model` (the ent#243 prompt-tier signal) now resolves from the row rather than always falling through to `model_used`.

Absent settings are **omitted** rather than sent as `null`, so a claim for a bare row still yields `{"system_prompt": …}` only.

## `timeout_seconds` needed the consumer too

The envelope alone would not have fixed the timeout: **the worker never read `timeout_seconds` at all**, running every pulled turn to `TRINITY_PULL_TURN_TIMEOUT` (900s default). `pull_worker` now resolves the row's budget with a fail-soft fallback to the pool default (missing / non-numeric / non-positive → default; never raises). The **result-delivery deadline stays keyed to the pool budget** (`max(row, pool)`), so honouring a short per-task timeout cannot shrink the retry window the lease reaper backstops — the backend lease derives from the agent's `execution_timeout_seconds`, not the row's.

This half lives in the agent base image, so it takes effect after `/rebuild-agent`. The backend half is live on deploy.

## Test

`tests/unit/test_2317_pull_envelope_parity.py` (new, 9 tests). The reason this bug survived is that both consumers were only ever tested against **hand-written** metadata fixtures shaped like whatever the consumer under test happened to read. So every test here runs off **one fixture built by the real producer** — an actual `BacklogService.enqueue` call against a fake db:

- `test_producer_keys_are_exhaustively_classified` — every key `enqueue` writes is either runtime-facing or backend-only. Adding a key to `enqueue` reds this until someone classifies it, which is the moment to ask whether the pull path needs it.
- `test_pull_envelope_and_push_drain_apply_the_same_settings` / `test_both_paths_apply_the_producers_recorded_values` — both consumers resolve the same producer keys to the same values, and to the producer's own values (so the pair cannot drift together onto the wrong thing).
- Plus: `task_overrides` populated not empty; `session_id` from `resume_session_id` and never the `chat_session_id` row id; `system_prompt` still composed; nested overlay still wins; absent settings omitted not nulled.

**7 of the 9 fail on the pre-fix code** (verified by stashing the fix). 4 more tests in `tests/unit/test_1081_pull_worker.py` cover the worker half; 3 of those fail pre-fix.

The file is order-safe under `pytest-randomly` (it imports every backend module *before* installing either stub, and carries the `_STUBBED_MODULE_NAMES`/`_restore_sys_modules` snapshot pair) — an earlier draft without that reddened `test_1081_pull_endpoints.py` under some seeds, which is noted in the file.

## Commands

```
cd tests
python -m pytest unit/test_2317_pull_envelope_parity.py unit/test_1081_pull_worker.py \
  unit/test_1081_pull_endpoints.py unit/test_1081_pull_mode.py unit/test_1081_lease_reaper.py \
  unit/test_1081_lease_sweep_exclusion.py unit/test_1081_physical_meter.py unit/test_backlog.py \
  unit/test_1449_backlog_metadata_scrub.py unit/test_1766_pull_pilot_exclusive.py \
  unit/test_2048_pull_pilot_reach.py unit/test_chat_sync_backlog.py -q
# 229 passed, 1 skipped

python -m pytest unit/ -q --randomly-seed=1     # 21 failed, 11862 passed, 30 skipped
python tests/lint_sys_modules.py                # OK, no new violations
python tests/lint_root_test_placement.py        # OK
```

The 21 failures are **identical on `origin/dev` with no changes applied** (same 21 ids, byte-for-byte) — all IPv4-mapped-IPv6 SSRF-guard cases (`test_736_a2a_outbound_*`, `test_ent14_registry_url_ssrf`, `test_ent399_ipv6_origin`, `test_mcp_validator`) that fail on a local Python 3.11/macOS interpreter; CI pins 3.13. Nothing in the pull/backlog area failed on either side. The pull-adjacent files were additionally run green under 8 `pytest-randomly` seeds.

## Notes on the issue's analysis

Three corrections, none of which change the fix:

1. **`max_turns` is dropped on the push path too**, so this was never a pull-only loss. `_spawn_drain` rebuilds `ParallelTaskRequest(max_turns=…)`, but `chat_execution_service.run_async_task` never forwards it to `TaskExecutionService.execute_task` (which has no `max_turns` parameter) and the `/api/task` payload the backend sends the agent contains no `max_turns` — it dies in `run_async_task`. After this PR the **pull** path honours it (the worker does pass it to `execute_headless`), so the asymmetry now runs the other way, in favour of the caller's stated intent. The push-side gap is real and worth its own issue; it is out of scope here.

2. **The issue's suggested fix is necessary but not sufficient for the timeout.** "Have the pull envelope read the same flat keys" fixes model/tools/turn-cap/session, but the worker never read `timeout_seconds` from the envelope, so the field it names as the visible production symptom needed the consumer change above.

3. **`chat_session_id` must NOT source `session_id`.** The issue says "align `session_id` with `chat_session_id` / `resume_session_id`"; only `resume_session_id` is correct. `chat_session_id` is a Trinity `chat_sessions` row id, while the envelope's `session_id` is the Claude Code session UUID that the worker feeds straight into `execute_headless(resume_session_id=…)` — putting the row id there would resume a session that does not exist. The test pins this explicitly.

Related, and deliberately **not** fixed here: `save_to_session` / `chat_session_id` / `user_message` / `create_new_session` / `inject_result` are applied post-turn by `run_async_task` on the push path, and the pull sink (`apply_task_result`) has no equivalent — so a pulled turn is not persisted into the caller's chat session and its result is not injected. That is a separate gap in the pull sink, not an envelope-shape bug, and the test classifies those keys as backend-only with that reasoning written down.
