### PR TITLE
refactor(execution): carve the pure response-readers out of the dispatch hot path (#2314)

### DIFF
--- a/src/backend/services/execution_classification.py
+++ b/src/backend/services/execution_classification.py
@@ -1,0 +1,214 @@
+"""Reading an agent's response: what did that execution actually mean? (#2314)
+
+Carved out of ``task_execution_service`` — the #2 code-health hotspot (2,305
+lines, CC 214) and the only top-3 one with no covering refactor issue until
+#2314.
+
+WHY THIS SEAM FIRST. The issue is explicit that a big-bang split mid-#1081 is
+the wrong shape, so this is the carve that migration cannot collide with: every
+function here is a PURE reader of an agent's HTTP response or of an execution's
+own numbers. Nothing here touches the DB, the capacity manager, the breakers,
+Redis, or the dispatch path #1081 is rewriting. A dependency analysis over the
+original module confirmed the whole group needs only ``typing``, ``httpx`` and
+the two constants below — no import back into the service, so the module is a
+LEAF and the circular-import count the dashboard reports stays at 0.
+
+WHAT LIVES HERE. One question, asked six ways:
+
+* ``_compute_context_used``      — how full was the context window
+* ``_is_reader_race_signature``  — is this "success with nothing to show" the
+                                   #678 stdout reader race, and therefore worth
+                                   one silent retry
+* ``detect_unresolved_slash_command`` — did the agent answer by quoting a slash
+                                   command back at us (#1410)
+* ``_extract_agent_error``       — what did a 502/504 body really say, and what
+                                   telemetry can be salvaged from it (#1853)
+* ``classify_switch_failure``    — is this failure the subscription's fault
+                                   (SUB-003 / #792)
+* ``_salvage_attempt_cost``      — what did the attempt cost before it failed
+
+NOT MOVED, deliberately: ``_alert_skill_not_found`` reads like a sibling of
+``detect_unresolved_slash_command`` but writes to the operator queue through the
+#1677 bounded-alert path. It is an EFFECT, not a classification, and pulling it
+here would import the queue into a leaf module and make this the seventh thing
+in a module whose value is that it is one thing.
+
+IMPORT COMPATIBILITY. ``task_execution_service`` re-exports every name below, so
+existing importers — ``chat_execution_service`` and six test modules — keep
+working unchanged. That is what makes this a pure refactor: no call site moved,
+no behaviour touched.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+import httpx
+
+def _compute_context_used(metadata: dict) -> Optional[int]:
+    """Derive context-window pressure (tokens used) from an
+    ``ExecutionMetadata.model_dump()`` dict.
+
+    Mirrors the success-path logic at the original call site: cache_read
+    + cache_creation is the stable signal (monotonic across a resumed
+    session), fall back to input_tokens when caching isn't engaged.
+    Returns None when no token signal is present.
+
+    Shared between the success path and the #678 HTTPError salvage so
+    both compute context_used the same way.
+    """
+    if not metadata:
+        return None
+    cache_read = metadata.get("cache_read_tokens") or 0
+    cache_create = metadata.get("cache_creation_tokens") or 0
+    if cache_read + cache_create > 0:
+        return cache_read + cache_create
+    input_tokens = metadata.get("input_tokens") or 0
+    return input_tokens if input_tokens > 0 else None
+
+
+# Conservative gating: only retry when the original turn was cheap and
+# the agent-server's classifier marked it as a reader-race (not a real
+# claude failure). num_turns < 5 keeps a 24-min execution like the
+# original #678 from being silently re-burned.
+_AUTO_RETRY_MAX_TURNS = 5
+
+
+def _is_reader_race_signature(detail) -> bool:
+    """True when a 502 detail body matches the stdout reader-race
+    signature and the original turn was cheap enough to retry.
+
+    The structured body comes from
+    ``error_classifier._classify_empty_result`` (Issue #678):
+
+        {
+            "message": "Execution completed without a result message ...",
+            "metadata": {...},
+            "raw_message_count": N,
+            "parse_failure_count": N,
+            "recovery_attempted": True,
+        }
+
+    Gating: raw_message_count == 0 (reader thread emitted nothing —
+    distinct from a partial stream), num_turns < 5 (cheap to retry),
+    parse_failure_count == 0 (no wire corruption).
+    """
+    if not isinstance(detail, dict):
+        return False
+    if not detail.get("recovery_attempted"):
+        return False
+    if detail.get("raw_message_count", 0) != 0:
+        return False
+    if detail.get("parse_failure_count", 0) != 0:
+        return False
+    meta = detail.get("metadata") or {}
+    num_turns = meta.get("num_turns") or 0
+    if num_turns >= _AUTO_RETRY_MAX_TURNS:
+        return False
+    msg = (detail.get("message") or "").lower()
+    return "result message" in msg
+
+
+# The agent runtime (Claude Code) answers a slash-command that doesn't resolve
+# to an installed skill with a normal, successful assistant turn — e.g.
+# "Unknown command: /generate". Anchored at the start of the (stripped)
+# response so an agent that merely mentions the phrase mid-prose is never
+# matched.
+_UNRESOLVED_COMMAND_RE = re.compile(
+    r"^\s*unknown (?:slash )?command:\s*(/\S+)", re.IGNORECASE
+)
+
+
+def detect_unresolved_slash_command(
+    message: Optional[str], response: Optional[str]
+) -> Optional[str]:
+    """Return the offending command when *message* was a slash-command
+    invocation and *response* is the runtime's unresolved-command reply (#1410).
+
+    A scheduled/triggered ``/foo`` whose skill is absent from the container
+    comes back as a successful $0 turn ("Unknown command: /foo"), so the
+    execution would otherwise record as SUCCESS and blend into legitimate
+    skipped/$0 runs — masking a dead agent function indefinitely. Detection is
+    gated on the SENT message being a slash-command so a normal turn that
+    happens to echo the phrase is never misclassified. Returns ``None`` when it
+    is not this specific shape.
+    """
+    if not message or not response:
+        return None
+    if not message.lstrip().startswith("/"):
+        return None
+    match = _UNRESOLVED_COMMAND_RE.match(response)
+    return match.group(1) if match else None
+
+
+def _extract_agent_error(
+    response: Optional[httpx.Response], fallback: str
+) -> tuple[str, dict, Any]:
+    """Pull a human error string, any #678 structured ``metadata``, and the
+    #1853 ``execution_log`` transcript from an agent error-response body. Shared
+    by the pre-raise switch path (#792) and the ``except httpx.HTTPError``
+    handler so both read the body identically.
+
+    ``execution_log`` is the raw stream-json transcript list the agent's
+    structured 502/504 body now carries (``_execution_error_502_detail`` /
+    ``_timeout_504_detail``); ``None`` for a bare-string body (old image) — the
+    graceful mixed-fleet degrade."""
+    error_msg = fallback
+    partial_metadata: dict = {}
+    execution_log: Any = None
+    if response is None:
+        return error_msg, partial_metadata, execution_log
+    try:
+        error_data = response.json()
+        detail = error_data.get("detail")
+        if isinstance(detail, dict):
+            # #678 structured body
+            error_msg = detail.get("message") or str(detail)
+            if isinstance(detail.get("metadata"), dict):
+                partial_metadata = detail["metadata"]
+            # #1853: the full stream-json transcript, salvaged onto the FAILED row.
+            execution_log = detail.get("execution_log")
+        elif "detail" in error_data:
+            error_msg = error_data["detail"]
+    except Exception:
+        if response.text:
+            error_msg = response.text[:500]
+    return error_msg, partial_metadata, execution_log
+
+
+def classify_switch_failure(response: httpx.Response) -> Optional[str]:
+    """Map an agent response to a SUB-003 switch ``failure_kind``, or None.
+
+    Mirrors the trigger surface SUB-003 uses in the ``except httpx.HTTPError``
+    handler so the #792 contract — "any switch-success retries" — is actually
+    true (not just 429/503 by status code):
+
+        429                          -> "rate_limit"
+        503 / 401 / 403 / 402        -> "auth"
+        other 4xx/5xx whose body trips ``is_auth_failure`` -> "auth"
+        anything else (incl. 2xx)    -> None
+    """
+    # Imported here (not at module scope) to match the except-handler import and
+    # keep the test patch target `subscription_auto_switch.is_auth_failure` live.
+    from services.subscription_auto_switch import is_auth_failure
+
+    code = response.status_code
+    if code == 429:
+        return "rate_limit"
+    if code in (503, 401, 403, 402):
+        return "auth"
+    if code >= 400:
+        error_msg, _, _ = _extract_agent_error(response, "")
+        if is_auth_failure(error_msg):
+            return "auth"
+    return None
+
+
+def _salvage_attempt_cost(partial_metadata: dict) -> float:
+    """Best-effort first-attempt cost from a salvaged ``metadata`` dict, for the
+    #678 R2 ``previous_attempt_cost`` rollup. A mid-run 429/auth can carry
+    nonzero cost — "≈$0" is not a contract (#792 review, Codex #3)."""
+    raw = partial_metadata.get("cost_usd")
+    if isinstance(raw, (int, float)) and raw > 0:
+        return float(raw)
+    return 0.0

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -83,6 +83,23 @@ def _resolve_agent_runtime(agent_name: str) -> str:
 
 logger = logging.getLogger(__name__)
 
+# #2314: these six pure response-readers and their two constants now live in
+# `execution_classification`. Re-exported HERE, not left as an import the
+# callers must chase, because `chat_execution_service` and six test modules
+# import them from this module today and a pure refactor must not move a single
+# call site. The `# noqa: F401` is load-bearing: the linter cannot see that the
+# public surface IS the point.
+from .execution_classification import (  # noqa: F401
+    _AUTO_RETRY_MAX_TURNS,
+    _UNRESOLVED_COMMAND_RE,
+    _compute_context_used,
+    _extract_agent_error,
+    _is_reader_race_signature,
+    _salvage_attempt_cost,
+    classify_switch_failure,
+    detect_unresolved_slash_command,
+)
+
 
 # ---------------------------------------------------------------------------
 # Result dataclass
@@ -179,37 +196,12 @@ class TerminalEnvelope:
 # ---------------------------------------------------------------------------
 
 
-def _compute_context_used(metadata: dict) -> Optional[int]:
-    """Derive context-window pressure (tokens used) from an
-    ``ExecutionMetadata.model_dump()`` dict.
-
-    Mirrors the success-path logic at the original call site: cache_read
-    + cache_creation is the stable signal (monotonic across a resumed
-    session), fall back to input_tokens when caching isn't engaged.
-    Returns None when no token signal is present.
-
-    Shared between the success path and the #678 HTTPError salvage so
-    both compute context_used the same way.
-    """
-    if not metadata:
-        return None
-    cache_read = metadata.get("cache_read_tokens") or 0
-    cache_create = metadata.get("cache_creation_tokens") or 0
-    if cache_read + cache_create > 0:
-        return cache_read + cache_create
-    input_tokens = metadata.get("input_tokens") or 0
-    return input_tokens if input_tokens > 0 else None
 
 
 # ---------------------------------------------------------------------------
 # Reader-race signature (Issue #678 auto-retry)
 # ---------------------------------------------------------------------------
 
-# Conservative gating: only retry when the original turn was cheap and
-# the agent-server's classifier marked it as a reader-race (not a real
-# claude failure). num_turns < 5 keeps a 24-min execution like the
-# original #678 from being silently re-burned.
-_AUTO_RETRY_MAX_TURNS = 5
 
 # The retry must not silently double the operator's timeout budget. Reader
 # races fire fast; 5 min is plenty. We pass `min(effective_timeout, this)`
@@ -218,39 +210,6 @@ _AUTO_RETRY_MAX_TURNS = 5
 _AUTO_RETRY_MAX_TIMEOUT_S = 300.0
 
 
-def _is_reader_race_signature(detail) -> bool:
-    """True when a 502 detail body matches the stdout reader-race
-    signature and the original turn was cheap enough to retry.
-
-    The structured body comes from
-    ``error_classifier._classify_empty_result`` (Issue #678):
-
-        {
-            "message": "Execution completed without a result message ...",
-            "metadata": {...},
-            "raw_message_count": N,
-            "parse_failure_count": N,
-            "recovery_attempted": True,
-        }
-
-    Gating: raw_message_count == 0 (reader thread emitted nothing —
-    distinct from a partial stream), num_turns < 5 (cheap to retry),
-    parse_failure_count == 0 (no wire corruption).
-    """
-    if not isinstance(detail, dict):
-        return False
-    if not detail.get("recovery_attempted"):
-        return False
-    if detail.get("raw_message_count", 0) != 0:
-        return False
-    if detail.get("parse_failure_count", 0) != 0:
-        return False
-    meta = detail.get("metadata") or {}
-    num_turns = meta.get("num_turns") or 0
-    if num_turns >= _AUTO_RETRY_MAX_TURNS:
-        return False
-    msg = (detail.get("message") or "").lower()
-    return "result message" in msg
 
 
 # ---------------------------------------------------------------------------
@@ -285,14 +244,6 @@ _AUTONOMOUS_TRIGGERS = frozenset(
      "a2a", "operator_response"}
 )
 
-# The agent runtime (Claude Code) answers a slash-command that doesn't resolve
-# to an installed skill with a normal, successful assistant turn — e.g.
-# "Unknown command: /generate". Anchored at the start of the (stripped)
-# response so an agent that merely mentions the phrase mid-prose is never
-# matched.
-_UNRESOLVED_COMMAND_RE = re.compile(
-    r"^\s*unknown (?:slash )?command:\s*(/\S+)", re.IGNORECASE
-)
 
 # #1677: the offending command is agent-RESPONSE-derived (`/\S+` — unbounded)
 # and is echoed into durable operator state (queue item + notification).
@@ -301,26 +252,6 @@ _UNRESOLVED_COMMAND_RE = re.compile(
 _COMMAND_DISPLAY_MAX = 200
 
 
-def detect_unresolved_slash_command(
-    message: Optional[str], response: Optional[str]
-) -> Optional[str]:
-    """Return the offending command when *message* was a slash-command
-    invocation and *response* is the runtime's unresolved-command reply (#1410).
-
-    A scheduled/triggered ``/foo`` whose skill is absent from the container
-    comes back as a successful $0 turn ("Unknown command: /foo"), so the
-    execution would otherwise record as SUCCESS and blend into legitimate
-    skipped/$0 runs — masking a dead agent function indefinitely. Detection is
-    gated on the SENT message being a slash-command so a normal turn that
-    happens to echo the phrase is never misclassified. Returns ``None`` when it
-    is not this specific shape.
-    """
-    if not message or not response:
-        return None
-    if not message.lstrip().startswith("/"):
-        return None
-    match = _UNRESOLVED_COMMAND_RE.match(response)
-    return match.group(1) if match else None
 
 
 async def _alert_skill_not_found(
@@ -442,77 +373,10 @@ async def _alert_skill_not_found(
 _SWITCH_RETRY_DELAY_S = 3.0
 
 
-def _extract_agent_error(
-    response: Optional[httpx.Response], fallback: str
-) -> tuple[str, dict, Any]:
-    """Pull a human error string, any #678 structured ``metadata``, and the
-    #1853 ``execution_log`` transcript from an agent error-response body. Shared
-    by the pre-raise switch path (#792) and the ``except httpx.HTTPError``
-    handler so both read the body identically.
-
-    ``execution_log`` is the raw stream-json transcript list the agent's
-    structured 502/504 body now carries (``_execution_error_502_detail`` /
-    ``_timeout_504_detail``); ``None`` for a bare-string body (old image) — the
-    graceful mixed-fleet degrade."""
-    error_msg = fallback
-    partial_metadata: dict = {}
-    execution_log: Any = None
-    if response is None:
-        return error_msg, partial_metadata, execution_log
-    try:
-        error_data = response.json()
-        detail = error_data.get("detail")
-        if isinstance(detail, dict):
-            # #678 structured body
-            error_msg = detail.get("message") or str(detail)
-            if isinstance(detail.get("metadata"), dict):
-                partial_metadata = detail["metadata"]
-            # #1853: the full stream-json transcript, salvaged onto the FAILED row.
-            execution_log = detail.get("execution_log")
-        elif "detail" in error_data:
-            error_msg = error_data["detail"]
-    except Exception:
-        if response.text:
-            error_msg = response.text[:500]
-    return error_msg, partial_metadata, execution_log
 
 
-def classify_switch_failure(response: httpx.Response) -> Optional[str]:
-    """Map an agent response to a SUB-003 switch ``failure_kind``, or None.
-
-    Mirrors the trigger surface SUB-003 uses in the ``except httpx.HTTPError``
-    handler so the #792 contract — "any switch-success retries" — is actually
-    true (not just 429/503 by status code):
-
-        429                          -> "rate_limit"
-        503 / 401 / 403 / 402        -> "auth"
-        other 4xx/5xx whose body trips ``is_auth_failure`` -> "auth"
-        anything else (incl. 2xx)    -> None
-    """
-    # Imported here (not at module scope) to match the except-handler import and
-    # keep the test patch target `subscription_auto_switch.is_auth_failure` live.
-    from services.subscription_auto_switch import is_auth_failure
-
-    code = response.status_code
-    if code == 429:
-        return "rate_limit"
-    if code in (503, 401, 403, 402):
-        return "auth"
-    if code >= 400:
-        error_msg, _, _ = _extract_agent_error(response, "")
-        if is_auth_failure(error_msg):
-            return "auth"
-    return None
 
 
-def _salvage_attempt_cost(partial_metadata: dict) -> float:
-    """Best-effort first-attempt cost from a salvaged ``metadata`` dict, for the
-    #678 R2 ``previous_attempt_cost`` rollup. A mid-run 429/auth can carry
-    nonzero cost — "≈$0" is not a contract (#792 review, Codex #3)."""
-    raw = partial_metadata.get("cost_usd")
-    if isinstance(raw, (int, float)) and raw > 0:
-        return float(raw)
-    return 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_2314_execution_classification_extraction.py
+++ b/tests/unit/test_2314_execution_classification_extraction.py
@@ -1,0 +1,186 @@
+"""#2314 — the first carve out of `task_execution_service`, pinned.
+
+`task_execution_service.py` is the #2 code-health hotspot and the only top-3 one
+that had no covering refactor issue. The issue is explicit that a big-bang split
+mid-#1081 is the wrong shape, so this is carve 1 of N: the six PURE readers of
+an agent's response, plus the two constants they own.
+
+These tests pin the three properties that make it a REFACTOR rather than a
+rewrite — and one of them is here because the sibling extraction in #1028
+shipped broken while three separate verifications said it was fine.
+"""
+from __future__ import annotations
+
+import ast
+import builtins
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SVC = _ROOT / "src" / "backend" / "services" / "task_execution_service.py"
+_NEW = _ROOT / "src" / "backend" / "services" / "execution_classification.py"
+
+MOVED = [
+    "_compute_context_used",
+    "_is_reader_race_signature",
+    "detect_unresolved_slash_command",
+    "_extract_agent_error",
+    "classify_switch_failure",
+    "_salvage_attempt_cost",
+]
+
+
+def _functions(src: str) -> dict[str, str]:
+    return {
+        n.name: ast.unparse(n)
+        for n in ast.parse(src).body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def test_every_moved_body_is_byte_identical_to_the_original():
+    """A refactor claim is only worth what proves it.
+
+    #1028 moved `lifespan`'s blocks 'verbatim', proved 518 == 518 identical
+    lines, and still shipped a branch where three phases raised `NameError` —
+    so 'I moved it carefully' is not evidence. This compares the parsed body of
+    every moved function against the same function on `origin/dev`.
+    """
+    old = subprocess.run(
+        ["git", "show", "origin/dev:src/backend/services/task_execution_service.py"],
+        capture_output=True, text=True, cwd=_ROOT,
+    ).stdout
+    if not old:
+        pytest.skip("origin/dev not available in this checkout")
+
+    before, after = _functions(old), _functions(_NEW.read_text())
+    for name in MOVED:
+        assert name in after, f"{name} did not arrive in the new module"
+        assert before[name] == after[name], f"{name} changed while being moved"
+
+
+def test_no_other_function_in_the_service_was_touched():
+    """The carve must not be a place where something else got 'tidied'."""
+    old = subprocess.run(
+        ["git", "show", "origin/dev:src/backend/services/task_execution_service.py"],
+        capture_output=True, text=True, cwd=_ROOT,
+    ).stdout
+    if not old:
+        pytest.skip("origin/dev not available in this checkout")
+
+    before, after = _functions(old), _functions(_SVC.read_text())
+    changed = [k for k in after if k in before and before[k] != after[k]]
+    assert changed == [], f"unrelated edits rode along: {changed}"
+
+
+def test_the_new_module_has_no_unresolved_names():
+    """THE #1028 GUARD, applied to a module rather than a function.
+
+    A moved chunk loses whatever its old module scope gave it, and the failure
+    is invisible in a diff: #1028's helpers referenced `_db` and
+    `message_router` — function-local imports shared through the enclosing
+    scope — and every use site sat inside `try/except`, so the boot succeeded
+    and two integrations were simply never wired.
+
+    This carve hit the same class immediately: the dependency analysis walked
+    the moved FUNCTIONS and missed that a moved CONSTANT
+    (`_UNRESOLVED_COMMAND_RE = re.compile(...)`) needed `re`. Caught by the
+    suite, not by reading. So the check covers every top-level statement, not
+    just the callables.
+    """
+    tree = ast.parse(_NEW.read_text())
+
+    bound: set[str] = set()
+    for n in tree.body:
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(n.name)
+        elif isinstance(n, ast.Assign):
+            bound |= {t.id for t in n.targets if isinstance(t, ast.Name)}
+        elif isinstance(n, (ast.Import, ast.ImportFrom)):
+            bound |= {(a.asname or a.name).split(".")[0] for a in n.names}
+
+    def locally_bound(node) -> set[str]:
+        out = {a.arg for a in ast.walk(node) if isinstance(a, ast.arg)}
+        for x in ast.walk(node):
+            if isinstance(x, ast.Name) and isinstance(x.ctx, ast.Store):
+                out.add(x.id)
+            elif isinstance(x, (ast.Import, ast.ImportFrom)):
+                # function-local imports are deliberate here — one keeps a test
+                # patch target live — and they DO bind the name.
+                out |= {(a.asname or a.name).split(".")[0] for a in x.names}
+            elif isinstance(x, ast.comprehension):
+                for t in ast.walk(x.target):
+                    if isinstance(t, ast.Name):
+                        out.add(t.id)
+        return out
+
+    known = bound | set(dir(builtins))
+    missing: set[str] = set()
+    for n in tree.body:
+        scope = locally_bound(n) if isinstance(
+            n, (ast.FunctionDef, ast.AsyncFunctionDef)) else set()
+        for x in ast.walk(n):
+            if isinstance(x, ast.Name) and isinstance(x.ctx, ast.Load):
+                if x.id not in known and x.id not in scope:
+                    missing.add(x.id)
+    assert not missing, (
+        f"names the new module uses but never binds: {sorted(missing)} — "
+        f"the #1028 class: a moved chunk lost something its old scope supplied"
+    )
+
+
+def test_the_service_still_re_exports_every_moved_name():
+    """Pure refactor means no CALL SITE moves. `chat_execution_service` and six
+    test modules import these from `task_execution_service` today."""
+    src = _SVC.read_text()
+    for name in MOVED + ["_AUTO_RETRY_MAX_TURNS", "_UNRESOLVED_COMMAND_RE"]:
+        assert name in src, f"{name} is no longer reachable from the old module"
+    assert "from .execution_classification import" in src
+
+
+def test_the_new_module_is_a_leaf():
+    """AC: the code-health dashboard reports 0 circular imports — keep it 0.
+
+    Asserted structurally rather than by running an import-graph tool, so it
+    fails in the PR that would create the cycle.
+    """
+    for node in ast.walk(ast.parse(_NEW.read_text())):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            target = getattr(node, "module", None) or ""
+            names = ",".join(a.name for a in node.names)
+            assert "task_execution_service" not in f"{target} {names}", (
+                "the carve must not import back into the module it came from"
+            )
+
+
+def test_the_carve_actually_shrank_the_hotspot():
+    """A decomposition that does not reduce the file is theatre."""
+    old = subprocess.run(
+        ["git", "show", "origin/dev:src/backend/services/task_execution_service.py"],
+        capture_output=True, text=True, cwd=_ROOT,
+    ).stdout
+    if not old:
+        pytest.skip("origin/dev not available in this checkout")
+    assert len(_SVC.read_text().split("\n")) < len(old.split("\n"))
+
+
+def test_the_effectful_sibling_stayed_behind():
+    """`_alert_skill_not_found` reads like a sibling of the slash-command
+    detector and is deliberately NOT here: it writes to the operator queue
+    through the #1677 bounded-alert path. Pulling it in would import the queue
+    into a leaf module and make this module two things instead of one."""
+    # Checked against DEFINITIONS, not file text: this module's own docstring
+    # explains why the function stayed behind, so a substring scan fails on its
+    # own documentation — the same trap that bit the #2429 CAS guard and the
+    # #2449 single-source guard earlier in this chain.
+    def _defines(path):
+        return {
+            n.name for n in ast.parse(path.read_text()).body
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+    assert "_alert_skill_not_found" not in _defines(_NEW)
+    assert "_alert_skill_not_found" in _defines(_SVC)


### PR DESCRIPTION
Related to #2314 — **first carve, and it does not close the AC.**

## Scope, stated up front

#2314 asks for no successor file over 800 lines. This takes `task_execution_service.py` from **2305 → 2169** and does not get there.

That's deliberate. The issue's own Technical Notes say to avoid a big-bang split mid-#1081 and prefer *paired small decompositions on seams the migration doesn't collide with*. The 1,252-line `TaskExecutionService` class is exactly where #1081 lands, so it isn't this PR's business. **The issue stays open.**

## The seam

`services/execution_classification.py` — six **pure** readers of an agent's response, plus the two constants they own:

| function | question it answers |
|---|---|
| `_compute_context_used` | how full was the context window |
| `_is_reader_race_signature` | is this the #678 stdout reader race |
| `detect_unresolved_slash_command` | did the agent quote a command back (#1410) |
| `_extract_agent_error` | what did a 502/504 body really say (#1853) |
| `classify_switch_failure` | is this the subscription's fault (#792) |
| `_salvage_attempt_cost` | what did the attempt cost before it failed |

Chosen by dependency analysis, not by eye: the whole group needs only `typing`, `httpx`, `re` and its own two constants. Nothing touches the DB, capacity, breakers, Redis or dispatch. The module is a **leaf** — it never imports back — so the dashboard's 0 circular imports stays 0.

**Not moved, deliberately.** `_alert_skill_not_found` reads like a sibling of the slash-command detector, but it *writes* to the operator queue via the #1677 bounded-alert path. It's an effect, not a classification; moving it would drag the queue into a leaf module and make this two things instead of one. Pinned by a test.

## Pure refactor — no call site moved

`task_execution_service` re-exports every name, so `chat_execution_service` and six test modules import them unchanged. No test churn, no behaviour change.

## Proved, not asserted

#1028 moved `lifespan`'s blocks "verbatim", proved 518 == 518 identical lines, passed a 21-test structural pin **and** an import smoke — and still shipped a branch where three phases raised `NameError` on names the enclosing scope had supplied. So this PR proves it instead:

- every moved body compared by **parsed AST** against `origin/dev` — **6/6 identical**
- **no other function** in the service changed — verified the same way
- the new module has **no unresolved names**

That last check earned its place immediately. My first dependency analysis walked the moved *functions* and missed that a moved *constant* (`_UNRESOLVED_COMMAND_RE = re.compile(...)`) needed `re` — the identical #1028 class, one statement type over. The suite caught it. The guard now covers every top-level statement, not just callables, and knows that the deliberate function-local import of `is_auth_failure` (which keeps a test patch target live) does bind its name.

## Verification

- 7 new extraction guards
- **135 passing** across all nine modules that import the moved names, unchanged
- leaf status asserted structurally, so the PR that would create a cycle fails

## Next carves, when #1081 allows

Terminal handling + the CAS gate · telemetry persistence · the reply envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eKBPKUFH7wNip9bjNLpc3
