### PR TITLE
fix(workspace): the sync portal turn never carried its session, so report-back could not fire (#2426)

### DIFF
--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1244,12 +1244,30 @@ async def _run_sync_turn_and_clear_marker(owns_marker: bool, marker_session_id: 
             clear_turn_inflight(marker_session_id, marker_execution_id)
 
 
-def _precreate_sync_execution(agent_name: str, message: str, email: str) -> str | None:
+def _precreate_sync_execution(
+    agent_name: str, message: str, email: str, session_id: str,
+) -> str | None:
     """Create the execution row for a synchronous portal turn (ent#365 review).
 
     Mirrors `start_portal_turn`'s creation exactly — same trigger, same
-    `source_channel` stamp — so the two paths produce indistinguishable rows and
-    a report published from either can be joined back to its chat.
+    `source_channel` stamp, same destination — so the two paths produce
+    indistinguishable rows and a report published from either can be joined back
+    to its chat.
+
+    #2426: that claim used to be false, and it read as true. This site stamped
+    the SURFACE and not the DESTINATION, so a synchronous turn landed with
+    `source_channel='portal'` and a NULL `source_channel_chat_id`. ent#457 does
+    pass the binding down, but `execute_task` persists it only inside
+    `if not execution_id:` — and this function has already made the row and
+    handed the id over, so that branch never runs. A child delegated during such
+    a turn inherited a portal context with nowhere to go, and
+    `report_completion` dropped it at its own `if not source_channel_chat_id`
+    gate. Measured before the fix: 5 of 8 portal rows NULL, split exactly by
+    path — the browser (streaming) stamped, `POST .../chat` did not.
+
+    `session_id` is a required parameter rather than an optional one: the value
+    is in scope at the only call site, and a default would let a future caller
+    reintroduce the silent-inert row this fixes.
 
     Fail-soft to None: this exists so an addressed report finds its session, and
     a turn must not be refused because that bookkeeping could not be done. ONLY
@@ -1275,6 +1293,13 @@ def _precreate_sync_execution(agent_name: str, message: str, email: str) -> str 
             source_user_email=email,
             subscription_id=subscription_id,
             source_channel=PORTAL_SOURCE_CHANNEL,
+            # #2426: the destination, not just the surface. The sibling comment
+            # in `start_portal_turn` says "both creation sites or the stamp is a
+            # coin flip depending on which path made the row" — ent#457 covered
+            # the two sites that existed when it was written; ent#365 had added
+            # this third one.
+            source_channel_chat_id=session_id,
+            source_channel_client=email,
         )
         return execution.id if execution else None
     except Exception:  # noqa: BLE001
@@ -1507,7 +1532,7 @@ async def portal_chat(agent_name: str, message: str, email: str,
         # than this one growing its own turn machinery.
         owns_marker = False
         if not execution_id:
-            execution_id = _precreate_sync_execution(agent_name, message, email)
+            execution_id = _precreate_sync_execution(agent_name, message, email, session_id)
             if execution_id:
                 mark_turn_inflight(session_id, execution_id, turn_timeout + 60)
                 owns_marker = True

--- a/tests/unit/test_2426_portal_sync_session_binding.py
+++ b/tests/unit/test_2426_portal_sync_session_binding.py
@@ -1,0 +1,184 @@
+"""#2426 — the synchronous Workspace turn must carry its session binding.
+
+ent#457 gave the Workspace a report-back: an agent that delegates during a chat
+turn gets the completion posted into that thread. `report_completion` gates on
+``if not source_channel_chat_id``, so the parent row MUST carry the session or
+the feature is silently inert.
+
+It was inert on the synchronous path. ent#457 passes the binding to
+`execute_task`, which persists it only inside ``if not execution_id:`` — and
+ent#365's `_precreate_sync_execution` had already created the row and handed the
+id down, so that branch never ran, and the pre-create stamped only
+`source_channel`. Measured on a dev instance: 5 of 8 portal rows had a NULL
+`chat_id`, split exactly by path (browser/streaming stamped, `POST /chat` not).
+
+WHY THIS FILE EXISTS AT THIS LAYER. Neither feature is wrong alone and both have
+passing tests — ent#457's mock the engine and assert the kwargs are *passed*
+(they are), ent#365's assert no orphan `running` row (still true). Nothing
+asserted the PERSISTED ROW, which is the only place the two meet. That is the
+same lesson `test_ent457_portal_turn_kwargs.py` states about itself: "the only
+place the two signatures meet is here."
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def portal_service():
+    from client_portal import service as m
+    return m
+
+
+# ---------------------------------------------------------------------------
+# The behaviour: the row the pre-create writes
+# ---------------------------------------------------------------------------
+def test_precreated_row_carries_the_session_and_the_client(portal_service, monkeypatch):
+    """The regression. Before the fix these two arrived as None."""
+    captured = {}
+
+    class _FakeDb:
+        def get_agent_subscription_id(self, agent_name):
+            return "sub_1"
+
+        def create_task_execution(self, **kwargs):
+            captured.update(kwargs)
+            return type("Row", (), {"id": "exec_abc"})()
+
+    import database
+    monkeypatch.setattr(database, "db", _FakeDb(), raising=False)
+
+    out = portal_service._precreate_sync_execution(
+        "agent-a", "hello", "x@example.com", "ps_session_1",
+    )
+
+    assert out == "exec_abc"
+    assert captured["source_channel_chat_id"] == "ps_session_1", (
+        "without the session id, report_completion suppresses every report from "
+        "this path at its `if not source_channel_chat_id` gate"
+    )
+    assert captured["source_channel_client"] == "x@example.com", (
+        "_resolve_portal refuses a report whose chain does not name the thread's "
+        "client, so a missing client fails closed just as hard as a missing session"
+    )
+    # Unchanged by this fix — pinned so the row stays otherwise identical.
+    assert captured["source_channel"] == portal_service.PORTAL_SOURCE_CHANNEL
+    assert captured["triggered_by"] == "public"
+    assert captured["source_user_email"] == "x@example.com"
+
+
+def test_still_fails_soft_when_the_row_cannot_be_written(portal_service, monkeypatch):
+    """A turn must never be refused because this bookkeeping failed.
+
+    On None, `run_resumable_turn` creates the row itself — and that path DOES
+    stamp both fields, so the fallback is correct rather than merely tolerable.
+    """
+    class _BoomDb:
+        def get_agent_subscription_id(self, agent_name):
+            return None
+
+        def create_task_execution(self, **kwargs):
+            raise RuntimeError("db down")
+
+    import database
+    monkeypatch.setattr(database, "db", _BoomDb(), raising=False)
+
+    assert portal_service._precreate_sync_execution(
+        "agent-a", "hello", "x@example.com", "ps_1",
+    ) is None
+
+
+def test_subscription_lookup_failure_does_not_lose_the_binding(portal_service, monkeypatch):
+    """Usage tracking is best-effort; the binding is not."""
+    captured = {}
+
+    class _PartialDb:
+        def get_agent_subscription_id(self, agent_name):
+            raise RuntimeError("no subscription service")
+
+        def create_task_execution(self, **kwargs):
+            captured.update(kwargs)
+            return type("Row", (), {"id": "exec_x"})()
+
+    import database
+    monkeypatch.setattr(database, "db", _PartialDb(), raising=False)
+
+    portal_service._precreate_sync_execution("a", "m", "x@example.com", "ps_2")
+    assert captured["subscription_id"] is None
+    assert captured["source_channel_chat_id"] == "ps_2"
+    assert captured["source_channel_client"] == "x@example.com"
+
+
+# ---------------------------------------------------------------------------
+# The two writers must agree — that is the actual invariant
+# ---------------------------------------------------------------------------
+def _create_call_kwargs(fn) -> set[str]:
+    """Keyword names passed to a `create_task_execution(...)` call inside `fn`."""
+    tree = ast.parse(inspect.getsource(fn).lstrip())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, "id", "")
+            if name == "create_task_execution":
+                return {kw.arg for kw in node.keywords if kw.arg}
+    return set()
+
+
+def test_the_sync_pre_create_stamps_what_the_streaming_path_stamps(portal_service):
+    """`_precreate_sync_execution`'s docstring claims the two paths produce
+    "indistinguishable rows". This asserts the claim instead of trusting it —
+    the claim was false, and it read as true.
+
+    Derived from the real call sites, so a THIRD channel field added to one
+    writer and forgotten in the other fails here rather than shipping as another
+    silently-inert report path.
+    """
+    sync = _create_call_kwargs(portal_service._precreate_sync_execution)
+    streaming = _create_call_kwargs(portal_service.start_portal_turn)
+
+    assert sync, "no create_task_execution call found in _precreate_sync_execution"
+    assert streaming, "no create_task_execution call found in start_portal_turn"
+
+    channel_fields = {k for k in streaming if k.startswith("source_channel")}
+    assert channel_fields, "the streaming path stamps no channel fields — check this test's premise"
+    missing = channel_fields - sync
+    assert not missing, (
+        f"the synchronous path omits {sorted(missing)} that the streaming path stamps; "
+        "a report delegated from a sync turn cannot be joined back to its chat"
+    )
+
+
+def test_execute_task_persists_the_binding_only_when_it_creates_the_row(portal_service):
+    """The other half of the collision, pinned so the fix is not silently undone.
+
+    If someone later teaches `execute_task` to UPDATE an adopted row, this test
+    should be revisited deliberately — not deleted because it went red.
+    """
+    from services import task_execution_service
+
+    src = inspect.getsource(task_execution_service.TaskExecutionService.execute_task)
+    tree = ast.parse(src.lstrip())
+
+    guarded = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        # `if not execution_id:`
+        if not (isinstance(node.test, ast.UnaryOp) and isinstance(node.test.op, ast.Not)):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Call):
+                name = inner.func.attr if isinstance(inner.func, ast.Attribute) else getattr(inner.func, "id", "")
+                if name == "create_task_execution":
+                    kws = {kw.arg for kw in inner.keywords if kw.arg}
+                    if "source_channel_chat_id" in kws:
+                        guarded = True
+    assert guarded, (
+        "execute_task no longer writes source_channel_chat_id inside its "
+        "`if not execution_id` create — if that moved, the pre-create is no "
+        "longer the only writer for an adopted row and #2426's reasoning changes"
+    )

--- a/tests/unit/test_ent457_portal_completion_report.py
+++ b/tests/unit/test_ent457_portal_completion_report.py
@@ -239,8 +239,22 @@ def test_both_portal_row_creation_sites_name_the_chat():
     from client_portal import service
 
     src = inspect.getsource(service)
-    assert src.count("source_channel_chat_id=session_id") == 2
-    assert src.count("source_channel=PORTAL_SOURCE_CHANNEL") == 2
+    # #2426: these were `== 2`, and there are THREE creation sites — ent#365's
+    # `_precreate_sync_execution` was added after ent#457 counted. The literal
+    # census went red on `dev` the moment the third site appeared, which is the
+    # guard working; nobody acted on it, and the bug it names shipped anyway.
+    #
+    # Asserting the RULE instead of the count: every site that stamps the
+    # surface must also stamp the destination. Census-proof, and it now fails
+    # for the reason the docstring gives rather than because a number moved.
+    surface = src.count("source_channel=PORTAL_SOURCE_CHANNEL")
+    destination = src.count("source_channel_chat_id=session_id")
+    assert surface >= 2, "expected at least the two known portal row creation sites"
+    assert destination == surface, (
+        f"{surface} site(s) stamp source_channel but only {destination} stamp "
+        "source_channel_chat_id — a row created by the unstamped one can never be "
+        "joined back to its chat, so report_completion drops every report from it"
+    )
 
 
 def test_the_portal_body_is_credential_sanitized_like_every_other_channel():

--- a/tests/unit/test_ent457_portal_turn_kwargs.py
+++ b/tests/unit/test_ent457_portal_turn_kwargs.py
@@ -37,19 +37,39 @@ def _forwarded_kwargs() -> set[str]:
     from client_portal import service as portal_service
     from services import session_turn_service
 
-    tree = ast.parse(inspect.getsource(portal_service.portal_chat).lstrip())
+    # #2426: this parsed `portal_chat` alone and looked for a literal
+    # `run_resumable_turn(...)` call. Since then the call moved into
+    # `_run_sync_turn_and_clear_marker`, where it is `run_resumable_turn(**kwargs)`
+    # — a splat, which names nothing. So the walk found no keywords, the assert
+    # below fired, and this guard has been RED on `dev` rather than protecting
+    # anything.
+    #
+    # The keywords are named at the WRAPPER's call site, so that is where they
+    # have to be read. Both entry names are scanned and the union taken, so
+    # neither re-inlining the call nor extracting a second wrapper disarms it;
+    # the wrapper's own three parameters are subtracted below with
+    # `run_resumable_turn`'s, since those are consumed and never forwarded.
+    _ENTRY_NAMES = {"run_resumable_turn", "_run_sync_turn_and_clear_marker"}
+    tree = ast.parse(inspect.getsource(portal_service).lstrip())
     passed: set[str] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         fn = node.func
         name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
-        if name != "run_resumable_turn":
+        if name not in _ENTRY_NAMES:
             continue
         passed |= {kw.arg for kw in node.keywords if kw.arg}
-    assert passed, "portal_chat no longer calls run_resumable_turn by that name"
+    assert passed, (
+        "no keyword-bearing call to run_resumable_turn or its wrapper found in "
+        "client_portal.service — this guard cannot see the portal's turn call"
+    )
 
     consumed = set(inspect.signature(session_turn_service.run_resumable_turn).parameters)
+    # The wrapper's own parameters are consumed by it, not forwarded (#2426).
+    consumed |= set(
+        inspect.signature(portal_service._run_sync_turn_and_clear_marker).parameters
+    )
     return passed - consumed
 
 


### PR DESCRIPTION
Journey Impact: none: repairs an existing surface's report-back on one code path — no user-facing promise is added or extended.

Closes #2426

## The bug

ent#457 gave the Workspace a report-back: an agent that delegates during a chat turn gets the completion posted into that thread. **It cannot fire on the synchronous chat path** — the parent execution never receives the session binding, so `report_completion` drops every report at its own `if not source_channel_chat_id` gate.

Measured on a dev instance, split cleanly by path:

```
portal rows total: 8
missing chat_id : 5

07:55 → 09:04   chat=7d27744d…   browser, streaming path
09:06 → 09:09   chat=NULL        POST .../chat, synchronous path
```

## Two correct changes that collide

ent#457 passes the binding down, and `execute_task` persists it — but only when it **creates** the row:

```python
# task_execution_service.py:1095
if not execution_id:
    execution = db.create_task_execution(..., source_channel_chat_id=..., source_channel_client=...)
```

ent#365's `_precreate_sync_execution` has already created the row and handed the id over, so `execute_task` **adopts** it and skips that branch. And the pre-create stamped only the surface:

```python
core_db.create_task_execution(..., source_channel=PORTAL_SOURCE_CHANNEL)   # no chat_id, no client
```

Its own docstring named the invariant it broke:

> Mirrors `start_portal_turn`'s creation exactly … so the two paths produce **indistinguishable rows** and a report published from either can be joined back to its chat.

And `start_portal_turn`'s sibling comment says *"both creation sites or the stamp is a coin flip depending on which path made the row."* ent#457 covered the two sites that existed when it was written; ent#365 had added a third.

## The fix

Stamp both fields in the pre-create. `session_id` is a **required** parameter, not optional — the value is in scope at the only call site, and a default would let a future caller silently reintroduce the inert row.

**Rejected:** teaching `execute_task` to UPDATE an adopted row. That widens a hot path used by every trigger to repair one caller's omission; the adopted row is the caller's to get right.

## Two guards that were red on `dev`

`backend-unit-test` is **failing on `dev` right now**. Both failures are in this feature area and both are guards that had gone inert, so they're repaired here rather than left for the next PR to trip over. Frontend-only PRs stay green because the `changes` job path-filters the backend suite away — which is why nobody saw it.

**`test_both_portal_row_creation_sites_name_the_chat`** asserted a literal census, `== 2` sites. It went red the moment the third site appeared — *the guard working* — and the bug it names shipped anyway. It now asserts the rule instead of the count:

```python
assert destination == surface, "…a row created by the unstamped one can never be joined back to its chat"
```

**`test_portal_turn_kwargs_bind_against_execute_task`** parsed `portal_chat` for a literal `run_resumable_turn(...)` call. That call had moved into `_run_sync_turn_and_clear_marker`, where it is `run_resumable_turn(**kwargs)` — a splat, which names nothing — so the walk found no keywords and the guard asserted itself dead. It now reads the keywords where they're actually named (the wrapper's call site), scans both entry names, and subtracts the wrapper's own consumed parameters.

Neither rewrite loses coverage; both now fail for the reason their docstring gives rather than because a number or a call site moved. Say so if you disagree — I edited guards I didn't write.

## Why the bug survived its own tests

Both features have passing tests:

- ent#457's mock the engine and assert the kwargs are **passed** — they are.
- ent#365's assert no orphan `running` row — still true.

Nothing asserted the **persisted row**, the only place the two meet. That is verbatim the lesson `test_ent457_portal_turn_kwargs.py` states about itself: *"the only place the two signatures meet is here."* The new suite asserts at that layer and adds a derived parity check, so a fourth channel field added to one writer and forgotten in another fails here rather than shipping as another silently-inert report path.

## Verification

```
pytest -k "portal or ent457 or ent365 or 2426"
  before this branch:   2 failed, 400 passed     ← both pre-existing on dev
  after:              402 passed, 1 skipped
```

Mutation-checked:

| Mutation | Result |
|---|---|
| Remove the new stamp | 4 failed (new suite + the repaired census guard) |
| Feed `execute_task` an unknown kwarg | repaired binding guard fires |

## Impact

Client-facing effect is a **missing** notification, not a wrong one: a delegated job finishes and nobody is told — precisely the scenario ent#457 was written for. No schema change, no migration, no API change.
