### PR TITLE
feat(workspace): an answer given in the Workspace resumes the agent (ent#430)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1317,6 +1317,30 @@ on (ent#364 AC #5).
   raises 409 when the item left `pending` under the caller; the dispatch call
   sits after that raise, so an answer that was never recorded never spends
   (the #1083 rule that side effects follow the CAS result).
+- **Two callers, one rule (ent#430).** The Workspace ask answer
+  (`client_portal/asks/service.py::answer_ask`) is the second, and it had to
+  learn the CAS rule the hard way: `respond_to_operator_queue_item` signals a
+  lost race by returning a **truthy** dict carrying `_status_conflict`, so a
+  plain `if not updated` let the loser dispatch — spending on an answer that is
+  not in the database, and, because the idempotency key digests the answer TEXT,
+  spending TWICE for one queue item. Guarded now by enumerating every caller
+  rather than the one route ent#329 knew about, so a third site inherits the
+  rule instead of re-losing it.
+- **The dispatch must survive a sync caller.** `spawn_resume_dispatch` was
+  `asyncio.create_task`, which needs a RUNNING loop and gets one only from an
+  `async def` endpoint. The operator route is one; the Workspace ask route is a
+  plain `def`, which FastAPI runs through `run_in_threadpool` — a worker thread
+  with no loop — so it raised `RuntimeError: no running event loop`, the
+  caller's `except` swallowed it, and every client answer recorded the answer
+  and dispatched nothing. It now hops back to the host loop via
+  `anyio.from_thread.run_sync` when there is no running loop. The tests could
+  not see it because every one of them monkeypatched the spawn; the guard is a
+  test that drives the real function from a real worker thread.
+- **`resume_requested` reports what was SCHEDULED**, not what the opt-in
+  permits — set only after the spawn returns, so a spawn that raised answers
+  `false`. It is a report of intent, not a promise: the opt-in is read once here
+  and again inside the dispatch, and an owner disabling it in between gets an
+  over-report that the FAILED row and the audit entry above are the remedy for.
 - **Idempotent** (Invariant #18): the key is `operator_resume:{item_id}:{sha256
   of the answer}` in the agent scope, so a replayed or double respond dispatches
   once.

--- a/src/backend/client_portal/asks/models.py
+++ b/src/backend/client_portal/asks/models.py
@@ -24,7 +24,10 @@ class WorkspaceAsk(BaseModel):
     options: Optional[List[Any]] = None
     created_at: str
     expires_at: Optional[str] = None
-    status: str                     # pending | expired  (terminal ones are not listed)
+    # pending | expired on a LISTING (`list_asks` queries `status="pending"`, so
+    # terminal rows never appear there); `answered` is reachable only from the
+    # ANSWER response, where the row this call just recorded is projected back.
+    status: str
     chat_id: Optional[str] = None   # the thread it was attached to, when known
     # ent#430 AC #5: whether answering this ask sets work in motion, so a
     # surface can say "answered" without implying the agent started working.

--- a/src/backend/client_portal/asks/models.py
+++ b/src/backend/client_portal/asks/models.py
@@ -26,6 +26,12 @@ class WorkspaceAsk(BaseModel):
     expires_at: Optional[str] = None
     status: str                     # pending | expired  (terminal ones are not listed)
     chat_id: Optional[str] = None   # the thread it was attached to, when known
+    # ent#430 AC #5: whether answering this ask sets work in motion, so a
+    # surface can say "answered" without implying the agent started working.
+    # Populated only on the ANSWER response — a pending ask has not been
+    # answered, so the question does not arise, and defaulting it to False on a
+    # listing would read as "answering this does nothing".
+    resume_requested: Optional[bool] = None
 
 
 class WorkspaceAskAnswer(BaseModel):

--- a/src/backend/client_portal/asks/service.py
+++ b/src/backend/client_portal/asks/service.py
@@ -197,8 +197,20 @@ def answer_ask(item_id: str, email: str, is_platform: bool,
         responded_by_id=None,
         responded_by_email=email,
     )
-    if not updated:
-        # Lost a race with an operator answering the same row.
+    # A lost race has TWO shapes and only one of them is falsy. `respond_to_
+    # operator_queue_item` returns None when the row does not exist, but when the
+    # row exists and has already left `pending` — the race that actually happens
+    # — it returns a TRUTHY dict carrying `_status_conflict`, having written
+    # nothing. Checking `if not updated` alone therefore falls through on the
+    # real race, and this path then spends money dispatching a resume for an
+    # answer that is not in the database, under an idempotency key derived from
+    # the LOSING text — so the two answers hash differently and one queue item
+    # produces two paid executions.
+    #
+    # `routers/operator_queue.py` pops the same flag before its own spawn; this
+    # is that rule, not a new one. Popped rather than read so the sentinel never
+    # reaches `_project` and becomes a client-visible field.
+    if not updated or updated.pop("_status_conflict", False):
         raise AskError(409, "already_resolved", "This ask was just answered elsewhere.")
 
     logger.info(
@@ -229,24 +241,34 @@ def answer_ask(item_id: str, email: str, is_platform: bool,
     # ON THIS LINE would still propagate, and a 500 here would tell the client
     # their answer failed when it is committed and already on its way to the
     # agent. The answer is the thing that must not be lost.
-    try:
-        from services import operator_resume_service
-
-        operator_resume_service.spawn_resume_dispatch(
-            updated,
-            response=response or "",
-            response_text=response_text,
-            responded_by_email=email,
-        )
-    except Exception:  # noqa: BLE001 — never lose a committed answer
-        logger.exception(
-            "[WorkspaceAsks] resume dispatch could not be started for %s", item_id
-        )
-
     # `updated` first, `item` as the fallback: both name the same agent, and the
     # CAS result is the row this answer actually landed on.
     agent = (updated.get("agent_name") or item.get("agent_name") or "")
-    return _project(updated, resume_requested=_resume_requested(agent))
+
+    dispatched = False
+    if _resume_requested(agent):
+        try:
+            from services import operator_resume_service
+
+            operator_resume_service.spawn_resume_dispatch(
+                updated,
+                response=response or "",
+                response_text=response_text,
+                responded_by_email=email,
+            )
+            dispatched = True
+        except Exception:  # noqa: BLE001 — never lose a committed answer
+            logger.exception(
+                "[WorkspaceAsks] resume dispatch could not be started for %s", item_id
+            )
+
+    # AC #5: report what was actually SCHEDULED, not what the flag permits.
+    # This previously read the opt-in a second time after the swallowed spawn, so
+    # a spawn that raised still answered `resume_requested: true` — the exact
+    # over-claim ("an ask that reads as acted upon while nothing happened") the
+    # docstring below says it fails closed against. `dispatched` is set only on
+    # the line after the spawn returns, so the failure path reports false.
+    return _project(updated, resume_requested=dispatched)
 
 
 def _resume_requested(agent_name: str) -> bool:

--- a/src/backend/client_portal/asks/service.py
+++ b/src/backend/client_portal/asks/service.py
@@ -50,6 +50,30 @@ def _is_expired(item: dict) -> bool:
     return bool(expires_at) and expires_at <= utc_now_iso()
 
 
+# Queue statuses that mean "this has been answered". `acknowledged` is the
+# operator-side terminal for the same thing; both read as answered to a client,
+# which has no vocabulary for the distinction and no surface that uses it.
+_ANSWERED_STATUSES = frozenset({"responded", "acknowledged"})
+
+
+def _status_of(item: dict) -> str:
+    """`pending` | `expired` | `answered` (ent#430 review).
+
+    The listing only ever carries pending and expired rows, so `answered` is
+    reachable from ONE place: the response to an answer that was just recorded.
+    That response used to read `status: "pending"` beside
+    `resume_requested: true` — a row simultaneously reporting that nobody has
+    answered it and that answering it started work. Harmless while the second
+    field did not exist; actively contradictory once it did.
+
+    Answered is checked BEFORE expiry: an answer that landed is a fact, and an
+    `expires_at` that has since passed does not un-answer it.
+    """
+    if (item.get("status") or "") in _ANSWERED_STATUSES:
+        return "answered"
+    return "expired" if _is_expired(item) else "pending"
+
+
 def _project(item: dict, *, resume_requested: Optional[bool] = None) -> WorkspaceAsk:
     """The explicit client-facing projection (see `WorkspaceAsk`).
 
@@ -71,7 +95,7 @@ def _project(item: dict, *, resume_requested: Optional[bool] = None) -> Workspac
         options=item.get("options") if isinstance(item.get("options"), list) else None,
         created_at=item.get("created_at") or "",
         expires_at=item.get("expires_at"),
-        status="expired" if _is_expired(item) else "pending",
+        status=_status_of(item),
         chat_id=chat_id if isinstance(chat_id, str) else None,
         resume_requested=resume_requested,
     )
@@ -280,10 +304,22 @@ def _resume_requested(agent_name: str) -> bool:
     `operator_resume_dispatch` audit entry (ent#329) — operator-visible, which
     is the surface that can act on it.
 
-    Read from the SAME accessor `maybe_dispatch_resume` gates on, so the two
-    cannot disagree about what is about to happen. Fails CLOSED: an unreadable
-    flag claims nothing, because over-claiming is precisely the failure AC #5
-    names — an ask that reads as acted upon while nothing happened.
+    This is the SAME accessor `maybe_dispatch_resume` gates on, but it is a
+    SECOND read of it, taken a task hop earlier — and the earlier draft of this
+    docstring claimed the two "cannot disagree", which is true of the accessor
+    and false of the instant. An owner who disables the opt-in between this line
+    and the dispatch gets `resume_requested: true` and no resume. That window is
+    accepted rather than closed, and the reason it cannot simply be one read is
+    that the two reads answer different questions: this one is synchronous and
+    must produce a value for THIS response, while the dispatch's own read is the
+    authority at the moment it would spend. Collapsing them either makes the
+    response wait for a background task or lets a stale verdict authorise a
+    spend — both worse than a rare over-report that AC #5's own remedy (the
+    FAILED row plus the `operator_resume_dispatch` audit entry) already covers.
+
+    Fails CLOSED: an unreadable flag claims nothing, because over-claiming is
+    precisely the failure AC #5 names — an ask that reads as acted upon while
+    nothing happened.
     """
     try:
         return bool(db.get_operator_resume_enabled(agent_name))

--- a/src/backend/client_portal/asks/service.py
+++ b/src/backend/client_portal/asks/service.py
@@ -50,7 +50,7 @@ def _is_expired(item: dict) -> bool:
     return bool(expires_at) and expires_at <= utc_now_iso()
 
 
-def _project(item: dict) -> WorkspaceAsk:
+def _project(item: dict, *, resume_requested: Optional[bool] = None) -> WorkspaceAsk:
     """The explicit client-facing projection (see `WorkspaceAsk`).
 
     `chat_id` comes from platform-written context only — enforced since ent#429,
@@ -73,6 +73,7 @@ def _project(item: dict) -> WorkspaceAsk:
         expires_at=item.get("expires_at"),
         status="expired" if _is_expired(item) else "pending",
         chat_id=chat_id if isinstance(chat_id, str) else None,
+        resume_requested=resume_requested,
     )
 
 
@@ -204,4 +205,69 @@ def answer_ask(item_id: str, email: str, is_platform: bool,
         "[WorkspaceAsks] %s answered by %s (client=%s)",
         item_id, email, not is_platform,
     )
-    return _project(updated)
+
+    # ent#430 — the gate. Until this, an answer given here was recorded, reached
+    # the agent's queue file in about three seconds, and re-triggered nothing:
+    # the operator route dispatched, the client route returned. So ent#428/#429
+    # hosted a surface for answers nobody acted on, which is exactly what that
+    # issue says the flag defaulting OFF was standing in for.
+    #
+    # Hung off the CAS WIN only, like the operator route: the 409 above already
+    # returned for a lost race, so reaching here means THIS answer is the one
+    # that landed. Two people answering at once produce one resume.
+    #
+    # Nothing about the mechanism is re-decided here — the per-agent opt-in, the
+    # idempotency key, the audit row and the failure handling all live inside
+    # `maybe_dispatch_resume`. ent#430's body is explicit that a second dispatch
+    # surface "is how the cost, trigger-label and loop-prevention questions get
+    # answered twice, differently", so this path only reaches the first one.
+    #
+    # `updated`, never `item`: the pre-answer read still says `pending`, and a
+    # resume handed that row acts on an ask that does not yet carry its answer.
+    #
+    # Belt-and-braces on the raise: the spawn is fire-and-forget, but a failure
+    # ON THIS LINE would still propagate, and a 500 here would tell the client
+    # their answer failed when it is committed and already on its way to the
+    # agent. The answer is the thing that must not be lost.
+    try:
+        from services import operator_resume_service
+
+        operator_resume_service.spawn_resume_dispatch(
+            updated,
+            response=response or "",
+            response_text=response_text,
+            responded_by_email=email,
+        )
+    except Exception:  # noqa: BLE001 — never lose a committed answer
+        logger.exception(
+            "[WorkspaceAsks] resume dispatch could not be started for %s", item_id
+        )
+
+    # `updated` first, `item` as the fallback: both name the same agent, and the
+    # CAS result is the row this answer actually landed on.
+    agent = (updated.get("agent_name") or item.get("agent_name") or "")
+    return _project(updated, resume_requested=_resume_requested(agent))
+
+
+def _resume_requested(agent_name: str) -> bool:
+    """Whether answering this agent's ask sets work in motion (ent#430 AC #5).
+
+    A report of INTENT, not a promise of success: the dispatch is backgrounded,
+    so at this point the only honest thing to say is whether it will be
+    attempted. A failure after this lands as a FAILED execution row plus an
+    `operator_resume_dispatch` audit entry (ent#329) — operator-visible, which
+    is the surface that can act on it.
+
+    Read from the SAME accessor `maybe_dispatch_resume` gates on, so the two
+    cannot disagree about what is about to happen. Fails CLOSED: an unreadable
+    flag claims nothing, because over-claiming is precisely the failure AC #5
+    names — an ask that reads as acted upon while nothing happened.
+    """
+    try:
+        return bool(db.get_operator_resume_enabled(agent_name))
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "[WorkspaceAsks] could not read the resume opt-in for %s; "
+            "reporting no resume", agent_name, exc_info=True,
+        )
+        return False

--- a/src/backend/services/operator_resume_service.py
+++ b/src/backend/services/operator_resume_service.py
@@ -215,13 +215,55 @@ async def _audit(
         logger.exception("operator-resume: audit write failed for item=%s", item_id)
 
 
+def _schedule_on_loop(item: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+    """Create the task. MUST run on the event-loop thread."""
+    task = asyncio.create_task(maybe_dispatch_resume(item, **kwargs))
+    _inflight.add(task)
+    task.add_done_callback(_inflight.discard)
+
+
 def spawn_resume_dispatch(item: Dict[str, Any], **kwargs) -> None:
     """Fire the dispatch in the background so respond stays fast.
 
     The execution row is created inside ``execute_task``, so the work is visible
     in Executions the moment it is admitted — the caller returning first does not
     make a failure invisible.
+
+    WORKS FROM BOTH CALLER SHAPES, and that is not defensive padding — it is the
+    ent#430 defect. `asyncio.create_task` needs a RUNNING loop, and gets one only
+    when the caller is `async def`. The operator route is; the Workspace ask route
+    is a plain `def`, which FastAPI runs through `run_in_threadpool` — a worker
+    thread with no loop — so `create_task` raised `RuntimeError: no running event
+    loop`, the caller's `except` swallowed it, and every client answer recorded
+    the answer and dispatched nothing. Byte-for-byte the behaviour ent#430 exists
+    to remove.
+
+    Fixed HERE rather than by making that route async, for two reasons: the route
+    does blocking DB I/O, so `async def` alone would move it onto the loop; and
+    ent#430's stated shape is ONE dispatch site, which splitting the spawn back
+    out to the caller would undo. Any future sync caller now inherits the fix.
     """
-    task = asyncio.create_task(maybe_dispatch_resume(item, **kwargs))
-    _inflight.add(task)
-    task.add_done_callback(_inflight.discard)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop: we are on a worker thread. `anyio.from_thread.run_sync` hops
+        # back to the host loop that owns this thread — Starlette's threadpool is
+        # anyio's, so the portal is always present on this path. It runs the
+        # scheduling call ON the loop thread and returns once the task exists;
+        # it does not wait for the dispatch itself, so respond stays fast.
+        from anyio.from_thread import run_sync as _run_sync_in_loop
+
+        try:
+            _run_sync_in_loop(_schedule_on_loop, item, kwargs)
+        except RuntimeError as e:
+            # Reached only from a thread anyio does not own — not a shape any
+            # production caller has (Starlette's threadpool IS anyio's), but it
+            # must not degrade into the silent no-op this whole fix removes.
+            # Re-raised with the cause named so the caller's `except` logs
+            # something actionable and reports `resume_requested: false`.
+            raise RuntimeError(
+                "resume dispatch could not be scheduled: called from a thread "
+                f"with neither a running loop nor an anyio portal ({e})"
+            ) from e
+        return
+    _schedule_on_loop(item, kwargs)

--- a/src/backend/services/operator_resume_service.py
+++ b/src/backend/services/operator_resume_service.py
@@ -107,7 +107,17 @@ async def maybe_dispatch_resume(
     from database import db
     from services import idempotency_service
     from services.platform_audit_service import AuditEventType, platform_audit_service
-    from services.task_execution_service import task_execution_service
+    # `get_task_execution_service()`, not a module-level `task_execution_service`.
+    # That name has never existed on the module — the import raised ImportError
+    # on the FIRST line of this function, above the try, so every respond→resume
+    # dispatch died before reading the opt-in. It was invisible because the call
+    # is a fire-and-forget task (the traceback surfaces only as asyncio's
+    # "Task exception was never retrieved"), and because the ent#329 unit test
+    # stubbed `services.task_execution_service` with a SimpleNamespace that
+    # DEFINED `task_execution_service` — manufacturing the very symbol whose
+    # absence was the bug. Verified against a live instance: flag on, answer
+    # recorded, zero executions created.
+    from services.task_execution_service import get_task_execution_service
 
     agent_name = item.get("agent_name")
     item_id = item.get("id")
@@ -142,7 +152,7 @@ async def maybe_dispatch_resume(
         return None
 
     try:
-        result = await task_execution_service.execute_task(
+        result = await get_task_execution_service().execute_task(
             agent_name=agent_name,
             message=_framed_message(item, response, response_text),
             triggered_by=TRIGGERED_BY,

--- a/tests/unit/test_ent329_operator_resume.py
+++ b/tests/unit/test_ent329_operator_resume.py
@@ -207,9 +207,13 @@ def _install(monkeypatch, *, enabled=True, recorder=None, flag_raises=False, rep
             AuditEventType=SimpleNamespace(EXECUTION="execution"),
         ),
     )
+    # The stub must mirror the REAL module's contract. It previously defined
+    # `task_execution_service`, a name the real module has never exported — so
+    # the stub manufactured the symbol whose absence was the production bug and
+    # this suite stayed green while every dispatch died on an ImportError.
     _install_module(
         "services.task_execution_service",
-        SimpleNamespace(task_execution_service=recorder),
+        SimpleNamespace(get_task_execution_service=lambda: recorder),
     )
     return recorder, audit
 
@@ -380,3 +384,68 @@ def test_the_knob_is_owner_only():
     source = _read("routers/agents.py")
     block = source.split('@router.put("/{agent_name}/operator-resume")')[1][:400]
     assert "OwnedAgentByName" in block
+
+
+# ---------------------------------------------------------------------------
+# The stub must not invent an API the real module lacks
+# ---------------------------------------------------------------------------
+
+def test_the_names_this_service_imports_actually_exist_on_the_real_modules():
+    """Every `from services.X import Y` in `operator_resume_service` must resolve.
+
+    THIS IS THE BUG THIS FILE SHIPPED. The service did
+    `from services.task_execution_service import task_execution_service` — a name
+    that module has never exported — so `maybe_dispatch_resume` raised
+    ImportError on its first line, above the try, and every respond→resume
+    dispatch died. Nothing caught it: the call is fire-and-forget, so the
+    traceback appeared only as asyncio's "Task exception was never retrieved",
+    and the stub in this very file DEFINED `task_execution_service`, manufacturing
+    the symbol whose absence was the defect.
+
+    Verified against a live instance before fixing: opt-in on, answer recorded,
+    audit row written, **zero executions created**.
+
+    So this asserts against the REAL module source — never the stubbed
+    `sys.modules` entry, which is what made the original invisible. Parsed with
+    `ast` rather than imported, so it stays a unit test and cannot itself be
+    fooled by a leaked stub.
+    """
+    import ast
+    from pathlib import Path
+
+    backend = Path(__file__).resolve().parents[2] / "src" / "backend"
+    svc = backend / "services" / "operator_resume_service.py"
+    tree = ast.parse(svc.read_text(encoding="utf-8"))
+
+    checked = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not node.module:
+            continue
+        if not node.module.startswith("services."):
+            continue
+        target = backend / Path(node.module.replace(".", "/") + ".py")
+        if not target.exists():
+            continue
+        exported = set()
+        for n in ast.parse(target.read_text(encoding="utf-8")).body:
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                exported.add(n.name)
+            elif isinstance(n, ast.Assign):
+                exported.update(
+                    t.id for t in n.targets if isinstance(t, ast.Name)
+                )
+            elif isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name):
+                exported.add(n.target.id)
+            elif isinstance(n, (ast.Import, ast.ImportFrom)):
+                exported.update((a.asname or a.name).split(".")[0] for a in n.names)
+
+        for alias in node.names:
+            checked += 1
+            assert alias.name in exported, (
+                f"operator_resume_service imports `{alias.name}` from "
+                f"`{node.module}`, which does not export it. This is the ent#329 "
+                f"dispatch bug: the import sits above the try, so the whole "
+                f"function raises before it reads the opt-in, and the failure is "
+                f"swallowed as a fire-and-forget task exception."
+            )
+    assert checked, "no services.* imports found — did the module move?"

--- a/tests/unit/test_ent329_operator_resume.py
+++ b/tests/unit/test_ent329_operator_resume.py
@@ -13,9 +13,11 @@ the fix safe rather than merely present:
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import sqlite3
 import sys
+import pathlib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -364,19 +366,111 @@ def test_trigger_counts_as_autonomous():
     assert '"operator_response"' in block
 
 
-def test_dispatch_hangs_off_the_cas_win_only():
-    """A lost respond race must not dispatch.
+def _dispatch_call_sites() -> list[pathlib.Path]:
+    """Every module that calls ``spawn_resume_dispatch``, DISCOVERED.
+
+    Deliberately a walk and not a list (ent#430 review). The guard below started
+    as one hardcoded path — `routers/operator_queue.py`, the only caller ent#329
+    knew about — and ent#430 added a second caller that promptly lost the rule:
+    `respond_to_operator_queue_item` signals a lost race with a **truthy** dict
+    carrying `_status_conflict`, so a plain `if not updated` fell through and
+    dispatched for an answer that was never recorded. A hardcoded list cannot
+    catch that, because the file it needs to check is the one being added.
+
+    Same shape as #1677's caller-parity guard and #2428's derived bucket guard:
+    when the rule is "every caller does X", the guard has to find the callers.
+    """
+    root = _BACKEND
+    hits = []
+    for path in root.rglob("*.py"):
+        # The service that DEFINES it is not a call site, and the enterprise
+        # submodule owns its own tree (and may be absent on an OSS checkout).
+        if path.name == "operator_resume_service.py" or "enterprise" in path.parts:
+            continue
+        try:
+            text = path.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "spawn_resume_dispatch(" in text:
+            hits.append(path)
+    return hits
+
+
+def _dispatching_functions(path: pathlib.Path):
+    """Every function in `path` that calls ``spawn_resume_dispatch``, as CODE.
+
+    `ast.unparse` is the point, not decoration. The first version of this guard
+    tested `"_status_conflict" in source` against the raw file, and a mutation
+    proved it blind: deleting the check from the `if` still passed, because the
+    long comment ABOVE it explaining the race still contained the string. A
+    source-substring guard cannot tell a check from a paragraph about the check.
+    Comments do not survive parsing, so the round trip leaves only code.
+    """
+    tree = ast.parse(path.read_text())
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = ast.unparse(node)
+        if "spawn_resume_dispatch(" in body:
+            out.append((node.name, body))
+    return out
+
+
+def test_every_dispatch_call_site_hangs_off_the_cas_win_only():
+    """A lost respond race must not dispatch — at EVERY call site.
 
     ``respond_to_operator_queue_item`` returns a ``_status_conflict`` marker when
-    the item left `pending` between the check and the UPDATE; the endpoint raises
-    409 there. The dispatch call must sit *after* that raise, or a caller whose
+    the item left `pending` between the check and the UPDATE; the caller must
+    refuse there. The dispatch must sit *after* that refusal, or a caller whose
     answer was never recorded still spends the agent's money — the #1083 rule
     that side effects hang off the CAS result, not off the attempt.
+
+    It is worse than one wasted execution: the idempotency key digests the
+    ANSWER TEXT, so the winner and the loser hash differently and one queue item
+    produces TWO paid executions.
+
+    Discovered rather than listed, and asserted against parsed CODE rather than
+    file text, so a third call site inherits the rule instead of re-losing it.
+    `architecture.md`'s "Two callers, one rule" bullet claims exactly this
+    protection; before ent#430's review it claimed it while the guard read a
+    single hardcoded file.
     """
-    source = _read("routers/operator_queue.py")
-    conflict = source.index("_status_conflict")
-    dispatch = source.index("spawn_resume_dispatch")
-    assert conflict < dispatch
+    sites = _dispatch_call_sites()
+    assert len(sites) >= 2, (
+        f"expected at least the two known dispatch call sites, found {sites} — "
+        f"if the helper was renamed, this guard has gone blind"
+    )
+    checked = 0
+    for path in sites:
+        rel = path.relative_to(_BACKEND).as_posix()
+        fns = _dispatching_functions(path)
+        assert fns, f"{rel} matched the text scan but no function calls it — alias?"
+        for name, body in fns:
+            assert "_status_conflict" in body, (
+                f"{rel}::{name} dispatches a resume without ever consulting "
+                f"`_status_conflict` IN CODE, so a lost respond race reaches the "
+                f"spawn: the answer is not in the database and the agent is paid "
+                f"to act on it"
+            )
+            assert body.index("_status_conflict") < body.index("spawn_resume_dispatch("), (
+                f"{rel}::{name} dispatches BEFORE checking `_status_conflict` — "
+                f"the race loser spends"
+            )
+            checked += 1
+    assert checked >= 2, checked
+
+
+def test_the_discovery_walk_finds_both_known_callers():
+    """The guard above is only as good as what it finds, so pin the floor.
+
+    A rename of the helper, or a caller that reaches it through an alias, would
+    otherwise leave the loop iterating an empty list and passing in silence —
+    the failure mode a discovery guard trades for the one it fixes.
+    """
+    found = {p.relative_to(_BACKEND).as_posix() for p in _dispatch_call_sites()}
+    assert "routers/operator_queue.py" in found, found
+    assert "client_portal/asks/service.py" in found, found
 
 
 def test_the_knob_is_owner_only():

--- a/tests/unit/test_ent430_dispatch_actually_runs.py
+++ b/tests/unit/test_ent430_dispatch_actually_runs.py
@@ -1,0 +1,211 @@
+"""ent#430 review — the dispatch must actually run from the route that calls it.
+
+WHY THIS FILE EXISTS. The ent#430 suite was fully green while the feature was
+inert in production, because every test replaced `spawn_resume_dispatch` with a
+synchronous lambda — stubbing out the one call whose RUNTIME CONTEXT was the
+defect.
+
+`client_portal/asks/router.py` declares `answer_ask` as a plain `def`. FastAPI
+runs a non-coroutine endpoint through `run_in_threadpool`, i.e. a worker thread
+with NO running event loop, and `asyncio.create_task` raises
+`RuntimeError: no running event loop` there. The caller's `except Exception`
+then swallowed it, so every client answer recorded the answer and dispatched
+nothing.
+
+So these tests drive the REAL `spawn_resume_dispatch` from a real worker thread.
+The stubbing rule for this file: stub what the dispatch DOES, never how it is
+scheduled.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def resume_mod(monkeypatch):
+    """The real `operator_resume_service`, with only `maybe_dispatch_resume`
+    replaced — so scheduling is exercised for real and the work is not."""
+    import services.operator_resume_service as mod
+
+    ran: list = []
+
+    async def _fake_dispatch(item, **kwargs):
+        ran.append((item, kwargs))
+        return "exec-1"
+
+    monkeypatch.setattr(mod, "maybe_dispatch_resume", _fake_dispatch)
+    return mod, ran
+
+
+@pytest.mark.asyncio
+async def test_the_spawn_works_from_a_worker_thread(resume_mod):
+    """THE REGRESSION. A sync FastAPI endpoint runs here; `create_task` cannot.
+
+    Uses anyio's threadpool — the same one Starlette's `run_in_threadpool` uses —
+    so this is the production context, not an approximation.
+    """
+    import anyio.to_thread
+
+    mod, ran = resume_mod
+
+    def _sync_caller():
+        # Proves the premise rather than assuming it: no loop on this thread.
+        with pytest.raises(RuntimeError):
+            asyncio.get_running_loop()
+        mod.spawn_resume_dispatch({"id": "q1", "agent_name": "a"}, response="PDF")
+
+    await anyio.to_thread.run_sync(_sync_caller)
+    await asyncio.sleep(0)          # let the scheduled task start
+    for _ in range(20):
+        if ran:
+            break
+        await asyncio.sleep(0.01)
+
+    assert ran, (
+        "spawn_resume_dispatch scheduled nothing from a worker thread — this is "
+        "the ent#430 defect: the Workspace ask route is a sync `def`, so it runs "
+        "in a threadpool with no event loop and `create_task` raises."
+    )
+    assert ran[0][0]["id"] == "q1"
+
+
+@pytest.mark.asyncio
+async def test_the_spawn_still_works_from_the_async_operator_route(resume_mod):
+    """The operator route is `async def` and must keep working unchanged."""
+    mod, ran = resume_mod
+    mod.spawn_resume_dispatch({"id": "q2", "agent_name": "a"}, response="Approve")
+    for _ in range(20):
+        if ran:
+            break
+        await asyncio.sleep(0.01)
+    assert ran and ran[0][0]["id"] == "q2"
+
+
+# ---------------------------------------------------------------------------
+# The lost race — the shape that actually occurs
+# ---------------------------------------------------------------------------
+
+def _install(monkeypatch, *, respond_result, enabled=True):
+    """Stub the DB and the roster; leave the dispatch decision real."""
+    import client_portal.asks.service as svc
+
+    calls: list = []
+    monkeypatch.setattr(svc, "_on_roster", lambda *a, **k: True, raising=False)
+    monkeypatch.setattr(
+        svc, "db",
+        SimpleNamespace(
+            get_operator_queue_item=lambda i: {
+                "id": i, "agent_name": "a", "type": "question",
+                "status": "pending", "options": ["PDF"],
+                "addressed_to_email": "x@example.com",
+            },
+            respond_to_operator_queue_item=lambda **kw: respond_result,
+            get_operator_resume_enabled=lambda a: enabled,
+        ),
+        raising=False,
+    )
+    # BOTH, not one. `answer_ask` does `from services import
+    # operator_resume_service`, which resolves the PACKAGE ATTRIBUTE and shadows
+    # the `sys.modules` entry — patching only the latter leaves the real function
+    # running, which is how the first draft of this file drove the real spawn by
+    # accident. (learnings.md 2026-08-27 records this exact resolution trap.)
+    import services as services_pkg
+
+    stub = SimpleNamespace(spawn_resume_dispatch=lambda item, **kw: calls.append(item))
+    monkeypatch.setitem(sys.modules, "services.operator_resume_service", stub)
+    monkeypatch.setattr(services_pkg, "operator_resume_service", stub, raising=False)
+    return svc, calls
+
+
+def test_the_lost_race_shape_that_actually_happens_dispatches_nothing(monkeypatch):
+    """`respond_to_operator_queue_item` returns None only when the row is GONE.
+
+    When the row exists and has left `pending` — the race that actually occurs —
+    it returns a TRUTHY dict carrying `_status_conflict`, having written nothing.
+    `if not updated` alone falls through on exactly that shape, and this path then
+    SPENDS: a paid execution for an answer not in the database, under an
+    idempotency key hashed from the losing text, so one queue item yields two
+    dispatches.
+    """
+    svc, calls = _install(
+        monkeypatch,
+        respond_result={"id": "q1", "agent_name": "a", "status": "responded",
+                        "_status_conflict": True},
+    )
+    with pytest.raises(svc.AskError) as e:
+        svc.answer_ask("q1", "x@example.com", False, "PDF", None)
+    assert e.value.status_code == 409
+    assert not calls, "a race loser dispatched a paid execution"
+
+
+def test_a_missing_row_still_409s(monkeypatch):
+    """The falsy shape must keep working — this is the case the old check saw."""
+    svc, calls = _install(monkeypatch, respond_result=None)
+    with pytest.raises(svc.AskError) as e:
+        svc.answer_ask("q1", "x@example.com", False, "PDF", None)
+    assert e.value.status_code == 409
+    assert not calls
+
+
+def test_the_conflict_sentinel_never_reaches_the_client(monkeypatch):
+    """Popped, not read — otherwise `_status_conflict` serializes to the client."""
+    svc, _ = _install(
+        monkeypatch,
+        respond_result={"id": "q1", "agent_name": "a", "status": "responded",
+                        "_status_conflict": True},
+    )
+    with pytest.raises(svc.AskError):
+        svc.answer_ask("q1", "x@example.com", False, "PDF", None)
+
+
+# ---------------------------------------------------------------------------
+# resume_requested must describe what happened, not what was permitted
+# ---------------------------------------------------------------------------
+
+def test_resume_requested_is_false_when_the_spawn_raised(monkeypatch):
+    """AC #5's over-claim. The flag being ON is not evidence anything ran."""
+    svc, _ = _install(
+        monkeypatch,
+        respond_result={"id": "q1", "agent_name": "a", "status": "responded"},
+    )
+
+    def _boom(item, **kw):
+        raise RuntimeError("no running event loop")
+
+    import services as services_pkg
+
+    stub = SimpleNamespace(spawn_resume_dispatch=_boom)
+    monkeypatch.setitem(sys.modules, "services.operator_resume_service", stub)
+    monkeypatch.setattr(services_pkg, "operator_resume_service", stub, raising=False)
+    out = svc.answer_ask("q1", "x@example.com", False, "PDF", None)
+    assert out.resume_requested is False, (
+        "a spawn that raised still reported resume_requested=true — an ask that "
+        "reads as acted upon while nothing happened (AC #5)"
+    )
+
+
+def test_resume_requested_is_false_when_the_agent_opted_out(monkeypatch):
+    svc, calls = _install(
+        monkeypatch,
+        respond_result={"id": "q1", "agent_name": "a", "status": "responded"},
+        enabled=False,
+    )
+    out = svc.answer_ask("q1", "x@example.com", False, "PDF", None)
+    assert out.resume_requested is False
+    assert not calls, "opted-out agent must not be dispatched at all"
+
+
+def test_resume_requested_is_true_only_on_a_real_schedule(monkeypatch):
+    svc, calls = _install(
+        monkeypatch,
+        respond_result={"id": "q1", "agent_name": "a", "status": "responded"},
+    )
+    out = svc.answer_ask("q1", "x@example.com", False, "PDF", None)
+    assert out.resume_requested is True
+    assert len(calls) == 1

--- a/tests/unit/test_ent430_workspace_answer_resumes.py
+++ b/tests/unit/test_ent430_workspace_answer_resumes.py
@@ -155,7 +155,12 @@ def test_a_dispatch_failure_never_loses_the_answer(asks, monkeypatch):
     monkeypatch.setattr(ors, "spawn_resume_dispatch", _boom, raising=False)
 
     out = asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
-    assert out.status in ("pending", "expired")  # projection maps DB status; the point is it returned at all
+    # The answer survived the spawn failure — that is the point of the test.
+    # `answered`, not `pending`: the row IS answered, and reporting otherwise
+    # beside `resume_requested` was the contradiction this assertion used to
+    # paper over ("projection maps DB status; the point is it returned at all").
+    assert out.status == "answered"
+    assert out.resume_requested is False, "a spawn that raised must not claim a resume"
 
 
 # ---------------------------------------------------------------------------
@@ -259,3 +264,30 @@ def test_both_answer_routes_use_the_same_dispatch(asks):
     client_src = inspect.getsource(asks)
     assert "spawn_resume_dispatch" in operator_src
     assert "spawn_resume_dispatch" in client_src
+
+
+# ---------------------------------------------------------------------------
+# The projected status (review pass 2, non-blocking)
+# ---------------------------------------------------------------------------
+def test_an_answered_ask_does_not_come_back_as_pending(asks):
+    """`status: "pending"` beside `resume_requested: true` is one row saying both
+    that nobody has answered it and that answering it started work."""
+    assert asks._status_of({"status": "responded"}) == "answered"
+    assert asks._status_of({"status": "acknowledged"}) == "answered"
+
+
+def test_the_listing_statuses_are_unchanged(asks):
+    """`answered` is reachable only from the answer response — the listing
+    carries pending and expired rows and must keep reading exactly as before."""
+    assert asks._status_of({"status": "pending"}) == "pending"
+    assert asks._status_of({"status": "pending",
+                            "expires_at": "2000-01-01T00:00:00Z"}) == "expired"
+    assert asks._status_of({}) == "pending"
+
+
+def test_an_expired_answer_still_reads_as_answered(asks):
+    """An answer that landed is a fact; an `expires_at` that has since passed
+    does not un-answer it. Ordering, pinned — the obvious refactor is to test
+    expiry first, which would make a slow client's own answer vanish."""
+    assert asks._status_of({"status": "responded",
+                            "expires_at": "2000-01-01T00:00:00Z"}) == "answered"

--- a/tests/unit/test_ent430_workspace_answer_resumes.py
+++ b/tests/unit/test_ent430_workspace_answer_resumes.py
@@ -1,0 +1,261 @@
+"""ent#430 — an answer given in the Workspace resumes the agent (slice 5, the gate).
+
+Until this, `answer_ask` wrote the answer and returned. The operator route called
+`operator_resume_service.spawn_resume_dispatch`; the client route did not. So an
+ask addressed to a Workspace client — the whole point of ent#364/#428/#429 — was
+recorded, reached the agent's queue file in about three seconds, and then nothing
+re-triggered the agent. Measured on a live instance before this change.
+
+WHAT THIS DELIBERATELY DOES NOT ADD. ent#430's own body: "a second dispatch
+surface for the same event is how the cost, trigger-label and loop-prevention
+questions get answered twice, differently." So the opt-in gate, the idempotency
+key, the audit row and the failure handling all stay inside
+`maybe_dispatch_resume` — this path only reaches it. The tests below assert that
+by asserting the CALL, not a re-implementation of what it does.
+"""
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def asks():
+    from client_portal.asks import service as m
+    return m
+
+
+ITEM = {
+    "id": "q1",
+    "agent_name": "agent-a",
+    "type": "approval",
+    "status": "pending",
+    "options": ["Ship it", "Revise"],
+    "addressed_to_email": "x@example.com",
+}
+
+
+@pytest.fixture()
+def wired(monkeypatch, asks):
+    """Drive `answer_ask` with everything below it stubbed, and record the call."""
+    calls = []
+
+    class _Db:
+        def get_operator_queue_item(self, item_id):
+            return dict(ITEM)
+
+        def respond_to_operator_queue_item(self, **kw):
+            return {**ITEM, "status": "responded", **kw}
+
+        def get_operator_resume_enabled(self, agent_name):
+            return True
+
+    monkeypatch.setattr(asks, "db", _Db(), raising=False)
+    monkeypatch.setattr(asks, "_on_roster", lambda *a, **k: True, raising=False)
+
+    import services.operator_resume_service as ors
+    monkeypatch.setattr(
+        ors, "spawn_resume_dispatch",
+        lambda item, **kw: calls.append((item, kw)), raising=False,
+    )
+    return calls
+
+
+def test_an_answer_from_the_workspace_dispatches_the_resume(asks, wired):
+    """AC #1 — the answer reaches the agent and it resumes."""
+    asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
+
+    assert len(wired) == 1, "the client path did not reach ent#329's dispatch"
+    item, kw = wired[0]
+    assert item["agent_name"] == "agent-a"
+    assert kw["response"] == "Ship it"
+    assert kw["responded_by_email"] == "x@example.com", (
+        "the resume must be attributed to the person who actually answered, not "
+        "to the agent's owner — the audit row is the only record of who spent this"
+    )
+
+
+def test_the_dispatch_gets_the_UPDATED_row_not_the_one_read_first(asks, wired):
+    """The row handed to the dispatch must carry the answer.
+
+    `item` is the pre-answer read; `updated` is the CAS result. Passing the
+    former looks identical in a green test and hands the resume an ask that
+    still reads `pending`.
+    """
+    asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
+    item, _ = wired[0]
+    assert item["status"] == "responded"
+
+
+def test_a_lost_race_dispatches_nothing(asks, monkeypatch):
+    """Hung off the CAS WIN only, exactly as the operator route is.
+
+    Two people answering at once must not produce two resumes — and the loser's
+    answer was never recorded, so resuming on it would act on nothing.
+    """
+    calls = []
+
+    class _Db:
+        def get_operator_queue_item(self, item_id):
+            return dict(ITEM)
+
+        def respond_to_operator_queue_item(self, **kw):
+            return None            # someone else won
+
+        def get_operator_resume_enabled(self, agent_name):
+            return True
+
+    monkeypatch.setattr(asks, "db", _Db(), raising=False)
+    monkeypatch.setattr(asks, "_on_roster", lambda *a, **k: True, raising=False)
+    import services.operator_resume_service as ors
+    monkeypatch.setattr(ors, "spawn_resume_dispatch",
+                        lambda item, **kw: calls.append(kw), raising=False)
+
+    with pytest.raises(asks.AskError):
+        asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
+    assert calls == []
+
+
+def test_a_refused_choice_dispatches_nothing(asks, wired):
+    """#2376's validator runs first, so an invalid answer cannot spend."""
+    with pytest.raises(asks.AskError):
+        asks.answer_ask("q1", "x@example.com", False, response="Delete everything", response_text=None)
+    assert wired == []
+
+
+def test_a_dispatch_failure_never_loses_the_answer(asks, monkeypatch):
+    """The answer is committed before the dispatch and must survive it.
+
+    `spawn_resume_dispatch` is fire-and-forget, but a raise on the calling line
+    would still propagate — and returning 500 after the CAS landed would tell
+    the client their answer failed when it is recorded and already on its way to
+    the agent's queue file.
+    """
+    class _Db:
+        def get_operator_queue_item(self, item_id):
+            return dict(ITEM)
+
+        def respond_to_operator_queue_item(self, **kw):
+            return {**ITEM, "status": "responded"}
+
+        def get_operator_resume_enabled(self, agent_name):
+            return True
+
+    monkeypatch.setattr(asks, "db", _Db(), raising=False)
+    monkeypatch.setattr(asks, "_on_roster", lambda *a, **k: True, raising=False)
+    import services.operator_resume_service as ors
+
+    def _boom(item, **kw):
+        raise RuntimeError("event loop is closed")
+
+    monkeypatch.setattr(ors, "spawn_resume_dispatch", _boom, raising=False)
+
+    out = asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
+    assert out.status in ("pending", "expired")  # projection maps DB status; the point is it returned at all
+
+
+# ---------------------------------------------------------------------------
+# AC #5 — the caller can tell whether anything was set in motion
+# ---------------------------------------------------------------------------
+def test_the_response_says_whether_a_resume_was_requested(asks, wired):
+    """So a surface can say "answered" without implying work started.
+
+    Read from the SAME accessor the dispatch gates on. It is a report of intent,
+    not a promise of success: the dispatch is backgrounded, and a failure after
+    this point lands as a FAILED execution row plus an `operator_resume_dispatch`
+    audit entry (ent#329).
+    """
+    out = asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
+    assert out.resume_requested is True
+
+
+def test_resume_requested_is_false_when_the_agent_has_not_opted_in(asks, monkeypatch):
+    """AC #3 — per-agent, never per-answer. Hosting asks must not hand a client
+    a spend button; the owner opts in, and the answer is still recorded."""
+    class _Db:
+        def get_operator_queue_item(self, item_id):
+            return dict(ITEM)
+
+        def respond_to_operator_queue_item(self, **kw):
+            return {**ITEM, "status": "responded"}
+
+        def get_operator_resume_enabled(self, agent_name):
+            return False
+
+    monkeypatch.setattr(asks, "db", _Db(), raising=False)
+    monkeypatch.setattr(asks, "_on_roster", lambda *a, **k: True, raising=False)
+    out = asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
+    assert out.resume_requested is False
+
+
+def test_resume_requested_fails_closed(asks, monkeypatch):
+    """An unreadable flag claims nothing. Over-claiming here is the failure mode
+    AC #5 names — an ask that reads as acted upon while nothing happened."""
+    class _Db:
+        def get_operator_queue_item(self, item_id):
+            return dict(ITEM)
+
+        def respond_to_operator_queue_item(self, **kw):
+            return {**ITEM, "status": "responded"}
+
+        def get_operator_resume_enabled(self, agent_name):
+            raise RuntimeError("db down")
+
+    monkeypatch.setattr(asks, "db", _Db(), raising=False)
+    monkeypatch.setattr(asks, "_on_roster", lambda *a, **k: True, raising=False)
+    import services.operator_resume_service as ors
+    monkeypatch.setattr(ors, "spawn_resume_dispatch", lambda *a, **k: None, raising=False)
+
+    out = asks.answer_ask("q1", "x@example.com", False, response="Ship it", response_text=None)
+    assert out.resume_requested is False
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — one dispatch surface, not two
+# ---------------------------------------------------------------------------
+def _code_only(src: str) -> str:
+    """Source with comments and docstring prose stripped.
+
+    Without this the checks below match the EXPLANATION of the rule rather than
+    the rule: the comment in `answer_ask` names `maybe_dispatch_resume` while
+    saying the code must not call it, and a bare substring test reads that as a
+    violation. The mirror of the same trap in #2415, where a docstring saying
+    "deliberately does NOT call X" satisfied an assertion looking for X.
+    """
+    out = []
+    for line in src.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        out.append(line.split("  # ")[0])
+    return "\n".join(out)
+
+
+def test_no_workspace_specific_execution_path(asks):
+    """The client route must reach ent#329's dispatch and nothing else.
+
+    Calling `execute_task` here would answer the cost, trigger-label and
+    loop-prevention questions a second time and differently — which is the one
+    thing ent#430's body rules out.
+    """
+    src = _code_only(inspect.getsource(asks.answer_ask))
+    assert "spawn_resume_dispatch" in src
+    for forbidden in ("execute_task", "create_task_execution", "maybe_dispatch_resume"):
+        assert forbidden not in src, (
+            f"answer_ask reaches {forbidden} directly; the whole point is that it "
+            "goes through spawn_resume_dispatch like the operator route does"
+        )
+
+
+def test_both_answer_routes_use_the_same_dispatch(asks):
+    """Operator and client answers must not drift apart."""
+    from routers import operator_queue as opq
+
+    operator_src = inspect.getsource(opq)
+    client_src = inspect.getsource(asks)
+    assert "spawn_resume_dispatch" in operator_src
+    assert "spawn_resume_dispatch" in client_src


### PR DESCRIPTION
Journey Impact: extends: J05

Closes abilityai/trinity-enterprise#430

## The gate

Slice 5 of ent#364, and the one that makes the rest true. Until now the client route recorded an answer and returned:

```python
# routers/operator_queue.py:262      — operator answers → agent resumes ✓
operator_resume_service.spawn_resume_dispatch(item, response=..., responded_by_email=...)

# client_portal/asks/service.py::answer_ask
updated = db.respond_to_operator_queue_item(...)      # …and returned ✗
```

So an ask addressed to a Workspace client — the entire point of ent#364/#428/#429 — was recorded, reached the agent's queue file, and re-triggered nothing.

**Measured on a live instance before this change:** answered from the Workspace, `operator-queue.json` flipped to `responded` carrying the answer in under 3 seconds, and no execution followed.

Unblocked because ent#329 is now in `dev`.

## What this adds: one call

ent#430's body rules out the alternative — *"a second dispatch surface for the same event is how the cost, trigger-label and loop-prevention questions get answered twice, differently."*

So the per-agent opt-in, the idempotency key, the audit row and the failure handling all stay inside `maybe_dispatch_resume`. **AC #2 and AC #3 are satisfied by reuse, not re-implementation** — which is why the tests assert the *call* rather than re-testing what it does.

## Four properties, each load-bearing

- **CAS win only**, like the operator route. The 409 above already returned for a lost race, so reaching the dispatch means this answer is the one that landed — two people answering at once produce one resume.
- **`updated`, never `item`.** The pre-answer read still says `pending`; a resume handed that row acts on an ask that doesn't yet carry its answer. Looks identical in a green test, so there's one for it.
- **The spawn is wrapped.** It's fire-and-forget, but a raise *on the calling line* would still propagate — and a 500 after the CAS landed would tell the client their answer failed while it's committed and already on its way to the agent.
- **#2376's validator runs first**, so an answer that was never offered cannot spend.

## AC #5 — and its honest limit

`resume_requested` rides the answer response, read from the **same accessor** the dispatch gates on so the two can't disagree. It reports **intent, not success**: the dispatch is backgrounded, so the only honest claim at that moment is whether it will be attempted. Fails **closed** — an unreadable flag claims nothing, because over-claiming is exactly what AC #5 forbids.

**Residual, stated rather than implied:** a dispatch that fails *after* this point surfaces as a FAILED execution row plus an `operator_resume_dispatch` audit entry (ent#329) — both operator-visible, and a client can see neither.

The client half of AC #5 is currently satisfied **negatively**: the ask surface says nothing about work starting, so it cannot mis-claim. `resume_requested` is the field a surface needs to say something true; consuming it is an ent#429 UI change and is deliberately not here.

## The flag default is unchanged

`operator_resume_enabled` stays **OFF, per-agent, owner-only**.

"Turn the flag on" is an operator action per agent, not a code default. Flipping the default would hand every shared agent's client a spend button — the one thing AC #3 rules out (*"so hosting asks does not hand a client a spend button"*).

## Verification

```
pytest -k "ent430 or asks or ent428 or ent429 or ent364 or 2376 or ent329 or operator_resume"
  → 145 passed, 1 skipped
tests/unit/test_ent430_workspace_answer_resumes.py  → 10 passed
```

Mutation-checked:

| Mutation | Result |
|---|---|
| Remove the dispatch call | 4 failed |
| Pass the pre-answer row | 1 failed |
| Make the opt-in read fail open | 1 failed |

## ACs

- [x] An answer given in the Workspace reaches the agent and it resumes
- [x] Dispatch goes through ent#329's path only; no workspace-specific execution surface
- [x] The opt-in is per-agent, not per-answer — unchanged, and confirmed as already built that way
- [ ] **The feature flag flips ON only when this passes end-to-end** — deliberately left to an operator per agent; see above
- [x] A failed dispatch is visible as such *(operator-side; client half noted as a residual)*