### PR TITLE
fix(ui): emotion avatars were cache-busted by a constant, so a regenerated avatar kept its old face for 24h (#2374)

### DIFF
--- a/src/backend/routers/avatar.py
+++ b/src/backend/routers/avatar.py
@@ -365,14 +365,46 @@ async def _generate_emotions_background(
 
 @router.get("/{agent_name}/avatar/emotions")
 async def get_avatar_emotions(agent_name: str):
-    """Return which emotion variant PNGs exist on disk for an agent. No auth required."""
+    """Which emotion variant images exist for an agent, and their version.
+
+    #2374: the `version` is the cache key the client MUST build emotion URLs
+    with. Variants are served from a stable URL under
+    `Cache-Control: public, max-age=86400`, so without a version tied to the
+    actual files a regenerated avatar keeps showing the OLD face for up to 24
+    hours. The client used to parse `?v=` out of `avatar_url` and fall back to
+    the constant `'1'` — which pins every emotion URL to one cache entry
+    forever, so regeneration was invisible until the entry expired.
+
+    The stamp is the newest mtime among the files being returned, not
+    `avatar_updated_at`. It tracks the VARIANTS rather than the base avatar,
+    which is what these URLs actually serve: regeneration replaces them one at a
+    time in the background, and each replacement moves the stamp, so a client
+    polling this endpoint re-keys its URLs as the new set lands instead of
+    holding whatever it cached on the first poll.
+
+    `0` means no variants exist — there is nothing to cache-bust.
+    """
     available = []
+    newest = 0.0
     for emotion in AVATAR_EMOTIONS:
-        if (AVATAR_DIR / f"{agent_name}_emotion_{emotion}.webp").exists():
+        for path in (AVATAR_DIR / f"{agent_name}_emotion_{emotion}.webp",
+                     AVATAR_DIR / f"{agent_name}_emotion_{emotion}.png"):
+            if not path.exists():
+                continue
             available.append(emotion)
-        elif (AVATAR_DIR / f"{agent_name}_emotion_{emotion}.png").exists():
-            available.append(emotion)
-    return {"agent_name": agent_name, "emotions": available}
+            try:
+                newest = max(newest, path.stat().st_mtime)
+            except OSError:
+                # A file that vanished between exists() and stat() is mid-
+                # regeneration. Skipping its mtime only understates the version,
+                # and the next poll picks it up — never fail the listing over it.
+                pass
+            break
+    return {
+        "agent_name": agent_name,
+        "emotions": available,
+        "version": str(int(newest)),
+    }
 
 
 @router.get("/{agent_name}/avatar/emotion/{emotion}")

--- a/src/frontend/src/utils/avatarEmotion.js
+++ b/src/frontend/src/utils/avatarEmotion.js
@@ -1,0 +1,62 @@
+/**
+ * Cache-busting for emotion avatar variants (#2374).
+ *
+ * Variants are served from a STABLE url — `/avatar/emotion/{emotion}` — under
+ * `Cache-Control: public, max-age=86400`. The only thing separating a fresh
+ * variant from a day-old cached one is the `?v=` the client appends, so getting
+ * that version wrong shows the PREVIOUS avatar's face after a regeneration.
+ *
+ * It was `agent.avatar_url?.split('v=')[1] || '1'`, which fails two ways:
+ *
+ *   1. It reads the version out of possibly-stale in-memory state. An avatar
+ *      regenerated in another tab, or before `agent` was refreshed, leaves
+ *      `avatar_url` unchanged — so every emotion url keys the same day-old
+ *      cache entry.
+ *   2. When `avatar_url` carries no `v=` the fallback collapses to the CONSTANT
+ *      `'1'`. Every emotion url is then permanently `?v=1`, and no regeneration
+ *      can ever change it: the browser serves the old variant until the entry
+ *      expires 24 hours later.
+ *
+ * The rule lives here because `AgentDetail.vue` cannot be mounted in this
+ * project's test setup (`@vue/test-utils` is not a dependency, vitest runs
+ * `environment: 'node'`), so a version derivation kept inline is one no test
+ * can reach.
+ */
+
+/**
+ * The cache-busting version for an agent's emotion URLs.
+ *
+ * Sources, best first:
+ *   1. `emotionsVersion` — the stamp `GET /avatar/emotions` returns, taken from
+ *      the newest variant file's mtime. It tracks the files these URLs actually
+ *      serve, so it moves as background regeneration replaces them.
+ *   2. the `v=` already on `avatarUrl` — the base avatar's `avatar_updated_at`.
+ *      Correct whenever the agent payload is fresh; kept as the fallback for a
+ *      backend that predates the stamp.
+ *   3. `fallback` (default: now) — NEVER a constant. A constant is precisely
+ *      what pinned the browser to one cache entry for 24 hours. A per-load
+ *      value costs one refetch per page load and cannot go stale, which is the
+ *      safe direction for a control whose failure mode is showing the wrong
+ *      face.
+ *
+ * `"0"` from the endpoint means "no variants exist", which is not a version —
+ * it falls through rather than becoming a new constant.
+ */
+export function emotionCacheVersion({ emotionsVersion, avatarUrl, fallback } = {}) {
+  const stamp = emotionsVersion == null ? '' : String(emotionsVersion).trim()
+  if (stamp && stamp !== '0') return stamp
+
+  const fromUrl = typeof avatarUrl === 'string' && avatarUrl.includes('v=')
+    ? avatarUrl.split('v=')[1]
+    : ''
+  // Guard against a `v=` that is empty or is followed by another param.
+  const parsed = (fromUrl || '').split('&')[0].trim()
+  if (parsed) return parsed
+
+  return String(fallback != null ? fallback : Date.now())
+}
+
+/** The emotion variant URL, cache-busted by `version`. */
+export function emotionAvatarUrl(agentName, emotion, version) {
+  return `/api/agents/${agentName}/avatar/emotion/${emotion}?v=${encodeURIComponent(version)}`
+}

--- a/src/frontend/src/views/AgentDetail.vue
+++ b/src/frontend/src/views/AgentDetail.vue
@@ -334,6 +334,7 @@ import axios from 'axios'
 import { useAgentsStore } from '../stores/agents'
 import { useAuthStore } from '../stores/auth'
 import { useSessionsStore } from '../stores/sessions'  // SESSION_TAB_2026-04 Phase 3
+import { emotionCacheVersion, emotionAvatarUrl as buildEmotionUrl } from '../utils/avatarEmotion'
 import NavBar from '../components/NavBar.vue'
 
 // Component name for KeepAlive matching
@@ -509,6 +510,7 @@ const avatarHasReference = ref(false)
 // Emotion avatar cycling state (AVATAR-002)
 const availableEmotions = ref([])
 const emotionAvatarUrl = ref(null)
+const emotionVersion = ref(null)   // #2374: stamp from GET /avatar/emotions
 const emotionCycleTimer = ref(null)
 
 const taskPrefillMessage = ref('')
@@ -1041,8 +1043,12 @@ async function loadAvailableEmotions() {
   try {
     const response = await axios.get(`/api/agents/${agent.value.name}/avatar/emotions`)
     availableEmotions.value = response.data.emotions || []
+    // #2374: carried alongside the list, so a regeneration landing between polls
+    // re-keys the URLs instead of being masked by the 24h cache.
+    emotionVersion.value = response.data.version || null
   } catch (err) {
     availableEmotions.value = []
+    emotionVersion.value = null
   }
 }
 
@@ -1052,8 +1058,19 @@ function cycleEmotion() {
     return
   }
   const emotion = availableEmotions.value[Math.floor(Math.random() * availableEmotions.value.length)]
-  const avatarVersion = agent.value.avatar_url?.split('v=')[1] || '1'
-  emotionAvatarUrl.value = `/api/agents/${agent.value.name}/avatar/emotion/${emotion}?v=${avatarVersion}`
+  // #2374: the version comes from the emotions endpoint's own stamp (the newest
+  // variant file's mtime), not from parsing `avatar_url` with a constant `'1'`
+  // fallback. That fallback pinned every emotion URL to ONE cache entry, and
+  // the variants are served `max-age=86400` — so a regenerated avatar kept
+  // showing the previous face for up to 24 hours.
+  emotionAvatarUrl.value = buildEmotionUrl(
+    agent.value.name,
+    emotion,
+    emotionCacheVersion({
+      emotionsVersion: emotionVersion.value,
+      avatarUrl: agent.value.avatar_url,
+    }),
+  )
 }
 
 function startEmotionCycling() {

--- a/src/frontend/tests/unit/avatarEmotionCache.spec.js
+++ b/src/frontend/tests/unit/avatarEmotionCache.spec.js
@@ -1,0 +1,118 @@
+/**
+ * #2374 — cycling emotion modes showed the PREVIOUS avatar's face.
+ *
+ * Emotion variants are served from a stable URL under
+ * `Cache-Control: public, max-age=86400`, so the `?v=` the client appends is the
+ * only thing separating a fresh variant from a day-old cached one. It was
+ * `agent.avatar_url?.split('v=')[1] || '1'`:
+ *
+ *   1. read out of possibly-stale in-memory state, so an avatar regenerated in
+ *      another tab left every emotion URL keyed to the old cache entry; and
+ *   2. falling back to the CONSTANT `'1'` whenever `avatar_url` carried no
+ *      `v=` — after which no regeneration could ever change the URL, and the
+ *      browser served the old variant until the entry expired 24h later.
+ *
+ * `AgentDetail.vue` cannot be mounted here (`@vue/test-utils` is not a
+ * dependency, vitest runs `environment: 'node'`), so the derivation lives in a
+ * pure module and the wiring is asserted from source.
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { emotionCacheVersion, emotionAvatarUrl } from '../../src/utils/avatarEmotion'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const agentDetail = fs.readFileSync(
+  path.resolve(__dirname, '../../src/views/AgentDetail.vue'), 'utf8',
+)
+
+describe('#2374 — the version tracks the actual variants', () => {
+  it('prefers the stamp the emotions endpoint returns', () => {
+    expect(emotionCacheVersion({
+      emotionsVersion: '1756300000',
+      avatarUrl: '/api/agents/a/avatar?v=1750000000',
+    })).toBe('1756300000')
+  })
+
+  it('a regenerated variant set changes the URL, so the cache is re-keyed', () => {
+    const before = emotionAvatarUrl('a', 'happy', emotionCacheVersion({ emotionsVersion: '100' }))
+    const after = emotionAvatarUrl('a', 'happy', emotionCacheVersion({ emotionsVersion: '200' }))
+    expect(before).not.toBe(after)
+  })
+
+  it('falls back to the base avatar version when the backend predates the stamp', () => {
+    expect(emotionCacheVersion({
+      avatarUrl: '/api/agents/a/avatar?v=1750000000',
+    })).toBe('1750000000')
+  })
+
+  it('treats "0" (no variants) as absent rather than as a new constant', () => {
+    expect(emotionCacheVersion({
+      emotionsVersion: '0',
+      avatarUrl: '/api/agents/a/avatar?v=1750000000',
+    })).toBe('1750000000')
+  })
+})
+
+describe('#2374 — the constant fallback is gone', () => {
+  it('never returns the literal 1 when nothing else is available', () => {
+    // The whole defect: a constant means every emotion URL keys ONE cache entry
+    // forever, and regeneration is invisible until it expires.
+    const v = emotionCacheVersion({ fallback: 1756300000 })
+    expect(v).toBe('1756300000')
+    expect(v).not.toBe('1')
+  })
+
+  it('an avatar_url with no v= does not collapse to a constant', () => {
+    const v = emotionCacheVersion({ avatarUrl: '/api/agents/a/avatar', fallback: 42 })
+    expect(v).toBe('42')
+  })
+
+  it.each([
+    ['empty v', '/api/agents/a/avatar?v='],
+    ['v then another param', '/api/agents/a/avatar?v=&x=1'],
+    ['no url at all', undefined],
+    ['null url', null],
+  ])('%s degrades to the per-load fallback, not a constant', (_l, url) => {
+    expect(emotionCacheVersion({ avatarUrl: url, fallback: 77 })).toBe('77')
+  })
+
+  it('reads a v= that is followed by another param', () => {
+    expect(emotionCacheVersion({ avatarUrl: '/api/agents/a/avatar?v=123&x=1' })).toBe('123')
+  })
+
+  it('defaults the fallback to now rather than to a constant', () => {
+    const a = emotionCacheVersion({})
+    expect(Number(a)).toBeGreaterThan(1_600_000_000_000)
+  })
+})
+
+describe('#2374 — the URL is built from the version', () => {
+  it('appends the version and escapes it', () => {
+    expect(emotionAvatarUrl('scribe', 'happy', '123'))
+      .toBe('/api/agents/scribe/avatar/emotion/happy?v=123')
+  })
+})
+
+describe('#2374 — the view uses the rule (what only source can answer)', () => {
+  it('no longer parses the version inline with a constant fallback', () => {
+    expect(agentDetail).not.toMatch(/split\('v='\)\[1\]\s*\|\|\s*'1'/)
+  })
+
+  it('builds emotion URLs through the shared helpers', () => {
+    expect(agentDetail).toContain('emotionCacheVersion(')
+    expect(agentDetail).toContain('buildEmotionUrl(')
+  })
+
+  it('stores the stamp the endpoint returns', () => {
+    expect(agentDetail).toMatch(/emotionVersion\.value = response\.data\.version/)
+  })
+
+  it('clears the stamp when the listing fails, rather than reusing a stale one', () => {
+    // A failed poll that kept the old stamp would keep serving the old cache
+    // entry — the same bug by a slower route.
+    expect(agentDetail).toMatch(/catch[\s\S]{0,140}emotionVersion\.value = null/)
+  })
+})


### PR DESCRIPTION
## Summary

Emotion variants are served from a **stable** URL under `Cache-Control: public, max-age=86400`, so the `?v=` the client appends is the only thing separating a fresh variant from a day-old cached one. It was:

```js
const avatarVersion = agent.value.avatar_url?.split('v=')[1] || '1'
```

Two failures, and the second is what made it permanent:

1. **Stale source.** Read out of possibly-stale in-memory state — an avatar regenerated in another tab, or before `agent` refreshed, leaves `avatar_url` unchanged, so every emotion URL keys the same old cache entry.
2. **A constant is not a cache-buster.** With no `v=` on `avatar_url` the fallback collapses to `'1'`. Every emotion URL is then permanently `?v=1`, and *no regeneration can ever change it* — the browser serves the previous face until the entry expires 24 hours later.

## The stamp tracks the variants, not the base avatar

`GET /avatar/emotions` now returns a `version`: the newest mtime among the files it is listing.

Deliberately **not** `avatar_updated_at`, though the issue suggests it. These URLs serve the *variants*, and regeneration replaces them one at a time in the background — so a stamp taken from the files moves as the new set lands, and a client polling this endpoint re-keys its URLs progressively instead of holding whatever it cached on the first poll. It also doesn't depend on the DB column being populated. This addresses the secondary race the issue flags, not just the primary suspect.

`"0"` (no variants) is treated as *absent* rather than as a new constant. A file that vanishes between `exists()` and `stat()` is mid-regeneration — skipping its mtime only understates the version and the next poll picks it up, so it never fails the listing.

## The fallback ladder never ends in a constant

endpoint stamp → the `v=` already on `avatar_url` (correct whenever the payload is fresh; the path for a backend predating the stamp) → a per-load value.

The last rung costs one refetch per page load and *cannot go stale*, which is the safe direction for a control whose failure mode is showing the wrong person's face. A failed poll **clears** the stamp rather than reusing a stale one — keeping it would be the same bug by a slower route.

The derivation lives in `utils/avatarEmotion.js` because `AgentDetail.vue` cannot be mounted in this project's test setup (`@vue/test-utils` isn't a dependency, vitest runs `environment: 'node'`), so a rule kept inline is a rule no test can reach.

## Acceptance criteria

| AC | Status |
|---|---|
| Cycling never shows a previous avatar's variant, same session | ✅ |
| Version tied to actual generation, not parsed with a `'1'` fallback | ✅ tied to the variant files themselves |
| Regeneration elsewhere reflected without a 24h stale window | ✅ stamp moves per poll |
| Regression test covering the version derivation | ✅ 17, mutation-checked |

## Verification

```
MUTANT: constant '1' fallback restored → 7 failed
restored                                → 17 passed
```

Full frontend suite 64 files / 1453 tests; `vite build` clean; backend avatar tests pass.

Closes #2374

🤖 Generated with [Claude Code](https://claude.com/claude-code)