### PR TITLE
fix(frontend): proxy /mcp through nginx so MCP survives a 80/443-only install

### DIFF
--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -72,6 +72,42 @@ server {
         chunked_transfer_encoding on;
     }
 
+    # Trinity MCP server (#2281 / hosted installs). The MCP server listens on
+    # its own container port 8080, and until now that port was the ONLY way to
+    # reach it — nothing proxied `/mcp`. That is fine while every port is
+    # published on 0.0.0.0, and breaks the moment an install exposes only
+    # 80/443, which is exactly what the DigitalOcean 1-Click does: Caddy has a
+    # single `reverse_proxy` pointed at this nginx, so an external MCP client
+    # (`https://<host>/mcp`) had nowhere to land and the platform's headline
+    # integration silently did not exist on a marketplace droplet.
+    #
+    # Proxied like /a2a/ rather than /api/: both are external-facing front
+    # doors onto a non-backend upstream, and both stream.
+    #
+    # `trinity-mcp-server` resolves on the agent network, which this container
+    # shares with it — verified in docker-compose{,.prod,.hosted}.yml, all three
+    # of which define that container_name. (The sibling compose has no frontend,
+    # so nginx never runs there.) nginx resolves upstreams at startup, so a
+    # compose file that ships this frontend WITHOUT an mcp-server would fail to
+    # boot rather than 502 — hence the check across all three.
+    location /mcp {
+        proxy_pass http://trinity-mcp-server:8080/mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+
+        # Streamable HTTP. The transport is the STATEFUL httpStream branch, so
+        # a session is a long-lived SSE response keyed by `Mcp-Session-Id`;
+        # buffering it would hold events until the buffer filled and make the
+        # session look hung. Same reasoning as /api/ and /a2a/.
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+    }
+
     # WebSocket support
     location /ws {
         proxy_pass http://trinity-backend:8000/ws;


### PR DESCRIPTION
Refs #2281.

## The gap

Nothing proxied `/mcp`. The MCP server was reachable only on its own published container port 8080 — invisible while every port is published on `0.0.0.0`, and fatal the moment an install exposes 80/443 and nothing else.

That install is the DigitalOcean 1-Click (#2281). Its Caddy has a single `reverse_proxy` pointed at this nginx, and this nginx proxied `/api/`, `/a2a/`, `/ws`, `/health` and `/` — no `/mcp` anywhere. So an external client pointed at `https://<droplet>/mcp` had nowhere to land, and the platform's headline integration silently did not exist on a marketplace droplet. Same for any install that firewalls the extra ports.

## Shape

Modelled on `/a2a/` rather than `/api/` — both are external-facing front doors onto an upstream that is not the backend, and both stream. `proxy_buffering off` for the same reason it's off there: the transport is the stateful `httpStream` branch, so a session is a long-lived SSE response keyed by `Mcp-Session-Id`, and buffering would hold events until the buffer filled and make the session look hung.

**nginx resolves upstreams at startup, not per request** — so a compose file shipping this frontend without an mcp-server would fail to *boot*, not 502. All three composes that run the frontend were checked for that `container_name` (dev, prod, hosted); the sibling compose defines no frontend, so this file never runs there. Confirmed empirically: `nginx -t` against a bare container fails with `host not found in upstream "trinity-backend"` and passes once the names resolve.

## Verification — against the running MCP server, not by inspection

A throwaway nginx on `trinity-agent-network` loaded with this config:

```
POST /mcp  (through proxy)        POST :8080/mcp  (direct)
status=200                        status=200
event: message                    event: message
data: {"result":{"protocolVersion":"2025-06-18",...
                                  data: {"result":{"protocolVersion":"2025-06-18",...
```

Response headers through the proxy:

```
HTTP/1.1 200 OK
Content-Type: text/event-stream
mcp-session-id: 3d7f7e7f-1ebc-4179-a6b8-96c8ae455b70
```

The `mcp-session-id` header survives — that's the one the stateful transport needs to keep a session alive.

## Not a widening

8080 is already published on `0.0.0.0` in both prod and hosted compose, and MCP's own bearer auth is unchanged. This narrows the surface by making one port sufficient.

`nginx.conf` is baked into the frontend image, so it ships with the next image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01218nVkqK7vU2jy9R73s4jT
