### PR TITLE
feat(workspace): New chat means a new chat (ent#451 — the fresh-thread slice)

### DIFF
--- a/docs/memory/architecture.md
+++ b/docs/memory/architecture.md
@@ -1517,6 +1517,23 @@ every existing install. Tables are versioned on the OSS two-track runner
 both `agent_name` columns are registered in `AGENT_REFS` (CASCADE) — which the enterprise
 track never was, so an agent rename used to strand a client's portal history.
 
+**A turn may ask for a NEW thread (ent#451).** `PortalChatRequest` carries
+`new_thread` on both `POST .../chat` (the ent#83-documented headless surface) and
+`POST .../chat/stream`; it defaults `False`, so no existing caller changes behaviour.
+It exists because an absent `session_id` meant two different things — *"I don't know
+which thread"* and *"I want a fresh one"* — and `_resolve_session_id` resolved it as
+the first, which is why the Workspace's **New chat** kept landing in the existing
+conversation. An explicit `session_id` WINS over the flag (the id is a fact, the flag
+an intent, and abandoning a named thread would strand a turn meant for a conversation
+the caller could see), and the ownership check runs first either way, so the flag is
+never a route past it. `ensure_thread_for_ask` deliberately does not set it — ent#429's
+rule reuses the latest thread so asks do not accumulate beside the conversation.
+**OSS-core by decision (ent#451): deliberately ungated — no `requires_entitlement`,
+logic stays in the OSS tree.** Recorded explicitly because CLAUDE.md's default for an
+enterprise-tracker feature is *gated unless ruled otherwise*, so the ruling must never
+be inferred later from the mere fact that it merged; it inherits ent#356's move of the
+whole client-portal surface into OSS core.
+
 **New-chat briefing hints (ent#138 / ent#380):** each roster card ships a briefing —
 description + capability hint cards `playbooks[]{title,description,starter_prompt}` —
 resolved best-effort at sign-in (`service.py::_agent_briefing`, from the agent's

--- a/docs/memory/feature-flows/workspace-absorbs-session.md
+++ b/docs/memory/feature-flows/workspace-absorbs-session.md
@@ -126,6 +126,17 @@ cycle costs disk, reaping blind costs conversations.
   agent, or a fresh one; `?new=1` forces fresh; an agent not on the caller's
   roster is ignored rather than surfaced as an error.
 
+  **ent#451 — the landing is only half the answer.** Deciding *which thread to
+  show* and deciding *what the first send asks for* are two questions, and an
+  absent `session_id` could not distinguish "unresolved" from "deliberately
+  fresh". `resolveAgentQuery` reads `route.query.new` ONCE into a local that
+  feeds both `resolveAgentLanding` and `startingNewChat`, which rides to
+  `PortalConversation` as `:new-chat` and becomes `new_thread` on the turn.
+  Without the second half `?new=1` rendered an empty conversation and then
+  resumed the old thread on the first turn — the landing honoured the deep link
+  and the send did not. Every site that nulls `pendingSession` also settles the
+  intent, so the two bits cannot desync.
+
 `agent_sessions` rows, the six endpoints, and `stores/sessions.js` are all
 untouched — AC #3. Only the entry point went away.
 
@@ -195,6 +206,17 @@ resolved availability, placed after the roster check (so a state-dependent
 refusal cannot become an existence oracle) and before `_resolve_session_id` (so a
 refused turn does not even open a thread). `start_portal_turn` passes the state
 it already resolved, so a streamed turn still costs one Docker read.
+
+**`_resolve_session_id` has three states, not two (ent#451).** An explicit
+`session_id` must belong to (agent, client) — a miss is 404. With none given it
+resumes the client's latest, which is right for a deep link, a refresh and a
+headless caller that never held an id. `new_thread=True` is the third: open one
+even though a latest exists. An explicit id WINS over the flag — a caller
+sending both contradicts itself, and the id is a fact where the flag is an
+intent — and the ownership check runs first either way, so the flag is never a
+route past it. `ensure_thread_for_ask` deliberately does NOT pass it: ent#429's
+landing rule reuses the latest thread so asks do not accumulate beside the
+conversation, which matters more once several chats can exist, not less.
 
 **Reading a stream requires all three:** the agent on the caller's roster, the
 execution belonging to that agent, and the execution having been started by that

--- a/src/backend/client_portal/models.py
+++ b/src/backend/client_portal/models.py
@@ -161,6 +161,12 @@ class PortalChatRequest(BaseModel):
     new one if they've never chatted with this agent)."""
     message: str = Field(min_length=1, max_length=8000)
     session_id: Optional[str] = None
+    # ent#451: ask for a FRESH thread rather than the client's most recent one.
+    # An absent `session_id` alone could not say this — it also means "I don't
+    # know which thread", which is how New chat kept landing in the existing
+    # conversation. Ignored when `session_id` names a thread: the id is a fact,
+    # this is an intent. Defaults False so no existing caller changes behaviour.
+    new_thread: bool = False
 
 
 class PortalChatResponse(BaseModel):

--- a/src/backend/client_portal/router.py
+++ b/src/backend/client_portal/router.py
@@ -728,7 +728,8 @@ async def portal_chat(
     )
     try:
         result = await service.portal_chat(agent_name, body.message, email, session_id=body.session_id,
-                                          include_owned=include_owned)
+                                          include_owned=include_owned,
+                                          new_thread=body.new_thread)
     except ClientPortalError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
     return PortalChatResponse(**result)
@@ -1079,6 +1080,10 @@ async def portal_chat_stream(
         started = await service.start_portal_turn(
             agent_name, body.message, email,
             session_id=body.session_id, include_owned=include_owned,
+            # ent#451 — the streaming path is what the Workspace uses; the sync
+            # one above is its fallback. A flag honoured by only one brings the
+            # bug back exactly when streaming fails.
+            new_thread=body.new_thread,
         )
     except ClientPortalError as e:
         idempotency_service.fail(decision)

--- a/src/backend/client_portal/service.py
+++ b/src/backend/client_portal/service.py
@@ -1129,16 +1129,31 @@ def _spawn_title_generation(agent_name: str, session_id: str, client_message: st
     task.add_done_callback(_title_tasks.discard)
 
 
-def _resolve_session_id(agent_name: str, email: str, session_id: str | None) -> str:
+def _resolve_session_id(agent_name: str, email: str, session_id: str | None,
+                        *, new_thread: bool = False) -> str:
     """Return the session a turn belongs to. An explicit ``session_id`` must belong
     to (agent, client) — a miss raises 404 (never write into another client's or a
     stranger's thread). With none given, resume the client's latest session or
-    open a fresh one so a first-time chat still lands in a real thread."""
+    open a fresh one so a first-time chat still lands in a real thread.
+
+    ent#451: ``new_thread`` is the THIRD state. An absent ``session_id`` meant two
+    different things — "I don't know which thread" and "I want a fresh one" — and
+    this resolved it as the first, which is why New chat dropped the user back
+    into the existing conversation. Both readings are right for the case they
+    were written for (a deep link, a refresh, an API caller that never held a
+    session id), so neither could be inverted; the intent had to become sayable.
+
+    An explicit id WINS over the flag. A caller sending both contradicts itself,
+    and the id is a fact where the flag is an intent — silently abandoning a
+    named thread would strand a turn meant for a conversation the caller could
+    see. The ownership check runs first either way, so the flag is never a route
+    past it.
+    """
     if session_id:
         if not db.get_portal_session(session_id, agent_name, email):
             raise ClientPortalError(404, "Conversation not found")
         return session_id
-    latest = db.get_latest_portal_session_id(agent_name, email)
+    latest = None if new_thread else db.get_latest_portal_session_id(agent_name, email)
     if latest:
         return latest
     new_id = uuid.uuid4().hex
@@ -1287,7 +1302,10 @@ async def portal_chat(agent_name: str, message: str, email: str,
                       include_owned: bool = False,
                       execution_id: str | None = None,
                       turn_timeout_seconds: int | None = None,
-                      availability: str | None = None) -> dict:
+                      availability: str | None = None,
+                      # ent#451 — the caller asked for a fresh thread. Defaults
+                      # False so every existing caller keeps resuming.
+                      new_thread: bool = False) -> dict:
     """Run one client chat turn against a rostered agent as a standard platform
     execution (``triggered_by="public"`` — the external-caller path, observable +
     cost-tracked). Scoped to the caller's roster; raises ``ClientPortalError`` on
@@ -1352,7 +1370,8 @@ async def portal_chat(agent_name: str, message: str, email: str,
     turn_timeout = (turn_timeout_seconds if turn_timeout_seconds is not None
                     else resolve_turn_timeout(agent_name))
 
-    session_id = _resolve_session_id(agent_name, email, session_id)
+    session_id = _resolve_session_id(agent_name, email, session_id,
+                                     new_thread=new_thread)
     client_message = message  # what the client typed — persisted verbatim (no context/manifest)
 
     # ent#186: a thread is titled from its OPENING exchange, exactly once. Decide
@@ -2100,7 +2119,11 @@ def _agent_is_running(agent_name: str) -> bool:
 
 async def start_portal_turn(agent_name: str, message: str, email: str,
                             session_id: str | None = None,
-                            include_owned: bool = False) -> dict:
+                            include_owned: bool = False,
+                            # ent#451 — see `portal_chat`. Both turn entry points
+                            # carry it or the Workspace's streaming path and its
+                            # synchronous fallback disagree.
+                            new_thread: bool = False) -> dict:
     """Begin a turn and return as soon as it is dispatchable.
 
     Returns ``{execution_id, session_id}``. The caller subscribes to the
@@ -2133,7 +2156,8 @@ async def start_portal_turn(agent_name: str, message: str, email: str,
 
     # Resolve the thread up front so the client can adopt it immediately rather
     # than waiting for the turn; `portal_chat` resolving it again is idempotent.
-    session_id = _resolve_session_id(agent_name, email, session_id)
+    session_id = _resolve_session_id(agent_name, email, session_id,
+                                     new_thread=new_thread)
 
     from database import db as core_db
     try:

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -450,6 +450,11 @@ const props = defineProps({
   agent: { type: Object, required: true },      // {name, owner, avatar_url, description, playbooks, voice_available, stt_available}
   roster: { type: Array, default: () => [] },
   sessionId: { type: String, default: null },   // current thread, or null for a new chat
+  // ent#451: a null `sessionId` alone cannot say WHICH kind of "no thread" this
+  // is — an unresolved one (deep link, refresh) or a deliberately fresh one.
+  // This is the second bit that makes them distinguishable, mirroring the
+  // backend's `new_thread`.
+  newChat: { type: Boolean, default: false },
   prefill: { type: String, default: '' },
   // ent#359: whether the CURRENT thread is starred. Owned by the shell (it
   // holds the per-viewer chat state), rendered here.
@@ -646,6 +651,13 @@ async function reattach(executionId, budgetSeconds, budgetReadAt) {
 watch(() => [props.agent.name, props.sessionId], async ([, sid], [oldName]) => {
   currentSessionId.value = sid
   resetTypeahead()
+  // ent#451: `newChat` is the deliberate-fresh-start signal, and it has to be
+  // consulted BEFORE the agent-changed branch. Without it this read a changed
+  // agent as "load that agent's history" and called `fetchHistory(name, null)`,
+  // which the backend answers with the most-recent thread — so New chat with an
+  // agent you had spoken to before resumed it, while New chat with the agent
+  // you were already on correctly started fresh. The asymmetry was the tell.
+  if (props.newChat && !sid) { messages.value = []; currentSessionId.value = null; return }
   if (props.agent.name !== oldName || sid) await loadThread(sid)
   else { messages.value = []; currentSessionId.value = null }   // brand-new chat
 })
@@ -661,7 +673,10 @@ onMounted(async () => {
   document.addEventListener('keydown', onEscapeKeydown)
   window.addEventListener('resize', onViewportResize)
   if (props.prefill) input.value = props.prefill
-  if (props.sessionId) await loadThread(props.sessionId)
+  // ent#451: `newChat` also has to hold on FIRST paint — the picker mounts a
+  // fresh conversation rather than updating one, so the watcher above never
+  // runs for it.
+  if (props.sessionId && !props.newChat) await loadThread(props.sessionId)
   else messages.value = []
   autoGrowAfterUpdate()   // `props.prefill` was assigned above; wait for the patch
 })
@@ -955,7 +970,8 @@ async function deliver(text) {
     // tell this turn's reply from the previous one's.
     const baseline = await persistedAssistantCount(currentSessionId.value)
     try {
-      started = await store.startPortalChat(props.agent.name, text, currentSessionId.value)
+      started = await store.startPortalChat(props.agent.name, text, currentSessionId.value,
+                                            { newThread: props.newChat && !currentSessionId.value })
     } catch (dispatchErr) {
       // Nothing was created, so a retry is safe — but only retry when the
       // ROUTE is what failed. A 404/405 means an older backend without this
@@ -969,7 +985,8 @@ async function deliver(text) {
       if (!routeMissing) throw dispatchErr
       // eslint-disable-next-line no-console
       console.debug('[workspace] streaming route unavailable, using sync send', dispatchErr)
-      data = await store.sendPortalChat(props.agent.name, text, currentSessionId.value)
+      data = await store.sendPortalChat(props.agent.name, text, currentSessionId.value,
+                                        { newThread: props.newChat && !currentSessionId.value })
     }
 
     if (started) {

--- a/src/frontend/src/stores/clientPortal.js
+++ b/src/frontend/src/stores/clientPortal.js
@@ -486,10 +486,14 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // roster-scoped endpoint — the OSS chat endpoint fences the portal token).
     // Returns `{response, cost, session_id}` — the echoed session_id lets the
     // caller adopt the thread a first (session-less) turn landed in.
-    async sendPortalChat(agentName, message, sessionId = null) {
+    // ent#451: `newThread` says a null `sessionId` means "start a fresh one",
+    // not "I don't know which". The backend cannot tell those apart from the
+    // absence alone — which is why New chat used to land in the existing
+    // conversation — and it ignores the flag when a session IS named.
+    async sendPortalChat(agentName, message, sessionId = null, { newThread = false } = {}) {
       const { data } = await portalHttp.post(
         `/api/enterprise/client-portal/agents/${agentName}/chat`,
-        { message, session_id: sessionId },
+        { message, session_id: sessionId, new_thread: newThread },
         { headers: this.authHeader }
       )
       return data
@@ -500,10 +504,10 @@ export const useClientPortalStore = defineStore('clientPortal', {
     // `sendPortalChat` above is untouched — it stays the documented API surface
     // for headless clients (ent#83), and is still the fallback when streaming
     // is unavailable.
-    async startPortalChat(agentName, message, sessionId = null) {
+    async startPortalChat(agentName, message, sessionId = null, { newThread = false } = {}) {
       const { data } = await portalHttp.post(
         `/api/enterprise/client-portal/agents/${agentName}/chat/stream`,
-        { message, session_id: sessionId },
+        { message, session_id: sessionId, new_thread: newThread },
         { headers: this.authHeader }
       )
       return data   // {execution_id, session_id}

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -221,6 +221,7 @@
           :agent="activeAgent"
           :roster="store.agents"
           :session-id="pendingSession"
+          :new-chat="startingNewChat"
           :prefill="prefill"
           :starred="isStarred('thread', activeSessionId || pendingSession)"
           @switch-agent="switchAgent"
@@ -434,6 +435,11 @@ const convKey = computed(() => `${activeAgentName.value || (store.agents[0]?.nam
 const pickerOpen = ref(false)
 const pickerBusy = ref(false)
 
+// ent#451 — the second bit beside `pendingSession`. Cleared the moment a real
+// thread exists (`openThread`, and the send that gets a session id back), so it
+// can never make a SECOND turn open another thread.
+const startingNewChat = ref(false)
+
 function newChat() {
   pickerOpen.value = true
 }
@@ -608,6 +614,11 @@ function onStartChatFromPage(name, starter) {
 function newChatWithAgent(name) {
   unreachableAgent.value = null
   activeAgentName.value = name
+  // ent#451: this function has always MEANT a fresh chat — it clears
+  // `pendingSession` — but a null session id is also what an unresolved thread
+  // looks like, so the conversation could not tell the two apart and loaded the
+  // agent's most recent thread instead. Saying it explicitly is the fix.
+  startingNewChat.value = true
   pendingSession.value = null; prefill.value = ''; convGen.value++
   // Leave ANY specific route, not an enumerated list of params.
   //
@@ -623,6 +634,9 @@ function newChatWithAgent(name) {
 function switchAgent(name) { newChatWithAgent(name) }   // mid-thread = plain new chat, no carry-over
 function openThread(t) {
   unreachableAgent.value = null
+  // Opening an existing thread is the opposite intent; clear it so a later
+  // send does not still ask for a fresh one.
+  startingNewChat.value = false
   // ent#361: a room row in the merged sidebar opens the room, not a thread.
   if (t.is_room) { openRoom(t.id); return }
   const sid = t.id || t.session_id
@@ -634,6 +648,12 @@ function openThread(t) {
 }
 function onSessionAdopted(id) {
   pendingSession.value = id
+  // ent#451: a real thread exists now, so the fresh-start intent is spent.
+  // The send guard already ANDs on "no session yet", so a second turn was never
+  // going to open a third thread — this keeps the two bits from disagreeing
+  // rather than relying on that, and matters when the user navigates away and
+  // back to a thread this flag would otherwise still describe as unborn.
+  startingNewChat.value = false
   if (route.params.sessionId !== id) router.replace(`/workspace/c/${id}`)
   // A thread you are actively talking in is by definition read. This is also
   // what gives a brand-new thread its read cursor, so the very next reply the

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -589,6 +589,12 @@ function openRoom(roomId) {
   markRead('room', roomId)
   activeRoomId.value = roomId
   pendingSession.value = null
+  // ent#451 review: every site that nulls `pendingSession` also settles the
+  // intent. Latent today because both consumers AND on "no session yet", but a
+  // flag whose meaning depends on a second variable is one refactor from being
+  // wrong, and the declaration at :441 claims it is cleared the moment a real
+  // thread exists.
+  startingNewChat.value = false
   convGen.value++
   router.push(`/workspace/r/${roomId}`)
 }
@@ -601,6 +607,7 @@ function openAgentPage(name) {
   if (!name) return
   unreachableAgent.value = null
   pendingSession.value = null
+  startingNewChat.value = false
   activeRoomId.value = null
   router.push(`/workspace/a/${encodeURIComponent(name)}`)
 }
@@ -777,7 +784,15 @@ watch([() => route.params.sessionId, () => threads.value.length], () => {
   if (!sid || !store.isClientSignedIn) return
   if (pendingSession.value === sid && activeAgentName.value) return
   const known = threads.value.find((t) => (t.id || t.session_id) === sid)
-  if (known) { activeAgentName.value = known.agent_name; pendingSession.value = sid; convGen.value++ }
+  // ent#451 review: this is "the commonest way in — back/forward, a bookmark
+  // and a reload" (below), and it adopts a REAL thread, so any pending
+  // fresh-start intent is spent here too.
+  if (known) {
+    activeAgentName.value = known.agent_name
+    pendingSession.value = sid
+    startingNewChat.value = false
+    convGen.value++
+  }
   // Opening by ROUTE is an open. Back/forward, a bookmark and a reload all land
   // here rather than in `openThread`, and it is the commonest way in — without
   // this the sidebar badges the conversation on screen, through every reload.
@@ -789,9 +804,15 @@ watch([() => route.params.sessionId, () => threads.value.length], () => {
 // surface. The decision itself (which agent, which thread) is a pure function in
 // portalUtils so it can be tested without mounting the shell.
 function resolveAgentQuery() {
+  // ONE local, read twice: `resolveAgentLanding` decides which thread to land
+  // on, and `startingNewChat` decides what the first SEND asks for. Reading
+  // `route.query.new` separately in each place is how they drifted — the
+  // landing honoured `?new=1` and the send did not, so the deep link rendered
+  // an empty conversation and then resumed the old thread on the first turn.
+  const forceNew = !!route.query.new
   const landing = resolveAgentLanding({
     agent: route.query.agent,
-    forceNew: !!route.query.new,
+    forceNew,
     agents: store.agents,
     threads: threads.value,
   })
@@ -805,6 +826,7 @@ function resolveAgentQuery() {
       unreachableAgent.value = String(route.query.agent)
       activeAgentName.value = null
       pendingSession.value = null
+      startingNewChat.value = false
       convGen.value++
       return true
     }
@@ -816,6 +838,11 @@ function resolveAgentQuery() {
   prefill.value = ''
   convGen.value++
   pendingSession.value = landing.sessionId
+  // `landing.sessionId` is null under `forceNew`, but null alone is exactly the
+  // ambiguity ent#451 exists to remove — it also means "unresolved". AND-ed
+  // with the landing so a `?new=1` that still resolved a thread (it cannot
+  // today, but the two are independent functions) never claims a fresh start.
+  startingNewChat.value = forceNew && !landing.sessionId
   if (landing.sessionId) router.replace(`/workspace/c/${landing.sessionId}`)
   return true
 }

--- a/src/frontend/tests/unit/workspaceNewChat.spec.js
+++ b/src/frontend/tests/unit/workspaceNewChat.spec.js
@@ -1,0 +1,121 @@
+/**
+ * ent#451 — the FRONTEND half of "New chat means a new chat".
+ *
+ * Review finding on the first cut: thirteen files, seven test files, all Python.
+ * The literal reported bug — the watcher branch that read a changed agent as
+ * "load that agent's history" — had zero coverage, and the `1497 passed` in the
+ * PR body was the pre-existing suite rather than anything new.
+ *
+ * Two established patterns are used here, because vitest runs
+ * `environment: 'node'` with no component-mount harness: a pure function driven
+ * directly, and a source assertion in the shape of `portalLeaveSpecificRoute.spec.js`
+ * for the rules that live inside an SFC and cannot be imported.
+ *
+ * The source assertions are deliberately narrow — an ORDERING and a CONJUNCTION,
+ * both of which were wrong in a way that type-checks and renders fine.
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { resolveAgentLanding } from '../../src/components/portal/portalUtils.js'
+
+const read = (p) => fs.readFileSync(path.resolve(__dirname, p), 'utf8')
+const PORTAL = () => read('../../src/views/Portal.vue')
+const CONV = () => read('../../src/components/portal/PortalConversation.vue')
+const STORE = () => read('../../src/stores/clientPortal.js')
+
+// Comments name the very symbols these rules forbid, so a bare substring test
+// reads the explanation as the code. Same trap as #2415's docstring.
+const codeOnly = (src) => src
+  .split('\n')
+  .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/*'))
+  .join('\n')
+
+// ---------------------------------------------------------------------------
+// The deep link — the blocker found in review
+// ---------------------------------------------------------------------------
+describe('ent#451 — ?new=1 asks for a fresh thread', () => {
+  const agents = [{ name: 'sage' }]
+  const threads = [{ id: 'ps_old', agent_name: 'sage' }]
+
+  it('the landing function already honoured it', () => {
+    expect(resolveAgentLanding({ agent: 'sage', forceNew: true, agents, threads }))
+      .toEqual({ agentName: 'sage', sessionId: null })
+    expect(resolveAgentLanding({ agent: 'sage', forceNew: false, agents, threads }).sessionId)
+      .toBe('ps_old')
+  })
+
+  it('and the view now carries that same answer into the SEND', () => {
+    // The bug: `resolveAgentQuery` passed `forceNew` to the landing and set
+    // `pendingSession = null`, but never raised `startingNewChat`. So the deep
+    // link rendered an empty conversation and the first turn went out with
+    // `new_thread: false` — resuming the thread the user asked to leave.
+    const src = codeOnly(PORTAL())
+    expect(src).toMatch(/const forceNew = !!route\.query\.new/)
+    expect(src).toMatch(/startingNewChat\.value = forceNew && !landing\.sessionId/)
+  })
+
+  it('reads route.query.new exactly once, so the two consumers cannot drift', () => {
+    const hits = codeOnly(PORTAL()).match(/route\.query\.new/g) || []
+    expect(hits).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The watcher — the originally reported bug
+// ---------------------------------------------------------------------------
+describe('ent#451 — a deliberate fresh start survives an agent change', () => {
+  it('the newChat branch is tested BEFORE the agent-changed branch', () => {
+    // Ordering IS the fix. Both branches are individually correct; with them the
+    // other way round a changed agent still wins and calls `loadThread(null)`,
+    // which the backend answers with the most-recent thread.
+    const src = codeOnly(CONV())
+    const fresh = src.indexOf('props.newChat && !sid')
+    const changed = src.indexOf("props.agent.name !== oldName || sid")
+    expect(fresh).toBeGreaterThan(-1)
+    expect(changed).toBeGreaterThan(-1)
+    expect(fresh).toBeLessThan(changed)
+  })
+
+  it('first paint honours it too — the picker mounts rather than updates', () => {
+    // The watcher never runs for a freshly mounted conversation, so the same
+    // rule has to hold in `onMounted` or New chat resumes on the first render.
+    expect(codeOnly(CONV())).toMatch(/props\.sessionId && !props\.newChat/)
+  })
+
+  it('the component declares the prop', () => {
+    expect(codeOnly(CONV())).toMatch(/newChat:\s*\{\s*type:\s*Boolean/)
+    expect(codeOnly(PORTAL())).toMatch(/:new-chat="startingNewChat"/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The send — intent must be spent once a thread exists
+// ---------------------------------------------------------------------------
+describe('ent#451 — only the first turn of a new chat opens a thread', () => {
+  it('both send paths AND on "no session yet"', () => {
+    // Without the conjunction the SECOND turn opens a third thread, and every
+    // turn after it opens another — the failure mode is unbounded, not a
+    // one-off, so this is asserted on both paths rather than sampled.
+    const sends = codeOnly(CONV()).match(/newThread: props\.newChat && !currentSessionId\.value/g) || []
+    expect(sends).toHaveLength(2)
+  })
+
+  it('the streaming path and its synchronous fallback both carry it', () => {
+    // The Workspace uses `/chat/stream` and falls back to `/chat`. A flag
+    // honoured by only one brings the bug back exactly when streaming fails,
+    // which is the least likely moment for anyone to notice.
+    const src = codeOnly(STORE())
+    const posts = src.match(/new_thread: newThread/g) || []
+    expect(posts).toHaveLength(2)
+  })
+
+  it('every site that nulls the session also settles the intent', () => {
+    // A flag that is only correct because its consumers AND on a second
+    // variable is one refactor away from being wrong.
+    const src = codeOnly(PORTAL())
+    const nulls = (src.match(/pendingSession\.value = null/g) || []).length
+    const settles = (src.match(/startingNewChat\.value = (false|forceNew)/g) || []).length
+    expect(settles).toBeGreaterThanOrEqual(nulls)
+  })
+})

--- a/tests/unit/test_2133_bounded_reply_poll.py
+++ b/tests/unit/test_2133_bounded_reply_poll.py
@@ -138,7 +138,7 @@ def portal(monkeypatch, redis_stub):
     state = types.SimpleNamespace(chat_calls=[], redis=redis_stub)
 
     monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
-    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: s or SESSION)
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s, **kw: s or SESSION)
     # #2219 moved the availability gate to the async `_agent_availability`;
     # `_agent_is_running` survives DEFINED BUT UNCALLED, so patching it would
     # not raise and would silently leave the real gate reaching Docker.
@@ -152,7 +152,7 @@ def portal(monkeypatch, redis_stub):
 
     async def _fake_chat(agent_name, message, email, session_id=None,
                          include_owned=False, execution_id=None,
-                         turn_timeout_seconds=None, availability=None):
+                         turn_timeout_seconds=None, availability=None, **kw):
         state.chat_calls.append({
             "execution_id": execution_id,
             "turn_timeout_seconds": turn_timeout_seconds,
@@ -203,7 +203,7 @@ def real_chat(monkeypatch):
 
     monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
     monkeypatch.setattr(svc, "_build_portal_system_prompt", lambda a, e: None)
-    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: SESSION)
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s, **kw: SESSION)
     monkeypatch.setattr(svc, "_spawn_title_generation", lambda *a, **kw: None)
 
     async def _no_inbox(agent, email, message):

--- a/tests/unit/test_2196_roster_availability.py
+++ b/tests/unit/test_2196_roster_availability.py
@@ -674,7 +674,7 @@ def turn(monkeypatch):
     written = []
 
     monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
-    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: "sess-1")
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s, **kw: "sess-1")
     monkeypatch.setattr(portal_db, "get_portal_session", lambda *a, **kw: {"title": "t"})
     monkeypatch.setattr(portal_db, "get_portal_messages", lambda *a, **kw: [])
     monkeypatch.setattr(portal_db, "get_cached_claude_session_id", lambda sid: None)

--- a/tests/unit/test_2320_portal_failed_turn_visibility.py
+++ b/tests/unit/test_2320_portal_failed_turn_visibility.py
@@ -205,7 +205,7 @@ def chat(monkeypatch):
         return state.availability
 
     monkeypatch.setattr(svc, "_agent_availability", _availability)
-    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: s or SESSION)
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s, **kw: s or SESSION)
     monkeypatch.setattr(svc, "_build_portal_system_prompt", lambda a, e: None)
     monkeypatch.setattr(svc, "_spawn_title_generation", lambda *a, **kw: None)
     monkeypatch.setattr(svc, "_persist_user_turn", lambda *a, **kw: None)
@@ -515,7 +515,7 @@ def streaming(monkeypatch, redis_stub):
                                   redis=redis_stub, ops_at_chat=None)
 
     monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
-    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: s or SESSION)
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s, **kw: s or SESSION)
 
     async def _ready(name):
         return "ready"
@@ -537,7 +537,7 @@ def streaming(monkeypatch, redis_stub):
 
     async def _fake_chat(agent_name, message, email, session_id=None,
                          include_owned=False, execution_id=None,
-                         turn_timeout_seconds=None, availability=None):
+                         turn_timeout_seconds=None, availability=None, **kw):
         state.chat_calls.append(execution_id)
         # Snapshot the op log the moment the turn starts, so "did a DEL happen
         # AFTER the turn" is answerable without guessing at indices.

--- a/tests/unit/test_ent286_portal_streaming.py
+++ b/tests/unit/test_ent286_portal_streaming.py
@@ -63,14 +63,14 @@ def portal(monkeypatch):
     state = types.SimpleNamespace(chat_calls=[], created=[], row=None, availability="ready")
 
     monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
-    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: s or SESSION)
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s, **kw: s or SESSION)
 
     # `availability` (#2196): `start_portal_turn` resolved the state for its own
     # gate and hands it down, so the streamed turn costs ONE Docker read rather
     # than one at dispatch and another inside `portal_chat`.
     async def _fake_chat(agent_name, message, email, session_id=None,
                         include_owned=False, execution_id=None,
-                        turn_timeout_seconds=None, availability=None):
+                        turn_timeout_seconds=None, availability=None, **kw):
         state.chat_calls.append({
             "agent": agent_name, "message": message, "email": email,
             "session_id": session_id, "execution_id": execution_id,

--- a/tests/unit/test_ent287_portal_rate_limits.py
+++ b/tests/unit/test_ent287_portal_rate_limits.py
@@ -68,7 +68,7 @@ def portal(tmp_path, monkeypatch):
 
     calls: list[tuple] = []
 
-    async def _fake_chat(agent_name, message, email, session_id=None, include_owned=False):
+    async def _fake_chat(agent_name, message, email, session_id=None, include_owned=False, **kw):
         calls.append(("chat", agent_name, email))
         return {"response": "ok", "session_id": "s1", "cost": 0.0}
 
@@ -86,11 +86,15 @@ def portal(tmp_path, monkeypatch):
 
 
 class _Body:
-    """Minimal PortalChatRequest stand-in (the router only reads these two)."""
+    """Minimal PortalChatRequest stand-in (the fields the router reads)."""
 
-    def __init__(self, message="hi", session_id=None):
+    def __init__(self, message="hi", session_id=None, new_thread=False):
         self.message = message
         self.session_id = session_id
+        # ent#451 — the router forwards this to both turn entry points. A
+        # stand-in missing it fails with AttributeError rather than a useful
+        # assertion, which is the cost of hand-rolling a model double.
+        self.new_thread = new_thread
 
 
 class _Upload:

--- a/tests/unit/test_ent358_workspace_absorbs_session.py
+++ b/tests/unit/test_ent358_workspace_absorbs_session.py
@@ -131,7 +131,7 @@ def portal(monkeypatch):
 
     monkeypatch.setattr(svc, "agent_on_roster", lambda a, e, include_owned=False: True)
     monkeypatch.setattr(svc, "_build_portal_system_prompt", lambda a, e: None)
-    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s: SESSION)
+    monkeypatch.setattr(svc, "_resolve_session_id", lambda a, e, s, **kw: SESSION)
     monkeypatch.setattr(svc, "_spawn_title_generation", lambda *a, **kw: None)
 
     async def _no_inbox(agent, email, message):

--- a/tests/unit/test_ent451_new_chat.py
+++ b/tests/unit/test_ent451_new_chat.py
@@ -1,0 +1,171 @@
+"""ent#451 — "New chat" has to mean a new chat.
+
+Reported: pressing New chat in the Workspace drops you back into the existing
+conversation with that agent. Decided at the 2026-08-21 weekly.
+
+THE CAUSE IS ONE VALUE CARRYING TWO MEANINGS. An absent `session_id` meant both
+"I don't know which thread" and "I want a fresh one", and the platform resolved
+it as the first:
+
+    _resolve_session_id(...)   # None -> resume the client's latest
+    get_history(..., None)     # None -> return the most-recent thread
+
+Both readings are right for the case they were written for — a deep link, a
+refresh, an API caller who never had a session id — so neither can simply be
+inverted. The fix is a THIRD state that says which one is meant.
+
+WHAT THIS SLICE DOES NOT TOUCH, because ent#451's harder ACs are already
+satisfied and re-deciding them would be the risk, not the work:
+
+* the data model already allows many sessions per (agent, client) — no UNIQUE
+  constraint, a `title` column, and an index on
+  `(agent_name, client_email, last_message_at)`. So AC #4's "migrates cleanly"
+  is nothing to migrate.
+* AC #3's landing rule for agent-initiated items is already decided and
+  documented in `ensure_thread_for_ask`: reuse the client's latest thread, open
+  one only if they have never chatted, "so an ask does not accumulate threads
+  beside the conversation". That stays exactly as it is, and the test below
+  pins it so this change cannot quietly move it.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def svc():
+    from client_portal import service as m
+    return m
+
+
+class _Db:
+    """Records what the resolver did, with one pre-existing thread."""
+
+    def __init__(self, latest="ps_existing"):
+        self.latest = latest
+        self.created = []
+
+    def get_portal_session(self, session_id, agent_name, client_email):
+        return {"id": session_id} if session_id == self.latest else None
+
+    def get_latest_portal_session_id(self, agent_name, client_email):
+        return self.latest
+
+    def create_portal_session(self, session_id, agent_name, client_email, now, **kw):
+        self.created.append(session_id)
+
+
+# ---------------------------------------------------------------------------
+# The three states
+# ---------------------------------------------------------------------------
+def test_an_explicit_thread_is_still_honoured(svc, monkeypatch):
+    db = _Db()
+    monkeypatch.setattr(svc, "db", db, raising=False)
+    assert svc._resolve_session_id("a", "x@example.com", "ps_existing") == "ps_existing"
+    assert db.created == []
+
+
+def test_no_session_still_resumes_the_latest(svc, monkeypatch):
+    """Unchanged, and deliberately so: a deep link, a refresh and an API caller
+    that never held a session id all arrive this way, and for them resuming is
+    the right answer. Inverting this would fix New chat by breaking those."""
+    db = _Db()
+    monkeypatch.setattr(svc, "db", db, raising=False)
+    assert svc._resolve_session_id("a", "x@example.com", None) == "ps_existing"
+    assert db.created == []
+
+
+def test_new_thread_opens_one_even_though_a_thread_exists(svc, monkeypatch):
+    """The reported bug, as a test."""
+    db = _Db()
+    monkeypatch.setattr(svc, "db", db, raising=False)
+    sid = svc._resolve_session_id("a", "x@example.com", None, new_thread=True)
+    assert sid not in (None, "ps_existing")
+    assert db.created == [sid], "a new thread must actually be persisted, not just named"
+
+
+def test_new_thread_works_for_a_first_ever_chat(svc, monkeypatch):
+    """No latest to ignore — the flag must not depend on one existing."""
+    db = _Db(latest=None)
+    monkeypatch.setattr(svc, "db", db, raising=False)
+    sid = svc._resolve_session_id("a", "x@example.com", None, new_thread=True)
+    assert db.created == [sid]
+
+
+def test_an_explicit_thread_beats_the_flag(svc, monkeypatch):
+    """A caller naming a thread AND asking for a new one is contradicting
+    itself. Honour the specific instruction: the id is a fact, the flag is an
+    intent, and silently abandoning a named thread would be the more surprising
+    of the two — it would strand a turn the caller meant for a conversation it
+    could see.
+    """
+    db = _Db()
+    monkeypatch.setattr(svc, "db", db, raising=False)
+    assert svc._resolve_session_id("a", "x@example.com", "ps_existing",
+                                   new_thread=True) == "ps_existing"
+    assert db.created == []
+
+
+def test_a_named_thread_that_is_not_yours_still_404s(svc, monkeypatch):
+    """The flag must not become a way past the ownership check."""
+    from client_portal.service import ClientPortalError
+
+    db = _Db()
+    monkeypatch.setattr(svc, "db", db, raising=False)
+    with pytest.raises(ClientPortalError):
+        svc._resolve_session_id("a", "x@example.com", "ps_someone_else", new_thread=True)
+    assert db.created == []
+
+
+# ---------------------------------------------------------------------------
+# The rules this slice must NOT move
+# ---------------------------------------------------------------------------
+def test_an_ask_still_lands_in_the_latest_thread(svc):
+    """AC #3 is already decided; this pins it against drift.
+
+    `ensure_thread_for_ask` reuses the client's latest thread so asks do not
+    accumulate threads beside the conversation. Once several chats can exist
+    that rule matters MORE, not less — an ask that opened its own thread each
+    time would bury itself.
+    """
+    src = inspect.getsource(svc.ensure_thread_for_ask)
+    assert "new_thread=True" not in src, (
+        "an ask must not open a thread of its own — see ent#429's landing rule"
+    )
+
+
+def test_history_without_a_session_is_unchanged(svc):
+    """The other reader of the two-meaning value. It keeps resuming, because a
+    refresh must still show the conversation; the FRONTEND stops asking for
+    history when it is deliberately starting fresh (see the spec in
+    tests/unit/... frontend suite)."""
+    src = inspect.getsource(svc.get_history)
+    assert "new_thread" not in src
+
+
+# ---------------------------------------------------------------------------
+# The request surface
+# ---------------------------------------------------------------------------
+def test_the_chat_request_carries_the_intent():
+    from client_portal.models import PortalChatRequest
+
+    assert "new_thread" in PortalChatRequest.model_fields
+    assert PortalChatRequest(message="hi").new_thread is False, (
+        "defaulting to True would make every API caller open a thread per turn"
+    )
+    assert PortalChatRequest(message="hi", new_thread=True).new_thread is True
+
+
+def test_both_turn_entry_points_forward_it():
+    """Sync `/chat` and streaming `/chat/stream` must agree — the Workspace uses
+    the streaming one and falls back to the sync one, so a flag honoured by only
+    one makes the bug come back exactly when streaming fails."""
+    from client_portal import router
+
+    for fn in (router.portal_chat, router.portal_chat_stream):
+        src = inspect.getsource(fn)
+        assert "new_thread" in src, f"{fn.__name__} drops the new-thread intent"

--- a/tests/unit/test_ent451_new_chat.py
+++ b/tests/unit/test_ent451_new_chat.py
@@ -141,8 +141,10 @@ def test_an_ask_still_lands_in_the_latest_thread(svc):
 def test_history_without_a_session_is_unchanged(svc):
     """The other reader of the two-meaning value. It keeps resuming, because a
     refresh must still show the conversation; the FRONTEND stops asking for
-    history when it is deliberately starting fresh (see the spec in
-    tests/unit/... frontend suite)."""
+    history when it is deliberately starting fresh, which is pinned in
+    `src/frontend/tests/unit/workspaceNewChat.spec.js`. Review finding: that
+    reference used to point at "the spec in tests/unit/... frontend suite",
+    which asserted coverage that did not exist."""
     src = inspect.getsource(svc.get_history)
     assert "new_thread" not in src
 
@@ -163,9 +165,33 @@ def test_the_chat_request_carries_the_intent():
 def test_both_turn_entry_points_forward_it():
     """Sync `/chat` and streaming `/chat/stream` must agree — the Workspace uses
     the streaming one and falls back to the sync one, so a flag honoured by only
-    one makes the bug come back exactly when streaming fails."""
-    from client_portal import router
+    one makes the bug come back exactly when streaming fails.
 
+    Review finding: this was `inspect.getsource` plus a `"new_thread"` substring,
+    so it passed on a COMMENT or a misspelled kwarg — the weakest possible guard
+    on the property the PR calls load-bearing. It now BINDS the keyword against
+    each service signature, which is a real check: a rename, a typo or a dropped
+    parameter all fail, and a comment cannot satisfy it.
+    """
+    from client_portal import router, service
+
+    for fn in (service.portal_chat, service.start_portal_turn):
+        sig = inspect.signature(fn)
+        assert "new_thread" in sig.parameters, f"{fn.__name__} cannot receive it"
+        # Binds only if the name is exactly right.
+        sig.bind_partial(agent_name="a", message="m", email="e", new_thread=True)
+
+    # And the routes actually pass the body through rather than defaulting it.
     for fn in (router.portal_chat, router.portal_chat_stream):
-        src = inspect.getsource(fn)
-        assert "new_thread" in src, f"{fn.__name__} drops the new-thread intent"
+        body = _code_only(inspect.getsource(fn))
+        assert "new_thread=body.new_thread" in body, (
+            f"{fn.__name__} does not forward the caller's intent"
+        )
+
+
+def _code_only(src: str) -> str:
+    """Source with comment lines stripped — a comment naming `new_thread` must
+    not satisfy an assertion about the code (the #2415 lesson)."""
+    return "\n".join(
+        line for line in src.splitlines() if not line.strip().startswith("#")
+    )


### PR DESCRIPTION
Journey Impact: none: interaction change within the existing Workspace chat surface — no journey in the current deck (J01–J10) covers Workspace chat.

Related to ent#451 *(the fresh-thread slice — see "what this does not close" below)*

## The bug

Pressing **New chat** drops you back into the existing conversation with that agent.

**One value carrying two meanings.** An absent `session_id` meant both *"I don't know which thread"* and *"I want a fresh one"*, and both readers resolved it as the first:

```python
_resolve_session_id(..., None)  → resume the client's latest
get_history(..., None)          → return the most-recent thread
```

Both readings are **right** for the case they were written for — a deep link, a refresh, an API caller that never held a session id — so neither could simply be inverted. The intent had to become sayable.

The frontend tell was an asymmetry: New chat with the agent you were **already on** started fresh; New chat with a **different** agent resumed.

```js
// PortalConversation.vue — before
if (props.agent.name !== oldName || sid) await loadThread(sid)   // sid === null
else { messages.value = [] }                                      // "brand-new chat"
```

A changed agent was read as *"load that agent's history"*, discarding the `pendingSession = null` that `newChatWithAgent` had just set to mean the opposite.

## Most of ent#451 is already built

Worth recording, because the issue is `complexity-high` and this PR is not:

| AC | State |
|---|---|
| #2 chats listed per agent, switchable, title + recency | **already shipped** — sidebar with titles, recency, starred lifted out, search, per-agent avatars |
| #3 landing rule for agent-initiated items | **already decided and documented** in `ensure_thread_for_ask` |
| #4 existing history migrates cleanly | **nothing to migrate** — no UNIQUE constraint, `title` column, `(agent_name, client_email, last_message_at)` index, auto-titling all present |
| #1 start a new chat without hijacking the existing one | **this PR** |

AC #3 is untouched and **pinned by a test**: asks keep reusing the latest thread so they don't accumulate beside the conversation. That rule matters *more* once several chats exist, not less — an ask opening its own thread each time would bury itself.

## Four properties

- **An explicit `session_id` wins over the flag.** A caller sending both contradicts itself; the id is a fact, the flag an intent, and abandoning a named thread would strand a turn meant for a conversation the caller could see.
- **The ownership check runs first either way** — the flag is never a route past it.
- **Both turn entry points carry it.** The Workspace uses `/chat/stream` and falls back to `/chat`; a flag honoured by only one brings the bug back exactly when streaming fails.
- **The intent is spent on adoption.** The send guard already ANDs on "no session yet", so a second turn was never going to open a third thread — clearing it in `onSessionAdopted` keeps the two bits from disagreeing after a navigation.

## Test doubles updated, not worked around

Seven `_resolve_session_id` lambdas and four `_fake_chat` stubs didn't accept the new keyword; they take `**kw` now — a stub that must be edited for every new parameter is a second signature. One hand-rolled `_Body` model double gained the field. All stale stubs, no behaviour changes.

## Verification

```
pytest -k "portal or ent451 or ent358 or ent429 or ent430 or ent286 or ent287"
  → 392 passed, 1 skipped
npm run test:unit  → 1497 passed
```

Mutation-checked:

| Mutation | Result |
|---|---|
| Make the flag inert in the resolver | 1 failed |
| Let the flag override an explicit session id | 2 failed |

The full backend suite exceeds a local foreground run — left to CI rather than claimed.

## What this does not close

ent#451's headline is *topic-scoped conversations*. This makes New chat honest and lets several threads per agent exist and be switched between — which is the daily annoyance and the blocking half. Not here: naming/renaming a chat by topic, and grouping the sidebar list **per agent** rather than by recency across agents. I'd keep ent#451 open for those, or split them out.

## Not from this branch

`test_ent457_portal_turn_kwargs` and `test_both_portal_row_creation_sites_name_the_chat` fail on `dev` today — `backend-unit-test` is red there. Both are repaired in **#2427**.
