### PR TITLE
fix(mobile): bound every /m request so a hung POST can't pin a control (#2446)

### DIFF
--- a/src/frontend/src/utils/boundedHttp.js
+++ b/src/frontend/src/utils/boundedHttp.js
@@ -1,0 +1,48 @@
+/**
+ * A bounded wrapper over the GLOBAL axios, for surfaces that deliberately do
+ * not use `api.js` (#2446).
+ *
+ * `/m` has its own auth and 401 story — `main.js` excludes it from the global
+ * interceptor's redirect — so it calls the raw `axios` global, which carries
+ * **no timeout**. Only the `api.js` instance sets one (30 s). A request that
+ * never settles therefore never reaches its `catch`/`finally`, which is not
+ * merely a stuck spinner: `/m` holds per-control in-flight guards
+ * (`respondingItems[id]`, `togglingAgents[name]`, `actionLoading`, …), and PR
+ * #2378 additionally exempts an in-flight operator-queue id from
+ * `pruneQueueItemState`. One hung POST leaves that card's Send disabled and its
+ * state unprunable for the life of the tab.
+ *
+ * Why not `axios.create()`: `stores/auth.js` authenticates by mutating
+ * `axios.defaults.headers.common.Authorization` at login and deleting it at
+ * logout. `create()` snapshots defaults at construction, so a module-level
+ * instance would miss a later sign-in and keep a stale header after sign-out.
+ * These wrappers call the global per request, so the header, the base config
+ * and the response interceptor all still resolve exactly as before — the only
+ * thing added is a bound.
+ *
+ * Why not `axios.defaults.timeout`: that is a process-wide mutation reaching
+ * every other surface, including ones with legitimately long requests.
+ *
+ * A caller-supplied `timeout` wins (the spread is after the default), so a
+ * genuinely long request stays expressible.
+ */
+import axios from 'axios'
+
+// Matches `api.js`'s instance timeout. Kept equal on purpose: two operator
+// surfaces answering "how long before we give up" differently is a difference
+// nobody can explain at 3am.
+export const REQUEST_TIMEOUT_MS = 30000
+
+function bounded(config) {
+  return { timeout: REQUEST_TIMEOUT_MS, ...(config || {}) }
+}
+
+export const http = {
+  get: (url, config) => axios.get(url, bounded(config)),
+  post: (url, data, config) => axios.post(url, data, bounded(config)),
+  put: (url, data, config) => axios.put(url, data, bounded(config)),
+  patch: (url, data, config) => axios.patch(url, data, bounded(config)),
+  delete: (url, config) => axios.delete(url, bounded(config)),
+}
+
+export default http

--- a/src/frontend/src/views/MobileAdmin.vue
+++ b/src/frontend/src/views/MobileAdmin.vue
@@ -593,7 +593,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch, reactive, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
-import axios from 'axios'
+import { http } from '../utils/boundedHttp'
 import { useAuthStore } from '../stores/auth'
 import { useAgentsStore } from '../stores/agents'
 import { agentNameTooltip } from '../utils/agentName'
@@ -760,9 +760,9 @@ async function fetchAgents() {
     // execution stats are decorative, so a failing stats call must not fail the
     // tab. `allSettled` instead of `all` for exactly that split.
     const [fleetRes, autonomyRes, statsRes] = await Promise.allSettled([
-      axios.get('/api/ops/fleet/status'),
-      axios.get('/api/agents/autonomy-status'),
-      axios.get('/api/agents/execution-stats', { params: { include_7d: true } })
+      http.get('/api/ops/fleet/status'),
+      http.get('/api/agents/autonomy-status'),
+      http.get('/api/agents/execution-stats', { params: { include_7d: true } })
     ])
     if (fleetRes.status !== 'fulfilled') throw fleetRes.reason
     if (autonomyRes.status !== 'fulfilled') throw autonomyRes.reason
@@ -814,7 +814,7 @@ async function fetchQueue() {
   const seq = ++queueFetchSeq
   loading.queue = true
   try {
-    const res = await axios.get('/api/operator-queue', { params: { limit: 100 } })
+    const res = await http.get('/api/operator-queue', { params: { limit: 100 } })
     if (seq !== queueFetchSeq) return // a newer fetch owns the list now
     // The endpoint returns {items, count}; `(res.data || []).filter` on that
     // object threw on every poll, so this tab always read "No pending items".
@@ -837,7 +837,7 @@ async function fetchQueue() {
 async function fetchNotifications() {
   loading.notifications = true
   try {
-    const res = await axios.get('/api/notifications', { params: { status: 'pending', limit: 100 } })
+    const res = await http.get('/api/notifications', { params: { status: 'pending', limit: 100 } })
     notifications.value = listFrom(res.data, 'notifications')
     hasLoaded.notifications = true
     lastLoadedAt.notifications = Date.now()
@@ -853,7 +853,7 @@ async function fetchNotifications() {
 async function fetchFleetHealth() {
   loading.fleet = true
   try {
-    const res = await axios.get('/api/ops/fleet/status')
+    const res = await http.get('/api/ops/fleet/status')
     fleetSummary.value = res.data.summary || { total: 0, running: 0, stopped: 0, high_context: 0 }
     hasLoaded.fleet = true
     lastLoadedAt.fleet = Date.now()
@@ -868,7 +868,7 @@ async function fetchFleetHealth() {
 
 async function fetchAgentLogs(name) {
   try {
-    const res = await axios.get(`/api/agents/${name}/logs`, { params: { tail: 30 } })
+    const res = await http.get(`/api/agents/${name}/logs`, { params: { tail: 30 } })
     agentLogs[name] = res.data.logs || 'No logs available'
   } catch (e) {
     agentLogs[name] = 'Failed to load logs'
@@ -913,9 +913,9 @@ async function toggleAgent(name, currentStatus) {
   togglingAgents[name] = true
   try {
     if (currentStatus === 'running') {
-      await axios.post(`/api/agents/${name}/stop`)
+      await http.post(`/api/agents/${name}/stop`)
     } else {
-      await axios.post(`/api/agents/${name}/start`)
+      await http.post(`/api/agents/${name}/start`)
     }
     await fetchAgents()
   } catch (e) {
@@ -929,7 +929,7 @@ async function toggleAutonomy(agent) {
   togglingAutonomy[agent.name] = true
   try {
     const newState = !agent.autonomy_enabled
-    await axios.put(`/api/agents/${agent.name}/autonomy`, { enabled: newState })
+    await http.put(`/api/agents/${agent.name}/autonomy`, { enabled: newState })
     agent.autonomy_enabled = newState
   } catch (e) {
     // The toggle reverts to the server value, so without this the switch just
@@ -977,7 +977,7 @@ function startNewChat() {
 
 async function loadChatSessions() {
   try {
-    const res = await axios.get(`/api/agents/${chatAgent.value}/chat/sessions`)
+    const res = await http.get(`/api/agents/${chatAgent.value}/chat/sessions`)
     chatSessions.value = res.data.sessions || []
   } catch (e) {
     chatSessions.value = []
@@ -988,7 +988,7 @@ async function selectSession(session) {
   chatSessionId.value = session.id
   showSessions.value = false
   try {
-    const res = await axios.get(`/api/agents/${chatAgent.value}/chat/sessions/${session.id}`)
+    const res = await http.get(`/api/agents/${chatAgent.value}/chat/sessions/${session.id}`)
     chatMessages.value = res.data.messages || []
     scrollChatToBottom()
   } catch (e) {
@@ -1038,7 +1038,7 @@ async function sendChatMessage() {
       async_mode: true
     }
 
-    const submitRes = await axios.post(`/api/agents/${chatAgent.value}/task`, payload)
+    const submitRes = await http.post(`/api/agents/${chatAgent.value}/task`, payload)
     const executionId = submitRes.data.execution_id
 
     // Poll for completion
@@ -1080,7 +1080,7 @@ async function pollExecution(agentName, executionId) {
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise(r => setTimeout(r, 5000))
     try {
-      const res = await axios.get(`/api/agents/${agentName}/executions/${executionId}`)
+      const res = await http.get(`/api/agents/${agentName}/executions/${executionId}`)
       const exec = res.data
       if (exec.status && exec.status !== 'running' && exec.status !== 'pending') {
         return exec
@@ -1184,7 +1184,7 @@ async function sendQueueResponse(item, body) {
   respondingItems[id] = true
   delete respondErrors[id]
   try {
-    await axios.post(`/api/operator-queue/${id}/respond`, body)
+    await http.post(`/api/operator-queue/${id}/respond`, body)
   } catch (e) {
     console.error('Failed to send queue response:', e?.response?.status ?? e?.message ?? e)
     respondingItems[id] = false
@@ -1236,7 +1236,7 @@ function acknowledgeQueueItem(item) {
 
 async function acknowledgeNotification(id) {
   try {
-    await axios.post(`/api/notifications/${id}/acknowledge`)
+    await http.post(`/api/notifications/${id}/acknowledge`)
     await fetchNotifications()
   } catch (e) {
     reportActionFailure(e, 'acknowledge that notification')
@@ -1283,13 +1283,13 @@ async function executeAction(action) {
   try {
     let res
     if (action === 'emergency-stop') {
-      res = await axios.post('/api/ops/emergency-stop')
+      res = await http.post('/api/ops/emergency-stop')
     } else if (action === 'fleet-restart') {
-      res = await axios.post('/api/ops/fleet/restart')
+      res = await http.post('/api/ops/fleet/restart')
     } else if (action === 'pause-schedules') {
-      res = await axios.post('/api/ops/schedules/pause')
+      res = await http.post('/api/ops/schedules/pause')
     } else if (action === 'resume-schedules') {
-      res = await axios.post('/api/ops/schedules/resume')
+      res = await http.post('/api/ops/schedules/resume')
     }
     actionResult.value = { success: true, message: res.data.message || 'Action completed' }
     await fetchFleetHealth()

--- a/src/frontend/tests/unit/boundedHttpTimeout.spec.js
+++ b/src/frontend/tests/unit/boundedHttpTimeout.spec.js
@@ -1,0 +1,112 @@
+/**
+ * #2446 — `/m` requests must be bounded.
+ *
+ * `/m` deliberately does not use the `api.js` instance (it owns its auth and
+ * 401 story), so it called the raw `axios` global, which carries no timeout. A
+ * POST that never settles never reaches its `catch`, so `sendQueueResponse`
+ * never runs `respondingItems[id] = false` — that card's Send stays disabled
+ * AND, since PR #2378 exempts an in-flight id from `pruneQueueItemState`, its
+ * per-card state stays unprunable for the life of the tab.
+ *
+ * Two things are pinned: the wrapper actually bounds every verb through the
+ * GLOBAL axios, and the view has no bare `axios.*` call left for a future edit
+ * to reintroduce. The second is a discovery guard over the source, so an
+ * unbounded call added to any other `/m` handler fails too — the respond POST
+ * is only the instance the issue reported; every other in-flight guard on that
+ * surface (`togglingAgents`, `togglingAutonomy`, `actionLoading`, …) is pinned
+ * by exactly the same hang.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { stripComments } from './helpers/stripComments'
+
+const calls = []
+vi.mock('axios', () => {
+  const record = (verb) => (...args) => {
+    calls.push([verb, ...args])
+    return Promise.resolve({ data: {} })
+  }
+  return {
+    default: {
+      get: record('get'),
+      post: record('post'),
+      put: record('put'),
+      patch: record('patch'),
+      delete: record('delete'),
+    },
+  }
+})
+
+const { http, REQUEST_TIMEOUT_MS } = await import('../../src/utils/boundedHttp')
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const MOBILE_ADMIN = resolve(HERE, '../../src/views/MobileAdmin.vue')
+
+beforeEach(() => {
+  calls.length = 0
+})
+
+describe('boundedHttp', () => {
+  it('matches the api.js instance timeout', () => {
+    const apiSrc = readFileSync(resolve(HERE, '../../src/api.js'), 'utf8')
+    const declared = /timeout:\s*(\d+)/.exec(stripComments(apiSrc))
+    expect(declared, 'api.js must declare an instance timeout').toBeTruthy()
+    expect(REQUEST_TIMEOUT_MS).toBe(Number(declared[1]))
+  })
+
+  it('bounds every verb it exposes', () => {
+    http.get('/a')
+    http.post('/b', { x: 1 })
+    http.put('/c', { x: 1 })
+    http.patch('/d', { x: 1 })
+    http.delete('/e')
+    expect(calls.map(c => c[0])).toEqual(['get', 'post', 'put', 'patch', 'delete'])
+    for (const call of calls) {
+      const config = call[call.length - 1]
+      expect(config.timeout, `${call[0]} was unbounded`).toBe(REQUEST_TIMEOUT_MS)
+    }
+  })
+
+  it('keeps caller config and lets an explicit timeout win', () => {
+    http.get('/a', { params: { limit: 100 } })
+    expect(calls[0][2]).toEqual({ timeout: REQUEST_TIMEOUT_MS, params: { limit: 100 } })
+    calls.length = 0
+    http.post('/b', null, { timeout: 1 })
+    expect(calls[0][3].timeout).toBe(1)
+  })
+
+  it('calls the global axios rather than a snapshot instance', () => {
+    // stores/auth.js authenticates by mutating axios.defaults.headers.common at
+    // login and deleting it at logout; axios.create() snapshots defaults at
+    // construction, so an instance would miss a later sign-in. Proven by the
+    // absence of a create() call, since a mocked instance would not surface here.
+    const src = stripComments(readFileSync(resolve(HERE, '../../src/utils/boundedHttp.js'), 'utf8'))
+    expect(src).not.toMatch(/axios\.create\s*\(/)
+  })
+})
+
+describe('MobileAdmin has no unbounded request left', () => {
+  it('makes every call through the bounded wrapper', () => {
+    const src = stripComments(readFileSync(MOBILE_ADMIN, 'utf8'))
+    const bare = [...src.matchAll(/\baxios\.(get|post|put|patch|delete)\s*\(/g)].map(m => m[0])
+    expect(bare, `unbounded axios call(s) in MobileAdmin.vue: ${bare.join(', ')}`).toEqual([])
+    expect(src).toMatch(/from\s+'\.\.\/utils\/boundedHttp'/)
+  })
+
+  it('actually still issues requests — the guard is not vacuous', () => {
+    const src = stripComments(readFileSync(MOBILE_ADMIN, 'utf8'))
+    const wrapped = [...src.matchAll(/\bhttp\.(get|post|put|patch|delete)\s*\(/g)]
+    expect(wrapped.length).toBeGreaterThan(10)
+  })
+
+  it('releases the in-flight guard on a failed respond', () => {
+    // The timeout is only useful because this line is reachable once the
+    // promise settles; before the bound it never was.
+    const src = stripComments(readFileSync(MOBILE_ADMIN, 'utf8'))
+    const fn = src.slice(src.indexOf('async function sendQueueResponse'))
+    const body = fn.slice(0, fn.indexOf('\n}\n'))
+    expect(body).toMatch(/catch[\s\S]*respondingItems\[id\] = false/)
+  })
+})


### PR DESCRIPTION
## What

`/m` deliberately does not use the `api.js` instance — it owns its auth and 401 story, and `main.js` excludes it from the global interceptor's redirect — so it called the raw `axios` global, which carries **no timeout**. Only `api.js` sets one (30 s).

A request that never settles never reaches its `catch`/`finally`. On this surface that is not merely a stuck spinner: `sendQueueResponse` releases its in-flight guard **in the catch**, and PR #2378 additionally exempts an in-flight operator-queue id from `pruneQueueItemState`. So one hung respond leaves that card's Send disabled **and** its per-card state unprunable for the life of the tab.

The prune exemption is not the thing to remove — it is the fix for a real reviewer finding (pruning a live guard re-enables Send under an outstanding POST and reports a recorded answer as not recorded). The missing piece was always the bound.

## Scope: the respond POST is the instance, the surface is the class

Every other in-flight guard on `/m` — `togglingAgents[name]`, `togglingAutonomy[name]`, `actionLoading`, `refreshing`, `pullRefreshing` — is pinned by exactly the same hang. So all **20** call sites move to a bounded wrapper rather than only the reported one.

## Why a wrapper and not the two obvious alternatives

`src/frontend/src/utils/boundedHttp.js` wraps the **global** axios per request:

- **Not `axios.create()`.** `stores/auth.js` authenticates by mutating `axios.defaults.headers.common.Authorization` at login and deleting it at logout. `create()` snapshots defaults at construction, so a module-level instance would miss a later sign-in and keep a stale header after sign-out. Calling the global per request leaves the header, the base config and the response interceptor resolving exactly as before — the only thing added is a bound.
- **Not `axios.defaults.timeout`.** A process-wide mutation reaching every other surface, including ones with legitimately long requests.
- A caller-supplied `timeout` still wins (the spread is after the default), so a long request stays expressible.

**30 s**, equal to `api.js` by intent and pinned to it by a test that reads the number out of `api.js` rather than restating it. `/m`'s own long operation is already safe: the chat submit posts `async_mode: true` and polls separately, so nothing on the surface legitimately exceeds the bound.

The error path needed no change — the `catch` already sets `respondingItems[id] = false` and shows a retryable message that deliberately makes no "nothing was changed" claim (a timed-out POST may have landed). The bound is what makes that path *reachable*.

## Tests

`tests/unit/boundedHttpTimeout.spec.js` (7 tests):

- The wrapper bounds every verb, preserves caller config, lets an explicit timeout win, and does not `create()` an instance.
- A **discovery guard** over `MobileAdmin.vue`: no bare `axios.<verb>(` may remain, so an unbounded call added to any future handler fails too. It scans through the shared `stripComments` helper — a guard that greps its own documentation for the string it forbids is a trap this repo has already sprung three times — and carries a non-vacuity assertion so it cannot pass by the view simply having stopped making requests.
- The constant is derived from `api.js`, so the two operator surfaces cannot drift into answering "how long before we give up" differently.

All three mutations were confirmed to red the suite before being reverted: drop the default timeout; reintroduce one bare `axios.post`; drift the constant away from `api.js`.

Frontend unit suite: **1534 passed** (69 files). No CSS touched, so the raw-color and loading-gate ratchets are unaffected.

Fixes #2446
