### PR TITLE
feat(ci): Journey Impact declaration, enforced at merge (#2350)

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,39 @@
+---
+name: Epic
+about: A delivery vehicle spanning several PRs, with named sub-issues
+title: 'Epic: '
+labels: type-epic
+assignees: ''
+---
+
+## Charter
+
+What this epic delivers, and what it deliberately does not.
+
+## Journey Impact
+
+<!-- #2350. One line, exactly one of:
+
+       Journey Impact: new: J11
+       Journey Impact: extends: J03
+       Journey Impact: none: <why this touches no promise>
+
+     `none` REQUIRES a reason — a bare `none` fails the check.
+
+     Declaring `new:` obliges this epic's first PR to carry a journey skeleton
+     under tests/journeys/. That is the point: a new promise that nothing
+     asserts is how coverage debt is created silently. A `strict=True` xfail
+     asserting the journey's invariants satisfies it.
+
+     The promise list lives in tests/journeys/catalog.yaml; invariant ids
+     resolve in docs/testing/orchestration-invariant-catalog.md. -->
+
+Journey Impact: 
+
+## Sub-issues
+
+- [ ] 
+
+## Acceptance
+
+How we know the epic is done — and what its rollup % does and does not mean.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,22 @@ Brief description of changes.
 
 Fixes #(issue number)
 
+## Journey Impact
+
+<!-- #2350. One line, exactly one of:
+
+       Journey Impact: new: J11
+       Journey Impact: extends: J03
+       Journey Impact: none: <why this touches no promise>
+
+     `none` REQUIRES a reason — a bare `none` fails the check. Declaring `new:`
+     obliges this PR to carry a journey skeleton under tests/journeys/; a
+     `strict=True` xfail asserting the journey's invariants is enough.
+
+     The promise list lives in tests/journeys/catalog.yaml. -->
+
+Journey Impact: 
+
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change that fixes an issue)

--- a/.github/workflows/journey-impact.yml
+++ b/.github/workflows/journey-impact.yml
@@ -1,0 +1,60 @@
+name: Journey Impact
+
+# Gate G1 of the journey-coverage deck (#2350).
+#
+# Every epic and user-facing feature declares what it does to the promise list.
+# The DECLARATION is cheap; the gate is the load-bearing part. An intake field
+# on its own would be `none:` for everything inside a month and would read as
+# compliance — so the burden sits on the `new:` path, where declaring a new
+# promise obliges the same PR to carry a skeleton for it. That is what stops
+# `none:` being the free option: choosing it is a visible claim, in writing,
+# next to a diff a reviewer can check it against.
+#
+# What FAILS: a malformed declaration (including a bare `none`), and a `new:`
+# declaration — on the PR or on an epic it references — with no skeleton in the
+# diff. What PASSES with a note: no declaration at all, deliberately, so
+# adopting the field does not red-X every in-flight PR and dependabot bump on
+# day one. Tightening that is a follow-up once the templates have been in use.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [dev, main]
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: journey-impact-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  journey-impact:
+    name: journey-impact
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Need the base to diff against for the skeleton check.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v7
+        with:
+          # #1891: must equal the image pin; tests/unit/test_1891_python_version_parity.py
+          # scans every workflow and fails on a stale one.
+          python-version: '3.13'
+
+      - name: Check the declaration
+        env:
+          # Through env, never `${{ }}` inside the shell body: a PR body is
+          # attacker-authored text, so interpolating it into a `run:` script is
+          # a command-injection sink.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: python scripts/ci/check_journey_impact.py

--- a/scripts/ci/check_journey_impact.py
+++ b/scripts/ci/check_journey_impact.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""CI driver for the Journey Impact gate (#2350, Gate G1).
+
+Thin: it gathers inputs (PR body, changed files, any referenced epic) and hands
+them to `journey_impact.decide`, which holds the decision and is unit-tested.
+Keeping the judgement out of a workflow's shell body is the point — a rule that
+only runs in CI is a rule nobody can test.
+
+Reads from the environment so no attacker-authored text ever reaches a shell.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from journey_impact import Declaration, decide, parse_declaration  # noqa: E402
+
+# `Fixes #N` / `Related to #N` / `Related to owner/repo#N`.
+_ISSUE_REF_RE = re.compile(
+    r"(?:closes|close|fixes|fix|resolves|resolve|related to|refs?|part of)\s+"
+    r"(?:(?P<repo>[\w.-]+/[\w.-]+))?#(?P<num>\d+)",
+    re.IGNORECASE,
+)
+MAX_DIFF_FILES = 400          # a huge PR should not turn the gate into a crawl
+MAX_FILE_BYTES = 200_000
+
+
+def changed_files(base: str, head: str):
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}...{head}"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        print(f"::warning::could not diff {base}...{head} ({e}); "
+              f"skeleton detection will see no files")
+        return []
+    paths = [p for p in out.splitlines() if p.strip()][:MAX_DIFF_FILES]
+    files = []
+    for p in paths:
+        try:
+            blob = subprocess.run(["git", "show", f"{head}:{p}"],
+                                  capture_output=True, text=True, check=True).stdout
+        except subprocess.CalledProcessError:
+            blob = ""          # deleted in this PR
+        files.append((p, blob[:MAX_FILE_BYTES]))
+    return files
+
+
+def epic_declarations(body: str, repo: str):
+    """Declarations on issues this PR references that are labelled `type-epic`.
+
+    Best-effort: a lookup failure is reported and does not fail the gate. The
+    obligation this gate enforces has to be legible to the author, and "the
+    issues API was briefly unavailable" is not something they can act on.
+    """
+    out = []
+    seen = set()
+    for m in _ISSUE_REF_RE.finditer(body or ""):
+        target_repo = m.group("repo") or repo
+        num = m.group("num")
+        key = (target_repo, num)
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            raw = subprocess.run(
+                ["gh", "issue", "view", num, "--repo", target_repo,
+                 "--json", "body,labels"],
+                capture_output=True, text=True, check=True,
+            ).stdout
+            data = json.loads(raw)
+        except Exception as e:  # noqa: BLE001
+            print(f"::warning::could not read {target_repo}#{num} ({type(e).__name__}); "
+                  f"not treating it as an epic")
+            continue
+        labels = {l.get("name") for l in (data.get("labels") or [])}
+        if "type-epic" not in labels:
+            continue
+        out.append((f"{target_repo}#{num}", parse_declaration(data.get("body"))))
+    return out
+
+
+def main() -> int:
+    body = os.environ.get("PR_BODY", "")
+    repo = os.environ.get("REPO", "")
+    base = os.environ.get("BASE_SHA", "")
+    head = os.environ.get("HEAD_SHA", "HEAD")
+
+    pr_decl = parse_declaration(body)
+    epics = epic_declarations(body, repo) if repo else []
+    # Only pay for the diff when something might oblige a skeleton.
+    needs_files = pr_decl.kind == "new" or any(
+        d.kind == "new" for _, d in epics
+    )
+    files = changed_files(base, head) if (needs_files and base) else []
+
+    verdict = decide(pr_declaration=pr_decl, epic_declarations=epics,
+                     changed_files=files)
+
+    for line in verdict.lines:
+        print(line)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as fh:
+            fh.write("## Journey Impact\n\n")
+            for line in verdict.lines:
+                fh.write(f"{line}\n\n")
+
+    if not verdict.ok:
+        print("::error title=Journey Impact::" + verdict.lines[-1].splitlines()[0])
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/journey_impact.py
+++ b/scripts/ci/journey_impact.py
@@ -1,0 +1,218 @@
+"""Journey Impact — parse the declaration and decide the gate (#2350, Gate G1).
+
+Every epic and user-facing feature declares what it does to the promise list:
+
+    Journey Impact: new: J11
+    Journey Impact: extends: J03
+    Journey Impact: none: refactor, no user-visible behaviour changes
+
+WHY THE GATE IS THE POINT. Ownership alone collapses into "PM nags, Eng
+defers". An intake FIELD alone is worse than nothing: everything would be
+declared `none:` in three weeks and the field would read as compliance. So the
+burden sits on the `new:` path — declaring a new promise obliges the same PR to
+carry a skeleton for it — which is what stops `none:` being the cheap escape.
+Choosing `none:` becomes a visible claim that the change touches no promise,
+made in writing, next to a diff a reviewer can compare it against.
+
+Pure functions, stdlib only: the decision is unit-tested rather than discovered
+in CI logs.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+# `new`/`extends` name a journey id (J01..J99). `none` takes free text.
+_DECL_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:\*\*)?journey\s*impact(?:\*\*)?\s*[:\-]\s*(?P<rest>.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_KIND_RE = re.compile(
+    r"^(?P<kind>new|extends|none)\b\s*[:\-]?\s*(?P<arg>.*)$", re.IGNORECASE
+)
+_JOURNEY_ID_RE = re.compile(r"^J\d{2}$")
+
+# A skeleton lives in the journey tier (#2335). Anything else is a test that
+# happens to mention a journey.
+_SKELETON_DIR = "tests/journeys/"
+
+# `strict=True` is what makes an xfail a claim rather than a shrug: it fails the
+# build the day the behaviour starts working, which is exactly when the
+# skeleton should stop being a skeleton.
+_STRICT_XFAIL_RE = re.compile(r"xfail\s*\([^)]*strict\s*=\s*True", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass
+class Declaration:
+    kind: Optional[str] = None          # new | extends | none | None (absent)
+    journey: Optional[str] = None       # J-id for new/extends
+    reason: Optional[str] = None        # free text for none
+    raw: Optional[str] = None
+    error: Optional[str] = None         # malformed, with the reason
+
+
+@dataclass
+class Verdict:
+    ok: bool
+    # Every path says WHAT it read and WHY it decided (#2350 AC 5). A gate that
+    # fails without naming the declaration it acted on is a gate people learn
+    # to re-run rather than read.
+    lines: list = field(default_factory=list)
+
+    def say(self, msg: str) -> "Verdict":
+        self.lines.append(msg)
+        return self
+
+
+def parse_declaration(body: Optional[str]) -> Declaration:
+    """Read the Journey Impact declaration out of an issue or PR body."""
+    if not body:
+        return Declaration()
+    matches = _DECL_RE.findall(body)
+    if not matches:
+        return Declaration()
+    # Last wins: an edited body keeps the correction, not the draft above it.
+    raw = matches[-1].strip()
+    # Strip a trailing HTML comment or template hint on the same line.
+    raw = re.sub(r"<!--.*?-->", "", raw).strip()
+    if not raw or raw.lower() in {"new:", "extends:", "none:", "_none_", "tbd"}:
+        return Declaration(raw=raw, error="the declaration is present but empty")
+
+    m = _KIND_RE.match(raw)
+    if not m:
+        return Declaration(
+            raw=raw,
+            error=f"{raw!r} is not one of `new: <id>`, `extends: <id>`, `none: <reason>`",
+        )
+    kind = m.group("kind").lower()
+    arg = m.group("arg").strip().strip("`").strip()
+
+    if kind == "none":
+        if not arg:
+            # AC 4. A bare `none` is the whole failure mode this gate exists to
+            # prevent: it is indistinguishable from not having thought about it.
+            return Declaration(kind=kind, raw=raw,
+                               error="`none` needs a reason — `none: <why this touches no promise>`")
+        return Declaration(kind=kind, reason=arg, raw=raw)
+
+    journey = arg.split()[0].strip(",.") if arg else ""
+    if not _JOURNEY_ID_RE.match(journey):
+        return Declaration(
+            kind=kind, raw=raw,
+            error=f"`{kind}` needs a journey id like J03, got {journey or '(nothing)'}",
+        )
+    return Declaration(kind=kind, journey=journey, raw=raw)
+
+
+def looks_like_skeleton(path: str, content: str, journey: Optional[str] = None) -> bool:
+    """Does this changed file carry a journey skeleton — for `journey`?
+
+    A `strict=True` xfail asserting the journey's invariants is sufficient
+    (AC 3): the point is a named, failing-on-success claim in the tier, not a
+    finished harness. A passing test obviously also counts.
+
+    The id binding is not pedantry. Without it, declaring `new: J11` is
+    satisfied by touching ANY file in the tier — including an unrelated edit to
+    an existing journey — which turns the obligation back into the compliance
+    theatre the gate exists to prevent. The skeleton must name the promise it
+    is standing in for, in its path or its body.
+    """
+    if not path.startswith(_SKELETON_DIR):
+        return False
+    if path.endswith(("catalog.yaml", "conftest.py", "__init__.py")):
+        return False
+    has_test = bool(
+        _STRICT_XFAIL_RE.search(content)
+        or re.search(r"^\s*def test_", content, re.MULTILINE)
+    )
+    if not has_test:
+        return False
+    if journey is None:
+        return True
+    hay = f"{path}\n{content}".upper()
+    # NOT `\b`: the id is routinely embedded underscore-delimited
+    # (`test_j07_journey.py`), and `_` is a word character, so `\bJ07\b` never
+    # matches the very filename the convention produces. Delimit on the
+    # characters that would actually make it a DIFFERENT id instead — a letter
+    # or digit either side — so J07 does not match J071 or XJ07.
+    pat = rf"(?<![A-Z0-9]){re.escape(journey.upper())}(?![A-Z0-9])"
+    return re.search(pat, hay) is not None
+
+
+def decide(
+    *,
+    pr_declaration: Declaration,
+    epic_declarations: Iterable[tuple] = (),   # (issue_ref, Declaration)
+    changed_files: Iterable[tuple] = (),       # (path, content)
+) -> Verdict:
+    """The gate. Fails on a malformed declaration, or on `new:` with no skeleton."""
+    v = Verdict(ok=True)
+
+    if pr_declaration.error:
+        v.ok = False
+        return v.say(f"PR declaration: {pr_declaration.raw!r}").say(
+            f"REJECTED — {pr_declaration.error}"
+        )
+
+    obligations = []
+    if pr_declaration.kind:
+        v.say(f"PR declares Journey Impact: {pr_declaration.raw!r}")
+        if pr_declaration.kind == "new":
+            obligations.append(("this PR", pr_declaration.journey))
+    else:
+        # Absence is not (yet) a failure: adopting the field must not red-X
+        # every in-flight PR and every dependabot bump on day one. It is
+        # reported loudly so the gap is visible, and tightening this is a
+        # deliberate follow-up once the templates have been in use.
+        v.say("PR declares no Journey Impact — allowed for now, but the "
+              "template asks for one; see .github/pull_request_template.md")
+
+    for ref, decl in epic_declarations:
+        if decl.error:
+            v.ok = False
+            v.say(f"epic {ref} declaration: {decl.raw!r}")
+            v.say(f"REJECTED — epic {ref}: {decl.error}")
+            return v
+        if decl.kind:
+            v.say(f"epic {ref} declares Journey Impact: {decl.raw!r}")
+            if decl.kind == "new":
+                obligations.append((f"epic {ref}", decl.journey))
+
+    if not obligations:
+        return v.say("PASSED — no `new:` declaration, so no skeleton is owed.")
+
+    files = list(changed_files)
+    tier_tests = [p for p, c in files if looks_like_skeleton(p, c)]
+    matched = []
+    for who, journey in obligations:
+        hits = [p for p, c in files if looks_like_skeleton(p, c, journey)]
+        if hits:
+            matched.append(f"{journey} ({', '.join(hits)})")
+            continue
+        v.ok = False
+        if tier_tests:
+            # The confusing case: they DID add a journey test, it just does not
+            # name the promise they declared. Say that, rather than "none found".
+            v.say(
+                f"REJECTED — {who} declares `new: {journey}`, and this PR does "
+                f"touch the journey tier ({', '.join(tier_tests)}) — but none of "
+                f"those files names {journey}. The skeleton has to name the "
+                f"promise it stands in for, or the obligation is satisfied by "
+                f"any unrelated edit in the tier."
+            )
+        else:
+            v.say(
+                f"REJECTED — {who} declares `new: {journey}`, which obliges this "
+                f"PR to carry a journey skeleton under {_SKELETON_DIR}. None found "
+                f"in {len(files)} changed file(s)."
+            )
+        v.say(
+            f"A `strict=True` xfail naming {journey} is enough:\n"
+            f"    @pytest.mark.xfail(strict=True, reason='{journey} not built yet')\n"
+            f"    def test_{journey.lower()}_promise(): ...\n"
+            f"Declaring a new promise and shipping nothing that asserts it is "
+            f"the gap this gate exists to close."
+        )
+        return v
+    return v.say("PASSED — skeleton present for " + "; ".join(matched))

--- a/scripts/ci/journey_impact.py
+++ b/scripts/ci/journey_impact.py
@@ -74,8 +74,15 @@ def parse_declaration(body: Optional[str]) -> Declaration:
         return Declaration()
     # Last wins: an edited body keeps the correction, not the draft above it.
     raw = matches[-1].strip()
-    # Strip a trailing HTML comment or template hint on the same line.
-    raw = re.sub(r"<!--.*?-->", "", raw).strip()
+    # Cut at the comment opener rather than matching a `<!-- ... -->` pair.
+    # `_DECL_RE` is line-bounded (`.+?` never crosses a newline), so `raw` is
+    # one line and everything from `<!--` on is comment — including the
+    # UNCLOSED case, which a pair-matching regex silently leaves in the reason
+    # (`none: fine <!-- todo` would have been read as the reason "fine <!--
+    # todo"). This is also why CodeQL's py/bad-tag-filter fires on the pair
+    # form: it cannot handle a comment spanning newlines. Truncating removes
+    # the construct and is strictly more correct for this input.
+    raw = raw.split("<!--", 1)[0].strip()
     if not raw or raw.lower() in {"new:", "extends:", "none:", "_none_", "tbd"}:
         return Declaration(raw=raw, error="the declaration is present but empty")
 

--- a/tests/unit/test_2350_journey_impact.py
+++ b/tests/unit/test_2350_journey_impact.py
@@ -1,0 +1,240 @@
+"""#2350 — the Journey Impact gate decides correctly (Gate G1).
+
+The declaration is cheap; the GATE is the load-bearing part. An intake field on
+its own would be `none:` for everything inside a month and would read as
+compliance — so the burden sits on the `new:` path, where declaring a new
+promise obliges the same PR to carry a skeleton for it. That is what stops
+`none:` being the free option.
+
+The decision therefore lives in a pure function and is tested here, not
+discovered in a CI log. A rule that only runs in CI is a rule nobody can check.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts/ci"))
+
+from journey_impact import (  # noqa: E402
+    decide, looks_like_skeleton, parse_declaration,
+)
+
+pytestmark = pytest.mark.unit
+
+SKELETON = ("tests/journeys/test_j11_journey.py", """
+import pytest
+
+@pytest.mark.xfail(strict=True, reason="J11 not built yet")
+def test_j11_promise():
+    assert False
+""")
+
+
+# --------------------------------------------------------------- parsing
+
+@pytest.mark.parametrize("body,kind,journey", [
+    ("Journey Impact: new: J11", "new", "J11"),
+    ("Journey Impact: extends: J03", "extends", "J03"),
+    ("**Journey Impact**: new: J07", "new", "J07"),
+    ("- Journey Impact - extends: J10", "extends", "J10"),
+    ("journey impact: NEW: J01", "new", "J01"),
+])
+def test_the_declaration_is_read_in_the_shapes_people_actually_write(body, kind, journey):
+    d = parse_declaration(body)
+    assert (d.kind, d.journey, d.error) == (kind, journey, None)
+
+
+def test_a_reason_is_required_for_none():
+    """AC 4, and the whole anti-gaming argument. A bare `none` is
+    indistinguishable from not having thought about it."""
+    bad = parse_declaration("Journey Impact: none")
+    assert bad.error and "needs a reason" in bad.error
+    good = parse_declaration("Journey Impact: none: pure refactor, no behaviour change")
+    assert good.kind == "none" and good.reason.startswith("pure refactor")
+
+
+def test_new_and_extends_need_a_real_journey_id():
+    assert parse_declaration("Journey Impact: new: the login one").error
+    assert parse_declaration("Journey Impact: extends:").error
+    assert parse_declaration("Journey Impact: new: J3").error       # J03, not J3
+
+
+def test_an_absent_declaration_is_absent_not_malformed():
+    """The two must not be conflated: absence is tolerated today, malformed
+    never is."""
+    d = parse_declaration("## Description\n\nSomething unrelated.")
+    assert d.kind is None and d.error is None
+
+
+def test_an_unfilled_template_placeholder_is_malformed_not_absent():
+    """The template ships `Journey Impact: ` with nothing after it. Reading
+    that as "absent" would make the field decorative on the exact PRs that
+    used the template."""
+    assert parse_declaration("Journey Impact: ").error
+    assert parse_declaration("Journey Impact: <!-- pick one -->").error
+
+
+def test_an_edited_body_keeps_the_correction_not_the_draft():
+    body = "Journey Impact: none\n\n...later...\n\nJourney Impact: new: J05"
+    d = parse_declaration(body)
+    assert (d.kind, d.journey) == ("new", "J05")
+
+
+# --------------------------------------------------------------- skeleton
+
+def test_the_skeleton_must_name_the_journey_it_stands_in_for():
+    """Without the id binding, `new: J11` is satisfied by ANY edit in the tier
+    — including an unrelated tweak to an existing journey — which hands the
+    obligation straight back to the compliance theatre the gate exists to
+    prevent."""
+    assert looks_like_skeleton(*SKELETON, "J11")
+    assert not looks_like_skeleton(*SKELETON, "J07")
+    # Naming it in the PATH is enough; the body need not repeat it.
+    assert looks_like_skeleton(
+        "tests/journeys/test_j07_journey.py",
+        "import pytest\n@pytest.mark.xfail(strict=True, reason='later')\ndef test_x(): ...\n",
+        "J07",
+    )
+
+
+def test_the_id_match_is_a_whole_token_not_a_substring():
+    """J1 must not satisfy J11, and J11 must not satisfy J1 — ids that differ
+    only by a digit are exactly the ones a typo produces."""
+    for content in ("def test_x(): pass  # J110", "def test_x(): pass  # XJ11"):
+        assert not looks_like_skeleton("tests/journeys/test_x_journey.py",
+                                       content, "J11"), content
+    # but the underscore-delimited filename convention DOES match
+    assert looks_like_skeleton("tests/journeys/test_j11_journey.py",
+                               "def test_x(): pass", "J11")
+
+
+def test_a_journey_test_that_names_the_wrong_promise_gets_its_own_message():
+    """The confusing case deserves better than "none found": they DID add a
+    journey test, it just does not name what they declared."""
+    other = ("tests/journeys/test_j07_journey.py",
+             "import pytest\n\n\ndef test_j07_promise():\n    assert True\n")
+    v = decide(pr_declaration=parse_declaration("Journey Impact: new: J11"),
+               changed_files=[other])
+    assert not v.ok
+    joined = "\n".join(v.lines)
+    assert "does touch the journey tier" in joined and "test_j07_journey.py" in joined
+
+
+def test_a_strict_xfail_in_the_tier_is_a_sufficient_skeleton():
+    """AC 3. `strict=True` is what makes it a claim rather than a shrug: it
+    fails the build the day the behaviour starts working, which is exactly
+    when the skeleton should stop being one."""
+    assert looks_like_skeleton(*SKELETON)
+
+
+def test_a_non_strict_xfail_is_not_a_skeleton():
+    assert not looks_like_skeleton(
+        "tests/journeys/test_j11_journey.py",
+        "import pytest\n@pytest.mark.xfail(reason='later')\ndef nope(): ...\n",
+    )
+
+
+def test_a_test_outside_the_tier_is_not_a_skeleton():
+    """A unit test that mentions a journey is not a journey harness — the tier
+    is where a live-stack promise can actually be asserted (#2335)."""
+    assert not looks_like_skeleton("tests/unit/test_j11.py", SKELETON[1])
+
+
+def test_the_catalog_and_scaffolding_do_not_count_as_a_skeleton():
+    """Declaring the promise in the catalog is #2338's job and is not the same
+    as asserting it — otherwise every `new:` would be satisfied by one YAML
+    line, which is the gaming this gate exists to prevent."""
+    assert not looks_like_skeleton("tests/journeys/catalog.yaml", "journeys: []")
+    assert not looks_like_skeleton("tests/journeys/conftest.py", "def test_x(): ...")
+
+
+# --------------------------------------------------------------- decision
+
+def test_new_without_a_skeleton_is_rejected():
+    """AC 2 — the load-bearing case."""
+    v = decide(pr_declaration=parse_declaration("Journey Impact: new: J11"),
+               changed_files=[("src/backend/main.py", "x = 1")])
+    assert not v.ok
+    joined = "\n".join(v.lines)
+    assert "J11" in joined and "skeleton" in joined
+
+
+def test_new_with_a_skeleton_passes():
+    v = decide(pr_declaration=parse_declaration("Journey Impact: new: J11"),
+               changed_files=[SKELETON, ("src/backend/main.py", "x = 1")])
+    assert v.ok, v.lines
+
+
+def test_extends_owes_no_skeleton():
+    """Extending an existing promise is covered by that journey's harness; the
+    obligation is specific to MINTING one."""
+    v = decide(pr_declaration=parse_declaration("Journey Impact: extends: J03"),
+               changed_files=[("src/backend/main.py", "x = 1")])
+    assert v.ok
+
+
+def test_an_epic_declaring_new_binds_the_prs_under_it():
+    """AC 2's actual wording: the epic declares, the PR must carry."""
+    v = decide(
+        pr_declaration=parse_declaration("Journey Impact: none: implementation detail"),
+        epic_declarations=[("owner/repo#1850", parse_declaration("Journey Impact: new: J11"))],
+        changed_files=[("src/backend/main.py", "x = 1")],
+    )
+    assert not v.ok
+    assert "epic owner/repo#1850" in "\n".join(v.lines)
+
+
+def test_a_malformed_epic_declaration_is_rejected_too():
+    v = decide(pr_declaration=parse_declaration("Journey Impact: none: fine"),
+               epic_declarations=[("o/r#1", parse_declaration("Journey Impact: none"))])
+    assert not v.ok
+
+
+def test_an_absent_declaration_passes_but_says_so():
+    """Deliberate: adopting the field must not red-X every in-flight PR and
+    dependabot bump on day one. The gap is reported rather than enforced, and
+    tightening it is a follow-up once the templates have been in use."""
+    v = decide(pr_declaration=parse_declaration("no field here"))
+    assert v.ok
+    assert "no Journey Impact" in "\n".join(v.lines)
+
+
+def test_every_verdict_says_what_it_read_and_why():
+    """AC 5. A gate that fails without naming the declaration it acted on is a
+    gate people learn to re-run rather than read."""
+    for body, files in (
+        ("Journey Impact: new: J11", []),
+        ("Journey Impact: new: J11", [SKELETON]),
+        ("Journey Impact: none", []),
+        ("Journey Impact: none: refactor", []),
+        ("nothing", []),
+    ):
+        v = decide(pr_declaration=parse_declaration(body), changed_files=files)
+        joined = "\n".join(v.lines)
+        assert joined.strip(), body
+        assert ("PASSED" in joined) or ("REJECTED" in joined), body
+
+
+# --------------------------------------------------------------- wiring
+
+def test_the_templates_carry_the_field():
+    """AC 1."""
+    for rel in (".github/pull_request_template.md", ".github/ISSUE_TEMPLATE/epic.md"):
+        body = (REPO / rel).read_text()
+        assert "Journey Impact" in body, rel
+        assert "none: <why this touches no promise>" in body, (
+            f"{rel} must show that `none` needs a REASON — that is the field's "
+            f"whole anti-gaming property"
+        )
+
+
+def test_the_workflow_never_interpolates_the_pr_body_into_a_shell():
+    """A PR body is attacker-authored. `${{ }}` inside a `run:` is a command
+    injection sink; the body must arrive through `env:`."""
+    wf = (REPO / ".github/workflows/journey-impact.yml").read_text()
+    assert "PR_BODY: ${{ github.event.pull_request.body }}" in wf
+    run_bodies = wf.split("run: ")[1:]
+    for chunk in run_bodies:
+        assert "github.event.pull_request.body" not in chunk

--- a/tests/unit/test_2350_journey_impact.py
+++ b/tests/unit/test_2350_journey_impact.py
@@ -76,6 +76,17 @@ def test_an_unfilled_template_placeholder_is_malformed_not_absent():
     assert parse_declaration("Journey Impact: <!-- pick one -->").error
 
 
+@pytest.mark.parametrize("body,reason", [
+    ("Journey Impact: none: fine <!-- todo -->", "fine"),
+    # The unclosed case is the one a pair-matching `<!--.*?-->` regex silently
+    # leaves in — it would read the reason as "fine <!-- todo". It is also why
+    # CodeQL flags that form (py/bad-tag-filter): it cannot span newlines.
+    ("Journey Impact: none: fine <!-- todo", "fine"),
+])
+def test_a_trailing_comment_is_cut_closed_or_not(body, reason):
+    assert parse_declaration(body).reason == reason
+
+
 def test_an_edited_body_keeps_the_correction_not_the_draft():
     body = "Journey Impact: none\n\n...later...\n\nJourney Impact: new: J05"
     d = parse_declaration(body)


### PR DESCRIPTION
## Description

**Gate G1** of the journey-coverage deck. Every epic and user-facing feature declares what it does to the promise list, and the declaration is **enforced at merge**:

```
Journey Impact: new: J11
Journey Impact: extends: J03
Journey Impact: none: <why this touches no promise>
```

The declaration is cheap; **the gate is the load-bearing part**. Ownership alone collapses into "PM nags, Eng defers", and an intake field on its own is worse than nothing — everything is `none:` inside a month and the field reads as compliance. So the burden sits on the `new:` path: declaring a new promise obliges the same PR to carry a skeleton for it. That is what stops `none:` being the cheap escape — choosing it becomes a visible claim, in writing, next to a diff a reviewer can check it against.

## Related Issue

Related to #2350

## Journey Impact

Journey Impact: none: CI/process gate, no user-facing promise

## What fails, what passes

| Input | Verdict |
|---|---|
| `none` (bare) | **REJECTED** — AC 4 |
| `new: J11` with no skeleton naming J11 | **REJECTED** |
| epic referenced by this PR declares `new: J11`, PR carries nothing | **REJECTED** |
| `new: J11` + `strict=True` xfail naming J11 under `tests/journeys/` | passes — AC 3 |
| `extends: J03` | passes (that promise already has a harness) |
| `none: <reason>` | passes |
| **no declaration at all** | **passes, with a loud note** |

That last row is deliberate: adopting the field must not red-X every in-flight PR and dependabot bump on day one. Tightening it is a follow-up once the templates have been in use.

## Two design points

**The skeleton is bound to the declared id.** Without that, `new: J11` is satisfied by any edit anywhere in the journey tier — including an unrelated tweak to an existing journey — which hands the obligation straight back to the theatre the gate exists to prevent. The id must appear in the skeleton's path or body.

The match deliberately does **not** use `\b`. Ids are routinely embedded underscore-delimited (`test_j07_journey.py`) and `_` is a word character, so `\bJ07\b` never matches the very filename the naming convention produces — it would have rejected correctly-named skeletons. It delimits on letters and digits instead, so `J07` still rejects `J071` and `XJ07`.

**The decision is a pure function**, in `scripts/ci/journey_impact.py`, not a workflow shell body — a rule that only runs in CI is a rule nobody can test. 26 unit tests cover the parser and the decision; removing the id binding fails three of them (mutation-checked).

## Security

A PR body is attacker-authored text, so it reaches the checker through `env:` and never through `${{ }}` inside a `run:` — pinned by a test that greps every `run:` body in the workflow.

## Acceptance criteria

- [x] Epic and PR templates carry the Journey Impact field
- [x] A PR under an epic declaring `new:` cannot merge without a journey skeleton present
- [x] A `strict=True` xfail asserting the journey's invariants satisfies the gate
- [x] `none: <reason>` requires a reason string — a bare `none` fails
- [x] The check reports which declaration it read and why it passed or failed

## Verification

```
26 passed   tests/unit/test_2350_journey_impact.py
32 passed   + test_1891_python_version_parity.py (new workflow's pin)
```

End-to-end against a real diff (the commit that added the journey tier):

```
$ PR_BODY="Journey Impact: new: J01" BASE_SHA=571bb964^ HEAD_SHA=571bb964 \
    python3 scripts/ci/check_journey_impact.py
PR declares Journey Impact: 'new: J01'
PASSED — skeleton present for J01 (…)
```

and the rejection path:

```
$ PR_BODY="Journey Impact: new: J11" … 
REJECTED — this PR declares `new: J11`, which obliges this PR to carry a
journey skeleton under tests/journeys/. None found in 0 changed file(s).
A `strict=True` xfail naming J11 is enough:
    @pytest.mark.xfail(strict=True, reason='J11 not built yet')
    def test_j11_promise(): ...
```

## Notes for the reviewer

- `tests/journeys/` lands with #2403 (R1). The gate is correct either way — no PR declares `new:` today, and a `new:` before the tier exists would simply create the first file there.
- **Residual, same as #2336 AC 4:** making this a *required* status check needs repo-admin settings and cannot be done from a PR.

## Type of Change

- [x] CI / process

🤖 Generated with [Claude Code](https://claude.com/claude-code)
