### PR TITLE
fix(agent): record WHERE a wedged reader thread is, instead of guessing again (#2455)

### DIFF
--- a/docker/base-image/agent_server/main.py
+++ b/docker/base-image/agent_server/main.py
@@ -33,6 +33,7 @@ from .auto_sync import schedule_auto_sync_if_enabled
 from .heartbeat import schedule_heartbeat
 from .services.result_callback import schedule_pending_result_resend
 from .services.orphan_sweeper import schedule_orphan_sweeper
+from .utils.thread_diagnostics import enable as _enable_thread_diagnostics
 from .services.pull_worker import (
     schedule_pull_workers,
     schedule_pending_pull_result_resend,
@@ -43,6 +44,12 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Create FastAPI application
+# #2455: arm the thread-stack dump BEFORE anything can wedge. Free until
+# used — a signal handler plus a function; no polling, no timer. Gives ops
+# `kill -USR1 <pid>` on a wedged container, and lets the stuck-reader
+# branches below dump automatically at the instant they notice.
+_enable_thread_diagnostics()
+
 app = FastAPI(
     title="Claude Agent API",
     description="Internal API for Claude Code agent (not exposed externally)",

--- a/docker/base-image/agent_server/services/subprocess_lifecycle.py
+++ b/docker/base-image/agent_server/services/subprocess_lifecycle.py
@@ -52,6 +52,8 @@ logger = logging.getLogger(__name__)
 # and die with the container.
 _DRAIN_BUDGET_SECONDS = 90
 
+from ..utils.thread_diagnostics import dump_all_threads as _dump_all_threads
+
 
 def _drain_bounded(
     process: subprocess.Popen,
@@ -126,6 +128,18 @@ def _drain_bounded(
             "deadlocked with reader thread's TextIOWrapper lock; reader threads are "
             "leaked daemon threads (pid=%s). Issue #728.",
             _DRAIN_BUDGET_SECONDS, process.pid,
+        )
+        # #2455: the EARLIEST moment we know something is wedged — dump here as
+        # well as in the post-kill branch, because the two are minutes apart and
+        # the thread can move between them. Note what this log line does NOT
+        # say and #2455 proves: the daemon thread running the drain is
+        # ABANDONED here, not stopped, so it keeps joining and eventually
+        # force-closes the pipes on its own schedule (observed: this budget
+        # expired at 90s and that thread logged its verdict at 603.7s). Both
+        # dumps are needed to see whether it is the same stack twice.
+        _dump_all_threads(
+            "drain budget exceeded — reader wedged, drain thread abandoned",
+            context=f"pid={process.pid} pgid={pgid} budget={_DRAIN_BUDGET_SECONDS}s",
         )
         # #1502: #728 unblocked the executor thread but LEFT THE PROCESS GROUP
         # ALIVE. The leaked reader is blocked reading a pipe a grandchild still

--- a/docker/base-image/agent_server/utils/subprocess_pgroup.py
+++ b/docker/base-image/agent_server/utils/subprocess_pgroup.py
@@ -47,6 +47,21 @@ except ImportError:  # pragma: no cover - exercised by unit tests
 
 logger = logging.getLogger(__name__)
 
+# #2455: imported at module SCOPE on purpose — a lazy import inside the stuck
+# branch would take the import lock while the process is already wedged, which
+# is the worst possible moment for it.
+#
+# Dual-path because this module is deliberately importable FLAT: its own test
+# adds `agent_server/utils` to `sys.path` and imports it by bare name (see the
+# comment at the top of `tests/unit/test_subprocess_pgroup.py`), and a bare
+# relative import breaks that with "attempted relative import with no known
+# parent package". Both arms resolve at import time, so the no-lazy-import
+# property above is preserved either way.
+try:  # package import (production)
+    from .thread_diagnostics import dump_all_threads as _dump_all_threads
+except ImportError:  # flat import (that module's own test harness)
+    from thread_diagnostics import dump_all_threads as _dump_all_threads
+
 
 # Informational env tag set on every Claude Popen (#817). The cleanup
 # path used to look for this tag in /proc/<pid>/environ as its third
@@ -306,6 +321,21 @@ async def drain_reader_threads(
             "grace — force-closing pipes; some buffered data may be lost "
             "(pid=%s, stuck_count=%s)",
             elapsed, process.pid, len(still_stuck),
+        )
+        # #2455: capture WHERE, before force-closing pipes changes the picture.
+        # Three fixes in this family (#728 pipe block, #1502 grandchild holder,
+        # #1661 sanitizer regex) each assumed a location and each was followed
+        # by a recurrence in a new shape; the #2455 occurrence had the reader
+        # in state R at 93.8% CPU 603.7s after SIGKILL, which fits none of
+        # them. This is the only moment the stack is guaranteed to be the
+        # wedged one, and it costs nothing until it fires.
+        _dump_all_threads(
+            "reader thread(s) still stuck after post-kill grace",
+            context=(
+                f"pid={process.pid} pgid={pgid} stuck_count={len(still_stuck)} "
+                f"elapsed={elapsed:.1f}s "
+                f"names={[t.name for t in still_stuck]}"
+            ),
         )
         safe_close_pipes(process)
 

--- a/docker/base-image/agent_server/utils/thread_diagnostics.py
+++ b/docker/base-image/agent_server/utils/thread_diagnostics.py
@@ -1,0 +1,129 @@
+"""Capture WHERE a stuck thread actually is, at the moment we notice (#2455).
+
+WHY THIS EXISTS. The #728 / #1502 / #1661 family all reason about a reader
+thread that will not return, and every mitigation so far has been built on an
+*assumption* about where it is stuck — blocked on a pipe (#728), holding a
+grandchild's write end open (#1502), inside a catastrophic sanitizer regex
+(#1661). Each assumption produced a real fix, and the failure kept coming back
+in a new shape, because nothing in the fleet ever recorded the thread's actual
+stack.
+
+The #2455 occurrence is the case that breaks the guessing: the reader was still
+stuck **603.7 s after the process group was SIGKILLed**, and `top -bH` showed it
+in state **R at 93.8% CPU** — a thread blocked on a pipe consumes no CPU, so
+whatever it was doing, it was not the thing three previous fixes assumed. The
+issue asks for exactly this: *"worth capturing where the thread actually is
+(py-spy / faulthandler on a live occurrence) rather than assuming
+blocked-on-pipe."*
+
+WHY NOT py-spy. It needs installing into a running production container, root
+or `SYS_PTRACE` (agents run non-root with `CAP_DROP: ALL`, Invariant #17), and a
+human present *while the wedge is live*. The wedge is rare, is noticed hours
+later, and self-clears on the container restart that ops reach for. `faulthandler`
+is in the standard library, needs no privileges, and can fire the instant the
+code itself concludes a thread is stuck — which is the only moment guaranteed to
+be during the event.
+
+WHAT IT COSTS WHEN NOTHING IS WRONG. Nothing. `dump_all_threads` is called only
+from the already-exceptional stuck/leaked branches, and `enable()` installs
+signal handlers that fire on request or on a fatal signal. There is no polling,
+no timer, and no per-line work.
+
+SAFETY. Output goes to the agent log via `logger`, never to a file the agent
+could read back and echo. Tracebacks name modules, functions and line numbers —
+never values — so this cannot surface a credential the way an argument dump
+would.
+"""
+from __future__ import annotations
+
+import faulthandler
+import logging
+import signal
+import sys
+import threading
+import traceback
+
+logger = logging.getLogger(__name__)
+
+# Bound the emitted text. A wedged process can hold dozens of threads and the
+# agent log is shipped to Vector; a dump is diagnostic, not an archive.
+MAX_DUMP_CHARS = 60_000
+
+_enabled = False
+
+
+def enable() -> None:
+    """Arm faulthandler for this process. Idempotent, never raises.
+
+    Two capabilities, both zero-cost until used:
+
+    * a fatal-signal handler (SIGSEGV/SIGABRT/…) so a hard crash leaves a stack
+      rather than a bare exit code;
+    * ``SIGUSR1`` → dump every thread's stack to stderr, so an operator holding
+      a wedged container can get the answer with ``kill -USR1 1`` and no extra
+      tooling, no privileges and no restart.
+
+    SIGUSR1 is chosen because nothing in the agent image uses it (SIGTERM/SIGINT
+    are the shutdown path, SIGUSR2 is left free) and because it is deliverable
+    from `docker kill --signal`.
+    """
+    global _enabled
+    if _enabled:
+        return
+    try:
+        faulthandler.enable(file=sys.stderr, all_threads=True)
+        if hasattr(faulthandler, "register") and hasattr(signal, "SIGUSR1"):
+            # chain=False: we are the only SIGUSR1 handler, and chaining to a
+            # default that terminates the process would turn a diagnostic into
+            # an outage.
+            faulthandler.register(
+                signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False,
+            )
+        _enabled = True
+        logger.info(
+            "[Diagnostics] faulthandler armed — `kill -USR1 <pid>` dumps every "
+            "thread's stack to the container log (#2455)"
+        )
+    except Exception as e:  # noqa: BLE001 — diagnostics must never break boot
+        logger.warning("[Diagnostics] could not arm faulthandler: %s", e)
+
+
+def dump_all_threads(reason: str, *, context: str = "") -> str:
+    """Log every thread's stack, and return what was logged.
+
+    Uses ``sys._current_frames()`` rather than ``faulthandler.dump_traceback``
+    because faulthandler writes to a real file DESCRIPTOR — it rejects an
+    in-memory buffer with ``fileno`` — and the whole point here is to get the
+    stacks into the agent's own structured log, which Vector already ships, not
+    onto a raw stderr line nobody correlates with the execution. faulthandler
+    keeps the jobs it is actually good at: the fatal-signal handler and the
+    ``SIGUSR1`` on-demand dump in :func:`enable`, both of which target stderr.
+
+    Returns the text (rather than None) so a caller can attach it to a result
+    envelope, or a test can assert on it without parsing the log.
+
+    Never raises: this runs on the teardown path of an execution that has
+    already gone wrong, and a diagnostic that can break that path is worse than
+    no diagnostic.
+    """
+    try:
+        frames = sys._current_frames()          # CPython; the agent runs CPython
+        by_ident = {t.ident: t for t in threading.enumerate()}
+        chunks = []
+        for ident, frame in frames.items():
+            t = by_ident.get(ident)
+            name = t.name if t is not None else "<unknown>"
+            daemon = t.daemon if t is not None else "?"
+            stack = "".join(traceback.format_stack(frame))
+            chunks.append(f"--- thread {name} (ident={ident}, daemon={daemon})\n{stack}")
+        text = "\n".join(chunks)
+        if len(text) > MAX_DUMP_CHARS:
+            text = text[:MAX_DUMP_CHARS] + f"\n… truncated at {MAX_DUMP_CHARS} chars"
+        logger.error(
+            "[Diagnostics] THREAD DUMP — %s%s | %d thread(s)\n%s",
+            reason, f" | {context}" if context else "", len(frames), text,
+        )
+        return text
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[Diagnostics] thread dump failed (%s): %s", reason, e)
+        return ""

--- a/tests/unit/test_2455_stuck_reader_diagnostics.py
+++ b/tests/unit/test_2455_stuck_reader_diagnostics.py
@@ -1,0 +1,222 @@
+"""#2455 — when a reader thread wedges, record WHERE it is.
+
+The #728 / #1502 / #1661 family has produced three fixes, each built on an
+assumption about the stuck thread's location, each followed by a recurrence in
+a new shape. The #2455 occurrence fits none of them: the reader was still stuck
+**603.7s after the process group was SIGKILLed**, in state `R` at 93.8% CPU —
+and a thread blocked on a pipe consumes no CPU.
+
+So this ships the measurement rather than a fourth guess. These tests pin the
+three properties that make it trustworthy on a production box:
+
+  1. it fires from the branches that CONCLUDE a thread is stuck, automatically;
+  2. it names the stuck thread and shows the frame it is parked in;
+  3. it cannot make the incident worse — never raises, bounded output.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_BASE = Path(__file__).resolve().parents[2] / "docker" / "base-image"
+if str(_BASE) not in sys.path:
+    sys.path.insert(0, str(_BASE))
+
+from agent_server.utils import thread_diagnostics as td  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# It answers the question the issue asks
+# --------------------------------------------------------------------------- #
+
+def test_the_dump_names_the_stuck_thread_and_shows_where_it_is():
+    """The whole deliverable. `stuck_count=1` told us a thread was stuck and
+    nothing else; three fixes were then written against guesses about which
+    line it sat on."""
+    release = threading.Event()
+
+    def parked():
+        release.wait(30)
+
+    t = threading.Thread(target=parked, name="reader-stdout-probe", daemon=True)
+    t.start()
+    try:
+        time.sleep(0.15)
+        text = td.dump_all_threads("probe", context="pid=4392 stuck_count=1")
+    finally:
+        release.set()
+        t.join(5)
+
+    assert "reader-stdout-probe" in text, "the dump must name the stuck thread"
+    assert "in parked" in text, "the dump must show the frame it is parked in"
+    assert "daemon=True" in text, "leaked readers are daemon threads — say so"
+
+
+def test_the_dump_is_bounded():
+    """A wedged process can hold dozens of threads and this log is shipped to
+    Vector. Diagnostic, not archive."""
+    assert td.MAX_DUMP_CHARS <= 100_000
+    text = td.dump_all_threads("bound check")
+    assert len(text) <= td.MAX_DUMP_CHARS + 64
+
+
+def test_the_dump_never_raises_into_the_teardown_path():
+    """It runs on the teardown of an execution that has ALREADY gone wrong. A
+    diagnostic that can break that path is worse than no diagnostic."""
+    broken = lambda: (_ for _ in ()).throw(RuntimeError("frames unavailable"))
+    original = sys._current_frames
+    sys._current_frames = broken            # type: ignore[assignment]
+    try:
+        assert td.dump_all_threads("forced failure") == ""
+    finally:
+        sys._current_frames = original      # type: ignore[assignment]
+
+
+def test_enable_is_idempotent_and_never_raises():
+    td.enable()
+    td.enable()          # second call must be a no-op, not a double handler
+    assert td._enabled is True
+
+
+# --------------------------------------------------------------------------- #
+# It is wired to the moments that matter — asserted against real source
+# --------------------------------------------------------------------------- #
+
+def _src(rel: str) -> str:
+    return (_BASE / "agent_server" / rel).read_text()
+
+
+def test_it_fires_from_the_post_kill_stuck_branch():
+    """The branch that force-closes pipes and accepts data loss. Dumping BEFORE
+    that call is the point — after it, the stack is no longer the wedged one."""
+    src = _src("utils/subprocess_pgroup.py")
+    stuck_log = src.index("still stuck after %.1fs post-kill")
+    dump = src.index("_dump_all_threads(", stuck_log)
+    close = src.index("safe_close_pipes(process)", stuck_log)
+    assert dump < close, "dump must run before the pipes are force-closed"
+
+
+def test_it_fires_from_the_budget_exceeded_branch_too():
+    """The EARLIEST moment we know a reader is wedged. The two branches are
+    minutes apart in the #2455 timeline (90s vs 603.7s), so one dump cannot
+    tell you whether the thread moved."""
+    src = _src("services/subprocess_lifecycle.py")
+    budget_log = src.index("Drain budget (%ds) exceeded")
+    assert "_dump_all_threads(" in src[budget_log:budget_log + 1500]
+
+
+def test_the_import_is_module_scope_not_inside_the_wedged_branch():
+    """A lazy import would run while the process is already wedged — the worst
+    moment to take the import lock."""
+    for rel in ("utils/subprocess_pgroup.py", "services/subprocess_lifecycle.py"):
+        src = _src(rel)
+        imp = src.index("import dump_all_threads as _dump_all_threads")
+        first_use = src.index("_dump_all_threads(")
+        assert imp < first_use, f"{rel}: import must precede the call site"
+
+
+def test_the_agent_server_arms_it_at_startup():
+    """`kill -USR1 <pid>` has to work on a container that is ALREADY wedged, so
+    the handler must be installed before anything can wedge — not lazily."""
+    src = _src("main.py")
+    assert "_enable_thread_diagnostics()" in src
+    assert src.index("_enable_thread_diagnostics()") < src.index("app = FastAPI(")
+
+
+def test_sigusr1_is_registered_without_chaining():
+    """Chaining to SIGUSR1's default disposition TERMINATES the process — that
+    would turn an operator's diagnostic into an outage on a live agent."""
+    src = _src("utils/thread_diagnostics.py")
+    assert "signal.SIGUSR1" in src
+    assert "chain=False" in src
+
+
+def test_the_dump_reports_module_and_line_never_values():
+    """Tracebacks carry frames, not locals. This runs on agent output that has
+    held credentials before (canary G-04), so the distinction is load-bearing —
+    an argument dump here would be a new leak surface."""
+    src = _src("utils/thread_diagnostics.py")
+    assert "format_stack" in src
+    for leaky in ("f_locals", "format_exception", "repr(frame"):
+        assert leaky not in src, f"{leaky} would put VALUES in the log"
+
+
+# --------------------------------------------------------------------------- #
+# End to end through the REAL drain, with a genuinely stuck reader
+# --------------------------------------------------------------------------- #
+
+def test_the_real_drain_dumps_a_genuinely_stuck_reader(caplog, monkeypatch):
+    """Drives `drain_reader_threads` itself rather than asserting on its source.
+
+    A source scan proves the call is written; only this proves it FIRES, that
+    the dump reaches the log, and that it names the thread an operator would
+    otherwise only know as `stuck_count=1`.
+    """
+    import asyncio
+    import logging
+    from agent_server.utils import subprocess_pgroup as sp
+
+    release = threading.Event()
+
+    def wedged():
+        release.wait(30)
+
+    stuck = threading.Thread(target=wedged, name="reader-wedged-probe", daemon=True)
+    stuck.start()
+
+    class _FakeProc:
+        pid = 4392
+        stdout = None
+        stderr = None
+        def poll(self): return 0
+
+    # Neither the kill nor the cgroup sweep is under test here, and both would
+    # reach for real processes.
+    monkeypatch.setattr(sp, "terminate_process_group", lambda *a, **k: None)
+    monkeypatch.setattr(sp, "safe_close_pipes", lambda *a, **k: None)
+    monkeypatch.setattr(sp, "kill_cgroup_orphans", lambda *a, **k: 0, raising=False)
+
+    try:
+        with caplog.at_level(logging.ERROR):
+            asyncio.run(sp.drain_reader_threads(
+                _FakeProc(), stuck, grace=1, post_kill_grace=1, pgid=4392,
+            ))
+    finally:
+        release.set()
+        stuck.join(5)
+
+    dumps = [r.getMessage() for r in caplog.records if "THREAD DUMP" in r.getMessage()]
+    assert dumps, "the stuck branch ran but no thread dump reached the log"
+    body = "\n".join(dumps)
+    assert "reader-wedged-probe" in body, "the dump must name the wedged reader"
+    assert "in wedged" in body, "the dump must show the frame it is parked in"
+    assert "stuck_count=1" in body, "carry the same identifier the old log gave"
+
+
+def test_subprocess_pgroup_stays_flat_importable():
+    """Regression on my own change (#2455).
+
+    `subprocess_pgroup.py` is deliberately importable FLAT — its own test adds
+    `agent_server/utils` to `sys.path` and imports it by bare name. A plain
+    relative import for the diagnostics helper broke that whole module with
+    "attempted relative import with no known parent package", taking 14 tests
+    with it. The dual-path import keeps both callers working; this pins it so
+    the fallback is not "tidied" away.
+    """
+    import importlib.util
+
+    utils_dir = _BASE / "agent_server" / "utils"
+    if str(utils_dir) not in sys.path:
+        sys.path.insert(0, str(utils_dir))
+    spec = importlib.util.spec_from_file_location(
+        "subprocess_pgroup_flat", utils_dir / "subprocess_pgroup.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)          # must not raise
+    assert hasattr(mod, "_dump_all_threads")


### PR DESCRIPTION
Related to #2455 — **diagnosis first; this does not claim to fix the wedge.**

## Why not a fix

#2455 is the fourth occurrence in the #728 / #1502 / #1661 family. Each earlier one produced a real fix built on an *assumption* about where the reader was stuck — blocked on a pipe (#728), a grandchild holding the write end (#1502), a catastrophic sanitizer regex (#1661) — and each was followed by a recurrence in a new shape. Nothing in the fleet has ever recorded the thread's actual stack.

The evidence in this issue fits none of the three: the reader was still stuck **603.7s after the process group was SIGKILLed**, in state **R at 93.8% CPU**. A thread blocked on a pipe consumes no CPU. Writing a fourth guess seemed like the wrong move.

## What I ruled out, with measurements, so nobody redoes it

**Not the sanitizer (#1661 class).** `sanitize_text` is linear — measured at 2k / 8k / 32k / 128k chars across three adversarial shapes:

| input | prose w/ spaces | one long token | long alnum run |
|---|---|---|---|
| 2,000 | 0.39 ms | 0.07 ms | 0.06 ms |
| 8,000 | 0.27 ms | 0.22 ms | 0.21 ms |
| 32,000 | 1.05 ms | 0.88 ms | 0.87 ms |
| 128,000 | 3.84 ms | 3.38 ms | 3.50 ms |

4× input → 4× time throughout. A 796 KB transcript does not wedge here.

**Not asyncio deadlines failing under GIL pressure.** I suspected the spinning thread starved the loop so `wait_for` could not fire — which would neatly explain a 30s grace resolving at 603.7s. Measured: with two Python threads spinning, `wait_for(timeout=1.0)` still returns at **1.01s**. CPython's switch interval lets the loop run. Hypothesis dead.

## What does explain the 603.7s

`_drain_bounded` **abandons** its daemon thread rather than stopping it:

```python
threading.Thread(target=_target, daemon=True).start()
if not done.wait(timeout=_DRAIN_BUDGET_SECONDS):     # 90s
    ... log "budget exceeded" ...; ... SIGKILL the group (#1502) ...
    return "budget_exceeded"                          # <- the thread keeps running
```

So the log order in the issue is exactly right: at 90s the caller gives up and kills the group, and the abandoned thread *then* logs its own "waiting 30s for natural drain" and force-closes the pipes at 603.7s. Two teardown paths operate on the same process and pipes, minutes apart.

Recorded in a code comment, **not changed here** — reordering teardown without knowing where the thread is stuck is how this family got four issues deep.

## What ships

`agent_server/utils/thread_diagnostics.py`:

- **`enable()`** — arms faulthandler at startup: fatal-signal handler, plus **`SIGUSR1`** so ops can `kill -USR1 <pid>` on a wedged container with no tooling, no privileges and no restart. (py-spy needs installing into production, `SYS_PTRACE` against `CAP_DROP: ALL`, and a human present *while the wedge is live*.)
- **`dump_all_threads()`** — logs every thread's name, daemon flag and current frame.

It fires **automatically from both moments the code concludes a thread is stuck**: the budget-exceeded branch (earliest signal) and the post-kill stuck branch (*before* `safe_close_pipes` — after it, the stack is no longer the wedged one). Those are minutes apart in this timeline, so one dump cannot show whether the thread moved.

Deliberate choices, each for a reason:
- `sys._current_frames()` for the in-log dump — faulthandler needs a real file *descriptor* and rejects a buffer, and these stacks belong in the structured log Vector already ships, not on an uncorrelated stderr line.
- `chain=False` on SIGUSR1 — chaining to its default disposition **terminates the process**; that would turn an operator's diagnostic into an outage.
- Frames only, never `f_locals` — this runs on agent output that has held credentials before (canary G-04); an argument dump would be a new leak surface.
- Zero cost when nothing is wrong: no polling, no timer, no per-line work.

## A regression I introduced and fixed

`subprocess_pgroup.py` is deliberately importable **flat** — its own test adds `agent_server/utils` to `sys.path` and imports it by bare name. My plain relative import broke that module entirely (`attempted relative import with no known parent package`, 14 tests down). Now a dual-path import, both arms resolving at import time so the no-lazy-import property holds, pinned by `test_subprocess_pgroup_stays_flat_importable`.

## Verification

12 tests, including one that drives the **real** `drain_reader_threads` with a genuinely stuck thread and asserts the dump reaches the log naming it — **verified to fail when the dump call is removed**. Wider suite (`subprocess / pgroup / drain / headless / agent_server / 2433 / 1502 / 1661 / parity`): **784 passed, 2 skipped**.

## What this needs next

A base-image rebuild to reach agents. On the next occurrence the log will carry the stuck thread's frame, and that should end the guessing.

Two adjacent defects I found while reading and did **not** touch here, since they are not the wedge and this PR should stay diagnostic:

1. `publish_log_entry` calls `asyncio.Queue.put_nowait` from a reader thread — `asyncio.Queue` is not thread-safe.
2. Past 1000 entries, every published line copies the whole buffer (`buffer[-max:]`) while holding the registry lock.

Happy to file both if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eKBPKUFH7wNip9bjNLpc3
