### PR TITLE
fix(subscriptions): take the rate-limited predicate off the event loop (#2443)

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -2711,6 +2711,11 @@ class DatabaseManager:
         """Throttled (429) in the last 2h — the DISPLAY predicate (#2352)."""
         return self._subscription_ops.is_subscription_rate_limited(subscription_id)
 
+    def rate_limited_subscription_ids(self, subscription_ids):
+        """The batched form of `is_subscription_rate_limited` — one query for a
+        whole sweep or dashboard poll (#2443)."""
+        return self._subscription_ops.rate_limited_subscription_ids(subscription_ids)
+
     def has_recent_subscription_failures(self, subscription_id: str, hours: int = 2):
         """Failed for ANY reason in the window — the CANDIDATE-SKIP predicate
         used by auto-switch and assignment (#2352). Not interchangeable with

--- a/src/backend/db/subscriptions.py
+++ b/src/backend/db/subscriptions.py
@@ -14,7 +14,7 @@ every return shape is preserved exactly.
 
 import uuid
 from datetime import datetime
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, List, Dict, Any, Sequence, Set, Tuple
 
 from sqlalchemy import select, insert, update, delete, func, and_
 
@@ -694,21 +694,70 @@ class SubscriptionOperations:
         in SQL — the exclusion documented on the two callers above is a
         property of this one comparison, not a second rule applied elsewhere.
         """
+        stmt = (
+            select(func.count().label("cnt"))
+            .select_from(subscription_rate_limit_events)
+            .where(
+                and_(
+                    subscription_rate_limit_events.c.subscription_id == subscription_id,
+                    *self._failure_event_window(hours=hours, kinds=kinds),
+                )
+            )
+        )
+        with get_engine().connect() as conn:
+            return int(conn.execute(stmt).scalar_one())
+
+    @staticmethod
+    def _failure_event_window(*, hours: int, kinds: Optional[Tuple[str, ...]] = None):
+        """The window + kind half of the failure-event predicate, WITHOUT the
+        subscription-id term.
+
+        Extracted so the single-id count above and the batched id-set below are
+        the same question asked of the same rows — one scoped to a row, one to
+        a set. Copying the two conditions into the batch instead would give the
+        display predicate two definitions of "recently rate-limited", which is
+        precisely the drift #2352 spent a fix untangling.
+        """
         conditions = [
-            subscription_rate_limit_events.c.subscription_id == subscription_id,
             # #476: iso_cutoff, not datetime('now', ...) — the format has to
             # match how occurred_at was written.
             subscription_rate_limit_events.c.occurred_at > iso_cutoff(hours),
         ]
         if kinds is not None:
             conditions.append(subscription_rate_limit_events.c.failure_kind.in_(kinds))
+        return conditions
+
+    def rate_limited_subscription_ids(
+        self, subscription_ids: Sequence[str]
+    ) -> Set[str]:
+        """The subset of ``subscription_ids`` that ``is_subscription_rate_limited``
+        would answer True for — in ONE query (#2443).
+
+        The per-id predicate is a synchronous SQLAlchemy call, and both of its
+        hot callers ask it once per subscription: the #447 recovery sweep (every
+        300s, now chunk-concurrent) and the dashboard pressure batch (every 60s).
+        Asking N times off the event loop is still N round-trips; asking once is
+        one, and it is the shape ``get_failure_event_counts_by_subscription``
+        already uses next door.
+
+        Empty input short-circuits without touching the DB — an ``IN ()`` is a
+        wasted round-trip whose answer is known.
+        """
+        ids = [s for s in dict.fromkeys(subscription_ids) if s]
+        if not ids:
+            return set()
         stmt = (
-            select(func.count().label("cnt"))
-            .select_from(subscription_rate_limit_events)
-            .where(and_(*conditions))
+            select(subscription_rate_limit_events.c.subscription_id)
+            .where(
+                and_(
+                    subscription_rate_limit_events.c.subscription_id.in_(ids),
+                    *self._failure_event_window(hours=2, kinds=("rate_limit",)),
+                )
+            )
+            .distinct()
         )
         with get_engine().connect() as conn:
-            return int(conn.execute(stmt).scalar_one())
+            return {row[0] for row in conn.execute(stmt)}
 
     def clear_rate_limit_events(self, agent_name: str, subscription_id: str) -> None:
         """Clear rate-limit events for an (agent, subscription) pair after successful switch."""

--- a/src/backend/services/subscription_headroom_service.py
+++ b/src/backend/services/subscription_headroom_service.py
@@ -42,7 +42,7 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Set
 
 import httpx
 
@@ -178,7 +178,9 @@ def parse_unified_headers(headers) -> Optional[dict]:
 async def _probe(subscription_id: str) -> Optional[dict]:
     """One probe call; returns the snapshot dict (with status) or None when the
     subscription has no usable token. Never raises; never logs the token."""
-    token = db.get_subscription_token(subscription_id)
+    # #2443: sync SQLAlchemy, and this one runs inside every probe — the
+    # sweep's hottest path. Same reason as the predicate above.
+    token = await asyncio.to_thread(db.get_subscription_token, subscription_id)
     if not token:
         return None
 
@@ -457,23 +459,58 @@ async def get_headroom(
     return _to_model(snapshot)
 
 
-def _believed_limited(subscription_id: str, snapshot: Optional[dict]) -> bool:
+def _believed_limited(
+    subscription_id: str,
+    snapshot: Optional[dict],
+    *,
+    limited_ids: Optional[Set[str]] = None,
+) -> bool:
     """Is this subscription currently PRESENTED as rate-limited? (#447)
 
     Deliberately the union of both arms the display resolver can fire on, so
     the recovery probe targets exactly the set of subscriptions wearing a
     `LIMIT` badge — including the common case where the badge comes from the
     stale 2h db predicate and no provider snapshot disagrees with it yet.
+
+    ``limited_ids`` (#2443) is the sweep's one batched read of the db arm. When
+    given, this function issues NO query and is safe to call directly from the
+    event loop; when absent it falls back to the per-id read, which the caller
+    must therefore run off the loop (``recover_probe`` does). The fallback is
+    kept rather than made mandatory so a one-off probe outside a sweep does not
+    have to build a set to ask about a single subscription.
     """
     if snapshot and snapshot.get("status") == "rate_limited":
         return True
+    if limited_ids is not None:
+        return subscription_id in limited_ids
     try:
         return bool(db.is_subscription_rate_limited(subscription_id))
     except Exception:  # noqa: BLE001 — a db blip must not stall the sweep
         return False
 
 
-async def recover_probe(subscription_id: str) -> str:
+def rate_limited_ids(subscription_ids: Sequence[str]) -> Set[str]:
+    """One threaded read of the db arm for a whole sweep or batch (#2443).
+
+    Fail-open to the EMPTY set, matching the per-id predicate's own
+    ``except -> False``: a db blip must not stall the sweep, and the direction
+    is the safe one — a subscription that is genuinely limited is re-examined
+    on the next 300s cycle, whereas failing the other way would probe every
+    subscription on the instance on every db error.
+
+    Callers wrap this in ``asyncio.to_thread``; it is deliberately sync so the
+    db call and the thread hop stay one decision at the call site.
+    """
+    try:
+        return db.rate_limited_subscription_ids(list(subscription_ids))
+    except Exception:  # noqa: BLE001 — same reason as the per-id predicate
+        logger.debug("rate_limited_ids read failed; treating as none-limited")
+        return set()
+
+
+async def recover_probe(
+    subscription_id: str, *, limited_ids: Optional[Set[str]] = None
+) -> str:
     """Re-probe ONE subscription believed limited; return a short outcome (#447).
 
     Never raises. Fail-CLOSED on Redis, exactly like the ambient path: a client
@@ -489,7 +526,16 @@ async def recover_probe(subscription_id: str) -> str:
     redis_ok, snapshot = _read_snapshot(subscription_id)
     if not redis_ok:
         return "redis_unavailable"
-    if not _believed_limited(subscription_id, snapshot):
+    # #2443: the db arm is a synchronous SQLAlchemy call. With the sweep's
+    # batched set it costs nothing; without one it goes to a thread, because a
+    # sync query landing during the 03:30 backup or the 04:30 VACUUM blocks
+    # /health, the WS dispatcher and every in-flight request for up to the 30s
+    # busy timeout (the reason `_record_history` states at length next door).
+    if limited_ids is not None:
+        believed = _believed_limited(subscription_id, snapshot, limited_ids=limited_ids)
+    else:
+        believed = await asyncio.to_thread(_believed_limited, subscription_id, snapshot)
+    if not believed:
         return "not_limited"
     age = _snapshot_age_seconds(snapshot) if snapshot else None
     if age is not None and age < RECOVERY_PROBE_SECONDS:
@@ -1051,7 +1097,13 @@ async def pressure_states(
     token is dead is no longer `rate_limited_now` — without the split the badge
     would simply trade one wrong word ("limit") for another ("429s").
     """
-    counts_24h = db.get_failure_event_counts_by_subscription(hours=24)
+    # #2443: both db arms are batched and threaded. This runs on the 60s
+    # dashboard poll, and the per-id predicate below used to be one synchronous
+    # query PER SUBSCRIPTION on the event loop.
+    counts_24h = await asyncio.to_thread(
+        db.get_failure_event_counts_by_subscription, hours=24
+    )
+    limited_ids = await asyncio.to_thread(rate_limited_ids, subscription_ids)
     out: Dict[str, Dict[str, Any]] = {}
     for sid in subscription_ids:
         # wait=False: the dashboard's 60s poll is the DEMAND signal for a
@@ -1060,7 +1112,7 @@ async def pressure_states(
         # Same one-gate resolver as `decorate_usage` — the per-agent chip and
         # the tile must never disagree about one subscription (#447).
         limited = resolve_rate_limited_now(
-            db_says_limited=db.is_subscription_rate_limited(sid), headroom=headroom
+            db_says_limited=sid in limited_ids, headroom=headroom
         )
         entry = counts_24h.get(sid) or {}
         by_kind = entry.get("by_kind") or {}

--- a/src/backend/services/subscription_recovery_service.py
+++ b/src/backend/services/subscription_recovery_service.py
@@ -72,7 +72,7 @@ import asyncio
 import logging
 import os
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from database import db
 from redis_breaker_util import get_breaker_redis
@@ -83,6 +83,7 @@ from services.subscription_headroom_service import (
     classify_headroom,
     ensure_reading,
     is_auto_refresh_enabled,
+    rate_limited_ids,
     recover_probe,
 )
 
@@ -226,7 +227,12 @@ class SubscriptionRecoveryService:
             await asyncio.sleep(max(1, sleep_for))
 
     async def _sweep_one(
-        self, sub: Any, *, threshold: int, alerting: bool
+        self,
+        sub: Any,
+        *,
+        threshold: int,
+        alerting: bool,
+        limited_ids: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
         """Recovery, then headroom sampling, for ONE subscription.
 
@@ -234,6 +240,12 @@ class SubscriptionRecoveryService:
         tidiness: a bug in the ent#434 evaluation must never stop #447's
         recovery detection, which is the only mechanism that clears a stale
         `LIMIT` badge (nothing clears a failure row on success).
+
+        ``limited_ids`` is the cycle's one batched read of the "believed
+        rate-limited" db arm (#2443). ``None`` — the default, so this stays
+        callable on its own — means `recover_probe` falls back to a per-id read
+        it runs off the event loop; the defect that fix closes (a sync query on
+        the loop) is closed on both paths, only the round-trip count differs.
 
         Recovery runs FIRST. `_probe_floor_ok` bounds probes at 60s per
         subscription, so whichever consumer probes first floors the other out.
@@ -249,7 +261,7 @@ class SubscriptionRecoveryService:
         }
 
         try:
-            result["outcome"] = await recover_probe(sid)
+            result["outcome"] = await recover_probe(sid, limited_ids=limited_ids)
         except Exception as e:  # noqa: BLE001 — one bad subscription must not
             # end the sweep; its siblings are independent.
             logger.warning("Recovery probe failed for %s: %s", sid, e)
@@ -307,11 +319,25 @@ class SubscriptionRecoveryService:
             threshold = alerts.DEFAULT_THRESHOLD_PCT
         alerting = threshold > 0
 
+        # #2443: ONE read of the "believed rate-limited" db arm for the whole
+        # sweep, off the event loop. It used to be a synchronous SQLAlchemy call
+        # per subscription inside `recover_probe`, and since the sweep became
+        # chunk-concurrent (ent#434) N of them land together — a sync query
+        # crossing the 03:30 backup or the 04:30 VACUUM blocks /health, the WS
+        # dispatcher and every in-flight request for up to the 30s busy timeout.
+        # Read once per cycle, not per chunk: a subscription that becomes
+        # limited mid-sweep is picked up on the next 300s cycle, well inside the
+        # 2h window the predicate asks about.
+        limited_ids = await asyncio.to_thread(rate_limited_ids, [s.id for s in subs])
+
         results: List[Dict[str, Any]] = []
         lease_ttl = max(60, RECOVERY_PROBE_SECONDS) * 3
         for chunk in _chunks(subs, _MAX_CONCURRENT_PROBES):
             results.extend(await asyncio.gather(*[
-                self._sweep_one(sub, threshold=threshold, alerting=alerting)
+                self._sweep_one(
+                    sub, threshold=threshold, alerting=alerting,
+                    limited_ids=limited_ids,
+                )
                 for sub in chunk
             ]))
             # Re-assert the lease between chunks rather than only at the top of

--- a/tests/unit/test_2443_headroom_off_loop.py
+++ b/tests/unit/test_2443_headroom_off_loop.py
@@ -1,0 +1,411 @@
+"""#2443 — the headroom service must not run synchronous DB calls on the loop.
+
+`_believed_limited` called `db.is_subscription_rate_limited(...)` straight from
+the event loop, once per subscription per 300s recovery sweep — and since the
+sweep became chunk-concurrent (ent#434) N of them land together. `_record_history`
+in the same module documents at length why that is forbidden: a sync SQLAlchemy
+call landing during the 03:30 backup or the 04:30 VACUUM blocks `/health`, the WS
+dispatcher and every in-flight request for up to the 30s busy timeout.
+
+Three things are pinned here, in order of durability:
+
+1. **The class, by discovery** — no `db.<x>(...)` call may appear in the body of
+   an `async def` anywhere in the two modules. That is the rule; the three
+   instances this issue names are just today's members of it, and a fourth added
+   next month is caught without anyone remembering to look.
+2. **The batch agrees with the per-id predicate**, derived over one fixture
+   rather than restated as cases — two spellings of "recently rate-limited" is
+   the drift #2352 spent a fix untangling.
+3. **The wiring** — the sweep takes one batched read and hands it down, and the
+   fallback path still reaches the DB from a worker thread.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import sqlite3
+import sys
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_THIS = Path(__file__).resolve()
+_REPO = _THIS.parent.parent.parent
+_BACKEND = _REPO / "src" / "backend"
+_BACKEND_STR = str(_BACKEND)
+while _BACKEND_STR in sys.path:
+    sys.path.remove(_BACKEND_STR)
+sys.path.insert(0, _BACKEND_STR)
+
+_MODULES = (
+    _BACKEND / "services" / "subscription_headroom_service.py",
+    _BACKEND / "services" / "subscription_recovery_service.py",
+)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "trinity.db"
+    monkeypatch.setenv("TRINITY_DB_PATH", str(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            email TEXT,
+            role TEXT NOT NULL DEFAULT 'user',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE subscription_credentials (
+            id TEXT PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL,
+            encrypted_credentials TEXT NOT NULL,
+            subscription_type TEXT,
+            rate_limit_tier TEXT,
+            owner_id INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE agent_ownership (
+            agent_name TEXT PRIMARY KEY,
+            owner_id INTEGER,
+            subscription_id TEXT,
+            use_platform_api_key INTEGER DEFAULT 1,
+            deleted_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE subscription_rate_limit_events (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT NOT NULL,
+            subscription_id TEXT NOT NULL,
+            error_message TEXT,
+            failure_kind TEXT,
+            occurred_at TEXT NOT NULL
+        )
+        """
+    )
+    # `get_subscription_usage` aggregates both consumption tables; empty is fine,
+    # absent is a hard error.
+    cur.execute(
+        """
+        CREATE TABLE chat_messages (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT,
+            subscription_id TEXT,
+            role TEXT,
+            timestamp TEXT,
+            context_used INTEGER,
+            output_tokens INTEGER,
+            cost REAL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE schedule_executions (
+            id TEXT PRIMARY KEY,
+            agent_name TEXT,
+            subscription_id TEXT,
+            status TEXT,
+            started_at TEXT,
+            context_used INTEGER,
+            cost REAL
+        )
+        """
+    )
+    now = _iso(datetime.now(timezone.utc))
+    cur.execute(
+        "INSERT INTO users (id, username, email, role, created_at, updated_at) "
+        "VALUES (1, 'tester', 'tester@example.com', 'admin', ?, ?)",
+        (now, now),
+    )
+    for sid, name in (("sub-a", "sub-A"), ("sub-b", "sub-B"), ("sub-c", "sub-C")):
+        cur.execute(
+            "INSERT INTO subscription_credentials "
+            "(id, name, encrypted_credentials, owner_id, created_at, updated_at) "
+            "VALUES (?, ?, 'enc', 1, ?, ?)",
+            (sid, name, now, now),
+        )
+    cur.execute(
+        "INSERT INTO agent_ownership (agent_name, owner_id, subscription_id, use_platform_api_key) "
+        "VALUES ('agent-x', 1, 'sub-a', 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    for mod in ("db.connection", "db.subscriptions"):
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    yield db_path
+
+
+@pytest.fixture
+def sub_ops(tmp_db):
+    from db.subscriptions import SubscriptionOperations
+
+    return SubscriptionOperations(encryption_service=MagicMock())
+
+
+def _event(db_path, subscription_id, *, minutes_ago=30, failure_kind="rate_limit",
+           agent="agent-x"):
+    occurred = _iso(datetime.now(timezone.utc) - timedelta(minutes=minutes_ago))
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO subscription_rate_limit_events "
+        "(id, agent_name, subscription_id, error_message, failure_kind, occurred_at) "
+        "VALUES (?, ?, ?, '', ?, ?)",
+        (uuid.uuid4().hex, agent, subscription_id, failure_kind, occurred),
+    )
+    conn.commit()
+    conn.close()
+
+
+
+# =============================================================================
+# 1. The class: no sync db call inside an async function (discovered)
+# =============================================================================
+
+def _sync_db_calls_in_async(path: Path) -> list:
+    """(function, db attribute, line) for every ``db.x(...)`` CALL that would
+    execute on the event loop.
+
+    A *reference* — ``asyncio.to_thread(db.x, arg)`` — is an Attribute, not a
+    Call, so it is correctly invisible here: that is the fixed form, and the
+    check is precisely the difference between the two.
+
+    Nested ``def``s are excluded: a sync helper defined inside an async function
+    runs wherever its caller puts it, and the ones in these modules are handed
+    to ``to_thread``. Async nesting is not excluded — an inner ``async def``
+    still runs on the loop.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders = []
+
+    def scan(node, fn_name):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef):
+                continue  # sync helper — see docstring
+            if isinstance(child, ast.AsyncFunctionDef):
+                scan(child, child.name)
+                continue
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and isinstance(child.func.value, ast.Name)
+                and child.func.value.id == "db"
+            ):
+                offenders.append((fn_name, child.func.attr, child.lineno))
+            scan(child, fn_name)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            scan(node, node.name)
+    return offenders
+
+
+@pytest.mark.parametrize("path", _MODULES, ids=lambda p: p.name)
+def test_no_sync_db_call_on_the_event_loop(path):
+    offenders = _sync_db_calls_in_async(path)
+    assert offenders == [], (
+        f"{path.name}: synchronous db call(s) inside an async function — "
+        f"{offenders}. Wrap in asyncio.to_thread, or batch the read for the "
+        "whole sweep (#2443)."
+    )
+
+
+def test_the_guard_can_actually_see_one():
+    """Non-vacuity: the walker must find a planted offender, or the test above
+    passes for the wrong reason on any future refactor of these modules."""
+    src = (
+        "import asyncio\n"
+        "async def f():\n"
+        "    ok = await asyncio.to_thread(db.threaded, 1)\n"
+        "    bad = db.on_the_loop(2)\n"
+        "    return ok, bad\n"
+    )
+    tmp = Path("/tmp/_2443_probe.py")
+    tmp.write_text(src)
+    found = _sync_db_calls_in_async(tmp)
+    assert [f[1] for f in found] == ["on_the_loop"]
+
+
+# =============================================================================
+# 2. The batch is the per-id predicate, derived
+# =============================================================================
+
+class TestBatchAgreesWithPerId:
+    def test_derived_over_a_mixed_fixture(self, sub_ops, tmp_db):
+        """Property, not cases: whatever the per-id predicate answers for each
+        subscription, the batch must return exactly that set. Stated this way it
+        keeps holding if the window or the kind filter is ever changed — a case
+        list would silently stop covering the change."""
+        _event(tmp_db, "sub-a", failure_kind="rate_limit")
+        _event(tmp_db, "sub-b", failure_kind="auth")
+        _event(tmp_db, "sub-b", failure_kind=None)
+        _event(tmp_db, "sub-c", failure_kind="rate_limit", minutes_ago=125)
+        ids = ["sub-a", "sub-b", "sub-c", "sub-missing"]
+
+        expected = {s for s in ids if sub_ops.is_subscription_rate_limited(s)}
+        assert sub_ops.rate_limited_subscription_ids(ids) == expected
+        assert expected == {"sub-a"}, "fixture must exercise both answers"
+
+    def test_one_row_answers_for_several_ids(self, sub_ops, tmp_db):
+        _event(tmp_db, "sub-a", failure_kind="rate_limit")
+        _event(tmp_db, "sub-c", failure_kind="rate_limit")
+        assert sub_ops.rate_limited_subscription_ids(
+            ["sub-a", "sub-b", "sub-c"]
+        ) == {"sub-a", "sub-c"}
+
+    def test_empty_input_asks_nothing(self, sub_ops, monkeypatch):
+        """An ``IN ()`` is a round-trip whose answer is already known. Proven by
+        making any engine access fatal."""
+        import db.subscriptions as mod
+
+        def _boom():  # pragma: no cover - must not be reached
+            raise AssertionError("touched the engine for an empty id list")
+
+        monkeypatch.setattr(mod, "get_engine", _boom)
+        assert sub_ops.rate_limited_subscription_ids([]) == set()
+        assert sub_ops.rate_limited_subscription_ids([None, ""]) == set()
+
+
+# =============================================================================
+# 3. The wiring
+# =============================================================================
+
+class TestWiring:
+    def test_precomputed_set_asks_no_question(self, monkeypatch):
+        import services.subscription_headroom_service as svc
+
+        def _boom(_sid):  # pragma: no cover - must not be reached
+            raise AssertionError("queried the db with a batched set in hand")
+
+        monkeypatch.setattr(svc.db, "is_subscription_rate_limited", _boom)
+        assert svc._believed_limited("s1", None, limited_ids={"s1"}) is True
+        assert svc._believed_limited("s2", None, limited_ids={"s1"}) is False
+
+    def test_snapshot_arm_still_wins_without_the_db(self, monkeypatch):
+        """The union is unchanged: a rate_limited snapshot is believed even when
+        the batch says otherwise (the provider is more recent than the window)."""
+        import services.subscription_headroom_service as svc
+
+        assert svc._believed_limited(
+            "s1", {"status": "rate_limited"}, limited_ids=set()
+        ) is True
+
+    def test_batch_helper_fails_open_to_empty(self, monkeypatch):
+        import services.subscription_headroom_service as svc
+
+        def _boom(_ids):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(svc.db, "rate_limited_subscription_ids", _boom)
+        assert svc.rate_limited_ids(["a", "b"]) == set()
+
+    def test_fallback_path_reaches_the_db_from_a_worker_thread(self, monkeypatch):
+        """No batched set ⇒ the per-id read still happens, but not on the loop.
+        Recorded by thread identity, which is the property that matters — a test
+        asserting "to_thread was called" would pass on a wrapper that awaits it
+        on the loop anyway."""
+        import services.subscription_headroom_service as svc
+
+        seen = {}
+
+        def _predicate(sid):
+            seen["thread"] = threading.get_ident()
+            return True
+
+        monkeypatch.setattr(svc.db, "is_subscription_rate_limited", _predicate)
+        monkeypatch.setattr(svc, "_read_snapshot", lambda sid: (True, None))
+        monkeypatch.setattr(svc, "_probe_floor_ok", lambda sid, snap: False)
+
+        async def _run():
+            loop_thread = threading.get_ident()
+            out = await svc.recover_probe("s1")
+            return loop_thread, out
+
+        loop_thread, out = asyncio.run(_run())
+        assert out == "floored", "must have got past the believed-limited gate"
+        assert seen["thread"] != loop_thread, "predicate ran on the event loop"
+
+    def test_pressure_states_reads_the_batch_once(self, monkeypatch):
+        """Was one synchronous query per subscription on the 60s dashboard
+        poll."""
+        import services.subscription_headroom_service as svc
+
+        calls = []
+        monkeypatch.setattr(
+            svc.db, "get_failure_event_counts_by_subscription",
+            lambda hours: {},
+        )
+        monkeypatch.setattr(
+            svc.db, "rate_limited_subscription_ids",
+            lambda ids: (calls.append(list(ids)) or set()),
+        )
+
+        def _boom(_sid):  # pragma: no cover - must not be reached
+            raise AssertionError("per-id predicate still used by pressure_states")
+
+        monkeypatch.setattr(svc.db, "is_subscription_rate_limited", _boom)
+
+        async def _hr(sid, wait=False):
+            return None
+
+        monkeypatch.setattr(svc, "get_headroom", _hr)
+
+        ids = [f"s{i}" for i in range(5)]
+        out = asyncio.run(svc.pressure_states(ids))
+        assert set(out) == set(ids)
+        assert calls == [ids], f"expected exactly one batched read, got {calls}"
+
+    def test_sweep_hands_the_batch_down(self, monkeypatch):
+        """The batch is useless if the cycle forgets to pass it — and the
+        fallback would hide that, since it still produces correct answers."""
+        import services.subscription_recovery_service as svc
+
+        class _Sub:
+            def __init__(self, sid):
+                self.id = sid
+                self.name = sid
+
+        monkeypatch.setattr(svc.db, "list_subscriptions", lambda: [_Sub("s1"), _Sub("s2")])
+        monkeypatch.setattr(svc, "rate_limited_ids", lambda ids: {"s1"})
+        monkeypatch.setattr(
+            svc.SubscriptionRecoveryService, "_try_acquire_leadership",
+            lambda self, ttl: True,
+        )
+
+        seen = []
+
+        async def _sweep_one(self, sub, *, threshold, alerting, limited_ids=None):
+            seen.append((sub.id, limited_ids))
+            return {"sid": sub.id, "outcome": "not_limited",
+                    "classification": None, "reading": None}
+
+        monkeypatch.setattr(svc.SubscriptionRecoveryService, "_sweep_one", _sweep_one)
+        asyncio.run(svc.SubscriptionRecoveryService().run_cycle())
+        assert seen and all(li == {"s1"} for _sid, li in seen), seen

--- a/tests/unit/test_447_subscription_reset_and_recovery.py
+++ b/tests/unit/test_447_subscription_reset_and_recovery.py
@@ -273,7 +273,7 @@ class TestRecoveryServiceWiring:
             mod.db, "list_subscriptions", lambda: [_Sub("a"), _Sub("b"), _Sub("c")]
         )
 
-        async def _probe(sid):
+        async def _probe(sid, **_kw):  # **_kw: #2443 passes limited_ids
             if sid == "b":
                 raise RuntimeError("boom")
             return "recovered" if sid == "a" else "not_limited"

--- a/tests/unit/test_ent434_headroom_alerts.py
+++ b/tests/unit/test_ent434_headroom_alerts.py
@@ -389,7 +389,7 @@ class TestSweepIsolation:
         would take that mechanism down with it."""
         import services.subscription_recovery_service as svc
 
-        async def _recovered(sid):
+        async def _recovered(sid, **_kw):  # **_kw: #2443 passes limited_ids
             return "recovered"
 
         async def _explode(sid, **kw):
@@ -588,7 +588,7 @@ class TestReviewRegressions:
         monkeypatch.setattr(alerts.db, "get_setting_value",
                             lambda k, default=None: "0")
 
-        async def _recovered(sid):
+        async def _recovered(sid, **_kw):  # **_kw: #2443 passes limited_ids
             return "not_limited"
         monkeypatch.setattr(svc, "recover_probe", _recovered)
         monkeypatch.setattr(
@@ -606,7 +606,7 @@ class TestReviewRegressions:
         otherwise an operator who turned it off still pays the quota."""
         import services.subscription_recovery_service as svc
 
-        async def _recovered(sid):
+        async def _recovered(sid, **_kw):  # **_kw: #2443 passes limited_ids
             return "not_limited"
 
         async def _must_not_run(*a, **k):  # pragma: no cover
@@ -725,7 +725,7 @@ def _wire_sweep(monkeypatch, subs, *, raises_for=(), classification=None):
     import services.subscription_headroom_alerts as alerts
     emitted = []
 
-    async def _recovered(sid):
+    async def _recovered(sid, **_kw):  # **_kw: #2443 passes limited_ids
         return "not_limited"
 
     async def _ensure(sid, *, max_age_seconds):


### PR DESCRIPTION
## What

`subscription_headroom_service._believed_limited` called `db.is_subscription_rate_limited(...)` **synchronously on the event loop**, once per subscription per 300s recovery sweep — and since the sweep became chunk-concurrent (ent#434), N of them land together. `_record_history`, in the same module, documents at length why that is forbidden: a sync SQLAlchemy call landing during the 03:30 backup or the 04:30 VACUUM blocks `/health`, the WS dispatcher and every in-flight request for up to the 30s busy timeout.

## Scope: the issue names one call, the module had three

All reached from the same 300s sweep or the 60s dashboard poll, so all three are fixed rather than only the reported path (the incomplete-fix rule — a defence added to one of two branches is how #686 / #1264 / #1153 each came back):

| Where | Was | Now |
|---|---|---|
| `_believed_limited` | one sync query per subscription per sweep | the sweep takes **one batched read per cycle** and hands the set down `_sweep_one` → `recover_probe`; with a set in hand the predicate issues no query at all |
| `_probe` | `db.get_subscription_token` on the loop, on the sweep's hottest path | `asyncio.to_thread` |
| `pressure_states` | one sync query **per subscription** on the 60s dashboard poll, plus an unthreaded `get_failure_event_counts_by_subscription` | both batched and threaded |

`limited_ids` is **optional everywhere**. Absent, `recover_probe` falls back to the per-id read wrapped in `to_thread` — so the defect is closed on both paths and only the round-trip count differs, and `_sweep_one` stays callable on its own (two existing tests call it directly).

## One predicate, not two spellings

`db.rate_limited_subscription_ids` shares the window + kind conditions with `_failure_event_count` through one extracted `_failure_event_window`, so the batch and the per-id predicate cannot answer differently. Two spellings of "recently rate-limited" is exactly the drift #2352 spent a fix untangling.

Empty input short-circuits without touching the engine (`IN ()` is a round-trip whose answer is known), and the service-level `rate_limited_ids` fails **open to the empty set** — matching the per-id predicate's own `except -> False`. That direction is deliberate: a db blip re-examines the subscription on the next 300s cycle, whereas failing the other way would probe every subscription on the instance on every db error.

Reading once per cycle rather than per chunk is safe because the predicate asks about a **2h** window: a subscription that becomes limited mid-sweep is picked up on the next cycle, 300s later.

## Tests

`tests/unit/test_2443_headroom_off_loop.py` (12 tests) pins the **class**, not the instances:

- An **AST discovery guard**: no `db.<x>(...)` **call** may appear in the body of any `async def` in either module, so a fourth instance added later is caught without anyone remembering to look. `asyncio.to_thread(db.x, arg)` is an *Attribute*, not a Call, and is correctly invisible to it — that difference **is** the check. A companion test plants an offender in a scratch module and asserts the walker sees it, so the guard cannot pass vacuously after a future refactor.
- The batch is pinned as a **property derived from** the per-id predicate over one mixed fixture (rate_limit / auth / NULL kind / outside-window / unknown id), not as a case list — so it keeps holding if the window or kind filter ever changes.
- The fallback is proven by **thread identity**, not by "`to_thread` was called" — a wrapper that awaits on the loop would satisfy the latter.

All three mutations were confirmed to red the suite before being reverted: revert `_probe`'s `to_thread`; drop the `limited_ids` hand-down in `run_cycle`; drift the batch window to 3h.

The `DatabaseManager` facade delegation was caught by these tests, not by review — the service called a method the facade did not expose, which would have been an `AttributeError` in production.

Affected suites: 280 passed (`test_447`, `test_ent434`, `test_471`, `test_2352`, `test_2396`, `test_433`, `test_2409`). The existing `recover_probe` stubs in test_447 / test_ent434 gained `**_kw`: the signature grew an *optional* keyword, which only breaks stubs that refuse it.

Fixes #2443
