### PR TITLE
fix(tests): defuse the hardcoded-timestamp time bomb in the #2467 fleet-list test

### DIFF
--- a/tests/unit/test_2467_turn_integrity.py
+++ b/tests/unit/test_2467_turn_integrity.py
@@ -453,6 +453,14 @@ class TestFacadeSignatureParity:
         )
 
 
+def _recent_iso(*, minutes_ago: int) -> str:
+    """A fresh ISO-Z timestamp shortly in the past, matching utc_now_iso()'s
+    format — rows built from it always sit inside a rolling hours=24 window."""
+    from datetime import datetime, timedelta, timezone
+    dt = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
 class TestListReadersCarryTheColumn:
     """AC #2's real surfaces: BOTH list readers with explicit column lists must
     return `turn_integrity` — `get_fleet_executions` (raw-SQL SELECT) and
@@ -510,8 +518,13 @@ class TestListReadersCarryTheColumn:
             "INSERT INTO schedule_executions(id, schedule_id, agent_name, status, "
             "started_at, completed_at, message, triggered_by, turn_integrity) "
             "VALUES (?,?,?,?,?,?,?,?,?)",
+            # Timestamps are derived from NOW, never hardcoded: get_fleet_executions
+            # defaults to hours=24, so a fixed started_at turned this into a time
+            # bomb — green until the calendar caught up, then red on every branch
+            # (first fired 2026-09-02T10:00Z, fleet-list arm only; the agent-summary
+            # arm has no window and kept passing).
             ("e-ti", "s1", "agent-ti", "success",
-             "2026-09-01T10:00:00.000000Z", "2026-09-01T10:01:00.000000Z",
+             _recent_iso(minutes_ago=10), _recent_iso(minutes_ago=9),
              "m", "schedule", self._TI),
         )
         conn.commit()


### PR DESCRIPTION
## Summary

`tests/unit/test_2467_turn_integrity.py::TestListReadersCarryTheColumn::test_fleet_list_returns_turn_integrity` inserts a row with a **hardcoded** `started_at = 2026-09-01T10:00Z`, while `get_fleet_executions` filters on its default `hours=24` window. The test was green until the calendar caught up and began failing on **every** branch at 2026-09-02T10:00 UTC (dev CI at 09:15Z today passed; any run after 10:00Z reds). Verified failing on clean `origin/dev` locally.

The sibling `test_agent_summary_list_returns_turn_integrity` kept passing because `get_agent_executions_summary` applies no window — which is why only one arm of the pair fired.

## Fix

Timestamps derive from `now(timezone.utc) - timedelta(minutes=…)` in `utc_now_iso()`'s exact format, so the row always sits inside a rolling 24h window. Full file: 33 passed.

Closes #2486 (filed in parallel with the same diagnosis — hardcoded started_at vs the hours=24 default window).

This unblocks `backend-unit-test` for every open PR (CI runs on the PR merge ref, so landing this on dev heals them without rebases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLfHNPtB5UCMk4LonZiJux