### PR TITLE
fix(ui): the SSH toggle read the ops payload one level too shallow, so it inverted the operator's intent (#2411)

### DIFF
--- a/src/frontend/src/utils/opsSettings.js
+++ b/src/frontend/src/utils/opsSettings.js
@@ -1,0 +1,60 @@
+/**
+ * Reading `GET /api/settings/ops/config` (#2411).
+ *
+ * The payload is nested TWICE, and the toggle in `Settings.vue` read it flat:
+ *
+ *     { settings: { ssh_access_enabled: { value: "true", default: "false",
+ *                                         description: "...", is_default: false } } }
+ *
+ * `response.data.ssh_access_enabled` is therefore `undefined`, `undefined ===
+ * 'true'` is `false`, and the SSH toggle rendered OFF no matter what was
+ * stored. Worse, the click handler computes `!sshAccessEnabled.value`, so with
+ * the state pinned to `false` the FIRST click always sent `true` — an operator
+ * with ephemeral SSH enabled, clicking to disable it, re-enabled it and then
+ * watched it render as off. The write path was always correct; only the read
+ * was broken, which is why a change appeared to stick for the session and
+ * silently reverted on reload.
+ *
+ * The rule lives here rather than inline because `Settings.vue` cannot be
+ * mounted in this project's test setup (`@vue/test-utils` is not a dependency
+ * and vitest runs `environment: 'node'`), so a rule kept in the SFC is a rule
+ * no test can reach — which is exactly how a one-line read bug survived in a
+ * security control. Issue #2411's own suggested fix,
+ * `response.data.settings?.ssh_access_enabled`, is still wrong for the same
+ * underlying reason: that resolves to the descriptor OBJECT, and
+ * `object === 'true'` is `false`. The `.value` hop is the one that matters.
+ */
+
+/**
+ * Read one ops setting as a boolean, from either payload shape.
+ *
+ * Accepts the descriptor form the endpoint actually returns
+ * (`{ value: "true", … }`) and a bare `"true"`, because the only thing that
+ * distinguishes them is a wrapper this reader does not need — and being
+ * tolerant here costs nothing while removing a whole class of one-sided
+ * mismatch.
+ *
+ * Everything unreadable degrades to `false`: absent key, absent `settings`,
+ * a null payload, a number, an unexpected object. `false` is the SAFE
+ * direction for every flag in this group — `ssh_access_enabled` defaults to
+ * `"false"` server-side, and a security control that cannot read its own state
+ * must not claim the permissive one.
+ */
+export function readOpsBool(payload, key) {
+  const entry = payload?.settings?.[key]
+  const raw = entry !== null && typeof entry === 'object' ? entry.value : entry
+  // Only a string can be `"true"`; a real boolean `true` is accepted too, since
+  // the column is TEXT today but nothing here should break if that changes.
+  if (raw === true) return true
+  return typeof raw === 'string' && raw.trim().toLowerCase() === 'true'
+}
+
+/**
+ * The value to SEND for a boolean ops setting. `PUT /ops/config` takes strings
+ * (`validate_ops_setting` requires `'true'`/`'false'` for a `bool` key), and
+ * pairing the writer with the reader here keeps the two spellings in one file
+ * rather than at opposite ends of a 3500-line SFC.
+ */
+export function opsBoolValue(enabled) {
+  return enabled ? 'true' : 'false'
+}

--- a/src/frontend/src/views/Settings.vue
+++ b/src/frontend/src/views/Settings.vue
@@ -2085,6 +2085,7 @@ import { useAuthStore } from '../stores/auth'
 import { useSettingsStore } from '../stores/settings'
 import { useSessionsStore } from '../stores/sessions'
 import { apiErrorMessage } from '../utils/apiError'
+import { readOpsBool, opsBoolValue } from '../utils/opsSettings'
 import { useEnterpriseStore } from '../stores/enterprise'
 import NavBar from '../components/NavBar.vue'
 import McpKeysTab from '../components/settings/McpKeysTab.vue'
@@ -3529,7 +3530,14 @@ async function loadOpsSettings() {
     const response = await axios.get('/api/settings/ops/config', {
       headers: authStore.authHeader
     })
-    sshAccessEnabled.value = response.data.ssh_access_enabled === 'true'
+    // #2411: the payload is nested TWICE — `{settings: {key: {value: "..."}}}`
+    // — and this read it flat, so it was `undefined === 'true'` on every load.
+    // The switch rendered OFF whatever was stored, and since the click handler
+    // negates that state, the first click always sent `true`: an operator with
+    // ephemeral SSH enabled, clicking to DISABLE it, turned it back on. The
+    // rule lives in `utils/opsSettings.js` because this SFC cannot be mounted
+    // in our test setup, and an unreachable rule is how this survived.
+    sshAccessEnabled.value = readOpsBool(response.data, 'ssh_access_enabled')
   } catch (e) {
     console.error('Failed to load ops settings:', e)
   }
@@ -3543,7 +3551,7 @@ async function toggleSshAccess() {
     const newValue = !sshAccessEnabled.value
     await axios.put('/api/settings/ops/config', {
       settings: {
-        ssh_access_enabled: newValue ? 'true' : 'false'
+        ssh_access_enabled: opsBoolValue(newValue)
       }
     }, {
       headers: authStore.authHeader

--- a/src/frontend/tests/unit/opsSettingsToggle.spec.js
+++ b/src/frontend/tests/unit/opsSettingsToggle.spec.js
@@ -1,0 +1,134 @@
+/**
+ * #2411 — the SSH access toggle read the ops payload one level too shallow.
+ *
+ * `GET /api/settings/ops/config` returns settings nested TWICE:
+ *
+ *     { settings: { ssh_access_enabled: { value: "true", default: "false", … } } }
+ *
+ * `Settings.vue` read `response.data.ssh_access_enabled`, which is `undefined`,
+ * so `undefined === 'true'` pinned the switch to OFF on every load. Because the
+ * click handler computes `!sshAccessEnabled.value`, the FIRST click then always
+ * sent `true` — an operator with ephemeral SSH enabled, clicking to disable it,
+ * re-enabled it and watched it render as off. The write path was always
+ * correct; the mismatch was one-sided, which is why it looked like it stuck for
+ * the session and reverted on reload.
+ *
+ * WHY A PURE MODULE. `Settings.vue` cannot be mounted here — `@vue/test-utils`
+ * is not a dependency and vitest runs `environment: 'node'` — so a rule kept
+ * inline is a rule no test can reach. That is precisely how a one-line read bug
+ * survived inside a security control. The decidable part now lives in
+ * `utils/opsSettings.js` and is tested directly; the two assertions that can
+ * only be answered from source (that the SFC calls it, and that the flat read
+ * is gone) are made by reading the file.
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { readOpsBool, opsBoolValue } from '../../src/utils/opsSettings'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const settingsVue = fs.readFileSync(
+  path.resolve(__dirname, '../../src/views/Settings.vue'), 'utf8',
+)
+
+// The payload shape the endpoint actually returns (routers/settings.py
+// `get_ops_settings` builds a descriptor per key, not a bare string).
+const realPayload = (value) => ({
+  settings: {
+    ssh_access_enabled: {
+      value,
+      default: 'false',
+      description: 'Enable ephemeral SSH access to agent containers via MCP tool (default: false)',
+      is_default: value === 'false',
+    },
+  },
+})
+
+describe('#2411 — the toggle reflects the STORED value', () => {
+  it('renders ON when the stored value is true', () => {
+    // AC #3, and the case that fails against the shipped read: the old
+    // expression reached for `response.data.ssh_access_enabled`, which is
+    // undefined here.
+    expect(readOpsBool(realPayload('true'), 'ssh_access_enabled')).toBe(true)
+  })
+
+  it('renders OFF when the stored value is false', () => {
+    expect(readOpsBool(realPayload('false'), 'ssh_access_enabled')).toBe(false)
+  })
+
+  it('is not satisfied by the fix the issue itself proposed', () => {
+    // Worth pinning. #2411 suggests `response.data.settings?.ssh_access_enabled`,
+    // which resolves to the DESCRIPTOR OBJECT — and `object === 'true'` is
+    // false, so the toggle would still have rendered OFF while looking fixed.
+    // The `.value` hop is the one that matters.
+    const descriptor = realPayload('true').settings.ssh_access_enabled
+    expect(descriptor === 'true').toBe(false)
+    expect(readOpsBool(realPayload('true'), 'ssh_access_enabled')).toBe(true)
+  })
+})
+
+describe('#2411 — one click inverts the stored value, not a pinned false', () => {
+  it('sends false when the stored value is true', () => {
+    // The bug in one line: with the read pinned to false, `!false` made every
+    // first click send `true` — the opposite of the operator's intent on the
+    // only path that matters for a security control.
+    const current = readOpsBool(realPayload('true'), 'ssh_access_enabled')
+    expect(opsBoolValue(!current)).toBe('false')
+  })
+
+  it('sends true when the stored value is false', () => {
+    const current = readOpsBool(realPayload('false'), 'ssh_access_enabled')
+    expect(opsBoolValue(!current)).toBe('true')
+  })
+})
+
+describe('#2411 — an unreadable payload degrades to the SAFE direction', () => {
+  // AC #4. `ssh_access_enabled` defaults to "false" server-side, so a control
+  // that cannot read its own state must not claim the permissive one.
+  it.each([
+    ['null payload', null],
+    ['undefined payload', undefined],
+    ['no settings key', {}],
+    ['settings is null', { settings: null }],
+    ['key absent', { settings: {} }],
+    ['descriptor without value', { settings: { ssh_access_enabled: {} } }],
+    ['value is null', { settings: { ssh_access_enabled: { value: null } } }],
+    ['value is a number', { settings: { ssh_access_enabled: { value: 1 } } }],
+    ['settings is a string', { settings: 'true' }],
+  ])('%s degrades to false without throwing', (_label, payload) => {
+    expect(() => readOpsBool(payload, 'ssh_access_enabled')).not.toThrow()
+    expect(readOpsBool(payload, 'ssh_access_enabled')).toBe(false)
+  })
+
+  it('only the exact string true is true', () => {
+    for (const v of ['True', ' true ', 'TRUE']) {
+      // Case and padding are tolerated — an ops value is written by our own
+      // PUT, but a hand-edited DB row should not silently read as false.
+      expect(readOpsBool(realPayload(v), 'ssh_access_enabled')).toBe(true)
+    }
+    for (const v of ['yes', '1', 'on', 'false', '']) {
+      expect(readOpsBool(realPayload(v), 'ssh_access_enabled')).toBe(false)
+    }
+  })
+})
+
+describe('#2411 — the SFC uses the rule (what only source can answer)', () => {
+  it('reads through readOpsBool rather than reaching into the payload', () => {
+    expect(settingsVue).toContain("readOpsBool(response.data, 'ssh_access_enabled')")
+  })
+
+  it('no longer contains the flat read that caused the bug', () => {
+    // The exact expression that shipped. If it reappears — here or for a
+    // sibling ops setting surfaced later — this fails.
+    expect(settingsVue).not.toMatch(/response\.data\.ssh_access_enabled/)
+  })
+
+  it('is the only place that reads ops/config, so there is no sibling mismatch', () => {
+    // AC #5, pinned rather than checked once by hand: a second GET added later
+    // must come through the same reader.
+    const gets = settingsVue.match(/axios\.get\('\/api\/settings\/ops\/config'/g) || []
+    expect(gets.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

The SSH access toggle read `GET /api/settings/ops/config` flat while the endpoint nests settings twice, so it was `undefined === 'true'` on every load: the switch rendered **OFF whatever was stored**, and since the click handler negates that state, the **first click always sent `true`** — an operator with ephemeral SSH enabled, clicking to disable it, re-enabled it and then watched it render as off.

The write path was always correct. The mismatch was one-sided, which is why it looked like a change stuck for the session and silently reverted on reload.

## The issue's own suggested fix is not sufficient

#2411 proposes `response.data.settings?.ssh_access_enabled`. That is **still wrong**, for the same underlying reason. `get_ops_settings` builds a *descriptor* per key:

```python
ops_config[key] = {"value": current_value, "default": default_value,
                   "description": ..., "is_default": ...}
```

So `settings.ssh_access_enabled` is an **object**, and `object === 'true'` is `false` — the toggle would still have rendered OFF while looking fixed. The `.value` hop is the one that matters, and a test pins it so the half-fix cannot come back as a "simplification".

## Why a pure module rather than a one-line edit

The issue says the value is in the test rather than the fix, and that is only achievable with a seam: `Settings.vue` cannot be mounted here — `@vue/test-utils` is not a dependency and vitest runs `environment: 'node'` — so a rule kept inline is a rule **no test can reach**. That is exactly how a one-line read bug survived inside a security control.

`utils/opsSettings.js` owns both spellings — `readOpsBool` for the read, `opsBoolValue` for the write — in one file rather than at opposite ends of a 3500-line SFC, which is what let them drift.

## Acceptance criteria

| AC | Status |
|---|---|
| Toggle reflects the stored value, verified both enabled and disabled | ✅ |
| With SSH enabled, one click **disables** it | ✅ |
| Regression test naming the issue that fails without the fix | ✅ mutation-checked, below |
| Malformed/absent payload degrades to `false` (safe direction) | ✅ 9 cases |
| No sibling binding shares the mismatch | ✅ and now **pinned by a test**, not eyeballed once |

The endpoint is untouched, per the issue's explicit instruction — `PUT /ops/config` takes the nested shape and the other ops readers depend on the current contract.

`false` is the safe degrade direction on purpose: `ssh_access_enabled` defaults to `"false"` server-side, and a control that cannot read its own state must not claim the permissive one.

## Verification

Each side of the fix was mutation-checked rather than assumed:

```
reader reverted to payload?.[key]           → 4 failed
SFC reverted to the flat read that shipped  → 2 failed
restored                                     → 18 passed
```

Full frontend suite: **64 files / 1454 tests**, green. `vite build` clean. Raw-color ratchet unaffected (no new colour usage).

Closes #2411

🤖 Generated with [Claude Code](https://claude.com/claude-code)