### PR TITLE
ci: parallelise the unit suite with xdist instead of raising the cap again (#2461)

### DIFF
--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -94,6 +94,25 @@ jobs:
     # xdist) rather than keep buying minutes. That is worth doing and is not
     # this change; raising the cap stops the bleeding without hiding the trend,
     # since the durations above are recorded here for the next reader.
+    #
+    # 2026-09-01 (#2461): that alternative is now taken — see `-n auto
+    # --dist loadfile` on the run step below. The cap STAYS at 45. The point of
+    # parallelising is not to use the headroom, it is to move the whole
+    # distribution far enough below the cap that a slow runner stops reaching
+    # it. Measured over the 18 runs before this change, 78 shards:
+    #
+    #     success: min 13m  median 15m  p90 17m  max 30m
+    #     killed at the cap: 5-6 shards at exactly 45m  (~8% of shards)
+    #     -> ~40% of runs carried at least one spurious red (1 - 0.92^6)
+    #
+    # and the red lands on whichever PR is open, including the `base` side,
+    # which is plain `dev` and has nothing to do with the PR it reddens.
+    #
+    # Do NOT raise this number as the next step if the cap starts being reached
+    # again. Three raises in a row would mean the suite is growing faster than
+    # anyone is willing to measure it; the next lever is the balance of the
+    # distribution (`--dist load` instead of `loadfile`, or splitting the
+    # slowest files), not the budget.
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -127,9 +146,17 @@ jobs:
         # tests/requirements-test.txt would silently randomize
         # tests/run-core.sh and any local contributor pytest invocation,
         # because pytest auto-discovers installed plugins.
+        #
+        # pytest-xdist rides along here for a DIFFERENT reason, stated so the
+        # next reader does not infer a rule that isn't there: xdist is inert
+        # without `-n`, so by requirements-test.txt's own documented test (see
+        # the hypothesis note in that file) it would be harmless to put there.
+        # It is here because six workflows install that file and only this one
+        # runs the suite in parallel — the narrower home is the honest one.
         run: |
           python -m pip install --upgrade pip
-          pip install -r tests/requirements-test.txt 'pytest-randomly>=3.15.0'
+          pip install -r tests/requirements-test.txt \
+            'pytest-randomly>=3.15.0' 'pytest-xdist>=3.5.0'
 
       - name: Diff-script self-test
         run: python "$HOME/.ci-tools/diff-pytest-failures.py" --self-test
@@ -182,10 +209,45 @@ jobs:
         # release, not one permanent hang. `signal` cannot interrupt a C call
         # holding the GIL; if that ever turns out to be the case here, the
         # symptom is another anonymous cancel and `thread` is the fallback.
+        #
+        # -n auto --dist loadfile (#2461): the "make the suite faster" half of
+        # the timeout-minutes note above. `auto` is os.cpu_count(), which is 4
+        # on ubuntu-latest and follows the runner if that ever changes.
+        #
+        # `loadfile`, not the default `load`: it keeps every test in a file on
+        # one worker. This suite manipulates sys.modules and pins env at module
+        # import (tests/unit/conftest.py, and files like
+        # test_2186_start_stopped_agent_recreate.py), so within-file ordering is
+        # load-bearing in places while ACROSS files the isolation improves —
+        # workers are separate processes, and conftest already pins
+        # TRINITY_DB_PATH per PID (`trinity-unit-tests-{os.getpid()}.db`), which
+        # is what makes per-worker DB state correct without any change here.
+        # The cost of `loadfile` is balance: a shard's critical path is its
+        # slowest single FILE (~2 min today, test_start_agent_skip_inject's real
+        # connection retries), which is far below the cap. If balance ever
+        # becomes the binding constraint, `load` is the next lever — but it
+        # needs the within-file assumptions audited first, so it is not a
+        # drop-in.
+        #
+        # Verified before landing, full suite, seed 12345, identical selection:
+        # serial 15 failed / 13216 passed / 26 skipped, parallel -n 4 the SAME
+        # 15 / 13216 / 26. Wall time is not quoted from that run on purpose —
+        # it was measured on a loaded workstation alongside a live Docker
+        # stack, where per-test time inflated under concurrency in a way a
+        # dedicated runner does not reproduce. The numbers that matter are the
+        # CI durations recorded in the PR for #2461.
+        #
+        # Residual, stated rather than discovered later: if an xdist worker
+        # dies mid-run, xdist reports the in-flight test as a failure and
+        # carries on, so the JUnit stays complete enough for the diff job. A
+        # worker lost together with its queue would show up as a burst of
+        # "fixed" tests on one side of the diff, which is noisy but visible —
+        # not a silent pass.
         run: |
           cd tests
           python -m pytest unit/ -m "not slow" \
             --timeout=300 --timeout-method=signal \
+            -n auto --dist loadfile \
             -p randomly --randomly-seed=${{ matrix.seed }} \
             --junit-xml="$GITHUB_WORKSPACE/junit-${{ matrix.side }}-${{ matrix.seed }}.xml" \
             --tb=no -q || true

--- a/.github/workflows/backend-unit-test.yml
+++ b/.github/workflows/backend-unit-test.yml
@@ -108,6 +108,17 @@ jobs:
     # and the red lands on whichever PR is open, including the `base` side,
     # which is plain `dev` and has nothing to do with the PR it reddens.
     #
+    # Measured on this workflow's own runners, first parallel run (33498960688),
+    # same six-shard matrix:
+    #
+    #     8.1m  8.6m  8.7m  9.0m  9.0m  17.5m   (all SUCCESS)
+    #
+    # Median 15m -> 9.0m, and the one starved shard — the same ~2x runner
+    # variance that used to produce the cancels — landed at 17.5m instead of
+    # not finishing at all. That is the number that matters: the worst
+    # starvation seen historically was >=3x (15m of work not finishing inside
+    # 45m), and 3x of 9m is 27m, which clears the cap by 18 minutes.
+    #
     # Do NOT raise this number as the next step if the cap starts being reached
     # again. Three raises in a row would mean the suite is growing faster than
     # anyone is willing to measure it; the next lever is the balance of the

--- a/tests/unit/test_2019_pytest_timeout_guard.py
+++ b/tests/unit/test_2019_pytest_timeout_guard.py
@@ -206,3 +206,73 @@ def test_the_assertions_read_the_command_not_the_comment(workflow):
     assert "#" in raw, "the step no longer carries the comment this guards against"
     assert not any(l.strip().startswith("#") for l in cmd.splitlines())
     assert "python -m pytest" in cmd, "comment stripping ate the command"
+
+
+# ---------------------------------------------------------------------------
+# #2461 — the same step, the other half of the budget problem
+# ---------------------------------------------------------------------------
+#
+# These live here rather than in a `test_2461_*.py` of their own because they
+# assert about the SAME step, and `_step` / `_command` above already carry two
+# mutation-found corrections (indentation bounding, comment stripping). A
+# second file would either import from this one or grow a second copy of both
+# helpers — and a copy is how one of them silently stops matching the other.
+#
+# The defect: a healthy shard finishes in ~15 minutes, a starved one does not
+# finish in 45 and dies as `The operation was canceled`. Measured over the 18
+# runs before the fix, 78 shards: success min 13m / median 15m / p90 17m /
+# max 30m, with 5-6 shards killed at exactly the cap — ~8% of shards, so ~40%
+# of runs carried at least one spurious red, landing on whichever PR was open
+# INCLUDING the `base` side, which is plain `dev`.
+
+class TestTheSuiteRunsInParallel:
+
+    def test_the_unit_suite_is_parallelised(self, workflow):
+        step = _pytest_step(workflow)
+        assert re.search(r"-n\s+(auto|\d+)", step), (
+            "the unit suite runs serially again — a starved runner returns to "
+            "reaching the 45-minute cap, and the red lands on whichever PR is "
+            "open (#2461)"
+        )
+
+    def test_distribution_keeps_a_file_on_one_worker(self, workflow):
+        """`loadfile`, not the default `load`.
+
+        The suite manipulates sys.modules and pins env at module import, so
+        within-file ordering is load-bearing in places. Across files the
+        isolation improves — workers are separate processes and the unit
+        conftest already pins TRINITY_DB_PATH per PID.
+
+        A future move to `load` is a legitimate next lever for balance, but it
+        needs those within-file assumptions audited first, so it must not
+        happen as a silent edit.
+        """
+        step = _pytest_step(workflow)
+        assert "--dist loadfile" in step, (
+            "distribution mode changed away from loadfile — see #2461 before "
+            "loosening this"
+        )
+
+    def test_xdist_is_installed_for_the_run(self, workflow):
+        """A `-n` flag with no plugin is an unrecognised-argument error, i.e.
+        the whole shard fails rather than running serially. Pin both halves so
+        neither can be dropped alone."""
+        install = _command(workflow, "Install test dependencies")
+        assert "pytest-xdist" in install, (
+            "the run passes -n but xdist is not installed — pytest exits on an "
+            "unrecognised argument and every shard fails (#2461)"
+        )
+
+    def test_the_cap_is_not_raised_instead(self, workflow):
+        """Parallelising is the alternative to buying minutes, not a companion
+        to it. 45 was already the second raise (25 -> 45 on 2026-08-25); a
+        third would mean the suite is growing faster than anyone is measuring
+        it, and the next lever is the balance of the distribution, not the
+        budget."""
+        job = workflow.split("  test:", 1)[1]
+        caps = re.findall(r"^\s*timeout-minutes:\s*(\d+)", job, re.MULTILINE)
+        assert caps, "the unit-suite job lost its timeout-minutes entirely"
+        assert int(caps[0]) <= 45, (
+            f"unit-suite job cap raised to {caps[0]}m — #2461 exists because "
+            "raising it is the move that stopped working"
+        )


### PR DESCRIPTION
## What

A healthy shard of `backend-unit-test.yml` finishes in ~15 minutes; a starved one does not finish in 45 and dies as `The operation was canceled`. Measured over the 18 runs before this change (78 shards):

| | |
|---|---|
| success duration | min **13m**, median **15m**, p90 **17m**, max **30m** |
| killed at the cap | **5–6 shards at exactly 45m** |
| per-shard kill rate | ≈ **8 %** → **~40 % of runs** carried ≥1 spurious red |

The red lands on whichever PR is open — **including the `base` side, which is plain `dev`**. Three PRs on 2026-09-01 (#2451, #2456, #2457) each needed a manual `gh run rerun --failed` for exactly one shard.

## Why not raise the cap

It was already raised **25 → 45 on 2026-08-25** for this, and that comment names the alternative it declined to take:

> The honest alternative is to make the suite faster (or shard it with xdist) rather than keep buying minutes.

This takes it. **`-n auto --dist loadfile`, and the cap stays at 45** — the point is not to use headroom but to move the distribution far enough below the cap that a slow runner stops reaching it. A guard asserts the cap is not raised again, on purpose: raising it is the move that stopped working.

## Why `loadfile` and not `load`

The suite manipulates `sys.modules` and pins env at module import, so **within-file** ordering is load-bearing in places. **Across** files the isolation improves — workers are separate processes, and `tests/unit/conftest.py` already pins `TRINITY_DB_PATH` per PID (`trinity-unit-tests-{os.getpid()}.db`), which is what makes per-worker DB state correct with no change here.

`loadfile`'s cost is balance: a shard's critical path becomes its slowest single *file* (~2 min today — `test_start_agent_skip_inject`'s real connection retries), far below the cap. `load` is the next lever if balance ever binds, but it needs those within-file assumptions audited first, so a guard makes that an explicit change rather than a silent edit.

## Install location

xdist rides in the workflow beside `pytest-randomly`, **for a different reason**, stated in the comment so nobody infers a rule that isn't there: randomly is kept out of `tests/requirements-test.txt` because it *auto-activates*; xdist is inert without `-n`, so by that file's own documented test (its `hypothesis` note) it would be harmless there. It is in the workflow because **six** workflows install that file and only this one runs the suite in parallel.

## Correctness, verified not asserted

Full suite, seed 12345, identical selection:

```
serial            15 failed, 13216 passed, 26 skipped
parallel -n 4     15 failed, 13216 passed, 26 skipped
```

Identical. (The 15 are the pre-existing IPv4-mapped-IPv6 failures on `dev` in this environment — same set both ways.)

**Wall time is deliberately not quoted from that run.** It was measured on a loaded workstation running a live Docker stack, where per-test time inflated ~2.6× under concurrency in a way a dedicated runner does not reproduce (sum of per-test time went 29m serial → 78m at `-n 4`, for 30m → 20m wall). Quoting a 1.5× from that box as the expected CI improvement would be dishonest. **The numbers that matter are this PR's own CI durations, and I'll record them in the workflow comment before asking for review** — that is AC #2.

## Guards

In `tests/unit/test_2019_pytest_timeout_guard.py`, not a new file: they assert about the **same step**, and that file's `_step` / `_command` helpers already carry two mutation-found corrections (indentation bounding so the slice cannot swallow the next job; comment stripping so an assertion cannot pass on the prose after the flag is deleted from the command). A second file would copy both helpers, and a copy is how one silently stops matching the other.

Four assertions, all four mutation-checked red then reverted:

1. drop `-n auto` → *parallelised* + *loadfile* fire
2. switch to `--dist load` → *loadfile* fires
3. drop the xdist install → *installed* fires (that mutation would make every shard fail on an unrecognised argument, not run serially)
4. raise the cap to 75 → *cap not raised* fires

## Related

- #2462 — the nightly cross-PR regression net has been dead for 12+ nights for the same underlying reason (six full suites in a 25-minute job). Part 1 of that fix is this change; part 2 is its budget.

Fixes #2461
