### PR TITLE
fix(ci): a pre-release tag must not publish `latest` to GHCR

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -161,11 +161,28 @@ jobs:
           # A dispatch therefore publishes `sha-<short>` and nothing else, which
           # is exactly what a smoke build needs. Re-cutting a release is done by
           # re-pushing the git tag, which fires `push` and takes the full set.
+          #
+          # `latest` additionally excludes PRE-RELEASE tags (`v0.9.5-rc1`). The
+          # `startsWith(refs/tags/v)` guard above answers "is this a version tag",
+          # not "is this a version anyone should be running" — and a release
+          # candidate is pushed precisely so a marketplace snapshot can be built
+          # from it BEFORE the payload is blessed, i.e. the one tag that must not
+          # become what every unpinned hosted install pulls on its next
+          # `start.sh --hosted`. The same hazard the dispatch gate exists for,
+          # arriving through the other door.
+          #
+          # The `-` test IS the semver prerelease rule (spec item 9: a prerelease
+          # is a hyphen plus dot-separated identifiers after patch), so it needs
+          # no list of `rc`/`beta`/`alpha` spellings to keep current. Note this
+          # cannot be delegated to metadata-action: its own prerelease handling
+          # ("pre-release will only extend {{version}}") applies to `type=semver`
+          # — which is why `{{major}}.{{minor}}` below is already safe — and has
+          # no effect whatsoever on a `type=raw` value.
           tags: |
             type=semver,pattern={{version}},enable=${{ github.event_name == 'push' }}
             type=semver,pattern=v{{version}},enable=${{ github.event_name == 'push' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
             type=raw,value=sha-${{ steps.prov.outputs.short_sha }}
 
       - name: Select build args for this image

--- a/tests/unit/test_2471_publish_images_prerelease_latest.py
+++ b/tests/unit/test_2471_publish_images_prerelease_latest.py
@@ -1,0 +1,94 @@
+"""Regression guard: a PRE-RELEASE tag must never publish `latest` to GHCR.
+
+Bug: `publish-images.yml` gated its `type=raw,value=latest` line on
+`startsWith(github.ref, 'refs/tags/v')` — which answers "is this a version tag",
+not "is this a version anyone should be running". `refs/tags/v0.9.5-rc1`
+satisfies that prefix, so pushing a release candidate would move `latest` and
+every unpinned hosted install would pull the RC on its next
+`start.sh --hosted`. An RC exists precisely to be built from BEFORE the payload
+is blessed (the marketplace snapshot needs GHCR images, #2281/#2471), so it is
+the one tag that must not become the default pull.
+
+metadata-action cannot be relied on here. Its documented prerelease handling —
+"pre-release will only extend {{version}}" — applies to `type=semver` entries,
+which is why `{{major}}.{{minor}}` needs no guard of its own, and has no effect
+at all on a `type=raw` value. The exclusion has to be written into the `enable:`
+expression, so it is pinned here rather than trusted.
+
+Same family as test_canary_env_prod_parity / test_1871_log_config_parity: a
+silent, single-line CI regression whose blast radius is every deployed install.
+
+Lives under tests/unit/ so the CI unit job (`cd tests && pytest unit/`) collects
+it — a guard must run where the bug would regress.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# tests/unit/<this file> → parent=tests/unit, .parent=tests, .parent=repo root
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "publish-images.yml"
+
+
+def _latest_line() -> str:
+    lines = [
+        ln.strip()
+        for ln in _WORKFLOW.read_text().splitlines()
+        if "type=raw,value=latest" in ln and not ln.strip().startswith("#")
+    ]
+    assert len(lines) == 1, f"expected exactly one `latest` tag rule, found {len(lines)}"
+    return lines[0]
+
+
+def test_latest_excludes_prerelease_tags() -> None:
+    """The `latest` rule must exclude a hyphenated (pre-release) tag name.
+
+    The `-` test IS the semver prerelease rule (spec item 9), so this asserts the
+    shape rather than a list of rc/beta/alpha spellings that would go stale.
+    """
+    line = _latest_line()
+    assert "!contains(github.ref_name, '-')" in line, (
+        "publish-images.yml publishes `latest` for pre-release tags. "
+        f"A `v*-rc1` push would walk `latest` backwards for every unpinned "
+        f"hosted install. Line was: {line}"
+    )
+
+
+def test_latest_still_gated_on_a_real_tag_push() -> None:
+    """The pre-existing guards must survive — the prerelease rule is additive.
+
+    Dropping either of these re-opens #2280's own hazard (a workflow_dispatch
+    smoke build becoming what every hosted install pulls).
+    """
+    line = _latest_line()
+    assert "github.event_name == 'push'" in line
+    assert "startsWith(github.ref, 'refs/tags/v')" in line
+
+
+def test_semver_patterns_are_untouched() -> None:
+    """`{{version}}` / `v{{version}}` must still publish for a pre-release.
+
+    An RC has to be pullable by its own exact tag — that is the whole point of
+    cutting one. Only the mutable `latest` pointer is withheld.
+    """
+    body = _WORKFLOW.read_text()
+    for pattern in ("type=semver,pattern={{version}}", "type=semver,pattern=v{{version}}"):
+        assert pattern in body, f"missing {pattern}"
+        rule = next(ln for ln in body.splitlines() if pattern in ln)
+        assert "ref_name" not in rule, (
+            f"the prerelease exclusion must NOT be applied to {pattern} — an RC "
+            f"must remain pullable by its exact tag. Line was: {rule.strip()}"
+        )
+
+
+def test_major_minor_is_left_to_metadata_action() -> None:
+    """`{{major}}.{{minor}}` carries no hyphen guard, deliberately.
+
+    metadata-action already withholds it for a pre-release. Adding a redundant
+    guard here would imply the semver entries need one, which is the confusion
+    that produced the bug.
+    """
+    body = _WORKFLOW.read_text()
+    rule = next(ln for ln in body.splitlines() if "{{major}}.{{minor}}" in ln)
+    assert "ref_name" not in rule, f"unexpected hyphen guard on major.minor: {rule.strip()}"


### PR DESCRIPTION
Prerequisite for cutting `v0.9.5-rc1`. Refs #2281, #2471 (the marketplace snapshot needs GHCR images from an RC tag).

## The bug

`publish-images.yml` gates its `latest` rule on the tag ref's prefix alone:

```yaml
type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
```

`refs/tags/v0.9.5-rc1` satisfies `startsWith(refs/tags/v)`. So pushing a release candidate republishes `latest`, and every unpinned hosted install pulls the RC on its next `start.sh --hosted`.

The workflow already argues against precisely this outcome, twelve lines above — *"a `workflow_dispatch` smoke build must never silently become what every hosted install pulls"*. The dispatch door was closed; the pre-release tag door was not.

It bites now rather than hypothetically: an RC is the **prerequisite** for the DigitalOcean snapshot. #2471's own sequencing is cut a tag → `publish-images.yml` fires → `packer build -var image_tag=<tag>`. The tag exists specifically to be built from *before* the payload is blessed, which makes it the one tag that must not become the default pull.

## The fix

```diff
-type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
```

Two things worth a reviewer's attention:

**Why not let metadata-action handle it.** It does handle it — for `type=semver`. Its documented rule is *"Pre-release (rc, beta, alpha) will only extend `{{version}}` … as tag"*, which is why `{{major}}.{{minor}}` on line 183 is already safe and correctly carries no guard of its own. That rule has no effect whatsoever on a `type=raw` value, so the exclusion has to be written into the `enable:` expression. A test pins that asymmetry in both directions, because "add the guard everywhere" is the natural wrong fix.

**Why `-` and not an rc/beta/alpha list.** The hyphen *is* the semver prerelease rule (spec item 9: a prerelease is a hyphen plus dot-separated identifiers after patch). A spelling list goes stale the first time someone tags `-pre` or `-canary`.

`{{version}}` and `v{{version}}` are deliberately untouched — an RC must stay pullable by its exact tag. Only the mutable pointer is withheld.

## Verification

- `tests/unit/test_2471_publish_images_prerelease_latest.py` — 4 tests, all passing. **Verified to actually catch the bug**: reverting the one-line change fails `test_latest_excludes_prerelease_tags`; the other three still pass, so the negative case is the one being asserted.
- The suite covers the regression in both directions: the exclusion is present on `latest`, the two pre-existing dispatch guards survive, and the exclusion is *absent* from `{{version}}`/`v{{version}}`/`{{major}}.{{minor}}`.
- `yaml.safe_load` on the workflow — parses.
- Not verified: an actual tag push. The expression is evaluated by Actions, not locally, and the only honest test of it is the RC push this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9bL6DZ8QVyrSvPybp5ZuK