### PR TITLE
feat(hosting): Packer bundle for the DigitalOcean Marketplace 1-Click (#2281)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,23 @@ wheels/
 !src/frontend/src/components/tiles/parts/
 !src/frontend/src/components/tiles/parts/**
 
+# Same class, worse: the packer bundle under `packer/digitalocean/files/` mirrors
+# a target filesystem, so its path segments collide with the BARE setuptools
+# patterns above by construction — `var/` AND `lib/` both swallow
+# `files/var/lib/cloud/scripts/per-instance/001-trinity`, and any future
+# `files/usr/lib/...` would go the same way. The whole payload tree is
+# re-included here rather than one path, because the next collision is a matter
+# of which directory the image needs next. The directory is re-included first
+# for the reason stated above; `**` then beats both bare patterns for
+# everything below it, including the intermediate `var/lib` directory.
+# Placed inside this block deliberately: the later `.env` / `*.log` rules still
+# apply underneath, so a stray secret in the bundle stays ignored.
+# Symptom if this is ever removed: `packer build` dies at
+# `install: cannot stat /tmp/trinity-files/...` — or ships a snapshot with no
+# boot hook — from a file that is present locally and absent from the commit.
+!packer/digitalocean/files/
+!packer/digitalocean/files/**
+
 # uv lockfile (repo uses pyproject.toml for pytest only; empty lockfile is noise)
 uv.lock
 

--- a/packer/digitalocean/README.md
+++ b/packer/digitalocean/README.md
@@ -1,0 +1,110 @@
+# Trinity — DigitalOcean Marketplace 1-Click snapshot
+
+Packer build for the Trinity 1-Click Droplet listing (#2281, epic #2332).
+
+## What this produces
+
+An Ubuntu 24.04 snapshot with Docker, Caddy and a pinned Trinity release already
+pulled, so a droplet created from it is serving Trinity over browser-trusted
+HTTPS about a minute after creation, with no input from the user.
+
+The snapshot is built **from prebuilt GHCR images** (#2280), not from source. A
+1-Click that spends 5–10 minutes compiling the agent base image on first boot
+fails the one-click bar — which is why #2280 gates this work.
+
+| Stage | What happens |
+|---|---|
+| Build | Docker + Caddy + ufw installed; Trinity checkout at `/opt/trinity`; all five images pulled at a pinned tag; agent base retagged `trinity-agent-base:latest` |
+| First boot | admin password resolved; `.env` written (including the provenance marker); Docker/ufw gap closed; Caddy issued a certificate for the droplet's own IP; `start.sh --hosted --unattended` |
+
+## Prerequisites
+
+- The release's images must exist on GHCR **and be publicly pullable**. New GHCR
+  packages default to private; the publish workflow's own "Verify anonymous pull"
+  step fails loudly when they are, with the fix in the error message.
+- `packer` ≥ 1.9, and a DigitalOcean API token with write scope.
+
+## Build
+
+```bash
+export DIGITALOCEAN_TOKEN=dop_v1_...
+packer init trinity.pkr.hcl
+packer build \
+  -var "do_token=$DIGITALOCEAN_TOKEN" \
+  -var "image_tag=v0.9.1" \
+  trinity.pkr.hcl
+```
+
+`image_tag` is required and may not be `latest` — the template rejects it. A
+snapshot that resolved `latest` at first boot would serve a different Trinity on
+every droplet created from one reviewed image, and Marketplace review approves a
+specific artifact.
+
+The build fails if DigitalOcean's own `99-img-check.sh` finds anything, so a
+snapshot is never created from a droplet that would be rejected at review.
+
+## Per-release update runbook
+
+1. Cut the Trinity release; confirm the `v*` tag published all five images and
+   that each package is public.
+2. `packer build` with the new `image_tag` (above).
+3. Vendor Portal → the Trinity listing → submit the new snapshot for review.
+   Programmatic alternative once the listing exists:
+   `PATCH https://api.digitalocean.com/api/v1/vendor-portal/apps/<app_id>`
+   (`app_id` comes from the listing URL in Vendor Portal).
+4. Update the listing's version string and any changed sizing guidance.
+
+## Design notes
+
+**Admin password.** DigitalOcean 1-Clicks have no vendor-defined input form at
+deploy time — verified against `digitalocean/marketplace-partners`, where the
+only prompt is the optional Managed Database checkbox. So the password is
+generated at first boot and printed in the MOTD, which the user reads from the
+control panel's browser Console (Droplet → Console); no SSH client is needed.
+
+An operator who prefers to choose it can supply one through *Additional Options →
+Startup scripts* on the Create page, as `#cloud-config`:
+
+```yaml
+#cloud-config
+write_files:
+  - path: /etc/trinity/admin-password
+    permissions: '0600'
+    content: "your-password-here"
+```
+
+It must be `write_files` and **not** a shell script. 1-Click per-instance code
+runs from cloud-init's `scripts-per-instance` module, which runs *before*
+`scripts-user`, so a user-data shell script would execute after first boot had
+already generated a password and started Trinity. `write_files` runs in the
+earlier `cloud_config` stage and lands in time.
+
+**TLS with no domain.** Let's Encrypt has issued certificates for bare IP
+addresses since 2026-01-15 via the `shortlived` ACME profile (~6-day validity,
+`http-01`/`tls-alpn-01` only). DigitalOcean's own 1-Click build standard mandates
+Caddy with `issuer acme` + `profile shortlived` for any app with an HTTP
+interface. A domain is a post-login upgrade, not a prerequisite.
+
+**Docker publishes past ufw.** `docker-compose.hosted.yml` publishes 8000, 8080,
+8686 and the OTel collector ports on `0.0.0.0`. Docker's iptables rules are
+consulted before ufw's chain, so `ufw deny 8000` on such a droplet is silently
+inert. First boot inserts a `DOCKER-USER` DROP rule for those ports on `eth0` —
+the one chain Docker leaves to the operator and evaluates first. They remain
+reachable from the host and between containers, which is what the platform uses.
+
+**The agent base image is not a compose service.** The backend creates agent
+containers from the literal local tag `trinity-agent-base:latest`, hardcoded in
+`agent_service/lifecycle.py` and allowlisted by SEC-172, and compose cannot
+retag. The build pulls the GHCR copy and tags it locally; `start.sh --hosted`
+does the same at run time. A bare `docker compose -f docker-compose.hosted.yml up`
+would start a platform that cannot create a single agent.
+
+**One installer, two image sources.** First boot calls the same
+`scripts/deploy/start.sh` every other install uses, with `--hosted --unattended`.
+A marketplace-specific copy of the installer is exactly the shape that has gone
+stale in this repo before (#1039, #1056, #1707, #1871).
+
+## Support
+
+GitHub Issues on `abilityai/trinity`, label `do-marketplace`.
+DigitalOcean does not build or support Trinity.

--- a/packer/digitalocean/README.md
+++ b/packer/digitalocean/README.md
@@ -86,11 +86,20 @@ Caddy with `issuer acme` + `profile shortlived` for any app with an HTTP
 interface. A domain is a post-login upgrade, not a prerequisite.
 
 **Docker publishes past ufw.** `docker-compose.hosted.yml` publishes 8000, 8080,
-8686 and the OTel collector ports on `0.0.0.0`. Docker's iptables rules are
-consulted before ufw's chain, so `ufw deny 8000` on such a droplet is silently
-inert. First boot inserts a `DOCKER-USER` DROP rule for those ports on `eth0` —
-the one chain Docker leaves to the operator and evaluates first. They remain
-reachable from the host and between containers, which is what the platform uses.
+8686, the OTel collector ports **and the frontend's `FRONTEND_PORT` (8081 here)**
+on `0.0.0.0`. Docker's iptables rules are consulted before ufw's chain, so
+`ufw deny 8000` on such a droplet is silently inert. First boot inserts a
+`DOCKER-USER` DROP rule for those ports on `eth0` — the one chain Docker leaves
+to the operator and evaluates first. They remain reachable from the host (Caddy
+proxies `127.0.0.1:8081`) and between containers, which is what the platform
+uses.
+
+8081 is the one that decides whether the TLS story holds at all: it is the SPA,
+moved off `:80` so Caddy can own 80/443, and compose's short port syntax binds it
+to every interface. Left out of the DROP list, the login page answers plain HTTP
+on `http://<ip>:8081` — past the certificate and past the `http→https` redirect.
+`tests/unit/test_2281_firstboot_port_exposure.py` keeps the list and the compose
+file from drifting apart.
 
 **The agent base image is not a compose service.** The backend creates agent
 containers from the literal local tag `trinity-agent-base:latest`, hardcoded in

--- a/packer/digitalocean/files/etc/update-motd.d/99-trinity
+++ b/packer/digitalocean/files/etc/update-motd.d/99-trinity
@@ -21,10 +21,26 @@ if [ -f "${STATE_DIR}/firstboot-failed" ]; then
     exit 0
 fi
 
-if [ -n "$IP" ]; then
-    echo "  Web UI:  https://${IP}"
+# The scheme comes from what first boot actually VERIFIED, not from what the
+# Caddyfile intended. Printing `https://` after a failed issuance sends the
+# user to a browser warning and tells them the box is fine.
+TLS="$(cat ${STATE_DIR}/tls-status 2>/dev/null)"
+if [ "$TLS" = "ok" ]; then
+    SCHEME="https"
 else
-    echo "  Web UI:  https://<this droplet's IP>"
+    SCHEME="http"
+fi
+
+if [ -n "$IP" ]; then
+    echo "  Web UI:  ${SCHEME}://${IP}"
+else
+    echo "  Web UI:  ${SCHEME}://<this droplet's IP>"
+fi
+
+if [ "$TLS" != "ok" ] && [ "$TLS" != "unknown" ]; then
+    echo
+    echo "  ⚠  HTTPS is NOT active — no certificate was issued for this IP."
+    echo "     Traffic is unencrypted. Check: journalctl -u caddy -n 100"
 fi
 
 if [ -r "${STATE_DIR}/admin-credentials" ]; then
@@ -43,7 +59,7 @@ fi
 
 echo
 echo "  Next:    open the Web UI, sign in, and follow the hardening guide"
-echo "           (a domain, and locking the instance to a VPN)."
+echo "           (add a domain, then serve it through a Cloudflare Tunnel)."
 echo "  Docs:    https://docs.ability.ai"
 echo "  Support: https://github.com/abilityai/trinity/issues  (label: do-marketplace)"
 echo "  DigitalOcean does not build or support Trinity."

--- a/packer/digitalocean/files/etc/update-motd.d/99-trinity
+++ b/packer/digitalocean/files/etc/update-motd.d/99-trinity
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Trinity 1-Click login banner.
+#
+# This is where a 1-Click user gets the admin password, because DigitalOcean
+# offers no deploy-time input form. They do NOT need an SSH client to read it:
+# the DigitalOcean control panel has a browser Console (Droplet -> Console),
+# which is one click and shows this text.
+STATE_DIR=/etc/trinity
+IP="$(cat ${STATE_DIR}/public-ip 2>/dev/null)"
+TAG="$(cat ${STATE_DIR}/baked-image-tag 2>/dev/null)"
+
+echo
+echo "  Trinity ${TAG:-} — the sovereign AI agents platform"
+echo "  ---------------------------------------------------------------"
+
+if [ -f "${STATE_DIR}/firstboot-failed" ]; then
+    echo "  ⚠  First boot did NOT complete."
+    echo "     Log:   /var/log/trinity-firstboot.log"
+    echo "     Retry: sudo /opt/trinity-firstboot/firstboot.sh"
+    echo
+    exit 0
+fi
+
+if [ -n "$IP" ]; then
+    echo "  Web UI:  https://${IP}"
+else
+    echo "  Web UI:  https://<this droplet's IP>"
+fi
+
+if [ -r "${STATE_DIR}/admin-credentials" ]; then
+    SOURCE="$(sed -n 's/^source=//p' ${STATE_DIR}/admin-credentials)"
+    PASSWORD="$(sed -n 's/^password=//p' ${STATE_DIR}/admin-credentials)"
+    if [ "$SOURCE" = "user-data" ]; then
+        echo "  Login:   admin / the password you supplied in user-data"
+    else
+        echo "  Login:   admin / ${PASSWORD}"
+        echo
+        echo "  ⚠  Change this password after your first login."
+    fi
+else
+    echo "  Login:   admin / see /etc/trinity/admin-credentials (root only)"
+fi
+
+echo
+echo "  Next:    open the Web UI, sign in, and follow the hardening guide"
+echo "           (a domain, and locking the instance to a VPN)."
+echo "  Docs:    https://docs.ability.ai"
+echo "  Support: https://github.com/abilityai/trinity/issues  (label: do-marketplace)"
+echo "  DigitalOcean does not build or support Trinity."
+echo

--- a/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
+++ b/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
@@ -143,6 +143,42 @@ http://${PUBLIC_IP} {
 CADDY
     systemctl enable caddy
     systemctl restart caddy
+
+    # --- Verify the certificate was actually issued --------------------------
+    # Without this the failure is SILENT and worse than silent: Caddy serves a
+    # TLS error, this script still exits 0, and the MOTD prints a confident
+    # `https://<ip>` URL. The user's first contact with Trinity is a browser
+    # warning on a box that reported success.
+    #
+    # The probe is `curl` against our own public IP with normal verification.
+    # Trinity is not started yet (that is step 6), so Caddy answers 502 — which
+    # is FINE and is the point: curl without `-f` treats an HTTP error as
+    # success, so a zero exit means the TLS handshake completed and the chain
+    # validated against the system trust store. That is exactly the claim being
+    # tested, and nothing weaker distinguishes "real Let's Encrypt certificate"
+    # from "Caddy fell back to its internal CA".
+    #
+    # ACME issuance is not instant, hence the poll. Never fatal: a droplet that
+    # serves over HTTP with an honest banner is far better than one that
+    # refuses to finish booting.
+    TLS_STATUS="failed"
+    for _ in $(seq 1 30); do
+        if curl -sS -o /dev/null --max-time 10 "https://${PUBLIC_IP}/" 2>/dev/null; then
+            TLS_STATUS="ok"
+            break
+        fi
+        sleep 5
+    done
+    printf '%s\n' "$TLS_STATUS" > "${STATE_DIR}/tls-status"
+    if [ "$TLS_STATUS" = "ok" ]; then
+        echo "TLS: certificate issued for ${PUBLIC_IP}."
+    else
+        echo "TLS: WARNING — no valid certificate for ${PUBLIC_IP} after ~150s." >&2
+        echo "     Trinity will still start and is reachable over http://${PUBLIC_IP}." >&2
+        echo "     Check: journalctl -u caddy -n 100" >&2
+    fi
+else
+    printf '%s\n' "unknown" > "${STATE_DIR}/tls-status"
 fi
 
 # --- 6. Start Trinity --------------------------------------------------------

--- a/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
+++ b/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# First-boot configuration for a Trinity DigitalOcean 1-Click droplet (#2281).
+# Runs ONCE per droplet, from /var/lib/cloud/scripts/per-instance/001-trinity.
+#
+# Everything droplet-specific lives here and nothing here is baked into the
+# snapshot: the admin password, the droplet's own IP, the certificate.
+set -euo pipefail
+
+STATE_DIR=/etc/trinity
+CRED_FILE="${STATE_DIR}/admin-credentials"
+USER_SUPPLIED_PW="${STATE_DIR}/admin-password"
+TRINITY_DIR=/opt/trinity
+LOG=/var/log/trinity-firstboot.log
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== Trinity first boot: $(date -u +%FT%TZ) ==="
+
+mkdir -p "$STATE_DIR"
+chmod 0700 "$STATE_DIR"
+
+# --- 1. Admin password -------------------------------------------------------
+# A 1-Click has no vendor-defined input form at deploy time (verified against
+# digitalocean/marketplace-partners: the only prompt is the optional Managed
+# Database checkbox), so the password cannot be collected in the UI.
+#
+# Two sources, in order:
+#   (a) user-data, if the operator supplied one. It must arrive as #cloud-config
+#       `write_files` and NOT as a shell script: 1-Click per-instance code runs
+#       from cloud-init's `scripts-per-instance` module, which runs BEFORE
+#       `scripts-user`, so a user-data shell script would execute after this
+#       script had already generated a password and started Trinity.
+#   (b) generated here, and shown in the MOTD.
+PW_SOURCE="generated"
+if [ -s "$USER_SUPPLIED_PW" ]; then
+    ADMIN_PASSWORD="$(head -c 512 "$USER_SUPPLIED_PW" | tr -d '\r\n')"
+    PW_SOURCE="user-data"
+    shred -u "$USER_SUPPLIED_PW" 2>/dev/null || rm -f "$USER_SUPPLIED_PW"
+fi
+if [ -z "${ADMIN_PASSWORD:-}" ]; then
+    ADMIN_PASSWORD="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 24)"
+fi
+
+# The MOTD never echoes a password the operator chose — they already have it,
+# and reprinting it widens where it exists for no benefit.
+umask 077
+if [ "$PW_SOURCE" = "user-data" ]; then
+    printf 'source=user-data\npassword=\n' > "$CRED_FILE"
+else
+    printf 'source=generated\npassword=%s\n' "$ADMIN_PASSWORD" > "$CRED_FILE"
+fi
+chmod 0600 "$CRED_FILE"
+
+# --- 2. Droplet identity -----------------------------------------------------
+# The metadata service is reachable only from the droplet itself.
+PUBLIC_IP="$(curl -fsS --max-time 10 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address || true)"
+if [ -z "$PUBLIC_IP" ]; then
+    echo "WARNING: could not read the public IP from the metadata service."
+    echo "         Caddy will be left unconfigured; Trinity will still start."
+fi
+echo "$PUBLIC_IP" > "${STATE_DIR}/public-ip"
+
+IMAGE_TAG="$(cat "${STATE_DIR}/baked-image-tag" 2>/dev/null || echo latest)"
+
+# --- 3. .env -----------------------------------------------------------------
+# start.sh --unattended generates SECRET_KEY, INTERNAL_API_SECRET,
+# CREDENTIAL_ENCRYPTION_KEY and AGENT_AUTH_SECRET itself when they are blank; we
+# only write what it cannot know.
+#
+# FRONTEND_PORT moves the SPA off :80 so Caddy can own :80/:443 and terminate
+# TLS in front of it.
+#
+# TRINITY_INSTALL_SOURCE is the #2380 provenance marker. It is an env var in
+# .env by that issue's explicit decision, NOT a marker file — config.py reads no
+# files, and a file would need a read-only bind mount in every compose file.
+cd "$TRINITY_DIR"
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+set_env() {
+    local key="$1" value="$2"
+    if grep -qE "^${key}=" .env; then
+        sed -i "s|^${key}=.*|${key}=${value}|" .env
+    else
+        printf '%s=%s\n' "$key" "$value" >> .env
+    fi
+}
+set_env ADMIN_PASSWORD "$ADMIN_PASSWORD"
+set_env FRONTEND_PORT 8081
+set_env TRINITY_IMAGE_TAG "$IMAGE_TAG"
+set_env TRINITY_INSTALL_SOURCE do-marketplace
+[ -n "$PUBLIC_IP" ] && set_env FRONTEND_URL "https://${PUBLIC_IP}"
+chmod 0600 .env
+
+# --- 4. Close the Docker/ufw gap --------------------------------------------
+# docker-compose.hosted.yml publishes 8000 (backend), 8080 (MCP), 8686 (Vector)
+# and the OTel collector's ports on 0.0.0.0. Docker's iptables rules are
+# consulted BEFORE ufw's chain, so those ports are reachable from the internet
+# on a droplet whose ufw says otherwise — `ufw deny 8000` is silently inert.
+#
+# DOCKER-USER is the one chain Docker leaves for the operator and evaluates
+# first, so the drop belongs here. Everything a user needs is served by Caddy on
+# 80/443; the container ports stay reachable from the host and from other
+# containers, which is what the platform itself uses.
+if ! iptables -C DOCKER-USER -i eth0 -p tcp -m multiport \
+       --dports 8000,8080,8686,4317,4318,8889,13133 -j DROP 2>/dev/null; then
+    iptables -I DOCKER-USER -i eth0 -p tcp -m multiport \
+      --dports 8000,8080,8686,4317,4318,8889,13133 -j DROP
+fi
+apt-get install -y -q iptables-persistent >/dev/null 2>&1 || true
+netfilter-persistent save >/dev/null 2>&1 || true
+
+# --- 5. Caddy ----------------------------------------------------------------
+# Let's Encrypt issues certificates for bare IP addresses as of 2026-01-15, via
+# the `shortlived` ACME profile (~6-day validity, http-01/tls-alpn-01 only). DO's
+# own 1-Click build standard mandates this pattern for any app with an HTTP
+# interface, so the droplet lands on browser-trusted HTTPS with no domain and no
+# user input. A domain becomes a post-login upgrade, not a prerequisite.
+if [ -n "$PUBLIC_IP" ]; then
+    cat > /etc/caddy/Caddyfile <<CADDY
+{
+    acme_ca https://acme-v02.api.letsencrypt.org/directory
+}
+
+https://${PUBLIC_IP} {
+    tls {
+        issuer acme {
+            profile shortlived
+        }
+    }
+    encode gzip
+
+    # Streaming endpoints must not be buffered: the Workspace reads execution
+    # logs over SSE (GET /api/executions/{id}/stream).
+    reverse_proxy 127.0.0.1:8081 {
+        flush_interval -1
+    }
+}
+
+http://${PUBLIC_IP} {
+    redir https://${PUBLIC_IP}{uri} permanent
+}
+CADDY
+    systemctl enable caddy
+    systemctl restart caddy
+fi
+
+# --- 6. Start Trinity --------------------------------------------------------
+# --hosted uses docker-compose.hosted.yml and the prebuilt images; --unattended
+# never prompts. Both flags are on the ONE installer rather than a marketplace
+# copy of it, which is the shape that has gone stale here before (#1039, #1056,
+# #1707, #1871).
+./scripts/deploy/start.sh --hosted --unattended
+
+echo "=== Trinity first boot complete ==="

--- a/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
+++ b/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
@@ -77,13 +77,22 @@ cd "$TRINITY_DIR"
 if [ ! -f .env ]; then
     cp .env.example .env
 fi
+# Rewrites the line rather than substituting into it. `sed "s|^k=.*|k=$value|"`
+# was wrong here (#2281 review I3): the replacement half is user-controlled on
+# the user-data password path, where `&` expands to the whole match, `\` escapes
+# and `|` ends the expression. The failure is the silent kind — `.env` holds a
+# mangled password while the MOTD states the operator's own password is in
+# effect. Rewriting needs no escaping of the value at all. `|| true` because
+# grep exits 1 when nothing matches, which is the ordinary first-write case, and
+# `cat >` rather than `mv` so .env keeps its own inode and mode.
 set_env() {
     local key="$1" value="$2"
-    if grep -qE "^${key}=" .env; then
-        sed -i "s|^${key}=.*|${key}=${value}|" .env
-    else
-        printf '%s=%s\n' "$key" "$value" >> .env
-    fi
+    local tmp
+    tmp="$(mktemp)"
+    grep -vE "^${key}=" .env > "$tmp" || true
+    printf '%s=%s\n' "$key" "$value" >> "$tmp"
+    cat "$tmp" > .env
+    rm -f "$tmp"
 }
 set_env ADMIN_PASSWORD "$ADMIN_PASSWORD"
 set_env FRONTEND_PORT 8081
@@ -93,22 +102,46 @@ set_env TRINITY_INSTALL_SOURCE do-marketplace
 chmod 0600 .env
 
 # --- 4. Close the Docker/ufw gap --------------------------------------------
-# docker-compose.hosted.yml publishes 8000 (backend), 8080 (MCP), 8686 (Vector)
-# and the OTel collector's ports on 0.0.0.0. Docker's iptables rules are
-# consulted BEFORE ufw's chain, so those ports are reachable from the internet
-# on a droplet whose ufw says otherwise — `ufw deny 8000` is silently inert.
+# docker-compose.hosted.yml publishes 8000 (backend), 8080 (MCP), 8686 (Vector),
+# the OTel collector's four ports, and the frontend's own FRONTEND_PORT on
+# 0.0.0.0. Docker's iptables rules are consulted BEFORE ufw's chain, so those
+# ports are reachable from the internet on a droplet whose ufw says otherwise —
+# `ufw deny 8000` is silently inert.
+#
+# 8081 is the entry that matters most and was missing (#2281 review C1): it is
+# the SPA itself, moved off :80 in step 3 so Caddy can own 80/443. Compose
+# publishes it with the short syntax `"${FRONTEND_PORT:-80}:8080"`, which binds
+# 0.0.0.0 — so without it the login page answers plain HTTP on
+# http://<ip>:8081, past both the TLS termination and the http→https redirect
+# this whole image is built around.
+#
+# One variable feeds both the probe and the insert: two hand-maintained lists
+# that disagree means the -C probe never matches its own rule and every re-run
+# stacks another. tests/unit/test_2281_firstboot_port_exposure.py keeps this
+# list from drifting from what compose actually publishes.
 #
 # DOCKER-USER is the one chain Docker leaves for the operator and evaluates
 # first, so the drop belongs here. Everything a user needs is served by Caddy on
-# 80/443; the container ports stay reachable from the host and from other
-# containers, which is what the platform itself uses.
+# 80/443; the container ports stay reachable from the host (Caddy proxies
+# 127.0.0.1:8081) and from other containers, which is what the platform uses.
+DROP_PORTS=8000,8080,8081,8686,4317,4318,8889,13133
 if ! iptables -C DOCKER-USER -i eth0 -p tcp -m multiport \
-       --dports 8000,8080,8686,4317,4318,8889,13133 -j DROP 2>/dev/null; then
+       --dports "$DROP_PORTS" -j DROP 2>/dev/null; then
     iptables -I DOCKER-USER -i eth0 -p tcp -m multiport \
-      --dports 8000,8080,8686,4317,4318,8889,13133 -j DROP
+      --dports "$DROP_PORTS" -j DROP
 fi
-apt-get install -y -q iptables-persistent >/dev/null 2>&1 || true
-netfilter-persistent save >/dev/null 2>&1 || true
+
+# iptables-persistent is installed at BUILD time (01-provision.sh). Installing
+# it here was `>/dev/null 2>&1 || true` (#2281 review I1) — at the busiest apt
+# moment a droplet ever has, and a transient mirror failure then made the save
+# silently impossible: the boot still reported success and the DROP rules were
+# simply gone at the next reboot, the ports reopening with no symptom anywhere.
+# Only the save remains, and its failure is now loud.
+if ! netfilter-persistent save; then
+    echo "WARNING: netfilter-persistent save failed. The DOCKER-USER DROP rules" >&2
+    echo "         are active NOW but will not survive a reboot." >&2
+    echo "         Re-run: /opt/trinity-firstboot/firstboot.sh" >&2
+fi
 
 # --- 5. Caddy ----------------------------------------------------------------
 # Let's Encrypt issues certificates for bare IP addresses as of 2026-01-15, via

--- a/packer/digitalocean/files/var/lib/cloud/scripts/per-instance/001-trinity
+++ b/packer/digitalocean/files/var/lib/cloud/scripts/per-instance/001-trinity
@@ -1,0 +1,12 @@
+#!/bin/bash
+# cloud-init per-instance hook — runs once per droplet, on first boot.
+#
+# Thin on purpose: the work lives in /opt/trinity-firstboot/firstboot.sh so it
+# can be re-run by hand during support without re-triggering cloud-init.
+#
+# A failure here must not leave cloud-init wedged, so the exit status is always
+# 0; the log is the record and the MOTD reports the state.
+/opt/trinity-firstboot/firstboot.sh || \
+  echo "Trinity first boot FAILED — see /var/log/trinity-firstboot.log" \
+    > /etc/trinity/firstboot-failed
+exit 0

--- a/packer/digitalocean/scripts/01-provision.sh
+++ b/packer/digitalocean/scripts/01-provision.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Build-time provisioner for the Trinity DigitalOcean 1-Click snapshot (#2281).
+# Everything here is baked into the image and shared by every droplet created
+# from it — so nothing droplet-specific and nothing secret may be produced here.
+set -euo pipefail
+
+: "${TRINITY_IMAGE_TAG:?TRINITY_IMAGE_TAG must be passed by the Packer build}"
+
+echo "=== Trinity 1-Click build: baking ${TRINITY_IMAGE_TAG} ==="
+
+# --- Base packages -----------------------------------------------------------
+apt-get update -q
+apt-get install -y -q ca-certificates curl gnupg git jq ufw debian-goodies
+
+# --- Docker (official repo, not the distro package) --------------------------
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+apt-get update -q
+apt-get install -y -q docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+systemctl enable docker
+
+# --- Caddy (reverse proxy + automatic certificates) --------------------------
+curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
+  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt \
+  > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update -q
+apt-get install -y -q caddy
+# Not enabled here: first boot writes the Caddyfile (it needs the droplet's own
+# IP) and starts it. A Caddy enabled with the packaged default would race first
+# boot for :80 and take a certificate for the wrong name.
+systemctl disable caddy
+
+# --- Trinity checkout --------------------------------------------------------
+# Pinned to the same tag as the images. A snapshot whose checkout and images
+# disagree is the one combination `start.sh --hosted` cannot detect: compose
+# would come from one release and the containers from another.
+git clone --depth 1 --branch "${TRINITY_IMAGE_TAG}" \
+  https://github.com/abilityai/trinity.git /opt/trinity
+
+# --- Pull the images so first boot pulls nothing -----------------------------
+# This is the entire point of the snapshot. Tags must match
+# docker-compose.hosted.yml's ghcr.io/abilityai/trinity-* references.
+for img in backend frontend scheduler mcp-server; do
+  docker pull "ghcr.io/abilityai/trinity-${img}:${TRINITY_IMAGE_TAG}"
+done
+
+# The agent base image is NOT a compose service and never will be: the backend
+# creates agent containers from the literal local tag `trinity-agent-base:latest`
+# (hardcoded in agent_service/lifecycle.py, SEC-172-allowlisted), and compose
+# cannot retag. `start.sh --hosted` does this pull+retag itself at run time; we
+# do it at build time so first boot has nothing to fetch. Both must agree.
+docker pull "ghcr.io/abilityai/trinity-agent-base:${TRINITY_IMAGE_TAG}"
+docker tag "ghcr.io/abilityai/trinity-agent-base:${TRINITY_IMAGE_TAG}" trinity-agent-base:latest
+
+# Third-party images docker-compose.hosted.yml pulls that are not ours.
+docker pull redis:7-alpine
+docker pull timberio/vector:0.43.1-alpine
+docker pull alpine:3.20
+
+# Record what was baked, for the MOTD and for support.
+mkdir -p /etc/trinity
+echo "${TRINITY_IMAGE_TAG}" > /etc/trinity/baked-image-tag
+
+# --- Firewall ----------------------------------------------------------------
+# ufw governs host ports. It does NOT govern Docker-published ports — Docker
+# inserts its own iptables rules ahead of ufw's chain, so `ufw deny 8000` on a
+# droplet publishing 8000:8000 is silently inert. That gap is closed by the
+# DOCKER-USER rules the first-boot script installs; ufw here covers ssh and the
+# Caddy listeners only.
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+
+# --- Place the per-instance and MOTD files -----------------------------------
+install -D -m 0755 /tmp/trinity-files/opt/trinity-firstboot/firstboot.sh \
+  /opt/trinity-firstboot/firstboot.sh
+install -D -m 0755 /tmp/trinity-files/var/lib/cloud/scripts/per-instance/001-trinity \
+  /var/lib/cloud/scripts/per-instance/001-trinity
+install -D -m 0755 /tmp/trinity-files/etc/update-motd.d/99-trinity \
+  /etc/update-motd.d/99-trinity
+rm -rf /tmp/trinity-files
+
+# Ubuntu's stock MOTD is noisy and pushes ours off the first screen; the
+# credential line is the one thing a 1-Click user must not miss.
+chmod -x /etc/update-motd.d/10-help-text /etc/update-motd.d/50-motd-news 2>/dev/null || true
+
+echo "=== build provisioning complete ==="

--- a/packer/digitalocean/scripts/01-provision.sh
+++ b/packer/digitalocean/scripts/01-provision.sh
@@ -25,12 +25,40 @@ apt-get install -y -q docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 systemctl enable docker
 
 # --- Caddy (reverse proxy + automatic certificates) --------------------------
+# PINNED, and the floor is load-bearing rather than hygiene. The whole
+# no-domain HTTPS story rests on Caddy issuing a Let's Encrypt certificate for
+# a bare IP, and Caddy could not do that until recently:
+# caddyserver/caddy#7399 — v2.10.0 fails outright with
+# "subject '<ip>' cannot have public IP certificate", the IPv4 fix landed via
+# mholt/acmez#47 (2025-12-17), and IPv6 was not resolved until 2026-04-25.
+# v2.11.3 (2026-05-12) is the first stable release carrying both.
+#
+# An unpinned `apt-get install caddy` happened to work only because the repo's
+# current stable is new enough. That is a silent dependency on a moving
+# upstream for a property this image is built around, and the symptom of
+# getting it wrong appears on a customer's droplet as a browser warning.
+CADDY_VERSION="2.11.4"
+CADDY_MIN_VERSION="2.11.3"
 curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
   | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt \
   > /etc/apt/sources.list.d/caddy-stable.list
 apt-get update -q
-apt-get install -y -q caddy
+apt-get install -y -q "caddy=${CADDY_VERSION}"
+
+# Assert the floor rather than trusting the pin. The pin can be edited, the
+# repo can drop a version, and a `caddy upgrade` on a running droplet can move
+# it — this is the check that survives all three. Deliberately NOT `apt-mark
+# hold`: forward versions carry the fix, and holding would block security
+# updates for the life of the droplet.
+_caddy_installed="$(caddy version | head -1 | sed 's/^v//' | cut -d' ' -f1)"
+if [ "$(printf '%s\n%s\n' "$CADDY_MIN_VERSION" "$_caddy_installed" \
+        | sort -V | head -1)" != "$CADDY_MIN_VERSION" ]; then
+    echo "FATAL: caddy ${_caddy_installed} is below ${CADDY_MIN_VERSION}, which" >&2
+    echo "       cannot issue Let's Encrypt IP certificates (caddyserver/caddy#7399)." >&2
+    exit 1
+fi
+echo "Caddy ${_caddy_installed} (floor ${CADDY_MIN_VERSION}) — IP certificates supported."
 # Not enabled here: first boot writes the Caddyfile (it needs the droplet's own
 # IP) and starts it. A Caddy enabled with the packaged default would race first
 # boot for :80 and take a certificate for the wrong name.

--- a/packer/digitalocean/scripts/01-provision.sh
+++ b/packer/digitalocean/scripts/01-provision.sh
@@ -24,6 +24,21 @@ apt-get update -q
 apt-get install -y -q docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 systemctl enable docker
 
+# --- iptables-persistent -----------------------------------------------------
+# Installed HERE rather than at first boot (#2281 review I1). First boot did it
+# as `>/dev/null 2>&1 || true` at the busiest apt moment a droplet ever has, so
+# a transient mirror failure left the DOCKER-USER DROP rules unsaved and gone at
+# the next reboot — silently. Baked once at build time it is deterministic for
+# every droplet from this snapshot, and first boot only has to run the save.
+#
+# The debconf answers must be preseeded: the package otherwise prompts to save
+# the CURRENT ruleset, and a prompt in a non-interactive Packer run hangs until
+# the provisioner times out. `false` on both — first boot saves the ruleset that
+# actually matters, after Docker and the DROP rules exist.
+echo iptables-persistent iptables-persistent/autosave_v4 boolean false | debconf-set-selections
+echo iptables-persistent iptables-persistent/autosave_v6 boolean false | debconf-set-selections
+apt-get install -y -q iptables-persistent
+
 # --- Caddy (reverse proxy + automatic certificates) --------------------------
 # PINNED, and the floor is load-bearing rather than hygiene. The whole
 # no-domain HTTPS story rests on Caddy issuing a Let's Encrypt certificate for
@@ -90,6 +105,20 @@ docker tag "ghcr.io/abilityai/trinity-agent-base:${TRINITY_IMAGE_TAG}" trinity-a
 docker pull redis:7-alpine
 docker pull timberio/vector:0.43.1-alpine
 docker pull alpine:3.20
+
+# The OTel collector is NOT profile-gated in docker-compose.hosted.yml — unlike
+# cloudflared, which is correctly skippable under `profiles: [tunnel]` — so
+# `start.sh --hosted` starts it on every droplet. Omitting it here (#2281 review
+# I2) left first boot pulling a few hundred megabytes, against the one property
+# this snapshot exists to have. Read from the checkout rather than hardcoded, so
+# a collector bump in compose cannot leave this line pinning a stale digest.
+OTEL_IMAGE="$(grep -oE 'otel/opentelemetry-collector-contrib:[0-9][^"'"'"'[:space:]]*' \
+  /opt/trinity/docker-compose.hosted.yml | head -1)"
+if [ -z "$OTEL_IMAGE" ]; then
+    echo "FATAL: could not resolve the OTel collector image from docker-compose.hosted.yml." >&2
+    exit 1
+fi
+docker pull "$OTEL_IMAGE"
 
 # Record what was baked, for the MOTD and for support.
 mkdir -p /etc/trinity

--- a/packer/digitalocean/scripts/90-cleanup-and-check.sh
+++ b/packer/digitalocean/scripts/90-cleanup-and-check.sh
@@ -9,8 +9,18 @@
 set -euo pipefail
 
 echo "=== Fetching DigitalOcean marketplace validation tooling ==="
-git clone --depth 1 https://github.com/digitalocean/marketplace-partners.git \
-  /tmp/marketplace-partners
+# PINNED, not HEAD (#2281 review I4). Both scripts below run as root and are the
+# last thing to touch the image a vendor review approves, so a moving
+# third-party target is not an acceptable input to a certified artifact — even
+# DigitalOcean's own canonical repo. Bump deliberately, having read the diff.
+# `fetch <sha>` rather than `clone --depth 1`: a shallow clone can only take a
+# ref, and github.com serves commit-SHA fetches.
+MP_COMMIT=b70878804ca27c01d5f5e882d26485defbaba210  # master @ 2026-07-16
+git init -q /tmp/marketplace-partners
+git -C /tmp/marketplace-partners remote add origin \
+  https://github.com/digitalocean/marketplace-partners.git
+git -C /tmp/marketplace-partners fetch -q --depth 1 origin "$MP_COMMIT"
+git -C /tmp/marketplace-partners checkout -q FETCH_HEAD
 
 echo "=== cleanup.sh ==="
 bash /tmp/marketplace-partners/scripts/90-cleanup.sh

--- a/packer/digitalocean/scripts/90-cleanup-and-check.sh
+++ b/packer/digitalocean/scripts/90-cleanup-and-check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Final build step: DigitalOcean's own cleanup, then their validation.
+#
+# Order is load-bearing and this must be the LAST provisioner. cleanup.sh
+# removes what must not be shared by every droplet created from the snapshot
+# (shell history, logs, SSH host keys, apt caches, cloud-init state); img_check.sh
+# then verifies it is gone. Anything that runs after img_check reintroduces
+# exactly what it just certified as absent.
+set -euo pipefail
+
+echo "=== Fetching DigitalOcean marketplace validation tooling ==="
+git clone --depth 1 https://github.com/digitalocean/marketplace-partners.git \
+  /tmp/marketplace-partners
+
+echo "=== cleanup.sh ==="
+bash /tmp/marketplace-partners/scripts/90-cleanup.sh
+
+echo "=== img_check.sh ==="
+# img_check exits non-zero on any finding, which fails the Packer build — the
+# snapshot is never created from a droplet that would be rejected at review.
+bash /tmp/marketplace-partners/scripts/99-img-check.sh

--- a/packer/digitalocean/trinity.pkr.hcl
+++ b/packer/digitalocean/trinity.pkr.hcl
@@ -1,0 +1,96 @@
+# DigitalOcean Marketplace 1-Click snapshot for Trinity (#2281).
+#
+# Build:  packer build -var "do_token=$DIGITALOCEAN_TOKEN" -var "image_tag=v0.9.1" trinity.pkr.hcl
+#
+# The snapshot is BUILT from prebuilt GHCR images (#2280) rather than from
+# source. A 1-Click that spends 5-10 minutes compiling the agent base image on
+# first boot fails the one-click bar, which is the whole reason #2280 gates this
+# issue.
+#
+# What happens at BUILD time (baked into the snapshot):
+#   - Docker + Caddy + ufw installed
+#   - the Trinity checkout placed at /opt/trinity
+#   - all five images pulled at a PINNED tag, agent base retagged locally
+#
+# What happens at FIRST BOOT (per droplet, see files/.../per-instance):
+#   - admin password resolved (user-data-supplied, else generated)
+#   - .env written, including TRINITY_INSTALL_SOURCE=do-marketplace
+#   - Caddy issued a Let's Encrypt certificate for the droplet's own IP
+#   - `start.sh --hosted --unattended` brings the stack up
+#
+# image_tag is deliberately REQUIRED and pinned, never `latest`: a snapshot that
+# resolves `latest` at first boot would serve a different Trinity on every
+# droplet created from one reviewed image, and Marketplace review approves a
+# specific artifact.
+
+packer {
+  required_plugins {
+    digitalocean = {
+      version = ">= 1.4.0"
+      source  = "github.com/digitalocean/digitalocean"
+    }
+  }
+}
+
+variable "do_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Trinity release tag to bake, e.g. v0.9.1. Never 'latest'."
+  validation {
+    condition     = var.image_tag != "latest" && length(var.image_tag) > 0
+    error_message = "image_tag must be a pinned release tag, not 'latest'."
+  }
+}
+
+variable "region" {
+  type    = string
+  default = "nyc3"
+}
+
+# DO's own guidance builds on the smallest size; the snapshot is size-agnostic.
+# The LISTING recommends 8 GB — that is a droplet-plan recommendation in the
+# listing copy, unrelated to what the image is built on.
+variable "build_size" {
+  type    = string
+  default = "s-2vcpu-4gb"
+}
+
+locals {
+  snapshot_name = "trinity-${replace(var.image_tag, ".", "-")}-${formatdate("YYYYMMDD", timestamp())}"
+}
+
+source "digitalocean" "trinity" {
+  api_token     = var.do_token
+  image         = "ubuntu-24-04-x64"
+  region        = var.region
+  size          = var.build_size
+  ssh_username  = "root"
+  snapshot_name = local.snapshot_name
+}
+
+build {
+  sources = ["source.digitalocean.trinity"]
+
+  # Files first: the per-instance script and MOTD must exist before cleanup runs.
+  provisioner "file" {
+    source      = "files/"
+    destination = "/tmp/trinity-files"
+  }
+
+  provisioner "shell" {
+    environment_vars = ["TRINITY_IMAGE_TAG=${var.image_tag}", "DEBIAN_FRONTEND=noninteractive"]
+    scripts          = ["scripts/01-provision.sh"]
+  }
+
+  # DO's own validation and cleanup, fetched from digitalocean/marketplace-partners.
+  # cleanup MUST run before img_check, and img_check MUST be the last thing that
+  # touches the droplet — anything after it can reintroduce exactly what it
+  # verified was gone (shell history, logs, host keys).
+  provisioner "shell" {
+    scripts = ["scripts/90-cleanup-and-check.sh"]
+  }
+}

--- a/packer/digitalocean/trinity.pkr.hcl
+++ b/packer/digitalocean/trinity.pkr.hcl
@@ -42,7 +42,7 @@ variable "image_tag" {
   description = "Trinity release tag to bake, e.g. v0.9.1. Never 'latest'."
   validation {
     condition     = var.image_tag != "latest" && length(var.image_tag) > 0
-    error_message = "image_tag must be a pinned release tag, not 'latest'."
+    error_message = "The image_tag variable must be a pinned release tag, not 'latest'."
   }
 }
 

--- a/tests/unit/test_2281_firstboot_port_exposure.py
+++ b/tests/unit/test_2281_firstboot_port_exposure.py
@@ -1,0 +1,137 @@
+"""Static guard: the 1-Click DROP list covers every port compose publishes (#2281).
+
+Bug (#2281 review C1): first boot moves the SPA to ``FRONTEND_PORT=8081`` so Caddy
+can own 80/443 and terminate TLS in front of it — but the ``DOCKER-USER`` DROP list
+that closes the Docker-past-ufw gap listed ``8000,8080,8686`` and the OTel ports and
+*not* 8081. ``docker-compose.hosted.yml`` publishes the frontend with the short
+syntax ``"${FRONTEND_PORT:-80}:8080"``, which binds ``0.0.0.0``, so the login page
+answered plain HTTP on ``http://<droplet-ip>:8081`` — past the certificate and past
+the ``http→https`` permanent redirect, on the image whose headline design note is
+that everything a user needs is served by Caddy on 80/443.
+
+The list is hand-maintained against a compose file in another directory, which is
+this repo's most-shipped bug shape (#1039, #1056, #1707, #1871, #2381): a port is
+added to one file and never reaches the other, and nothing fails — the droplet
+boots, Trinity works, and one more service is quietly on the public internet.
+
+``packer build`` cannot catch it either: it is deferred to the first release with
+GHCR images, and even then the rule is *installed* correctly — it simply does not
+cover the port. So the guard is repo-side, in the existing unit job.
+
+Pure stdlib + PyYAML: no docker daemon, no backend import.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_ROOT = Path(__file__).resolve().parents[2]
+_HOSTED = _ROOT / "docker-compose.hosted.yml"
+_FIRSTBOOT = (
+    _ROOT / "packer" / "digitalocean" / "files" / "opt" / "trinity-firstboot" / "firstboot.sh"
+)
+
+# `DROP_PORTS=8000,8080,8081,...` — one variable feeds both the -C probe and the
+# -I insert, so there is exactly one list to read.
+_DROP_RE = re.compile(r"^DROP_PORTS=([0-9,]+)\s*$", re.MULTILINE)
+# `set_env FRONTEND_PORT 8081`
+_FRONTEND_PORT_RE = re.compile(r"^set_env\s+FRONTEND_PORT\s+(\d+)\s*$", re.MULTILINE)
+# `${FRONTEND_PORT:-80}:8080` / `8000:8000` / `127.0.0.1:8686:8686`
+_HOST_PORT_RE = re.compile(r"^(?:(?P<ip>[\d.]+):)?(?P<host>\$\{[^}]+\}|\d+):\d+")
+
+
+@pytest.fixture(scope="module")
+def firstboot() -> str:
+    return _FIRSTBOOT.read_text()
+
+
+@pytest.fixture(scope="module")
+def drop_ports(firstboot: str) -> set[int]:
+    m = _DROP_RE.search(firstboot)
+    assert m, "firstboot.sh no longer declares a single DROP_PORTS list"
+    return {int(p) for p in m.group(1).split(",")}
+
+
+@pytest.fixture(scope="module")
+def frontend_port(firstboot: str) -> int:
+    m = _FRONTEND_PORT_RE.search(firstboot)
+    assert m, "firstboot.sh no longer sets FRONTEND_PORT"
+    return int(m.group(1))
+
+
+def _published_host_ports(frontend_port: int) -> dict[str, set[int]]:
+    """Host ports each hosted-compose service publishes, resolved for this droplet.
+
+    Only bindings that reach an external interface count: an explicit ``127.0.0.1:``
+    host IP is already unreachable from the internet and needs no DROP rule.
+    """
+    compose = yaml.safe_load(_HOSTED.read_text())
+    out: dict[str, set[int]] = {}
+    for name, svc in (compose.get("services") or {}).items():
+        for entry in svc.get("ports") or []:
+            if isinstance(entry, dict):  # long syntax
+                host_ip = entry.get("host_ip")
+                published = entry.get("published")
+                if host_ip and host_ip.startswith("127."):
+                    continue
+                if published is not None:
+                    out.setdefault(name, set()).add(int(published))
+                continue
+            m = _HOST_PORT_RE.match(str(entry))
+            assert m, f"unparsed port entry on {name}: {entry!r}"
+            if (m.group("ip") or "").startswith("127."):
+                continue
+            host = m.group("host")
+            if host.startswith("${"):
+                # The only variable in play is FRONTEND_PORT, and first boot sets
+                # it explicitly — so the value that matters is the droplet's, not
+                # the `:-80` default any other install would get.
+                assert "FRONTEND_PORT" in host, f"unknown port variable on {name}: {host}"
+                out.setdefault(name, set()).add(frontend_port)
+            else:
+                out.setdefault(name, set()).add(int(host))
+    return out
+
+
+def test_every_published_port_is_dropped(drop_ports: set[int], frontend_port: int) -> None:
+    published = _published_host_ports(frontend_port)
+    missing = {
+        name: sorted(ports - drop_ports)
+        for name, ports in published.items()
+        if ports - drop_ports
+    }
+    assert not missing, (
+        "docker-compose.hosted.yml publishes these host ports on 0.0.0.0 and the "
+        "1-Click DOCKER-USER DROP list does not cover them, so they are reachable "
+        f"from the internet on every droplet: {missing}. Add them to DROP_PORTS in "
+        "packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh."
+    )
+
+
+def test_frontend_port_is_dropped(drop_ports: set[int], frontend_port: int) -> None:
+    """The regression itself, named — the SPA is the one that must not leak.
+
+    Subsumed by the parity test above, kept separate because a future refactor of
+    the compose parsing must not be able to quietly stop covering this case.
+    """
+    assert frontend_port in drop_ports, (
+        f"first boot moves the SPA to :{frontend_port} so Caddy owns 80/443, but "
+        "the DROP list leaves it exposed — plain HTTP, no redirect, no certificate."
+    )
+
+
+def test_probe_and_insert_share_one_list(firstboot: str) -> None:
+    """A -C probe that differs from the -I insert never matches its own rule.
+
+    It would then insert a duplicate DROP on every re-run of first boot, which is
+    the documented recovery step for a failed boot.
+    """
+    dports = re.findall(r'--dports\s+(\S+)', firstboot)
+    assert dports, "firstboot.sh no longer installs a multiport DROP rule"
+    assert set(dports) == {'"$DROP_PORTS"'}, (
+        f"the DROP rule's port list is spelled more than one way: {sorted(set(dports))}"
+    )

--- a/tests/unit/test_2281_packer_bundle_tracked.py
+++ b/tests/unit/test_2281_packer_bundle_tracked.py
@@ -1,0 +1,90 @@
+"""Regression guard: every file the packer bundle installs must be tracked in git.
+
+Bug (#2281 review): `packer/digitalocean/files/var/lib/cloud/scripts/per-instance/
+001-trinity` — the cloud-init boot hook, i.e. the one file that makes a droplet do
+anything at all — was written locally and silently never committed. `.gitignore`
+carries the bare setuptools patterns `var/` and `lib/`, which git applies at every
+depth, so `git add packer/` skipped it and `git status` stayed clean. The bundle
+mirrors a target filesystem, so this collision is structural rather than unlucky:
+a future `files/usr/lib/...` would go the same way.
+
+Nothing that ran on the PR could see it. `packer validate` never reads the payload
+tree, `shellcheck` only sees the files it is handed, and `packer build` — the one
+step that would have died at `install: cannot stat` — is deliberately deferred to
+the first release with GHCR images, i.e. to the vendor-submission moment.
+
+So the guard is repo-side and runs in the existing unit job: for each
+`install ... /tmp/trinity-files/<path>` in the provision script, assert the
+corresponding `packer/digitalocean/files/<path>` is tracked. `git ls-files` rather
+than `os.path.exists`, so the check fails on the developer's own machine where the
+file is present-but-untracked — the state in which the bug was actually written.
+Mode is asserted too: a boot hook installed 0755 from a 0644 source is a silently
+inert droplet.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# tests/unit/<this file> → parent=tests/unit, .parent=tests, .parent=repo root
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_PROVISION = _REPO_ROOT / "packer" / "digitalocean" / "scripts" / "01-provision.sh"
+_BUNDLE_ROOT = _REPO_ROOT / "packer" / "digitalocean" / "files"
+
+# `install -D -m 0755 /tmp/trinity-files/<src> \` — the packer `file` provisioner
+# uploads `files/` to `/tmp/trinity-files`, so <src> is a path inside the bundle.
+_INSTALL_RE = re.compile(r"/tmp/trinity-files/(\S+)")
+
+
+def _bundle_sources() -> list[str]:
+    text = _PROVISION.read_text()
+    return sorted({m.group(1) for m in _INSTALL_RE.finditer(text)})
+
+
+def _tracked_bundle_files() -> dict[str, str]:
+    """Map bundle-relative path → git mode, for what git actually has."""
+    out = subprocess.run(
+        ["git", "ls-files", "-s", "--", "packer/digitalocean/files"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    tracked: dict[str, str] = {}
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        meta, path = line.split("\t", 1)
+        mode = meta.split()[0]
+        tracked[path[len("packer/digitalocean/files/") :]] = mode
+    return tracked
+
+
+def test_provision_script_is_present():
+    assert _PROVISION.is_file(), f"missing {_PROVISION}"
+
+
+def test_every_installed_source_is_tracked():
+    sources = _bundle_sources()
+    assert sources, "no /tmp/trinity-files/... install sources found — did the script move?"
+
+    tracked = _tracked_bundle_files()
+    missing = [s for s in sources if s not in tracked]
+    assert not missing, (
+        "01-provision.sh installs bundle files that git does not track: "
+        f"{missing}. They may exist locally and be swallowed by a bare .gitignore "
+        "pattern (`var/`, `lib/`, `parts/`, …) — re-include the path in .gitignore "
+        "and commit the file, or `packer build` dies at `install: cannot stat`."
+    )
+
+
+@pytest.mark.parametrize("source", _bundle_sources())
+def test_installed_source_is_executable(source: str):
+    # Every current install site uses `-m 0755`; a 0644 source would still install
+    # 0755, but the intent should be visible in the tree the reviewer reads.
+    mode = _tracked_bundle_files().get(source)
+    assert mode == "100755", f"{source} is tracked as {mode}, expected 100755"


### PR DESCRIPTION
Refs #2281 (does not close it — the vendor application and listing are separate, human-gated steps).

## What

The Packer bundle that produces the DigitalOcean Marketplace 1-Click snapshot. Seven files under a new top-level `packer/`:

| file | role |
|---|---|
| `trinity.pkr.hcl` | DO builder, Ubuntu 24.04, `image_tag` required and `latest` refused |
| `scripts/01-provision.sh` | build time: Docker, Caddy, ufw, pinned checkout, all five images pulled, agent base retagged |
| `scripts/90-cleanup-and-check.sh` | DO's `90-cleanup.sh` then `99-img-check.sh`, last provisioner |
| `files/opt/trinity-firstboot/firstboot.sh` | per-droplet: password, `.env`, `DOCKER-USER` rules, Caddyfile, `start.sh --hosted --unattended` |
| `files/var/lib/cloud/scripts/per-instance/001-trinity` | thin hook, never wedges cloud-init |
| `files/etc/update-motd.d/99-trinity` | credentials, URL, next steps, the DO-doesn't-support-this line |
| `README.md` | build, per-release update runbook, design notes |

Nothing baked into the snapshot is droplet-specific: the admin password, the droplet's own IP and the certificate are all resolved at first boot.

## Two findings worth a reviewer's attention

**Docker publishes past ufw.** `docker-compose.hosted.yml` publishes 8000, 8080, 8686 and the OTel ports on `0.0.0.0`, and Docker's iptables rules are traversed before ufw's, so a `ufw deny 8000` on a public droplet is silently inert. Handled here with a `DOCKER-USER` DROP on `eth0`. Worth knowing beyond this PR: `docker-compose.prod.yml` carries the identical bindings, so this is not specific to the hosted file or to droplets — being filed separately.

**Path correction.** DO's script is `99-img-check.sh` (hyphen), not `img_check.sh` as #2281's AC2 spells it. Verified against the `digitalocean/marketplace-partners` tree.

## Verification

- `packer validate` — **caught a real defect, fixed in c6b49fc1.** HCL requires a validation message to start with an uppercase letter; the `image_tag` message began with the lowercase variable name, so the whole template failed to validate *before any builder ran* — which made the `image_tag != "latest"` guard unreachable. Both paths now exercised: a pinned tag validates, `-var image_tag=latest` is refused by the rule at `trinity.pkr.hcl:43`.
- `caddy validate` on the generated Caddyfile (heredoc extracted, IP substituted, run through `caddy:2`) — **valid configuration**.
- `packer fmt -check`, `bash -n` and `shellcheck -S warning` on all five scripts — clean.

**Not verified, and it gates the listing rather than this PR:**

- `packer build` — needs a DO token *and* the GHCR images, which do not exist yet: `publish-images.yml` has never run, because the newest tag `v0.9.0` predates it. The snapshot must be built from the first release that carries both that workflow and #2381.
- The no-domain HTTPS premise. `firstboot.sh:116` relies on Let's Encrypt issuing for bare IPs via the `shortlived` ACME profile. If that is not generally available, first boot lands on a certificate error and the listing is dead on arrival. Nothing in this repo checks it — worth confirming before the vendor submission.
- Anything requiring Linux and root: cloud-init ordering, the `DOCKER-USER` rules, systemd units.

## Sequencing

This does not block on the release, but the snapshot it produces does. Order is: cut a release → `publish-images.yml` fires → `packer build -var image_tag=<that tag>` → submit the snapshot ID in the Vendor Portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01218nVkqK7vU2jy9R73s4jT
