### PR TITLE
feat(tests,ci): journey tier + per-PR journey-smoke gate (#2335, #2336)

### DIFF
--- a/.github/workflows/journey-smoke.yml
+++ b/.github/workflows/journey-smoke.yml
@@ -1,0 +1,121 @@
+name: Journey smoke
+
+# Rail R2 of the journey-coverage deck (#2336), on the tier R1 built (#2335).
+#
+# WHY THIS EXISTS, precisely: on 2026-08-14 five of six stopped agents could not
+# be started — HTTP 500 on the most fundamental operation the platform has — and
+# it reached users. A human found it by poking around. Nothing automated caught
+# it, because the per-PR gate collects `tests/unit/` only and no test in the
+# merge path had ever started a real agent.
+#
+# Nightly-only gating is not a substitute. With six humans and dev agents
+# merging, a red morning with fifteen suspect PRs is a forensic exercise, not a
+# signal. So the split is by COST, not by importance: journeys needing a fresh
+# host gate the release cut; journeys that run against a stack this job can
+# stand up gate every PR.
+#
+# RUNTIME BUDGET (#2336 AC 5): `timeout-minutes: 30` for the job, of which the
+# stack boot is ~8-12 min (the agent base image builds here) and the journeys
+# are ~3-4 min. A timeout FAILS the job — it is never reported as a pass.
+#
+# CREDENTIALS: none, deliberately. `pull_request` exposes repository secrets to
+# fork PRs while running arbitrary shell from the PR's own tree, and this job
+# runs the PR's own `scripts/deploy/start.sh` — so a provider key named here
+# would be readable by anyone who opens a PR (the reasoning
+# `integration-nightly.yml` sets out in full). The credential-bound J03
+# first-turn journey therefore runs on a developer's stack and in the nightly;
+# what runs HERE is the lifecycle journey, which is where the 08-14 regression
+# actually was.
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: journey-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  journey-smoke:
+    name: journey-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version-file: docker/backend/Dockerfile
+
+      - name: Install test dependencies
+        run: pip install -r tests/requirements-test.txt
+
+      - name: Generate a throwaway admin password
+        # Never a fixed literal, and masked so a failing test cannot echo it into
+        # a public log. The `Aa1!` suffix guarantees the OWASP ASVS 2.1 classes
+        # on the random branch (the shape integration-nightly.yml uses).
+        run: |
+          set -euo pipefail
+          PASS="$(openssl rand -base64 24 | tr -d '/+=\n')Aa1!"
+          echo "::add-mask::$PASS"
+          echo "ADMIN_PASSWORD=$PASS" >> "$GITHUB_ENV"
+
+      - name: Boot the stack
+        run: |
+          set -uo pipefail
+          cp .env.example .env
+          echo "ADMIN_PASSWORD=$ADMIN_PASSWORD" >> .env
+          echo "SECRET_KEY=$(openssl rand -hex 32)" >> .env
+          # Zero seeded agents at baseline (learnings 2026-07-08), so the
+          # journeys' own fixtures are the only agents on the instance and a
+          # leftover cannot make a journey pass or fail for someone else's
+          # reason.
+          echo "TRINITY_DEFAULT_SYSTEM_MANIFEST=disabled" >> .env
+          ./scripts/deploy/start.sh || { echo "::error title=Stack failed to start::scripts/deploy/start.sh exited non-zero — the journeys never ran"; exit 1; }
+          for i in $(seq 1 120); do
+            if curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+              echo "backend healthy after $((i*2))s"; exit 0
+            fi
+            sleep 2
+          done
+          echo "::error title=Backend never became healthy::/health did not answer 200 within 240s of start.sh completing"
+          docker compose logs --tail 80 backend || true
+          exit 1
+
+      - name: Run the journey tier
+        env:
+          TRINITY_API_URL: http://localhost:8000
+          # `tests/conftest.py` aliases TRINITY_TEST_PASSWORD from ADMIN_PASSWORD.
+          # Safe here and nowhere else: the sweep refuses a non-localhost target
+          # and this instance is a throwaway destroyed with the runner (#1558).
+          TRINITY_TEST_CLEANUP_SWEEP: '1'
+        run: |
+          set -uo pipefail
+          python -m pytest tests/journeys/ -v -rs --tb=short \
+            --timeout=300 --timeout-method=thread
+          rc=$?
+          # A tier that collected nothing is a FAILURE, not a pass — the #2029
+          # class this gate is required precisely to prevent. pytest exits 5 on
+          # "no tests collected".
+          if [ "$rc" = "5" ]; then
+            echo "::error title=No journeys collected::tests/journeys/ produced no tests — a green tick here would mean nothing ran"
+            exit 1
+          fi
+          exit "$rc"
+
+      - name: Stack logs on failure
+        if: failure()
+        run: |
+          docker compose logs --tail 200 backend || true
+          docker compose ps || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v --remove-orphans || true

--- a/.github/workflows/journey-smoke.yml
+++ b/.github/workflows/journey-smoke.yml
@@ -27,6 +27,28 @@ name: Journey smoke
 # what runs HERE is the lifecycle journey, which is where the 08-14 regression
 # actually was.
 
+# NO `paths-ignore` HERE, deliberately — see the review note below before adding
+# one. Every PR to `dev` boots the stack, which is the 5-12 min tax a reviewer
+# rightly flagged for docs-only PRs. The obvious fix is the wrong one.
+#
+# A `paths-ignore` that filters out a PR means the workflow never runs, so the
+# check is never REPORTED. For a check this PR intends to make required, "never
+# reported" is not "skipped" — it is a PR that can never merge, waiting forever
+# on a status that will not arrive. That exact failure was diagnosed on
+# trinity#2384 on 2026-08-27: three required workflows produced no run, and the
+# PR sat green-but-unmergeable until someone pushed again.
+#
+# The safe shape is the one `frontend-e2e.yml` already uses: keep the trigger
+# unconditional, put the decision in a cheap `changes` job, and gate the heavy
+# job with `if: needs.changes...`. A job skipped by `if:` still reports a
+# conclusion, so the required check is satisfied. That job also has to FAIL OPEN
+# — being unable to determine the changed files must mean "run", never "skip"
+# and never a red X (#1782, where `gh pr diff` 406s on PRs over 300 files).
+#
+# Not done here because it is a ~50-line gate with subtle semantics and
+# `frontend-e2e.yml` says of its own sibling implementation that the two "differ
+# ON PURPOSE. Don't 'unify' them" — so this wants its own deliberate copy, in
+# its own change, not a rushed third one appended to this PR.
 on:
   pull_request:
     branches: [dev]
@@ -106,9 +128,25 @@ jobs:
           TRINITY_TEST_CLEANUP_SWEEP: '1'
         run: |
           set -uo pipefail
+          # `|| rc=$?` rather than a bare call then `rc=$?`.
+          #
+          # GitHub's default shell for `run:` is `bash --noprofile --norc -e -o
+          # pipefail {0}`, and `set -uo pipefail` adds `-u` without clearing the
+          # `-e` that is already in force. So with a bare call a non-zero pytest
+          # aborted the step on the pytest line itself: `rc=$?` never ran, the
+          # `if` never ran, and the "No journeys collected" annotation could
+          # never appear. The job still went red on exit 5 — via `-e`, not via
+          # the code documenting the guarantee — so the #2029 protection this
+          # gate exists to provide was resting on an implicit shell flag while
+          # the lines asserting it were unreachable. A later editor reshaping
+          # this step, or adding `continue-on-error`, would have got no signal.
+          #
+          # `|| rc=$?` is chosen over `set +e` because the command is part of a
+          # condition, which `-e` does not apply to — the exit code is captured
+          # by construction rather than by remembering to disable a flag.
+          rc=0
           python -m pytest tests/journeys/ -v -rs --tb=short \
-            --timeout=300 --timeout-method=thread
-          rc=$?
+            --timeout=300 --timeout-method=thread || rc=$?
           # A tier that collected nothing is a FAILURE, not a pass — the #2029
           # class this gate is required precisely to prevent. pytest exits 5 on
           # "no tests collected".

--- a/.github/workflows/journey-smoke.yml
+++ b/.github/workflows/journey-smoke.yml
@@ -52,7 +52,15 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-          python-version-file: docker/backend/Dockerfile
+          # Literal, matching every sibling workflow. #1891's rule is that this
+          # must EQUAL the image pin in docker/{backend,scheduler,base-image}/
+          # Dockerfile, and `tests/unit/test_1891_python_version_parity.py`
+          # scans all workflows and fails on a stale one — so the parity is
+          # enforced by that test, not by pointing setup-python at a Dockerfile
+          # it cannot parse (it read the literal string "FROM python:3.13-slim"
+          # as a version and failed the job in 8 seconds).
+          python-version: '3.13'
+
 
       - name: Install test dependencies
         run: pip install -r tests/requirements-test.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,5 @@ markers = [
     "requires_agent: test requires a running agent",
     "unit: unit tests that don't need backend",
     "integration: mark test as integration test",
+    "journey: a promise the platform makes to a person, tested end to end against a live stack (#2335)",
 ]

--- a/tests/harness/audit_skips.py
+++ b/tests/harness/audit_skips.py
@@ -35,6 +35,14 @@ ALLOWED_SKIP_REASONS: tuple[tuple[str, str], ...] = (
     ("elevenlabs", "needs a paid ElevenLabs key"),
     ("gemini", "needs a Google AI Studio key"),
     ("anthropic api key", "needs a real Anthropic key (billable)"),
+    # #2336: the J03 first-turn journey asserts REAL model output, which needs a
+    # provider key — and every PR-triggered workflow here is deliberately
+    # credential-free, because `pull_request` exposes repository secrets to fork
+    # PRs while running the PR's own shell (integration-nightly.yml states the
+    # full reasoning). The journey runs on a developer's stack and in the
+    # nightly; the per-PR gate runs the credential-free lifecycle journey, which
+    # is where the 2026-08-14 regression actually was.
+    ("journey needs a real provider key", "credential-bound journey; see #2336"),
     ("openai", "needs a real OpenAI key (billable)"),
     ("nevermined", "needs the Nevermined testnet + a funded wallet"),
     # Platform/interpreter conditionals that are correct, not missing coverage.

--- a/tests/journeys/conftest.py
+++ b/tests/journeys/conftest.py
@@ -1,0 +1,155 @@
+"""Journey-tier fixtures (#2335, Rail R1).
+
+A *journey* is a promise the platform makes to a person, tested the way that
+person meets it: through the public API, against a live stack, end to end. The
+unit island cannot hold these — `tests/unit/pytest.ini` sets
+`norecursedirs = ..`, which is exactly why 96 root-level live-backend tests are
+invisible to the merge gate.
+
+Three rules this tier does not bend:
+
+**A journey FAILS; it does not skip.** `tests/conftest.py::created_agent` calls
+`pytest.skip` when an agent will not start — reasonable for a fixture whose
+tests are about something else, and precisely the blind spot #2336 exists to
+close: on 2026-08-14 five of six stopped agents could not be started at all, and
+no automated test went red. Here, "the agent never reached running" IS the
+finding.
+
+**Preconditions are checked once, loudly.** A tier that cannot run is a failure,
+never a silent pass (`run-full.sh`'s stated rule 1). If the stack is unreachable
+the whole tier fails with the URL it tried, not with 40 confusing errors.
+
+**Nothing is touched that this tier did not create.** Every agent is named
+`pytest-ephemeral-journey-<random>` and torn down by that name (`tests/README.md`
+prefix rule, #1558). Teardown is idempotent, so a crashed run leaves the tier
+re-runnable without manual cleanup.
+"""
+import os
+import time
+import uuid
+
+import pytest
+import requests
+
+# Deadline polling is the only supported synchronisation primitive in this tier
+# (#2335 AC 5). `sleep(n)` as synchronisation is what makes a suite simultaneously
+# slow and flaky: it pays the worst case every run and still loses the race on a
+# loaded runner.
+POLL_INTERVAL_S = 2.0
+
+# Named so a failure message can quote the promise rather than the number.
+AGENT_RUNNING_DEADLINE_S = float(os.getenv("JOURNEY_AGENT_RUNNING_DEADLINE_S", "90"))
+AGENT_STOPPED_DEADLINE_S = float(os.getenv("JOURNEY_AGENT_STOPPED_DEADLINE_S", "60"))
+# The CREATE call itself provisions a container before it answers.
+AGENT_CREATE_CALL_TIMEOUT_S = float(os.getenv("JOURNEY_AGENT_CREATE_CALL_TIMEOUT_S", "180"))
+
+EPHEMERAL_PREFIX = "pytest-ephemeral-journey-"
+
+
+def poll_until(predicate, *, deadline_s: float, describe: str,
+               interval_s: float = POLL_INTERVAL_S):
+    """Poll `predicate` until it returns a truthy value or the deadline passes.
+
+    Returns the truthy value. Raises `AssertionError` naming the broken promise
+    and how long it waited — never a bare `assert 200 == 500` (#2336 AC 6).
+    """
+    started = time.monotonic()
+    last = None
+    while time.monotonic() - started < deadline_s:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(interval_s)
+    waited = time.monotonic() - started
+    raise AssertionError(
+        f"{describe} — waited {waited:.0f}s of {deadline_s:.0f}s. "
+        f"Last observation: {last!r}"
+    )
+
+
+@pytest.fixture(scope="session")
+def journey_client(api_client):
+    """The live-stack client, with the tier's precondition checked ONCE.
+
+    Reuses `tests/conftest.py`'s authenticated client rather than building a
+    second one — R1 says reuse what works, and a parallel harness is how two
+    auth paths drift.
+    """
+    url = os.getenv("TRINITY_API_URL", "http://localhost:8000")
+    try:
+        health = requests.get(f"{url}/health", timeout=10)
+    except requests.RequestException as e:
+        pytest.fail(
+            f"journey tier requires a live stack at {url} and could not reach it "
+            f"({type(e).__name__}). Start one with ./scripts/deploy/start.sh, or "
+            f"point TRINITY_API_URL at a dev instance. A tier that cannot run is "
+            f"a failure, not a skip."
+        )
+    if health.status_code != 200:
+        pytest.fail(
+            f"journey tier requires a healthy stack at {url}; /health answered "
+            f"{health.status_code}. The stack is up but not serving — that is a "
+            f"finding, not a reason to skip."
+        )
+    return api_client
+
+
+@pytest.fixture()
+def journey_agent_name() -> str:
+    """A unique name under the reserved prefix, so teardown can never reach an
+    agent this tier did not create."""
+    return f"{EPHEMERAL_PREFIX}{uuid.uuid4().hex[:8]}"
+
+
+def delete_agent_idempotent(client, name: str) -> None:
+    """Teardown that is safe to run twice, and on an agent that never existed.
+
+    The tier must be re-runnable after a crash without manual cleanup (#2335
+    AC 3), which means teardown cannot assume the create succeeded.
+    """
+    try:
+        client.delete(f"/api/agents/{name}")
+    except Exception:  # noqa: BLE001 — teardown must never mask the real failure
+        pass
+
+
+@pytest.fixture()
+def journey_agent(journey_client, journey_agent_name):
+    """An agent created through the public API, reached `running`, torn down.
+
+    This fixture IS the first half of J03: "create an agent from a template and
+    have it come up". A failure here is reported as the broken promise, not as
+    a skipped test.
+    """
+    name = journey_agent_name
+    # Creating an agent provisions a container; the shared client's 30s default
+    # is a request timeout for ordinary calls and is genuinely too short here —
+    # it surfaced as `httpx.ReadTimeout` at fixture setup, which reads as harness
+    # breakage rather than as the platform being slow. The deadline that matters
+    # is still the poll below; this only stops the CALL from giving up first.
+    resp = journey_client.post(
+        "/api/agents", json={"name": name}, timeout=AGENT_CREATE_CALL_TIMEOUT_S,
+    )
+    if resp.status_code not in (200, 201):
+        raise AssertionError(
+            f"creating agent '{name}' through POST /api/agents answered "
+            f"{resp.status_code}: {resp.text[:400]}. Creating an agent is the "
+            f"first thing anyone does with Trinity."
+        )
+
+    def is_running():
+        check = journey_client.get(f"/api/agents/{name}")
+        if check.status_code != 200:
+            return None
+        state = check.json()
+        return state if state.get("status") == "running" else None
+
+    try:
+        agent = poll_until(
+            is_running,
+            deadline_s=AGENT_RUNNING_DEADLINE_S,
+            describe=f"agent '{name}' was created but never reached 'running'",
+        )
+        yield agent
+    finally:
+        delete_agent_idempotent(journey_client, name)

--- a/tests/journeys/conftest.py
+++ b/tests/journeys/conftest.py
@@ -127,16 +127,6 @@ def journey_agent(journey_client, journey_agent_name):
     # it surfaced as `httpx.ReadTimeout` at fixture setup, which reads as harness
     # breakage rather than as the platform being slow. The deadline that matters
     # is still the poll below; this only stops the CALL from giving up first.
-    resp = journey_client.post(
-        "/api/agents", json={"name": name}, timeout=AGENT_CREATE_CALL_TIMEOUT_S,
-    )
-    if resp.status_code not in (200, 201):
-        raise AssertionError(
-            f"creating agent '{name}' through POST /api/agents answered "
-            f"{resp.status_code}: {resp.text[:400]}. Creating an agent is the "
-            f"first thing anyone does with Trinity."
-        )
-
     def is_running():
         check = journey_client.get(f"/api/agents/{name}")
         if check.status_code != 200:
@@ -144,7 +134,27 @@ def journey_agent(journey_client, journey_agent_name):
         state = check.json()
         return state if state.get("status") == "running" else None
 
+    # The CREATE is inside the try, so the finally reaches a partial one.
+    #
+    # It used to sit above, with its `raise AssertionError` outside the block —
+    # so a create that provisioned the ownership row and THEN failed (a 500
+    # after the row is written, or a read timeout on a request the backend went
+    # on to complete) left an agent teardown never touched. That breaks this
+    # tier's own rule that it is re-runnable after a crash with no manual
+    # cleanup, and it breaks it on the path where cleanup matters most: the
+    # failure case. Moving it in costs nothing — `delete_agent_idempotent` is
+    # already safe on an agent that was never created.
     try:
+        resp = journey_client.post(
+            "/api/agents", json={"name": name}, timeout=AGENT_CREATE_CALL_TIMEOUT_S,
+        )
+        if resp.status_code not in (200, 201):
+            raise AssertionError(
+                f"creating agent '{name}' through POST /api/agents answered "
+                f"{resp.status_code}: {resp.text[:400]}. Creating an agent is the "
+                f"first thing anyone does with Trinity."
+            )
+
         agent = poll_until(
             is_running,
             deadline_s=AGENT_RUNNING_DEADLINE_S,

--- a/tests/journeys/test_agent_lifecycle_journey.py
+++ b/tests/journeys/test_agent_lifecycle_journey.py
@@ -42,6 +42,10 @@ def test_a_stopped_agent_can_be_started_again(journey_client, journey_agent):
     Both directions are polled to a deadline, and each failure names which half
     of the round trip broke — "stopped but never restarted" and "never stopped"
     send you to different code.
+
+    The restart is deliberately made to require a CONTAINER RECREATE, because
+    that is the condition the regression needed. Without it this journey passes
+    against the broken code (measured, not assumed).
     """
     name = journey_agent["name"]
 
@@ -53,6 +57,24 @@ def test_a_stopped_agent_can_be_started_again(journey_client, journey_agent):
         lambda: _status(journey_client, name) in ("stopped", "exited"),
         deadline_s=AGENT_STOPPED_DEADLINE_S,
         describe=f"agent '{name}' was asked to stop but never left 'running'",
+    )
+
+    # Force the condition the 08-14 regression actually needed. #2186's title
+    # says it exactly: "starting a stopped agent no longer 500s WHEN A RECREATE
+    # IS NEEDED". A fresh agent stopped and started immediately has no config
+    # drift, so `start_agent_internal` takes the plain-start path and the bug is
+    # unreachable — verified empirically: replaying the regression with this
+    # step absent left the gate GREEN, which is the whole reason AC #3 exists.
+    #
+    # Changing the resource limits while stopped makes `check_resource_limits_match`
+    # false, so the next start must recreate the container — the exact path that
+    # raised 500 for five of six agents.
+    drift = journey_client.put(
+        f"/api/agents/{name}/resources", json={"memory": "2g", "cpu": "1"},
+    )
+    assert drift.status_code in (200, 202), (
+        f"could not change resources on stopped agent '{name}' to force a "
+        f"recreate: {drift.status_code} {drift.text[:200]}"
     )
 
     start = journey_client.post(f"/api/agents/{name}/start")

--- a/tests/journeys/test_agent_lifecycle_journey.py
+++ b/tests/journeys/test_agent_lifecycle_journey.py
@@ -1,0 +1,71 @@
+"""Journey: an agent can be created, stopped, and started again (#2336).
+
+**This is the regression of 2026-08-14 written down as a test.** On that day five
+of six stopped agents could not be started — HTTP 500 on the single most
+fundamental operation the platform offers — and it reached users. Nothing caught
+it, because the per-PR gate collects `tests/unit/` only and no automated test
+ever started a real agent.
+
+Deliberately credential-free: nothing here asks an LLM for anything, so it runs
+on every PR including from forks, where the repo will not (and should not)
+expose a provider key. The 08-14 failure was in the START path, not the model.
+"""
+import pytest
+
+from .conftest import (
+    AGENT_RUNNING_DEADLINE_S,
+    AGENT_STOPPED_DEADLINE_S,
+    poll_until,
+)
+
+pytestmark = pytest.mark.journey
+
+
+def _status(client, name):
+    resp = client.get(f"/api/agents/{name}")
+    return resp.json().get("status") if resp.status_code == 200 else None
+
+
+def test_a_created_agent_reaches_running(journey_agent):
+    """The `journey_agent` fixture performs create-and-wait; this asserts the
+    promise it was waiting for actually held, so the journey has a named test
+    rather than only a fixture."""
+    assert journey_agent.get("status") == "running", (
+        f"agent came up in state {journey_agent.get('status')!r} rather than "
+        f"'running' — 'create an agent' is the first promise Trinity makes"
+    )
+
+
+def test_a_stopped_agent_can_be_started_again(journey_client, journey_agent):
+    """Stop it, then start it. The 08-14 regression lived exactly here.
+
+    Both directions are polled to a deadline, and each failure names which half
+    of the round trip broke — "stopped but never restarted" and "never stopped"
+    send you to different code.
+    """
+    name = journey_agent["name"]
+
+    stop = journey_client.post(f"/api/agents/{name}/stop")
+    assert stop.status_code in (200, 202), (
+        f"stopping agent '{name}' answered {stop.status_code}: {stop.text[:300]}"
+    )
+    poll_until(
+        lambda: _status(journey_client, name) in ("stopped", "exited"),
+        deadline_s=AGENT_STOPPED_DEADLINE_S,
+        describe=f"agent '{name}' was asked to stop but never left 'running'",
+    )
+
+    start = journey_client.post(f"/api/agents/{name}/start")
+    assert start.status_code in (200, 202), (
+        f"starting stopped agent '{name}' answered {start.status_code}: "
+        f"{start.text[:300]} — this is the 2026-08-14 regression: five of six "
+        f"stopped agents answered 500 here and it reached users"
+    )
+    poll_until(
+        lambda: _status(journey_client, name) == "running",
+        deadline_s=AGENT_RUNNING_DEADLINE_S,
+        describe=(
+            f"agent '{name}' was started after a stop but never reached "
+            f"'running' again"
+        ),
+    )

--- a/tests/journeys/test_agent_lifecycle_journey.py
+++ b/tests/journeys/test_agent_lifecycle_journey.py
@@ -69,12 +69,44 @@ def test_a_stopped_agent_can_be_started_again(journey_client, journey_agent):
     # Changing the resource limits while stopped makes `check_resource_limits_match`
     # false, so the next start must recreate the container — the exact path that
     # raised 500 for five of six agents.
+    # The values are DERIVED from what the agent currently has, not hardcoded.
+    # This step read `{"memory": "2g", "cpu": "1"}`, which forced a recreate only
+    # because `AGENT_DEFAULT_MEMORY == "4g"` and `AGENT_DEFAULT_CPU == "2"` at the
+    # time — constants this test never reads, and which an operator can move at
+    # runtime through `PUT /api/settings/agent-defaults/resources`. Set the fleet
+    # default to 2g/1 and the PUT becomes a no-op, `check_resource_limits_match`
+    # stays true, no recreate happens, and this journey silently loses its teeth
+    # in exactly the way it already lost them twice.
+    before = journey_client.get(f"/api/agents/{name}/resources")
+    assert before.status_code == 200, (
+        f"could not read current resources for stopped agent '{name}': "
+        f"{before.status_code} {before.text[:200]}"
+    )
+    cur = before.json()
+    cur_mem = cur.get("memory") or cur.get("current_memory")
+    cur_cpu = str(cur.get("cpu") or cur.get("current_cpu") or "")
+    # Any other legal value will do; the point is only that it DIFFERS.
+    want_mem = "1g" if str(cur_mem).startswith("2") else "2g"
+    want_cpu = "2" if cur_cpu.startswith("1") else "1"
+
     drift = journey_client.put(
-        f"/api/agents/{name}/resources", json={"memory": "2g", "cpu": "1"},
+        f"/api/agents/{name}/resources", json={"memory": want_mem, "cpu": want_cpu},
     )
     assert drift.status_code in (200, 202), (
         f"could not change resources on stopped agent '{name}' to force a "
         f"recreate: {drift.status_code} {drift.text[:200]}"
+    )
+
+    # Assert the drift actually took, so "could not force a recreate" fails with
+    # its own name instead of surfacing later as "the restart 500'd" — or worse,
+    # as a green run that exercised the plain-start path.
+    after = journey_client.get(f"/api/agents/{name}/resources").json()
+    assert (after.get("memory"), str(after.get("cpu"))) == (want_mem, want_cpu), (
+        f"resources did not change on '{name}': asked for {want_mem}/{want_cpu}, "
+        f"read back {after.get('memory')}/{after.get('cpu')} (was {cur_mem}/{cur_cpu}). "
+        f"Without a real change there is no config drift, `start_agent_internal` "
+        f"takes the plain-start path, and the #2186 regression this journey "
+        f"exists to catch is unreachable"
     )
 
     start = journey_client.post(f"/api/agents/{name}/start")

--- a/tests/journeys/test_first_turn_journey.py
+++ b/tests/journeys/test_first_turn_journey.py
@@ -1,0 +1,72 @@
+"""Journey J03: a person's first turn with an agent produces real output (#2336).
+
+**Credential-bound, and that is a real constraint rather than an oversight.**
+"Real output" means a real model answered, which needs a provider key. Every
+PR-triggered workflow in this repo is deliberately credential-free —
+`integration-nightly.yml` states the reason in full: `pull_request`-family
+triggers expose repository secrets to fork PRs while running arbitrary shell
+from the PR's own tree, so a key named there is readable by anyone who opens a
+PR.
+
+So this journey runs where a key can safely exist (a developer's stack, the
+nightly), and the per-PR gate runs the credential-free lifecycle journey beside
+it. The skip below is allowlisted in `tests/harness/audit_skips.py` — visible,
+reasoned, and never silent.
+"""
+import os
+
+import pytest
+
+from .conftest import poll_until
+
+pytestmark = pytest.mark.journey
+
+FIRST_TURN_DEADLINE_S = float(os.getenv("JOURNEY_FIRST_TURN_DEADLINE_S", "180"))
+
+
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY") or os.getenv("ANTHROPIC_API_KEY") == "placeholder",
+    reason="journey needs a real provider key",
+)
+def test_first_chat_turn_returns_real_output(journey_client, journey_agent):
+    """Send the first message and get a real answer back.
+
+    Asserts the promise, not the plumbing: a non-empty response the platform
+    persisted, reachable afterwards through the history the user would read.
+    """
+    name = journey_agent["name"]
+
+    resp = journey_client.post(
+        f"/api/agents/{name}/chat",
+        json={"message": "Reply with the single word: ready"},
+        timeout=FIRST_TURN_DEADLINE_S,
+    )
+    assert resp.status_code == 200, (
+        f"first chat turn with '{name}' answered {resp.status_code}: "
+        f"{resp.text[:400]} — this is the first thing a person does after "
+        f"creating an agent"
+    )
+    body = resp.json()
+    answer = (body.get("response") or "").strip()
+    assert answer, (
+        f"agent '{name}' answered the first turn with an EMPTY response. "
+        f"A blank reply is indistinguishable from a working agent in every "
+        f"status field, which is why this asserts the words and not the 200."
+    )
+
+    # ...and the platform kept it, so the person can come back to it.
+    def persisted():
+        hist = journey_client.get(f"/api/agents/{name}/chat/history/persistent")
+        if hist.status_code != 200:
+            return None
+        messages = hist.json().get("messages") or hist.json() or []
+        return messages if messages else None
+
+    poll_until(
+        persisted,
+        deadline_s=30,
+        describe=(
+            f"agent '{name}' answered the first turn but nothing was persisted — "
+            f"the conversation would be gone on reload"
+        ),
+    )

--- a/tests/run-full.sh
+++ b/tests/run-full.sh
@@ -173,6 +173,12 @@ run_tier git-sync    300 git_sync/
 run_tier security    300 security/
 run_tier scheduler   300 scheduler_tests/
 run_tier agent-server 300 agent_server/
+# Journey tier (#2335, Rail R1). Live-stack by definition: these drive the
+# public API against a running instance the way a person does. Longer per-test
+# timeout than any other tier because a journey legitimately waits on a
+# container coming up — 90s to `running` is the platform's own bound, not this
+# harness's impatience.
+run_tier journeys 900 journeys/
 
 # Root-level live-backend tests (everything not owned by a tier above).
 run_tier api 900 . \

--- a/tests/run-full.sh
+++ b/tests/run-full.sh
@@ -181,10 +181,43 @@ run_tier agent-server 300 agent_server/
 run_tier journeys 900 journeys/
 
 # Root-level live-backend tests (everything not owned by a tier above).
-run_tier api 900 . \
-    --ignore=unit --ignore=integration --ignore=git_sync --ignore=security \
-    --ignore=scheduler_tests --ignore=agent_server --ignore=manual --ignore=deploy \
-    --ignore=harness
+#
+# The ignore list is DERIVED, not hand-mirrored. It was written out by hand and
+# `journeys` was added as a tier above without being added below, so `api`
+# collected `journeys/` a second time from `.` — every journey agent created and
+# torn down twice, the container time paid twice, and one journey failure
+# reported under two tier names. That is the new-producer-not-in-the-consumer-
+# allowlist class, and adding one `--ignore=` would leave the next tier to
+# repeat it.
+#
+# TIER_DIRS is the single list. `NON_TIER_DIRS` are directories `api` must also
+# not collect but that no tier owns: `manual/` and `deploy/` are opt-in, and
+# `harness/` and the support packages hold no tests of their own.
+TIER_DIRS=(unit integration git_sync security scheduler_tests agent_server journeys)
+NON_TIER_DIRS=(manual deploy harness fixtures testing_utils testkit)
+
+# And the list is CHECKED against the tree, because a derived list is only as
+# good as its inputs: a new directory under tests/ that nobody wired would still
+# be silently swept into `api`. Failing here names it instead.
+_unclassified=()
+for _d in tests/*/; do
+    _d="${_d#tests/}"; _d="${_d%/}"
+    case " ${TIER_DIRS[*]} ${NON_TIER_DIRS[*]} " in
+        *" ${_d} "*) ;;
+        *) _unclassified+=("${_d}") ;;
+    esac
+done
+if [ ${#_unclassified[@]} -gt 0 ]; then
+    printf '\n\033[1;31m== tests/run-full.sh: unclassified test directories\033[0m\n'
+    printf '   %s\n' "${_unclassified[@]}"
+    printf '   Add each to TIER_DIRS (with its own run_tier line) or to NON_TIER_DIRS.\n'
+    printf '   Left unwired they are collected a SECOND time by the api tier.\n\n'
+    exit 1
+fi
+
+api_ignores=()
+for _d in "${TIER_DIRS[@]}" "${NON_TIER_DIRS[@]}"; do api_ignores+=("--ignore=${_d}"); done
+run_tier api 900 . "${api_ignores[@]}"
 
 # Documented run-standalone tests: they assert route ORDER on a pristine
 # `sys.modules`, so any earlier import of the app makes them vacuous. Separate


### PR DESCRIPTION
## Summary

**Rails R1 + R2 of the journey-coverage deck**, together: R2 is a gate with nothing to run without R1, and R1 is a tier nothing enforces without R2.

The thing this exists for, concretely: on **2026-08-14 five of six stopped agents could not be started** — HTTP 500 on the most fundamental operation the platform has — and it reached users. A human found it by poking around. Nothing automated caught it, because the per-PR gate collects `tests/unit/` only and no test in the merge path had ever started a real agent.

## R1 — `tests/journeys/` + `run-full.sh --tier journeys`

Reuses the existing harness rather than building a second one, as the issue asks: per-tier verdicts, the timeout, the venv pin and the skip audit all come for free, and `run_tier` made the wiring literally one line.

**Three rules the tier does not bend:**

- **A journey FAILS; it does not skip.** `tests/conftest.py::created_agent` calls `pytest.skip` when an agent will not start — reasonable for a fixture whose tests are about something else, and *precisely* the blind spot here. In this tier, "the agent never reached running" **is** the finding.
- **Preconditions are checked once, loudly.** An unreachable stack fails the tier naming the URL it tried, not 40 confusing errors downstream. A tier that cannot run is a failure, never a silent pass — `run-full.sh`'s own stated rule 1.
- **Nothing is touched that the tier did not create.** Every agent is `pytest-ephemeral-journey-<hex>`, torn down by that name; teardown is idempotent, so a crashed run leaves the tier re-runnable with no manual cleanup.

`poll_until` is the only synchronisation primitive — `sleep`-as-synchronisation pays the worst case every run and still loses the race on a loaded runner. Failures name the broken promise and how long they waited:

> `agent 'pytest-ephemeral-journey-a1b2c3d4' was created but never reached 'running' — waited 90s of 90s.`

never a bare `assert 200 == 500`.

## R2 — `.github/workflows/journey-smoke.yml`

Every PR to `dev`. **30-minute bounded job** whose timeout *fails* rather than passes, and which treats "collected nothing" (pytest exit 5) as a failure — the #2029 class a required check exists to prevent.

## Two things I want visible rather than glossed

**1. AC #2 ("a real chat turn with real output") is credential-bound, and this repo deliberately withholds credentials from PR triggers.** `pull_request` exposes repository secrets to fork PRs while running arbitrary shell from the PR's own tree — `integration-nightly.yml` sets out the full reasoning and keeps itself credential-free for exactly that reason.

So the J03 first-turn journey **ships in the tier** (runs on a developer's stack and in the nightly) and skips with an **allowlisted, visible** reason otherwise. What gates every PR is the lifecycle journey — create → running → stop → start → running — which is where the 08-14 regression actually was.

Resolving AC #2 properly needs a same-repo-only workflow with an environment approval. That is a security decision, not something to slip into this PR.

**2. AC #3 is done, and it earned its keep — it failed twice before it passed.**

*First attempt:* reverted `ecf1327f` exactly as the issue says. Gate went **green**. Correctly so: `ecf1327f` (#2092) is the commit that **caused** the regression, so reverting it removes the bug. The fix to revert is `35a24d0c` (#2186). **The issue's replay instruction should be corrected.**

*Second attempt:* reverted `35a24d0c`. Gate went **green again** — and this one was my bug. #2186's title states the condition precisely: the 500 happened *"when a recreate is needed"*. A fresh agent stopped and started immediately has no config drift, so `start_agent_internal` takes the plain-start path and the regression is unreachable. **The journey had no teeth**, and only a real replay could have shown that.

*Third:* the journey now changes resource limits while the agent is stopped, forcing `check_resource_limits_match` false and putting the restart on the recreate path. Red, on the right assertion, with the right message.

I would not have found either problem from a green run. Worth keeping in mind for the rest of the deck: a journey that has never been watched failing is a journey of unknown value.

## Test Plan

- [x] `pytest tests/journeys/ --collect-only` → 3 collected
- [x] `run_tier journeys 900 journeys/` wired; marker registered in `pyproject.toml`
- [x] Skip-audit extended with the credential reason, so the one skip is allowlisted rather than silent
- [x] **Live green run** — this PR's own `journey-smoke`: **2 passed, 1 skipped in 36.99s**, whole job **5m07s** of a 30m budget. Both lifecycle journeys created and drove a real agent.
- [x] **AC #3 — the gate goes RED on the regression.** Proven in a throwaway PR (#2404, closed and deleted):
  ```
  test_a_stopped_agent_can_be_started_again FAILED
  E  AssertionError: starting stopped agent 'pytest-ephemeral-journey-e15347a9'
     answered 500: {"detail":"Failed to start agent (ValueError …)"}
     — this is the 2026-08-14 regression: five of six stopped agents
       answered 500 here and it reached users
  ```
- [ ] Make it a required check (repo admin) — after the replay proves it

Related to #2335 · Related to #2336 · Related to #1958 (absorbed)
