### PR TITLE
ci(nightly): make the cross-PR regression net able to finish, and unable to die quietly (#2462)

### DIFF
--- a/.github/workflows/backend-unit-nightly.yml
+++ b/.github/workflows/backend-unit-nightly.yml
@@ -391,17 +391,25 @@ jobs:
       issues: write           # PR conversation comments are issue comments
       pull-requests: write
     steps:
-      # #2462: `dev`, pinned, never PR code. The architecture rule at the top
-      # of this file is that untrusted PR code must not share a job with a
-      # write-capable token — this checkout is the same trust level as the
-      # workflow file itself, and it exists so the verdict logic can live in a
-      # module a test can execute instead of as inline `github-script` prose.
-      # A false all-clear on a regression detector is the error nothing
-      # downstream corrects, so that logic must be testable.
-      - name: Checkout dev (trusted — verdict module only)
+      # #2462: the verdict module, from THE COMMIT THIS WORKFLOW CAME FROM.
+      #
+      # The architecture rule at the top of this file is that untrusted PR code
+      # must not share a job with a write-capable token. `github.sha` satisfies
+      # it exactly: this workflow has only `schedule` and `workflow_dispatch`
+      # triggers, both of which run a ref a repo writer chose, so it is the same
+      # trust level as the workflow definition being executed — if that commit
+      # cannot be trusted, neither can the YAML deciding to check it out. PR
+      # code is still never checked out in this job.
+      #
+      # `ref: dev` was tried first and is WRONG in a way that only shows up when
+      # it matters: a dispatch from a branch runs that branch's workflow against
+      # `dev`'s module, so the two can disagree — and on the run that proved
+      # this fix, `dev` did not have the module at all and the job died with
+      # MODULE_NOT_FOUND. Workflow and module must come from one commit.
+      - name: Checkout the verdict module (trusted, same commit as this workflow)
         uses: actions/checkout@v7
         with:
-          ref: dev
+          ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
           sparse-checkout: scripts/ci

--- a/.github/workflows/backend-unit-nightly.yml
+++ b/.github/workflows/backend-unit-nightly.yml
@@ -24,6 +24,15 @@ on:
 # No top-level permissions — each job declares its own narrow scope.
 permissions: {}
 
+env:
+  # ONE definition of the seed set (#2462). `discover` builds a matrix leg per
+  # seed from it and `comment` requires exactly these seeds before it will
+  # publish a verdict, so the two cannot disagree about how many legs a
+  # complete answer takes. Restating the list in either place is how a fourth
+  # seed silently makes every PR permanently unverified, or a removed one
+  # silently lowers the bar.
+  NIGHTLY_SEEDS: '12345 67890 99999'
+
 concurrency:
   group: backend-unit-nightly
   cancel-in-progress: false
@@ -57,11 +66,19 @@ jobs:
             echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          matrix=$(echo "$prs" | jq -c '{include: [.[] | {
-            pr_number: .number,
-            head_ref: .headRefName,
-            head_sha: .headRefOid
-          }]}')
+          # #2462: one leg per (PR, seed), not one leg per PR running all six
+          # suites. A leg is now base+head for ONE seed — two suites, which fits
+          # a budget; six never did. Keeping base and head for the same seed in
+          # the SAME leg is what lets the regression diff stay where it is,
+          # inside the job that holds the trusted stashed copy of the script.
+          matrix=$(echo "$prs" | jq -c --arg seeds "$NIGHTLY_SEEDS" \
+            '{include: [.[] | . as $pr
+              | (($seeds | split(" ")) | map({
+                  pr_number: $pr.number,
+                  head_ref: $pr.headRefName,
+                  head_sha: $pr.headRefOid,
+                  seed: .
+                }))] | flatten}')
           {
             echo "has_prs=true"
             echo "matrix<<MATRIX_EOF"
@@ -70,11 +87,43 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   test:
-    name: pytest (PR #${{ matrix.pr_number }})
+    name: pytest (PR #${{ matrix.pr_number }}, seed ${{ matrix.seed }})
     needs: discover
     if: needs.discover.outputs.has_prs == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # #2462: this job had `timeout-minutes: 25` while running SIX full unit
+    # suites (three seeds x base and head). One suite was ~15 minutes, so a leg
+    # needed ~90 minutes of a 25-minute budget and every leg for a mergeable PR
+    # was cancelled at the cap. Twelve consecutive nights of `cancelled` in the
+    # queryable history, and no result for any mergeable PR in any of them. The
+    # only legs that "succeeded" finished in 46 seconds — the merge-conflict
+    # short-circuits, i.e. exactly the ones that ran nothing.
+    #
+    # Nobody noticed because the workflow is structurally incapable of
+    # reporting its own death: it is scheduled (so a cancel notifies no one and
+    # blocks no PR), and the diff step is gated on the suite step completing,
+    # so a capped leg produces no artifact, no diff and no comment. Silence and
+    # success look identical from outside.
+    #
+    # Two changes, and BOTH are needed — either alone leaves it broken:
+    #
+    #   1. a leg is now ONE seed (base + head = two suites), not three seeds
+    #      x two sides = six;
+    #   2. the suites run under xdist, the #2461 change, measured at ~9 min per
+    #      suite on these runners against ~15 min serial.
+    #
+    # So a leg is ~18 minutes of suite plus ~4 of full-history checkout, merge
+    # and install: ~22. 60 is ~2.7x that, which clears the worst runner
+    # starvation actually measured on this repo's runners (1.94x, from #2461's
+    # 17.5m shard beside its 9.0m siblings).
+    #
+    # Residual, stated rather than discovered later: a pathological ~3x runner
+    # still reaches this cap. The difference from before is blast radius and
+    # visibility — it now costs ONE SEED of one PR instead of that PR's entire
+    # verdict, the PR is reported as unverified rather than silently skipped
+    # (see the all-seeds rule in `comment`), and a sweep that dies wholesale
+    # fails the run loudly instead of ending `cancelled`.
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:
@@ -154,13 +203,36 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r tests/requirements-test.txt 'pytest-randomly>=3.15.0'
+          pip install -r tests/requirements-test.txt \
+            'pytest-randomly>=3.15.0' 'pytest-xdist>=3.5.0'
 
       - name: Diff-script self-test (trusted copy)
         run: python "$HOME/.ci-tools/diff-pytest-failures.py" --self-test
 
       - name: Run unit suite (base = origin/dev, head = merge commit)
         if: steps.merge.outputs.merge_conflict == 'false'
+        # #2462: ONE seed per leg — the loops that ran all three are gone. Base
+        # and head for that seed stay in this workspace so the diff below can
+        # still run here, under the trusted stashed script, rather than needing
+        # a fourth job that downloads junit artifacts from an untrusted one.
+        #
+        # -n auto --dist loadfile is #2461's change, for #2461's reasons —
+        # see backend-unit-test.yml, where the flags, the loadfile rationale
+        # (this suite manipulates sys.modules and pins env at module import,
+        # so within-file ordering is load-bearing) and the measured
+        # before/after all live. Repeating the reasoning here would give it two
+        # homes and one of them would go stale.
+        #
+        # --timeout=300 --timeout-method=signal is NEW on this workflow and was
+        # simply missing: #2019 added it to the PR-blocking workflow after four
+        # anonymous cancels in one day, and this one never got it. Without it a
+        # single stalled test consumes the whole leg and dies without naming
+        # itself — the same failure, on the workflow where nobody is watching.
+        #
+        # `|| true` is unchanged and still load-bearing: pytest exits non-zero
+        # while ANY test fails, and `dev` has a known non-empty baseline, so
+        # the BASE side must keep running or there is nothing to diff against.
+        # The diff step is what decides this leg's verdict.
         run: |
           set -euo pipefail
           # Snapshot the merge commit so we can come back to it.
@@ -168,21 +240,21 @@ jobs:
 
           # Base run = origin/dev tip, before merge.
           git switch --detach origin/dev
-          for seed in 12345 67890 99999; do
-            ( cd tests && python -m pytest unit/ -m "not slow" \
-                -p randomly --randomly-seed=$seed \
-                --junit-xml="$GITHUB_WORKSPACE/junit-base-pr${{ matrix.pr_number }}-$seed.xml" \
-                --tb=no -q || true )
-          done
+          ( cd tests && python -m pytest unit/ -m "not slow" \
+              --timeout=300 --timeout-method=signal \
+              -n auto --dist loadfile \
+              -p randomly --randomly-seed=${{ matrix.seed }} \
+              --junit-xml="$GITHUB_WORKSPACE/junit-base-pr${{ matrix.pr_number }}-${{ matrix.seed }}.xml" \
+              --tb=no -q || true )
 
           # Head run = merge commit.
           git switch --detach "$MERGE_SHA"
-          for seed in 12345 67890 99999; do
-            ( cd tests && python -m pytest unit/ -m "not slow" \
-                -p randomly --randomly-seed=$seed \
-                --junit-xml="$GITHUB_WORKSPACE/junit-head-pr${{ matrix.pr_number }}-$seed.xml" \
-                --tb=no -q || true )
-          done
+          ( cd tests && python -m pytest unit/ -m "not slow" \
+              --timeout=300 --timeout-method=signal \
+              -n auto --dist loadfile \
+              -p randomly --randomly-seed=${{ matrix.seed }} \
+              --junit-xml="$GITHUB_WORKSPACE/junit-head-pr${{ matrix.pr_number }}-${{ matrix.seed }}.xml" \
+              --tb=no -q || true )
 
       - name: Run regression diff (trusted copy)
         if: steps.merge.outputs.merge_conflict == 'false'
@@ -190,9 +262,9 @@ jobs:
         run: |
           set +e
           python "$HOME/.ci-tools/diff-pytest-failures.py" \
-            --base junit-base-pr${{ matrix.pr_number }}-*.xml \
-            --head junit-head-pr${{ matrix.pr_number }}-*.xml \
-            --out "diff-pr${{ matrix.pr_number }}.md"
+            --base junit-base-pr${{ matrix.pr_number }}-${{ matrix.seed }}.xml \
+            --head junit-head-pr${{ matrix.pr_number }}-${{ matrix.seed }}.xml \
+            --out "diff-pr${{ matrix.pr_number }}-${{ matrix.seed }}.md"
           rc=$?
           if [ $rc -eq 0 ]; then
             echo "regression=false" >> "$GITHUB_OUTPUT"
@@ -223,10 +295,11 @@ jobs:
           # ALL-CLEAR on a regression detector, which nothing corrects.
           #
           # Writing no file is the honest answer: the comment job enumerates
-          # `status-pr*.json`, so a missing one means this PR is skipped and any
-          # existing sticky is left exactly as it was.
+          # `status-pr*.json` and requires one per seed (#2462), so a missing
+          # one means this PR is reported as UNVERIFIED and any existing sticky
+          # is left exactly as it was — never overwritten with a tick.
           if [ -z "$merge_conflict" ]; then
-            echo "::warning::merge verdict unknown for PR ${{ matrix.pr_number }} — no status written, sticky left untouched"
+            echo "::warning::merge verdict unknown for PR ${{ matrix.pr_number }} seed ${{ matrix.seed }} — no status written, PR reported unverified"
             exit 0
           fi
 
@@ -238,28 +311,51 @@ jobs:
             if [ "$merge_conflict" = "true" ]; then
               regression="false"
             else
-              echo "::warning::regression verdict unknown for PR ${{ matrix.pr_number }} — no status written, sticky left untouched"
+              echo "::warning::regression verdict unknown for PR ${{ matrix.pr_number }} seed ${{ matrix.seed }} — no status written, PR reported unverified"
               exit 0
             fi
           fi
           jq -n \
             --arg pr "${{ matrix.pr_number }}" \
+            --arg seed "${{ matrix.seed }}" \
             --arg head_sha "${{ matrix.head_sha }}" \
             --arg merge_conflict "$merge_conflict" \
             --arg regression "$regression" \
-            '{pr_number: ($pr|tonumber), head_sha: $head_sha,
+            '{pr_number: ($pr|tonumber), seed: $seed, head_sha: $head_sha,
               merge_conflict: ($merge_conflict == "true"),
               regression: ($regression == "true")}' \
-            > "status-pr${{ matrix.pr_number }}.json"
+            > "status-pr${{ matrix.pr_number }}-${{ matrix.seed }}.json"
+
+      - name: Leg summary
+        # #2462 AC 3: a leg that was CAPPED and a leg that legitimately had
+        # nothing to run were indistinguishable from outside — the 46-second
+        # merge-conflict skips were the only "successes" for twelve nights, and
+        # nothing on the run page said so. This writes what this leg actually
+        # did, so the Actions summary answers the question without opening a
+        # log. It cannot run at all when the job is cancelled at the cap, and
+        # that ABSENCE is itself the distinguishing signal.
+        if: always()
+        run: |
+          {
+            echo "### PR #${{ matrix.pr_number }} — seed ${{ matrix.seed }}"
+            if [ "${{ steps.merge.outputs.merge_conflict }}" = "true" ]; then
+              echo "- merge conflict against \`dev\` — suite deliberately not run"
+            elif [ "${{ steps.merge.outputs.merge_conflict }}" = "false" ]; then
+              echo "- suite ran (base + head, seed ${{ matrix.seed }})"
+              echo "- regression: ${{ steps.diff.outputs.regression || 'unknown' }}"
+            else
+              echo "- no merge verdict — leg failed before the suite could run"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: nightly-pr-${{ matrix.pr_number }}
+          name: nightly-pr-${{ matrix.pr_number }}-seed-${{ matrix.seed }}
           path: |
-            diff-pr${{ matrix.pr_number }}.md
-            status-pr${{ matrix.pr_number }}.json
+            diff-pr${{ matrix.pr_number }}-${{ matrix.seed }}.md
+            status-pr${{ matrix.pr_number }}-${{ matrix.seed }}.json
           if-no-files-found: warn
           retention-days: 14
 
@@ -270,9 +366,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      contents: read          # #2462: to check out the TRUSTED verdict module
       issues: write           # PR conversation comments are issue comments
       pull-requests: write
     steps:
+      # #2462: `dev`, pinned, never PR code. The architecture rule at the top
+      # of this file is that untrusted PR code must not share a job with a
+      # write-capable token — this checkout is the same trust level as the
+      # workflow file itself, and it exists so the verdict logic can live in a
+      # module a test can execute instead of as inline `github-script` prose.
+      # A false all-clear on a regression detector is the error nothing
+      # downstream corrects, so that logic must be testable.
+      - name: Checkout dev (trusted — verdict module only)
+        uses: actions/checkout@v7
+        with:
+          ref: dev
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: scripts/ci
+          sparse-checkout-cone-mode: false
+
       - name: Download all nightly artifacts
         uses: actions/download-artifact@v8
         with:
@@ -293,47 +406,105 @@ jobs:
       # #2029 considered a second, coarser belt here — gating this step on
       # `needs.test.result == 'success'` — and it is deliberately NOT applied.
       # `test` is a MATRIX job, so its result is `failure` when any single leg
-      # fails: one PR's infrastructure hiccup would suppress the report for
+      # fails: one leg's infrastructure hiccup would suppress the report for
       # every other PR in the sweep, trading a false green for a silence that
       # is just as wrong and affects PRs that were fine.
       #
-      # The per-PR guard in `Write status JSON` is already both precise and
-      # complete: a leg with no verdict writes no file, the loop below
-      # enumerates what exists, and only that PR is skipped. The all-legs-failed
-      # case falls out of the same mechanism — no files, no comments.
+      # The per-leg guard in `Write status JSON` is precise: a leg with no
+      # verdict writes no file, the script below enumerates what exists, and
+      # #2462's completeness rule means the affected PR is reported unverified
+      # rather than given a tick on a partial answer.
+      #
+      # What #2029 could not have anticipated is the all-legs-failed case,
+      # which under the old 25-minute budget was EVERY night for twelve nights:
+      # no files, no comments, and a run that ends without a red mark anywhere.
+      # That one is now `core.setFailed` in the script — the sweep is allowed
+      # to say nothing about a PR, but not to say nothing at all and pass.
       - name: Post or update sticky comment per PR
         uses: actions/github-script@v9
         env:
           PATHS: ${{ steps.list.outputs.paths }}
+          # Passed explicitly rather than relied on from the workflow-level
+          # env, so the completeness rule below reads its seed set from the
+          # same place `discover` builds the matrix from, visibly.
+          NIGHTLY_SEEDS: ${{ env.NIGHTLY_SEEDS }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
+            const { verdictFor, groupByPr } = require(
+              `${process.env.GITHUB_WORKSPACE}/scripts/ci/nightly-verdict.js`
+            );
             const marker = '<!-- nightly-unit-suite -->';
 
             const paths = (process.env.PATHS || '').split('\n').map(s => s.trim()).filter(Boolean);
+            const expectedSeeds = (process.env.NIGHTLY_SEEDS || '').split(' ').filter(Boolean);
+
+            // #2462: a sweep that produced NOTHING while PRs were open is the
+            // exact signature of the twelve dead nights — every leg capped, no
+            // artifact, no comment, run ends without a red mark anywhere. It
+            // must not exit 0. A run where every PR merge-conflicted still
+            // writes a status per leg, so zero files with PRs present can only
+            // mean the legs themselves died.
             if (paths.length === 0) {
-              core.info('No status JSONs found — nothing to comment on.');
+              core.setFailed(
+                'Nightly produced no status artifacts while open PRs existed — every test leg failed ' +
+                'or was cancelled. This is the #2462 signature; check the test job durations.'
+              );
               return;
             }
 
+            // #2462: legs are per (PR, seed) now, so a PR's verdict is the
+            // union of its seeds. Group first, then decide — and the deciding
+            // lives in scripts/ci/nightly-verdict.js, which a test executes.
+            const parsed = [];
             for (const p of paths) {
               try {
-                const status = JSON.parse(fs.readFileSync(p, 'utf8'));
-                const pr = status.pr_number;
-                const diffPath = `diff-pr${pr}.md`;
+                parsed.push(JSON.parse(fs.readFileSync(p, 'utf8')));
+              } catch (err) {
+                core.warning(`Failed to read ${p}: ${err.message}`);
+              }
+            }
+            const byPr = groupByPr(parsed);
+
+            for (const [pr, legs] of byPr) {
+              try {
+                const verdict = verdictFor(legs, expectedSeeds);
+
+                if (verdict.status === 'unverified') {
+                  core.warning(
+                    `PR #${pr}: unverified — no result for seed(s) ${verdict.missing.join(', ') || '(none reported)'}. ` +
+                    'Sticky left untouched.'
+                  );
+                  continue;
+                }
+
+                const status = {
+                  merge_conflict: verdict.status === 'merge_conflict',
+                  regression: verdict.status === 'regression',
+                  head_sha: verdict.headSha,
+                };
+                const regressed = (verdict.regressed || []).map(
+                  l => ({ ...l, diffPath: `diff-pr${pr}-${l.seed}.md` })
+                );
 
                 let body;
                 if (status.merge_conflict) {
                   body = `${marker}\n⚠️ **Nightly unit-suite check skipped — merge conflict against \`dev\`.**\n\nResolve by running \`git merge dev\` locally and pushing the result. The next nightly run will re-test once the conflict is gone.`;
                 } else if (status.regression) {
-                  let diffMd = '_diff artifact missing_';
-                  if (fs.existsSync(diffPath)) {
-                    diffMd = fs.readFileSync(diffPath, 'utf8');
-                  }
-                  body = `${marker}\n⚠️ **Nightly unit-suite found regressions when this PR is merged into \`dev\`.**\n\n<details>\n<summary>Regression details (head_sha: \`${status.head_sha}\`)</summary>\n\n${diffMd}\n\n</details>\n\n_Reproduce locally:_ \`git merge dev && tests/run-core.sh\``;
+                  // Name the seed on each block. Under pytest-randomly the
+                  // seed is the reproduction instruction, so a diff without it
+                  // tells a reviewer what broke but not how to see it again.
+                  const sections = regressed.map(l => {
+                    const md = fs.existsSync(l.diffPath)
+                      ? fs.readFileSync(l.diffPath, 'utf8')
+                      : '_diff artifact missing_';
+                    return `**Seed \`${l.seed}\`**\n\n${md}`;
+                  }).join('\n\n---\n\n');
+                  const scope = `${regressed.length} of ${verdict.total} seeds`;
+                  body = `${marker}\n⚠️ **Nightly unit-suite found regressions when this PR is merged into \`dev\`** (${scope}).\n\n<details>\n<summary>Regression details (head_sha: \`${status.head_sha}\`)</summary>\n\n${sections}\n\n</details>\n\n_Reproduce locally:_ \`git merge dev && ( cd tests && python -m pytest unit/ -m "not slow" -p randomly --randomly-seed=${regressed[0].seed} )\``;
                 } else {
-                  body = `${marker}\n✅ **Nightly unit-suite clean** when this PR is merged into \`dev\` (head_sha: \`${status.head_sha}\`).`;
+                  body = `${marker}\n✅ **Nightly unit-suite clean** when this PR is merged into \`dev\`, all ${verdict.total} seeds (head_sha: \`${status.head_sha}\`).`;
                 }
 
                 // Find existing sticky comment by marker (paginated).
@@ -383,7 +554,7 @@ jobs:
                   core.info(`PR #${pr}: clean and no prior comment — nothing to post.`);
                 }
               } catch (err) {
-                // Per-PR failure must not take out the rest of the matrix.
-                core.warning(`Failed to process ${p}: ${err.message}`);
+                // Per-PR failure must not take out the rest of the sweep.
+                core.warning(`Failed to process PR #${pr}: ${err.message}`);
               }
             }

--- a/.github/workflows/backend-unit-nightly.yml
+++ b/.github/workflows/backend-unit-nightly.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '0 6 * * *'   # 06:00 UTC = 07:00 London
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Sweep only this PR (blank = every open PR, as the schedule does)'
+        required: false
+        type: string
 
 # No top-level permissions — each job declares its own narrow scope.
 permissions: {}
@@ -54,12 +59,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # #2462: a manual dispatch may scope the sweep to ONE PR. The
+          # scheduled run passes nothing and is unchanged. This exists because
+          # verifying a change to this workflow otherwise means sweeping every
+          # open PR and posting bot comments on other people's work to prove
+          # your own fix — the demonstration should not have a blast radius
+          # wider than the thing being demonstrated.
+          #
+          # Filtered by `select`, not by fetching the single PR: an id that is
+          # closed, targets another base, or does not exist then yields an
+          # empty set and the honest `has_prs=false` path, rather than a matrix
+          # leg that fails deep inside the merge step.
+          only='${{ inputs.pr_number }}'
           prs=$(gh pr list \
             --repo "${{ github.repository }}" \
             --base dev \
             --state open \
             --limit 50 \
             --json number,headRefName,headRefOid)
+          if [ -n "$only" ]; then
+            prs=$(echo "$prs" | jq -c --argjson only "$only" '[.[] | select(.number == $only)]')
+            echo "Scoped to PR #$only: $(echo "$prs" | jq 'length') match(es)"
+          fi
           count=$(echo "$prs" | jq 'length')
           if [ "$count" = "0" ]; then
             echo "has_prs=false" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/nightly-verdict.js
+++ b/scripts/ci/nightly-verdict.js
@@ -1,0 +1,75 @@
+/**
+ * Per-PR verdict for the nightly cross-PR regression sweep (#2462).
+ *
+ * Extracted from the `comment` job's inline `github-script` body so the one
+ * piece of new logic that can produce a FALSE ALL-CLEAR is executable by a
+ * test. Everything here is pure — no `fs`, no `github`, no `core` — so the
+ * workflow keeps owning I/O and API calls and this owns only the decision.
+ *
+ * CommonJS on purpose: `actions/github-script` runs the inline body under
+ * `require()`, so an ESM `export` here would be unloadable by the one caller
+ * that matters. Vitest imports it through CJS interop.
+ *
+ * Background: legs are per (PR, seed) since #2462, because the previous shape
+ * ran six full suites in one 25-minute job and was cancelled every night for
+ * twelve consecutive nights. A PR's verdict is therefore the union of its
+ * seeds, and "how many seeds make a complete answer" is a question this file
+ * must answer the same way `discover` builds the matrix.
+ */
+
+/**
+ * @param {Array<{seed: string|number, regression: boolean, merge_conflict: boolean, head_sha: string}>} legs
+ * @param {Array<string>} expectedSeeds
+ * @returns {{status: 'unverified'|'merge_conflict'|'regression'|'clean', missing?: string[], regressed?: object[], headSha?: string, total?: number}}
+ */
+function verdictFor(legs, expectedSeeds) {
+  const seen = new Set((legs || []).map((l) => String(l.seed)));
+  const missing = (expectedSeeds || []).filter((s) => !seen.has(String(s)));
+
+  // An INCOMPLETE set is not a clean one. #2029's rule — absence of a verdict
+  // is its own state — applies per seed: two green seeds and one that never
+  // reported says nothing about the third, and a tick published on that
+  // partial answer is the false all-clear the rule exists to prevent.
+  //
+  // Checked FIRST, before the conflict and regression arms. A missing seed
+  // means we do not know what that seed would have said, and that is true
+  // whatever the seeds that did report happen to say.
+  if (missing.length > 0) return { status: 'unverified', missing };
+
+  // Reachable only when expectedSeeds is empty AND no legs reported, i.e. a
+  // misconfiguration rather than a result. Guarded explicitly so it cannot
+  // fall through to `clean` on an empty array.
+  if (legs.length === 0) return { status: 'unverified', missing: [] };
+
+  const headSha = legs[0].head_sha;
+
+  // A conflict is not a test result — the suite never ran — so it outranks the
+  // regression arm rather than being merged with it.
+  if (legs.some((l) => l.merge_conflict)) {
+    return { status: 'merge_conflict', headSha, total: legs.length };
+  }
+
+  // ANY seed is enough to condemn. pytest-randomly is here precisely because
+  // an order-dependent failure appears under one seed and not another, so "one
+  // seed regressed" IS the finding — averaging it away would delete the signal
+  // the seeds exist to produce.
+  const regressed = legs.filter((l) => l.regression);
+  if (regressed.length > 0) {
+    return { status: 'regression', headSha, regressed, total: legs.length };
+  }
+
+  return { status: 'clean', headSha, total: legs.length };
+}
+
+/** Group per-leg status objects by PR number, input order preserved. */
+function groupByPr(statuses) {
+  const byPr = new Map();
+  for (const s of statuses || []) {
+    const pr = s.pr_number;
+    if (!byPr.has(pr)) byPr.set(pr, []);
+    byPr.get(pr).push(s);
+  }
+  return byPr;
+}
+
+module.exports = { verdictFor, groupByPr }

--- a/src/frontend/tests/unit/nightlyVerdict.spec.js
+++ b/src/frontend/tests/unit/nightlyVerdict.spec.js
@@ -1,0 +1,109 @@
+/**
+ * #2462 — the nightly's per-PR verdict, the one path that can publish a lie.
+ *
+ * The sweep runs one leg per (PR, seed) and a PR's verdict is the union of its
+ * seeds, so the aggregation decides whether a green tick appears on a PR whose
+ * suite may not have finished. That is exactly the failure #2029 fixed one
+ * layer down ("absence of a verdict is its own state"), and the reason the
+ * logic is a module rather than inline `github-script` prose: an inline body
+ * cannot be executed by a test, and a false ALL-CLEAR on a regression detector
+ * is the error nothing downstream corrects.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'node:module'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const require_ = createRequire(import.meta.url)
+const { verdictFor, groupByPr } = require_(
+  resolve(HERE, '../../../../scripts/ci/nightly-verdict.js'),
+)
+
+const SEEDS = ['12345', '67890', '99999']
+const leg = (seed, over = {}) => ({
+  seed,
+  pr_number: 1,
+  head_sha: 'abc123',
+  regression: false,
+  merge_conflict: false,
+  ...over,
+})
+
+describe('an incomplete answer is never a clean one', () => {
+  it('a missing seed is unverified, not clean', () => {
+    const v = verdictFor([leg('12345'), leg('67890')], SEEDS)
+    expect(v.status).toBe('unverified')
+    expect(v.missing).toEqual(['99999'])
+  })
+
+  it('two green seeds do not vouch for a third that never reported', () => {
+    // The precise shape of the twelve dead nights, had the old code shipped a
+    // tick from a partial set: everything that ran was fine, and that says
+    // nothing whatever about the leg that was cancelled at the cap.
+    expect(verdictFor([leg('12345'), leg('67890')], SEEDS).status).not.toBe('clean')
+  })
+
+  it('no legs at all is unverified, not clean', () => {
+    expect(verdictFor([], SEEDS).status).toBe('unverified')
+  })
+
+  it('unverified outranks a regression seen in the seeds that did report', () => {
+    // Deliberate: with a seed missing we do not know the full answer, and
+    // "unverified" is the honest word for that. The regressed seed is still
+    // in the warning log; what must not happen is a confident verdict built
+    // from a partial set, in either direction.
+    const v = verdictFor([leg('12345', { regression: true }), leg('67890')], SEEDS)
+    expect(v.status).toBe('unverified')
+  })
+})
+
+describe('a complete answer', () => {
+  it('is clean when every seed is clean', () => {
+    const v = verdictFor(SEEDS.map((s) => leg(s)), SEEDS)
+    expect(v.status).toBe('clean')
+    expect(v.total).toBe(3)
+    expect(v.headSha).toBe('abc123')
+  })
+
+  it('condemns on ANY seed — order-dependence is the finding, not noise', () => {
+    // pytest-randomly exists here because a failure that appears under one
+    // seed and not another is real. Averaging it away deletes the signal the
+    // seeds are for.
+    const v = verdictFor(
+      [leg('12345'), leg('67890'), leg('99999', { regression: true })],
+      SEEDS,
+    )
+    expect(v.status).toBe('regression')
+    expect(v.regressed.map((l) => l.seed)).toEqual(['99999'])
+    expect(v.total).toBe(3)
+  })
+
+  it('reports a merge conflict ahead of any regression arm', () => {
+    // A conflict means the suite never ran, so it is not a test result and
+    // must not be rendered as one.
+    const v = verdictFor(
+      SEEDS.map((s) => leg(s, { merge_conflict: true, regression: true })),
+      SEEDS,
+    )
+    expect(v.status).toBe('merge_conflict')
+  })
+})
+
+describe('grouping', () => {
+  it('splits legs by PR and keeps every one', () => {
+    const legs = [
+      { ...leg('12345'), pr_number: 10 },
+      { ...leg('67890'), pr_number: 11 },
+      { ...leg('99999'), pr_number: 10 },
+    ]
+    const byPr = groupByPr(legs)
+    expect([...byPr.keys()].sort()).toEqual([10, 11])
+    expect(byPr.get(10)).toHaveLength(2)
+    expect(byPr.get(11)).toHaveLength(1)
+  })
+
+  it('tolerates an empty sweep without inventing a PR', () => {
+    expect([...groupByPr([]).keys()]).toEqual([])
+  })
+})

--- a/tests/unit/test_1941_nightly_merge_depth.py
+++ b/tests/unit/test_1941_nightly_merge_depth.py
@@ -161,6 +161,27 @@ def _comment_job():
     pytest.fail("no job posts the sticky comment any more")
 
 
+def _branch_body(script: str, opener: str) -> str:
+    """The lines of a shell `if` branch, ending at a line that is exactly `fi`.
+
+    Bounded on a TOKEN, not on the substring "fi" (#2462). The original form,
+    `guard.split("fi")[0]`, truncated at the first occurrence anywhere — and
+    "fi" occurs inside ordinary English: it fired the moment a warning message
+    in that branch used the word "unverified", cutting the slice before the
+    `exit 0` the assertion looks for and reporting a guard that was in fact
+    present. Same family as this file's own comment-stripping: a check that
+    matches inside words tests the prose, not the code.
+    """
+    lines = script.splitlines()
+    start = next(i for i, l in enumerate(lines) if opener in l)
+    out = []
+    for line in lines[start + 1:]:
+        if line.strip() == "fi":
+            break
+        out.append(line)
+    return "\n".join(out)
+
+
 def test_an_unknown_merge_verdict_writes_no_status_file():
     """The #2029 defect: this step is `if: always()`, so it also runs when the
     job died before the merge produced an answer. The unset output stringifies
@@ -176,8 +197,8 @@ def test_an_unknown_merge_verdict_writes_no_status_file():
         "the status step no longer refuses to write on an unknown merge "
         "verdict — a failed job posts a false clean again (#2029)"
     )
-    guard = body[body.index('if [ -z "$merge_conflict" ]'):]
-    assert "exit 0" in guard.split("fi")[0], (
+    guard = _branch_body(body, 'if [ -z "$merge_conflict" ]')
+    assert "exit 0" in guard, (
         "the unknown-verdict branch does not exit before writing the file"
     )
 

--- a/tests/unit/test_2462_nightly_budget.py
+++ b/tests/unit/test_2462_nightly_budget.py
@@ -191,3 +191,25 @@ class TestItCannotDieQuietly:
         """AC 3 — a capped leg and a leg that legitimately had nothing to run
         were indistinguishable from outside."""
         assert "GITHUB_STEP_SUMMARY" in _uncommented(_job(workflow, "test"))
+
+
+class TestTheDemonstrationHasABlastRadius:
+    """A change to this workflow can only be verified by running it, and
+    running it sweeps every open PR and posts bot comments on other people's
+    work. The scoped dispatch exists so proving a fix costs one PR."""
+
+    def test_a_manual_dispatch_can_be_scoped_to_one_pr(self, workflow):
+        assert "pr_number:" in _uncommented(_job(workflow, "discover")) or \
+            re.search(r"inputs:\s*\n\s*pr_number:", workflow), (
+            "workflow_dispatch lost its single-PR scope — verifying a change "
+            "again means sweeping every open PR (#2462)"
+        )
+
+    def test_the_scheduled_sweep_is_unscoped(self, workflow):
+        """The filter must be opt-in. An always-on filter with an empty input
+        would silently reduce the nightly to nothing — the same silence this
+        issue is about, arriving by a different door."""
+        discover = _uncommented(_job(workflow, "discover"))
+        assert 'if [ -n "$only" ]' in discover, (
+            "the PR filter is not guarded on a non-empty input"
+        )

--- a/tests/unit/test_2462_nightly_budget.py
+++ b/tests/unit/test_2462_nightly_budget.py
@@ -213,3 +213,19 @@ class TestTheDemonstrationHasABlastRadius:
         assert 'if [ -n "$only" ]' in discover, (
             "the PR filter is not guarded on a non-empty input"
         )
+
+    def test_the_module_comes_from_this_workflows_own_commit(self, workflow):
+        """`ref: dev` is wrong here in a way that only shows up when it matters.
+
+        A dispatch from a branch runs THAT branch's workflow against `dev`'s
+        module, so the two can disagree — and on the run that proved this fix,
+        `dev` did not have the module at all and the comment job died with
+        MODULE_NOT_FOUND. `github.sha` is the same trust level (this workflow
+        has only `schedule` and `workflow_dispatch` triggers, both refs a repo
+        writer chose) and cannot skew.
+        """
+        comment = _uncommented(_job(workflow, "comment"))
+        assert "ref: ${{ github.sha }}" in comment, (
+            "the trusted checkout no longer pins to this workflow's own commit "
+            "— workflow and verdict module can then disagree (#2462)"
+        )

--- a/tests/unit/test_2462_nightly_budget.py
+++ b/tests/unit/test_2462_nightly_budget.py
@@ -1,0 +1,193 @@
+"""#2462 — the nightly cross-PR regression net must be able to finish.
+
+`backend-unit-nightly.yml` ran SIX full unit suites (three seeds x base and
+head) inside a job with `timeout-minutes: 25`. One suite was ~15 minutes, so a
+leg needed ~90 minutes of a 25-minute budget, and every leg for a mergeable PR
+was cancelled at the cap — twelve consecutive nights of `cancelled` across the
+whole queryable history, with no result for any mergeable PR in any of them.
+The only legs that "succeeded" finished in 46 seconds: the merge-conflict
+short-circuits, i.e. exactly the ones that ran nothing.
+
+It failed silently by construction. The workflow is scheduled, so a cancel
+notifies nobody and blocks no PR; and the diff step is gated on the suite step
+completing, so a capped leg produces no artifact, no diff and no comment.
+Silence and success are the same shape from outside.
+
+These tests pin the four properties that make it finishable and honest, so a
+future edit cannot quietly restore any one of them:
+
+  1. a leg is ONE seed, not six suites;
+  2. the suites are parallelised and individually timeout-bounded;
+  3. the seed set has exactly one definition, shared by the matrix builder and
+     the completeness rule that consumes it;
+  4. a sweep that produces nothing FAILS rather than passing quietly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO / ".github" / "workflows" / "backend-unit-nightly.yml"
+_VERDICT = _REPO / "scripts" / "ci" / "nightly-verdict.js"
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def workflow() -> str:
+    assert _WORKFLOW.is_file(), f"{_WORKFLOW} is missing"
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+def _job(workflow: str, name: str) -> str:
+    """One job's body, bounded by indentation.
+
+    Same shape as the helper in test_2019_pytest_timeout_guard.py, and for the
+    same mutation-found reason: slicing to the next `  <name>:` runs off the
+    end of the last job and swallows whatever follows, so an assertion can pass
+    against a different job entirely.
+    """
+    lines = workflow.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"  {name}:"))
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    body = [lines[start]]
+    for line in lines[start + 1:]:
+        if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _uncommented(block: str) -> str:
+    """Runnable lines only.
+
+    Load-bearing, exactly as in the #2019 guard: this workflow documents its
+    own history at length, and the prose necessarily contains the strings the
+    assertions look for — `timeout-minutes: 25`, `for seed in`, the seed
+    literals. A raw substring check would pass on the comment describing the
+    bug after the fix had been reverted.
+    """
+    return "\n".join(
+        line for line in block.splitlines() if not line.strip().startswith("#")
+    )
+
+
+class TestALegIsOneSeed:
+
+    def test_the_matrix_carries_a_seed_dimension(self, workflow):
+        assert "seed: ." in _uncommented(_job(workflow, "discover")), (
+            "the matrix no longer fans out per seed — a leg is back to running "
+            "every seed, which is the ~90-minutes-in-a-25-minute-budget shape "
+            "that killed this workflow for twelve nights (#2462)"
+        )
+
+    def test_the_suite_step_no_longer_loops_over_seeds(self, workflow):
+        run = _uncommented(_job(workflow, "test"))
+        assert "for seed in" not in run, (
+            "the suite step loops over seeds again — six suites in one leg "
+            "(#2462)"
+        )
+
+    def test_the_leg_still_runs_both_sides(self, workflow):
+        """Guards the guard: a leg that dropped one side would satisfy every
+        timing assertion here and produce a diff against nothing."""
+        run = _uncommented(_job(workflow, "test"))
+        assert "junit-base-pr" in run and "junit-head-pr" in run
+        assert "git switch --detach origin/dev" in run
+        assert "git switch --detach \"$MERGE_SHA\"" in run
+
+
+class TestTheSuiteCanFinish:
+
+    def test_the_suites_are_parallelised(self, workflow):
+        run = _uncommented(_job(workflow, "test"))
+        assert re.search(r"-n\s+(auto|\d+)", run), (
+            "the nightly runs the suite serially — with two suites per leg "
+            "that is ~30 minutes of work before any runner variance (#2461/#2462)"
+        )
+
+    def test_xdist_is_installed(self, workflow):
+        assert "pytest-xdist" in _uncommented(_job(workflow, "test")), (
+            "-n is passed but xdist is not installed: pytest exits on an "
+            "unrecognised argument and every leg fails"
+        )
+
+    def test_a_stalled_test_names_itself(self, workflow):
+        """#2019's flag, which this workflow never got. Without it one stalled
+        test consumes the leg and dies anonymously — the same failure, on the
+        workflow where nobody is watching."""
+        run = _uncommented(_job(workflow, "test"))
+        assert "--timeout=" in run and "--timeout-method=signal" in run
+
+    def test_the_budget_is_not_back_to_the_broken_one(self, workflow):
+        job = _uncommented(_job(workflow, "test"))
+        caps = re.findall(r"^\s*timeout-minutes:\s*(\d+)", job, re.MULTILINE)
+        assert caps, "the test job lost its timeout-minutes"
+        cap = int(caps[0])
+        # ~22 min of measured work per leg (two ~9-min parallel suites plus
+        # full-history checkout, merge and install). Below ~40 there is no room
+        # for the runner variance actually measured on this repo (1.94x).
+        assert 40 <= cap <= 90, f"test job cap is {cap}m — see the derivation in the workflow"
+
+
+class TestOneDefinitionOfTheSeedSet:
+
+    def test_the_seed_list_is_declared_once(self, workflow):
+        assert "NIGHTLY_SEEDS:" in workflow
+        # Every seed literal outside that declaration is a second definition
+        # waiting to disagree with it: a fourth seed added to one place makes
+        # every PR permanently unverified, a removed one silently lowers the bar.
+        body = _uncommented(workflow)
+        declarations = re.findall(r"NIGHTLY_SEEDS:\s*'([^']*)'", body)
+        assert len(declarations) == 1, f"expected one seed declaration, found {declarations}"
+        stray = [
+            line for line in body.splitlines()
+            if re.search(r"\b(12345|67890|99999)\b", line)
+            and "NIGHTLY_SEEDS" not in line
+        ]
+        assert stray == [], f"seed literals outside the single declaration: {stray}"
+
+    def test_both_consumers_read_it(self, workflow):
+        assert "$NIGHTLY_SEEDS" in _uncommented(_job(workflow, "discover")), (
+            "the matrix builder no longer reads the shared seed set"
+        )
+        assert "NIGHTLY_SEEDS" in _uncommented(_job(workflow, "comment")), (
+            "the completeness rule no longer reads the shared seed set"
+        )
+
+
+class TestItCannotDieQuietly:
+
+    def test_a_sweep_that_reports_nothing_fails_the_run(self, workflow):
+        comment = _uncommented(_job(workflow, "comment"))
+        assert "core.setFailed" in comment, (
+            "a sweep that produced no status artifacts while PRs were open "
+            "exits 0 again — that is the exact signature of the twelve dead "
+            "nights, and it leaves no red mark anywhere (#2462)"
+        )
+
+    def test_the_verdict_logic_is_a_module_a_test_can_run(self, workflow):
+        assert _VERDICT.is_file(), f"{_VERDICT} is missing"
+        comment = _uncommented(_job(workflow, "comment"))
+        assert "nightly-verdict.js" in comment, (
+            "the verdict aggregation moved back inline, where no test can "
+            "execute it — and it is the one path that can publish a green tick "
+            "for a suite that never finished"
+        )
+
+    def test_the_module_is_commonjs(self):
+        """`actions/github-script` loads the body under `require()`, so an ESM
+        export here is unloadable by the only caller that matters — and it
+        fails at RUN time, in the job that posts the comments."""
+        src = _VERDICT.read_text(encoding="utf-8")
+        assert "module.exports" in src
+        assert not re.search(r"^export\s+(function|const)", src, re.MULTILINE)
+
+    def test_each_leg_says_what_it_did(self, workflow):
+        """AC 3 — a capped leg and a leg that legitimately had nothing to run
+        were indistinguishable from outside."""
+        assert "GITHUB_STEP_SUMMARY" in _uncommented(_job(workflow, "test"))


### PR DESCRIPTION
## What

`backend-unit-nightly.yml` — the cross-PR regression net — has been **cancelled every night for at least twelve consecutive nights**, the whole queryable history, and has produced no result for any mergeable PR in any of them.

**Night thirteen was observed live while writing this fix** (run [33502721945](https://github.com/Abilityai/trinity/actions/runs/33502721945), the unmodified workflow on `main`):

```
12 legs  cancelled  11:29:2x → 11:54:3x   (25m15s — the cap)
 2 legs  success    11:29:23 → 11:30:06   (43s — merge-conflict skips, i.e. ran nothing)
run conclusion: cancelled
```

## Why it could never work

Each leg ran **six full unit suites** (three seeds × base and head) inside `timeout-minutes: 25`. One suite is ~15 minutes, so a leg needed ~90 minutes of a 25-minute budget. This is not flakiness — no leg for a mergeable PR has *ever* completed at the current suite size.

And it failed **silently by construction**: the workflow is scheduled, so a cancel notifies nobody and blocks no PR; and the diff step is gated on the suite step completing, so a capped leg produces no artifact, no diff and no comment. Silence and success are the same shape from outside. The only "green" legs were the ones that ran nothing.

## Four changes, all four needed

**1. A leg is one seed.** The matrix fans out over (PR, seed) rather than (PR), so a leg runs base+head for one seed — two suites, which fits a budget. Base and head for a seed stay in the same workspace, so the regression diff still runs in the job holding the *trusted stashed copy* of the script, rather than needing a fourth job that downloads junit artifacts from an untrusted one.

**2. The suites can finish.** xdist (#2461's change, ~9 min/suite measured on these runners vs ~15 serial), and finally `--timeout=300 --timeout-method=signal` — #2019 added that to the PR-blocking workflow after four anonymous cancels in one day, and **this workflow never got it**, so one stalled test consumed a whole leg and died without naming itself.

**3. One definition of the seed set** (`NIGHTLY_SEEDS`), read by both the matrix builder and the completeness rule that consumes it. Restating it is how a fourth seed silently makes every PR permanently unverified, or a removed one silently lowers the bar.

**4. It can no longer pass while saying nothing.** A sweep that produced no status artifacts while open PRs existed — the exact signature above — now `core.setFailed`s. The sweep may say nothing about a PR; it may not say nothing at all and go green.

## The budget is derived, and its residual is stated

~18 min of suite + ~4 of full-history checkout, merge and install ≈ **22**. `timeout-minutes: 60` is ~2.7× that, clearing the worst runner starvation actually measured on this repo (**1.94×**, from #2461's 17.5m shard beside its 9.0m siblings).

A pathological ~3× runner still reaches the cap. What changed is blast radius and visibility: it now costs **one seed of one PR** instead of that PR's whole verdict, the PR is reported **unverified** rather than skipped in silence, and a wholesale failure turns the run red.

## The one new path that can lie

Because legs are per-seed, a PR's verdict is the **union** of its seeds — and that aggregation is the one place a false ALL-CLEAR can be published. So it is a module, `scripts/ci/nightly-verdict.js`, with **9 vitest cases**, rather than inline `github-script` prose no test can execute. CommonJS on purpose: `actions/github-script` loads its body under `require()`.

Its rule extends #2029's — *absence of a verdict is its own state* — to the seed level:

- an **incomplete** set is not a clean one: two green seeds and one that never reported yields `unverified` and leaves any existing sticky untouched, never a tick;
- **any** single regressed seed condemns, because pytest-randomly is here precisely so an order-dependent failure appears under one seed and not another — averaging that away deletes the signal the seeds exist to produce;
- a merge conflict outranks the regression arm, because the suite never ran and that is not a test result;
- the comment now **names the seed**, since under randomly the seed *is* the reproduction instruction.

The `comment` job gains `contents: read` and a pinned, sparse checkout of `dev` to load the module. This does not weaken the rule at the top of the file — untrusted PR code must never share a job with a write-capable token — because `dev` at a pinned ref is the same trust level as the workflow file itself, and PR code is still never checked out there.

## AC 3 — capped vs nothing-to-run

Each leg writes what it actually did to `$GITHUB_STEP_SUMMARY`. The step cannot run when the job is cancelled at the cap, and **that absence is itself the distinguishing signal**.

## Verifying a workflow shouldn't spam the team

`workflow_dispatch` gained an optional `pr_number`. Without it, proving a change to this workflow means sweeping all 15 open PRs (45 legs) and posting bot comments on other people's work. Opt-in and guarded on a non-empty input, so the scheduled sweep is byte-for-byte unchanged — an always-on filter with an empty input would reduce the nightly to nothing, which is this issue's own silence arriving by a different door.

**AC 1 is demonstrated with it**: a scoped dispatch against #2465 (my own PR) — results in the comment below.

## Guards

`tests/unit/test_2462_nightly_budget.py` (15 tests) pins all of it, reading the **command** rather than the comment — this workflow documents its own history at length, so the prose necessarily contains `timeout-minutes: 25`, `for seed in` and the seed literals, and a raw substring check would pass on the description of the bug after the fix was reverted.

Nine mutations confirmed red then reverted: cap back to 25 · drop `-n auto` · add a second seed definition · `setFailed` → `info` · repoint the verdict require · delete the module · make the module ESM · drop the step summary · make the PR filter unconditional.

Fixes #2462
