### PR TITLE
fix(workspace): an ask's answer travels as the decision the agent reads (#2375)

### DIFF
--- a/src/backend/client_portal/asks/models.py
+++ b/src/backend/client_portal/asks/models.py
@@ -40,10 +40,15 @@ class WorkspaceAsk(BaseModel):
 class WorkspaceAskAnswer(BaseModel):
     """An answer from the addressee.
 
-    `response` is the chosen option (or approve/deny); `response_text` is free
-    text. Both optional individually, at least one required — an empty answer is
-    not an answer, and recording one would clear the ask while telling the agent
-    nothing.
+    `response` is the DECISION — the chosen option or the typed answer — and it
+    is what the agent reads: the sync write-back copies it to the queue file
+    verbatim and the ent#329 resume framing presents it as "the answer".
+    `response_text` is an optional free-text NOTE riding alongside a decision;
+    it cannot stand alone (#2375: the Workspace panel used to post a typed
+    answer as `response_text`, the service coerced the missing `response` to
+    "", and the agent read an empty answer). Both stay Optional at the model so
+    the service can refuse with its own named 422 (`empty_answer`) instead of a
+    bare validation shape; the service is the gate.
     """
     response: Optional[str] = Field(default=None, max_length=500)
     response_text: Optional[str] = Field(default=None, max_length=4000)

--- a/src/backend/client_portal/asks/service.py
+++ b/src/backend/client_portal/asks/service.py
@@ -169,10 +169,17 @@ def list_asks(email: str, is_platform: bool, agent_name: Optional[str] = None) -
 def answer_ask(item_id: str, email: str, is_platform: bool,
                response: Optional[str], response_text: Optional[str]) -> WorkspaceAsk:
     """Answer one ask as the addressee. Raises `AskError` with a named code."""
-    if not (response or response_text):
+    # #2375: the decision is REQUIRED. `response` is the field the agent reads
+    # (the write-back copies it to the queue file verbatim; the ent#329 resume
+    # frames it as "the answer"), so a note-only body would clear the ask while
+    # handing the agent an empty answer — exactly the bug this gate closes. The
+    # operator route's model (`OperatorResponse.response: str`) already requires
+    # it; this aligns the two contracts.
+    if not (response and response.strip()):
         raise AskError(422, "empty_answer",
-                       "An answer needs a choice or some text — an empty answer would "
-                       "clear the ask while telling the agent nothing.")
+                       "An answer needs a decision in `response` — that is the field "
+                       "the agent reads; `response_text` is only a note and cannot "
+                       "stand alone.")
 
     item = db.get_operator_queue_item(item_id)
     # Uniform 404 for missing / not-mine / off-roster: a distinguishable 403 would
@@ -216,7 +223,7 @@ def answer_ask(item_id: str, email: str, is_platform: bool,
 
     updated = db.respond_to_operator_queue_item(
         item_id=item_id,
-        response=response or "",
+        response=response,
         response_text=response_text,
         responded_by_id=None,
         responded_by_email=email,
@@ -276,7 +283,7 @@ def answer_ask(item_id: str, email: str, is_platform: bool,
 
             operator_resume_service.spawn_resume_dispatch(
                 updated,
-                response=response or "",
+                response=response,
                 response_text=response_text,
                 responded_by_email=email,
             )

--- a/src/backend/services/operator_queue_choices.py
+++ b/src/backend/services/operator_queue_choices.py
@@ -74,11 +74,14 @@ def validate_response_choice(item: dict, response: Optional[str]) -> None:
     on its behalf, and the whole point is that the recorded decision is one the
     agent can compare against its own list.
 
-    An empty or absent `response` is NOT rejected here. Both entry points allow
-    an answer carried entirely by `response_text` (the Workspace asks path has
-    its own `empty_answer` refusal for a truly empty one), and turning a
-    text-only answer into a 422 would break a working path in the name of
-    validating a field that was never filled in.
+    An empty or absent `response` is NOT rejected here — emptiness is each
+    entry point's own contract, not this validator's: the operator route
+    requires `response` at the model (`OperatorResponse.response: str`) and the
+    Workspace asks path refuses a missing/blank decision with its named
+    `empty_answer` 422 (#2375 — it previously accepted note-only bodies and
+    coerced the decision to "", which is how agents received empty answers).
+    This function answers ONE question: when a decision IS present on an
+    approval, was it one the agent offered?
     """
     if not response:
         return

--- a/src/frontend/src/components/portal/PortalAsks.vue
+++ b/src/frontend/src/components/portal/PortalAsks.vue
@@ -56,19 +56,57 @@
       >Open the conversation</button>
 
       <template v-else>
-        <div v-if="ask.options?.length" class="mt-2 flex flex-wrap gap-2">
-          <button
-            v-for="opt in ask.options"
-            :key="String(opt)"
-            type="button"
-            :disabled="busyId === ask.id"
-            class="rounded-lg bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 text-white text-xs font-medium px-2.5 py-1.5"
-            :data-testid="`portal-ask-option-${ask.id}`"
-            @click="answer(ask, String(opt))"
-          >{{ opt }}</button>
-        </div>
+        <!-- #2375: controls come from the shared kind rule (queueResponseKind),
+             so this surface cannot drift from desktop QueueCard and /m. An
+             approval is select → optional note → explicit Send — never a
+             one-tap irreversible answer; the tapped option only arms Send. -->
+        <template v-if="controlsKind(ask) === 'approval'">
+          <div class="mt-2 flex flex-wrap gap-2" role="radiogroup">
+            <button
+              v-for="opt in optionsOf(ask)"
+              :key="opt"
+              type="button"
+              :disabled="busyId === ask.id"
+              class="rounded-lg border text-xs font-medium px-2.5 py-1.5 disabled:opacity-50"
+              :class="picks[ask.id] === opt
+                ? 'bg-action-primary-600 border-action-primary-600 text-white'
+                : 'bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:border-action-primary-500'"
+              :aria-pressed="picks[ask.id] === opt"
+              :data-testid="`portal-ask-option-${ask.id}`"
+              @click="picks[ask.id] = picks[ask.id] === opt ? null : opt"
+            >{{ opt }}</button>
+          </div>
+          <form class="mt-2 flex items-center gap-2" @submit.prevent="submit(ask)">
+            <input
+              v-model="notes[ask.id]"
+              type="text"
+              :disabled="busyId === ask.id"
+              placeholder="Add a note (optional)…"
+              class="flex-1 min-w-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2.5 py-1.5 text-sm"
+              :data-testid="`portal-ask-note-${ask.id}`"
+            />
+            <button
+              type="submit"
+              :disabled="busyId === ask.id || !picks[ask.id]"
+              class="rounded-lg bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 text-white text-xs font-medium px-2.5 py-1.5"
+              :data-testid="`portal-ask-send-${ask.id}`"
+            >{{ busyId === ask.id ? 'Sending…' : 'Send' }}</button>
+          </form>
+        </template>
 
-        <form v-else class="mt-2 flex items-center gap-2" @submit.prevent="answer(ask, null, drafts[ask.id])">
+        <!-- An alert only wants acknowledging; "Got it" mirrors desktop and /m. -->
+        <button
+          v-else-if="controlsKind(ask) === 'acknowledge'"
+          type="button"
+          :disabled="busyId === ask.id"
+          class="mt-2 rounded-lg bg-action-primary-600 hover:bg-action-primary-700 disabled:opacity-50 text-white text-xs font-medium px-2.5 py-1.5"
+          :data-testid="`portal-ask-ack-${ask.id}`"
+          @click="submit(ask)"
+        >{{ busyId === ask.id ? 'Sending…' : 'Got it' }}</button>
+
+        <!-- A question (or an approval that offered no options) takes a typed
+             answer — sent as the DECISION (`response`), never as a note (#2375). -->
+        <form v-else class="mt-2 flex items-center gap-2" @submit.prevent="submit(ask)">
           <input
             v-model="drafts[ask.id]"
             type="text"
@@ -94,6 +132,7 @@
 import { computed, reactive, ref } from 'vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
 import { expiredLabel, askThreadLink } from './portalUtils'
+import { optionsOf, queueResponseKind, buildQueueResponse, queueTypeLabel } from '@/utils/operatorQueue'
 
 const props = defineProps({
   // Omit to render every ask addressed to this user (chat/global); pass a name to
@@ -109,7 +148,9 @@ const emit = defineEmits(['open-thread'])
 
 const store = useClientPortalStore()
 const busyId = ref(null)
-const drafts = reactive({})
+const drafts = reactive({})   // question: the typed answer (the DECISION)
+const picks = reactive({})    // approval: the selected option
+const notes = reactive({})    // approval: the optional free-text note
 const errors = reactive({})
 
 const items = computed(() =>
@@ -117,15 +158,31 @@ const items = computed(() =>
 )
 const visible = computed(() => store.asksAvailable && items.value.length > 0)
 
-const KINDS = { question: 'Question', approval: 'Approval needed', alert: 'Update' }
-const kindLabel = (kind) => KINDS[kind] || 'Question'
+// #2375: one label set and one controls rule across desktop, /m and the
+// Workspace — both come from utils/operatorQueue, the single home #2370
+// established. An ask's `kind` is the queue row's `type` verbatim.
+const kindLabel = (kind) => queueTypeLabel(kind) || 'Question'
+const controlsKind = (ask) => queueResponseKind({ type: ask.kind, options: ask.options })
 
-async function answer(ask, response, text = null) {
+async function submit(ask) {
+  // The shared builder decides the wire shape: the decision travels as
+  // `response` (the field the agent reads), a note as `response_text`. It
+  // returns null when there is nothing valid to send — no option picked,
+  // blank answer — and the controls stay armed.
+  const body = buildQueueResponse({
+    kind: controlsKind(ask),
+    option: picks[ask.id],
+    note: notes[ask.id] || '',
+    answer: drafts[ask.id] || '',
+  })
+  if (!body) return
   busyId.value = ask.id
   errors[ask.id] = null
   try {
-    await store.answerAsk(ask.id, { response, responseText: text || null })
+    await store.answerAsk(ask.id, { response: body.response, responseText: body.response_text })
     delete drafts[ask.id]
+    delete picks[ask.id]
+    delete notes[ask.id]
   } catch (err) {
     // The backend's refusals are already written for a human ("This ask expired
     // before it was answered."), so surface them rather than replacing them with

--- a/src/frontend/src/components/portal/PortalAsks.vue
+++ b/src/frontend/src/components/portal/PortalAsks.vue
@@ -61,7 +61,7 @@
              approval is select → optional note → explicit Send — never a
              one-tap irreversible answer; the tapped option only arms Send. -->
         <template v-if="controlsKind(ask) === 'approval'">
-          <div class="mt-2 flex flex-wrap gap-2" role="radiogroup">
+          <div class="mt-2 flex flex-wrap gap-2">
             <button
               v-for="opt in optionsOf(ask)"
               :key="opt"
@@ -80,6 +80,7 @@
             <input
               v-model="notes[ask.id]"
               type="text"
+              maxlength="4000"
               :disabled="busyId === ask.id"
               placeholder="Add a note (optional)…"
               class="flex-1 min-w-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2.5 py-1.5 text-sm"
@@ -110,6 +111,7 @@
           <input
             v-model="drafts[ask.id]"
             type="text"
+            maxlength="500"
             :disabled="busyId === ask.id"
             placeholder="Your answer…"
             class="flex-1 min-w-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2.5 py-1.5 text-sm"

--- a/src/frontend/tests/unit/workspaceAsks.spec.js
+++ b/src/frontend/tests/unit/workspaceAsks.spec.js
@@ -19,6 +19,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 import { expiredLabel, askThreadLink } from '@/components/portal/portalUtils'
+import { buildQueueResponse } from '@/utils/operatorQueue'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 vi.hoisted(() => {
   const mem = new Map()
@@ -279,5 +282,79 @@ describe('the inline-in-chat surface filters by agent NAME', () => {
     expect(src).toContain('store.asksForAgent(props.agent.name)')
     expect(src).not.toContain('store.asksForAgent(props.agent)')
     expect(src).toMatch(/:agent-name="agent\.name"/)
+  })
+})
+
+
+describe('#2375 — the wire shape of an answer', () => {
+  // The component cannot be mounted (vitest is environment:'node' with no
+  // harness), so the rule splits: the PAYLOAD is pinned through the shared
+  // builder the component calls, and the WIRING is source-asserted below.
+  it('a typed answer to a question travels as the DECISION, never as a note', () => {
+    expect(buildQueueResponse({ kind: 'question', answer: '  deploy tuesday  ' }))
+      .toEqual({ response: 'deploy tuesday', response_text: null })
+  })
+
+  it('an approval sends the picked option verbatim, with the note riding beside it', () => {
+    expect(buildQueueResponse({ kind: 'approval', option: 'Approve', note: ' after 6pm ' }))
+      .toEqual({ response: 'Approve', response_text: 'after 6pm' })
+  })
+
+  it('an approval with nothing picked sends NOTHING — Send stays disarmed', () => {
+    expect(buildQueueResponse({ kind: 'approval', option: null, note: 'just a note' }))
+      .toBeNull()
+  })
+
+  it('an alert acknowledges', () => {
+    expect(buildQueueResponse({ kind: 'acknowledge' }))
+      .toEqual({ response: 'acknowledged', response_text: null })
+  })
+
+  it('the store forwards exactly what the builder produced', async () => {
+    portalHttp.get.mockResolvedValueOnce({ data: [ask('a1')] })
+    await store.fetchAsks()
+    portalHttp.post.mockResolvedValueOnce({ data: { ...ask('a1'), status: 'responded' } })
+
+    const body = buildQueueResponse({ kind: 'question', answer: 'deploy tuesday' })
+    await store.answerAsk('a1', { response: body.response, responseText: body.response_text })
+
+    const [, posted] = portalHttp.post.mock.calls[0]
+    expect(posted).toEqual({ response: 'deploy tuesday', response_text: null })
+  })
+})
+
+describe('#2375 — the panel goes through the shared module (source-asserted)', () => {
+  const sfc = readFileSync(
+    fileURLToPath(new URL('../../src/components/portal/PortalAsks.vue', import.meta.url)),
+    'utf8',
+  )
+
+  it('imports the one home of the payload, the controls rule and the labels', () => {
+    expect(sfc).toMatch(
+      /import \{ optionsOf, queueResponseKind, buildQueueResponse, queueTypeLabel \} from '@\/utils\/operatorQueue'/,
+    )
+  })
+
+  it('never one-taps an option straight into an answer', () => {
+    // The exact regression: option buttons used to call answer() directly, so a
+    // tap on an irreversible decision had no note and no explicit submit.
+    expect(sfc).not.toMatch(/@click="answer\(/)
+    // A tap only arms Send: the option click writes the pick, nothing else.
+    expect(sfc).toMatch(/@click="picks\[ask\.id\] = /)
+    expect(sfc).toMatch(/:disabled="busyId === ask\.id \|\| !picks\[ask\.id\]"/)
+  })
+
+  it('builds every submission through buildQueueResponse', () => {
+    expect(sfc).toMatch(/const body = buildQueueResponse\(/)
+    expect(sfc).not.toMatch(/responseText: text \|\| null/)
+  })
+
+  it('renders the shared type labels, not a third bespoke set', () => {
+    expect(sfc).toMatch(/queueTypeLabel\(kind\)/)
+    expect(sfc).not.toMatch(/Approval needed/)
+  })
+
+  it('an approval carries an optional note field', () => {
+    expect(sfc).toMatch(/portal-ask-note-\$\{ask\.id\}/)
   })
 })

--- a/tests/unit/test_ent428_workspace_asks.py
+++ b/tests/unit/test_ent428_workspace_asks.py
@@ -287,6 +287,46 @@ def test_an_empty_answer_is_refused(asks_db, client_email):
     assert (ei.value.status_code, ei.value.code) == (422, "empty_answer")
 
 
+def test_a_note_only_answer_is_refused_as_empty(asks_db, client_email):
+    """#2375: `response` is the decision the agent reads — the write-back copies
+    it to the queue file verbatim and the ent#329 resume frames it as "the
+    answer". The old gate accepted `response_text` alone and coerced the missing
+    decision to "", so the Workspace's typed answers reached agents empty. A
+    note cannot stand alone."""
+    from database import db
+    from client_portal.asks import service
+    item_id = _raise_ask(addressed=client_email)
+
+    with pytest.raises(service.AskError) as ei:
+        service.answer_ask(item_id, client_email, False, None, "my actual answer")
+    assert (ei.value.status_code, ei.value.code) == (422, "empty_answer")
+    # And nothing was written: the ask still waits.
+    assert db.get_operator_queue_item(item_id)["status"] == "pending"
+
+
+def test_a_whitespace_decision_is_refused_as_empty(asks_db, client_email):
+    from client_portal.asks import service
+    item_id = _raise_ask(addressed=client_email)
+
+    with pytest.raises(service.AskError) as ei:
+        service.answer_ask(item_id, client_email, False, "   ", None)
+    assert (ei.value.status_code, ei.value.code) == (422, "empty_answer")
+
+
+def test_the_recorded_decision_is_verbatim_never_a_coerced_empty(asks_db, client_email):
+    """#2375: the row's `response` holds exactly what was sent — and the note
+    rides `response_text` beside it, not instead of it."""
+    from database import db
+    from client_portal.asks import service
+    item_id = _raise_ask(addressed=client_email)
+
+    service.answer_ask(item_id, client_email, False, "yes", "with a caveat")
+
+    row = db.get_operator_queue_item(item_id)
+    assert row["response"] == "yes"
+    assert row["response_text"] == "with a caveat"
+
+
 def test_someone_elses_ask_is_a_uniform_404(asks_db, client_email):
     """Not 403. A distinguishable refusal would let any client enumerate ask ids."""
     from client_portal.asks import service


### PR DESCRIPTION
## Summary

Closes #2375 — the Workspace asks panel handed agents **empty answers**: a typed answer to a question ask was posted as `response_text` with `response: null`, the service coerced the missing decision to `""`, and the agent — told by the protocol to read `response` — got nothing. Approval asks were answered **one-tap** (no note, no explicit submit) with a third bespoke label set. Same class as #2370's `/m` bug: a hand-built respond payload bypassing the shared builder.

## Frontend

`PortalAsks.vue` now routes everything through `utils/operatorQueue` (the single home #2370 established):

- **Controls by the shared kind rule** (`queueResponseKind`): approval with options → select an option (tap only *arms* Send) → optional note → **explicit Send**; alert → "Got it"; question or option-less approval → typed answer.
- **Payload by the shared builder** (`buildQueueResponse`): the decision travels as `response` — verbatim for options, trimmed for typed answers — and a note as `response_text`, never the other way around.
- **Labels by `queueTypeLabel`** — one label set across desktop, `/m` and the Workspace ("Needs approval" / "Question" / "Heads up").
- Per-card honest-failure rendering untouched; `picks`/`notes`/`drafts` clear on success.

## Backend (AC 4 — the coercion)

`answer_ask` now **requires the decision**: a note-only or whitespace-only body is a named **422 `empty_answer`** whose message says which field the agent reads — aligning this contract with the operator route's `OperatorResponse.response: str`. Both `response or ""` coercions are gone, so the row, the write-back and the ent#329 resume dispatch all carry the answer verbatim. `WorkspaceAskAnswer` keeps Optional fields deliberately (the service owns the named-422 shape rather than a bare Pydantic 422) — documented in the model.

## Tests (AC 5)

- **Backend** (`test_ent428_workspace_asks.py` +3): note-only refused **and nothing written** (the ask still waits), whitespace-only refused, recorded decision verbatim with the note beside it.
- **Frontend** (`workspaceAsks.spec.js` +10): the wire shape pinned for question / approval+note / nothing-picked / alert through the shared builder, store passthrough of the built body, and the component wiring source-asserted (imports the shared module, no one-tap `@click="answer(`, option tap only writes the pick, Send disarmed without one, shared labels, note field present).

## Verification

- Backend: **120 passed** across every suite touching the asks service (ent#428, both ent#430 suites, #2376 membership, ent#329 resume, portal binding/kwargs).
- Frontend: **73 files / 1,596 tests** green; `npm run build` clean.
- No note-only success case existed anywhere in the suites, so the tightened contract breaks no tested behaviour; a stale cached bundle now gets the named 422 surfaced by the panel's existing error rendering instead of silently recording an empty answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLfHNPtB5UCMk4LonZiJux
