### PR TITLE
fix(operator-queue): an approval's decision must be one the agent offered (#2376)

### DIFF
--- a/docs/memory/feature-flows/operating-room.md
+++ b/docs/memory/feature-flows/operating-room.md
@@ -191,6 +191,30 @@ Event handling in the store (`handleWebSocketEvent`, line 177-200):
 
 The type pill text comes from `utils/operatorQueue.js::queueTypeLabel` (`Needs approval` / `Question` / `Heads up`), shared with `/m` (#2370). **The `/m` mobile admin mirrors this table** — approval: select → restated consequence → optional note → `Cancel` + `Send: <option>` (nothing sends on one tap); question: text + Send; alert: `Got it` — and builds the identical body via `buildQueueResponse` (see [mobile-admin-pwa.md](mobile-admin-pwa.md)). The Workspace asks panel posts to its own endpoint/model and is **not** yet a consumer of the shared builder (#2375).
 
+**An approval's decision must be one it OFFERED (#2376).** `OperatorResponse.response`
+is a bare `str` and every layer passed it through verbatim — router, DB write,
+and the write-back into the agent's own queue file — so no layer checked
+membership. #2370 recorded `response: "approved"` against
+`options: ["Approve", "Deny"]` for five months without a single 4xx, and the
+agent read back a decision string it never offered.
+`services/operator_queue_choices.py` is the one rule: for `type == "approval"`
+with a usable options list, a non-empty `response` outside it is a named **422**
+`response_not_an_offered_option` **carrying the offered list** — a refusal that
+does not name agent-authored strings leaves the operator guessing. Matching is
+**exact**: only the agent knows whether `approve` and `Approve` mean the same
+thing to it, so normalising here would answer that on its behalf. Exempt, all
+spelled as the same absence rather than as special cases at the call site:
+questions, alerts, approvals that offered nothing, a non-list or non-string
+blob, and one whose options were replaced by the #1632 size-cap marker (that
+placeholder RECORDS that the choices were dropped, so it is neither binding nor
+selectable). A text-only answer is untouched — an empty `response` means the
+field was never filled in, not that it is wrong. The rule sits at the SINK
+rather than in a router because this is the approval channel for irreversible
+actions (#1402, ent#329) with four producers today; both writers
+(`routers/operator_queue.py`, `client_portal/asks/service.py`) call it, and an
+AST caller-parity guard (`tests/unit/test_2376_approval_response_membership.py`,
+the #1677 shape) fails CI if a third writer appears without it.
+
 ### NavBar Badge
 
 `src/frontend/src/components/NavBar.vue`:

--- a/src/backend/client_portal/asks/router.py
+++ b/src/backend/client_portal/asks/router.py
@@ -30,8 +30,10 @@ router = APIRouter(
 
 
 def _raise(e: AskError):
+    # #2376: merge any structured fields the refusal carries (the offered
+    # options, today) beside the code and message rather than only in prose.
     raise HTTPException(status_code=e.status_code,
-                        detail={"code": e.code, "message": e.detail})
+                        detail={"code": e.code, "message": e.detail, **e.data})
 
 
 @router.get("", response_model=List[WorkspaceAsk])

--- a/src/backend/client_portal/asks/service.py
+++ b/src/backend/client_portal/asks/service.py
@@ -12,6 +12,10 @@ import logging
 from typing import List, Optional
 
 from database import db
+from services.operator_queue_choices import (
+    ResponseNotOfferedError,
+    validate_response_choice,
+)
 from utils.helpers import utc_now_iso
 
 from .models import WorkspaceAsk
@@ -27,11 +31,18 @@ _VISIBLE_KINDS = ("question", "approval", "alert")
 class AskError(Exception):
     """A named, actionable refusal — never a bare 422 from a validator."""
 
-    def __init__(self, status_code: int, code: str, detail: str):
+    def __init__(self, status_code: int, code: str, detail: str,
+                 data: Optional[dict] = None):
         super().__init__(detail)
         self.status_code = status_code
         self.code = code
         self.detail = detail
+        # #2376: extra machine-readable fields for the refusals that have them
+        # (today: the options an approval actually offered). A client cannot act
+        # on "that is not a valid choice" without being told what the choices
+        # were, and re-deriving them by parsing the message is the thing that
+        # breaks the day the wording changes.
+        self.data = data or {}
 
 
 def _is_expired(item: dict) -> bool:
@@ -170,6 +181,14 @@ def answer_ask(item_id: str, email: str, is_platform: bool,
     # client has no row there. Writing one would be a lie in the audit trail, so
     # the responder KIND is recorded instead — "answered by a client" must stay
     # distinguishable from "answered by an operator whose account was deleted".
+    # #2376: same rule as the operator route, from the one shared validator —
+    # a copy per entry point is how the two drift, and this path answers the
+    # same rows.
+    try:
+        validate_response_choice(item, response)
+    except ResponseNotOfferedError as e:
+        raise AskError(422, e.code, str(e), {"offered_options": e.options})
+
     updated = db.respond_to_operator_queue_item(
         item_id=item_id,
         response=response or "",

--- a/src/backend/routers/operator_queue.py
+++ b/src/backend/routers/operator_queue.py
@@ -15,6 +15,10 @@ from database import db
 from dependencies import get_current_user
 from db_models import User
 from services.platform_audit_service import platform_audit_service, AuditEventType
+from services.operator_queue_choices import (
+    ResponseNotOfferedError,
+    validate_response_choice,
+)
 from services import operator_resume_service
 
 
@@ -213,6 +217,23 @@ async def respond_to_queue_item(
         raise HTTPException(
             status_code=400,
             detail=f"Cannot respond to item with status '{existing['status']}'"
+        )
+
+    # #2376: the decision has to be one the AGENT offered. Nothing checked this
+    # at any layer, so #2370 recorded `"approved"` against `["Approve", "Deny"]`
+    # for five months with no 4xx — the agent read back a string it never
+    # offered. Named 422 rather than a bare one: the options are agent-authored,
+    # so a refusal that does not list them leaves the operator guessing.
+    try:
+        validate_response_choice(existing, body.response)
+    except ResponseNotOfferedError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": e.code,
+                "message": str(e),
+                "offered_options": e.options,
+            },
         )
 
     item = db.respond_to_operator_queue_item(

--- a/src/backend/services/operator_queue_choices.py
+++ b/src/backend/services/operator_queue_choices.py
@@ -1,0 +1,89 @@
+"""The one rule for "is this a decision the agent actually offered?" (#2376).
+
+`OperatorResponse.response` is a bare `str`, and every layer passed it through
+verbatim — router, DB write, and the write-back into the agent's own queue file.
+Nothing checked that an **approval** item's recorded decision was one of the
+options the agent offered, so #2370 shipped `response: "approved"` against
+`options: ["Approve", "Deny"]` for five months without a single 4xx. The agent
+reads back a decision string it never offered and has to guess.
+
+This is the approval channel for irreversible actions (#1402 poison-park,
+ent#329 respond -> resume, the TARGET_ARCHITECTURE v2 human gate), and it has
+four producers today — the desktop store, `/m`, the Workspace asks panel and the
+MCP tool. The next one can re-ship the class unless the SINK refuses, which is
+why the check lives here rather than in any one router.
+
+A leaf on purpose: `operator_queue_service` instantiates its sync-service
+singleton and imports `AgentClient` at module scope, and the Workspace asks path
+must not drag either in to answer a question about a list of strings.
+"""
+
+from typing import Optional, Sequence
+
+# The placeholder `operator_queue_service` substitutes when an agent's own
+# options blob blows the ingestion size cap (#1632). It is NOT an offered
+# choice — it is the record that the choices were dropped — so an item wearing
+# it has no usable options and is exempt below.
+OPTIONS_DROPPED_MARKER = "(options omitted: exceeded size cap)"
+
+
+class ResponseNotOfferedError(ValueError):
+    """An approval decision that is not one of the item's own options.
+
+    Carries the offered list so the caller can name it: a 422 that says only
+    "invalid" leaves the operator guessing at strings the AGENT authored.
+    """
+
+    code = "response_not_an_offered_option"
+
+    def __init__(self, response: str, options: Sequence[str]):
+        self.response = response
+        self.options = list(options)
+        super().__init__(
+            f"{response!r} is not one of the options this approval offered: "
+            f"{self.options}"
+        )
+
+
+def usable_options(item: dict) -> Optional[list]:
+    """The options an approval item genuinely offered, or None.
+
+    None means "this item does not constrain the answer" — a question or an
+    alert, an approval that offered nothing, a malformed blob, or one whose
+    options were dropped at ingestion. Every one of those must stay answerable,
+    so they are all spelled as the same absence rather than as special cases at
+    the call site.
+    """
+    if (item or {}).get("type") != "approval":
+        return None
+    options = item.get("options")
+    if not isinstance(options, list) or not options:
+        return None
+    # An entry that is not a string cannot be matched against, and a list that
+    # is only the dropped-marker offered nothing.
+    choices = [o for o in options if isinstance(o, str) and o != OPTIONS_DROPPED_MARKER]
+    return choices or None
+
+
+def validate_response_choice(item: dict, response: Optional[str]) -> None:
+    """Raise `ResponseNotOfferedError` when an approval's decision was not offered.
+
+    Exact string match, deliberately. The options are AGENT-authored, so the
+    agent is the only party that knows whether `"approve"` and `"Approve"` mean
+    the same thing to it — normalising here would silently answer that question
+    on its behalf, and the whole point is that the recorded decision is one the
+    agent can compare against its own list.
+
+    An empty or absent `response` is NOT rejected here. Both entry points allow
+    an answer carried entirely by `response_text` (the Workspace asks path has
+    its own `empty_answer` refusal for a truly empty one), and turning a
+    text-only answer into a 422 would break a working path in the name of
+    validating a field that was never filled in.
+    """
+    if not response:
+        return
+    choices = usable_options(item)
+    if choices is None:
+        return
+    if response not in choices:
+        raise ResponseNotOfferedError(response, choices)

--- a/src/backend/services/operator_queue_service.py
+++ b/src/backend/services/operator_queue_service.py
@@ -26,6 +26,7 @@ from typing import Optional
 from database import db
 from redis_breaker_util import get_breaker_redis
 from services import rate_limiter
+from services.operator_queue_choices import OPTIONS_DROPPED_MARKER
 from services.agent_client import AgentClient
 from utils.helpers import utc_now_iso
 
@@ -162,7 +163,10 @@ _ID_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
 
 # Inline truncation marker (kept short so the clamped field length stays ≤ cap).
 _TRUNC_MARKER = "…[truncated]"
-_OPTIONS_DROPPED_MARKER = "(options omitted: exceeded size cap)"
+# #2376: one definition, imported. The respond-side validator has to exempt
+# items wearing this marker, and a second literal would drift the day either
+# side is reworded — leaving the sink accepting a placeholder as a decision.
+_OPTIONS_DROPPED_MARKER = OPTIONS_DROPPED_MARKER
 
 # #1632: single Redis key for the operator-queue sync leader (mirror monitoring
 # #1464). Only the lease-holder runs a poll cycle, so `--workers 2` doesn't

--- a/tests/unit/test_2376_approval_response_membership.py
+++ b/tests/unit/test_2376_approval_response_membership.py
@@ -1,0 +1,194 @@
+"""#2376 — an approval's recorded decision must be one the agent offered.
+
+`OperatorResponse.response` is a bare `str` and every layer passed it through
+verbatim, so nothing checked membership. #2370 shipped `response: "approved"`
+against `options: ["Approve", "Deny"]` for five months without a single 4xx —
+the agent read back a decision string it never offered.
+
+This is the approval channel for irreversible actions, with four producers
+today, so the check belongs at the SINK rather than in whichever router happens
+to be next. The suite therefore pins three things: the rule itself, that BOTH
+entry points reach it, and that no future third writer can skip it.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO = Path(__file__).resolve().parents[2]
+_BACKEND = str(_REPO / "src" / "backend")
+while _BACKEND in sys.path:
+    sys.path.remove(_BACKEND)
+sys.path.insert(0, _BACKEND)
+
+from services.operator_queue_choices import (  # noqa: E402
+    OPTIONS_DROPPED_MARKER,
+    ResponseNotOfferedError,
+    usable_options,
+    validate_response_choice,
+)
+
+
+def _approval(options):
+    return {"id": "q1", "type": "approval", "status": "pending", "options": options}
+
+
+# ---------------------------------------------------------------------------
+# The rule
+# ---------------------------------------------------------------------------
+
+def test_the_exact_2370_case_is_refused():
+    """The case that shipped: `"approved"` against `["Approve", "Deny"]`."""
+    with pytest.raises(ResponseNotOfferedError) as e:
+        validate_response_choice(_approval(["Approve", "Deny"]), "approved")
+    assert e.value.code == "response_not_an_offered_option"
+    # The refusal must NAME the options — they are agent-authored, so an
+    # operator cannot guess them from a bare "invalid".
+    assert e.value.options == ["Approve", "Deny"]
+    assert "Approve" in str(e.value)
+
+
+def test_an_offered_option_is_accepted():
+    validate_response_choice(_approval(["Approve", "Deny"]), "Approve")
+    validate_response_choice(_approval(["Approve", "Deny"]), "Deny")
+
+
+def test_matching_is_exact_because_the_options_are_agent_authored():
+    """Only the agent knows whether `approve` and `Approve` mean the same thing
+    to it; normalising here would answer that on its behalf, and the recorded
+    decision has to be one it can compare against its own list."""
+    for near_miss in ("approve", "APPROVE", " Approve", "Approve "):
+        with pytest.raises(ResponseNotOfferedError):
+            validate_response_choice(_approval(["Approve", "Deny"]), near_miss)
+
+
+# ---------------------------------------------------------------------------
+# Everything that must stay answerable (AC #2)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("item", [
+    pytest.param({"type": "question", "options": ["a", "b"]}, id="question"),
+    pytest.param({"type": "alert", "options": ["a", "b"]}, id="alert"),
+    pytest.param({"type": "approval", "options": None}, id="approval-no-options"),
+    pytest.param({"type": "approval", "options": []}, id="approval-empty-options"),
+    pytest.param({"type": "approval", "options": "Approve"}, id="options-not-a-list"),
+    pytest.param({"type": "approval", "options": [1, 2]}, id="options-not-strings"),
+    pytest.param({}, id="no-type"),
+])
+def test_items_that_do_not_constrain_the_answer_are_unaffected(item):
+    validate_response_choice(item, "anything at all")
+    assert usable_options(item) is None
+
+
+def test_the_size_cap_marker_is_not_an_offered_choice():
+    """#1632 replaces an oversize options blob with a placeholder. It records
+    that the choices were DROPPED — treating it as an offered option would let
+    the placeholder itself be recorded as a decision, and treating the item as
+    constrained would make it unanswerable."""
+    item = _approval([OPTIONS_DROPPED_MARKER])
+    assert usable_options(item) is None
+    validate_response_choice(item, "Approve")          # answerable
+    validate_response_choice(item, OPTIONS_DROPPED_MARKER)
+
+
+def test_the_marker_alongside_real_options_leaves_the_real_ones_binding():
+    item = _approval(["Approve", OPTIONS_DROPPED_MARKER])
+    assert usable_options(item) == ["Approve"]
+    validate_response_choice(item, "Approve")
+    with pytest.raises(ResponseNotOfferedError):
+        validate_response_choice(item, OPTIONS_DROPPED_MARKER)
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_a_text_only_answer_is_not_rejected(empty):
+    """Both entry points allow an answer carried entirely by `response_text`,
+    and the asks path has its own `empty_answer` refusal for a truly empty one.
+    Turning a text-only answer into a 422 would break a working path in the name
+    of validating a field nobody filled in."""
+    validate_response_choice(_approval(["Approve", "Deny"]), empty)
+
+
+def test_acknowledged_items_never_reach_the_rule():
+    """AC #2 names `acknowledged` explicitly. Both entry points refuse a
+    non-pending item BEFORE the validator, so the exemption is structural."""
+    import inspect
+    from routers import operator_queue as r
+    src = inspect.getsource(r.respond_to_queue_item)
+    assert src.index("!= \"pending\"") < src.index("validate_response_choice")
+
+
+# ---------------------------------------------------------------------------
+# Both entry points, and no third one (AC #3)
+# ---------------------------------------------------------------------------
+
+_WRITER = "respond_to_operator_queue_item"
+
+_EXPECTED_CALLERS = {
+    "routers/operator_queue.py": "the operator route (JWT / MCP)",
+    "client_portal/asks/service.py": "the Workspace asks answer path",
+}
+
+
+def _writer_callers() -> dict:
+    found = {}
+    for path in (_REPO / "src" / "backend").rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+            if name == _WRITER:
+                found[str(path.relative_to(_REPO / "src" / "backend"))] = True
+    return found
+
+
+def test_every_writer_of_a_response_validates_it_first():
+    """The #1677 caller-parity shape. A validator both routers happen to call is
+    one PR away from a third writer that does not — and this sink is the
+    approval channel for irreversible actions, so the failure is silent and
+    consequential. A new caller must be added to `_EXPECTED_CALLERS` and must
+    validate, or this fails at CI."""
+    callers = _writer_callers()
+    assert set(callers) == set(_EXPECTED_CALLERS), (
+        f"writers of {_WRITER} changed: {sorted(callers)}. Every one must call "
+        f"validate_response_choice first (#2376); add it here with its reason."
+    )
+    for rel in callers:
+        src = (_REPO / "src" / "backend" / rel).read_text(encoding="utf-8")
+        assert "validate_response_choice" in src, (
+            f"{rel} writes an operator-queue response without validating it "
+            f"against the item's offered options (#2376)"
+        )
+
+
+def test_the_dropped_marker_has_one_definition():
+    """The validator must exempt the same string the ingestion clamp writes. Two
+    literals drift the day either side is reworded, and the sink would then
+    accept a placeholder as a decision."""
+    from services import operator_queue_service as svc
+    assert svc._OPTIONS_DROPPED_MARKER is OPTIONS_DROPPED_MARKER
+
+
+def test_both_entry_points_surface_a_named_422_listing_the_options():
+    """AC #1 and #4: the refusal has to be actionable at the HTTP boundary, not
+    just raised. The MCP tool stringifies the raw body into its structured
+    error, so the options reach the agent."""
+    import inspect
+    from routers import operator_queue as r
+    from client_portal.asks import service as asks
+
+    op_src = inspect.getsource(r.respond_to_queue_item)
+    assert "offered_options" in op_src and "422" in op_src
+
+    ask_src = inspect.getsource(asks.answer_ask)
+    assert "offered_options" in ask_src
+    assert "e.code" in ask_src, "the asks refusal must carry the shared code"


### PR DESCRIPTION
## Summary

`OperatorResponse.response` is a bare `str`, and the router, the DB write and the write-back into the agent's own queue file all passed it through verbatim. No layer checked that an **approval** item's recorded decision was one of the options the agent authored — so #2370 shipped `response: "approved"` against `options: ["Approve", "Deny"]` for five months without a single 4xx, and the agent read back a decision string it never offered.

## At the sink, not in a router

This is the approval channel for irreversible actions (#1402 poison-park, ent#329 respond→resume, the TARGET_ARCHITECTURE v2 human gate), with four producers today. A rule living in whichever router is next re-ships the class the first time someone adds a channel button or an ops agent — so `services/operator_queue_choices.py` owns it and both writers call it.

A **leaf** module rather than `operator_queue_service`: that module instantiates its sync-service singleton and imports `AgentClient` at module scope, and the Workspace asks path must not drag either in to answer a question about a list of strings.

## The rule, and what it deliberately does not do

- **Exact match.** The options are agent-authored, so only the agent knows whether `approve` and `Approve` mean the same thing to it. Normalising would answer that on its behalf, when the point is that the recorded decision is one the agent can compare against its own list.
- **The 422 carries the offered options.** A refusal saying only "invalid" leaves the operator guessing at strings they never wrote.
- **An empty `response` is not rejected.** Both entry points allow an answer carried entirely by `response_text`; a 422 there would break a working path to validate a field nobody filled in.
- **`acknowledged` never reaches the rule** because both writers refuse a non-pending item first — structural, and pinned by asserting the ordering rather than by comment.

Exempt cases are all spelled as the same absence rather than as special cases at the call site: questions, alerts, approvals offering nothing, a non-list or non-string blob, and — worth naming — one whose options are the **#1632 size-cap marker**. That placeholder *records that the choices were dropped*, so treating it as offered would let it be recorded as a decision, and treating the item as constrained would make it unanswerable.

`_OPTIONS_DROPPED_MARKER` now imports from the leaf: two literals drift the day either side is reworded, and the sink would then accept the placeholder as a decision.

## Acceptance criteria

| AC | Status |
|---|---|
| Named 422 listing offered options, exact match, real-options only | ✅ |
| Questions / alerts / no-usable-options / `acknowledged` unaffected | ✅ 7 exempt shapes |
| Check in ONE place reached by both entry points | ✅ and **enforced**, not just done |
| MCP surfaces the 422 structurally | ✅ pinned by test |
| Tests on both entry points incl. the marker-list case | ✅ 18 |

## Verification

AC #3 is the one worth calling out: rather than asserting "both call it", an **AST caller-parity guard** (the #1677 shape) pins the writer set of `db.respond_to_operator_queue_item` to exactly the two known callers and requires each to validate. A third writer fails CI.

```
MUTANT: asks path stops validating   → 2 failed
restored                              → 18 passed
```

244 pass across the operator-queue, asks, #1632, #1677 and ent#329 suites.

MCP needed no change — `ApiError` embeds the raw body in `.message`, so the structured detail already reaches `respond_to_operator_queue`'s `{error: msg}`. Pinned by test rather than assumed.

Closes #2376

🤖 Generated with [Claude Code](https://claude.com/claude-code)