### PR TITLE
test(2467): derive the fleet-list fixture timestamp from now, not a literal date

### DIFF
--- a/tests/unit/test_2467_turn_integrity.py
+++ b/tests/unit/test_2467_turn_integrity.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -506,12 +507,19 @@ class TestListReadersCarryTheColumn:
             )
             """
         )
+        # Relative, never a literal date: `get_fleet_executions` defaults to a
+        # 24h `hours` window, so a fixed `started_at` is a time bomb — this
+        # fixture shipped with "2026-09-01T10:00:00Z", passed every run until
+        # 2026-09-02 10:00 UTC, then failed every `dev` push after it (run
+        # 33634096378) with `assert 0 == 1` and no code change anywhere.
+        started = datetime.now(timezone.utc) - timedelta(minutes=5)
+        fmt = "%Y-%m-%dT%H:%M:%S.%fZ"  # the utc_now_iso() shape the readers parse
         conn.execute(
             "INSERT INTO schedule_executions(id, schedule_id, agent_name, status, "
             "started_at, completed_at, message, triggered_by, turn_integrity) "
             "VALUES (?,?,?,?,?,?,?,?,?)",
             ("e-ti", "s1", "agent-ti", "success",
-             "2026-09-01T10:00:00.000000Z", "2026-09-01T10:01:00.000000Z",
+             started.strftime(fmt), (started + timedelta(minutes=1)).strftime(fmt),
              "m", "schedule", self._TI),
         )
         conn.commit()


### PR DESCRIPTION
Refs #2467 (follow-up to #2473 — a test time bomb, not a product change).

## What broke

`dev`'s `backend-unit-test` push run went red on the #2471 merge (run 33634096378): one failure in 13,527,

```
FAILED unit/test_2467_turn_integrity.py::TestListReadersCarryTheColumn::test_fleet_list_returns_turn_integrity - assert 0 == 1
```

#2471 touches nothing under `src/` or this test. The cause is the fixture: it inserts `started_at = "2026-09-01T10:00:00Z"` as a literal, and `get_fleet_executions` defaults to `hours=24` (`db/schedules/stats.py:338`). So the row fell out of the window at 2026-09-02 10:00 UTC — the previous push (dd910564, 09:15 UTC) was green, and the same test fails on that commit today. The sibling `get_agent_executions_summary` reader has no window, which is why only one of the pair went red.

## Fix

Both timestamps are derived from `datetime.now(timezone.utc)` in the `utc_now_iso()` shape the readers parse. A comment on the fixture names the trap so the next reader doesn't re-plant it.

## Verification

- `tests/unit/test_2467_turn_integrity.py`: 33 passed (run twice) on this branch; the single test fails deterministically on `dev` and on dd910564 without the change.
- `grep` for other `get_fleet_executions` tests carrying a `"2026-` literal: this was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012d5K93m76zw4Rn193FXvsJ